### PR TITLE
Add Database Isolation Unit Tests

### DIFF
--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -155,61 +155,51 @@ mod tests {
 
     #[test_log::test]
     fn test_dbtx_insert_elements() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_insert_elements(mem_db.into());
+        fedimint_api::db::verify_insert_elements(MemDatabase::new().into());
     }
 
     #[test_log::test]
     fn test_dbtx_remove_nonexisting() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_remove_nonexisting(mem_db.into());
+        fedimint_api::db::verify_remove_nonexisting(MemDatabase::new().into());
     }
 
     #[test_log::test]
     fn test_dbtx_remove_existing() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_remove_nonexisting(mem_db.into());
+        fedimint_api::db::verify_remove_nonexisting(MemDatabase::new().into());
     }
 
     #[test_log::test]
     fn test_dbtx_read_own_writes() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_read_own_writes(mem_db.into());
+        fedimint_api::db::verify_read_own_writes(MemDatabase::new().into());
     }
 
     #[test_log::test]
     fn test_dbtx_prevent_dirty_reads() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_prevent_dirty_reads(mem_db.into());
+        fedimint_api::db::verify_prevent_dirty_reads(MemDatabase::new().into());
     }
 
     #[test_log::test]
     fn test_dbtx_find_by_prefix() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_find_by_prefix(mem_db.into());
+        fedimint_api::db::verify_find_by_prefix(MemDatabase::new().into());
     }
 
     #[test_log::test]
     fn test_dbtx_commit() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_commit(mem_db.into());
+        fedimint_api::db::verify_commit(MemDatabase::new().into());
     }
 
     #[test_log::test]
     fn test_dbtx_prevent_nonrepeatable_reads() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_prevent_nonrepeatable_reads(mem_db.into());
+        fedimint_api::db::verify_prevent_nonrepeatable_reads(MemDatabase::new().into());
     }
 
     #[test_log::test]
     fn test_dbtx_rollback_to_savepoint() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_rollback_to_savepoint(mem_db.into());
