### PR TITLE
version-hash command for mint-client-cli and mint-rpc-client

### DIFF
--- a/client/cli/build.rs
+++ b/client/cli/build.rs
@@ -1,0 +1,18 @@
+use std::{env, fs::File, process::Command};
+fn main() {
+    if env::var_os("GIT_HASH").is_none() {
+        let git_hash = if File::open("./../../.git/HEAD").is_ok() {
+            let output = Command::new("git")
+                .args(&["rev-parse", "HEAD"])
+                .output()
+                .unwrap();
+            String::from_utf8(output.stdout).unwrap()
+        } else {
+            // we set a fake hash here and make it easily recognizable
+            // by giving it a prefix (0x0123456)
+            String::from("0x01234569afbe457afa1d2683a099c7af48a523c")
+        };
+        println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+        println!("cargo:rerun-if-env-changed=GIT_HASH");
+    }
+}

--- a/client/cli/src/bin/mint-rpc-client.rs
+++ b/client/cli/src/bin/mint-rpc-client.rs
@@ -1,23 +1,45 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use fedimint_api::PeerId;
 use mint_client::api::WsFederationApi;
 use mint_client::query::TrustAllPeers;
 use url::Url;
 
 #[derive(Parser)]
-struct ApiCall {
-    url: Url,
-    method: String,
-    #[clap(default_value = "null")]
-    arg: String,
+#[clap(version)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Print the latest git commit hash this bin. was build with
+    VersionHash,
+    ApiCall {
+        /// The url to use for the api call
+        url: Url,
+        /// The rpc method
+        method: String,
+        /// Args that will be serialized and send with the request
+        #[clap(default_value = "null")]
+        arg: String,
+    },
 }
 
 #[tokio::main]
 async fn main() {
-    let call = ApiCall::parse();
-    let arg: serde_json::Value = serde_json::from_str(&call.arg).unwrap();
-    let api = WsFederationApi::new(0, vec![(PeerId::from(0), call.url)]);
-    let response: serde_json::Value = api.request(&call.method, arg, TrustAllPeers).await.unwrap();
-    let formatted = serde_json::to_string_pretty(&response).unwrap();
-    print!("{}", formatted);
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::VersionHash => {
+            println!("{}", env!("GIT_HASH"));
+        }
+        Commands::ApiCall { url, method, arg } => {
+            let arg: serde_json::Value = serde_json::from_str(&arg).unwrap();
+            let api = WsFederationApi::new(0, vec![(PeerId::from(0), url)]);
+            let response: serde_json::Value =
+                api.request(&method, arg, TrustAllPeers).await.unwrap();
+            let formatted = serde_json::to_string_pretty(&response).unwrap();
+            print!("{}", formatted);
+        }
+    }
 }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -1,5 +1,5 @@
 use bitcoin::{secp256k1, Address, Transaction};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use fedimint_api::{Amount, OutPoint, TransactionId};
 use fedimint_core::config::{load_from_file, ClientConfig};
 use fedimint_core::modules::ln::contracts::ContractId;
