### PR TITLE
CI code coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,3 +103,26 @@ jobs:
         run: cargo install --force cargo-udeps
       - name: Run cargo udeps
         run: cargo udeps
+
+  coverage:
+    runs-on: buildjet-8vcpu-ubuntu-2004
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true


### PR DESCRIPTION
Coverage in CI addresses #288 
For the uploading to codecov to work an admin needs to create a token and set as a secret (`CODECOV_TOKEN`) in the env.
We need to use `nightly` because it wants to compile `minimint-derrive` which has a feature [attribute](https://doc.rust-lang.org/error-index.html#E0554)