### PR TITLE
Defer gateway registration intil the gateway is run

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -242,12 +242,11 @@ impl GatewayTest {
             Default::default(),
         ));
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
-        let server = LnGateway::new(client.clone(), ln_client, sender, receiver, bind_addr)
-            .await
-            .expect("Gateway failed to register with federation");
+        let mut gateway = LnGateway::new(client.clone(), ln_client, sender, receiver, bind_addr);
+        gateway.run().await.expect("Failed to run gateway");
 
         GatewayTest {
-            server,
+            server: gateway,
             keys,
             user,
             client,

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -105,8 +105,6 @@ async fn initialize_gateway(
     let ln_client = Box::new(Mutex::new(ln_client));
 
     LnGateway::new(federation_client, ln_client, sender, receiver, bind_addr)
-        .await
-        .expect("Failed to register with federation")
 }
 
 /// Send message to LnGateway over channel and receive response over onshot channel


### PR DESCRIPTION
To address one of the side effects of creating a new Gateway, this PR proposes deferring gateway registration until when we call `run()` on a gateway instance

Part 1 addressing Issue #481 