### PR TITLE
Fix docs pointing to gw-balance, use gateway-cli instead

### DIFF
--- a/docs/dev-running.md
+++ b/docs/dev-running.md
@@ -112,10 +112,10 @@ First let's have the gateway execute a peg-in so it has an ecash token balance. 
 $ ./scripts/pegin.sh 10000 1
 ```
 
-Now we can use `lightning-cli` of the node where the gateway plugin is running to get our ecash token balance:
+Now we can use `gateway-cli` of the node where the gateway plugin is running to get our ecash token balance:
 
 ```shell
-$ ln1 gw-balance
+$ gateway-cli balance Hals_trusty_mint
 {
    "balance_msat": 10000000
 }


### PR DESCRIPTION
Discussion about this in Discord: https://discordapp.com/channels/990354215060795454/990354215878688860/1042886970117992468

Summary:

I was following along in dev-running.md and the `ln1 gw-balance` command did not work. I did not see any relevant mention of "gateway" or "gw" when running `ln1 help`.

@dpc helped to point out there is the `gateway-cli` command, which led to this change. 