### PR TITLE
Refactor some stuff out of `fedimint-server`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,7 +795,6 @@ dependencies = [
  "fedimint-build",
  "fedimint-core",
  "fedimint-derive",
- "fedimint-rocksdb",
  "fedimint-wallet",
  "futures",
  "hbbft",

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -263,7 +263,7 @@ mod tests {
                 move |cfg, db| {
                     let btc_rpc_clone = btc_rpc.clone();
                     async move {
-                        Wallet::new_with_bitcoind(cfg, db, || btc_rpc_clone.clone().into())
+                        Wallet::new_with_bitcoind(cfg, db, btc_rpc_clone.clone().into())
                             .await
                             .unwrap()
                     }

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -1,5 +1,6 @@
 use crate::PeerId;
 use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 /// Part of a config that needs to be generated to bootstrap a new federation.
@@ -19,4 +20,11 @@ pub trait GenerateConfig: Sized {
 
     /// Asserts that the public keys in the config are and panics otherwise (no way to recover)
     fn validate_config(&self, identity: &PeerId);
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BitcoindRpcCfg {
+    pub btc_rpc_address: String,
+    pub btc_rpc_user: String,
+    pub btc_rpc_pass: String,
 }

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -28,7 +28,6 @@ mint-client = { path = "../client/client-lib" }
 fedimint-api = { path = "../fedimint-api" }
 fedimint-core = { path = "../fedimint-core" }
 fedimint-derive = { path = "../fedimint-derive" }
-fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 fedimint-wallet = { path = "../modules/fedimint-wallet", features = ["native"] }
 rand = "0.6.5"
 rayon = "1.5.0"

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -20,7 +20,7 @@ use fedimint_api::db::Database;
 use fedimint_api::{NumPeers, PeerId};
 use fedimint_core::modules::ln::LightningModule;
 use fedimint_core::modules::wallet::bitcoind::BitcoindRpc;
-use fedimint_core::modules::wallet::{bitcoincore_rpc, Wallet};
+use fedimint_core::modules::wallet::Wallet;
 
 use fedimint_api::config::GenerateConfig;
 use fedimint_core::epoch::{ConsensusItem, EpochHistory, EpochVerifyError};
@@ -71,31 +71,24 @@ pub struct FedimintServer {
     pub api: Arc<dyn IFederationApi>,
 }
 
-/// Start all the components of the mint and plug them together
-pub async fn run_fedimint(cfg: ServerConfig, db: Database) {
-    let server = FedimintServer::new(cfg.clone(), db).await;
-    spawn(net::api::run_server(cfg, server.consensus.clone()));
-    server.run_consensus().await;
-}
-
 impl FedimintServer {
-    pub async fn new(cfg: ServerConfig, db: Database) -> Self {
+    /// Start all the components of the mint and plug them together
+    pub async fn run(cfg: ServerConfig, db: Database, bitcoincore_rpc: BitcoindRpc) {
+        let server = FedimintServer::new(cfg.clone(), db, bitcoincore_rpc).await;
+        spawn(net::api::run_server(cfg, server.consensus.clone()));
+        server.run_consensus().await;
+    }
+    pub async fn new(cfg: ServerConfig, db: Database, bitcoincore_rpc: BitcoindRpc) -> Self {
         let connector: PeerConnector<EpochMessage> =
             TlsTcpConnector::new(cfg.tls_config()).into_dyn();
 
-        Self::new_with(
-            cfg.clone(),
-            db,
-            bitcoincore_rpc::bitcoind_gen(cfg.wallet.clone()),
-            connector,
-        )
-        .await
+        Self::new_with(cfg.clone(), db, bitcoincore_rpc, connector).await
     }
 
     pub async fn new_with(
         cfg: ServerConfig,
         database: Database,
-        bitcoind: impl Fn() -> BitcoindRpc,
+        bitcoind: BitcoindRpc,
         connector: PeerConnector<EpochMessage>,
     ) -> Self {
         cfg.validate_config(&cfg.identity);

--- a/fedimintd/src/main.rs
+++ b/fedimintd/src/main.rs
@@ -54,8 +54,12 @@ async fn main() {
     }
 
     let cfg: ServerConfig = load_from_file(&opts.cfg_path);
-    let db_path = opts.db_path;
-    run_fedimint(cfg, db_path).await;
+
+    let db = fedimint_rocksdb::RocksDb::open(opts.db_path)
+        .expect("Error opening DB")
+        .into();
+
+    run_fedimint(cfg, db).await;
 
     #[cfg(feature = "telemetry")]
     opentelemetry::global::shutdown_tracer_provider();

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -127,8 +127,9 @@ pub async fn fixtures(
             info!("Testing with REAL Bitcoin and Lightning services");
             let dir = env::var("FM_TEST_DIR").expect("Must have test dir defined for real tests");
             let wallet_config = server_config.iter().last().unwrap().1.wallet.clone();
-            let bitcoin_rpc = bitcoincore_rpc::bitcoind_gen(wallet_config.clone());
-            let bitcoin = RealBitcoinTest::new(wallet_config);
+            let bitcoin_rpc = bitcoincore_rpc::make_bitcoind_rpc(&wallet_config.btc_rpc)
+                .expect("Could not create bitcoinrpc");
+            let bitcoin = RealBitcoinTest::new(&wallet_config.btc_rpc);
             let socket_gateway = PathBuf::from(dir.clone()).join("ln1/regtest/lightning-rpc");
             let socket_other = PathBuf::from(dir.clone()).join("ln2/regtest/lightning-rpc");
             let lightning =
@@ -142,7 +143,13 @@ pub async fn fixtures(
             let connect_gen =
                 |cfg: &ServerConfig| TlsTcpConnector::new(cfg.tls_config()).into_dyn();
             let fed_db = || rocks(dir.clone()).into();
-            let fed = FederationTest::new(server_config, &fed_db, &bitcoin_rpc, &connect_gen).await;
+            let fed = FederationTest::new(
+                server_config,
+                &fed_db,
+                &|| bitcoin_rpc.clone(),
+                &connect_gen,
+            )
+            .await;
 
             let user_cfg = UserClientConfig(client_config.clone());
             let user_db = rocks(dir.clone()).into();
@@ -719,7 +726,7 @@ impl FederationTest {
             let fedimint = FedimintServer::new_with(
                 cfg.clone(),
                 database.clone(),
-                bitcoin_gen,
+                bitcoin_gen(),
                 connect_gen(cfg),
             )
             .await;

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -13,8 +13,8 @@ use fedimint_api::Amount;
 use lightning_invoice::Invoice;
 use serde::Serialize;
 
+use fedimint_api::config::BitcoindRpcCfg;
 use fedimint_api::encoding::Decodable;
-use fedimint_wallet::config::WalletConfig;
 use fedimint_wallet::txoproof::TxOutProof;
 
 use crate::fixtures::{BitcoinTest, LightningTest};
@@ -88,13 +88,10 @@ pub struct RealBitcoinTest {
 impl RealBitcoinTest {
     const ERROR: &'static str = "Bitcoin RPC returned an error";
 
-    pub fn new(wallet_config: WalletConfig) -> Self {
+    pub fn new(rpc_cfg: &BitcoindRpcCfg) -> Self {
         let client = Client::new(
-            &(wallet_config.btc_rpc_address),
-            Auth::UserPass(
-                wallet_config.btc_rpc_user.clone(),
-                wallet_config.btc_rpc_pass.clone(),
-            ),
+            &(rpc_cfg.btc_rpc_address),
+            Auth::UserPass(rpc_cfg.btc_rpc_user.clone(), rpc_cfg.btc_rpc_pass.clone()),
         )
         .expect(Self::ERROR);
 

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -2,7 +2,7 @@ use crate::keys::CompressedPublicKey;
 use crate::{Feerate, PegInDescriptor};
 use bitcoin::secp256k1::rand::{CryptoRng, RngCore};
 use bitcoin::Network;
-use fedimint_api::config::GenerateConfig;
+use fedimint_api::config::{BitcoindRpcCfg, GenerateConfig};
 use fedimint_api::{NumPeers, PeerId};
 use miniscript::descriptor::Wsh;
 use serde::{Deserialize, Serialize};
@@ -18,10 +18,9 @@ pub struct WalletConfig {
     pub peg_in_key: secp256k1::SecretKey,
     pub finality_delay: u32,
     pub default_fee: Feerate,
-    pub btc_rpc_address: String,
-    pub btc_rpc_user: String,
-    pub btc_rpc_pass: String,
     pub fee_consensus: FeeConsensus,
+    #[serde(flatten)]
+    pub btc_rpc: BitcoindRpcCfg,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -90,9 +89,11 @@ impl GenerateConfig for WalletConfig {
                     peg_in_key: *sk,
                     finality_delay: FINALITY_DELAY,
                     default_fee: Feerate { sats_per_kvb: 1000 },
-                    btc_rpc_address: "127.0.0.1:18443".to_string(),
-                    btc_rpc_user: "bitcoin".to_string(),
-                    btc_rpc_pass: "bitcoin".to_string(),
+                    btc_rpc: BitcoindRpcCfg {
+                        btc_rpc_address: "127.0.0.1:18443".to_string(),
+                        btc_rpc_user: "bitcoin".to_string(),
+                        btc_rpc_pass: "bitcoin".to_string(),
+                    },
                     fee_consensus: FeeConsensus::default(),
                 };
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -544,15 +544,15 @@ impl Wallet {
     pub async fn new_with_bitcoind(
         cfg: WalletConfig,
         db: Database,
-        bitcoind_gen: impl Fn() -> BitcoindRpc,
+        bitcoind: BitcoindRpc,
     ) -> Result<Wallet, WalletError> {
-        let broadcaster_bitcoind_rpc = bitcoind_gen();
+        let broadcaster_bitcoind_rpc = bitcoind.clone();
         let broadcaster_db = db.clone();
         fedimint_api::task::spawn(async move {
             run_broadcast_pending_tx(broadcaster_db, broadcaster_bitcoind_rpc).await;
         });
 
-        let bitcoind_rpc = bitcoind_gen();
+        let bitcoind_rpc = bitcoind;
 
         let bitcoind_net = bitcoind_rpc.get_network().await;
         if bitcoind_net != cfg.network {


### PR DESCRIPTION
The goal for `fedimint-server` is being a very generic "consensus running common code". That means it generally should not be creating concrete instances of stuff.

More comments in the commit messages.