### PR TITLE
Fix build timeout

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -131,7 +131,7 @@ jobs:
   containers:
     name: "Containers"
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v17


### PR DESCRIPTION
After we moved container build from buildjet to default github machines it seems that when dependencies change, it takes longer than 30 minutes.

It shouldn't usually be a problem (in most PRs deps don't change), so increasing the timeout a bit should be enough.