### PR TITLE
gitignore .direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ln2
 it
 .idea
 .tmpenv
+.direnv


### PR DESCRIPTION
When using `nix-direnv` as [recommended by @dpc](https://discord.com/channels/990354215060795454/992109822055030845/1011755463072817223) I get a `.direnv` file that isn't gitignored