### PR TITLE
Some `scripts/final-checks.sh` fixes

### DIFF
--- a/scripts/final-checks.sh
+++ b/scripts/final-checks.sh
@@ -1,16 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Checks to run before opening a PR, should be run from fedimint source root dir
 # See tests/README.md for information on setting up Bitcoin / Lightning so the integration tests can complete
 
 set -e
 
-cargo fmt --all
-cargo +nightly clippy --fix --lib --bins --tests --examples --workspace --allow-dirty
+cargo clippy --fix --lib --bins --tests --examples --workspace --allow-dirty
 nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes .#lint --command ./misc/git-hooks/pre-commit
 
 export FM_TEST_DISABLE_MOCKS=0
-cargo +nightly test --release
+cargo test --release
 
 if [ "$1" == "nix" ]; then
   nix-shell --run ./scripts/cli-test.sh


### PR DESCRIPTION
* POSIX-compat hashbang (so that it works in NixOS)
* Remove redundant fmt check (pre-commit check already checks it)
* Remove `+nightly` - we're locking on `stable`, it should work and
  it works on my system.