### PR TITLE
Add federation & guardian names to server & client configs

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -146,12 +146,12 @@ impl From<&ClientConfig> for WsFederationConnect {
     fn from(config: &ClientConfig) -> Self {
         let max_evil = config.max_evil;
         let members: Vec<(PeerId, Url)> = config
-            .api_endpoints
+            .nodes
             .iter()
             .enumerate()
-            .map(|(id, url)| {
+            .map(|(id, node)| {
                 let peer_id = PeerId::from(id as u16); // FIXME: potentially wrong, currently works imo
-                let url = url.clone();
+                let url = node.url.clone();
                 (peer_id, url)
             })
             .collect();

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -172,12 +172,12 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             config.as_ref().max_evil,
             config
                 .as_ref()
-                .api_endpoints
+                .nodes
                 .iter()
                 .enumerate()
-                .map(|(id, url)| {
+                .map(|(id, node)| {
                     let peer_id = PeerId::from(id as u16); // FIXME: potentially wrong, currently works imo
-                    let url = url.clone();
+                    let url = node.url.clone();
                     (peer_id, url)
                 })
                 .collect(),

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -7,8 +7,15 @@ use std::path::Path;
 use url::Url;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct Node {
+    pub url: Url,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ClientConfig {
-    pub api_endpoints: Vec<Url>,
+    pub federation_name: String,
+    pub nodes: Vec<Node>,
     pub mint: MintClientConfig,
     pub wallet: WalletClientConfig,
     pub ln: LightningModuleClientConfig,

--- a/fedimint/src/bin/configgen.rs
+++ b/fedimint/src/bin/configgen.rs
@@ -36,6 +36,10 @@ struct Options {
         required = true
     )]
     denominations: Vec<Amount>,
+
+    /// Federation name
+    #[clap(long = "federation-name", default_value = "Hal's trusty mint")]
+    federation_name: String,
 }
 
 fn main() {
@@ -45,6 +49,7 @@ fn main() {
         hbbft_base_port,
         api_base_port,
         denominations: amount_tiers,
+        federation_name,
     } = Options::parse();
     let mut rng = OsRng::new().unwrap();
 
@@ -61,6 +66,7 @@ fn main() {
         hbbft_base_port,
         api_base_port,
         amount_tiers,
+        federation_name,
     };
 
     let (server_cfg, client_cfg) =

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -109,6 +109,7 @@ pub async fn fixtures(
     }
 
     let params = ServerConfigParams {
+        federation_name: "Test federation".into(),
         hbbft_base_port: base_port,
         api_base_port: base_port + num_peers,
         amount_tiers: amount_tiers.to_vec(),
@@ -329,11 +330,11 @@ impl UserTest {
             config.0.max_evil,
             config
                 .0
-                .api_endpoints
+                .nodes
                 .iter()
                 .enumerate()
                 .filter(|(id, _)| peers.contains(&PeerId::from(*id as u16)))
-                .map(|(id, url)| (PeerId::from(id as u16), url.clone()))
+                .map(|(id, node)| (PeerId::from(id as u16), node.url.clone()))
                 .collect(),
         ));
 


### PR DESCRIPTION
In order to support multiple federations on [Fluttermint](https://github.com/futurepaul/fluttermint) / [Webimint](https://github.com/justinmoon/webimint/), we need some kind of name to refer to the federations by. 

While we're at it, I added names to the federation "nodes". If the federation experiences downtime, this would allow the user to know who to talk to in order to fix it. Question: would "servers" or "guardians" be better name than "node"? "peer" isn't right client POV because client doesn't participate in consensus.