+        fedimint_api::db::verify_rollback_to_savepoint(MemDatabase::new().into());
     }
 
     #[test_log::test]
     fn test_dbtx_phantom_entry() {
-        let mem_db = MemDatabase::new();
-        fedimint_api::db::verify_phantom_entry(mem_db.into());
+        fedimint_api::db::verify_phantom_entry(MemDatabase::new().into());
     }
 }

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -154,8 +154,62 @@ mod tests {
     use super::MemDatabase;
 
     #[test_log::test]
-    fn test_basic_dbtx_rw() {
+    fn test_dbtx_insert_elements() {
         let mem_db = MemDatabase::new();
-        crate::db::tests::test_dbtx_impl(mem_db.into());
+        fedimint_api::db::verify_insert_elements(mem_db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_remove_nonexisting() {
+        let mem_db = MemDatabase::new();
+        fedimint_api::db::verify_remove_nonexisting(mem_db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_remove_existing() {
+        let mem_db = MemDatabase::new();
+        fedimint_api::db::verify_remove_nonexisting(mem_db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_read_own_writes() {
+        let mem_db = MemDatabase::new();
+        fedimint_api::db::verify_read_own_writes(mem_db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_prevent_dirty_reads() {
+        let mem_db = MemDatabase::new();
+        fedimint_api::db::verify_prevent_dirty_reads(mem_db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_find_by_prefix() {
+        let mem_db = MemDatabase::new();
+        fedimint_api::db::verify_find_by_prefix(mem_db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_commit() {
+        let mem_db = MemDatabase::new();
+        fedimint_api::db::verify_commit(mem_db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_prevent_nonrepeatable_reads() {
+        let mem_db = MemDatabase::new();
+        fedimint_api::db::verify_prevent_nonrepeatable_reads(mem_db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_rollback_to_savepoint() {
+        let mem_db = MemDatabase::new();
+        fedimint_api::db::verify_rollback_to_savepoint(mem_db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_phantom_entry() {
+        let mem_db = MemDatabase::new();
+        fedimint_api::db::verify_phantom_entry(mem_db.into());
     }
 }

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -108,7 +108,11 @@ pub trait IDatabaseTransaction<'a>: 'a {
 
     fn rollback_tx_to_savepoint(&mut self);
 
-    /// Ideally, avoid using this in fedimint client code as not all database transaction
+    /// Create a savepoint during the transaction that can be rolled back to using
+    /// rollback_tx_to_savepoint. Rolling back to the savepoint will atomically remove the writes
+    /// that were applied since the savepoint was created.
+    ///
+    /// Warning: Avoid using this in fedimint client code as not all database transaction
     /// implementations will support setting a savepoint during a transaction.
     fn set_tx_savepoint(&mut self);
 }

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -110,124 +110,87 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
 mod fedimint_rocksdb_tests {
     use crate::RocksDb;
 
-    #[test_log::test]
-    fn test_dbtx_insert_elements() {
+    fn open_temp_db(temp_path: &str) -> RocksDb {
         let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-insert-elements")
+            .prefix(temp_path)
             .tempdir()
             .unwrap();
 
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_insert_elements(db.into());
+        RocksDb::open(path).unwrap()
+    }
+
+    #[test_log::test]
+    fn test_dbtx_insert_elements() {
+        fedimint_api::db::verify_insert_elements(
+            open_temp_db("fcb-rocksdb-test-insert-elements").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_remove_nonexisting() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-remove-nonexisting")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_remove_nonexisting(db.into());
+        fedimint_api::db::verify_remove_nonexisting(
+            open_temp_db("fcb-rocksdb-test-remove-nonexisting").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_remove_existing() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-remove-existing")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_remove_nonexisting(db.into());
+        fedimint_api::db::verify_remove_existing(
+            open_temp_db("fcb-rocksdb-test-remove-existing").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_read_own_writes() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-read-own-writes")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_read_own_writes(db.into());
+        fedimint_api::db::verify_read_own_writes(
+            open_temp_db("fcb-rocksdb-test-read-own-writes").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_prevent_dirty_reads() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-prevent-dirty-reads")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_prevent_dirty_reads(db.into());
+        fedimint_api::db::verify_prevent_dirty_reads(
+            open_temp_db("fcb-rocksdb-test-prevent-dirty-reads").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_find_by_prefix() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-find-by-prefix")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_find_by_prefix(db.into());
+        fedimint_api::db::verify_find_by_prefix(
+            open_temp_db("fcb-rocksdb-test-find-by-prefix").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_commit() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-commit")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_commit(db.into());
+        fedimint_api::db::verify_commit(open_temp_db("fcb-rocksdb-test-commit").into());
     }
 
     #[test_log::test]
     fn test_dbtx_prevent_nonrepeatable_reads() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-prevent-nonrepeatable-reads")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_prevent_nonrepeatable_reads(db.into());
+        fedimint_api::db::verify_prevent_nonrepeatable_reads(
+            open_temp_db("fcb-rocksdb-test-prevent-nonrepeatable-reads").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_rollback_to_savepoint() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-rollback-to-savepoint")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_rollback_to_savepoint(db.into());
+        fedimint_api::db::verify_rollback_to_savepoint(
+            open_temp_db("fcb-rocksdb-test-rollback-to-savepoint").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_phantom_entry() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-phantom-entry")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::verify_phantom_entry(db.into());
+        fedimint_api::db::verify_phantom_entry(
+            open_temp_db("fcb-rocksdb-test-phantom-entry").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_write_conflict() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-rocksdb-test-write-conflict")
-            .tempdir()
-            .unwrap();
-
-        let db = RocksDb::open(path).unwrap();
-        fedimint_api::db::expect_write_conflict(db.into());
+        fedimint_api::db::expect_write_conflict(
+            open_temp_db("fcb-rocksdb-test-write-conflict").into(),
+        );
     }
 }

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -72,7 +72,7 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
         let mut options = rocksdb::ReadOptions::default();
         options.set_iterate_range(rocksdb::PrefixRange(prefix.clone()));
         let iter = self.0.snapshot().iterator_opt(
-            rocksdb::IteratorMode::From(&prefix.clone(), rocksdb::Direction::Forward),
+            rocksdb::IteratorMode::From(&prefix, rocksdb::Direction::Forward),
             options,
         );
         Box::new(

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -192,16 +192,86 @@ impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
 }
 
 #[cfg(test)]
-mod tests {
+mod fedimint_sled_tests {
     use crate::SledDb;
 
     #[test_log::test]
-    fn test_basic_dbtx_rw() {
+    fn test_dbtx_insert_elements() {
         let path = tempfile::Builder::new()
-            .prefix("fcb-sled-test")
+            .prefix("fcb-sled-test-insert-elements")
             .tempdir()
             .unwrap();
         let db = SledDb::open(path, "default").unwrap();
-        fedimint_api::db::test_dbtx_impl(db.into());
+        fedimint_api::db::verify_insert_elements(db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_remove_nonexisting() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-sled-test-remove-nonexisting")
+            .tempdir()
+            .unwrap();
+        let db = SledDb::open(path, "default").unwrap();
+        fedimint_api::db::verify_remove_nonexisting(db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_remove_existing() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-sled-test-remove-existing")
+            .tempdir()
+            .unwrap();
+        let db = SledDb::open(path, "default").unwrap();
+        fedimint_api::db::verify_remove_nonexisting(db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_read_own_writes() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-sled-test-read-own-writes")
+            .tempdir()
+            .unwrap();
+        let db = SledDb::open(path, "default").unwrap();
+        fedimint_api::db::verify_read_own_writes(db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_prevent_dirty_reads() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-sled-test-prevent-dirty-reads")
+            .tempdir()
+            .unwrap();
+        let db = SledDb::open(path, "default").unwrap();
+        fedimint_api::db::verify_prevent_dirty_reads(db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_find_by_prefix() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-sled-test-find-by-prefix")
+            .tempdir()
+            .unwrap();
+        let db = SledDb::open(path, "default").unwrap();
+        fedimint_api::db::verify_find_by_prefix(db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_commit() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-sled-test-commit")
+            .tempdir()
+            .unwrap();
+        let db = SledDb::open(path, "default").unwrap();
+        fedimint_api::db::verify_commit(db.into());
+    }
+
+    #[test_log::test]
+    fn test_dbtx_rollback_to_savepoint() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-sled-test-rollback-to-savepoint")
+            .tempdir()
+            .unwrap();
+        let db = SledDb::open(path, "default").unwrap();
+        fedimint_api::db::verify_rollback_to_savepoint(db.into());
     }
 }

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -195,83 +195,65 @@ impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
 mod fedimint_sled_tests {
     use crate::SledDb;
 
-    #[test_log::test]
-    fn test_dbtx_insert_elements() {
+    fn open_temp_db(temp_path: &str) -> SledDb {
         let path = tempfile::Builder::new()
-            .prefix("fcb-sled-test-insert-elements")
+            .prefix(temp_path)
             .tempdir()
             .unwrap();
-        let db = SledDb::open(path, "default").unwrap();
-        fedimint_api::db::verify_insert_elements(db.into());
+        SledDb::open(path, "default").unwrap()
+    }
+
+    #[test_log::test]
+    fn test_dbtx_insert_elements() {
+        fedimint_api::db::verify_insert_elements(
+            open_temp_db("fcb-sled-test-insert-elements").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_remove_nonexisting() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-sled-test-remove-nonexisting")
-            .tempdir()
-            .unwrap();
-        let db = SledDb::open(path, "default").unwrap();
-        fedimint_api::db::verify_remove_nonexisting(db.into());
+        fedimint_api::db::verify_remove_nonexisting(
+            open_temp_db("fcb-sled-test-remove-nonexisting").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_remove_existing() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-sled-test-remove-existing")
-            .tempdir()
-            .unwrap();
-        let db = SledDb::open(path, "default").unwrap();
-        fedimint_api::db::verify_remove_nonexisting(db.into());
+        fedimint_api::db::verify_remove_existing(
+            open_temp_db("fcb-sled-test-remove-existing").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_read_own_writes() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-sled-test-read-own-writes")
-            .tempdir()
-            .unwrap();
-        let db = SledDb::open(path, "default").unwrap();
-        fedimint_api::db::verify_read_own_writes(db.into());
+        fedimint_api::db::verify_read_own_writes(
+            open_temp_db("fcb-sled-test-read-own-writes").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_prevent_dirty_reads() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-sled-test-prevent-dirty-reads")
-            .tempdir()
-            .unwrap();
-        let db = SledDb::open(path, "default").unwrap();
-        fedimint_api::db::verify_prevent_dirty_reads(db.into());
+        fedimint_api::db::verify_prevent_dirty_reads(
+            open_temp_db("fcb-sled-test-prevent-dirty-reads").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_find_by_prefix() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-sled-test-find-by-prefix")
-            .tempdir()
-            .unwrap();
-        let db = SledDb::open(path, "default").unwrap();
-        fedimint_api::db::verify_find_by_prefix(db.into());
+        fedimint_api::db::verify_find_by_prefix(
+            open_temp_db("fcb-sled-test-find-by-prefix").into(),
+        );
     }
 
     #[test_log::test]
     fn test_dbtx_commit() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-sled-test-commit")
-            .tempdir()
-            .unwrap();
-        let db = SledDb::open(path, "default").unwrap();
-        fedimint_api::db::verify_commit(db.into());
+        fedimint_api::db::verify_commit(open_temp_db("fcb-sled-test-commit").into());
     }
 
     #[test_log::test]
     fn test_dbtx_rollback_to_savepoint() {
-        let path = tempfile::Builder::new()
-            .prefix("fcb-sled-test-rollback-to-savepoint")
-            .tempdir()
-            .unwrap();
-        let db = SledDb::open(path, "default").unwrap();
-        fedimint_api::db::verify_rollback_to_savepoint(db.into());
+        fedimint_api::db::verify_rollback_to_savepoint(
+            open_temp_db("fcb-sled-test-rollback-to-savepoint").into(),
+        );
     }
 }


### PR DESCRIPTION
This PR adds unit tests that verify the database isolation level of the database implementation. The following unit tests are added:

test_dbtx_insert_elements
test_dbtx_remove_nonexisting
test_dbtx_remove_existing
test_dbtx_read_own_writes
test_dbtx_prevent_dirty_reads
test_dbtx_find_by_prefix
test_dbtx_commit
test_dbtx_prevent_nonrepeatable_reads
test_dbtx_rollback_to_savepoint
test_dbtx_phantom_entry
test_dbtx_write_conflict

The idea is to isolate each anamoly that can happen at isolation levels that are lower than serializable or snapshot isolation. Adding new db implementations should be much easier because running these tests again the implementation should reveal if it's isolation level is sufficient or not.

Currently, rocksdb is the only implementation that satisifies all the tests and prevents all anamolies. MemoryDB satisifies all anamolies except Lost Writes, which should be fine for testing since we don't expect write-write conflicts. SledDB doesn't currently support non-repeatable read, phantom record, and lost write. It should ideally be removed soon.