### PR TITLE
Turn `Option<T>` into `type Cancellable<T> = Result<T, Cancelled>;`

### DIFF
--- a/crypto/hkdf/src/lib.rs
+++ b/crypto/hkdf/src/lib.rs
@@ -110,8 +110,9 @@ impl<H: BitcoinHash> Hkdf<H> {
 
 #[cfg(test)]
 mod tests {
-    use crate::Hkdf;
     use bitcoin_hashes::Hash as BitcoinHash;
+
+    use crate::Hkdf;
 
     #[test]
     #[should_panic(expected = "RFC5869 only supports output length of up to 255*HashLength")]

--- a/fedimint-api/src/cancellable.rs
+++ b/fedimint-api/src/cancellable.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+/// An error used as a "cancelled" marker in [`Cancellable`].
+#[derive(Error, Debug)]
+#[error("Operation cancelled")]
+pub struct Cancelled;
+
+/// Operation that can potentially get cancelled returning no result (e.g. program shutdown).
+pub type Cancellable<T> = std::result::Result<T, Cancelled>;

--- a/fedimint-api/src/lib.rs
+++ b/fedimint-api/src/lib.rs
@@ -20,6 +20,7 @@ pub use crate::core::{client, server};
 use crate::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry};
 
 pub mod bitcoin_rpc;
+pub mod cancellable;
 pub mod config;
 pub mod core;
 pub mod db;

--- a/fedimint-api/src/net/peers.rs
+++ b/fedimint-api/src/net/peers.rs
@@ -3,6 +3,8 @@ use fedimint_api::PeerId;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use crate::cancellable::Cancellable;
+
 /// Owned [`PeerConnections`] trait object type
 pub type AnyPeerConnections<M> = Box<dyn PeerConnections<M> + Send + Unpin + 'static>;
 
@@ -26,14 +28,10 @@ where
     ///
     /// The message is sent immediately and cached if the peer is reachable and only cached
     /// otherwise.
-    ///
-    /// Returns `None` during process shutdown
-    async fn send(&mut self, peers: &[PeerId], msg: T) -> Option<()>;
+    async fn send(&mut self, peers: &[PeerId], msg: T) -> Cancellable<()>;
 
     /// Await receipt of a message from any connected peer.
-    ///
-    /// Returns `None` during process shutdown
-    async fn receive(&mut self) -> Option<(PeerId, T)>;
+    async fn receive(&mut self) -> Cancellable<(PeerId, T)>;
 
     /// Removes a peer connection in case of misbehavior
     async fn ban_peer(&mut self, peer: PeerId);

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use async_trait::async_trait;
+use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::BitcoindRpcCfg;
 use fedimint_api::config::{DkgMessage, DkgRunner, GenerateConfig};
 use fedimint_api::net::peers::AnyPeerConnections;
@@ -202,11 +203,11 @@ impl GenerateConfig for ServerConfig {
         params: &Self::Params,
         mut rng: impl RngCore + CryptoRng,
         task_group: &mut TaskGroup,
-    ) -> Result<Option<(Self, Self::ClientConfig)>, Self::ConfigError> {
+    ) -> Result<Cancellable<(Self, Self::ClientConfig)>, Self::ConfigError> {
         // in case we are running by ourselves, avoid DKG
         if peers.len() == 1 {
             let (server, client) = Self::trusted_dealer_gen(peers, params, rng);
-            return Ok(Some((server[our_id].clone(), client)));
+            return Ok(Ok((server[our_id].clone(), client)));
         }
         info!("Peer {} running distributed key generation...", our_id);
 
@@ -216,10 +217,10 @@ impl GenerateConfig for ServerConfig {
         dkg.add(KeyType::Epoch, peers.threshold());
 
         // run DKG for epoch and hbbft keys
-        let keys = if let Some(v) = dkg.run_g1(connections, &mut rng).await {
+        let keys = if let Ok(v) = dkg.run_g1(connections, &mut rng).await {
             v
         } else {
-            return Ok(None);
+            return Ok(Err(Cancelled));
         };
         let (hbbft_pks, hbbft_sks) = keys[&KeyType::Hbbft].threshold_crypto();
         let (epoch_pks, epoch_sks) = keys[&KeyType::Epoch].threshold_crypto();
@@ -230,42 +231,41 @@ impl GenerateConfig for ServerConfig {
             btc_rpc_user: "bitcoin".into(),
             btc_rpc_pass: "bitcoin".into(),
         };
-        let (wallet_server_cfg, wallet_client_cfg) = if let Some(v) =
+        let (wallet_server_cfg, wallet_client_cfg) = if let Ok(v) =
             WalletConfig::distributed_gen(&mut wallet, our_id, peers, bitcoin, &mut rng, task_group)
                 .await
                 .expect("wallet error")
         {
             v
         } else {
-            return Ok(None);
+            return Ok(Err(Cancelled));
         };
 
         let mut ln = connect(params.lightning_dkg.clone(), params.tls.clone(), task_group).await;
-        let (ln_server_cfg, ln_client_cfg) = if let Some(v) =
-            LightningModuleConfig::distributed_gen(
-                &mut ln,
-                our_id,
-                peers,
-                &(),
-                &mut rng,
-                task_group,
-            )
-            .await?
+        let (ln_server_cfg, ln_client_cfg) = if let Ok(v) = LightningModuleConfig::distributed_gen(
+            &mut ln,
+            our_id,
+            peers,
+            &(),
+            &mut rng,
+            task_group,
+        )
+        .await?
         {
             v
         } else {
-            return Ok(None);
+            return Ok(Err(Cancelled));
         };
 
         let mut mint = connect(params.mint_dkg.clone(), params.tls.clone(), task_group).await;
         let param = &params.amount_tiers;
-        let (mint_server_cfg, mint_client_cfg) = if let Some(v) =
+        let (mint_server_cfg, mint_client_cfg) = if let Ok(v) =
             MintConfig::distributed_gen(&mut mint, our_id, peers, param, &mut rng, task_group)
                 .await?
         {
             v
         } else {
-            return Ok(None);
+            return Ok(Err(Cancelled));
         };
 
         let server = ServerConfig {
@@ -293,7 +293,7 @@ impl GenerateConfig for ServerConfig {
             ln: ln_client_cfg,
         };
 
-        Ok(Some((server, client)))
+        Ok(Ok((server, client)))
     }
 }
 

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
+use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::GenerateConfig;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
@@ -117,7 +118,7 @@ async fn main() {
         } => {
             let key = get_key(password, dir_out_path.join(SALT_FILE));
             let (pk_bytes, nonce) = encrypted_read(&key, dir_out_path.join(TLS_PK));
-            let (server, client) = if let Some(v) = run_dkg(
+            let (server, client) = if let Ok(v) = run_dkg(
                 &dir_out_path,
                 denominations,
                 federation_name,
@@ -156,7 +157,7 @@ async fn run_dkg(
     bitcoind_rpc: String,
     pk: rustls::PrivateKey,
     task_group: &mut TaskGroup,
-) -> Option<(ServerConfig, ClientConfig)> {
+) -> Cancellable<(ServerConfig, ClientConfig)> {
     let peers: BTreeMap<PeerId, PeerServerParams> = certs
         .into_iter()
         .sorted()


### PR DESCRIPTION
This makes it easier to understand and harder to accidentally forget to handle.