### PR TITLE
Switch container build back to BuildJet

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -130,7 +130,7 @@ jobs:
 
   containers:
     name: "Containers"
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We are hitting the 30' timeout with GH Action runners, waiting longer isn't a good solution imo.