### PR TITLE
Use nightly rustfmt

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -1,11 +1,16 @@
+use core::fmt;
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt::Debug;
+use std::path::PathBuf;
+use std::process::exit;
+
 use bitcoin::{secp256k1, Address, Transaction};
 use clap::{Parser, Subcommand};
 use fedimint_api::{Amount, NumPeers, OutPoint, TieredMulti, TransactionId};
 use fedimint_core::config::{load_from_file, ClientConfig};
 use fedimint_core::modules::ln::contracts::ContractId;
 use fedimint_core::modules::wallet::txoproof::TxOutProof;
-
-use core::fmt;
 use mint_client::api::{WsFederationApi, WsFederationConnect};
 use mint_client::mint::SpendableNote;
 use mint_client::query::CurrentConsensus;
@@ -16,11 +21,6 @@ use mint_client::utils::{
 use mint_client::{Client, UserClientConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::BTreeMap;
-use std::error::Error;
-use std::fmt::Debug;
-use std::path::PathBuf;
-use std::process::exit;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Serialize)]

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -11,18 +11,13 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use api::FederationApi;
-use fedimint_api::db::Database;
-use fedimint_api::tiered::InvalidAmountTierError;
-use fedimint_api::TieredMulti;
-use futures::StreamExt;
-
 use bitcoin::util::key::KeyPair;
 use bitcoin::{secp256k1, Address, Transaction as BitcoinTransaction};
-
 use bitcoin_hashes::{sha256, Hash};
-use futures::stream::FuturesUnordered;
-
+use fedimint_api::db::Database;
 use fedimint_api::task::sleep;
+use fedimint_api::tiered::InvalidAmountTierError;
+use fedimint_api::TieredMulti;
 use fedimint_api::{
     db::batch::{Accumulator, BatchItem, DbBatch},
     Amount, FederationModule, OutPoint, PeerId, TransactionId,
@@ -47,6 +42,8 @@ use fedimint_core::{
     },
     transaction::{Input, Output},
 };
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use lightning::ln::PaymentSecret;
 use lightning::routing::gossip::RoutingFees;
 use lightning::routing::router::{RouteHint, RouteHintHop};

--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -1,4 +1,3 @@
-use crate::ln::outgoing::OutgoingContractData;
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_core::modules::ln::contracts::ContractId;
@@ -6,6 +5,7 @@ use fedimint_core::modules::ln::LightningGateway;
 
 use super::incoming::ConfirmedInvoice;
 use super::outgoing::OutgoingContractAccount;
+use crate::ln::outgoing::OutgoingContractData;
 
 const DB_PREFIX_OUTGOING_PAYMENT: u8 = 0x23;
 const DB_PREFIX_OUTGOING_PAYMENT_CLAIM: u8 = 0x24;

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -3,11 +3,8 @@ pub mod db;
 pub mod incoming;
 pub mod outgoing;
 
-use crate::api::ApiError;
-use crate::ln::db::{OutgoingPaymentKey, OutgoingPaymentKeyPrefix};
-use crate::ln::incoming::IncomingContractAccount;
-use crate::ln::outgoing::{OutgoingContractAccount, OutgoingContractData};
-use crate::utils::ClientContext;
+use std::time::Duration;
+
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use fedimint_api::db::batch::BatchTx;
 use fedimint_api::task::timeout;
@@ -23,11 +20,15 @@ use fedimint_core::modules::ln::{
 };
 use lightning_invoice::Invoice;
 use rand::{CryptoRng, RngCore};
-use std::time::Duration;
 use thiserror::Error;
 
 use self::db::ConfirmedInvoiceKey;
 use self::incoming::ConfirmedInvoice;
+use crate::api::ApiError;
+use crate::ln::db::{OutgoingPaymentKey, OutgoingPaymentKeyPrefix};
+use crate::ln::incoming::IncomingContractAccount;
+use crate::ln::outgoing::{OutgoingContractAccount, OutgoingContractData};
+use crate::utils::ClientContext;
 
 pub struct LnClient<'c> {
     pub config: &'c LightningModuleClientConfig,
