### PR TITLE
Register Federations  on Gateway

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -4,7 +4,8 @@ use bitcoin::{Address, Amount, Transaction};
 use clap::{Parser, Subcommand};
 use fedimint_server::modules::wallet::txoproof::TxOutProof;
 use ln_gateway::{
-    config::GatewayConfig, BalancePayload, DepositAddressPayload, DepositPayload, WithdrawPayload,
+    config::GatewayConfig, BalancePayload, DepositAddressPayload, DepositPayload,
+    RegisterFedPayload, WithdrawPayload,
 };
 use mint_client::{utils::from_hex, FederationId};
 use serde::Serialize;
@@ -57,6 +58,11 @@ pub enum Commands {
         amount: Amount,
         /// The address to send the funds to
         address: Address,
+    },
+    /// Register federation with the gateway
+    RegisterFed {
+        /// ConnectInfo code to connect to the federation
+        connect: String,
     },
 }
 
@@ -144,6 +150,15 @@ async fn main() {
                     amount,
                     address,
                 },
+            )
+            .await;
+        }
+        Commands::RegisterFed { connect } => {
+            call(
+                source_password(cli.rpcpassword),
+                cli.url,
+                String::from("/register"),
+                RegisterFedPayload { connect },
             )
             .await;
         }

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Error> {
         RocksDbGatewayClientBuilder::new(work_dir.clone()).into();
 
     // Create gateway instance
-    let mut gateway = LnGateway::new(gw_cfg, ln_rpc, tx, rx, bind_addr);
+    let mut gateway = LnGateway::new(gw_cfg, ln_rpc, tx, rx, bind_addr, client_builder.clone());
 
     // Build and register the default federation
     // TODO: Register default federation through gateway webserver api

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -46,7 +46,15 @@ async fn main() -> Result<(), Error> {
         RocksDbGatewayClientBuilder::new(work_dir.clone()).into();
 
     // Create gateway instance
-    let mut gateway = LnGateway::new(gw_cfg, ln_rpc, tx, rx, bind_addr, client_builder.clone());
+    let mut gateway = LnGateway::new(
+        gw_cfg,
+        ln_rpc,
+        client_builder.clone(),
+        tx,
+        rx,
+        bind_addr,
+        pub_key,
+    );
 
     // Build and register the default federation
     // TODO: Register default federation through gateway webserver api

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -1,16 +1,20 @@
-use std::{fs::File, net::SocketAddr, path::Path, path::PathBuf, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use cln_plugin::Error;
 use fedimint_server::config::{load_from_file, ClientConfig};
 use ln_gateway::{
-    cln::build_cln_rpc, config::GatewayConfig, ln::LnRpcRef, rpc::GatewayRpcSender, GatewayRequest,
-    LnGateway,
+    client::{GatewayClientBuilder, RocksDbGatewayClientBuilder},
+    cln::build_cln_rpc,
+    config::GatewayConfig,
+    ln::LnRpcRef,
+    rpc::GatewayRpcSender,
+    GatewayRequest, LnGateway,
 };
-use mint_client::{Client, GatewayClientConfig};
+use mint_client::GatewayClientConfig;
 use rand::thread_rng;
 use secp256k1::{KeyPair, PublicKey};
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::warn;
 use url::Url;
 
 #[tokio::main]
@@ -37,21 +41,35 @@ async fn main() -> Result<(), Error> {
     let gw_cfg_path = work_dir.clone().join("gateway.config");
     let gw_cfg: GatewayConfig = load_from_file(&gw_cfg_path);
 
+    // Create federation client builder
+    let client_builder: GatewayClientBuilder =
+        RocksDbGatewayClientBuilder::new(work_dir.clone()).into();
+
+    // Create gateway instance
     let mut gateway = LnGateway::new(gw_cfg, ln_rpc, tx, rx, bind_addr);
 
-    let default_fed = Arc::new(build_federation_client(pub_key, bind_addr, work_dir)?);
-    gateway.register_federation(default_fed).await?;
+    // Build and register the default federation
+    // TODO: Register default federation through gateway webserver api
+    let client_cfg = build_federation_client_cfg(pub_key, bind_addr, work_dir)?;
+    let default_fed = client_builder.build(client_cfg.clone())?;
+    gateway.register_federation(Arc::new(default_fed)).await?;
+    if let Err(e) = client_builder.save_config(client_cfg.clone()) {
+        warn!(
+            "Failed to save default federation client configuration: {}",
+            e
+        );
+    }
 
     gateway.run().await.expect("gateway failed to run");
     Ok(())
 }
 
 /// Build a new federation client with RocksDb and config at a given path
-fn build_federation_client(
+fn build_federation_client_cfg(
     node_pub_key: PublicKey,
     bind_addr: SocketAddr,
     work_dir: PathBuf,
-) -> Result<Client<GatewayClientConfig>, Error> {
+) -> Result<GatewayClientConfig, Error> {
     // Create a gateway client configuration
     let client_cfg_path = work_dir.join("client.json");
     let client_cfg: ClientConfig = load_from_file(&client_cfg_path);
@@ -60,41 +78,12 @@ fn build_federation_client(
     let ctx = secp256k1::Secp256k1::new();
     let kp_fed = KeyPair::new(&ctx, &mut rng);
 
-    let client_cfg = GatewayClientConfig {
+    Ok(GatewayClientConfig {
         client_config: client_cfg,
         redeem_key: kp_fed,
         timelock_delta: 10,
         node_pub_key,
         api: Url::parse(format!("http://{}", bind_addr).as_str())
             .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),
-    };
-
-    // TODO: With support for multiple federations and federation registration through config code
-    // the gateway should be able back-up all registered federations in a snapshot or db.
-    save_federation_client_cfg(work_dir.clone(), &client_cfg);
-
-    // Create a database
-    let db_path = work_dir.join("gateway.db");
-    let db = fedimint_rocksdb::RocksDb::open(db_path)
-        .expect("Error opening DB")
-        .into();
-
-    // Create context
-    let ctx = secp256k1::Secp256k1::new();
-
-    Ok(Client::new(client_cfg, db, ctx))
-}
-
-/// Persist federation client cfg to [`gateway.json`] file
-fn save_federation_client_cfg(work_dir: PathBuf, client_cfg: &GatewayClientConfig) {
-    let path: PathBuf = work_dir.join("gateway.json");
-    if !Path::new(&path).is_file() {
-        debug!("Creating new gateway cfg file at {}", path.display());
-        let file = File::create(path).expect("Could not create gateway cfg file");
-        serde_json::to_writer_pretty(file, &client_cfg).expect("Could not write gateway cfg");
-    } else {
-        debug!("Gateway cfg file already exists at {}", path.display());
-        let file = File::open(path).expect("Could not load gateway cfg file");
-        serde_json::to_writer_pretty(file, &client_cfg).expect("Could not write gateway cfg");
-    }
+    })
 }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use fedimint_api::{db::Database, dyn_newtype_define};
+use mint_client::{Client, FederationId, GatewayClientConfig};
+
+use crate::Result;
+
+/// Trait for gateway federation client builders
+pub trait IGatewayClientBuilder {
+    /// Build a new gateway federation client
+    fn build(&self, config: GatewayClientConfig) -> Result<Client<GatewayClientConfig>>;
+
+    /// Create a new database for the gateway federation client
+    fn create_database(&self, federation_id: FederationId) -> Result<Database>;
+
+    /// Save and persist the configuration of the gateway federation client
+    fn save_config(&self, config: GatewayClientConfig) -> Result<()>;
+}
+
+dyn_newtype_define! {
+  /// Arc reference to a Gateway federation client builder
+  #[derive(Clone)]
+  pub GatewayClientBuilder(Arc<IGatewayClientBuilder>)
+}

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -1,7 +1,12 @@
-use std::sync::Arc;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use fedimint_api::{db::Database, dyn_newtype_define};
 use mint_client::{Client, FederationId, GatewayClientConfig};
+use tracing::debug;
 
 use crate::Result;
 
@@ -21,4 +26,57 @@ dyn_newtype_define! {
   /// Arc reference to a Gateway federation client builder
   #[derive(Clone)]
   pub GatewayClientBuilder(Arc<IGatewayClientBuilder>)
+}
+
+#[derive(Debug, Clone)]
+pub struct RocksDbGatewayClientBuilder {
+    pub work_dir: PathBuf,
+}
+
+/// Default gateway clinet builder which constructs clients with RocksDb
+/// and saves the config at the given work directory
+impl RocksDbGatewayClientBuilder {
+    pub fn new(work_dir: PathBuf) -> Self {
+        Self { work_dir }
+    }
+}
+
+/// Builds a new federation client with RocksDb
+/// On successful build, the configuration is saved to a file at the builder work directory
+impl IGatewayClientBuilder for RocksDbGatewayClientBuilder {
+    fn build(&self, config: GatewayClientConfig) -> Result<Client<GatewayClientConfig>> {
+        let federation_id = FederationId(config.client_config.federation_name.clone());
+
+        let db = self.create_database(federation_id)?;
+        let ctx = secp256k1::Secp256k1::new();
+
+        Ok(Client::new(config, db, ctx))
+    }
+
+    /// Create a client database
+    fn create_database(&self, federation_id: FederationId) -> Result<Database> {
+        let db_path = self.work_dir.join(format!("{}.db", federation_id.0));
+        let db = fedimint_rocksdb::RocksDb::open(db_path)
+            .expect("Error opening DB")
+            .into();
+        Ok(db)
+    }
+
+    /// Persist federation client cfg to [`<federation_id>.json`] file
+    fn save_config(&self, config: GatewayClientConfig) -> Result<()> {
+        let federation_id = FederationId(config.client_config.federation_name.clone());
+        let path: PathBuf = self.work_dir.join(format!("{}.json", federation_id.0));
+
+        if !Path::new(&path).is_file() {
+            debug!("Creating new gateway cfg file at {}", path.display());
+            let file = File::create(path).expect("Could not create gateway cfg file");
+            serde_json::to_writer_pretty(file, &config).expect("Could not write gateway cfg");
+        } else {
+            debug!("Gateway cfg file already exists at {}", path.display());
+            let file = File::open(path).expect("Could not load gateway cfg file");
+            serde_json::to_writer_pretty(file, &config).expect("Could not write gateway cfg");
+        }
+
+        Ok(())
+    }
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -35,7 +35,10 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error};
 use webserver::run_webserver;
 
-use crate::ln::{LightningError, LnRpc};
+use crate::{
+    client::GatewayClientBuilder,
+    ln::{LightningError, LnRpc},
+};
 
 pub type Result<T> = std::result::Result<T, LnGatewayError>;
 
@@ -164,6 +167,7 @@ pub struct LnGateway {
     ln_client: Arc<dyn LnRpc>,
     webserver: tokio::task::JoinHandle<axum::response::Result<()>>,
     receiver: mpsc::Receiver<GatewayRequest>,
+    client_builder: GatewayClientBuilder,
 }
 
 impl LnGateway {
@@ -173,6 +177,7 @@ impl LnGateway {
         sender: mpsc::Sender<GatewayRequest>,
         receiver: mpsc::Receiver<GatewayRequest>,
         bind_addr: SocketAddr,
+        client_builder: GatewayClientBuilder,
     ) -> Self {
         // Run webserver asynchronously in tokio
         let webserver = tokio::spawn(run_webserver(config.password.clone(), bind_addr, sender));
@@ -183,6 +188,7 @@ impl LnGateway {
             ln_client,
             webserver,
             receiver,
+            client_builder,
         }
     }
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -39,6 +39,11 @@ use crate::ln::{LightningError, LnRpc};
 pub type Result<T> = std::result::Result<T, LnGatewayError>;
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterFedPayload {
+    pub connect: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ReceivePaymentPayload {
     // NOTE: On ReceivePayment signal from ln_rpc,
     // we extract the relevant federation id from the accepted htlc
@@ -86,7 +91,8 @@ pub struct GatewayInfo {
 #[derive(Debug)]
 pub enum GatewayRequest {
     Info(GatewayRequestInner<InfoPayload>),
-    ReceiveInvoice(GatewayRequestInner<ReceivePaymentPayload>),
+    RegisterFederation(GatewayRequestInner<RegisterFedPayload>),
+    ReceivePayment(GatewayRequestInner<ReceivePaymentPayload>),
     PayInvoice(GatewayRequestInner<PayInvoicePayload>),
     Balance(GatewayRequestInner<BalancePayload>),
     DepositAddress(GatewayRequestInner<DepositAddressPayload>),
@@ -121,10 +127,11 @@ macro_rules! impl_gateway_request_trait {
 }
 
 impl_gateway_request_trait!(InfoPayload, GatewayInfo, GatewayRequest::Info);
+impl_gateway_request_trait!(RegisterFedPayload, (), GatewayRequest::RegisterFederation);
 impl_gateway_request_trait!(
     ReceivePaymentPayload,
     Preimage,
-    GatewayRequest::ReceiveInvoice
+    GatewayRequest::ReceivePayment
 );
 impl_gateway_request_trait!(PayInvoicePayload, (), GatewayRequest::PayInvoice);
 impl_gateway_request_trait!(BalancePayload, Amount, GatewayRequest::Balance);
@@ -178,6 +185,13 @@ impl LnGateway {
         }
     }
 
+    fn select_actor(&self, federation_id: FederationId) -> Result<Arc<GatewayActor>> {
+        self.actors
+            .get(&federation_id)
+            .cloned()
+            .ok_or(LnGatewayError::UnknownFederation)
+    }
+
     /// Register a federation to the gateway.
     ///
     /// # Returns
@@ -198,11 +212,10 @@ impl LnGateway {
         Ok(actor)
     }
 
-    fn select_actor(&self, federation_id: FederationId) -> Result<Arc<GatewayActor>> {
-        self.actors
-            .get(&federation_id)
-            .cloned()
-            .ok_or(LnGatewayError::UnknownFederation)
+    // Webserver handler for requests to register a federation
+    async fn handle_register_federation(&self, _payload: RegisterFedPayload) -> Result<()> {
+        // TODO: Implement register federation
+        Ok(())
     }
 
     async fn handle_get_info(&self, _payload: InfoPayload) -> Result<GatewayInfo> {
@@ -293,12 +306,15 @@ impl LnGateway {
             while let Ok(msg) = self.receiver.try_recv() {
                 tracing::trace!("Gateway received message {:?}", msg);
                 match msg {
-                    GatewayRequest::Info(payload) => {
-                        payload
-                            .handle(|payload| self.handle_get_info(payload))
+                    GatewayRequest::Info(inner) => {
+                        inner.handle(|payload| self.handle_get_info(payload)).await;
+                    }
+                    GatewayRequest::RegisterFederation(inner) => {
+                        inner
+                            .handle(|payload| self.handle_register_federation(payload))
                             .await;
                     }
-                    GatewayRequest::ReceiveInvoice(inner) => {
+                    GatewayRequest::ReceivePayment(inner) => {
                         inner
                             .handle(|payload| self.handle_receive_invoice_msg(payload))
                             .await;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod actor;
+pub mod client;
 pub mod cln;
 pub mod config;
 pub mod ln;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -12,32 +12,41 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::{
     io::Cursor,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
-use actor::GatewayActor;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use bitcoin::{Address, Transaction};
-use cln::HtlcAccepted;
-use config::GatewayConfig;
-use fedimint_api::{Amount, TransactionId};
-use fedimint_server::modules::ln::contracts::Preimage;
-use fedimint_server::modules::wallet::txoproof::TxOutProof;
+use fedimint_api::{Amount, NumPeers, TransactionId};
+use fedimint_server::{
+    config::ClientConfig,
+    modules::{ln::contracts::Preimage, wallet::txoproof::TxOutProof},
+};
 use futures::Future;
 use mint_client::{
-    ln::PayInvoicePayload, mint::MintClientError, ClientError, FederationId, GatewayClient,
+    api::{WsFederationApi, WsFederationConnect},
+    ln::PayInvoicePayload,
+    mint::MintClientError,
+    query::CurrentConsensus,
+    ClientError, FederationId, GatewayClient, GatewayClientConfig,
 };
+use rand::thread_rng;
+use secp256k1::{KeyPair, PublicKey};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, error};
-use webserver::run_webserver;
+use tracing::{debug, error, warn};
+use url::Url;
 
 use crate::{
+    actor::GatewayActor,
     client::GatewayClientBuilder,
+    cln::HtlcAccepted,
+    config::GatewayConfig,
     ln::{LightningError, LnRpc},
+    webserver::run_webserver,
 };
 
 pub type Result<T> = std::result::Result<T, LnGatewayError>;
@@ -163,37 +172,47 @@ where
 
 pub struct LnGateway {
     config: GatewayConfig,
-    actors: HashMap<FederationId, Arc<GatewayActor>>,
+    actors: Mutex<HashMap<FederationId, Arc<GatewayActor>>>,
     ln_client: Arc<dyn LnRpc>,
     webserver: tokio::task::JoinHandle<axum::response::Result<()>>,
     receiver: mpsc::Receiver<GatewayRequest>,
     client_builder: GatewayClientBuilder,
+    // TODO: consider wrapping bind_addr, and node_pubkey in GatewayConfig
+    bind_addr: SocketAddr,
+    pub_key: PublicKey,
 }
 
 impl LnGateway {
     pub fn new(
         config: GatewayConfig,
         ln_client: Arc<dyn LnRpc>,
+        client_builder: GatewayClientBuilder,
+        // TODO: consider encapsulating message channel within LnGateway
         sender: mpsc::Sender<GatewayRequest>,
         receiver: mpsc::Receiver<GatewayRequest>,
+        // TODO: consider wrapping bind_addr, and node_pubkey in GatewayConfig
         bind_addr: SocketAddr,
-        client_builder: GatewayClientBuilder,
+        pub_key: PublicKey,
     ) -> Self {
         // Run webserver asynchronously in tokio
         let webserver = tokio::spawn(run_webserver(config.password.clone(), bind_addr, sender));
 
         Self {
             config,
-            actors: HashMap::new(),
+            actors: Mutex::new(HashMap::new()),
             ln_client,
             webserver,
             receiver,
             client_builder,
+            bind_addr,
+            pub_key,
         }
     }
 
     fn select_actor(&self, federation_id: FederationId) -> Result<Arc<GatewayActor>> {
         self.actors
+            .lock()
+            .map_err(|_| LnGatewayError::Other(anyhow::anyhow!("Failed to select an actor")))?
             .get(&federation_id)
             .cloned()
             .ok_or(LnGatewayError::UnknownFederation)
@@ -205,7 +224,7 @@ impl LnGateway {
     ///
     /// A `GatewayActor` that can be used to execute gateway functions for the federation
     pub async fn register_federation(
-        &mut self,
+        &self,
         client: Arc<GatewayClient>,
     ) -> Result<Arc<GatewayActor>> {
         let actor = Arc::new(
@@ -215,21 +234,66 @@ impl LnGateway {
         );
 
         let federation_id = FederationId(client.config().client_config.federation_name);
-        self.actors.insert(federation_id, actor.clone());
+        if let Ok(mut actors) = self.actors.lock() {
+            actors.insert(federation_id, actor.clone());
+        }
         Ok(actor)
     }
 
     // Webserver handler for requests to register a federation
-    async fn handle_register_federation(&self, _payload: RegisterFedPayload) -> Result<()> {
-        // TODO: Implement register federation
+    async fn handle_register_federation(&self, payload: RegisterFedPayload) -> Result<()> {
+        let connect: WsFederationConnect =
+            serde_json::from_str(&payload.connect).expect("Invalid federation connect info");
+        let api = WsFederationApi::new(connect.members);
+
+        let client_cfg: ClientConfig = api
+            .request(
+                "/config",
+                (),
+                CurrentConsensus::new(api.peers().one_honest()),
+            )
+            .await
+            .expect("Failed to get client config");
+
+        let mut rng = thread_rng();
+        let ctx = secp256k1::Secp256k1::new();
+        let kp_fed = KeyPair::new(&ctx, &mut rng);
+
+        let gw_client_cfg = GatewayClientConfig {
+            client_config: client_cfg,
+            redeem_key: kp_fed,
+            timelock_delta: 10,
+            node_pub_key: self.pub_key,
+            api: Url::parse(format!("http://{}", self.bind_addr).as_str())
+                .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),
+        };
+
+        let client = self.client_builder.build(gw_client_cfg.clone())?;
+
+        if let Err(e) = self.register_federation(Arc::new(client)).await {
+            error!("Failed to register federation: {}", e);
+        }
+
+        if let Err(e) = self.client_builder.save_config(gw_client_cfg) {
+            warn!(
+                "Failed to save default federation client configuration: {}",
+                e
+            );
+        }
+
         Ok(())
     }
 
     async fn handle_get_info(&self, _payload: InfoPayload) -> Result<GatewayInfo> {
-        Ok(GatewayInfo {
-            version_hash: env!("GIT_HASH").to_string(),
-            federations: self.actors.keys().cloned().collect(),
-        })
+        if let Ok(actors) = self.actors.lock() {
+            return Ok(GatewayInfo {
+                version_hash: env!("GIT_HASH").to_string(),
+                federations: actors.keys().cloned().collect(),
+            });
+        }
+        Err(LnGatewayError::Other(anyhow::anyhow!(
+            "Failed to fetch gateway get info"
+        )))
     }
 
     async fn handle_receive_invoice_msg(&self, payload: ReceivePaymentPayload) -> Result<Preimage> {

--- a/gateway/ln-gateway/src/webserver.rs
+++ b/gateway/ln-gateway/src/webserver.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 
 use crate::{
     rpc::GatewayRpcSender, BalancePayload, DepositAddressPayload, DepositPayload, GatewayRequest,
-    InfoPayload, LnGatewayError, WithdrawPayload,
+    InfoPayload, LnGatewayError, RegisterFedPayload, WithdrawPayload,
 };
 
 pub async fn run_webserver(
@@ -30,6 +30,7 @@ pub async fn run_webserver(
         .route("/address", post(address))
         .route("/deposit", post(deposit))
         .route("/withdraw", post(withdraw))
+        .route("/register", post(register))
         .layer(RequireAuthorizationLayer::bearer(&authkey));
 
     let app = Router::new()
@@ -105,6 +106,16 @@ async fn withdraw(
 async fn pay_invoice(
     Extension(rpc): Extension<GatewayRpcSender>,
     Json(payload): Json<PayInvoicePayload>,
+) -> Result<impl IntoResponse, LnGatewayError> {
+    rpc.send(payload).await?;
+    Ok(())
+}
+
+/// Register a new federation
+#[instrument(skip_all, err)]
+async fn register(
+    Extension(rpc): Extension<GatewayRpcSender>,
+    Json(payload): Json<RegisterFedPayload>,
 ) -> Result<impl IntoResponse, LnGatewayError> {
     rpc.send(payload).await?;
     Ok(())

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -354,18 +354,20 @@ impl GatewayTest {
                 .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),
             node_pub_key,
         };
+
         let client = Arc::new(GatewayClient::new(
             gw_cfg,
             database.clone(),
             Default::default(),
         ));
+
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
         let adapter = Arc::new(ln_client_adapter);
         let ln_client = Arc::clone(&adapter);
 
         let gw_cfg = GatewayConfig {
             password: "abc".into(),
-            default_federation: FederationId(client.config().client_config.federation_name),
+            default_federation: FederationId(client.config().client_config.federation_name.clone()),
         };
 
         let mut gateway = LnGateway::new(gw_cfg, ln_client, sender, receiver, bind_addr);

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -364,7 +364,7 @@ impl GatewayTest {
             default_federation: FederationId(gw_client_cfg.client_config.federation_name.clone()),
         };
 
-        let mut gateway = LnGateway::new(
+        let gateway = LnGateway::new(
             gw_cfg,
             ln_client,
             sender,

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -364,7 +364,14 @@ impl GatewayTest {
             default_federation: FederationId(gw_client_cfg.client_config.federation_name.clone()),
         };
 
-        let mut gateway = LnGateway::new(gw_cfg, ln_client, sender, receiver, bind_addr);
+        let mut gateway = LnGateway::new(
+            gw_cfg,
+            ln_client,
+            sender,
+            receiver,
+            bind_addr,
+            client_builder.clone(),
+        );
 
         let client = Arc::new(
             client_builder

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -59,8 +59,8 @@ use ln_gateway::{
     GatewayRequest, LnGateway,
 };
 use mint_client::{
-    api::WsFederationApi, mint::SpendableNote, FederationId, GatewayClient, GatewayClientConfig,
-    UserClient, UserClientConfig,
+    api::WsFederationApi, mint::SpendableNote, Client, FederationId, GatewayClient,
+    GatewayClientConfig, UserClient, UserClientConfig,
 };
 use rand::rngs::OsRng;
 use rand::RngCore;
@@ -98,7 +98,7 @@ pub fn secp() -> secp256k1::Secp256k1<secp256k1::All> {
 #[non_exhaustive]
 pub struct Fixtures {
     pub fed: FederationTest,
-    pub user: UserTest,
+    pub user: UserTest<UserClientConfig>,
     pub bitcoin: Box<dyn BitcoinTest>,
     pub gateway: GatewayTest,
     pub lightning: Box<dyn LightningTest>,
@@ -167,9 +167,9 @@ pub async fn fixtures(num_peers: u16, amount_tiers: &[Amount]) -> anyhow::Result
             )
             .await;
 
-            let user_cfg = UserClientConfig(client_config.clone());
             let user_db = rocks(dir.clone()).into();
-            let user = UserTest::new(user_cfg.clone(), peers, user_db);
+            let user_cfg = UserClientConfig(client_config.clone());
+            let user = UserTest::new(Arc::new(create_user_client(user_cfg, peers, user_db)));
             user.client.await_consensus_block_height(0).await?;
 
             let gateway = GatewayTest::new(
@@ -214,7 +214,7 @@ pub async fn fixtures(num_peers: u16, amount_tiers: &[Amount]) -> anyhow::Result
 
             let user_db = MemDatabase::new().into();
             let user_cfg = UserClientConfig(client_config.clone());
-            let user = UserTest::new(user_cfg.clone(), peers, user_db);
+            let user = UserTest::new(Arc::new(create_user_client(user_cfg, peers, user_db)));
             user.client.await_consensus_block_height(0).await?;
 
             let gateway = GatewayTest::new(
@@ -235,6 +235,34 @@ pub async fn fixtures(num_peers: u16, amount_tiers: &[Amount]) -> anyhow::Result
             })
         }
     }
+}
+
+pub fn peers(peers: &[u16]) -> Vec<PeerId> {
+    peers
+        .iter()
+        .map(|i| PeerId::from(*i))
+        .collect::<Vec<PeerId>>()
+}
+
+/// Creates a new user client connected to the given peers
+pub fn create_user_client(
+    config: UserClientConfig,
+    peers: Vec<PeerId>,
+    db: Database,
+) -> UserClient {
+    let api = WsFederationApi::new(
+        config
+            .0
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(id, _)| peers.contains(&PeerId::from(*id as u16)))
+            .map(|(id, node)| (PeerId::from(id as u16), node.url.clone()))
+            .collect(),
+    )
+    .into();
+
+    UserClient::new_with_api(config, db, api, Default::default())
 }
 
 async fn distributed_config(
@@ -320,7 +348,7 @@ pub struct GatewayTest {
     pub actor: Arc<GatewayActor>,
     pub adapter: Arc<LnRpcAdapter>,
     pub keys: LightningGateway,
-    pub user: UserTest,
+    pub user: UserTest<GatewayClientConfig>,
     pub client: Arc<GatewayClient>,
 }
 
@@ -367,35 +395,27 @@ impl GatewayTest {
         let gateway = LnGateway::new(
             gw_cfg,
             ln_client,
+            client_builder.clone(),
             sender,
             receiver,
             bind_addr,
-            client_builder.clone(),
+            node_pub_key,
         );
 
         let client = Arc::new(
             client_builder
-                .build(gw_client_cfg)
+                .build(gw_client_cfg.clone())
                 .expect("Could not build gateway client"),
         );
-
-        // The UserTest returned as part of GatewayTest
-        // needs to share a database with the gateway client built above
-
-        // WIP: BLOCKING: Adapt the gateway client into user_client for creating UserTest instance
-        let user_cfg = UserClientConfig(client_config.clone());
-        let database: Database = MemDatabase::new().into();
-        let user_client = UserClient::new(user_cfg.clone(), database.clone(), Default::default());
-        let user = UserTest {
-            client: user_client,
-            config: user_cfg,
-        };
 
         let actor = gateway
             .register_federation(client.clone())
             .await
             .expect("Could not register federation");
         // Note: We don't run the gateway in test scenarios
+
+        // Create a user test from gateway federation client
+        let user = UserTest::new(client.clone());
 
         GatewayTest {
             actor,
@@ -407,19 +427,16 @@ impl GatewayTest {
     }
 }
 
-pub struct UserTest {
-    pub client: UserClient,
-    pub config: UserClientConfig,
+#[derive(Clone)]
+pub struct UserTest<C> {
+    pub client: Arc<Client<C>>,
+    pub config: C,
 }
 
-impl UserTest {
-    /// Returns a new user client connected to a subset of peers.
-    pub fn new_client(&self, peers: &[u16]) -> Self {
-        let peers = peers
-            .iter()
-            .map(|i| PeerId::from(*i))
-            .collect::<Vec<PeerId>>();
-        Self::new(self.config.clone(), peers, MemDatabase::new().into())
+impl<T: AsRef<ClientConfig> + Clone> UserTest<T> {
+    pub fn new(client: Arc<Client<T>>) -> Self {
+        let config = client.config();
+        UserTest { client, config }
     }
 
     /// Helper to simplify the peg_out method calls
@@ -446,24 +463,6 @@ impl UserTest {
     /// Returns sum total of all coins
     pub fn total_coins(&self) -> Amount {
         self.client.coins().total_amount()
-    }
-
-    fn new(config: UserClientConfig, peers: Vec<PeerId>, db: Database) -> Self {
-        let api = WsFederationApi::new(
-            config
-                .0
-                .nodes
-                .iter()
-                .enumerate()
-                .filter(|(id, _)| peers.contains(&PeerId::from(*id as u16)))
-                .map(|(id, node)| (PeerId::from(id as u16), node.url.clone()))
-                .collect(),
-        )
-        .into();
-
-        let client = UserClient::new_with_api(config.clone(), db, api, Default::default());
-
-        UserTest { client, config }
     }
 
     pub async fn assert_total_coins(&self, amount: Amount) {
@@ -568,7 +567,11 @@ impl FederationTest {
     }
 
     /// Helper to issue change for a user
-    pub async fn spend_ecash(&self, user: &UserTest, amount: Amount) -> TieredMulti<SpendableNote> {
+    pub async fn spend_ecash<C: AsRef<ClientConfig> + Clone>(
+        &self,
+        user: &UserTest<C>,
+        amount: Amount,
+    ) -> TieredMulti<SpendableNote> {
         let coins = user.client.mint_client().select_coins(amount).unwrap();
         if coins.total_amount() == amount {
             return user.client.spend_ecash(amount, rng()).await.unwrap();
@@ -584,7 +587,12 @@ impl FederationTest {
 
     /// Mines a UTXO then mints coins for user, assuring that the balance sheet of the federation
     /// nets out to zero.
-    pub async fn mine_and_mint(&self, user: &UserTest, bitcoin: &dyn BitcoinTest, amount: Amount) {
+    pub async fn mine_and_mint<C: AsRef<ClientConfig> + Clone>(
+        &self,
+        user: &UserTest<C>,
+        bitcoin: &dyn BitcoinTest,
+        amount: Amount,
+    ) {
         assert_eq!(amount.milli_sat % 1000, 0);
         let sats = bitcoin::Amount::from_sat(amount.milli_sat / 1000);
         self.mine_spendable_utxo(user, bitcoin, sats);
@@ -593,16 +601,20 @@ impl FederationTest {
 
     /// Inserts coins directly into the databases of federation nodes, runs consensus to sign them
     /// then fetches the coins for the user client.
-    pub async fn mint_coins_for_user(&self, user: &UserTest, amount: Amount) {
+    pub async fn mint_coins_for_user<C: AsRef<ClientConfig> + Clone>(
+        &self,
+        user: &UserTest<C>,
+        amount: Amount,
+    ) {
         self.database_add_coins_for_user(user, amount);
         self.run_consensus_epochs(1).await;
         user.client.fetch_all_coins().await;
     }
 
     /// Mines a UTXO owned by the federation.
-    pub fn mine_spendable_utxo(
+    pub fn mine_spendable_utxo<C: AsRef<ClientConfig> + Clone>(
         &self,
-        user: &UserTest,
+        user: &UserTest<C>,
         bitcoin: &dyn BitcoinTest,
         amount: bitcoin::Amount,
     ) {
@@ -651,7 +663,11 @@ impl FederationTest {
     }
 
     /// Inserts coins directly into the databases of federation nodes
-    pub fn database_add_coins_for_user(&self, user: &UserTest, amount: Amount) -> OutPoint {
+    pub fn database_add_coins_for_user<C: AsRef<ClientConfig> + Clone>(
+        &self,
+        user: &UserTest<C>,
+        amount: Amount,
+    ) -> OutPoint {
         let bytes: [u8; 32] = rand::random();
         let out_point = OutPoint {
             txid: fedimint_api::TransactionId::from_inner(bytes),


### PR DESCRIPTION
**Merge after #869**

Support remote federation registration through gateway webserver. This PR adds:
- `/register` endpoint for gateway admin to register a new federation to serve. Perhaps this is done from some admin ui dashboard
- CLI capability for registering federations to the Gateway: `gateway-cli register-fed <connect-info>`
    
- [ ] **Future:** `/remove` for deregistering federations?