### PR TITLE
Add `coreutils` to the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -471,6 +471,7 @@
                 (hiPrio pkgs.bashInteractive)
                 tmux
                 tmuxinator
+                coreutils
 
                 fedimintd.package
                 fedimint-tests.package


### PR DESCRIPTION
Since tmuxinator and other scripts are using `sed`,
we probably want these reproducibly set in the shell.