### PR TITLE
Hash Federation ID in gateway

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -104,6 +104,12 @@ pub struct PaymentParameters {
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, Hash, PartialEq)]
 pub struct FederationId(pub String);
 
+impl FederationId {
+    pub fn hash(&self) -> sha256::Hash {
+        sha256::Hash::hash(self.0.as_bytes())
+    }
+}
+
 impl FromStr for FederationId {
     type Err = anyhow::Error;
 

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -7,7 +7,7 @@ use fedimint_server::modules::{
     ln::contracts::{ContractId, Preimage},
     wallet::txoproof::TxOutProof,
 };
-use mint_client::{GatewayClient, PaymentParameters};
+use mint_client::{FederationId, GatewayClient, PaymentParameters};
 use rand::{CryptoRng, RngCore};
 use tracing::{debug, info, instrument, warn};
 
@@ -15,10 +15,11 @@ use crate::{ln::LnRpc, utils::retry, LnGatewayError, Result};
 
 pub struct GatewayActor {
     client: Arc<GatewayClient>,
+    pub id: FederationId,
 }
 
 impl GatewayActor {
-    pub async fn new(client: Arc<GatewayClient>) -> Result<Self> {
+    pub async fn new(client: Arc<GatewayClient>, id: FederationId) -> Result<Self> {
         // Retry regster gateway federation client with federation
         match retry(
             String::from("Register With Federation"),
@@ -38,7 +39,7 @@ impl GatewayActor {
             Err(e) => warn!("Failed to register with federation: {}", e),
         }
 
-        Ok(Self { client })
+        Ok(Self { client, id })
     }
 
     /// Fetch all coins minted for this gateway by the federation

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -58,7 +58,7 @@ impl IGatewayClientBuilder for RocksDbGatewayClientBuilder {
 
     /// Create a client database
     fn create_database(&self, federation_id: FederationId) -> Result<Database> {
-        let db_path = self.work_dir.join(format!("{}.db", federation_id.0));
+        let db_path = self.work_dir.join(format!("{}.db", federation_id.hash()));
         let db = fedimint_rocksdb::RocksDb::open(db_path)
             .expect("Error opening DB")
             .into();
@@ -68,7 +68,8 @@ impl IGatewayClientBuilder for RocksDbGatewayClientBuilder {
     /// Persist federation client cfg to [`<federation_id>.json`] file
     fn save_config(&self, config: GatewayClientConfig) -> Result<()> {
         let federation_id = FederationId(config.client_config.federation_name.clone());
-        let path: PathBuf = self.work_dir.join(format!("{}.json", federation_id.0));
+
+        let path: PathBuf = self.work_dir.join(format!("{}.json", federation_id.hash()));
 
         if !Path::new(&path).is_file() {
             debug!("Creating new gateway cfg file at {}", path.display());

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -228,13 +228,14 @@ impl LnGateway {
         &self,
         client: Arc<GatewayClient>,
     ) -> Result<Arc<GatewayActor>> {
+        let federation_id = FederationId(client.config().client_config.federation_name);
+
         let actor = Arc::new(
-            GatewayActor::new(client.clone())
+            GatewayActor::new(client.clone(), federation_id.clone())
                 .await
                 .expect("Failed to create actor"),
         );
 
-        let federation_id = FederationId(client.config().client_config.federation_name);
         if let Ok(mut actors) = self.actors.lock() {
             actors.insert(federation_id.hash(), actor.clone());
         }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -99,7 +99,7 @@ pub struct WithdrawPayload {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GatewayInfo {
     pub version_hash: String,
-    pub federations: Vec<Sha256Hash>,
+    pub federations: Vec<FederationId>,
 }
 
 #[derive(Debug)]
@@ -290,7 +290,7 @@ impl LnGateway {
         if let Ok(actors) = self.actors.lock() {
             return Ok(GatewayInfo {
                 version_hash: env!("GIT_HASH").to_string(),
-                federations: actors.keys().cloned().collect(),
+                federations: actors.iter().map(|(_, actor)| actor.id.clone()).collect(),
             });
         }
         Err(LnGatewayError::Other(anyhow::anyhow!(


### PR DESCRIPTION
When building gateway clients using RocksDB, we create a file seeded with the federation id provided when registering the federation. Since the ID is an unknown value, we would expose a [path traversal attack](https://owasp.org/www-community/attacks/Path_Traversal) surface by just using the plain federation id value, which is currently an unsanitized string.

This PR proposes hashing of the federation id value before use in the gateway
#754 has proposals for defining how Federation IDs are derived. We should add this as a consideration in defining Federation IDs