### PR TITLE
coverage and test can be one step

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -53,8 +53,14 @@ jobs:
       - name: Clippy workspace
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceClippy
 
-      - name: Test workspace
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceTest
+      - name: Test and coverage workspace
+        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceTestandCov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: result/lcov.info
+          fail_ci_if_error: true
 
       - name: Latency Tests
         # run: nix-shell --command ./scripts/latency-test.sh
@@ -71,30 +77,3 @@ jobs:
       - name: Integration Tests
         # run: nix-shell --command ./scripts/rust-tests.sh
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.rust-tests
-
-  # Code Coverage will build using a completely different profile (neither debug/release)
-  # Which means we can not reuse much from `build` job. Might as well run it as another
-  # build in parallel
-  ccov:
-    name: "Code coverage"
-    runs-on: buildjet-8vcpu-ubuntu-2004
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v15
-        with:
-          nix_path: nixpkgs=channel:nixos-22.05
-      - uses: cachix/cachix-action@v10
-        with:
-          name: fedimint
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build and run tests with Code Coverage
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceCov
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: result/lcov.info
-          fail_ci_if_error: true

--- a/flake.nix
+++ b/flake.nix
@@ -180,9 +180,11 @@
           doCheck = false;
         });
 
-        workspaceTest = craneLib.cargoBuild (commonArgs // {
+        workspaceTestandCov = craneLib.cargoBuild (commonArgs // {
           cargoArtifacts = workspaceBuild;
+          cargoBuildCommand = "mkdir -p $out && cargo llvm-cov --workspace --lcov --output-path $out/lcov.info";
           doCheck = true;
+          nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
         });
 
         # Note: can't use `cargoClippy` because it implies `--all-targets`, while
@@ -227,13 +229,6 @@
           };
           doCheck = false;
         };
-
-        llvmCovWorkspace = craneLib.cargoBuild (commonArgs // {
-          cargoArtifacts = workspaceDeps;
-          cargoBuildCommand = "mkdir -p $out && cargo llvm-cov --workspace --lcov --output-path $out/lcov.info";
-          doCheck = true;
-          nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
-        });
 
         minimint = pkg {
           name = "minimint";
@@ -333,8 +328,8 @@
           deps = workspaceDeps;
           workspaceBuild = workspaceBuild;
           workspaceClippy = workspaceClippy;
-          workspaceTest = workspaceTest;
-          workspaceCov = llvmCovWorkspace;
+          workspaceTestandCov = workspaceTestandCov;
+          cargoUdeps = cargoUdeps;
 
           cli-test = {
             latency = cliTestLatency;


### PR DESCRIPTION
testing CI
- removed `--all-features` so we can use stable (avoiding the ''diagnostics` flag): should I now list all other flags manually ? we didn't run the tests with any flags but maybe we should ?
- 
- can add a commit that removes `udeps` as well if wanted
