### PR TITLE
Rename mint-client-cli to fedimint-cli

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -155,9 +155,9 @@ jobs:
           nix build -L .#container.ln-gateway-clightning
           echo "ln_gateway_clightning_container_tag=$(docker load < result | awk '{ print $3 }')" >> $GITHUB_ENV
 
-      - name: Build mint-client-cli container
+      - name: Build fedimint-cli container
         run: |
-          nix build -L .#container.mint-client-cli
+          nix build -L .#container.fedimint-cli
           echo "mint_client_cli_container_tag=$(docker load < result | awk '{ print $3 }')" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
@@ -172,4 +172,4 @@ jobs:
         run: |
           nix_tag=${{ env.fedimintd_container_tag }} && hub_tag="fedimint/fedimintd:${GITHUB_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.ln_gateway_clightning_container_tag }} && hub_tag="fedimint/ln-gateway-clightning:${GITHUB_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
-          nix_tag=${{ env.mint_client_cli_container_tag }} && hub_tag="fedimint/mint-client-cli:${GITHUB_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
+          nix_tag=${{ env.mint_client_cli_container_tag }} && hub_tag="fedimint/fedimint-cli:${GITHUB_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"

--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -6,7 +6,7 @@ pre_window:
   - alias ln1="\$FM_LN1"
   - alias ln2="\$FM_LN2"
   - alias btc_client="\$FM_BTC_CLIENT"
-  - alias mint-client-cli="\$FM_MINT_CLIENT"
+  - alias fedimint-cli="\$FM_MINT_CLIENT"
   - alias mint_rpc_client="\$FM_MINT_RPC_CLIENT"
 tmux_detached: false
 windows:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,28 @@ name = "fedimint-build"
 version = "0.1.0"
 
 [[package]]
+name = "fedimint-cli"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "bitcoin_hashes",
+ "clap",
+ "fedimint-api",
+ "fedimint-build",
+ "fedimint-core",
+ "fedimint-rocksdb",
+ "lightning-invoice",
+ "mint-client",
+ "rand 0.6.5",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "fedimint-core"
 version = "0.1.0"
 dependencies = [
@@ -1846,28 +1868,6 @@ dependencies = [
  "test-log",
  "thiserror",
  "threshold_crypto",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
-name = "mint-client-cli"
-version = "0.1.0"
-dependencies = [
- "bitcoin",
- "bitcoin_hashes",
- "clap",
- "fedimint-api",
- "fedimint-build",
- "fedimint-core",
- "fedimint-rocksdb",
- "lightning-invoice",
- "mint-client",
- "rand 0.6.5",
- "serde",
- "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "mint-client-cli"
+name = "fedimint-cli"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
 edition = "2021"
-description = "mint-client-cli is a command line interface wrapper for the client library."
+description = "fedimint-cli is a command line interface wrapper for the client library."
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,7 +12,7 @@ name = "mint-rpc-client"
 path = "src/bin/mint-rpc-client.rs"
 
 [[bin]]
-name = "mint-client-cli"
+name = "fedimint-cli"
 path = "src/main.rs"
 
 [dependencies]

--- a/docs/dev-running.md
+++ b/docs/dev-running.md
@@ -44,7 +44,7 @@ The previous step has already set up an e-cash client with a funded wallet for y
 You can view your client's holdings using the `info` command:
 
 ```shell
-$ mint-client-cli info
+$ fedimint-cli info
 
 {
   "info": {
@@ -62,7 +62,7 @@ The `spend` subcommand allows sending notes to another client. This will select 
 The notes are base64 encoded into a token and printed as the `token` field.
 
 ```shell
-$ mint-client-cli spend 400000
+$ fedimint-cli spend 400000
 
 {
   "spend": {
@@ -74,7 +74,7 @@ $ mint-client-cli spend 400000
 The `validate` subcommand checks the validity of the signatures without claiming the notes. It does not check if the nonce is unspent. Validity will be printed as the `all_valid` boolean.
 
 ```shell
-$ mint-client-cli validate AQAAAAAAAABAQg8AAA...
+$ fedimint-cli validate AQAAAAAAAABAQg8AAA...
 
 {
   "validate": {
@@ -87,10 +87,10 @@ $ mint-client-cli validate AQAAAAAAAABAQg8AAA...
 A receiving client can now reissue these notes to claim them and avoid double spends:
 
 ```shell
-$ mint-client-cli reissue AQAAAAAAAABAQg8AAA...
+$ fedimint-cli reissue AQAAAAAAAABAQg8AAA...
 > ...
 
-$ mint-client-cli fetch
+$ fedimint-cli fetch
 
 {
   "fetch": {
@@ -135,7 +135,7 @@ $ ln2 invoice 100000 test test 1m
 Pay the invoice by copying the `bolt11` invoice field:
 
 ```shell
-$ mint-client-cli ln-pay "lnbcrt1u1p3vdl3ds..."
+$ fedimint-cli ln-pay "lnbcrt1u1p3vdl3ds..."
 ```
 
 Confirm the invoice was paid
@@ -156,7 +156,7 @@ $ ln2 listinvoices test
 
 Create our own invoice:
 ```shell
-$ mint-client-cli ln-invoice 1000 "description"
+$ fedimint-cli ln-invoice 1000 "description"
 
 {
   "ln_invoice": {
@@ -174,9 +174,9 @@ $ ln2 pay lnbcrt1u1p3vcp...
 Have mint client check that payment succeeded, fetch notes, and display new balances:
 
 ```shell
-$ mint-client-cli wait-invoice lnbcrt1u1p3vcp...
-$ mint-client-cli fetch
-$ mint-client-cli info
+$ fedimint-cli wait-invoice lnbcrt1u1p3vcp...
+$ fedimint-cli fetch
+$ fedimint-cli info
 ```
 
 ### Other options
@@ -184,12 +184,12 @@ $ mint-client-cli info
 There also exist some other, more experimental commands that can be explored using the `--help` flag:
 
 ```shell
-$ mint-client-cli help
+$ fedimint-cli help
 
-mint-client-cli 
+fedimint-cli 
 
 USAGE:
-    mint-client-cli <WORKDIR> <SUBCOMMAND>
+    fedimint-cli <WORKDIR> <SUBCOMMAND>
 
 ARGS:
     <WORKDIR>    

--- a/flake.nix
+++ b/flake.nix
@@ -466,9 +466,9 @@
           ];
         };
 
-        mint-client-cli = pkg {
-          name = "mint-client-cli";
-          bin = "mint-client-cli";
+        fedimint-cli = pkg {
+          name = "fedimint-cli";
+          bin = "fedimint-cli";
           dirs = [
             "client/clientd"
             "client/client-lib"
@@ -583,7 +583,7 @@
           fedimint-tests = fedimint-tests;
           ln-gateway = replace-git-hash { name = "ln-gateway"; package = ln-gateway; };
           clientd = replace-git-hash { name = "clientd"; package = clientd; };
-          mint-client-cli = replace-git-hash { name = "mint-client-cli"; package = mint-client-cli; };
+          fedimint-cli = replace-git-hash { name = "fedimint-cli"; package = fedimint-cli; };
 
           inherit workspaceDeps
             workspaceBuild
@@ -670,12 +670,12 @@
                 '';
               };
 
-            mint-client-cli = pkgs.dockerTools.buildLayeredImage {
-              name = "mint-client-cli";
-              contents = [ mint-client-cli pkgs.bash pkgs.coreutils ];
+            fedimint-cli = pkgs.dockerTools.buildLayeredImage {
+              name = "fedimint-cli";
+              contents = [ fedimint-cli pkgs.bash pkgs.coreutils ];
               config = {
                 Cmd = [
-                  "${mint-client-cli}/bin/mint-client-cli"
+                  "${fedimint-cli}/bin/fedimint-cli"
                 ];
               };
             };

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,7 +33,7 @@ $FM_BIN_DIR/configgen generate --out-dir $FM_CFG_DIR --num-nodes $FM_FED_SIZE --
 export FM_LN1="lightning-cli --network regtest --lightning-dir=$FM_LN1_DIR"
 export FM_LN2="lightning-cli --network regtest --lightning-dir=$FM_LN2_DIR"
 export FM_BTC_CLIENT="bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin"
-export FM_MINT_CLIENT="$FM_BIN_DIR/mint-client-cli $FM_CFG_DIR"
+export FM_MINT_CLIENT="$FM_BIN_DIR/fedimint-cli $FM_CFG_DIR"
 export FM_MINT_RPC_CLIENT="$FM_BIN_DIR/mint-rpc-client"
 export FM_CLIENTD="$FM_BIN_DIR/clientd"
 export FM_CLIENTD_CLI="$FM_BIN_DIR/clientd-cli"

--- a/scripts/tmux-user-shell.sh
+++ b/scripts/tmux-user-shell.sh
@@ -24,9 +24,9 @@ scripts/pegin.sh 20000.0 1 > /dev/null 2>&1
 echo Done!
 echo
 echo "This shell provides the following commands:"
-echo "  mint-client-cli:  cli client to interact with the federation"
+echo "  fedimint-cli:  cli client to interact with the federation"
 echo "  ln1, ln2:     cli clients for the two lightning nodes (1 is gateway)"
 echo "  btc_client:   cli client for bitcoind"
 echo
-echo Use mint-client-cli as follows:
-mint-client-cli --help
+echo Use fedimint-cli as follows:
+fedimint-cli --help


### PR DESCRIPTION
`mint-client-cli` isn't a good name. Kinda hard to remember, and hard to type.

`fedimint-cli` is easier to remember, but still not super easy to type.