### PR TITLE
Add license and additional manifest fields to cargo.tomls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,17 @@
-[workspace]
+name = "fedimint"
+version = "0.1.0"
+authors = ["The Fedimint Developers"]
+edition = "2018"
+description = "Fedimint is a prototype Federated Chaumian E-Cash Mint implementation, natively compatible with Bitcoin & the Lightning Network. This project is under heavy development, DO NOT USE WITH REAL FUNDS."
+documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
+readme = "README.md"
+homepage = "https://fedimint.org"
+repository = "https://github.com/fedimint/fedimint"
+license = "MIT"
+license-file = "LICENSE"
+keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
+[workspace]
 members = [
     "crypto/tbs",
     "ln-gateway",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 name = "fedimint"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "Fedimint is a prototype Federated Chaumian E-Cash Mint implementation, natively compatible with Bitcoin & the Lightning Network. This project is under heavy development, DO NOT USE WITH REAL FUNDS."
 documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
 readme = "README.md"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mint-client-cli"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "mint-client-cli is a command line interface wrapper for the client library."
 license = "MIT"
 license-file = "../LICENSE"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "mint-client-cli"
 version = "0.1.0"
-edition = "2021"
+authors = ["The Fedimint Developers"]
+edition = "2018"
+description = "mint-client-cli is a command line interface wrapper for the client library."
+license = "MIT"
+license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "mint-client"
 version = "0.1.0"
-authors = ["elsirion <elsirion@protonmail.com>"]
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "mint-client provides a library for sending transactions to the federation."
+license = "MIT"
+license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "mint_client"
 path = "src/lib.rs"
+
 
 [dependencies]
 anyhow = "1.0.58"

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mint-client"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "mint-client provides a library for sending transactions to the federation."
 license = "MIT"
 license-file = "../LICENSE"

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "clientd"
 version = "0.1.0"
-edition = "2021"
+authors = ["The Fedimint Developers"]
+edition = "2018"
+description = "clientd is the root client process for client-lib subprocesses to send/receive transactions."
+license = "MIT"
+license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clientd"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "clientd is the root client process for client-lib subprocesses to send/receive transactions."
 license = "MIT"
 license-file = "../LICENSE"

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tbs"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "tbs is a helper cryptography library for threshold blind signatures"
 license = "MIT"
 license-file = "../../LICENSE"

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "tbs"
 version = "0.1.0"
-authors = ["elsirion <elsirion@protonmail.com>"]
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "tbs is a helper cryptography library for threshold blind signatures"
+license = "MIT"
+license-file = "../../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-api"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "fedimint-api provides the common serialization and database representations for communication between crates"
 license = "MIT"
 license-file = "../LICENSE"

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "fedimint-api"
 version = "0.1.0"
-authors = ["elsirion <elsirion@protonmail.com>"]
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "fedimint-api provides the common serialization and database representations for communication between crates"
+license = "MIT"
+license-file = "../LICENSE"
 
 [lib]
 name = "fedimint_api"

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-core"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "fedimint-core provides common code used by both client and server. Can't be in fedimint-api because it depends on modules."
 license = "MIT"
 license-file = "../LICENSE"

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "fedimint-core"
-version = "0.0.0"
-edition = "2021"
+version = "0.1.0"
+authors = ["The Fedimint Developers"]
+edition = "2018"
+description = "fedimint-core provides common code used by both client and server. Can't be in fedimint-api because it depends on modules."
+license = "MIT"
+license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "fedimint-derive"
 version = "0.1.0"
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "fedimint-derive provides helper macros for serialization."
+license = "MIT"
+license-file = "../LICENSE"
 
 [lib]
 proc-macro = true

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-derive"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "fedimint-derive provides helper macros for serialization."
 license = "MIT"
 license-file = "../LICENSE"

--- a/fedimint/Cargo.toml
+++ b/fedimint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "fedimint is the main consensus code for processing transactions and REST API"
 license = "MIT"
 license-file = "../LICENSE"

--- a/fedimint/Cargo.toml
+++ b/fedimint/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "fedimint"
 version = "0.1.0"
-authors = ["elsirion <elsirion@protonmail.com>"]
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "fedimint is the main consensus code for processing transactions and REST API"
+license = "MIT"
+license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "fedimint-tests"
 version = "0.1.0"
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "integrationtests contains end-to-end testing with interactions between users, lightning gateways, the blockchain, and federations, under expected, edge-case, and adversarial environments. See README for detailed instructions and examples."
+license = "MIT"
+license-file = "../LICENSE"
 
 [[test]]
 name = "fedimint-tests"

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-tests"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "integrationtests contains end-to-end testing with interactions between users, lightning gateways, the blockchain, and federations, under expected, edge-case, and adversarial environments. See README for detailed instructions and examples."
 license = "MIT"
 license-file = "../LICENSE"

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ln-gateway"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "ln-gateway is a core lightning plugin which allows a Lightning node operator to receive or pay Lightning invoices on behalf of fedimint users."
 license = "MIT"
 license-file = "../LICENSE"

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "ln-gateway"
 version = "0.1.0"
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "ln-gateway is a core lightning plugin which allows a Lightning node operator to receive or pay Lightning invoices on behalf of fedimint users."
+license = "MIT"
+license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/modules/fedimint-ln/Cargo.toml
+++ b/modules/fedimint-ln/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-ln"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
 license = "MIT"
 license-file = "../../LICENSE"

--- a/modules/fedimint-ln/Cargo.toml
+++ b/modules/fedimint-ln/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "fedimint-ln"
 version = "0.1.0"
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "fedimint-ln is a lightning payment service module."
+license = "MIT"
+license-file = "../../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/modules/fedimint-mint/Cargo.toml
+++ b/modules/fedimint-mint/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "fedimint-mint"
 version = "0.1.0"
-authors = ["elsirion <elsirion@protonmail.com>"]
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "fedimint-mint is a chaumian ecash mint module."
+license = "MIT"
+license-file = "../../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/modules/fedimint-mint/Cargo.toml
+++ b/modules/fedimint-mint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-mint"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
 license = "MIT"
 license-file = "../../LICENSE"

--- a/modules/fedimint-wallet/Cargo.toml
+++ b/modules/fedimint-wallet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-wallet"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
-edition = "2018"
+edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
 license = "MIT"
 license-file = "../../LICENSE"

--- a/modules/fedimint-wallet/Cargo.toml
+++ b/modules/fedimint-wallet/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "fedimint-wallet"
 version = "0.1.0"
-authors = ["elsirion <elsirion@protonmail.com>"]
+authors = ["The Fedimint Developers"]
 edition = "2018"
+description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
+license = "MIT"
+license-file = "../../LICENSE"
 
 [lib]
 name = "fedimint_wallet"


### PR DESCRIPTION
Updated per recommendations in #450 

2018->2021 edition jump across all cargo.tomls is a separate commit, can remove if this is a problem.

Changed authors to "The Fedimint Developers"
Added descriptions.
Added License="MIT" and path to LICENSE.md file
Changed all lib/bin versioning to 0.1.0