### PR TITLE
fedimint-cli: Use `untagged` for cli output

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -25,6 +25,7 @@ use tracing_subscriber::EnvFilter;
 
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "snake_case"))]
+#[serde(untagged)]
 enum CliOutput {
     VersionHash {
         hash: String,

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -16,8 +16,8 @@ start_gateway
 #### BEGIN TESTS ####
 
 # reissue
-TOKENS=$($FM_MINT_CLIENT spend '42000msat' | jq -r '.spend.token')
-[[ $($FM_MINT_CLIENT info | jq -r '.info.total_amount') = "9958000" ]]
+TOKENS=$($FM_MINT_CLIENT spend '42000msat' | jq -r '.token')
+[[ $($FM_MINT_CLIENT info | jq -r '.total_amount') = "9958000" ]]
 $FM_MINT_CLIENT validate $TOKENS
 $FM_MINT_CLIENT reissue $TOKENS
 $FM_MINT_CLIENT fetch
@@ -47,7 +47,7 @@ INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"
 [[ "$INVOICE_STATUS" = "paid" ]]
 
 # incoming lightning
-INVOICE="$($FM_MINT_CLIENT ln-invoice '100000msat' 'integration test' | jq -r '.ln_invoice.invoice')"
+INVOICE="$($FM_MINT_CLIENT ln-invoice '100000msat' 'integration test' | jq -r '.invoice')"
 INVOICE_RESULT=$($FM_LN2 pay $INVOICE)
 INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"
 [[ "$INVOICE_STATUS" = "complete" ]]

--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -20,7 +20,7 @@ time1=$(date +%s.%N)
 for i in $( seq 1 $ITERATIONS )
 do
   echo "REISSUE $i"
-  TOKENS=$($FM_MINT_CLIENT spend 1000 | jq -r '.spend.token')
+  TOKENS=$($FM_MINT_CLIENT spend 1000 | jq -r '.token')
   $FM_MINT_CLIENT reissue $TOKENS
   $FM_MINT_CLIENT fetch
 done
@@ -44,7 +44,7 @@ time3=$(date +%s.%N)
 for i in $( seq 1 $ITERATIONS )
 do
   echo "LN RECEIVE $i"
-  INVOICE="$($FM_MINT_CLIENT ln-invoice '500000msat' '$RANDOM' | jq -r '.ln_invoice.invoice')"
+  INVOICE="$($FM_MINT_CLIENT ln-invoice '500000msat' '$RANDOM' | jq -r '.invoice')"
   INVOICE_RESULT=$($FM_LN2 pay $INVOICE)
   INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"
   echo "RESULT $INVOICE_STATUS"

--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -17,7 +17,7 @@ FINALITY_DELAY=$(get_finality_delay)
 echo "Pegging in $PEG_IN_AMOUNT with confirmation in $FINALITY_DELAY blocks"
 
 # get a peg-in address from either the gateway or the client
-if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($FM_LN1 -H gw-address)"; else ADDR="$($FM_MINT_CLIENT peg-in-address | jq -r '.peg_in_address.address')"; fi
+if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($FM_LN1 -H gw-address)"; else ADDR="$($FM_MINT_CLIENT peg-in-address | jq -r '.address')"; fi
 # send bitcoin to that address and save the txid
 TX_ID=$(send_bitcoin $ADDR $PEG_IN_AMOUNT)
 # wait for confirmation and wait for the fed to sync


### PR DESCRIPTION
This turns output from:

```
{
  "version_hash": {
    "hash": "2e302d6ff96c8b34492deade0c3c1d96c26cccb7"
  }
}
```

to:

```
{
  "hash": "2e302d6ff96c8b34492deade0c3c1d96c26cccb7"
}
```

I don't see a point of the additional nesting level and explitting tag, as the user knows which format to expect, as it was requested explicitily.

My second prefered option would be internally-tagged: https://serde.rs/enum-representations.html#internally-tagged