### PR TITLE
Receive invoice to a specific federation

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -76,7 +76,10 @@ async fn main() {
             serde_json::to_writer_pretty(
                 cfg_file,
                 &GatewayConfig {
+                    // TODO: Generate a strong random password
                     password: source_password(cli.rpcpassword),
+                    // TODO: Remove this field with hardcoded value once we have fixed Issue 664:
+                    default_federation: FederationId("Hals_trusty_mint".into()),
                 },
             )
             .expect("Failed to write gateway configs to file");

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -37,9 +37,10 @@ async fn main() -> Result<(), Error> {
     let gw_cfg_path = work_dir.clone().join("gateway.config");
     let gw_cfg: GatewayConfig = load_from_file(&gw_cfg_path);
 
-    let federation_client = Arc::new(build_federation_client(pub_key, bind_addr, work_dir)?);
-    let mut gateway = LnGateway::new(gw_cfg, federation_client.clone(), ln_rpc, tx, rx, bind_addr);
-    gateway.register_federation(federation_client).await?;
+    let mut gateway = LnGateway::new(gw_cfg, ln_rpc, tx, rx, bind_addr);
+
+    let default_fed = Arc::new(build_federation_client(pub_key, bind_addr, work_dir)?);
+    gateway.register_federation(default_fed).await?;
 
     gateway.run().await.expect("gateway failed to run");
     Ok(())

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -1,6 +1,10 @@
+use mint_client::FederationId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GatewayConfig {
     pub password: String,
+    // FIXME: Issue 664: We should avoid having a special reference to a federation
+    // all requests, including `ReceiveInvoicePayload`, should contain the federation id
+    pub default_federation: FederationId,
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -261,11 +261,12 @@ impl LnGateway {
         // TODO: try to drive forward outgoing and incoming payments that were interrupted
         loop {
             let least_wait_until = Instant::now() + Duration::from_millis(100);
-            for fetch_result in self.federation_client.fetch_all_coins().await {
-                if let Err(e) = fetch_result {
-                    debug!(error = %e, "Fetching coins failed")
-                };
-            }
+
+            // Sync wallet for the default federation
+            // TODO: We should sync wallets for all the federation clients
+            self.select_actor(self.config.default_federation.clone())?
+                .fetch_all_coins()
+                .await;
 
             // Handle messages from webserver and plugin
             while let Ok(msg) = self.receiver.try_recv() {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -54,8 +54,8 @@ use itertools::Itertools;
 use lightning_invoice::Invoice;
 use ln_gateway::{actor::GatewayActor, config::GatewayConfig, GatewayRequest, LnGateway};
 use mint_client::{
-    api::WsFederationApi, mint::SpendableNote, GatewayClient, GatewayClientConfig, UserClient,
-    UserClientConfig,
+    api::WsFederationApi, mint::SpendableNote, FederationId, GatewayClient, GatewayClientConfig,
+    UserClient, UserClientConfig,
 };
 use rand::rngs::OsRng;
 use rand::RngCore;
@@ -362,16 +362,13 @@ impl GatewayTest {
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
         let adapter = Arc::new(ln_client_adapter);
         let ln_client = Arc::clone(&adapter);
-        let mut gateway = LnGateway::new(
-            GatewayConfig {
-                password: "abc".into(),
-            },
-            client.clone(),
-            ln_client,
-            sender,
-            receiver,
-            bind_addr,
-        );
+
+        let gw_cfg = GatewayConfig {
+            password: "abc".into(),
+            default_federation: FederationId(client.config().client_config.federation_name),
+        };
+
+        let mut gateway = LnGateway::new(gw_cfg, ln_client, sender, receiver, bind_addr);
 
         let actor = gateway
             .register_federation(client.clone())


### PR DESCRIPTION
**Merge after #794**

Use actors to receive invoice to a specific federation.
This PR temporarily introduces the concept of a _default_federation_ in `GatewayConfig` because we have pending work to identify federation context within the `HtlcAccepted` message routing hint, as proposed by Issue #664 

Eventually, we will be able to receive invoices on behalf of users in any of the Federations served by the gateway. However, the limitation above means we can only receive invoices on behalf of users within the federation referenced by _default_federation_ in config.
