### PR TITLE
Rename ReceiveInvoicePayload to ReceivePaymentPayload

### DIFF
--- a/gateway/ln-gateway/src/cln.rs
+++ b/gateway/ln-gateway/src/cln.rs
@@ -12,7 +12,7 @@ use tokio::io::{stdin, stdout};
 use tokio::sync::Mutex;
 use tracing::{debug, error, instrument};
 
-use crate::ReceiveInvoicePayload;
+use crate::ReceivePaymentPayload;
 use crate::{
     ln::{LightningError, LnRpc, LnRpcRef},
     rpc::GatewayRpcSender,
@@ -116,7 +116,7 @@ async fn htlc_accepted_hook(
     let htlc_accepted: HtlcAccepted = serde_json::from_value(value)?;
     let preimage = plugin
         .state()
-        .send(ReceiveInvoicePayload { htlc_accepted })
+        .send(ReceivePaymentPayload { htlc_accepted })
         .await?;
     let pk = preimage.to_public_key()?;
     Ok(serde_json::json!({

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -5,6 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct GatewayConfig {
     pub password: String,
     // FIXME: Issue 664: We should avoid having a special reference to a federation
-    // all requests, including `ReceiveInvoicePayload`, should contain the federation id
+    // all requests, including `ReceivePaymentPayload`, should contain the federation id
     pub default_federation: FederationId,
 }


### PR DESCRIPTION
**ReceiveInvoice** is a misnomer, which does not describe the event where a gateway is accepting htlcs on behalf of the user. 

The best descriptive name we could come up with is **ReceivePayment**, so this pr renames the payload