### PR TITLE
Gateway actors for serving multiple federations

### DIFF
--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -1,0 +1,209 @@
+use std::sync::Arc;
+
+use bitcoin::{Address, Transaction};
+use bitcoin_hashes::sha256;
+use fedimint_api::{Amount, OutPoint, TransactionId};
+use fedimint_server::modules::{
+    ln::contracts::{ContractId, Preimage},
+    wallet::txoproof::TxOutProof,
+};
+use mint_client::{GatewayClient, PaymentParameters};
+use rand::{CryptoRng, RngCore};
+use tracing::{debug, instrument, warn};
+
+use crate::{ln::LnRpc, LnGatewayError, Result};
+
+pub struct GatewayActor {
+    client: Arc<GatewayClient>,
+}
+
+impl GatewayActor {
+    pub fn new(client: Arc<GatewayClient>) -> Self {
+        Self { client }
+    }
+
+    pub async fn buy_preimage_offer(
+        &self,
+        payment_hash: &sha256::Hash,
+        amount: &Amount,
+        rng: impl RngCore + CryptoRng,
+    ) -> Result<(OutPoint, ContractId)> {
+        let (outpoint, contract_id) = self
+            .client
+            .buy_preimage_offer(payment_hash, amount, rng)
+            .await?;
+        Ok((outpoint, contract_id))
+    }
+
+    // TODO: Move this API to messaging
+    pub async fn await_preimage_decryption(&self, outpoint: OutPoint) -> Result<Preimage> {
+        let preimage = self.client.await_preimage_decryption(outpoint).await?;
+        Ok(preimage)
+    }
+
+    #[instrument(skip_all, fields(%contract_id))]
+    pub async fn pay_invoice(
+        &self,
+        ln_rpc: Arc<dyn LnRpc>,
+        contract_id: ContractId,
+    ) -> Result<OutPoint> {
+        debug!("Fetching contract");
+        let rng = rand::rngs::OsRng;
+        let contract_account = self.client.fetch_outgoing_contract(contract_id).await?;
+
+        let payment_params = self
+            .client
+            .validate_outgoing_account(&contract_account)
+            .await?;
+
+        debug!(
+            account = ?contract_account,
+            "Fetched and validated contract account"
+        );
+
+        self.client.save_outgoing_payment(contract_account.clone());
+
+        let is_internal_payment = payment_params.maybe_internal
+            && self
+                .client
+                .ln_client()
+                .offer_exists(payment_params.payment_hash)
+                .await
+                .unwrap_or(false);
+
+        let preimage_res = if is_internal_payment {
+            self.buy_preimage_internal(&payment_params.payment_hash, &payment_params.invoice_amount)
+                .await
+        } else {
+            self.buy_preimage_external(ln_rpc, &contract_account.contract.invoice, &payment_params)
+                .await
+        };
+
+        match preimage_res {
+            Ok(preimage) => {
+                let outpoint = self
+                    .client
+                    .claim_outgoing_contract(contract_id, preimage, rng)
+                    .await?;
+
+                Ok(outpoint)
+            }
+            Err(e) => {
+                warn!("Invoice payment failed: {}. Aborting", e);
+                // FIXME: combine both errors?
+                self.client.abort_outgoing_payment(contract_id).await?;
+                Err(e)
+            }
+        }
+    }
+
+    pub async fn buy_preimage_internal(
+        &self,
+        payment_hash: &sha256::Hash,
+        invoice_amount: &Amount,
+    ) -> Result<Preimage> {
+        let mut rng = rand::rngs::OsRng;
+        let (out_point, contract_id) = self
+            .client
+            .buy_preimage_offer(payment_hash, invoice_amount, &mut rng)
+            .await?;
+
+        debug!("Awaiting decryption of preimage of hash {}", payment_hash);
+        match self.client.await_preimage_decryption(out_point).await {
+            Ok(preimage) => {
+                debug!("Decrypted preimage {:?}", preimage);
+                Ok(preimage)
+            }
+            Err(e) => {
+                warn!("Failed to decrypt preimage. Now requesting a refund: {}", e);
+                self.client
+                    .refund_incoming_contract(contract_id, rng)
+                    .await?;
+                Err(LnGatewayError::ClientError(e))
+            }
+        }
+    }
+
+    pub async fn buy_preimage_external(
+        &self,
+        ln_rpc: Arc<dyn LnRpc>,
+        invoice: &str,
+        payment_params: &PaymentParameters,
+    ) -> Result<Preimage> {
+        match ln_rpc
+            .pay(
+                invoice,
+                payment_params.max_delay,
+                payment_params.max_fee_percent(),
+            )
+            .await
+        {
+            Ok(preimage) => {
+                debug!(?preimage, "Successfully paid LN invoice");
+                Ok(preimage)
+            }
+            Err(e) => {
+                warn!("LN payment failed, aborting");
+                Err(LnGatewayError::CouldNotRoute(e))
+            }
+        }
+    }
+
+    pub async fn await_outgoing_contract_claimed(
+        &self,
+        contract_id: ContractId,
+        outpoint: OutPoint,
+    ) -> Result<()> {
+        Ok(self
+            .client
+            .await_outgoing_contract_claimed(contract_id, outpoint)
+            .await?)
+    }
+
+    pub fn get_deposit_address(&self) -> Result<Address> {
+        let mut rng = rand::rngs::OsRng;
+        Ok(self.client.get_new_pegin_address(&mut rng))
+    }
+
+    pub async fn deposit(
+        &self,
+        txout_proof: TxOutProof,
+        transaction: Transaction,
+    ) -> Result<TransactionId> {
+        let rng = rand::rngs::OsRng;
+
+        self.client
+            .peg_in(txout_proof, transaction, rng)
+            .await
+            .map_err(LnGatewayError::ClientError)
+    }
+
+    pub async fn withdraw(
+        &self,
+        amount: bitcoin::Amount,
+        address: Address,
+    ) -> Result<TransactionId> {
+        let rng = rand::rngs::OsRng;
+
+        let peg_out = self
+            .client
+            .new_peg_out_with_fees(amount, address)
+            .await
+            .expect("Failed to create pegout with fees");
+        self.client
+            .peg_out(peg_out, rng)
+            .await
+            .map_err(LnGatewayError::ClientError)
+            .map(|out_point| out_point.txid)
+    }
+
+    pub async fn get_balance(&self) -> Result<Amount> {
+        self.client
+            .fetch_all_coins()
+            .await
+            .into_iter()
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        Ok(self.client.coins().total_amount())
+    }
+}

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -38,14 +38,7 @@ async fn main() -> Result<(), Error> {
     let gw_cfg: GatewayConfig = load_from_file(&gw_cfg_path);
 
     let federation_client = Arc::new(build_federation_client(pub_key, bind_addr, work_dir)?);
-    let mut gateway = LnGateway::new(
-        gw_cfg,
-        federation_client.clone(),
-        ln_rpc,
-        tx,
-        rx,
-        bind_addr,
-    );
+    let mut gateway = LnGateway::new(gw_cfg, federation_client.clone(), ln_rpc, tx, rx, bind_addr);
     gateway.register_federation(federation_client).await?;
 
     gateway.run().await.expect("gateway failed to run");

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -37,15 +37,16 @@ async fn main() -> Result<(), Error> {
     let gw_cfg_path = work_dir.clone().join("gateway.config");
     let gw_cfg: GatewayConfig = load_from_file(&gw_cfg_path);
 
-    let federation_client = build_federation_client(pub_key, bind_addr, work_dir)?;
+    let federation_client = Arc::new(build_federation_client(pub_key, bind_addr, work_dir)?);
     let mut gateway = LnGateway::new(
         gw_cfg,
-        Arc::new(federation_client),
+        federation_client.clone(),
         ln_rpc,
         tx,
         rx,
         bind_addr,
     );
+    gateway.register_federation(federation_client).await?;
 
     gateway.run().await.expect("gateway failed to run");
     Ok(())

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -6,6 +6,7 @@ pub mod rpc;
 pub mod webserver;
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::{
     io::Cursor,
@@ -13,6 +14,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use actor::GatewayActor;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use bitcoin::{Address, Transaction};
@@ -138,6 +140,7 @@ where
 }
 
 pub struct LnGateway {
+    actors: HashMap<FederationId, Arc<GatewayActor>>,
     federation_client: Arc<GatewayClient>,
     ln_client: Arc<dyn LnRpc>,
     webserver: tokio::task::JoinHandle<axum::response::Result<()>>,
@@ -157,6 +160,7 @@ impl LnGateway {
         let webserver = tokio::spawn(run_webserver(cfg.password, bind_addr, sender));
 
         Self {
+            actors: HashMap::new(),
             federation_client,
             ln_client,
             webserver,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -188,6 +188,13 @@ impl LnGateway {
         Ok(actor)
     }
 
+    fn select_actor(&self, federation_id: FederationId) -> Result<Arc<GatewayActor>> {
+        self.actors
+            .get(&federation_id)
+            .cloned()
+            .ok_or(LnGatewayError::UnknownFederation)
+    }
+
     pub async fn buy_preimage_offer(
         &self,
         payment_hash: &sha256::Hash,
@@ -465,6 +472,8 @@ pub enum LnGatewayError {
     CouldNotRoute(LightningError),
     #[error("Mint client error: {0:?}")]
     MintClientE(#[from] MintClientError),
+    #[error("Actor not found")]
+    UnknownFederation,
     #[error("Other: {0:?}")]
     Other(#[from] anyhow::Error),
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod actor;
 pub mod cln;
 pub mod config;
 pub mod ln;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -168,6 +168,26 @@ impl LnGateway {
         }
     }
 
+    /// Register a federation to the gateway.
+    ///
+    /// # Returns
+    ///
+    /// A `GatewayActor` that can be used to execute gateway functions for the federation
+    pub async fn register_federation(
+        &mut self,
+        client: Arc<GatewayClient>,
+    ) -> Result<Arc<GatewayActor>> {
+        let actor = Arc::new(
+            GatewayActor::new(client.clone())
+                .await
+                .expect("Failed to create actor"),
+        );
+
+        let federation_id = FederationId(client.config().client_config.federation_name);
+        self.actors.insert(federation_id, actor.clone());
+        Ok(actor)
+    }
+
     pub async fn buy_preimage_offer(
         &self,
         payment_hash: &sha256::Hash,


### PR DESCRIPTION
**Merge after #868**

Implement a simplified gataeway actor pattern to support running execution of gateway functions for multiple federations. A gateway actor is a 1:1 representation of a Federation in the context of the gateway. The actor:
- encapsulates a federation client
- exposes a logical api on the federation client, with the following functions possible:
  - `sync_wallet` - Fetch coins this gateway owns in the federation and settle the wallet state. Future: we should find a way of automating this sync operation
  - `buy_preimage_offer` - Buy a lightning preimage listed for sale inside the federation served by this actor
  - `await_preimage_decryption` - Wait for preimage decryption by the federation served by this actor
  - `pay_invoice` - Pay an invoice on behalf of a user in the federation served by this actor
  - `buy_preimage_internal` - Buy a preimage when completing an internal payment in the federation served by this actor
  - `buy_preimage_external` - Buy a preimage when completing an external payment for the federation
  - `await_outgoing_contract_claimed` - Wait for outgoing contract confirmation by the federation served by this actor
  - `get_deposit_address` - Get an address for depositing funds (peg-in) to the federation served by this actor
  - `deposit` - Deposit funds (peg-in) to the federation served by this actor
  - `withdraw` - Withdraw funds (peg-out) from the federation served by this actor
  - `get_balance` - Get the current e-cash balance this gateway has in the federation served by this actor

Externally, the gateway exposes an api `register_federation`. This creates a new actor for servicing the federation.

### Beyond this PR, we could:
- [ ] #664
  - [x] - implement an external ( webserver & cli ) api to support federation registration
  - [ ] - add federation identifier information in the routing hint. Add an extra hop for this (?)
- [ ] Run actor actions in isolated threads for perf
- [ ] Implement **self payments** where a single gateway facilitates payments across two federations it serves
- [ ] Test, test, test!