### PR TITLE
cli-test.sh waits for CLN block processing to complete before attempting lightning payments

### DIFF
--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -36,6 +36,7 @@ RECEIVED=$($FM_BTC_CLIENT getreceivedbyaddress $PEG_OUT_ADDR)
 
 # outgoing lightning
 INVOICE="$($FM_LN2 invoice 100000 test test 1m | jq -r '.bolt11')"
+await_cln_block_processing
 $FM_MINT_CLIENT ln-pay $INVOICE
 # Check that ln-gateway has received the ecash notes from the user payment
 # 100,000 sats + 100 sats without processing fee

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -32,6 +32,24 @@ function await_server_on_port() {
   done
 }
 
+# Check that core-lightning block-proccessing is caught up
+# CLI integration tests should call this before attempting to pay invoices
+function await_cln_block_processing() {
+  EXPECTED_BLOCK_HEIGHT="$($FM_BTC_CLIENT getblockchaininfo | jq -r '.blocks')"
+
+  # ln1
+  until [ $EXPECTED_BLOCK_HEIGHT == "$($FM_LN1 getinfo | jq -r '.blockheight')" ]
+  do
+      sleep $POLL_INTERVAL
+  done
+
+  # ln2
+  until [ $EXPECTED_BLOCK_HEIGHT == "$($FM_LN2 getinfo | jq -r '.blockheight')" ]
+  do
+      sleep $POLL_INTERVAL
+  done
+}
+
 # Function for killing processes stored in FM_PID_FILE
 function kill_fedimint_processes {
   # shellcheck disable=SC2046


### PR DESCRIPTION
Attempt to fix intermittant CI failure in `cli-test.sh` where we're mining blocks too quickly ([according to Rusty Russell](https://github.com/fedimint/fedimint/issues/222#issuecomment-1257313464)).