### PR TITLE
Revert "Link our binaries with `mold` to make it faster"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
-
-[target.aarch64-apple-darwin]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,6 @@
             perl
             fenix-channel.rustc
             fenix-channel.clippy
-            mold
           ] ++ lib.optionals stdenv.isDarwin [
             libiconv
             darwin.apple_sdk.frameworks.Security


### PR DESCRIPTION
This reverts commit d1ff166f5d254c95a20d3ad19185c4e78770063c.

Fixes #526