### PR TITLE
Use nix-provided, dynmically linked rocksdb

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 # mold is currently broken on MacOS
 # [target.aarch64-apple-darwin]


### PR DESCRIPTION
By switching to a nix-provided rocksdb we can reduce compilation times, especially on first dev env setup since it can be fetched from cachix.