### PR TITLE
Encrypt configs at rest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,8 @@ dependencies = [
  "rand",
  "rayon",
  "rcgen",
+ "ring",
+ "rpassword",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -2852,6 +2854,16 @@ checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b763cb66df1c928432cc35053f8bd4cec3335d8559fc16010017d16b3c1680"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -23,6 +23,8 @@ name = "distributedgen"
 path  = "src/bin/distributedgen.rs"
 
 [dependencies]
+ring = "0.16.20"
+rpassword = "7.0.0"
 anyhow = "1.0.65"
 async-trait = "0.1.42"
 bincode = "1.3.1"

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -1,0 +1,93 @@
+/// Encrypt and authenticate data stored on the filesystem with a user-supplied password.
+///
+/// We encrypt the configs to prevent attackers from learning the private keys if they gain
+/// file access.  We authenticate the configs to prevent attackers from manipulating the
+/// encrypted files.
+///
+/// Users can safely back-up config and salt files on other media the attacker accesses if they do
+/// not learn the password and the password has enough entropy to prevent brute-forcing (e.g.
+/// 6 random words).  Switching to a memory-hard algorithm like Argon2 would be more future-proof
+/// and safe for weaker passwords.
+///
+/// We use the ChaCha20 stream cipher with Poly1305 message authentication standardized
+/// in IETF RFC 8439.  PBKDF2 with 1M iterations is used for key stretching along with a 128-bit
+/// salt that is randomly generated to discourage rainbow attacks.  HMAC-SHA256 is used for the
+/// authentication code.  All crypto is from the widely-used `ring` crate we also use for TLS.
+pub mod encrypt {
+    use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, NONCE_LEN};
+
+    use ring::{aead, digest, pbkdf2};
+    use std::fs;
+    use std::num::NonZeroU32;
+    use std::path::PathBuf;
+
+    const ITERATIONS: Option<NonZeroU32> = NonZeroU32::new(1_000_000);
+
+    // server files
+    pub const SALT_FILE: &str = "salt";
+    pub const CONFIG_FILE: &str = "config";
+    pub const DB_FILE: &str = "database";
+    pub const TLS_PK: &str = "tls-pk";
+    pub const TLS_CERT: &str = "tls-cert";
+
+    /// Write `data` encrypted to a `file` with an unused `nonce` that will be encoded in the file
+    pub fn encrypted_write(mut data: Vec<u8>, key: &LessSafeKey, nonce: Nonce, file: PathBuf) {
+        let mut bytes = nonce.as_ref().to_vec();
+        key.seal_in_place_append_tag(nonce, Aad::empty(), &mut data)
+            .expect("encrypted");
+        bytes.append(&mut data);
+        fs::write(file, &hex::encode(bytes)).expect("Can't write file.");
+    }
+
+    /// Reads encrypted data from a file, returns an incremented nonce for encrypting the next file
+    pub fn encrypted_read(key: &LessSafeKey, file: PathBuf) -> (Vec<u8>, Nonce) {
+        let hex = fs::read_to_string(file).expect("Can't read file.");
+        let mut bytes = hex::decode(hex).expect("not hex encoded");
+        let (nonce_bytes, encrypted_bytes) = bytes.split_at_mut(NONCE_LEN);
+        let (nonce, incremented) = increment_nonce(nonce_bytes);
+        key.open_in_place(nonce, Aad::empty(), encrypted_bytes)
+            .expect("decrypts");
+        let mut encrypted_bytes = encrypted_bytes.to_vec();
+        encrypted_bytes.truncate(encrypted_bytes.len() - key.algorithm().tag_len());
+        (encrypted_bytes, incremented)
+    }
+
+    pub fn get_key(password: Option<String>, salt_path: PathBuf) -> LessSafeKey {
+        let password = match password {
+            None => rpassword::prompt_password("Enter a password to encrypt configs: ").unwrap(),
+            Some(password) => {
+                println!(
+                    "WARNING: Passing in a password from the command line may be less secure!"
+                );
+                password
+            }
+        };
+
+        let salt_str = fs::read_to_string(salt_path).expect("Can't read salt file");
+        let salt = hex::decode(salt_str).expect("Can't decode hex");
+        let mut key = [0u8; digest::SHA256_OUTPUT_LEN];
+        let algo = pbkdf2::PBKDF2_HMAC_SHA256;
+        pbkdf2::derive(
+            algo,
+            ITERATIONS.unwrap(),
+            &salt,
+            password.as_bytes(),
+            &mut key,
+        );
+        let key = UnboundKey::new(&aead::CHACHA20_POLY1305, &key).expect("created key");
+        LessSafeKey::new(key)
+    }
+
+    /// returns a nonce from bytes and an incremented nonce for encrpyting the next message
+    fn increment_nonce(nonce: &[u8]) -> (Nonce, Nonce) {
+        let mut bytes = nonce.to_vec();
+        bytes[0] += 1;
+        let n1 = Nonce::assume_unique_for_key(nonce.try_into().expect("right len"));
+        let n2 = Nonce::assume_unique_for_key(bytes.try_into().expect("right len"));
+        (n1, n2)
+    }
+
+    pub fn zero_nonce() -> Nonce {
+        Nonce::assume_unique_for_key([0; NONCE_LEN])
+    }
+}

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -175,7 +175,7 @@ impl WalletClientConfig {
         Self {
             peg_in_descriptor,
             network: Network::Regtest,
-            finality_delay: 0,
+            finality_delay: FINALITY_DELAY,
             fee_consensus: Default::default(),
         }
     }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,7 +32,7 @@ for ((ID=0; ID<FM_FED_SIZE; ID++));
 do
   mkdir $FM_CFG_DIR/server-$ID
   base_port=$(echo "4000 + $ID * 10" | bc -l)
