### PR TITLE
[Do Not Review] Generic Gateway Instantiation

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -24,7 +24,6 @@ use fedimint_ln::LightningGateway;
 use fedimint_wallet::bitcoincore_rpc;
 use itertools::Itertools;
 use lightning_invoice::Invoice;
-use ln_gateway::GatewayRequest;
 use rand::rngs::OsRng;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
@@ -241,9 +240,8 @@ impl GatewayTest {
             database.clone(),
             Default::default(),
         ));
-        let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
-        let mut gateway = LnGateway::new(client.clone(), ln_client, sender, receiver, bind_addr);
-        gateway.run().await.expect("Failed to run gateway");
+        let mut gateway = LnGateway::new(client.clone(), ln_client);
+        gateway.run(bind_addr).await.expect("Failed to run gateway");
 
         GatewayTest {
             server: gateway,

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -242,12 +242,11 @@ impl GatewayTest {
             Default::default(),
         ));
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
-        let server = LnGateway::new(client.clone(), ln_client, sender, receiver, bind_addr)
-            .await
-            .expect("Gateway failed to register with federation");
+        let mut gateway = LnGateway::new(client.clone(), ln_client, sender, receiver, bind_addr);
+        gateway.run().await.expect("Failed to run gateway");
 
         GatewayTest {
-            server,
+            server: gateway,
             keys,
             user,
             client,

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -105,8 +105,6 @@ async fn initialize_gateway(
     let ln_client = Box::new(Mutex::new(ln_client));
 
     LnGateway::new(federation_client, ln_client, sender, receiver, bind_addr)
-        .await
-        .expect("Failed to register with federation")
 }
 
 /// Send message to LnGateway over channel and receive response over onshot channel


### PR DESCRIPTION
I was recently looking to move a server instantiation side-effect out of gateway instantiation `LnGateway::new()`. What was looking like a simple mod to add an `Option<webserver>` to[ this line](https://github.com/fedimint/fedimint/blob/2a02caab33e97895ccffc24cd2b7eb445f1daa5f/ln-gateway/src/lib.rs#L113), quickly spiraled out of hand the moment I tried to hide webserver messaging channel opening within the `LnGateway` instance.

> Note: Making webserver optional while we are still getting channel (sender, receiver) from outside `LnGateway` is sufficient to move webserver instantiation side-effect out of `LnGateway::new()`, but is not very useful

Currently, [the channel is opened before `LnGateway` instantiation](https://github.com/fedimint/fedimint/blob/2a02caab33e97895ccffc24cd2b7eb445f1daa5f/ln-gateway/src/bin/ln_gateway.rs#L177) so we can[ use the message channel sender to share state](https://github.com/fedimint/fedimint/blob/master/ln-gateway/src/bin/ln_gateway.rs#L179) with a cln-plugin used to [spawn a c-ln rpc we use as ln-client](https://github.com/fedimint/fedimint/blob/master/ln-gateway/src/bin/ln_gateway.rs#L90:L105) within `LnGateway`

### Ideas:
- Generalize basic configs options for initializing a gateway: { 'workdir', 'host', 'port' }, and decouple these from cln-plugin builder
- Hide the message channel sharing between the ln rpc and `LnGateway` webserver : This probably just needs some indirection on how we create and compose Lightning client rpc with the gateway