### PR TITLE
Remove `no_consensus_db` from modules

### DIFF
--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -582,12 +582,12 @@ mod tests {
         let contract_data = refund_inputs.into_iter().next().unwrap();
         let (refund_key, refund_input) =
             client.create_refund_outgoing_contract_input(&contract_data);
-        assert!(fed.lock().await.verify_input(&refund_input).is_err());
+        assert!(fed.lock().await.verify_input(&refund_input).await.is_err());
 
         // We need to compensate for the wallet's confirmation target
         fed.lock().await.set_block_height(timelock as u64);
 
-        let meta = fed.lock().await.verify_input(&refund_input).unwrap();
+        let meta = fed.lock().await.verify_input(&refund_input).await.unwrap();
         let refund_pk = secp256k1_zkp::XOnlyPublicKey::from_keypair(refund_key).0;
         assert_eq!(meta.keys, vec![refund_pk]);
         assert_eq!(meta.amount.amount, expected_amount);

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -392,7 +392,7 @@ mod tests {
                 .await
                 .fetch_from_all(|m, db| {
                     m.get_contract_account(
-                        &db.begin_transaction(ModuleRegistry::default()),
+                        &mut db.begin_transaction(ModuleRegistry::default()),
                         contract,
                     )
                 })

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -499,7 +499,6 @@ mod tests {
     use bitcoin::Address;
     use fedimint_api::backup::SignedBackupRequest;
     use fedimint_api::config::ModuleConfigGenParams;
-    use fedimint_api::core::{Decoder, MODULE_KEY_MINT};
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::db::Database;
     use fedimint_api::encoding::ModuleRegistry;
@@ -508,7 +507,6 @@ mod tests {
     use fedimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
     use fedimint_core::modules::ln::contracts::ContractId;
     use fedimint_core::modules::ln::{ContractAccount, LightningGateway};
-    use fedimint_core::modules::mint::common::MintModuleDecoder;
     use fedimint_core::modules::mint::config::MintClientConfig;
     use fedimint_core::modules::mint::{Mint, MintConfigGenerator, MintOutput};
     use fedimint_core::modules::wallet::PegOutFees;
@@ -627,35 +625,24 @@ mod tests {
         }
     }
 
-    fn mint_decoders() -> ModuleRegistry {
-        vec![(MODULE_KEY_MINT, Decoder::from_typed(MintModuleDecoder))]
-            .into_iter()
-            .collect()
-    }
-
     async fn new_mint_and_client() -> (
         Arc<tokio::sync::Mutex<Fed>>,
         MintClientConfig,
         ClientContext,
     ) {
-        let fed =
-            Arc::new(
-                tokio::sync::Mutex::new(
-                    FakeFed::<Mint>::new(
-                        4,
-                        |cfg, db| async move {
-                            Ok(Mint::new(cfg.to_typed().unwrap(), db, mint_decoders()))
-                        },
-                        &ModuleConfigGenParams {
-                            mint_amounts: vec![Amount::from_sat(1), Amount::from_sat(10)],
-                            ..ModuleConfigGenParams::fake_config_gen_params()
-                        },
-                        &MintConfigGenerator,
-                    )
-                    .await
-                    .unwrap(),
-                ),
-            );
+        let fed = Arc::new(tokio::sync::Mutex::new(
+            FakeFed::<Mint>::new(
+                4,
+                |cfg, _db| async move { Ok(Mint::new(cfg.to_typed().unwrap())) },
+                &ModuleConfigGenParams {
+                    mint_amounts: vec![Amount::from_sat(1), Amount::from_sat(10)],
+                    ..ModuleConfigGenParams::fake_config_gen_params()
+                },
+                &MintConfigGenerator,
+            )
+            .await
+            .unwrap(),
+        ));
 
         let api = FakeApi { mint: fed.clone() };
 

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -762,7 +762,7 @@ mod tests {
             .await;
         dbtx.commit_tx().await.expect("DB Error");
 
-        let meta = fed.lock().await.verify_input(&input).unwrap();
+        let meta = fed.lock().await.verify_input(&input).await.unwrap();
         assert_eq!(meta.amount.amount, SPEND_AMOUNT);
         assert_eq!(
             meta.keys,
@@ -781,7 +781,7 @@ mod tests {
         assert_eq!(client.coins().total_amount(), SPEND_AMOUNT);
 
         // Double spends aren't possible
-        assert!(fed.lock().await.verify_input(&input).is_err());
+        assert!(fed.lock().await.verify_input(&input).await.is_err());
 
         // We can exactly spend the remainder
         let mut dbtx = client
@@ -805,7 +805,7 @@ mod tests {
             .await;
         dbtx.commit_tx().await.expect("DB Error");
 
-        let meta = fed.lock().await.verify_input(&input).unwrap();
+        let meta = fed.lock().await.verify_input(&input).await.unwrap();
         assert_eq!(meta.amount.amount, SPEND_AMOUNT);
         assert_eq!(
             meta.keys,

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -423,7 +423,7 @@ mod tests {
         assert!(btc_rpc.is_btc_sent_to(amount, addr).await);
 
         let wallet_value = fed.lock().await.fetch_from_all(|wallet, db| {
-            wallet.get_wallet_value(&db.begin_transaction(ModuleRegistry::default()))
+            wallet.get_wallet_value(&mut db.begin_transaction(ModuleRegistry::default()))
         });
         assert_eq!(wallet_value, bitcoin::Amount::from_sat(0));
 
@@ -433,7 +433,7 @@ mod tests {
         fed.lock().await.consensus_round(&[], &[]).await;
 
         let wallet_value = fed.lock().await.fetch_from_all(|wallet, db| {
-            wallet.get_wallet_value(&db.begin_transaction(ModuleRegistry::default()))
+            wallet.get_wallet_value(&mut db.begin_transaction(ModuleRegistry::default()))
         });
         assert!(wallet_value > bitcoin::Amount::from_sat(0));
     }

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -96,9 +96,9 @@ macro_rules! module_plugin_trait_define {
 
         impl<T> $module_ty for T
         where
-            T: $plugin_ty + DynEncodable + 'static,
+            T: $plugin_ty + DynEncodable + 'static + Send + Sync,
         {
-            fn as_any(&self) -> &(dyn Any + 'static) {
+            fn as_any(&self) -> &(dyn Any + 'static + Send + Sync) {
                 self
             }
 
@@ -316,7 +316,7 @@ impl Decoder {
 ///
 /// General purpose code should use [`Input`] instead
 pub trait ModuleInput: Debug + DynEncodable {
-    fn as_any(&self) -> &(dyn Any + 'static);
+    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync);
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> Input;
     fn dyn_hash(&self) -> u64;
@@ -346,7 +346,7 @@ newtype_impl_eq_passthrough!(Input);
 ///
 /// General purpose code should use [`Output`] instead
 pub trait ModuleOutput: Debug + DynEncodable {
-    fn as_any(&self) -> &(dyn Any + 'static);
+    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync);
     fn module_key(&self) -> ModuleKey;
 
     fn clone(&self) -> Output;
@@ -377,7 +377,7 @@ pub enum FinalizationError {
 }
 
 pub trait ModuleOutputOutcome: Debug + DynEncodable {
-    fn as_any(&self) -> &(dyn Any + 'static);
+    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync);
     /// Module key
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> OutputOutcome;
@@ -415,7 +415,7 @@ dyn_newtype_impl_dyn_clone_passhthrough!(OutputOutcome);
 newtype_impl_eq_passthrough!(OutputOutcome);
 
 pub trait ModuleConsensusItem: Debug + DynEncodable {
-    fn as_any(&self) -> &(dyn Any + 'static);
+    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync);
     /// Module key
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> ConsensusItem;

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -94,10 +94,10 @@ pub trait IServerModule: Debug {
     /// function has no side effects and may be called at any time. False positives due to outdated
     /// database state are ok since they get filtered out after consensus has been reached on them
     /// and merely generate a warning.
-    fn validate_input<'a>(
+    async fn validate_input<'a>(
         &self,
-        interconnect: &dyn ModuleInterconect,
-        dbtx: &DatabaseTransaction<'a>,
+        interconnect: &'a dyn ModuleInterconect,
+        dbtx: &mut DatabaseTransaction<'_>,
         verification_cache: &VerificationCache,
         input: &Input,
     ) -> Result<InputMeta, ModuleError>;
@@ -306,10 +306,10 @@ where
     /// function has no side effects and may be called at any time. False positives due to outdated
     /// database state are ok since they get filtered out after consensus has been reached on them
     /// and merely generate a warning.
-    fn validate_input<'a>(
+    async fn validate_input<'a>(
         &self,
-        interconnect: &dyn ModuleInterconect,
-        dbtx: &DatabaseTransaction<'a>,
+        interconnect: &'a dyn ModuleInterconect,
+        dbtx: &mut DatabaseTransaction<'_>,
         verification_cache: &VerificationCache,
         input: &Input,
     ) -> Result<InputMeta, ModuleError> {
@@ -326,6 +326,7 @@ where
                 .downcast_ref::<<Self as ServerModulePlugin>::Input>()
                 .expect("incorrect input type passed to module plugin"),
         )
+        .await
         .map(Into::into)
     }
 
@@ -448,13 +449,17 @@ where
             .into_iter()
             .map(|ApiEndpoint { path, handler }| ApiEndpoint {
                 path,
-                handler: Box::new(move |module: &ServerModule, value: serde_json::Value| {
-                    let typed_module = module
-                        .as_any()
-                        .downcast_ref::<T>()
-                        .expect("the dispatcher should always call with the right module");
-                    Box::pin(handler(typed_module, value))
-                }),
+                handler: Box::new(
+                    move |module: &ServerModule,
+                          dbtx: fedimint_api::db::DatabaseTransaction<'_>,
+                          value: serde_json::Value| {
+                        let typed_module = module
+                            .as_any()
+                            .downcast_ref::<T>()
+                            .expect("the dispatcher should always call with the right module");
+                        Box::pin(handler(typed_module, dbtx, value))
+                    },
+                ),
             })
             .collect()
     }

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -69,10 +69,10 @@ pub trait IServerModule: Debug {
     fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self);
+    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>);
 
     /// This module's contribution to the next consensus proposal
-    async fn consensus_proposal(&self) -> Vec<ConsensusItem>;
+    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<ConsensusItem>;
 
     /// This function is called once before transaction processing starts. All module consensus
     /// items of this round are supplied as `consensus_items`. The batch will be committed to the
@@ -158,13 +158,17 @@ pub trait IServerModule: Debug {
     /// Retrieve the current status of the output. Depending on the module this might contain data
     /// needed by the client to access funds or give an estimate of when funds will be available.
     /// Returns `None` if the output is unknown, **NOT** if it is just not ready yet.
-    fn output_status(&self, out_point: OutPoint) -> Option<OutputOutcome>;
+    fn output_status(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        out_point: OutPoint,
+    ) -> Option<OutputOutcome>;
 
     /// Queries the database and returns all assets and liabilities of the module.
     ///
     /// Summing over all modules, if liabilities > assets then an error has occurred in the database
     /// and consensus should halt.
-    fn audit(&self, audit: &mut Audit);
+    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit);
 
     /// Defines the prefix for API endpoints defined by the module.
     ///
@@ -240,13 +244,13 @@ where
     }
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self) {
-        <Self as ServerModulePlugin>::await_consensus_proposal(self).await
+    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
+        <Self as ServerModulePlugin>::await_consensus_proposal(self, dbtx).await
     }
 
     /// This module's contribution to the next consensus proposal
-    async fn consensus_proposal(&self) -> Vec<ConsensusItem> {
-        <Self as ServerModulePlugin>::consensus_proposal(self)
+    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<ConsensusItem> {
+        <Self as ServerModulePlugin>::consensus_proposal(self, dbtx)
             .await
             .into_iter()
             .map(Into::into)
@@ -419,16 +423,20 @@ where
     /// Retrieve the current status of the output. Depending on the module this might contain data
     /// needed by the client to access funds or give an estimate of when funds will be available.
     /// Returns `None` if the output is unknown, **NOT** if it is just not ready yet.
-    fn output_status(&self, out_point: OutPoint) -> Option<OutputOutcome> {
-        <Self as ServerModulePlugin>::output_status(self, out_point).map(Into::into)
+    fn output_status(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        out_point: OutPoint,
+    ) -> Option<OutputOutcome> {
+        <Self as ServerModulePlugin>::output_status(self, dbtx, out_point).map(Into::into)
     }
 
     /// Queries the database and returns all assets and liabilities of the module.
     ///
     /// Summing over all modules, if liabilities > assets then an error has occurred in the database
     /// and consensus should halt.
-    fn audit(&self, audit: &mut Audit) {
-        <Self as ServerModulePlugin>::audit(self, audit)
+    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
+        <Self as ServerModulePlugin>::audit(self, dbtx, audit)
     }
 
     fn api_base_name(&self) -> &'static str {

--- a/fedimint-api/src/module/audit.rs
+++ b/fedimint-api/src/module/audit.rs
@@ -20,8 +20,12 @@ impl Audit {
         }
     }
 
-    pub fn add_items<KP, F>(&mut self, dbtx: &DatabaseTransaction, key_prefix: &KP, to_milli_sat: F)
-    where
+    pub fn add_items<KP, F>(
+        &mut self,
+        dbtx: &mut DatabaseTransaction,
+        key_prefix: &KP,
+        to_milli_sat: F,
+    ) where
         KP: DatabaseKeyPrefix + DatabaseKeyPrefixConst + 'static,
         F: Fn(KP::Key, KP::Value) -> i64,
     {

--- a/fedimint-api/src/module/interconnect.rs
+++ b/fedimint-api/src/module/interconnect.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use super::ApiError;
 
 /// Provides an interface to call APIs of other modules
-#[async_trait]
-pub trait ModuleInterconect {
+#[async_trait(?Send)]
+pub trait ModuleInterconect: Sync + Send {
     /// Simulates a call to an API endpoint of another module.
     /// This has lower latency.
     async fn call(

--- a/fedimint-api/src/module/interconnect.rs
+++ b/fedimint-api/src/module/interconnect.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use super::ApiError;
 
 /// Provides an interface to call APIs of other modules
-#[async_trait(?Send)]
+#[async_trait]
 pub trait ModuleInterconect: Sync + Send {
     /// Simulates a call to an API endpoint of another module.
     /// This has lower latency.

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -117,7 +117,7 @@ macro_rules! __api_endpoint {
 
             async fn handle<'a, 'b>(
                 $state: &'a Self::State,
-                $dbtx: fedimint_api::db::DatabaseTransaction<'b>,
+                mut $dbtx: fedimint_api::db::DatabaseTransaction<'b>,
                 $param: Self::Param,
             ) -> ::std::result::Result<Self::Response, $crate::module::ApiError> {
                 $body

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -9,7 +9,7 @@ pub struct FedimintInterconnect<'a> {
     pub fedimint: &'a FedimintConsensus,
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
     async fn call(
         &self,

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -9,7 +9,7 @@ pub struct FedimintInterconnect<'a> {
     pub fedimint: &'a FedimintConsensus,
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
     async fn call(
         &self,
@@ -25,7 +25,8 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
                     .find(|endpoint| endpoint.path == path)
                     .ok_or_else(|| ApiError::not_found(String::from("Method not found")))?;
 
-                return (endpoint.handler)(module, data).await;
+                return (endpoint.handler)(module, self.fedimint.database_transaction(), data)
+                    .await;
             }
         }
         panic!("Module not registered: {}", module_name);

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -119,13 +119,14 @@ where
         <Module as ServerModulePlugin>::Input: Send + Sync,
     {
         let fake_ic = FakeInterconnect::new_block_height_responder(self.block_height.clone());
+        let decoders = self.decoders();
 
         // TODO: only include some of the proposals for realism
         let mut consensus = vec![];
-        for (id, member, _db) in &mut self.members {
+        for (id, member, db) in &mut self.members {
             consensus.extend(
                 member
-                    .consensus_proposal()
+                    .consensus_proposal(&db.begin_transaction(decoders.clone()))
                     .await
                     .into_iter()
                     .map(|ci| (*id, ci)),
@@ -171,11 +172,9 @@ where
         // in terms of outcomes. This may change later once end_consensus_epoch is pulled out of the
         // main consensus loop into another thread to optimize latency. This test will probably fail
         // then.
-        assert_all_equal(
-            self.members
-                .iter()
-                .map(|(_, member, _)| member.output_status(out_point)),
-        )
+        assert_all_equal(self.members.iter().map(|(_, member, db)| {
+            member.output_status(&mut db.begin_transaction(self.decoders()), out_point)
+        }))
     }
 
     pub async fn patch_dbs<U>(&mut self, update: U)

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -96,11 +96,7 @@ async fn main() -> anyhow::Result<()> {
 
     task_group.install_kill_handler();
 
-    let mint = fedimint_core::modules::mint::Mint::new(
-        cfg.get_module_config("mint")?,
-        db.clone(),
-        all_decoders(),
-    );
+    let mint = fedimint_core::modules::mint::Mint::new(cfg.get_module_config("mint")?);
 
     let wallet = Wallet::new_with_bitcoind(
         cfg.get_module_config("wallet")?,

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
     .await
     .expect("Couldn't create wallet");
 
-    let ln = LightningModule::new(cfg.get_module_config("ln")?, db.clone(), all_decoders());
+    let ln = LightningModule::new(cfg.get_module_config("ln")?);
 
     let mut consensus = FedimintConsensus::new(cfg.clone(), db);
     consensus.register_module(mint.into());

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -929,11 +929,7 @@ impl FederationTest {
             let db = database_gen();
             let mut task_group = task_group.clone();
 
-            let mint = Mint::new(
-                cfg.get_module_config("mint").unwrap(),
-                db.clone(),
-                all_decoders(),
-            );
+            let mint = Mint::new(cfg.get_module_config("mint").unwrap());
 
             let wallet = Wallet::new_with_bitcoind(
                 cfg.get_module_config("wallet").unwrap(),

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -945,11 +945,7 @@ impl FederationTest {
             .await
             .expect("Couldn't create wallet");
 
-            let ln = LightningModule::new(
-                cfg.get_module_config("ln").unwrap(),
-                db.clone(),
-                all_decoders(),
-            );
+            let ln = LightningModule::new(cfg.get_module_config("ln").unwrap());
 
             let mut consensus = FedimintConsensus::new(cfg.clone(), db.clone());
             consensus.register_module(mint.into());

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -567,7 +567,8 @@ impl FederationTest {
     }
 
     /// Submit a fedimint transaction to all federation servers
-    pub fn submit_transaction(
+    #[allow(clippy::await_holding_refcell_ref)] // TODO: fix, it's just a test
+    pub async fn submit_transaction(
         &self,
         transaction: fedimint_server::transaction::Transaction,
     ) -> Result<(), TransactionSubmissionError> {
@@ -576,7 +577,8 @@ impl FederationTest {
                 .borrow_mut()
                 .fedimint
                 .consensus
-                .submit_transaction(transaction.clone())?;
+                .submit_transaction(transaction.clone())
+                .await?;
         }
         Ok(())
     }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -808,7 +808,7 @@ impl FederationTest {
             .as_any()
             .downcast_ref::<Wallet>()
             .unwrap()
-            .consensus_height(&server.consensus.db.begin_transaction(all_decoders()))
+            .consensus_height(&mut server.consensus.db.begin_transaction(all_decoders()))
             .unwrap_or(0);
         let proposal = block_on(server.consensus.get_consensus_proposal());
 

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -12,10 +12,8 @@ use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::TieredMulti;
 use fedimint_ln::contracts::{Preimage, PreimageDecryptionShare};
 use fedimint_ln::LightningConsensusItem;
-
-use fedimint_mint::{MintOutputConfirmation, OutputConfirmationSignatures};
-
 use fedimint_mint::config::MintClientConfig;
+use fedimint_mint::{MintOutputConfirmation, OutputConfirmationSignatures};
 use fedimint_server::all_decoders;
 use fedimint_server::consensus::TransactionSubmissionError::TransactionError;
 use fedimint_server::epoch::ConsensusItem;

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -15,6 +15,8 @@ use fedimint_ln::LightningConsensusItem;
 
 use fedimint_mint::{MintOutputConfirmation, OutputConfirmationSignatures};
 
+use fedimint_mint::config::MintClientConfig;
+use fedimint_server::all_decoders;
 use fedimint_server::consensus::TransactionSubmissionError::TransactionError;
 use fedimint_server::epoch::ConsensusItem;
 use fedimint_server::transaction::legacy::Output;
@@ -824,8 +826,25 @@ async fn receive_lightning_payment_invalid_preimage() -> Result<()> {
     );
     let mut builder = TransactionBuilder::default();
     builder.output(Output::LN(offer_output));
-    let tx = user.create_tx(builder).await;
-    fed.submit_transaction(tx.into_type_erased()).unwrap();
+    let tbs_pks = &user
+        .config
+        .0
+        .get_module::<MintClientConfig>("mint")?
+        .tbs_pks;
+    let context = &user.client.mint_client().context;
+    let mut dbtx = context.db.begin_transaction(all_decoders());
+    let client = &user.client;
+    let tx = builder
+        .build(
+            sats(0),
+            &mut dbtx,
+            |amount| async move { client.mint_client().new_ecash_note(&secp(), amount).await },
+            &secp(),
+            tbs_pks,
+            rng(),
+        )
+        .await;
+    fed.submit_transaction(tx.into_type_erased()).await.unwrap();
     fed.run_consensus_epochs(1).await; // process offer
 
     // Gateway escrows ecash to trigger preimage decryption by the federation
@@ -1071,7 +1090,7 @@ async fn unbalanced_transactions_get_rejected() -> Result<()> {
         .input_coins(user.client.mint_client().coins())
         .unwrap();
     let tx = user.create_tx(builder).await;
-    let response = fed.submit_transaction(tx.into_type_erased());
+    let response = fed.submit_transaction(tx.into_type_erased()).await;
 
     assert_matches!(
         response,

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -35,7 +35,7 @@ async fn test_account() {
 
     let mut fed = FakeFed::<LightningModule>::new(
         4,
-        |cfg, db| async move { Ok(LightningModule::new(cfg.to_typed()?, db, ln_decoders())) },
+        |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
         &ModuleConfigGenParams::fake_config_gen_params(),
         &LightningModuleConfigGen,
     )
@@ -85,7 +85,7 @@ async fn test_outgoing() {
 
     let mut fed = FakeFed::<LightningModule>::new(
         4,
-        |cfg, db| async move { Ok(LightningModule::new(cfg.to_typed()?, db, ln_decoders())) },
+        |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
         &ModuleConfigGenParams::fake_config_gen_params(),
         &LightningModuleConfigGen,
     )
@@ -184,7 +184,7 @@ async fn test_incoming() {
 
     let mut fed = FakeFed::<LightningModule>::new(
         4,
-        |cfg, db| async move { Ok(LightningModule::new(cfg.to_typed()?, db, ln_decoders())) },
+        |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
         &ModuleConfigGenParams::fake_config_gen_params(),
         &LightningModuleConfigGen,
     )

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -71,12 +71,12 @@ async fn test_account() {
         amount: Amount::from_sat(42),
         witness: None,
     };
-    let meta = fed.verify_input(&account_input).unwrap();
+    let meta = fed.verify_input(&account_input).await.unwrap();
     assert_eq!(meta.keys, vec![kp.x_only_public_key().0]);
 
     fed.consensus_round(&[account_input.clone()], &[]).await;
 
-    assert!(fed.verify_input(&account_input).is_err());
+    assert!(fed.verify_input(&account_input).await.is_err());
 }
 
 #[test_log::test(tokio::test)]
@@ -152,7 +152,10 @@ j5r6drg6k6zcqj0fcwg"
         amount: Amount::from_sat(42),
         witness: None,
     };
-    let err = fed.verify_input(&account_input_no_witness).unwrap_err();
+    let err = fed
+        .verify_input(&account_input_no_witness)
+        .await
+        .unwrap_err();
     assert_eq!(
         format!("{err}"),
         format!("{}", LightningModuleError::MissingPreimage)
@@ -164,12 +167,12 @@ j5r6drg6k6zcqj0fcwg"
         amount: Amount::from_sat(42),
         witness: Some(preimage),
     };
-    let meta = fed.verify_input(&account_input_witness).unwrap();
+    let meta = fed.verify_input(&account_input_witness).await.unwrap();
     assert_eq!(meta.keys, vec![gw_pk]);
 
     // Test case 2: after timeout
     fed.set_block_height(42);
-    let meta = fed.verify_input(&account_input_no_witness).unwrap();
+    let meta = fed.verify_input(&account_input_no_witness).await.unwrap();
     assert_eq!(meta.keys, vec![user_pk]);
 
     fed.consensus_round(&[account_input_no_witness], &[]).await;
@@ -249,7 +252,7 @@ async fn test_incoming() {
         amount: Amount::from_sat(42),
         witness: None,
     };
-    let error = fed.verify_input(&incoming_input).unwrap_err();
+    let error = fed.verify_input(&incoming_input).await.unwrap_err();
     assert_eq!(
         format!("{error}"),
         format!("{}", LightningModuleError::ContractNotReady)
@@ -266,7 +269,7 @@ async fn test_incoming() {
         _ => panic!(),
     };
 
-    let meta = fed.verify_input(&incoming_input).unwrap();
+    let meta = fed.verify_input(&incoming_input).await.unwrap();
     assert_eq!(meta.keys, vec![user_pk]);
 
     // TODO: test faulty encrypted preimage

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -217,7 +217,7 @@ async fn test_incoming() {
 
     fed.consensus_round(&[], &[(offer_out_point, offer_output)])
         .await;
-    let offers = fed.fetch_from_all(|m, db| m.get_offers(&db.begin_transaction(ln_decoders())));
+    let offers = fed.fetch_from_all(|m, db| m.get_offers(&mut db.begin_transaction(ln_decoders())));
     assert_eq!(offers, vec![offer.clone()]);
 
     let contract = Contract::Incoming(IncomingContract {

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -45,7 +45,7 @@ impl DatabaseKeyPrefixConst for NonceKeyPrefix {
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ProposedPartialSignatureKey {
-    pub request_id: OutPoint, // tx + output idx
+    pub out_point: OutPoint, // tx + output idx
 }
 
 impl DatabaseKeyPrefixConst for ProposedPartialSignatureKey {

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -291,13 +291,16 @@ impl ServerModulePlugin for Mint {
         MintModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self) {
-        if self.consensus_proposal().await.is_empty() {
+    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
+        if self.consensus_proposal(dbtx).await.is_empty() {
             std::future::pending().await
         }
     }
 
-    async fn consensus_proposal(&self) -> Vec<Self::ConsensusItem> {
+    async fn consensus_proposal(
+        &self,
+        _dbtx: &DatabaseTransaction<'_>,
+    ) -> Vec<Self::ConsensusItem> {
         self.non_consensus_db
             .begin_transaction(self.decoders.clone())
             .find_by_prefix(&ProposedPartialSignaturesKeyPrefix)
@@ -584,7 +587,11 @@ impl ServerModulePlugin for Mint {
         drop_peers.into_iter().collect()
     }
 
-    fn output_status(&self, out_point: OutPoint) -> Option<Self::OutputOutcome> {
+    fn output_status(
+        &self,
+        _dbtx: &mut DatabaseTransaction<'_>,
+        out_point: OutPoint,
+    ) -> Option<Self::OutputOutcome> {
         let dbtx = self
             .non_consensus_db
             .begin_transaction(self.decoders.clone());
@@ -611,7 +618,7 @@ impl ServerModulePlugin for Mint {
         }
     }
 
-    fn audit(&self, audit: &mut Audit) {
+    fn audit(&self, _dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
         audit.add_items(
             &self
                 .non_consensus_db

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -353,10 +353,10 @@ impl ServerModulePlugin for Mint {
         VerificationCache { valid_coins }
     }
 
-    fn validate_input<'a, 'b>(
+    async fn validate_input<'a, 'b>(
         &self,
         _interconnect: &dyn ModuleInterconect,
-        dbtx: &DatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransaction<'b>,
         verification_cache: &Self::VerificationCache,
         input: &'a Self::Input,
     ) -> Result<InputMeta, ModuleError> {
@@ -404,7 +404,9 @@ impl ServerModulePlugin for Mint {
         input: &'b Self::Input,
         cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
-        let meta = self.validate_input(interconnect, dbtx, cache, input)?;
+        let meta = self
+            .validate_input(interconnect, dbtx, cache, input)
+            .await?;
 
         for (amount, coin) in input.iter_items() {
             let key = NonceKey(coin.0.clone());
@@ -641,14 +643,14 @@ impl ServerModulePlugin for Mint {
         vec![
             api_endpoint! {
                 "/backup",
-                async |module: &Mint, request: SignedBackupRequest| -> () {
+                async |module: &Mint, _dbtx, request: SignedBackupRequest| -> () {
                     module
                         .handle_backup_request(request).await
                 }
             },
             api_endpoint! {
                 "/recover",
-                async |module: &Mint, id: secp256k1_zkp::XOnlyPublicKey| -> Vec<u8> {
+                async |module: &Mint, _dbtx, id: secp256k1_zkp::XOnlyPublicKey| -> Vec<u8> {
                     module
                         .handle_recover_request(id).await
                         .ok_or_else(|| ApiError::not_found(String::from("Backup not found")))

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -360,17 +360,11 @@ impl ServerModulePlugin for Wallet {
         WalletModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self) {
+    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
         let mut our_target_height = self.target_height().await;
-        let last_consensus_height = self
-            .consensus_height(
-                &self
-                    .non_consensus_db
-                    .begin_transaction(self.decoders.clone()),
-            )
-            .unwrap_or(0);
+        let last_consensus_height = self.consensus_height(dbtx).unwrap_or(0);
 
-        if self.consensus_proposal().await.len() == 1 {
+        if self.consensus_proposal(dbtx).await.len() == 1 {
             while our_target_height <= last_consensus_height {
                 our_target_height = self.target_height().await;
                 sleep(Duration::from_millis(1000)).await;
@@ -378,7 +372,10 @@ impl ServerModulePlugin for Wallet {
         }
     }
 
-    async fn consensus_proposal<'a>(&'a self) -> Vec<Self::ConsensusItem> {
+    async fn consensus_proposal<'a>(
+        &'a self,
+        _dbtx: &DatabaseTransaction<'_>,
+    ) -> Vec<Self::ConsensusItem> {
         let dbtx = self
             .non_consensus_db
             .begin_transaction(self.decoders.clone());
@@ -699,14 +696,18 @@ impl ServerModulePlugin for Wallet {
         drop_peers
     }
 
-    fn output_status(&self, out_point: OutPoint) -> Option<Self::OutputOutcome> {
+    fn output_status(
+        &self,
+        _dbtx: &mut DatabaseTransaction<'_>,
+        out_point: OutPoint,
+    ) -> Option<Self::OutputOutcome> {
         self.non_consensus_db
             .begin_transaction(self.decoders.clone())
             .get_value(&PegOutBitcoinTransaction(out_point))
             .expect("DB error")
     }
 
-    fn audit(&self, audit: &mut Audit) {
+    fn audit(&self, _dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
         let dbtx = self
             .non_consensus_db
             .begin_transaction(self.decoders.clone());

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -363,6 +363,8 @@ impl ServerModulePlugin for Wallet {
         if self.consensus_proposal(dbtx).await.len() == 1 {
             while our_target_height <= last_consensus_height {
                 our_target_height = self.target_height().await;
+                // FIXME: remove after modularization finishes
+                #[cfg(not(target_family = "wasm"))]
                 sleep(Duration::from_millis(1000)).await;
             }
         }
@@ -1419,6 +1421,8 @@ pub async fn run_broadcast_pending_tx(
 ) {
     while !tg_handle.is_shutting_down() {
         broadcast_pending_tx(db.begin_transaction(modules.clone()), &rpc).await;
+        // FIXME: remove after modularization finishes
+        #[cfg(not(target_family = "wasm"))]
         fedimint_api::task::sleep(Duration::from_secs(10)).await;
     }
 }


### PR DESCRIPTION
related to #937 

By removing the database reference from the modules we avoid accidental misuse by reading from the database directly while writing to a transaction.