### PR TITLE
Change cli's default log level to 'error'

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -301,7 +301,7 @@ struct PayRequest {
 async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("error")),
         )
         .with_writer(std::io::stderr)
         .init();


### PR DESCRIPTION
CLI is way too noisy right now. 

If you want more verbosity, just set `RUST_LOG` to an [`tracing_subscriber::EnvFilter` directive](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html).