### PR TITLE
Add validate command to cli

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -167,7 +167,10 @@ async fn main() {
             info!(%id, "Started reissuance, please fetch the result later");
         }
         Command::Validate { coins } => {
-            client.validate_tokens(coins).await.expect("Invalid tokens");
+            client
+                .validate_tokens(&coins)
+                .await
+                .expect("Invalid tokens");
         }
         Command::Spend { amount } => {
             match client.select_and_spend_coins(amount) {

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -45,6 +45,12 @@ enum Command {
         coins: Coins<SpendableCoin>,
     },
 
+    /// Validate tokens without claiming them (only checks if signatures valid, does not check if nonce unspent)
+    Validate {
+        #[clap(parse(from_str = parse_coins))]
+        coins: Coins<SpendableCoin>,
+    },
+
     /// Prepare coins to send to a third party as a payment
     Spend {
         #[clap(parse(try_from_str = parse_fedimint_amount))]
@@ -159,6 +165,9 @@ async fn main() {
             info!(coins = %coins.amount(), "Starting reissuance transaction");
             let id = client.reissue(coins, &mut rng).await.unwrap();
             info!(%id, "Started reissuance, please fetch the result later");
+        }
+        Command::Validate { coins } => {
+            client.validate_tokens(coins).await.expect("Invalid tokens");
         }
         Command::Spend { amount } => {
             match client.select_and_spend_coins(amount) {

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -167,10 +167,17 @@ async fn main() {
             info!(%id, "Started reissuance, please fetch the result later");
         }
         Command::Validate { coins } => {
-            client
-                .validate_tokens(&coins)
-                .await
-                .expect("Invalid tokens");
+            let validate_result = client.validate_tokens(&coins).await;
+
+            match validate_result {
+                Ok(()) => {
+                    println!("All tokens have valid signatures");
+                }
+                Err(e) => {
+                    println!("Found invalid token: {:?}", e);
+                    std::process::exit(-1);
+                }
+            }
         }
         Command::Spend { amount } => {
             match client.select_and_spend_coins(amount) {

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -234,6 +234,21 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         Ok(OutPoint { txid, out_idx: 0 })
     }
 
+    /// Validate tokens without claiming them. This function checks if signatures are valid
+    /// based on the federation public key. It does not check if the nonce is unspent.
+    pub async fn validate_tokens(&self, coins: Coins<SpendableCoin>) -> Result<()> {
+        let tbs_pks = &self.mint_client().context.config.tbs_pks;
+        if coins
+            .iter()
+            .map(|(amt, coin)| coin.coin.verify(*tbs_pks.tier(&amt).unwrap()))
+            .all(|x| x) {
+                println!("All tokens have valid signatures")
+            } else {
+                println!("Found invalid signature")
+            }
+        Ok(())
+    }
+
     pub async fn pay_for_coins<R: RngCore + CryptoRng>(
         &self,
         coins: Coins<BlindToken>,

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -236,16 +236,17 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
 
     /// Validate tokens without claiming them. This function checks if signatures are valid
     /// based on the federation public key. It does not check if the nonce is unspent.
-    pub async fn validate_tokens(&self, coins: Coins<SpendableCoin>) -> Result<()> {
+    pub async fn validate_tokens(&self, coins: &Coins<SpendableCoin>) -> Result<()> {
         let tbs_pks = &self.mint_client().config.tbs_pks;
         if coins
             .iter()
             .map(|(amt, coin)| coin.coin.verify(*tbs_pks.tier(&amt).unwrap()))
-            .all(|x| x) {
-                println!("All tokens have valid signatures")
-            } else {
-                println!("Found invalid signature")
-            }
+            .all(|x| x)
+        {
+            println!("All tokens have valid signatures")
+        } else {
+            println!("Found invalid signature")
+        }
         Ok(())
     }
 

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -237,7 +237,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     /// Validate tokens without claiming them. This function checks if signatures are valid
     /// based on the federation public key. It does not check if the nonce is unspent.
     pub async fn validate_tokens(&self, coins: Coins<SpendableCoin>) -> Result<()> {
-        let tbs_pks = &self.mint_client().context.config.tbs_pks;
+        let tbs_pks = &self.mint_client().config.tbs_pks;
         if coins
             .iter()
             .map(|(amt, coin)| coin.coin.verify(*tbs_pks.tier(&amt).unwrap()))

--- a/docs/dev-running.md
+++ b/docs/dev-running.md
@@ -56,6 +56,14 @@ $ mint-client-cli spend 400000
 AQAAAAAAAABAQg8AAA...
 ```
 
+The `validate` subcommand checks the validity of the signatures without claiming the tokens. It does not check if the nonce is unspent.
+
+```shell
+$ mint-client-cli validate AQAAAAAAAABAQg8AAA...
+
+All tokens have valid signatures
+```
+
 A receiving client can now reissue these coins to claim them and avoid double spends:
 
 ```shell
@@ -154,17 +162,21 @@ OPTIONS:
     -h, --help    Print help information
 
 SUBCOMMANDS:
+    connect-info      Config enabling client to establish websocket connection to federation
     fetch             Fetch (re-)issued coins and finalize issuance process
     help              Print this message or the help of the given subcommand(s)
     info              Display wallet info (holdings, tiers)
-    ln-pay            Pay a lightning invoice via a gateway
+    join-federation   Join a federation using it's ConnectInfo
     ln-invoice        Create a lightning invoice to receive payment via gateway
+    ln-pay            Pay a lightning invoice via a gateway
     peg-in            Issue tokens in exchange for a peg-in proof (not yet implemented, just
                           creates coins)
     peg-in-address    Generate a new peg-in address, funds sent to it can later be claimed
     peg-out           Withdraw funds from the federation
     reissue           Reissue tokens received from a third party to avoid double spends
     spend             Prepare coins to send to a third party as a payment
-    wait-block-height    Wait for the fed to reach a consensus block height
+    validate          Validate tokens without claiming them (only checks if signatures valid,
+                          does not check if nonce unspent)
+    wait-block-height Wait for the fed to reach a consensus block height
     wait-invoice      Wait for incoming invoice to be paid
 ```

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -15,6 +15,7 @@ start_gateway
 
 # reissue
 TOKENS=$($FM_MINT_CLIENT spend '42000msat')
+$FM_MINT_CLIENT validate $TOKENS
 $FM_MINT_CLIENT reissue $TOKENS
 $FM_MINT_CLIENT fetch
 


### PR DESCRIPTION
Addresses https://github.com/fedimint/fedimint/issues/362

- Created function `validate_tokens` that verifies signatures by calling `Coin::verify` (does not check if nonce spent)
- Update cli with `Validate` command
- Updated readme with expected usage

Example usage:
```
$ mint-client-cli validate AQAAAAAAAABAQg8AAA...

All tokens have valid signatures
```
