### PR TITLE
Don't use `-L` argument for `nix`

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -48,29 +48,29 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build workspace
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceBuild
+        run: nix build --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceBuild
 
       - name: Clippy workspace
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceClippy
+        run: nix build --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceClippy
 
       - name: Test workspace
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceTest
+        run: nix build --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceTest
 
       - name: Latency Tests
         # run: nix-shell --command ./scripts/latency-test.sh
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.latency
+        run: nix build --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.latency
 
       - name: CLI Tests
         # run: nix-shell --command ./scripts/cli-test.sh
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.cli
+        run: nix build --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.cli
 
       - name: Clientd and clientd-cli tests
         # run: nix-shell --command ./scripts/clientd-tests.sh
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.clientd
+        run: nix build --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.clientd
 
       - name: Integration Tests
         # run: nix-shell --command ./scripts/rust-tests.sh
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.rust-tests
+        run: nix build --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.rust-tests
 
   # Code Coverage will build using a completely different profile (neither debug/release)
   # Which means we can not reuse much from `build` job. Might as well run it as another
@@ -90,7 +90,7 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build and run tests with Code Coverage
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceCov
+        run: nix build --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceCov
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
I don't even know what it does, and can't find documentation for it.