### PR TITLE
update mini->fedi and links in lifecycle.md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "bitcoin_hashes"
 version = "0.10.0"
-source = "git+https://github.com/fedimint/bitcoin_hashes?branch=minimint#fb2be02f95fac4d21cc8822f4bf63166c7aa8d47"
+source = "git+https://github.com/fedimint/bitcoin_hashes?branch=fedimint#fb2be02f95fac4d21cc8822f4bf63166c7aa8d47"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-bitcoin_hashes = { version = "0.10.0", git = 'https://github.com/fedimint/bitcoin_hashes', branch = 'minimint' }
+bitcoin_hashes = { version = "0.10.0", git = 'https://github.com/fedimint/bitcoin_hashes', branch = 'fedimint' }
 secp256k1-zkp = { git = "https://github.com/fedimint/rust-secp256k1-zkp/", branch = "sanket-pr" }
 cln-plugin = { git = "https://github.com/ElementsProject/lightning", rev = "42783aa" }
 cln-rpc = { git = "https://github.com/ElementsProject/lightning", rev = "42783aa" }

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,6 +1,6 @@
 # What is a transaction
 
-- A [`Transaction`](https://github.com/fedimint/fedimint/blob/master/fedimint-core/src/transaction.rs) Consists of inputs and outputs
+- A [`Transaction`](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint-core/src/transaction.rs#L12) Consists of inputs and outputs
   - Each input and output belongs to a certain module (e.g. Mint, Wallet, …)
   - All inputs have to add up to the same sum as all outputs
 - Also contains a signature

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,11 +1,11 @@
 # What is a transaction
 
-* A [`Transaction`](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint-core/src/transaction.rs#L12-L16) Consists of inputs and outputs
-  * Each input and output belongs to a certain module (e.g. Mint, Wallet, …)
-  * All inputs have to add up to the same sum as all outputs
-* Also contains a signature
-  * Each input has an associated secret/public key pair
-  * The signature is a MuSig2 multi signature with all these input keys signing the entire transaction
+- A [`Transaction`](https://github.com/fedimint/fedimint/blob/master/fedimint-core/src/transaction.rs) Consists of inputs and outputs
+  - Each input and output belongs to a certain module (e.g. Mint, Wallet, …)
+  - All inputs have to add up to the same sum as all outputs
+- Also contains a signature
+  - Each input has an associated secret/public key pair
+  - The signature is a MuSig2 multi signature with all these input keys signing the entire transaction
 
 ```rust
 pub struct Transaction {
@@ -22,19 +22,22 @@ pub enum Input {
 ```
 
 # Transaction Creation
-* [One client module for each federation module](https://github.com/fedimint/fedimint/tree/master/client/client-lib/src)
-* There are specialized user and gateway clients that use these to construct transactions
-* [E.g. deposit](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/client/client-lib/src/clients/user.rs#L103-L125)
+
+- [One client module for each federation module](https://github.com/fedimint/fedimint/tree/master/client/client-lib/src)
+- There are specialized user and gateway clients that use these to construct transactions
+- [E.g. deposit](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/client/client-lib/src/lib.rs#L190)
 
 # Transaction processing
-* [Submit transaction](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint/src/consensus/mod.rs#L92), first validation
-* [Save to DB](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint/src/consensus/mod.rs#L149-L152)
-* [Generate consensus proposal](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint/src/consensus/mod.rs#L294-L335) with all transactions submitted in the meantime
-* [Propose to HBBFT](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint/src/lib.rs#L135-L149)
-* [Process all transactions that were agreed on](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint/src/consensus/mod.rs#L337)
-* [Each input](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint/src/consensus/mod.rs#L348-L379) and output are processed by its respective module, e.g. for the [Mint module](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/modules/minimint-mint/src/lib.rs#L195-L214)
-* Some operations need a second round to submit signature shares, they are submitted via [per-module consensus items](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint-api/src/module/mod.rs#L141-L144) (see also [Generate consensus proposal](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint/src/consensus/mod.rs#L294-L335))
-* These are also [processed by their respective module](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/modules/minimint-mint/src/lib.rs#L120-L135)
+
+- [Submit transaction](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint/src/consensus/mod.rs#L105), first validation
+- [Save to DB](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint/src/consensus/mod.rs#L115)
+- [Generate consensus proposal](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint/src/consensus/mod.rs#L386) with all transactions submitted in the meantime
+- [Propose to HBBFT](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint/src/lib.rs#L132)
+- [Process all transactions that were agreed on](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint/src/consensus/mod.rs#L436)
+- [Each input](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint/src/consensus/mod.rs#L447) and output are processed by its respective module, e.g. for the [Mint module](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/modules/fedimint-mint/src/lib.rs#L194)
+- Some operations need a second round to submit signature shares, they are submitted via [per-module consensus items](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint-api/src/module/mod.rs#L141) (see also [Generate consensus proposal](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint/src/consensus/mod.rs#L386))
+- These are also [processed by their respective module](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/modules/fedimint-mint/src/lib.rs#L119)
 
 # Modules
-* [For more details, look at the docs, they are great (at least for modules)!](https://github.com/fedimint/minimint/blob/563c600287decd47e89e15e29ab478648395f378/minimint-api/src/module/mod.rs#L128-L248)
+
+- [For more details, look at the docs, they are great (at least for modules)!](https://github.com/fedimint/fedimint/blob/a1f57e3c6ff860a9c4a998bf88ebad73ebdb67c9/fedimint-api/src/module/mod.rs#L129)


### PR DESCRIPTION
(rebased to master, squashed commits)

Addresses #429 

Switches bitcoin-hashes, on fedimint fork, minimint -> fedimint branch.
Updates Cargo.lock with fedimint bitcoin-hashes branch.
Updates lifecycle.md links minimint -> fedimint.