### PR TITLE
Offer cachix binary cache via flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -916,4 +916,9 @@
             };
           };
       });
+
+  nixConfig = {
+    extra-substituters = [ "https://fedimint.cachix.org" ];
+    extra-trusted-public-keys = [ "fedimint.cachix.org-1:FpJJjy1iPVlvyv4OMiN5y9+/arFLPcnZhZVVCHCDYTs=" ];
+  };
 }


### PR DESCRIPTION
I noticed that helix does it:

https://github.com/helix-editor/helix/blob/master/flake.nix#L176

and wanted to try it.

There are some problems with it though:

* It asks on `nix develop` if you want use these settings and if you want to remember them. Not a problem on it's own but ...
* If you are using `direnv` it will just get stuck, as direnv doesn't allow stdin from the subcommands it starts (or something like that). You have to ctrl+c it, and then run `nix develop` manually and make it remember settings. Papercut.
* On my system I get `warning: ignoring untrusted substituter 'https://fedimint.cachix.org'` and I'm not sure what is wrong.