### PR TITLE
Add sorted denominations to CLI `validate` and `info` commands

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -43,7 +43,7 @@ enum CliOutput {
 
     Validate {
         all_valid: bool,
-        details: HashMap<SpendableNote, bool>,
+        details: HashMap<Amount, usize>,
     },
 
     Spend {
@@ -411,15 +411,19 @@ async fn handle_command(
         }
         Command::Validate { coins } => {
             let validate_result = client.validate_note_signatures(&coins).await;
+            let details_vec = coins
+                .iter_tiers()
+                .map(|(amount, coins)| (amount.to_owned(), coins.len()))
+                .collect();
 
             match validate_result {
                 Ok(()) => Ok(CliOutput::Validate {
                     all_valid: true,
-                    details: ([].iter().cloned().collect()),
+                    details: (details_vec),
                 }),
                 Err(_) => Ok(CliOutput::Validate {
                     all_valid: false,
-                    details: ([].iter().cloned().collect()),
+                    details: (details_vec),
                 }),
             }
         }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -16,7 +16,7 @@ use mint_client::utils::{
 use mint_client::{Client, UserClientConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt::Debug;
 use std::path::PathBuf;
@@ -43,7 +43,7 @@ enum CliOutput {
 
     Validate {
         all_valid: bool,
-        details: HashMap<Amount, usize>,
+        details: BTreeMap<Amount, usize>,
     },
 
     Spend {
@@ -65,7 +65,7 @@ enum CliOutput {
     Info {
         total_amount: Amount,
         total_num_notes: usize,
-        details: HashMap<Amount, usize>,
+        details: BTreeMap<Amount, usize>,
     },
 
     LnInvoice {


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/591 and https://github.com/fedimint/fedimint/issues/606

- Add denominations to `validate` command
- Sort denominations in `validate` and `info` commands by using BTreeMap

Example
```
$ mint-client-cli spend 3275

{
  "spend": {
    "token": "BAAAAAAAAA..."
  }
}

$ mint-client-cli validate BAAAAAAAAA...

{
  "validate": {
    "all_valid": true,
    "details": {
      "1000": 5,
      "10000": 7,
      "100000": 2,
      "1000000": 3
    }
  }
}

$ mint-client-cli info

{
  "info": {
    "total_amount": 6725000,
    "total_num_notes": 20,
    "details": {
      "1000": 5,
      "10000": 2,
      "100000": 7,
      "1000000": 6
    }
  }
}
```