### PR TITLE
refactor fixture building and add a LnRpc wrapper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -545,36 +545,6 @@
               '';
             };
 
-            # Integration test shell - meant for running all the integration tests
-            # (usually from the CI) # which meants it includes all the project binaries,
-            # but it doesn't include dev tools etc.
-            integrationTests = pkgs.mkShell {
-
-              buildInputs = workspaceDeps.buildInputs;
-              nativeBuildInputs = with pkgs; workspaceDeps.nativeBuildInputs ++ [
-                bc
-                perl
-                bitcoind
-                clightning-dev
-                jq
-                procps
-                # This is required to prevent a mangled bash shell in nix develop
-                # see: https://discourse.nixos.org/t/interactive-bash-with-nix-develop-flake/15486
-                (hiPrio pkgs.bashInteractive)
-                tmux
-                tmuxinator
-                coreutils
-
-                fedimintd.package
-                fedimint-tests.package
-                ln-gateway.package
-                mint-client-cli.package
-                clientd.package
-              ];
-
-              LIBCLANG_PATH = "${pkgs.libclang.lib}/lib/";
-            };
-
             # this shell is used only in CI, so it should contain minimum amount
             # of stuff to avoid building and caching things we don't need
             lint = pkgs.mkShell {

--- a/integrationtests/tests/fixtures/fake.rs
+++ b/integrationtests/tests/fixtures/fake.rs
@@ -23,7 +23,7 @@ use crate::fixtures::{BitcoinTest, LightningTest};
 
 #[derive(Clone, Debug)]
 pub struct FakeLightningTest {
-    pub gateway_node_pub_key: secp256k1::PublicKey,
+    gateway_node_pub_key: secp256k1::PublicKey,
     gateway_node_sec_key: secp256k1::SecretKey,
     amount_sent: Arc<Mutex<u64>>,
 }
@@ -61,6 +61,10 @@ impl LightningTest for FakeLightningTest {
 
     fn amount_sent(&self) -> Amount {
         Amount::from_msat(*self.amount_sent.lock().unwrap())
+    }
+
+    fn pub_key(&self) -> secp256k1::PublicKey {
+        self.gateway_node_pub_key
     }
 }
 

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -23,7 +23,7 @@ pub struct RealLightningTest {
     rpc_gateway: LightningRPC,
     rpc_other: LightningRPC,
     initial_balance: Amount,
-    pub gateway_node_pub_key: secp256k1::PublicKey,
+    gateway_node_pub_key: secp256k1::PublicKey,
 }
 
 impl LightningTest for RealLightningTest {
@@ -39,6 +39,9 @@ impl LightningTest for RealLightningTest {
     fn amount_sent(&self) -> Amount {
         self.initial_balance
             .sub(Self::channel_balance(&self.rpc_gateway))
+    }
+    fn pub_key(&self) -> secp256k1::PublicKey {
+        self.gateway_node_pub_key
     }
 }
 

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -105,7 +105,7 @@ async fn initialize_gateway(
         .into_dyn();
     let ctx = secp256k1::Secp256k1::new();
     let federation_client = Arc::new(Client::new(gw_client_cfg, db, ctx));
-    let ln_client = Box::new(Mutex::new(ln_client));
+    let ln_client = Arc::new(Mutex::new(ln_client));
 
     LnGateway::new(federation_client, ln_client, sender, receiver, bind_addr)
 }

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -117,13 +117,11 @@ pub struct LnGateway {
 impl LnGateway {
     pub fn new(
         federation_client: Arc<GatewayClient>,
-        ln_client: Box<dyn LnRpc>,
+        ln_client: Arc<dyn LnRpc>,
         sender: mpsc::Sender<GatewayRequest>,
         receiver: mpsc::Receiver<GatewayRequest>,
         bind_addr: SocketAddr,
     ) -> Self {
-        let ln_client: Arc<dyn LnRpc> = ln_client.into();
-
         // Run webserver asynchronously in tokio
         let webserver = tokio::spawn(run_webserver(bind_addr, sender));
 

--- a/ln-gateway/src/ln.rs
+++ b/ln-gateway/src/ln.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::convert::TryInto;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use cln_rpc::model::requests::PayRequest;
@@ -64,5 +66,55 @@ impl LnRpc for Mutex<cln_rpc::ClnRpc> {
                 Err(LightningError(code))
             }
         }
+    }
+}
+
+/// Control the behavoir of the LnRpc by exposing the same interface but attach configurations and
+/// methods to it.
+pub struct LnRpcAdapter {
+    ln_client: Box<dyn LnRpc>,
+    fail_invoice: Arc<Mutex<HashMap<String, u8>>>,
+}
+
+impl LnRpcAdapter {
+    pub fn new(ln_client: Box<dyn LnRpc>) -> Self {
+        let fail_invoice = Arc::new(Mutex::new(HashMap::new()));
+
+        LnRpcAdapter {
+            ln_client,
+            fail_invoice,
+        }
+    }
+
+    /// Tell the LnRpc to fail the payment x-times until succeeding (or trying to succeed in the
+    /// case of real LnRpc
+    pub async fn fail_invoice(&self, invoice: String, times: u8) {
+        self.fail_invoice.lock().await.insert(invoice, times + 1);
+    }
+}
+
+#[async_trait]
+impl LnRpc for LnRpcAdapter {
+    async fn pay(
+        &self,
+        invoice_str: &str,
+        max_delay: u64,
+        max_fee_percent: f64,
+    ) -> Result<[u8; 32], LightningError> {
+        self.fail_invoice
+            .lock()
+            .await
+            .entry(invoice_str.to_string())
+            .and_modify(|counter| {
+                *counter -= 1;
+            });
+        if let Some(counter) = self.fail_invoice.lock().await.get(invoice_str) {
+            if *counter > 0 {
+                return Err(LightningError(None));
+            }
+        }
+        self.ln_client
+            .pay(invoice_str, max_delay, max_fee_percent)
+            .await
     }
 }


### PR DESCRIPTION
This PR changes the way the fixtures are generated to give more flexibility. Even though it is not the textbook builder pattern you'll be able to use it like that, and add configuration methods in between `Fixtures::new()` and `build()`

@okjodom had a very good idea to use the adapter pattern and wrap the `LnRpc` in a data structure with attached behavior. We also give that to the user see [test](https://github.com/fedimint/fedimint/pull/639/files#diff-65346ef6c368a5bdd16ebdbd8c21d969117d3caf775417f5ca6b2f3c49c81045R807)  (the test can be removed when it's used in 'organic' tests)