### PR TITLE
Improve shutdown and panic handling - TaskGroup everything

### DIFF
--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -40,7 +40,7 @@ gloo-timers = { version = "0.2.4", features = ["futures"] }
 wasm-bindgen-futures = "0.4.33"
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "sync", "time", "signal"] }
 
 [dev-dependencies]
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -21,6 +21,7 @@ use tbs::serde_impl;
 use tbs::Scalar;
 
 use crate::net::peers::AnyPeerConnections;
+use crate::task::TaskGroup;
 use crate::PeerId;
 
 /// Part of a config that needs to be generated to bootstrap a new federation.
@@ -50,6 +51,7 @@ pub trait GenerateConfig: Sized {
         peers: &[PeerId],
         params: &Self::Params,
         rng: impl RngCore + CryptoRng,
+        task_group: &mut TaskGroup,
     ) -> Result<(Self, Self::ClientConfig), Self::ConfigError>;
 }
 

--- a/fedimint-api/src/net/peers.rs
+++ b/fedimint-api/src/net/peers.rs
@@ -26,10 +26,14 @@ where
     ///
     /// The message is sent immediately and cached if the peer is reachable and only cached
     /// otherwise.
-    async fn send(&mut self, peers: &[PeerId], msg: T);
+    ///
+    /// Returns `None` during process shutdown
+    async fn send(&mut self, peers: &[PeerId], msg: T) -> Option<()>;
 
     /// Await receipt of a message from any connected peer.
-    async fn receive(&mut self) -> (PeerId, T);
+    ///
+    /// Returns `None` during process shutdown
+    async fn receive(&mut self) -> Option<(PeerId, T)>;
 
     /// Removes a peer connection in case of misbehavior
     async fn ban_peer(&mut self, peer: PeerId);

--- a/fedimint-api/src/task.rs
+++ b/fedimint-api/src/task.rs
@@ -9,7 +9,10 @@ use futures::lock::Mutex;
 pub use imp::*;
 use thiserror::Error;
 #[cfg(not(target_family = "wasm"))]
+use tokio::sync::oneshot;
+#[cfg(not(target_family = "wasm"))]
 use tokio::task::JoinHandle;
+use tracing::debug;
 use tracing::info;
 #[cfg(target_family = "wasm")]
 type JoinHandle<T> = futures::future::Ready<anyhow::Result<T>>;
@@ -22,9 +25,24 @@ pub struct Elapsed;
 struct TaskGroupInner {
     /// Was the shutdown requested, either externally or due to any task failure?
     is_shutting_down: AtomicBool,
+    on_shutdown: Mutex<Vec<Box<dyn FnOnce() + Send>>>,
     join: Mutex<Vec<(String, JoinHandle<()>)>>,
 }
 
+impl TaskGroupInner {
+    pub async fn shutdown(&self) {
+        loop {
+            let f_opt = self.on_shutdown.lock().await.pop();
+
+            if let Some(f) = f_opt {
+                f();
+            } else {
+                break;
+            }
+        }
+        self.is_shutting_down.store(true, SeqCst);
+    }
+}
 /// A group of task working together
 ///
 /// Using this struct it is possible to spawn one or more
@@ -51,6 +69,15 @@ impl TaskGroup {
         }
     }
 
