### PR TITLE
Debug CI failures, introduce task groups, error handling improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
 name = "fedimint-tests"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "async-trait",
  "bitcoin",

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -551,8 +551,11 @@ async fn handle_command(
                 )
         }
         Command::WaitBlockHeight { height } => {
-            client.await_consensus_block_height(height).await;
-            Ok(CliOutput::WaitBlockHeight { reached: (height) })
+            client.await_consensus_block_height(height).await.transform(
+                |_| CliOutput::WaitBlockHeight { reached: (height) },
+                CliErrorKind::Timeout,
+                "timeout reached",
+            )
         }
         Command::ConnectInfo => {
             let info = WsFederationConnect::from(client.config().as_ref());

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -13,7 +13,7 @@ use clientd::{
 };
 use clientd::{Json as JsonExtract, SpendPayload};
 use fedimint_core::config::load_from_file;
-use mint_client::{Client, UserClientConfig};
+use mint_client::{Client, ClientError, UserClientConfig};
 use rand::rngs::OsRng;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
@@ -127,7 +127,10 @@ async fn wait_block_height(
     JsonExtract(payload): JsonExtract<WaitBlockHeightPayload>,
 ) -> Result<impl IntoResponse, ClientdError> {
     let client = &state.client;
-    client.await_consensus_block_height(payload.height).await;
+    client
+        .await_consensus_block_height(payload.height)
+        .await
+        .map_err(|_e| ClientError::Timeout)?;
     json_success!("done")
 }
 

--- a/fedimintd/src/main.rs
+++ b/fedimintd/src/main.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use fedimint_api::db::Database;
+use fedimint_api::task::TaskGroup;
 use fedimint_core::modules::ln::LightningModule;
 use fedimint_mint_server::MintServerModule;
 use fedimint_server::config::ServerConfig;
@@ -86,11 +87,14 @@ async fn main() -> anyhow::Result<()> {
         .into();
     let btc_rpc = fedimint_bitcoind::bitcoincore_rpc::make_bitcoind_rpc(&cfg.wallet.btc_rpc)?;
 
+    let mut task_group = TaskGroup::new();
+
     let mint = fedimint_core::modules::mint::Mint::new(cfg.mint.clone(), db.clone());
 
-    let wallet = Wallet::new_with_bitcoind(cfg.wallet.clone(), db.clone(), btc_rpc)
-        .await
-        .expect("Couldn't create wallet");
+    let wallet =
+        Wallet::new_with_bitcoind(cfg.wallet.clone(), db.clone(), btc_rpc, &mut task_group)
+            .await
+            .expect("Couldn't create wallet");
 
     let ln = LightningModule::new(cfg.ln.clone(), db.clone());
 

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -11,6 +11,7 @@ name = "fedimint-tests"
 path = "tests/tests.rs"
 
 [dev-dependencies]
+anyhow = "1.0.65"
 assert_matches = "1.5.0"
 async-trait = "0.1.42"
 bitcoin = "0.29.1"

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -2,6 +2,7 @@ mod fixtures;
 
 use std::time::Duration;
 
+use anyhow::Result;
 use assert_matches::assert_matches;
 use bitcoin::{Amount, KeyPair};
 use fedimint_api::TieredMulti;
@@ -24,10 +25,10 @@ use tracing::debug;
 use crate::fixtures::FederationTest;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn peg_in_and_peg_out_with_fees() {
+async fn peg_in_and_peg_out_with_fees() -> anyhow::Result<()> {
     let peg_in_amount: u64 = 5000;
     let peg_out_amount: u64 = 1200; // amount requires minted change
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
 
     let peg_in_address = user.client.get_new_pegin_address(rng());
     let (proof, tx) = bitcoin.send_and_mine_block(&peg_in_address, Amount::from_sat(peg_in_amount));
@@ -68,11 +69,13 @@ async fn peg_in_and_peg_out_with_fees() {
     user.assert_total_coins(sats(peg_in_amount - peg_out_amount) - fees)
         .await;
     assert_eq!(fed.max_balance_sheet(), 0);
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn peg_outs_are_rejected_if_fees_are_too_low() {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+async fn peg_outs_are_rejected_if_fees_are_too_low() -> Result<()> {
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
     let peg_out_amount = Amount::from_sat(1000);
     let peg_out_address = bitcoin.get_new_address();
 
@@ -87,11 +90,13 @@ async fn peg_outs_are_rejected_if_fees_are_too_low() {
     peg_out.fees.fee_rate.sats_per_kvb = 10;
     // TODO: return a better error message to clients
     assert!(user.client.peg_out(peg_out, rng()).await.is_err());
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn peg_outs_are_only_allowed_once_per_epoch() {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+async fn peg_outs_are_only_allowed_once_per_epoch() -> Result<()> {
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
     let address1 = bitcoin.get_new_address();
     let address2 = bitcoin.get_new_address();
 
@@ -109,11 +114,13 @@ async fn peg_outs_are_only_allowed_once_per_epoch() {
     user.client.reissue_pending_coins(rng()).await.unwrap();
     fed.run_consensus_epochs(2).await; // reissue the coins from the tx that failed
     user.assert_total_coins(sats(5000 - 1000) - fees).await;
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn peg_outs_must_wait_for_available_utxos() {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+async fn peg_outs_must_wait_for_available_utxos() -> Result<()> {
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
     let address1 = bitcoin.get_new_address();
     let address2 = bitcoin.get_new_address();
 
@@ -136,11 +143,13 @@ async fn peg_outs_must_wait_for_available_utxos() {
     fed.run_consensus_epochs(2).await;
     fed.broadcast_transactions().await;
     assert_eq!(bitcoin.mine_block_and_get_received(&address2), sats(2000));
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn ecash_can_be_exchanged_directly_between_users() {
-    let (fed, user_send, bitcoin, _, _) = fixtures(4, &[sats(10), sats(100), sats(1000)]).await;
+async fn ecash_can_be_exchanged_directly_between_users() -> Result<()> {
+    let (fed, user_send, bitcoin, _, _) = fixtures(4, &[sats(10), sats(100), sats(1000)]).await?;
     let user_receive = user_send.new_client(&[0, 1, 2]);
 
     fed.mine_and_mint(&user_send, &*bitcoin, sats(5000)).await;
@@ -154,11 +163,12 @@ async fn ecash_can_be_exchanged_directly_between_users() {
     user_send.assert_total_coins(sats(1500)).await;
     user_receive.assert_total_coins(sats(3500)).await;
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn ecash_cannot_double_spent_with_different_nodes() {
-    let (fed, user1, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
+async fn ecash_cannot_double_spent_with_different_nodes() -> Result<()> {
+    let (fed, user1, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
     fed.mine_and_mint(&user1, &*bitcoin, sats(5000)).await;
     let ecash = fed.spend_ecash(&user1, sats(2000)).await;
 
@@ -172,11 +182,12 @@ async fn ecash_cannot_double_spent_with_different_nodes() {
     assert!(res2.is_err() || res3.is_err()); //no double spend
     assert_eq!(user2.total_coins() + user3.total_coins(), sats(2000));
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn ecash_in_wallet_can_sent_through_a_tx() {
-    let (fed, user_send, bitcoin, _, _) = fixtures(2, &[sats(100), sats(500)]).await;
+async fn ecash_in_wallet_can_sent_through_a_tx() -> Result<()> {
+    let (fed, user_send, bitcoin, _, _) = fixtures(2, &[sats(100), sats(500)]).await?;
     let user_receive = user_send.new_client(&[0]);
 
     fed.mine_and_mint(&user_send, &*bitcoin, sats(1100)).await;
@@ -199,6 +210,7 @@ async fn ecash_in_wallet_can_sent_through_a_tx() {
         .assert_coin_amounts(vec![sats(100), sats(100), sats(500)])
         .await;
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 async fn drop_peer_3_during_epoch(fed: &FederationTest) {
@@ -218,8 +230,9 @@ async fn drop_peer_3_during_epoch(fed: &FederationTest) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn drop_peers_who_dont_contribute_peg_out_psbts() {
-    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(1), sats(10), sats(100), sats(1000)]).await;
+async fn drop_peers_who_dont_contribute_peg_out_psbts() -> Result<()> {
+    let (fed, user, bitcoin, _, _) =
+        fixtures(4, &[sats(1), sats(10), sats(100), sats(1000)]).await?;
     fed.mine_and_mint(&user, &*bitcoin, sats(3000)).await;
 
     let peg_out_address = bitcoin.get_new_address();
@@ -238,11 +251,12 @@ async fn drop_peers_who_dont_contribute_peg_out_psbts() {
     );
     assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn drop_peers_who_dont_contribute_decryption_shares() {
-    let (fed, user, bitcoin, gateway, _) = fixtures(4, &[sats(100), sats(1000)]).await;
+async fn drop_peers_who_dont_contribute_decryption_shares() -> Result<()> {
+    let (fed, user, bitcoin, gateway, _) = fixtures(4, &[sats(100), sats(1000)]).await?;
     let payment_amount = sats(2000);
     fed.mine_and_mint(&gateway.user, &*bitcoin, sats(3000))
         .await;
@@ -283,11 +297,12 @@ async fn drop_peers_who_dont_contribute_decryption_shares() {
     user.assert_total_coins(payment_amount).await;
     assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn drop_peers_who_dont_contribute_blind_sigs() {
-    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await;
+async fn drop_peers_who_dont_contribute_blind_sigs() -> Result<()> {
+    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await?;
     fed.mine_spendable_utxo(&user, &*bitcoin, Amount::from_sat(2000));
     fed.database_add_coins_for_user(&user, sats(2000));
 
@@ -296,11 +311,12 @@ async fn drop_peers_who_dont_contribute_blind_sigs() {
 
     user.assert_total_coins(sats(2000)).await;
     assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn drop_peers_who_contribute_bad_sigs() {
-    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await;
+async fn drop_peers_who_contribute_bad_sigs() -> Result<()> {
+    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await?;
     fed.mine_spendable_utxo(&user, &*bitcoin, Amount::from_sat(2000));
     let out_point = fed.database_add_coins_for_user(&user, sats(2000));
     let bad_proposal = vec![ConsensusItem::Mint(PartiallySignedRequest {
@@ -313,12 +329,13 @@ async fn drop_peers_who_contribute_bad_sigs() {
 
     user.assert_total_coins(sats(2000)).await;
     assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn lightning_gateway_pays_internal_invoice() {
+async fn lightning_gateway_pays_internal_invoice() -> Result<()> {
     let (fed, sending_user, bitcoin, gateway, lightning) =
-        fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+        fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
 
     // Fund the gateway so it can route internal payments
     fed.mine_and_mint(&gateway.user, &*bitcoin, sats(2000))
@@ -401,12 +418,13 @@ async fn lightning_gateway_pays_internal_invoice() {
 
     assert_eq!(lightning.amount_sent().await, sats(0)); // We did not route any payments over the lightning network
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn lightning_gateway_pays_outgoing_invoice() {
+async fn lightning_gateway_pays_outgoing_invoice() -> Result<()> {
     let (fed, user, bitcoin, gateway, lightning) =
-        fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+        fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
     let invoice = lightning.invoice(sats(1000), None).await;
 
     fed.mine_and_mint(&user, &*bitcoin, sats(2000)).await;
@@ -446,12 +464,13 @@ async fn lightning_gateway_pays_outgoing_invoice() {
     tokio::time::sleep(Duration::from_millis(500)).await; // FIXME need to wait for listfunds to update
     assert_eq!(lightning.amount_sent().await, sats(1000));
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn lightning_gateway_claims_refund_for_internal_invoice() {
+async fn lightning_gateway_claims_refund_for_internal_invoice() -> Result<()> {
     let (fed, sending_user, bitcoin, gateway, lightning) =
-        fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+        fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
 
     // Fund the gateway so it can route internal payments
     fed.mine_and_mint(&gateway.user, &*bitcoin, sats(2000))
@@ -511,20 +530,22 @@ async fn lightning_gateway_claims_refund_for_internal_invoice() {
 
     assert_eq!(lightning.amount_sent().await, sats(0)); // We did not route any payments over the lightning network
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn set_lightning_invoice_expiry() {
-    let (_, _, _, _, lightning) = fixtures(2, &[sats(10), sats(1000)]).await;
+async fn set_lightning_invoice_expiry() -> Result<()> {
+    let (_, _, _, _, lightning) = fixtures(2, &[sats(10), sats(1000)]).await?;
     let invoice = lightning.invoice(sats(1000), 600.into());
     assert_eq!(invoice.await.expiry_time(), Duration::from_secs(600));
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn receive_lightning_payment_valid_preimage() {
+async fn receive_lightning_payment_valid_preimage() -> Result<()> {
     let starting_balance = sats(2000);
     let preimage_price = sats(100);
-    let (fed, user, bitcoin, gateway, _) = fixtures(2, &[sats(1000), sats(100)]).await;
+    let (fed, user, bitcoin, gateway, _) = fixtures(2, &[sats(1000), sats(100)]).await?;
     fed.mine_and_mint(&gateway.user, &*bitcoin, starting_balance)
         .await;
     assert_eq!(user.total_coins(), sats(0));
@@ -585,13 +606,14 @@ async fn receive_lightning_payment_valid_preimage() {
         .await;
     user.assert_total_coins(preimage_price).await;
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn receive_lightning_payment_invalid_preimage() {
+async fn receive_lightning_payment_invalid_preimage() -> Result<()> {
     let starting_balance = sats(2000);
     let payment_amount = sats(100);
-    let (fed, user, bitcoin, gateway, _) = fixtures(2, &[sats(1000), sats(100)]).await;
+    let (fed, user, bitcoin, gateway, _) = fixtures(2, &[sats(1000), sats(100)]).await?;
     fed.mine_and_mint(&gateway.user, &*bitcoin, starting_balance)
         .await;
     assert_eq!(user.total_coins(), sats(0));
@@ -648,11 +670,12 @@ async fn receive_lightning_payment_invalid_preimage() {
     gateway.user.assert_total_coins(starting_balance).await;
     user.assert_total_coins(sats(0)).await;
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn lightning_gateway_cannot_claim_invalid_preimage() {
-    let (fed, user, bitcoin, gateway, lightning) = fixtures(2, &[sats(10), sats(1000)]).await;
+async fn lightning_gateway_cannot_claim_invalid_preimage() -> Result<()> {
+    let (fed, user, bitcoin, gateway, lightning) = fixtures(2, &[sats(10), sats(1000)]).await?;
     let invoice = lightning.invoice(sats(1000), None);
 
     fed.mine_and_mint(&user, &*bitcoin, sats(1010)).await; // 1% LN fee
@@ -682,11 +705,12 @@ async fn lightning_gateway_cannot_claim_invalid_preimage() {
         .count();
     assert_eq!(ln_items, 0);
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn lightning_gateway_can_abort_payment_to_return_user_funds() {
-    let (fed, user, bitcoin, gateway, lightning) = fixtures(2, &[sats(10), sats(1000)]).await;
+async fn lightning_gateway_can_abort_payment_to_return_user_funds() -> Result<()> {
+    let (fed, user, bitcoin, gateway, lightning) = fixtures(2, &[sats(10), sats(1000)]).await?;
     let invoice = lightning.invoice(sats(1000), None);
 
     fed.mine_and_mint(&user, &*bitcoin, sats(1010)).await; // 1% LN fee
@@ -722,11 +746,12 @@ async fn lightning_gateway_can_abort_payment_to_return_user_funds() {
     user.client.fetch_coins(outpoint).await.unwrap();
     assert_eq!(user.total_coins(), sats(1010));
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn runs_consensus_if_tx_submitted() {
-    let (fed, user_send, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
+async fn runs_consensus_if_tx_submitted() -> Result<()> {
+    let (fed, user_send, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
     let user_receive = user_send.new_client(&[0]);
 
     fed.mine_and_mint(&user_send, &*bitcoin, sats(5000)).await;
@@ -746,11 +771,12 @@ async fn runs_consensus_if_tx_submitted() {
 
     user_receive.assert_total_coins(sats(5000)).await;
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn runs_consensus_if_new_block() {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
+async fn runs_consensus_if_new_block() -> Result<()> {
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
     let peg_in_address = user.client.get_new_pegin_address(rng());
     bitcoin.mine_blocks(100);
     let (proof, tx) = bitcoin.send_and_mine_block(&peg_in_address, Amount::from_sat(1000));
@@ -770,19 +796,21 @@ async fn runs_consensus_if_new_block() {
     fed.run_consensus_epochs(2).await; // peg-in + blind sign
     user.assert_total_coins(sats(1000)).await;
     assert_eq!(fed.max_balance_sheet(), 0);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[should_panic]
 async fn audit_negative_balance_sheet_panics() {
-    let (fed, user, _, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
-    fed.mint_coins_for_user(&user, sats(2000)).await;
-    fed.run_consensus_epochs(1).await;
+    if let Ok((fed, user, _, _, _)) = fixtures(2, &[sats(100), sats(1000)]).await {
+        fed.mint_coins_for_user(&user, sats(2000)).await;
+        fed.run_consensus_epochs(1).await;
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn unbalanced_transactions_get_rejected() {
-    let (fed, user, bitcoin, _, lightning) = fixtures(2, &[sats(100), sats(1000)]).await;
+async fn unbalanced_transactions_get_rejected() -> Result<()> {
+    let (fed, user, bitcoin, _, lightning) = fixtures(2, &[sats(100), sats(1000)]).await?;
     // cannot make change for this invoice (results in unbalanced tx)
     let invoice = lightning.invoice(sats(777), None);
 
@@ -794,18 +822,20 @@ async fn unbalanced_transactions_get_rejected() {
 
     // TODO return a more useful error
     assert!(response.is_err());
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn can_have_federations_with_one_peer() {
-    let (fed, user, bitcoin, _, _) = fixtures(1, &[sats(100), sats(1000)]).await;
+async fn can_have_federations_with_one_peer() -> Result<()> {
+    let (fed, user, bitcoin, _, _) = fixtures(1, &[sats(100), sats(1000)]).await?;
     fed.mine_and_mint(&user, &*bitcoin, sats(1000)).await;
     user.assert_total_coins(sats(1000)).await;
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn can_get_signed_epoch_history() {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
+async fn can_get_signed_epoch_history() -> Result<()> {
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
 
     fed.mine_and_mint(&user, &*bitcoin, sats(1000)).await;
     fed.mine_and_mint(&user, &*bitcoin, sats(1000)).await;
@@ -817,18 +847,19 @@ async fn can_get_signed_epoch_history() {
     assert_eq!(epoch0.verify_sig(&pubkey), Ok(()));
     assert_eq!(epoch0.verify_hash(&None), Ok(()));
     assert_eq!(epoch1.verify_hash(&Some(epoch0)), Ok(()));
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn rejoin_consensus_single_peer() {
-    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await;
+async fn rejoin_consensus_single_peer() -> Result<()> {
+    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await?;
 
     // Keep peer 3 out of consensus
     bitcoin.mine_blocks(110);
     fed.subset_peers(&[0, 1, 2]).run_consensus_epochs(1).await;
     bitcoin.mine_blocks(100);
     fed.subset_peers(&[0, 1, 2]).run_consensus_epochs(1).await;
-    let height = user.client.await_consensus_block_height(0).await;
+    let height = user.client.await_consensus_block_height(0).await?;
 
     join_all(vec![
         Either::Left(async {
@@ -843,14 +874,15 @@ async fn rejoin_consensus_single_peer() {
     // Ensure peer 3 rejoined and caught up to consensus
     let user = user.new_client(&[1, 2, 3]);
     assert_eq!(
-        user.client.await_consensus_block_height(height).await,
+        user.client.await_consensus_block_height(height).await?,
         height
     );
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn rejoin_consensus_threshold_peers() {
-    let (fed, _, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
+async fn rejoin_consensus_threshold_peers() -> Result<()> {
+    let (fed, _, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
     let peer0 = fed.subset_peers(&[0]);
     let peer1 = fed.subset_peers(&[1]);
 
@@ -868,4 +900,5 @@ async fn rejoin_consensus_threshold_peers() {
 
     // confirm that the entire federation can rejoin at an epoch
     timeout(Duration::from_secs(15), rejoin).await.unwrap();
+    Ok(())
 }


### PR DESCRIPTION
This is a bit of chaos, but to sum up:

* we must not use unbounded retries in the client code operations
* I'd like to introduce some more structured task control
