### PR TITLE
Remove unnecessary struct `BorrowedClientContext`

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -64,7 +64,7 @@ use crate::ln::LnClientError;
 use crate::mint::db::{CoinKey, PendingCoinsKeyPrefix};
 use crate::mint::{CoinFinalizationData, MintClientError};
 use crate::transaction::TransactionBuilder;
-use crate::utils::{network_to_currency, OwnedClientContext};
+use crate::utils::{network_to_currency, ClientContext};
 use crate::wallet::WalletClientError;
 use crate::{
     api::{ApiError, FederationApi},
@@ -110,7 +110,7 @@ impl From<GatewayClientConfig> for LightningGateway {
 }
 
 pub struct Client<C> {
-    inner: Arc<(C, OwnedClientContext)>,
+    inner: Arc<(C, ClientContext)>,
 }
 
 impl AsRef<ClientConfig> for GatewayClientConfig {
@@ -178,7 +178,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         api: Box<dyn FederationApi>,
         secp: Secp256k1<All>,
     ) -> Client<T> {
-        let context = OwnedClientContext { db, api, secp };
+        let context = ClientContext { db, api, secp };
         Self {
             inner: Arc::new((config, context)),
         }

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -5,8 +5,8 @@ pub mod transaction;
 pub mod utils;
 pub mod wallet;
 
+use std::time::Duration;
 use std::time::SystemTime;
-use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
 
@@ -110,7 +110,8 @@ impl From<GatewayClientConfig> for LightningGateway {
 }
 
 pub struct Client<C> {
-    inner: Arc<(C, ClientContext)>,
+    config: C,
+    context: ClientContext,
 }
 
 impl AsRef<ClientConfig> for GatewayClientConfig {
@@ -127,31 +128,28 @@ impl AsRef<ClientConfig> for UserClientConfig {
 
 impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     pub fn ln_client(&self) -> LnClient {
-        let (config, context) = &*self.inner;
         LnClient {
-            config: &config.as_ref().ln,
-            context,
+            config: &self.config.as_ref().ln,
+            context: &self.context,
         }
     }
 
     pub fn mint_client(&self) -> MintClient {
-        let (config, context) = &*self.inner;
         MintClient {
-            config: &config.as_ref().mint,
-            context,
+            config: &self.config.as_ref().mint,
+            context: &self.context,
         }
     }
 
     pub fn wallet_client(&self) -> WalletClient {
-        let (config, context) = &*self.inner;
         WalletClient {
-            config: &config.as_ref().wallet,
-            context,
+            config: &self.config.as_ref().wallet,
+            context: &self.context,
         }
     }
 
     pub fn config(&self) -> T {
-        self.inner.0.clone()
+        self.config.clone()
     }
 
     pub fn new(config: T, db: Box<dyn Database>, secp: Secp256k1<All>) -> Self {
@@ -178,9 +176,9 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         api: Box<dyn FederationApi>,
         secp: Secp256k1<All>,
     ) -> Client<T> {
-        let context = ClientContext { db, api, secp };
         Self {
-            inner: Arc::new((config, context)),
+            config,
+            context: ClientContext { db, api, secp },
         }
     }
 
@@ -210,7 +208,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     ) -> Result<TransactionId> {
         Ok(self
             .mint_client()
-            .submit_tx_with_change(&self.inner.0.as_ref().fee_consensus(), tx, batch, rng)
+            .submit_tx_with_change(&self.config.as_ref().fee_consensus(), tx, batch, rng)
             .await?)
     }
 
@@ -227,7 +225,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         mut rng: R,
     ) -> Result<OutPoint> {
         let mut tx = TransactionBuilder::default();
-        tx.input_coins(coins, &self.inner.1.secp)?;
+        tx.input_coins(coins, &self.context.secp)?;
         let txid = self
             .submit_tx_with_change(tx, DbBatch::new(), &mut rng)
             .await?;
@@ -244,7 +242,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         let mut tx = TransactionBuilder::default();
 
         let input_coins = self.mint_client().select_coins(coins.amount())?;
-        tx.input_coins(input_coins, &self.inner.1.secp)?;
+        tx.input_coins(input_coins, &self.context.secp)?;
         tx.output(Output::Mint(coins));
         let txid = self.submit_tx_with_change(tx, batch, &mut rng).await?;
 
@@ -260,7 +258,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         let mut batch = DbBatch::new();
         self.mint_client()
             .receive_coins(amount, batch.transaction(), rng, create_tx);
-        self.inner.1.db.apply_batch(batch).expect("DB error");
+        self.context.db.apply_batch(batch).expect("DB error");
     }
 
     pub async fn new_peg_out_with_fees(
@@ -269,8 +267,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         recipient: Address,
     ) -> Result<PegOut> {
         let fees = self
-            .inner
-            .1
+            .context
             .api
             .fetch_peg_out_fees(&recipient, &amount)
             .await?;
@@ -290,10 +287,10 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         let batch = DbBatch::new();
         let mut tx = TransactionBuilder::default();
 
-        let funding_amount = self.inner.0.as_ref().wallet.fee_consensus.peg_out_abs
+        let funding_amount = self.config.as_ref().wallet.fee_consensus.peg_out_abs
             + (peg_out.amount + peg_out.fees.amount()).into();
         let coins = self.mint_client().select_coins(funding_amount)?;
-        tx.input_coins(coins, &self.inner.1.secp)?;
+        tx.input_coins(coins, &self.context.secp)?;
         let peg_out_idx = tx.output(Output::Wallet(peg_out));
 
         let fedimint_tx_id = self.submit_tx_with_change(tx, batch, &mut rng).await?;
@@ -317,7 +314,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         let address = self
             .wallet_client()
             .get_new_pegin_address(batch.transaction(), rng);
-        self.inner.1.db.apply_batch(batch).expect("DB error");
+        self.context.db.apply_batch(batch).expect("DB error");
         address
     }
 
@@ -334,7 +331,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             })
         }));
         tx.commit();
