### PR TITLE
Use debug builds for dev work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,22 @@ repository = "https://github.com/fedimint/fedimint"
 license-file = "LICENSE"
 keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
+
+# in dev mode optimize crates that are perf-critical (usually just crypto crates)
+[profile.dev.package]
+secp256k1 = { opt-level = 2 }
+secp256k1-zkp = { opt-level = 2 }
+secp256k1-sys = { opt-level = 2 }
+secp256k1-zkp-sys = { opt-level = 2 }
+ff = { opt-level = 2 }
+group = { opt-level = 2 }
+pairings = { opt-level = 2 }
+rand_core = { opt-level = 2 }
+byteorder = { opt-level = 2 }
+zeroize = { opt-level = 2 }
+bls12_381 = { opt-level = 2 }
+subtle = { opt-level = 2 }
+
 [patch.crates-io]
 secp256k1-zkp = { git = "https://github.com/dpc/rust-secp256k1-zkp/", branch = "sanket-pr" }
 cln-plugin = { git = "https://github.com/ElementsProject/lightning", rev = "42783aa" }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,11 +11,11 @@ echo "Setting up env variables in $FM_TMP_DIR"
 # Builds the rust executables and sets environment variables
 SRC_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 cd $SRC_DIR || exit 1
-cargo build --release
+cargo build
 
 # Define temporary directories to not overwrite manually created config if run locally
 export FM_TEST_DIR=$FM_TMP_DIR
-export FM_BIN_DIR="$SRC_DIR/target/release"
+export FM_BIN_DIR="$SRC_DIR/target/debug"
 export FM_PID_FILE="$FM_TMP_DIR/.pid"
 export FM_LN1_DIR="$FM_TEST_DIR/ln1"
 export FM_LN2_DIR="$FM_TEST_DIR/ln2"

--- a/scripts/final-checks.sh
+++ b/scripts/final-checks.sh
@@ -9,7 +9,7 @@ cargo clippy --fix --lib --bins --tests --examples --workspace --allow-dirty
 nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes .#lint --command ./misc/git-hooks/pre-commit
 
 export FM_TEST_DISABLE_MOCKS=0
-cargo test --release
+cargo test
 
 if [ "$1" == "nix" ]; then
   ./scripts/cli-test.sh

--- a/scripts/gw-reload.sh
+++ b/scripts/gw-reload.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-cargo build --release --bin ln_gateway
+cargo build --bin ln_gateway
 
 $FM_LN1 plugin stop ln_gateway &> /dev/null || true
 $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR &> /dev/null

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -7,4 +7,4 @@ export RUST_LOG=info
 source ./scripts/setup-tests.sh
 
 export FM_TEST_DISABLE_MOCKS=1
-cargo test --release -p fedimint-tests -- --test-threads=1
+cargo test -p fedimint-tests -- --test-threads=1


### PR DESCRIPTION
This should make setting up the dev environment much faster.

If we need more performance for crypto operations, we should use:

https://doc.rust-lang.org/cargo/reference/profiles.html#overrides

to optimize only the most important crypto crates.