### PR TITLE
Timing tweaks in shell scripts

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -25,12 +25,12 @@ windows:
           - echo $! >> $FM_PID_FILE
           - fg
         - ln1:
-          - sleep 1 # wait for bitcoind
+          - sleep 5 # wait for bitcoind and federation
           - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 --plugin=$FM_BIN_DIR/ln_gateway --fedimint-cfg=$FM_CFG_DIR &
           - echo $! >> $FM_PID_FILE
           - fg
         - ln2:
-          - sleep 1 # wait for bitcoind
+          - sleep 5 # wait for bitcoind and federation
           - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN2_DIR --addr=127.0.0.1:9001 &
           - echo $! >> $FM_PID_FILE
           - fg

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -385,6 +385,9 @@ impl LnGateway {
 
     pub async fn run(&mut self) -> Result<()> {
         // Regster gateway with federation
+        // FIXME: This call is critically dependent on the federation being up and running.
+        // We should either use a retry strategy, OR register federations on the gateway at runtime
+        // as proposed in https://github.com/fedimint/fedimint/issues/699
         self.federation_client
             .register_with_federation(self.federation_client.config().into())
             .await

--- a/scripts/tmux-user-shell.sh
+++ b/scripts/tmux-user-shell.sh
@@ -12,6 +12,10 @@ echo Setting up bitcoind ...
 btc_client createwallet default > /dev/null 2>&1
 mine_blocks 101 > /dev/null 2>&1
 
+# Wait for the lightning clients to start (ln1 and ln2 are started with a 5s delay after bitcoind and deferation start)
+# FIXME: After tackling https://github.com/fedimint/fedimint/issues/699, this can be removed
+sleep 10
+
 echo Setting up lightning channel ...
 open_channel > /dev/null 2>&1
 


### PR DESCRIPTION
Starting the gateway CLN plugin runs the gateway. On run, the gateway attempts to register with a federation. If the federation is not ready, the gateway registration call fails, which in turn would fail the CLN plugin start.

The recent change to encrypt configs at rest (#808) marginally slows down the federation start, which then leads into the situation described above. As a temporary fix, this PR tweaks our sleep timers in the shell scripts we use to orchestrate federation and gateway start by:
- delaying CLN1 (with plugin) and CLN2 by 5s each to ensure the federation is started
- delaying channel opens by 10s to ensure the CLN instances are up and running

Follow Ups:
- [ ] We should look to complete work proposed by #699, such that the gateway does not need a federation configuration at boot, but can register federations later, at runtime. Alternatively
- [x] **Alternative solution:**  We should use retries for the gateway registration  action, instead of relying on timing to sequence the boot process [WIP] - #840 
