### PR TITLE
Delete (not unnecessary) build of merged PR

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -9,8 +9,6 @@ on:
     branches: [ "main", "master", "devel" ]
   pull_request:
     branches: [ "main", "master", "devel" ]
-    types:
-      - closed
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
It is redundant with "push to master" one.