### PR TITLE
Register Federations on Gateway using Connect Info

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -2,12 +2,12 @@ use std::path::PathBuf;
 
 use bitcoin::{Address, Amount, Transaction};
 use clap::{Parser, Subcommand};
-use fedimint_server::{config::load_from_file, modules::wallet::txoproof::TxOutProof};
+use fedimint_server::modules::wallet::txoproof::TxOutProof;
 use ln_gateway::{
     config::GatewayConfig, BalancePayload, DepositAddressPayload, DepositPayload,
     RegisterFedPayload, WithdrawPayload,
 };
-use mint_client::{utils::from_hex, FederationId, GatewayClientConfig};
+use mint_client::{utils::from_hex, FederationId};
 use serde::Serialize;
 
 #[derive(Parser)]
@@ -62,8 +62,8 @@ pub enum Commands {
     },
     /// Register federation with the gateway
     RegisterFed {
-        /// Path to file with gateway federation client configuration
-        config_file: PathBuf,
+        /// ConnectInfo code to connect to the federation
+        connect: String,
     },
 }
 
@@ -154,15 +154,12 @@ async fn main() {
             )
             .await;
         }
-        Commands::RegisterFed { config_file } => {
-            let config: GatewayClientConfig = load_from_file(&config_file);
+        Commands::RegisterFed { connect } => {
             call(
                 source_password(cli.rpcpassword),
                 cli.url,
                 String::from("/register"),
-                RegisterFedPayload {
-                    config: Box::new(config),
-                },
+                RegisterFedPayload { connect },
             )
             .await;
         }

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Error> {
         RocksDbGatewayClientBuilder::new(work_dir.clone()).into();
 
     // Create gateway instance
-    let mut gateway = LnGateway::new(gw_cfg, ln_rpc, tx, rx, bind_addr);
+    let mut gateway = LnGateway::new(gw_cfg, ln_rpc, tx, rx, bind_addr, client_builder.clone());
 
     // Build and register the default federation
     // TODO: Register default federation through gateway webserver api

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -46,7 +46,15 @@ async fn main() -> Result<(), Error> {
         RocksDbGatewayClientBuilder::new(work_dir.clone()).into();
 
     // Create gateway instance
-    let mut gateway = LnGateway::new(gw_cfg, ln_rpc, tx, rx, bind_addr, client_builder.clone());
+    let mut gateway = LnGateway::new(
+        gw_cfg,
+        ln_rpc,
+        client_builder.clone(),
+        tx,
+        rx,
+        bind_addr,
+        pub_key,
+    );
 
     // Build and register the default federation
     // TODO: Register default federation through gateway webserver api

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -1,16 +1,20 @@
-use std::{fs::File, net::SocketAddr, path::Path, path::PathBuf, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use cln_plugin::Error;
 use fedimint_server::config::{load_from_file, ClientConfig};
 use ln_gateway::{
-    cln::build_cln_rpc, config::GatewayConfig, ln::LnRpcRef, rpc::GatewayRpcSender, GatewayRequest,
-    LnGateway,
+    client::{GatewayClientBuilder, RocksDbGatewayClientBuilder},
+    cln::build_cln_rpc,
+    config::GatewayConfig,
+    ln::LnRpcRef,
+    rpc::GatewayRpcSender,
+    GatewayRequest, LnGateway,
 };
-use mint_client::{Client, GatewayClientConfig};
+use mint_client::GatewayClientConfig;
 use rand::thread_rng;
 use secp256k1::{KeyPair, PublicKey};
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::warn;
 use url::Url;
 
 #[tokio::main]
@@ -37,21 +41,35 @@ async fn main() -> Result<(), Error> {
     let gw_cfg_path = work_dir.clone().join("gateway.config");
     let gw_cfg: GatewayConfig = load_from_file(&gw_cfg_path);
 
+    // Create federation client builder
+    let client_builder: GatewayClientBuilder =
+        RocksDbGatewayClientBuilder::new(work_dir.clone()).into();
+
+    // Create gateway instance
     let mut gateway = LnGateway::new(gw_cfg, ln_rpc, tx, rx, bind_addr);
 
-    let default_fed = Arc::new(build_federation_client(pub_key, bind_addr, work_dir)?);
-    gateway.register_federation(default_fed).await?;
+    // Build and register the default federation
+    // TODO: Register default federation through gateway webserver api
+    let client_cfg = build_federation_client_cfg(pub_key, bind_addr, work_dir)?;
+    let default_fed = client_builder.build(client_cfg.clone())?;
+    gateway.register_federation(Arc::new(default_fed)).await?;
+    if let Err(e) = client_builder.save_config(client_cfg.clone()) {
+        warn!(
+            "Failed to save default federation client configuration: {}",
+            e
+        );
+    }
 
     gateway.run().await.expect("gateway failed to run");
     Ok(())
 }
 
 /// Build a new federation client with RocksDb and config at a given path
-fn build_federation_client(
+fn build_federation_client_cfg(
     node_pub_key: PublicKey,
     bind_addr: SocketAddr,
     work_dir: PathBuf,
-) -> Result<Client<GatewayClientConfig>, Error> {
+) -> Result<GatewayClientConfig, Error> {
     // Create a gateway client configuration
     let client_cfg_path = work_dir.join("client.json");
     let client_cfg: ClientConfig = load_from_file(&client_cfg_path);
@@ -60,41 +78,12 @@ fn build_federation_client(
     let ctx = secp256k1::Secp256k1::new();
     let kp_fed = KeyPair::new(&ctx, &mut rng);
 
-    let client_cfg = GatewayClientConfig {
+    Ok(GatewayClientConfig {
         client_config: client_cfg,
         redeem_key: kp_fed,
         timelock_delta: 10,
         node_pub_key,
         api: Url::parse(format!("http://{}", bind_addr).as_str())
             .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),
-    };
-
-    // TODO: With support for multiple federations and federation registration through config code
-    // the gateway should be able back-up all registered federations in a snapshot or db.
-    save_federation_client_cfg(work_dir.clone(), &client_cfg);
-
-    // Create a database
-    let db_path = work_dir.join("gateway.db");
-    let db = fedimint_rocksdb::RocksDb::open(db_path)
-        .expect("Error opening DB")
-        .into();
-
-    // Create context
-    let ctx = secp256k1::Secp256k1::new();
-
-    Ok(Client::new(client_cfg, db, ctx))
-}
-
-/// Persist federation client cfg to [`gateway.json`] file
-fn save_federation_client_cfg(work_dir: PathBuf, client_cfg: &GatewayClientConfig) {
-    let path: PathBuf = work_dir.join("gateway.json");
-    if !Path::new(&path).is_file() {
-        debug!("Creating new gateway cfg file at {}", path.display());
-        let file = File::create(path).expect("Could not create gateway cfg file");
-        serde_json::to_writer_pretty(file, &client_cfg).expect("Could not write gateway cfg");
-    } else {
-        debug!("Gateway cfg file already exists at {}", path.display());
-        let file = File::open(path).expect("Could not load gateway cfg file");
-        serde_json::to_writer_pretty(file, &client_cfg).expect("Could not write gateway cfg");
-    }
+    })
 }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use fedimint_api::{db::Database, dyn_newtype_define};
+use mint_client::{Client, FederationId, GatewayClientConfig};
+
+use crate::Result;
+
+/// Trait for gateway federation client builders
+pub trait IGatewayClientBuilder {
+    /// Build a new gateway federation client
+    fn build(&self, config: GatewayClientConfig) -> Result<Client<GatewayClientConfig>>;
+
+    /// Create a new database for the gateway federation client
+    fn create_database(&self, federation_id: FederationId) -> Result<Database>;
+
+    /// Save and persist the configuration of the gateway federation client
+    fn save_config(&self, config: GatewayClientConfig) -> Result<()>;
+}
+
+dyn_newtype_define! {
+  /// Arc reference to a Gateway federation client builder
+  #[derive(Clone)]
+  pub GatewayClientBuilder(Arc<IGatewayClientBuilder>)
+}

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -1,7 +1,12 @@
-use std::sync::Arc;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use fedimint_api::{db::Database, dyn_newtype_define};
 use mint_client::{Client, FederationId, GatewayClientConfig};
+use tracing::debug;
 
 use crate::Result;
 
@@ -21,4 +26,57 @@ dyn_newtype_define! {
   /// Arc reference to a Gateway federation client builder
   #[derive(Clone)]
   pub GatewayClientBuilder(Arc<IGatewayClientBuilder>)
+}
+
+#[derive(Debug, Clone)]
+pub struct RocksDbGatewayClientBuilder {
+    pub work_dir: PathBuf,
+}
+
+/// Default gateway clinet builder which constructs clients with RocksDb
+/// and saves the config at the given work directory
+impl RocksDbGatewayClientBuilder {
+    pub fn new(work_dir: PathBuf) -> Self {
+        Self { work_dir }
+    }
+}
+
+/// Builds a new federation client with RocksDb
+/// On successful build, the configuration is saved to a file at the builder work directory
+impl IGatewayClientBuilder for RocksDbGatewayClientBuilder {
+    fn build(&self, config: GatewayClientConfig) -> Result<Client<GatewayClientConfig>> {
+        let federation_id = FederationId(config.client_config.federation_name.clone());
+
+        let db = self.create_database(federation_id)?;
+        let ctx = secp256k1::Secp256k1::new();
+
+        Ok(Client::new(config, db, ctx))
+    }
+
+    /// Create a client database
+    fn create_database(&self, federation_id: FederationId) -> Result<Database> {
+        let db_path = self.work_dir.join(format!("{}.db", federation_id.0));
+        let db = fedimint_rocksdb::RocksDb::open(db_path)
+            .expect("Error opening DB")
+            .into();
+        Ok(db)
+    }
+
+    /// Persist federation client cfg to [`<federation_id>.json`] file
+    fn save_config(&self, config: GatewayClientConfig) -> Result<()> {
+        let federation_id = FederationId(config.client_config.federation_name.clone());
+        let path: PathBuf = self.work_dir.join(format!("{}.json", federation_id.0));
+
+        if !Path::new(&path).is_file() {
+            debug!("Creating new gateway cfg file at {}", path.display());
+            let file = File::create(path).expect("Could not create gateway cfg file");
+            serde_json::to_writer_pretty(file, &config).expect("Could not write gateway cfg");
+        } else {
+            debug!("Gateway cfg file already exists at {}", path.display());
+            let file = File::open(path).expect("Could not load gateway cfg file");
+            serde_json::to_writer_pretty(file, &config).expect("Could not write gateway cfg");
+        }
+
+        Ok(())
+    }
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod actor;
+pub mod client;
 pub mod cln;
 pub mod config;
 pub mod ln;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -36,7 +36,10 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error};
 use webserver::run_webserver;
 
-use crate::ln::{LightningError, LnRpc};
+use crate::{
+    client::GatewayClientBuilder,
+    ln::{LightningError, LnRpc},
+};
 
 pub type Result<T> = std::result::Result<T, LnGatewayError>;
 
@@ -165,6 +168,7 @@ pub struct LnGateway {
     ln_client: Arc<dyn LnRpc>,
     webserver: tokio::task::JoinHandle<axum::response::Result<()>>,
     receiver: mpsc::Receiver<GatewayRequest>,
+    client_builder: GatewayClientBuilder,
 }
 
 impl LnGateway {
@@ -174,6 +178,7 @@ impl LnGateway {
         sender: mpsc::Sender<GatewayRequest>,
         receiver: mpsc::Receiver<GatewayRequest>,
         bind_addr: SocketAddr,
+        client_builder: GatewayClientBuilder,
     ) -> Self {
         // Run webserver asynchronously in tokio
         let webserver = tokio::spawn(run_webserver(config.password.clone(), bind_addr, sender));
@@ -184,6 +189,7 @@ impl LnGateway {
             ln_client,
             webserver,
             receiver,
+            client_builder,
         }
     }
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -22,18 +22,24 @@ use axum::response::{IntoResponse, Response};
 use bitcoin::{Address, Transaction};
 use cln::HtlcAccepted;
 use config::GatewayConfig;
-use fedimint_api::{Amount, TransactionId};
+use fedimint_api::{Amount, NumPeers, TransactionId};
+use fedimint_server::config::ClientConfig;
 use fedimint_server::modules::ln::contracts::Preimage;
 use fedimint_server::modules::wallet::txoproof::TxOutProof;
 use futures::Future;
+use mint_client::api::{WsFederationApi, WsFederationConnect};
+use mint_client::query::CurrentConsensus;
+use mint_client::GatewayClientConfig;
 use mint_client::{
     ln::PayInvoicePayload, mint::MintClientError, ClientError, FederationId, GatewayClient,
-    GatewayClientConfig,
 };
+use rand::thread_rng;
+use secp256k1::{KeyPair, PublicKey};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error};
+use url::Url;
 use webserver::run_webserver;
 
 use crate::{
@@ -45,7 +51,7 @@ pub type Result<T> = std::result::Result<T, LnGatewayError>;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RegisterFedPayload {
-    pub config: Box<GatewayClientConfig>,
+    pub connect: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -169,16 +175,22 @@ pub struct LnGateway {
     webserver: tokio::task::JoinHandle<axum::response::Result<()>>,
     receiver: mpsc::Receiver<GatewayRequest>,
     client_builder: GatewayClientBuilder,
+    // TODO: consider wrapping bind_addr, and node_pubkey in GatewayConfig
+    bind_addr: SocketAddr,
+    pub_key: PublicKey,
 }
 
 impl LnGateway {
     pub fn new(
         config: GatewayConfig,
         ln_client: Arc<dyn LnRpc>,
+        client_builder: GatewayClientBuilder,
+        // TODO: consider encapsulating message channel within LnGateway
         sender: mpsc::Sender<GatewayRequest>,
         receiver: mpsc::Receiver<GatewayRequest>,
+        // TODO: consider wrapping bind_addr, and node_pubkey in GatewayConfig
         bind_addr: SocketAddr,
-        client_builder: GatewayClientBuilder,
+        pub_key: PublicKey,
     ) -> Self {
         // Run webserver asynchronously in tokio
         let webserver = tokio::spawn(run_webserver(config.password.clone(), bind_addr, sender));
@@ -190,6 +202,8 @@ impl LnGateway {
             webserver,
             receiver,
             client_builder,
+            bind_addr,
+            pub_key,
         }
     }
 
@@ -229,7 +243,33 @@ impl LnGateway {
 
     // Webserver handler for requests to register a federation
     async fn handle_register_federation(&self, payload: RegisterFedPayload) -> Result<()> {
-        let client = self.client_builder.build(*payload.config)?;
+        let connect: WsFederationConnect =
+            serde_json::from_str(&payload.connect).expect("Invalid federation connect info");
+        let api = WsFederationApi::new(connect.members);
+
+        let client_cfg: ClientConfig = api
+            .request(
+                "/config",
+                (),
+                CurrentConsensus::new(api.peers().one_honest()),
+            )
+            .await
+            .expect("Failed to get client config");
+
+        let mut rng = thread_rng();
+        let ctx = secp256k1::Secp256k1::new();
+        let kp_fed = KeyPair::new(&ctx, &mut rng);
+
+        let gw_client_cfg = GatewayClientConfig {
+            client_config: client_cfg,
+            redeem_key: kp_fed,
+            timelock_delta: 10,
+            node_pub_key: self.pub_key,
+            api: Url::parse(format!("http://{}", self.bind_addr).as_str())
+                .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),
+        };
+
+        let client = self.client_builder.build(gw_client_cfg)?;
 
         if let Err(e) = self.register_federation(Arc::new(client)).await {
             error!("Failed to register federation: {}", e);

--- a/gateway/ln-gateway/src/webserver.rs
+++ b/gateway/ln-gateway/src/webserver.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 
 use crate::{
     rpc::GatewayRpcSender, BalancePayload, DepositAddressPayload, DepositPayload, GatewayRequest,
-    InfoPayload, LnGatewayError, WithdrawPayload,
+    InfoPayload, LnGatewayError, RegisterFedPayload, WithdrawPayload,
 };
 
 pub async fn run_webserver(
@@ -30,6 +30,7 @@ pub async fn run_webserver(
         .route("/address", post(address))
         .route("/deposit", post(deposit))
         .route("/withdraw", post(withdraw))
+        .route("/register", post(register))
         .layer(RequireAuthorizationLayer::bearer(&authkey));
 
     let app = Router::new()
@@ -105,6 +106,16 @@ async fn withdraw(
 async fn pay_invoice(
     Extension(rpc): Extension<GatewayRpcSender>,
     Json(payload): Json<PayInvoicePayload>,
+) -> Result<impl IntoResponse, LnGatewayError> {
+    rpc.send(payload).await?;
+    Ok(())
+}
+
+/// Register a new federation
+#[instrument(skip_all, err)]
+async fn register(
+    Extension(rpc): Extension<GatewayRpcSender>,
+    Json(payload): Json<RegisterFedPayload>,
 ) -> Result<impl IntoResponse, LnGatewayError> {
     rpc.send(payload).await?;
     Ok(())

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -354,18 +354,20 @@ impl GatewayTest {
                 .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),
             node_pub_key,
         };
+
         let client = Arc::new(GatewayClient::new(
             gw_cfg,
             database.clone(),
             Default::default(),
         ));
+
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
         let adapter = Arc::new(ln_client_adapter);
         let ln_client = Arc::clone(&adapter);
 
         let gw_cfg = GatewayConfig {
             password: "abc".into(),
-            default_federation: FederationId(client.config().client_config.federation_name),
+            default_federation: FederationId(client.config().client_config.federation_name.clone()),
         };
 
         let mut gateway = LnGateway::new(gw_cfg, ln_client, sender, receiver, bind_addr);

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -364,7 +364,7 @@ impl GatewayTest {
             default_federation: FederationId(gw_client_cfg.client_config.federation_name.clone()),
         };
 
-        let mut gateway = LnGateway::new(
+        let gateway = LnGateway::new(
             gw_cfg,
             ln_client,
             sender,

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -395,10 +395,11 @@ impl GatewayTest {
         let gateway = LnGateway::new(
             gw_cfg,
             ln_client,
+            client_builder.clone(),
             sender,
             receiver,
             bind_addr,
-            client_builder.clone(),
+            node_pub_key,
         );
 
         let client = Arc::new(

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -364,7 +364,14 @@ impl GatewayTest {
             default_federation: FederationId(gw_client_cfg.client_config.federation_name.clone()),
         };
 
-        let mut gateway = LnGateway::new(gw_cfg, ln_client, sender, receiver, bind_addr);
+        let mut gateway = LnGateway::new(
+            gw_cfg,
+            ln_client,
+            sender,
+            receiver,
+            bind_addr,
+            client_builder.clone(),
+        );
 
         let client = Arc::new(
             client_builder


### PR DESCRIPTION
Instead of registering with some known gateway client config, this PR supports use of connect info to register federations on the gateway

closes #699 