### PR TITLE
Unify Preimage definition for incoming and outgoing contracts

### DIFF
--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -13,10 +13,10 @@ use fedimint_api::db::batch::BatchTx;
 use fedimint_api::task::timeout;
 use fedimint_api::Amount;
 use fedimint_core::modules::ln::config::LightningModuleClientConfig;
-use fedimint_core::modules::ln::contracts::incoming::{EncryptedPreimage, IncomingContractOffer};
+use fedimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
 use fedimint_core::modules::ln::contracts::outgoing::OutgoingContract;
 use fedimint_core::modules::ln::contracts::{
-    Contract, ContractId, FundedContract, IdentifyableContract,
+    Contract, ContractId, EncryptedPreimage, FundedContract, IdentifyableContract, Preimage,
 };
 use fedimint_core::modules::ln::{
     ContractAccount, ContractInput, ContractOrOfferOutput, ContractOutput, LightningGateway,
@@ -176,7 +176,7 @@ impl<'c> LnClient<'c> {
         &self,
         amount: Amount,
         payment_hash: Sha256Hash,
-        payment_secret: [u8; 32],
+        payment_secret: Preimage,
     ) -> ContractOrOfferOutput {
         ContractOrOfferOutput::Offer(IncomingContractOffer {
             amount,

--- a/client/client-lib/src/ln/outgoing.rs
+++ b/client/client-lib/src/ln/outgoing.rs
@@ -1,7 +1,8 @@
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::Amount;
-use fedimint_core::modules::ln::contracts::outgoing::{OutgoingContract, Preimage};
-use fedimint_core::modules::ln::contracts::IdentifyableContract;
+use fedimint_core::modules::ln::contracts::{
+    outgoing::OutgoingContract, IdentifyableContract, Preimage,
+};
 use fedimint_core::modules::ln::ContractInput;
 
 #[derive(Debug, Encodable, Decodable)]

--- a/fedimint-core/src/outcome.rs
+++ b/fedimint-core/src/outcome.rs
@@ -1,6 +1,7 @@
 use fedimint_api::FederationModule;
-use fedimint_ln::contracts::incoming::{DecryptedPreimage, OfferId, Preimage};
+use fedimint_ln::contracts::incoming::OfferId;
 use fedimint_ln::contracts::{AccountContractOutcome, ContractOutcome, OutgoingContractOutcome};
+use fedimint_ln::contracts::{DecryptedPreimage, Preimage};
 use fedimint_ln::LightningModule;
 use fedimint_mint::SigResponse;
 use fedimint_wallet::{PegOutOutcome, Wallet};
@@ -52,9 +53,7 @@ impl Final for OutputOutcome {
             OutputOutcome::LN(fedimint_ln::OutputOutcome::Contract { outcome, .. }) => {
                 match outcome {
                     ContractOutcome::Account(_) => true,
-                    ContractOutcome::Incoming(
-                        fedimint_ln::contracts::incoming::DecryptedPreimage::Some(_),
-                    ) => true,
+                    ContractOutcome::Incoming(DecryptedPreimage::Some(_)) => true,
                     ContractOutcome::Incoming(_) => false,
                     ContractOutcome::Outgoing(_) => true,
                 }

--- a/integrationtests/tests/fixtures/fake.rs
+++ b/integrationtests/tests/fixtures/fake.rs
@@ -13,8 +13,8 @@ use lightning::ln::PaymentSecret;
 use lightning_invoice::{Currency, Invoice, InvoiceBuilder};
 use rand::rngs::OsRng;
 
-use fedimint::modules::ln::contracts::Preimage;
 use fedimint_api::Amount;
+use fedimint_server::modules::ln::contracts::Preimage;
 use fedimint_wallet::bitcoind::IBitcoindRpc;
 use fedimint_wallet::txoproof::TxOutProof;
 use fedimint_wallet::Feerate;

--- a/integrationtests/tests/fixtures/fake.rs
+++ b/integrationtests/tests/fixtures/fake.rs
@@ -13,6 +13,7 @@ use lightning::ln::PaymentSecret;
 use lightning_invoice::{Currency, Invoice, InvoiceBuilder};
 use rand::rngs::OsRng;
 
+use fedimint::modules::ln::contracts::Preimage;
 use fedimint_api::Amount;
 use fedimint_wallet::bitcoind::IBitcoindRpc;
 use fedimint_wallet::txoproof::TxOutProof;
@@ -23,20 +24,20 @@ use crate::fixtures::{BitcoinTest, LightningTest};
 
 #[derive(Clone, Debug)]
 pub struct FakeLightningTest {
+    pub preimage: Preimage,
     pub gateway_node_pub_key: secp256k1::PublicKey,
     gateway_node_sec_key: secp256k1::SecretKey,
     amount_sent: Arc<Mutex<u64>>,
 }
 
 impl FakeLightningTest {
-    const PREIMAGE: [u8; 32] = [1; 32];
-
     pub fn new() -> Self {
         let ctx = bitcoin::secp256k1::Secp256k1::new();
         let kp = KeyPair::new(&ctx, &mut OsRng::new().unwrap());
         let amount_sent = Arc::new(Mutex::new(0));
 
         FakeLightningTest {
+            preimage: Preimage([1; 32]),
             gateway_node_sec_key: SecretKey::from_keypair(&kp),
             gateway_node_pub_key: PublicKey::from_keypair(&kp),
             amount_sent,
@@ -50,7 +51,7 @@ impl LightningTest for FakeLightningTest {
 
         InvoiceBuilder::new(Currency::Regtest)
             .description("".to_string())
-            .payment_hash(sha256::Hash::hash(&FakeLightningTest::PREIMAGE))
+            .payment_hash(sha256::Hash::hash(&self.preimage.0))
             .current_timestamp()
             .min_final_cltv_expiry(0)
             .payment_secret(PaymentSecret([0; 32]))
@@ -71,11 +72,11 @@ impl LnRpc for FakeLightningTest {
         invoice_str: &str,
         _max_delay: u64,
         _max_fee_percent: f64,
-    ) -> Result<[u8; 32], LightningError> {
+    ) -> Result<Preimage, LightningError> {
         let invoice: Invoice = invoice_str.parse().unwrap();
         *self.amount_sent.lock().unwrap() += invoice.amount_milli_satoshis().unwrap();
 
-        Ok(FakeLightningTest::PREIMAGE)
+        Ok(self.preimage.clone())
     }
 }
 

--- a/integrationtests/tests/fixtures/utils.rs
+++ b/integrationtests/tests/fixtures/utils.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use fedimint_ln::contracts::Preimage;
 use ln_gateway::ln::{LightningError, LnRpc};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -36,7 +37,7 @@ impl LnRpc for LnRpcAdapter {
         invoice_str: &str,
         max_delay: u64,
         max_fee_percent: f64,
-    ) -> Result<[u8; 32], LightningError> {
+    ) -> Result<Preimage, LightningError> {
         self.fail_invoices
             .lock()
             .await

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -133,9 +133,10 @@ async fn htlc_accepted_hook(
 ) -> Result<serde_json::Value, Error> {
     let htlc_accepted: HtlcAccepted = serde_json::from_value(value)?;
     let preimage = gw_rpc(plugin, htlc_accepted).await?;
+    let pk = preimage.to_public_key()?;
     Ok(serde_json::json!({
       "result": "resolve",
-      "payment_key": preimage,
+      "payment_key": pk.to_string(),
     }))
 }
 

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -15,7 +15,6 @@ use futures::Future;
 use mint_client::mint::MintClientError;
 use mint_client::{ClientError, GatewayClient, PaymentParameters};
 use rand::{CryptoRng, RngCore};
-use secp256k1::XOnlyPublicKey;
 use serde::{Deserialize, Deserializer};
 use std::borrow::Cow;
 use std::net::SocketAddr;
@@ -302,11 +301,8 @@ impl LnGateway {
             rand::rngs::OsRng::new().expect("only systems with a randomness source are supported");
 
         debug!("Incoming htlc for payment hash {}", payment_hash);
-        let pk_slice = self
-            .buy_preimage_internal(&payment_hash, &invoice_amount, &mut rng)
-            .await?;
-        let pk = XOnlyPublicKey::from_slice(&pk_slice).expect("Invalid preimage");
-        Ok(Preimage(pk))
+        self.buy_preimage_internal(&payment_hash, &invoice_amount, &mut rng)
+            .await
     }
 
     async fn handle_balance_msg(&self) -> Result<Amount> {

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -9,7 +9,7 @@ use bitcoin::{Address, Transaction};
 use bitcoin_hashes::sha256;
 use cln::HtlcAccepted;
 use fedimint_api::{Amount, OutPoint, TransactionId};
-use fedimint_server::modules::ln::contracts::{Preimage, ContractId};
+use fedimint_server::modules::ln::contracts::{ContractId, Preimage};
 use fedimint_server::modules::wallet::txoproof::TxOutProof;
 use futures::Future;
 use mint_client::mint::MintClientError;

--- a/ln-gateway/src/ln.rs
+++ b/ln-gateway/src/ln.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use async_trait::async_trait;
 use cln_rpc::model::requests::PayRequest;
-use fedimint::modules::ln::contracts::Preimage;
+use fedimint_server::modules::ln::contracts::Preimage;
 use tokio::sync::Mutex;
 use tracing::{debug, instrument};
 

--- a/modules/fedimint-ln/src/contracts/outgoing.rs
+++ b/modules/fedimint-ln/src/contracts/outgoing.rs
@@ -27,10 +27,6 @@ pub struct OutgoingContract {
     pub cancelled: bool,
 }
 
-/// Preimage in the context of [`OutgoingContract`]s
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
-pub struct Preimage(pub [u8; 32]);
-
 impl IdentifyableContract for OutgoingContract {
     fn contract_id(&self) -> ContractId {
         let mut engine = ContractId::engine();

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -1,5 +1,4 @@
-use crate::contracts::incoming::{IncomingContractOffer, PreimageDecryptionShare};
-use crate::contracts::ContractId;
+use crate::contracts::{incoming::IncomingContractOffer, ContractId, PreimageDecryptionShare};
 use crate::{ContractAccount, LightningGateway, OutputOutcome};
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};


### PR DESCRIPTION
We previously have Preimages defined as a `random 32-byte` slice for Outgoing contracts, and as confirmed `XOnlyPubKey` for Incoming contracts.
To have uniform guarantees of validity between Incoming and Outgoing contracts this PR proposes we always define and expect Preimages to be 32 byte data slices, with ready conversion into pub keys when required

closes #605 