### PR TITLE
Remove the generic `R: RngCore + CryptoRng` from `FedimintConsensus`

### DIFF
--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -4,19 +4,14 @@ use async_trait::async_trait;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::ApiError;
 use fedimint_api::FederationModule;
-use rand::CryptoRng;
-use secp256k1_zkp::rand::RngCore;
 use serde_json::Value;
 
-pub struct FedimintInterconnect<'a, R: RngCore + CryptoRng> {
-    pub fedimint: &'a FedimintConsensus<R>,
+pub struct FedimintInterconnect<'a> {
+    pub fedimint: &'a FedimintConsensus,
 }
 
 #[async_trait]
-impl<'a, R> ModuleInterconect for FedimintInterconnect<'a, R>
-where
-    R: RngCore + CryptoRng,
-{
+impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
     async fn call(
         &self,
         module: &'static str,

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -28,7 +28,6 @@ use fedimint_core::outcome::TransactionStatus;
 use futures::future::select_all;
 use hbbft::honey_badger::Batch;
 use rand::rngs::OsRng;
-use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use std::iter::FromIterator;
@@ -68,12 +67,9 @@ pub struct ConsensusProposal {
 
 // TODO: we should make other fields private and get rid of this
 #[non_exhaustive]
-pub struct FedimintConsensus<R>
-where
-    R: RngCore + CryptoRng,
-{
+pub struct FedimintConsensus {
     /// Cryptographic random number generator used for everything
-    pub rng_gen: Box<dyn RngGenerator<Rng = R>>,
+    pub rng_gen: Box<dyn RngGenerator<Rng = OsRng>>,
     /// Configuration describing the federation and containing our secrets
     pub cfg: ServerConfig,
 
@@ -102,7 +98,7 @@ struct VerificationCaches {
     ln: <LightningModule as FederationModule>::VerificationCache,
 }
 
-impl FedimintConsensus<OsRng> {
+impl FedimintConsensus {
     pub fn new(
         cfg: ServerConfig,
         mint: Mint,
@@ -122,10 +118,7 @@ impl FedimintConsensus<OsRng> {
     }
 }
 
-impl<R> FedimintConsensus<R>
-where
-    R: RngCore + CryptoRng,
-{
+impl FedimintConsensus {
     pub fn submit_transaction(
         &self,
         transaction: Transaction,
@@ -628,31 +621,31 @@ where
         audit
     }
 
-    fn build_interconnect(&self) -> FedimintInterconnect<R> {
+    fn build_interconnect(&self) -> FedimintInterconnect {
         FedimintInterconnect { fedimint: self }
     }
 }
 
-impl<R: RngCore + CryptoRng> AsRef<Wallet> for FedimintConsensus<R> {
+impl AsRef<Wallet> for FedimintConsensus {
     fn as_ref(&self) -> &Wallet {
         &self.wallet
     }
 }
 
-impl<R: RngCore + CryptoRng> AsRef<Mint> for FedimintConsensus<R> {
+impl AsRef<Mint> for FedimintConsensus {
     fn as_ref(&self) -> &Mint {
         &self.mint
     }
 }
 
-impl<R: RngCore + CryptoRng> AsRef<LightningModule> for FedimintConsensus<R> {
+impl AsRef<LightningModule> for FedimintConsensus {
     fn as_ref(&self) -> &LightningModule {
         &self.ln
     }
 }
 
-impl<R: RngCore + CryptoRng> AsRef<FedimintConsensus<R>> for FedimintConsensus<R> {
-    fn as_ref(&self) -> &FedimintConsensus<R> {
+impl AsRef<FedimintConsensus> for FedimintConsensus {
+    fn as_ref(&self) -> &FedimintConsensus {
         self
     }
 }

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -62,7 +62,7 @@ pub enum EpochMessage {
 }
 
 pub struct FedimintServer {
-    pub consensus: Arc<FedimintConsensus<OsRng>>,
+    pub consensus: Arc<FedimintConsensus>,
     pub connections: AnyPeerConnections<EpochMessage>,
     pub cfg: ServerConfig,
     pub hbbft: HoneyBadger<Vec<ConsensusItem>, PeerId>,
@@ -71,12 +71,12 @@ pub struct FedimintServer {
 
 impl FedimintServer {
     /// Start all the components of the mint and plug them together
-    pub async fn run(cfg: ServerConfig, consensus: FedimintConsensus<OsRng>) {
+    pub async fn run(cfg: ServerConfig, consensus: FedimintConsensus) {
         let server = FedimintServer::new(cfg.clone(), consensus).await;
         spawn(net::api::run_server(cfg, server.consensus.clone()));
         server.run_consensus().await;
     }
-    pub async fn new(cfg: ServerConfig, consensus: FedimintConsensus<OsRng>) -> Self {
+    pub async fn new(cfg: ServerConfig, consensus: FedimintConsensus) -> Self {
         let connector: PeerConnector<EpochMessage> =
             TlsTcpConnector::new(cfg.tls_config()).into_dyn();
 
@@ -85,7 +85,7 @@ impl FedimintServer {
 
     pub async fn new_with(
         cfg: ServerConfig,
-        consensus: FedimintConsensus<OsRng>,
+        consensus: FedimintConsensus,
         connector: PeerConnector<EpochMessage>,
     ) -> Self {
         cfg.validate_config(&cfg.identity);


### PR DESCRIPTION
It might have been a historical leftover, but it seems better to just standardize on one and stick with it.