@@ -252,9 +253,8 @@ pub enum LnClientError {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::IFederationApi;
-    use crate::ln::LnClient;
-    use crate::ClientContext;
+    use std::sync::Arc;
+
     use async_trait::async_trait;
     use bitcoin::Address;
     use fedimint_api::db::batch::DbBatch;
@@ -271,9 +271,12 @@ mod tests {
     use fedimint_core::outcome::{OutputOutcome, TransactionStatus};
     use fedimint_core::transaction::Transaction;
     use lightning_invoice::Invoice;
-    use std::sync::Arc;
     use threshold_crypto::PublicKey;
     use url::Url;
+
+    use crate::api::IFederationApi;
+    use crate::ln::LnClient;
+    use crate::ClientContext;
 
     type Fed = FakeFed<LightningModule, LightningModuleClientConfig>;
 

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -1,8 +1,9 @@
-use crate::mint::{NoteIssuanceRequests, SpendableNote};
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{Amount, OutPoint, TieredMulti, TransactionId};
 use fedimint_core::modules::mint::Nonce;
+
+use crate::mint::{NoteIssuanceRequests, SpendableNote};
 
 pub const DB_PREFIX_COIN: u8 = 0x20;
 pub const DB_PREFIX_OUTPUT_FINALIZATION_DATA: u8 = 0x21;

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -1,8 +1,6 @@
 pub mod db;
 
-use crate::api::ApiError;
-use crate::transaction::TransactionBuilder;
-use crate::utils::ClientContext;
+use std::time::Duration;
 
 use db::{CoinKey, CoinKeyPrefix, OutputFinalizationKey, OutputFinalizationKeyPrefix};
 use fedimint_api::db::batch::{Accumulator, BatchItem, BatchTx, DbBatch};
@@ -14,14 +12,16 @@ use fedimint_core::modules::mint::config::MintClientConfig;
 use fedimint_core::modules::mint::{BlindNonce, Nonce, Note, SigResponse, SignRequest};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-
 use rand::{CryptoRng, RngCore};
 use secp256k1_zkp::{Secp256k1, Signing};
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 use tbs::{blind_message, unblind_signature, AggregatePublicKey, BlindedMessage, BlindingKey};
 use thiserror::Error;
 use tracing::{debug, trace, warn};
+
+use crate::api::ApiError;
+use crate::transaction::TransactionBuilder;
+use crate::utils::ClientContext;
 
 /// Federation module client for the Mint module. It can both create transaction inputs and outputs
 /// of the mint type.
@@ -357,10 +357,8 @@ impl From<InvalidAmountTierError> for CoinFinalizationError {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::IFederationApi;
+    use std::sync::Arc;
 
-    use crate::mint::MintClient;
-    use crate::{ClientContext, TransactionBuilder};
     use async_trait::async_trait;
     use bitcoin::hashes::Hash;
     use bitcoin::Address;
@@ -379,8 +377,11 @@ mod tests {
     use fedimint_core::outcome::{OutputOutcome, TransactionStatus};
     use fedimint_core::transaction::Transaction;
     use futures::executor::block_on;
-    use std::sync::Arc;
     use threshold_crypto::PublicKey;
+
+    use crate::api::IFederationApi;
+    use crate::mint::MintClient;
+    use crate::{ClientContext, TransactionBuilder};
 
     type Fed = FakeFed<Mint, MintClientConfig>;
 

--- a/client/client-lib/src/query.rs
+++ b/client/client-lib/src/query.rs
@@ -1,12 +1,14 @@
-use crate::api::{FedResponse, Result};
-use crate::ApiError;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+
 use fedimint_api::PeerId;
 use fedimint_core::epoch::EpochHistory;
 use jsonrpsee_core::Error as JsonRpcError;
 use jsonrpsee_types::error::CallError as RpcCallError;
-use std::collections::{HashMap, HashSet};
-use std::hash::Hash;
 use threshold_crypto::PublicKey;
+
+use crate::api::{FedResponse, Result};
+use crate::ApiError;
 
 /// Returns a result from the first responding peer
 pub struct TrustAllPeers;

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -1,15 +1,15 @@
-use rand::{CryptoRng, RngCore};
-
-use crate::mint::db::{CoinKey, OutputFinalizationKey, PendingCoinsKey};
-use crate::mint::NoteIssuanceRequests;
-use crate::{MintClientError, SpendableNote};
 use bitcoin::KeyPair;
 use fedimint_api::db::batch::{BatchItem, BatchTx};
 use fedimint_api::{Amount, OutPoint, Tiered, TieredMulti};
 use fedimint_core::config::FeeConsensus;
 use fedimint_core::modules::mint::{BlindNonce, Note};
 use fedimint_core::transaction::{Input, Output, Transaction};
+use rand::{CryptoRng, RngCore};
 use tbs::AggregatePublicKey;
+
+use crate::mint::db::{CoinKey, OutputFinalizationKey, PendingCoinsKey};
+use crate::mint::NoteIssuanceRequests;
+use crate::{MintClientError, SpendableNote};
 
 pub struct TransactionBuilder {
     input_notes: TieredMulti<SpendableNote>,

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -1,12 +1,13 @@
 use std::str::FromStr;
 
-use crate::api::FederationApi;
-use crate::mint::SpendableNote;
 use bitcoin::{secp256k1, Network};
 use fedimint_api::db::Database;
 use fedimint_api::encoding::Decodable;
 use fedimint_api::{ParseAmountError, TieredMulti};
 use lightning_invoice::Currency;
+
+use crate::api::FederationApi;
+use crate::mint::SpendableNote;
 
 pub fn parse_coins(s: &str) -> anyhow::Result<TieredMulti<SpendableNote>> {
     let bytes = base64::decode(s)?;

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -1,4 +1,3 @@
-use crate::utils::ClientContext;
 use bitcoin::Address;
 use bitcoin::KeyPair;
 use db::PegInKey;
@@ -7,13 +6,14 @@ use fedimint_api::Amount;
 use fedimint_core::modules::wallet::config::WalletClientConfig;
 use fedimint_core::modules::wallet::tweakable::Tweakable;
 use fedimint_core::modules::wallet::txoproof::{PegInProof, PegInProofError, TxOutProof};
-
-use crate::ApiError;
 use fedimint_core::modules::wallet::PegOutOutcome;
 use miniscript::descriptor::DescriptorTrait;
 use rand::{CryptoRng, RngCore};
 use thiserror::Error;
 use tracing::debug;
+
+use crate::utils::ClientContext;
+use crate::ApiError;
 
 mod db;
 
@@ -142,17 +142,16 @@ pub enum WalletClientError {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::IFederationApi;
-    use crate::wallet::WalletClient;
-    use crate::ClientContext;
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use async_trait::async_trait;
     use bitcoin::{Address, Txid};
-
+    use bitcoin_hashes::Hash;
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::module::testing::FakeFed;
     use fedimint_api::{OutPoint, TransactionId};
-
-    use bitcoin_hashes::Hash;
     use fedimint_core::epoch::EpochHistory;
     use fedimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
     use fedimint_core::modules::ln::contracts::ContractId;
@@ -167,10 +166,11 @@ mod tests {
     };
     use fedimint_core::outcome::{OutputOutcome, TransactionStatus};
     use fedimint_core::transaction::Transaction;
-    use std::str::FromStr;
-    use std::sync::Arc;
-    use std::time::Duration;
     use threshold_crypto::PublicKey;
+
+    use crate::api::IFederationApi;
+    use crate::wallet::WalletClient;
+    use crate::ClientContext;
 
     type Fed = FakeFed<Wallet, WalletClientConfig>;
     type SharedFed = Arc<tokio::sync::Mutex<Fed>>;

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -1,3 +1,6 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::{Extension, Router, Server};
@@ -12,8 +15,6 @@ use clientd::{Json as JsonExtract, SpendPayload};
 use fedimint_core::config::load_from_file;
 use mint_client::{Client, UserClientConfig};
 use rand::rngs::OsRng;
-use std::path::PathBuf;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tower::ServiceBuilder;

--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -3,8 +3,11 @@
 //! This library implements an ad-hoc threshold blind signature scheme based on BLS signatures using
 //! the (unrelated) BLS12-381 curve.
 
-use crate::hash::{hash_bytes_to_curve, hash_to_curve};
-use crate::poly::Poly;
+use std::hash::Hasher;
+
+pub use bls12_381::G1Affine as MessagePoint;
+pub use bls12_381::G2Affine as PubKeyPoint;
+pub use bls12_381::Scalar;
 use bls12_381::{pairing, G1Affine, G1Projective, G2Affine, G2Projective};
 use ff::Field;
 use group::Curve;
@@ -13,11 +16,9 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha3::digest::generic_array::typenum::U32;
 use sha3::Digest;
-use std::hash::Hasher;
 
-pub use bls12_381::G1Affine as MessagePoint;
-pub use bls12_381::G2Affine as PubKeyPoint;
-pub use bls12_381::Scalar;
+use crate::hash::{hash_bytes_to_curve, hash_to_curve};
+use crate::poly::Poly;
 
 pub mod hash;
 pub mod poly;

--- a/crypto/tbs/src/poly.rs
+++ b/crypto/tbs/src/poly.rs
@@ -1,9 +1,11 @@
-use crate::FromRandom;
-use ff::Field;
-use rand::RngCore;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Mul, MulAssign};
+
+use ff::Field;
+use rand::RngCore;
+
+use crate::FromRandom;
 
 #[derive(Debug)]
 pub struct Poly<G, S>

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -1,7 +1,9 @@
-use crate::PeerId;
+use std::collections::BTreeMap;
+
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+
+use crate::PeerId;
 
 /// Part of a config that needs to be generated to bootstrap a new federation.
 pub trait GenerateConfig: Sized {

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -1,11 +1,13 @@
-use super::batch::{BatchItem, DbBatch};
-use super::IDatabase;
-use crate::db::PrefixIter;
-use anyhow::Result;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::Mutex;
+
+use anyhow::Result;
 use tracing::error;
+
+use super::batch::{BatchItem, DbBatch};
+use super::IDatabase;
+use crate::db::PrefixIter;
 
 #[derive(Debug, Default)]
 pub struct MemDatabase {

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -1,12 +1,14 @@
-use crate::dyn_newtype_define;
-use crate::encoding::{Decodable, Encodable};
-use anyhow::Result;
-use batch::DbBatch;
 use std::error::Error;
 use std::fmt::Debug;
 use std::sync::Arc;
+
+use anyhow::Result;
+use batch::DbBatch;
 use thiserror::Error;
 use tracing::trace;
+
+use crate::dyn_newtype_define;
+use crate::encoding::{Decodable, Encodable};
 
 pub mod batch;
 pub mod mem_impl;

--- a/fedimint-api/src/encoding/btc.rs
+++ b/fedimint-api/src/encoding/btc.rs
@@ -1,6 +1,8 @@
-use crate::encoding::{Decodable, DecodeError, Encodable};
-use bitcoin::hashes::Hash as BitcoinHash;
 use std::io::Error;
+
+use bitcoin::hashes::Hash as BitcoinHash;
+
+use crate::encoding::{Decodable, DecodeError, Encodable};
 
 macro_rules! impl_encode_decode_bridge {
     ($btc_type:ty) => {
@@ -81,10 +83,12 @@ impl Decodable for bitcoin::hashes::sha256::Hash {
 
 #[cfg(test)]
 mod tests {
-    use crate::encoding::{Decodable, Encodable};
-    use bitcoin::hashes::Hash as BitcoinHash;
     use std::io::Cursor;
     use std::str::FromStr;
+
+    use bitcoin::hashes::Hash as BitcoinHash;
+
+    use crate::encoding::{Decodable, Encodable};
 
     #[test_log::test]
     fn sha256_roundtrip() {

--- a/fedimint-api/src/encoding/mod.rs
+++ b/fedimint-api/src/encoding/mod.rs
@@ -6,9 +6,10 @@ mod btc;
 mod secp256k1;
 mod tbs;
 
-pub use fedimint_derive::{Decodable, Encodable};
 use std::fmt::{Debug, Formatter};
 use std::io::{Error, Read, Write};
+
+pub use fedimint_derive::{Decodable, Encodable};
 use thiserror::Error;
 use url::Url;
 

--- a/fedimint-api/src/encoding/secp256k1.rs
+++ b/fedimint-api/src/encoding/secp256k1.rs
@@ -1,6 +1,8 @@
-use crate::encoding::{Decodable, DecodeError, Encodable};
-use secp256k1_zkp::ecdsa::Signature;
 use std::io::{Error, Read, Write};
+
+use secp256k1_zkp::ecdsa::Signature;
+
+use crate::encoding::{Decodable, DecodeError, Encodable};
 
 impl Encodable for secp256k1_zkp::ecdsa::Signature {
     fn consensus_encode<W: std::io::Write>(&self, mut writer: W) -> Result<usize, std::io::Error> {
@@ -79,9 +81,10 @@ impl Decodable for bitcoin::KeyPair {
 
 #[cfg(test)]
 mod tests {
-    use super::super::tests::test_roundtrip;
     use secp256k1_zkp::hashes::Hash as BitcoinHash;
     use secp256k1_zkp::Message;
+
+    use super::super::tests::test_roundtrip;
 
     #[test_log::test]
     fn test_ecdsa_sig() {

--- a/fedimint-api/src/encoding/tbs.rs
+++ b/fedimint-api/src/encoding/tbs.rs
@@ -57,8 +57,9 @@ impl Decodable for tbs::BlindingKey {
 
 #[cfg(test)]
 mod tests {
-    use super::super::tests::test_roundtrip;
     use tbs::{BlindedMessage, BlindingKey};
+
+    use super::super::tests::test_roundtrip;
 
     #[test_log::test]
     fn test_message_macro() {

--- a/fedimint-api/src/lib.rs
+++ b/fedimint-api/src/lib.rs
@@ -1,21 +1,21 @@
 extern crate self as fedimint_api;
 
+use std::collections::BTreeMap;
+use std::io::Error;
+use std::num::ParseIntError;
+use std::str::FromStr;
+
 use bitcoin::Denomination;
 use bitcoin_hashes::sha256::Hash as Sha256;
 pub use bitcoin_hashes::Hash as BitcoinHash;
 use bitcoin_hashes::{borrow_slice_impl, hash_newtype, hex_fmt_impl, index_impl, serde_impl};
 pub use module::{FederationModule, InputMeta};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::io::Error;
-use std::num::ParseIntError;
-use std::str::FromStr;
 use thiserror::Error;
-
-use crate::encoding::{Decodable, DecodeError, Encodable};
-
 pub use tiered::Tiered;
 pub use tiered_multi::*;
+
+use crate::encoding::{Decodable, DecodeError, Encodable};
 
 pub mod config;
 pub mod db;

--- a/fedimint-api/src/module/audit.rs
+++ b/fedimint-api/src/module/audit.rs
@@ -1,6 +1,6 @@
-use crate::db::{Database, DatabaseKeyPrefix, DatabaseKeyPrefixConst};
-
 use std::fmt::{Display, Formatter};
+
+use crate::db::{Database, DatabaseKeyPrefix, DatabaseKeyPrefixConst};
 
 #[derive(Default)]
 pub struct Audit {

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -2,17 +2,18 @@ pub mod audit;
 pub mod interconnect;
 pub mod testing;
 
-use crate::db::batch::BatchTx;
-use crate::{Amount, PeerId};
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use rand::CryptoRng;
 use secp256k1_zkp::rand::RngCore;
 use secp256k1_zkp::XOnlyPublicKey;
-use std::collections::HashSet;
 
+use crate::db::batch::BatchTx;
 use crate::module::audit::Audit;
 use crate::module::interconnect::ModuleInterconect;
+use crate::{Amount, PeerId};
 
 pub struct InputMeta<'a> {
     pub amount: Amount,

--- a/fedimint-api/src/module/testing.rs
+++ b/fedimint-api/src/module/testing.rs
@@ -1,19 +1,18 @@
-use async_trait::async_trait;
-
-use crate::config::GenerateConfig;
-use crate::db::batch::DbBatch;
-use crate::db::mem_impl::MemDatabase;
-use crate::db::Database;
-
-use crate::module::interconnect::ModuleInterconect;
-use crate::{Amount, FederationModule, InputMeta, OutPoint, PeerId};
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use async_trait::async_trait;
+
 use super::ApiError;
+use crate::config::GenerateConfig;
+use crate::db::batch::DbBatch;
+use crate::db::mem_impl::MemDatabase;
+use crate::db::Database;
+use crate::module::interconnect::ModuleInterconect;
+use crate::{Amount, FederationModule, InputMeta, OutPoint, PeerId};
 
 pub struct FakeFed<M, CC> {
     members: Vec<(PeerId, M, Database)>,

--- a/fedimint-api/src/task.rs
+++ b/fedimint-api/src/task.rs
@@ -9,9 +9,9 @@ pub struct Elapsed;
 
 #[cfg(not(target_family = "wasm"))]
 mod imp {
-    use super::*;
-
     pub use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+    use super::*;
 
     pub fn spawn<F>(future: F)
     where
@@ -47,11 +47,10 @@ mod imp {
 
 #[cfg(target_family = "wasm")]
 mod imp {
+    pub use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
     use futures::FutureExt;
 
     use super::*;
-
-    pub use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
     pub fn spawn<F>(future: F)
     where

--- a/fedimint-api/src/tiered.rs
+++ b/fedimint-api/src/tiered.rs
@@ -1,7 +1,8 @@
-use fedimint_api::Amount;
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
+
+use fedimint_api::Amount;
+use serde::{Deserialize, Serialize};
 use tbs::{PublicKeyShare, SecretKeyShare};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]

--- a/fedimint-api/src/tiered_multi.rs
+++ b/fedimint-api/src/tiered_multi.rs
@@ -1,10 +1,12 @@
-use crate::tiered::InvalidAmountTierError;
-use crate::{Amount, Tiered};
-use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
+
+use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
+use serde::{Deserialize, Serialize};
+
+use crate::tiered::InvalidAmountTierError;
+use crate::{Amount, Tiered};
 
 /// Represents coins of different denominations.
 ///
@@ -278,8 +280,9 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::TieredMulti;
     use fedimint_api::Amount;
+
+    use crate::TieredMulti;
 
     #[test]
     fn select_coins_returns_exact_amount() {

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -1,9 +1,10 @@
+use std::path::Path;
+
 use fedimint_ln::config::LightningModuleClientConfig;
 use fedimint_mint::config::MintClientConfig;
 use fedimint_wallet::config::WalletClientConfig;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
 use url::Url;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -1,4 +1,5 @@
-use crate::transaction::Transaction;
+use std::collections::{BTreeMap, HashSet};
+
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::sha256::HashEngine;
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
@@ -6,8 +7,9 @@ use fedimint_api::{BitcoinHash, FederationModule, PeerId};
 use fedimint_derive::UnzipConsensus;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashSet};
 use threshold_crypto::{PublicKey, PublicKeySet, Signature, SignatureShare};
+
+use crate::transaction::Transaction;
 
 #[derive(
     Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, UnzipConsensus, Encodable, Decodable,
@@ -182,13 +184,15 @@ impl Decodable for EpochSignatureShare {
 
 #[cfg(test)]
 mod tests {
-    use crate::epoch::{ConsensusItem, EpochSignatureShare, Sha256};
-    use crate::epoch::{EpochHistory, EpochSignature, EpochVerifyError, OutcomeHistory};
+    use std::collections::HashSet;
+
     use fedimint_api::rand::Rand07Compat;
     use fedimint_api::PeerId;
     use rand::rngs::OsRng;
-    use std::collections::HashSet;
     use threshold_crypto::{SecretKey, SecretKeySet};
+
+    use crate::epoch::{ConsensusItem, EpochSignatureShare, Sha256};
+    use crate::epoch::{EpochHistory, EpochSignature, EpochVerifyError, OutcomeHistory};
 
     fn signed_history(
         epoch: u16,

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -1,4 +1,3 @@
-use crate::config::FeeConsensus;
 use bitcoin::hashes::Hash as BitcoinHash;
 use bitcoin::XOnlyPublicKey;
 use fedimint_api::encoding::{Decodable, Encodable};
@@ -7,6 +6,8 @@ use rand::Rng;
 use secp256k1_zkp::{schnorr, Secp256k1, Signing, Verification};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+use crate::config::FeeConsensus;
 
 /// An atomic value transfer operation within the Fedimint system and consensus
 ///

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -1,12 +1,12 @@
+use std::path::Path;
+
 use anyhow::Result;
 use fedimint_api::db::batch::{BatchItem, DbBatch};
 use fedimint_api::db::IDatabase;
 use fedimint_api::db::PrefixIter;
-use rocksdb::OptimisticTransactionDB;
-use std::path::Path;
-use tracing::{error, trace};
-
 pub use rocksdb;
+use rocksdb::OptimisticTransactionDB;
+use tracing::{error, trace};
 
 #[derive(Debug)]
 pub struct RocksDb(rocksdb::OptimisticTransactionDB);

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -1,21 +1,20 @@
-use fedimint_api::rand::Rand07Compat;
-pub use fedimint_core::config::*;
+use std::collections::{BTreeMap, HashMap};
 
-use crate::net::peers::{ConnectionConfig, NetworkConfig};
 use fedimint_api::config::GenerateConfig;
+use fedimint_api::rand::Rand07Compat;
 use fedimint_api::PeerId;
+pub use fedimint_core::config::*;
 use fedimint_core::modules::ln::config::LightningModuleConfig;
 use fedimint_core::modules::mint::config::MintConfig;
 use fedimint_core::modules::wallet::config::WalletConfig;
 use hbbft::crypto::serde_impl::SerdeSecret;
 use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+use tokio_rustls::rustls;
 use url::Url;
 
-use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
-
 use crate::net::connect::TlsConfig;
-use tokio_rustls::rustls;
+use crate::net::peers::{ConnectionConfig, NetworkConfig};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
@@ -261,9 +260,10 @@ pub(crate) fn gen_cert_and_key(
 }
 
 mod serde_tls_cert {
+    use std::borrow::Cow;
+
     use serde::de::Error;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use std::borrow::Cow;
     use tokio_rustls::rustls;
 
     pub fn serialize<S>(cert: &rustls::Certificate, serializer: S) -> Result<S::Ok, S::Error>
@@ -285,9 +285,10 @@ mod serde_tls_cert {
 }
 
 mod serde_tls_key {
+    use std::borrow::Cow;
+
     use serde::de::Error;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use std::borrow::Cow;
     use tokio_rustls::rustls;
 
     pub fn serialize<S>(key: &rustls::PrivateKey, serializer: S) -> Result<S::Ok, S::Error>

--- a/fedimint-server/src/consensus/conflictfilter.rs
+++ b/fedimint-server/src/consensus/conflictfilter.rs
@@ -1,10 +1,12 @@
-use crate::transaction::{Input, Output, Transaction};
+use std::collections::HashSet;
+
 use fedimint_api::TieredMulti;
 use fedimint_core::modules::ln::contracts::{ContractId, IdentifyableContract};
 use fedimint_core::modules::ln::ContractOrOfferOutput;
 use fedimint_core::modules::mint::Note;
 use fedimint_core::modules::wallet::txoproof::PegInProof;
-use std::collections::HashSet;
+
+use crate::transaction::{Input, Output, Transaction};
 
 pub trait ConflictFilterable<T>
 where

--- a/fedimint-server/src/consensus/debug.rs
+++ b/fedimint-server/src/consensus/debug.rs
@@ -1,10 +1,12 @@
-use crate::{ConsensusItem, ConsensusOutcome};
+use std::fmt::Write;
+
 use fedimint_core::modules::ln::contracts::Contract;
 use fedimint_core::modules::ln::{ContractOrOfferOutput, ContractOutput, DecryptionShareCI};
 use fedimint_core::modules::mint::PartiallySignedRequest;
 use fedimint_core::transaction::{Input, Output, Transaction};
 use fedimint_wallet::{PegOutSignatureItem, RoundConsensusItem, WalletConsensusItem};
-use std::fmt::Write;
+
+use crate::{ConsensusItem, ConsensusOutcome};
 
 /// outputs a useful debug message for epochs indicating what happened
 pub fn epoch_message(consensus: &ConsensusOutcome) -> String {

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -1,12 +1,12 @@
-use crate::consensus::FedimintConsensus;
 use async_trait::async_trait;
-
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::ApiError;
 use fedimint_api::FederationModule;
 use rand::CryptoRng;
 use secp256k1_zkp::rand::RngCore;
 use serde_json::Value;
+
+use crate::consensus::FedimintConsensus;
 
 pub struct FedimintInterconnect<'a, R: RngCore + CryptoRng> {
     pub fedimint: &'a FedimintConsensus<R>,

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -4,16 +4,10 @@ mod conflictfilter;
 pub mod debug;
 mod interconnect;
 
-use crate::config::ServerConfig;
-use crate::consensus::conflictfilter::ConflictFilterable;
-use crate::consensus::interconnect::FedimintInterconnect;
-use crate::db::{
-    AcceptedTransactionKey, DropPeerKey, DropPeerKeyPrefix, EpochHistoryKey, LastEpochKey,
-    ProposedTransactionKey, ProposedTransactionKeyPrefix, RejectedTransactionKey,
-};
-use crate::outcome::OutputOutcome;
-use crate::rng::RngGenerator;
-use crate::transaction::{Input, Output, Transaction, TransactionError};
+use std::collections::{BTreeMap, HashSet};
+use std::iter::FromIterator;
+use std::sync::Arc;
+
 use fedimint_api::db::batch::{AccumulatorTx, BatchItem, BatchTx, DbBatch};
 use fedimint_api::db::Database;
 use fedimint_api::encoding::{Decodable, Encodable};
@@ -28,12 +22,20 @@ use futures::future::select_all;
 use hbbft::honey_badger::Batch;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashSet};
-use std::iter::FromIterator;
-use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, info_span, instrument, trace, warn};
+
+use crate::config::ServerConfig;
+use crate::consensus::conflictfilter::ConflictFilterable;
+use crate::consensus::interconnect::FedimintInterconnect;
+use crate::db::{
+    AcceptedTransactionKey, DropPeerKey, DropPeerKeyPrefix, EpochHistoryKey, LastEpochKey,
+    ProposedTransactionKey, ProposedTransactionKeyPrefix, RejectedTransactionKey,
+};
+use crate::outcome::OutputOutcome;
+use crate::rng::RngGenerator;
+use crate::transaction::{Input, Output, Transaction, TransactionError};
 
 pub type ConsensusOutcome = Batch<Vec<ConsensusItem>, PeerId>;
 pub type HoneyBadgerMessage = hbbft::honey_badger::Message<PeerId>;

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,10 +1,12 @@
-use crate::consensus::AcceptedTransaction;
-use crate::transaction::Transaction;
+use std::fmt::Debug;
+
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{PeerId, TransactionId};
 use fedimint_core::epoch::EpochHistory;
-use std::fmt::Debug;
+
+use crate::consensus::AcceptedTransaction;
+use crate::transaction::Transaction;
 
 pub const DB_PREFIX_PROPOSED_TRANSACTION: u8 = 0x01;
 pub const DB_PREFIX_ACCEPTED_TRANSACTION: u8 = 0x02;

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -5,28 +5,25 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use fedimint_api::rand::Rand07Compat;
-use hbbft::honey_badger::{HoneyBadger, Message};
-use hbbft::{Epoched, NetworkInfo, Target};
-
-use rand::rngs::OsRng;
-use rand::{CryptoRng, RngCore};
-use tokio::sync::Notify;
-use tokio::task::spawn;
-use tracing::{info, warn};
-
 use config::ServerConfig;
+use fedimint_api::config::GenerateConfig;
 use fedimint_api::db::Database;
+use fedimint_api::rand::Rand07Compat;
 use fedimint_api::{NumPeers, PeerId};
+use fedimint_core::epoch::{ConsensusItem, EpochHistory, EpochVerifyError};
 use fedimint_core::modules::ln::LightningModule;
 use fedimint_core::modules::wallet::bitcoind::BitcoindRpc;
 use fedimint_core::modules::wallet::Wallet;
-
-use fedimint_api::config::GenerateConfig;
-use fedimint_core::epoch::{ConsensusItem, EpochHistory, EpochVerifyError};
 pub use fedimint_core::*;
+use hbbft::honey_badger::{HoneyBadger, Message};
+use hbbft::{Epoched, NetworkInfo, Target};
 use mint_client::api::{IFederationApi, WsFederationApi};
+use rand::rngs::OsRng;
+use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+use tokio::task::spawn;
+use tracing::{info, warn};
 
 use crate::consensus::{
     ConsensusOutcome, ConsensusOutcomeConversion, ConsensusProposal, FedimintConsensus,

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -1,26 +1,27 @@
 //! Implements the client API through which users interact with the federation
-use crate::config::ServerConfig;
-use crate::consensus::FedimintConsensus;
-use crate::transaction::Transaction;
+use std::fmt::Formatter;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
 use fedimint_api::{
     config::GenerateConfig,
     module::{api_endpoint, ApiEndpoint, ApiError},
     FederationModule, TransactionId,
 };
+use fedimint_core::config::ClientConfig;
 use fedimint_core::epoch::EpochHistory;
 use fedimint_core::outcome::TransactionStatus;
 use futures::FutureExt;
-use std::fmt::Formatter;
-use std::panic::AssertUnwindSafe;
-use std::sync::Arc;
-use tracing::{debug, error};
-
-use fedimint_core::config::ClientConfig;
 use jsonrpsee::{
     types::{error::CallError, ErrorObject},
     ws_server::WsServerBuilder,
     RpcModule,
 };
+use tracing::{debug, error};
+
+use crate::config::ServerConfig;
+use crate::consensus::FedimintConsensus;
+use crate::transaction::Transaction;
 
 #[derive(Clone)]
 struct State {

--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -1,19 +1,21 @@
 //! Provides an abstract network connection interface and multiple implementations
 
-use crate::net::framed::{AnyFramedTransport, BidiFramed, FramedTransport};
-use async_trait::async_trait;
-use fedimint_api::PeerId;
-use futures::Stream;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;
+
+use async_trait::async_trait;
+use fedimint_api::PeerId;
+use futures::Stream;
 use tokio::io::{ReadHalf, WriteHalf};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::rustls::server::AllowAnyAuthenticatedClient;
 use tokio_rustls::rustls::RootCertStore;
 use tokio_rustls::{rustls, TlsAcceptor, TlsConnector, TlsStream};
+
+use crate::net::framed::{AnyFramedTransport, BidiFramed, FramedTransport};
 
 /// Shared [`Connector`] trait object
 pub type SharedAnyConnector<M> = Arc<dyn Connector<M> + Send + Sync + Unpin + 'static>;
@@ -216,22 +218,24 @@ where
 /// Fake network stack used in tests
 #[allow(unused_imports)]
 pub mod mock {
-    use crate::net::connect::{ConnectResult, Connector};
-    use crate::net::framed::{BidiFramed, FramedTransport};
-    use anyhow::Error;
-    use fedimint_api::PeerId;
-    use futures::{FutureExt, SinkExt, Stream, StreamExt};
     use std::collections::HashMap;
     use std::fmt::Debug;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::Arc;
     use std::time::Duration;
+
+    use anyhow::Error;
+    use fedimint_api::PeerId;
+    use futures::{FutureExt, SinkExt, Stream, StreamExt};
     use tokio::io::{
         AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream, ReadHalf, WriteHalf,
     };
     use tokio::sync::mpsc::Sender;
     use tokio::sync::Mutex;
+
+    use crate::net::connect::{ConnectResult, Connector};
+    use crate::net::framed::{BidiFramed, FramedTransport};
 
     pub struct MockNetwork {
         clients: Arc<Mutex<HashMap<String, Sender<DuplexStream>>>>,
@@ -399,12 +403,13 @@ pub mod mock {
 
 #[cfg(test)]
 mod tests {
+    use fedimint_api::PeerId;
+    use futures::{SinkExt, StreamExt};
+
     use crate::config::gen_cert_and_key;
     use crate::net::connect::{ConnectionListener, TlsConfig};
     use crate::net::framed::AnyFramedTransport;
     use crate::{Connector, TlsTcpConnector};
-    use fedimint_api::PeerId;
-    use futures::{SinkExt, StreamExt};
 
     fn gen_connector_config(count: usize) -> Vec<TlsConfig> {
         let peer_keys = (0..count)

--- a/fedimint-server/src/net/framed.rs
+++ b/fedimint-server/src/net/framed.rs
@@ -1,12 +1,13 @@
 //! Adapter that implements a message based protocol on top of a stream based one
-use bytes::{Buf, BufMut, BytesMut};
-use futures::{Sink, Stream};
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+
+use bytes::{Buf, BufMut, BytesMut};
+use futures::{Sink, Stream};
 use tokio::io::{AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio_util::codec::{FramedRead, FramedWrite};
@@ -227,11 +228,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::net::framed::BidiFramed;
+    use std::time::Duration;
+
     use futures::{SinkExt, StreamExt};
     use serde::{Deserialize, Serialize};
-    use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, ReadHalf, WriteHalf};
+
+    use crate::net::framed::BidiFramed;
 
     #[tokio::test]
     async fn test_roundtrip() {

--- a/fedimint-server/src/net/queue.rs
+++ b/fedimint-server/src/net/queue.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
+
+use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -1,15 +1,15 @@
 //! Sled implementation of the `Database` trait. It should not be used anymore since it has known
 //! issues and is unmaintained. Please use `rocksdb` instead.
 
+use std::path::Path;
+
 use anyhow::Result;
 use fedimint_api::db::batch::{BatchItem, DbBatch};
 use fedimint_api::db::IDatabase;
 use fedimint_api::db::PrefixIter;
-use sled::transaction::TransactionError;
-use std::path::Path;
-use tracing::error;
-
 pub use sled;
+use sled::transaction::TransactionError;
+use tracing::error;
 
 #[derive(Debug)]
 pub struct SledDb(sled::Tree);

--- a/fedimintd/src/bin/configgen.rs
+++ b/fedimintd/src/bin/configgen.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 use fedimint_api::config::GenerateConfig;
 use fedimint_api::{Amount, NumPeers, PeerId};
 use fedimint_server::config::{ServerConfig, ServerConfigParams};
 use rand::rngs::OsRng;
-use std::path::PathBuf;
 
 #[derive(Parser)]
 struct Cli {

--- a/fedimintd/src/main.rs
+++ b/fedimintd/src/main.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use clap::Parser;
 use fedimint_server::config::{load_from_file, ServerConfig};
 use fedimint_server::FedimintServer;
-
 use fedimint_wallet::bitcoincore_rpc;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;

--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,7 @@
             };
 
         fenixChannel = fenix.packages.${system}.stable;
+        fenixChannelNightly = fenix.packages.${system}.latest;
 
         fenixToolchain = (fenixChannel.withComponents [
           "rustc"
@@ -113,8 +114,11 @@
           "clippy"
           "rust-analysis"
           "rust-src"
-          "rustfmt"
           "llvm-tools-preview"
+        ]);
+
+        fenixToolchainRustfmt = (fenixChannelNightly.withComponents [
+          "rustfmt"
         ]);
 
         fenixToolchainCrossAll = with fenix.packages.${system}; combine ([
@@ -694,6 +698,7 @@
             buildInputs = commonArgs.buildInputs;
             nativeBuildInputs = with pkgs; commonArgs.nativeBuildInputs ++ [
               fenix.packages.${system}.rust-analyzer
+              fenixToolchainRustfmt
               cargo-llvm-cov
               cargo-udeps
 
@@ -756,7 +761,7 @@
             # of stuff to avoid building and caching things we don't need
             lint = pkgs.mkShell {
               nativeBuildInputs = [
-                pkgs.rustfmt
+                fenixToolchainRustfmt
                 pkgs.nixpkgs-fmt
                 pkgs.shellcheck
                 pkgs.git

--- a/integrationtests/tests/fixtures/fake.rs
+++ b/integrationtests/tests/fixtures/fake.rs
@@ -9,16 +9,15 @@ use bitcoin::util::merkleblock::PartialMerkleTree;
 use bitcoin::{
     secp256k1, Address, Block, BlockHash, BlockHeader, KeyPair, Network, Transaction, TxOut,
 };
-use lightning::ln::PaymentSecret;
-use lightning_invoice::{Currency, Invoice, InvoiceBuilder};
-use rand::rngs::OsRng;
-
 use fedimint_api::Amount;
 use fedimint_server::modules::ln::contracts::Preimage;
 use fedimint_wallet::bitcoind::IBitcoindRpc;
 use fedimint_wallet::txoproof::TxOutProof;
 use fedimint_wallet::Feerate;
+use lightning::ln::PaymentSecret;
+use lightning_invoice::{Currency, Invoice, InvoiceBuilder};
 use ln_gateway::ln::{LightningError, LnRpc};
+use rand::rngs::OsRng;
 
 use crate::fixtures::{BitcoinTest, LightningTest};
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -14,37 +14,18 @@ use bitcoin::hashes::{sha256, Hash};
 use bitcoin::KeyPair;
 use bitcoin::{secp256k1, Address, Transaction};
 use cln_rpc::ClnRpc;
-use fedimint_api::Amount;
-use fedimint_api::FederationModule;
-use fedimint_api::OutPoint;
-use fedimint_api::PeerId;
-use futures::executor::block_on;
-use futures::future::{join_all, select_all};
-use hbbft::honey_badger::Batch;
-
-use fedimint_api::task::spawn;
-use fedimint_ln::LightningGateway;
-use fedimint_wallet::{bitcoincore_rpc, WalletConsensusItem};
-use itertools::Itertools;
-use lightning_invoice::Invoice;
-use ln_gateway::GatewayRequest;
-use rand::RngCore;
-
-use rand::rngs::OsRng;
-
-use tokio::sync::Mutex;
-
-use tracing::info;
-use tracing_subscriber::EnvFilter;
-use url::Url;
-
-use crate::fixtures::utils::LnRpcAdapter;
 use fake::{FakeBitcoinTest, FakeLightningTest};
 use fedimint_api::config::GenerateConfig;
 use fedimint_api::db::batch::DbBatch;
 use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::Database;
+use fedimint_api::task::spawn;
+use fedimint_api::Amount;
+use fedimint_api::FederationModule;
+use fedimint_api::OutPoint;
+use fedimint_api::PeerId;
 use fedimint_api::TieredMulti;
+use fedimint_ln::LightningGateway;
 use fedimint_server::config::ServerConfigParams;
 use fedimint_server::config::{ClientConfig, ServerConfig};
 use fedimint_server::consensus::{ConsensusOutcome, ConsensusProposal};
@@ -59,11 +40,26 @@ use fedimint_wallet::config::WalletConfig;
 use fedimint_wallet::db::UTXOKey;
 use fedimint_wallet::txoproof::TxOutProof;
 use fedimint_wallet::SpendableUTXO;
+use fedimint_wallet::{bitcoincore_rpc, WalletConsensusItem};
+use futures::executor::block_on;
+use futures::future::{join_all, select_all};
+use hbbft::honey_badger::Batch;
+use itertools::Itertools;
+use lightning_invoice::Invoice;
+use ln_gateway::GatewayRequest;
 use ln_gateway::LnGateway;
 use mint_client::api::WsFederationApi;
 use mint_client::mint::SpendableNote;
 use mint_client::{GatewayClient, GatewayClientConfig, UserClient, UserClientConfig};
+use rand::rngs::OsRng;
+use rand::RngCore;
 use real::{RealBitcoinTest, RealLightningTest};
+use tokio::sync::Mutex;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+use url::Url;
+
+use crate::fixtures::utils::LnRpcAdapter;
 
 mod fake;
 mod real;

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -7,15 +7,13 @@ use bitcoin::secp256k1;
 use bitcoin::{Address, Transaction};
 use bitcoincore_rpc::Client;
 use bitcoincore_rpc::{Auth, RpcApi};
-
 use clightningrpc::LightningRPC;
-use fedimint_api::Amount;
-use lightning_invoice::Invoice;
-use serde::Serialize;
-
 use fedimint_api::config::BitcoindRpcCfg;
 use fedimint_api::encoding::Decodable;
+use fedimint_api::Amount;
 use fedimint_wallet::txoproof::TxOutProof;
+use lightning_invoice::Invoice;
+use serde::Serialize;
 
 use crate::fixtures::{BitcoinTest, LightningTest};
 

--- a/integrationtests/tests/fixtures/utils.rs
+++ b/integrationtests/tests/fixtures/utils.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use fedimint_ln::contracts::Preimage;
 use ln_gateway::ln::{LightningError, LnRpc};
-use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::Mutex;
 
 /// A proxy for the underlying LnRpc which can be used to add behavoir to it using the "Decorator pattern"

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -4,15 +4,6 @@ use std::time::Duration;
 
 use assert_matches::assert_matches;
 use bitcoin::{Amount, KeyPair};
-
-use fixtures::{fixtures, rng, sats, secp, sha256};
-use futures::executor::block_on;
-use futures::future::{join_all, Either};
-use threshold_crypto::{SecretKey, SecretKeyShare};
-use tokio::time::timeout;
-use tracing::debug;
-
-use crate::fixtures::FederationTest;
 use fedimint_api::db::batch::DbBatch;
 use fedimint_api::TieredMulti;
 use fedimint_ln::contracts::{Preimage, PreimageDecryptionShare};
@@ -22,8 +13,16 @@ use fedimint_server::epoch::ConsensusItem;
 use fedimint_server::transaction::Output;
 use fedimint_wallet::PegOutSignatureItem;
 use fedimint_wallet::WalletConsensusItem::PegOutSignature;
+use fixtures::{fixtures, rng, sats, secp, sha256};
+use futures::executor::block_on;
+use futures::future::{join_all, Either};
 use mint_client::transaction::TransactionBuilder;
 use mint_client::ClientError;
+use threshold_crypto::{SecretKey, SecretKeyShare};
+use tokio::time::timeout;
+use tracing::debug;
+
+use crate::fixtures::FederationTest;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_in_and_peg_out_with_fees() {

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -5,6 +5,11 @@ use std::sync::Arc;
 use bitcoin_hashes::hex::ToHex;
 use cln_plugin::{options, Builder, Error, Plugin};
 use cln_rpc::ClnRpc;
+use fedimint_server::config::load_from_file;
+use ln_gateway::{
+    cln::HtlcAccepted, BalancePayload, DepositAddressPayload, DepositPayload, GatewayRequest,
+    GatewayRequestTrait, LnGateway, LnGatewayError, WithdrawPayload,
+};
 use mint_client::{Client, GatewayClientConfig};
 use rand::thread_rng;
 use secp256k1::KeyPair;
@@ -13,12 +18,6 @@ use tokio::io::{stdin, stdout};
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::error;
 use url::Url;
-
-use fedimint_server::config::load_from_file;
-use ln_gateway::{
-    cln::HtlcAccepted, BalancePayload, DepositAddressPayload, DepositPayload, GatewayRequest,
-    GatewayRequestTrait, LnGateway, LnGatewayError, WithdrawPayload,
-};
 
 type PluginState = Arc<Mutex<mpsc::Sender<GatewayRequest>>>;
 

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -2,7 +2,14 @@ pub mod cln;
 pub mod ln;
 pub mod webserver;
 
-use crate::ln::{LightningError, LnRpc};
+use std::borrow::Cow;
+use std::net::SocketAddr;
+use std::{
+    io::Cursor,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use bitcoin::{Address, Transaction};
@@ -16,17 +23,12 @@ use mint_client::mint::MintClientError;
 use mint_client::{ClientError, GatewayClient, PaymentParameters};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Deserializer};
-use std::borrow::Cow;
-use std::net::SocketAddr;
-use std::{
-    io::Cursor,
-    sync::Arc,
-    time::{Duration, Instant},
-};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, instrument, warn};
 use webserver::run_webserver;
+
+use crate::ln::{LightningError, LnRpc};
 
 pub type Result<T> = std::result::Result<T, LnGatewayError>;
 

--- a/ln-gateway/src/webserver.rs
+++ b/ln-gateway/src/webserver.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use axum::{routing::post, Extension, Json, Router};
+use fedimint_server::modules::ln::contracts::ContractId;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tower_http::cors::CorsLayer;
@@ -8,7 +9,6 @@ use tracing::{debug, instrument};
 
 use crate::GatewayRequestInner;
 use crate::{GatewayRequest, LnGatewayError};
-use fedimint_server::modules::ln::contracts::ContractId;
 
 #[instrument(skip_all, err)]
 pub async fn pay_invoice(

--- a/modules/fedimint-ln/src/config.rs
+++ b/modules/fedimint-ln/src/config.rs
@@ -1,9 +1,10 @@
+use std::collections::BTreeMap;
+
 use fedimint_api::config::GenerateConfig;
 use fedimint_api::rand::Rand07Compat;
 use fedimint_api::{NumPeers, PeerId};
 use secp256k1::rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningModuleConfig {

--- a/modules/fedimint-ln/src/contracts/account.rs
+++ b/modules/fedimint-ln/src/contracts/account.rs
@@ -1,7 +1,8 @@
-use crate::contracts::{ContractId, IdentifyableContract};
 use bitcoin_hashes::Hash as BitcoinHash;
 use fedimint_api::encoding::{Decodable, Encodable};
 use serde::{Deserialize, Serialize};
+
+use crate::contracts::{ContractId, IdentifyableContract};
 
 /// A generic contract to hold money in a pub key locked account
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]

--- a/modules/fedimint-ln/src/contracts/incoming.rs
+++ b/modules/fedimint-ln/src/contracts/incoming.rs
@@ -1,11 +1,13 @@
-use crate::contracts::{ContractId, DecryptedPreimage, EncryptedPreimage, IdentifyableContract};
+use std::io::Error;
+
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
 use bitcoin_hashes::{borrow_slice_impl, hash_newtype, hex_fmt_impl, index_impl, serde_impl};
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_api::OutPoint;
 use serde::{Deserialize, Serialize};
-use std::io::Error;
+
+use crate::contracts::{ContractId, DecryptedPreimage, EncryptedPreimage, IdentifyableContract};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct IncomingContractOffer {

--- a/modules/fedimint-ln/src/contracts/mod.rs
+++ b/modules/fedimint-ln/src/contracts/mod.rs
@@ -2,13 +2,14 @@ pub mod account;
 pub mod incoming;
 pub mod outgoing;
 
+use std::io::Error;
+
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
 use bitcoin_hashes::{borrow_slice_impl, hash_newtype, hex_fmt_impl, index_impl, serde_impl};
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_api::OutPoint;
 use serde::{Deserialize, Serialize};
-use std::io::Error;
 
 /// Anything representing a contract which thus has an associated [`ContractId`]
 pub trait IdentifyableContract: Encodable {

--- a/modules/fedimint-ln/src/contracts/outgoing.rs
+++ b/modules/fedimint-ln/src/contracts/outgoing.rs
@@ -1,7 +1,8 @@
-use crate::contracts::{ContractId, IdentifyableContract};
 use bitcoin_hashes::Hash as BitcoinHash;
 use fedimint_api::encoding::{Decodable, Encodable};
 use serde::{Deserialize, Serialize};
+
+use crate::contracts::{ContractId, IdentifyableContract};
 
 const CANCELLATION_TAG: &str = "outgoing contract cancellation";
 

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -1,9 +1,10 @@
-use crate::contracts::{incoming::IncomingContractOffer, ContractId, PreimageDecryptionShare};
-use crate::{ContractAccount, LightningGateway, OutputOutcome};
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{OutPoint, PeerId};
 use secp256k1::PublicKey;
+
+use crate::contracts::{incoming::IncomingContractOffer, ContractId, PreimageDecryptionShare};
+use crate::{ContractAccount, LightningGateway, OutputOutcome};
 
 const DB_PREFIX_CONTRACT: u8 = 0x40;
 const DB_PREFIX_OFFER: u8 = 0x41;

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -14,6 +14,27 @@ pub mod config;
 pub mod contracts;
 mod db;
 
+use std::collections::{HashMap, HashSet};
+use std::ops::Sub;
+
+use async_trait::async_trait;
+use bitcoin_hashes::Hash as BitcoinHash;
+use db::{LightningGatewayKey, LightningGatewayKeyPrefix};
+use fedimint_api::db::batch::{BatchItem, BatchTx};
+use fedimint_api::db::Database;
+use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::module::audit::Audit;
+use fedimint_api::module::interconnect::ModuleInterconect;
+use fedimint_api::module::{api_endpoint, ApiEndpoint, ApiError};
+use fedimint_api::{Amount, FederationModule, PeerId};
+use fedimint_api::{InputMeta, OutPoint};
+use itertools::Itertools;
+use secp256k1::rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::{debug, error, info_span, instrument, trace, warn};
+use url::Url;
+
 use crate::config::LightningModuleConfig;
 use crate::contracts::{
     incoming::{IncomingContractOffer, OfferId},
@@ -25,27 +46,6 @@ use crate::db::{
     ContractUpdateKey, OfferKey, OfferKeyPrefix, ProposeDecryptionShareKey,
     ProposeDecryptionShareKeyPrefix,
 };
-use async_trait::async_trait;
-use bitcoin_hashes::Hash as BitcoinHash;
-use db::{LightningGatewayKey, LightningGatewayKeyPrefix};
-use itertools::Itertools;
-
-use fedimint_api::db::batch::{BatchItem, BatchTx};
-use fedimint_api::db::Database;
-use fedimint_api::encoding::{Decodable, Encodable};
-use fedimint_api::module::audit::Audit;
-use fedimint_api::module::interconnect::ModuleInterconect;
-use fedimint_api::module::{api_endpoint, ApiEndpoint, ApiError};
-use fedimint_api::{Amount, FederationModule, PeerId};
-use fedimint_api::{InputMeta, OutPoint};
-use secp256k1::rand::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::ops::Sub;
-use url::Url;
-
-use thiserror::Error;
-use tracing::{debug, error, info_span, instrument, trace, warn};
 
 /// The lightning module implements an account system. It does not have the privacy guarantees of
 /// the e-cash mint module but instead allows for smart contracting. There exist three contract

--- a/modules/fedimint-mint/src/config.rs
+++ b/modules/fedimint-mint/src/config.rs
@@ -1,9 +1,10 @@
+use std::collections::{BTreeMap, HashMap};
+use std::iter::FromIterator;
+
 use fedimint_api::config::GenerateConfig;
 use fedimint_api::{Amount, NumPeers, PeerId, Tiered, TieredMultiZip};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
-use std::iter::FromIterator;
 use tbs::{dealer_keygen, Aggregatable, AggregatePublicKey, PublicKeyShare};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -1,7 +1,8 @@
-use crate::{Nonce, PartialSigResponse, SigResponse};
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{Amount, OutPoint, PeerId};
+
+use crate::{Nonce, PartialSigResponse, SigResponse};
 
 const DB_PREFIX_COIN_NONCE: u8 = 0x10;
 const DB_PREFIX_PROPOSED_PARTIAL_SIG: u8 = 0x11;

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -1,9 +1,8 @@
-use crate::config::MintConfig;
-use crate::db::{
-    MintAuditItemKey, MintAuditItemKeyPrefix, NonceKey, OutputOutcomeKey,
-    ProposedPartialSignatureKey, ProposedPartialSignaturesKeyPrefix, ReceivedPartialSignatureKey,
-    ReceivedPartialSignatureKeyOutputPrefix, ReceivedPartialSignaturesKeyPrefix,
-};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::hash::Hash;
+use std::iter::FromIterator;
+use std::ops::Sub;
+
 use async_trait::async_trait;
 use fedimint_api::db::batch::{BatchItem, BatchTx, DbBatch};
 use fedimint_api::db::Database;
@@ -19,17 +18,19 @@ use itertools::Itertools;
 use rand::{CryptoRng, RngCore};
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap, HashSet};
-
-use std::hash::Hash;
-use std::iter::FromIterator;
-use std::ops::Sub;
 use tbs::{
     combine_valid_shares, sign_blinded_msg, verify_blind_share, Aggregatable, AggregatePublicKey,
     PublicKeyShare, SecretKeyShare,
 };
 use thiserror::Error;
 use tracing::{debug, error, warn};
+
+use crate::config::MintConfig;
+use crate::db::{
+    MintAuditItemKey, MintAuditItemKeyPrefix, NonceKey, OutputOutcomeKey,
+    ProposedPartialSignatureKey, ProposedPartialSignaturesKeyPrefix, ReceivedPartialSignatureKey,
+    ReceivedPartialSignatureKeyOutputPrefix, ReceivedPartialSignaturesKeyPrefix,
+};
 
 pub mod config;
 
@@ -731,13 +732,14 @@ impl From<InvalidAmountTierError> for MintError {
 
 #[cfg(test)]
 mod test {
-    use crate::config::{FeeConsensus, MintClientConfig};
-    use crate::{BlindNonce, CombineError, Mint, MintConfig, PeerErrorType};
     use fedimint_api::config::GenerateConfig;
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::{Amount, PeerId, TieredMulti};
     use rand::rngs::OsRng;
     use tbs::{blind_message, unblind_signature, verify, AggregatePublicKey, Message};
+
+    use crate::config::{FeeConsensus, MintClientConfig};
+    use crate::{BlindNonce, CombineError, Mint, MintConfig, PeerErrorType};
 
     const THRESHOLD: usize = 1;
     const MINTS: usize = 5;

--- a/modules/fedimint-wallet/src/bitcoincore_rpc.rs
+++ b/modules/fedimint-wallet/src/bitcoincore_rpc.rs
@@ -1,5 +1,6 @@
-use crate::bitcoind::IBitcoindRpc;
-use crate::{bitcoind::BitcoindRpc, Feerate};
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
 use async_trait::async_trait;
 use bitcoin::{Block, BlockHash, Network, Transaction};
 use bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
@@ -7,9 +8,10 @@ use bitcoincore_rpc::Auth;
 use fedimint_api::config::BitcoindRpcCfg;
 use fedimint_api::module::__reexports::serde_json::Value;
 use serde::Deserialize;
-use std::sync::atomic::Ordering;
-use std::time::Duration;
 use tracing::warn;
+
+use crate::bitcoind::IBitcoindRpc;
+use crate::{bitcoind::BitcoindRpc, Feerate};
 
 pub fn make_bitcoind_rpc(cfg: &BitcoindRpcCfg) -> Result<BitcoindRpc, bitcoincore_rpc::Error> {
     let bitcoind_client = bitcoincore_rpc::Client::new(

--- a/modules/fedimint-wallet/src/bitcoind.rs
+++ b/modules/fedimint-wallet/src/bitcoind.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use crate::Feerate;
 use async_trait::async_trait;
 use bitcoin::{BlockHash, Transaction};
 use fedimint_api::dyn_newtype_define;
+
+use crate::Feerate;
 
 /// Trait that allows interacting with the Bitcoin blockchain
 ///
@@ -52,13 +53,15 @@ dyn_newtype_define! {
 
 #[allow(dead_code)]
 pub mod test {
-    use super::IBitcoindRpc;
-    use crate::Feerate;
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::{Arc, Mutex};
+
     use async_trait::async_trait;
     use bitcoin::hashes::Hash;
     use bitcoin::{Block, BlockHash, BlockHeader, Network, Transaction};
-    use std::collections::{HashMap, VecDeque};
-    use std::sync::{Arc, Mutex};
+
+    use super::IBitcoindRpc;
+    use crate::Feerate;
 
     #[derive(Debug, Default)]
     pub struct FakeBitcoindRpcState {

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -1,12 +1,14 @@
-use crate::keys::CompressedPublicKey;
-use crate::{Feerate, PegInDescriptor};
+use std::collections::BTreeMap;
+
 use bitcoin::secp256k1::rand::{CryptoRng, RngCore};
 use bitcoin::Network;
 use fedimint_api::config::{BitcoindRpcCfg, GenerateConfig};
 use fedimint_api::{NumPeers, PeerId};
 use miniscript::descriptor::Wsh;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+
+use crate::keys::CompressedPublicKey;
+use crate::{Feerate, PegInDescriptor};
 
 const FINALITY_DELAY: u32 = 10;
 

--- a/modules/fedimint-wallet/src/db.rs
+++ b/modules/fedimint-wallet/src/db.rs
@@ -1,10 +1,11 @@
-use crate::{
-    PegOutOutcome, PendingTransaction, RoundConsensus, SpendableUTXO, UnsignedTransaction,
-};
 use bitcoin::{BlockHash, Txid};
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use secp256k1::ecdsa::Signature;
+
+use crate::{
+    PegOutOutcome, PendingTransaction, RoundConsensus, SpendableUTXO, UnsignedTransaction,
+};
 
 const DB_PREFIX_BLOCK_HASH: u8 = 0x30;
 const DB_PREFIX_UTXO: u8 = 0x31;

--- a/modules/fedimint-wallet/src/keys.rs
+++ b/modules/fedimint-wallet/src/keys.rs
@@ -1,10 +1,12 @@
-use crate::tweakable::{Contract, Tweakable};
+use std::str::FromStr;
+
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{Secp256k1, Verification};
 use bitcoin::PublicKey;
 use miniscript::{MiniscriptKey, ToPublicKey};
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+
+use crate::tweakable::{Contract, Tweakable};
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct CompressedPublicKey {

--- a/modules/fedimint-wallet/src/tweakable.rs
+++ b/modules/fedimint-wallet/src/tweakable.rs
@@ -1,6 +1,7 @@
+use std::io::Write;
+
 use bitcoin::hashes::{sha256, Hash as BitcoinHash, Hmac, HmacEngine};
 use secp256k1::{Secp256k1, Verification};
-use std::io::Write;
 
 /// An object that can be used as a ricardian contract to tweak a key
 pub trait Contract {

--- a/modules/fedimint-wallet/src/txoproof.rs
+++ b/modules/fedimint-wallet/src/txoproof.rs
@@ -1,5 +1,7 @@
-use crate::keys::CompressedPublicKey;
-use crate::tweakable::{Contract, Tweakable};
+use std::borrow::Cow;
+use std::hash::Hash;
+use std::io::Cursor;
+
 use bitcoin::util::merkleblock::PartialMerkleTree;
 use bitcoin::{BlockHash, BlockHeader, OutPoint, Transaction, Txid};
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
@@ -7,11 +9,11 @@ use miniscript::{Descriptor, DescriptorTrait, TranslatePk2};
 use secp256k1::{Secp256k1, Verification};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::Cow;
-use std::hash::Hash;
-use std::io::Cursor;
 use thiserror::Error;
 use validator::{Validate, ValidationError};
+
+use crate::keys::CompressedPublicKey;
+use crate::tweakable::{Contract, Tweakable};
 
 /// A proof about a script owning a certain output. Verifyable using headers only.
 #[derive(Clone, Debug, PartialEq, Serialize, Eq, Hash, Deserialize, Validate, Encodable)]
@@ -283,9 +285,11 @@ pub enum PegInProofError {
 
 #[cfg(test)]
 mod tests {
-    use super::TxOutProof;
-    use fedimint_api::encoding::Decodable;
     use std::io::Cursor;
+
+    use fedimint_api::encoding::Decodable;
+
+    use super::TxOutProof;
 
     #[test_log::test]
     fn test_txoutproof_happy_path() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
I was reading comments under recent announcement of creation of Rust Style Team:

https://www.reddit.com/r/rust/comments/xreg1a/announcing_the_rust_style_team/

and someone mentioned:

```
group_imports = StdExternalCrate
```

and it seemed like such a nice way to format imports, but available only on nightly rust.

So I wondered if it would be possible to use stable compiler, but nightly `rustmft` and it seems it would work.

Presenting for consideration.