### PR TITLE
Do not fail on codecov upload failures

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -104,7 +104,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: result/lcov.info
-          fail_ci_if_error: true
 
   wasm32:
     name: "Cross-compile: ${{ matrix.build }}"


### PR DESCRIPTION
These are mostly advisory, and there's no point wasting time re-running them, I think.