### PR TITLE
Move database impls into their own crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sled",
  "thiserror",
  "tokio",
  "tower",
@@ -681,7 +680,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "sled",
  "tbs",
  "thiserror",
  "threshold_crypto",
@@ -714,9 +712,7 @@ dependencies = [
  "secp256k1-zkp",
  "serde",
  "serde_json",
- "sled",
  "tbs",
- "tempfile",
  "test-log",
  "thiserror",
  "tokio",
@@ -816,6 +812,19 @@ dependencies = [
  "anyhow",
  "fedimint-api",
  "rocksdb",
+ "tempfile",
+ "test-log",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "fedimint-sled"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "fedimint-api",
+ "sled",
  "tempfile",
  "test-log",
  "tracing",
@@ -1676,7 +1685,6 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "sled",
  "thiserror",
  "tokio",
  "tower-http",
@@ -1814,7 +1822,6 @@ dependencies = [
  "rand 0.6.5",
  "serde",
  "serde_json",
- "sled",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,10 +406,10 @@ dependencies = [
  "clap",
  "fedimint-api",
  "fedimint-core",
+ "fedimint-rocksdb",
  "mint-client",
  "rand 0.6.5",
  "reqwest",
- "rocksdb",
  "serde",
  "serde_json",
  "sled",
@@ -664,6 +664,7 @@ dependencies = [
  "fedimint-api",
  "fedimint-core",
  "fedimint-derive",
+ "fedimint-rocksdb",
  "fedimint-wallet",
  "futures",
  "hbbft",
@@ -676,7 +677,6 @@ dependencies = [
  "rand 0.6.5",
  "rayon",
  "rcgen",
- "rocksdb",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -711,7 +711,6 @@ dependencies = [
  "lightning-invoice",
  "rand 0.6.5",
  "rand 0.7.3",
- "rocksdb",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -811,6 +810,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-rocksdb"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "fedimint-api",
+ "rocksdb",
+ "tempfile",
+ "test-log",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "fedimint-tests"
 version = "0.1.0"
 dependencies = [
@@ -824,6 +836,7 @@ dependencies = [
  "fedimint-api",
  "fedimint-ln",
  "fedimint-mint",
+ "fedimint-rocksdb",
  "fedimint-wallet",
  "futures",
  "hbbft",
@@ -833,7 +846,6 @@ dependencies = [
  "ln-gateway",
  "mint-client",
  "rand 0.6.5",
- "rocksdb",
  "serde",
  "threshold_crypto",
  "tokio",
@@ -1655,12 +1667,12 @@ dependencies = [
  "cln-rpc",
  "fedimint",
  "fedimint-api",
+ "fedimint-rocksdb",
  "futures",
  "hex",
  "lightning-invoice",
  "mint-client",
  "rand 0.6.5",
- "rocksdb",
  "secp256k1",
  "serde",
  "serde_json",
@@ -1796,10 +1808,10 @@ dependencies = [
  "clap",
  "fedimint-api",
  "fedimint-core",
+ "fedimint-rocksdb",
  "lightning-invoice",
  "mint-client",
  "rand 0.6.5",
- "rocksdb",
  "serde",
  "serde_json",
  "sled",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "fedimint-core",
     "fedimint-derive",
     "fedimint-api",
+    "fedimint-rocksdb",
     "client/cli",
     "client/client-lib",
     "client/clientd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "fedimint-derive",
     "fedimint-api",
     "fedimint-rocksdb",
+    "fedimint-sled",
     "client/cli",
     "client/client-lib",
     "client/clientd",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -26,7 +26,6 @@ fedimint-core = { path = "../../fedimint-core" }
 fedimint-rocksdb = { path = "../../fedimint-rocksdb" }
 rand = "0.6.5"
 serde = { version = "1.0.118", features = [ "derive" ] }
-sled = "0.34.6"
 tokio = { version = "1.21.0", features = ["full"] }
 tracing ="0.1.22"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -21,10 +21,10 @@ bitcoin_hashes = "0.10.0"
 clap = { version = "3.2.20", features = ["derive"] }
 lightning-invoice = "0.18.0"
 mint-client = { path = "../client-lib" }
-fedimint-api = { path = "../../fedimint-api", features = ["rocksdb"] }
+fedimint-api = { path = "../../fedimint-api" }
 fedimint-core = { path = "../../fedimint-core" }
+fedimint-rocksdb = { path = "../../fedimint-rocksdb" }
 rand = "0.6.5"
-rocksdb = "0.19.0"
 serde = { version = "1.0.118", features = [ "derive" ] }
 sled = "0.34.6"
 tokio = { version = "1.21.0", features = ["full"] }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -335,16 +335,16 @@ async fn main() {
         let cfg_path = cli.workdir.join("client.json");
         let db_path = cli.workdir.join("client.db");
         let cfg: UserClientConfig = load_from_file(&cfg_path);
-        let db: rocksdb::OptimisticTransactionDB<rocksdb::SingleThreaded> =
-            rocksdb::OptimisticTransactionDB::open_default(&db_path)
-                .or_terminate(CliErrorKind::IOError, "could not open transaction db");
+        let db = fedimint_rocksdb::RocksDb::open(db_path)
+            .or_terminate(CliErrorKind::IOError, "could not open transaction db")
+            .into_dyn();
 
         let rng = rand::rngs::OsRng::new().or_terminate(
             CliErrorKind::OSError,
             "failed to acquire random number generator from OS",
         );
 
-        let client = Client::new(cfg.clone(), Box::new(db), Default::default());
+        let client = Client::new(cfg.clone(), db, Default::default());
 
         let cli_result = handle_command(cli, client, rng).await;
 

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -29,7 +29,6 @@ anyhow = "1.0.65"
 async-trait = "0.1.57"
 bitcoin = { version = "0.28.1", features = [ "serde" ] }
 bitcoin_hashes = "0.10.0"
-sled = "0.34.6"
 reqwest = { version = "0.11.0", features = [ "json" ], default-features = false }
 tokio = { version = "1.21.0", features = ["full"] }
 serde = { version = "1.0.118", features = [ "derive" ] }

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -22,9 +22,9 @@ path = "src/main.rs"
 
 [dependencies]
 mint-client = { path = "../client-lib" }
-fedimint-api = { path = "../../fedimint-api", features = [ "rocksdb" ] }
+fedimint-api = { path = "../../fedimint-api" }
 fedimint-core = { path = "../../fedimint-core" }
-rocksdb = "0.19.0"
+fedimint-rocksdb = { path = "../../fedimint-rocksdb" }
 anyhow = "1.0.65"
 async-trait = "0.1.57"
 bitcoin = { version = "0.28.1", features = [ "serde" ] }

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -42,10 +42,11 @@ async fn main() {
     let cfg_path = opts.workdir.join("client.json");
     let db_path = opts.workdir.join("client.db");
     let cfg: UserClientConfig = load_from_file(&cfg_path);
-    let db: rocksdb::OptimisticTransactionDB<rocksdb::SingleThreaded> =
-        rocksdb::OptimisticTransactionDB::open_default(&db_path).unwrap();
+    let db = fedimint_rocksdb::RocksDb::open(db_path)
+        .expect("Error opening DB")
+        .into_dyn();
 
-    let client = Arc::new(Client::new(cfg.clone(), Box::new(db), Default::default()));
+    let client = Arc::new(Client::new(cfg.clone(), db, Default::default()));
     let (tx, mut rx) = mpsc::channel(1024);
     let rng = OsRng::new().unwrap();
 

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -25,7 +25,6 @@ rand07 = { version = "0.7", package = "rand" }
 secp256k1-zkp = { version = "0.6.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
 serde = { version = "1.0.118", features = [ "derive" ] }
 serde_json = "1.0.85"
-sled = "0.34"
 tbs = { path = "../crypto/tbs"}
 thiserror = "1.0.23"
 tracing ="0.1.22"
@@ -44,6 +43,5 @@ wasm-bindgen-futures = "0.4.33"
 tokio = { version = "1.21.0", features = ["rt", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
-tempfile = "3.3.0"
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -23,7 +23,6 @@ fedimint-derive = { path = "../fedimint-derive" }
 rand = "0.6.0"
 rand07 = { version = "0.7", package = "rand" }
 secp256k1-zkp = { version = "0.6.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
-rocksdb = { version = "0.19.0", optional = true }
 serde = { version = "1.0.118", features = [ "derive" ] }
 serde_json = "1.0.85"
 sled = "0.34"

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -8,9 +8,9 @@ use tracing::trace;
 
 pub mod batch;
 pub mod mem_impl;
-#[cfg(feature = "rocksdb")]
-mod rocksdb_impl;
 pub mod sled_impl;
+
+pub use tests::test_db_impl;
 
 pub trait DatabaseKeyPrefixConst {
     const DB_PREFIX: u8;
@@ -205,7 +205,6 @@ impl DecodingError {
     }
 }
 
-#[cfg(test)]
 mod tests {
     use super::Database;
     use crate::db::DatabaseKeyPrefixConst;

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -8,7 +8,6 @@ use tracing::trace;
 
 pub mod batch;
 pub mod mem_impl;
-pub mod sled_impl;
 
 pub use tests::test_db_impl;
 

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fedimint-rocksdb"
+version = "0.1.0"
+authors = ["The Fedimint Developers"]
+edition = "2021"
+description = "fedimint-rocksdb provides a rocksdb-backed database implementation for Fedimint."
+license = "MIT"
+
+[lib]
+name = "fedimint_rocksdb"
+path = "src/lib.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.64"
+fedimint-api = { path = "../fedimint-api" }
+rocksdb = { version = "0.19.0" }
+tracing = "0.1.22"
+
+[dev-dependencies]
+tempfile = "3.3.0"
+test-log = { version = "0.2", features = [ "trace" ], default-features = false }
+tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }

--- a/fedimint-sled/Cargo.toml
+++ b/fedimint-sled/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fedimint-sled"
+version = "0.1.0"
+authors = ["The Fedimint Developers"]
+edition = "2021"
+description = "fedimint-sled provides a sled-backed database implementation for Fedimint."
+license = "MIT"
+
+[lib]
+name = "fedimint_sled"
+path = "src/lib.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.64"
+fedimint-api = { path = "../fedimint-api" }
+sled = "0.34"
+tracing = "0.1.22"
+
+[dev-dependencies]
+tempfile = "3.3.0"
+test-log = { version = "0.2", features = [ "trace" ], default-features = false }
+tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -1,23 +1,57 @@
 //! Sled implementation of the `Database` trait. It should not be used anymore since it has known
 //! issues and is unmaintained. Please use `rocksdb` instead.
 
-use super::batch::{BatchItem, DbBatch};
-use super::{Database, DecodingError};
-use crate::db::PrefixIter;
 use anyhow::Result;
+use fedimint_api::db::batch::{BatchItem, DbBatch};
+use fedimint_api::db::Database;
+use fedimint_api::db::PrefixIter;
 use sled::transaction::TransactionError;
+use std::path::Path;
 use tracing::error;
 
+pub use sled;
+
+#[derive(Debug)]
+pub struct SledDb(sled::Tree);
+
+impl SledDb {
+    pub fn open(db_path: impl AsRef<Path>, tree: &str) -> Result<SledDb, sled::Error> {
+        let db = sled::open(db_path)?.open_tree(tree)?;
+        Ok(SledDb(db))
+    }
+
+    pub fn into_dyn(self) -> Box<dyn Database> {
+        Box::new(self)
+    }
+
+    pub fn inner(&self) -> &sled::Tree {
+        &self.0
+    }
+}
+
+impl From<sled::Tree> for SledDb {
+    fn from(db: sled::Tree) -> Self {
+        SledDb(db)
+    }
+}
+
+impl From<SledDb> for sled::Tree {
+    fn from(db: SledDb) -> Self {
+        db.0
+    }
+}
+
 // TODO: maybe make the concrete impl its own crate
-impl Database for sled::Tree {
+impl Database for SledDb {
     fn raw_insert_entry(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
-        let ret = self.insert(key, value)?.map(|bytes| bytes.to_vec());
-        self.flush().expect("DB failure");
+        let ret = self.inner().insert(key, value)?.map(|bytes| bytes.to_vec());
+        self.inner().flush().expect("DB failure");
         Ok(ret)
     }
 
     fn raw_get_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self
+            .inner()
             .get(key)
             .map_err(anyhow::Error::from)?
             .map(|bytes| bytes.to_vec()))
@@ -25,15 +59,16 @@ impl Database for sled::Tree {
 
     fn raw_remove_entry(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         let ret = self
+            .inner()
             .remove(key)
             .map_err(anyhow::Error::from)?
             .map(|bytes| bytes.to_vec());
-        self.flush().expect("DB failure");
+        self.inner().flush().expect("DB failure");
         Ok(ret)
     }
 
     fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_> {
-        Box::new(self.scan_prefix(key_prefix).map(|res| {
+        Box::new(self.inner().scan_prefix(key_prefix).map(|res| {
             res.map(|(key_bytes, value_bytes)| (key_bytes.to_vec(), value_bytes.to_vec()))
                 .map_err(anyhow::Error::from)
         }))
@@ -43,6 +78,7 @@ impl Database for sled::Tree {
         let batch: Vec<_> = batch.into();
 
         let ret = self
+            .inner()
             .transaction::<_, _, TransactionError>(|t| {
                 for change in batch.iter() {
                     match change {
@@ -70,19 +106,14 @@ impl Database for sled::Tree {
                 Ok(())
             })
             .map_err(anyhow::Error::from);
-        self.flush().expect("DB failure");
+        self.inner().flush().expect("DB failure");
         ret
-    }
-}
-
-impl From<DecodingError> for sled::transaction::ConflictableTransactionError<DecodingError> {
-    fn from(e: DecodingError) -> Self {
-        sled::transaction::ConflictableTransactionError::Abort(e)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::SledDb;
     use std::sync::Arc;
 
     #[test_log::test]
@@ -91,7 +122,7 @@ mod tests {
             .prefix("fcb-sled-test")
             .tempdir()
             .unwrap();
-        let db = sled::open(path).unwrap();
-        crate::db::tests::test_db_impl(Arc::new(db.open_tree("default").unwrap()));
+        let db = SledDb::open(path, "default").unwrap();
+        fedimint_api::db::test_db_impl(Arc::new(db));
     }
 }

--- a/fedimint/Cargo.toml
+++ b/fedimint/Cargo.toml
@@ -50,7 +50,6 @@ secp256k1-zkp = { version = "0.6.0", features = [ "global-context", "bitcoin_has
 serde = { version = "1.0.118", features = [ "derive" ] }
 serde_json = "1.0.85"
 sha3 = "0.10.4"
-sled = "0.34.6"
 tbs = { path = "../crypto/tbs" }
 thiserror = "1.0.23"
 tokio = { version = "1.21.0", features = ["full"] }

--- a/fedimint/Cargo.toml
+++ b/fedimint/Cargo.toml
@@ -36,9 +36,10 @@ hex = "0.4.2"
 itertools = "0.10.5"
 jsonrpsee = { version = "0.15.1", features = ["ws-server"] }
 mint-client = { path = "../client/client-lib" }
-fedimint-api = { path = "../fedimint-api", features = ["rocksdb"] }
+fedimint-api = { path = "../fedimint-api" }
 fedimint-core = { path = "../fedimint-core" }
 fedimint-derive = { path = "../fedimint-derive" }
+fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 fedimint-wallet = { path = "../modules/fedimint-wallet", features = ["native"] }
 opentelemetry = { version = "0.18.0", optional = true }
 opentelemetry-jaeger = { version = "0.16.0", optional = true }
@@ -46,7 +47,6 @@ rand = "0.6.5"
 rayon = "1.5.0"
 rcgen = "0.9.2"
 secp256k1-zkp = { version = "0.6.0", features = [ "global-context", "bitcoin_hashes" ] }
-rocksdb = "0.19.0"
 serde = { version = "1.0.118", features = [ "derive" ] }
 serde_json = "1.0.85"
 sha3 = "0.10.4"

--- a/fedimint/src/lib.rs
+++ b/fedimint/src/lib.rs
@@ -86,7 +86,7 @@ impl FedimintServer {
 
         Self::new_with(
             cfg.clone(),
-            Arc::new(rocksdb::OptimisticTransactionDB::open_default(&db_path).unwrap()),
+            Arc::new(fedimint_rocksdb::RocksDb::open(db_path).expect("Error opening DB")),
             bitcoincore_rpc::bitcoind_gen(cfg.wallet.clone()),
             connector,
         )

--- a/flake.nix
+++ b/flake.nix
@@ -301,6 +301,7 @@
             "fedimint-api"
             "fedimint-core"
             "fedimint-derive"
+            "fedimint-rocksdb"
             "modules/fedimint-ln"
             "modules/fedimint-mint"
             "modules/fedimint-wallet"

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -26,10 +26,10 @@ fedimint = { path = "../fedimint/" }
 fedimint-api = { path = "../fedimint-api" }
 fedimint-ln = { path = "../modules/fedimint-ln" }
 fedimint-mint = { path = "../modules/fedimint-mint" }
+fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 fedimint-wallet = { path = "../modules/fedimint-wallet" }
 mint-client = { path = "../client/client-lib" }
 rand = "0.6.5"
-rocksdb = "0.19.0"
 serde = { version = "1.0.118", features = [ "derive" ] }
 tokio = { version = "1.21.0", features = ["full"] }
 tracing ="0.1.22"

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -28,7 +28,6 @@ use rand::RngCore;
 
 use rand::rngs::OsRng;
 
-use rocksdb::OptimisticTransactionDB;
 use tokio::sync::Mutex;
 
 use tracing::info;
@@ -186,9 +185,9 @@ pub async fn fixtures(
     }
 }
 
-fn rocks(dir: String) -> OptimisticTransactionDB<rocksdb::SingleThreaded> {
+fn rocks(dir: String) -> fedimint_rocksdb::RocksDb {
     let db_dir = PathBuf::from(dir).join(format!("db-{}", rng().next_u64()));
-    OptimisticTransactionDB::open_default(db_dir).unwrap()
+    fedimint_rocksdb::RocksDb::open(db_dir).unwrap()
 }
 
 pub trait BitcoinTest {

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -34,7 +34,6 @@ rand = "0.6"
 secp256k1 = "0.22.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
-sled = "0.34.6"
 thiserror = "1.0.30"
 tracing = { version = "0.1.26", default-features = false, features= ["log", "attributes", "std"] }
 tokio = {version = "1.21", features = ["full"]}

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -27,10 +27,10 @@ futures = "0.3.21"
 hex = "0.4.3"
 lightning-invoice = "0.18.0"
 fedimint = { path = "../fedimint/" }
-fedimint-api = { path = "../fedimint-api", features = ["rocksdb"] }
+fedimint-api = { path = "../fedimint-api" }
+fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 mint-client = { path = "../client/client-lib" }
 rand = "0.6"
-rocksdb = "0.19.0"
 secp256k1 = "0.22.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -100,10 +100,11 @@ async fn initialize_gateway(
     // Run the gateway
     let db_path = workdir.join("gateway.db");
     let gw_client_cfg: GatewayClientConfig = load_from_file(&cfg_path);
-    let db: rocksdb::OptimisticTransactionDB<rocksdb::SingleThreaded> =
-        rocksdb::OptimisticTransactionDB::open_default(&db_path).unwrap();
+    let db = fedimint_rocksdb::RocksDb::open(db_path)
+        .expect("Error opening DB")
+        .into_dyn();
     let ctx = secp256k1::Secp256k1::new();
-    let federation_client = Arc::new(Client::new(gw_client_cfg, Box::new(db), ctx));
+    let federation_client = Arc::new(Client::new(gw_client_cfg, db, ctx));
     let ln_client = Box::new(Mutex::new(ln_client));
 
     LnGateway::new(federation_client, ln_client, sender, receiver, bind_addr)


### PR DESCRIPTION
This way we don't have to use feature flags on `fedimint-api` anymore and make sure third party DB implementations would actually work.