### PR TITLE
Gateway info

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -44,6 +44,9 @@ pub struct ReceiveInvoicePayload {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct InfoPayload;
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BalancePayload {
     pub federation_id: FederationId,
 }
@@ -72,8 +75,15 @@ pub struct WithdrawPayload {
     pub address: Address,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GatewayInfo {
+    pub version_hash: String,
+    pub federations: Vec<FederationId>,
+}
+
 #[derive(Debug)]
 pub enum GatewayRequest {
+    Info(GatewayRequestInner<InfoPayload>),
     ReceiveInvoice(GatewayRequestInner<ReceiveInvoicePayload>),
     PayInvoice(GatewayRequestInner<PayInvoicePayload>),
     Balance(GatewayRequestInner<BalancePayload>),
@@ -107,6 +117,8 @@ macro_rules! impl_gateway_request_trait {
         }
     };
 }
+
+impl_gateway_request_trait!(InfoPayload, GatewayInfo, GatewayRequest::Info);
 impl_gateway_request_trait!(
     ReceiveInvoicePayload,
     Preimage,

--- a/gateway/ln-gateway/src/webserver.rs
+++ b/gateway/ln-gateway/src/webserver.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 
 use crate::{
     rpc::GatewayRpcSender, BalancePayload, DepositAddressPayload, DepositPayload, GatewayRequest,
-    LnGatewayError, WithdrawPayload,
+    InfoPayload, LnGatewayError, WithdrawPayload,
 };
 
 pub async fn run_webserver(
@@ -49,11 +49,12 @@ pub async fn run_webserver(
 /// Display gateway ecash token balance
 #[debug_handler]
 #[instrument(skip_all, err)]
-async fn info(_: Extension<GatewayRpcSender>) -> Result<impl IntoResponse, LnGatewayError> {
-    // TODO: source actual gateway info
-    Ok(Json(
-        json!({ "url": "http://127.0.0.1:8080", "federations": "1" }),
-    ))
+async fn info(
+    Extension(rpc): Extension<GatewayRpcSender>,
+    Json(payload): Json<InfoPayload>,
+) -> Result<impl IntoResponse, LnGatewayError> {
+    let info = rpc.send(payload).await?;
+    Ok(Json(json!(info)))
 }
 
 /// Display gateway ecash token balance


### PR DESCRIPTION
Show realistic gateway info. Example:
```
$ gateway-cli info
{
  "federations": [
     "Hals_trusty_mint",
     "Coinbase_better"
  ],
  "version_hash": "67b8510c22180a99937201fc14706e2ec3a384a3"
}
```

closes #818