+    pub async fn shutdown(&self) {
+        self.inner.shutdown().await
+    }
+
+    pub async fn shutdown_join_all(self) -> anyhow::Result<()> {
+        self.shutdown().await;
+        self.join_all().await
+    }
+
     #[cfg(not(target_family = "wasm"))]
     pub async fn spawn<Fut>(
         &mut self,
@@ -75,6 +102,29 @@ impl TaskGroup {
         guard.completed = true;
     }
 
+    #[cfg(not(target_family = "wasm"))]
+    pub async fn spawn_local<Fut>(
+        &mut self,
+        name: impl Into<String>,
+        f: impl FnOnce(TaskHandle) -> Fut + 'static,
+    ) where
+        Fut: Future<Output = ()> + 'static,
+    {
+        let name = name.into();
+        let mut guard = TaskPanicGuard {
+            name: name.clone(),
+            inner: self.inner.clone(),
+            completed: false,
+        };
+        let handle = self.make_handle();
+
+        if let Some(handle) = self::imp::spawn_local(async move {
+            f(handle).await;
+        }) {
+            self.inner.join.lock().await.push((name, handle));
+        }
+        guard.completed = true;
+    }
     // TODO: Send vs lack of Send bound; do something about it
     #[cfg(target_family = "wasm")]
     pub async fn spawn<Fut>(
@@ -100,14 +150,12 @@ impl TaskGroup {
         guard.completed = true;
     }
 
-    pub fn shutdown(&self) {
-        self.inner.is_shutting_down.store(true, SeqCst);
-    }
-
     pub async fn join_all(self) -> anyhow::Result<()> {
         for (name, join) in self.inner.join.lock().await.drain(..) {
+            debug!("Waiting for {name} task to finish");
             join.await
-                .map_err(|e| anyhow!("Thread {name} panicked with: {e}"))?
+                .map_err(|e| anyhow!("Thread {name} panicked with: {e}"))?;
+            debug!("{name} task finished.");
         }
         Ok(())
     }
@@ -143,8 +191,30 @@ pub struct TaskHandle {
 }
 
 impl TaskHandle {
+    /// Is task group shutting down?
+    ///
+    /// Every task in a task group should detect and stop if `true`.
     pub fn is_shutting_down(&self) -> bool {
         self.inner.is_shutting_down.load(SeqCst)
+    }
+
+    pub async fn on_shutdown(&self, f: impl FnOnce() + Send + 'static) {
+        self.inner.on_shutdown.lock().await.push(Box::new(f))
+    }
+
+    /// Make a [`oneshot::Receiver`] that will fire on shutdown
+    ///
+    /// Tasks can use `select` on the return value to handle shutdown
+    /// signal during otherwise blocking operation.
+    #[cfg(not(target_family = "wasm"))]
+    pub async fn make_shutdown_rx(&self) -> oneshot::Receiver<()> {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        self.on_shutdown(|| {
+            let _ = shutdown_tx.send(());
+        })
+        .await;
+
+        shutdown_rx
     }
 }
 
@@ -159,6 +229,13 @@ mod imp {
         F: Future<Output = ()> + Send + 'static,
     {
         Some(tokio::spawn(future))
+    }
+
+    pub(crate) fn spawn_local<F>(future: F) -> Option<JoinHandle<()>>
+    where
+        F: Future<Output = ()> + 'static,
+    {
+        Some(tokio::task::spawn_local(future))
     }
 
     pub fn block_in_place<F, R>(f: F) -> R
@@ -200,6 +277,14 @@ mod imp {
     {
         wasm_bindgen_futures::spawn_local(future);
         None
+    }
+
+    pub(crate) fn spawn_local<F>(future: F) -> Option<JoinHandle<()>>
+    where
+        // No Send needed on wasm
+        F: Future<Output = ()> + 'static,
+    {
+        self::spawn(future)
     }
 
     pub fn block_in_place<F, R>(f: F) -> R

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use fedimint_api::net::peers::PeerConnections;
+use fedimint_api::task::{TaskGroup, TaskHandle};
 use fedimint_api::PeerId;
 use fedimint_core::config::Node;
 use futures::future::select_all;
@@ -20,7 +21,6 @@ use rand::{thread_rng, Rng};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{Receiver, Sender};
-use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tracing::{debug, error, info, instrument, trace, warn};
 use url::Url;
@@ -44,13 +44,11 @@ pub type PeerConnector<M> = AnyConnector<PeerMessage<M>>;
 /// encrypted.
 pub struct ReconnectPeerConnections<T> {
     connections: HashMap<PeerId, PeerConnection<T>>,
-    _listen_task: JoinHandle<()>,
 }
 
 struct PeerConnection<T> {
     outgoing: Sender<T>,
     incoming: Receiver<T>,
-    _io_task: JoinHandle<()>,
 }
 
 /// Specifies the network configuration for federation-internal communication
@@ -130,7 +128,11 @@ where
     /// [`Connector`](crate::net::connect::Connector). See [`ReconnectPeerConnections`] for
     /// requirements on the `Connector`.
     #[instrument(skip_all)]
-    pub async fn new(cfg: NetworkConfig, connect: PeerConnector<T>) -> Self {
+    pub async fn new(
+        cfg: NetworkConfig,
+        connect: PeerConnector<T>,
+        task_group: &mut TaskGroup,
+    ) -> Self {
         let shared_connector: SharedAnyConnector<PeerMessage<T>> = connect.into();
 
         let (connection_senders, connections) = cfg
@@ -149,36 +151,42 @@ where
                             cfg.clone(),
                             shared_connector.clone(),
                             connection_receiver,
+                            task_group,
                         ),
                     ),
                 )
             })
             .unzip();
 
-        let listen_task = tokio::spawn(Self::run_listen_task(
-            cfg,
-            shared_connector,
-            connection_senders,
-        ));
+        task_group
+            .spawn("listen task", move |handle| {
+                Self::run_listen_task(cfg, shared_connector, connection_senders, handle)
+            })
+            .await;
 
-        ReconnectPeerConnections {
-            connections,
-            _listen_task: listen_task,
-        }
+        ReconnectPeerConnections { connections }
     }
 
     async fn run_listen_task(
         cfg: NetworkConfig,
         connect: SharedAnyConnector<PeerMessage<T>>,
         mut connection_senders: HashMap<PeerId, Sender<AnyFramedTransport<PeerMessage<T>>>>,
+        task_handle: TaskHandle,
     ) {
         let mut listener = connect
             .listen(cfg.bind_addr.clone())
             .await
             .expect("Could not bind port");
 
-        loop {
-            let (peer, connection) = match listener.next().await.expect("Listener closed") {
+        let mut shutdown_rx = task_handle.make_shutdown_rx().await;
+
+        while !task_handle.is_shutting_down() {
+            let new_connection = tokio::select! {
+                maybe_msg = listener.next() => { maybe_msg },
+                _ = &mut shutdown_rx => { break; },
+            };
+
+            let (peer, connection) = match new_connection.expect("Listener closed") {
                 Ok(connection) => connection,
                 Err(e) => {
                     error!(mint = ?cfg.identity, err = %e, "Error while opening incoming connection");
@@ -258,9 +266,13 @@ impl<M> PeerConnectionStateMachine<M>
 where
     M: Debug + Clone,
 {
-    async fn run(mut self) {
-        while let Some(new_self) = self.state_transition().await {
-            self = new_self;
+    async fn run(mut self, task_handle: &TaskHandle) {
+        while !task_handle.is_shutting_down() {
+            if let Some(new_self) = self.state_transition().await {
+                self = new_self;
+            } else {
+                break;
+            }
         }
     }
 
@@ -517,23 +529,30 @@ where
         cfg: ConnectionConfig,
         connect: SharedAnyConnector<PeerMessage<M>>,
         incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,
+        task_group: &mut TaskGroup,
     ) -> PeerConnection<M> {
         let (outgoing_sender, outgoing_receiver) = tokio::sync::mpsc::channel::<M>(1024);
         let (incoming_sender, incoming_receiver) = tokio::sync::mpsc::channel::<M>(1024);
 
-        let io_thread = tokio::spawn(Self::run_io_thread(
-            incoming_sender,
-            outgoing_receiver,
-            id,
-            cfg,
-            connect,
-            incoming_connections,
+        futures::executor::block_on(task_group.spawn(
+            format!("io-thread-peer-{}", id),
+            move |handle| async move {
+                Self::run_io_thread(
+                    incoming_sender,
+                    outgoing_receiver,
+                    id,
+                    cfg,
+                    connect,
+                    incoming_connections,
+                    &handle,
+                )
+                .await
+            },
         ));
 
         PeerConnection {
             outgoing: outgoing_sender,
             incoming: incoming_receiver,
-            _io_task: io_thread,
         }
     }
 
@@ -553,6 +572,7 @@ where
         cfg: ConnectionConfig,
         connect: SharedAnyConnector<PeerMessage<M>>,
         incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,
+        task_handle: &TaskHandle,
     ) {
         let common = CommonPeerConnectionState {
             resend_queue: Default::default(),
@@ -571,7 +591,7 @@ where
             state: initial_state,
         };
 
-        state_machine.run().await
+        state_machine.run(task_handle).await;
     }
 }
 
@@ -580,6 +600,7 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
+    use fedimint_api::task::TaskGroup;
     use fedimint_api::PeerId;
     use futures::Future;
     use tracing_subscriber::EnvFilter;
@@ -605,45 +626,51 @@ mod tests {
                     .unwrap_or_else(|_| EnvFilter::new("info,fedimint::net=trace")),
             )
             .init();
+        let task_group = TaskGroup::new();
 
-        let net = MockNetwork::new();
+        {
+            let net = MockNetwork::new();
 
-        let peers = ["a", "b", "c"]
-            .iter()
-            .enumerate()
-            .map(|(idx, &peer)| {
-                let cfg = ConnectionConfig {
-                    address: peer.to_string(),
+            let peers = ["a", "b", "c"]
+                .iter()
+                .enumerate()
+                .map(|(idx, &peer)| {
+                    let cfg = ConnectionConfig {
+                        address: peer.to_string(),
+                    };
+                    (PeerId::from(idx as u16 + 1), cfg)
+                })
+                .collect::<HashMap<_, _>>();
+
+            let peers_ref = &peers;
+            let net_ref = &net;
+            let build_peers = move |bind: &'static str, id: u16, mut task_group: TaskGroup| async move {
+                let cfg = NetworkConfig {
+                    identity: PeerId::from(id),
+                    bind_addr: bind.to_string(),
+                    peers: peers_ref.clone(),
                 };
-                (PeerId::from(idx as u16 + 1), cfg)
-            })
-            .collect::<HashMap<_, _>>();
-
-        let peers_ref = &peers;
-        let net_ref = &net;
-        let build_peers = |bind: &'static str, id: u16| async move {
-            let cfg = NetworkConfig {
-                identity: PeerId::from(id),
-                bind_addr: bind.to_string(),
-                peers: peers_ref.clone(),
+                let connect = net_ref.connector(cfg.identity).into_dyn();
+                ReconnectPeerConnections::<u64>::new(cfg, connect, &mut task_group).await
             };
-            let connect = net_ref.connector(cfg.identity).into_dyn();
-            ReconnectPeerConnections::<u64>::new(cfg, connect).await
-        };
 
-        let mut peers_a = build_peers("a", 1).await;
-        let mut peers_b = build_peers("b", 2).await;
+            let mut peers_a = build_peers("a", 1, task_group.clone()).await;
+            let mut peers_b = build_peers("b", 2, task_group.clone()).await;
 
-        peers_a.send(&[PeerId::from(2)], 42).await;
-        let recv = timeout(peers_b.receive()).await.unwrap();
-        assert_eq!(recv.0, PeerId::from(1));
-        assert_eq!(recv.1, 42);
+            peers_a.send(&[PeerId::from(2)], 42).await;
+            let recv = timeout(peers_b.receive()).await.unwrap();
+            assert_eq!(recv.0, PeerId::from(1));
+            assert_eq!(recv.1, 42);
 
-        peers_a.send(&[PeerId::from(3)], 21).await;
+            peers_a.send(&[PeerId::from(3)], 21).await;
 
-        let mut peers_c = build_peers("c", 3).await;
-        let recv = timeout(peers_c.receive()).await.unwrap();
-        assert_eq!(recv.0, PeerId::from(1));
-        assert_eq!(recv.1, 21);
+            let mut peers_c = build_peers("c", 3, task_group.clone()).await;
+            let recv = timeout(peers_c.receive()).await.unwrap();
+            assert_eq!(recv.0, PeerId::from(1));
+            assert_eq!(recv.1, 21);
+        }
+
+        task_group.shutdown().await;
+        task_group.join_all().await.unwrap();
     }
 }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -11,7 +11,8 @@ use fedimint_server::FedimintServer;
 use fedimint_wallet::Wallet;
 use fedimintd::encrypt::*;
 use fedimintd::ui::run_ui;
-use tokio::spawn;
+use tokio::signal;
+use tracing::info;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer;
@@ -68,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
 
     if let Some(ui_port) = opts.ui_port {
         // Spawn UI, wait for it to finish
-        spawn(run_ui(opts.cfg_path.clone(), sender, ui_port));
+        tokio::spawn(run_ui(opts.cfg_path.clone(), sender, ui_port));
         receiver
             .recv()
             .await
@@ -89,6 +90,15 @@ async fn main() -> anyhow::Result<()> {
     let mut task_group = TaskGroup::new();
     let local_task_set = tokio::task::LocalSet::new();
     let _guard = local_task_set.enter();
+
+    tokio::spawn({
+        let task_group = task_group.clone();
+        async move {
+            wait_for_shutdown_signal().await;
+            info!("signal received, starting graceful shutdown");
+            task_group.shutdown().await;
+        }
+    });
 
     let mint = fedimint_core::modules::mint::Mint::new(cfg.mint.clone(), db.clone());
 
@@ -112,4 +122,28 @@ async fn main() -> anyhow::Result<()> {
     opentelemetry::global::shutdown_tracer_provider();
 
     Ok(())
+}
+
+async fn wait_for_shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
 }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -89,18 +89,19 @@ pub fn secp() -> secp256k1::Secp256k1<secp256k1::All> {
     bitcoin::secp256k1::Secp256k1::new()
 }
 
+#[non_exhaustive]
+pub struct Fixtures {
+    pub fed: FederationTest,
+    pub user: UserTest,
+    pub bitcoin: Box<dyn BitcoinTest>,
+    pub gateway: GatewayTest,
+    pub lightning: Box<dyn LightningTest>,
+    pub task_group: TaskGroup,
+}
+
 /// Generates the fixtures for an integration test and spawns API and HBBFT consensus threads for
 /// federation nodes starting at port 4000.
-pub async fn fixtures(
-    num_peers: u16,
-    amount_tiers: &[Amount],
-) -> anyhow::Result<(
-    FederationTest,
-    UserTest,
-    Box<dyn BitcoinTest>,
-    GatewayTest,
-    Box<dyn LightningTest>,
-)> {
+pub async fn fixtures(num_peers: u16, amount_tiers: &[Amount]) -> anyhow::Result<Fixtures> {
     let mut task_group = TaskGroup::new();
     let base_port = BASE_PORT.fetch_add(num_peers * 10, Ordering::Relaxed);
 
@@ -171,7 +172,14 @@ pub async fn fixtures(
             )
             .await;
 
-            Ok((fed, user, Box::new(bitcoin), gateway, Box::new(lightning)))
+            Ok(Fixtures {
+                fed,
+                user,
+                bitcoin: Box::new(bitcoin),
+                gateway,
+                lightning: Box::new(lightning),
+                task_group,
+            })
         }
         _ => {
             info!("Testing with FAKE Bitcoin and Lightning services");
@@ -209,7 +217,14 @@ pub async fn fixtures(
             )
             .await;
 
-            Ok((fed, user, Box::new(bitcoin), gateway, Box::new(lightning)))
+            Ok(Fixtures {
+                fed,
+                user,
+                bitcoin: Box::new(bitcoin),
+                gateway,
+                lightning: Box::new(lightning),
+                task_group,
+            })
         }
     }
 }

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -13,7 +13,7 @@ use fedimint_server::epoch::ConsensusItem;
 use fedimint_server::transaction::Output;
 use fedimint_wallet::PegOutSignatureItem;
 use fedimint_wallet::WalletConsensusItem::PegOutSignature;
-use fixtures::{fixtures, rng, sats, secp, sha256};
+use fixtures::{fixtures, rng, sats, secp, sha256, Fixtures};
 use futures::executor::block_on;
 use futures::future::{join_all, Either};
 use mint_client::transaction::TransactionBuilder;
@@ -28,7 +28,13 @@ use crate::fixtures::FederationTest;
 async fn peg_in_and_peg_out_with_fees() -> anyhow::Result<()> {
     let peg_in_amount: u64 = 5000;
     let peg_out_amount: u64 = 1200; // amount requires minted change
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
 
     let peg_in_address = user.client.get_new_pegin_address(rng());
     let (proof, tx) = bitcoin.send_and_mine_block(&peg_in_address, Amount::from_sat(peg_in_amount));
@@ -70,12 +76,18 @@ async fn peg_in_and_peg_out_with_fees() -> anyhow::Result<()> {
         .await;
     assert_eq!(fed.max_balance_sheet(), 0);
 
-    Ok(())
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_outs_are_rejected_if_fees_are_too_low() -> Result<()> {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
     let peg_out_amount = Amount::from_sat(1000);
     let peg_out_address = bitcoin.get_new_address();
 
@@ -91,12 +103,18 @@ async fn peg_outs_are_rejected_if_fees_are_too_low() -> Result<()> {
     // TODO: return a better error message to clients
     assert!(user.client.peg_out(peg_out, rng()).await.is_err());
 
-    Ok(())
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_outs_are_only_allowed_once_per_epoch() -> Result<()> {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
     let address1 = bitcoin.get_new_address();
     let address2 = bitcoin.get_new_address();
 
@@ -115,12 +133,18 @@ async fn peg_outs_are_only_allowed_once_per_epoch() -> Result<()> {
     fed.run_consensus_epochs(2).await; // reissue the coins from the tx that failed
     user.assert_total_coins(sats(5000 - 1000) - fees).await;
 
-    Ok(())
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_outs_must_wait_for_available_utxos() -> Result<()> {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
     let address1 = bitcoin.get_new_address();
     let address2 = bitcoin.get_new_address();
 
@@ -144,12 +168,18 @@ async fn peg_outs_must_wait_for_available_utxos() -> Result<()> {
     fed.broadcast_transactions().await;
     assert_eq!(bitcoin.mine_block_and_get_received(&address2), sats(2000));
 
-    Ok(())
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ecash_can_be_exchanged_directly_between_users() -> Result<()> {
-    let (fed, user_send, bitcoin, _, _) = fixtures(4, &[sats(10), sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user: user_send,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(4, &[sats(10), sats(100), sats(1000)]).await?;
     let user_receive = user_send.new_client(&[0, 1, 2]);
 
     fed.mine_and_mint(&user_send, &*bitcoin, sats(5000)).await;
@@ -163,12 +193,19 @@ async fn ecash_can_be_exchanged_directly_between_users() -> Result<()> {
     user_send.assert_total_coins(sats(1500)).await;
     user_receive.assert_total_coins(sats(3500)).await;
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ecash_cannot_double_spent_with_different_nodes() -> Result<()> {
-    let (fed, user1, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user: user1,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(100), sats(1000)]).await?;
     fed.mine_and_mint(&user1, &*bitcoin, sats(5000)).await;
     let ecash = fed.spend_ecash(&user1, sats(2000)).await;
 
@@ -182,12 +219,19 @@ async fn ecash_cannot_double_spent_with_different_nodes() -> Result<()> {
     assert!(res2.is_err() || res3.is_err()); //no double spend
     assert_eq!(user2.total_coins() + user3.total_coins(), sats(2000));
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ecash_in_wallet_can_sent_through_a_tx() -> Result<()> {
-    let (fed, user_send, bitcoin, _, _) = fixtures(2, &[sats(100), sats(500)]).await?;
+    let Fixtures {
+        fed,
+        user: user_send,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(100), sats(500)]).await?;
     let user_receive = user_send.new_client(&[0]);
 
     fed.mine_and_mint(&user_send, &*bitcoin, sats(1100)).await;
@@ -210,7 +254,8 @@ async fn ecash_in_wallet_can_sent_through_a_tx() -> Result<()> {
         .assert_coin_amounts(vec![sats(100), sats(100), sats(500)])
         .await;
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 async fn drop_peer_3_during_epoch(fed: &FederationTest) {
@@ -231,8 +276,13 @@ async fn drop_peer_3_during_epoch(fed: &FederationTest) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn drop_peers_who_dont_contribute_peg_out_psbts() -> Result<()> {
-    let (fed, user, bitcoin, _, _) =
-        fixtures(4, &[sats(1), sats(10), sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(4, &[sats(1), sats(10), sats(100), sats(1000)]).await?;
     fed.mine_and_mint(&user, &*bitcoin, sats(3000)).await;
 
     let peg_out_address = bitcoin.get_new_address();
@@ -251,12 +301,20 @@ async fn drop_peers_who_dont_contribute_peg_out_psbts() -> Result<()> {
     );
     assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn drop_peers_who_dont_contribute_decryption_shares() -> Result<()> {
-    let (fed, user, bitcoin, gateway, _) = fixtures(4, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        gateway,
+        task_group,
+        ..
+    } = fixtures(4, &[sats(100), sats(1000)]).await?;
     let payment_amount = sats(2000);
     fed.mine_and_mint(&gateway.user, &*bitcoin, sats(3000))
         .await;
@@ -297,12 +355,19 @@ async fn drop_peers_who_dont_contribute_decryption_shares() -> Result<()> {
     user.assert_total_coins(payment_amount).await;
     assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn drop_peers_who_dont_contribute_blind_sigs() -> Result<()> {
-    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(4, &[sats(100), sats(1000)]).await?;
     fed.mine_spendable_utxo(&user, &*bitcoin, Amount::from_sat(2000));
     fed.database_add_coins_for_user(&user, sats(2000));
 
@@ -311,12 +376,19 @@ async fn drop_peers_who_dont_contribute_blind_sigs() -> Result<()> {
 
     user.assert_total_coins(sats(2000)).await;
     assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn drop_peers_who_contribute_bad_sigs() -> Result<()> {
-    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(4, &[sats(100), sats(1000)]).await?;
     fed.mine_spendable_utxo(&user, &*bitcoin, Amount::from_sat(2000));
     let out_point = fed.database_add_coins_for_user(&user, sats(2000));
     let bad_proposal = vec![ConsensusItem::Mint(PartiallySignedRequest {
@@ -329,13 +401,21 @@ async fn drop_peers_who_contribute_bad_sigs() -> Result<()> {
 
     user.assert_total_coins(sats(2000)).await;
     assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn lightning_gateway_pays_internal_invoice() -> Result<()> {
-    let (fed, sending_user, bitcoin, gateway, lightning) =
-        fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user: sending_user,
+        bitcoin,
+        gateway,
+        lightning,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
 
     // Fund the gateway so it can route internal payments
     fed.mine_and_mint(&gateway.user, &*bitcoin, sats(2000))
@@ -418,13 +498,21 @@ async fn lightning_gateway_pays_internal_invoice() -> Result<()> {
 
     assert_eq!(lightning.amount_sent().await, sats(0)); // We did not route any payments over the lightning network
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn lightning_gateway_pays_outgoing_invoice() -> Result<()> {
-    let (fed, user, bitcoin, gateway, lightning) =
-        fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        gateway,
+        lightning,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
     let invoice = lightning.invoice(sats(1000), None).await;
 
     fed.mine_and_mint(&user, &*bitcoin, sats(2000)).await;
@@ -464,13 +552,21 @@ async fn lightning_gateway_pays_outgoing_invoice() -> Result<()> {
     tokio::time::sleep(Duration::from_millis(500)).await; // FIXME need to wait for listfunds to update
     assert_eq!(lightning.amount_sent().await, sats(1000));
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn lightning_gateway_claims_refund_for_internal_invoice() -> Result<()> {
-    let (fed, sending_user, bitcoin, gateway, lightning) =
-        fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user: sending_user,
+        bitcoin,
+        gateway,
+        lightning,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(100), sats(1000)]).await?;
 
     // Fund the gateway so it can route internal payments
     fed.mine_and_mint(&gateway.user, &*bitcoin, sats(2000))
@@ -530,22 +626,35 @@ async fn lightning_gateway_claims_refund_for_internal_invoice() -> Result<()> {
 
     assert_eq!(lightning.amount_sent().await, sats(0)); // We did not route any payments over the lightning network
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn set_lightning_invoice_expiry() -> Result<()> {
-    let (_, _, _, _, lightning) = fixtures(2, &[sats(10), sats(1000)]).await?;
+    let Fixtures {
+        lightning,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(1000)]).await?;
     let invoice = lightning.invoice(sats(1000), 600.into());
     assert_eq!(invoice.await.expiry_time(), Duration::from_secs(600));
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn receive_lightning_payment_valid_preimage() -> Result<()> {
     let starting_balance = sats(2000);
     let preimage_price = sats(100);
-    let (fed, user, bitcoin, gateway, _) = fixtures(2, &[sats(1000), sats(100)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        gateway,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(1000), sats(100)]).await?;
     fed.mine_and_mint(&gateway.user, &*bitcoin, starting_balance)
         .await;
     assert_eq!(user.total_coins(), sats(0));
@@ -606,14 +715,22 @@ async fn receive_lightning_payment_valid_preimage() -> Result<()> {
         .await;
     user.assert_total_coins(preimage_price).await;
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn receive_lightning_payment_invalid_preimage() -> Result<()> {
     let starting_balance = sats(2000);
     let payment_amount = sats(100);
-    let (fed, user, bitcoin, gateway, _) = fixtures(2, &[sats(1000), sats(100)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        gateway,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(1000), sats(100)]).await?;
     fed.mine_and_mint(&gateway.user, &*bitcoin, starting_balance)
         .await;
     assert_eq!(user.total_coins(), sats(0));
@@ -670,12 +787,21 @@ async fn receive_lightning_payment_invalid_preimage() -> Result<()> {
     gateway.user.assert_total_coins(starting_balance).await;
     user.assert_total_coins(sats(0)).await;
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn lightning_gateway_cannot_claim_invalid_preimage() -> Result<()> {
-    let (fed, user, bitcoin, gateway, lightning) = fixtures(2, &[sats(10), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        gateway,
+        lightning,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(1000)]).await?;
     let invoice = lightning.invoice(sats(1000), None);
 
     fed.mine_and_mint(&user, &*bitcoin, sats(1010)).await; // 1% LN fee
@@ -705,12 +831,21 @@ async fn lightning_gateway_cannot_claim_invalid_preimage() -> Result<()> {
         .count();
     assert_eq!(ln_items, 0);
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn lightning_gateway_can_abort_payment_to_return_user_funds() -> Result<()> {
-    let (fed, user, bitcoin, gateway, lightning) = fixtures(2, &[sats(10), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        gateway,
+        lightning,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(10), sats(1000)]).await?;
     let invoice = lightning.invoice(sats(1000), None);
 
     fed.mine_and_mint(&user, &*bitcoin, sats(1010)).await; // 1% LN fee
@@ -746,12 +881,19 @@ async fn lightning_gateway_can_abort_payment_to_return_user_funds() -> Result<()
     user.client.fetch_coins(outpoint).await.unwrap();
     assert_eq!(user.total_coins(), sats(1010));
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn runs_consensus_if_tx_submitted() -> Result<()> {
-    let (fed, user_send, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user: user_send,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(100), sats(1000)]).await?;
     let user_receive = user_send.new_client(&[0]);
 
     fed.mine_and_mint(&user_send, &*bitcoin, sats(5000)).await;
@@ -771,12 +913,19 @@ async fn runs_consensus_if_tx_submitted() -> Result<()> {
 
     user_receive.assert_total_coins(sats(5000)).await;
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn runs_consensus_if_new_block() -> Result<()> {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(100), sats(1000)]).await?;
     let peg_in_address = user.client.get_new_pegin_address(rng());
     bitcoin.mine_blocks(100);
     let (proof, tx) = bitcoin.send_and_mine_block(&peg_in_address, Amount::from_sat(1000));
@@ -796,21 +945,36 @@ async fn runs_consensus_if_new_block() -> Result<()> {
     fed.run_consensus_epochs(2).await; // peg-in + blind sign
     user.assert_total_coins(sats(1000)).await;
     assert_eq!(fed.max_balance_sheet(), 0);
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[should_panic]
 async fn audit_negative_balance_sheet_panics() {
-    if let Ok((fed, user, _, _, _)) = fixtures(2, &[sats(100), sats(1000)]).await {
+    if let Ok(Fixtures {
+        fed,
+        user,
+        task_group,
+        ..
+    }) = fixtures(2, &[sats(100), sats(1000)]).await
+    {
         fed.mint_coins_for_user(&user, sats(2000)).await;
         fed.run_consensus_epochs(1).await;
+        task_group.shutdown_join_all().await.unwrap();
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn unbalanced_transactions_get_rejected() -> Result<()> {
-    let (fed, user, bitcoin, _, lightning) = fixtures(2, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        lightning,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(100), sats(1000)]).await?;
     // cannot make change for this invoice (results in unbalanced tx)
     let invoice = lightning.invoice(sats(777), None);
 
@@ -822,20 +986,34 @@ async fn unbalanced_transactions_get_rejected() -> Result<()> {
 
     // TODO return a more useful error
     assert!(response.is_err());
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_have_federations_with_one_peer() -> Result<()> {
-    let (fed, user, bitcoin, _, _) = fixtures(1, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(1, &[sats(100), sats(1000)]).await?;
     fed.mine_and_mint(&user, &*bitcoin, sats(1000)).await;
     user.assert_total_coins(sats(1000)).await;
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_signed_epoch_history() -> Result<()> {
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(100), sats(1000)]).await?;
 
     fed.mine_and_mint(&user, &*bitcoin, sats(1000)).await;
     fed.mine_and_mint(&user, &*bitcoin, sats(1000)).await;
@@ -847,12 +1025,19 @@ async fn can_get_signed_epoch_history() -> Result<()> {
     assert_eq!(epoch0.verify_sig(&pubkey), Ok(()));
     assert_eq!(epoch0.verify_hash(&None), Ok(()));
     assert_eq!(epoch1.verify_hash(&Some(epoch0)), Ok(()));
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rejoin_consensus_single_peer() -> Result<()> {
-    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        user,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(4, &[sats(100), sats(1000)]).await?;
 
     // Keep peer 3 out of consensus
     bitcoin.mine_blocks(110);
@@ -877,12 +1062,18 @@ async fn rejoin_consensus_single_peer() -> Result<()> {
         user.client.await_consensus_block_height(height).await?,
         height
     );
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rejoin_consensus_threshold_peers() -> Result<()> {
-    let (fed, _, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await?;
+    let Fixtures {
+        fed,
+        bitcoin,
+        task_group,
+        ..
+    } = fixtures(2, &[sats(100), sats(1000)]).await?;
     let peer0 = fed.subset_peers(&[0]);
     let peer1 = fed.subset_peers(&[1]);
 
@@ -900,5 +1091,6 @@ async fn rejoin_consensus_threshold_peers() -> Result<()> {
 
     // confirm that the entire federation can rejoin at an epoch
     timeout(Duration::from_secs(15), rejoin).await.unwrap();
-    Ok(())
+
+    task_group.shutdown_join_all().await
 }

--- a/modules/fedimint-ln/src/config.rs
+++ b/modules/fedimint-ln/src/config.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use fedimint_api::config::{DkgMessage, DkgRunner, GenerateConfig};
 use fedimint_api::net::peers::AnyPeerConnections;
+use fedimint_api::task::TaskGroup;
 use fedimint_api::{NumPeers, PeerId};
 use secp256k1::rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -87,6 +88,7 @@ impl GenerateConfig for LightningModuleConfig {
         peers: &[PeerId],
         _params: &Self::Params,
         mut rng: impl RngCore + CryptoRng,
+        _task_group: &mut TaskGroup,
     ) -> Result<(Self, Self::ClientConfig), Self::ConfigError> {
         let mut dkg = DkgRunner::new((), peers.threshold(), our_id, peers);
         let (pks, sks) = dkg.run_g1(connections, &mut rng).await[&()].threshold_crypto();

--- a/modules/fedimint-mint/src/config.rs
+++ b/modules/fedimint-mint/src/config.rs
@@ -4,6 +4,7 @@ use std::iter::FromIterator;
 use async_trait::async_trait;
 use fedimint_api::config::{scalar, DkgMessage, DkgRunner, GenerateConfig};
 use fedimint_api::net::peers::AnyPeerConnections;
+use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, NumPeers, PeerId, Tiered, TieredMultiZip};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -117,6 +118,7 @@ impl GenerateConfig for MintConfig {
         peers: &[PeerId],
         params: &Self::Params,
         mut rng: impl RngCore + CryptoRng,
+        _task_group: &mut TaskGroup,
     ) -> Result<(Self, Self::ClientConfig), Self::ConfigError> {
         let mut dkg = DkgRunner::multi(params.to_vec(), peers.threshold(), our_id, peers);
         let amounts_keys = dkg

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -5,6 +5,7 @@ use bitcoin::secp256k1::rand::{CryptoRng, RngCore};
 use bitcoin::Network;
 use fedimint_api::config::{BitcoindRpcCfg, GenerateConfig};
 use fedimint_api::net::peers::AnyPeerConnections;
+use fedimint_api::task::TaskGroup;
 use fedimint_api::{Feerate, NumPeers, PeerId};
 use miniscript::descriptor::Wsh;
 use secp256k1::SecretKey;
@@ -120,6 +121,7 @@ impl GenerateConfig for WalletConfig {
         peers: &[PeerId],
         params: &Self::Params,
         mut rng: impl RngCore + CryptoRng,
+        _task_group: &mut TaskGroup,
     ) -> Result<(Self, Self::ClientConfig), Self::ConfigError> {
         let secp = secp256k1::Secp256k1::new();
         let (sk, pk) = secp.generate_keypair(&mut rng);

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -22,7 +22,9 @@ function open_channel() {
 function await_block_sync() {
   FINALITY_DELAY=$(get_finality_delay)
   EXPECTED_BLOCK_HEIGHT="$(( $($FM_BTC_CLIENT getblockchaininfo | jq -r '.blocks') - $FINALITY_DELAY ))"
+  echo "Node at ${EXPECTED_BLOCK_HEIGHT}H"
   $FM_MINT_CLIENT wait-block-height $EXPECTED_BLOCK_HEIGHT
+  echo "Mint at ${EXPECTED_BLOCK_HEIGHT}H"
 }
 
 function await_server_on_port() {

--- a/scripts/reconnect-test.sh
+++ b/scripts/reconnect-test.sh
@@ -19,6 +19,7 @@ await_block_sync
 sleep 5
 
 # test a peer missing out on epochs and needing to rejoin
+echo "Kill server1..."
 kill $server1
 mine_blocks 100
 await_block_sync
@@ -28,11 +29,14 @@ await_block_sync
 
 # FIXME should await a response from all 4 peers instead of this hack
 sleep 5
+echo "Kill server2..."
 kill $server2
 await_block_sync
 
 # now test what happens if consensus needs to be restarted
+echo "Kill server3..."
 kill $server3
+echo "Kill server4..."
 kill $server4
 ./scripts/start-fed.sh
 mine_blocks 100

--- a/scripts/reconnect-test.sh
+++ b/scripts/reconnect-test.sh
@@ -16,7 +16,7 @@ mine_blocks 110
 await_block_sync
 
 # FIXME should await a response from all 4 peers instead of this hack
-sleep 5
+sleep 15
 
 # test a peer missing out on epochs and needing to rejoin
 echo "Kill server1..."
@@ -28,16 +28,18 @@ await_block_sync
 ./scripts/start-fed.sh
 
 # FIXME should await a response from all 4 peers instead of this hack
-sleep 5
+sleep 15
 echo "Kill server2..."
 kill $server2
 await_block_sync
 
 # now test what happens if consensus needs to be restarted
+sleep 15
 echo "Kill server3..."
 kill $server3
 echo "Kill server4..."
 kill $server4
+sleep 15
 ./scripts/start-fed.sh
 mine_blocks 100
 await_block_sync

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -2,6 +2,8 @@
 
 set -u
 
+echo "Setting up tests..."
+
 FM_FED_SIZE=${1:-4}
 
 source ./scripts/build.sh $FM_FED_SIZE

--- a/scripts/start-fed.sh
+++ b/scripts/start-fed.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Generates the configs and starts the federation nodes
 
+echo "Staring Federation..."
 set -euxo pipefail
 SKIPPED_SERVERS=${1:-0}
 


### PR DESCRIPTION
Follow-through with `TaskGroup`-based improvements.

The fundamental premise here is that shutting down a program is a primary consideration
and code:

* threads should handle shutdown condition gracefully without exploding (panics, weird errors),
* panic in one thread should cause other threads to finish gracefully,
* no panic should go unnoticed,
* tests should spin-down all threads and make sure none of them failed.

In long term this should help debugging and building more sophisticated and larger e2e tests.


I'm not a fan of these `Option<Result<T, SomeError>>` for "cancelleble results", but I guess we could live with them for now, and [upgrade to some better Rust cancellable result handling approach](https://users.rust-lang.org/t/state-of-art-cancellabe-option-result-or-result-option-handling/83420/9) in the future.