### PR TITLE
Fix typo in Flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -419,7 +419,7 @@
                 tmux
                 tmuxinator
 
-                fedimint.package
+                fedimintd.package
                 fedimint-tests.package
                 ln-gateway.package
                 mint-client-cli.package


### PR DESCRIPTION
I'm hitting this error when running tmuxinator.sh

error: undefined variable 'fedimint'

       at /nix/store/4bjsf2f7zmjmjlhb7bcl2sz9x38y7007-source/flake.nix:422:17:

          421|
          422|                 fedimint.package
             |                 ^
          423|                 fedimint-tests.package
(use '--show-trace' to show detailed location information)

I think there's a small typo in flake.nix that causes this to fail (fedimint.package needs to be fedimintd.package)