### PR TITLE
do peg-in in smaller steps and add some helper fns

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -48,3 +48,7 @@ function start_gateway() {
 function get_finality_delay() {
     cat $FM_CFG_DIR/server-0.json | jq -r '.wallet.finality_delay'
 }
+
+function sat_to_btc() {
+    echo "scale=8; $1/100000000" | bc | awk '{printf "%.8f\n", $0}'
+}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -20,7 +20,7 @@ function open_channel() {
 }
 
 function await_block_sync() {
-  FINALITY_DELAY=$(cat $FM_CFG_DIR/server-0.json | jq -r '.wallet.finality_delay')
+  FINALITY_DELAY=$(get_finality_delay)
   EXPECTED_BLOCK_HEIGHT="$(( $($FM_BTC_CLIENT getblockchaininfo | jq -r '.blocks') - $FINALITY_DELAY ))"
   $FM_MINT_CLIENT wait-block-height $EXPECTED_BLOCK_HEIGHT
 }
@@ -43,4 +43,8 @@ function kill_minimint_processes {
 function start_gateway() {
   $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway minimint-cfg=$FM_CFG_DIR &
   sleep 1 # wait for plugin to start
+}
+
+function get_finality_delay() {
+    cat $FM_CFG_DIR/server-0.json | jq -r '.wallet.finality_delay'
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -52,3 +52,33 @@ function get_finality_delay() {
 function sat_to_btc() {
     echo "scale=8; $1/100000000" | bc | awk '{printf "%.8f\n", $0}'
 }
+
+#caller should call mine_blocks() after this
+function send_bitcoin() {
+    local RECV_ADDRESS
+    RECV_ADDRESS=$1
+    local SEND_AMT
+    SEND_AMT=$2
+
+    local TX_ID
+    TX_ID="$($FM_BTC_CLIENT sendtoaddress $RECV_ADDRESS "$(sat_to_btc $SEND_AMT)")"
+    echo $TX_ID
+}
+
+function get_txout_proof() {
+    local TX_ID
+    TX_ID=$1
+
+    local TXOUT_PROOF
+    TXOUT_PROOF="$($FM_BTC_CLIENT gettxoutproof "[\"$TX_ID\"]")"
+    echo $TXOUT_PROOF
+}
+
+function get_raw_transaction() {
+    local TX_ID
+    TX_ID=$1
+
+    local TRANSACTION
+    TRANSACTION="$($FM_BTC_CLIENT getrawtransaction $TX_ID)"
+    echo $TRANSACTION
+}

--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -13,7 +13,7 @@ export POLL_INTERVAL
 PEG_IN_AMOUNT=${PEG_IN_AMOUNT:-$1}
 USE_GATEWAY=${2:-0}
 
-FINALITY_DELAY=$(cat $FM_CFG_DIR/server-0.json | jq -r '.wallet.finality_delay')
+FINALITY_DELAY=$(get_finality_delay)
 echo "Pegging in $PEG_IN_AMOUNT with confirmation in $FINALITY_DELAY blocks"
 
 # Get a peg-in address, which is derived from the federation's descriptor in which every key was tweaked with the same

--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -21,7 +21,7 @@ echo "Pegging in $PEG_IN_AMOUNT with confirmation in $FINALITY_DELAY blocks"
 if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($FM_LN1 -H gw-address)"; else ADDR="$($FM_MINT_CLIENT peg-in-address)"; fi
 
 # We send the amount we want to peg-in to this address
-TX_ID="$($FM_BTC_CLIENT sendtoaddress $ADDR 0"$(echo "scale=8; $PEG_IN_AMOUNT/100000000" | bc )")"
+TX_ID="$($FM_BTC_CLIENT sendtoaddress $ADDR "$(sat_to_btc $PEG_IN_AMOUNT)")"
 
 # Now we "wait" for confirmations
 $FM_BTC_CLIENT generatetoaddress 11 "$($FM_BTC_CLIENT getnewaddress)"


### PR DESCRIPTION
- added a few helper functions which can be used in the future.
- fixed a small bug in the sat to btc calculation (amounts > 100.000.000 sat would not work because there is a 0 in front of it)
- provide a quick way to peg-in manually (or do whatever with the `TXOUTPROOF` and `TRANSACTION`)