### PR TITLE
don't check two times for peg-in-too-small

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -199,12 +199,6 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             .wallet_client()
             .create_pegin_input(txout_proof, btc_transaction)?;
 
-        let amount = Amount::from_sat(peg_in_proof.tx_output().value)
-            .saturating_sub(self.context.config.as_ref().wallet.fee_consensus.peg_in_abs);
-        if amount == Amount::ZERO {
-            return Err(ClientError::PegInAmountTooSmall);
-        }
-
         tx.input(&mut vec![peg_in_key], Input::Wallet(Box::new(peg_in_proof)));
 
         self.submit_tx_with_change(tx, DbBatch::new(), &mut rng)

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -97,10 +97,9 @@ impl<'c> WalletClient<'c> {
         peg_in_proof
             .verify(self.context.secp, &self.context.config.peg_in_descriptor)
             .map_err(WalletClientError::PegInProofError)?;
-        let sats = peg_in_proof.tx_output().value;
 
-        let amount =
-            Amount::from_sat(sats).saturating_sub(self.context.config.fee_consensus.peg_in_abs);
+        let amount = Amount::from_sat(peg_in_proof.tx_output().value)
+            .saturating_sub(self.context.config.fee_consensus.peg_in_abs);
         if amount == Amount::ZERO {
             return Err(WalletClientError::PegInAmountTooSmall);
         }


### PR DESCRIPTION
We don't need to check two times for an amount that is too small.