### PR TITLE
Make remove_entry async in IDatabaseTransaction trait

### DIFF
--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -137,7 +137,7 @@ pub trait IServerModule: Debug {
     /// This function may only be called after `begin_consensus_epoch` and before
     /// `end_consensus_epoch`. Data is only written to the database once all transactions have been
     /// processed.
-    fn apply_output<'a>(
+    async fn apply_output<'a>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
         output: &Output,
@@ -384,7 +384,7 @@ where
     /// This function may only be called after `begin_consensus_epoch` and before
     /// `end_consensus_epoch`. Data is only written to the database once all transactions have been
     /// processed.
-    fn apply_output<'a>(
+    async fn apply_output<'a>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
         output: &Output,
@@ -399,6 +399,7 @@ where
                 .expect("incorrect output type passed to module plugin"),
             out_point,
         )
+        .await
     }
 
     /// This function is called once all transactions have been processed and changes were written

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -84,7 +84,7 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
         Ok(self.tx_data.get(key).cloned())
     }
 
-    fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         // Remove data from copy so we can read our own writes
         let ret = self.tx_data.remove(&key.to_vec());
         self.operations
@@ -126,7 +126,7 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
         Ok(())
     }
 
-    fn rollback_tx_to_savepoint(&mut self) {
+    async fn rollback_tx_to_savepoint(&mut self) {
         self.tx_data = self.savepoint.clone();
 
         // Remove any pending operations beyond the savepoint
@@ -163,14 +163,14 @@ mod tests {
         fedimint_api::db::verify_insert_elements(MemDatabase::new().into()).await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_remove_nonexisting() {
-        fedimint_api::db::verify_remove_nonexisting(MemDatabase::new().into());
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_remove_nonexisting() {
+        fedimint_api::db::verify_remove_nonexisting(MemDatabase::new().into()).await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_remove_existing() {
-        fedimint_api::db::verify_remove_nonexisting(MemDatabase::new().into());
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_remove_existing() {
+        fedimint_api::db::verify_remove_nonexisting(MemDatabase::new().into()).await;
     }
 
     #[test_log::test]
@@ -198,9 +198,9 @@ mod tests {
         fedimint_api::db::verify_prevent_nonrepeatable_reads(MemDatabase::new().into()).await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_rollback_to_savepoint() {
-        fedimint_api::db::verify_rollback_to_savepoint(MemDatabase::new().into());
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_rollback_to_savepoint() {
+        fedimint_api::db::verify_rollback_to_savepoint(MemDatabase::new().into()).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -290,7 +290,7 @@ pub trait ServerModulePlugin: Debug + Sized {
     /// This function may only be called after `begin_consensus_epoch` and before
     /// `end_consensus_epoch`. Data is only written to the database once all transactions have been
     /// processed.
-    fn apply_output<'a, 'b>(
+    async fn apply_output<'a, 'b>(
         &'a self,
         dbtx: &mut DatabaseTransaction<'b>,
         output: &'a Self::Output,

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -113,7 +113,7 @@ impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
             .map(|bytes| bytes.to_vec()))
     }
 
-    fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         let ret = self.raw_get_bytes(key);
         self.operations
             .push(DatabaseOperation::Delete(DatabaseDeleteOperation {
@@ -182,7 +182,7 @@ impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
         ret
     }
 
-    fn rollback_tx_to_savepoint(&mut self) {
+    async fn rollback_tx_to_savepoint(&mut self) {
         // Remove any pending operations beyond the savepoint
         let removed_ops = self.num_pending_operations - self.num_savepoint_operations;
         for _i in 0..removed_ops {
@@ -215,18 +215,20 @@ mod fedimint_sled_tests {
         .await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_remove_nonexisting() {
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_remove_nonexisting() {
         fedimint_api::db::verify_remove_nonexisting(
             open_temp_db("fcb-sled-test-remove-nonexisting").into(),
-        );
+        )
+        .await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_remove_existing() {
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_remove_existing() {
         fedimint_api::db::verify_remove_existing(
             open_temp_db("fcb-sled-test-remove-existing").into(),
-        );
+        )
+        .await;
     }
 
     #[test_log::test]
@@ -256,10 +258,11 @@ mod fedimint_sled_tests {
         fedimint_api::db::verify_commit(open_temp_db("fcb-sled-test-commit").into()).await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_rollback_to_savepoint() {
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_rollback_to_savepoint() {
         fedimint_api::db::verify_rollback_to_savepoint(
             open_temp_db("fcb-sled-test-rollback-to-savepoint").into(),
-        );
+        )
+        .await;
     }
 }

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -152,6 +152,7 @@ where
             for (out_point, output) in outputs {
                 member
                     .apply_output(&mut dbtx, output, *out_point)
+                    .await
                     .expect("Faulty output");
             }
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -718,6 +718,7 @@ impl FederationTest {
                         .get(&MODULE_KEY_MINT)
                         .unwrap()
                         .apply_output(&mut dbtx, &MintOutput(tokens.clone()).into(), out_point)
+                        .await
                         .unwrap();
                     dbtx.commit_tx().await.expect("DB Error");
                 }

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -828,7 +828,8 @@ async fn receive_lightning_payment_invalid_preimage() -> Result<()> {
         &secp(),
         tbs_pks,
         rng(),
-    );
+    )
+    .await;
     fed.submit_transaction(tx.into_type_erased());
     fed.run_consensus_epochs(1).await; // process offer
 

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -821,15 +821,16 @@ async fn receive_lightning_payment_invalid_preimage() -> Result<()> {
         .context
         .db
         .begin_transaction(all_decoders());
-    let tx = builder.build(
-        sats(0),
-        &mut dbtx,
-        |dbtx| user.client.mint_client().new_ecash_note(&secp(), dbtx),
-        &secp(),
-        tbs_pks,
-        rng(),
-    )
-    .await;
+    let tx = builder
+        .build(
+            sats(0),
+            &mut dbtx,
+            |dbtx| user.client.mint_client().new_ecash_note(&secp(), dbtx),
+            &secp(),
+            tbs_pks,
+            rng(),
+        )
+        .await;
     fed.submit_transaction(tx.into_type_erased());
     fed.run_consensus_epochs(1).await; // process offer
 


### PR DESCRIPTION
As a continuation of making the IDatabaseTransaction async, this PR makes remove_entry and rollback_to_savepoint async. This allows the executor to switch to a different thread in case some I/O is happening during remove_entry or rollback_to_savepoint.

I am only changing remove_entry and rollback_to_savepoint currently to keep the PR smaller and easier to review. The rest of the functions will be made async next.