### PR TITLE
331: Group database key prefixes as enums.

### DIFF
--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -7,17 +7,21 @@ use super::incoming::ConfirmedInvoice;
 use super::outgoing::OutgoingContractAccount;
 use crate::ln::outgoing::OutgoingContractData;
 
-const DB_PREFIX_OUTGOING_PAYMENT: u8 = 0x23;
-const DB_PREFIX_OUTGOING_PAYMENT_CLAIM: u8 = 0x24;
-const DB_PREFIX_OUTGOING_CONTRACT_ACCOUNT: u8 = 0x25;
-const DB_PREFIX_CONFIRMED_INVOICE: u8 = 0x26;
-const DB_PREFIX_LIGHTNING_GATEWAY: u8 = 0x28;
+#[repr(u8)]
+#[derive(Clone)]
+pub enum DbKeyPrefix {
+    OutgoingPayment = 0x23,
+    OutgoingPaymentClaim = 0x24,
+    OutgoingContractAccount = 0x25,
+    ConfirmedInvoice = 0x26,
+    LightningGateway = 0x28,
+}
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutgoingPaymentKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for OutgoingPaymentKey {
-    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_PAYMENT;
+    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPayment as u8;
     type Key = Self;
     type Value = OutgoingContractData;
 }
@@ -26,7 +30,7 @@ impl DatabaseKeyPrefixConst for OutgoingPaymentKey {
 pub struct OutgoingPaymentKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OutgoingPaymentKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_PAYMENT;
+    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPayment as u8;
     type Key = OutgoingPaymentKey;
     type Value = OutgoingContractData;
 }
