### PR TITLE
Use debug builds in the CI

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -48,35 +48,35 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build workspace
-        run: nix build -L .#workspaceBuild
+        run: nix build -L .#debug.workspaceBuild
 
       - name: Clippy workspace
-        run: nix build -L .#workspaceClippy
+        run: nix build -L .#debug.workspaceClippy
 
       - name: Run cargo doc
-        run: nix build -L .#workspaceDoc
+        run: nix build -L .#debug.workspaceDoc
 
       - name: Run cargo audit
-        run: nix build -L .#workspaceAudit
+        run: nix build -L .#debug.workspaceAudit
 
       # `ccov` job will run `cargo test`, so no need to spend time on it here
       # - name: Test workspace
       #   run: nix build -L .#workspaceTest
 
       - name: Reconnect Tests
-        run: nix build -L .#cli-test.reconnect
+        run: nix build -L .#debug.cli-test.reconnect
 
       - name: Latency Tests
-        run: nix build -L .#cli-test.latency
+        run: nix build -L .#debug.cli-test.latency
 
       - name: CLI Tests
-        run: nix build -L .#cli-test.cli
+        run: nix build -L .#debug.cli-test.cli
 
       - name: Clientd and clientd-cli tests
-        run: nix build -L .#cli-test.clientd
+        run: nix build -L .#debug.cli-test.clientd
 
       - name: Integration Tests (no fixtures)
-        run: nix build -L .#cli-test.rust-tests
+        run: nix build -L .#debug.cli-test.rust-tests
 
 
   # Code Coverage will build using a completely different profile (neither debug/release)
@@ -97,7 +97,7 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build and run tests with Code Coverage
-        run: nix build -L .#workspaceCov
+        run: nix build -L .#debug.workspaceCov
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/flake.nix
+++ b/flake.nix
@@ -630,7 +630,7 @@
         # Technically nested sets are not allowed in `packages`, so we can
         # dump the nested things here. They'll work the same way for most
         # purposes (like `nix build`).
-        legacyPackages = {
+        legacyPackages = rec {
           # Debug Builds
           #
           # This works by using `overrideAttrs` on output derivations to set `CARGO_PROFILE`, and importantly
@@ -647,7 +647,7 @@
               (name: deriv: replace-git-hash {
                 inherit name; package = overrideCargoProfileRecursively deriv "dev";
               })
-              outputsPackages)
+              outputsPackages) // { cli-test = (builtins.mapAttrs (name: deriv: overrideCargoProfileRecursively deriv "dev") cli-test); }
           ;
 
           cli-test = {


### PR DESCRIPTION
This could possibly lead to faster CI times, at the expense of higher cachix utilization.

After we've switched to using `cargo build` (debug mode build) in the test script, we haven't noticed that it caused the CI times to increase significantly, because the tests running `cargo build`  can't reuse the artifacts that CI build in release mode:

![Screenshot from 2022-10-15 19-33-12](https://user-images.githubusercontent.com/9209/196015130-d0a71f63-727a-4201-be40-f620889dcaf9.png)

![Screenshot from 2022-10-15 19-39-55](https://user-images.githubusercontent.com/9209/196015280-481ede29-300d-4ca2-8fae-768087cc696d.png)


Switching our CI to build in debug mode fixes it and restores better build times:

![Screenshot from 2022-10-15 19-34-33](https://user-images.githubusercontent.com/9209/196015163-c5d1ea59-2297-47df-80a6-c72f708f4371.png)

![Screenshot from 2022-10-15 19-40-12](https://user-images.githubusercontent.com/9209/196015283-730c0be1-0fd9-4e20-8d5e-a86a6b0ad8d2.png)

Debug mode is faster than it release before even ignoring this particular issue (being fixed). 