-  $FM_BIN_DIR/distributedgen create-cert --out-dir $FM_CFG_DIR/server-$ID --base-port $base_port --name "Server-$ID"
+  $FM_BIN_DIR/distributedgen create-cert --out-dir $FM_CFG_DIR/server-$ID --base-port $base_port --name "Server-$ID" --password "pass$ID"
   CERTS="$CERTS,$(cat $FM_CFG_DIR/server-$ID/tls-cert)"
 done
 CERTS=${CERTS:1}
@@ -40,16 +40,12 @@ echo "Running DKG with certs: $CERTS"
 
 for ((ID=0; ID<FM_FED_SIZE; ID++));
 do
-  $FM_BIN_DIR/distributedgen run --out-dir $FM_CFG_DIR/server-$ID --certs $CERTS &
+  $FM_BIN_DIR/distributedgen run --out-dir $FM_CFG_DIR/server-$ID --certs $CERTS --password "pass$ID" &
 done
 wait
 
-# Move the client config and all server configs to root dir
+# Move the client config to root dir
 mv $FM_CFG_DIR/server-0/client.json $FM_CFG_DIR/
-for ((ID=0; ID<FM_FED_SIZE; ID++));
-do
-  mv $FM_CFG_DIR/server-$ID/server-$ID.json $FM_CFG_DIR/
-done
 
 # Define clients
 export FM_LN1="lightning-cli --network regtest --lightning-dir=$FM_LN1_DIR"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -64,7 +64,7 @@ function start_gateway() {
 }
 
 function get_finality_delay() {
-    cat $FM_CFG_DIR/server-0.json | jq -r '.wallet.finality_delay'
+    cat $FM_CFG_DIR/client.json | jq -r '.wallet.finality_delay'
 }
 
 function sat_to_btc() {

--- a/scripts/start-fed.sh
+++ b/scripts/start-fed.sh
@@ -7,6 +7,6 @@ SKIPPED_SERVERS=${1:-0}
 # Start the federation members inside the temporary directory
 for ((ID=SKIPPED_SERVERS; ID<FM_FED_SIZE; ID++)); do
   echo "starting mint $ID"
-  ( ($FM_BIN_DIR/fedimintd $FM_CFG_DIR/server-$ID.json $FM_CFG_DIR/mint-$ID.db 2>&1 & echo $! >&3 ) 3>>$FM_PID_FILE | sed -e "s/^/mint $ID: /" ) &
+  ( ($FM_BIN_DIR/fedimintd $FM_CFG_DIR/server-$ID "pass$ID" 2>&1 & echo $! >&3 ) 3>>$FM_PID_FILE | sed -e "s/^/mint $ID: /" ) &
 done
 


### PR DESCRIPTION
Since the guardian servers will be publicly known we should reduce the attack surface by not storing private keys in plaintext which would be easy targets for attackers with access to the filesystem or a backup of the config file.  This PR encrypts the server configs containing private keys at-rest using a password supplied by the user.

- Password can be supplied at a prompt during config generation and server start-up to avoid being in command history
- Uses PBKDF2_HMAC_SHA256 to hash the password to reduce the effectiveness of brute-force attacks
- Uses CHACHA20_POLY1305 to authenticate and encrypt the configs (so they cannot be tampered with)

Note we will need to modify the nonce generation if we intend to generate multiple versions of the configs with the same password (once we have a need for versioned configs).

Fix #724