### PR TITLE
Add basic replit support

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,63 @@
+# Replit support (note: currently broken)
+#
+# # Problem: no support for Nix Flakes
+#
+# I tried manual nix upgrade with `sh <(curl -L https://nixos.org/nix/install) --no-daemon`, and it works.
+# However it is taking a lot of storage, which is scarce. Turns out that by adding `nix` to `replit.nix`
+# We can get a newer version for free (from shared `/nix`) cache.
+#
+# That's kind of the name of the game here - trying to re-use as much as possible from the shared space,
+# so it doesn't count as our own storage, since every replit is getting btrfs 
+#
+# # Problem: low space
+#
+# With default 500M, we can't do anything (other than editing files). With 1GB (on a hacker plan) it seems
+# it might be possible to at least get the `cargo check` working if debug symbols etc. are disabled.
+# See `[env]` section below. Once that works, we could get `rust-analyzer` working (which needs `cargo check`
+# internally)
+#
+# # Problem: bindgen
+#
+# Bindgen doesn't like lack of `nix develop` to set all the env and tooling it needs. After setting:
+# `export LIBCLANG_PATH="$(nix-build '<nixpkgs>' --no-build-output -A llvmPackages_11.libclang.lib)/lib"`
+# The bindgen compiles, but rocksdb doesn't because it tries to link with the hosts's (Ubuntu 20.04) old glibc
+# version. Trying to enforce Nix glibc with `LD_LIBRARY_PATH` leads to problems with compiling C files,
+# which seem to be similiar to describe here: https://hoverbear.org/blog/rust-bindgen-in-nix/
+#
+# It might be possible to get it work, but requires every-increasing complexity.
+#
+# This was a blocker, so I eventually figured out a better way to support flakes.
+#
+# # Problem: `nix develop` too large
+#
+# There's too many depdencies in default shell, so I created a minimal `.#replit` dev shell.
+#
+# With this `bidgen` works.
+run = "nix --extra-experimental-features nix-command --extra-experimental-features flakes develop .#replit -c cargo check"
+hidden = ["target"]
+
+[env]
+CARGO_PROFILE_DEV_CODEGEN_UNITS="8"
+CARGO_PROFILE_DEV_DEBUG="0"
+CARGO_PROFILE_DEV_LTO="false"
+CARGO_PROFILE_DEV_INCREMENTAL="false"
+CARGO_PROFILE_DEV_OPT_LEVEL="s"
+
+[packager]
+language = "rust"
+
+[packager.features]
+packageSearch = true
+
+[languages.rust]
+pattern = "**/*.rs"
+
+[languages.rust.languageServer]
+start = "nix --extra-experimental-features nix-command --extra-experimental-features flakes develop .#replit -c rust-analyzer"
+
+[nix]
+# this must be kept in sync with `nixpkgs` channel in `flake.nix`
+channel = "stable-22_05"
+
+[gitHubImport]
+requiredFiles = [".replit", "replit.nix"]

--- a/fedimint-api/src/db/rocksdb_impl.rs
+++ b/fedimint-api/src/db/rocksdb_impl.rs
@@ -29,7 +29,7 @@ impl Database for rocksdb::OptimisticTransactionDB {
                     let (key_bytes, value_bytes) = res.expect("DB error");
                     key_bytes
                         .starts_with(&prefix)
-                        .then_some((key_bytes, value_bytes))
+                        .then(|| (key_bytes, value_bytes))
                 })
                 .map(|(key_bytes, value_bytes)| (key_bytes.to_vec(), value_bytes.to_vec()))
                 .map(Ok),

--- a/flake.nix
+++ b/flake.nix
@@ -493,6 +493,14 @@
                 pkgs.git
               ];
             };
+
+            replit = pkgs.mkShell {
+              nativeBuildInputs = with pkgs; [
+                pkg-config
+                openssl
+              ];
+              LIBCLANG_PATH = "${pkgs.libclang.lib}/lib/";
+            };
           };
       });
 }

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,16 @@
+{ pkgs }: {
+  deps = [
+    pkgs.gcc
+    pkgs.mold
+    pkgs.rustc
+    pkgs.rustfmt
+    pkgs.cargo
+    pkgs.cargo-edit
+    pkgs.rust-analyzer
+    pkgs.clang
+    pkgs.libclang.lib
+    pkgs.pkg-config
+    pkgs.openssl
+    pkgs.nix
+  ];
+}


### PR DESCRIPTION
It is possible to work on Fedimint in Replit.

Limitations:

* paid version required ($7/mo) to get 1GB of storage
* only `cargo-check` + `rust-analyzer` (hopefully)

I've put details in the comments of `.replit` file.

Status:

* `cargo c` works, so it's possible to see if everything compiles
* rust-analyzer's features like auto-completion, jump to definition, inline error highlighting seem to work as well

It takes good 20 minutes for everything to compile up when initially launched, but it should be usable enough for screen sharing and collaborative work.

![Screenshot from 2022-09-10 23-29-24](https://user-images.githubusercontent.com/9209/189515312-33bb3fd2-0c80-451d-82e8-4c1b48eb3ccd.png)
