### PR TITLE
fixed cargo.toml warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,3 @@
-name = "fedimint"
-version = "0.1.0"
-authors = ["The Fedimint Developers"]
-edition = "2021"
-description = "Fedimint is a prototype Federated Chaumian E-Cash Mint implementation, natively compatible with Bitcoin & the Lightning Network. This project is under heavy development, DO NOT USE WITH REAL FUNDS."
-documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
-readme = "README.md"
-homepage = "https://fedimint.org"
-repository = "https://github.com/fedimint/fedimint"
-license = "MIT"
-license-file = "LICENSE"
-keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
-
 [workspace]
 members = [
     "crypto/tbs",
@@ -28,6 +15,19 @@ members = [
     "integrationtests",
 ]
 resolver = "2"
+
+[workspace.metadata]
+name = "fedimint"
+version = "0.1.0"
+authors = ["The Fedimint Developers"]
+edition = "2021"
+description = "Fedimint is a prototype Federated Chaumian E-Cash Mint implementation, natively compatible with Bitcoin & the Lightning Network. This project is under heavy development, DO NOT USE WITH REAL FUNDS."
+documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
+readme = "README.md"
+homepage = "https://fedimint.org"
+repository = "https://github.com/fedimint/fedimint"
+license-file = "LICENSE"
+keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
 [patch.crates-io]
 bitcoin_hashes = { version = "0.10.0", git = 'https://github.com/fedimint/bitcoin_hashes', branch = 'minimint' }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "mint-client-cli is a command line interface wrapper for the client library."
 license = "MIT"
-license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "mint-client provides a library for sending transactions to the federation."
 license = "MIT"
-license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "clientd is the root client process for client-lib subprocesses to send/receive transactions."
 license = "MIT"
-license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "tbs is a helper cryptography library for threshold blind signatures"
 license = "MIT"
-license-file = "../../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-api provides the common serialization and database representations for communication between crates"
 license = "MIT"
-license-file = "../LICENSE"
 
 [lib]
 name = "fedimint_api"

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-core provides common code used by both client and server. Can't be in fedimint-api because it depends on modules."
 license = "MIT"
-license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-derive provides helper macros for serialization."
 license = "MIT"
-license-file = "../LICENSE"
 
 [lib]
 proc-macro = true

--- a/fedimint/Cargo.toml
+++ b/fedimint/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint is the main consensus code for processing transactions and REST API"
 license = "MIT"
-license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "integrationtests contains end-to-end testing with interactions between users, lightning gateways, the blockchain, and federations, under expected, edge-case, and adversarial environments. See README for detailed instructions and examples."
 license = "MIT"
-license-file = "../LICENSE"
 
 [[test]]
 name = "fedimint-tests"

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "ln-gateway is a core lightning plugin which allows a Lightning node operator to receive or pay Lightning invoices on behalf of fedimint users."
 license = "MIT"
-license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/modules/fedimint-ln/Cargo.toml
+++ b/modules/fedimint-ln/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
 license = "MIT"
-license-file = "../../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/modules/fedimint-mint/Cargo.toml
+++ b/modules/fedimint-mint/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
 license = "MIT"
-license-file = "../../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/modules/fedimint-wallet/Cargo.toml
+++ b/modules/fedimint-wallet/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
 license = "MIT"
-license-file = "../../LICENSE"
 
 [lib]
 name = "fedimint_wallet"


### PR DESCRIPTION
Removes the "unused key" warnings by putting the top level metadata into [workspace.metadata].

Removes the "only need license or license-file" warnings: removed the license-file path for all sub-crates (kept license="MIT"), kept license-file path for top level crate linking to the actual LICENSE.md