### PR TITLE
Update README to say Fedimint instead of MiniMint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MiniMint
+# Fedimint
 
-MiniMint is a federated [Chaumian e-cash](https://en.wikipedia.org/wiki/Ecash) mint backed by bitcoin with deposits and withdrawals that can occur on-chain or via Lightning.
+Fedimint is a federated [Chaumian e-cash](https://en.wikipedia.org/wiki/Ecash) mint backed by bitcoin with deposits and withdrawals that can occur on-chain or via Lightning.
 
 **DO NOT USE IT WITH REAL MONEY, THERE ARE MULTIPLE KNOWN SECURITY ISSUES.**
 
@@ -12,7 +12,7 @@ Visit our [Telegram group](https://t.me/fedimint) for high-level discussions (no
 
 To get started with development have a look at the:
 * [Developer discord](https://discord.gg/dZYajBMsEB) - only for programming questions and discussing the codebase
-* [GitHub Issues](https://github.com/fedimint/minimint/issues) - things to fix, planned features, longer term architectural choices, etc.
+* [GitHub Issues](https://github.com/fedimint/fedimint/issues) - things to fix, planned features, longer term architectural choices, etc.
 * [Architecture](docs/architecture.md) - high-level description of the codebase and design
 * [Integration tests](integrationtests/README.md) - instructions on how to write and run the integration tests
 * [Scripts](scripts/README.md) - useful scripts for running the tests and federation
@@ -20,21 +20,21 @@ To get started with development have a look at the:
 PRs fixing TODOs or issues are always welcome, but please discuss more involved changes in an issue first. Smaller PRs to fix typos, broken links etc. are also very welcome.
 Happy hacking!
 
-## Running MiniMint
-MiniMint consists of three kinds of executables:
+## Running Fedimint
+Fedimint consists of three kinds of executables:
 * **Federation nodes** - servers who form the mint by running a consensus protocol
 * **Lightning gateways** - allows users send and receive over Lightning by bridging between the mint and an LN node
 * **User clients** - handles user communication with the mint and the gateway
 
 ### Prerequisites
-In order to run MiniMint you will need:
+In order to run Fedimint you will need:
 - The [Rust toolchain](https://www.rust-lang.org/tools/install) to build and run the executables
 - The [Nix package manager](https://nixos.org/download.html) for managing build and test dependencies
 
-Clone and `cd` into the MiniMint repo:
+Clone and `cd` into the Fedimint repo:
 ```shell
-git clone git@github.com:fedimint/minimint.git
-cd minimint
+git clone git@github.com:fedimint/fedimint.git
+cd fedimint
 ```
 
 ### Setting up the federation

--- a/minimint/src/net/connect.rs
+++ b/minimint/src/net/connect.rs
@@ -410,8 +410,7 @@ mod tests {
         let peer_keys = (0..count)
             .map(|id| {
                 let peer = PeerId::from(id as u16);
-                let cert_key = gen_cert_and_key(&format!("peer-{}", peer.to_usize())).unwrap();
-                cert_key
+                gen_cert_and_key(&format!("peer-{}", peer.to_usize())).unwrap()
             })
             .collect::<Vec<_>>();
 

--- a/minimint/src/net/peers.rs
+++ b/minimint/src/net/peers.rs
@@ -504,10 +504,10 @@ where
         if connected_peer == self.peer {
             Ok(conn)
         } else {
-            return Err(anyhow::anyhow!(
+            Err(anyhow::anyhow!(
                 "Peer identified itself incorrectly: {:?}",
                 connected_peer
-            ));
+            ))
         }
     }
 }


### PR DESCRIPTION
This will be the second step (after renaming the repo) towards the
rebranding. Later the code changes (#293) will follow.