### PR TITLE
Allow peers to resync up to consensus

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -60,6 +60,10 @@ jobs:
       # - name: Test workspace
       #   run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceTest
 
+      - name: Reconnect Tests
+        # run: nix-shell --command ./scripts/reconnect-test.sh
+        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.reconnect
+
       - name: Latency Tests
         # run: nix-shell --command ./scripts/latency-test.sh
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#cli-test.latency

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,7 @@ dependencies = [
  "hex",
  "itertools",
  "jsonrpsee",
+ "mint-client",
  "opentelemetry",
  "opentelemetry-jaeger",
  "rand 0.6.5",

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -6,8 +6,8 @@ use fedimint_api::{BitcoinHash, FederationModule, PeerId};
 use fedimint_derive::UnzipConsensus;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use threshold_crypto::{PublicKey, Signature, SignatureShare};
+use std::collections::{BTreeMap, HashSet};
+use threshold_crypto::{PublicKey, PublicKeySet, Signature, SignatureShare};
 
 #[derive(
     Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, UnzipConsensus, Encodable, Decodable,
@@ -71,12 +71,45 @@ impl EpochHistory {
         }
     }
 
-    /// verifies the sig, the hash, and the merkle tree
-    pub fn verify(
+    pub fn add_sig_to_prev(
         &self,
-        pks: &PublicKey,
-        prev_epoch: Option<&EpochHistory>,
-    ) -> Result<(), EpochVerifyError> {
+        pks: &PublicKeySet,
+        mut prev_epoch: EpochHistory,
+    ) -> Result<EpochHistory, EpochVerifyError> {
+        let mut contributing_peers = HashSet::new();
+
+        let sigs: BTreeMap<_, _> = self
+            .outcome
+            .items
+            .iter()
+            .flat_map(|(peer, items)| items.iter().map(|i| (*peer, i)))
+            .filter_map(|(peer, item)| match item {
+                ConsensusItem::EpochInfo(EpochSignatureShare(sig)) => Some((peer, sig)),
+                _ => None,
+            })
+            .filter(|(peer, sig)| {
+                let pub_key = pks.public_key_share(peer.to_usize());
+                pub_key.verify(sig, prev_epoch.hash)
+            })
+            .map(|(peer, sig)| {
+                contributing_peers.insert(peer);
+                (peer.to_usize(), sig)
+            })
+            .collect();
+
+        if let Ok(final_sig) = pks.combine_signatures(sigs) {
+            assert!(pks.public_key().verify(&final_sig, prev_epoch.hash));
+
+            prev_epoch.signature = Some(EpochSignature(final_sig));
+            Ok(prev_epoch)
+        } else {
+            Err(EpochVerifyError::NotEnoughValidSigShares(
+                contributing_peers,
+            ))
+        }
+    }
+
+    pub fn verify_sig(&self, pks: &PublicKey) -> Result<(), EpochVerifyError> {
         if let Some(sig) = &self.signature {
             if !pks.verify(&sig.0, self.hash) {
                 return Err(EpochVerifyError::InvalidSignature);
@@ -85,6 +118,10 @@ impl EpochHistory {
             return Err(EpochVerifyError::MissingSignature);
         }
 
+        Ok(())
+    }
+
+    pub fn verify_hash(&self, prev_epoch: &Option<EpochHistory>) -> Result<(), EpochVerifyError> {
         if self.outcome.epoch > 0 {
             match prev_epoch {
                 None => return Err(EpochVerifyError::MissingPreviousEpoch),
@@ -110,6 +147,7 @@ pub enum EpochVerifyError {
     MissingPreviousEpoch,
     InvalidEpochHash,
     InvalidPreviousEpochHash,
+    NotEnoughValidSigShares(HashSet<PeerId>),
 }
 
 impl Encodable for EpochSignature {
@@ -144,14 +182,17 @@ impl Decodable for EpochSignatureShare {
 
 #[cfg(test)]
 mod tests {
-    use crate::epoch::Sha256;
+    use crate::epoch::{ConsensusItem, EpochSignatureShare, Sha256};
     use crate::epoch::{EpochHistory, EpochSignature, EpochVerifyError, OutcomeHistory};
+    use fedimint_api::rand::Rand07Compat;
     use fedimint_api::PeerId;
-    use threshold_crypto::SecretKey;
+    use rand::rngs::OsRng;
+    use std::collections::HashSet;
+    use threshold_crypto::{SecretKey, SecretKeySet};
 
     fn signed_history(
         epoch: u16,
-        prev_epoch: Option<&EpochHistory>,
+        prev_epoch: &Option<EpochHistory>,
         sk: &SecretKey,
     ) -> EpochHistory {
         let missing_sig = history(epoch, prev_epoch, None);
@@ -161,12 +202,12 @@ mod tests {
 
     fn history(
         epoch: u16,
-        prev_epoch: Option<&EpochHistory>,
+        prev_epoch: &Option<EpochHistory>,
         signature: Option<EpochSignature>,
     ) -> EpochHistory {
         let items = vec![(PeerId::from(epoch), vec![])];
         let outcome = OutcomeHistory {
-            last_hash: prev_epoch.map(|epoch| epoch.hash),
+            last_hash: prev_epoch.clone().map(|epoch| epoch.hash),
             items,
             epoch: epoch as u64,
         };
@@ -179,13 +220,55 @@ mod tests {
     }
 
     #[test]
+    fn adds_sig_to_prev_epoch() {
+        let rng = OsRng::new().unwrap();
+        let sk_set = SecretKeySet::random(2, &mut Rand07Compat(rng));
+        let pk_set = sk_set.public_keys();
+
+        let epoch0 = history(0, &None, None);
+        let mut epoch1 = history(1, &Some(epoch0.clone()), None);
+
+        let peers = [PeerId::from(0), PeerId::from(1), PeerId::from(2)];
+        let sigs: Vec<(PeerId, Vec<ConsensusItem>)> = peers
+            .iter()
+            .map(|&peer| {
+                let sig = sk_set.secret_key_share(peer.to_usize()).sign(&epoch0.hash);
+                (
+                    peer,
+                    vec![ConsensusItem::EpochInfo(EpochSignatureShare(sig))],
+                )
+            })
+            .collect();
+
+        epoch1.outcome = OutcomeHistory {
+            epoch: 1,
+            last_hash: None,
+            items: sigs[0..1].to_vec(),
+        };
+        let contributing = HashSet::from([PeerId::from(0)]);
+        let result = epoch1.add_sig_to_prev(&pk_set, epoch0.clone()).unwrap_err();
+        assert_eq!(
+            result,
+            EpochVerifyError::NotEnoughValidSigShares(contributing)
+        );
+
+        epoch1.outcome = OutcomeHistory {
+            epoch: 1,
+            last_hash: None,
+            items: sigs,
+        };
+        let epoch0 = epoch1.add_sig_to_prev(&pk_set, epoch0).unwrap();
+        assert_eq!(epoch0.verify_sig(&pk_set.public_key()), Ok(()));
+    }
+
+    #[test]
     fn verifies_hash() {
         let sk: SecretKey = SecretKey::random();
-        let pk = sk.public_key();
+        let _pk = sk.public_key();
         let wrong_hash: Sha256 = Default::default();
         let sig = EpochSignature(sk.sign(&wrong_hash));
 
-        let epoch0 = history(0, None, Some(sig));
+        let epoch0 = history(0, &None, Some(sig));
         let epoch = EpochHistory {
             outcome: epoch0.outcome,
             hash: wrong_hash,
@@ -193,7 +276,7 @@ mod tests {
         };
 
         assert_eq!(
-            epoch.verify(&pk, None),
+            epoch.verify_hash(&None),
             Err(EpochVerifyError::InvalidEpochHash)
         );
     }
@@ -201,22 +284,22 @@ mod tests {
     #[test]
     fn verifies_merkle_tree() {
         let sk: SecretKey = SecretKey::random();
-        let pk = sk.public_key();
+        let _pk = sk.public_key();
 
-        let epoch0 = signed_history(0, None, &sk);
-        let epoch1 = signed_history(1, Some(&epoch0), &sk);
-        let epoch2 = signed_history(2, Some(&epoch1), &sk);
+        let epoch0 = signed_history(0, &None, &sk);
+        let epoch1 = signed_history(1, &Some(epoch0.clone()), &sk);
+        let epoch2 = signed_history(2, &Some(epoch1.clone()), &sk);
 
-        assert_eq!(epoch0.verify(&pk, None), Ok(()));
-        assert_eq!(epoch1.verify(&pk, Some(&epoch0)), Ok(()));
-        assert_eq!(epoch2.verify(&pk, Some(&epoch1)), Ok(()));
+        assert_eq!(epoch0.verify_hash(&None), Ok(()));
+        assert_eq!(epoch1.verify_hash(&Some(epoch0)), Ok(()));
+        assert_eq!(epoch2.verify_hash(&Some(epoch1.clone())), Ok(()));
 
         assert_eq!(
-            epoch1.verify(&pk, None),
+            epoch1.verify_hash(&None),
             Err(EpochVerifyError::MissingPreviousEpoch)
         );
         assert_eq!(
-            epoch1.verify(&pk, Some(&epoch2)),
+            epoch1.verify_hash(&Some(epoch2)),
             Err(EpochVerifyError::InvalidPreviousEpochHash)
         );
     }
@@ -226,21 +309,21 @@ mod tests {
         let sk: SecretKey = SecretKey::random();
         let pk = sk.public_key();
 
-        let epoch0 = signed_history(0, None, &sk);
-        let epoch1 = signed_history(1, Some(&epoch0), &sk);
+        let epoch0 = signed_history(0, &None, &sk);
+        let epoch1 = signed_history(1, &Some(epoch0.clone()), &sk);
 
-        assert_eq!(epoch0.verify(&pk, None), Ok(()));
-        assert_eq!(epoch1.verify(&pk, Some(&epoch0)), Ok(()));
+        assert_eq!(epoch0.verify_sig(&pk), Ok(()));
+        assert_eq!(epoch1.verify_sig(&pk), Ok(()));
 
-        let epoch0_wrong = history(0, None, epoch1.signature);
-        let epoch1_wrong = history(1, Some(&epoch0), epoch0.signature.clone());
+        let epoch0_wrong = history(0, &None, epoch1.signature);
+        let epoch1_wrong = history(1, &Some(epoch0.clone()), epoch0.signature);
 
         assert_eq!(
-            epoch0_wrong.verify(&pk, None),
+            epoch0_wrong.verify_sig(&pk),
             Err(EpochVerifyError::InvalidSignature)
         );
         assert_eq!(
-            epoch1_wrong.verify(&pk, Some(&epoch0)),
+            epoch1_wrong.verify_sig(&pk),
             Err(EpochVerifyError::InvalidSignature)
         );
     }

--- a/fedimint/Cargo.toml
+++ b/fedimint/Cargo.toml
@@ -35,6 +35,7 @@ hbbft = { git = "https://github.com/fedimint/hbbft" }
 hex = "0.4.2"
 itertools = "0.10.0"
 jsonrpsee = { version = "0.14.0", features = ["ws-server"] }
+mint-client = { path = "../client/client-lib" }
 fedimint-api = { path = "../fedimint-api", features = ["rocksdb"] }
 fedimint-core = { path = "../fedimint-core" }
 fedimint-derive = { path = "../fedimint-derive" }

--- a/fedimint/src/db.rs
+++ b/fedimint/src/db.rs
@@ -67,7 +67,7 @@ impl DatabaseKeyPrefixConst for DropPeerKeyPrefix {
     type Value = ();
 }
 
-#[derive(Debug, Encodable, Decodable)]
+#[derive(Debug, Copy, Clone, Encodable, Decodable)]
 pub struct EpochHistoryKey(pub u64);
 
 impl DatabaseKeyPrefixConst for EpochHistoryKey {

--- a/fedimint/src/net/framed.rs
+++ b/fedimint/src/net/framed.rs
@@ -235,7 +235,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_roundtrip() {
-        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
         enum TestEnum {
             Foo,
             Bar(u64),
@@ -265,7 +265,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_not_try_parse_partial() {
-        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
         enum TestEnum {
             Foo,
             Bar(u64),

--- a/flake.nix
+++ b/flake.nix
@@ -214,6 +214,11 @@
           doCheck = false;
         });
 
+        cliTestReconnect = craneLib.cargoBuild (commonCliTestArgs // {
+          cargoArtifacts = workspaceBuild;
+          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/reconnect-test.sh";
+        });
+
         cliTestLatency = craneLib.cargoBuild (commonCliTestArgs // {
           cargoArtifacts = workspaceBuild;
           cargoBuildCommand = "patchShebangs ./scripts && ./scripts/latency-test.sh";
@@ -377,6 +382,7 @@
           workspaceCov = workspaceLlvmCov;
 
           cli-test = {
+            reconnect = cliTestReconnect;
             latency = cliTestLatency;
             cli = cliTestCli;
             clientd = cliTestClientd;

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -17,7 +17,6 @@ use cln_rpc::ClnRpc;
 use futures::executor::block_on;
 use futures::future::{join_all, select_all};
 use hbbft::honey_badger::Batch;
-use hbbft::honey_badger::Message;
 
 use fedimint_api::task::spawn;
 use fedimint_ln::LightningGateway;
@@ -40,7 +39,7 @@ use fedimint::net::connect::mock::MockNetwork;
 use fedimint::net::connect::{Connector, TlsTcpConnector};
 use fedimint::net::peers::PeerConnector;
 use fedimint::transaction::Output;
-use fedimint::{consensus, FedimintServer};
+use fedimint::{consensus, EpochMessage, FedimintServer};
 use fedimint_api::config::GenerateConfig;
 use fedimint_api::db::batch::DbBatch;
 use fedimint_api::db::mem_impl::MemDatabase;
@@ -490,8 +489,9 @@ impl FederationTest {
 
     /// Inserts coins directly into the databases of federation nodes
     pub fn database_add_coins_for_user(&self, user: &UserTest, amount: Amount) -> OutPoint {
+        let bytes: [u8; 32] = rand::random();
         let out_point = OutPoint {
-            txid: Default::default(),
+            txid: fedimint_api::TransactionId::from_inner(bytes),
             out_idx: 0,
         };
 
@@ -576,6 +576,14 @@ impl FederationTest {
         self.update_last_consensus();
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
+    pub async fn rejoin_consensus(&self) {
+        for server in &self.servers {
+            let mut s = server.borrow_mut();
+            s.fedimint.rejoin_consensus().await;
+        }
+    }
+
     // Necessary to allow servers to progress concurrently, should be fine since the same server
     // will never run an epoch concurrently with itself.
     #[allow(clippy::await_holding_refcell_ref)]
@@ -628,7 +636,7 @@ impl FederationTest {
     async fn new(
         server_config: BTreeMap<PeerId, ServerConfig>,
         bitcoin_gen: &impl Fn() -> Box<dyn BitcoindRpc>,
-        connect_gen: &impl Fn(&ServerConfig) -> PeerConnector<Message<PeerId>>,
+        connect_gen: &impl Fn(&ServerConfig) -> PeerConnector<EpochMessage>,
     ) -> Self {
         let servers = join_all(server_config.values().map(|cfg| async move {
             let bitcoin_rpc = bitcoin_gen();

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,7 @@ Here you can find scripts for running and testing Fedimint:
 * `start-fed.sh` - Generates the configs and starts the federation nodes
 * `pegin.sh` - Calls the CLI to peg into the federation
 * `rust-tests.sh` - Runs the all the Rust integration tests (required for PRs)
+* `reconnect-test.sh` - Runs a test to see if peers that died can rejoin consensus
 * `latency-test.sh` - Runs a test to determine the latency of certain user actions
 * `cli-test.sh` - Runs a CLI-based integration test (required for PRs)
 * `final-checks.sh` - Checks to run before opening a PR

--- a/scripts/final-checks.sh
+++ b/scripts/final-checks.sh
@@ -6,10 +6,11 @@
 set -e
 
 cargo fmt --all
-cargo clippy --fix --lib --bins --tests --examples --workspace --allow-dirty
+cargo +nightly clippy --fix --lib --bins --tests --examples --workspace --allow-dirty
+nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes .#lint --command ./misc/git-hooks/pre-commit
 
 export FM_TEST_DISABLE_MOCKS=0
-cargo test
+cargo +nightly test --release
 
 if [ "$1" == "nix" ]; then
   nix-shell --run ./scripts/cli-test.sh

--- a/scripts/reconnect-test.sh
+++ b/scripts/reconnect-test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Runs a test to see what happens if a server dies and rejoins
+
+set -euxo pipefail
+export RUST_LOG=info
+
+source ./scripts/setup-tests.sh
+./scripts/start-fed.sh
+
+server2=$(tail -2 $FM_PID_FILE | head -1)
+server1=$(tail -1 $FM_PID_FILE | head -1)
+
+mine_blocks 110
+await_block_sync
+
+kill $server1
+
+mine_blocks 100
+await_block_sync
+
+mine_blocks 100
+await_block_sync
+
+./scripts/start-fed.sh
+# FIXME should await a response from all 4 peers instead of this hack
+sleep 5
+kill $server2
+await_block_sync

--- a/scripts/start-fed.sh
+++ b/scripts/start-fed.sh
@@ -2,7 +2,7 @@
 # Generates the configs and starts the federation nodes
 
 set -euxo pipefail
-SKIPPED_SERVERS=${SKIPPED_SERVERS:-0}
+SKIPPED_SERVERS=${1:-0}
 
 # Start the federation members inside the temporary directory
 for ((ID=SKIPPED_SERVERS; ID<FM_FED_SIZE; ID++)); do


### PR DESCRIPTION
Allows peers to resync up to consensus
   - Upon start-up (possibly from crash) we send `RejoinRequest` to all peers
   - Peers send the HBBFT `next_epoch` back to us and last signed epoch history
   - We validate the epoch history sigs and that epoch history is within `f + 3` of the `next_epoch`
   - Take `max(next_epoch)` from `2f + 1` peers an run HBBFT to produce an outcome
   - Download all the epochs we've missed and process them as we can validate them
