### PR TITLE
distributed config gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,6 +1390,7 @@ dependencies = [
  "sled",
  "tbs",
  "thiserror",
+ "threshold_crypto",
  "tokio",
  "tokio-rustls",
  "tokio-util 0.6.10",

--- a/minimint-api/src/lib.rs
+++ b/minimint-api/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub mod db;
 pub mod encoding;
 pub mod module;
+pub mod net;
 pub mod rand;
 pub mod task;
 

--- a/minimint-api/src/net/mod.rs
+++ b/minimint-api/src/net/mod.rs
@@ -1,0 +1,1 @@
+pub mod peers;

--- a/minimint-api/src/net/peers.rs
+++ b/minimint-api/src/net/peers.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+use minimint_api::PeerId;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Owned [`PeerConnections`] trait object type
+pub type AnyPeerConnections<M> = Box<dyn PeerConnections<M> + Send + Unpin + 'static>;
+
+/// Connection manager that tries to keep connections open to all peers
+///
+/// Production implementations of this trait have to ensure that:
+/// * Connections to peers are authenticated and encrypted
+/// * Messages are received exactly once and in the order they were sent
+/// * Connections are reopened when closed
+/// * Messages are cached in case of short-lived network interruptions and resent on reconnect, this
+///   avoids the need to rejoin the consensus, which is more tricky.
+///
+/// In case of longer term interruptions the message cache has to be dropped to avoid DoS attacks.
+/// The thus disconnected peer will need to rejoin the consensus at a later time.  
+#[async_trait]
+pub trait PeerConnections<T>
+where
+    T: Serialize + DeserializeOwned + Unpin + Send,
+{
+    /// Send a message to a specific peer.
+    ///
+    /// The message is sent immediately and cached if the peer is reachable and only cached
+    /// otherwise.
+    async fn send(&mut self, peers: &[PeerId], msg: T);
+
+    /// Await receipt of a message from any connected peer.
+    async fn receive(&mut self) -> (PeerId, T);
+
+    /// Removes a peer connection in case of misbehavior
+    async fn ban_peer(&mut self, peer: PeerId);
+
+    /// Converts the struct to a `PeerConnection` trait object
+    fn to_any(self) -> AnyPeerConnections<T>
+    where
+        Self: Sized + Send + Unpin + 'static,
+    {
+        Box::new(self)
+    }
+}

--- a/minimint/Cargo.toml
+++ b/minimint/Cargo.toml
@@ -18,6 +18,7 @@ bytes = "1.1.0"
 clap = { version = "3.1.18", features = ["derive"] }
 futures = "0.3.9"
 hbbft = { git = "https://github.com/fedimint/hbbft" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 hex = "0.4.2"
 itertools = "0.10.0"
 jsonrpsee = { version = "0.14.0", features = ["ws-server"] }

--- a/minimint/src/bin/configgen.rs
+++ b/minimint/src/bin/configgen.rs
@@ -11,6 +11,9 @@ struct Options {
     nodes: u16,
     hbbft_base_port: u16,
     api_base_port: u16,
+    keygen_base_port: u16,
+    wallet_base_port: u16,
+    lightning_base_port: u16,
     amount_tiers: Vec<Amount>,
 }
 
@@ -20,6 +23,9 @@ fn main() {
         nodes,
         hbbft_base_port,
         api_base_port,
+        keygen_base_port,
+        wallet_base_port,
+        lightning_base_port,
         amount_tiers,
     } = Options::parse();
     let mut rng = OsRng::new().unwrap();
@@ -36,11 +42,14 @@ fn main() {
     let params = ServerConfigParams {
         hbbft_base_port,
         api_base_port,
+        keygen_base_port,
+        wallet_base_port,
+        lightning_base_port,
         amount_tiers,
     };
 
     let (server_cfg, client_cfg) =
-        ServerConfig::trusted_dealer_gen(&peers, max_evil, &params, &mut rng);
+        ServerConfig::trusted_dealer_gen(&peers, max_evil, &(params, None), &mut rng);
 
     for (id, cfg) in server_cfg {
         let mut path: PathBuf = cfg_path.clone();

--- a/minimint/src/config.rs
+++ b/minimint/src/config.rs
@@ -6,14 +6,24 @@ use hbbft::crypto::serde_impl::SerdeSecret;
 use minimint_api::config::GenerateConfig;
 use minimint_api::PeerId;
 use minimint_core::modules::ln::config::LightningModuleConfig;
-use minimint_core::modules::mint::config::MintConfig;
+use minimint_core::modules::mint::config::{MintClientConfig, MintConfig};
 use minimint_core::modules::wallet::config::WalletConfig;
 use rand::{CryptoRng, RngCore};
 
+use crate::minimint_api::net::peers::PeerConnections;
+use crate::net::connect::Connector;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::net::connect::TlsConfig;
+use crate::{ReconnectPeerConnections, TlsTcpConnector};
+use async_trait::async_trait;
+
+use threshold_crypto::{PublicKeySet, SecretKeyShare};
+
+use minimint_api::net::peers::AnyPeerConnections;
+
+use serde::de::DeserializeOwned;
 use tokio_rustls::rustls;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,9 +38,9 @@ pub struct ServerConfig {
 
     pub peers: BTreeMap<PeerId, Peer>,
     #[serde(with = "serde_binary_human_readable")]
-    pub hbbft_sks: hbbft::crypto::serde_impl::SerdeSecret<hbbft::crypto::SecretKeyShare>,
+    pub hbbft_sks: SerdeSecret<SecretKeyShare>,
     #[serde(with = "serde_binary_human_readable")]
-    pub hbbft_pk_set: hbbft::crypto::PublicKeySet,
+    pub hbbft_pk_set: PublicKeySet,
 
     pub wallet: WalletConfig,
     pub mint: MintConfig,
@@ -47,16 +57,30 @@ pub struct Peer {
     pub tls_cert: rustls::Certificate,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ServerConfigParams {
     pub hbbft_base_port: u16,
     pub api_base_port: u16,
+    pub keygen_base_port: u16,
+    pub wallet_base_port: u16,
+    pub lightning_base_port: u16,
     pub amount_tiers: Vec<minimint_api::Amount>,
 }
 
+pub struct RemoteServerConfig {
+    pub tls: TlsConfig,
+    pub hbbft: NetworkConfig,
+    pub wallet: AnyPeerConnections<<WalletConfig as GenerateConfig>::ConfigMessage>,
+    pub lightning: AnyPeerConnections<<LightningModuleConfig as GenerateConfig>::ConfigMessage>,
+    pub configs: (MintConfig, MintClientConfig),
+}
+
+#[async_trait(?Send)]
 impl GenerateConfig for ServerConfig {
-    type Params = ServerConfigParams;
+    type Params = (ServerConfigParams, Option<RemoteServerConfig>);
     type ClientConfig = ClientConfig;
+    type ConfigMessage = <LightningModuleConfig as GenerateConfig>::ConfigMessage;
+    type ConfigError = ();
 
     fn trusted_dealer_gen(
         peers: &[PeerId],
@@ -64,25 +88,20 @@ impl GenerateConfig for ServerConfig {
         params: &Self::Params,
         mut rng: impl RngCore + CryptoRng,
     ) -> (BTreeMap<PeerId, Self>, Self::ClientConfig) {
+        let (params, _) = params;
         let netinfo = hbbft::NetworkInfo::generate_map(peers.to_vec(), &mut Rand07Compat(&mut rng))
             .expect("Could not generate HBBFT netinfo");
-        let tls_keys = peers
-            .iter()
-            .map(|peer| {
-                let (cert, key) = gen_cert_and_key(&format!("peer-{}", peer.to_usize())).unwrap();
-                (*peer, (cert, key))
-            })
-            .collect::<HashMap<_, _>>();
+        let tls_keys = gen_tls_configs(peers);
 
         let cfg_peers = netinfo
             .iter()
-            .map(|(&id, _)| {
+            .map(|(&id, _netinf)| {
                 let id_u16: u16 = id.into();
                 let peer = Peer {
                     connection: ConnectionConfig {
                         addr: format!("127.0.0.1:{}", params.hbbft_base_port + id_u16),
                     },
-                    tls_cert: tls_keys[&id].0.clone(),
+                    tls_cert: tls_keys[&id].our_certificate.clone(),
                 };
 
                 (id, peer)
@@ -113,8 +132,8 @@ impl GenerateConfig for ServerConfig {
                     identity: id,
                     hbbft_bind_addr: format!("127.0.0.1:{}", params.hbbft_base_port + id_u16),
                     api_bind_addr: format!("127.0.0.1:{}", params.api_base_port + id_u16),
-                    tls_cert: tls_keys[&id].0.clone(),
-                    tls_key: tls_keys[&id].1.clone(),
+                    tls_cert: tls_keys[&id].our_certificate.clone(),
+                    tls_key: tls_keys[&id].our_private_key.clone(),
                     peers: cfg_peers.clone(),
                     hbbft_sks: SerdeSecret(netinf.secret_key_share().unwrap().clone()),
                     hbbft_pk_set: netinf.public_key_set().clone(),
@@ -140,6 +159,101 @@ impl GenerateConfig for ServerConfig {
         };
 
         (server_config, client_config)
+    }
+
+    async fn distributed_gen(
+        connections: &mut AnyPeerConnections<Self::ConfigMessage>,
+        our_id: &PeerId,
+        peers: &[PeerId],
+        max_evil: usize,
+        params: &mut Self::Params,
+        mut rng: impl RngCore + CryptoRng,
+    ) -> Result<(Self, Self::ClientConfig), Self::ConfigError> {
+        let (params, remote) = match params {
+            (params, Some(remote_cfg)) => (params, remote_cfg),
+            _ => panic!("Remote server configs need to be passed in distributed config gen"),
+        };
+
+        // HBBFT threshold key generation
+        // TODO should probably refactor to a shared threshold crypto module
+        let (sk, pk) = LightningModuleConfig::distributed_threshold_gen(
+            connections,
+            our_id,
+            peers,
+            max_evil,
+            &mut rng,
+        )
+        .await;
+
+        let wallet = &mut remote.wallet;
+        let (wsc, wcc) =
+            WalletConfig::distributed_gen(wallet, our_id, peers, max_evil, &mut (), &mut rng)
+                .await
+                .unwrap();
+
+        let ln = &mut remote.lightning;
+        let (ln_server_cfg, ln_client_cfg) =
+            LightningModuleConfig::distributed_gen(ln, our_id, peers, max_evil, &mut (), &mut rng)
+                .await
+                .unwrap();
+
+        let cfg_peers = peers
+            .iter()
+            .map(|id| {
+                let id_u16: u16 = (*id).into();
+                let address = remote.hbbft.peers.get(id).unwrap();
+                let tls_cert = remote.tls.peer_certs.get(id).unwrap().clone();
+                // FIXME replace with proper port configuration
+                let base_address = address.addr.split(':').next().unwrap();
+                let peer = Peer {
+                    connection: ConnectionConfig {
+                        addr: format!("{}:{}", base_address, (params.hbbft_base_port + id_u16)),
+                    },
+                    tls_cert,
+                };
+
+                (*id, peer)
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        let fee_consensus = FeeConsensus {
+            fee_coin_spend_abs: minimint_api::Amount::ZERO,
+            fee_peg_in_abs: minimint_api::Amount::ZERO,
+            fee_coin_issuance_abs: minimint_api::Amount::ZERO,
+            fee_peg_out_abs: minimint_api::Amount::ZERO,
+            fee_contract_input: minimint_api::Amount::ZERO,
+            fee_contract_output: minimint_api::Amount::ZERO,
+        };
+
+        let id_u16: u16 = (*our_id).into();
+        let config = ServerConfig {
+            identity: *our_id,
+            hbbft_bind_addr: format!("127.0.0.1:{}", params.hbbft_base_port + id_u16),
+            api_bind_addr: format!("127.0.0.1:{}", params.api_base_port + id_u16),
+            tls_cert: remote.tls.our_certificate.clone(),
+            tls_key: remote.tls.our_private_key.clone(),
+            peers: cfg_peers,
+            hbbft_sks: SerdeSecret(SecretKeyShare::from_mut(&mut sk.clone())),
+            hbbft_pk_set: pk.clone(),
+            wallet: wsc,
+            mint: remote.configs.0.clone(),
+            ln: ln_server_cfg,
+            fee_consensus: fee_consensus.clone(),
+        };
+
+        let client_config = ClientConfig {
+            max_evil,
+            api_endpoints: peers
+                .iter()
+                .map(|&peer| format!("ws://127.0.0.1:{}", params.api_base_port + u16::from(peer)))
+                .collect(),
+            mint: remote.configs.1.clone(),
+            wallet: wcc,
+            ln: ln_client_cfg,
+            fee_consensus,
+        };
+
+        Ok((config, client_config))
     }
 }
 
@@ -174,6 +288,70 @@ impl ServerConfig {
 
     pub fn max_faulty(&self) -> usize {
         hbbft::util::max_faulty(self.peers.len())
+    }
+}
+
+pub async fn gen_connections<T>(
+    base_port: u16,
+    our_id: &PeerId,
+    peers: &[PeerId],
+    certs: TlsConfig,
+) -> AnyPeerConnections<T>
+where
+    T: std::fmt::Debug + Clone + Serialize + DeserializeOwned + Unpin + Send + Sync + 'static,
+{
+    let connector = TlsTcpConnector::new(certs).to_any();
+    let network = gen_local_network_config(base_port, our_id, peers);
+    ReconnectPeerConnections::new(network, connector)
+        .await
+        .to_any()
+}
+
+pub fn gen_tls_configs(peers: &[PeerId]) -> HashMap<PeerId, TlsConfig> {
+    let keys: HashMap<PeerId, (rustls::Certificate, rustls::PrivateKey)> = peers
+        .iter()
+        .map(|peer| {
+            let (cert, key) = gen_cert_and_key(&format!("peer-{}", peer.to_usize())).unwrap();
+            (*peer, (cert, key))
+        })
+        .collect::<HashMap<_, _>>();
+    let certs: HashMap<PeerId, rustls::Certificate> = keys
+        .iter()
+        .map(|(peer, (cert, _))| (*peer, cert.clone()))
+        .collect::<HashMap<_, _>>();
+    keys.iter()
+        .map(|(peer, (cert, key))| {
+            (
+                *peer,
+                TlsConfig {
+                    our_certificate: cert.clone(),
+                    our_private_key: key.clone(),
+                    peer_certs: certs.clone(),
+                },
+            )
+        })
+        .collect::<HashMap<_, _>>()
+}
+
+pub fn gen_local_network_config(
+    base_port: u16,
+    our_id: &PeerId,
+    peers: &[PeerId],
+) -> NetworkConfig {
+    NetworkConfig {
+        identity: *our_id,
+        bind_addr: format!("127.0.0.1:{}", base_port + u16::from(*our_id)),
+        peers: peers
+            .iter()
+            .map(|&id| {
+                (
+                    id,
+                    ConnectionConfig {
+                        addr: format!("127.0.0.1:{}", base_port + u16::from(id)),
+                    },
+                )
+            })
+            .collect(),
     }
 }
 

--- a/minimint/src/net/peers.rs
+++ b/minimint/src/net/peers.rs
@@ -10,13 +10,15 @@ use async_trait::async_trait;
 use futures::future::select_all;
 use futures::{SinkExt, StreamExt};
 use hbbft::Target;
+use minimint_api::net::peers::PeerConnections;
 use minimint_api::PeerId;
 use rand::{thread_rng, Rng};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::cmp::min;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::Debug;
+use std::ops::Sub;
 use std::time::Duration;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
@@ -26,49 +28,9 @@ use tracing::{debug, error, info, instrument, trace, warn};
 /// Maximum connection failures we consider for our back-off strategy
 const MAX_FAIL_RECONNECT_COUNTER: u64 = 300;
 
-/// Owned [`PeerConnections`] trait object type
-pub type AnyPeerConnections<M> = Box<dyn PeerConnections<M> + Send + Unpin + 'static>;
-
 /// Owned [`Connector`](crate::net::connect::Connector) trait object used by
 /// [`ReconnectPeerConnections`]
 pub type PeerConnector<M> = AnyConnector<PeerMessage<M>>;
-
-/// Connection manager that tries to keep connections open to all peers
-///
-/// Production implementations of this trait have to ensure that:
-/// * Connections to peers are authenticated and encrypted
-/// * Messages are received exactly once and in the order they were sent
-/// * Connections are reopened when closed
-/// * Messages are cached in case of short-lived network interruptions and resent on reconnect, this
-///   avoids the need to rejoin the consensus, which is more tricky.
-///
-/// In case of longer term interruptions the message cache has to be dropped to avoid DoS attacks.
-/// The thus disconnected peer will need to rejoin the consensus at a later time.  
-#[async_trait]
-pub trait PeerConnections<T>
-where
-    T: Serialize + DeserializeOwned + Unpin + Send,
-{
-    /// Send a message to a target, either all peers or a specific one.
-    ///
-    /// The message is sent immediately and cached if the peer is reachable and only cached
-    /// otherwise.
-    async fn send(&mut self, target: Target<PeerId>, msg: T);
-
-    /// Await receipt of a message from any connected peer.
-    async fn receive(&mut self) -> (PeerId, T);
-
-    /// Removes a peer connection in case of misbehavior
-    async fn ban_peer(&mut self, peer: PeerId);
-
-    /// Converts the struct to a `PeerConnection` trait object
-    fn to_any(self) -> AnyPeerConnections<T>
-    where
-        Self: Sized + Send + Unpin + 'static,
-    {
-        Box::new(self)
-    }
-}
 
 /// Connection manager that automatically reconnects to peers
 ///
@@ -231,24 +193,13 @@ impl<T> PeerConnections<T> for ReconnectPeerConnections<T>
 where
     T: std::fmt::Debug + Serialize + DeserializeOwned + Clone + Unpin + Send + Sync + 'static,
 {
-    async fn send(&mut self, target: Target<PeerId>, msg: T) {
-        trace!(?target, "Sending message to");
-        match target {
-            Target::AllExcept(not_to) => {
-                for (peer, connection) in &mut self.connections {
-                    if !not_to.contains(peer) {
-                        connection.send(msg.clone()).await;
-                    }
-                }
-            }
-            Target::Nodes(peer_ids) => {
-                for peer_id in peer_ids {
-                    if let Some(peer) = self.connections.get_mut(&peer_id) {
-                        peer.send(msg.clone()).await;
-                    } else {
-                        trace!(peer = ?peer_id, "Not sending message to unknown peer (maybe banned)");
-                    }
-                }
+    async fn send(&mut self, peers: &[PeerId], msg: T) {
+        for peer_id in peers {
+            trace!(?peer_id, "Sending message to");
+            if let Some(peer) = self.connections.get_mut(peer_id) {
+                peer.send(msg.clone()).await;
+            } else {
+                trace!(peer = ?peer_id, "Not sending message to unknown peer (maybe banned)");
             }
         }
     }
@@ -270,6 +221,21 @@ where
     async fn ban_peer(&mut self, peer: PeerId) {
         self.connections.remove(&peer);
         warn!("Peer {} banned.", peer);
+    }
+}
+
+pub trait PeerSlice {
+    fn peers(&self, all_peers: &BTreeSet<PeerId>) -> Vec<PeerId>;
+}
+
+impl PeerSlice for Target<PeerId> {
+    fn peers(&self, all_peers: &BTreeSet<PeerId>) -> Vec<PeerId> {
+        let set = match self {
+            Target::AllExcept(exclude) => all_peers.sub(&exclude),
+            Target::Nodes(include) => include.clone()
+        };
+
+        set.into_iter().collect()
     }
 }
 
@@ -587,10 +553,8 @@ mod tests {
         ConnectionConfig, NetworkConfig, PeerConnections, ReconnectPeerConnections,
     };
     use futures::Future;
-    use hbbft::Target;
     use minimint_api::PeerId;
-    use std::collections::{BTreeSet, HashMap};
-    use std::iter::FromIterator;
+    use std::collections::HashMap;
     use std::time::Duration;
     use tracing_subscriber::EnvFilter;
 
@@ -638,16 +602,12 @@ mod tests {
         let mut peers_a = build_peers("a", 1).await;
         let mut peers_b = build_peers("b", 2).await;
 
-        peers_a
-            .send(Target::Nodes(BTreeSet::from_iter([PeerId::from(2)])), 42)
-            .await;
+        peers_a.send(&[PeerId::from(2)], 42).await;
         let recv = timeout(peers_b.receive()).await.unwrap();
         assert_eq!(recv.0, PeerId::from(1));
         assert_eq!(recv.1, 42);
 
-        peers_a
-            .send(Target::Nodes(BTreeSet::from_iter([PeerId::from(3)])), 21)
-            .await;
+        peers_a.send(&[PeerId::from(3)], 21).await;
 
         let mut peers_c = build_peers("c", 3).await;
         let recv = timeout(peers_c.receive()).await.unwrap();

--- a/minimint/src/net/peers.rs
+++ b/minimint/src/net/peers.rs
@@ -231,8 +231,8 @@ pub trait PeerSlice {
 impl PeerSlice for Target<PeerId> {
     fn peers(&self, all_peers: &BTreeSet<PeerId>) -> Vec<PeerId> {
         let set = match self {
-            Target::AllExcept(exclude) => all_peers.sub(&exclude),
-            Target::Nodes(include) => include.clone()
+            Target::AllExcept(exclude) => all_peers.sub(exclude),
+            Target::Nodes(include) => include.clone(),
         };
 
         set.into_iter().collect()

--- a/modules/minimint-ln/src/config.rs
+++ b/modules/minimint-ln/src/config.rs
@@ -1,16 +1,22 @@
+use async_trait::async_trait;
 use minimint_api::config::GenerateConfig;
 use minimint_api::rand::Rand07Compat;
 use minimint_api::PeerId;
 use secp256k1::rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
+
+use minimint_api::net::peers::AnyPeerConnections;
+use threshold_crypto::ff::Field;
+use threshold_crypto::group::{CurveAffine, CurveProjective};
+use threshold_crypto::poly::{BivarCommitment, BivarPoly, Poly};
+use threshold_crypto::{Fr, G1Affine, PublicKeySet, SecretKeyShare, G1};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningModuleConfig {
-    pub threshold_pub_keys: threshold_crypto::PublicKeySet,
+    pub threshold_pub_keys: PublicKeySet,
     // TODO: propose serde(with = "…") based protection upstream instead
-    pub threshold_sec_key:
-        threshold_crypto::serde_impl::SerdeSecret<threshold_crypto::SecretKeyShare>,
+    pub threshold_sec_key: threshold_crypto::serde_impl::SerdeSecret<SecretKeyShare>,
     pub threshold: usize,
 }
 
@@ -19,9 +25,12 @@ pub struct LightningModuleClientConfig {
     pub threshold_pub_key: threshold_crypto::PublicKey,
 }
 
+#[async_trait(?Send)]
 impl GenerateConfig for LightningModuleConfig {
     type Params = ();
     type ClientConfig = LightningModuleClientConfig;
+    type ConfigMessage = ThresholdKeyGen;
+    type ConfigError = ();
 
     fn trusted_dealer_gen(
         peers: &[PeerId],
@@ -29,8 +38,8 @@ impl GenerateConfig for LightningModuleConfig {
         _params: &Self::Params,
         rng: impl RngCore + CryptoRng,
     ) -> (BTreeMap<PeerId, Self>, Self::ClientConfig) {
-        let threshold = peers.len() - max_evil;
-        let sks = threshold_crypto::SecretKeySet::random(threshold - 1, &mut Rand07Compat(rng));
+        let threshold = peers.len() - max_evil - 1;
+        let sks = threshold_crypto::SecretKeySet::random(threshold, &mut Rand07Compat(rng));
         let pks = sks.public_keys();
 
         let server_cfg = peers
@@ -54,5 +63,224 @@ impl GenerateConfig for LightningModuleConfig {
         };
 
         (server_cfg, client_cfg)
+    }
+
+    async fn distributed_gen(
+        connections: &mut AnyPeerConnections<Self::ConfigMessage>,
+        our_id: &PeerId,
+        peers: &[PeerId],
+        max_evil: usize,
+        _params: &mut Self::Params,
+        mut rng: impl RngCore + CryptoRng,
+    ) -> Result<(Self, Self::ClientConfig), Self::ConfigError> {
+        let threshold = peers.len() - max_evil - 1;
+        let (mut sk, pk) =
+            Self::distributed_threshold_gen(connections, our_id, peers, threshold, &mut rng).await;
+
+        let server_cfg = LightningModuleConfig {
+            threshold_pub_keys: pk.clone(),
+            threshold_sec_key: threshold_crypto::serde_impl::SerdeSecret(SecretKeyShare::from_mut(
+                &mut sk,
+            )),
+            threshold,
+        };
+
+        let client_cfg = LightningModuleClientConfig {
+            threshold_pub_key: pk.public_key(),
+        };
+
+        Ok((server_cfg, client_cfg))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub enum ThresholdKeyGen {
+    Commit(Poly, BivarCommitment),
+    Verify(BivarCommitment, #[serde(with = "serde_g1")] G1),
+}
+
+impl LightningModuleConfig {
+    pub async fn distributed_threshold_gen<'a>(
+        connections: &mut AnyPeerConnections<ThresholdKeyGen>,
+        our_id: &'a PeerId,
+        peers: &'a [PeerId],
+        threshold: usize,
+        rng: &'a mut (impl RngCore + CryptoRng),
+    ) -> (Fr, PublicKeySet) {
+        let mut sk: Fr = Fr::zero();
+        let mut pk = Poly::zero().commitment();
+        let mut commits = BTreeMap::<PeerId, (Poly, BivarCommitment)>::new();
+        let mut verifies = BTreeMap::<BivarCommitment, HashSet<PeerId>>::new();
+
+        // create our secrets and add them to our keys
+        let our_poly = BivarPoly::random(threshold, &mut Rand07Compat(rng));
+        let our_commit = BivarPoly::commitment(&our_poly);
+        sk.add_assign(&our_poly.row(our_id.as_row()).evaluate(Fr::zero()));
+        pk += our_commit.row(0_usize);
+
+        for peer in peers {
+            let msg = ThresholdKeyGen::Commit(our_poly.row(peer.as_row()), our_commit.clone());
+            connections.send(&[*peer], msg).await;
+        }
+
+        // run until all other peers have verified every commit
+        let num_others = peers.len() - 1;
+
+        while verifies.values().map(|v| v.len()).sum::<usize>() < (peers.len() * num_others) {
+            match connections.receive().await {
+                (sender, ThresholdKeyGen::Commit(poly, commit)) => {
+                    for peer in peers {
+                        let val = poly.evaluate(peer.as_row());
+                        let val_g1 = G1Affine::one().mul(val).into_affine().into_projective();
+                        connections
+                            .send(&[*peer], ThresholdKeyGen::Verify(commit.clone(), val_g1))
+                            .await;
+                    }
+
+                    // verify commitment and that each peer only sends 1
+                    assert_eq!(poly.commitment(), commit.row(our_id.as_row()));
+                    assert!(commits.insert(sender, (poly, commit.clone())).is_none());
+                    let verifiers = verifies.entry(commit).or_insert_with(HashSet::default);
+                    verifiers.insert(*our_id);
+                }
+                (sender, ThresholdKeyGen::Verify(commit, val_g1)) => {
+                    // verify and add commitment
+                    assert_eq!(commit.evaluate(sender.as_row(), our_id.as_row()), val_g1);
+                    let verifiers = verifies.entry(commit).or_insert_with(HashSet::default);
+                    verifiers.insert(sender);
+                }
+            }
+        }
+
+        assert_eq!(commits.len(), num_others);
+        commits.values().for_each(|(poly, commit)| {
+            // add to our secret key and public key, asserting there were enough verifications
+            assert_eq!(verifies.get(commit).unwrap().len(), num_others);
+            sk.add_assign(&poly.evaluate(Fr::zero()));
+            pk += commit.row(0_usize);
+        });
+
+        (sk, PublicKeySet::from(pk))
+    }
+}
+
+mod serde_g1 {
+    use serde::de::Error;
+    use serde::{Deserialize, Deserializer, Serializer};
+    use threshold_crypto::group::{CurveAffine, CurveProjective, EncodedPoint};
+    use threshold_crypto::pairing::bls12_381::G1Compressed;
+    use threshold_crypto::G1;
+
+    pub fn serialize<S>(key: &G1, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = key.into_affine().into_compressed();
+        serializer.serialize_bytes(bytes.as_ref())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<G1, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
+        if bytes.len() != 48 {
+            return Err(D::Error::invalid_length(bytes.len(), &"48 bytes"));
+        }
+        let mut g1 = G1Compressed::empty();
+        g1.as_mut().copy_from_slice(&bytes);
+        Ok(g1.into_affine().unwrap().into_projective())
+    }
+}
+
+trait PeerRow {
+    fn as_row(&self) -> usize;
+}
+
+impl PeerRow for PeerId {
+    fn as_row(&self) -> usize {
+        (u16::from(*self) as usize) + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::ThresholdKeyGen;
+    use minimint_api::rand::Rand07Compat;
+    use secp256k1::rand::prelude::ThreadRng;
+    use std::collections::BTreeMap;
+    use threshold_crypto::ff::Field;
+    use threshold_crypto::group::{CurveAffine, CurveProjective};
+    use threshold_crypto::poly::{BivarCommitment, BivarPoly, Poly};
+    use threshold_crypto::{Fr, G1Affine, PublicKeySet, SecretKeyShare, G1};
+
+    fn rng() -> Rand07Compat<ThreadRng> {
+        Rand07Compat(secp256k1::rand::thread_rng())
+    }
+
+    #[test]
+    fn test_g1_serde() {
+        let commit = BivarPoly::random(1, &mut rng()).commitment();
+        let g1 = ThresholdKeyGen::Verify(commit, G1::random(&mut rng()));
+        let g1_deser = serde_json::from_str(&serde_json::to_string(&g1).unwrap()).unwrap();
+        assert_eq!(g1, g1_deser);
+    }
+
+    #[test]
+    fn test_threshold_sigs() {
+        let peers = 4;
+        let max_evil = 1;
+        let threshold = peers - max_evil;
+
+        let polys: Vec<BivarPoly> = (0..peers)
+            .map(|_| BivarPoly::random(threshold - 1, &mut rng()))
+            .collect();
+        let commits: Vec<BivarCommitment> = polys.iter().map(BivarPoly::commitment).collect();
+
+        let mut sum_commit = Poly::zero().commitment();
+
+        let mut sks: Vec<Fr> = vec![Fr::zero(); peers];
+        for (our_poly, commit) in polys.iter().zip(commits) {
+            for (i, sk) in sks.iter_mut().enumerate() {
+                let poly = our_poly.row(i + 1);
+                assert_eq!(poly.commitment(), commit.row(i + 1));
+
+                for j in 0..polys.len() {
+                    let val = poly.evaluate(j + 1);
+                    let val_g1 = G1Affine::one().mul(val);
+                    assert_eq!(commit.evaluate(i + 1, j + 1), val_g1);
+                }
+
+                sk.add_assign(&poly.evaluate(Fr::zero()));
+            }
+            sum_commit += commit.row(0_usize);
+        }
+
+        let threshold_pub_key = PublicKeySet::from(sum_commit);
+        let sk1 = SecretKeyShare::from_mut(&mut sks[0].clone());
+        assert_eq!(
+            threshold_pub_key.public_key_share(0_usize),
+            sk1.public_key_share()
+        );
+
+        let msg = b"Totally real news";
+        let ciphertext = threshold_pub_key.public_key().encrypt(&msg[..]);
+
+        let shares: BTreeMap<_, _> = sks
+            .iter_mut()
+            .enumerate()
+            .take(threshold)
+            .map(|(i, sk)| {
+                let dec_share = SecretKeyShare::from_mut(sk)
+                    .decrypt_share(&ciphertext)
+                    .expect("ciphertext is invalid");
+                (i, dec_share)
+            })
+            .collect();
+
+        let decrypted = threshold_pub_key
+            .decrypt(&shares, &ciphertext)
+            .expect("decryption shares match");
+        assert_eq!(msg[..], decrypted[..]);
     }
 }

--- a/modules/minimint-mint/src/config.rs
+++ b/modules/minimint-mint/src/config.rs
@@ -1,5 +1,7 @@
 use crate::Keys;
+use async_trait::async_trait;
 use minimint_api::config::GenerateConfig;
+use minimint_api::net::peers::AnyPeerConnections;
 use minimint_api::{Amount, PeerId};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -17,9 +19,12 @@ pub struct MintClientConfig {
     pub tbs_pks: Keys<AggregatePublicKey>,
 }
 
+#[async_trait(?Send)]
 impl GenerateConfig for MintConfig {
     type Params = [Amount];
     type ClientConfig = MintClientConfig;
+    type ConfigMessage = ();
+    type ConfigError = ();
 
     fn trusted_dealer_gen(
         peers: &[PeerId],
@@ -68,5 +73,16 @@ impl GenerateConfig for MintConfig {
         };
 
         (mint_cfg, client_cfg)
+    }
+
+    async fn distributed_gen(
+        _connections: &mut AnyPeerConnections<Self::ConfigMessage>,
+        _our_id: &PeerId,
+        _peers: &[PeerId],
+        _max_evil: usize,
+        _params: &mut Self::Params,
+        _rng: impl RngCore + CryptoRng,
+    ) -> Result<(Self, Self::ClientConfig), Self::ConfigError> {
+        todo!()
     }
 }

--- a/modules/minimint-wallet/src/config.rs
+++ b/modules/minimint-wallet/src/config.rs
@@ -1,8 +1,10 @@
 use crate::keys::CompressedPublicKey;
 use crate::{Feerate, PegInDescriptor};
+use async_trait::async_trait;
 use bitcoin::secp256k1::rand::{CryptoRng, RngCore};
 use bitcoin::Network;
 use minimint_api::config::GenerateConfig;
+use minimint_api::net::peers::AnyPeerConnections;
 use minimint_api::PeerId;
 use miniscript::descriptor::Wsh;
 use serde::{Deserialize, Serialize};
@@ -29,9 +31,12 @@ pub struct WalletClientConfig {
     pub network: Network,
 }
 
+#[async_trait(?Send)]
 impl GenerateConfig for WalletConfig {
     type Params = ();
     type ClientConfig = WalletClientConfig;
+    type ConfigMessage = CompressedPublicKey;
+    type ConfigError = ();
 
     fn trusted_dealer_gen(
         peers: &[PeerId],
@@ -85,5 +90,55 @@ impl GenerateConfig for WalletConfig {
         };
 
         (wallet_cfg, client_cfg)
+    }
+
+    async fn distributed_gen(
+        connections: &mut AnyPeerConnections<Self::ConfigMessage>,
+        our_id: &PeerId,
+        peers: &[PeerId],
+        max_evil: usize,
+        _params: &mut Self::Params,
+        mut rng: impl RngCore + CryptoRng,
+    ) -> Result<(Self, Self::ClientConfig), Self::ConfigError> {
+        let secp = secp256k1::Secp256k1::new();
+        let (sk, pk) = secp.generate_keypair(&mut rng);
+        let our_key = CompressedPublicKey { key: pk };
+        let mut peer_peg_in_keys: BTreeMap<PeerId, CompressedPublicKey> = BTreeMap::new();
+
+        connections.send(peers, our_key.clone()).await;
+
+        for _ in 1..peers.len() {
+            let (peer, msg) = connections.receive().await;
+            peer_peg_in_keys.insert(peer, msg);
+        }
+        peer_peg_in_keys.insert(*our_id, our_key);
+        assert_eq!(peer_peg_in_keys.len(), peers.len());
+
+        let peg_in_descriptor = PegInDescriptor::Wsh(
+            Wsh::new_sortedmulti(
+                peers.len() - max_evil,
+                peer_peg_in_keys.iter().map(|(_, pk)| pk.clone()).collect(),
+            )
+            .unwrap(),
+        );
+
+        let wallet_cfg = WalletConfig {
+            network: Network::Regtest,
+            peg_in_descriptor: peg_in_descriptor.clone(),
+            peer_peg_in_keys,
+            peg_in_key: sk,
+            finalty_delay: 10,
+            default_fee: Feerate { sats_per_kvb: 1000 },
+            btc_rpc_address: "127.0.0.1:18443".to_string(),
+            btc_rpc_user: "bitcoin".to_string(),
+            btc_rpc_pass: "bitcoin".to_string(),
+        };
+
+        let client_cfg = WalletClientConfig {
+            peg_in_descriptor,
+            network: Network::Regtest,
+        };
+
+        Ok((wallet_cfg, client_cfg))
     }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,7 +27,7 @@ mkdir -p $FM_BTC_DIR
 mkdir -p $FM_CFG_DIR
 
 # Generate federation client config
-$FM_BIN_DIR/configgen -- $FM_CFG_DIR $FM_FED_SIZE 4000 5000 1000 10000 100000 1000000 10000000
+$FM_BIN_DIR/configgen -- $FM_CFG_DIR $FM_FED_SIZE 4000 5000 5100 5200 5300 1000 10000 100000 1000000 10000000
 
 # Define clients
 export FM_LN1="lightning-cli --network regtest --lightning-dir=$FM_LN1_DIR"

--- a/scripts/final-checks.sh
+++ b/scripts/final-checks.sh
@@ -14,7 +14,7 @@ cargo test
 export MINIMINT_TEST_REAL=1
 ./scripts/rust-tests.sh
 ./scripts/cli-test.sh
-./scripts/clientd-test.sh
+./scripts/clientd-tests.sh
 sleep 3
 
 echo "CLI test exit status $?"


### PR DESCRIPTION
Initial distributed config gen code for fixing #284.

Initially we can support joining with a config file containing the web addresses and TLS certs of all peers.  Once connected, the peers run DKG for each module, save the new configs back to the filesystem (for restarting).

Eventually it'd be nice to support an easy format for users to copy+paste and allow for a bootstrapping where we trust one peer to connect us to the others.  This will make it easier to join a federation through an invite from one of the members.

- [x] wallet module
- [x] lightning module (SKS)
- [x] server
- [x] integration tests
- [x] eliminate SKS duplication
- [ ] update all threshold_crypto libs #499
- [ ] switch to hbbft DKG
- [ ] implement new configs
