### PR TITLE
Allow setting the network to run on in `distributedgen`

### DIFF
--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -431,6 +431,7 @@ impl ServerConfigParams {
             .collect::<BTreeMap<_, _>>()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn gen_params(
         bind_address: String,
         key: rustls::PrivateKey,
@@ -439,6 +440,7 @@ impl ServerConfigParams {
         peers: &BTreeMap<PeerId, PeerServerParams>,
         federation_name: String,
         bitcoind_rpc: String,
+        network: bitcoin::network::constants::Network,
     ) -> ServerConfigParams {
         let peer_certs: HashMap<PeerId, rustls::Certificate> = peers
             .iter()
@@ -465,7 +467,9 @@ impl ServerConfigParams {
             amount_tiers,
             federation_name,
             bitcoind_rpc,
-            other: BTreeMap::new(),
+            other: vec![("network".into(), network.to_string().into())]
+                .into_iter()
+                .collect(),
         }
     }
 
@@ -530,6 +534,7 @@ impl ServerConfigParams {
                     &peer_params,
                     federation_name.to_string(),
                     bitcoind_rpc.to_string(),
+                    bitcoin::network::constants::Network::Regtest,
                 );
                 (*peer, params)
             })

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -82,6 +82,10 @@ enum Command {
         )]
         denominations: Vec<Amount>,
 
+        /// The bitcoin network that fedimint will be running on
+        #[arg(long = "network", default_value = "regtest")]
+        network: bitcoin::network::constants::Network,
+
         /// The password that encrypts the configs, will prompt if not passed in
         #[arg(long = "password")]
         password: Option<String>,
@@ -120,6 +124,7 @@ async fn main() {
             bind_address,
             bitcoind_rpc,
             denominations,
+            network,
             password,
         } => {
             let key = get_key(password, dir_out_path.join(SALT_FILE));
@@ -131,6 +136,7 @@ async fn main() {
                 federation_name,
                 certs,
                 bitcoind_rpc,
+                network,
                 rustls::PrivateKey(pk_bytes),
                 &mut task_group,
             )
@@ -164,6 +170,7 @@ async fn run_dkg(
     federation_name: String,
     certs: Vec<String>,
     bitcoind_rpc: String,
+    network: bitcoin::network::constants::Network,
     pk: rustls::PrivateKey,
     task_group: &mut TaskGroup,
 ) -> Cancellable<(ServerConfig, ClientConfig)> {
@@ -190,6 +197,7 @@ async fn run_dkg(
         &peers,
         federation_name,
         bitcoind_rpc,
+        network,
     );
     let peer_ids: Vec<PeerId> = peers.keys().cloned().collect();
     let server_conn =

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -92,13 +92,14 @@ impl WalletConfig {
         sk: SecretKey,
         threshold: usize,
         btc_rpc: BitcoindRpcCfg,
+        network: bitcoin::network::constants::Network,
     ) -> Self {
         let peg_in_descriptor = PegInDescriptor::Wsh(
             Wsh::new_sortedmulti(threshold, pubkeys.iter().map(|(_, pk)| *pk).collect()).unwrap(),
         );
 
         Self {
-            network: Network::Regtest,
+            network,
             peg_in_descriptor,
             peer_peg_in_keys: pubkeys,
             peg_in_key: sk,


### PR DESCRIPTION
Since the config is encrypted now we need a way to change all the interesting configs.

fixes #977, related to #960