### PR TITLE
Switch back to stable, tweak some stuff to make it possible

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Clippy workspace
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceClippy
 
-      - name: "`cargo udeps`"
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cargoUdeps
-
       - name: Test workspace
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceTest
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,23 @@
+on:
+  schedule:
+    - cron:  '30 5,17 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+name: Daily check
+
+jobs:
+  check-unused-dependencies:
+    runs-on: buildjet-4vcpu-ubuntu-2004
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Installs cargo-udeps
+        run: cargo install --force cargo-udeps
+      - name: Run cargo udeps
+        run: cargo udeps

--- a/flake.nix
+++ b/flake.nix
@@ -217,9 +217,25 @@
           cargoBuildCommand = "patchShebangs ./scripts && ./scripts/rust-tests.sh";
         });
 
+        cargo-udeps = with pkgs; craneLib.buildPackage rec {
+          pname = "cargo-udeps";
+          version = "0.1.30";
+          nativeBuildInputs = [ pkg-config ];
+
+          # TODO figure out how to use provided curl instead of compiling curl from curl-sys
+          buildInputs = [ openssl ]
+            ++ lib.optionals stdenv.isDarwin [ CoreServices Security libiconv SystemConfiguration ];
+
+          src = pkgs.fetchCrate {
+            inherit pname version;
+            sha256 = "sha256-KF4nZ2qhjh7nytDu4npovvCkl22bOqQZo14/o8uj5p8=";
+          };
+          doCheck = false;
+        };
+
         cargoUdeps = craneLib.cargoBuild (commonArgs // {
           cargoArtifacts = workspaceBuild;
-          cargoBuildCommand = "${pkgs.cargo-udeps}/bin/cargo-udeps udeps --workspace --all-targets --release";
+          cargoBuildCommand = "${cargo-udeps}/bin/cargo-udeps udeps --workspace --all-targets --release";
           doInstallCargoArtifacts = false;
         });
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
           "llvm-tools-preview"
         ]);
 
-        fenix-channel = fenix.packages.${system}.complete;
+        fenix-channel = fenix.packages.${system}.stable;
 
         craneLib = crane.lib.${system}.overrideToolchain fenix-toolchain;
 
@@ -230,7 +230,7 @@
 
         llvmCovWorkspace = craneLib.cargoBuild (commonArgs // {
           cargoArtifacts = workspaceDeps;
-          cargoBuildCommand = "mkdir -p $out && cargo llvm-cov --all-features --workspace --lcov --output-path $out/lcov.info";
+          cargoBuildCommand = "mkdir -p $out && cargo llvm-cov --workspace --lcov --output-path $out/lcov.info";
           doCheck = true;
           nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
         });

--- a/flake.nix
+++ b/flake.nix
@@ -217,28 +217,6 @@
           cargoBuildCommand = "patchShebangs ./scripts && ./scripts/rust-tests.sh";
         });
 
-        cargo-udeps = with pkgs; craneLib.buildPackage rec {
-          pname = "cargo-udeps";
-          version = "0.1.30";
-          nativeBuildInputs = [ pkg-config ];
-
-          # TODO figure out how to use provided curl instead of compiling curl from curl-sys
-          buildInputs = [ openssl ]
-            ++ lib.optionals stdenv.isDarwin [ CoreServices Security libiconv SystemConfiguration ];
-
-          src = pkgs.fetchCrate {
-            inherit pname version;
-            sha256 = "sha256-KF4nZ2qhjh7nytDu4npovvCkl22bOqQZo14/o8uj5p8=";
-          };
-          doCheck = false;
-        };
-
-        cargoUdeps = craneLib.cargoBuild (commonArgs // {
-          cargoArtifacts = workspaceBuild;
-          cargoBuildCommand = "${cargo-udeps}/bin/cargo-udeps udeps --workspace --all-targets --release";
-          doInstallCargoArtifacts = false;
-        });
-
         cargo-llvm-cov = craneLib.buildPackage rec {
           pname = "cargo-llvm-cov";
           version = "0.4.14";
@@ -357,7 +335,6 @@
           workspaceClippy = workspaceClippy;
           workspaceTest = workspaceTest;
           workspaceCov = llvmCovWorkspace;
-          cargoUdeps = cargoUdeps;
 
           cli-test = {
             latency = cliTestLatency;


### PR DESCRIPTION
Bunch of commits (each with separate short commit message).

* move back to stable by
  * droping `--all-features` from code coverage
  * moving `cargo-udeps` to separate workflow that will run daily

Keeping the "Update cargo-udeps to latest crates.io version" just for reference if I need it later.