### PR TITLE
devcontainer: Only flake.* files are needed to run `nix develop`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /etc/nix && echo "sandbox = false" >> /etc/nix/nix.conf
 
 # Use nix to build project dependencies.
 USER nonroot
-ADD --chown=nonroot:nonroot . /home/nonroot/tmp_src
+ADD --chown=nonroot:nonroot flake.* /home/nonroot/tmp_src/
 RUN . /home/nonroot/.nix-profile/etc/profile.d/nix.sh && \
     (cd /home/nonroot/tmp_src && nix develop --extra-experimental-features nix-command --extra-experimental-features flakes)
 # Setup bashrc with nix develop trigger.


### PR DESCRIPTION
This should save couple of megs.

More discussion in: #426