### PR TITLE
minor clientd rectification

### DIFF
--- a/client/clientd/src/bin/clientd-cli.rs
+++ b/client/clientd/src/bin/clientd-cli.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use bitcoin::Transaction;
 use clap::{Parser, Subcommand};
 use clientd::{call, PegInPayload, SpendPayload, WaitBlockHeightPayload};
-use fedimint_api::{module::__reexports::serde_json, Amount};
+use fedimint_api::Amount;
 use fedimint_core::modules::wallet::txoproof::TxOutProof;
 use mint_client::utils::{from_hex, parse_fedimint_amount};
 

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -145,8 +145,8 @@ async fn spend(
 ) -> Result<impl IntoResponse, ClientdError> {
     let client = &state.client;
 
-    let coins = client.select_and_spend_coins(payload.0.amount)?;
-    json_success!(SpendResponse { coins })
+    let notes = client.select_and_spend_coins(payload.0.amount)?;
+    json_success!(SpendResponse { notes })
 }
 
 async fn fetch(client: Arc<Client<UserClientConfig>>) {
@@ -156,11 +156,11 @@ async fn fetch(client: Arc<Client<UserClientConfig>>) {
         match item {
             Ok(out_point) => {
                 //TODO: Log event
-                info!("fetched coins: {}", out_point);
+                info!("fetched notes: {}", out_point);
             }
             Err(err) => {
                 //TODO: Log event
-                info!("error fetching coins: {}", err);
+                info!("error fetching notes: {}", err);
             }
         }
     }


### PR DESCRIPTION
This PR deletes the re-export that slipped in somehow pointed out by @elsirion in the last PR.
Also did some renames and a better type for the `TieredCount` regarding #492 and #503