### PR TITLE
Take off some CI jobs from buildjet

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   lint:
     name: "Lint"
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -113,7 +113,7 @@ jobs:
 
   wasm32:
     name: "Cross-compile: wasm32"
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -130,7 +130,7 @@ jobs:
 
   containers:
     name: "Containers"
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -4,7 +4,7 @@ name: Markdown Link Check
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
           # - android
         include:
           - build: wasm32
-            runs-on: buildjet-8vcpu-ubuntu-2004
+            runs-on: ubuntu-22.04
             target: wasm32-unknown-unknown
             use-cross: false
             extra-build-args: "--target wasm32-unknown-unknown --package mint-client"
@@ -30,7 +30,7 @@ jobs:
             # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
             build-in-pr: false
           # - build: android
-          #   runs-on: ubuntu-latest
+          #   runs-on: ubuntu-22.04
           #   target: aarch64-linux-android
           #   use-cross: true
 


### PR DESCRIPTION
These are builds that tend to be finishing faster anyway, so they are not bottlenecks. The cpus saved in buildjet can get used for other builds that need it more.