### PR TITLE
Change IDatabaseTransaction and commit_tx to be async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "fedimint-build",
  "fedimint-core",
  "fedimint-rocksdb",
+ "futures",
  "mint-client",
  "rand",
  "reqwest",
@@ -951,6 +952,7 @@ dependencies = [
  "bincode",
  "counter",
  "fedimint-api",
+ "futures",
  "itertools",
  "rand",
  "rayon",
@@ -996,10 +998,12 @@ name = "fedimint-rocksdb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "fedimint-api",
  "rocksdb",
  "tempfile",
  "test-log",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1046,10 +1050,12 @@ name = "fedimint-sled"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "fedimint-api",
  "sled",
  "tempfile",
  "test-log",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1062,6 +1068,7 @@ dependencies = [
  "bitcoin",
  "fedimint-api",
  "fedimint-bitcoind",
+ "futures",
  "rand",
  "secp256k1-zkp",
  "serde_json",

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -387,7 +387,7 @@ async fn handle_command(
             hash: env!("GIT_HASH").to_string(),
         }),
         Command::PegInAddress => {
-            let peg_in_address = client.get_new_pegin_address(rng);
+            let peg_in_address = client.get_new_pegin_address(rng).await;
             Ok(CliOutput::PegInAddress {
                 address: (peg_in_address),
             })

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -357,11 +357,11 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         Ok(OutPoint { txid, out_idx: 0 })
     }
 
-    pub fn receive_coins(
-        &self,
-        amount: Amount,
-        create_tx: impl FnMut(TieredMulti<BlindNonce>) -> OutPoint,
-    ) {
+    pub async fn receive_coins<F, Fut>(&self, amount: Amount, create_tx: F)
+    where
+        F: FnMut(TieredMulti<BlindNonce>) -> Fut,
+        Fut: futures::Future<Output = OutPoint>,
+    {
         let mut dbtx = self.context.db.begin_transaction();
         self.mint_client().receive_coins(
             amount,
@@ -369,7 +369,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             |tx| self.mint_client().new_ecash_note(&self.context.secp, tx),
             create_tx,
         );
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
     }
 
     pub async fn new_peg_out_with_fees(
@@ -419,10 +419,10 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     /// - this function will write to the clients DB
     ///
     /// read more on fedimints address derivation: <https://fedimint.org/Fedimint/wallet/>
-    pub fn get_new_pegin_address<R: RngCore + CryptoRng>(&self, rng: R) -> Address {
+    pub async fn get_new_pegin_address<R: RngCore + CryptoRng>(&self, rng: R) -> Address {
         let mut dbtx = self.context.db.begin_transaction();
         let address = self.wallet_client().get_new_pegin_address(&mut dbtx, rng);
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
         address
     }
 
@@ -471,7 +471,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             })
             .expect("DB Error");
         });
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
 
         Ok(final_coins)
     }
@@ -482,7 +482,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     pub async fn fetch_coins<'a>(&self, outpoint: OutPoint) -> Result<()> {
         let mut dbtx = self.context.db.begin_transaction();
         self.mint_client().fetch_coins(&mut dbtx, outpoint).await?;
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
         Ok(())
     }
 
@@ -513,7 +513,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             all_coins.extend(coins);
             dbtx.remove_entry(&key).expect("DB Error");
         }
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
 
         self.reissue(all_coins, rng).await
     }
@@ -614,7 +614,7 @@ impl Client<UserClientConfig> {
         let mut dbtx = self.context.db.begin_transaction();
         dbtx.insert_entry(&LightningGatewayKey, &gateway)
             .expect("DB error");
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
         Ok(gateway)
     }
 
