### PR TITLE
Enable reqwest TLS feature in client lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2446,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -2440,15 +2454,19 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -27,7 +27,7 @@ miniscript = "7.0.0"
 fedimint-core = { path = "../../fedimint-core" }
 fedimint-api = { path = "../../fedimint-api" }
 rand = "0.6.5"
-reqwest = { version = "0.11.0", features = [ "json" ], default-features = false }
+reqwest = { version = "0.11.0", features = [ "json", "rustls-tls" ], default-features = false }
 secp256k1-zkp = { version = "0.6.0", features = [ "serde", "bitcoin_hashes" ] }
 serde = "1.0.118"
 tbs = { path = "../../crypto/tbs" }


### PR DESCRIPTION
Currently TLS connections to the LN GW appear to work using `mint-client-cli` but not the fluttermint android app. I'm not sure why `mint-client-cli` works, we need to explicitly add TLS support imo and this PR does it (maybe some other dep activates it accidentally?). 