### PR TITLE
upgrade-threshold-crypto-libs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.22.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
@@ -267,15 +267,16 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bls12_381"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a829c821999c06be34de314eaeb7dd1b42be38661178bc26ad47a4eacebdb0f9"
+checksum = "62250ece575fa9b22068b3a8d59586f01d426dd7785522efd97632959e71c986"
 dependencies = [
- "ff 0.11.1",
- "group 0.11.0",
- "pairing 0.21.0",
+ "ff",
+ "group",
+ "pairing",
  "rand_core 0.6.3",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -680,12 +681,12 @@ dependencies = [
  "bitcoin_hashes",
  "fedimint-derive",
  "futures",
- "getrandom 0.2.7",
+ "getrandom",
  "gloo-timers",
  "hex",
  "lightning-invoice",
  "rand 0.6.5",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rocksdb",
  "secp256k1-zkp",
  "serde",
@@ -837,38 +838,13 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b967a3ee6ae993f0094174257d404a5818f58be79d67a1aea1ec8996d28906"
-dependencies = [
- "byteorder",
- "ff_derive",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "ff"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "bitvec",
  "rand_core 0.6.3",
  "subtle",
-]
-
-[[package]]
-name = "ff_derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3776aaf60a45037a9c3cabdd8542b38693acaa3e241ff957181b72579d29feb"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote 1.0.21",
- "syn 1.0.99",
 ]
 
 [[package]]
@@ -905,9 +881,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1029,17 +1005,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
@@ -1047,7 +1012,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1115,23 +1080,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.6.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15be54742789e36f03307c8fdf0621201e1345e94f1387282024178b5e9ec8c"
-dependencies = [
- "ff 0.6.0",
- "rand 0.7.3",
- "rand_xorshift 0.2.0",
-]
-
-[[package]]
-name = "group"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
  "byteorder",
- "ff 0.11.1",
+ "ff",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -1164,7 +1118,7 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 [[package]]
 name = "hbbft"
 version = "0.1.1"
-source = "git+https://github.com/fedimint/hbbft#54370366b58c435cf0963a7467731e218da99370"
+source = "git+https://github.com/jkitman/hbbft?branch=upgrade-threshold-crypto-libs#45bdde7a30dc41b437214239e07d013f79a82300"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1173,7 +1127,7 @@ dependencies = [
  "hex_fmt",
  "init_with",
  "log",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rand_derive",
  "reed-solomon-erasure",
  "serde",
@@ -1765,7 +1719,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -1777,27 +1731,6 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg 1.1.0",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg 1.1.0",
- "num-traits",
 ]
 
 [[package]]
@@ -1905,23 +1838,11 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "pairing"
-version = "0.16.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8290dea210a712682cd65031dc2b34fd132cf2729def3df7ee08f0737ff5ed6"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
- "byteorder",
- "ff 0.6.0",
- "group 0.6.0",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "pairing"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e415e349a3006dd7d9482cdab1c980a845bed1377777d768cb693a44540b42"
-dependencies = [
- "group 0.11.0",
+ "group",
 ]
 
 [[package]]
@@ -2087,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2101,26 +2022,13 @@ dependencies = [
  "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
- "rand_hc 0.1.0",
+ "rand_hc",
  "rand_isaac",
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift 0.1.1",
+ "rand_xorshift",
  "winapi",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -2142,16 +2050,6 @@ checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
  "autocfg 0.1.8",
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2181,20 +2079,11 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
 ]
 
 [[package]]
@@ -2214,15 +2103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 dependencies = [
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2276,15 +2156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2810,8 +2681,8 @@ dependencies = [
  "bincode",
  "bls12_381",
  "clap",
- "ff 0.11.1",
- "group 0.11.0",
+ "ff",
+ "group",
  "hex",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -2900,17 +2771,19 @@ dependencies = [
 [[package]]
 name = "threshold_crypto"
 version = "0.4.0"
-source = "git+https://github.com/fedimint/threshold_crypto#3d2c6ade0c1e4f6dbd412e28d4626f626d12b76f"
+source = "git+https://github.com/elsirion/threshold_crypto?branch=2022-08-upgrade-pairing#59394b770dc957bebd6e0bd1c29d91755fa303ba"
 dependencies = [
+ "bls12_381",
  "byteorder",
- "ff 0.6.0",
- "group 0.6.0",
+ "ff",
+ "group",
  "hex_fmt",
  "log",
- "pairing 0.16.0",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "pairing",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
+ "subtle",
  "thiserror",
  "tiny-keccak",
  "zeroize",
@@ -3313,12 +3186,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -3505,9 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
 ]

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -17,13 +17,13 @@ name = "tbs"
 path = "src/lib.rs"
 
 [dependencies]
-bls12_381 = "0.6.0"
-ff = "0.11.0"
-group = "0.11.0"
+bls12_381 = { version = "0.7.0", features = [ "zeroize", "groups" ] }
+ff = "0.12.0"
+group = "0.12.0"
 hex = "0.4.2"
-rand = "0.8.4"
+rand = "0.8.5"
 rand_chacha = "0.3.1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.104", features = ["derive"] }
 sha3 = "0.9.1"
 
 [dev-dependencies]

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -21,7 +21,7 @@ hex = "0.4.3"
 lightning-invoice = "0.17.0"
 fedimint-derive = { path = "../fedimint-derive" }
 rand = "0.6.0"
-rand07 = { version = "0.7", package = "rand" }
+rand08 = { version = "0.8.5", package = "rand" }
 secp256k1-zkp = { version = "0.6.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
 rocksdb = { version = "0.19.0", optional = true }
 serde = { version = "1.0.118", features = [ "derive" ] }

--- a/fedimint-api/src/rand.rs
+++ b/fedimint-api/src/rand.rs
@@ -1,7 +1,7 @@
-// rand 0.6 -> rand 0.7 adapter
-pub struct Rand07Compat<R: rand::RngCore>(pub R);
+// rand 0.6 -> rand 0.8.5 adapter
+pub struct Rand085Compat<R: rand::RngCore>(pub R);
 
-impl<R: rand::RngCore> rand07::RngCore for Rand07Compat<R> {
+impl<R: rand::RngCore> rand08::RngCore for Rand085Compat<R> {
     fn next_u32(&mut self) -> u32 {
         self.0.next_u32()
     }
@@ -14,9 +14,9 @@ impl<R: rand::RngCore> rand07::RngCore for Rand07Compat<R> {
         self.0.fill_bytes(dest)
     }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand07::Error> {
-        self.0.try_fill_bytes(dest).map_err(rand07::Error::new)
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand08::Error> {
+        self.0.try_fill_bytes(dest).map_err(rand08::Error::new)
     }
 }
 
-impl<R: rand::RngCore + rand::CryptoRng> rand07::CryptoRng for Rand07Compat<R> {}
+impl<R: rand::RngCore + rand::CryptoRng> rand08::CryptoRng for Rand085Compat<R> {}

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -32,5 +32,5 @@ sha3 = "0.9.1"
 tbs = { path = "../crypto/tbs" }
 thiserror = "1.0.23"
 tracing ="0.1.22"
-threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
+threshold_crypto = { git = "https://github.com/elsirion/threshold_crypto", branch = "2022-08-upgrade-pairing" }
 bitcoin_hashes = "0.10.0"

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -184,7 +184,7 @@ impl Decodable for EpochSignatureShare {
 mod tests {
     use crate::epoch::{ConsensusItem, EpochSignatureShare, Sha256};
     use crate::epoch::{EpochHistory, EpochSignature, EpochVerifyError, OutcomeHistory};
-    use fedimint_api::rand::Rand07Compat;
+    use fedimint_api::rand::Rand085Compat;
     use fedimint_api::PeerId;
     use rand::rngs::OsRng;
     use std::collections::HashSet;
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn adds_sig_to_prev_epoch() {
         let rng = OsRng::new().unwrap();
-        let sk_set = SecretKeySet::random(2, &mut Rand07Compat(rng));
+        let sk_set = SecretKeySet::random(2, &mut Rand085Compat(rng));
         let pk_set = sk_set.public_keys();
 
         let epoch0 = history(0, &None, None);

--- a/fedimint/Cargo.toml
+++ b/fedimint/Cargo.toml
@@ -31,7 +31,7 @@ bitcoin = "0.28.1"
 bytes = "1.1.0"
 clap = { version = "3.1.18", features = ["derive"] }
 futures = "0.3.9"
-hbbft = { git = "https://github.com/fedimint/hbbft" }
+hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
 hex = "0.4.2"
 itertools = "0.10.0"
 jsonrpsee = { version = "0.14.0", features = ["ws-server"] }
@@ -59,4 +59,4 @@ tokio-util = { version = "0.6.0", features = [ "codec" ] }
 tracing ="0.1.22"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
 tracing-opentelemetry = { version = "0.17.2", optional = true}
-threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
+threshold_crypto = { git = "https://github.com/elsirion/threshold_crypto", branch = "2022-08-upgrade-pairing" }

--- a/fedimint/src/config.rs
+++ b/fedimint/src/config.rs
@@ -1,4 +1,4 @@
-use fedimint_api::rand::Rand07Compat;
+use fedimint_api::rand::Rand085Compat;
 pub use fedimint_core::config::*;
 
 use crate::net::peers::{ConnectionConfig, NetworkConfig};
@@ -66,10 +66,11 @@ impl GenerateConfig for ServerConfig {
         params: &Self::Params,
         mut rng: impl RngCore + CryptoRng,
     ) -> (BTreeMap<PeerId, Self>, Self::ClientConfig) {
-        let netinfo = hbbft::NetworkInfo::generate_map(peers.to_vec(), &mut Rand07Compat(&mut rng))
-            .expect("Could not generate HBBFT netinfo");
+        let netinfo =
+            hbbft::NetworkInfo::generate_map(peers.to_vec(), &mut Rand085Compat(&mut rng))
+                .expect("Could not generate HBBFT netinfo");
         let epochinfo =
-            hbbft::NetworkInfo::generate_map(peers.to_vec(), &mut Rand07Compat(&mut rng))
+            hbbft::NetworkInfo::generate_map(peers.to_vec(), &mut Rand085Compat(&mut rng))
                 .expect("Could not generate HBBFT netinfo");
 
         let tls_keys = peers

--- a/fedimint/src/lib.rs
+++ b/fedimint/src/lib.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use fedimint_api::rand::Rand07Compat;
+use fedimint_api::rand::Rand085Compat;
 use hbbft::honey_badger::{HoneyBadger, Message};
 use hbbft::{Epoched, NetworkInfo, Target};
 use rand::rngs::OsRng;
@@ -314,7 +314,7 @@ impl FedimintServer {
 
         let step = self
             .hbbft
-            .propose(&proposal.items, &mut Rand07Compat(rng))
+            .propose(&proposal.items, &mut Rand085Compat(rng))
             .expect("HBBFT propose failed");
 
         for msg in step.messages {

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -33,5 +33,5 @@ serde = { version = "1.0.118", features = [ "derive" ] }
 tokio = { version = "1.0.1", features = ["full"] }
 tracing ="0.1.22"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
-hbbft = { git = "https://github.com/fedimint/hbbft" }
-threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
+hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
+threshold_crypto = { git = "https://github.com/elsirion/threshold_crypto", branch = "2022-08-upgrade-pairing" }

--- a/modules/fedimint-ln/Cargo.toml
+++ b/modules/fedimint-ln/Cargo.toml
@@ -23,7 +23,7 @@ lightning-invoice = "0.17.0"
 fedimint-api = { path = "../../fedimint-api" }
 secp256k1 = { version="0.22.1", default-features=false }
 serde = {version = "1.0.130", features = [ "derive" ] }
-threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
+threshold_crypto = { git = "https://github.com/elsirion/threshold_crypto", branch = "2022-08-upgrade-pairing" }
 thiserror = "1.0.23"
 tracing = "0.1.29"
 serde_json = "1.0.82"

--- a/modules/fedimint-ln/src/config.rs
+++ b/modules/fedimint-ln/src/config.rs
@@ -1,5 +1,5 @@
 use fedimint_api::config::GenerateConfig;
-use fedimint_api::rand::Rand07Compat;
+use fedimint_api::rand::Rand085Compat;
 use fedimint_api::PeerId;
 use secp256k1::rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -32,7 +32,7 @@ impl GenerateConfig for LightningModuleConfig {
         rng: impl RngCore + CryptoRng,
     ) -> (BTreeMap<PeerId, Self>, Self::ClientConfig) {
         let threshold = peers.len() - max_evil;
-        let sks = threshold_crypto::SecretKeySet::random(threshold - 1, &mut Rand07Compat(rng));
+        let sks = threshold_crypto::SecretKeySet::random(threshold - 1, &mut Rand085Compat(rng));
         let pks = sks.public_keys();
 
         let server_cfg = peers


### PR DESCRIPTION
Update the `threshold_crypto` related libs.

See also
https://github.com/fedimint/hbbft/pull/7
https://github.com/fedimint/threshold_crypto/pull/3