### PR TITLE
Federation Database Transactions

### DIFF
--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -20,8 +20,11 @@ pub struct MemDatabase {
 #[derive(Debug)]
 pub struct MemTransaction<'a> {
     operations: Vec<DatabaseOperation>,
-    tx_data: Mutex<BTreeMap<Vec<u8>, Vec<u8>>>,
+    tx_data: BTreeMap<Vec<u8>, Vec<u8>>,
     db: &'a MemDatabase,
+    savepoint: BTreeMap<Vec<u8>, Vec<u8>>,
+    num_pending_operations: usize,
+    num_savepoint_operations: usize,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -99,10 +102,14 @@ impl IDatabase for MemDatabase {
     }
 
     fn begin_transaction(&self) -> DatabaseTransaction {
+        let db_copy = self.data.lock().unwrap().clone();
         MemTransaction {
             operations: Vec::new(),
-            tx_data: Mutex::new(self.data.lock().unwrap().clone()),
+            tx_data: db_copy.clone(),
             db: self,
+            savepoint: db_copy,
+            num_pending_operations: 0,
+            num_savepoint_operations: 0,
         }
         .into()
     }
@@ -112,37 +119,34 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
     fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let val = self.raw_get_bytes(key);
         // Insert data from copy so we can read our own writes
-        self.tx_data
-            .lock()
-            .unwrap()
-            .insert(key.to_vec(), value.clone());
+        self.tx_data.insert(key.to_vec(), value.clone());
         self.operations
             .push(DatabaseOperation::Insert(DatabaseInsertOperation {
                 key: key.to_vec(),
                 value,
             }));
+        self.num_pending_operations += 1;
         val
     }
 
     fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        Ok(self.tx_data.lock().unwrap().get(key).cloned())
+        Ok(self.tx_data.get(key).cloned())
     }
 
     fn raw_remove_entry(&mut self, key: &[u8]) -> Result<()> {
         // Remove data from copy so we can read our own writes
-        self.tx_data.lock().unwrap().remove(&key.to_vec());
+        self.tx_data.remove(&key.to_vec());
         self.operations
             .push(DatabaseOperation::Delete(DatabaseDeleteOperation {
                 key: key.to_vec(),
             }));
+        self.num_pending_operations += 1;
         Ok(())
     }
 
     fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_> {
         let mut data = self
             .tx_data
-            .lock()
-            .unwrap()
             .range::<Vec<u8>, _>((key_prefix.to_vec())..)
             .take_while(|(key, _)| key.starts_with(key_prefix))
             .map(|(key, value)| (key.clone(), value.clone()))
@@ -169,6 +173,21 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
         }
 
         Ok(())
+    }
+
+    fn rollback(&mut self) {
+        self.tx_data = self.savepoint.clone();
+
+        // Remove any pending operations beyond the savepoint
+        let removed_ops = self.num_pending_operations - self.num_savepoint_operations;
+        for _i in 0..removed_ops {
+            self.operations.pop();
+        }
+    }
+
+    fn set_tx_savepoint(&mut self) {
+        self.savepoint = self.tx_data.clone();
+        self.num_savepoint_operations = self.num_pending_operations;
     }
 }
 

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -117,6 +117,8 @@ impl IDatabase for MemDatabase {
     }
 }
 