@@ -638,7 +638,7 @@ impl Client<UserClientConfig> {
             &mut rng,
         )?;
 
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
 
         let (contract_id, amount) = match &contract {
             ContractOrOfferOutput::Contract(c) => {
@@ -692,7 +692,7 @@ impl Client<UserClientConfig> {
         dbtx.remove_entry(&OutgoingPaymentKey(contract_id))
             .expect("DB error")
             .ok_or(ClientError::DeleteUnknownOutgoingContract)?;
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
 
         Ok(OutPoint { txid, out_idx: 0 })
     }
@@ -787,7 +787,7 @@ impl Client<UserClientConfig> {
             invoice,
             keypair: payment_keypair,
         };
-        self.ln_client().save_confirmed_invoice(&confirmed);
+        self.ln_client().save_confirmed_invoice(&confirmed).await;
 
         Ok(confirmed)
     }
@@ -928,14 +928,14 @@ impl Client<GatewayClientConfig> {
     ///
     /// Note though that extended periods of staying offline will result in loss of funds anyway if
     /// the client can not claim the respective contract in time.
-    pub fn save_outgoing_payment(&self, contract: OutgoingContractAccount) {
+    pub async fn save_outgoing_payment(&self, contract: OutgoingContractAccount) {
         let mut dbtx = self.context.db.begin_transaction();
         dbtx.insert_entry(
             &OutgoingContractAccountKey(contract.contract.contract_id()),
             &contract,
         )
         .expect("DB error");
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
     }
 
     /// Lists all previously saved transactions that have not been driven to completion so far
@@ -955,7 +955,7 @@ impl Client<GatewayClientConfig> {
             .remove_entry(&OutgoingContractAccountKey(contract_id))
             .expect("DB error")
             .ok_or(ClientError::CancelUnknownOutgoingContract)?;
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
 
         let cancel_signature = self.context.secp.sign_schnorr(
             &contract_account.contract.cancellation_message().into(),
@@ -998,7 +998,7 @@ impl Client<GatewayClientConfig> {
             .expect("DB Error");
         dbtx.insert_entry(&OutgoingPaymentClaimKey(contract_id), &())
             .expect("DB Error");
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
 
         tx.input(&mut vec![self.config.redeem_key], input);
         let txid = self.submit_tx_with_change(tx, rng).await?;
@@ -1118,7 +1118,7 @@ impl Client<GatewayClientConfig> {
         let mut dbtx = self.context.db.begin_transaction();
         dbtx.remove_entry(&OutgoingPaymentClaimKey(contract_id))
             .expect("DB error");
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
         Ok(())
     }
 

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -249,11 +249,11 @@ impl<'c> LnClient<'c> {
             .map_err(LnClientError::ApiError)
     }
 
-    pub fn save_confirmed_invoice(&self, invoice: &ConfirmedInvoice) {
+    pub async fn save_confirmed_invoice(&self, invoice: &ConfirmedInvoice) {
         let mut dbtx = self.context.db.begin_transaction();
         dbtx.insert_entry(&ConfirmedInvoiceKey(invoice.contract_id()), invoice)
             .expect("Db error");
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
     }
 
     pub fn get_confirmed_invoice(&self, contract_id: ContractId) -> Result<ConfirmedInvoice> {
@@ -487,7 +487,7 @@ mod tests {
             .create_outgoing_output(&mut dbtx, invoice.clone(), &gateway, timelock, &mut rng)
             .unwrap();
 
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
 
         let contract = match &output {
             ContractOrOfferOutput::Contract(c) => &c.contract,

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -698,12 +698,30 @@ mod tests {
         };
 
         let client_ref: &'static MintClient<'static> = Box::leak(Box::new(client));
+
+        /*
+        let issuance_thread = || {
+            block_on(async {
+                let handles = (0..ITERATIONS).map(|_| async move {
+                    let mut tx = client_ref.context.db.begin_transaction();
+                    let (_, nonce) = client_ref.new_ecash_note(secp256k1_zkp::SECP256K1, &mut tx);
+                    tx.commit_tx().await.map(|_| nonce).ok()
+                });
+
+                let res = futures::future::join_all(handles).await;
+                let filtered = res.into_iter().filter(|op| op.is_some());
+                filtered.map(|op| op.unwrap()).collect::<Vec<BlindNonce>>()
+            })
+        };
+        */
+
         let issuance_thread = || {
             (0..ITERATIONS)
                 .filter_map(|_| {
                     let mut tx = client_ref.context.db.begin_transaction();
                     let (_, nonce) = client_ref.new_ecash_note(secp256k1_zkp::SECP256K1, &mut tx);
-                    tx.commit_tx().map(|_| nonce).ok()
+                    //tx.commit_tx().await.map(|_| nonce).ok()
+                    Some(nonce)
                 })
                 .collect::<Vec<BlindNonce>>()
         };

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -251,7 +251,9 @@ impl<'c> MintClient<'c> {
                 loop {
                     match self.fetch_coins(&mut dbtx, out_point).await {
                         Ok(_) => {
-                            dbtx.commit_tx().await.expect("DB Error");
+                            futures::executor::block_on(async {
+                                dbtx.commit_tx().await.expect("DB Error");
+                            });
                             return Ok(out_point);
                         }
                         // TODO: make mint error more expressive (currently any HTTP error) and maybe use custom return type instead of error for retrying

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -163,22 +163,25 @@ impl<'c> MintClient<'c> {
             "Federation is faulty, returned wrong tx id."
         );
 
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
         Ok(txid)
     }
 
-    pub fn receive_coins<'a>(
+    pub async fn receive_coins<'a, F, Fut>(
         &self,
         amount: Amount,
         dbtx: &mut DatabaseTransaction<'a>,
         coin_gen: impl Fn(&mut DatabaseTransaction<'_>) -> (NoteIssuanceRequest, BlindNonce),
-        mut create_tx: impl FnMut(TieredMulti<BlindNonce>) -> OutPoint,
-    ) {
+        mut create_tx: F,
+    ) where
+        F: FnMut(TieredMulti<BlindNonce>) -> Fut,
+        Fut: futures::Future<Output = OutPoint>,
+    {
         let mut builder = TransactionBuilder::default();
 
         let (finalization, coins) =
             builder.create_output_coins(amount, || coin_gen(dbtx), &self.config.tbs_pks);
-        let out_point = create_tx(coins);
+        let out_point = create_tx(coins).await;
         dbtx.insert_new_entry(&OutputFinalizationKey(out_point), &finalization)
             .expect("DB Error");
     }
@@ -248,7 +251,7 @@ impl<'c> MintClient<'c> {
                 loop {
                     match self.fetch_coins(&mut dbtx, out_point).await {
                         Ok(_) => {
-                            dbtx.commit_tx().expect("DB Error");
+                            dbtx.commit_tx().await.expect("DB Error");
                             return Ok(out_point);
                         }
                         // TODO: make mint error more expressive (currently any HTTP error) and maybe use custom return type instead of error for retrying
@@ -553,21 +556,23 @@ mod tests {
         let out_point = OutPoint { txid, out_idx: 0 };
 
         let mut dbtx = client_db.begin_transaction();
-        client.receive_coins(
-            amt,
-            &mut dbtx,
-            |dbtx| client.new_ecash_note(secp256k1_zkp::SECP256K1, dbtx),
-            |output| {
-                // Agree on output
-                let mut fed = block_on(fed.lock());
-                block_on(fed.consensus_round(&[], &[(out_point, output)]));
-                // Generate signatures
-                block_on(fed.consensus_round(&[], &[]));
+        client
+            .receive_coins(
+                amt,
+                &mut dbtx,
+                |dbtx| client.new_ecash_note(secp256k1_zkp::SECP256K1, dbtx),
+                |output| async {
+                    // Agree on output
+                    let mut fed = block_on(fed.lock());
+                    block_on(fed.consensus_round(&[], &[(out_point, output)]));
+                    // Generate signatures
+                    block_on(fed.consensus_round(&[], &[]));
 
-                out_point
-            },
-        );
-        dbtx.commit_tx().expect("DB Error");
+                    out_point
+                },
+            )
+            .await;
+        dbtx.commit_tx().await.expect("DB Error");
 
         client.fetch_all_coins().await;
     }
@@ -618,7 +623,7 @@ mod tests {
             tbs_pks,
             rng,
         );
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
 
         let meta = fed.lock().await.verify_input(&input).unwrap();
         assert_eq!(meta.amount.amount, SPEND_AMOUNT);
@@ -656,7 +661,7 @@ mod tests {
             tbs_pks,
             rng,
         );
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
 
         let meta = fed.lock().await.verify_input(&input).unwrap();
         assert_eq!(meta.amount.amount, SPEND_AMOUNT);

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -699,29 +699,15 @@ mod tests {
 
         let client_ref: &'static MintClient<'static> = Box::leak(Box::new(client));
 
-        /*
-        let issuance_thread = || {
-            block_on(async {
-                let handles = (0..ITERATIONS).map(|_| async move {
-                    let mut tx = client_ref.context.db.begin_transaction();
-                    let (_, nonce) = client_ref.new_ecash_note(secp256k1_zkp::SECP256K1, &mut tx);
-                    tx.commit_tx().await.map(|_| nonce).ok()
-                });
-
-                let res = futures::future::join_all(handles).await;
-                let filtered = res.into_iter().filter(|op| op.is_some());
-                filtered.map(|op| op.unwrap()).collect::<Vec<BlindNonce>>()
-            })
-        };
-        */
-
         let issuance_thread = || {
             (0..ITERATIONS)
                 .filter_map(|_| {
-                    let mut tx = client_ref.context.db.begin_transaction();
-                    let (_, nonce) = client_ref.new_ecash_note(secp256k1_zkp::SECP256K1, &mut tx);
-                    //tx.commit_tx().await.map(|_| nonce).ok()
-                    Some(nonce)
+                    block_on(async {
+                        let mut tx = client_ref.context.db.begin_transaction();
+                        let (_, nonce) =
+                            client_ref.new_ecash_note(secp256k1_zkp::SECP256K1, &mut tx);
+                        tx.commit_tx().await.map(|_| nonce).ok()
+                    })
                 })
                 .collect::<Vec<BlindNonce>>()
         };

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -334,29 +334,29 @@ mod tests {
         };
 
         // generate fake UTXO
-        fed.lock().await.patch_dbs(|db| {
-            let out_point = bitcoin::OutPoint::default();
-            let tweak = [42; 32];
-            let utxo = SpendableUTXO {
-                tweak,
-                amount: bitcoin::Amount::from_sat(48000),
-            };
+        fed.lock()
+            .await
+            .patch_dbs(|dbtx| {
+                let out_point = bitcoin::OutPoint::default();
+                let tweak = [42; 32];
+                let utxo = SpendableUTXO {
+                    tweak,
+                    amount: bitcoin::Amount::from_sat(48000),
+                };
 
-            let mut dbtx = db.begin_transaction();
-            dbtx.insert_entry(&UTXOKey(out_point), &utxo).unwrap();
+                dbtx.insert_entry(&UTXOKey(out_point), &utxo).unwrap();
 
-            dbtx.insert_entry(
-                &RoundConsensusKey,
-                &RoundConsensus {
-                    block_height: 0,
-                    fee_rate: Feerate { sats_per_kvb: 0 },
-                    randomness_beacon: tweak,
-                },
-            )
-            .unwrap();
-
-            dbtx.commit_tx().expect("DB Error");
-        });
+                dbtx.insert_entry(
+                    &RoundConsensusKey,
+                    &RoundConsensus {
+                        block_height: 0,
+                        fee_rate: Feerate { sats_per_kvb: 0 },
+                        randomness_beacon: tweak,
+                    },
+                )
+                .unwrap();
+            })
+            .await;
 
         let addr = Address::from_str("msFGPqHVk8rbARMd69FfGYxwcboZLemdBi").unwrap();
         let amount = bitcoin::Amount::from_sat(42000);

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -29,6 +29,7 @@ anyhow = "1.0.66"
 async-trait = "0.1.57"
 bitcoin = { version = "0.29.2", features = [ "serde" ] }
 bitcoin_hashes = "0.11.0"
+futures = "0.3"
 reqwest = { version = "0.11.12", features = [ "json" ], default-features = false }
 tokio = { version = "1.21.2", features = ["full"] }
 serde = { version = "1.0.147", features = [ "derive" ] }

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -172,7 +172,7 @@ async fn spend(
 
 async fn fetch(client: Arc<Client<UserClientConfig>>) {
     //TODO: log txid or error (handle unwrap)
-    let batch = futures::executor::block_on(async { client.fetch_all_coins().await });
+    let batch = client.fetch_all_coins().await;
     for item in batch.iter() {
         match item {
             Ok(out_point) => {

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -98,7 +98,6 @@ dyn_newtype_define! {
 /// | RocksDB  | Prevented          | Prevented  | Prevented           | Prevented      | Prevented   |
 #[async_trait(?Send)]
 pub trait IDatabaseTransaction<'a>: 'a + Send {
->>>>>>> 5c08a23fe (Rebase onto master)
     fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>>;
 
     fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.66"
+async-trait = "0.1"
 fedimint-api = { path = "../fedimint-api" }
 rocksdb = { version = "0.19.0" }
 tracing = "0.1.37"
@@ -22,3 +23,6 @@ tracing = "0.1.37"
 tempfile = "3.3.0"
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+
+[target.'cfg(not(target_family="wasm"))'.dependencies]
+tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "sync", "time"] }

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -193,9 +193,7 @@ fn server_endpoints() -> &'static [ApiEndpoint<FedimintConsensus>] {
                 let transaction: Transaction = serde_json::from_str(&string).map_err(|e| ApiError::bad_request(e.to_string()))?;
                 let tx_id = transaction.tx_hash();
 
-                fedimint
-                    .submit_transaction(transaction)
-                    .map_err(|e| ApiError::bad_request(e.to_string()))?;
+                fedimint.submit_transaction(transaction).map_err(|e| ApiError::bad_request(e.to_string()))?;
 
                 Ok(tx_id)
             }

--- a/fedimint-sled/Cargo.toml
+++ b/fedimint-sled/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.66"
+async-trait = "0.1"
 fedimint-api = { path = "../fedimint-api" }
 sled = "0.34"
 tracing = "0.1.37"
@@ -22,3 +23,6 @@ tracing = "0.1.37"
 tempfile = "3.3.0"
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+
+[target.'cfg(not(target_family="wasm"))'.dependencies]
+tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "sync", "time"] }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = "*"
 bitcoin = "0.29.2"
 fedimint-api  = { path = "../fedimint-api" }
 fedimint-bitcoind = { path = "../fedimint-bitcoind" }
+futures = "0.3"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
 serde_json = "*"
 rand = "0.8"

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -90,7 +90,9 @@ impl GatewayActor {
             "Fetched and validated contract account"
         );
 
-        self.client.save_outgoing_payment(contract_account.clone());
+        self.client
+            .save_outgoing_payment(contract_account.clone())
+            .await;
 
         let is_internal_payment = payment_params.maybe_internal
             && self
@@ -189,9 +191,9 @@ impl GatewayActor {
             .await?)
     }
 
-    pub fn get_deposit_address(&self) -> Result<Address> {
+    pub async fn get_deposit_address(&self) -> Result<Address> {
         let rng = rand::rngs::OsRng;
-        Ok(self.client.get_new_pegin_address(rng))
+        Ok(self.client.get_new_pegin_address(rng).await)
     }
 
     pub async fn deposit(

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -338,6 +338,7 @@ impl LnGateway {
     async fn handle_address_msg(&self, payload: DepositAddressPayload) -> Result<Address> {
         self.select_actor(payload.federation_id)?
             .get_deposit_address()
+            .await
     }
 
     async fn handle_deposit_msg(&self, payload: DepositPayload) -> Result<TransactionId> {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -627,19 +627,20 @@ impl FederationTest {
             .unwrap();
 
         for server in &self.servers {
-            let svr = server.borrow_mut();
-            let mut dbtx = svr.database.begin_transaction();
+            block_on(async {
+                let svr = server.borrow_mut();
+                let mut dbtx = svr.database.begin_transaction();
 
-            dbtx.insert_new_entry(
-                &UTXOKey(input.outpoint()),
-                &SpendableUTXO {
-                    tweak: input.tweak_contract_key().serialize(),
-                    amount: bitcoin::Amount::from_sat(input.tx_output().value),
-                },
-            )
-            .expect("DB Error");
-
-            dbtx.commit_tx().await.expect("DB Error");
+                dbtx.insert_new_entry(
+                    &UTXOKey(input.outpoint()),
+                    &SpendableUTXO {
+                        tweak: input.tweak_contract_key().serialize(),
+                        amount: bitcoin::Amount::from_sat(input.tx_output().value),
+                    },
+                )
+                .expect("DB Error");
+                dbtx.commit_tx().await.expect("DB Error");
+            });
         }
     }
 

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -16,7 +16,7 @@ use fedimint_server::epoch::ConsensusItem;
 use fedimint_server::transaction::Output;
 use fedimint_wallet::PegOutSignatureItem;
 use fedimint_wallet::WalletConsensusItem::PegOutSignature;
-use fixtures::{fixtures, rng, sats, secp, sha256};
+use fixtures::{fixtures, rng, sats, secp, sha256, Fixtures};
 use futures::future::{join_all, Either};
 use mint_client::transaction::TransactionBuilder;
 use mint_client::ClientError;
@@ -263,13 +263,16 @@ async fn ecash_in_wallet_can_sent_through_a_tx() -> Result<()> {
         vec![sats(100), sats(500), sats(500)]
     );
 
-    user_receive.client.receive_coins(sats(400), |coins| {
-        user_send
-            .client
-            .pay_to_blind_nonces(coins, rng())
-            .await
-            .unwrap()
-    });
+    user_receive
+        .client
+        .receive_coins(sats(400), |coins| async {
+            user_send
+                .client
+                .pay_to_blind_nonces(coins, rng())
+                .await
+                .unwrap()
+        })
+        .await;
 
     fed.run_consensus_epochs(2).await; // process transaction + sign new coins
 

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -679,7 +679,9 @@ impl FederationModule for LightningModule {
             api_endpoint! {
                 "/register_gateway",
                 async |module: &LightningModule, gateway: LightningGateway| -> () {
-                    module.register_gateway(gateway);
+                    futures::executor::block_on( async {
+                       module.register_gateway(gateway).await;
+                    });
                     Ok(())
                 }
             },
@@ -738,11 +740,11 @@ impl LightningModule {
             .collect()
     }
 
-    pub fn register_gateway(&self, gateway: LightningGateway) {
+    pub async fn register_gateway(&self, gateway: LightningGateway) {
         let mut dbtx = self.db.begin_transaction();
         dbtx.insert_entry(&LightningGatewayKey(gateway.node_pub_key), &gateway)
             .expect("DB error");
-        dbtx.commit_tx().expect("DB Error");
+        dbtx.commit_tx().await.expect("DB Error");
     }
 }
 

--- a/modules/fedimint-mint/Cargo.toml
+++ b/modules/fedimint-mint/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.66"
 async-trait = "0.1"
 bincode = "1.3.1"
 counter = "0.5.7"
+futures = "0.3"
 itertools = "0.10.5"
 fedimint-api = { path = "../../fedimint-api" }
 rand = "0.8"


### PR DESCRIPTION
As mentioned [here](https://github.com/fedimint/fedimint/issues/848), we would like the database transaction trait to be asynchronous. This allows for the async executor to do something else while a thread is blocked on I/O. Ideally we want the entire trait to be asynchronous, as the rest of the operations could potentially block on I/O as well. 

Changing the entire trait is a large change so this PR is scoped to just commit_tx.

I tried to not use block_on (and use await instead) wherever possible, but the remaining areas where block_on is used caused problems when attempting to make them async/await (most of the issues were with matching an API_endpoint handler or the commit_tx was in a closure that wasn't easily able to be made async). Feedback welcome if there's ideas on how to reduce the number of block_on calls or if the currnet change is sufficient.