### PR TITLE
Gateway message channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
 name = "ln-gateway"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "axum 0.5.16",
  "bitcoin",

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -17,6 +17,7 @@ name = "ln_gateway"
 path = "src/bin/ln_gateway.rs"
 
 [dependencies]
+anyhow = "1.0.65"
 async-trait = "0.1.52"
 axum = "0.5.16"
 bitcoin_hashes = "0.11.0"

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cln;
 pub mod ln;
+pub mod rpc;
 pub mod webserver;
 
 use std::borrow::Cow;

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -411,6 +411,8 @@ pub enum LnGatewayError {
     CouldNotRoute(LightningError),
     #[error("Mint client error: {0:?}")]
     MintClientE(#[from] MintClientError),
+    #[error("Other: {0:?}")]
+    Other(#[from] anyhow::Error),
 }
 
 pub fn serde_hex_deserialize<'d, T: bitcoin::consensus::Decodable, D: Deserializer<'d>>(

--- a/ln-gateway/src/rpc.rs
+++ b/ln-gateway/src/rpc.rs
@@ -1,0 +1,32 @@
+use anyhow::Error;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::{GatewayRequest, GatewayRequestTrait, Result};
+
+#[derive(Debug, Clone)]
+pub struct GatewayRpcSender {
+    sender: mpsc::Sender<GatewayRequest>,
+}
+
+/// A two-way rpc channel for [`GatewayRequest`]s.
+///
+/// The channel consists of a long lived sender and receiver used to pass along the original message
+/// And a short lived (oneshot tx, rx) is used to receive a response in the opposite direction as the original message.
+impl GatewayRpcSender {
+    pub fn new(sender: mpsc::Sender<GatewayRequest>) -> Self {
+        Self { sender }
+    }
+
+    pub async fn send<R>(&self, message: R) -> std::result::Result<R::Response, Error>
+    where
+        R: GatewayRequestTrait,
+    {
+        let (sender, receiver) = oneshot::channel::<Result<R::Response>>();
+        let msg = message.to_enum(sender);
+        self.sender
+            .send(msg)
+            .await
+            .expect("failed to send over channel");
+        Ok(receiver.await.expect("Failed to send over channel")?)
+    }
+}


### PR DESCRIPTION
[Reconsidering Gateway Architecture](https://github.com/fedimint/fedimint/pull/709): Gateway Messaging

Defines `GatewayMessageChannel` for sending and responding to `GatewayRequest` messages between gateway components.
The message channel is bi-directional, consisting of a long lived sender for sending messages to a receiver (messaging hub) within the gateway. Responses are sent back via one-shot messages to the originator of the messaging sequence.

Application: We apply the message sender to `webserver` component of the gateway

