### PR TITLE
Require out-dir when generating gateway config

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -28,7 +28,6 @@ pub enum Commands {
     /// NOTE: This command can only be used on a local gateway
     GenerateConfig {
         /// The gateway configuration directory
-        #[clap(default_value = ".gateway")]
         out_dir: PathBuf,
     },
     /// Display CLI version hash


### PR DESCRIPTION
Remove configured default out dir on gataway-cli generate-config. Makes the CLI predictable to user