+// In-memory database transaction should only be used for test code and never for production
+// as it doesn't properly implement MVCC
 impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
     fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let val = self.raw_get_bytes(key);

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -168,6 +168,10 @@ pub trait IDatabaseTransaction<'a>: 'a {
     fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_>;
 
     fn commit_tx(self: Box<Self>) -> Result<()>;
+
+    fn rollback(&mut self);
+
+    fn set_tx_savepoint(&mut self);
 }
 
 dyn_newtype_define! {
@@ -538,5 +542,36 @@ mod tests {
         assert_eq!(dbtx3.get_value(&TestKey(42)).unwrap(), Some(TestVal(0)));
         assert_eq!(dbtx3.get_value(&TestKey(55)).unwrap(), Some(TestVal(9999)));
         assert_eq!(dbtx3.get_value(&TestKey(54)).unwrap(), Some(TestVal(8888)));
+
+        // Verify that setting a savepoint and rolling back a transaction erases a write
+        let mut dbtx_rollback = db.begin_transaction();
+
+        assert!(dbtx_rollback
+            .insert_entry(&TestKey(20), &TestVal(2000))
+            .is_ok());
+
+        dbtx_rollback.set_tx_savepoint();
+
+        assert!(dbtx_rollback
+            .insert_entry(&TestKey(21), &TestVal(2001))
+            .is_ok());
+
+        assert_eq!(
+            dbtx_rollback.get_value(&TestKey(20)).unwrap(),
+            Some(TestVal(2000))
+        );
+        assert_eq!(
+            dbtx_rollback.get_value(&TestKey(21)).unwrap(),
+            Some(TestVal(2001))
+        );
+
+        dbtx_rollback.rollback();
+
+        assert_eq!(
+            dbtx_rollback.get_value(&TestKey(20)).unwrap(),
+            Some(TestVal(2000))
+        );
+
+        assert_eq!(dbtx_rollback.get_value(&TestKey(21)).unwrap(), None);
     }
 }

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -171,6 +171,8 @@ pub trait IDatabaseTransaction<'a>: 'a {
 
     fn rollback_tx_to_savepoint(&mut self);
 
+    // Ideally, avoid using this in fedimint client code as not all database transaction
+    // implementations will support setting a savepoint during a transaction.
     fn set_tx_savepoint(&mut self);
 }
 

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -169,7 +169,7 @@ pub trait IDatabaseTransaction<'a>: 'a {
 
     fn commit_tx(self: Box<Self>) -> Result<()>;
 
-    fn rollback(&mut self);
+    fn rollback_tx_to_savepoint(&mut self);
 
     fn set_tx_savepoint(&mut self);
 }
@@ -565,7 +565,7 @@ mod tests {
             Some(TestVal(2001))
         );
 
-        dbtx_rollback.rollback();
+        dbtx_rollback.rollback_tx_to_savepoint();
 
         assert_eq!(
             dbtx_rollback.get_value(&TestKey(20)).unwrap(),

--- a/fedimint-api/src/module/testing.rs
+++ b/fedimint-api/src/module/testing.rs
@@ -9,7 +9,6 @@ use fedimint_api::module::TransactionItemAmount;
 
 use super::ApiError;
 use crate::config::GenerateConfig;
-use crate::db::batch::DbBatch;
 use crate::db::mem_impl::MemDatabase;
 use crate::db::Database;
 use crate::module::interconnect::ModuleInterconect;
@@ -114,7 +113,6 @@ where
 
         let peers: HashSet<PeerId> = self.members.iter().map(|p| p.0).collect();
         for (_peer, member, db) in &mut self.members {
-            let mut batch = DbBatch::new();
             let database = db as &mut Database;
             let mut dbtx = database.begin_transaction();
 
@@ -125,25 +123,24 @@ where
             let cache = member.build_verification_cache(inputs.iter());
             for input in inputs {
                 member
-                    .apply_input(&fake_ic, batch.transaction(), input, &cache)
+                    .apply_input(&fake_ic, &mut dbtx, input, &cache)
                     .expect("Faulty input");
             }
 
             for (out_point, output) in outputs {
                 member
-                    .apply_output(batch.transaction(), output, *out_point)
+                    .apply_output(&mut dbtx, output, *out_point)
                     .expect("Faulty output");
             }
 
             dbtx.commit_tx().expect("DB Error");
-            database.apply_batch(batch).expect("DB error");
 
-            let mut batch = DbBatch::new();
+            let mut dbtx = database.begin_transaction();
             member
-                .end_consensus_epoch(&peers, batch.transaction(), &mut rng)
+                .end_consensus_epoch(&peers, &mut dbtx, &mut rng)
                 .await;
 
-            database.apply_batch(batch).expect("DB error");
+            dbtx.commit_tx().expect("DB Error");
         }
     }
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -110,7 +110,9 @@ impl IDatabase for RocksDb {
     }
 
     fn begin_transaction(&self) -> DatabaseTransaction {
-        RocksDbTransaction(self.0.transaction()).into()
+        let mut tx: DatabaseTransaction = RocksDbTransaction(self.0.transaction()).into();
+        tx.set_tx_savepoint();
+        tx
     }
 }
 
