### PR TITLE
Do not panic in peer connection IO handling thread.

### DIFF
--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
 
-use crate::ui::Guardian;
 use fedimint_api::config::{BitcoindRpcCfg, GenerateConfig};
 use fedimint_api::{Amount, PeerId};
 use fedimint_core::config::{ClientConfig, Node};
@@ -13,6 +12,8 @@ use rand::rngs::OsRng;
 use rand::{CryptoRng, RngCore};
 use threshold_crypto::serde_impl::SerdeSecret;
 use url::Url;
+
+use crate::ui::Guardian;
 
 pub fn configgen(
     federation_name: String,

--- a/fedimintd/src/ui/mod.rs
+++ b/fedimintd/src/ui/mod.rs
@@ -11,6 +11,7 @@ use axum::{
 };
 use fedimint_api::config::BitcoindRpcCfg;
 use fedimint_core::config::ClientConfig;
+use fedimint_server::config::ServerConfig;
 use http::StatusCode;
 use mint_client::api::WsFederationConnect;
 use qrcode_generator::QrCodeEcc;
@@ -19,7 +20,6 @@ use serde::Deserialize;
 use tokio::sync::mpsc::Sender;
 
 use crate::ui::configgen::configgen;
-use fedimint_server::config::ServerConfig;
 mod configgen;
 
 fn run_fedimint(state: &mut RwLockWriteGuard<State>) {


### PR DESCRIPTION
I keep seeing these panics:

```
cargo-package> thread 'tokio-runtime-worker' panicked at 'Peer connection was dropped', /build/source/fedimint-server/src/net/peers.rs:439:37
cargo-package> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
cargo-package> thread 'tokio-runtime-worker' panicked at 'Peer connection was dropped', /build/source/fedimint-server/src/net/peers.rs:297:37
cargo-package> thread 'thread 'tokio-runtime-worker' panicked at 'tokio-runtime-workerPeer connection was dropped', /build/source/fedimint-server/src/net/peers.rs:439:37
```

when running integration tests, and they are spooking me.

It seems the IO thread should just finish instead of panicking and the cause of the panic is the parent thread is gone, and nothing to do with the connection itself (unless I misunderstand the code).