### PR TITLE
wrap the gateways ln_client to gain controll over it

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -35,6 +35,7 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 use url::Url;
 
+use crate::fixtures::utils::LnRpcAdapter;
 use fake::{FakeBitcoinTest, FakeLightningTest};
 use fedimint::config::ServerConfigParams;
 use fedimint::config::{ClientConfig, ServerConfig};
@@ -55,7 +56,6 @@ use fedimint_wallet::config::WalletConfig;
 use fedimint_wallet::db::UTXOKey;
 use fedimint_wallet::txoproof::TxOutProof;
 use fedimint_wallet::SpendableUTXO;
-use ln_gateway::ln::LnRpc;
 use ln_gateway::LnGateway;
 use mint_client::api::WsFederationApi;
 use mint_client::mint::SpendableNote;
@@ -64,6 +64,7 @@ use real::{RealBitcoinTest, RealLightningTest};
 
 mod fake;
 mod real;
+mod utils;
 
 static BASE_PORT: AtomicU16 = AtomicU16::new(4000_u16);
 
@@ -130,11 +131,12 @@ pub async fn fixtures(
             let socket_other = PathBuf::from(dir.clone()).join("ln2/regtest/lightning-rpc");
             let lightning =
                 RealLightningTest::new(socket_gateway.clone(), socket_other.clone()).await;
-            let lightning_rpc = Mutex::new(
+            let gateway_lightning_rpc = Mutex::new(
                 ClnRpc::new(socket_gateway.clone())
                     .await
                     .expect("connect to ln_socket"),
             );
+            let lightning_rpc_adapter = LnRpcAdapter::new(Box::new(gateway_lightning_rpc));
 
             let connect_gen =
                 |cfg: &ServerConfig| TlsTcpConnector::new(cfg.tls_config()).into_dyn();
@@ -147,7 +149,7 @@ pub async fn fixtures(
             user.client.await_consensus_block_height(0).await;
 
             let gateway = GatewayTest::new(
-                Box::new(lightning_rpc),
+                lightning_rpc_adapter,
                 client_config.clone(),
                 lightning.gateway_node_pub_key,
                 base_port + num_peers + 1,
@@ -161,6 +163,7 @@ pub async fn fixtures(
             let bitcoin = FakeBitcoinTest::new();
             let bitcoin_rpc = || bitcoin.clone().into();
             let lightning = FakeLightningTest::new();
+            let ln_rpc_adapter = LnRpcAdapter::new(Box::new(lightning.clone()));
             let net = MockNetwork::new();
             let net_ref = &net;
             let connect_gen = move |cfg: &ServerConfig| net_ref.connector(cfg.identity).into_dyn();
@@ -174,7 +177,7 @@ pub async fn fixtures(
             user.client.await_consensus_block_height(0).await;
 
             let gateway = GatewayTest::new(
-                Box::new(lightning.clone()),
+                ln_rpc_adapter,
                 client_config.clone(),
                 lightning.gateway_node_pub_key,
                 base_port + num_peers + 1,
@@ -220,6 +223,7 @@ pub trait LightningTest {
 
 pub struct GatewayTest {
     pub server: LnGateway,
+    pub adapter: Arc<LnRpcAdapter>,
     pub keys: LightningGateway,
     pub user: UserTest,
     pub client: Arc<GatewayClient>,
@@ -227,7 +231,7 @@ pub struct GatewayTest {
 
 impl GatewayTest {
     async fn new(
-        ln_client: Box<dyn LnRpc>,
+        ln_client_adapter: LnRpcAdapter,
         client_config: ClientConfig,
         node_pub_key: secp256k1::PublicKey,
         bind_port: u16,
@@ -266,6 +270,8 @@ impl GatewayTest {
             Default::default(),
         ));
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
+        let adapter = Arc::new(ln_client_adapter);
+        let ln_client = Arc::clone(&adapter);
         let gateway = LnGateway::new(client.clone(), ln_client, sender, receiver, bind_addr);
         // Normally, this client registration with the federation is automated as part of running the gateway
         // In test cases, we want to register without running a gateway
@@ -276,6 +282,7 @@ impl GatewayTest {
 
         GatewayTest {
             server: gateway,
+            adapter,
             keys,
             user,
             client,

--- a/integrationtests/tests/fixtures/utils.rs
+++ b/integrationtests/tests/fixtures/utils.rs
@@ -1,0 +1,57 @@
+use async_trait::async_trait;
+use ln_gateway::ln::{LightningError, LnRpc};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// A proxy for the underlying LnRpc which can be used to add behavoir to it using the "Decorator pattern"
+pub struct LnRpcAdapter {
+    /// The actual LnRpc that we add behavior to.
+    client: Box<dyn LnRpc>,
+    /// A pair of <Invoice> and <Count> where client.pay() will fail <Count> times for each <Invoice>
+    fail_invoices: Arc<Mutex<HashMap<String, u8>>>,
+}
+
+impl LnRpcAdapter {
+    pub fn new(client: Box<dyn LnRpc>) -> Self {
+        let fail_invoices = Arc::new(Mutex::new(HashMap::new()));
+
+        LnRpcAdapter {
+            client,
+            fail_invoices,
+        }
+    }
+
+    /// Register <invoice> to fail <times> before (attempt) succeeding. The invoice will be dropped from the HashMap after succeeding
+    #[allow(dead_code)]
+    pub async fn fail_invoice(&self, invoice: String, times: u8) {
+        self.fail_invoices.lock().await.insert(invoice, times + 1);
+    }
+}
+
+#[async_trait]
+impl LnRpc for LnRpcAdapter {
+    async fn pay(
+        &self,
+        invoice_str: &str,
+        max_delay: u64,
+        max_fee_percent: f64,
+    ) -> Result<[u8; 32], LightningError> {
+        self.fail_invoices
+            .lock()
+            .await
+            .entry(invoice_str.to_string())
+            .and_modify(|counter| {
+                *counter -= 1;
+            });
+        if let Some(counter) = self.fail_invoices.lock().await.get(invoice_str) {
+            if *counter > 0 {
+                return Err(LightningError(None));
+            }
+        }
+        self.fail_invoices.lock().await.remove(invoice_str);
+        self.client
+            .pay(invoice_str, max_delay, max_fee_percent)
+            .await
+    }
+}

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -105,7 +105,7 @@ async fn initialize_gateway(
         .into();
     let ctx = secp256k1::Secp256k1::new();
     let federation_client = Arc::new(Client::new(gw_client_cfg, db, ctx));
-    let ln_client = Box::new(Mutex::new(ln_client));
+    let ln_client = Arc::new(Mutex::new(ln_client));
 
     LnGateway::new(federation_client, ln_client, sender, receiver, bind_addr)
 }

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -118,13 +118,11 @@ pub struct LnGateway {
 impl LnGateway {
     pub fn new(
         federation_client: Arc<GatewayClient>,
-        ln_client: Box<dyn LnRpc>,
+        ln_client: Arc<dyn LnRpc>,
         sender: mpsc::Sender<GatewayRequest>,
         receiver: mpsc::Receiver<GatewayRequest>,
         bind_addr: SocketAddr,
     ) -> Self {
-        let ln_client: Arc<dyn LnRpc> = ln_client.into();
-
         // Run webserver asynchronously in tokio
         let webserver = tokio::spawn(run_webserver(bind_addr, sender));
 

--- a/ln-gateway/src/ln.rs
+++ b/ln-gateway/src/ln.rs
@@ -17,7 +17,7 @@ pub trait LnRpc: Send + Sync + 'static {
 }
 
 #[derive(Debug)]
-pub struct LightningError(Option<i32>);
+pub struct LightningError(pub Option<i32>);
 
 #[async_trait]
 impl LnRpc for Mutex<cln_rpc::ClnRpc> {


### PR DESCRIPTION
This PR introduces a wrapper around the `ln_client` the gatway uses to gain control over it in tests. This was @okjodom idea and is called the [Decorator pattern](https://en.wikipedia.org/wiki/Decorator_pattern). We can use this in the same manner for other trait objects in the same manner but this one is  only for the gateway.