### PR TITLE
client-lib: fix failure on API endpoints with standard ports

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -271,7 +271,9 @@ pub trait JsonRpcClient: ClientT + Sized {
 #[async_trait]
 impl JsonRpcClient for WsClient {
     async fn connect(url: &Url) -> std::result::Result<Self, JsonRpcError> {
-        WsClientBuilder::default().build(url).await
+        WsClientBuilder::default()
+            .build(url_to_string_with_default_port(url)) // Hack for default ports, see fn docs
+            .await
     }
 
     fn is_connected(&self) -> bool {
@@ -292,10 +294,18 @@ impl<C> WsFederationApi<C> {
         WsFederationApi {
             members: members
                 .into_iter()
-                .map(|(peer_id, url)| FederationMember {
-                    peer_id,
-                    url,
-                    client: RwLock::new(None),
+                .map(|(peer_id, url)| {
+                    assert!(
+                        url.port_or_known_default().is_some(),
+                        "API client requires a port"
+                    );
+                    assert!(url.host().is_some(), "API client requires a target host");
+
+                    FederationMember {
+                        peer_id,
+                        url,
+                        client: RwLock::new(None),
+                    }
                 })
                 .collect(),
             max_evil,
@@ -350,6 +360,21 @@ impl<C: JsonRpcClient> FederationMember<C> {
             }
         }
     }
+}
+
+/// `jsonrpsee` converts the `Url` to a `&str` internally and then parses it as an `Uri`.
+/// Unfortunately `Url` swallows ports that it considers default ports (e.g. 80 and 443 for HTTP(S))
+/// which makes the `Uri` parsing fail in these cases. This function works around this limitation in
+/// a limited way (not fully standard compliant, but work for our use case).
+fn url_to_string_with_default_port(url: &Url) -> String {
+    format!(
+        "{}://{}:{}{}",
+        url.scheme(),
+        url.host().expect("Asserted on construction"),
+        url.port_or_known_default()
+            .expect("Asserted on construction"),
+        url.path()
+    )
 }
 
 impl<C: JsonRpcClient> WsFederationApi<C> {

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -366,6 +366,8 @@ impl<C: JsonRpcClient> FederationMember<C> {
 /// Unfortunately `Url` swallows ports that it considers default ports (e.g. 80 and 443 for HTTP(S))
 /// which makes the `Uri` parsing fail in these cases. This function works around this limitation in
 /// a limited way (not fully standard compliant, but work for our use case).
+///
+/// See https://github.com/paritytech/jsonrpsee/issues/554#issue-1048646896
 fn url_to_string_with_default_port(url: &Url) -> String {
     format!(
         "{}://{}:{}{}",


### PR DESCRIPTION
Before this change the client fails to connect to WS API endpoints that use standard ports (80 for ws, 443 for wss) due to `Url` trying to be clever.