@@ -27,6 +27,9 @@ use tracing_subscriber::EnvFilter;
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "snake_case"))]
 enum CliOutput {
+    VersionHash {
+        hash: String,
+    },
     PegInAddress {
         address: Address,
     },
@@ -158,14 +161,30 @@ impl fmt::Display for CliError {
 impl Error for CliError {}
 
 #[derive(Parser)]
-struct Options {
+#[clap(version)]
+struct Cli {
+    /// The working directory of the client containing the config and db
     workdir: PathBuf,
     #[clap(subcommand)]
     command: Command,
 }
 
 #[derive(Parser)]
+#[clap(version)]
+struct CliNoWorkdir {
+    #[clap(subcommand)]
+    command: CommandNoWorkdir,
+}
+
+#[derive(Subcommand)]
+enum CommandNoWorkdir {
+    /// Print the latest git commit hash this bin. was build with
+    VersionHash,
+}
+#[derive(Subcommand)]
 enum Command {
+    /// Print the latest git commit hash this bin. was build with
+    VersionHash,
     /// Generate a new peg-in address, funds sent to it can later be claimed
     PegInAddress,
 
@@ -280,7 +299,6 @@ struct PayRequest {
 
 #[tokio::main]
 async fn main() {
-    let opts = Options::parse();
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
@@ -288,64 +306,80 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
 
-    if let Command::JoinFederation { connect } = opts.command {
-        let connect_obj: WsFederationConnect = serde_json::from_str(&connect)
-            .or_terminate(CliErrorKind::InvalidValue, "invalid connect info");
-        let api = WsFederationApi::new(connect_obj.max_evil, connect_obj.members);
-        let cfg: ClientConfig = api
-            .request("/config", (), CurrentConsensus::new(connect_obj.max_evil))
-            .await
-            .or_terminate(
-                CliErrorKind::NetworkError,
-                "couldn't download config from peer",
+    if let Ok(cli) = Cli::try_parse() {
+        if let Command::JoinFederation { connect } = cli.command {
+            let connect_obj: WsFederationConnect = serde_json::from_str(&connect)
+                .or_terminate(CliErrorKind::InvalidValue, "invalid connect info");
+            let api = WsFederationApi::new(connect_obj.max_evil, connect_obj.members);
+            let cfg: ClientConfig = api
+                .request("/config", (), CurrentConsensus::new(connect_obj.max_evil))
+                .await
+                .or_terminate(
+                    CliErrorKind::NetworkError,
+                    "couldn't download config from peer",
+                );
+            let cfg_path = cli.workdir.join("client.json");
+            std::fs::create_dir_all(&cli.workdir)
+                .or_terminate(CliErrorKind::IOError, "failed to create config directory");
+            let writer = std::fs::File::create(cfg_path)
+                .or_terminate(CliErrorKind::IOError, "couldn't create config.json");
+            serde_json::to_writer_pretty(writer, &cfg)
+                .or_terminate(CliErrorKind::IOError, "couldn't write config");
+            println!(
+                "{}",
+                &CliOutput::JoinFederation { joined: (connect) }.to_string()
             );
-        let cfg_path = opts.workdir.join("client.json");
-        std::fs::create_dir_all(&opts.workdir)
-            .or_terminate(CliErrorKind::IOError, "failed to create config directory");
-        let writer = std::fs::File::create(cfg_path)
-            .or_terminate(CliErrorKind::IOError, "couldn't create config.json");
-        serde_json::to_writer_pretty(writer, &cfg)
-            .or_terminate(CliErrorKind::IOError, "couldn't write config");
-        println!(
-            "{}",
-            &CliOutput::JoinFederation { joined: (connect) }.to_string()
+            return;
+        };
+
+        let cfg_path = cli.workdir.join("client.json");
+        let db_path = cli.workdir.join("client.db");
+        let cfg: UserClientConfig = load_from_file(&cfg_path);
+        let db: rocksdb::OptimisticTransactionDB<rocksdb::SingleThreaded> =
+            rocksdb::OptimisticTransactionDB::open_default(&db_path)
+                .or_terminate(CliErrorKind::IOError, "could not open transaction db");
+
+        let rng = rand::rngs::OsRng::new().or_terminate(
+            CliErrorKind::OSError,
+            "failed to acquire random number generator from OS",
         );
-        return;
-    };
 
-    let cfg_path = opts.workdir.join("client.json");
-    let db_path = opts.workdir.join("client.db");
-    let cfg: UserClientConfig = load_from_file(&cfg_path);
-    let db: rocksdb::OptimisticTransactionDB<rocksdb::SingleThreaded> =
-        rocksdb::OptimisticTransactionDB::open_default(&db_path)
-            .or_terminate(CliErrorKind::IOError, "could not open transaction db");
+        let client = Client::new(cfg.clone(), Box::new(db), Default::default());
 
-    let rng = rand::rngs::OsRng::new().or_terminate(
-        CliErrorKind::OSError,
-        "failed to acquire random number generator from OS",
-    );
+        let cli_result = handle_command(cli, client, rng).await;
 
-    let client = Client::new(cfg.clone(), Box::new(db), Default::default());
-
-    let cli_result = handle_command(opts, client, rng).await;
-
-    match cli_result {
-        Ok(output) => {
-            println!("{}", output);
+        match cli_result {
+            Ok(output) => {
+                println!("{}", output);
+            }
+            Err(err) => {
+                println!("{}", err);
+                exit(1);
+            }
         }
-        Err(err) => {
-            println!("{}", err);
-            exit(1);
-        }
+    } else {
+        // Only commands that don't need the workdir can be used here
+        let cli = CliNoWorkdir::parse();
+        //TODO: remove allow when there are more commands
+        #[allow(irrefutable_let_patterns)]
+        if let CommandNoWorkdir::VersionHash = cli.command {
+            println!(
+                "{}",
+                CliOutput::VersionHash {
+                    hash: env!("GIT_HASH").to_string()
+                }
+            );
+        };
     }
 }
 
 async fn handle_command(
-    opts: Options,
+    cli: Cli,
     client: Client<UserClientConfig>,
     mut rng: rand::rngs::OsRng,
 ) -> CliResult {
-    match opts.command {
+    match cli.command {
+        Command::VersionHash => unreachable!(),
         Command::PegInAddress => {
             let peg_in_address = client.get_new_pegin_address(&mut rng);
             Ok(CliOutput::PegInAddress {


### PR DESCRIPTION
I decided to also do some refactoring to make the CLI logic cleaner and also give the option to work without workdir.

This is a step towards #555 the other binaries that need to be changed are:
1. clientd
2. clientd-cli
3. configgen
4. fedimintd
5. ln-gateway

I think it is best if I do each of them in a individual PR.  