### PR TITLE
Don't sync old block hashes when starting a new federation

### DIFF
--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -961,7 +961,9 @@ impl Wallet {
         dbtx: &mut DatabaseTransaction<'a>,
         new_height: u32,
     ) {
-        let old_height = self.consensus_height(dbtx).unwrap_or(0);
+        let old_height = self
+            .consensus_height(dbtx)
+            .unwrap_or_else(|| new_height.saturating_sub(10));
         if new_height < old_height {
             info!(
                 new_height,


### PR DESCRIPTION
When the federation is started nobody should know the descriptor yet, so nobody should have any peg-ins from the time before it was started. This means we don't really need to sync old block hashes.