### PR TITLE
clientd wait_block_height

### DIFF
--- a/client/clientd/src/bin/clientd-cli.rs
+++ b/client/clientd/src/bin/clientd-cli.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use clientd::call;
+use clientd::{call, WaitBlockHeightPayload};
 use minimint_api::module::__reexports::serde_json;
 use serde::Serialize;
 
@@ -22,6 +22,9 @@ enum Commands {
     Pending,
     /// rpc-method: pegin_address()
     NewPegInAddress,
+    /// rpc-method: wait_block_height()
+    #[clap(arg_required_else_help = true)]
+    WaitBlockHeight { height: u64 },
 }
 #[tokio::main]
 async fn main() {
@@ -36,6 +39,10 @@ async fn main() {
         }
         Commands::NewPegInAddress => {
             print_json(call("", "/get_new_peg_in_address").await, args.raw_json);
+        }
+        Commands::WaitBlockHeight { height } => {
+            let params = WaitBlockHeightPayload { height };
+            print_json(call(&params, "/wait_block_height").await, args.raw_json);
         }
     }
 }

--- a/client/clientd/src/lib.rs
+++ b/client/clientd/src/lib.rs
@@ -12,6 +12,11 @@ pub enum RpcResult {
     #[serde(rename = "failure")]
     Failure(serde_json::Value),
 }
+/// struct to process wait_block_height request payload
+#[derive(Deserialize, Serialize)]
+pub struct WaitBlockHeightPayload {
+    pub height: u64,
+}
 
 #[derive(Serialize)]
 pub struct InfoResponse {

--- a/scripts/clientd-tests.sh
+++ b/scripts/clientd-tests.sh
@@ -7,6 +7,9 @@ export RUST_LOG=info
 source ./scripts/setup-tests.sh
 ./scripts/start-fed.sh
 
+FINALITY_DELAY=$(cat $FM_CFG_DIR/server-0.json | jq -r '.wallet.finality_delay')
+EXPECTED_BLOCK_HEIGHT="$(( $($FM_BTC_CLIENT getblockchaininfo | jq -r '.blocks') - $FINALITY_DELAY ))"
+
 #start clientd
 $FM_CLIENTD $FM_CFG_DIR &
 echo $! >> $FM_PID_FILE
@@ -16,3 +19,4 @@ await_server_on_port 8081
 [[ $($FM_CLIENTD_CLI info | jq -r 'has("success")') = true ]]
 [[ $($FM_CLIENTD_CLI pending | jq -r 'has("success")') = true ]]
 [[ $($FM_CLIENTD_CLI new-peg-in-address | jq -r 'has("success")') = true ]]
+[[ $($FM_CLIENTD_CLI wait-block-height  $EXPECTED_BLOCK_HEIGHT | jq -r 'has("success")') = true ]]


### PR DESCRIPTION
analogous to the `mint-client-cli`

will be needed for testing the following endpoints (e.g `peg_in`)
because `clientd` and `mint-client-cli` can never run simultaneously 