### PR TITLE
Update lightning and lightning-invoice crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,18 +2033,18 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.111"
+version = "0.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86c207bcbca1c9dfb3668b81e2ad35b81370e583f2f8c5ee642a9f07925b05e"
+checksum = "5deb857f23c88083ac09bc31fe4eadccf4b2779fb3c973862691258bff38b0e2"
 dependencies = [
  "bitcoin",
 ]
 
 [[package]]
 name = "lightning-invoice"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023d5bd83191e13281b877526efb503a96aaae7ef97c7ba6359ba73f9c1bee11"
+checksum = "0fc6ec960257cddce1b85d5ce258821a6138dcd0ae9fd9661b2c3061df588289"
 dependencies = [
  "bech32",
  "bitcoin_hashes",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 clap = { version = "4.0.18", features = ["derive"] }
-lightning-invoice = "0.19.0"
+lightning-invoice = "0.20.0"
 mint-client = { path = "../client-lib" }
 fedimint-api = { path = "../../fedimint-api" }
 fedimint-core = { path = "../../fedimint-core" }

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -22,8 +22,8 @@ bitcoin_hashes = "0.11.0"
 futures = "0.3.24"
 hex = "0.4.3"
 hkdf = { path = "../../crypto/hkdf" }
-lightning-invoice = "0.19.0"
-lightning = "0.0.111"
+lightning-invoice = "0.20.0"
+lightning = "0.0.112"
 miniscript = { version = "7.0.0", git = "https://github.com/rust-bitcoin/rust-miniscript/", rev = "2f1535e470c75fad85dbad8633986aae36a89a92" }
 fedimint-core = { path = "../../fedimint-core" }
 fedimint-api = { path = "../../fedimint-api" }

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -18,7 +18,7 @@ bitcoin = { version = "0.29.2", features = [ "rand", "serde" ] }
 bitcoin_hashes = { version = "0.11", features = ["serde"] }
 futures = "0.3.24"
 hex = "0.4.3"
-lightning-invoice = "0.19.0"
+lightning-invoice = "0.20.0"
 fedimint-derive = { path = "../fedimint-derive" }
 hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
 rand = "0.8.5"

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -27,7 +27,7 @@ cln-rpc = "0.1"
 cln-plugin = "0.1"
 futures = "0.3.24"
 hex = "0.4.3"
-lightning-invoice = "0.19.0"
+lightning-invoice = "0.20.0"
 fedimint-server = { path = "../../fedimint-server/" }
 fedimint-api = { path = "../../fedimint-api" }
 fedimint-rocksdb = { path = "../../fedimint-rocksdb" }

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -19,9 +19,9 @@ bitcoincore-rpc = "0.16.0"
 cln-rpc = "0.1.0"
 futures = "0.3.24"
 itertools = "0.10.5"
-lightning-invoice = "0.19.0"
+lightning-invoice = "0.20.0"
 ln-gateway = { path = "../gateway/ln-gateway" }
-lightning = "0.0.111"
+lightning = "0.0.112"
 fedimint-server = { path = "../fedimint-server" }
 fedimint-bitcoind = { path = "../fedimint-bitcoind" }
 fedimint-api = { path = "../fedimint-api" }

--- a/modules/fedimint-ln/Cargo.toml
+++ b/modules/fedimint-ln/Cargo.toml
@@ -19,8 +19,8 @@ bincode = "1"
 bitcoin_hashes = "0.11.0"
 futures = "0.3.24"
 itertools = "0.10.5"
-lightning = "0.0.111"
-lightning-invoice = "0.19.0"
+lightning = "0.0.112"
+lightning-invoice = "0.20.0"
 fedimint-api = { path = "../../fedimint-api" }
 secp256k1 = { version="0.24.1", default-features=false }
 serde = {version = "1.0.147", features = [ "derive" ] }


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/pull/858 and https://github.com/fedimint/fedimint/pull/857. Couldn't upgrade one without the other.