### PR TITLE
Make module errors abstract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,7 @@ dependencies = [
 name = "fedimint-ln"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bincode",
  "bitcoin_hashes",

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -12,14 +12,14 @@ use fedimint_api::core::ModuleKey;
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
-use fedimint_api::module::TransactionItemAmount;
+use fedimint_api::module::{ModuleError, TransactionItemAmount};
 use fedimint_api::server::ServerModule;
 use fedimint_api::{Amount, FederationModule, OutPoint, PeerId, TransactionId};
 use fedimint_core::epoch::*;
-use fedimint_core::modules::ln::{LightningModule, LightningModuleError};
-use fedimint_core::modules::mint::{Mint, MintError};
+use fedimint_core::modules::ln::LightningModule;
+use fedimint_core::modules::mint::Mint;
 use fedimint_core::outcome::TransactionStatus;
-use fedimint_wallet::{Wallet, WalletError};
+use fedimint_wallet::Wallet;
 use futures::future::select_all;
 use hbbft::honey_badger::Batch;
 use rand::rngs::OsRng;
@@ -714,17 +714,17 @@ pub enum TransactionSubmissionError {
     #[error("High level transaction error: {0}")]
     TransactionError(#[from] TransactionError),
     #[error("Input coin error: {0}")]
-    InputCoinError(MintError),
+    InputCoinError(ModuleError),
     #[error("Input peg-in error: {0}")]
-    InputPegIn(WalletError),
+    InputPegIn(ModuleError),
     #[error("LN contract input error: {0}")]
-    ContractInputError(LightningModuleError),
+    ContractInputError(ModuleError),
     #[error("Output coin error: {0}")]
-    OutputCoinError(MintError),
+    OutputCoinError(ModuleError),
     #[error("Output coin error: {0}")]
-    OutputPegOut(WalletError),
+    OutputPegOut(ModuleError),
     #[error("LN contract output error: {0}")]
-    ContractOutputError(LightningModuleError),
+    ContractOutputError(ModuleError),
     #[error("Transaction conflict error")]
     TransactionConflictError,
 }

--- a/modules/fedimint-ln/Cargo.toml
+++ b/modules/fedimint-ln/Cargo.toml
@@ -13,6 +13,7 @@ name = "fedimint_ln"
 path = "src/lib.rs"
 
 [dependencies]
+anyhow = "1.0.65"
 async-trait = "0.1"
 bincode = "1"
 bitcoin_hashes = "0.11.0"

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -121,7 +121,10 @@ async fn test_outgoing() {
         witness: None,
     };
     let err = fed.verify_input(&account_input_no_witness).unwrap_err();
-    assert_eq!(err, LightningModuleError::MissingPreimage);
+    assert_eq!(
+        format!("{err}"),
+        format!("{}", LightningModuleError::MissingPreimage)
+    );
 
     // Ok
     let account_input_witness = ContractInput {
@@ -211,7 +214,10 @@ async fn test_incoming() {
         witness: None,
     };
     let error = fed.verify_input(&incoming_input).unwrap_err();
-    assert_eq!(error, LightningModuleError::ContractNotReady);
+    assert_eq!(
+        format!("{error}"),
+        format!("{}", LightningModuleError::ContractNotReady)
+    );
 
     fed.consensus_round(&[], &[]).await;
     match fed.output_outcome(incoming_out_point).unwrap() {


### PR DESCRIPTION
Currently `FedimintModule` trait uses errors that are imported from the specific modules. This is not possible in a post-modularization code.

As a initial step toward modularization, make all the errors returned by the server side module abstract (anyhow::Error).

In the future we might want to specify some concrete Error variants with `Other` being just an escape hatch.