### PR TITLE
Remove serde impls

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -100,7 +100,12 @@ impl FederationApi {
                         outputs_len,
                         out_point.out_idx as usize,
                     ))
-                    .and_then(|output| output.try_into_variant().map_err(ApiError::CoreError))
+                    .and_then(|output| {
+                        output
+                            .try_into_inner(&module_decode_stubs())? // FIXME: modularize
+                            .try_into_variant()
+                            .map_err(ApiError::CoreError)
+                    })
             }
         }
     }

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -242,7 +242,7 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
                 let response = FedResponse {
                     peer: response.peer,
                     result: response.result.and_then(|hist| {
-                        hist.try_into_inner(&self.modules)
+                        hist.try_into_inner(self.modules)
                             .map_err(|e| jsonrpsee_core::Error::Custom(e.to_string()))
                     }),
                 };

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -39,7 +40,7 @@ use crate::query::{
 
 #[cfg_attr(target_family = "wasm", async_trait(? Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
-pub trait IFederationApi: Send + Sync {
+pub trait IFederationApi: Debug + Send + Sync {
     /// Fetch the outcome of an entire transaction
     async fn fetch_tx_outcome(&self, tx: TransactionId) -> Result<TransactionStatus>;
 
@@ -199,7 +200,7 @@ impl ApiError {
 
 #[cfg_attr(target_family = "wasm", async_trait(? Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
-impl<C: JsonRpcClient + Send + Sync> IFederationApi for WsFederationApi<C> {
+impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<C> {
     /// Fetch the outcome of an entire transaction
     async fn fetch_tx_outcome(&self, tx: TransactionId) -> Result<TransactionStatus> {
         self.request(

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -16,7 +16,7 @@ use fedimint_core::modules::ln::contracts::ContractId;
 use fedimint_core::modules::ln::{ContractAccount, LightningGateway};
 use fedimint_core::modules::wallet::PegOutFees;
 use fedimint_core::outcome::{TransactionStatus, TryIntoOutcome};
-use fedimint_core::transaction::Transaction;
+use fedimint_core::transaction::{SerdeTransaction, Transaction};
 use fedimint_core::CoreError;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -222,7 +222,7 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
         // TODO: check the id is correct
         self.request(
             "/transaction",
-            tx,
+            SerdeTransaction::from(&tx),
             CurrentConsensus::new(self.peers().one_honest()),
         )
         .await

--- a/client/client-lib/src/ln/decode_stub.rs
+++ b/client/client-lib/src/ln/decode_stub.rs
@@ -1,4 +1,4 @@
-use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::client::ClientModulePlugin;
 use fedimint_api::core::{ModuleKey, MODULE_KEY_LN};
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::ServerModulePlugin;
@@ -7,7 +7,7 @@ use fedimint_core::modules::ln::LightningModule;
 #[derive(Debug)]
 pub struct LnDecoder;
 
-impl ModuleClient for LnDecoder {
+impl ClientModulePlugin for LnDecoder {
     type Decoder = <LightningModule as ServerModulePlugin>::Decoder;
     type Module = LightningModule;
     const MODULE_KEY: ModuleKey = MODULE_KEY_LN;

--- a/client/client-lib/src/ln/decode_stub.rs
+++ b/client/client-lib/src/ln/decode_stub.rs
@@ -1,0 +1,28 @@
+use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::{ModuleKey, MODULE_KEY_LN};
+use fedimint_api::module::TransactionItemAmount;
+use fedimint_api::ServerModulePlugin;
+use fedimint_core::modules::ln::LightningModule;
+
+#[derive(Debug)]
+pub struct LnDecoder;
+
+impl ModuleClient for LnDecoder {
+    type Decoder = <LightningModule as ServerModulePlugin>::Decoder;
+    type Module = LightningModule;
+    const MODULE_KEY: ModuleKey = MODULE_KEY_LN;
+
+    fn input_amount(
+        &self,
+        _input: &<Self::Module as ServerModulePlugin>::Input,
+    ) -> TransactionItemAmount {
+        unimplemented!()
+    }
+
+    fn output_amount(
+        &self,
+        _output: &<Self::Module as ServerModulePlugin>::Output,
+    ) -> TransactionItemAmount {
+        unimplemented!()
+    }
+}

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -7,7 +7,7 @@ pub mod outgoing;
 use std::time::Duration;
 
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
-use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::client::ClientModulePlugin;
 use fedimint_api::core::{ModuleKey, MODULE_KEY_LN};
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::module::TransactionItemAmount;
@@ -43,7 +43,7 @@ pub struct LnClient<'c> {
     pub context: &'c ClientContext,
 }
 
-impl<'a> ModuleClient for LnClient<'a> {
+impl<'a> ClientModulePlugin for LnClient<'a> {
     type Decoder = <LightningModule as ServerModulePlugin>::Decoder;
     type Module = LightningModule;
     const MODULE_KEY: ModuleKey = MODULE_KEY_LN;

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -1,11 +1,14 @@
 // TODO: once user and mint client are merged, make this private again
 pub mod db;
+pub mod decode_stub;
 pub mod incoming;
 pub mod outgoing;
 
 use std::time::Duration;
 
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
+use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::{ModuleKey, MODULE_KEY_LN};
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::task::timeout;
@@ -32,15 +35,18 @@ use crate::ln::db::{OutgoingPaymentKey, OutgoingPaymentKeyPrefix};
 use crate::ln::incoming::IncomingContractAccount;
 use crate::ln::outgoing::{OutgoingContractAccount, OutgoingContractData};
 use crate::utils::ClientContext;
-use crate::{FederationId, ModuleClient};
+use crate::FederationId;
 
+#[derive(Debug)]
 pub struct LnClient<'c> {
     pub config: LightningModuleClientConfig,
     pub context: &'c ClientContext,
 }
 
 impl<'a> ModuleClient for LnClient<'a> {
+    type Decoder = <LightningModule as ServerModulePlugin>::Decoder;
     type Module = LightningModule;
+    const MODULE_KEY: ModuleKey = MODULE_KEY_LN;
 
     fn input_amount(
         &self,

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -339,6 +339,7 @@ mod tests {
 
     type Fed = FakeFed<LightningModule>;
 
+    #[derive(Debug)]
     struct FakeApi {
         mint: Arc<tokio::sync::Mutex<Fed>>,
     }

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -359,13 +359,14 @@ mod tests {
             let mint = self.mint.lock().await;
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
-                outputs: vec![OutputOutcome::LN(
+                outputs: vec![(&OutputOutcome::LN(
                     mint.output_outcome(OutPoint {
                         txid: tx,
                         out_idx: 0,
                     })
                     .unwrap(),
-                )],
+                ))
+                    .into()],
             })
         }
 

--- a/client/client-lib/src/mint/decode_stub.rs
+++ b/client/client-lib/src/mint/decode_stub.rs
@@ -1,0 +1,28 @@
+use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::{ModuleKey, MODULE_KEY_MINT};
+use fedimint_api::module::TransactionItemAmount;
+use fedimint_api::ServerModulePlugin;
+use fedimint_core::modules::mint::Mint;
+
+#[derive(Debug)]
+pub struct MintDecoder;
+
+impl ModuleClient for MintDecoder {
+    type Decoder = <Mint as ServerModulePlugin>::Decoder;
+    type Module = Mint;
+    const MODULE_KEY: ModuleKey = MODULE_KEY_MINT;
+
+    fn input_amount(
+        &self,
+        _input: &<Self::Module as ServerModulePlugin>::Input,
+    ) -> TransactionItemAmount {
+        unimplemented!()
+    }
+
+    fn output_amount(
+        &self,
+        _output: &<Self::Module as ServerModulePlugin>::Output,
+    ) -> TransactionItemAmount {
+        unimplemented!()
+    }
+}

--- a/client/client-lib/src/mint/decode_stub.rs
+++ b/client/client-lib/src/mint/decode_stub.rs
@@ -1,4 +1,4 @@
-use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::client::ClientModulePlugin;
 use fedimint_api::core::{ModuleKey, MODULE_KEY_MINT};
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::ServerModulePlugin;
@@ -7,7 +7,7 @@ use fedimint_core::modules::mint::Mint;
 #[derive(Debug)]
 pub struct MintDecoder;
 
-impl ModuleClient for MintDecoder {
+impl ClientModulePlugin for MintDecoder {
     type Decoder = <Mint as ServerModulePlugin>::Decoder;
     type Module = Mint;
     const MODULE_KEY: ModuleKey = MODULE_KEY_MINT;

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use db::{CoinKey, CoinKeyPrefix, OutputFinalizationKey, OutputFinalizationKeyPrefix};
 use fedimint_api::config::ClientConfig;
-use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::client::ClientModulePlugin;
 use fedimint_api::core::{ModuleKey, MODULE_KEY_MINT};
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::encoding::{Decodable, Encodable};
@@ -72,7 +72,7 @@ pub struct SpendableNote {
     pub spend_key: KeyPair,
 }
 
-impl<'a> ModuleClient for MintClient<'a> {
+impl<'a> ClientModulePlugin for MintClient<'a> {
     type Decoder = <Mint as ServerModulePlugin>::Decoder;
     type Module = Mint;
     const MODULE_KEY: ModuleKey = MODULE_KEY_MINT;

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -1,10 +1,13 @@
 pub mod db;
+pub mod decode_stub;
 
 use std::borrow::Cow;
 use std::time::Duration;
 
 use db::{CoinKey, CoinKeyPrefix, OutputFinalizationKey, OutputFinalizationKeyPrefix};
 use fedimint_api::config::ClientConfig;
+use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::{ModuleKey, MODULE_KEY_MINT};
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::TransactionItemAmount;
@@ -26,12 +29,13 @@ use crate::api::ApiError;
 use crate::mint::db::LastECashNoteIndexKey;
 use crate::transaction::TransactionBuilder;
 use crate::utils::ClientContext;
-use crate::{ChildId, Client, DerivableSecret, ModuleClient};
+use crate::{ChildId, Client, DerivableSecret};
 
 const MINT_E_CASH_TYPE_CHILD_ID: ChildId = ChildId(0);
 
 /// Federation module client for the Mint module. It can both create transaction inputs and outputs
 /// of the mint type.
+#[derive(Debug)]
 pub struct MintClient<'c> {
     pub config: MintClientConfig,
     pub context: &'c ClientContext,
@@ -69,7 +73,9 @@ pub struct SpendableNote {
 }
 
 impl<'a> ModuleClient for MintClient<'a> {
+    type Decoder = <Mint as ServerModulePlugin>::Decoder;
     type Module = Mint;
+    const MODULE_KEY: ModuleKey = MODULE_KEY_MINT;
 
     fn input_amount(
         &self,

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -446,6 +446,7 @@ mod tests {
 
     type Fed = FakeFed<Mint>;
 
+    #[derive(Debug)]
     struct FakeApi {
         mint: Arc<tokio::sync::Mutex<Fed>>,
     }

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -466,13 +466,14 @@ mod tests {
             let mint = self.mint.lock().await;
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
-                outputs: vec![OutputOutcome::Mint(
+                outputs: vec![(&OutputOutcome::Mint(
                     mint.output_outcome(OutPoint {
                         txid: tx,
                         out_idx: 0,
                     })
                     .unwrap(),
-                )],
+                ))
+                    .into()],
             })
         }
 

--- a/client/client-lib/src/secrets.rs
+++ b/client/client-lib/src/secrets.rs
@@ -1,5 +1,7 @@
 //! Scheme for deriving deterministic secret keys
 
+use std::fmt::Formatter;
+
 use fedimint_api::encoding::{Decodable, Encodable};
 use hkdf::hashes::Sha512;
 use hkdf::Hkdf;
@@ -57,4 +59,10 @@ fn tagged_derive(tag: &[u8; 8], derivation: ChildId) -> [u8; 16] {
     derivation_info[0..8].copy_from_slice(&tag[..]);
     derivation_info[8..16].copy_from_slice(&derivation.0.to_le_bytes()[..]);
     derivation_info
+}
+
+impl std::fmt::Debug for DerivableSecret {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DerivableSecret")
+    }
 }

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -1,5 +1,6 @@
 use bitcoin::KeyPair;
 use fedimint_api::config::ClientConfig;
+use fedimint_api::core::client::ModuleClient;
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::{Amount, OutPoint, Tiered, TieredMulti};
@@ -11,7 +12,7 @@ use tracing::debug;
 
 use crate::mint::db::{CoinKey, OutputFinalizationKey, PendingCoinsKey};
 use crate::mint::{NoteIssuanceRequest, NoteIssuanceRequests};
-use crate::{Client, MintClientError, ModuleClient, SpendableNote};
+use crate::{Client, MintClientError, SpendableNote};
 
 pub struct TransactionBuilder {
     input_notes: TieredMulti<SpendableNote>,

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -1,6 +1,6 @@
 use bitcoin::KeyPair;
 use fedimint_api::config::ClientConfig;
-use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::client::ClientModulePlugin;
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::{Amount, OutPoint, Tiered, TieredMulti};

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -54,6 +54,7 @@ pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Er
     secp256k1::PublicKey::from_str(s)
 }
 
+#[derive(Debug)]
 pub struct ClientContext {
     pub db: Database,
     pub api: FederationApi,

--- a/client/client-lib/src/wallet/decode_stub.rs
+++ b/client/client-lib/src/wallet/decode_stub.rs
@@ -1,4 +1,4 @@
-use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::client::ClientModulePlugin;
 use fedimint_api::core::{ModuleKey, MODULE_KEY_WALLET};
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::ServerModulePlugin;
@@ -7,7 +7,7 @@ use fedimint_core::modules::wallet::Wallet;
 #[derive(Debug)]
 pub struct WalletDecoder;
 
-impl ModuleClient for WalletDecoder {
+impl ClientModulePlugin for WalletDecoder {
     type Decoder = <Wallet as ServerModulePlugin>::Decoder;
     type Module = Wallet;
     const MODULE_KEY: ModuleKey = MODULE_KEY_WALLET;

--- a/client/client-lib/src/wallet/decode_stub.rs
+++ b/client/client-lib/src/wallet/decode_stub.rs
@@ -1,0 +1,28 @@
+use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::{ModuleKey, MODULE_KEY_WALLET};
+use fedimint_api::module::TransactionItemAmount;
+use fedimint_api::ServerModulePlugin;
+use fedimint_core::modules::wallet::Wallet;
+
+#[derive(Debug)]
+pub struct WalletDecoder;
+
+impl ModuleClient for WalletDecoder {
+    type Decoder = <Wallet as ServerModulePlugin>::Decoder;
+    type Module = Wallet;
+    const MODULE_KEY: ModuleKey = MODULE_KEY_WALLET;
+
+    fn input_amount(
+        &self,
+        _input: &<Self::Module as ServerModulePlugin>::Input,
+    ) -> TransactionItemAmount {
+        unimplemented!()
+    }
+
+    fn output_amount(
+        &self,
+        _output: &<Self::Module as ServerModulePlugin>::Output,
+    ) -> TransactionItemAmount {
+        unimplemented!()
+    }
+}

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -1,7 +1,7 @@
 use bitcoin::Address;
 use bitcoin::KeyPair;
 use db::PegInKey;
-use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::client::ClientModulePlugin;
 use fedimint_api::core::{ModuleKey, MODULE_KEY_WALLET};
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::module::TransactionItemAmount;
@@ -28,7 +28,7 @@ pub struct WalletClient<'c> {
     pub context: &'c ClientContext,
 }
 
-impl<'a> ModuleClient for WalletClient<'a> {
+impl<'a> ClientModulePlugin for WalletClient<'a> {
     type Decoder = <Wallet as ServerModulePlugin>::Decoder;
     type Module = Wallet;
     const MODULE_KEY: ModuleKey = MODULE_KEY_WALLET;

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -1,6 +1,8 @@
 use bitcoin::Address;
 use bitcoin::KeyPair;
 use db::PegInKey;
+use fedimint_api::core::client::ModuleClient;
+use fedimint_api::core::{ModuleKey, MODULE_KEY_WALLET};
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::{Amount, ServerModulePlugin};
@@ -13,19 +15,23 @@ use thiserror::Error;
 use tracing::debug;
 
 use crate::utils::ClientContext;
-use crate::{ApiError, ModuleClient};
+use crate::ApiError;
 
 mod db;
+pub mod decode_stub;
 
 /// Federation module client for the Wallet module. It can both create transaction inputs and
 /// outputs of the wallet (on-chain) type.
+#[derive(Debug)]
 pub struct WalletClient<'c> {
     pub config: WalletClientConfig,
     pub context: &'c ClientContext,
 }
 
 impl<'a> ModuleClient for WalletClient<'a> {
+    type Decoder = <Wallet as ServerModulePlugin>::Decoder;
     type Module = Wallet;
+    const MODULE_KEY: ModuleKey = MODULE_KEY_WALLET;
 
     fn input_amount(
         &self,

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -222,9 +222,10 @@ mod tests {
         ) -> crate::api::Result<TransactionStatus> {
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
-                outputs: vec![OutputOutcome::Wallet(WalletOutputOutcome(
+                outputs: vec![(&OutputOutcome::Wallet(WalletOutputOutcome(
                     Txid::from_slice([0; 32].as_slice()).unwrap(),
-                ))],
+                )))
+                    .into()],
             })
         }
 

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -202,6 +202,7 @@ mod tests {
     type Fed = FakeFed<Wallet>;
     type SharedFed = Arc<tokio::sync::Mutex<Fed>>;
 
+    #[derive(Debug)]
     struct FakeApi {
         // for later use once wallet outcomes are implemented
         _mint: SharedFed,

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -16,6 +16,7 @@ use fedimint_api::{
 
 pub mod encode;
 
+pub mod client;
 pub mod server;
 
 /// A module key identifing a module

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -4,6 +4,7 @@
 //!
 //! This (Rust) module defines common interoperability types
 //! and functionality that is used on both client and sever side.
+use std::fmt::Debug;
 use std::io;
 use std::{any::Any, collections::BTreeMap};
 
@@ -83,7 +84,7 @@ macro_rules! module_plugin_trait_define {
         $newtype_ty:ident, $plugin_ty:ident, $module_ty:ident, { $($extra_methods:tt)*  } { $($extra_impls:tt)* }
     ) => {
         pub trait $plugin_ty:
-            DynEncodable + Decodable + Encodable + Clone + Send + Sync + 'static
+            std::fmt::Debug + DynEncodable + Decodable + Encodable + Clone + Send + Sync + 'static
         {
             fn module_key(&self) -> ModuleKey;
 
@@ -202,7 +203,7 @@ impl ModuleDecode for () {
 /// Something that can be an [`Input`] in a [`Transaction`]
 ///
 /// General purpose code should use [`Input`] instead
-pub trait ModuleInput: DynEncodable {
+pub trait ModuleInput: Debug + DynEncodable {
     fn as_any(&self) -> &(dyn Any + 'static);
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> Input;
@@ -226,7 +227,7 @@ dyn_newtype_impl_dyn_clone_passhthrough!(Input);
 /// Something that can be an [`Output`] in a [`Transaction`]
 ///
 /// General purpose code should use [`Output`] instead
-pub trait ModuleOutput: DynEncodable {
+pub trait ModuleOutput: Debug + DynEncodable {
     fn as_any(&self) -> &(dyn Any + 'static);
     fn module_key(&self) -> ModuleKey;
 
@@ -251,7 +252,7 @@ pub enum FinalizationError {
     SomethingWentWrong,
 }
 
-pub trait ModuleOutputOutcome: DynEncodable {
+pub trait ModuleOutputOutcome: Debug + DynEncodable {
     fn as_any(&self) -> &(dyn Any + '_);
     /// Module key
     fn module_key(&self) -> ModuleKey;
@@ -272,7 +273,7 @@ module_dyn_newtype_impl_encode_decode! {
 }
 dyn_newtype_impl_dyn_clone_passhthrough!(OutputOutcome);
 
-pub trait ModuleConsensusItem: DynEncodable {
+pub trait ModuleConsensusItem: Debug + DynEncodable {
     fn as_any(&self) -> &(dyn Any + 'static);
     /// Module key
     fn module_key(&self) -> ModuleKey;

--- a/fedimint-api/src/core/client.rs
+++ b/fedimint-api/src/core/client.rs
@@ -12,7 +12,7 @@ use crate::module::TransactionItemAmount;
 use crate::{dyn_newtype_define, DecodeError, ModuleDecode, ServerModulePlugin};
 
 #[async_trait]
-pub trait ModuleClient: Debug {
+pub trait ClientModulePlugin: Debug {
     type Decoder: PluginDecode;
     type Module: ServerModulePlugin;
 
@@ -52,10 +52,10 @@ dyn_newtype_define!(
 
 impl<T> IClientModule for T
 where
-    T: ModuleClient + 'static,
+    T: ClientModulePlugin + 'static,
 {
     fn module_key(&self) -> ModuleKey {
-        <T as ModuleClient>::MODULE_KEY
+        <T as ClientModulePlugin>::MODULE_KEY
     }
 
     fn as_any(&self) -> &(dyn Any + 'static) {
@@ -63,19 +63,19 @@ where
     }
 
     fn decode_input(&self, r: &mut dyn Read) -> Result<Input, DecodeError> {
-        <T as ModuleClient>::Decoder::decode_input(r)
+        <T as ClientModulePlugin>::Decoder::decode_input(r)
     }
 
     fn decode_output(&self, r: &mut dyn Read) -> Result<Output, DecodeError> {
-        <T as ModuleClient>::Decoder::decode_output(r)
+        <T as ClientModulePlugin>::Decoder::decode_output(r)
     }
 
     fn decode_output_outcome(&self, r: &mut dyn Read) -> Result<OutputOutcome, DecodeError> {
-        <T as ModuleClient>::Decoder::decode_output_outcome(r)
+        <T as ClientModulePlugin>::Decoder::decode_output_outcome(r)
     }
 
     fn decode_consensus_item(&self, r: &mut dyn Read) -> Result<ConsensusItem, DecodeError> {
-        <T as ModuleClient>::Decoder::decode_consensus_item(r)
+        <T as ClientModulePlugin>::Decoder::decode_consensus_item(r)
     }
 }
 

--- a/fedimint-api/src/core/client.rs
+++ b/fedimint-api/src/core/client.rs
@@ -1,0 +1,98 @@
+use std::any::Any;
+use std::fmt::Debug;
+use std::io;
+use std::io::Read;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::core::{ConsensusItem, Input, Output, OutputOutcome};
+use crate::core::{ModuleKey, PluginDecode};
+use crate::module::TransactionItemAmount;
+use crate::{dyn_newtype_define, DecodeError, ModuleDecode, ServerModulePlugin};
+
+#[async_trait]
+pub trait ModuleClient: Debug {
+    type Decoder: PluginDecode;
+    type Module: ServerModulePlugin;
+
+    const MODULE_KEY: ModuleKey;
+
+    /// Returns the amount represented by the input and the fee its processing requires
+    fn input_amount(
+        &self,
+        input: &<Self::Module as ServerModulePlugin>::Input,
+    ) -> TransactionItemAmount;
+
+    /// Returns the amount represented by the output and the fee its processing requires
+    fn output_amount(
+        &self,
+        output: &<Self::Module as ServerModulePlugin>::Output,
+    ) -> TransactionItemAmount;
+}
+
+pub trait IClientModule: Debug {
+    fn module_key(&self) -> ModuleKey;
+
+    fn as_any(&self) -> &(dyn Any + 'static);
+
+    fn decode_input(&self, r: &mut dyn io::Read) -> Result<Input, DecodeError>;
+
+    fn decode_output(&self, r: &mut dyn io::Read) -> Result<Output, DecodeError>;
+
+    fn decode_output_outcome(&self, r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError>;
+
+    fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
+}
+
+dyn_newtype_define!(
+    #[derive(Clone)]
+    pub ClientModule(Arc<IClientModule>)
+);
+
+impl<T> IClientModule for T
+where
+    T: ModuleClient + 'static,
+{
+    fn module_key(&self) -> ModuleKey {
+        <T as ModuleClient>::MODULE_KEY
+    }
+
+    fn as_any(&self) -> &(dyn Any + 'static) {
+        self
+    }
+
+    fn decode_input(&self, r: &mut dyn Read) -> Result<Input, DecodeError> {
+        <T as ModuleClient>::Decoder::decode_input(r)
+    }
+
+    fn decode_output(&self, r: &mut dyn Read) -> Result<Output, DecodeError> {
+        <T as ModuleClient>::Decoder::decode_output(r)
+    }
+
+    fn decode_output_outcome(&self, r: &mut dyn Read) -> Result<OutputOutcome, DecodeError> {
+        <T as ModuleClient>::Decoder::decode_output_outcome(r)
+    }
+
+    fn decode_consensus_item(&self, r: &mut dyn Read) -> Result<ConsensusItem, DecodeError> {
+        <T as ModuleClient>::Decoder::decode_consensus_item(r)
+    }
+}
+
+impl ModuleDecode for ClientModule {
+    fn decode_input(&self, r: &mut dyn io::Read) -> Result<Input, DecodeError> {
+        (**self).decode_input(r)
+    }
+
+    fn decode_output(&self, r: &mut dyn io::Read) -> Result<Output, DecodeError> {
+        (**self).decode_output(r)
+    }
+
+    fn decode_output_outcome(&self, r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError> {
+        (**self).decode_output_outcome(r)
+    }
+
+    fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError> {
+        (**self).decode_consensus_item(r)
+    }
+}

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -18,7 +18,7 @@ use crate::module::{
     ApiEndpoint, InputMeta, ModuleError, ServerModulePlugin, TransactionItemAmount,
 };
 
-pub trait ModuleVerificationCache {
+pub trait ModuleVerificationCache: Debug {
     fn as_any(&self) -> &(dyn Any + 'static);
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> VerificationCache;
@@ -29,7 +29,7 @@ dyn_newtype_define! {
 }
 
 // TODO: make macro impl that doesn't force en/decodable
-pub trait PluginVerificationCache: Clone + Send + Sync + 'static {
+pub trait PluginVerificationCache: Clone + Debug + Send + Sync + 'static {
     fn module_key(&self) -> ModuleKey;
 }
 
@@ -53,7 +53,7 @@ where
 ///
 /// Server side Fedimint mondule needs to implement this trait.
 #[async_trait(?Send)]
-pub trait IServerModule {
+pub trait IServerModule: Debug {
     fn module_key(&self) -> ModuleKey;
 
     fn as_any(&self) -> &(dyn Any + 'static);

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -59,7 +59,7 @@ pub trait DatabaseValue: Sized + SerializableDatabaseValue {
 
 pub type PrefixIter<'a> = Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + Send + 'a>;
 
-pub trait IDatabase: Send + Sync {
+pub trait IDatabase: Debug + Send + Sync {
     fn begin_transaction(&self) -> DatabaseTransaction;
 }
 

--- a/fedimint-api/src/macros.rs
+++ b/fedimint-api/src/macros.rs
@@ -68,6 +68,12 @@ macro_rules! _dyn_newtype_define_inner {
                 Self($container::new(i))
             }
         }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
     };
     (   $(#[$outer:meta])*
         $vis:vis $name:ident<$lifetime:lifetime>($container:ident<$trait:ident>)

--- a/fedimint-api/src/macros.rs
+++ b/fedimint-api/src/macros.rs
@@ -155,7 +155,7 @@ macro_rules! serde_module_encoding_wrapper {
         impl From<&$wrapped> for $wrapper_name {
             fn from(eh: &$wrapped) -> Self {
                 let mut bytes = vec![];
-                eh.consensus_encode(&mut bytes)
+                fedimint_api::encoding::Encodable::consensus_encode(eh, &mut bytes)
                     .expect("Writing to buffer can never fail");
                 $wrapper_name(bytes)
             }
@@ -163,11 +163,11 @@ macro_rules! serde_module_encoding_wrapper {
 
         impl $wrapper_name {
             pub fn try_into_inner<M: fedimint_api::core::ModuleDecode>(
-                self,
+                &self,
                 modules: &fedimint_api::encoding::ModuleRegistry<M>,
             ) -> Result<$wrapped, fedimint_api::encoding::DecodeError> {
-                let mut reader = std::io::Cursor::new(self.0);
-                Decodable::consensus_decode(&mut reader, modules)
+                let mut reader = std::io::Cursor::new(&self.0);
+                fedimint_api::encoding::Decodable::consensus_decode(&mut reader, modules)
             }
         }
     };

--- a/fedimint-api/src/macros.rs
+++ b/fedimint-api/src/macros.rs
@@ -149,7 +149,7 @@ macro_rules! dyn_newtype_impl_dyn_clone_passhthrough {
 #[macro_export]
 macro_rules! serde_module_encoding_wrapper {
     ($wrapper_name:ident, $wrapped:ty) => {
-        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+        #[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
         pub struct $wrapper_name(Vec<u8>);
 
         impl From<&$wrapped> for $wrapper_name {
@@ -157,7 +157,7 @@ macro_rules! serde_module_encoding_wrapper {
                 let mut bytes = vec![];
                 eh.consensus_encode(&mut bytes)
                     .expect("Writing to buffer can never fail");
-                SerdeEpochHistory(bytes)
+                $wrapper_name(bytes)
             }
         }
 

--- a/fedimint-api/src/macros.rs
+++ b/fedimint-api/src/macros.rs
@@ -162,11 +162,11 @@ macro_rules! serde_module_encoding_wrapper {
         }
 
         impl $wrapper_name {
-            pub fn try_into_inner<M: ModuleDecode>(
+            pub fn try_into_inner<M: fedimint_api::core::ModuleDecode>(
                 self,
-                modules: &ModuleRegistry<M>,
-            ) -> Result<$wrapped, DecodeError> {
-                let mut reader = Cursor::new(self.0);
+                modules: &fedimint_api::encoding::ModuleRegistry<M>,
+            ) -> Result<$wrapped, fedimint_api::encoding::DecodeError> {
+                let mut reader = std::io::Cursor::new(self.0);
                 Decodable::consensus_decode(&mut reader, modules)
             }
         }

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -2,6 +2,7 @@ pub mod audit;
 pub mod interconnect;
 
 use std::collections::{BTreeMap, HashSet};
+use std::fmt::Debug;
 
 use async_trait::async_trait;
 use futures::future::BoxFuture;
@@ -205,7 +206,7 @@ pub trait FederationModuleConfigGen {
 }
 
 #[async_trait(?Send)]
-pub trait ServerModulePlugin: Sized {
+pub trait ServerModulePlugin: Debug + Sized {
     type Decoder: PluginDecode;
     type Input: PluginInput;
     type Output: PluginOutput;

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -62,7 +62,7 @@ struct Client<T>(T);
 #[async_trait]
 impl<T> IBitcoindRpc for Client<T>
 where
-    T: ::bitcoincore_rpc::RpcApi + Send + Sync,
+    T: ::bitcoincore_rpc::RpcApi + Debug + Send + Sync,
 {
     async fn get_network(&self) -> Result<Network> {
         let network = fedimint_api::task::block_in_place(|| {

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -23,7 +24,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 ///
 /// Functions may panic if if the bitcoind node is not reachable.
 #[async_trait]
-pub trait IBitcoindRpc: Send + Sync {
+pub trait IBitcoindRpc: Debug + Send + Sync {
     /// Returns the Bitcoin network the node is connected to
     async fn get_network(&self) -> Result<bitcoin::Network>;
 

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -38,7 +38,7 @@ pub struct EpochHistory {
 
 serde_module_encoding_wrapper!(SerdeEpochHistory, EpochHistory);
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
 pub struct OutcomeHistory {
     pub epoch: u64,
     pub last_hash: Option<Sha256>,

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -1,10 +1,11 @@
 use std::collections::{BTreeMap, HashSet};
+use std::io::Cursor;
 
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::sha256::HashEngine;
 use fedimint_api::core::ModuleDecode;
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable, ModuleRegistry, UnzipConsensus};
-use fedimint_api::{BitcoinHash, PeerId, ServerModulePlugin};
+use fedimint_api::{serde_module_encoding_wrapper, BitcoinHash, PeerId, ServerModulePlugin};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::{PublicKey, PublicKeySet, Signature, SignatureShare};
@@ -28,12 +29,14 @@ pub struct EpochSignatureShare(pub SignatureShare);
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct EpochSignature(pub Signature);
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
 pub struct EpochHistory {
     pub outcome: OutcomeHistory,
     pub hash: Sha256,
     pub signature: Option<EpochSignature>,
 }
+
+serde_module_encoding_wrapper!(SerdeEpochHistory, EpochHistory);
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct OutcomeHistory {

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashSet};
-use std::io::Cursor;
 
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::sha256::HashEngine;

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -12,9 +12,7 @@ use threshold_crypto::{PublicKey, PublicKeySet, Signature, SignatureShare};
 
 use crate::transaction::Transaction;
 
-#[derive(
-    Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, UnzipConsensus, Encodable, Decodable,
-)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, UnzipConsensus, Encodable, Decodable)]
 pub enum ConsensusItem {
     EpochInfo(EpochSignatureShare),
     Transaction(Transaction),
@@ -22,6 +20,8 @@ pub enum ConsensusItem {
     Wallet(<fedimint_wallet::Wallet as ServerModulePlugin>::ConsensusItem),
     LN(<fedimint_ln::LightningModule as ServerModulePlugin>::ConsensusItem),
 }
+
+serde_module_encoding_wrapper!(SerdeConsensusItem, ConsensusItem);
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct EpochSignatureShare(pub SignatureShare);

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -1,7 +1,7 @@
 use bitcoin::hashes::Hash as BitcoinHash;
 use bitcoin::XOnlyPublicKey;
 use fedimint_api::encoding::{Decodable, Encodable};
-use fedimint_api::{Amount, ServerModulePlugin, TransactionId};
+use fedimint_api::{serde_module_encoding_wrapper, Amount, ServerModulePlugin, TransactionId};
 use rand::Rng;
 use secp256k1_zkp::{schnorr, Secp256k1, Signing, Verification};
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ use thiserror::Error;
 /// An atomic value transfer operation within the Fedimint system and consensus
 ///
 /// The mint enforces that the total value of the outputs equals the total value of the inputs, to prevent creating funds out of thin air. In some cases, the value of the inputs and outputs can both be 0 e.g. when creating an offer to a Lightning Gateway.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
 pub struct Transaction {
     /// [`Input`]s consumed by the transaction
     pub inputs: Vec<Input>,
@@ -19,6 +19,8 @@ pub struct Transaction {
     /// Aggregated MuSig2 signature over all the public keys of the inputs
     pub signature: Option<schnorr::Signature>,
 }
+
+serde_module_encoding_wrapper!(SerdeTransaction, Transaction);
 
 /// An Input consumed by a Transaction is defined within a Fedimint Module.
 ///

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -40,6 +40,7 @@ use crate::rng::RngGenerator;
 use crate::transaction::{Input, Output, Transaction, TransactionError};
 use crate::OsRngGen;
 
+pub type SerdeConsensusOutcome = Batch<Vec<SerdeConsensusItem>, PeerId>;
 pub type ConsensusOutcome = Batch<Vec<ConsensusItem>, PeerId>;
 pub type HoneyBadgerMessage = hbbft::honey_badger::Message<PeerId>;
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -535,41 +535,41 @@ impl FedimintConsensus {
             .expect("DB error");
 
         if let Some(accepted_tx) = accepted {
-            let outputs = accepted_tx
-                .transaction
-                .outputs
-                .iter()
-                .enumerate()
-                .map(|(out_idx, output)| {
-                    let outpoint = OutPoint {
-                        txid,
-                        out_idx: out_idx as u64,
-                    };
-                    match output {
-                        Output::Mint(_) => {
-                            let outcome = self
-                                .mint
-                                .output_status(outpoint)
-                                .expect("the transaction was processed, so should be known");
-                            OutputOutcome::Mint(outcome)
-                        }
-                        Output::Wallet(_) => {
-                            let outcome = self
-                                .wallet
-                                .output_status(outpoint)
-                                .expect("the transaction was processed, so should be known");
-                            OutputOutcome::Wallet(outcome)
-                        }
-                        Output::LN(_) => {
-                            let outcome = self
-                                .ln
-                                .output_status(outpoint)
-                                .expect("the transaction was processed, so should be known");
-                            OutputOutcome::LN(outcome)
-                        }
-                    }
-                })
-                .collect();
+            let outputs =
+                accepted_tx
+                    .transaction
+                    .outputs
+                    .iter()
+                    .enumerate()
+                    .map(|(out_idx, output)| {
+                        let outpoint = OutPoint {
+                            txid,
+                            out_idx: out_idx as u64,
+                        };
+                        let outcome =
+                            match output {
+                                Output::Mint(_) => {
+                                    let outcome = self.mint.output_status(outpoint).expect(
+                                        "the transaction was processed, so should be known",
+                                    );
+                                    OutputOutcome::Mint(outcome)
+                                }
+                                Output::Wallet(_) => {
+                                    let outcome = self.wallet.output_status(outpoint).expect(
+                                        "the transaction was processed, so should be known",
+                                    );
+                                    OutputOutcome::Wallet(outcome)
+                                }
+                                Output::LN(_) => {
+                                    let outcome = self.ln.output_status(outpoint).expect(
+                                        "the transaction was processed, so should be known",
+                                    );
+                                    OutputOutcome::LN(outcome)
+                                }
+                            };
+                        (&outcome).into()
+                    })
+                    .collect();
 
             return Some(crate::outcome::TransactionStatus::Accepted {
                 epoch: accepted_tx.epoch,

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -23,7 +23,6 @@ use fedimint_wallet::Wallet;
 use futures::future::select_all;
 use hbbft::honey_badger::Batch;
 use rand::rngs::OsRng;
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, info_span, instrument, trace, warn};
@@ -91,7 +90,7 @@ pub struct FedimintConsensus {
     pub transaction_notify: Arc<Notify>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
 pub struct AcceptedTransaction {
     pub epoch: u64,
     pub transaction: Transaction,

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -23,7 +23,7 @@ use tracing::{debug, error};
 
 use crate::config::ServerConfig;
 use crate::consensus::FedimintConsensus;
-use crate::transaction::Transaction;
+use crate::transaction::SerdeTransaction;
 
 /// A state of fedimint server passed to each rpc handler callback
 #[derive(Clone)]
@@ -199,7 +199,9 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
                 // deserializing Transaction from json Value always fails
                 // we need to convert it to string first
                 let string = serde_json::to_string(&transaction).map_err(|e| ApiError::bad_request(e.to_string()))?;
-                let transaction: Transaction = serde_json::from_str(&string).map_err(|e| ApiError::bad_request(e.to_string()))?;
+                let serde_transaction: SerdeTransaction = serde_json::from_str(&string).map_err(|e| ApiError::bad_request(e.to_string()))?;
+                let transaction = serde_transaction.try_into_inner(&fedimint.modules).map_err(|e| ApiError::bad_request(e.to_string()))?;
+
                 let tx_id = transaction.tx_hash();
 
                 fedimint.submit_transaction(transaction).map_err(|e| ApiError::bad_request(e.to_string()))?;

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -11,7 +11,7 @@ use fedimint_api::{
     task::TaskHandle,
     ServerModulePlugin, TransactionId,
 };
-use fedimint_core::epoch::EpochHistory;
+use fedimint_core::epoch::SerdeEpochHistory;
 use fedimint_core::outcome::TransactionStatus;
 use futures::FutureExt;
 use jsonrpsee::{
@@ -220,9 +220,9 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
         },
         api_endpoint! {
             "/fetch_epoch_history",
-            async |fedimint: &FedimintConsensus, epoch: u64| -> EpochHistory {
+            async |fedimint: &FedimintConsensus, epoch: u64| -> SerdeEpochHistory {
                 let epoch = fedimint.epoch_history(epoch).ok_or_else(|| ApiError::not_found(String::from("epoch not found")))?;
-                Ok(epoch)
+                Ok((&epoch).into())
             }
         },
         api_endpoint! {

--- a/fedimint-testing/src/bitcoind.rs
+++ b/fedimint-testing/src/bitcoind.rs
@@ -15,7 +15,7 @@ pub struct FakeBitcoindRpcState {
     tx_in_blocks: HashMap<BlockHash, Vec<Transaction>>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct FakeBitcoindRpc {
     state: Arc<Mutex<FakeBitcoindRpcState>>,
 }

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -16,6 +16,7 @@ use fedimint_api::{OutPoint, PeerId, ServerModulePlugin};
 
 pub mod bitcoind;
 
+#[derive(Debug)]
 pub struct FakeFed<Module> {
     members: Vec<(PeerId, Module, Database)>,
     client_cfg: ClientModuleConfig,

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -14,7 +15,7 @@ use tracing::debug;
 use crate::Result;
 
 /// Trait for gateway federation client builders
-pub trait IGatewayClientBuilder {
+pub trait IGatewayClientBuilder: Debug {
     /// Build a new gateway federation client
     fn build(&self, config: GatewayClientConfig) -> Result<Client<GatewayClientConfig>>;
 

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -80,6 +80,7 @@ use crate::db::{
 /// [Account]: contracts::account::AccountContract
 /// [Outgoing]: contracts::outgoing::OutgoingContract
 /// [Incoming]: contracts::incoming::IncomingContract
+#[derive(Debug)]
 pub struct LightningModule {
     cfg: LightningModuleConfig,
     db: Database,

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -56,6 +56,7 @@ mod db;
 /// Data structures taking into account different amount tiers
 
 /// Federated mint member mint
+#[derive(Debug)]
 pub struct Mint {
     cfg: MintConfig,
     sec_key: Tiered<SecretKeyShare>,

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -100,6 +100,7 @@ pub struct RoundConsensus {
     pub randomness_beacon: [u8; 32],
 }
 
+#[derive(Debug)]
 pub struct Wallet {
     cfg: WalletConfig,
     secp: Secp256k1<All>,


### PR DESCRIPTION
Remove `serde` impls from structs that won't be able to have them anymore as soon as they get type-erased.

Builds on #945 