### PR TITLE
Fix gw-reload.sh

### DIFF
--- a/scripts/gw-reload.sh
+++ b/scripts/gw-reload.sh
@@ -4,7 +4,8 @@
 set -euo pipefail
 
 cargo build --release --bin ln_gateway
-$LN1 plugin stop ln_gateway &> /dev/null
-$LN1 -k plugin subcommand=start plugin=$BIN_DIR/ln_gateway fedimint-cfg=$CFG_DIR &> /dev/null
+
+$FM_LN1 plugin stop ln_gateway &> /dev/null || true
+$FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR &> /dev/null
 
 echo "Gateway plugin reloaded"


### PR DESCRIPTION
Fix this little script which re-compiles and reloads lightning gateway in core-lightning. Hadn't used for a couple months and variable names changed. Useful little script ...