-        self.inner.1.db.apply_batch(batch).expect("DB error");
+        self.context.db.apply_batch(batch).expect("DB error");
         Ok(coins)
     }
 
@@ -346,7 +343,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         self.mint_client()
             .fetch_coins(batch.transaction(), outpoint)
             .await?;
-        self.inner.1.db.apply_batch(batch).expect("DB error");
+        self.context.db.apply_batch(batch).expect("DB error");
         Ok(())
     }
 
@@ -354,8 +351,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     /// inputs back.
     pub async fn reissue_pending_coins<R: RngCore + CryptoRng>(&self, rng: R) -> Result<OutPoint> {
         let pending = self
-            .inner
-            .1
+            .context
             .db
             .find_by_prefix(&PendingCoinsKeyPrefix)
             .map(|res| res.expect("DB error"));
@@ -363,7 +359,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         let stream = pending
             .map(|(key, coins)| async move {
                 loop {
-                    match self.inner.1.api.fetch_tx_outcome(key.0).await {
+                    match self.context.api.fetch_tx_outcome(key.0).await {
                         Ok(TransactionStatus::Rejected(_)) => return (key, coins),
                         Ok(TransactionStatus::Accepted { .. }) => {
                             return (key, Coins::<SpendableCoin>::default())
@@ -382,14 +378,14 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             tx.append_delete(key);
         }
         tx.commit();
-        self.inner.1.db.apply_batch(batch).unwrap();
+        self.context.db.apply_batch(batch).unwrap();
 
         self.reissue(all_coins, rng).await
     }
 
     pub async fn await_consensus_block_height(&self, block_height: u64) -> u64 {
         loop {
-            match self.inner.1.api.fetch_consensus_block_height().await {
+            match self.context.api.fetch_consensus_block_height().await {
                 Ok(height) if height >= block_height => return height,
                 _ => sleep(Duration::from_millis(100)).await,
             }
@@ -414,8 +410,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     }
 
     pub async fn fetch_epoch_history(&self, epoch: u64) -> Result<EpochHistory> {
-        self.inner
-            .1
+        self.context
             .api
             .fetch_epoch_history(epoch)
             .await
@@ -427,8 +422,7 @@ impl Client<UserClientConfig> {
     pub async fn fetch_gateway(&self) -> Result<LightningGateway> {
         // fetch gateway from db
         if let Some(gateway) = self
-            .inner
-            .1
+            .context
             .db
             .get_value(&LightningGatewayKey)
             .expect("DB error")
@@ -437,13 +431,12 @@ impl Client<UserClientConfig> {
         }
 
         // if db is empty, fetch from federation and save to db
-        let gateways = self.inner.1.api.fetch_gateways().await?;
+        let gateways = self.context.api.fetch_gateways().await?;
         if gateways.is_empty() {
             return Err(ClientError::NoGateways);
         };
         let gateway = gateways[0].clone();
-        self.inner
-            .1
+        self.context
             .db
             .insert_entry(&LightningGatewayKey, &gateway)
             .expect("DB error");
@@ -458,7 +451,7 @@ impl Client<UserClientConfig> {
         let mut batch = DbBatch::new();
         let mut tx = TransactionBuilder::default();
 
-        let consensus_height = self.inner.1.api.fetch_consensus_block_height().await?;
+        let consensus_height = self.context.api.fetch_consensus_block_height().await?;
         let absolute_timelock = consensus_height + TIMELOCK;
 
         let contract = self.ln_client().create_outgoing_output(
@@ -478,7 +471,7 @@ impl Client<UserClientConfig> {
         let ln_output = Output::LN(contract);
 
         let coins = self.mint_client().select_coins(ln_output.amount())?;
-        tx.input_coins(coins, &self.inner.1.secp)?;
+        tx.input_coins(coins, &self.context.secp)?;
         tx.output(ln_output);
         let txid = self.submit_tx_with_change(tx, batch, &mut rng).await?;
         let outpoint = OutPoint { txid, out_idx: 0 };
@@ -487,8 +480,7 @@ impl Client<UserClientConfig> {
     }
 
     pub async fn await_outgoing_contract_acceptance(&self, outpoint: OutPoint) -> Result<()> {
-        self.inner
-            .1
+        self.context
             .api
             .await_output_outcome::<OutgoingContractOutcome>(outpoint, Duration::from_secs(30))
             .await
@@ -503,13 +495,13 @@ impl Client<UserClientConfig> {
         mut rng: R,
     ) -> Result<ConfirmedInvoice> {
         let gateway = self.fetch_gateway().await?;
-        let payment_keypair = KeyPair::new(&self.inner.1.secp, &mut rng);
+        let payment_keypair = KeyPair::new(&self.context.secp, &mut rng);
         let raw_payment_secret = payment_keypair.public_key().serialize();
         let payment_hash = bitcoin::secp256k1::hashes::sha256::Hash::hash(&raw_payment_secret);
         let payment_secret = PaymentSecret(raw_payment_secret);
 
         // Temporary lightning node pubkey
-        let (node_secret_key, node_public_key) = self.inner.1.secp.generate_keypair(&mut rng);
+        let (node_secret_key, node_public_key) = self.context.secp.generate_keypair(&mut rng);
 
         // Route hint instructing payer how to route to gateway
         let gateway_route_hint = RouteHint(vec![RouteHintHop {
@@ -533,7 +525,7 @@ impl Client<UserClientConfig> {
         let duration_since_epoch =
             Duration::from_secs_f64(js_sys::Date::new_0().get_time() / 1000.);
 
-        let invoice = InvoiceBuilder::new(network_to_currency(self.inner.0 .0.wallet.network))
+        let invoice = InvoiceBuilder::new(network_to_currency(self.config.0.wallet.network))
             .amount_milli_satoshis(amount.milli_sat)
             .description(description)
             .payment_hash(payment_hash)
@@ -543,8 +535,7 @@ impl Client<UserClientConfig> {
             .payee_pub_key(node_public_key)
             .private_route(gateway_route_hint)
             .build_signed(|hash| {
-                self.inner
-                    .1
+                self.context
                     .secp
                     .sign_ecdsa_recoverable(hash, &node_secret_key)
             })?;
@@ -564,8 +555,7 @@ impl Client<UserClientConfig> {
         // Await acceptance by the federation
         let timeout = std::time::Duration::from_secs(15);
         let outpoint = OutPoint { txid, out_idx: 0 };
-        self.inner
-            .1
+        self.context
             .api
             .await_output_outcome::<OfferId>(outpoint, timeout)
             .await?;
@@ -634,7 +624,7 @@ impl Client<GatewayClientConfig> {
         &self,
         account: &OutgoingContractAccount,
     ) -> Result<PaymentParameters> {
-        let our_pub_key = secp256k1_zkp::XOnlyPublicKey::from_keypair(&self.inner.0.redeem_key);
+        let our_pub_key = secp256k1_zkp::XOnlyPublicKey::from_keypair(&self.config.redeem_key);
 
         if account.contract.gateway_key != our_pub_key {
             return Err(ClientError::NotOurKey);
@@ -659,12 +649,12 @@ impl Client<GatewayClientConfig> {
         let max_fee_percent =
             (max_absolute_fee.milli_sat as f64) / (invoice_amount.milli_sat as f64);
 
-        let consensus_block_height = self.inner.1.api.fetch_consensus_block_height().await?;
+        let consensus_block_height = self.context.api.fetch_consensus_block_height().await?;
         // Calculate max delay taking into account current consensus block height and our safety
         // margin.
         let max_delay = (account.contract.timelock as u64)
             .checked_sub(consensus_block_height)
-            .and_then(|delta| delta.checked_sub(self.inner.0.timelock_delta))
+            .and_then(|delta| delta.checked_sub(self.config.timelock_delta))
             .ok_or(ClientError::TimeoutTooClose)?;
 
         Ok(PaymentParameters {
@@ -680,8 +670,7 @@ impl Client<GatewayClientConfig> {
     /// Note though that extended periods of staying offline will result in loss of funds anyway if
     /// the client can not claim the respective contract in time.
     pub fn save_outgoing_payment(&self, contract: OutgoingContractAccount) {
-        self.inner
-            .1
+        self.context
             .db
             .insert_entry(
                 &OutgoingContractAccountKey(contract.contract.contract_id()),
@@ -692,8 +681,7 @@ impl Client<GatewayClientConfig> {
 
     /// Lists all previously saved transactions that have not been driven to completion so far
     pub fn list_pending_outgoing(&self) -> Vec<OutgoingContractAccount> {
-        self.inner
-            .1
+        self.context
             .db
             .find_by_prefix(&OutgoingContractAccountKeyPrefix)
             .map(|res| res.expect("DB error").1)
@@ -703,8 +691,7 @@ impl Client<GatewayClientConfig> {
     /// Abort payment if our node can't route it
     pub fn abort_outgoing_payment(&self, contract_id: ContractId) {
         // FIXME: implement abort by gateway to give funds back to user prematurely
-        self.inner
-            .1
+        self.context
             .db
             .remove_entry(&OutgoingContractAccountKey(contract_id))
             .expect("DB error");
@@ -733,7 +720,7 @@ impl Client<GatewayClientConfig> {
             batch.append_insert(OutgoingPaymentClaimKey(contract_id), ());
         });
 
-        tx.input(&mut vec![self.inner.0.redeem_key], input);
+        tx.input(&mut vec![self.config.redeem_key], input);
         let txid = self.submit_tx_with_change(tx, batch, rng).await?;
 
         Ok(OutPoint { txid, out_idx: 0 })
@@ -756,10 +743,10 @@ impl Client<GatewayClientConfig> {
         // Inputs
         let mut builder = TransactionBuilder::default();
         let coins = self.mint_client().select_coins(offer.amount)?;
-        builder.input_coins(coins, &self.inner.1.secp)?;
+        builder.input_coins(coins, &self.context.secp)?;
 
         // Outputs
-        let our_pub_key = secp256k1_zkp::XOnlyPublicKey::from_keypair(&self.inner.0.redeem_key);
+        let our_pub_key = secp256k1_zkp::XOnlyPublicKey::from_keypair(&self.config.redeem_key);
         let contract = Contract::Incoming(IncomingContract {
             hash: offer.hash,
             encrypted_preimage: offer.encrypted_preimage.clone(),
@@ -795,7 +782,7 @@ impl Client<GatewayClientConfig> {
 
         // Input claims this contract
         builder.input(
-            &mut vec![self.inner.0.redeem_key],
+            &mut vec![self.config.redeem_key],
             Input::LN(contract_account.claim()),
         );
         let mint_tx_id = self.submit_tx_with_change(builder, batch, rng).await?;
@@ -805,8 +792,7 @@ impl Client<GatewayClientConfig> {
     /// Lists all claim transactions for outgoing contracts that we have submitted but were not part
     /// of the consensus yet.
     pub fn list_pending_claimed_outgoing(&self) -> Vec<ContractId> {
-        self.inner
-            .1
+        self.context
             .db
             .find_by_prefix(&OutgoingPaymentClaimKeyPrefix)
             .map(|res| res.expect("DB error").0 .0)
@@ -816,8 +802,7 @@ impl Client<GatewayClientConfig> {
     /// Wait for a lightning preimage gateway has purchased to be decrypted by the federation
     pub async fn await_preimage_decryption(&self, outpoint: OutPoint) -> Result<Preimage> {
         Ok(self
-            .inner
-            .1
+            .context
             .api
             .await_output_outcome::<Preimage>(outpoint, Duration::from_secs(10))
             .await?)
@@ -831,8 +816,7 @@ impl Client<GatewayClientConfig> {
         contract_id: ContractId,
         outpoint: OutPoint,
     ) -> Result<()> {
-        self.inner
-            .1
+        self.context
             .api
             .await_output_outcome::<OutgoingContractOutcome>(outpoint, Duration::from_secs(10))
             .await?;
@@ -841,8 +825,7 @@ impl Client<GatewayClientConfig> {
         // to fetch the blind signatures for the newly issued tokens, but as long as the
         // federation is honest as a whole they will produce the signatures, so we don't
         // have to worry
-        self.inner
-            .1
+        self.context
             .db
             .remove_entry(&OutgoingPaymentClaimKey(contract_id))
             .expect("DB error");
@@ -859,8 +842,7 @@ impl Client<GatewayClientConfig> {
 
     /// Register this gateway with the federation
     pub async fn register_with_federation(&self, config: LightningGateway) -> Result<()> {
-        self.inner
-            .1
+        self.context
             .api
             .register_gateway(config)
             .await

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -7,7 +7,7 @@ use crate::api::ApiError;
 use crate::ln::db::{OutgoingPaymentKey, OutgoingPaymentKeyPrefix};
 use crate::ln::incoming::IncomingContractAccount;
 use crate::ln::outgoing::{OutgoingContractAccount, OutgoingContractData};
-use crate::utils::OwnedClientContext;
+use crate::utils::ClientContext;
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use fedimint_api::db::batch::BatchTx;
 use fedimint_api::Amount;
@@ -30,7 +30,7 @@ use self::incoming::ConfirmedInvoice;
 
 pub struct LnClient<'c> {
     pub config: &'c LightningModuleClientConfig,
-    pub context: &'c OwnedClientContext,
+    pub context: &'c ClientContext,
 }
 
 #[allow(dead_code)]
@@ -197,7 +197,7 @@ pub enum LnClientError {
 mod tests {
     use crate::api::FederationApi;
     use crate::ln::LnClient;
-    use crate::OwnedClientContext;
+    use crate::ClientContext;
     use async_trait::async_trait;
     use bitcoin::Address;
     use fedimint_api::db::batch::DbBatch;
@@ -292,7 +292,7 @@ mod tests {
     async fn new_mint_and_client() -> (
         Arc<tokio::sync::Mutex<Fed>>,
         LightningModuleClientConfig,
-        OwnedClientContext,
+        ClientContext,
     ) {
         let fed = Arc::new(tokio::sync::Mutex::new(
             FakeFed::<LightningModule, LightningModuleClientConfig>::new(
@@ -306,7 +306,7 @@ mod tests {
         let api = FakeApi { mint: fed.clone() };
         let client_config = fed.lock().await.client_cfg().clone();
 
-        let client_context = OwnedClientContext {
+        let client_context = ClientContext {
             db: Box::new(MemDatabase::new()),
             api: Box::new(api),
             secp: secp256k1_zkp::Secp256k1::new(),

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -7,7 +7,7 @@ use crate::api::ApiError;
 use crate::ln::db::{OutgoingPaymentKey, OutgoingPaymentKeyPrefix};
 use crate::ln::incoming::IncomingContractAccount;
 use crate::ln::outgoing::{OutgoingContractAccount, OutgoingContractData};
-use crate::utils::BorrowedClientContext;
+use crate::utils::OwnedClientContext;
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use fedimint_api::db::batch::BatchTx;
 use fedimint_api::Amount;
@@ -29,7 +29,8 @@ use self::db::ConfirmedInvoiceKey;
 use self::incoming::ConfirmedInvoice;
 
 pub struct LnClient<'c> {
-    pub context: BorrowedClientContext<'c, LightningModuleClientConfig>,
+    pub config: &'c LightningModuleClientConfig,
+    pub context: &'c OwnedClientContext,
 }
 
 #[allow(dead_code)]
@@ -54,7 +55,7 @@ impl<'c> LnClient<'c> {
             Amount::from_msat(contract_amount_msat)
         };
 
-        let user_sk = bitcoin::KeyPair::new(self.context.secp, &mut rng);
+        let user_sk = bitcoin::KeyPair::new(&self.context.secp, &mut rng);
 
         let contract = OutgoingContract {
             hash: *invoice.payment_hash(),
@@ -147,7 +148,7 @@ impl<'c> LnClient<'c> {
             hash: payment_hash,
             encrypted_preimage: EncryptedPreimage::new(
                 payment_secret,
-                &self.context.config.threshold_pub_key,
+                &self.config.threshold_pub_key,
             ),
         })
     }
@@ -290,7 +291,8 @@ mod tests {
 
     async fn new_mint_and_client() -> (
         Arc<tokio::sync::Mutex<Fed>>,
-        OwnedClientContext<LightningModuleClientConfig>,
+        LightningModuleClientConfig,
+        OwnedClientContext,
     ) {
         let fed = Arc::new(tokio::sync::Mutex::new(
             FakeFed::<LightningModule, LightningModuleClientConfig>::new(
@@ -302,24 +304,25 @@ mod tests {
             .await,
         ));
         let api = FakeApi { mint: fed.clone() };
+        let client_config = fed.lock().await.client_cfg().clone();
 
         let client_context = OwnedClientContext {
-            config: fed.lock().await.client_cfg().clone(),
             db: Box::new(MemDatabase::new()),
             api: Box::new(api),
             secp: secp256k1_zkp::Secp256k1::new(),
         };
 
-        (fed, client_context)
+        (fed, client_config, client_context)
     }
 
     #[test_log::test(tokio::test)]
     async fn test_outgoing() {
         let mut rng = rand::thread_rng();
-        let (fed, client_context) = new_mint_and_client().await;
+        let (fed, client_config, client_context) = new_mint_and_client().await;
 
         let client = LnClient {
-            context: client_context.borrow_with_module_config(|x| x),
+            config: &client_config,
+            context: &client_context,
         };
 
         fed.lock().await.set_block_height(1);

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -2,7 +2,7 @@ pub mod db;
 
 use crate::api::ApiError;
 use crate::transaction::TransactionBuilder;
-use crate::utils::OwnedClientContext;
+use crate::utils::ClientContext;
 
 use db::{CoinKey, CoinKeyPrefix, OutputFinalizationKey, OutputFinalizationKeyPrefix};
 use fedimint_api::db::batch::{Accumulator, BatchItem, BatchTx, DbBatch};
@@ -29,7 +29,7 @@ use tracing::{debug, trace, warn};
 /// of the mint type.
 pub struct MintClient<'c> {
     pub config: &'c MintClientConfig,
-    pub context: &'c OwnedClientContext,
+    pub context: &'c ClientContext,
 }
 
 /// Client side representation of one coin in an issuance request that keeps all necessary
@@ -359,7 +359,7 @@ mod tests {
     use crate::api::FederationApi;
 
     use crate::mint::MintClient;
-    use crate::{OwnedClientContext, TransactionBuilder};
+    use crate::{ClientContext, TransactionBuilder};
     use async_trait::async_trait;
     use bitcoin::hashes::Hash;
     use bitcoin::Address;
@@ -451,7 +451,7 @@ mod tests {
     async fn new_mint_and_client() -> (
         Arc<tokio::sync::Mutex<Fed>>,
         MintClientConfig,
-        OwnedClientContext,
+        ClientContext,
     ) {
         let fed = Arc::new(tokio::sync::Mutex::new(
             FakeFed::<Mint, MintClientConfig>::new(
@@ -466,7 +466,7 @@ mod tests {
 
         let client_config = fed.lock().await.client_cfg().clone();
 
-        let client_context = OwnedClientContext {
+        let client_context = ClientContext {
             db: Box::new(MemDatabase::new()),
             api: Box::new(api),
             secp: secp256k1_zkp::Secp256k1::new(),

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -43,7 +43,7 @@ pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_api::Amount, ParseAmoun
         fedimint_api::Amount::from_str_in(s, bitcoin::Denomination::Satoshi)
     }
 }
-pub struct OwnedClientContext {
+pub struct ClientContext {
     pub db: Box<dyn Database>,
     pub api: Box<dyn FederationApi>,
     pub secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -43,36 +43,10 @@ pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_api::Amount, ParseAmoun
         fedimint_api::Amount::from_str_in(s, bitcoin::Denomination::Satoshi)
     }
 }
-
-pub struct BorrowedClientContext<'a, C> {
-    pub config: &'a C,
-    pub db: &'a dyn Database,
-    pub api: &'a dyn FederationApi,
-    pub secp: &'a secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
-}
-
-pub struct OwnedClientContext<C> {
-    pub config: C,
+pub struct OwnedClientContext {
     pub db: Box<dyn Database>,
     pub api: Box<dyn FederationApi>,
     pub secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
-}
-
-impl<CO> OwnedClientContext<CO> {
-    pub fn borrow_with_module_config<'c, CB, F>(
-        &'c self,
-        to_cfg: F,
-    ) -> BorrowedClientContext<'c, CB>
-    where
-        F: FnOnce(&'c CO) -> &'c CB,
-    {
-        BorrowedClientContext {
-            config: to_cfg(&self.config),
-            db: self.db.as_ref(),
-            api: self.api.as_ref(),
-            secp: &self.secp,
-        }
-    }
 }
 
 pub fn network_to_currency(network: Network) -> Currency {

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -1,4 +1,4 @@
-use crate::utils::OwnedClientContext;
+use crate::utils::ClientContext;
 use bitcoin::Address;
 use bitcoin::KeyPair;
 use db::PegInKey;
@@ -21,7 +21,7 @@ mod db;
 /// outputs of the wallet (on-chain) type.
 pub struct WalletClient<'c> {
     pub config: &'c WalletClientConfig,
-    pub context: &'c OwnedClientContext,
+    pub context: &'c ClientContext,
 }
 
 impl<'c> WalletClient<'c> {
@@ -144,7 +144,7 @@ pub enum WalletClientError {
 mod tests {
     use crate::api::FederationApi;
     use crate::wallet::WalletClient;
-    use crate::OwnedClientContext;
+    use crate::ClientContext;
     use async_trait::async_trait;
     use bitcoin::{Address, Txid};
 
@@ -239,7 +239,7 @@ mod tests {
     async fn new_mint_and_client() -> (
         Arc<tokio::sync::Mutex<Fed>>,
         WalletClientConfig,
-        OwnedClientContext,
+        ClientContext,
         FakeBitcoindRpcController,
     ) {
         let btc_rpc = FakeBitcoindRpc::new();
@@ -267,7 +267,7 @@ mod tests {
         let api = FakeApi { _mint: fed.clone() };
         let client_config = fed.lock().await.client_cfg().clone();
 
-        let client = OwnedClientContext {
+        let client = ClientContext {
             db: Box::new(MemDatabase::new()),
             api: Box::new(api),
             secp: secp256k1_zkp::Secp256k1::new(),

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -1,5 +1,6 @@
-use crate::utils::BorrowedClientContext;
-use bitcoin::{Address, KeyPair};
+use crate::utils::OwnedClientContext;
+use bitcoin::Address;
+use bitcoin::KeyPair;
 use db::PegInKey;
 use fedimint_api::db::batch::BatchTx;
 use fedimint_api::Amount;
@@ -19,7 +20,8 @@ mod db;
 /// Federation module client for the Wallet module. It can both create transaction inputs and
 /// outputs of the wallet (on-chain) type.
 pub struct WalletClient<'c> {
-    pub context: BorrowedClientContext<'c, WalletClientConfig>,
+    pub config: &'c WalletClientConfig,
+    pub context: &'c OwnedClientContext,
 }
 
 impl<'c> WalletClient<'c> {
@@ -37,19 +39,18 @@ impl<'c> WalletClient<'c> {
         mut batch: BatchTx<'_>,
         mut rng: R,
     ) -> Address {
-        let peg_in_keypair = bitcoin::KeyPair::new(self.context.secp, &mut rng);
+        let peg_in_keypair = bitcoin::KeyPair::new(&self.context.secp, &mut rng);
         let peg_in_pub_key = secp256k1_zkp::XOnlyPublicKey::from_keypair(&peg_in_keypair);
 
         // TODO: check at startup that no bare descriptor is used in config
         // TODO: check if there are other failure cases
         let script = self
-            .context
             .config
             .peg_in_descriptor
-            .tweak(&peg_in_pub_key, self.context.secp)
+            .tweak(&peg_in_pub_key, &self.context.secp)
             .script_pubkey();
         debug!(?script);
-        let address = Address::from_script(&script, self.context.config.network)
+        let address = Address::from_script(&script, self.config.network)
             .expect("Script from descriptor should have an address");
 
         batch.append_insert_new(
@@ -84,7 +85,7 @@ impl<'c> WalletClient<'c> {
             })
             .ok_or(WalletClientError::NoMatchingPegInFound)?;
         let secret_tweak_key =
-            bitcoin::KeyPair::from_seckey_slice(self.context.secp, &secret_tweak_key_bytes)
+            bitcoin::KeyPair::from_seckey_slice(&self.context.secp, &secret_tweak_key_bytes)
                 .expect("sec key was generated and saved by us");
 
         let peg_in_proof = PegInProof::new(
@@ -96,11 +97,11 @@ impl<'c> WalletClient<'c> {
         .map_err(WalletClientError::PegInProofError)?;
 
         peg_in_proof
-            .verify(self.context.secp, &self.context.config.peg_in_descriptor)
+            .verify(&self.context.secp, &self.config.peg_in_descriptor)
             .map_err(WalletClientError::PegInProofError)?;
 
         let amount = Amount::from_sat(peg_in_proof.tx_output().value)
-            .saturating_sub(self.context.config.fee_consensus.peg_in_abs);
+            .saturating_sub(self.config.fee_consensus.peg_in_abs);
         if amount == Amount::ZERO {
             return Err(WalletClientError::PegInAmountTooSmall);
         }
@@ -237,7 +238,8 @@ mod tests {
 
     async fn new_mint_and_client() -> (
         Arc<tokio::sync::Mutex<Fed>>,
-        OwnedClientContext<WalletClientConfig>,
+        WalletClientConfig,
+        OwnedClientContext,
         FakeBitcoindRpcController,
     ) {
         let btc_rpc = FakeBitcoindRpc::new();
@@ -263,22 +265,23 @@ mod tests {
         ));
 
         let api = FakeApi { _mint: fed.clone() };
+        let client_config = fed.lock().await.client_cfg().clone();
 
         let client = OwnedClientContext {
-            config: fed.lock().await.client_cfg().clone(),
             db: Box::new(MemDatabase::new()),
             api: Box::new(api),
             secp: secp256k1_zkp::Secp256k1::new(),
         };
 
-        (fed, client, btc_rpc_controller)
+        (fed, client_config, client, btc_rpc_controller)
     }
 
     #[test_log::test(tokio::test)]
     async fn create_output() {
-        let (fed, client_context, btc_rpc) = new_mint_and_client().await;
+        let (fed, client_config, client_context, btc_rpc) = new_mint_and_client().await;
         let _client = WalletClient {
-            context: client_context.borrow_with_module_config(|x| x),
+            config: &client_config,
+            context: &client_context,
         };
 
         // generate fake UTXO


### PR DESCRIPTION
### What was done
* Remove struct `BorrowedClientContext`
* Rename `OwnedClientContext` to `ClientContext`

### Why
We don't need `BorrowedClientContext` as we can just borrow the entirety of `OwnedClientContext` (renamed to `ClientContext`) if we held the config externally.