### PR TITLE
return results instead of unwraps

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -49,11 +49,7 @@ pub trait FederationApi: Send + Sync {
     async fn fetch_consensus_block_height(&self) -> Result<u64>;
 
     /// Fetch the expected peg-out fees given a peg-out tx
-    async fn fetch_peg_out_fees(
-        &self,
-        address: &Address,
-        amount: &Amount,
-    ) -> Result<Option<PegOutFees>>;
+    async fn fetch_peg_out_fees(&self, address: &Address, amount: &Amount) -> Result<PegOutFees>;
 
     /// Fetch available lightning gateways
     async fn fetch_gateways(&self) -> Result<Vec<LightningGateway>>;
@@ -239,11 +235,7 @@ impl<C: JsonRpcClient + Send + Sync> FederationApi for WsFederationApi<C> {
         self.request("/wallet/block_height", ()).await
     }
 
-    async fn fetch_peg_out_fees(
-        &self,
-        address: &Address,
-        amount: &Amount,
-    ) -> Result<Option<PegOutFees>> {
+    async fn fetch_peg_out_fees(&self, address: &Address, amount: &Amount) -> Result<PegOutFees> {
         self.request("/wallet/peg_out_fees", (address, amount.as_sat()))
             .await
     }

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -270,13 +270,13 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             .context
             .api
             .fetch_peg_out_fees(&recipient, &amount)
-            .await?;
-        fees.map(|fees| PegOut {
+            .await
+            .map_err(|_| ClientError::PegOutWaitingForUTXOs)?;
+        Ok(PegOut {
             recipient,
             amount,
             fees,
         })
-        .ok_or(ClientError::PegOutWaitingForUTXOs)
     }
 
     pub async fn peg_out<R: RngCore + CryptoRng>(

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -272,7 +272,7 @@ mod tests {
             &self,
             _address: &Address,
             _amount: &bitcoin::Amount,
-        ) -> crate::api::Result<Option<PegOutFees>> {
+        ) -> crate::api::Result<PegOutFees> {
             unimplemented!();
         }
 

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -431,7 +431,7 @@ mod tests {
             &self,
             _address: &Address,
             _amount: &bitcoin::Amount,
-        ) -> crate::api::Result<Option<PegOutFees>> {
+        ) -> crate::api::Result<PegOutFees> {
             unimplemented!();
         }
 

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -219,7 +219,7 @@ mod tests {
             &self,
             _address: &Address,
             _amount: &bitcoin::Amount,
-        ) -> crate::api::Result<Option<PegOutFees>> {
+        ) -> crate::api::Result<PegOutFees> {
             unimplemented!();
         }
 


### PR DESCRIPTION
This is a step toward: #451 #416 #374 
I'll start handling unwraps/expects for the the `1.` mentioned [here](https://github.com/fedimint/fedimint/issues/416#issuecomment-1225370000).
My plan is to:
- either handle `unwraps` as errors or turn them into `expects` with a good message
- look at `expects` and decide if they can be handled as errors and if not, look whether the message needs to be improved

##### This PR only covers `unwraps` from `modules/fedimint-wallet/src/lib.rs`
##### Next PR will cover `expects`

### I'll try to refactor the functions to bubble up the errors but might not make a decision on how to handle them finally so this will remain a issue 

I decided to exchange most `Option` for `Result` because they were implicitly treated as results anyway