### PR TITLE
Fix git hook installation for `git worktree` users

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -768,8 +768,9 @@
 
             shellHook = ''
               # auto-install git hooks
-              if [[ ! -d .git/hooks ]]; then mkdir .git/hooks; fi
-              for hook in misc/git-hooks/* ; do ln -sf "../../$hook" "./.git/hooks/" ; done
+              dot_git="$(git rev-parse --git-common-dir)"
+              if [[ ! -d "$dot_git/hooks" ]]; then mkdir "$dot_git/hooks"; fi
+              for hook in misc/git-hooks/* ; do ln -sf "$(pwd)/$hook" "$dot_git/hooks/" ; done
               ${pkgs.git}/bin/git config commit.template misc/git-hooks/commit-template.txt
 
               # workaround https://github.com/rust-lang/cargo/issues/11020


### PR DESCRIPTION
When using `git-worktree` the `.git` directory is shared between worktrees and not just in `./git` of the current worktree. This commit handles this new case as well.