### PR TITLE
docs: update mint client cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,17 @@ The previous step has already set up an e-cash client with a funded wallet for y
 You can view your client's holdings using the `info` command:
 
 ```shell
-$ mint_client info
+$ mint-client-cli info
 
-INFO mint_client_cli: We own 18 coins with a total value of 99000000 msat
-INFO mint_client_cli: We own 9 coins of denomination 1000000 msat
-INFO mint_client_cli: We own 9 coins of denomination 10000000 msat
+We own 18 coins with a total value of 99000000 msat
+We own 9 coins of denomination 1000000 msat
+We own 9 coins of denomination 10000000 msat
 ```
 
 The `spend` subcommand allows sending tokens to another client. This will select the smallest possible set of the client's coins that represents a given amount. The coins are base64 encoded and printed to stdout.
 
 ```shell
-$ mint_client spend 400000
+$ mint-client-cli spend 400000
 
 AQAAAAAAAABAQg8AAA...
 ```
@@ -74,10 +74,10 @@ AQAAAAAAAABAQg8AAA...
 A receiving client can now reissue these coins to claim them and avoid double spends:
 
 ```shell
-$ mint_client reissue AQAAAAAAAABAQg8AAA...
-$ mint_client fetch
+$ mint-client-cli reissue AQAAAAAAAABAQg8AAA...
+$ mint-client-cli fetch
 
-INFO mint_client_cli: Fetched coins issuance=5b1ac4e9604...
+Fetched coins issuance=5b1ac4e9604...
 ```
 
 ### Using the gateway
@@ -111,7 +111,7 @@ $ ln2 invoice 100000 test test 1m
 Pay the invoice by copying the `bolt11` invoice field:
 
 ```shell
-$ mint_client ln-pay "lnbcrt1u1p3vdl3ds..."
+$ mint-client-cli ln-pay "lnbcrt1u1p3vdl3ds..."
 ```
 
 Confirm the invoice was paid
@@ -132,7 +132,7 @@ $ ln2 listinvoices test
 
 Create our own invoice:
 ```shell
-$ mint_client ln-invoice 1000 "description"
+$ mint-client-cli ln-invoice 1000 "description"
 lnbcrt1u1p3vcp...
 ```
 
@@ -145,9 +145,9 @@ $ ln2 pay lnbcrt1u1p3vcp...
 Have mint client check that payment succeeded, fetch coins, and display new balances:
 
 ```shell
-$ mint_client wait-invoice lnbcrt1u1p3vcp... 
-$ mint_client fetch
-$ mint_client info
+$ mint-client-cli wait-invoice lnbcrt1u1p3vcp...
+$ mint-client-cli fetch
+$ mint-client-cli info
 ```
 
 ### Other options
@@ -155,7 +155,7 @@ $ mint_client info
 There also exist some other, more experimental commands that can be explored using the `--help` flag:
 
 ```shell
-$ mint_client help
+$ mint-client-cli help
 
 mint-client-cli 
 


### PR DESCRIPTION
While working through the cli tutorial, I noticed `mint_cli` is had been renamed to `mint-client-cli` after #329 