### PR TITLE
Link our binaries with `mold` to make it faster

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-apple-darwin]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,7 @@
             perl
             fenix-channel.rustc
             fenix-channel.clippy
+            mold
           ] ++ lib.optionals stdenv.isDarwin [
             libiconv
             darwin.apple_sdk.frameworks.Security


### PR DESCRIPTION
Tested by rebuilding `fedimintd` from scratch after modifing it's main file.

Before:

```
________________________________________________________
Executed in   26.79 secs    fish           external
   usr time  138.53 secs    3.28 millis  138.53 secs
   sys time    2.22 secs    1.08 millis    2.22 secs
```

After:

```
________________________________________________________
Executed in   23.74 secs    fish           external
   usr time  136.10 secs    2.19 millis  136.10 secs
   sys time    1.65 secs    1.75 millis    1.65 secs
```

This includes both compiling `fedimintd` package, and then linking it. Considering that we've building multiple binaries in our CI, it's probably worthwhile.

For `nix develop` users this will be transparent. Users not using it will have to install `mold`, or comment out/delete `.cargo/config.toml`