### PR TITLE
fix nix-flake packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -335,7 +335,8 @@
         };
 
         ln-gateway = pkg {
-          name = "ln_gateway";
+          name = "ln-gateway";
+          bin = "ln-gateway";
           dirs = [
             "crypto/tbs"
             "client/client-lib"
@@ -344,6 +345,7 @@
             "fedimint-api"
             "fedimint-core"
             "fedimint-derive"
+            "fedimint-rocksdb"
             "ln-gateway"
             "modules/fedimint-mint"
             "modules/fedimint-wallet"
@@ -352,6 +354,7 @@
 
         mint-client-cli = pkg {
           name = "mint-client-cli";
+          bin = "mint-client-cli";
           dirs = [
             "client/clientd"
             "client/client-lib"
@@ -385,6 +388,7 @@
 
         clientd = pkg {
           name = "clientd";
+          bin = "clientd";
           dirs = [
             "client/cli"
             "client/client-lib"
@@ -393,6 +397,7 @@
             "fedimint-api"
             "fedimint-core"
             "fedimint-derive"
+            "fedimint-rocksdb"
             "modules/fedimint-ln"
             "modules/fedimint-mint"
             "modules/fedimint-wallet"


### PR DESCRIPTION
Noticed some errors when running with `nix shell .#<package> -c <bin-name>`
For example `nix shell .#fedimint -c configgen` works but 
`nix shell .#ln-gateway -c webserver`, `nix shell .#mint-client-cli -c mint-rpc-client`, `nix shell .#clientd -c clientd-cli` do not work:
`called without required argument 'bin'`

- another fix `ln_gateway` -> `ln-gateway` is the correct name
- and add `fedimint-rocksdb` where needed (or else the comands would fail with `error: couldn't read fedimint-rocksdb/src/lib.rs: No such file or directory (os error 2)`)