### PR TITLE
create api for signed epoch history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,6 +1510,7 @@ dependencies = [
  "sled",
  "tbs",
  "thiserror",
+ "threshold_crypto",
  "tokio",
  "tokio-rustls",
  "tokio-util 0.6.10",
@@ -1557,6 +1558,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bitcoin",
+ "bitcoin_hashes",
  "futures",
  "hex",
  "itertools",
@@ -1572,6 +1574,7 @@ dependencies = [
  "sha3",
  "tbs",
  "thiserror",
+ "threshold_crypto",
  "tracing",
 ]
 

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -20,6 +20,7 @@ use jsonrpsee_ws_client::{WsClient, WsClientBuilder};
 use jsonrpsee_wasm_client::{Client as WsClient, WasmClientBuilder as WsClientBuilder};
 
 use bitcoin::{Address, Amount};
+use minimint_core::epoch::EpochHistory;
 use minimint_core::modules::wallet::PegOutFees;
 use std::time::Duration;
 use thiserror::Error;
@@ -32,6 +33,8 @@ pub trait FederationApi: Send + Sync {
 
     /// Submit a transaction to all federation members
     async fn submit_transaction(&self, tx: Transaction) -> Result<TransactionId>;
+
+    async fn fetch_epoch_history(&self, epoch: u64) -> Result<EpochHistory>;
 
     // TODO: more generic module API extensibility
     /// Fetch ln contract state
@@ -196,6 +199,10 @@ impl<C: JsonRpcClient + Send + Sync> FederationApi for WsFederationApi<C> {
     async fn submit_transaction(&self, tx: Transaction) -> Result<TransactionId> {
         // TODO: check the id is correct
         self.request("/transaction", tx).await
+    }
+
+    async fn fetch_epoch_history(&self, epoch: u64) -> Result<EpochHistory> {
+        self.request("/fetch_epoch_history", epoch).await
     }
 
     async fn fetch_contract(&self, contract: ContractId) -> Result<ContractAccount> {

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -28,6 +28,7 @@ use minimint_api::{
     },
     Amount, OutPoint, PeerId, TransactionId,
 };
+use minimint_core::epoch::EpochHistory;
 use minimint_core::modules::ln::contracts::incoming::{
     DecryptedPreimage, IncomingContract, IncomingContractOffer, OfferId, Preimage,
 };
@@ -423,6 +424,14 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     pub fn list_active_issuances(&self) -> Vec<(OutPoint, CoinFinalizationData)> {
         self.mint_client().list_active_issuances()
     }
+
+    pub async fn fetch_epoch_history(&self, epoch: u64) -> Result<EpochHistory> {
+        self.context
+            .api
+            .fetch_epoch_history(epoch)
+            .await
+            .map_err(|e| e.into())
+    }
 }
 
 impl Client<UserClientConfig> {
@@ -552,7 +561,7 @@ impl Client<UserClientConfig> {
             .await?;
 
         // Await acceptance by the federation
-        let timeout = std::time::Duration::from_secs(10);
+        let timeout = std::time::Duration::from_secs(15);
         let outpoint = OutPoint { txid, out_idx: 0 };
         self.context
             .api

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -204,6 +204,7 @@ mod tests {
     use minimint_api::db::mem_impl::MemDatabase;
     use minimint_api::module::testing::FakeFed;
     use minimint_api::{Amount, OutPoint, TransactionId};
+    use minimint_core::epoch::EpochHistory;
     use minimint_core::modules::ln::config::LightningModuleClientConfig;
     use minimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
     use minimint_core::modules::ln::contracts::{ContractId, IdentifyableContract};
@@ -279,6 +280,10 @@ mod tests {
         }
 
         async fn register_gateway(&self, _gateway: LightningGateway) -> crate::api::Result<()> {
+            unimplemented!()
+        }
+
+        async fn fetch_epoch_history(&self, _epoch: u64) -> crate::api::Result<EpochHistory> {
             unimplemented!()
         }
     }

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -372,6 +372,7 @@ mod tests {
     use minimint_api::db::Database;
     use minimint_api::module::testing::FakeFed;
     use minimint_api::{Amount, OutPoint, TransactionId};
+    use minimint_core::epoch::EpochHistory;
     use minimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
     use minimint_core::modules::ln::contracts::ContractId;
     use minimint_core::modules::ln::{ContractAccount, LightningGateway};
@@ -442,6 +443,10 @@ mod tests {
         }
 
         async fn register_gateway(&self, _gateway: LightningGateway) -> crate::api::Result<()> {
+            unimplemented!()
+        }
+
+        async fn fetch_epoch_history(&self, _epoch: u64) -> crate::api::Result<EpochHistory> {
             unimplemented!()
         }
     }

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -134,6 +134,8 @@ mod tests {
     use minimint_api::db::mem_impl::MemDatabase;
     use minimint_api::module::testing::FakeFed;
     use minimint_api::{OutPoint, TransactionId};
+
+    use minimint_core::epoch::EpochHistory;
     use minimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
     use minimint_core::modules::ln::contracts::ContractId;
     use minimint_core::modules::ln::{ContractAccount, LightningGateway};
@@ -206,6 +208,10 @@ mod tests {
         }
 
         async fn register_gateway(&self, _gateway: LightningGateway) -> crate::api::Result<()> {
+            unimplemented!()
+        }
+
+        async fn fetch_epoch_history(&self, _epoch: u64) -> crate::api::Result<EpochHistory> {
             unimplemented!()
         }
     }

--- a/docs/database.md
+++ b/docs/database.md
@@ -24,6 +24,9 @@ The Database is split into different key spaces based on prefixing that can be u
 | Pending Transactions  | `0x01` | Transaction ID (sha256, 32bytes) | Transaction                     |
 | Accepted Transactions | `0x02` | Transaction ID (sha256, 32bytes) | Confirmation epoch, Transaction |
 | Drop Peer             | `0x03` | Peer ID (u16)                    |                                 |
+| Rejected Transaction  | `0x04` | Transaction ID (sha256, 32bytes) | Reason for rejection (string)   |
+| Epoch History         | `0x05` | Epoch ID (u16)                   | Epoch history record            |
+| Last Epoch            | `0x06` | none                             | Epoch history key               |
 
 ### Mint
 

--- a/minimint-core/Cargo.toml
+++ b/minimint-core/Cargo.toml
@@ -29,3 +29,5 @@ sha3 = "0.9.1"
 tbs = { path = "../crypto/tbs" }
 thiserror = "1.0.23"
 tracing ="0.1.22"
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
+bitcoin_hashes = "0.10.0"

--- a/minimint-core/src/epoch.rs
+++ b/minimint-core/src/epoch.rs
@@ -1,0 +1,247 @@
+use crate::transaction::Transaction;
+use bitcoin_hashes::sha256::Hash as Sha256;
+use bitcoin_hashes::sha256::HashEngine;
+use itertools::Itertools;
+use minimint_api::encoding::{Decodable, DecodeError, Encodable};
+use minimint_api::{BitcoinHash, FederationModule, PeerId};
+use minimint_derive::UnzipConsensus;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use threshold_crypto::{PublicKey, Signature, SignatureShare};
+
+#[derive(
+    Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, UnzipConsensus, Encodable, Decodable,
+)]
+pub enum ConsensusItem {
+    EpochInfo(EpochSignatureShare),
+    Transaction(Transaction),
+    Mint(<minimint_mint::Mint as FederationModule>::ConsensusItem),
+    Wallet(<minimint_wallet::Wallet as FederationModule>::ConsensusItem),
+    LN(<minimint_ln::LightningModule as FederationModule>::ConsensusItem),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct EpochSignatureShare(pub SignatureShare);
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct EpochSignature(pub Signature);
+
+#[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable)]
+pub struct EpochHistory {
+    pub outcome: OutcomeHistory,
+    pub hash: Sha256,
+    pub signature: Option<EpochSignature>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable)]
+pub struct OutcomeHistory {
+    pub epoch: u64,
+    pub last_hash: Option<Sha256>,
+    pub items: Vec<(PeerId, Vec<ConsensusItem>)>,
+}
+
+impl OutcomeHistory {
+    pub fn hash(&self) -> Sha256 {
+        let mut engine = HashEngine::default();
+        self.consensus_encode(&mut engine).unwrap();
+        Sha256::from_engine(engine)
+    }
+}
+
+impl EpochHistory {
+    pub fn new(
+        epoch: u64,
+        contributions: BTreeMap<PeerId, Vec<ConsensusItem>>,
+        prev_epoch: &Option<EpochHistory>,
+    ) -> Self {
+        let items = contributions
+            .into_iter()
+            .sorted_by_key(|(peer, _)| *peer)
+            .collect();
+        let outcome = OutcomeHistory {
+            last_hash: prev_epoch.clone().map(|epoch| epoch.hash),
+            items,
+            epoch,
+        };
+
+        EpochHistory {
+            hash: outcome.hash(),
+            outcome,
+            signature: None,
+        }
+    }
+
+    /// verifies the sig, the hash, and the merkle tree
+    pub fn verify(
+        &self,
+        pks: &PublicKey,
+        prev_epoch: Option<&EpochHistory>,
+    ) -> Result<(), EpochVerifyError> {
+        if let Some(sig) = &self.signature {
+            if !pks.verify(&sig.0, self.hash) {
+                return Err(EpochVerifyError::InvalidSignature);
+            }
+        } else {
+            return Err(EpochVerifyError::MissingSignature);
+        }
+
+        if self.outcome.epoch > 0 {
+            match prev_epoch {
+                None => return Err(EpochVerifyError::MissingPreviousEpoch),
+                Some(epoch) if Some(epoch.outcome.hash()) != self.outcome.last_hash => {
+                    return Err(EpochVerifyError::InvalidPreviousEpochHash)
+                }
+                _ => {}
+            }
+        }
+
+        if self.hash == self.outcome.hash() {
+            Ok(())
+        } else {
+            Err(EpochVerifyError::InvalidEpochHash)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum EpochVerifyError {
+    MissingSignature,
+    InvalidSignature,
+    MissingPreviousEpoch,
+    InvalidEpochHash,
+    InvalidPreviousEpochHash,
+}
+
+impl Encodable for EpochSignature {
+    fn consensus_encode<W: std::io::Write>(&self, writer: W) -> Result<usize, std::io::Error> {
+        self.0.to_bytes().consensus_encode(writer)
+    }
+}
+
+impl Decodable for EpochSignature {
+    fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<Self, DecodeError> {
+        let mut bytes = [0u8; 96];
+        d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
+        Ok(EpochSignature(Signature::from_bytes(&bytes).unwrap()))
+    }
+}
+
+impl Encodable for EpochSignatureShare {
+    fn consensus_encode<W: std::io::Write>(&self, writer: W) -> Result<usize, std::io::Error> {
+        self.0.to_bytes().consensus_encode(writer)
+    }
+}
+
+impl Decodable for EpochSignatureShare {
+    fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<Self, DecodeError> {
+        let mut bytes = [0u8; 96];
+        d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
+        Ok(EpochSignatureShare(
+            SignatureShare::from_bytes(&bytes).unwrap(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::epoch::Sha256;
+    use crate::epoch::{EpochHistory, EpochSignature, EpochVerifyError, OutcomeHistory};
+    use minimint_api::PeerId;
+    use threshold_crypto::SecretKey;
+
+    fn signed_history(
+        epoch: u16,
+        prev_epoch: Option<&EpochHistory>,
+        sk: &SecretKey,
+    ) -> EpochHistory {
+        let missing_sig = history(epoch, prev_epoch, None);
+        let signature = sk.sign(missing_sig.outcome.hash());
+        history(epoch, prev_epoch, Some(EpochSignature(signature)))
+    }
+
+    fn history(
+        epoch: u16,
+        prev_epoch: Option<&EpochHistory>,
+        signature: Option<EpochSignature>,
+    ) -> EpochHistory {
+        let items = vec![(PeerId::from(epoch), vec![])];
+        let outcome = OutcomeHistory {
+            last_hash: prev_epoch.map(|epoch| epoch.hash),
+            items,
+            epoch: epoch as u64,
+        };
+
+        EpochHistory {
+            hash: outcome.hash(),
+            outcome,
+            signature,
+        }
+    }
+
+    #[test]
+    fn verifies_hash() {
+        let sk: SecretKey = SecretKey::random();
+        let pk = sk.public_key();
+        let wrong_hash: Sha256 = Default::default();
+        let sig = EpochSignature(sk.sign(&wrong_hash));
+
+        let epoch0 = history(0, None, Some(sig));
+        let epoch = EpochHistory {
+            outcome: epoch0.outcome,
+            hash: wrong_hash,
+            signature: epoch0.signature,
+        };
+
+        assert_eq!(
+            epoch.verify(&pk, None),
+            Err(EpochVerifyError::InvalidEpochHash)
+        );
+    }
+
+    #[test]
+    fn verifies_merkle_tree() {
+        let sk: SecretKey = SecretKey::random();
+        let pk = sk.public_key();
+
+        let epoch0 = signed_history(0, None, &sk);
+        let epoch1 = signed_history(1, Some(&epoch0), &sk);
+        let epoch2 = signed_history(2, Some(&epoch1), &sk);
+
+        assert_eq!(epoch0.verify(&pk, None), Ok(()));
+        assert_eq!(epoch1.verify(&pk, Some(&epoch0)), Ok(()));
+        assert_eq!(epoch2.verify(&pk, Some(&epoch1)), Ok(()));
+
+        assert_eq!(
+            epoch1.verify(&pk, None),
+            Err(EpochVerifyError::MissingPreviousEpoch)
+        );
+        assert_eq!(
+            epoch1.verify(&pk, Some(&epoch2)),
+            Err(EpochVerifyError::InvalidPreviousEpochHash)
+        );
+    }
+
+    #[test]
+    fn verifies_sigs() {
+        let sk: SecretKey = SecretKey::random();
+        let pk = sk.public_key();
+
+        let epoch0 = signed_history(0, None, &sk);
+        let epoch1 = signed_history(1, Some(&epoch0), &sk);
+
+        assert_eq!(epoch0.verify(&pk, None), Ok(()));
+        assert_eq!(epoch1.verify(&pk, Some(&epoch0)), Ok(()));
+
+        let epoch0_wrong = history(0, None, epoch1.signature);
+        let epoch1_wrong = history(1, Some(&epoch0), epoch0.signature.clone());
+
+        assert_eq!(
+            epoch0_wrong.verify(&pk, None),
+            Err(EpochVerifyError::InvalidSignature)
+        );
+        assert_eq!(
+            epoch1_wrong.verify(&pk, Some(&epoch0)),
+            Err(EpochVerifyError::InvalidSignature)
+        );
+    }
+}

--- a/minimint-core/src/lib.rs
+++ b/minimint-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod modules {
 
 /// MiniMint toplevel config
 pub mod config;
+pub mod epoch;
 pub mod outcome;
 pub mod transaction;
 

--- a/minimint-derive/src/lib.rs
+++ b/minimint-derive/src/lib.rs
@@ -52,7 +52,7 @@ pub fn derive_unzip_consensus(input: TokenStream) -> TokenStream {
         }
 
         pub struct #unzip_struct_ident {
-            #(#unzip_s_ident: Vec<(PeerId, #unzip_s_type)>),*
+            #(pub #unzip_s_ident: Vec<(PeerId, #unzip_s_type)>),*
         }
 
         impl<I> #unzip_trait_ident for I

--- a/minimint/Cargo.toml
+++ b/minimint/Cargo.toml
@@ -56,3 +56,4 @@ tokio-util = { version = "0.6.0", features = [ "codec" ] }
 tracing ="0.1.22"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
 tracing-opentelemetry = { version = "0.17.2", optional = true}
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }

--- a/minimint/src/consensus/debug.rs
+++ b/minimint/src/consensus/debug.rs
@@ -22,6 +22,7 @@ pub fn epoch_message(consensus: &ConsensusOutcome) -> String {
 
 fn item_message(item: &ConsensusItem) -> String {
     match item {
+        ConsensusItem::EpochInfo(_) => "Outcome Signature".to_string(),
         ConsensusItem::Wallet(WalletConsensusItem::RoundConsensus(RoundConsensusItem {
             block_height,
             ..

--- a/minimint/src/db.rs
+++ b/minimint/src/db.rs
@@ -3,12 +3,15 @@ use crate::transaction::Transaction;
 use minimint_api::db::DatabaseKeyPrefixConst;
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_api::{PeerId, TransactionId};
+use minimint_core::epoch::EpochHistory;
 use std::fmt::Debug;
 
 pub const DB_PREFIX_PROPOSED_TRANSACTION: u8 = 0x01;
 pub const DB_PREFIX_ACCEPTED_TRANSACTION: u8 = 0x02;
 pub const DB_PREFIX_DROP_PEER: u8 = 0x03;
 pub const DB_PREFIX_REJECTED_TRANSACTION: u8 = 0x04;
+pub const DB_PREFIX_EPOCH_HISTORY: u8 = 0x05;
+pub const DB_PREFIX_LAST_EPOCH: u8 = 0x06;
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct ProposedTransactionKey(pub TransactionId);
@@ -62,4 +65,22 @@ impl DatabaseKeyPrefixConst for DropPeerKeyPrefix {
     const DB_PREFIX: u8 = DB_PREFIX_DROP_PEER;
     type Key = DropPeerKey;
     type Value = ();
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct EpochHistoryKey(pub u64);
+
+impl DatabaseKeyPrefixConst for EpochHistoryKey {
+    const DB_PREFIX: u8 = DB_PREFIX_EPOCH_HISTORY;
+    type Key = Self;
+    type Value = EpochHistory;
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct LastEpochKey;
+
+impl DatabaseKeyPrefixConst for LastEpochKey {
+    const DB_PREFIX: u8 = DB_PREFIX_LAST_EPOCH;
+    type Key = Self;
+    type Value = EpochHistoryKey;
 }

--- a/minimint/src/lib.rs
+++ b/minimint/src/lib.rs
@@ -21,9 +21,10 @@ use minimint_core::modules::ln::LightningModule;
 use minimint_core::modules::wallet::bitcoind::BitcoindRpc;
 use minimint_core::modules::wallet::{bitcoincore_rpc, Wallet};
 
+use minimint_core::epoch::ConsensusItem;
 pub use minimint_core::*;
 
-use crate::consensus::{ConsensusItem, ConsensusOutcome, ConsensusProposal, MinimintConsensus};
+use crate::consensus::{ConsensusOutcome, ConsensusProposal, MinimintConsensus};
 use crate::net::connect::{Connector, TlsTcpConnector};
 use crate::net::peers::{
     AnyPeerConnections, PeerConnections, PeerConnector, ReconnectPeerConnections,

--- a/minimint/src/net/api.rs
+++ b/minimint/src/net/api.rs
@@ -7,6 +7,7 @@ use minimint_api::{
     module::{api_endpoint, ApiEndpoint, ApiError},
     FederationModule, TransactionId,
 };
+use minimint_core::epoch::EpochHistory;
 use minimint_core::outcome::TransactionStatus;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -124,6 +125,13 @@ fn server_endpoints() -> &'static [ApiEndpoint<MinimintConsensus<rand::rngs::OsR
 
                 debug!(transaction = %tx_hash, "Sending outcome");
                 Ok(tx_status)
+            }
+        },
+        api_endpoint! {
+            "/fetch_epoch_history",
+            async |minimint: &MinimintConsensus<rand::rngs::OsRng>, epoch: u64| -> EpochHistory {
+                let epoch = minimint.epoch_history(epoch).ok_or_else(|| ApiError::not_found(String::from("epoch not found")))?;
+                Ok(epoch)
             }
         },
     ];

--- a/modules/minimint-mint/src/lib.rs
+++ b/modules/minimint-mint/src/lib.rs
@@ -47,7 +47,7 @@ pub struct Mint {
     db: Arc<dyn Database>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct PartiallySignedRequest {
     pub out_point: OutPoint,
     pub partial_signature: PartialSigResponse,

--- a/modules/minimint-wallet/src/lib.rs
+++ b/modules/minimint-wallet/src/lib.rs
@@ -61,13 +61,15 @@ pub type PartialSig = Vec<u8>;
 
 pub type PegInDescriptor = Descriptor<CompressedPublicKey>;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, UnzipConsensus)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, UnzipConsensus, Encodable, Decodable,
+)]
 pub enum WalletConsensusItem {
     RoundConsensus(RoundConsensusItem),
     PegOutSignature(PegOutSignatureItem),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct RoundConsensusItem {
     pub block_height: u32, // FIXME: use block hash instead, but needs more complicated verification logic
     pub fee_rate: Feerate,

--- a/scripts/final-checks.sh
+++ b/scripts/final-checks.sh
@@ -14,7 +14,7 @@ cargo test
 export MINIMINT_TEST_REAL=1
 ./scripts/rust-tests.sh
 ./scripts/cli-test.sh
-./scripts/clientd-test.sh
+./scripts/clientd-tests.sh
 sleep 3
 
 echo "CLI test exit status $?"


### PR DESCRIPTION
First task in #320.

- Save epoch history to the database
- Use threshold sigs as consensus items to sign merkle tree hashes of the epochs
- Drop peers that do not contribute valid sigs
- Expose a history API to allow clients to download epoch history

Seems to add ~.1s to various actions in `latency-test.sh`