### PR TITLE
Fix rejoin consensus by resending requests

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -25,7 +25,7 @@ use hbbft::honey_badger::Batch;
 use rand::rngs::OsRng;
 use thiserror::Error;
 use tokio::sync::Notify;
-use tracing::{debug, error, info, info_span, instrument, trace, warn};
+use tracing::{debug, error, info_span, instrument, trace, warn};
 
 use crate::config::ServerConfig;
 use crate::consensus::conflictfilter::ConflictFilterable;
@@ -219,7 +219,6 @@ impl FedimintConsensus {
 
     #[instrument(skip_all, fields(epoch = consensus_outcome.epoch))]
     pub async fn process_consensus_outcome(&self, consensus_outcome: ConsensusOutcome) {
-        info!("{}", debug::epoch_message(&consensus_outcome));
         let epoch = consensus_outcome.epoch;
         let epoch_peers: HashSet<PeerId> =
             consensus_outcome.contributions.keys().copied().collect();


### PR DESCRIPTION
Fixes an intermittent issue (~10%) that stalls integration tests on `rejoin_consensus_single_peer`.

Appears that sometimes peers don't respond to the `RejoinConsensus` request, this will retry that request until responses are receive from all peers.