### PR TITLE
Add traits to type-erased newtypes

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -39,7 +40,7 @@ use crate::query::{
 
 #[cfg_attr(target_family = "wasm", async_trait(? Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
-pub trait IFederationApi: Send + Sync {
+pub trait IFederationApi: Debug + Send + Sync {
     /// Fetch the outcome of an entire transaction
     async fn fetch_tx_outcome(&self, tx: TransactionId) -> Result<TransactionStatus>;
 
@@ -199,7 +200,7 @@ impl ApiError {
 
 #[cfg_attr(target_family = "wasm", async_trait(? Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
-impl<C: JsonRpcClient + Send + Sync> IFederationApi for WsFederationApi<C> {
+impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<C> {
     /// Fetch the outcome of an entire transaction
     async fn fetch_tx_outcome(&self, tx: TransactionId) -> Result<TransactionStatus> {
         self.request(

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -339,6 +339,7 @@ mod tests {
 
     type Fed = FakeFed<LightningModule>;
 
+    #[derive(Debug)]
     struct FakeApi {
         mint: Arc<tokio::sync::Mutex<Fed>>,
     }

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -446,6 +446,7 @@ mod tests {
 
     type Fed = FakeFed<Mint>;
 
+    #[derive(Debug)]
     struct FakeApi {
         mint: Arc<tokio::sync::Mutex<Fed>>,
     }

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -202,6 +202,7 @@ mod tests {
     type Fed = FakeFed<Wallet>;
     type SharedFed = Arc<tokio::sync::Mutex<Fed>>;
 
+    #[derive(Debug)]
     struct FakeApi {
         // for later use once wallet outcomes are implemented
         _mint: SharedFed,

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -4,6 +4,7 @@
 //!
 //! This (Rust) module defines common interoperability types
 //! and functionality that is used on both client and sever side.
+use std::fmt::Debug;
 use std::io;
 use std::{any::Any, collections::BTreeMap};
 
@@ -83,7 +84,7 @@ macro_rules! module_plugin_trait_define {
         $newtype_ty:ident, $plugin_ty:ident, $module_ty:ident, { $($extra_methods:tt)*  } { $($extra_impls:tt)* }
     ) => {
         pub trait $plugin_ty:
-            DynEncodable + Decodable + Encodable + Clone + Send + Sync + 'static
+            std::fmt::Debug + DynEncodable + Decodable + Encodable + Clone + Send + Sync + 'static
         {
             fn module_key(&self) -> ModuleKey;
 
@@ -202,7 +203,7 @@ impl ModuleDecode for () {
 /// Something that can be an [`Input`] in a [`Transaction`]
 ///
 /// General purpose code should use [`Input`] instead
-pub trait ModuleInput: DynEncodable {
+pub trait ModuleInput: Debug + DynEncodable {
     fn as_any(&self) -> &(dyn Any + 'static);
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> Input;
@@ -226,7 +227,7 @@ dyn_newtype_impl_dyn_clone_passhthrough!(Input);
 /// Something that can be an [`Output`] in a [`Transaction`]
 ///
 /// General purpose code should use [`Output`] instead
-pub trait ModuleOutput: DynEncodable {
+pub trait ModuleOutput: Debug + DynEncodable {
     fn as_any(&self) -> &(dyn Any + 'static);
     fn module_key(&self) -> ModuleKey;
 
@@ -251,7 +252,7 @@ pub enum FinalizationError {
     SomethingWentWrong,
 }
 
-pub trait ModuleOutputOutcome: DynEncodable {
+pub trait ModuleOutputOutcome: Debug + DynEncodable {
     fn as_any(&self) -> &(dyn Any + '_);
     /// Module key
     fn module_key(&self) -> ModuleKey;
@@ -272,7 +273,7 @@ module_dyn_newtype_impl_encode_decode! {
 }
 dyn_newtype_impl_dyn_clone_passhthrough!(OutputOutcome);
 
-pub trait ModuleConsensusItem: DynEncodable {
+pub trait ModuleConsensusItem: Debug + DynEncodable {
     fn as_any(&self) -> &(dyn Any + 'static);
     /// Module key
     fn module_key(&self) -> ModuleKey;

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -18,7 +18,7 @@ use crate::module::{
     ApiEndpoint, InputMeta, ModuleError, ServerModulePlugin, TransactionItemAmount,
 };
 
-pub trait ModuleVerificationCache {
+pub trait ModuleVerificationCache: Debug {
     fn as_any(&self) -> &(dyn Any + 'static);
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> VerificationCache;
@@ -29,7 +29,7 @@ dyn_newtype_define! {
 }
 
 // TODO: make macro impl that doesn't force en/decodable
-pub trait PluginVerificationCache: Clone + Send + Sync + 'static {
+pub trait PluginVerificationCache: Clone + Debug + Send + Sync + 'static {
     fn module_key(&self) -> ModuleKey;
 }
 
@@ -53,7 +53,7 @@ where
 ///
 /// Server side Fedimint mondule needs to implement this trait.
 #[async_trait(?Send)]
-pub trait IServerModule {
+pub trait IServerModule: Debug {
     fn module_key(&self) -> ModuleKey;
 
     fn as_any(&self) -> &(dyn Any + 'static);

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -59,7 +59,7 @@ pub trait DatabaseValue: Sized + SerializableDatabaseValue {
 
 pub type PrefixIter<'a> = Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + Send + 'a>;
 
-pub trait IDatabase: Send + Sync {
+pub trait IDatabase: Debug + Send + Sync {
     fn begin_transaction(&self) -> DatabaseTransaction;
 }
 

--- a/fedimint-api/src/macros.rs
+++ b/fedimint-api/src/macros.rs
@@ -68,6 +68,12 @@ macro_rules! _dyn_newtype_define_inner {
                 Self($container::new(i))
             }
         }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
     };
     (   $(#[$outer:meta])*
         $vis:vis $name:ident<$lifetime:lifetime>($container:ident<$trait:ident>)

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -2,6 +2,7 @@ pub mod audit;
 pub mod interconnect;
 
 use std::collections::{BTreeMap, HashSet};
+use std::fmt::Debug;
 
 use async_trait::async_trait;
 use futures::future::BoxFuture;
@@ -205,7 +206,7 @@ pub trait FederationModuleConfigGen {
 }
 
 #[async_trait(?Send)]
-pub trait ServerModulePlugin: Sized {
+pub trait ServerModulePlugin: Debug + Sized {
     type Decoder: PluginDecode;
     type Input: PluginInput;
     type Output: PluginOutput;

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -62,7 +62,7 @@ struct Client<T>(T);
 #[async_trait]
 impl<T> IBitcoindRpc for Client<T>
 where
-    T: ::bitcoincore_rpc::RpcApi + Send + Sync,
+    T: ::bitcoincore_rpc::RpcApi + Debug + Send + Sync,
 {
     async fn get_network(&self) -> Result<Network> {
         let network = fedimint_api::task::block_in_place(|| {

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -23,7 +24,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 ///
 /// Functions may panic if if the bitcoind node is not reachable.
 #[async_trait]
-pub trait IBitcoindRpc: Send + Sync {
+pub trait IBitcoindRpc: Debug + Send + Sync {
     /// Returns the Bitcoin network the node is connected to
     async fn get_network(&self) -> Result<bitcoin::Network>;
 

--- a/fedimint-testing/src/bitcoind.rs
+++ b/fedimint-testing/src/bitcoind.rs
@@ -15,7 +15,7 @@ pub struct FakeBitcoindRpcState {
     tx_in_blocks: HashMap<BlockHash, Vec<Transaction>>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct FakeBitcoindRpc {
     state: Arc<Mutex<FakeBitcoindRpcState>>,
 }

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -16,6 +16,7 @@ use fedimint_api::{OutPoint, PeerId, ServerModulePlugin};
 
 pub mod bitcoind;
 
+#[derive(Debug)]
 pub struct FakeFed<Module> {
     members: Vec<(PeerId, Module, Database)>,
     client_cfg: ClientModuleConfig,

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -14,7 +15,7 @@ use tracing::debug;
 use crate::Result;
 
 /// Trait for gateway federation client builders
-pub trait IGatewayClientBuilder {
+pub trait IGatewayClientBuilder: Debug {
     /// Build a new gateway federation client
     fn build(&self, config: GatewayClientConfig) -> Result<Client<GatewayClientConfig>>;
 

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -80,6 +80,7 @@ use crate::db::{
 /// [Account]: contracts::account::AccountContract
 /// [Outgoing]: contracts::outgoing::OutgoingContract
 /// [Incoming]: contracts::incoming::IncomingContract
+#[derive(Debug)]
 pub struct LightningModule {
     cfg: LightningModuleConfig,
     db: Database,

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -56,6 +56,7 @@ mod db;
 /// Data structures taking into account different amount tiers
 
 /// Federated mint member mint
+#[derive(Debug)]
 pub struct Mint {
     cfg: MintConfig,
     sec_key: Tiered<SecretKeyShare>,

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -100,6 +100,7 @@ pub struct RoundConsensus {
     pub randomness_beacon: [u8; 32],
 }
 
+#[derive(Debug)]
 pub struct Wallet {
     cfg: WalletConfig,
     secp: Secp256k1<All>,


### PR DESCRIPTION
This PR adds `Debug` to all dyn newtypes and `PartialEq` as well as `Hash` to the ones associated with modules (`Input`, `Output`, `OutputOutcome`, `ConsensusItem`).