### PR TITLE
CLI spend command makes exact change

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -386,7 +386,7 @@ async fn handle_command(
                 }),
             }
         }
-        Command::Spend { amount } => client.select_and_spend_coins(amount).transform(
+        Command::Spend { amount } => client.spend_ecash(amount, rng).await.transform(
             |v| CliOutput::Spend {
                 token: (serialize_coins(&v)),
             },

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -110,7 +110,7 @@ impl<'c> MintClient<'c> {
         &self,
         amount: Amount,
         mut tx: BatchTx,
-        rng: R,
+        rng: &mut R,
         mut create_tx: impl FnMut(TieredMulti<BlindNonce>) -> OutPoint,
     ) {
         let mut builder = TransactionBuilder::default();
@@ -209,7 +209,7 @@ impl CoinFinalizationData {
         amount: Amount,
         amount_tiers: &Tiered<K>,
         ctx: &Secp256k1<C>,
-        mut rng: impl RngCore + CryptoRng,
+        rng: &mut (impl RngCore + CryptoRng),
     ) -> (CoinFinalizationData, SignRequest)
     where
         C: Signing,
@@ -218,7 +218,7 @@ impl CoinFinalizationData {
             TieredMulti::represent_amount(amount, amount_tiers)
                 .into_iter()
                 .map(|(amt, ())| {
-                    let (request, blind_msg) = CoinRequest::new(ctx, &mut rng);
+                    let (request, blind_msg) = CoinRequest::new(ctx, rng);
                     ((amt, request), (amt, blind_msg))
                 })
                 .unzip();
@@ -283,12 +283,12 @@ impl CoinRequest {
     /// message
     fn new<C>(
         ctx: &Secp256k1<C>,
-        mut rng: impl RngCore + CryptoRng,
+        rng: &mut (impl RngCore + CryptoRng),
     ) -> (CoinRequest, BlindedMessage)
     where
         C: Signing,
     {
-        let spend_key = bitcoin::KeyPair::new(ctx, &mut rng);
+        let spend_key = bitcoin::KeyPair::new(ctx, rng);
         let nonce = Nonce(spend_key.public_key());
         let (blinding_key, blinded_nonce) = blind_message(nonce.to_message());
 

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -89,7 +89,7 @@ impl TransactionBuilder {
         amount: Amount,
         secp: &secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
         tbs_pks: &Tiered<AggregatePublicKey>,
-        rng: R,
+        rng: &mut R,
     ) {
         let (coin_finalization_data, coin_output) =
             self.create_output_coins(amount, secp, tbs_pks, rng);
@@ -107,7 +107,7 @@ impl TransactionBuilder {
         amount: Amount,
         secp: &secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
         tbs_pks: &Tiered<AggregatePublicKey>,
-        rng: R,
+        rng: &mut R,
     ) -> (CoinFinalizationData, TieredMulti<BlindNonce>) {
         let (coin_finalization_data, sig_req) =
             CoinFinalizationData::new(amount, tbs_pks, secp, rng);

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -144,8 +144,9 @@ async fn spend(
     payload: JsonExtract<SpendPayload>,
 ) -> Result<impl IntoResponse, ClientdError> {
     let client = &state.client;
+    let rng = state.rng.clone();
 
-    let notes = client.select_and_spend_coins(payload.0.amount)?;
+    let notes = client.spend_ecash(payload.0.amount, rng).await?;
     json_success!(SpendResponse { notes })
 }
 

--- a/fedimint/src/consensus/mod.rs
+++ b/fedimint/src/consensus/mod.rs
@@ -106,6 +106,11 @@ where
         &self,
         transaction: Transaction,
     ) -> Result<(), TransactionSubmissionError> {
+        // we already processed the transaction before the request was received
+        if self.transaction_status(transaction.tx_hash()).is_some() {
+            return Ok(());
+        }
+
         let tx_hash = transaction.tx_hash();
         debug!(%tx_hash, "Received mint transaction");
 

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -141,7 +141,7 @@ async fn peg_outs_must_wait_for_available_utxos() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn minted_coins_can_be_exchanged_between_users() {
+async fn ecash_can_be_exchanged_directly_between_users() {
     let (fed, user_send, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await;
     let user_receive = user_send.new_client(&[0, 1, 2]);
 
@@ -149,24 +149,24 @@ async fn minted_coins_can_be_exchanged_between_users() {
     assert_eq!(user_send.total_coins(), sats(5000));
     assert_eq!(user_receive.total_coins(), sats(0));
 
-    let coins = user_send.client.select_and_spend_coins(sats(3000)).unwrap();
-    user_receive.client.reissue(coins, rng()).await.unwrap();
+    let ecash = fed.spend_ecash(&user_send, sats(3500)).await;
+    user_receive.client.reissue(ecash, rng()).await.unwrap();
     fed.run_consensus_epochs(2).await; // process transaction + sign new coins
 
-    user_send.assert_total_coins(sats(2000)).await;
-    user_receive.assert_total_coins(sats(3000)).await;
+    user_send.assert_total_coins(sats(1500)).await;
+    user_receive.assert_total_coins(sats(3500)).await;
     assert_eq!(fed.max_balance_sheet(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn minted_coins_cannot_double_spent_with_different_nodes() {
+async fn ecash_cannot_double_spent_with_different_nodes() {
     let (fed, user1, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
     fed.mine_and_mint(&user1, &*bitcoin, sats(5000)).await;
-    let coins = user1.client.select_and_spend_coins(sats(2000)).unwrap();
+    let ecash = fed.spend_ecash(&user1, sats(2000)).await;
 
     let (user2, user3) = (user1.new_client(&[0]), user1.new_client(&[1]));
-    let out2 = user2.client.reissue(coins.clone(), rng()).await.unwrap();
-    let out3 = user3.client.reissue(coins, rng()).await.unwrap();
+    let out2 = user2.client.reissue(ecash.clone(), rng()).await.unwrap();
+    let out3 = user3.client.reissue(ecash, rng()).await.unwrap();
     fed.run_consensus_epochs(2).await; // process transaction + sign new coins
 
     assert!(
@@ -180,7 +180,7 @@ async fn minted_coins_cannot_double_spent_with_different_nodes() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn minted_coins_in_wallet_can_be_split_into_change() {
+async fn ecash_in_wallet_can_sent_through_a_tx() {
     let (fed, user_send, bitcoin, _, _) = fixtures(2, &[sats(100), sats(500)]).await;
     let user_receive = user_send.new_client(&[0]);
 
@@ -646,13 +646,13 @@ async fn runs_consensus_if_tx_submitted() {
     let user_receive = user_send.new_client(&[0]);
 
     fed.mine_and_mint(&user_send, &*bitcoin, sats(5000)).await;
-    let coins = user_send.client.select_and_spend_coins(sats(5000)).unwrap();
+    let ecash = fed.spend_ecash(&user_send, sats(5000)).await;
 
     // If epochs run before the reissue tx, then there won't be any coins to fetch
     join_all(vec![
         Either::Left(async {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            user_receive.client.reissue(coins, rng()).await.unwrap();
+            user_receive.client.reissue(ecash, rng()).await.unwrap();
         }),
         Either::Right(async {
             fed.await_consensus_epochs(2).await;

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -3,11 +3,13 @@
 
 set -euxo pipefail
 export RUST_LOG=info
-export PEG_IN_AMOUNT=99999
 
+export PEG_IN_AMOUNT=10000
 source ./scripts/setup-tests.sh
 ./scripts/start-fed.sh
 ./scripts/pegin.sh # peg in user
+
+export PEG_IN_AMOUNT=99999
 start_gateway
 ./scripts/pegin.sh $PEG_IN_AMOUNT 1 # peg in gateway
 
@@ -15,6 +17,7 @@ start_gateway
 
 # reissue
 TOKENS=$($FM_MINT_CLIENT spend '42000msat' | jq -r '.spend.token')
+[[ $($FM_MINT_CLIENT info | jq -r '.info.total_amount') = "9958000" ]]
 $FM_MINT_CLIENT validate $TOKENS
 $FM_MINT_CLIENT reissue $TOKENS
 $FM_MINT_CLIENT fetch


### PR DESCRIPTION
The `receive_coins` function is the way we should transfer ecash in production because it's the safer/faster option.

However, for demonstrating ecash as a bearer note, this changes the `spend_ecash` function so that it will reissue exact change for spending.

Fixes #592