### PR TITLE
Fix development shell for non POSIX-Compliant default shells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -414,6 +414,9 @@
                 cargo-llvm-cov
                 cargo-udeps
 
+                # This is required to prevent a mangled bash shell in nix develop
+                # see: https://discourse.nixos.org/t/interactive-bash-with-nix-develop-flake/15486
+                (hiPrio pkgs.bashInteractive)
                 tmux
                 tmuxinator
 
@@ -453,6 +456,9 @@
                 clightning-dev
                 jq
                 procps
+                # This is required to prevent a mangled bash shell in nix develop
+                # see: https://discourse.nixos.org/t/interactive-bash-with-nix-develop-flake/15486
+                (hiPrio pkgs.bashInteractive)
                 tmux
                 tmuxinator
 

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -17,8 +17,7 @@ echo "Running in temporary directory $FM_TEST_DIR"
 
 env | sed -En 's/(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
 
-SHELL=$(which bash)
-bash -c "SHELL=$SHELL tmuxinator local"
+SHELL=$(which bash) tmuxinator local
 tmux -L fedimint-dev kill-session -t fedimint-dev || true
 pkill bitcoind
 pkill lightningd

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -17,7 +17,8 @@ echo "Running in temporary directory $FM_TEST_DIR"
 
 env | sed -En 's/(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
 
-tmuxinator local
+export SHELL=$(which bash)
+bash -c "SHELL=$SHELL tmuxinator local"
 tmux -L fedimint-dev kill-session -t fedimint-dev || true
 pkill bitcoind
 pkill lightningd

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -17,7 +17,7 @@ echo "Running in temporary directory $FM_TEST_DIR"
 
 env | sed -En 's/(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
 
-export SHELL=$(which bash)
+SHELL=$(which bash)
 bash -c "SHELL=$SHELL tmuxinator local"
 tmux -L fedimint-dev kill-session -t fedimint-dev || true
 pkill bitcoind


### PR DESCRIPTION
This PR will patch the recently made changes to `tmuxinator.sh` for use with non-POSIX-compliant shells.
Tmuxinator will use the `SHELL` variable by default which breaks `source` compatibility inside tmux