### PR TITLE
Attempt gateway registration with retry

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cln;
 pub mod config;
 pub mod ln;
 pub mod rpc;
+pub mod utils;
 pub mod webserver;
 
 use std::borrow::Cow;

--- a/gateway/ln-gateway/src/utils.rs
+++ b/gateway/ln-gateway/src/utils.rs
@@ -1,0 +1,37 @@
+use std::{future::Future, result::Result, time::Duration};
+
+use tokio::time::sleep;
+use tracing::info;
+
+/// Retry an operation util the operation succeeds, OR
+/// The maximum number of attempts are made without success
+pub async fn retry<F, R, T>(
+    op_name: String,
+    op_fn: F,
+    wait: Duration,
+    max_retries: u32,
+) -> Result<T, anyhow::Error>
+where
+    F: Fn() -> R,
+    R: Future<Output = Result<T, anyhow::Error>>,
+{
+    let mut att = 0;
+    loop {
+        match op_fn().await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                att += 1;
+                if att > max_retries {
+                    return Err(e);
+                }
+                info!(
+                    "{} failed with error: {}. Retrying in {} seconds",
+                    op_name,
+                    e,
+                    wait.as_secs()
+                );
+                sleep(wait).await;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Starting the gateway CLN plugin runs the gateway. On run, the gateway attempts to register with a federation. If the federation is not ready, the gateway registration call fails, which in turn would fail the CLN plugin start.

The recent change to encrypt configs at rest (https://github.com/fedimint/fedimint/pull/808) marginally slows down the federation start, which then leads into the situation described above.

This PR attempts to use retries for the gateway registration action, instead of relying on timing to sequence the boot process.