### PR TITLE
Do not run `cargo check` when building deps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,8 @@
           src = filterWorkspaceDepsBuildFiles ./.;
           pname = "fedimint-dependencies";
           doCheck = false;
+          # we do not care about running `cargo check`
+          cargoCheckCommand = "true";
         });
 
         # a function to define cargo&nix package, listing


### PR DESCRIPTION
This saves 40MBs of cache storage per build