### PR TITLE
Re-enable mold, but not on MacOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,7 @@
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
-[target.aarch64-apple-darwin]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+# mold is currently broken on MacOS
+# [target.aarch64-apple-darwin]
+# linker = "clang"
+# rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-apple-darwin]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,7 @@
             perl
             fenix-channel.rustc
             fenix-channel.clippy
+            mold
           ] ++ lib.optionals stdenv.isDarwin [
             libiconv
             darwin.apple_sdk.frameworks.Security

--- a/flake.nix
+++ b/flake.nix
@@ -132,10 +132,12 @@
             perl
             fenix-channel.rustc
             fenix-channel.clippy
-            mold
           ] ++ lib.optionals stdenv.isDarwin [
             libiconv
             darwin.apple_sdk.frameworks.Security
+          ] ++ lib.optionals (!stdenv.isDarwin) [
+            # mold is currently broken on MacOS
+            mold
           ];
 
           nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
Looking at compile times on some under-powered laptops, I think this change is worthwhile including, and we can just skip MacOS right now.