### PR TITLE
Manage gateway run function using task groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bitcoin",
+ "fedimint-api",
  "fedimint-ln",
  "lightning-invoice",
  "ln-gateway",

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -62,7 +62,7 @@ impl IDatabase for MemDatabase {
 
 // In-memory database transaction should only be used for test code and never for production
 // as it doesn't properly implement MVCC
-#[async_trait(?Send)]
+#[async_trait]
 impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
     fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let val = self.raw_get_bytes(key);

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -96,7 +96,7 @@ dyn_newtype_define! {
 /// | MemoryDB | Prevented          | Prevented  | Prevented           | Prevented      | Possible    |
 /// | SledDB   | Prevented          | Prevented  | Possible            | Possible       | Possible    |
 /// | RocksDB  | Prevented          | Prevented  | Prevented           | Prevented      | Prevented   |
-#[async_trait(?Send)]
+#[async_trait]
 pub trait IDatabaseTransaction<'a>: 'a + Send {
     fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>>;
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -51,7 +51,7 @@ impl IDatabase for RocksDb {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
     fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let val = self.0.get(key).unwrap();

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -65,7 +65,7 @@ impl IDatabase for SledDb {
 
 // Sled database transaction should only be used for test code and never for production
 // as it doesn't properly implement MVCC
-#[async_trait(?Send)]
+#[async_trait]
 impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
     fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let val = self.raw_get_bytes(key);

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -1,4 +1,5 @@
 use cln_plugin::Error;
+use fedimint_api::task::TaskGroup;
 use fedimint_server::config::load_from_file;
 use ln_gateway::{
     client::{GatewayClientBuilder, RocksDbGatewayClientBuilder},
@@ -8,6 +9,7 @@ use ln_gateway::{
     LnGateway,
 };
 use tokio::sync::mpsc;
+use tracing::error;
 
 /// Fedimint gateway packaged as a CLN plugin
 #[tokio::main]
@@ -34,10 +36,15 @@ async fn main() -> Result<(), Error> {
         RocksDbGatewayClientBuilder::new(work_dir.clone()).into();
 
     // Create gateway instance
-    let mut gateway = LnGateway::new(gw_cfg, ln_rpc, client_builder, tx, rx);
+    let task_group = TaskGroup::new();
+    let gateway = LnGateway::new(gw_cfg, ln_rpc, client_builder, tx, rx, task_group.clone());
 
-    // Start gateway
-    gateway.run().await.expect("gateway failed to run");
+    if let Err(e) = gateway.run().await {
+        task_group.shutdown_join_all().await?;
+
+        error!("Gateway stopped with error: {}", e);
+        return Err(e.into());
+    }
 
     Ok(())
 }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -152,7 +152,7 @@ where
     T: GatewayRequestTrait,
     T::Response: std::fmt::Debug,
 {
-    pub async fn handle<F: Fn(T) -> FF, FF: Future<Output = Result<T::Response>>>(
+    pub async fn handle<F: Fn(T) -> FF, FF: Future<Output = Result<T::Response>> + Send>(
         self,
         handler: F,
     ) {

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -40,7 +40,7 @@ pub async fn run_webserver(
     axum::Server::bind(&bind_addr)
         .serve(app.into_make_service())
         .await
-        .unwrap();
+        .expect("Failed to start webserver");
 
     Ok(())
 }

--- a/gateway/tests/Cargo.toml
+++ b/gateway/tests/Cargo.toml
@@ -13,6 +13,7 @@ path = "tests/tests.rs"
 [dev-dependencies]
 async-trait = "0.1.42"
 bitcoin = "0.29.2"
+fedimint-api = { path = "../../fedimint-api" }
 fedimint-ln = { path = "../../modules/fedimint-ln" }
 lightning-invoice = "0.20.0"
 ln-gateway = { path = "../ln-gateway" }

--- a/gateway/tests/tests/fixtures.rs
+++ b/gateway/tests/tests/fixtures.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bitcoin::{secp256k1, KeyPair};
+use fedimint_api::task::TaskGroup;
 use fedimint_ln::contracts::Preimage;
 use lightning_invoice::Invoice;
 use ln_gateway::{
@@ -20,7 +21,7 @@ pub fn fixtures(gw_cfg: GatewayConfig) -> LnGateway {
     let client_builder: GatewayClientBuilder = MemoryDbGatewayClientBuilder {}.into();
     let (tx, rx) = mpsc::channel::<GatewayRequest>(100);
 
-    LnGateway::new(gw_cfg, ln_rpc, client_builder, tx, rx)
+    LnGateway::new(gw_cfg, ln_rpc, client_builder, tx, rx, TaskGroup::new())
 }
 
 struct MockLnRpc {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -407,7 +407,14 @@ impl GatewayTest {
             default_federation: FederationId(gw_client_cfg.client_config.federation_name.clone()),
         };
 
-        let gateway = LnGateway::new(gw_cfg, ln_rpc, client_builder.clone(), sender, receiver);
+        let gateway = LnGateway::new(
+            gw_cfg,
+            ln_rpc,
+            client_builder.clone(),
+            sender,
+            receiver,
+            TaskGroup::new(),
+        );
 
         let client = Arc::new(
             client_builder


### PR DESCRIPTION
Apply TaskGroup control  to Gateway run function to allow for controlled shutdown of the gateway webserver and the main loop. A TaskGroup are injected into the `LnGateway` instance to allow shutdown by whoever created the gateway instance.

Part 3 of #938 
closes #919 