### PR TITLE
Create gateway test framework crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway-tests"
+version = "0.1.0"
+dependencies = [
+ "ln-gateway",
+ "tokio",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crypto/tbs",
     "gateway/ln-gateway",
     "gateway/cli",
+    "gateway/tests",
     "fedimintd",
     "fedimint-bitcoind",
     "fedimint-core",

--- a/flake.nix
+++ b/flake.nix
@@ -655,6 +655,13 @@
           ];
         };
 
+        gateway-tests = pkg {
+          name = "gateway-tests";
+          dirs = [
+            "gateway/ln-gateway"
+          ];
+        };
+
         # Replace placeholder git hash in a binary
         #
         # To avoid impurity, we use a git hash placeholder when building binaries

--- a/gateway/tests/Cargo.toml
+++ b/gateway/tests/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "gateway-tests"
+version = "0.1.0"
+authors = ["The Fedimint Developers"]
+edition = "2021"
+description = "Fedimint gateway integration tests validating the interactions between the gateway components and it's dependencies"
+license = "MIT"
+
+[[test]]
+name = "gateway-tests"
+path = "tests/tests.rs"
+
+[dev-dependencies]
+ln-gateway = { path = "../ln-gateway" }
+tokio = { version = "1.21.2", features = ["full"] }

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -1,0 +1,2 @@
+#[tokio::test(flavor = "multi_thread")]
+async fn test_gateway_webserver_authentication() {}


### PR DESCRIPTION
Create a testing crate at `gateway/tests` to host integration tests for the Gateway