### PR TITLE
Gateway Server Authentiation

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -26,6 +26,7 @@ windows:
           - fg
         - ln1:
           - sleep 5 # wait for bitcoind and federation
+          - gateway-cli generate-config $FM_CFG_DIR #generate gateway config
           - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 --plugin=$FM_BIN_DIR/ln_gateway --fedimint-cfg=$FM_CFG_DIR &
           - echo $! >> $FM_PID_FILE
           - fg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "ln-gateway",
  "mint-client",
  "reqwest",
+ "rpassword",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,6 +3548,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
 dependencies = [
+ "base64",
  "bitflags",
  "bytes",
  "futures-core",

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -20,6 +20,7 @@ fedimint-server = { path = "../../fedimint-server/" }
 ln-gateway = { path= "../ln-gateway" }
 mint-client = { path = "../../client/client-lib" }
 reqwest = { version = "0.11.12", features = [ "json" ], default-features = false }
+rpassword = "7.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.86"
 tokio = {version = "1.21", features = ["full"]}

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1.0.86"
 thiserror = "1.0.37"
 tracing = { version = "0.1.37", default-features = false, features= ["log", "attributes", "std"] }
 tokio = {version = "1.21", features = ["full"]}
-tower-http = { version = "0.3.4", features = ["cors"] }
+tower-http = { version = "0.3.4", features = ["cors", "auth"] }
 url = { version = "2.3.1", features = ["serde"] }
 
 [build-dependencies]

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GatewayConfig {
+    pub password: String,
+}

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cln;
+pub mod config;
 pub mod ln;
 pub mod rpc;
 pub mod webserver;
@@ -17,6 +18,7 @@ use axum::response::{IntoResponse, Response};
 use bitcoin::{Address, Transaction};
 use bitcoin_hashes::sha256;
 use cln::HtlcAccepted;
+use config::GatewayConfig;
 use fedimint_api::{Amount, OutPoint, TransactionId};
 use fedimint_server::modules::ln::contracts::{ContractId, Preimage};
 use fedimint_server::modules::wallet::txoproof::TxOutProof;
@@ -161,6 +163,7 @@ pub struct LnGateway {
 
 impl LnGateway {
     pub fn new(
+        cfg: GatewayConfig,
         federation_client: Arc<GatewayClient>,
         ln_client: Arc<dyn LnRpc>,
         sender: mpsc::Sender<GatewayRequest>,
@@ -168,7 +171,7 @@ impl LnGateway {
         bind_addr: SocketAddr,
     ) -> Self {
         // Run webserver asynchronously in tokio
-        let webserver = tokio::spawn(run_webserver(bind_addr, sender));
+        let webserver = tokio::spawn(run_webserver(cfg.password, bind_addr, sender));
 
         Self {
             federation_client,

--- a/gateway/ln-gateway/src/webserver.rs
+++ b/gateway/ln-gateway/src/webserver.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 pub async fn run_webserver(
+    authkey: String,
     bind_addr: SocketAddr,
     sender: mpsc::Sender<GatewayRequest>,
 ) -> axum::response::Result<()> {
@@ -22,9 +23,6 @@ pub async fn run_webserver(
     // Public routes on gateway webserver
     let routes = Router::new().route("/pay_invoice", post(pay_invoice));
 
-    // TODO: source user configured auth token from gateway config
-    const SERVER_AUTH_TOKEN: &str = "theresnosecondbest";
-
     // Authenticated, public routes used for gateway administration
     let admin_routes = Router::new()
         .route("/info", post(info))
@@ -32,7 +30,7 @@ pub async fn run_webserver(
         .route("/address", post(address))
         .route("/deposit", post(deposit))
         .route("/withdraw", post(withdraw))
-        .layer(RequireAuthorizationLayer::bearer(SERVER_AUTH_TOKEN));
+        .layer(RequireAuthorizationLayer::bearer(&authkey));
 
     let app = Router::new()
         .merge(routes)

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -51,6 +51,7 @@ use futures::future::{join_all, select_all};
 use hbbft::honey_badger::Batch;
 use itertools::Itertools;
 use lightning_invoice::Invoice;
+use ln_gateway::config::GatewayConfig;
 use ln_gateway::GatewayRequest;
 use ln_gateway::LnGateway;
 use mint_client::api::WsFederationApi;
@@ -317,7 +318,16 @@ impl GatewayTest {
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
         let adapter = Arc::new(ln_client_adapter);
         let ln_client = Arc::clone(&adapter);
-        let gateway = LnGateway::new(client.clone(), ln_client, sender, receiver, bind_addr);
+        let gateway = LnGateway::new(
+            GatewayConfig {
+                password: "abc".into(),
+            },
+            client.clone(),
+            ln_client,
+            sender,
+            receiver,
+            bind_addr,
+        );
         // Normally, this client registration with the federation is automated as part of running the gateway
         // In test cases, we want to register without running a gateway
         client

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -55,7 +55,7 @@ export FM_MINT_CLIENT="$FM_BIN_DIR/fedimint-cli --workdir $FM_CFG_DIR"
 export FM_MINT_RPC_CLIENT="$FM_BIN_DIR/mint-rpc-client"
 export FM_CLIENTD="$FM_BIN_DIR/clientd"
 export FM_CLIENTD_CLI="$FM_BIN_DIR/clientd-cli"
-export FM_GATEWAY_CLI="$FM_BIN_DIR/gateway-cli"
+export FM_GATEWAY_CLI="$FM_BIN_DIR/gateway-cli --rpcpassword=theresnosecondbest"
 
 # Alias clients
 alias ln1="\$FM_LN1"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -59,6 +59,7 @@ function kill_fedimint_processes {
 }
 
 function start_gateway() {
+  $FM_GATEWAY_CLI generate-config $FM_CFG_DIR # generate gateway config
   $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR &
   sleep 1 # wait for plugin to start
 }


### PR DESCRIPTION
First pass implement gateway server auth by requiring a bearer token in requests. Turns out [tower_http](https://crates.io/crates/tower-http) has really nice auth middlewares that are plug and play with axum server.

TODO:
- [x] complete validation of  transport security impl using `tower_http::auth`
- [x] **Admin Configured Passkey**: source gateway server passkey from gateway configs, instead of the passkey hard coded in server

closes #807 
