### PR TITLE
Run integration tests only in ccov job

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -55,8 +55,9 @@ jobs:
       - name: Clippy workspace
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceClippy
 
-      - name: Test workspace
-        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceTest
+      # `ccov` job will run `cargo test`, so no need to spend time on it here
+      # - name: Test workspace
+      #   run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceTest
 
       - name: Latency Tests
         # run: nix-shell --command ./scripts/latency-test.sh
@@ -70,7 +71,7 @@ jobs:
         # run: nix-shell --command ./scripts/clientd-tests.sh
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.clientd
 
-      - name: Integration Tests
+      - name: Integration Tests (no fixtures)
         # run: nix-shell --command ./scripts/rust-tests.sh
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.rust-tests
 

--- a/flake.nix
+++ b/flake.nix
@@ -244,7 +244,8 @@
 
         llvmCovWorkspace = craneLib.cargoBuild (commonArgs // {
           cargoArtifacts = workspaceDeps;
-          cargoBuildCommand = "mkdir -p $out && cargo llvm-cov --workspace --lcov --output-path $out/lcov.info";
+          # TODO: as things are right now, the integration tests can't run in parallel
+          cargoBuildCommand = "mkdir -p $out && env RUST_TEST_THREADS=1 cargo llvm-cov --workspace --lcov --output-path $out/lcov.info";
           doCheck = true;
           nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
         });


### PR DESCRIPTION
Also run them on one thread only.

Fix #397