### PR TITLE
Forward `nix-shell` to default `nix develop` shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -10,4 +10,4 @@
   # Since a lot of existing CI tests is based on `shell.nix`
   # we forward to the integrationTests shell, instead of the
   # default (developer) shell.
-).shellNix.devShells."${builtins.currentSystem}".integrationTests
+).shellNix


### PR DESCRIPTION
For a while it was forwarding to a custom shell,
so that CI scripts were happy, but these were migrated
to `nix-ci` already.