### PR TITLE
Cleanup Clientd Integration Test

### DIFF
--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -251,9 +251,7 @@ impl<'c> MintClient<'c> {
                 loop {
                     match self.fetch_coins(&mut dbtx, out_point).await {
                         Ok(_) => {
-                            futures::executor::block_on(async {
-                                dbtx.commit_tx().await.expect("DB Error");
-                            });
+                            dbtx.commit_tx().await.expect("DB Error");
                             return Ok(out_point);
                         }
                         // TODO: make mint error more expressive (currently any HTTP error) and maybe use custom return type instead of error for retrying

--- a/scripts/clientd-tests.sh
+++ b/scripts/clientd-tests.sh
@@ -32,9 +32,6 @@ TRANSACTION="$($FM_BTC_CLIENT getrawtransaction $TX_ID)"
 #perform peg-in
 [[ $($FM_CLIENTD_CLI peg-in $TXOUT_PROOF $TRANSACTION| jq -r 'has("data")') = true ]]
 
-#until we can check th (peg-in) tx status we just have to sleep to wait for fetch
-#the sleep here is unneccessary high but a I want to be sure to avoid unnecessary CI failure
-sleep 20 
 #spend
 ECASH=$($FM_CLIENTD_CLI spend 1000);
 [[ $(echo $ECASH | jq -r 'has("data")') = true ]]


### PR DESCRIPTION
The clientd integration test curerntly uses a separate thread for fetching the coins that are signed by the federation. This causes race conditions because the client needs to know when the coins have been signed before fetching. To solve this, I have added a new function on the client that will await a signature response from the Mint. [Decided not to add a CLI command ](https://github.com/fedimint/fedimint/issues/910)as it is not needed currently and we ideally want to move away from polling. 

The clientd integration test will now just wait for the signature response from the mint, then call fetch aferwards, which means that the fetch will succeed and will avoid the race conditions we were running into before.