### PR TITLE
Cache `cargo doc` of dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,7 +153,8 @@
 
         workspaceDeps = craneLib.buildDepsOnly (commonArgs // {
           src = filterWorkspaceDepsBuildFiles ./.;
-          pname = "fedimint-dependencies";
+          pname = "workspace-deps";
+          buildPhaseCargoCommand = "cargo doc && cargo check --profile release --all-targets && cargo build --profile release --all-targets";
           doCheck = false;
         });
 
@@ -189,11 +190,13 @@
         };
 
         workspaceBuild = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-build";
           cargoArtifacts = workspaceDeps;
           doCheck = false;
         });
 
         workspaceTest = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-test";
           cargoArtifacts = workspaceBuild;
           doCheck = true;
         });
@@ -202,9 +205,10 @@
         # we can't build benches on stable
         # See: https://github.com/ipetkov/crane/issues/64
         workspaceClippy = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-clippy";
           cargoArtifacts = workspaceBuild;
 
-          cargoBuildCommand = "cargo clippy --profile release --lib --bins --tests --examples --workspace -- --deny warnings";
+          cargoBuildCommand = "cargo clippy --profile release --no-deps --lib --bins --tests --examples --workspace -- --deny warnings";
           doInstallCargoArtifacts = false;
           doCheck = false;
         });
@@ -243,6 +247,7 @@
         };
 
         llvmCovWorkspace = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-llvm-cov";
           cargoArtifacts = workspaceDeps;
           # TODO: as things are right now, the integration tests can't run in parallel
           cargoBuildCommand = "mkdir -p $out && env RUST_TEST_THREADS=1 cargo llvm-cov --workspace --lcov --output-path $out/lcov.info";
@@ -251,6 +256,7 @@
         });
 
         workspaceDoc = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-doc";
           cargoArtifacts = workspaceBuild;
           cargoBuildCommand = "env RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links' cargo doc --no-deps --document-private-items && cp -a target/doc $out";
           doCheck = false;


### PR DESCRIPTION
It seems it's possible to not have to rebuild the `workspaceDoc` step
from scratch, by executing `cargo doc` during the step that builds
only dependencies.