### PR TITLE
Check for peg-in amount underflow

### DIFF
--- a/minimint-api/src/lib.rs
+++ b/minimint-api/src/lib.rs
@@ -222,7 +222,7 @@ where
             })
             .collect::<Coins<C>>();
 
-        if amount == Amount::from_msat(0) {
+        if amount == Amount::ZERO {
             Some(coins)
         } else {
             None
@@ -248,6 +248,8 @@ impl Coins<()> {
 }
 
 impl Amount {
+    pub const ZERO: Self = Self { milli_sat: 0 };
+
     pub fn from_msat(msat: u64) -> Amount {
         Amount { milli_sat: msat }
     }
@@ -255,6 +257,12 @@ impl Amount {
     pub fn from_sat(sat: u64) -> Amount {
         Amount {
             milli_sat: sat * 1000,
+        }
+    }
+
+    pub fn saturating_sub(self, other: Amount) -> Self {
+        Amount {
+            milli_sat: self.milli_sat.saturating_sub(other.milli_sat),
         }
     }
 }

--- a/minimint/src/config.rs
+++ b/minimint/src/config.rs
@@ -94,9 +94,9 @@ impl GenerateConfig for ServerConfig {
             MintConfig::trusted_dealer_gen(peers, max_evil, params.amount_tiers.as_ref(), &mut rng);
 
         let fee_consensus = FeeConsensus {
-            fee_coin_spend_abs: minimint_api::Amount::from_sat(0),
+            fee_coin_spend_abs: minimint_api::Amount::ZERO,
             fee_peg_in_abs: minimint_api::Amount::from_sat(500),
-            fee_coin_issuance_abs: minimint_api::Amount::from_sat(0),
+            fee_coin_issuance_abs: minimint_api::Amount::ZERO,
             fee_peg_out_abs: minimint_api::Amount::from_sat(500),
         };
 


### PR DESCRIPTION
- New `ClientError` variant for peg-in amount too small
- Add `Amount::ZERO` constant replaces `Amount::from_x(0)` in codebase
- Add `Amount::saturating_sub` function