### PR TITLE
wasm: fix invoice generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,6 +1708,7 @@ dependencies = [
  "bitcoin_hashes",
  "futures",
  "hex",
+ "js-sys",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "jsonrpsee-wasm-client",

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0.82"
 jsonrpsee-ws-client = "0.14.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
+js-sys = "0.3.59"
 jsonrpsee-wasm-client = "0.14.0"
 
 [dev-dependencies]


### PR DESCRIPTION
The `InvoiceBuilder::current_timestamp` uses `SystemTime::now()` internally, which is unimplemented on wasm and thus panics.

We can use [`getTime`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime) on `new Date()` on wasm.
This is not done in std library because `wasm32-unknown-unknown` can't garauntee presence of a JS runtime.