### PR TITLE
Create the .git/hooks dir if non-existent in nix cmd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -441,6 +441,7 @@
 
               shellHook = ''
                 # auto-install git hooks
+                if [[ ! -d .git/hooks ]]; then mkdir .git/hooks; fi
                 for hook in misc/git-hooks/* ; do ln -sf "../../$hook" "./.git/hooks/" ; done
                 ${pkgs.git}/bin/git config commit.template misc/git-hooks/commit-template.txt
 


### PR DESCRIPTION
On a fresh clone, 'nix develop' showed this error message:

ln: failed to create symbolic link './.git/hooks/': No such file or directory ln: failed to create symbolic link './.git/hooks/': No such file or directory

After this change, the error message goes away, since the script will now create the directory if it does not exist.

I am a complete noob to this repository and to nix, so forgive me if I missed something. I searched the repo for `hooks` and it led me to this code. After changing this code and running `nix develop` again, the hooks directory exists and there are scripts in the directory.