### PR TITLE
Update crane & improve `flake.nix`

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Run cargo doc
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceDoc
 
+      - name: Run cargo audit
+        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceAudit
+
       # `ccov` job will run `cargo test`, so no need to spend time on it here
       # - name: Test workspace
       #   run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#workspaceTest

--- a/flake.lock
+++ b/flake.lock
@@ -9,16 +9,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1660447363,
-        "narHash": "sha256-Y1OtGWEb0bgFlp9YULaiYcgfEoHVIz1NuXwzlFZ/0HE=",
+        "lastModified": 1662608853,
+        "narHash": "sha256-XevBt/KxyRIjFwXIIojZ7kaVOVi14NPTWG1sKeLjLzc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "5548a68f5d4d60a2315ab1232e6fba5528e71dc8",
+        "rev": "2d5e7fbfcee984424fe4ad4b3b077c62d18fe1cf",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
+        "rev": "2d5e7fbfcee984424fe4ad4b3b077c62d18fe1cf",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1662565102,
+        "narHash": "sha256-q5xeKP5yYAVQr+ylDx1aw1b8fUC0Oi/ztqNKlN9Tj5M=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "7f6f544c3916f78d209ebda5de700ca42e2e1089",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
     "crane": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -124,6 +140,7 @@
     },
     "root": {
       "inputs": {
+        "advisory-db": "advisory-db",
         "crane": "crane",
         "fenix": "fenix",
         "flake-compat": "flake-compat_2",

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    crane.url = "github:ipetkov/crane";
+    crane.url = "github:ipetkov/crane?rev=2d5e7fbfcee984424fe4ad4b3b077c62d18fe1cf"; # v0.6
     crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     fenix = {
@@ -209,11 +209,11 @@
         # Note: can't use `cargoClippy` because it implies `--all-targets`, while
         # we can't build benches on stable
         # See: https://github.com/ipetkov/crane/issues/64
-        workspaceClippy = craneLib.cargoBuild (commonArgs // {
+        workspaceClippy = craneLib.cargoClippy (commonArgs // {
           pname = "workspace-clippy";
           cargoArtifacts = workspaceDeps;
 
-          cargoBuildCommand = "cargo clippy --profile release --no-deps --lib --bins --tests --examples --workspace -- --deny warnings";
+          cargoClippyExtraArgs = "--all-targets --no-deps -- --deny warnings";
           doInstallCargoArtifacts = false;
           doCheck = false;
         });

--- a/flake.nix
+++ b/flake.nix
@@ -210,9 +210,6 @@
           doCheck = true;
         });
 
-        # Note: can't use `cargoClippy` because it implies `--all-targets`, while
-        # we can't build benches on stable
-        # See: https://github.com/ipetkov/crane/issues/64
         workspaceClippy = craneLib.cargoClippy (commonArgs // {
           pname = "workspace-clippy";
           cargoArtifacts = workspaceDeps;

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,13 @@
       url = "github:edolstra/flake-compat";
       flake = false;
     };
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, flake-compat, fenix, crane }:
+  outputs = { self, nixpkgs, flake-utils, flake-compat, fenix, crane, advisory-db }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -218,6 +222,11 @@
           doCheck = false;
         });
 
