### PR TITLE
Run daily check on a free github action machine

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ name: Daily check
 
 jobs:
   check-unused-dependencies:
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
For some reason daily check [failed with](https://github.com/dpc/fedimint/actions/runs/2873032165):

> This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.

I'm not sure why it happened, but since this workflow is not blocking anyone, it's OK if it's slower but free, and maybe it will fix the issue as well.