### PR TITLE
Use `cargo fmt` instead of `rustfmt` for linting

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,11 @@
           "rustfmt"
         ]);
 
+        fenixToolchainCargoFmt = (fenixChannelNightly.withComponents [
+          "cargo"
+          "rustfmt"
+        ]);
+
         fenixToolchainCrossAll = with fenix.packages.${system}; combine ([
           stable.cargo
           stable.rustc
@@ -781,7 +786,7 @@
             # of stuff to avoid building and caching things we don't need
             lint = pkgs.mkShell {
               nativeBuildInputs = [
-                fenixToolchainRustfmt
+                fenixToolchainCargoFmt
                 pkgs.nixpkgs-fmt
                 pkgs.shellcheck
                 pkgs.git

--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -31,7 +31,7 @@ nixpkgs-fmt --check $(echo "$git_ls_files" | grep -E '.*\.nix$')
 # Note: avoid `cargo fmt --all` so we don't need extra stuff in `ci` shell
 # so that CI is faster
 # shellcheck disable=SC2046
-rustfmt --edition 2021 --check $(echo "$git_ls_files" | grep -E '.*\.rs$')
+cargo fmt --all --check
 
 
 >&2 echo "Checking shell script files ..."


### PR DESCRIPTION
Apparently, despite both reporting the same `--version` there are some minor differences in how they want to format the code. Maybe a bug, maybe something I don't know about. But it seems easier to just use `cargo fmt` for linting in CI.