+        workspaceAudit = craneLib.cargoAudit (commonArgs // {
+          pname = "workspace-clippy";
+          inherit advisory-db;
+        });
+
         cliTestReconnect = craneLib.cargoBuild (commonCliTestArgs // {
           cargoArtifacts = workspaceBuild;
           cargoBuildCommand = "patchShebangs ./scripts && ./scripts/reconnect-test.sh";
@@ -380,6 +389,7 @@
           workspaceTest = workspaceTest;
           workspaceDoc = workspaceDoc;
           workspaceCov = workspaceLlvmCov;
+          workspaceAudit = workspaceAudit;
 
           cli-test = {
             reconnect = cliTestReconnect;

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,18 @@
 
         craneLib = crane.lib.${system}.overrideToolchain fenix-toolchain;
 
+        cargo-llvm-cov = craneLib.buildPackage rec {
+          pname = "cargo-llvm-cov";
+          version = "0.4.14";
+          buildInputs = commonArgs.buildInputs;
+
+          src = pkgs.fetchCrate {
+            inherit pname version;
+            sha256 = "sha256-DY5eBSx/PSmKaG7I6scDEbyZQ5hknA/pfl0KjTNqZlo=";
+          };
+          doCheck = false;
+        };
+
         # some extra utilities that cli-tests require
         cliTestsDeps = with pkgs; [
           bc
@@ -166,6 +178,85 @@
           doCheck = false;
         });
 
+        workspaceBuild = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-build";
+          cargoArtifacts = workspaceDeps;
+          doCheck = false;
+        });
+
+        workspaceTest = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-test";
+          cargoBuildCommand = "true";
+          cargoArtifacts = workspaceDeps;
+          doCheck = true;
+        });
+
+        workspaceClippy = craneLib.cargoClippy (commonArgs // {
+          pname = "workspace-clippy";
+          cargoArtifacts = workspaceDeps;
+
+          cargoClippyExtraArgs = "--all-targets --no-deps -- --deny warnings";
+          doInstallCargoArtifacts = false;
+          doCheck = false;
+        });
+
+        workspaceDoc = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-doc";
+          cargoArtifacts = workspaceDeps;
+          cargoBuildCommand = "env RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links' cargo doc --no-deps --document-private-items && cp -a target/doc $out";
+          doCheck = false;
+        });
+
+        workspaceAudit = craneLib.cargoAudit (commonArgs // {
+          pname = "workspace-clippy";
+          inherit advisory-db;
+        });
+
+        # Build only deps, but with llvm-cov so `workspaceCov` can reuse them cached
+        workspaceDepsCov = craneLib.buildDepsOnly (commonArgs // {
+          pname = "workspace-deps-llvm-cov";
+          src = filterWorkspaceDepsBuildFiles ./.;
+          cargoBuildCommand = "cargo llvm-cov --workspace";
+          nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
+          doCheck = false;
+        });
+
+        workspaceCov = craneLib.cargoBuild (commonArgs // {
+          pname = "workspace-llvm-cov";
+          cargoArtifacts = workspaceDepsCov;
+          # TODO: as things are right now, the integration tests can't run in parallel
+          cargoBuildCommand = "mkdir -p $out && env RUST_TEST_THREADS=1 cargo llvm-cov --workspace --lcov --output-path $out/lcov.info";
+          doCheck = false;
+          nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
+        });
+
+        cliTestReconnect = craneLib.cargoBuild (commonCliTestArgs // {
+          cargoArtifacts = workspaceBuild;
+          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/reconnect-test.sh";
+        });
+
+        cliTestLatency = craneLib.cargoBuild (commonCliTestArgs // {
+          cargoArtifacts = workspaceBuild;
+          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/latency-test.sh";
+          doInstallCargoArtifacts = false;
+        });
+
+        cliTestCli = craneLib.cargoBuild (commonCliTestArgs // {
+          cargoArtifacts = workspaceBuild;
+          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/cli-test.sh";
+        });
+
+        cliTestClientd = craneLib.cargoBuild (commonCliTestArgs // {
+          cargoArtifacts = workspaceBuild;
+          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/clientd-tests.sh";
+        });
+
+        cliRustTests = craneLib.cargoBuild (commonCliTestArgs // {
+          cargoArtifacts = workspaceBuild;
+          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/rust-tests.sh";
+        });
+
+
         # a function to define cargo&nix package, listing
         # all the dependencies (as dir) to help limit the
         # amount of things that need to rebuild when some
@@ -196,96 +287,6 @@
             };
           };
         };
