### PR TITLE
add api consistency strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "tbs",
  "test-log",
  "thiserror",
+ "threshold_crypto",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/client/cli/src/bin/mint-rpc-client.rs
+++ b/client/cli/src/bin/mint-rpc-client.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use fedimint_api::PeerId;
 use mint_client::api::WsFederationApi;
+use mint_client::query::TrustAllPeers;
 use url::Url;
 
 #[derive(Parser)]
@@ -16,7 +17,7 @@ async fn main() {
     let call = ApiCall::parse();
     let arg: serde_json::Value = serde_json::from_str(&call.arg).unwrap();
     let api = WsFederationApi::new(0, vec![(PeerId::from(0), call.url)]);
-    let response: serde_json::Value = api.request(&call.method, arg).await.unwrap();
+    let response: serde_json::Value = api.request(&call.method, arg, TrustAllPeers).await.unwrap();
     let formatted = serde_json::to_string_pretty(&response).unwrap();
     print!("{}", formatted);
 }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -9,6 +9,7 @@ use fedimint_core::modules::wallet::txoproof::TxOutProof;
 use core::fmt;
 use mint_client::api::{WsFederationApi, WsFederationConnect};
 use mint_client::mint::SpendableNote;
+use mint_client::query::CurrentConsensus;
 use mint_client::utils::{
     from_hex, parse_bitcoin_amount, parse_coins, parse_fedimint_amount, parse_node_pub_key,
     serialize_coins,
@@ -291,10 +292,13 @@ async fn main() {
         let connect_obj: WsFederationConnect = serde_json::from_str(&connect)
             .or_terminate(CliErrorKind::InvalidValue, "invalid connect info");
         let api = WsFederationApi::new(connect_obj.max_evil, connect_obj.members);
-        let cfg: ClientConfig = api.request("/config", ()).await.or_terminate(
-            CliErrorKind::NetworkError,
-            "couldn't download config from peer",
-        );
+        let cfg: ClientConfig = api
+            .request("/config", (), CurrentConsensus::new(connect_obj.max_evil))
+            .await
+            .or_terminate(
+                CliErrorKind::NetworkError,
+                "couldn't download config from peer",
+            );
         let cfg_path = opts.workdir.join("client.json");
         std::fs::create_dir_all(&opts.workdir)
             .or_terminate(CliErrorKind::IOError, "failed to create config directory");

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -37,6 +37,7 @@ jsonrpsee-types = "0.15.1"
 jsonrpsee-core = { version = "0.15.1", features = [ "client" ] }
 serde_json = "1.0.82"
 url = { version = "2.2.2", features = ["serde"] }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 jsonrpsee-ws-client = "0.15.1"

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -378,6 +378,7 @@ mod tests {
     use fedimint_core::transaction::Transaction;
     use futures::executor::block_on;
     use std::sync::Arc;
+    use threshold_crypto::PublicKey;
 
     type Fed = FakeFed<Mint, MintClientConfig>;
 
@@ -442,7 +443,11 @@ mod tests {
             unimplemented!()
         }
 
-        async fn fetch_epoch_history(&self, _epoch: u64) -> crate::api::Result<EpochHistory> {
+        async fn fetch_epoch_history(
+            &self,
+            _epoch: u64,
+            _pk: PublicKey,
+        ) -> crate::api::Result<EpochHistory> {
             unimplemented!()
         }
     }

--- a/client/client-lib/src/query.rs
+++ b/client/client-lib/src/query.rs
@@ -1,0 +1,210 @@
+use crate::api::{FedResponse, Result};
+use crate::ApiError;
+use fedimint_api::PeerId;
+use fedimint_core::epoch::EpochHistory;
+use jsonrpsee_core::Error as JsonRpcError;
+use jsonrpsee_types::error::CallError as RpcCallError;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+use threshold_crypto::PublicKey;
+
+/// Returns a result from the first responding peer
+pub struct TrustAllPeers;
+
+impl<R> QueryStrategy<R> for TrustAllPeers {
+    fn process(&mut self, response: FedResponse<R>) -> QueryStep<R> {
+        let FedResponse { peer: _, result } = response;
+        QueryStep::Finished(result.map_err(ApiError::RpcError))
+    }
+}
+
+/// Returns first epoch with a valid sig, otherwise wait till f+1 agree
+pub struct ValidHistory {
+    epoch_pk: PublicKey,
+    current: CurrentConsensus<EpochHistory>,
+}
+
+impl ValidHistory {
+    pub fn new(epoch_pk: PublicKey, max_evil: usize) -> Self {
+        Self {
+            epoch_pk,
+            current: CurrentConsensus::new(max_evil),
+        }
+    }
+}
+
+impl QueryStrategy<EpochHistory> for ValidHistory {
+    fn process(&mut self, response: FedResponse<EpochHistory>) -> QueryStep<EpochHistory> {
+        let FedResponse { peer, result } = response;
+        match result {
+            Ok(epoch) if epoch.verify_sig(&self.epoch_pk).is_ok() => QueryStep::Finished(Ok(epoch)),
+            result => self.current.process(FedResponse { peer, result }),
+        }
+    }
+}
+
+/// Returns the deduplicated union of f+1 responses
+pub struct UnionResponses<R> {
+    responses: HashSet<PeerId>,
+    results: HashSet<R>,
+    current: CurrentConsensus<Vec<R>>,
+    max_evil: usize,
+}
+
+impl<R> UnionResponses<R> {
+    pub fn new(max_evil: usize) -> Self {
+        Self {
+            responses: HashSet::new(),
+            results: HashSet::new(),
+            current: CurrentConsensus::new(max_evil),
+            max_evil,
+        }
+    }
+}
+
+impl<R: Hash + Eq + Clone> QueryStrategy<Vec<R>> for UnionResponses<R> {
+    fn process(&mut self, response: FedResponse<Vec<R>>) -> QueryStep<Vec<R>> {
+        if let FedResponse {
+            peer,
+            result: Ok(result),
+        } = response
+        {
+            self.results.extend(result.into_iter());
+            self.responses.insert(peer);
+
+            if self.responses.len() > self.max_evil {
+                QueryStep::Finished(Ok(self.results.drain().collect()))
+            } else {
+                QueryStep::Continue
+            }
+        } else {
+            // handle error case using the CurrentConsensus method
+            self.current.process(response)
+        }
+    }
+}
+
+/// Returns when f+1 responses are equal, retrying on 404 errors
+pub struct Retry404<R> {
+    current: CurrentConsensus<R>,
+}
+
+impl<R> Retry404<R> {
+    pub fn new(max_evil: usize) -> Self {
+        Self {
+            current: CurrentConsensus::new(max_evil),
+        }
+    }
+}
+
+impl<R: Hash + Eq + Clone> QueryStrategy<R> for Retry404<R> {
+    fn process(&mut self, response: FedResponse<R>) -> QueryStep<R> {
+        let FedResponse { peer, result } = response;
+        match result {
+            Err(JsonRpcError::Call(RpcCallError::Custom(e))) if e.code() == 404 => {
+                QueryStep::Request(HashSet::from([peer]))
+            }
+            result => self.current.process(FedResponse { peer, result }),
+        }
+    }
+}
+
+/// Returns when f+1 responses are equal, retrying after every 2f+1 responses
+// FIXME: should be replaced by queries for specific epochs in case we cannot get enough responses
+// FIXME: for any single epoch
+pub struct EventuallyConsistent<R> {
+    responses: HashSet<PeerId>,
+    current: CurrentConsensus<R>,
+    max_evil: usize,
+}
+
+impl<R> EventuallyConsistent<R> {
+    pub fn new(max_evil: usize) -> Self {
+        Self {
+            responses: HashSet::new(),
+            current: CurrentConsensus::new(max_evil),
+            max_evil,
+        }
+    }
+}
+
+impl<R: Hash + Eq + Clone> QueryStrategy<R> for EventuallyConsistent<R> {
+    fn process(&mut self, response: FedResponse<R>) -> QueryStep<R> {
+        let honest_threshold = self.max_evil * 2 + 1;
+        self.responses.insert(response.peer);
+
+        match self.current.process(response) {
+            QueryStep::Continue if self.responses.len() == honest_threshold => {
+                let result = QueryStep::Request(self.responses.clone());
+                self.responses.clear();
+                result
+            }
+            result => result,
+        }
+    }
+}
+
+/// Returns when f+1 responses are equal
+pub struct CurrentConsensus<R> {
+    pub results: HashMap<R, HashSet<PeerId>>,
+    pub errors: HashMap<PeerId, JsonRpcError>,
+    max_evil: usize,
+}
+
+impl<R> CurrentConsensus<R> {
+    pub fn new(max_evil: usize) -> Self {
+        Self {
+            results: HashMap::new(),
+            errors: HashMap::new(),
+            max_evil,
+        }
+    }
+}
+
+impl<R: Hash + Eq + Clone> QueryStrategy<R> for CurrentConsensus<R> {
+    fn process(&mut self, response: FedResponse<R>) -> QueryStep<R> {
+        match response {
+            FedResponse {
+                peer,
+                result: Ok(result),
+            } => {
+                let peers = self.results.entry(result).or_insert_with(HashSet::new);
+                peers.insert(peer);
+            }
+            FedResponse {
+                peer,
+                result: Err(error),
+            } => {
+                self.errors.insert(peer, error);
+            }
+        }
+
+        for (result, peers) in self.results.iter() {
+            if peers.len() > self.max_evil {
+                return QueryStep::Finished(Ok(result.clone()));
+            }
+        }
+
+        if self.errors.len() > self.max_evil {
+            let (_, error) = self.errors.drain().next().expect("non-empty");
+            return QueryStep::Finished(Err(ApiError::RpcError(error)));
+        }
+
+        QueryStep::Continue
+    }
+}
+
+pub trait QueryStrategy<R> {
+    fn process(&mut self, response: FedResponse<R>) -> QueryStep<R>;
+}
+
+/// Results from the strategy handling a response from a peer
+///
+/// `Request` sending requests to some of the peers
+/// `Continue` awaiting and handling responses
+/// `Finished` return a final result
+pub enum QueryStep<R> {
+    Request(HashSet<PeerId>),
+    Continue,
+    Finished(Result<R>),
+}

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -170,6 +170,7 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
     use std::time::Duration;
+    use threshold_crypto::PublicKey;
 
     type Fed = FakeFed<Wallet, WalletClientConfig>;
     type SharedFed = Arc<tokio::sync::Mutex<Fed>>;
@@ -231,7 +232,11 @@ mod tests {
             unimplemented!()
         }
 
-        async fn fetch_epoch_history(&self, _epoch: u64) -> crate::api::Result<EpochHistory> {
+        async fn fetch_epoch_history(
+            &self,
+            _epoch: u64,
+            _pk: PublicKey,
+        ) -> crate::api::Result<EpochHistory> {
             unimplemented!()
         }
     }

--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -13,6 +13,7 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha3::digest::generic_array::typenum::U32;
 use sha3::Digest;
+use std::hash::Hasher;
 
 pub use bls12_381::G1Affine as MessagePoint;
 pub use bls12_381::G2Affine as PubKeyPoint;
@@ -67,6 +68,14 @@ impl Message {
     /// **IMPORTANT**: `from_bytes` includes a tag in the hash, this doesn't
     pub fn from_hash(hash: impl Digest<OutputSize = U32>) -> Message {
         Message(hash_to_curve::<G1Projective, _>(hash).to_affine())
+    }
+}
+
+#[allow(clippy::derive_hash_xor_eq)]
+impl std::hash::Hash for AggregatePublicKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let serialized = self.0.to_compressed();
+        state.write(&serialized);
     }
 }
 

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use url::Url;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ClientConfig {
     pub api_endpoints: Vec<Url>,
     pub mint: MintClientConfig,
@@ -25,7 +25,7 @@ impl ClientConfig {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct FeeConsensus {
     pub wallet: fedimint_wallet::config::FeeConsensus,
     pub mint: fedimint_mint::config::FeeConsensus,

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -26,14 +26,14 @@ pub struct EpochSignatureShare(pub SignatureShare);
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct EpochSignature(pub Signature);
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct EpochHistory {
     pub outcome: OutcomeHistory,
     pub hash: Sha256,
     pub signature: Option<EpochSignature>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct OutcomeHistory {
     pub epoch: u64,
     pub last_hash: Option<Sha256>,

--- a/fedimint/src/lib.rs
+++ b/fedimint/src/lib.rs
@@ -211,17 +211,9 @@ impl FedimintServer {
         }
         info!("Rejoining consensus: created outcome");
 
-        // FIXME: Should handle failing and querying other peers
-        loop {
-            match self.download_history(outcomes[0].clone()).await {
-                Ok(_) => {
-                    break;
-                }
-                Err(e) => {
-                    warn!("Download error {:?}", e)
-                }
-            }
-        }
+        self.download_history(outcomes[0].clone())
+            .await
+            .expect("Download error");
     }
 
     /// Requests, verifies and processes history from peers
@@ -240,7 +232,8 @@ impl FedimintServer {
                 let contributions = last_outcome.contributions.clone();
                 EpochHistory::new(last_outcome.epoch, contributions, &prev_epoch)
             } else {
-                let result = self.api.fetch_epoch_history(epoch_num).await;
+                let epoch_pk = self.cfg.epoch_pk_set.public_key();
+                let result = self.api.fetch_epoch_history(epoch_num, epoch_pk).await;
                 result.map_err(|_| EpochVerifyError::MissingPreviousEpoch)?
             };
 

--- a/modules/fedimint-ln/src/config.rs
+++ b/modules/fedimint-ln/src/config.rs
@@ -15,7 +15,7 @@ pub struct LightningModuleConfig {
     pub fee_consensus: FeeConsensus,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct LightningModuleClientConfig {
     pub threshold_pub_key: threshold_crypto::PublicKey,
     pub fee_consensus: FeeConsensus,
@@ -77,7 +77,7 @@ impl GenerateConfig for LightningModuleConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct FeeConsensus {
     pub contract_input: fedimint_api::Amount,
     pub contract_output: fedimint_api::Amount,

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -104,7 +104,7 @@ pub struct ContractOutput {
     pub contract: contracts::Contract,
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize, Clone)]
 pub struct ContractAccount {
     pub amount: fedimint_api::Amount,
     pub contract: contracts::FundedContract,
@@ -121,7 +121,7 @@ pub enum OutputOutcome {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable, PartialEq, Eq, Hash)]
 pub struct LightningGateway {
     pub mint_pub_key: secp256k1::XOnlyPublicKey,
     pub node_pub_key: secp256k1::PublicKey,

--- a/modules/fedimint-mint/src/config.rs
+++ b/modules/fedimint-mint/src/config.rs
@@ -16,7 +16,7 @@ pub struct MintConfig {
     pub threshold: usize,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct MintClientConfig {
     pub tbs_pks: Tiered<AggregatePublicKey>,
     pub fee_consensus: FeeConsensus,
@@ -109,7 +109,7 @@ impl GenerateConfig for MintConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct FeeConsensus {
     pub coin_issuance_abs: fedimint_api::Amount,
     pub coin_spend_abs: fedimint_api::Amount,

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -24,7 +24,7 @@ pub struct WalletConfig {
     pub fee_consensus: FeeConsensus,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct WalletClientConfig {
     /// The federations public peg-in-descriptor
     pub peg_in_descriptor: PegInDescriptor,
@@ -35,7 +35,7 @@ pub struct WalletClientConfig {
     pub fee_consensus: FeeConsensus,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct FeeConsensus {
     pub peg_in_abs: fedimint_api::Amount,
     pub peg_out_abs: fedimint_api::Amount,


### PR DESCRIPTION
API consistency checks to make clients robust against misbehaving peers and move towards removing polling
- Process responses concurrently to defend against non-responding peers
- Move retries behind the API layer to reduce requests, simplify client code, support subscriptions eventually
- Create strategies for consistent API results to defend against peers returning conflicting results

Implemented strategies (all strategies return an error if f+1 peers return errors):
- `TrustAllPeers` Returns a result from the first responding peer
- `ValidHistory` Returns first epoch with a valid sig, otherwise wait till f+1 agree
- `UnionResponses` Returns the deduplicated union of f+1 responses
- `Retry404` Returns when f+1 responses are equal, retrying on 404 errors
- `CurrentConsensus` Returns when f+1 responses are equal
- `EventuallyConsistent` Returns when f+1 responses are equal, retrying after every 2f+1 responses

Fixes #449 and fixes #193
Prerequisite for #231 and #320
Needs a follow-up PR to make `fetch_output_outcome` part of the API #368.
Took some inspiration from @Maan2003 #277