### PR TITLE
Multiplexing peer connection improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "tbs",
+ "test-log",
  "thiserror",
  "threshold_crypto",
  "tokio",

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -24,7 +24,8 @@ use tbs::Scalar;
 use url::Url;
 
 use crate::cancellable::Cancellable;
-use crate::multiplexed::{ModuleIdRef, ModuleMultiplexer};
+use crate::core::ModuleKey;
+use crate::net::peers::MuxPeerConnections;
 use crate::Amount;
 use crate::PeerId;
 
@@ -434,8 +435,8 @@ where
     /// Create keys from G2 (96B keys, 48B messages) used in `tbs`
     pub async fn run_g2(
         &mut self,
-        module_id: ModuleIdRef<'_>,
-        connections: &ModuleMultiplexer<DkgPeerMsg>,
+        module_id: ModuleKey,
+        connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         rng: &mut (impl RngCore + CryptoRng),
     ) -> Cancellable<HashMap<T, DkgKeys<G2Projective>>> {
         self.run(module_id, G2Projective::generator(), connections, rng)
@@ -445,8 +446,8 @@ where
     /// Create keys from G1 (48B keys, 96B messages) used in `threshold_crypto`
     pub async fn run_g1(
         &mut self,
-        module_id: ModuleIdRef<'_>,
-        connections: &ModuleMultiplexer<DkgPeerMsg>,
+        module_id: ModuleKey,
+        connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         rng: &mut (impl RngCore + CryptoRng),
     ) -> Cancellable<HashMap<T, DkgKeys<G1Projective>>> {
         self.run(module_id, G1Projective::generator(), connections, rng)
@@ -456,9 +457,9 @@ where
     /// Runs the DKG algorithms with our peers
     pub async fn run<G: DkgGroup>(
         &mut self,
-        module_id: ModuleIdRef<'_>,
+        module_id: ModuleKey,
         group: G,
-        connections: &ModuleMultiplexer<DkgPeerMsg>,
+        connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         rng: &mut (impl RngCore + CryptoRng),
     ) -> Cancellable<HashMap<T, DkgKeys<G>>>
     where

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -25,6 +25,15 @@ pub mod server;
 /// of module-specific data.
 pub type ModuleKey = u16;
 
+/// Temporary constant for the modules we already have
+///
+/// To be removed after modularization is complete.
+pub const MODULE_KEY_WALLET: u16 = 0;
+pub const MODULE_KEY_MINT: u16 = 1;
+pub const MODULE_KEY_LN: u16 = 2;
+// not really a module
+pub const MODULE_KEY_GLOBAL: u16 = 1024;
+
 /// Implement `Encodable` and `Decodable` for a "module dyn newtype"
 ///
 /// "Module dyn newtype" is just a "dyn newtype" used by general purpose

--- a/fedimint-api/src/lib.rs
+++ b/fedimint-api/src/lib.rs
@@ -27,7 +27,6 @@ pub mod db;
 pub mod encoding;
 pub mod macros;
 pub mod module;
-pub mod multiplexed;
 pub mod net;
 pub mod task;
 pub mod tiered;

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -11,9 +11,10 @@ use thiserror::Error;
 use crate::cancellable::Cancellable;
 use crate::config::{ClientModuleConfig, DkgPeerMsg, ModuleConfigGenParams, ServerModuleConfig};
 use crate::db::DatabaseTransaction;
+use crate::encoding::ModuleKey;
 use crate::module::audit::Audit;
 use crate::module::interconnect::ModuleInterconect;
-use crate::multiplexed::ModuleMultiplexer;
+use crate::net::peers::MuxPeerConnections;
 use crate::task::TaskGroup;
 use crate::{Amount, PeerId};
 
@@ -184,7 +185,7 @@ pub trait FederationModuleConfigGen {
 
     async fn distributed_gen(
         &self,
-        connections: &ModuleMultiplexer<DkgPeerMsg>,
+        connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         our_id: &PeerId,
         peers: &[PeerId],
         params: &ModuleConfigGenParams,

--- a/fedimint-api/src/multiplexed.rs
+++ b/fedimint-api/src/multiplexed.rs
@@ -14,7 +14,7 @@ type Mutex<T> = std::marker::PhantomData<T>;
 
 use tracing::{debug, error};
 
-use crate::{cancellable::Cancellable, net::peers::AnyPeerConnections, PeerId};
+use crate::{cancellable::Cancellable, net::peers::PeerConnections, PeerId};
 
 /// TODO: Use proper ModuleId after modularization is complete
 pub type ModuleId = String;
@@ -46,7 +46,7 @@ impl<Msg> Default for ModuleMultiplexerOutOfOrder<Msg> {
 /// Shared, mutable (wrapped in mutex) data of [`ModuleMultiplexer`].
 struct ModuleMultiplexerInner<Msg> {
     /// Underlying connection pool
-    connections: Mutex<AnyPeerConnections<ModuleMultiplexed<Msg>>>,
+    connections: Mutex<PeerConnections<ModuleMultiplexed<Msg>>>,
     /// Messages that arrived before an interested thread asked for them
     out_of_order: Mutex<ModuleMultiplexerOutOfOrder<Msg>>,
 }
@@ -73,7 +73,7 @@ where
     Msg: Serialize + DeserializeOwned + Unpin + Send + Debug,
 {
     #[cfg(not(target_family = "wasm"))]
-    pub fn new(connections: AnyPeerConnections<ModuleMultiplexed<Msg>>) -> Self {
+    pub fn new(connections: PeerConnections<ModuleMultiplexed<Msg>>) -> Self {
         Self {
             inner: Arc::new(ModuleMultiplexerInner {
                 connections: Mutex::new(connections),
@@ -83,7 +83,7 @@ where
     }
 
     #[cfg(target_family = "wasm")]
-    pub fn new(connections: AnyPeerConnections<ModuleMultiplexed<Msg>>) -> Self {
+    pub fn new(connections: PeerConnections<ModuleMultiplexed<Msg>>) -> Self {
         unimplemented!();
     }
 

--- a/fedimint-api/src/net/peers.rs
+++ b/fedimint-api/src/net/peers.rs
@@ -8,6 +8,9 @@ use serde::Serialize;
 
 use crate::cancellable::Cancellable;
 
+#[cfg(not(target_family = "wasm"))]
+pub mod fake;
+
 /// Owned [`PeerConnections`] trait object type
 pub struct PeerConnections<Msg>(Box<dyn IPeerConnections<Msg> + Send + Unpin + 'static>);
 

--- a/fedimint-api/src/net/peers.rs
+++ b/fedimint-api/src/net/peers.rs
@@ -63,6 +63,7 @@ where
 }
 
 /// Owned [`MuxPeerConnections`] trait object type
+#[derive(Clone)]
 pub struct MuxPeerConnections<MuxKey, Msg>(
     Arc<dyn IMuxPeerConnections<MuxKey, Msg> + Send + Sync + Unpin + 'static>,
 );

--- a/fedimint-api/src/net/peers/fake.rs
+++ b/fedimint-api/src/net/peers/fake.rs
@@ -1,0 +1,86 @@
+/// Fake (channel-based) implementation of [`super::PeerConnections`].
+use std::time::Duration;
+
+use async_trait::async_trait;
+use fedimint_api::cancellable::{Cancellable, Cancelled};
+use fedimint_api::net::peers::{IPeerConnections, PeerConnections};
+use fedimint_api::task::TaskHandle;
+use fedimint_api::PeerId;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::time::sleep;
+
+struct FakePeerConnections<Msg> {
+    tx: Sender<Msg>,
+    rx: Receiver<Msg>,
+    peer_id: PeerId,
+    task_handle: TaskHandle,
+}
+
+#[async_trait]
+impl<Msg> IPeerConnections<Msg> for FakePeerConnections<Msg>
+where
+    Msg: Serialize + DeserializeOwned + Unpin + Send,
+{
+    async fn send(&mut self, peers: &[PeerId], msg: Msg) -> Cancellable<()> {
+        assert_eq!(peers, &[self.peer_id]);
+
+        // If the peer is gone, just pretend we are going to resend
+        // the msg eventually, even if it will never happen.
+        let _ = self.tx.send(msg).await;
+        Ok(())
+    }
+
+    async fn receive(&mut self) -> Cancellable<(PeerId, Msg)> {
+        // Just like a real implementation, do not return
+        // if the peer is gone.
+        while !self.task_handle.is_shutting_down() {
+            if let Some(msg) = self.rx.recv().await {
+                return Ok((self.peer_id, msg));
+            } else {
+                sleep(Duration::from_secs(10)).await
+            }
+        }
+        Err(Cancelled)
+    }
+
+    /// Removes a peer connection in case of misbehavior
+    async fn ban_peer(&mut self, _peer: PeerId) {
+        unimplemented!();
+    }
+}
+
+/// Create a fake link between `peer1` and `peer2` for test purposes
+///
+/// `buf_size` controlls the size of the `tokio::mpsc::channel` used
+/// under the hood (both ways).
+pub fn make_fake_peer_connection<Msg>(
+    peer1: PeerId,
+    peer2: PeerId,
+    buf_size: usize,
+    task_handle: TaskHandle,
+) -> (PeerConnections<Msg>, PeerConnections<Msg>)
+where
+    Msg: Serialize + DeserializeOwned + Unpin + Send + 'static,
+{
+    let (tx1, rx1) = mpsc::channel(buf_size);
+    let (tx2, rx2) = mpsc::channel(buf_size);
+
+    (
+        FakePeerConnections {
+            tx: tx1,
+            rx: rx2,
+            peer_id: peer2,
+            task_handle: task_handle.clone(),
+        }
+        .into_dyn(),
+        FakePeerConnections {
+            tx: tx2,
+            rx: rx1,
+            peer_id: peer1,
+            task_handle,
+        }
+        .into_dyn(),
+    )
+}

--- a/fedimint-api/src/task.rs
+++ b/fedimint-api/src/task.rs
@@ -64,7 +64,7 @@ impl TaskGroup {
         Self::default()
     }
 
-    fn make_handle(&self) -> TaskHandle {
+    pub fn make_handle(&self) -> TaskHandle {
         TaskHandle {
             inner: self.inner.clone(),
         }
@@ -224,6 +224,7 @@ impl Drop for TaskPanicGuard {
     }
 }
 
+#[derive(Clone)]
 pub struct TaskHandle {
     inner: Arc<TaskGroupInner>,
 }

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -45,6 +45,7 @@ threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 
 [build-dependencies]
 fedimint-build = { path = "../fedimint-build" }

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -6,9 +6,9 @@ use fedimint_api::config::{
     BitcoindRpcCfg, ClientConfig, DkgPeerMsg, DkgRunner, ModuleConfigGenParams, Node,
     ServerModuleConfig, TypedServerModuleConfig,
 };
+use fedimint_api::core::{ModuleKey, MODULE_KEY_GLOBAL};
 use fedimint_api::module::FederationModuleConfigGen;
-use fedimint_api::multiplexed::ModuleMultiplexer;
-use fedimint_api::net::peers::{IPeerConnections, PeerConnections};
+use fedimint_api::net::peers::{IPeerConnections, MuxPeerConnections, PeerConnections};
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
 pub use fedimint_core::config::*;
@@ -264,7 +264,7 @@ impl ServerConfig {
     }
 
     pub async fn distributed_gen(
-        connections: &ModuleMultiplexer<DkgPeerMsg>,
+        connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         our_id: &PeerId,
         peers: &[PeerId],
         params: &ServerConfigParams,
@@ -284,7 +284,7 @@ impl ServerConfig {
         dkg.add(KeyType::Epoch, peers.threshold());
 
         // run DKG for epoch and hbbft keys
-        let keys = if let Ok(v) = dkg.run_g1("global", connections, &mut rng).await {
+        let keys = if let Ok(v) = dkg.run_g1(MODULE_KEY_GLOBAL, connections, &mut rng).await {
             v
         } else {
             return Ok(Err(Cancelled));

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -8,7 +8,7 @@ use fedimint_api::config::{
 };
 use fedimint_api::module::FederationModuleConfigGen;
 use fedimint_api::multiplexed::ModuleMultiplexer;
-use fedimint_api::net::peers::AnyPeerConnections;
+use fedimint_api::net::peers::{IPeerConnections, PeerConnections};
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
 pub use fedimint_core::config::*;
@@ -26,7 +26,6 @@ use tokio_rustls::rustls;
 use tracing::info;
 use url::Url;
 
-use crate::fedimint_api::net::peers::PeerConnections;
 use crate::fedimint_api::NumPeers;
 use crate::net::connect::Connector;
 use crate::net::connect::TlsConfig;
@@ -543,7 +542,7 @@ pub async fn connect<T>(
     network: NetworkConfig,
     certs: TlsConfig,
     task_group: &mut TaskGroup,
-) -> AnyPeerConnections<T>
+) -> PeerConnections<T>
 where
     T: std::fmt::Debug + Clone + Serialize + DeserializeOwned + Unpin + Send + Sync + 'static,
 {

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use config::ServerConfig;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
-use fedimint_api::net::peers::AnyPeerConnections;
+use fedimint_api::net::peers::PeerConnections;
 use fedimint_api::task::{TaskGroup, TaskHandle};
 use fedimint_api::{NumPeers, PeerId};
 use fedimint_core::epoch::{ConsensusItem, EpochHistory, EpochVerifyError};
@@ -24,7 +24,7 @@ use crate::consensus::{
     ConsensusOutcome, ConsensusOutcomeConversion, ConsensusProposal, FedimintConsensus,
 };
 use crate::db::{EpochHistoryKey, LastEpochKey};
-use crate::fedimint_api::net::peers::PeerConnections;
+use crate::fedimint_api::net::peers::IPeerConnections;
 use crate::net::connect::{Connector, TlsTcpConnector};
 use crate::net::peers::PeerSlice;
 use crate::net::peers::{PeerConnector, ReconnectPeerConnections};
@@ -57,7 +57,7 @@ pub enum EpochMessage {
 
 pub struct FedimintServer {
     pub consensus: Arc<FedimintConsensus>,
-    pub connections: AnyPeerConnections<EpochMessage>,
+    pub connections: PeerConnections<EpochMessage>,
     pub cfg: ServerConfig,
     pub hbbft: HoneyBadger<Vec<ConsensusItem>, PeerId>,
     pub api: Arc<dyn IFederationApi>,

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -42,6 +42,9 @@ pub mod net;
 /// Fedimint toplevel config
 pub mod config;
 
+/// Implementation of multiplexed peer connections
+pub mod multiplexed;
+
 /// Some abstractions to handle randomness
 mod rng;
 

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -19,6 +19,12 @@ use crate::PeerId;
 pub type ModuleId = String;
 pub type ModuleIdRef<'a> = &'a str;
 
+/// Amount of per-peer messages after which we will stop throwing them away.
+///
+/// It's hard to predict how many messages is too many, but we have
+/// to draw the line somewhere.
+pub const MAX_PEER_OUT_OF_ORDER_MESSAGES: u64 = 10000;
+
 /// A `Msg` that can target a specific destination module
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ModuleMultiplexed<MuxKey, Msg> {
@@ -135,7 +141,7 @@ where
                 let mut out_of_order = self.inner.out_of_order.lock().await;
                 // TODO: use `raw_entry` to avoid clone once stable
                 let peer_msgs_pending_count = out_of_order.peer_counts.entry(peer).or_default();
-                if *peer_msgs_pending_count < 1000 {
+                if *peer_msgs_pending_count < MAX_PEER_OUT_OF_ORDER_MESSAGES {
                     *peer_msgs_pending_count += 1;
                     out_of_order
                         .msgs

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -164,89 +164,15 @@ where
 pub mod test {
     use std::time::Duration;
 
-    use async_trait::async_trait;
-    use fedimint_api::cancellable::{Cancellable, Cancelled};
-    use fedimint_api::net::peers::{IMuxPeerConnections, IPeerConnections, PeerConnections};
-    use fedimint_api::task::{TaskGroup, TaskHandle};
+    use fedimint_api::net::peers::fake::make_fake_peer_connection;
+    use fedimint_api::net::peers::IMuxPeerConnections;
+    use fedimint_api::task::TaskGroup;
     use fedimint_api::PeerId;
     use rand::rngs::OsRng;
     use rand::Rng;
-    use serde::de::DeserializeOwned;
-    use serde::Serialize;
-    use tokio::sync::mpsc::{self, Receiver, Sender};
     use tokio::time::sleep;
 
     use crate::multiplexed::PeerConnectionMultiplexer;
-
-    struct FakePeerConnections<Msg> {
-        tx: Sender<Msg>,
-        rx: Receiver<Msg>,
-        peer_id: PeerId,
-        task_handle: TaskHandle,
-    }
-
-    #[async_trait]
-    impl<Msg> IPeerConnections<Msg> for FakePeerConnections<Msg>
-    where
-        Msg: Serialize + DeserializeOwned + Unpin + Send,
-    {
-        async fn send(&mut self, peers: &[PeerId], msg: Msg) -> Cancellable<()> {
-            assert_eq!(peers, &[self.peer_id]);
-
-            // If the peer is gone, just pretend we are going to resend
-            // the msg eventually, even if it will never happen.
-            let _ = self.tx.send(msg).await;
-            Ok(())
-        }
-
-        async fn receive(&mut self) -> Cancellable<(PeerId, Msg)> {
-            // Just like a real implementation, do not return
-            // if the peer is gone.
-            while !self.task_handle.is_shutting_down() {
-                if let Some(msg) = self.rx.recv().await {
-                    return Ok((self.peer_id, msg));
-                } else {
-                    sleep(Duration::from_secs(10)).await
-                }
-            }
-            Err(Cancelled)
-        }
-
-        /// Removes a peer connection in case of misbehavior
-        async fn ban_peer(&mut self, _peer: PeerId) {
-            unimplemented!();
-        }
-    }
-
-    pub fn fake_link<Msg>(
-        peer1: PeerId,
-        peer2: PeerId,
-        buf_size: usize,
-        task_handle: TaskHandle,
-    ) -> (PeerConnections<Msg>, PeerConnections<Msg>)
-    where
-        Msg: Serialize + DeserializeOwned + Unpin + Send + 'static,
-    {
-        let (tx1, rx1) = mpsc::channel(buf_size);
-        let (tx2, rx2) = mpsc::channel(buf_size);
-
-        (
-            FakePeerConnections {
-                tx: tx1,
-                rx: rx2,
-                peer_id: peer2,
-                task_handle: task_handle.clone(),
-            }
-            .into_dyn(),
-            FakePeerConnections {
-                tx: tx2,
-                rx: rx1,
-                peer_id: peer1,
-                task_handle,
-            }
-            .into_dyn(),
-        )
-    }
 
     /// Send over many messages a multiplexed fake link
     ///
@@ -268,7 +194,7 @@ pub mod test {
             let peer1 = PeerId::from(0);
             let peer2 = PeerId::from(1);
 
-            let (conn1, conn2) = fake_link(peer1, peer2, 1000, task_handle.clone());
+            let (conn1, conn2) = make_fake_peer_connection(peer1, peer2, 1000, task_handle.clone());
             let (conn1, conn2) = (
                 PeerConnectionMultiplexer::new(conn1).into_dyn(),
                 PeerConnectionMultiplexer::new(conn2).into_dyn(),

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -214,7 +214,10 @@ pub mod test {
                         for msg_i in 0..NUM_MSGS_PER_MODULE {
                             // add some random jitter
                             if OsRng.gen() {
-                                sleep(Duration::from_millis(1)).await;
+                                // Note that randomized sleep in sender is larger than
+                                // in receiver, to avoid just running with always full
+                                // queues.
+                                sleep(Duration::from_millis(2)).await;
                             }
                             if task_handle.is_shutting_down() {
                                 break;

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -1,6 +1,6 @@
 //! Implements a connection manager for communication with other federation members
 //!
-//! The main interface is [`PeerConnections`] and its main implementation is
+//! The main interface is [`fedimint_api::net::peers::IPeerConnections`] and its main implementation is
 //! [`ReconnectPeerConnections`], see these for details.
 
 use std::cmp::min;
@@ -625,7 +625,6 @@ mod tests {
     use fedimint_api::task::TaskGroup;
     use fedimint_api::PeerId;
     use futures::Future;
-    use tracing_subscriber::EnvFilter;
 
     use crate::net::connect::mock::MockNetwork;
     use crate::net::connect::Connector;
@@ -640,14 +639,8 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(100), f).await.ok()
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_connect() {
-        tracing_subscriber::fmt()
-            .with_env_filter(
-                EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| EnvFilter::new("info,fedimint::net=trace")),
-            )
-            .init();
         let task_group = TaskGroup::new();
 
         {

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::Node;
-use fedimint_api::net::peers::PeerConnections;
+use fedimint_api::net::peers::IPeerConnections;
 use fedimint_api::task::{TaskGroup, TaskHandle};
 use fedimint_api::PeerId;
 use futures::future::select_all;
@@ -228,7 +228,7 @@ impl PeerSlice for Target<PeerId> {
 }
 
 #[async_trait]
-impl<T> PeerConnections<T> for ReconnectPeerConnections<T>
+impl<T> IPeerConnections<T> for ReconnectPeerConnections<T>
 where
     T: std::fmt::Debug + Serialize + DeserializeOwned + Clone + Unpin + Send + Sync + 'static,
 {
@@ -630,7 +630,7 @@ mod tests {
     use crate::net::connect::mock::MockNetwork;
     use crate::net::connect::Connector;
     use crate::net::peers::{
-        ConnectionConfig, NetworkConfig, PeerConnections, ReconnectPeerConnections,
+        ConnectionConfig, IPeerConnections, NetworkConfig, ReconnectPeerConnections,
     };
 
     async fn timeout<F, T>(f: F) -> Option<T>

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -5,10 +5,11 @@ use std::path::{Path, PathBuf};
 use clap::{Parser, Subcommand};
 use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::ClientConfig;
-use fedimint_api::multiplexed::ModuleMultiplexer;
+use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
 use fedimint_server::config::{PeerServerParams, ServerConfig, ServerConfigParams};
+use fedimint_server::multiplexed::PeerConnectionMultiplexer;
 use fedimintd::encrypt::*;
 use itertools::Itertools;
 use rand::rngs::OsRng;
@@ -185,7 +186,7 @@ async fn run_dkg(
     let server_conn =
         fedimint_server::config::connect(params.server_dkg.clone(), params.tls.clone(), task_group)
             .await;
-    let connections = ModuleMultiplexer::new(server_conn);
+    let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
     ServerConfig::distributed_gen(&connections, &our_id, &peer_ids, &params, OsRng, task_group)
         .await
         .expect("failed to run DKG to generate configs")

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -20,7 +20,7 @@ use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::ClientConfig;
 use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::Database;
-use fedimint_api::multiplexed::ModuleMultiplexer;
+use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
 use fedimint_api::FederationModule;
@@ -36,6 +36,7 @@ use fedimint_server::config::{connect, ServerConfig};
 use fedimint_server::consensus::FedimintConsensus;
 use fedimint_server::consensus::{ConsensusOutcome, ConsensusProposal};
 use fedimint_server::epoch::ConsensusItem;
+use fedimint_server::multiplexed::PeerConnectionMultiplexer;
 use fedimint_server::net::connect::mock::MockNetwork;
 use fedimint_server::net::connect::{Connector, TlsTcpConnector};
 use fedimint_server::net::peers::PeerConnector;
@@ -293,7 +294,7 @@ async fn distributed_config(
                     &mut task_group,
                 )
                 .await;
-                let connections = ModuleMultiplexer::new(server_conn);
+                let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
 
                 let rng = OsRng;
                 let cfg = ServerConfig::distributed_gen(

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -26,6 +26,7 @@ use fedimint_api::config::{
     ClientModuleConfig, DkgPeerMsg, DkgRunner, ModuleConfigGenParams, ServerModuleConfig,
     TypedServerModuleConfig,
 };
+use fedimint_api::core::{ModuleKey, MODULE_KEY_LN};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
@@ -34,7 +35,7 @@ use fedimint_api::module::{
     api_endpoint, ApiEndpoint, ApiError, FederationModuleConfigGen, IntoModuleError, ModuleError,
     TransactionItemAmount,
 };
-use fedimint_api::multiplexed::ModuleMultiplexer;
+use fedimint_api::net::peers::MuxPeerConnections;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, FederationModule, NumPeers, PeerId};
 use fedimint_api::{InputMeta, OutPoint};
@@ -198,14 +199,14 @@ impl FederationModuleConfigGen for LightningModuleConfigGen {
 
     async fn distributed_gen(
         &self,
-        connections: &ModuleMultiplexer<DkgPeerMsg>,
+        connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         our_id: &PeerId,
         peers: &[PeerId],
         _params: &ModuleConfigGenParams,
         _task_group: &mut TaskGroup,
     ) -> anyhow::Result<Cancellable<(ServerModuleConfig, ClientModuleConfig)>> {
         let mut dkg = DkgRunner::new((), peers.threshold(), our_id, peers);
-        let g1 = if let Ok(g1) = dkg.run_g1("ln", connections, &mut OsRng).await {
+        let g1 = if let Ok(g1) = dkg.run_g1(MODULE_KEY_LN, connections, &mut OsRng).await {
             g1
         } else {
             return Ok(Err(Cancelled));

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -10,6 +10,7 @@ use fedimint_api::config::{
     scalar, ClientModuleConfig, DkgPeerMsg, DkgRunner, ModuleConfigGenParams, ServerModuleConfig,
     TypedServerModuleConfig,
 };
+use fedimint_api::core::{ModuleKey, MODULE_KEY_MINT};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::__reexports::serde_json;
@@ -18,7 +19,7 @@ use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
     ApiEndpoint, FederationModuleConfigGen, IntoModuleError, ModuleError, TransactionItemAmount,
 };
-use fedimint_api::multiplexed::ModuleMultiplexer;
+use fedimint_api::net::peers::MuxPeerConnections;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::tiered::InvalidAmountTierError;
 use fedimint_api::{
@@ -190,7 +191,7 @@ impl FederationModuleConfigGen for MintConfigGenerator {
 
     async fn distributed_gen(
         &self,
-        connections: &ModuleMultiplexer<DkgPeerMsg>,
+        connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         our_id: &PeerId,
         peers: &[PeerId],
         params: &ModuleConfigGenParams,
@@ -202,7 +203,7 @@ impl FederationModuleConfigGen for MintConfigGenerator {
             our_id,
             peers,
         );
-        let g2 = if let Ok(g2) = dkg.run_g2("mint", connections, &mut OsRng).await {
+        let g2 = if let Ok(g2) = dkg.run_g2(MODULE_KEY_MINT, connections, &mut OsRng).await {
             g2
         } else {
             return Ok(Err(Cancelled));


### PR DESCRIPTION
Abstract away multiplexed connection behind a "dyn newtype".

Move implementation into `fedeimint-server`v This allows avoiding
wasm conditional compilation hacks, and cleans up the whole thing a bit.

Add multiplexing tests, as the implementation is non-trivial.