-
-        workspaceBuild = craneLib.cargoBuild (commonArgs // {
-          pname = "workspace-build";
-          cargoArtifacts = workspaceDeps;
-          doCheck = false;
-        });
-
-        workspaceTest = craneLib.cargoBuild (commonArgs // {
-          pname = "workspace-test";
-          cargoBuildCommand = "true";
-          cargoArtifacts = workspaceDeps;
-          doCheck = true;
-        });
-
-        workspaceClippy = craneLib.cargoClippy (commonArgs // {
-          pname = "workspace-clippy";
-          cargoArtifacts = workspaceDeps;
-
-          cargoClippyExtraArgs = "--all-targets --no-deps -- --deny warnings";
-          doInstallCargoArtifacts = false;
-          doCheck = false;
-        });
-
-        workspaceAudit = craneLib.cargoAudit (commonArgs // {
-          pname = "workspace-clippy";
-          inherit advisory-db;
-        });
-
-        cliTestReconnect = craneLib.cargoBuild (commonCliTestArgs // {
-          cargoArtifacts = workspaceBuild;
-          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/reconnect-test.sh";
-        });
-
-        cliTestLatency = craneLib.cargoBuild (commonCliTestArgs // {
-          cargoArtifacts = workspaceBuild;
-          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/latency-test.sh";
-          doInstallCargoArtifacts = false;
-        });
-
-        cliTestCli = craneLib.cargoBuild (commonCliTestArgs // {
-          cargoArtifacts = workspaceBuild;
-          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/cli-test.sh";
-        });
-
-        cliTestClientd = craneLib.cargoBuild (commonCliTestArgs // {
-          cargoArtifacts = workspaceBuild;
-          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/clientd-tests.sh";
-        });
-
-        cliRustTests = craneLib.cargoBuild (commonCliTestArgs // {
-          cargoArtifacts = workspaceBuild;
-          cargoBuildCommand = "patchShebangs ./scripts && ./scripts/rust-tests.sh";
-        });
-
-        cargo-llvm-cov = craneLib.buildPackage rec {
-          pname = "cargo-llvm-cov";
-          version = "0.4.14";
-          buildInputs = commonArgs.buildInputs;
-
-          src = pkgs.fetchCrate {
-            inherit pname version;
-            sha256 = "sha256-DY5eBSx/PSmKaG7I6scDEbyZQ5hknA/pfl0KjTNqZlo=";
-          };
-          doCheck = false;
-        };
-
-        # Build only deps, but with llvm-cov so `workspaceCov` can reuse them cached
-        workspaceDepsLlvmCov = craneLib.buildDepsOnly (commonArgs // {
-          pname = "workspace-deps-llvm-cov";
-          src = filterWorkspaceDepsBuildFiles ./.;
-          cargoBuildCommand = "cargo llvm-cov --workspace";
-          nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
-          doCheck = false;
-        });
-
-        workspaceLlvmCov = craneLib.cargoBuild (commonArgs // {
-          pname = "workspace-llvm-cov";
-          cargoArtifacts = workspaceDepsLlvmCov;
-          # TODO: as things are right now, the integration tests can't run in parallel
-          cargoBuildCommand = "mkdir -p $out && env RUST_TEST_THREADS=1 cargo llvm-cov --workspace --lcov --output-path $out/lcov.info";
-          doCheck = false;
-          nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
-        });
-
-        workspaceDoc = craneLib.cargoBuild (commonArgs // {
-          pname = "workspace-doc";
-          cargoArtifacts = workspaceDeps;
-          cargoBuildCommand = "env RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links' cargo doc --no-deps --document-private-items && cp -a target/doc $out";
-          doCheck = false;
-        });
 
         fedimintd = pkg {
           name = "fedimintd";
@@ -380,13 +381,13 @@
           clientd = clientd.package;
           mint-client-cli = mint-client-cli.package;
 
-          deps = workspaceDeps;
-          workspaceBuild = workspaceBuild;
-          workspaceClippy = workspaceClippy;
-          workspaceTest = workspaceTest;
-          workspaceDoc = workspaceDoc;
-          workspaceCov = workspaceLlvmCov;
-          workspaceAudit = workspaceAudit;
+          inherit workspaceDeps
+            workspaceBuild
+            workspaceClippy
+            workspaceTest
+            workspaceDoc
+            workspaceCov
+            workspaceAudit;
 
           cli-test = {
             reconnect = cliTestReconnect;


### PR DESCRIPTION
* [New version of `crane` was released](https://github.com/ipetkov/crane/releases/tag/v0.6.0) so use it, and while at it:
* Pin `crane` from now on
* **Run `cargo-audit`** on every PR
* Clean up a bit

Notably we will want to run `nix flake lock --update-input advisory-db` from time to time, to download latest advisories from RustSec db.