### PR TITLE
When running tests, don't bother with strong `pbkdf2`

### DIFF
--- a/fedimintd/src/encrypt.rs
+++ b/fedimintd/src/encrypt.rs
@@ -20,7 +20,8 @@ use std::path::PathBuf;
 use ring::aead::{Aad, LessSafeKey, Nonce, UnboundKey, NONCE_LEN};
 use ring::{aead, digest, pbkdf2};
 
-const ITERATIONS: Option<NonZeroU32> = NonZeroU32::new(1_000_000);
+const ITERATIONS_PROD: Option<NonZeroU32> = NonZeroU32::new(1_000_000);
+const ITERATIONS_DEBUG: Option<NonZeroU32> = NonZeroU32::new(1);
 
 // server files
 pub const SALT_FILE: &str = "salt";
@@ -66,7 +67,11 @@ pub fn get_key(password: Option<String>, salt_path: PathBuf) -> LessSafeKey {
     let algo = pbkdf2::PBKDF2_HMAC_SHA256;
     pbkdf2::derive(
         algo,
-        ITERATIONS.unwrap(),
+        if std::env::var("FM_TEST_FAST_WEAK_CRYPTO").as_deref() == Ok("1") {
+            ITERATIONS_DEBUG.unwrap()
+        } else {
+            ITERATIONS_PROD.unwrap()
+        },
         &salt,
         password.as_bytes(),
         &mut key,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,8 @@ echo "Run with 'source ./scripts/build.sh [fed_size] [dir]"
 # allow for overriding arguments
 export FM_FED_SIZE=${1:-4}
 export FM_TMP_DIR=${2-"$(mktemp -d)"}
+export FM_TEST_FAST_WEAK_CRYPTO="1"
+
 echo "Setting up env variables in $FM_TMP_DIR"
 
 # Builds the rust executables and sets environment variables


### PR DESCRIPTION
This makes the test federation setup *much* faster.