### PR TITLE
Change `Decodable<M>` to `Decodable`

### DIFF
--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -20,11 +20,11 @@ pub fn serialize_coins(c: &TieredMulti<SpendableNote>) -> String {
     base64::encode(&bytes)
 }
 
-pub fn from_hex<D: Decodable<()>>(s: &str) -> Result<D, anyhow::Error> {
+pub fn from_hex<D: Decodable>(s: &str) -> Result<D, anyhow::Error> {
     let bytes = hex::decode(s)?;
     Ok(D::consensus_decode(
         &mut std::io::Cursor::new(bytes),
-        &BTreeMap::new(),
+        &BTreeMap::<_, ()>::new(),
     )?)
 }
 

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -19,9 +19,6 @@ pub mod encode;
 pub mod client;
 pub mod server;
 
-pub use self::client::*;
-pub use self::server::*;
-
 /// A module key identifing a module
 ///
 /// Used as an unique ID, and also as prefix in serialization
@@ -47,22 +44,14 @@ macro_rules! module_dyn_newtype_impl_encode_decode {
             }
         }
 
-        impl Decodable<$crate::server::ServerModule> for $name {
-            fn consensus_decode<R: std::io::Read>(
+        impl Decodable for $name {
+            fn consensus_decode<M, R: std::io::Read>(
                 r: &mut R,
-                modules: &BTreeMap<ModuleKey, $crate::server::ServerModule>,
-            ) -> Result<Self, DecodeError> {
-                $crate::core::encode::module_decode_key_prefixed_decodable(r, modules, |r, m| {
-                    m.$decode_fn(r)
-                })
-            }
-        }
-
-        impl Decodable<$crate::client::ClientModule> for $name {
-            fn consensus_decode<R: std::io::Read>(
-                r: &mut R,
-                modules: &BTreeMap<ModuleKey, $crate::client::ClientModule>,
-            ) -> Result<Self, DecodeError> {
+                modules: &BTreeMap<ModuleKey, M>,
+            ) -> Result<Self, DecodeError>
+            where
+                M: $crate::core::ModuleDecode,
+            {
                 $crate::core::encode::module_decode_key_prefixed_decodable(r, modules, |r, m| {
                     m.$decode_fn(r)
                 })
@@ -87,7 +76,7 @@ macro_rules! module_plugin_trait_define {
         $newtype_ty:ident, $plugin_ty:ident, $module_ty:ident, { $($extra_methods:tt)*  } { $($extra_impls:tt)* }
     ) => {
         pub trait $plugin_ty:
-            DynEncodable + Decodable<()> + Encodable + Clone + Send + Sync + 'static
+            DynEncodable + Decodable + Encodable + Clone + Send + Sync + 'static
         {
             fn module_key(&self) -> ModuleKey;
 
@@ -115,13 +104,13 @@ macro_rules! module_plugin_trait_define {
     };
 }
 
-/// Common functionality of a Fedimint module
+/// Module Decoder trait
 ///
-/// Both backend and server part of the module will need
-/// things like decoding module-specific data.
-pub trait ModuleCommon {
-    fn module_key() -> ModuleKey;
-
+/// Static-polymorphism version of [`ModuleDecode`]
+///
+/// All methods are static, as the decoding code is supposed to be instance-independent,
+/// at least until we start to support modules with overriden [`ModuleKey`]s
+pub trait PluginDecode {
     /// Decode `SpendableOutput` compatible with this module, after the module key prefix was already decoded
     fn decode_spendable_output(r: &mut dyn io::Read) -> Result<SpendableOutput, DecodeError>;
 
@@ -136,6 +125,58 @@ pub trait ModuleCommon {
 
     /// Decode `OutputOutcome` compatible with this module, after the module key prefix was already decoded
     fn decode_output_outcome(r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError>;
+
+    /// Decode `ConsensusItem` compatible with this module, after the module key prefix was already decoded
+    fn decode_consensus_item(r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
+}
+
+pub trait ModuleDecode {
+    /// Decode `SpendableOutput` compatible with this module, after the module key prefix was already decoded
+    fn decode_spendable_output(&self, r: &mut dyn io::Read)
+        -> Result<SpendableOutput, DecodeError>;
+
+    /// Decode `Input` compatible with this module, after the module key prefix was already decoded
+    fn decode_input(&self, r: &mut dyn io::Read) -> Result<Input, DecodeError>;
+
+    /// Decode `Output` compatible with this module, after the module key prefix was already decoded
+    fn decode_output(&self, r: &mut dyn io::Read) -> Result<Output, DecodeError>;
+
+    /// Decode `PendingOutput` compatible with this module, after the module key prefix was already decoded
+    fn decode_pending_output(&self, r: &mut dyn io::Read) -> Result<PendingOutput, DecodeError>;
+
+    /// Decode `OutputOutcome` compatible with this module, after the module key prefix was already decoded
+    fn decode_output_outcome(&self, r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError>;
+
+    /// Decode `ConsensusItem` compatible with this module, after the module key prefix was already decoded
+    fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
+}
+
+impl ModuleDecode for () {
+    fn decode_spendable_output(
+        &self,
+        _r: &mut dyn io::Read,
+    ) -> Result<SpendableOutput, DecodeError> {
+        panic!("() is just a placeholder for when modules are not needed and should never be actually called");
+    }
+    fn decode_input(&self, _r: &mut dyn io::Read) -> Result<Input, DecodeError> {
+        panic!("() is just a placeholder for when modules are not needed and should never be actually called");
+    }
+
+    fn decode_output(&self, _r: &mut dyn io::Read) -> Result<Output, DecodeError> {
+        panic!("() is just a placeholder for when modules are not needed and should never be actually called");
+    }
+
+    fn decode_pending_output(&self, _r: &mut dyn io::Read) -> Result<PendingOutput, DecodeError> {
+        panic!("() is just a placeholder for when modules are not needed and should never be actually called");
+    }
+
+    fn decode_output_outcome(&self, _r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError> {
+        panic!("() is just a placeholder for when modules are not needed and should never be actually called");
+    }
+
+    fn decode_consensus_item(&self, _r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError> {
+        panic!("() is just a placeholder for when modules are not needed and should never be actually called");
+    }
 }
 
 /// Something that can be an [`Input`] in a [`Transaction`]
@@ -301,6 +342,27 @@ module_dyn_newtype_impl_encode_decode! {
 }
 dyn_newtype_impl_dyn_clone_passhthrough!(OutputOutcome);
 
+pub trait ModuleConsensusItem: DynEncodable {
+    fn as_any(&self) -> &(dyn Any + 'static);
+    /// Module key
+    fn module_key(&self) -> ModuleKey;
+    fn clone(&self) -> ConsensusItem;
+}
+
+dyn_newtype_define! {
+    /// An owned, immutable output of a [`Transaction`] before it was finalized
+    pub ConsensusItem(Box<ModuleConsensusItem>)
+}
+module_plugin_trait_define! {
+    ConsensusItem, PluginConsensusItem, ModuleConsensusItem,
+    { }
+    { }
+}
+module_dyn_newtype_impl_encode_decode! {
+    ConsensusItem, decode_consensus_item
+}
+dyn_newtype_impl_dyn_clone_passhthrough!(ConsensusItem);
+
 #[derive(Encodable, Decodable)]
 pub struct Signature;
 
@@ -312,15 +374,18 @@ pub struct Transaction {
     signature: Signature,
 }
 
-impl<M> Decodable<M> for Transaction
+impl Decodable for Transaction
 where
-    Input: Decodable<M>,
-    Output: Decodable<M>,
+    Input: Decodable,
+    Output: Decodable,
 {
-    fn consensus_decode<R: std::io::Read>(
+    fn consensus_decode<M, R: std::io::Read>(
         r: &mut R,
         modules: &BTreeMap<ModuleKey, M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         Ok(Self {
             inputs: Decodable::consensus_decode(r, modules)?,
             outputs: Decodable::consensus_decode(r, modules)?,

--- a/fedimint-api/src/core/encode.rs
+++ b/fedimint-api/src/core/encode.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, io};
 
 use fedimint_api::encoding::{Decodable, DecodeError};
 
+use super::ModuleDecode;
 use crate::encoding::ModuleKey;
 
 pub fn module_decode_key_prefixed_decodable<T, F, R, M>(
@@ -12,6 +13,7 @@ pub fn module_decode_key_prefixed_decodable<T, F, R, M>(
 where
     R: io::Read,
     F: FnOnce(&mut R, &M) -> Result<T, DecodeError>,
+    M: ModuleDecode,
 {
     let key = ModuleKey::consensus_decode(&mut d, modules)?;
 

--- a/fedimint-api/src/encoding/btc.rs
+++ b/fedimint-api/src/encoding/btc.rs
@@ -2,7 +2,10 @@ use std::io::Error;
 
 use bitcoin::hashes::Hash as BitcoinHash;
 
-use crate::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
+use crate::{
+    core::ModuleDecode,
+    encoding::{Decodable, DecodeError, Encodable, ModuleRegistry},
+};
 
 macro_rules! impl_encode_decode_bridge {
     ($btc_type:ty) => {
@@ -15,11 +18,14 @@ macro_rules! impl_encode_decode_bridge {
             }
         }
 
-        impl<M> crate::encoding::Decodable<M> for $btc_type {
-            fn consensus_decode<D: std::io::Read>(
+        impl crate::encoding::Decodable for $btc_type {
+            fn consensus_decode<M, D: std::io::Read>(
                 d: &mut D,
                 _modules: &ModuleRegistry<M>,
-            ) -> Result<Self, crate::encoding::DecodeError> {
+            ) -> Result<Self, crate::encoding::DecodeError>
+            where
+                M: $crate::core::ModuleDecode,
+            {
                 bitcoin::consensus::Decodable::consensus_decode(d)
                     .map_err(crate::encoding::DecodeError::from_err)
             }
@@ -42,11 +48,14 @@ impl Encodable for bitcoin::Amount {
     }
 }
 
-impl<M> Decodable<M> for bitcoin::Amount {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for bitcoin::Amount {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         Ok(bitcoin::Amount::from_sat(u64::consensus_decode(
             d, modules,
         )?))
@@ -62,11 +71,14 @@ impl Encodable for bitcoin::Address {
     }
 }
 
-impl<M> Decodable<M> for bitcoin::Address {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for bitcoin::Address {
+    fn consensus_decode<M, D: std::io::Read>(
         mut d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let network = bitcoin::Network::from_magic(u32::consensus_decode(&mut d, modules)?)
             .ok_or_else(|| DecodeError::from_str("Unknown network"))?;
         let script_pk = bitcoin::Script::consensus_decode(&mut d, modules)?;
@@ -82,11 +94,14 @@ impl Encodable for bitcoin::hashes::sha256::Hash {
     }
 }
 
-impl<M> Decodable<M> for bitcoin::hashes::sha256::Hash {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for bitcoin::hashes::sha256::Hash {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         Ok(bitcoin::hashes::sha256::Hash::from_inner(
             Decodable::consensus_decode(d, modules)?,
         ))

--- a/fedimint-api/src/encoding/secp256k1.rs
+++ b/fedimint-api/src/encoding/secp256k1.rs
@@ -3,7 +3,10 @@ use std::io::{Error, Read, Write};
 use secp256k1_zkp::ecdsa::Signature;
 
 use super::ModuleRegistry;
-use crate::encoding::{Decodable, DecodeError, Encodable};
+use crate::{
+    core::ModuleDecode,
+    encoding::{Decodable, DecodeError, Encodable},
+};
 
 impl Encodable for secp256k1_zkp::ecdsa::Signature {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
@@ -13,11 +16,14 @@ impl Encodable for secp256k1_zkp::ecdsa::Signature {
     }
 }
 
-impl<M> Decodable<M> for secp256k1_zkp::ecdsa::Signature {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for secp256k1_zkp::ecdsa::Signature {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         Signature::from_compact(&<[u8; 64]>::consensus_decode(d, modules)?)
             .map_err(DecodeError::from_err)
     }
@@ -31,11 +37,14 @@ impl Encodable for secp256k1_zkp::XOnlyPublicKey {
     }
 }
 
-impl<M> Decodable<M> for secp256k1_zkp::XOnlyPublicKey {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for secp256k1_zkp::XOnlyPublicKey {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         secp256k1_zkp::XOnlyPublicKey::from_slice(&<[u8; 32]>::consensus_decode(d, modules)?)
             .map_err(DecodeError::from_err)
     }
@@ -47,11 +56,14 @@ impl Encodable for secp256k1_zkp::PublicKey {
     }
 }
 
-impl<M> Decodable<M> for secp256k1_zkp::PublicKey {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for secp256k1_zkp::PublicKey {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         secp256k1_zkp::PublicKey::from_slice(&<[u8; 33]>::consensus_decode(d, modules)?)
             .map_err(DecodeError::from_err)
     }
@@ -69,11 +81,14 @@ impl Encodable for secp256k1_zkp::schnorr::Signature {
     }
 }
 
-impl<M> Decodable<M> for secp256k1_zkp::schnorr::Signature {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for secp256k1_zkp::schnorr::Signature {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let bytes =
             <[u8; secp256k1_zkp::constants::SCHNORR_SIGNATURE_SIZE]>::consensus_decode(d, modules)?;
         secp256k1_zkp::schnorr::Signature::from_slice(&bytes).map_err(DecodeError::from_err)
@@ -86,11 +101,14 @@ impl Encodable for bitcoin::KeyPair {
     }
 }
 
-impl<M> Decodable<M> for bitcoin::KeyPair {
-    fn consensus_decode<D: Read>(
+impl Decodable for bitcoin::KeyPair {
+    fn consensus_decode<M, D: Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let sec_bytes = <[u8; 32]>::consensus_decode(d, modules)?;
         Self::from_seckey_slice(secp256k1_zkp::global::SECP256K1, &sec_bytes) // FIXME: evaluate security risk of global ctx
             .map_err(DecodeError::from_err)

--- a/fedimint-api/src/encoding/tbs.rs
+++ b/fedimint-api/src/encoding/tbs.rs
@@ -1,9 +1,12 @@
 use super::ModuleRegistry;
-use crate::encoding::{Decodable, DecodeError, Encodable};
+use crate::{
+    core::ModuleDecode,
+    encoding::{Decodable, DecodeError, Encodable},
+};
 
 macro_rules! impl_external_encode_bls {
     ($ext:ident $(:: $ext_path:ident)*, $group:ty, $byte_len:expr) => {
-        impl crate::encoding::Encodable for $ext $(:: $ext_path)* {
+        impl $crate::encoding::Encodable for $ext $(:: $ext_path)* {
             fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
                 let bytes = self.0.to_compressed();
                 writer.write_all(&bytes)?;
@@ -11,11 +14,11 @@ macro_rules! impl_external_encode_bls {
             }
         }
 
-        impl<M> crate::encoding::Decodable<M> for $ext $(:: $ext_path)* {
-            fn consensus_decode<D: std::io::Read>(
+        impl $crate::encoding::Decodable for $ext $(:: $ext_path)* {
+            fn consensus_decode<M, D: std::io::Read>(
                 d: &mut D,
                 _modules: &crate::encoding::ModuleRegistry<M>,
-            ) -> Result<Self, crate::encoding::DecodeError> {
+            ) -> Result<Self, crate::encoding::DecodeError> where M : $crate::core::ModuleDecode {
                 let mut bytes = [0u8; $byte_len];
                 d.read_exact(&mut bytes).map_err(crate::encoding::DecodeError::from_err)?;
                 let msg = <$group>::from_compressed(&bytes);
@@ -43,11 +46,14 @@ impl Encodable for tbs::BlindingKey {
     }
 }
 
-impl<M> Decodable<M> for tbs::BlindingKey {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for tbs::BlindingKey {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         _modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let mut bytes = [0u8; 32];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
         let key = tbs::Scalar::from_bytes(&bytes);

--- a/fedimint-api/src/lib.rs
+++ b/fedimint-api/src/lib.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 pub use tiered::Tiered;
 pub use tiered_multi::*;
 
+use crate::core::ModuleDecode;
 pub use crate::core::{client, server};
 use crate::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
 
@@ -295,11 +296,14 @@ impl Encodable for TransactionId {
     }
 }
 
-impl<M> Decodable<M> for TransactionId {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for TransactionId {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         _modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let mut bytes = [0u8; 32];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
         Ok(TransactionId::from_inner(bytes))

--- a/fedimint-api/src/tiered_multi.rs
+++ b/fedimint-api/src/tiered_multi.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
 use serde::{Deserialize, Serialize};
 
+use crate::core::ModuleDecode;
 use crate::encoding::ModuleRegistry;
 use crate::tiered::InvalidAmountTierError;
 use crate::{Amount, Tiered};
@@ -208,14 +209,17 @@ where
     }
 }
 
-impl<M, C> Decodable<M> for TieredMulti<C>
+impl<C> Decodable for TieredMulti<C>
 where
-    C: Decodable<M>,
+    C: Decodable,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let mut res = BTreeMap::new();
         let len = u64::consensus_decode(d, modules)?;
         for _ in 0..len {

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -4,7 +4,8 @@
 
 use std::collections::BTreeMap;
 
-use fedimint_api::core::{ClientModule, ModuleKey, Output, SpendableOutput, Transaction};
+use fedimint_api::client::ClientModule;
+use fedimint_api::core::{ModuleKey, Output, SpendableOutput, Transaction};
 use fedimint_api::Amount;
 use thiserror::Error;
 

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::sha256::HashEngine;
+use fedimint_api::core::ModuleDecode;
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry, UnzipConsensus};
 use fedimint_api::{BitcoinHash, FederationModule, PeerId};
 use itertools::Itertools;
@@ -157,11 +158,14 @@ impl Encodable for EpochSignature {
     }
 }
 
-impl<M> Decodable<M> for EpochSignature {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for EpochSignature {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         _modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let mut bytes = [0u8; 96];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
         Ok(EpochSignature(Signature::from_bytes(&bytes).unwrap()))
@@ -174,11 +178,14 @@ impl Encodable for EpochSignatureShare {
     }
 }
 
-impl<M> Decodable<M> for EpochSignatureShare {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for EpochSignatureShare {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         _modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let mut bytes = [0u8; 96];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
         Ok(EpochSignatureShare(

--- a/fedimint-derive/src/lib.rs
+++ b/fedimint-derive/src/lib.rs
@@ -195,8 +195,9 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
                     .map(|(idx, _)| format_ident!("field_{}", idx))
                     .collect::<Vec<_>>();
                 quote! {
-                    impl<M> ::fedimint_api::encoding::Decodable<M> for #ident {
-                        fn consensus_decode<D: std::io::Read>(d: &mut D, modules: &::fedimint_api::encoding::ModuleRegistry<M>) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError> {
+                    impl ::fedimint_api::encoding::Decodable for #ident {
+                        fn consensus_decode<M, D: std::io::Read>(d: &mut D, modules: &::fedimint_api::encoding::ModuleRegistry<M>) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError>
+                            where M : ::fedimint_api::core::ModuleDecode {
                             let mut len = 0;
                             #(let #field_names = ::fedimint_api::encoding::Decodable::consensus_decode(d, modules)?;)*
                             Ok(#ident(#(#field_names,)*))
@@ -210,8 +211,9 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
                     .map(|field| field.ident.clone().unwrap())
                     .collect::<Vec<_>>();
                 quote! {
-                    impl<M> ::fedimint_api::encoding::Decodable<M> for #ident {
-                        fn consensus_decode<D: std::io::Read>(d: &mut D, modules: &::fedimint_api::encoding::ModuleRegistry<M>) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError> {
+                    impl ::fedimint_api::encoding::Decodable for #ident {
+                        fn consensus_decode<M, D: std::io::Read>(d: &mut D, modules: &::fedimint_api::encoding::ModuleRegistry<M>) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError>
+                            where M: ::fedimint_api::core::ModuleDecode {
                             let mut len = 0;
                             #(let #field_names = ::fedimint_api::encoding::Decodable::consensus_decode(d, modules)?;)*
                             Ok(#ident{
@@ -257,9 +259,10 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
             });
 
             quote! {
-                impl<M> ::fedimint_api::encoding::Decodable<M> for #ident {
-                    fn consensus_decode<D: std::io::Read>(d: &mut D, modules: &::fedimint_api::encoding::ModuleRegistry<M>) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError> {
-                        let variant = <u64 as ::fedimint_api::encoding::Decodable<M>>::consensus_decode(d, modules)? as usize;
+                impl ::fedimint_api::encoding::Decodable for #ident {
+                    fn consensus_decode<M, D: std::io::Read>(d: &mut D, modules: &::fedimint_api::encoding::ModuleRegistry<M>) -> std::result::Result<Self, ::fedimint_api::encoding::DecodeError>
+                        where M: ::fedimint_api::core::ModuleDecode {
+                        let variant = <u64 as ::fedimint_api::encoding::Decodable>::consensus_decode(d, modules)? as usize;
                         let decoded = match variant {
                             #(#match_arms)*
                             _ => {

--- a/flake.nix
+++ b/flake.nix
@@ -547,7 +547,6 @@
           name = "gateway-cli";
           bin = "gateway-cli";
           dirs = [
-            "core"
             "crypto/tbs"
             "client/client-lib"
             "modules/fedimint-ln"

--- a/modules/fedimint-ln/src/contracts/incoming.rs
+++ b/modules/fedimint-ln/src/contracts/incoming.rs
@@ -3,6 +3,7 @@ use std::io::Error;
 use bitcoin_hashes::hash_newtype;
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
+use fedimint_api::core::ModuleDecode;
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
 use fedimint_api::OutPoint;
 use serde::{Deserialize, Serialize};
@@ -94,11 +95,14 @@ impl Encodable for OfferId {
     }
 }
 
-impl<M> Decodable<M> for OfferId {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for OfferId {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         Ok(OfferId::from_inner(Decodable::consensus_decode(
             d, modules,
         )?))

--- a/modules/fedimint-ln/src/contracts/mod.rs
+++ b/modules/fedimint-ln/src/contracts/mod.rs
@@ -7,6 +7,7 @@ use std::io::Error;
 use bitcoin_hashes::hash_newtype;
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
+use fedimint_api::core::ModuleDecode;
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
 use fedimint_api::OutPoint;
 use serde::{Deserialize, Serialize};
@@ -109,11 +110,14 @@ impl Encodable for ContractId {
     }
 }
 
-impl<M> Decodable<M> for ContractId {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for ContractId {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         Ok(ContractId::from_inner(Decodable::consensus_decode(
             d, modules,
         )?))
@@ -167,11 +171,14 @@ impl Encodable for EncryptedPreimage {
     }
 }
 
-impl<M> Decodable<M> for EncryptedPreimage {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for EncryptedPreimage {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let bytes = Vec::<u8>::consensus_decode(d, modules)?;
         Ok(EncryptedPreimage(
             bincode::deserialize(&bytes).map_err(DecodeError::from_err)?,
@@ -187,11 +194,14 @@ impl Encodable for PreimageDecryptionShare {
     }
 }
 
-impl<M> Decodable<M> for PreimageDecryptionShare {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for PreimageDecryptionShare {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let bytes = Vec::<u8>::consensus_decode(d, modules)?;
         Ok(PreimageDecryptionShare(
             bincode::deserialize(&bytes).map_err(DecodeError::from_err)?,

--- a/modules/fedimint-wallet/src/txoproof.rs
+++ b/modules/fedimint-wallet/src/txoproof.rs
@@ -6,6 +6,7 @@ use std::io::Cursor;
 
 use bitcoin::util::merkleblock::PartialMerkleTree;
 use bitcoin::{BlockHash, BlockHeader, OutPoint, Transaction, Txid};
+use fedimint_api::core::ModuleDecode;
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
 use miniscript::{Descriptor, TranslatePk};
 use secp256k1::{Secp256k1, Verification};
@@ -56,11 +57,14 @@ impl TxOutProof {
     }
 }
 
-impl<M> Decodable<M> for TxOutProof {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for TxOutProof {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let block_header = BlockHeader::consensus_decode(d, modules)?;
         let merkle_proof = PartialMerkleTree::consensus_decode(d, modules)?;
 
@@ -290,11 +294,14 @@ impl PartialEq for TxOutProof {
 
 impl Eq for TxOutProof {}
 
-impl<M> Decodable<M> for PegInProof {
-    fn consensus_decode<D: std::io::Read>(
+impl Decodable for PegInProof {
+    fn consensus_decode<M, D: std::io::Read>(
         d: &mut D,
         modules: &ModuleRegistry<M>,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodeError>
+    where
+        M: ModuleDecode,
+    {
         let slf = PegInProof {
             txout_proof: TxOutProof::consensus_decode(d, modules)?,
             transaction: Transaction::consensus_decode(d, modules)?,

--- a/modules/mint-client/src/lib.rs
+++ b/modules/mint-client/src/lib.rs
@@ -1,10 +1,9 @@
-use fedimint_api::core::{
-    ClientModulePlugin, FedimintClientCore, Output, PendingOutput, PollPendingOutputs,
-};
+use fedimint_api::client::{ClientModulePlugin, FedimintClientCore, PollPendingOutputs};
+use fedimint_api::core::{Output, PendingOutput};
 use fedimint_api::Amount;
 use fedimint_mint_common::{
-    MintInput, MintModuleCommon, MintOutput, MintOutputOutcome, MintPendingOutput,
-    MintSpendableOutput,
+    MintInput, MintModuleDecoder, MintOutput, MintOutputOutcome, MintPendingOutput,
+    MintSpendableOutput, MINT_MODULE_KEY,
 };
 
 #[derive(Clone)]
@@ -53,13 +52,16 @@ impl MintClientModule {
 }
 
 impl ClientModulePlugin for MintClientModule {
-    type Common = MintModuleCommon;
+    type Decoder = MintModuleDecoder;
     type Input = MintInput;
     type Output = MintOutput;
     type PendingOutput = MintPendingOutput;
     type SpendableOutput = MintSpendableOutput;
     type OutputOutcome = MintOutputOutcome;
 
+    fn module_key(&self) -> fedimint_api::core::ModuleKey {
+        MINT_MODULE_KEY
+    }
     fn init(&self, _core: FedimintClientCore) {
         todo!()
     }

--- a/modules/mint-common/src/lib.rs
+++ b/modules/mint-common/src/lib.rs
@@ -1,8 +1,9 @@
 use std::{collections::BTreeMap, io};
 
 use fedimint_api::core::{
-    Input, ModuleCommon, ModuleKey, Output, OutputOutcome, PendingOutput, PluginInput,
-    PluginOutput, PluginOutputOutcome, PluginPendingOutput, PluginSpendableOutput, SpendableOutput,
+    ConsensusItem, Input, ModuleKey, Output, OutputOutcome, PendingOutput, PluginConsensusItem,
+    PluginDecode, PluginInput, PluginOutput, PluginOutputOutcome, PluginPendingOutput,
+    PluginSpendableOutput, SpendableOutput,
 };
 use fedimint_api::{
     encoding::{Decodable, DecodeError, Encodable},
@@ -13,12 +14,9 @@ pub const MINT_MODULE_KEY: u16 = 0;
 
 // TODO: DELME
 #[derive(Default, Clone)]
-pub struct MintModuleCommon;
+pub struct MintModuleDecoder;
 
-impl ModuleCommon for MintModuleCommon {
-    fn module_key() -> ModuleKey {
-        MINT_MODULE_KEY
-    }
+impl PluginDecode for MintModuleDecoder {
     fn decode_spendable_output(mut d: &mut dyn io::Read) -> Result<SpendableOutput, DecodeError> {
         Ok(SpendableOutput::from(
             MintSpendableOutput::consensus_decode(&mut d, &BTreeMap::<_, ()>::new())?,
@@ -48,6 +46,15 @@ impl ModuleCommon for MintModuleCommon {
     fn decode_input(mut d: &mut dyn io::Read) -> Result<Input, DecodeError> {
         Ok(Input::from(MintInput::consensus_decode(
             &mut d,
+            &BTreeMap::<_, ()>::new(),
+        )?))
+    }
+
+    fn decode_consensus_item(
+        mut r: &mut dyn io::Read,
+    ) -> Result<fedimint_api::core::ConsensusItem, DecodeError> {
+        Ok(ConsensusItem::from(MintConsensusItem::consensus_decode(
+            &mut r,
             &BTreeMap::<_, ()>::new(),
         )?))
     }
@@ -115,5 +122,14 @@ impl PluginInput for MintInput {
 
     fn amount(&self) -> Amount {
         todo!()
+    }
+}
+
+#[derive(Encodable, Decodable, Clone)]
+pub struct MintConsensusItem;
+
+impl PluginConsensusItem for MintConsensusItem {
+    fn module_key(&self) -> ModuleKey {
+        MINT_MODULE_KEY
     }
 }

--- a/modules/mint-server/src/lib.rs
+++ b/modules/mint-server/src/lib.rs
@@ -1,10 +1,9 @@
 use std::collections::HashSet;
 
 use async_trait::async_trait;
-use fedimint_api::core::{
-    Error, InputMeta, ModuleKey, PluginConsensusItem, PluginVerificationCache, ServerModulePlugin,
-};
+use fedimint_api::core::{ModuleKey, PluginConsensusItem};
 use fedimint_api::server::InitHandle;
+use fedimint_api::server::{Error, InputMeta, PluginVerificationCache, ServerModulePlugin};
 use fedimint_api::{
     db::DatabaseTransaction,
     encoding::{Decodable, Encodable},
@@ -12,7 +11,7 @@ use fedimint_api::{
     Amount, OutPoint, PeerId,
 };
 use fedimint_mint_common::{
-    MintInput, MintModuleCommon, MintOutput, MintOutputOutcome, MintPendingOutput,
+    MintInput, MintModuleDecoder, MintOutput, MintOutputOutcome, MintPendingOutput,
     MintSpendableOutput, MINT_MODULE_KEY,
 };
 
@@ -45,7 +44,7 @@ impl MintServerModule {
 
 #[async_trait(?Send)]
 impl ServerModulePlugin for MintServerModule {
-    type Common = MintModuleCommon;
+    type Decoder = MintModuleDecoder;
     type Input = MintInput;
     type Output = MintOutput;
     type PendingOutput = MintPendingOutput;
@@ -53,6 +52,10 @@ impl ServerModulePlugin for MintServerModule {
     type OutputOutcome = MintOutputOutcome;
     type ConsensusItem = MintConsensusItem;
     type VerificationCache = MintVerificationCache;
+
+    fn module_key(&self) -> ModuleKey {
+        MINT_MODULE_KEY
+    }
 
     fn init(&self, backend: &mut dyn InitHandle) {
         // TODO: delete this dummy endpoint


### PR DESCRIPTION
After a while of working with the current version of Decodable
I've hit a wall, with not being able to express:

```
trait Smth : for <M : Decoder> Decodable<M>
```

without some heavy HKT machiner.

This led to a realization that the current form is conceptually
wrong. I don't need a trait that is parametrized by `M`.
I need one trait, that when impleemnted guarantee that any `M`
(with a bound) can be used.