### PR TITLE
fixes a bug where filtered txs stay proposed

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -272,6 +272,8 @@ impl FedimintConsensus {
                     &format!("{:?}", TransactionSubmissionError::TransactionConflictError),
                 )
                 .expect("DB Error");
+                dbtx.remove_entry(&ProposedTransactionKey(transaction.tx_hash()))
+                    .expect("DB Error");
             }
 
             let caches = self.build_verification_caches(ok_tx.iter());


### PR DESCRIPTION
Fixes a bug that caused `peg_outs_are_only_allowed_once_per_epoch` to stall.

The user submits 2 conflicting txs, one of which will be filtered out, then the user reissues the coins from the failed tx.  We were not removing the conflicting tx from the database which could cause a conflict with the reissue transaction.

The reason the test stalls rather than fails is because the the epoch isn't empty (contains failed tx), but there are no new tx notifications or proposals to trigger a new consensus epoch.

Not sure why this failure is popping up now, bug has existed for some time.