### PR TITLE
Simple CLN gateway init

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -26,7 +26,7 @@ windows:
           - fg
         - ln1:
           - sleep 5 # wait for bitcoind and federation
-          - gateway-cli generate-config $FM_CFG_DIR #generate gateway config
+          - gateway-cli generate-config 127.0.0.1:8080 $FM_CFG_DIR #generate gateway config
           - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 --plugin=$FM_BIN_DIR/ln_gateway --fedimint-cfg=$FM_CFG_DIR &
           - echo $! >> $FM_PID_FILE
           - fg

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{net::SocketAddr, path::PathBuf};
 
 use bitcoin::{Address, Amount, Transaction};
 use clap::{Parser, Subcommand};
@@ -83,6 +83,7 @@ async fn main() {
             serde_json::to_writer_pretty(
                 cfg_file,
                 &GatewayConfig {
+                    address: SocketAddr::from(([127, 0, 0, 1], 8080)),
                     // TODO: Generate a strong random password
                     password: source_password(cli.rpcpassword),
                     // TODO: Remove this field with hardcoded value once we have fixed Issue 664:

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -30,6 +30,8 @@ pub enum Commands {
     /// Ganerate gateway configuration
     /// NOTE: This command can only be used on a local gateway
     GenerateConfig {
+        /// The address of the gateway webserver
+        address: SocketAddr,
         /// The gateway configuration directory
         out_dir: PathBuf,
     },
@@ -72,7 +74,10 @@ pub enum Commands {
 async fn main() {
     let cli = Cli::parse();
     match cli.command {
-        Commands::GenerateConfig { mut out_dir } => {
+        Commands::GenerateConfig {
+            address,
+            mut out_dir,
+        } => {
             // Recursively create config directory if it doesn't exist
             std::fs::create_dir_all(&out_dir).expect("Failed to create config directory");
             // Create config file
@@ -83,7 +88,7 @@ async fn main() {
             serde_json::to_writer_pretty(
                 cfg_file,
                 &GatewayConfig {
-                    address: SocketAddr::from(([127, 0, 0, 1], 8080)),
+                    address,
                     // TODO: Generate a strong random password
                     password: source_password(cli.rpcpassword),
                     // TODO: Remove this field with hardcoded value once we have fixed Issue 664:

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -1,8 +1,13 @@
+use std::net::SocketAddr;
+
 use mint_client::FederationId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GatewayConfig {
+    /// webserver address
+    pub address: SocketAddr,
+    /// webserver authentication password
     pub password: String,
     // FIXME: Issue 664: We should avoid having a special reference to a federation
     // all requests, including `ReceivePaymentPayload`, should contain the federation id

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -144,11 +144,17 @@ impl LnGateway {
         let ctx = secp256k1::Secp256k1::new();
         let kp_fed = KeyPair::new(&ctx, &mut rng);
 
+        let node_pub_key = self
+            .ln_client
+            .pubkey()
+            .await
+            .expect("Failed to get node pubkey from Lightning node");
+
         let gw_client_cfg = GatewayClientConfig {
             client_config: client_cfg,
             redeem_key: kp_fed,
             timelock_delta: 10,
-            node_pub_key: self.pub_key,
+            node_pub_key,
             api: Url::parse(format!("http://{}", self.bind_addr).as_str())
                 .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),
         };

--- a/gateway/ln-gateway/src/ln.rs
+++ b/gateway/ln-gateway/src/ln.rs
@@ -6,6 +6,9 @@ use secp256k1::PublicKey;
 
 #[async_trait]
 pub trait LnRpc: Send + Sync + 'static {
+    /// Get the public key of the lightning node
+    async fn pubkey(&self) -> Result<PublicKey, LightningError>;
+
     /// Attempt to pay an invoice and block till it succeeds, fails or times out
     async fn pay(
         &self,

--- a/gateway/ln-gateway/src/ln.rs
+++ b/gateway/ln-gateway/src/ln.rs
@@ -1,5 +1,3 @@
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
-
 use async_trait::async_trait;
 use fedimint_server::modules::ln::contracts::Preimage;
 use secp256k1::PublicKey;
@@ -16,14 +14,6 @@ pub trait LnRpc: Send + Sync + 'static {
         max_delay: u64,
         max_fee_percent: f64,
     ) -> Result<Preimage, LightningError>;
-}
-
-#[derive(Clone)]
-pub struct LnRpcRef {
-    pub ln_rpc: Arc<dyn LnRpc>,
-    pub bind_addr: SocketAddr,
-    pub pub_key: PublicKey,
-    pub work_dir: PathBuf,
 }
 
 #[derive(Debug)]

--- a/integrationtests/tests/fixtures/fake.rs
+++ b/integrationtests/tests/fixtures/fake.rs
@@ -73,7 +73,7 @@ impl LightningTest for FakeLightningTest {
 #[async_trait]
 impl LnRpc for FakeLightningTest {
     async fn pubkey(&self) -> Result<PublicKey, LightningError> {
-        Ok(self.gateway_node_pub_key.clone())
+        Ok(self.gateway_node_pub_key)
     }
 
     async fn pay(

--- a/integrationtests/tests/fixtures/fake.rs
+++ b/integrationtests/tests/fixtures/fake.rs
@@ -72,6 +72,10 @@ impl LightningTest for FakeLightningTest {
 
 #[async_trait]
 impl LnRpc for FakeLightningTest {
+    async fn pubkey(&self) -> Result<PublicKey, LightningError> {
+        Ok(self.gateway_node_pub_key.clone())
+    }
+
     async fn pay(
         &self,
         invoice: lightning_invoice::Invoice,

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -398,22 +398,15 @@ impl GatewayTest {
 
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
         let adapter = Arc::new(ln_client_adapter);
-        let ln_client = Arc::clone(&adapter);
+        let ln_rpc = Arc::clone(&adapter);
 
         let gw_cfg = GatewayConfig {
+            address: bind_addr,
             password: "abc".into(),
             default_federation: FederationId(gw_client_cfg.client_config.federation_name.clone()),
         };
 
-        let gateway = LnGateway::new(
-            gw_cfg,
-            ln_client,
-            client_builder.clone(),
-            sender,
-            receiver,
-            bind_addr,
-            node_pub_key,
-        );
+        let gateway = LnGateway::new(gw_cfg, ln_rpc, client_builder.clone(), sender, receiver);
 
         let client = Arc::new(
             client_builder

--- a/integrationtests/tests/fixtures/utils.rs
+++ b/integrationtests/tests/fixtures/utils.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bitcoin::secp256k1::PublicKey;
 use fedimint_ln::contracts::Preimage;
 use ln_gateway::ln::{LightningError, LnRpc};
 use tokio::sync::Mutex;
@@ -33,6 +34,10 @@ impl LnRpcAdapter {
 
 #[async_trait]
 impl LnRpc for LnRpcAdapter {
+    async fn pubkey(&self) -> Result<PublicKey, LightningError> {
+        self.client.pubkey().await
+    }
+
     async fn pay(
         &self,
         invoice: lightning_invoice::Invoice,

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -61,7 +61,7 @@ function kill_fedimint_processes {
 }
 
 function start_gateway() {
-  $FM_GATEWAY_CLI generate-config $FM_CFG_DIR # generate gateway config
+  $FM_GATEWAY_CLI generate-config '127.0.0.1:8080' $FM_CFG_DIR # generate gateway config
   $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR &
   sleep 5 # wait for plugin to start
   gw_register_fed


### PR DESCRIPTION
- [x] make `address` a gateway config parameter
- [x] replace `port` and `host` config options from cln plugin with the `address` in gateway config
- [x] generically source node pubkey from gateway `LnRpc`