### PR TITLE
make logging less noisy

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -12,7 +12,7 @@ use jsonrpsee_core::client::ClientT;
 use jsonrpsee_core::Error as JsonRpcError;
 use jsonrpsee_types::error::CallError as RpcCallError;
 use serde::{Deserialize, Serialize};
-use tracing::{error, instrument, warn};
+use tracing::{error, info, instrument};
 
 #[cfg(not(target_family = "wasm"))]
 use jsonrpsee_ws_client::{WsClient, WsClientBuilder};
@@ -303,7 +303,7 @@ impl<C> WsFederationApi<C> {
 }
 
 impl<C: JsonRpcClient> FederationMember<C> {
-    #[instrument(fields(peer = %self.peer_id), skip_all, err)]
+    #[instrument(fields(peer = %self.peer_id), skip_all)]
     pub async fn request<R>(
         &self,
         method: &str,
@@ -321,7 +321,7 @@ impl<C: JsonRpcClient> FederationMember<C> {
             _ => {}
         };
 
-        warn!("web socket not connected, reconnecting");
+        info!("web socket not connected, reconnecting");
 
         drop(rclient);
         let mut wclient = self.client.write().await;

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -461,6 +461,7 @@ impl Client<UserClientConfig> {
             .expect("DB error");
         Ok(gateway)
     }
+
     pub async fn fund_outgoing_ln_contract<R: RngCore + CryptoRng>(
         &self,
         invoice: Invoice,

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -142,7 +142,8 @@ impl TransactionBuilder {
         // move input coins to pending state, awaiting a transaction
         if !self.input_coins.coins.is_empty() {
             batch.append_from_iter(self.input_coins.iter().map(|(amount, coin)| {
-                BatchItem::delete(CoinKey {
+                // maybe_delete because coins might have been received from another user directly
+                BatchItem::maybe_delete(CoinKey {
                     amount,
                     nonce: coin.coin.0.clone(),
                 })

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
-use tracing::{error, trace};
+use tracing::error;
 
 #[derive(Debug, Default, Clone)]
 pub struct MemDatabase {
@@ -66,8 +66,7 @@ impl Database for MemDatabase {
                         .raw_insert_entry(&element.key.to_bytes(), element.value.to_bytes())?
                         .is_some()
                     {
-                        error!("Database replaced element! This should not happen!");
-                        trace!("Problematic key: {:?}", element.key);
+                        error!("Database replaced element! {:?}", element.key);
                     }
                 }
                 BatchItem::InsertElement(element) => {
@@ -75,8 +74,7 @@ impl Database for MemDatabase {
                 }
                 BatchItem::DeleteElement(key) => {
                     if self.raw_remove_entry(&key.to_bytes())?.is_none() {
-                        error!("Database deleted absent element! This should not happen!");
-                        trace!("Problematic key: {:?}", key);
+                        error!("Database deleted absent element! {:?}", key);
                     }
                 }
                 BatchItem::MaybeDeleteElement(key) => {

--- a/fedimint-api/src/db/sled_impl.rs
+++ b/fedimint-api/src/db/sled_impl.rs
@@ -3,7 +3,7 @@ use super::{Database, DecodingError};
 use crate::db::PrefixIter;
 use anyhow::Result;
 use sled::transaction::TransactionError;
-use tracing::{error, trace};
+use tracing::error;
 
 // TODO: maybe make the concrete impl its own crate
 impl Database for sled::Tree {
@@ -42,8 +42,7 @@ impl Database for sled::Tree {
                         if t.insert(element.key.to_bytes(), element.value.to_bytes())?
                             .is_some()
                         {
-                            error!("Database replaced element! This should not happen!");
-                            trace!("Problematic key: {:?}", element.key);
+                            error!("Database replaced element! {:?}", element.key);
                         }
                     }
                     BatchItem::InsertElement(element) => {
@@ -51,8 +50,7 @@ impl Database for sled::Tree {
                     }
                     BatchItem::DeleteElement(key) => {
                         if t.remove(key.to_bytes())?.is_none() {
-                            error!("Database deleted absent element! This should not happen!");
-                            trace!("Problematic key: {:?}", key);
+                            error!("Database deleted absent element! {:?}", key);
                         }
                     }
                     BatchItem::MaybeDeleteElement(key) => {


### PR DESCRIPTION
Fixes #367

Note the `jsonrpsee_core` warnings could be suppressed through the logging level if necessary or maybe by running clientd instead of starting and shutting down the cli.