### PR TITLE
Use actual federation id to gateway-cli in shell scripts

### DIFF
--- a/crypto/hkdf/src/lib.rs
+++ b/crypto/hkdf/src/lib.rs
@@ -110,8 +110,9 @@ impl<H: BitcoinHash> Hkdf<H> {
 
 #[cfg(test)]
 mod tests {
-    use crate::Hkdf;
     use bitcoin_hashes::Hash as BitcoinHash;
+
+    use crate::Hkdf;
 
     #[test]
     #[should_panic(expected = "RFC5869 only supports output length of up to 255*HashLength")]

--- a/fedimintd/src/bin/configgen.rs
+++ b/fedimintd/src/bin/configgen.rs
@@ -47,7 +47,7 @@ enum Command {
         denominations: Vec<Amount>,
 
         /// Federation name
-        #[arg(long = "federation-name", default_value = "Hal's trusty mint")]
+        #[arg(long = "federation-name", default_value = "Hals_trusty_mint")]
         federation_name: String,
     },
 }

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -53,7 +53,7 @@ enum Command {
         dir_out_path: PathBuf,
 
         /// Federation name, same for all peers
-        #[arg(long = "federation-name", default_value = "Hal's trusty mint")]
+        #[arg(long = "federation-name", default_value = "Hals_trusty_mint")]
         federation_name: String,
 
         /// Comma-separated list of connection certs from all peers (including ours)

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -40,7 +40,8 @@ await_cln_block_processing
 $FM_MINT_CLIENT ln-pay $INVOICE
 # Check that ln-gateway has received the ecash notes from the user payment
 # 100,000 sats + 100 sats without processing fee
-LN_GATEWAY_BALANCE="$($FM_GATEWAY_CLI balance 'mock_federation_id' | jq -r '.balance_msat')"
+FED_NAME="$(get_federation_name)"
+LN_GATEWAY_BALANCE="$($FM_GATEWAY_CLI balance $FED_NAME | jq -r '.balance_msat')"
 [[ "$LN_GATEWAY_BALANCE" = "100100000" ]]
 INVOICE_RESULT="$($FM_LN2 waitinvoice test)"
 INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -101,3 +101,7 @@ function get_raw_transaction() {
     TRANSACTION="$($FM_BTC_CLIENT getrawtransaction $TX_ID)"
     echo $TRANSACTION
 }
+
+function get_federation_name() {
+    cat $FM_CFG_DIR/client.json | jq -r '.federation_name'
+}

--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -16,8 +16,10 @@ USE_GATEWAY=${2:-0}
 FINALITY_DELAY=$(get_finality_delay)
 echo "Pegging in $PEG_IN_AMOUNT with confirmation in $FINALITY_DELAY blocks"
 
+FED_NAME="$(get_federation_name)"
+
 # get a peg-in address from either the gateway or the client
-if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($FM_GATEWAY_CLI address 'mock_federation_id' | jq -r '.address')"; else ADDR="$($FM_MINT_CLIENT peg-in-address | jq -r '.address')"; fi
+if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($FM_GATEWAY_CLI address "$FED_NAME" | jq -r '.address')"; else ADDR="$($FM_MINT_CLIENT peg-in-address | jq -r '.address')"; fi
 # send bitcoin to that address and save the txid
 TX_ID=$(send_bitcoin $ADDR $PEG_IN_AMOUNT)
 # wait for confirmation and wait for the fed to sync
@@ -29,7 +31,7 @@ TRANSACTION=$(get_raw_transaction $TX_ID)
 
 # With these proofs we can instruct the client to start the peg-in process. Our client will add the tweak used to derive
 # the peg-in address to the request so that the federation can claim the funds later.
-if [ "$USE_GATEWAY" == 1 ]; then $FM_GATEWAY_CLI deposit "mock_federation_id" "$TXOUT_PROOF" "$TRANSACTION"; else $FM_MINT_CLIENT peg-in "$TXOUT_PROOF" "$TRANSACTION"; fi
+if [ "$USE_GATEWAY" == 1 ]; then $FM_GATEWAY_CLI deposit "$FED_NAME" "$TXOUT_PROOF" "$TRANSACTION"; else $FM_MINT_CLIENT peg-in "$TXOUT_PROOF" "$TRANSACTION"; fi
 
 # Since the process is asynchronous have to come back to fetch the result later. We choose to do this right away and
 # just block till we get our tokens.


### PR DESCRIPTION
Where we previously passed in  a placeholder value, this PR uses configured federation name as id in gateway-cli calls in shell scripts.

The caveat is, we change the configured federation name slightly to make it a cli friendly value without spaces or string marker `'`