@@ -35,7 +39,7 @@ impl DatabaseKeyPrefixConst for OutgoingPaymentKeyPrefix {
 pub struct OutgoingPaymentClaimKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKey {
-    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_PAYMENT_CLAIM;
+    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPaymentClaim as u8;
     type Key = Self;
     type Value = ();
 }
@@ -44,7 +48,7 @@ impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKey {
 pub struct OutgoingPaymentClaimKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_PAYMENT_CLAIM;
+    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPaymentClaim as u8;
     type Key = OutgoingPaymentClaimKey;
     type Value = ();
 }
@@ -53,7 +57,7 @@ impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKeyPrefix {
 pub struct OutgoingContractAccountKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for OutgoingContractAccountKey {
-    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_CONTRACT_ACCOUNT;
+    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingContractAccount as u8;
     type Key = Self;
     type Value = OutgoingContractAccount;
 }
@@ -62,7 +66,7 @@ impl DatabaseKeyPrefixConst for OutgoingContractAccountKey {
 pub struct OutgoingContractAccountKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OutgoingContractAccountKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_CONTRACT_ACCOUNT;
+    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingContractAccount as u8;
     type Key = OutgoingContractAccountKey;
     type Value = OutgoingContractAccount;
 }
@@ -71,7 +75,7 @@ impl DatabaseKeyPrefixConst for OutgoingContractAccountKeyPrefix {
 pub struct ConfirmedInvoiceKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for ConfirmedInvoiceKey {
-    const DB_PREFIX: u8 = DB_PREFIX_CONFIRMED_INVOICE;
+    const DB_PREFIX: u8 = DbKeyPrefix::ConfirmedInvoice as u8;
     type Key = Self;
     type Value = ConfirmedInvoice;
 }
@@ -80,7 +84,7 @@ impl DatabaseKeyPrefixConst for ConfirmedInvoiceKey {
 pub struct ConfirmedInvoiceKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ConfirmedInvoiceKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_CONFIRMED_INVOICE;
+    const DB_PREFIX: u8 = DbKeyPrefix::ConfirmedInvoice as u8;
     type Key = ConfirmedInvoiceKey;
     type Value = ConfirmedInvoice;
 }
@@ -89,7 +93,7 @@ impl DatabaseKeyPrefixConst for ConfirmedInvoiceKeyPrefix {
 pub struct LightningGatewayKey;
 
 impl DatabaseKeyPrefixConst for LightningGatewayKey {
-    const DB_PREFIX: u8 = DB_PREFIX_LIGHTNING_GATEWAY;
+    const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
     type Key = Self;
     type Value = LightningGateway;
 }

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -5,9 +5,13 @@ use fedimint_core::modules::mint::Nonce;
 
 use crate::mint::{NoteIssuanceRequests, SpendableNote};
 
-pub const DB_PREFIX_COIN: u8 = 0x20;
-pub const DB_PREFIX_OUTPUT_FINALIZATION_DATA: u8 = 0x21;
-pub const DB_PREFIX_PENDING_COINS: u8 = 0x27;
+#[repr(u8)]
+#[derive(Clone)]
+pub enum DbKeyPrefix {
+    Coin = 0x20,
+    OutputFinalizationData = 0x21,
+    PendingCoins = 0x27,
+}
 
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct CoinKey {
@@ -16,7 +20,7 @@ pub struct CoinKey {
 }
 
 impl DatabaseKeyPrefixConst for CoinKey {
-    const DB_PREFIX: u8 = DB_PREFIX_COIN;
+    const DB_PREFIX: u8 = DbKeyPrefix::Coin as u8;
     type Key = Self;
     type Value = SpendableNote;
 }
@@ -25,7 +29,7 @@ impl DatabaseKeyPrefixConst for CoinKey {
 pub struct CoinKeyPrefix;
 
 impl DatabaseKeyPrefixConst for CoinKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_COIN;
+    const DB_PREFIX: u8 = DbKeyPrefix::Coin as u8;
     type Key = CoinKey;
     type Value = SpendableNote;
 }
@@ -34,7 +38,7 @@ impl DatabaseKeyPrefixConst for CoinKeyPrefix {
 pub struct PendingCoinsKey(pub TransactionId);
 
 impl DatabaseKeyPrefixConst for PendingCoinsKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PENDING_COINS;
+    const DB_PREFIX: u8 = DbKeyPrefix::PendingCoins as u8;
     type Key = Self;
     type Value = TieredMulti<SpendableNote>;
 }
@@ -43,7 +47,7 @@ impl DatabaseKeyPrefixConst for PendingCoinsKey {
 pub struct PendingCoinsKeyPrefix;
 
 impl DatabaseKeyPrefixConst for PendingCoinsKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_PENDING_COINS;
+    const DB_PREFIX: u8 = DbKeyPrefix::PendingCoins as u8;
     type Key = PendingCoinsKey;
     type Value = TieredMulti<SpendableNote>;
 }
@@ -52,7 +56,7 @@ impl DatabaseKeyPrefixConst for PendingCoinsKeyPrefix {
 pub struct OutputFinalizationKey(pub OutPoint);
 
 impl DatabaseKeyPrefixConst for OutputFinalizationKey {
-    const DB_PREFIX: u8 = DB_PREFIX_OUTPUT_FINALIZATION_DATA;
+    const DB_PREFIX: u8 = DbKeyPrefix::OutputFinalizationData as u8;
     type Key = Self;
     type Value = NoteIssuanceRequests;
 }
@@ -61,7 +65,7 @@ impl DatabaseKeyPrefixConst for OutputFinalizationKey {
 pub struct OutputFinalizationKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OutputFinalizationKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_OUTPUT_FINALIZATION_DATA;
+    const DB_PREFIX: u8 = DbKeyPrefix::OutputFinalizationData as u8;
     type Key = OutputFinalizationKey;
     type Value = NoteIssuanceRequests;
 }

--- a/client/client-lib/src/wallet/db.rs
+++ b/client/client-lib/src/wallet/db.rs
@@ -2,7 +2,11 @@ use bitcoin::Script;
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 
-pub const DB_PREFIX_PEG_IN: u8 = 0x22;
+#[repr(u8)]
+#[derive(Clone)]
+pub enum DbKeyPrefix {
+    PegIn = 0x22,
+}
 
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct PegInKey {
@@ -10,7 +14,7 @@ pub struct PegInKey {
 }
 
 impl DatabaseKeyPrefixConst for PegInKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PEG_IN;
+    const DB_PREFIX: u8 = DbKeyPrefix::PegIn as u8;
     type Key = Self;
     type Value = [u8; 32]; // TODO: introduce newtype
 }
@@ -19,7 +23,7 @@ impl DatabaseKeyPrefixConst for PegInKey {
 pub struct PegInPrefixKey;
 
 impl DatabaseKeyPrefixConst for PegInPrefixKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PEG_IN;
+    const DB_PREFIX: u8 = DbKeyPrefix::PegIn as u8;
     type Key = PegInKey;
     type Value = [u8; 32];
 }

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -381,14 +381,18 @@ mod tests {
     use crate::db::DatabaseKeyPrefixConst;
     use crate::encoding::{Decodable, Encodable};
 
-    const DB_PREFIX_TEST: u8 = 0x42;
-    const ALT_DB_PREFIX_TEST: u8 = 0x43;
+    #[repr(u8)]
+    #[derive(Clone)]
+    pub enum TestDbKeyPrefix {
+        Test = 0x42,
+        AltTest = 0x43,
+    }
 
     #[derive(Debug, Encodable, Decodable)]
     struct TestKey(u64);
 
     impl DatabaseKeyPrefixConst for TestKey {
-        const DB_PREFIX: u8 = DB_PREFIX_TEST;
+        const DB_PREFIX: u8 = TestDbKeyPrefix::Test as u8;
         type Key = Self;
         type Value = TestVal;
     }
@@ -397,7 +401,7 @@ mod tests {
     struct DbPrefixTestPrefix;
 
     impl DatabaseKeyPrefixConst for DbPrefixTestPrefix {
-        const DB_PREFIX: u8 = DB_PREFIX_TEST;
+        const DB_PREFIX: u8 = TestDbKeyPrefix::Test as u8;
         type Key = TestKey;
         type Value = TestVal;
     }
@@ -406,7 +410,7 @@ mod tests {
     struct AltTestKey(u64);
 
     impl DatabaseKeyPrefixConst for AltTestKey {
-        const DB_PREFIX: u8 = ALT_DB_PREFIX_TEST;
+        const DB_PREFIX: u8 = TestDbKeyPrefix::AltTest as u8;
         type Key = Self;
         type Value = TestVal;
     }
@@ -415,7 +419,7 @@ mod tests {
     struct AltDbPrefixTestPrefix;
 
     impl DatabaseKeyPrefixConst for AltDbPrefixTestPrefix {
-        const DB_PREFIX: u8 = ALT_DB_PREFIX_TEST;
+        const DB_PREFIX: u8 = TestDbKeyPrefix::AltTest as u8;
         type Key = AltTestKey;
         type Value = TestVal;
     }

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -8,18 +8,22 @@ use fedimint_core::epoch::EpochHistory;
 use crate::consensus::AcceptedTransaction;
 use crate::transaction::Transaction;
 
-pub const DB_PREFIX_PROPOSED_TRANSACTION: u8 = 0x01;
-pub const DB_PREFIX_ACCEPTED_TRANSACTION: u8 = 0x02;
-pub const DB_PREFIX_DROP_PEER: u8 = 0x03;
-pub const DB_PREFIX_REJECTED_TRANSACTION: u8 = 0x04;
-pub const DB_PREFIX_EPOCH_HISTORY: u8 = 0x05;
-pub const DB_PREFIX_LAST_EPOCH: u8 = 0x06;
+#[repr(u8)]
+#[derive(Clone)]
+pub enum DbKeyPrefix {
+    ProposedTransaction = 0x01,
+    AcceptedTransaction = 0x02,
+    DropPeer = 0x03,
+    RejectedTransaction = 0x04,
+    EpochHistory = 0x05,
+    LastEpoch = 0x06,
+}
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct ProposedTransactionKey(pub TransactionId);
 
 impl DatabaseKeyPrefixConst for ProposedTransactionKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PROPOSED_TRANSACTION;
+    const DB_PREFIX: u8 = DbKeyPrefix::ProposedTransaction as u8;
     type Key = Self;
     type Value = Transaction;
 }
@@ -28,7 +32,7 @@ impl DatabaseKeyPrefixConst for ProposedTransactionKey {
 pub struct ProposedTransactionKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ProposedTransactionKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_PROPOSED_TRANSACTION;
+    const DB_PREFIX: u8 = DbKeyPrefix::ProposedTransaction as u8;
     type Key = ProposedTransactionKey;
     type Value = Transaction;
 }
@@ -37,7 +41,7 @@ impl DatabaseKeyPrefixConst for ProposedTransactionKeyPrefix {
 pub struct AcceptedTransactionKey(pub TransactionId);
 
 impl DatabaseKeyPrefixConst for AcceptedTransactionKey {
-    const DB_PREFIX: u8 = DB_PREFIX_ACCEPTED_TRANSACTION;
+    const DB_PREFIX: u8 = DbKeyPrefix::AcceptedTransaction as u8;
     type Key = Self;
     type Value = AcceptedTransaction;
 }
@@ -46,7 +50,7 @@ impl DatabaseKeyPrefixConst for AcceptedTransactionKey {
 pub struct RejectedTransactionKey(pub TransactionId);
 
 impl DatabaseKeyPrefixConst for RejectedTransactionKey {
-    const DB_PREFIX: u8 = DB_PREFIX_REJECTED_TRANSACTION;
+    const DB_PREFIX: u8 = DbKeyPrefix::RejectedTransaction as u8;
     type Key = Self;
     type Value = String;
 }
@@ -55,7 +59,7 @@ impl DatabaseKeyPrefixConst for RejectedTransactionKey {
 pub struct DropPeerKey(pub PeerId);
 
 impl DatabaseKeyPrefixConst for DropPeerKey {
-    const DB_PREFIX: u8 = DB_PREFIX_DROP_PEER;
+    const DB_PREFIX: u8 = DbKeyPrefix::DropPeer as u8;
     type Key = Self;
     type Value = ();
 }
@@ -64,7 +68,7 @@ impl DatabaseKeyPrefixConst for DropPeerKey {
 pub struct DropPeerKeyPrefix;
 
 impl DatabaseKeyPrefixConst for DropPeerKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_DROP_PEER;
+    const DB_PREFIX: u8 = DbKeyPrefix::DropPeer as u8;
     type Key = DropPeerKey;
     type Value = ();
 }
@@ -73,7 +77,7 @@ impl DatabaseKeyPrefixConst for DropPeerKeyPrefix {
 pub struct EpochHistoryKey(pub u64);
 
 impl DatabaseKeyPrefixConst for EpochHistoryKey {
-    const DB_PREFIX: u8 = DB_PREFIX_EPOCH_HISTORY;
+    const DB_PREFIX: u8 = DbKeyPrefix::EpochHistory as u8;
     type Key = Self;
     type Value = EpochHistory;
 }
@@ -82,7 +86,7 @@ impl DatabaseKeyPrefixConst for EpochHistoryKey {
 pub struct LastEpochKey;
 
 impl DatabaseKeyPrefixConst for LastEpochKey {
-    const DB_PREFIX: u8 = DB_PREFIX_LAST_EPOCH;
+    const DB_PREFIX: u8 = DbKeyPrefix::LastEpoch as u8;
     type Key = Self;
     type Value = EpochHistoryKey;
 }

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -6,18 +6,22 @@ use secp256k1::PublicKey;
 use crate::contracts::{incoming::IncomingContractOffer, ContractId, PreimageDecryptionShare};
 use crate::{ContractAccount, LightningGateway, OutputOutcome};
 
-const DB_PREFIX_CONTRACT: u8 = 0x40;
-const DB_PREFIX_OFFER: u8 = 0x41;
-const DB_PREFIX_PROPOSE_DECRYPTION_SHARE: u8 = 0x42;
-const DB_PREFIX_AGREED_DECRYPTION_SHARE: u8 = 0x43;
-const DB_PREFIX_CONTRACT_UPDATE: u8 = 0x44;
-const DB_PREFIX_LIGHTNING_GATEWAY: u8 = 0x45;
+#[repr(u8)]
+#[derive(Clone)]
+pub enum DbKeyPrefix {
+    Contract = 0x40,
+    Offer = 0x41,
+    ProposeDecryptionShare = 0x42,
+    AgreedDecryptionShare = 0x43,
+    ContractUpdate = 0x44,
+    LightningGateway = 0x45,
+}
 
 #[derive(Debug, Clone, Copy, Encodable, Decodable)]
 pub struct ContractKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for ContractKey {
-    const DB_PREFIX: u8 = DB_PREFIX_CONTRACT;
+    const DB_PREFIX: u8 = DbKeyPrefix::Contract as u8;
     type Key = Self;
     type Value = ContractAccount;
 }
@@ -26,7 +30,7 @@ impl DatabaseKeyPrefixConst for ContractKey {
 pub struct ContractKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ContractKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_CONTRACT;
+    const DB_PREFIX: u8 = DbKeyPrefix::Contract as u8;
     type Key = ContractKey;
     type Value = ContractAccount;
 }
@@ -35,7 +39,7 @@ impl DatabaseKeyPrefixConst for ContractKeyPrefix {
 pub struct ContractUpdateKey(pub OutPoint);
 
 impl DatabaseKeyPrefixConst for ContractUpdateKey {
-    const DB_PREFIX: u8 = DB_PREFIX_CONTRACT_UPDATE;
+    const DB_PREFIX: u8 = DbKeyPrefix::ContractUpdate as u8;
     type Key = Self;
     type Value = OutputOutcome;
 }
@@ -44,7 +48,7 @@ impl DatabaseKeyPrefixConst for ContractUpdateKey {
 pub struct OfferKey(pub bitcoin_hashes::sha256::Hash);
 
 impl DatabaseKeyPrefixConst for OfferKey {
-    const DB_PREFIX: u8 = DB_PREFIX_OFFER;
+    const DB_PREFIX: u8 = DbKeyPrefix::Offer as u8;
     type Key = Self;
     type Value = IncomingContractOffer;
 }
@@ -53,7 +57,7 @@ impl DatabaseKeyPrefixConst for OfferKey {
 pub struct OfferKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OfferKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_OFFER;
+    const DB_PREFIX: u8 = DbKeyPrefix::Offer as u8;
     type Key = OfferKey;
     type Value = IncomingContractOffer;
 }
@@ -63,7 +67,7 @@ impl DatabaseKeyPrefixConst for OfferKeyPrefix {
 pub struct ProposeDecryptionShareKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for ProposeDecryptionShareKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PROPOSE_DECRYPTION_SHARE;
+    const DB_PREFIX: u8 = DbKeyPrefix::ProposeDecryptionShare as u8;
     type Key = Self;
     type Value = PreimageDecryptionShare;
 }
@@ -73,7 +77,7 @@ impl DatabaseKeyPrefixConst for ProposeDecryptionShareKey {
 pub struct ProposeDecryptionShareKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ProposeDecryptionShareKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_PROPOSE_DECRYPTION_SHARE;
+    const DB_PREFIX: u8 = DbKeyPrefix::ProposeDecryptionShare as u8;
     type Key = ProposeDecryptionShareKey;
     type Value = PreimageDecryptionShare;
 }
@@ -83,7 +87,7 @@ impl DatabaseKeyPrefixConst for ProposeDecryptionShareKeyPrefix {
 pub struct AgreedDecryptionShareKey(pub ContractId, pub PeerId);
 
 impl DatabaseKeyPrefixConst for AgreedDecryptionShareKey {
-    const DB_PREFIX: u8 = DB_PREFIX_AGREED_DECRYPTION_SHARE;
+    const DB_PREFIX: u8 = DbKeyPrefix::AgreedDecryptionShare as u8;
     type Key = Self;
     type Value = PreimageDecryptionShare;
 }
@@ -93,7 +97,7 @@ impl DatabaseKeyPrefixConst for AgreedDecryptionShareKey {
 pub struct AgreedDecryptionShareKeyPrefix;
 
 impl DatabaseKeyPrefixConst for AgreedDecryptionShareKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_AGREED_DECRYPTION_SHARE;
+    const DB_PREFIX: u8 = DbKeyPrefix::AgreedDecryptionShare as u8;
     type Key = AgreedDecryptionShareKey;
     type Value = PreimageDecryptionShare;
 }
@@ -102,7 +106,7 @@ impl DatabaseKeyPrefixConst for AgreedDecryptionShareKeyPrefix {
 pub struct LightningGatewayKey(pub PublicKey);
 
 impl DatabaseKeyPrefixConst for LightningGatewayKey {
-    const DB_PREFIX: u8 = DB_PREFIX_LIGHTNING_GATEWAY;
+    const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
     type Key = Self;
     type Value = LightningGateway;
 }
@@ -111,7 +115,7 @@ impl DatabaseKeyPrefixConst for LightningGatewayKey {
 pub struct LightningGatewayKeyPrefix;
 
 impl DatabaseKeyPrefixConst for LightningGatewayKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_LIGHTNING_GATEWAY;
+    const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
     type Key = LightningGatewayKey;
     type Value = LightningGateway;
 }

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -4,17 +4,21 @@ use fedimint_api::{Amount, OutPoint, PeerId};
 
 use crate::{Nonce, PartialSigResponse, SigResponse};
 
-const DB_PREFIX_COIN_NONCE: u8 = 0x10;
-const DB_PREFIX_PROPOSED_PARTIAL_SIG: u8 = 0x11;
-const DB_PREFIX_RECEIVED_PARTIAL_SIG: u8 = 0x12;
-const DB_PREFIX_OUTPUT_OUTCOME: u8 = 0x13;
-const DB_PREFIX_MINT_AUDIT_ITEM: u8 = 0x14;
+#[repr(u8)]
+#[derive(Clone)]
+pub enum DbKeyPrefix {
+    CoinNonce = 0x10,
+    ProposedPartialSig = 0x11,
+    ReceivedPartialSig = 0x12,
+    OutputOutcome = 0x13,
+    MintAuditItem = 0x14,
+}
 
 #[derive(Debug, Clone, Encodable, Decodable, Eq, PartialEq, Hash)]
 pub struct NonceKey(pub Nonce);
 
 impl DatabaseKeyPrefixConst for NonceKey {
-    const DB_PREFIX: u8 = DB_PREFIX_COIN_NONCE;
+    const DB_PREFIX: u8 = DbKeyPrefix::CoinNonce as u8;
     type Key = Self;
     type Value = ();
 }
@@ -25,7 +29,7 @@ pub struct ProposedPartialSignatureKey {
 }
 
 impl DatabaseKeyPrefixConst for ProposedPartialSignatureKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PROPOSED_PARTIAL_SIG;
+    const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
     type Key = Self;
     type Value = PartialSigResponse;
 }
@@ -34,7 +38,7 @@ impl DatabaseKeyPrefixConst for ProposedPartialSignatureKey {
 pub struct ProposedPartialSignaturesKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ProposedPartialSignaturesKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_PROPOSED_PARTIAL_SIG;
+    const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
     type Key = ProposedPartialSignatureKey;
     type Value = PartialSigResponse;
 }
@@ -46,7 +50,7 @@ pub struct ReceivedPartialSignatureKey {
 }
 
 impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKey {
-    const DB_PREFIX: u8 = DB_PREFIX_RECEIVED_PARTIAL_SIG;
+    const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = Self;
     type Value = PartialSigResponse;
 }
@@ -57,7 +61,7 @@ pub struct ReceivedPartialSignatureKeyOutputPrefix {
 }
 
 impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKeyOutputPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_RECEIVED_PARTIAL_SIG;
+    const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = ReceivedPartialSignatureKey;
     type Value = PartialSigResponse;
 }
@@ -66,7 +70,7 @@ impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKeyOutputPrefix {
 pub struct ReceivedPartialSignaturesKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ReceivedPartialSignaturesKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_RECEIVED_PARTIAL_SIG;
+    const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = ReceivedPartialSignatureKey;
     type Value = PartialSigResponse;
 }
@@ -76,7 +80,7 @@ impl DatabaseKeyPrefixConst for ReceivedPartialSignaturesKeyPrefix {
 pub struct OutputOutcomeKey(pub OutPoint);
 
 impl DatabaseKeyPrefixConst for OutputOutcomeKey {
-    const DB_PREFIX: u8 = DB_PREFIX_OUTPUT_OUTCOME;
+    const DB_PREFIX: u8 = DbKeyPrefix::OutputOutcome as u8;
     type Key = Self;
     type Value = SigResponse;
 }
@@ -91,7 +95,7 @@ pub enum MintAuditItemKey {
 }
 
 impl DatabaseKeyPrefixConst for MintAuditItemKey {
-    const DB_PREFIX: u8 = DB_PREFIX_MINT_AUDIT_ITEM;
+    const DB_PREFIX: u8 = DbKeyPrefix::MintAuditItem as u8;
     type Key = Self;
     type Value = Amount;
 }
@@ -100,7 +104,7 @@ impl DatabaseKeyPrefixConst for MintAuditItemKey {
 pub struct MintAuditItemKeyPrefix;
 
 impl DatabaseKeyPrefixConst for MintAuditItemKeyPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_MINT_AUDIT_ITEM;
+    const DB_PREFIX: u8 = DbKeyPrefix::MintAuditItem as u8;
     type Key = MintAuditItemKey;
     type Value = Amount;
 }

--- a/modules/fedimint-wallet/src/db.rs
+++ b/modules/fedimint-wallet/src/db.rs
@@ -7,19 +7,23 @@ use crate::{
     PegOutOutcome, PendingTransaction, RoundConsensus, SpendableUTXO, UnsignedTransaction,
 };
 
-const DB_PREFIX_BLOCK_HASH: u8 = 0x30;
-const DB_PREFIX_UTXO: u8 = 0x31;
-const DB_PREFIX_ROUND_CONSENSUS: u8 = 0x32;
-const DB_PREFIX_UNSIGNED_TRANSACTION: u8 = 0x34;
-const DB_PREFIX_PENDING_TRANSACTION: u8 = 0x35;
-const DB_PREFIX_PEG_OUT_TX_SIG_CI: u8 = 0x36;
-const DB_PREFIX_PEG_OUT_BITCOIN_OUT_POINT: u8 = 0x37;
+#[repr(u8)]
+#[derive(Clone)]
+pub enum DbKeyPrefix {
+    BlockHash = 0x30,
+    Utxo = 0x31,
+    RoundConsensus = 0x32,
+    UnsignedTransaction = 0x34,
+    PendingTransaction = 0x35,
+    PegOutTxSigCi = 0x36,
+    PegOutBitcoinOutPoint = 0x37,
+}
 
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct BlockHashKey(pub BlockHash);
 
 impl DatabaseKeyPrefixConst for BlockHashKey {
-    const DB_PREFIX: u8 = DB_PREFIX_BLOCK_HASH;
+    const DB_PREFIX: u8 = DbKeyPrefix::BlockHash as u8;
     type Key = Self;
     type Value = ();
 }
@@ -28,7 +32,7 @@ impl DatabaseKeyPrefixConst for BlockHashKey {
 pub struct UTXOKey(pub bitcoin::OutPoint);
 
 impl DatabaseKeyPrefixConst for UTXOKey {
-    const DB_PREFIX: u8 = DB_PREFIX_UTXO;
+    const DB_PREFIX: u8 = DbKeyPrefix::Utxo as u8;
     type Key = Self;
     type Value = SpendableUTXO;
 }
@@ -37,7 +41,7 @@ impl DatabaseKeyPrefixConst for UTXOKey {
 pub struct UTXOPrefixKey;
 
 impl DatabaseKeyPrefixConst for UTXOPrefixKey {
-    const DB_PREFIX: u8 = DB_PREFIX_UTXO;
+    const DB_PREFIX: u8 = DbKeyPrefix::Utxo as u8;
     type Key = UTXOKey;
     type Value = SpendableUTXO;
 }
@@ -46,7 +50,7 @@ impl DatabaseKeyPrefixConst for UTXOPrefixKey {
 pub struct RoundConsensusKey;
 
 impl DatabaseKeyPrefixConst for RoundConsensusKey {
-    const DB_PREFIX: u8 = DB_PREFIX_ROUND_CONSENSUS;
+    const DB_PREFIX: u8 = DbKeyPrefix::RoundConsensus as u8;
     type Key = Self;
     type Value = RoundConsensus;
 }
@@ -55,7 +59,7 @@ impl DatabaseKeyPrefixConst for RoundConsensusKey {
 pub struct UnsignedTransactionKey(pub Txid);
 
 impl DatabaseKeyPrefixConst for UnsignedTransactionKey {
-    const DB_PREFIX: u8 = DB_PREFIX_UNSIGNED_TRANSACTION;
+    const DB_PREFIX: u8 = DbKeyPrefix::UnsignedTransaction as u8;
     type Key = Self;
     type Value = UnsignedTransaction;
 }
@@ -64,7 +68,7 @@ impl DatabaseKeyPrefixConst for UnsignedTransactionKey {
 pub struct UnsignedTransactionPrefixKey;
 
 impl DatabaseKeyPrefixConst for UnsignedTransactionPrefixKey {
-    const DB_PREFIX: u8 = DB_PREFIX_UNSIGNED_TRANSACTION;
+    const DB_PREFIX: u8 = DbKeyPrefix::UnsignedTransaction as u8;
     type Key = UnsignedTransactionKey;
     type Value = UnsignedTransaction;
 }
@@ -73,7 +77,7 @@ impl DatabaseKeyPrefixConst for UnsignedTransactionPrefixKey {
 pub struct PendingTransactionKey(pub Txid);
 
 impl DatabaseKeyPrefixConst for PendingTransactionKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PENDING_TRANSACTION;
+    const DB_PREFIX: u8 = DbKeyPrefix::PendingTransaction as u8;
     type Key = Self;
     type Value = PendingTransaction;
 }
@@ -82,7 +86,7 @@ impl DatabaseKeyPrefixConst for PendingTransactionKey {
 pub struct PendingTransactionPrefixKey;
 
 impl DatabaseKeyPrefixConst for PendingTransactionPrefixKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PENDING_TRANSACTION;
+    const DB_PREFIX: u8 = DbKeyPrefix::PendingTransaction as u8;
     type Key = PendingTransactionKey;
     type Value = PendingTransaction;
 }
@@ -91,7 +95,7 @@ impl DatabaseKeyPrefixConst for PendingTransactionPrefixKey {
 pub struct PegOutTxSignatureCI(pub Txid);
 
 impl DatabaseKeyPrefixConst for PegOutTxSignatureCI {
-    const DB_PREFIX: u8 = DB_PREFIX_PEG_OUT_TX_SIG_CI;
+    const DB_PREFIX: u8 = DbKeyPrefix::PegOutTxSigCi as u8;
     type Key = Self;
     type Value = Vec<Signature>; // TODO: define newtype
 }
@@ -100,7 +104,7 @@ impl DatabaseKeyPrefixConst for PegOutTxSignatureCI {
 pub struct PegOutTxSignatureCIPrefix;
 
 impl DatabaseKeyPrefixConst for PegOutTxSignatureCIPrefix {
-    const DB_PREFIX: u8 = DB_PREFIX_PEG_OUT_TX_SIG_CI;
+    const DB_PREFIX: u8 = DbKeyPrefix::PegOutTxSigCi as u8;
     type Key = PegOutTxSignatureCI;
     type Value = Vec<Signature>;
 }
@@ -109,7 +113,7 @@ impl DatabaseKeyPrefixConst for PegOutTxSignatureCIPrefix {
 pub struct PegOutBitcoinTransaction(pub fedimint_api::OutPoint);
 
 impl DatabaseKeyPrefixConst for PegOutBitcoinTransaction {
-    const DB_PREFIX: u8 = DB_PREFIX_PEG_OUT_BITCOIN_OUT_POINT;
+    const DB_PREFIX: u8 = DbKeyPrefix::PegOutBitcoinOutPoint as u8;
     type Key = Self;
     type Value = PegOutOutcome;
 }


### PR DESCRIPTION
This commit reformulates database key prefixes such that they are grouped into enums.

Currently, key prefixes are listed as separate const values. This formulation makes it difficult to manage key prefixes (import, iterate, test, etc), particularly when it comes to dbdump. This commit simplifies key prefix management using enums and a key prefix trait. It also makes it possible to test and ensure key prefixes are locally unique.