### PR TITLE
Add `group_imports = StdExternalCrate` to `rustfmt.toml`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
More gradual version of #707 