### PR TITLE
Turn `Decodable` into `ModuleDecodable<M>` but leave the name as is

### DIFF
--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -1,5 +1,5 @@
 use fedimint_api::db::DatabaseKeyPrefixConst;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_core::modules::ln::contracts::ContractId;
 use fedimint_core::modules::ln::LightningGateway;
 

--- a/client/client-lib/src/ln/incoming.rs
+++ b/client/client-lib/src/ln/incoming.rs
@@ -1,5 +1,5 @@
 use bitcoin::secp256k1::KeyPair;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::Amount;
 use fedimint_core::modules::ln::contracts::incoming::IncomingContract;
 use fedimint_core::modules::ln::contracts::{ContractId, IdentifyableContract};

--- a/client/client-lib/src/ln/outgoing.rs
+++ b/client/client-lib/src/ln/outgoing.rs
@@ -1,4 +1,4 @@
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::Amount;
 use fedimint_core::modules::ln::contracts::{
     outgoing::OutgoingContract, IdentifyableContract, Preimage,

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -1,5 +1,5 @@
 use fedimint_api::db::DatabaseKeyPrefixConst;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::{Amount, OutPoint, TieredMulti, TransactionId};
 use fedimint_core::modules::mint::Nonce;
 

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use db::{CoinKey, CoinKeyPrefix, OutputFinalizationKey, OutputFinalizationKeyPrefix};
 use fedimint_api::db::batch::{Accumulator, BatchItem, BatchTx, DbBatch};
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::tiered::InvalidAmountTierError;
 use fedimint_api::{Amount, FederationModule, OutPoint, Tiered, TieredMulti, TransactionId};

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bitcoin::{secp256k1, Network};
@@ -19,9 +20,12 @@ pub fn serialize_coins(c: &TieredMulti<SpendableNote>) -> String {
     base64::encode(&bytes)
 }
 
-pub fn from_hex<D: Decodable>(s: &str) -> Result<D, anyhow::Error> {
+pub fn from_hex<D: Decodable<()>>(s: &str) -> Result<D, anyhow::Error> {
     let bytes = hex::decode(s)?;
-    Ok(D::consensus_decode(&mut std::io::Cursor::new(bytes))?)
+    Ok(D::consensus_decode(
+        &mut std::io::Cursor::new(bytes),
+        &BTreeMap::new(),
+    )?)
 }
 
 pub fn parse_bitcoin_amount(

--- a/client/client-lib/src/wallet/db.rs
+++ b/client/client-lib/src/wallet/db.rs
@@ -1,6 +1,6 @@
 use bitcoin::Script;
 use fedimint_api::db::DatabaseKeyPrefixConst;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 
 pub const DB_PREFIX_PEG_IN: u8 = 0x22;
 

--- a/core/api/src/encode.rs
+++ b/core/api/src/encode.rs
@@ -2,29 +2,7 @@ use std::{collections::BTreeMap, io};
 
 use fedimint_api::encoding::{Decodable, DecodeError};
 
-use super::ModuleKey;
-
-/// Value that can be decoded, but only using the required supported modules of type `M`
-pub trait ModuleDecodable<M>: Sized {
-    /// Decode an object with a well-defined format
-    fn consensus_decode<R: std::io::Read>(
-        r: &mut R,
-        modules: &BTreeMap<ModuleKey, M>,
-    ) -> Result<Self, DecodeError>;
-}
-
-impl<T, M> ModuleDecodable<M> for Vec<T>
-where
-    T: ModuleDecodable<M>,
-{
-    fn consensus_decode<R: std::io::Read>(
-        mut r: &mut R,
-        modules: &BTreeMap<ModuleKey, M>,
-    ) -> Result<Self, DecodeError> {
-        let len = u64::consensus_decode(&mut r)?;
-        (0..len).map(|_| T::consensus_decode(r, modules)).collect()
-    }
-}
+use crate::ModuleKey;
 
 pub fn module_decode_key_prefixed_decodable<T, F, R, M>(
     mut d: &mut R,
@@ -35,7 +13,7 @@ where
     R: io::Read,
     F: FnOnce(&mut R, &M) -> Result<T, DecodeError>,
 {
-    let key = ModuleKey::consensus_decode(&mut d)?;
+    let key = ModuleKey::consensus_decode(&mut d, modules)?;
 
     match modules.get(&key) {
         Some(module) => decode_fn(d, module),

--- a/fedimint-api/src/encoding/mod.rs
+++ b/fedimint-api/src/encoding/mod.rs
@@ -6,6 +6,7 @@ mod btc;
 mod secp256k1;
 mod tbs;
 
+use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
 use std::io::{Error, Read, Write};
 
@@ -57,10 +58,18 @@ pub trait Encodable {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error>;
 }
 
+// TODO: unify and/or make a newtype?
+pub type ModuleKey = u16;
+
+pub type ModuleRegistry<M> = BTreeMap<ModuleKey, M>;
+
 /// Data which can be encoded in a consensus-consistent way
-pub trait Decodable: Sized {
+pub trait Decodable<M>: Sized {
     /// Decode an object with a well-defined format
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError>;
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        _modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError>;
 }
 
 impl Encodable for Url {
@@ -69,9 +78,12 @@ impl Encodable for Url {
     }
 }
 
-impl Decodable for Url {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        String::consensus_decode(d)?
+impl<M> Decodable<M> for Url {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        String::consensus_decode(d, modules)?
             .parse::<Url>()
             .map_err(DecodeError::from_err)
     }
@@ -96,9 +108,10 @@ macro_rules! impl_encode_decode_num {
             }
         }
 
-        impl Decodable for $num_type {
+        impl<M> Decodable<M> for $num_type {
             fn consensus_decode<D: std::io::Read>(
                 d: &mut D,
+                _modules: &ModuleRegistry<M>,
             ) -> Result<Self, crate::encoding::DecodeError> {
                 let mut bytes = [0u8; (<$num_type>::BITS / 8) as usize];
                 d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
@@ -126,9 +139,9 @@ macro_rules! impl_encode_decode_tuple {
         }
 
         #[allow(non_snake_case)]
-        impl<$($x: Decodable),*> Decodable for ($($x),*) {
-            fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-                Ok(($({let $x = Decodable::consensus_decode(d)?; $x }),*))
+        impl<M, $($x: Decodable<M>),*> Decodable<M> for ($($x),*) {
+            fn consensus_decode<D: std::io::Read>(d: &mut D, modules: &ModuleRegistry<M>) -> Result<Self, DecodeError> {
+                Ok(($({let $x = Decodable::consensus_decode(d, modules)?; $x }),*))
             }
         }
     );
@@ -161,13 +174,16 @@ where
     }
 }
 
-impl<T> Decodable for Vec<T>
+impl<M, T> Decodable<M> for Vec<T>
 where
-    T: Decodable,
+    T: Decodable<M>,
 {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        let len = u64::consensus_decode(d)?;
-        (0..len).map(|_| T::consensus_decode(d)).collect()
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        let len = u64::consensus_decode(d, modules)?;
+        (0..len).map(|_| T::consensus_decode(d, modules)).collect()
     }
 }
 
@@ -184,15 +200,18 @@ where
     }
 }
 
-impl<T, const SIZE: usize> Decodable for [T; SIZE]
+impl<M, T, const SIZE: usize> Decodable<M> for [T; SIZE]
 where
-    T: Decodable + Debug + Default + Copy,
+    T: Decodable<M> + Debug + Default + Copy,
 {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
         // todo: impl without copy
         let mut data = [T::default(); SIZE];
         for item in data.iter_mut() {
-            *item = T::consensus_decode(d)?;
+            *item = T::consensus_decode(d, modules)?;
         }
         Ok(data)
     }
@@ -214,15 +233,18 @@ where
     }
 }
 
-impl<T> Decodable for Option<T>
+impl<M, T> Decodable<M> for Option<T>
 where
-    T: Decodable,
+    T: Decodable<M>,
 {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        let flag = u8::consensus_decode(d)?;
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        let flag = u8::consensus_decode(d, modules)?;
         match flag {
             0 => Ok(None),
-            1 => Ok(Some(T::consensus_decode(d)?)),
+            1 => Ok(Some(T::consensus_decode(d, modules)?)),
             _ => Err(DecodeError::from_str(
                 "Invalid flag for option enum, expected 0 or 1",
             )),
@@ -239,12 +261,15 @@ where
     }
 }
 
-impl<T> Decodable for Box<T>
+impl<M, T> Decodable<M> for Box<T>
 where
-    T: Decodable,
+    T: Decodable<M>,
 {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        Ok(Box::new(T::consensus_decode(d)?))
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        Ok(Box::new(T::consensus_decode(d, modules)?))
     }
 }
 
@@ -257,8 +282,11 @@ impl Encodable for () {
     }
 }
 
-impl Decodable for () {
-    fn consensus_decode<D: std::io::Read>(_d: &mut D) -> Result<Self, DecodeError> {
+impl<M> Decodable<M> for () {
+    fn consensus_decode<D: std::io::Read>(
+        _d: &mut D,
+        _modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
         Ok(())
     }
 }
@@ -269,9 +297,12 @@ impl Encodable for String {
     }
 }
 
-impl Decodable for String {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        String::from_utf8(Decodable::consensus_decode(d)?).map_err(DecodeError::from_err)
+impl<M> Decodable<M> for String {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        String::from_utf8(Decodable::consensus_decode(d, modules)?).map_err(DecodeError::from_err)
     }
 }
 
@@ -281,9 +312,12 @@ impl Encodable for lightning_invoice::Invoice {
     }
 }
 
-impl Decodable for lightning_invoice::Invoice {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        String::consensus_decode(d)?
+impl<M> Decodable<M> for lightning_invoice::Invoice {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        String::consensus_decode(d, modules)?
             .parse::<lightning_invoice::Invoice>()
             .map_err(DecodeError::from_err)
     }
@@ -297,8 +331,11 @@ impl Encodable for bool {
     }
 }
 
-impl Decodable for bool {
-    fn consensus_decode<D: Read>(d: &mut D) -> Result<Self, DecodeError> {
+impl<M> Decodable<M> for bool {
+    fn consensus_decode<D: Read>(
+        d: &mut D,
+        _modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
         let mut bool_as_u8 = [0u8];
         d.read_exact(&mut bool_as_u8)
             .map_err(DecodeError::from_err)?;
@@ -341,28 +378,28 @@ impl std::fmt::Display for DecodeError {
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::Debug;
     use std::io::Cursor;
+    use std::{collections::BTreeMap, fmt::Debug};
 
-    use crate::encoding::{Decodable, Encodable};
+    use crate::encoding::{Decodable, Encodable, ModuleRegistry};
 
     pub(crate) fn test_roundtrip<T>(value: T)
     where
-        T: Encodable + Decodable + Eq + Debug,
+        T: Encodable + Decodable<()> + Eq + Debug,
     {
         let mut bytes = Vec::new();
         let len = value.consensus_encode(&mut bytes).unwrap();
         assert_eq!(len, bytes.len());
 
         let mut cursor = Cursor::new(bytes);
-        let decoded = T::consensus_decode(&mut cursor).unwrap();
+        let decoded = T::consensus_decode(&mut cursor, &BTreeMap::<_, ()>::new()).unwrap();
         assert_eq!(value, decoded);
         assert_eq!(cursor.position(), len as u64);
     }
 
     pub(crate) fn test_roundtrip_expected<T>(value: T, expected: &[u8])
     where
-        T: Encodable + Decodable + Eq + Debug,
+        T: Encodable + Decodable<()> + Eq + Debug,
     {
         let mut bytes = Vec::new();
         let len = value.consensus_encode(&mut bytes).unwrap();
@@ -370,7 +407,7 @@ mod tests {
         assert_eq!(&expected, &bytes);
 
         let mut cursor = Cursor::new(bytes);
-        let decoded = T::consensus_decode(&mut cursor).unwrap();
+        let decoded = T::consensus_decode(&mut cursor, &BTreeMap::<_, ()>::new()).unwrap();
         assert_eq!(value, decoded);
         assert_eq!(cursor.position(), len as u64);
     }

--- a/fedimint-api/src/encoding/secp256k1.rs
+++ b/fedimint-api/src/encoding/secp256k1.rs
@@ -2,6 +2,7 @@ use std::io::{Error, Read, Write};
 
 use secp256k1_zkp::ecdsa::Signature;
 
+use super::ModuleRegistry;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 
 impl Encodable for secp256k1_zkp::ecdsa::Signature {
@@ -12,9 +13,13 @@ impl Encodable for secp256k1_zkp::ecdsa::Signature {
     }
 }
 
-impl Decodable for secp256k1_zkp::ecdsa::Signature {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        Signature::from_compact(&<[u8; 64]>::consensus_decode(d)?).map_err(DecodeError::from_err)
+impl<M> Decodable<M> for secp256k1_zkp::ecdsa::Signature {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        Signature::from_compact(&<[u8; 64]>::consensus_decode(d, modules)?)
+            .map_err(DecodeError::from_err)
     }
 }
 
@@ -26,9 +31,12 @@ impl Encodable for secp256k1_zkp::XOnlyPublicKey {
     }
 }
 
-impl Decodable for secp256k1_zkp::XOnlyPublicKey {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        secp256k1_zkp::XOnlyPublicKey::from_slice(&<[u8; 32]>::consensus_decode(d)?)
+impl<M> Decodable<M> for secp256k1_zkp::XOnlyPublicKey {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        secp256k1_zkp::XOnlyPublicKey::from_slice(&<[u8; 32]>::consensus_decode(d, modules)?)
             .map_err(DecodeError::from_err)
     }
 }
@@ -39,9 +47,12 @@ impl Encodable for secp256k1_zkp::PublicKey {
     }
 }
 
-impl Decodable for secp256k1_zkp::PublicKey {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        secp256k1_zkp::PublicKey::from_slice(&<[u8; 33]>::consensus_decode(d)?)
+impl<M> Decodable<M> for secp256k1_zkp::PublicKey {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        secp256k1_zkp::PublicKey::from_slice(&<[u8; 33]>::consensus_decode(d, modules)?)
             .map_err(DecodeError::from_err)
     }
 }
@@ -58,9 +69,13 @@ impl Encodable for secp256k1_zkp::schnorr::Signature {
     }
 }
 
-impl Decodable for secp256k1_zkp::schnorr::Signature {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        let bytes = <[u8; secp256k1_zkp::constants::SCHNORR_SIGNATURE_SIZE]>::consensus_decode(d)?;
+impl<M> Decodable<M> for secp256k1_zkp::schnorr::Signature {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        let bytes =
+            <[u8; secp256k1_zkp::constants::SCHNORR_SIGNATURE_SIZE]>::consensus_decode(d, modules)?;
         secp256k1_zkp::schnorr::Signature::from_slice(&bytes).map_err(DecodeError::from_err)
     }
 }
@@ -71,9 +86,12 @@ impl Encodable for bitcoin::KeyPair {
     }
 }
 
-impl Decodable for bitcoin::KeyPair {
-    fn consensus_decode<D: Read>(d: &mut D) -> Result<Self, DecodeError> {
-        let sec_bytes = <[u8; 32]>::consensus_decode(d)?;
+impl<M> Decodable<M> for bitcoin::KeyPair {
+    fn consensus_decode<D: Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        let sec_bytes = <[u8; 32]>::consensus_decode(d, modules)?;
         Self::from_seckey_slice(secp256k1_zkp::global::SECP256K1, &sec_bytes) // FIXME: evaluate security risk of global ctx
             .map_err(DecodeError::from_err)
     }

--- a/fedimint-api/src/encoding/tbs.rs
+++ b/fedimint-api/src/encoding/tbs.rs
@@ -1,3 +1,4 @@
+use super::ModuleRegistry;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 
 macro_rules! impl_external_encode_bls {
@@ -10,8 +11,11 @@ macro_rules! impl_external_encode_bls {
             }
         }
 
-        impl crate::encoding::Decodable for $ext $(:: $ext_path)* {
-            fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, crate::encoding::DecodeError> {
+        impl<M> crate::encoding::Decodable<M> for $ext $(:: $ext_path)* {
+            fn consensus_decode<D: std::io::Read>(
+                d: &mut D,
+                _modules: &crate::encoding::ModuleRegistry<M>,
+            ) -> Result<Self, crate::encoding::DecodeError> {
                 let mut bytes = [0u8; $byte_len];
                 d.read_exact(&mut bytes).map_err(crate::encoding::DecodeError::from_err)?;
                 let msg = <$group>::from_compressed(&bytes);
@@ -39,8 +43,11 @@ impl Encodable for tbs::BlindingKey {
     }
 }
 
-impl Decodable for tbs::BlindingKey {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
+impl<M> Decodable<M> for tbs::BlindingKey {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        _modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
         let mut bytes = [0u8; 32];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
         let key = tbs::Scalar::from_bytes(&bytes);

--- a/fedimint-api/src/lib.rs
+++ b/fedimint-api/src/lib.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 pub use tiered::Tiered;
 pub use tiered_multi::*;
 
-use crate::encoding::{Decodable, DecodeError, Encodable};
+use crate::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
 
 pub mod config;
 pub mod db;
@@ -293,8 +293,11 @@ impl Encodable for TransactionId {
     }
 }
 
-impl Decodable for TransactionId {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
+impl<M> Decodable<M> for TransactionId {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        _modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
         let mut bytes = [0u8; 32];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
         Ok(TransactionId::from_inner(bytes))

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::sha256::HashEngine;
-use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
+use fedimint_api::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
 use fedimint_api::{BitcoinHash, FederationModule, PeerId};
 use fedimint_derive::UnzipConsensus;
 use itertools::Itertools;
@@ -158,8 +158,11 @@ impl Encodable for EpochSignature {
     }
 }
 
-impl Decodable for EpochSignature {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
+impl<M> Decodable<M> for EpochSignature {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        _modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
         let mut bytes = [0u8; 96];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
         Ok(EpochSignature(Signature::from_bytes(&bytes).unwrap()))
@@ -172,8 +175,11 @@ impl Encodable for EpochSignatureShare {
     }
 }
 
-impl Decodable for EpochSignatureShare {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
+impl<M> Decodable<M> for EpochSignatureShare {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        _modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
         let mut bytes = [0u8; 96];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
         Ok(EpochSignatureShare(

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -1,6 +1,6 @@
 use bitcoin::hashes::Hash as BitcoinHash;
 use bitcoin::XOnlyPublicKey;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::{Amount, FederationModule, TransactionId};
 use rand::Rng;
 use secp256k1_zkp::{schnorr, Secp256k1, Signing, Verification};

--- a/fedimint-derive/src/lib.rs
+++ b/fedimint-derive/src/lib.rs
@@ -195,10 +195,10 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
                     .map(|(idx, _)| format_ident!("field_{}", idx))
                     .collect::<Vec<_>>();
                 quote! {
-                    impl Decodable for #ident {
-                        fn consensus_decode<D: std::io::Read>(d: &mut D) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError> {
+                    impl<M> Decodable<M> for #ident {
+                        fn consensus_decode<D: std::io::Read>(d: &mut D, modules: &ModuleRegistry<M>) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError> {
                             let mut len = 0;
-                            #(let #field_names = Decodable::consensus_decode(d)?;)*
+                            #(let #field_names = Decodable::consensus_decode(d, modules)?;)*
                             Ok(#ident(#(#field_names,)*))
                         }
                     }
@@ -210,10 +210,10 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
                     .map(|field| field.ident.clone().unwrap())
                     .collect::<Vec<_>>();
                 quote! {
-                    impl Decodable for #ident {
-                        fn consensus_decode<D: std::io::Read>(d: &mut D) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError> {
+                    impl<M> Decodable<M> for #ident {
+                        fn consensus_decode<D: std::io::Read>(d: &mut D, modules: &ModuleRegistry<M>) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError> {
                             let mut len = 0;
-                            #(let #field_names = Decodable::consensus_decode(d)?;)*
+                            #(let #field_names = Decodable::consensus_decode(d, modules)?;)*
                             Ok(#ident{
                                 #(#field_names,)*
                             })
@@ -235,7 +235,7 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
                         .collect::<Vec<_>>();
                     quote! {
                         #variant_idx => {
-                            #(let #variant_fields = Decodable::consensus_decode(d)?;)*
+                            #(let #variant_fields = Decodable::consensus_decode(d, modules)?;)*
                             #ident::#variant_ident(#(#variant_fields,)*)
                         }
                     }
@@ -247,7 +247,7 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
                         .collect::<Vec<_>>();
                     quote! {
                         #variant_idx => {
-                            #(let #variant_fields = Decodable::consensus_decode(d)?;)*
+                            #(let #variant_fields = Decodable::consensus_decode(d, modules)?;)*
                             #ident::#variant_ident{
                                 #(#variant_fields,)*
                             }
@@ -257,9 +257,9 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
             });
 
             quote! {
-                impl Decodable for #ident {
-                    fn consensus_decode<D: std::io::Read>(d: &mut D) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError> {
-                        let variant = <u64 as Decodable>::consensus_decode(d)? as usize;
+                impl<M> Decodable<M> for #ident {
+                    fn consensus_decode<D: std::io::Read>(d: &mut D, modules: &ModuleRegistry<M>) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError> {
+                        let variant = <u64 as Decodable<M>>::consensus_decode(d, modules)? as usize;
                         let decoded = match variant {
                             #(#match_arms)*
                             _ => {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use fedimint_api::db::batch::{AccumulatorTx, BatchItem, BatchTx, DbBatch};
 use fedimint_api::db::Database;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::{Amount, FederationModule, OutPoint, PeerId, TransactionId};

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use fedimint_api::db::DatabaseKeyPrefixConst;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::{PeerId, TransactionId};
 use fedimint_core::epoch::EpochHistory;
 

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io::Cursor;
 use std::ops::Sub;
 use std::path::PathBuf;
@@ -111,11 +112,14 @@ impl BitcoinTest for RealBitcoinTest {
             .client
             .get_raw_transaction(&id, None)
             .expect(Self::ERROR);
-        let proof = TxOutProof::consensus_decode(&mut Cursor::new(
-            self.client
-                .get_tx_out_proof(&[id], None)
-                .expect(Self::ERROR),
-        ))
+        let proof = TxOutProof::consensus_decode(
+            &mut Cursor::new(
+                self.client
+                    .get_tx_out_proof(&[id], None)
+                    .expect(Self::ERROR),
+            ),
+            &BTreeMap::<_, ()>::new(),
+        )
         .expect(Self::ERROR);
 
         (proof, tx)

--- a/modules/fedimint-ln/src/contracts/account.rs
+++ b/modules/fedimint-ln/src/contracts/account.rs
@@ -1,5 +1,5 @@
 use bitcoin_hashes::Hash as BitcoinHash;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use serde::{Deserialize, Serialize};
 
 use crate::contracts::{ContractId, IdentifyableContract};

--- a/modules/fedimint-ln/src/contracts/incoming.rs
+++ b/modules/fedimint-ln/src/contracts/incoming.rs
@@ -3,7 +3,7 @@ use std::io::Error;
 use bitcoin_hashes::hash_newtype;
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
-use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
+use fedimint_api::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
 use fedimint_api::OutPoint;
 use serde::{Deserialize, Serialize};
 
@@ -94,8 +94,13 @@ impl Encodable for OfferId {
     }
 }
 
-impl Decodable for OfferId {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        Ok(OfferId::from_inner(Decodable::consensus_decode(d)?))
+impl<M> Decodable<M> for OfferId {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        Ok(OfferId::from_inner(Decodable::consensus_decode(
+            d, modules,
+        )?))
     }
 }

--- a/modules/fedimint-ln/src/contracts/mod.rs
+++ b/modules/fedimint-ln/src/contracts/mod.rs
@@ -7,7 +7,7 @@ use std::io::Error;
 use bitcoin_hashes::hash_newtype;
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
-use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
+use fedimint_api::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
 use fedimint_api::OutPoint;
 use serde::{Deserialize, Serialize};
 
@@ -109,9 +109,14 @@ impl Encodable for ContractId {
     }
 }
 
-impl Decodable for ContractId {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        Ok(ContractId::from_inner(Decodable::consensus_decode(d)?))
+impl<M> Decodable<M> for ContractId {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        Ok(ContractId::from_inner(Decodable::consensus_decode(
+            d, modules,
+        )?))
     }
 }
 
@@ -162,9 +167,12 @@ impl Encodable for EncryptedPreimage {
     }
 }
 
-impl Decodable for EncryptedPreimage {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        let bytes = Vec::<u8>::consensus_decode(d)?;
+impl<M> Decodable<M> for EncryptedPreimage {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        let bytes = Vec::<u8>::consensus_decode(d, modules)?;
         Ok(EncryptedPreimage(
             bincode::deserialize(&bytes).map_err(DecodeError::from_err)?,
         ))
@@ -179,9 +187,12 @@ impl Encodable for PreimageDecryptionShare {
     }
 }
 
-impl Decodable for PreimageDecryptionShare {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Self, DecodeError> {
-        let bytes = Vec::<u8>::consensus_decode(d)?;
+impl<M> Decodable<M> for PreimageDecryptionShare {
+    fn consensus_decode<D: std::io::Read>(
+        d: &mut D,
+        modules: &ModuleRegistry<M>,
+    ) -> Result<Self, DecodeError> {
+        let bytes = Vec::<u8>::consensus_decode(d, modules)?;
         Ok(PreimageDecryptionShare(
             bincode::deserialize(&bytes).map_err(DecodeError::from_err)?,
         ))

--- a/modules/fedimint-ln/src/contracts/outgoing.rs
+++ b/modules/fedimint-ln/src/contracts/outgoing.rs
@@ -1,5 +1,5 @@
 use bitcoin_hashes::Hash as BitcoinHash;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use serde::{Deserialize, Serialize};
 
 use crate::contracts::{ContractId, IdentifyableContract};

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -1,5 +1,5 @@
 use fedimint_api::db::DatabaseKeyPrefixConst;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::{OutPoint, PeerId};
 use secp256k1::PublicKey;
 

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -22,7 +22,7 @@ use bitcoin_hashes::Hash as BitcoinHash;
 use db::{LightningGatewayKey, LightningGatewayKeyPrefix};
 use fedimint_api::db::batch::BatchTx;
 use fedimint_api::db::{Database, DatabaseTransaction};
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{api_endpoint, ApiEndpoint, ApiError, TransactionItemAmount};

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -1,5 +1,5 @@
 use fedimint_api::db::DatabaseKeyPrefixConst;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::{Amount, OutPoint, PeerId};
 
 use crate::{Nonce, PartialSigResponse, SigResponse};

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -6,7 +6,7 @@ use std::ops::Sub;
 use async_trait::async_trait;
 use fedimint_api::db::batch::{BatchItem, BatchTx, DbBatch};
 use fedimint_api::db::{Database, DatabaseTransaction};
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{ApiEndpoint, TransactionItemAmount};

--- a/modules/fedimint-wallet/src/db.rs
+++ b/modules/fedimint-wallet/src/db.rs
@@ -1,6 +1,6 @@
 use bitcoin::{BlockHash, Txid};
 use fedimint_api::db::DatabaseKeyPrefixConst;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use secp256k1::ecdsa::Signature;
 
 use crate::{

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -17,7 +17,7 @@ use bitcoin::{
 use bitcoin::{PackedLockTime, Sequence};
 use fedimint_api::db::batch::{BatchItem, BatchTx};
 use fedimint_api::db::{Database, DatabaseTransaction};
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::ApiEndpoint;

--- a/modules/mint-common/src/lib.rs
+++ b/modules/mint-common/src/lib.rs
@@ -1,7 +1,7 @@
-use std::io;
+use std::{collections::BTreeMap, io};
 
 use fedimint_api::{
-    encoding::{Decodable, DecodeError, Encodable},
+    encoding::{Decodable, DecodeError, Encodable, ModuleRegistry},
     Amount,
 };
 use fedimint_core_api::{
@@ -21,27 +21,35 @@ impl ModuleCommon for MintModuleCommon {
     }
     fn decode_spendable_output(mut d: &mut dyn io::Read) -> Result<SpendableOutput, DecodeError> {
         Ok(SpendableOutput::from(
-            MintSpendableOutput::consensus_decode(&mut d)?,
+            MintSpendableOutput::consensus_decode(&mut d, &BTreeMap::<_, ()>::new())?,
         ))
     }
 
     fn decode_pending_output(mut d: &mut dyn io::Read) -> Result<PendingOutput, DecodeError> {
         Ok(PendingOutput::from(MintPendingOutput::consensus_decode(
             &mut d,
+            &BTreeMap::<_, ()>::new(),
         )?))
     }
 
     fn decode_output(mut d: &mut dyn io::Read) -> Result<Output, DecodeError> {
-        Ok(Output::from(MintOutput::consensus_decode(&mut d)?))
+        Ok(Output::from(MintOutput::consensus_decode(
+            &mut d,
+            &BTreeMap::<_, ()>::new(),
+        )?))
     }
     fn decode_output_outcome(mut d: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError> {
         Ok(OutputOutcome::from(MintOutputOutcome::consensus_decode(
             &mut d,
+            &BTreeMap::<_, ()>::new(),
         )?))
     }
 
     fn decode_input(mut d: &mut dyn io::Read) -> Result<Input, DecodeError> {
-        Ok(Input::from(MintInput::consensus_decode(&mut d)?))
+        Ok(Input::from(MintInput::consensus_decode(
+            &mut d,
+            &BTreeMap::<_, ()>::new(),
+        )?))
     }
 }
 

--- a/modules/mint-server/src/lib.rs
+++ b/modules/mint-server/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use fedimint_api::{
     db::batch::BatchTx,
-    encoding::{Decodable, Encodable},
+    encoding::{Decodable, Encodable, ModuleRegistry},
     module::{audit::Audit, interconnect::ModuleInterconect},
     Amount, OutPoint, PeerId,
 };


### PR DESCRIPTION
It's hard to keep interoperability between two different decoding traits.

Instead, we can unify to the more general one (supporting modules) and ignore / fake the modules where we don't need them (most of the time).

Notably [`BTreeMap::new()` doesn't allocate anything](https://doc.rust-lang.org/src/alloc/collections/btree/map.rs.html#585) so it should be cheap to fake it, even when performance is important.