### PR TITLE
serialize preimage as hex on send to cln plugin

### DIFF
--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use bitcoin_hashes::hex::ToHex;
 use cln_plugin::{options, Builder, Error, Plugin};
 use cln_rpc::ClnRpc;
 use mint_client::{Client, GatewayClientConfig};
@@ -133,10 +134,9 @@ async fn htlc_accepted_hook(
 ) -> Result<serde_json::Value, Error> {
     let htlc_accepted: HtlcAccepted = serde_json::from_value(value)?;
     let preimage = gw_rpc(plugin, htlc_accepted).await?;
-    let pk = preimage.to_public_key()?;
     Ok(serde_json::json!({
       "result": "resolve",
-      "payment_key": pk.to_string(),
+      "payment_key": preimage.0.to_hex(),
     }))
 }
 


### PR DESCRIPTION
Replaces previous `bytes > pubkey > string` conversion when serializing preimage and sending to cln plugin