### PR TITLE
Gateway detection and support for internal payments within a Mint

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -14,7 +14,7 @@ use futures::StreamExt;
 use bitcoin::util::key::KeyPair;
 use bitcoin::{secp256k1, Address, Transaction as BitcoinTransaction};
 
-use bitcoin_hashes::Hash;
+use bitcoin_hashes::{sha256, Hash};
 use futures::stream::FuturesUnordered;
 
 use fedimint_api::task::sleep;
@@ -84,8 +84,18 @@ pub type UserClient = Client<UserClientConfig>;
 #[derive(Debug)]
 pub struct PaymentParameters {
     pub max_delay: u64,
+    pub invoice_amount: Amount,
+    pub max_send_amount: Amount,
+    pub payment_hash: sha256::Hash,
+    pub maybe_internal: bool,
+}
+
+impl PaymentParameters {
     // FIXME: change to absolute fee to avoid rounding errors
-    pub max_fee_percent: f64,
+    pub fn max_fee_percent(&self) -> f64 {
+        let max_absolute_fee = self.max_send_amount - self.invoice_amount;
+        (max_absolute_fee.milli_sat as f64) / (self.invoice_amount.milli_sat as f64)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -657,8 +667,6 @@ impl Client<GatewayClientConfig> {
             .map_err(ClientError::LnClientError)
     }
 
-    /// Check if we can claim the contract account and returns the max delay in blocks for how long
-    /// other nodes on the route are allowed to delay the payment.
     pub async fn validate_outgoing_account(
         &self,
         account: &OutgoingContractAccount,
@@ -684,10 +692,6 @@ impl Client<GatewayClientConfig> {
             return Err(ClientError::Underfunded(invoice_amount, account.amount));
         }
 
-        let max_absolute_fee = account.amount - invoice_amount;
-        let max_fee_percent =
-            (max_absolute_fee.milli_sat as f64) / (invoice_amount.milli_sat as f64);
-
         let consensus_block_height = self.context.api.fetch_consensus_block_height().await?;
         // Calculate max delay taking into account current consensus block height and our safety
         // margin.
@@ -698,8 +702,22 @@ impl Client<GatewayClientConfig> {
 
         Ok(PaymentParameters {
             max_delay,
-            max_fee_percent,
+            invoice_amount,
+            max_send_amount: account.amount,
+            payment_hash: *invoice.payment_hash(),
+            maybe_internal: self.is_maybe_internal_payment(&invoice),
         })
+    }
+
+    /// Returns true if the invoice contains us as a routing hint
+    fn is_maybe_internal_payment(&self, invoice: &Invoice) -> bool {
+        let maybe_route_hint_first_id = invoice
+            .route_hints()
+            .first()
+            .and_then(|rh| rh.0.first())
+            .map(|hop| hop.src_node_id);
+
+        Some(self.config().node_pub_key) == maybe_route_hint_first_id
     }
 
     /// Save the details about an outgoing payment the client is about to process. This function has


### PR DESCRIPTION
Enable gateways to detect payments internal to a mint, and resolve these without paying itself (the gateway) over the LN network.

To detecting internal payments when attempting to pay an invoice (outgoing contract), the gateway uses the invoice hash to requests for any existing offer from the gateway. Existence of such an offer indicates that the payment is internal to a gateway, otherwise gateway should treat this invoice as a normal external route.

On detecting an internal payment from an invoice, the gateway attempts to buys the offer and then proceeds to request a decryption of the preimage from the offer it bought. With decrypted preimage, the gateway proceeds to claim the original outgoing contract, thereby collecting fees for it's work facilitating this internal payment.

### Additional:
- If a gateway does not get a decrypted preimage after paying the offer, it can proceed to claw back funds from the offer

Closes #461, Closes #486 