### PR TITLE
Fix `cargo doc`

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -427,7 +427,7 @@ impl<C: JsonRpcClient> FederationMember<C> {
 /// which makes the `Uri` parsing fail in these cases. This function works around this limitation in
 /// a limited way (not fully standard compliant, but work for our use case).
 ///
-/// See https://github.com/paritytech/jsonrpsee/issues/554#issue-1048646896
+/// See <https://github.com/paritytech/jsonrpsee/issues/554#issue-1048646896>
 fn url_to_string_with_default_port(url: &Url) -> String {
     format!(
         "{}://{}:{}{}",

--- a/modules/fedimint-ln/src/contracts/mod.rs
+++ b/modules/fedimint-ln/src/contracts/mod.rs
@@ -122,7 +122,7 @@ impl Preimage {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::InvalidPublicKey`] if the Preimage does not represent a valid Secp256k1 point x coordinate.
+    /// Returns [`secp256k1::Error::InvalidPublicKey`] if the Preimage does not represent a valid Secp256k1 point x coordinate.
     pub fn to_public_key(&self) -> Result<secp256k1::XOnlyPublicKey, secp256k1::Error> {
         secp256k1::XOnlyPublicKey::from_slice(&self.0)
     }


### PR DESCRIPTION
There is some problem in our CI - either on our side in `flake.nix` or inside `crane` and it ignores `cargo doc` errors. I'm investigating but in the meantime, this fixes the issue that was overlooked because of it.