### PR TITLE
manage gateways via mint-client-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ ln2
 it
 .idea
 .tmpenv
+.vscode

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -9,7 +9,8 @@ use minimint_core::modules::wallet::txoproof::TxOutProof;
 
 use mint_client::mint::SpendableCoin;
 use mint_client::utils::{
-    from_hex, parse_bitcoin_amount, parse_coins, parse_minimint_amount, serialize_coins,
+    from_hex, parse_bitcoin_amount, parse_coins, parse_lightning_gateway, parse_minimint_amount,
+    serialize_coins,
 };
 use mint_client::{Client, GatewaySelection, UserClientConfig};
 use serde::{Deserialize, Serialize};
@@ -80,6 +81,12 @@ enum Command {
 
     /// List gateways
     Gateways { active: bool },
+
+    /// Activate a gateway
+    GatewaysActivate {
+        #[clap(parse(try_from_str = parse_lightning_gateway))]
+        gateway: LightningGateway,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -234,6 +241,12 @@ async fn main() {
                     i, gateway.mint_pub_key, gateway.node_pub_key
                 );
             }
+        }
+        Command::GatewaysActivate { gateway } => {
+            client
+                .activate_gateway(gateway)
+                .await
+                .expect("Failed to activate gateway");
         }
     }
 }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -220,6 +220,7 @@ async fn main() {
 
             if active {
                 // List any gateways saved in the client database.
+                println!("Looking up gateways in database...");
                 gateways = client
                     .select_gateways(GatewaySelection::Active)
                     .await
@@ -228,6 +229,7 @@ async fn main() {
                 println!("Found {} active gateways : ", gateways.len());
             } else {
                 // List any gateways registered with the federation.
+                println!("Fetching gateways from federation...");
                 gateways = client
                     .select_gateways(GatewaySelection::Registered)
                     .await
@@ -235,11 +237,8 @@ async fn main() {
                 println!("Found {} registered gateways : ", gateways.len());
             }
 
-            for (i, gateway) in gateways.iter().enumerate() {
-                println!(
-                    "{}: mint_pub_key: {}, node_pub_key: {}",
-                    i, gateway.mint_pub_key, gateway.node_pub_key
-                );
+            for (_, gateway) in gateways.iter().enumerate() {
+                println!("{}", serde_json::to_string(&gateway).unwrap());
             }
         }
         Command::GatewaysActivate { gateway } => {

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -87,6 +87,12 @@ enum Command {
         #[clap(parse(try_from_str = parse_lightning_gateway))]
         gateway: LightningGateway,
     },
+
+    /// Deactivate a gateway
+    GatewaysDeactivate {
+        #[clap(parse(try_from_str = parse_lightning_gateway))]
+        gateway: LightningGateway,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -246,6 +252,12 @@ async fn main() {
                 .activate_gateway(gateway)
                 .await
                 .expect("Failed to activate gateway");
+        }
+        Command::GatewaysDeactivate { gateway } => {
+            client
+                .deactivate_gateway(gateway)
+                .await
+                .expect("Failed to deactivate gateway");
         }
     }
 }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -79,7 +79,7 @@ enum Command {
     WaitBlockHeight { height: u64 },
 
     /// List gateways
-    ListGateways { active: bool },
+    Gateways { active: bool },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -208,7 +208,7 @@ async fn main() {
         Command::WaitBlockHeight { height } => {
             client.await_consensus_block_height(height).await;
         }
-        Command::ListGateways { active } => {
+        Command::Gateways { active } => {
             let gateways: Vec<LightningGateway>;
 
             if active {

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -488,6 +488,22 @@ impl Client<UserClientConfig> {
         Ok(())
     }
 
+    pub async fn deactivate_gateway(&self, gateway: LightningGateway) -> Result<()> {
+        let gateways = match self.select_gateways(GatewaySelection::Active).await {
+            Ok(mut active_gateways) => {
+                active_gateways.retain(|g| g != &gateway);
+                active_gateways
+            }
+            Err(_) => return Err(ClientError::NoActiveGateways),
+        };
+
+        self.context
+            .db
+            .insert_entry(&ActiveLightningGatewaysKey, &gateways)
+            .expect("DB error");
+        Ok(())
+    }
+
     async fn fetch_gateway(&self) -> Result<LightningGateway> {
         let gateways = match self.select_gateways(GatewaySelection::Active).await {
             Ok(gateways) => gateways,

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -463,7 +463,7 @@ impl Client<UserClientConfig> {
             GatewaySelection::Registered => {
                 let registered_gateways = self.context.api.fetch_gateways().await?;
                 if registered_gateways.is_empty() {
-                    Err(ClientError::NoRegisteredGateways)
+                    return Err(ClientError::NoRegisteredGateways);
                 };
                 Ok(registered_gateways)
             }

--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -11,7 +11,7 @@ const DB_PREFIX_OUTGOING_PAYMENT: u8 = 0x23;
 const DB_PREFIX_OUTGOING_PAYMENT_CLAIM: u8 = 0x24;
 const DB_PREFIX_OUTGOING_CONTRACT_ACCOUNT: u8 = 0x25;
 const DB_PREFIX_CONFIRMED_INVOICE: u8 = 0x26;
-const DB_PREFIX_LIGHTNING_GATEWAY: u8 = 0x28;
+const DB_PREFIX_ACTIVE_LIGHTNING_GATEWAYS: u8 = 0x28;
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutgoingPaymentKey(pub ContractId);
@@ -86,10 +86,10 @@ impl DatabaseKeyPrefixConst for ConfirmedInvoiceKeyPrefix {
 }
 
 #[derive(Debug, Encodable, Decodable)]
-pub struct LightningGatewayKey;
+pub struct ActiveLightningGatewaysKey;
 
-impl DatabaseKeyPrefixConst for LightningGatewayKey {
-    const DB_PREFIX: u8 = DB_PREFIX_LIGHTNING_GATEWAY;
+impl DatabaseKeyPrefixConst for ActiveLightningGatewaysKey {
+    const DB_PREFIX: u8 = DB_PREFIX_ACTIVE_LIGHTNING_GATEWAYS;
     type Key = Self;
-    type Value = LightningGateway;
+    type Value = Vec<LightningGateway>;
 }

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -5,6 +5,7 @@ use lightning_invoice::Currency;
 use minimint_api::db::Database;
 use minimint_api::encoding::Decodable;
 use minimint_api::ParseAmountError;
+use minimint_core::modules::ln::{LightningGateway, LightningModuleError};
 use minimint_core::modules::mint::tiered::coins::Coins;
 
 pub fn parse_coins(s: &str) -> Coins<SpendableCoin> {
@@ -42,6 +43,14 @@ pub fn parse_minimint_amount(s: &str) -> Result<minimint_api::Amount, ParseAmoun
         //default to satoshi
         minimint_api::Amount::from_str_in(s, bitcoin::Denomination::Satoshi)
     }
+}
+
+pub fn parse_lightning_gateway(s: &str) -> Result<LightningGateway, LightningModuleError> {
+    let gateway: LightningGateway = match serde_json::from_str(s) {
+        Ok(g) => g,
+        Err(_) => return Err(LightningModuleError::ParseGatewayError),
+    };
+    Ok(gateway)
 }
 
 pub struct BorrowedClientContext<'a, C> {

--- a/modules/minimint-ln/src/lib.rs
+++ b/modules/minimint-ln/src/lib.rs
@@ -120,7 +120,7 @@ pub enum OutputOutcome {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable, Hash, Eq, PartialEq)]
 pub struct LightningGateway {
     pub mint_pub_key: secp256k1::XOnlyPublicKey,
     pub node_pub_key: secp256k1::PublicKey,

--- a/modules/minimint-ln/src/lib.rs
+++ b/modules/minimint-ln/src/lib.rs
@@ -671,4 +671,6 @@ pub enum LightningModuleError {
     InsufficientIncomingFunding(Amount, Amount),
     #[error("No offer found for payment hash {0}")]
     NoOffer(secp256k1::hashes::sha256::Hash),
+    #[error("Error parsing string as LightningGateway")]
+    ParseGatewayError,
 }


### PR DESCRIPTION
Addressing #366  by introducing `mint-client-cli` commands for interacting with the gateways. These are applicable in the following ways:
- `mint-client-cli gateways`: list all gateways registered with the mint and available to this client
- `mint-client-cli gateways -- 1`: list all gateways stored by the client in the db. These were previously sourced from the mint
- `mint-client-cli gateways-activate -- '{ serialized gateway }`: save gateway to client db
- `mint-client-cli gateways-deactivate -- '{ serialized gateway }`: remove gateway from client db