### PR TITLE
Add `rust-analyzer` back to the dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -360,6 +360,7 @@
               buildInputs = workspaceDeps.buildInputs;
               nativeBuildInputs = with pkgs; workspaceDeps.nativeBuildInputs ++ [
                 fenix-toolchain
+                fenix.packages.${system}.rust-analyzer
                 cargo-llvm-cov
                 cargo-udeps
 


### PR DESCRIPTION
I've accidentally removed it when refactoring flake.nix.