### PR TITLE
clientd: spend endpoint and some imporovements

### DIFF
--- a/client/clientd/src/bin/clientd-cli.rs
+++ b/client/clientd/src/bin/clientd-cli.rs
@@ -72,9 +72,9 @@ fn print_response(response: Result<serde_json::Value>, raw: bool) {
     match response {
         Ok(json) => {
             if raw {
-                println!("{}", serde_json::to_string(&json).unwrap());
+                serde_json::to_writer(std::io::stdout(), &json).unwrap();
             } else {
-                println!("{}", serde_json::to_string_pretty(&json).unwrap());
+                serde_json::to_writer_pretty(std::io::stdout(), &json).unwrap();
             }
         }
         Err(err) => eprintln!("{}", err),

--- a/client/clientd/src/bin/clientd-cli.rs
+++ b/client/clientd/src/bin/clientd-cli.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use bitcoin::Transaction;
 use clap::{Parser, Subcommand};
-use clientd::{call, PegInPayload, WaitBlockHeightPayload};
-use fedimint_api::module::__reexports::serde_json;
+use clientd::{call, PegInPayload, SpendPayload, WaitBlockHeightPayload};
+use fedimint_api::{module::__reexports::serde_json, Amount};
 use fedimint_core::modules::wallet::txoproof::TxOutProof;
-use mint_client::utils::from_hex;
+use mint_client::utils::{from_hex, parse_fedimint_amount};
 
 #[derive(Parser)]
 #[clap(author, version, about = "a json-rpc cli application")]
@@ -36,6 +36,13 @@ enum Commands {
         #[clap(parse(try_from_str = from_hex))]
         transaction: Transaction,
     },
+    //TODO: Encode coins and/or give option (flag) to get them raw
+    /// rpc-method_ spend()
+    Spend {
+        /// A minimint (ecash) amount
+        #[clap(parse(try_from_str = parse_fedimint_amount))]
+        amount: Amount,
+    },
 }
 #[tokio::main]
 async fn main() {
@@ -64,6 +71,10 @@ async fn main() {
                 transaction,
             };
             print_response(call(&params, "/peg_in").await, args.raw_json);
+        }
+        Commands::Spend { amount } => {
+            let params = SpendPayload { amount };
+            print_response(call(&params, "/spend").await, args.raw_json);
         }
     }
 }

--- a/client/clientd/src/lib.rs
+++ b/client/clientd/src/lib.rs
@@ -44,6 +44,11 @@ pub struct PegInPayload {
 }
 
 #[derive(Deserialize, Serialize)]
