### PR TITLE
Rename `to_any` to `into_dyn`

### DIFF
--- a/fedimint/src/lib.rs
+++ b/fedimint/src/lib.rs
@@ -82,7 +82,7 @@ pub async fn run_fedimint(cfg: ServerConfig, db_path: PathBuf) {
 impl FedimintServer {
     pub async fn new(cfg: ServerConfig, db_path: PathBuf) -> Self {
         let connector: PeerConnector<EpochMessage> =
-            TlsTcpConnector::new(cfg.tls_config()).to_any();
+            TlsTcpConnector::new(cfg.tls_config()).into_dyn();
 
         Self::new_with(
             cfg.clone(),
@@ -121,7 +121,7 @@ impl FedimintServer {
 
         let connections = ReconnectPeerConnections::new(cfg.network_config(), connector)
             .await
-            .to_any();
+            .into_dyn();
 
         let net_info = NetworkInfo::new(
             cfg.identity,

--- a/fedimint/src/net/connect.rs
+++ b/fedimint/src/net/connect.rs
@@ -41,7 +41,7 @@ pub trait Connector<M> {
     async fn listen(&self, bind_addr: String) -> Result<ConnectionListener<M>, anyhow::Error>;
 
     /// Transform this concrete `Connector` into an owned trait object version of itself
-    fn to_any(self) -> AnyConnector<M>
+    fn into_dyn(self) -> AnyConnector<M>
     where
         Self: Sized + Send + Sync + Unpin + 'static,
     {
@@ -140,7 +140,7 @@ impl PeerCertStore {
             BidiFramed::<_, WriteHalf<TlsStream<TcpStream>>, ReadHalf<TlsStream<TcpStream>>>::new(
                 tls_conn,
             )
-            .to_any();
+            .into_dyn();
         Ok((auth_peer, framed))
     }
 }
@@ -182,7 +182,7 @@ where
             BidiFramed::<_, WriteHalf<TlsStream<TcpStream>>, ReadHalf<TlsStream<TcpStream>>>::new(
                 tls_conn,
             )
-            .to_any();
+            .into_dyn();
 
         Ok((peer, framed))
     }
@@ -272,7 +272,7 @@ pub mod mock {
                 let framed = BidiFramed::<M, WriteHalf<DuplexStream>, ReadHalf<DuplexStream>>::new(
                     stream_our,
                 )
-                .to_any();
+                .into_dyn();
                 Ok((peer, framed))
             } else {
                 return Err(anyhow::anyhow!("can't connect"));
@@ -299,7 +299,7 @@ pub mod mock {
                         BidiFramed::<M, WriteHalf<DuplexStream>, ReadHalf<DuplexStream>>::new(
                             connection,
                         )
-                        .to_any();
+                        .into_dyn();
 
                     Some((Ok((peer, framed)), receive))
                 })

--- a/fedimint/src/net/framed.rs
+++ b/fedimint/src/net/framed.rs
@@ -28,7 +28,7 @@ pub trait FramedTransport<T>:
     );
 
     /// Transforms concrete `FramedTransport` object into an owned trait object
-    fn to_any(self) -> AnyFramedTransport<T>
+    fn into_dyn(self) -> AnyFramedTransport<T>
     where
         Self: Sized + Send + Unpin + 'static,
     {

--- a/fedimint/src/net/peers.rs
+++ b/fedimint/src/net/peers.rs
@@ -63,7 +63,7 @@ where
     async fn ban_peer(&mut self, peer: PeerId);
 
     /// Converts the struct to a `PeerConnection` trait object
-    fn to_any(self) -> AnyPeerConnections<T>
+    fn into_dyn(self) -> AnyPeerConnections<T>
     where
         Self: Sized + Send + Unpin + 'static,
     {
@@ -640,7 +640,7 @@ mod tests {
                 bind_addr: bind.to_string(),
                 peers: peers_ref.clone(),
             };
-            let connect = net_ref.connector(cfg.identity).to_any();
+            let connect = net_ref.connector(cfg.identity).into_dyn();
             ReconnectPeerConnections::<u64>::new(cfg, connect).await
         };
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -137,7 +137,8 @@ pub async fn fixtures(
                     .expect("connect to ln_socket"),
             );
 
-            let connect_gen = |cfg: &ServerConfig| TlsTcpConnector::new(cfg.tls_config()).to_any();
+            let connect_gen =
+                |cfg: &ServerConfig| TlsTcpConnector::new(cfg.tls_config()).into_dyn();
             let fed_db = || Arc::new(rocks(dir.clone())) as Arc<dyn Database>;
             let fed = FederationTest::new(server_config, &fed_db, &bitcoin_rpc, &connect_gen).await;
 
@@ -163,7 +164,7 @@ pub async fn fixtures(
             let lightning = FakeLightningTest::new();
             let net = MockNetwork::new();
             let net_ref = &net;
-            let connect_gen = move |cfg: &ServerConfig| net_ref.connector(cfg.identity).to_any();
+            let connect_gen = move |cfg: &ServerConfig| net_ref.connector(cfg.identity).into_dyn();
 
             let fed_db = || Arc::new(MemDatabase::new()) as Arc<dyn Database>;
             let fed = FederationTest::new(server_config, &fed_db, &bitcoin_rpc, &connect_gen).await;


### PR DESCRIPTION
@dpc noted that `(in)to_any` is inaccurate in #611. https://github.com/fedimint/fedimint/pull/611#discussion_r977904507