### PR TITLE
Warn users if their local binaries can get in a way

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -400,6 +400,13 @@
                 # auto-install git hooks
                 for hook in misc/git-hooks/* ; do ln -sf "../../$hook" "./.git/hooks/" ; done
                 ${pkgs.git}/bin/git config commit.template misc/git-hooks/commit-template.txt
+
+                # workaround https://github.com/rust-lang/cargo/issues/11020
+                cargo_cmd_bins=( $(ls $HOME/.cargo/bin/cargo-{clippy,add} 2>/dev/null) )
+                if (( ''${#cargo_cmd_bins[@]} != 0 )); then
+                  echo "Warning: Detected binaries that might conflict with reproducible environment: ''${cargo_cmd_bins[@]}" 1>&2
+                  echo "Warning: Considering deleting them. See https://github.com/rust-lang/cargo/issues/11020 for details" 1>&2
+                fi
               '';
             };
 


### PR DESCRIPTION
Upstream cargo issue: https://github.com/rust-lang/cargo/issues/11020