### PR TITLE
fix nix failing due to missing diir

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -287,6 +287,7 @@
           extraDirs = [
             "crypto/tbs"
             "ln-gateway"
+            "client/client-lib"
             "fedimint-api"
             "fedimint-core"
             "fedimint-derive"


### PR DESCRIPTION
Quick fix for failing nix-build on master.