### PR TITLE
Add mint-client-cli 'list-gateways' and 'switch-gateway' command

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -1,4 +1,4 @@
-use bitcoin::{Address, Transaction};
+use bitcoin::{secp256k1, Address, Transaction};
 use bitcoin_hashes::hex::ToHex;
 use clap::Parser;
 use fedimint_api::Amount;
@@ -9,7 +9,8 @@ use fedimint_core::modules::wallet::txoproof::TxOutProof;
 use mint_client::api::{WsFederationApi, WsFederationConnect};
 use mint_client::mint::SpendableCoin;
 use mint_client::utils::{
-    from_hex, parse_bitcoin_amount, parse_coins, parse_fedimint_amount, serialize_coins,
+    from_hex, parse_bitcoin_amount, parse_coins, parse_fedimint_amount, parse_node_pub_key,
+    serialize_coins,
 };
 use mint_client::{Client, UserClientConfig};
 use serde::{Deserialize, Serialize};
@@ -87,6 +88,13 @@ enum Command {
 
     /// List registered gateways
     ListGateways,
+
+    /// Switch active gateway
+    SwitchGateway {
+        /// node public key for a gateway
+        #[clap(parse(try_from_str = parse_node_pub_key))]
+        pubkey: secp256k1::PublicKey,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -240,7 +248,9 @@ async fn main() {
             let info = WsFederationConnect::from(client.config().as_ref());
             println!("{}", serde_json::to_string(&info).unwrap());
         }
-        Command::JoinFederation { .. } => unreachable!(),
+        Command::JoinFederation { .. } => {
+            unreachable!()
+        }
         Command::ListGateways {} => {
             println!("Fetching gateways from federation...");
             let gateways = client
@@ -250,7 +260,7 @@ async fn main() {
             println!("Found {} registered gateways : ", gateways.len());
             if !gateways.is_empty() {
                 let mut gateways_json = json!(&gateways);
-                if let Ok(active_gateway) = client.fetch_gateway().await {
+                if let Ok(active_gateway) = client.fetch_active_gateway().await {
                     gateways_json
                         .as_array_mut()
                         .expect("gateways_json is not an array")
@@ -268,6 +278,20 @@ async fn main() {
                     to_string_pretty(&gateways_json).expect("failed to deserialize gateways")
                 );
             }
+        }
+        Command::SwitchGateway { pubkey } => {
+            let gateway = client
+                .switch_active_gateway(Some(pubkey))
+                .await
+                .expect("Failed to switch active gateway");
+            println!("Successfully switched to gateway with the following details");
+            let mut gateway_json = json!(&gateway);
+            gateway_json["active"] = json!(true);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&gateway_json)
+                    .expect("Failed to deserialize activated gateway")
+            );
         }
     }
 }

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -419,6 +419,9 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
 }
 
 impl Client<UserClientConfig> {
+    pub async fn fetch_registered_gateways(&self) -> Result<Vec<LightningGateway>> {
+        Ok(self.context.api.fetch_gateways().await?)
+    }
     pub async fn fetch_gateway(&self) -> Result<LightningGateway> {
         // fetch gateway from db
         if let Some(gateway) = self
@@ -431,10 +434,7 @@ impl Client<UserClientConfig> {
         }
 
         // if db is empty, fetch from federation and save to db
-        let gateways = self.context.api.fetch_gateways().await?;
-        if gateways.is_empty() {
-            return Err(ClientError::NoGateways);
-        };
+        let gateways = self.fetch_registered_gateways().await?;
         let gateway = gateways[0].clone();
         self.context
             .db

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -1,6 +1,8 @@
+use std::str::FromStr;
+
 use crate::api::FederationApi;
 use crate::mint::SpendableCoin;
-use bitcoin::Network;
+use bitcoin::{secp256k1, Network};
 use fedimint_api::db::Database;
 use fedimint_api::encoding::Decodable;
 use fedimint_api::ParseAmountError;
@@ -43,6 +45,11 @@ pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_api::Amount, ParseAmoun
         fedimint_api::Amount::from_str_in(s, bitcoin::Denomination::Satoshi)
     }
 }
+
+pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Error> {
+    secp256k1::PublicKey::from_str(s)
+}
+
 pub struct ClientContext {
     pub db: Box<dyn Database>,
     pub api: Box<dyn FederationApi>,


### PR DESCRIPTION
Introducing mint-client-cli commands for interacting with the gateways.
This PR proposes:
- [x] `mint-client-cli list-gateways` to lists all gateways registered with the mint,
- [x] `mint-client-cli switch-gateway` to activate a different gateway.

These commands allow interactions and management of gateways from CLI as proposed in Issue #366 

### Demo:
1. `list-gateways` shows all registered gateways, with their activation status.
```
$ mint-client-cli list-gateways

Found 1 registered gateways :
[
  {
    "mint_pub_key": "b1f4d07fe3d5a754d47dd58b9db2710ab292d125a9cba3a854c1524c92201135",
    "node_pub_key": "03c218a54e57553fa0a466900b5b7de4c51db421138084a52e45fbdfd21103e560",
    "api": "http://127.0.0.1:8080",
    "active": false
  }
]
```
2. `switch-gateway <node_pub_key>` shows all registered gateways, with their activation status. *It might be useful to allow selection with either pubkey, so `mint_pub_key` would work as well*
```
$ mint-client-cli switch-gateway 03c218a54e57553fa0a466900b5b7de4c51db421138084a52e45fbdfd21103e560

Successfully switched to gateway with the following details
{
  "mint_pub_key": "b1f4d07fe3d5a754d47dd58b9db2710ab292d125a9cba3a854c1524c92201135",
  "node_pub_key": "03c218a54e57553fa0a466900b5b7de4c51db421138084a52e45fbdfd21103e560",
  "api": "http://127.0.0.1:8080",
  "active": true
}
```
3. `list-gateways` shows all registered gateways, with their updated activation status after `switch-gateway`
```
$ mint-client-cli list-gateways

Found 1 registered gateways :
[
  {
    "mint_pub_key": "b1f4d07fe3d5a754d47dd58b9db2710ab292d125a9cba3a854c1524c92201135",
    "node_pub_key": "03c218a54e57553fa0a466900b5b7de4c51db421138084a52e45fbdfd21103e560",
    "api": "http://127.0.0.1:8080",
    "active": true
  }
]
```