@@ -151,7 +153,7 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
         Ok(())
     }
 
-    fn rollback(&mut self) {
+    fn rollback_tx_to_savepoint(&mut self) {
         match self.0.rollback_to_savepoint() {
             Ok(()) => {}
             _ => {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -8,8 +8,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::iter::FromIterator;
 use std::sync::Arc;
 
-use fedimint_api::db::batch::{AccumulatorTx, BatchItem, BatchTx, DbBatch};
-use fedimint_api::db::Database;
+use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::TransactionItemAmount;
@@ -237,23 +236,17 @@ impl FedimintConsensus {
 
         // Begin consensus epoch
         {
-            let mut db_vec = vec![
-                self.db.begin_transaction(),
-                self.db.begin_transaction(),
-                self.db.begin_transaction(),
-            ];
+            let mut dbtx = self.db.begin_transaction();
             self.wallet
-                .begin_consensus_epoch(&mut db_vec[0], wallet_cis, self.rng_gen.get_rng())
+                .begin_consensus_epoch(&mut dbtx, wallet_cis, self.rng_gen.get_rng())
                 .await;
             self.mint
-                .begin_consensus_epoch(&mut db_vec[1], mint_cis, self.rng_gen.get_rng())
+                .begin_consensus_epoch(&mut dbtx, mint_cis, self.rng_gen.get_rng())
                 .await;
             self.ln
-                .begin_consensus_epoch(&mut db_vec[2], ln_cis, self.rng_gen.get_rng())
+                .begin_consensus_epoch(&mut dbtx, ln_cis, self.rng_gen.get_rng())
                 .await;
-            db_vec
-                .into_iter()
-                .for_each(|tx| tx.commit_tx().expect("DB Error"));
+            dbtx.commit_tx().expect("DB Error");
         }
 
         // Process transactions
@@ -270,14 +263,15 @@ impl FedimintConsensus {
                 .filter_conflicts(|(_, tx)| tx)
                 .partitioned();
 
-            let mut db_batch = DbBatch::new();
-            let mut batch_tx = db_batch.transaction();
+            let mut dbtx = self.db.begin_transaction();
+            dbtx.set_tx_savepoint();
 
             for transaction in err_tx {
-                batch_tx.append_insert(
-                    RejectedTransactionKey(transaction.tx_hash()),
-                    format!("{:?}", TransactionSubmissionError::TransactionConflictError),
-                );
+                dbtx.insert_entry(
+                    &RejectedTransactionKey(transaction.tx_hash()),
+                    &format!("{:?}", TransactionSubmissionError::TransactionConflictError),
+                )
+                .expect("DB Error");
             }
 
             let caches = self.build_verification_caches(ok_tx.iter());
@@ -286,67 +280,65 @@ impl FedimintConsensus {
                 // in_scope to make sure that no await is in the middle of the span
                 let _enter = span.in_scope(|| {
                     trace!(?transaction);
-                    batch_tx.append_maybe_delete(ProposedTransactionKey(transaction.tx_hash()));
+                    dbtx.maybe_remove_entry(&ProposedTransactionKey(transaction.tx_hash()))
+                        .expect("DB Error");
 
                     // TODO: use borrowed transaction
-                    match self.process_transaction(
-                        batch_tx.subtransaction(),
-                        transaction.clone(),
-                        &caches,
-                    ) {
+                    match self.process_transaction(&mut dbtx, transaction.clone(), &caches) {
                         Ok(()) => {
-                            batch_tx.append_insert(
-                                AcceptedTransactionKey(transaction.tx_hash()),
-                                AcceptedTransaction { epoch, transaction },
-                            );
+                            dbtx.insert_entry(
+                                &AcceptedTransactionKey(transaction.tx_hash()),
+                                &AcceptedTransaction { epoch, transaction },
+                            )
+                            .expect("DB Error");
                         }
                         Err(error) => {
+                            dbtx.rollback();
                             warn!(%error, "Transaction failed");
-                            batch_tx.append_insert(
-                                RejectedTransactionKey(transaction.tx_hash()),
-                                format!("{:?}", error),
-                            );
+                            dbtx.insert_entry(
+                                &RejectedTransactionKey(transaction.tx_hash()),
+                                &format!("{:?}", error),
+                            )
+                            .expect("DB Error");
                         }
                     }
                 });
             }
-            batch_tx.commit();
-            self.db.apply_batch(db_batch).expect("DB error");
+            dbtx.commit_tx().expect("DB Error");
         }
 
         // End consensus epoch
         {
-            let mut db_batch = DbBatch::new();
+            let mut dbtx = self.db.begin_transaction();
             let mut drop_peers = Vec::<PeerId>::new();
 
-            self.save_epoch_history(outcome, db_batch.transaction(), &mut drop_peers);
+            self.save_epoch_history(outcome, &mut dbtx, &mut drop_peers);
 
             let mut drop_wallet = self
                 .wallet
-                .end_consensus_epoch(&epoch_peers, db_batch.transaction(), self.rng_gen.get_rng())
+                .end_consensus_epoch(&epoch_peers, &mut dbtx, self.rng_gen.get_rng())
                 .await;
 
             let mut drop_mint = self
                 .mint
-                .end_consensus_epoch(&epoch_peers, db_batch.transaction(), self.rng_gen.get_rng())
+                .end_consensus_epoch(&epoch_peers, &mut dbtx, self.rng_gen.get_rng())
                 .await;
 
             let mut drop_ln = self
                 .ln
-                .end_consensus_epoch(&epoch_peers, db_batch.transaction(), self.rng_gen.get_rng())
+                .end_consensus_epoch(&epoch_peers, &mut dbtx, self.rng_gen.get_rng())
                 .await;
 
             drop_peers.append(&mut drop_wallet);
             drop_peers.append(&mut drop_mint);
             drop_peers.append(&mut drop_ln);
 
-            let mut batch_tx = db_batch.transaction();
             for peer in drop_peers {
-                batch_tx.append_insert(DropPeerKey(peer), ());
+                dbtx.insert_entry(&DropPeerKey(peer), &())
+                    .expect("DB Error");
             }
-            batch_tx.commit();
 
-            self.db.apply_batch(db_batch).expect("DB error");
+            dbtx.commit_tx().expect("DB Error");
         }
 
         let audit = self.audit();
@@ -362,10 +354,10 @@ impl FedimintConsensus {
         self.db.get_value(&EpochHistoryKey(epoch)).unwrap()
     }
 
-    fn save_epoch_history(
+    fn save_epoch_history<'a>(
         &self,
         outcome: ConsensusOutcome,
-        mut transaction: AccumulatorTx<BatchItem>,
+        dbtx: &mut DatabaseTransaction<'a>,
         drop_peers: &mut Vec<PeerId>,
     ) {
         let prev_epoch_key = EpochHistoryKey(outcome.epoch.saturating_sub(1));
@@ -379,7 +371,10 @@ impl FedimintConsensus {
             let pks = &self.cfg.epoch_pk_set;
 
             match current.add_sig_to_prev(pks, prev_epoch) {
-                Ok(prev_epoch) => transaction.append_insert(prev_epoch_key, prev_epoch),
+                Ok(prev_epoch) => {
+                    dbtx.insert_entry(&prev_epoch_key, &prev_epoch)
+                        .expect("DB Error");
+                }
                 Err(EpochVerifyError::NotEnoughValidSigShares(contributing_peers)) => {
                     warn!("Unable to sign epoch {}", prev_epoch_key.0);
                     for peer in peers {
@@ -393,9 +388,10 @@ impl FedimintConsensus {
             }
         }
 
-        transaction.append_insert(LastEpochKey, EpochHistoryKey(current.outcome.epoch));
-        transaction.append_insert(EpochHistoryKey(current.outcome.epoch), current);
-        transaction.commit();
+        dbtx.insert_entry(&LastEpochKey, &EpochHistoryKey(current.outcome.epoch))
+            .expect("DB Error");
+        dbtx.insert_entry(&EpochHistoryKey(current.outcome.epoch), &current)
+            .expect("DB Error");
     }
 
     pub async fn await_consensus_proposal(&self) {
@@ -457,9 +453,9 @@ impl FedimintConsensus {
         ConsensusProposal { items, drop_peers }
     }
 
-    fn process_transaction(
+    fn process_transaction<'a>(
         &self,
-        mut batch: BatchTx,
+        dbtx: &mut DatabaseTransaction<'a>,
         transaction: Transaction,
         caches: &VerificationCaches,
     ) -> Result<(), TransactionSubmissionError> {
@@ -472,30 +468,15 @@ impl FedimintConsensus {
             let meta = match input {
                 Input::Mint(coins) => self
                     .mint
-                    .apply_input(
-                        &self.build_interconnect(),
-                        batch.subtransaction(),
-                        coins,
-                        &caches.mint,
-                    )
+                    .apply_input(&self.build_interconnect(), dbtx, coins, &caches.mint)
                     .map_err(TransactionSubmissionError::InputCoinError)?,
                 Input::Wallet(peg_in) => self
                     .wallet
-                    .apply_input(
-                        &self.build_interconnect(),
-                        batch.subtransaction(),
-                        peg_in,
-                        &caches.wallet,
-                    )
+                    .apply_input(&self.build_interconnect(), dbtx, peg_in, &caches.wallet)
                     .map_err(TransactionSubmissionError::InputPegIn)?,
                 Input::LN(input) => self
                     .ln
-                    .apply_input(
-                        &self.build_interconnect(),
-                        batch.subtransaction(),
-                        input,
-                        &caches.ln,
-                    )
+                    .apply_input(&self.build_interconnect(), dbtx, input, &caches.ln)
                     .map_err(TransactionSubmissionError::ContractInputError)?,
             };
             pub_keys.push(meta.puk_keys);
@@ -511,15 +492,15 @@ impl FedimintConsensus {
             let amount = match output {
                 Output::Mint(new_tokens) => self
                     .mint
-                    .apply_output(batch.subtransaction(), &new_tokens, out_point)
+                    .apply_output(dbtx, &new_tokens, out_point)
                     .map_err(TransactionSubmissionError::OutputCoinError)?,
                 Output::Wallet(peg_out) => self
                     .wallet
-                    .apply_output(batch.subtransaction(), &peg_out, out_point)
+                    .apply_output(dbtx, &peg_out, out_point)
                     .map_err(TransactionSubmissionError::OutputPegOut)?,
                 Output::LN(output) => self
                     .ln
-                    .apply_output(batch.subtransaction(), &output, out_point)
+                    .apply_output(dbtx, &output, out_point)
                     .map_err(TransactionSubmissionError::ContractOutputError)?,
             };
             funding_verifier.add_output(amount);
@@ -527,7 +508,6 @@ impl FedimintConsensus {
 
         funding_verifier.verify_funding()?;
 
-        batch.commit();
         Ok(())
     }
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -264,7 +264,6 @@ impl FedimintConsensus {
                 .partitioned();
 
             let mut dbtx = self.db.begin_transaction();
-            dbtx.set_tx_savepoint();
 
             for transaction in err_tx {
                 dbtx.insert_entry(
@@ -293,7 +292,7 @@ impl FedimintConsensus {
                             .expect("DB Error");
                         }
                         Err(error) => {
-                            dbtx.rollback();
+                            dbtx.rollback_tx_to_savepoint();
                             warn!(%error, "Transaction failed");
                             dbtx.insert_entry(
                                 &RejectedTransactionKey(transaction.tx_hash()),

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -131,6 +131,8 @@ impl IDatabase for SledDb {
     }
 }
 
+// Sled database transaction should only be used for test code and never for production
+// as it doesn't properly implement MVCC
 impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
     fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let val = self.raw_get_bytes(key);

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -20,7 +20,6 @@ use std::ops::Sub;
 use async_trait::async_trait;
 use bitcoin_hashes::Hash as BitcoinHash;
 use db::{LightningGatewayKey, LightningGatewayKeyPrefix};
-use fedimint_api::db::batch::BatchTx;
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
@@ -264,10 +263,10 @@ impl FederationModule for LightningModule {
         })
     }
 
-    fn apply_input<'a, 'b>(
+    fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        mut batch: BatchTx<'a>,
+        dbtx: &mut DatabaseTransaction<'c>,
         input: &'b Self::TxInput,
         cache: &Self::VerificationCache,
     ) -> Result<InputMeta<'b>, Self::Error> {
@@ -280,9 +279,9 @@ impl FederationModule for LightningModule {
             .expect("DB error")
             .expect("Should fail validation if contract account doesn't exist");
         contract_account.amount -= meta.amount.amount;
-        batch.append_insert(account_db_key, contract_account);
+        dbtx.insert_entry(&account_db_key, &contract_account)
+            .expect("DB Error");
 
-        batch.commit();
         Ok(meta)
     }
 
@@ -355,9 +354,9 @@ impl FederationModule for LightningModule {
         }
     }
 
-    fn apply_output<'a>(
+    fn apply_output<'a, 'b>(
         &'a self,
-        mut batch: BatchTx<'a>,
+        dbtx: &mut DatabaseTransaction<'b>,
         output: &'a Self::TxOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, Self::Error> {
@@ -378,15 +377,17 @@ impl FederationModule for LightningModule {
                         amount: amount.amount,
                         contract: contract.contract.clone().to_funded(out_point),
                     });
-                batch.append_insert(contract_db_key, updated_contract_account);
+                dbtx.insert_entry(&contract_db_key, &updated_contract_account)
+                    .expect("DB Error");
 
-                batch.append_insert_new(
-                    ContractUpdateKey(out_point),
-                    OutputOutcome::Contract {
+                dbtx.insert_new_entry(
+                    &ContractUpdateKey(out_point),
+                    &OutputOutcome::Contract {
                         id: contract.contract.contract_id(),
                         outcome: contract.contract.to_outcome(),
                     },
-                );
+                )
+                .expect("DB Error");
 
                 if let Contract::Incoming(incoming) = &contract.contract {
                     let offer = self
@@ -400,20 +401,23 @@ impl FederationModule for LightningModule {
                         .threshold_sec_key
                         .decrypt_share(&incoming.encrypted_preimage.0)
                         .expect("We checked for decryption share validity on contract creation");
-                    batch.append_insert_new(
-                        ProposeDecryptionShareKey(contract.contract.contract_id()),
-                        PreimageDecryptionShare(decryption_share),
-                    );
-                    batch.append_delete(OfferKey(offer.hash));
+                    dbtx.insert_new_entry(
+                        &ProposeDecryptionShareKey(contract.contract.contract_id()),
+                        &PreimageDecryptionShare(decryption_share),
+                    )
+                    .expect("DB Error");
+                    dbtx.remove_entry(&OfferKey(offer.hash)).expect("DB Error");
                 }
             }
             ContractOrOfferOutput::Offer(offer) => {
-                batch.append_insert_new(
-                    ContractUpdateKey(out_point),
-                    OutputOutcome::Offer { id: offer.id() },
-                );
+                dbtx.insert_new_entry(
+                    &ContractUpdateKey(out_point),
+                    &OutputOutcome::Offer { id: offer.id() },
+                )
+                .expect("DB Error");
                 // TODO: sanity-check encrypted preimage size
-                batch.append_insert_new(OfferKey(offer.hash), (*offer).clone());
+                dbtx.insert_new_entry(&OfferKey(offer.hash), &(*offer).clone())
+                    .expect("DB Error");
             }
             ContractOrOfferOutput::CancelOutgoing { contract, .. } => {
                 let updated_contract_account = {
@@ -435,11 +439,11 @@ impl FederationModule for LightningModule {
                     contract_account
                 };
 
-                batch.append_insert(ContractKey(*contract), updated_contract_account);
+                dbtx.insert_entry(&ContractKey(*contract), &updated_contract_account)
+                    .expect("DB Error");
             }
         }
 
-        batch.commit();
         Ok(amount)
     }
 
@@ -447,7 +451,7 @@ impl FederationModule for LightningModule {
     async fn end_consensus_epoch<'a>(
         &'a self,
         consensus_peers: &HashSet<PeerId>,
-        mut batch: BatchTx<'a>,
+        dbtx: &mut DatabaseTransaction<'a>,
         _rng: impl RngCore + CryptoRng + 'a,
     ) -> Vec<PeerId> {
         // Decrypt preimages
@@ -474,7 +478,8 @@ impl FederationModule for LightningModule {
                 _ => {
                     warn!("Received decryption share for non-existent incoming contract");
                     for peer in peers {
-                        batch.append_delete(AgreedDecryptionShareKey(contract_id, peer));
+                        dbtx.remove_entry(&AgreedDecryptionShareKey(contract_id, peer))
+                            .expect("DB Error");
                     }
                     continue;
                 }
@@ -540,9 +545,11 @@ impl FederationModule for LightningModule {
             };
 
             // Delete decryption shares once we've decrypted the preimage
-            batch.append_delete(ProposeDecryptionShareKey(contract_id));
+            dbtx.remove_entry(&ProposeDecryptionShareKey(contract_id))
+                .expect("DB Error");
             for peer in peers {
-                batch.append_delete(AgreedDecryptionShareKey(contract_id, peer));
+                dbtx.remove_entry(&AgreedDecryptionShareKey(contract_id, peer))
+                    .expect("DB Error");
             }
 
             let decrypted_preimage = if preimage_vec.len() == 32
@@ -578,7 +585,8 @@ impl FederationModule for LightningModule {
             };
             incoming.contract.decrypted_preimage = decrypted_preimage.clone();
             trace!(?contract_account, "Updating contract account");
-            batch.append_insert(contract_db_key, contract_account);
+            dbtx.insert_entry(&contract_db_key, &contract_account)
+                .expect("DB Error");
 
             // Update output outcome
             let outcome_db_key = ContractUpdateKey(out_point);
@@ -595,9 +603,9 @@ impl FederationModule for LightningModule {
                 _ => panic!("We are expeccting an incoming contract"),
             };
             *incoming_contract_outcome_preimage = decrypted_preimage.clone();
-            batch.append_insert(outcome_db_key, outcome);
+            dbtx.insert_entry(&outcome_db_key, &outcome)
+                .expect("DB Error");
         }
-        batch.commit();
 
         bad_peers
     }


### PR DESCRIPTION
This PR changes the rest of the consensus code to use the new DatabaseTransaction trait. It also introduces a necessary rollback() and set_tx_savepoint() API that allows a database transaction to save a state and rollback to that state in case of failure. Added implementations for all the databases (mem, rocksdb, sled).

Specifically, this PR changes apply_input, apply_output, process_transaction, and end_consensus_epoch to use DatabaseTransactions.