### PR TITLE
recover from consensus restart

### DIFF
--- a/fedimint/src/config.rs
+++ b/fedimint/src/config.rs
@@ -214,8 +214,14 @@ impl ServerConfig {
         self.identity.into()
     }
 
+    /// how many peers can be evil without breaking consensus
     pub fn max_faulty(&self) -> usize {
         hbbft::util::max_faulty(self.peers.len())
+    }
+
+    /// how many peers are required for consensus
+    pub fn threshold(&self) -> usize {
+        hbbft::util::max_faulty(self.peers.len()) * 2 + 1
     }
 
     pub fn fee_consensus(&self) -> fedimint_core::config::FeeConsensus {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -584,7 +584,9 @@ impl FederationTest {
     pub async fn rejoin_consensus(&self) {
         for server in &self.servers {
             let mut s = server.borrow_mut();
-            s.fedimint.rejoin_consensus().await;
+            s.fedimint
+                .rejoin_consensus(Duration::from_secs(1), &mut rng())
+                .await;
         }
     }
 
@@ -601,10 +603,7 @@ impl FederationTest {
         s.dropped_peers
             .append(&mut consensus.get_consensus_proposal().await.drop_peers);
 
-        s.last_consensus = s
-            .fedimint
-            .run_consensus_epoch(proposal, &mut OsRng::new().unwrap())
-            .await;
+        s.last_consensus = s.fedimint.run_consensus_epoch(proposal, &mut rng()).await;
 
         for outcome in &s.last_consensus {
             consensus.process_consensus_outcome(outcome.clone()).await;

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -9,6 +9,7 @@ use fixtures::{fixtures, rng, sats, secp, sha256};
 use futures::executor::block_on;
 use futures::future::{join_all, Either};
 use threshold_crypto::{SecretKey, SecretKeyShare};
+use tokio::time::timeout;
 
 use crate::fixtures::FederationTest;
 use fedimint::epoch::ConsensusItem;
@@ -666,4 +667,26 @@ async fn rejoin_consensus_single_peer() {
         user.client.await_consensus_block_height(height).await,
         height
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejoin_consensus_threshold_peers() {
+    let (fed, _, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
+    let peer0 = fed.subset_peers(&[0]);
+    let peer1 = fed.subset_peers(&[1]);
+
+    bitcoin.mine_blocks(110);
+    fed.run_consensus_epochs(1).await;
+
+    let rejoin = join_all(vec![
+        Either::Left(async {
+            peer0.rejoin_consensus().await;
+        }),
+        Either::Right(async {
+            peer1.rejoin_consensus().await;
+        }),
+    ]);
+
+    // confirm that the entire federation can rejoin at an epoch
+    timeout(Duration::from_secs(15), rejoin).await.unwrap();
 }

--- a/scripts/reconnect-test.sh
+++ b/scripts/reconnect-test.sh
@@ -7,22 +7,33 @@ export RUST_LOG=info
 source ./scripts/setup-tests.sh
 ./scripts/start-fed.sh
 
+server4=$(tail -4 $FM_PID_FILE | head -1)
+server3=$(tail -3 $FM_PID_FILE | head -1)
 server2=$(tail -2 $FM_PID_FILE | head -1)
 server1=$(tail -1 $FM_PID_FILE | head -1)
 
 mine_blocks 110
 await_block_sync
 
+# FIXME should await a response from all 4 peers instead of this hack
+sleep 5
+
+# test a peer missing out on epochs and needing to rejoin
 kill $server1
-
 mine_blocks 100
 await_block_sync
-
 mine_blocks 100
 await_block_sync
-
 ./scripts/start-fed.sh
+
 # FIXME should await a response from all 4 peers instead of this hack
 sleep 5
 kill $server2
+await_block_sync
+
+# now test what happens if consensus needs to be restarted
+kill $server3
+kill $server4
+./scripts/start-fed.sh
+mine_blocks 100
 await_block_sync


### PR DESCRIPTION
Next step for #320, handles the case where consensus needs to be started due to crashes that affect a large number of peers.

- Upon restart we request the `next_epoch` from all peers (including our own)
    - If a threshold `2f+1` respond with the same epoch, go with that (this is the case when we are all restarting)
    - If not, then consensus is on-going so peers may be on different epochs, wait for them all to respond with a timeout of 1min, then take the `max(next_epoch)` so long as it falls within bounds of the last signed history (within `f+3` epochs) to prevent malicious peers from delaying us too long
   - If that doesn't work then manual intervention is required to determine what to do with the epoch that was only partially saved by consensus