### PR TITLE
Optimize `ring` in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ byteorder = { opt-level = 2 }
 zeroize = { opt-level = 2 }
 bls12_381 = { opt-level = 2 }
 subtle = { opt-level = 2 }
+ring = { opt-level = 2 }
 
 [patch.crates-io]
 secp256k1-zkp = { git = "https://github.com/dpc/rust-secp256k1-zkp/", branch = "sanket-pr" }


### PR DESCRIPTION
This speeds up CPU-heavy `pbkdf2` by a lot, making our tests more snappy.