+pub struct SpendPayload {
+    pub amount: Amount,
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct InfoResponse {
     coins: Vec<CoinsByTier>,
     pending: PendingResponse,
@@ -96,6 +101,11 @@ pub struct PegInAddressResponse {
 #[derive(Deserialize, Serialize)]
 pub struct PegInOutResponse {
     pub txid: TransactionId,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct SpendResponse {
+    pub coins: Coins<SpendableCoin>,
 }
 
 /// Holds a e-cash tier (msat by convention) and a quantity of coins

--- a/client/clientd/src/lib.rs
+++ b/client/clientd/src/lib.rs
@@ -165,3 +165,25 @@ where
         }
     }
 }
+
+#[macro_export(local_inner_macros)]
+macro_rules! json_success {
+    () => {
+        {
+       let body = serde_json::json!({
+            "data": {}
+       });
+
+       Ok(axum::Json(body))
+        }
+    };
+    ($payload:expr) => {
+        {
+       let body = serde_json::json!({
+            "data": $payload
+       });
+
+       Ok(axum::Json(body))
+    }
+    };
+}

--- a/client/clientd/src/lib.rs
+++ b/client/clientd/src/lib.rs
@@ -21,12 +21,17 @@ use thiserror::Error;
 pub enum ClientdError {
     #[error("Client error: {0}")]
     ClientError(#[from] ClientError),
+    #[error("Fatal server error, action reqired")]
+    ServerError,
 }
 
 impl IntoResponse for ClientdError {
     fn into_response(self) -> Response {
         let payload = json!({ "error": self.to_string(), });
-        let code = StatusCode::BAD_REQUEST;
+        let code = match self {
+            ClientdError::ClientError(_) => StatusCode::BAD_REQUEST,
+            ClientdError::ServerError => StatusCode::INTERNAL_SERVER_ERROR,
+        };
         Result::<(), _>::Err((code, axum::Json(payload))).into_response()
     }
 }

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -132,7 +132,10 @@ async fn peg_in(
     let transaction = payload.0.transaction;
     let txid = client.peg_in(txout_proof, transaction, &mut rng).await?;
     info!("Started peg-in {}", txid.to_hex());
-    fetch_signal.send(()).await.unwrap(); //TODO: handle 500 server error
+    fetch_signal
+        .send(())
+        .await
+        .map_err(|_| ClientdError::ServerError)?;
     json_success!(PegInOutResponse { txid })
 }
 

--- a/scripts/clientd-tests.sh
+++ b/scripts/clientd-tests.sh
@@ -7,6 +7,10 @@ export RUST_LOG=info
 source ./scripts/setup-tests.sh
 ./scripts/start-fed.sh
 
+#this is a workaround to test the spend command (because we can't fetch with clientd yet)
+#TODO: remove this when implementing clientd fetching
+./scripts/pegin.sh 1000 # peg in user
+
 #start clientd
 $FM_CLIENTD $FM_CFG_DIR &
 echo $! >> $FM_PID_FILE
@@ -31,3 +35,7 @@ TRANSACTION="$($FM_BTC_CLIENT getrawtransaction $TX_ID)"
 
 #perform peg-in
 [[ $($FM_CLIENTD_CLI peg-in $TXOUT_PROOF $TRANSACTION| jq -r 'has("data")') = true ]]
+
+#spend
+ECASH=$($FM_CLIENTD_CLI spend 1000);
+[[ $(echo $ECASH | jq -r 'has("data")') = true ]]

--- a/scripts/clientd-tests.sh
+++ b/scripts/clientd-tests.sh
@@ -13,10 +13,10 @@ echo $! >> $FM_PID_FILE
 await_server_on_port 8081
 
 #### BEGIN TESTS ####
-[[ $($FM_CLIENTD_CLI info | jq -r 'has("coins")') = true ]]
-[[ $($FM_CLIENTD_CLI pending | jq -r 'has("transactions")') = true ]]
-[[ $($FM_CLIENTD_CLI new-peg-in-address | jq -r 'has("peg_in_address")') = true ]]
-ADDR=$($FM_CLIENTD_CLI new-peg-in-address | jq -r '.peg_in_address');
+[[ $($FM_CLIENTD_CLI info | jq -r 'has("data")') = true ]]
+[[ $($FM_CLIENTD_CLI pending | jq -r 'has("data")') = true ]]
+[[ $($FM_CLIENTD_CLI new-peg-in-address | jq -r 'has("data")') = true ]]
+ADDR=$($FM_CLIENTD_CLI new-peg-in-address | jq -r '.data.peg_in_address');
 
 #for peg-in we need the TxOutProof and a Transaction
 TX_ID="$($FM_BTC_CLIENT sendtoaddress $ADDR 0.001)"
@@ -24,10 +24,10 @@ $FM_BTC_CLIENT generatetoaddress 11 "$($FM_BTC_CLIENT getnewaddress)"
 
 #wait until valid (also test the wait-block-height endpoint)
 EXPECTED_BLOCK_HEIGHT="$(( $($FM_BTC_CLIENT getblockchaininfo | jq -r '.blocks') - $(get_finality_delay) ))"
-[[ $($FM_CLIENTD_CLI wait-block-height  $EXPECTED_BLOCK_HEIGHT | jq -r '.') = "done" ]]
+[[ $($FM_CLIENTD_CLI wait-block-height  $EXPECTED_BLOCK_HEIGHT | jq -r '.data') = "done" ]]
 
 TXOUT_PROOF="$($FM_BTC_CLIENT gettxoutproof "[\"$TX_ID\"]")"
 TRANSACTION="$($FM_BTC_CLIENT getrawtransaction $TX_ID)"
 
 #perform peg-in
-[[ $($FM_CLIENTD_CLI peg-in $TXOUT_PROOF $TRANSACTION| jq -r 'has("txid")') = true ]]
+[[ $($FM_CLIENTD_CLI peg-in $TXOUT_PROOF $TRANSACTION| jq -r 'has("data")') = true ]]

--- a/scripts/clientd-tests.sh
+++ b/scripts/clientd-tests.sh
@@ -7,10 +7,6 @@ export RUST_LOG=info
 source ./scripts/setup-tests.sh
 ./scripts/start-fed.sh
 
-#this is a workaround to test the spend command (because we can't fetch with clientd yet)
-#TODO: remove this when implementing clientd fetching
-./scripts/pegin.sh 1000 # peg in user
-
 #start clientd
 $FM_CLIENTD $FM_CFG_DIR &
 echo $! >> $FM_PID_FILE
@@ -36,6 +32,9 @@ TRANSACTION="$($FM_BTC_CLIENT getrawtransaction $TX_ID)"
 #perform peg-in
 [[ $($FM_CLIENTD_CLI peg-in $TXOUT_PROOF $TRANSACTION| jq -r 'has("data")') = true ]]
 
+#until we can check th (peg-in) tx status we just have to sleep to wait for fetch
+#the sleep here is unneccessary high but a I want to be sure to avoid unnecessary CI failure
+sleep 20 
 #spend
 ECASH=$($FM_CLIENTD_CLI spend 1000);
 [[ $(echo $ECASH | jq -r 'has("data")') = true ]]

--- a/scripts/clientd-tests.sh
+++ b/scripts/clientd-tests.sh
@@ -23,7 +23,7 @@ await_server_on_port 8081
 ADDR=$($FM_CLIENTD_CLI new-peg-in-address | jq -r '.data.peg_in_address');
 
 #for peg-in we need the TxOutProof and a Transaction
-TX_ID="$($FM_BTC_CLIENT sendtoaddress $ADDR 0.001)"
+TX_ID="$($FM_BTC_CLIENT sendtoaddress $ADDR 0.00001)"
 $FM_BTC_CLIENT generatetoaddress 11 "$($FM_BTC_CLIENT getnewaddress)"
 
 #wait until valid (also test the wait-block-height endpoint)


### PR DESCRIPTION
### This PR mainly introduces the spend, and fetching functionality for clientd

I also addressed improvement requests and open TODOs from #384 in commits:
- `write json directly to stdout`
- `use macro for success response`
- `add server failure error`

Even though I wanted to keep the PR small I needed the extra stuff to implement the spend endpoint without having to add TODOs/workarounds which I'd need to come back later to.

### **Note for Reviewers**
In case you go through each individual commit, know that I addressed all `//TODO: ..`, in later commits. 
With  exemption of `//TODO: Log event` in the `fetch` function and the `//TODO: Encode coins` in the cli