### PR TITLE
Disable Mold on ARM

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -151,8 +151,8 @@
           ] ++ lib.optionals stdenv.isDarwin [
             libiconv
             darwin.apple_sdk.frameworks.Security
-          ] ++ lib.optionals (!stdenv.isDarwin) [
-            # mold is currently broken on MacOS
+          ] ++ lib.optionals (!(stdenv.isAarch64 || stdenv.isDarwin)) [
+            # mold is currently broken on ARM and MacOS
             mold
           ];
 


### PR DESCRIPTION
[It's marked as "broken" on ARM and MacOS](https://github.com/NixOS/nixpkgs/blob/nixos-22.05/pkgs/development/tools/mold/default.nix#L46)

Encountered this setting up a NixOS dev VM on my M1 following [this neat guide](https://github.com/mitchellh/nixos-config).