### PR TITLE
daily dependency audit

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -30,3 +30,11 @@ jobs:
 
       - name: Run cargo udeps
         run: cargo udeps --all-targets --all-features
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`cargo audit` is very usefull (install it with `cargo install cargo-audit`) we should also add it to the CI on push (if `.toml`) changes but now fedimint is not regarded usable anyway so this would just slow down development