### PR TITLE
Add timeout to nix-ci.yml

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -18,6 +18,7 @@ jobs:
   lint:
     name: "Lint"
     runs-on: buildjet-2vcpu-ubuntu-2004
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v15
@@ -35,6 +36,7 @@ jobs:
   build:
     name: "Build"
     runs-on: buildjet-8vcpu-ubuntu-2004
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v15
@@ -79,6 +81,7 @@ jobs:
   ccov:
     name: "Code coverage"
     runs-on: buildjet-8vcpu-ubuntu-2004
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v15


### PR DESCRIPTION
When we are using buildjet runners we want tighter timeouts since they
cost us money and we don't want an accidental infinite loop to run for
the default 6h.