### PR TITLE
Remove (now redundant - done by ci-nix) wasm32 build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,17 +13,10 @@ jobs:
     strategy:
       matrix:
         build:
-          - wasm32
           - macos
           # TODO: Needs clang and possibly other binaries
           # - android
         include:
-          - build: wasm32
-            runs-on: ubuntu-22.04
-            target: wasm32-unknown-unknown
-            use-cross: false
-            extra-build-args: "--target wasm32-unknown-unknown --package mint-client"
-            build-in-pr: true
           - build: macos
             runs-on: macos-latest
             use-cross: false


### PR DESCRIPTION
It seems Github Actions require the job that I'm removing to pass ... Welcome to the Github Action California... :shrug: 