### PR TITLE
Remove nix-shell from documentation

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -64,23 +64,18 @@ jobs:
       #   run: nix build -L .#workspaceTest
 
       - name: Reconnect Tests
-        # run: nix-shell --command ./scripts/reconnect-test.sh
         run: nix build -L .#cli-test.reconnect
 
       - name: Latency Tests
-        # run: nix-shell --command ./scripts/latency-test.sh
         run: nix build -L .#cli-test.latency
 
       - name: CLI Tests
-        # run: nix-shell --command ./scripts/cli-test.sh
         run: nix build -L .#cli-test.cli
 
       - name: Clientd and clientd-cli tests
-        # run: nix-shell --command ./scripts/clientd-tests.sh
         run: nix build -L .#cli-test.clientd
 
       - name: Integration Tests (no fixtures)
-        # run: nix-shell --command ./scripts/rust-tests.sh
         run: nix build -L .#cli-test.rust-tests
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ it
 .idea
 .tmpenv
 .direnv
+.vscode

--- a/docs/nix_instructions.md
+++ b/docs/nix_instructions.md
@@ -18,15 +18,16 @@ git clone git@github.com:fedimint/fedimint.git
 ```
 Enter development shell: 
 ```nix
-nix-shell
+nix develop
 ```
 Setup development environment locally:
 ```nix
 nix-build default.nix
 ```
-Run integration tests with nix-shell:
+Run integration tests with nix develop:
 ```nix
-nix-shell --command ./scripts/integrationtest.sh
+nix develop
+./scripts/integrationtest.sh
 ```
 
 ### nix-flakes:

--- a/integrationtests/README.md
+++ b/integrationtests/README.md
@@ -56,7 +56,7 @@ You may wish to run `cargo test -p fedimint-tests <test-name>` to prevent concur
 Make sure you've [installed](https://nixos.org/manual/nix/stable/quick-start.html) Nix in order to run the correct versions of bitcoind and lightningd.
 Then you can run the following commands to start the services:
 ```shell
-nix-shell
+nix develop
 source ./scripts/setup-tests.sh
 ```
 
@@ -67,7 +67,7 @@ export FM_TEST_DISABLE_MOCKS=1
 cargo test -p fedimint-tests -- --test-threads=1
 ```
 
-If you wish to clean-up the services you either exit the nix-shell or run:
+If you wish to clean-up the services run:
 ```shell
 kill_fedimint_processes
 ```

--- a/scripts/final-checks.sh
+++ b/scripts/final-checks.sh
@@ -12,9 +12,9 @@ export FM_TEST_DISABLE_MOCKS=0
 cargo test --release
 
 if [ "$1" == "nix" ]; then
-  nix-shell --run ./scripts/cli-test.sh
-  nix-shell --run ./scripts/rust-tests.sh
-  nix-shell --run ./scripts/clientd-tests.sh
+  ./scripts/cli-test.sh
+  ./scripts/rust-tests.sh
+  ./scripts/clientd-tests.sh
 fi
 
 echo "Tests succeeded"


### PR DESCRIPTION
Creating a new PR to remove nix-shell from documentation as it has been replaced by nix develop.

This PR also adds .vscode to the .gitignore file to allow for local vs code configurations.