### PR TITLE
Improve gateway client builder

### DIFF
--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -2,7 +2,7 @@ use cln_plugin::Error;
 use fedimint_api::task::TaskGroup;
 use fedimint_server::config::load_from_file;
 use ln_gateway::{
-    client::{GatewayClientBuilder, RocksDbGatewayClientBuilder},
+    client::{GatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder},
     cln::{build_cln_rpc, ClnRpcRef},
     config::GatewayConfig,
     rpc::{GatewayRequest, GatewayRpcSender},
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Error> {
 
     // Create federation client builder
     let client_builder: GatewayClientBuilder =
-        RocksDbGatewayClientBuilder::new(work_dir.clone()).into();
+        StandardGatewayClientBuilder::new(work_dir.clone(), RocksDbFactory.into()).into();
 
     // Create gateway instance
     let task_group = TaskGroup::new();

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -56,9 +56,6 @@ pub trait IGatewayClientBuilder: Debug {
     /// Build a new gateway federation client
     async fn build(&self, config: GatewayClientConfig) -> Result<Client<GatewayClientConfig>>;
 
-    /// Create a new database for the gateway federation client
-    fn create_database(&self, federation_id: FederationId) -> Result<Database>;
-
     /// Save and persist the configuration of the gateway federation client
     fn save_config(&self, config: GatewayClientConfig) -> Result<()>;
 
@@ -66,44 +63,38 @@ pub trait IGatewayClientBuilder: Debug {
 }
 
 dyn_newtype_define! {
-  /// Arc reference to a Gateway federation client builder
-  #[derive(Clone)]
-  pub GatewayClientBuilder(Arc<IGatewayClientBuilder>)
+    /// dyn newtype for a Gateway federation client builder
+    #[derive(Clone)]
+    pub GatewayClientBuilder(Arc<IGatewayClientBuilder>)
 }
 
 #[derive(Debug, Clone)]
-pub struct RocksDbGatewayClientBuilder {
-    pub work_dir: PathBuf,
+pub struct StandardGatewayClientBuilder {
+    work_dir: PathBuf,
+    db_factory: DbFactory,
 }
 
-/// Default gateway clinet builder which constructs clients with RocksDb
-/// and saves the config at the given work directory
-impl RocksDbGatewayClientBuilder {
-    pub fn new(work_dir: PathBuf) -> Self {
-        Self { work_dir }
+impl StandardGatewayClientBuilder {
+    pub fn new(work_dir: PathBuf, db_factory: DbFactory) -> Self {
+        Self {
+            work_dir,
+            db_factory,
+        }
     }
 }
 
-/// Builds a new federation client with RocksDb
-/// On successful build, the configuration is saved to a file at the builder work directory
 #[async_trait]
-impl IGatewayClientBuilder for RocksDbGatewayClientBuilder {
+impl IGatewayClientBuilder for StandardGatewayClientBuilder {
+    /// Build a new gateway federation client
     async fn build(&self, config: GatewayClientConfig) -> Result<Client<GatewayClientConfig>> {
         let federation_id = FederationId(config.client_config.federation_name.clone());
 
-        let db = self.create_database(federation_id)?;
+        let db = self
+            .db_factory
+            .create_database(federation_id, self.work_dir.clone())?;
         let ctx = secp256k1::Secp256k1::new();
 
         Ok(Client::new(config, db, ctx).await)
-    }
-
-    /// Create a client database
-    fn create_database(&self, federation_id: FederationId) -> Result<Database> {
-        let db_path = self.work_dir.join(format!("{}.db", federation_id.hash()));
-        let db = fedimint_rocksdb::RocksDb::open(db_path)
-            .expect("Error opening DB")
-            .into();
-        Ok(db)
     }
 
     /// Persist federation client cfg to [`<federation_id>.json`] file
@@ -125,6 +116,7 @@ impl IGatewayClientBuilder for RocksDbGatewayClientBuilder {
         Ok(())
     }
 
+    /// Load all gateway client configs from the work directory
     fn load_configs(&self) -> Result<Vec<GatewayClientConfig>> {
         Ok(std::fs::read_dir(&self.work_dir)
             .map_err(|e| LnGatewayError::Other(anyhow::Error::new(e)))?
@@ -154,35 +146,5 @@ impl IGatewayClientBuilder for RocksDbGatewayClientBuilder {
                     .ok()
             })
             .collect())
-    }
-}
-
-// Builds a new federation client with MemoryDb
-#[derive(Default, Debug, Clone)]
-pub struct MemoryDbGatewayClientBuilder {}
-
-#[async_trait]
-impl IGatewayClientBuilder for MemoryDbGatewayClientBuilder {
-    async fn build(&self, config: GatewayClientConfig) -> Result<Client<GatewayClientConfig>> {
-        let federation_id = FederationId(config.client_config.federation_name.clone());
-
-        let db = self.create_database(federation_id)?;
-        let ctx = secp256k1::Secp256k1::new();
-
-        Ok(Client::new(config, db, ctx).await)
-    }
-
-    /// Create a client database
-    fn create_database(&self, _federation_id: FederationId) -> Result<Database> {
-        Ok(MemDatabase::new().into())
-    }
-
-    /// Persist gateway federation client cfg
-    fn save_config(&self, _config: GatewayClientConfig) -> Result<()> {
-        unimplemented!()
-    }
-
-    fn load_configs(&self) -> Result<Vec<GatewayClientConfig>> {
-        Ok(vec![])
     }
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -17,16 +17,12 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use bitcoin::Address;
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
-use fedimint_api::{config::ClientConfig, task::TaskGroup, Amount, NumPeers, TransactionId};
+use fedimint_api::{task::TaskGroup, Amount, TransactionId};
 use fedimint_server::modules::ln::contracts::Preimage;
 use mint_client::{
-    api::{WsFederationApi, WsFederationConnect},
-    ln::PayInvoicePayload,
-    mint::MintClientError,
-    query::CurrentConsensus,
-    ClientError, FederationId, GatewayClient, GatewayClientConfig,
+    api::WsFederationConnect, ln::PayInvoicePayload, mint::MintClientError, ClientError,
+    FederationId, GatewayClient,
 };
-use secp256k1::KeyPair;
 use thiserror::Error;
 use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
@@ -134,20 +130,6 @@ impl LnGateway {
     async fn handle_register_federation(&self, payload: RegisterFedPayload) -> Result<()> {
         let connect: WsFederationConnect =
             serde_json::from_str(&payload.connect).expect("Invalid federation connect info");
-        let api = WsFederationApi::new(connect.members);
-
-        let client_cfg: ClientConfig = api
-            .request(
-                "/config",
-                (),
-                CurrentConsensus::new(api.peers().one_honest()),
-            )
-            .await
-            .expect("Failed to get client config");
-
-        let mut rng = rand::rngs::OsRng;
-        let ctx = secp256k1::Secp256k1::new();
-        let kp_fed = KeyPair::new(&ctx, &mut rng);
 
         let node_pub_key = self
             .ln_rpc
@@ -155,21 +137,24 @@ impl LnGateway {
             .await
             .expect("Failed to get node pubkey from Lightning node");
 
-        let gw_client_cfg = GatewayClientConfig {
-            client_config: client_cfg,
-            redeem_key: kp_fed,
-            timelock_delta: 10,
-            node_pub_key,
-            api: self.config.announce_address.clone(),
-        };
+        let gw_client_cfg = self
+            .client_builder
+            .create_config(connect, node_pub_key, self.config.announce_address.clone())
+            .await
+            .expect("Failed to create gateway client config");
 
-        let client = self.client_builder.build(gw_client_cfg.clone()).await?;
+        let client = Arc::new(
+            self.client_builder
+                .build(gw_client_cfg.clone())
+                .await
+                .expect("Failed to build gateway client"),
+        );
 
-        if let Err(e) = self.register_federation(Arc::new(client)).await {
+        if let Err(e) = self.register_federation(client.clone()).await {
             error!("Failed to register federation: {}", e);
         }
 
-        if let Err(e) = self.client_builder.save_config(gw_client_cfg) {
+        if let Err(e) = self.client_builder.save_config(client.config()) {
             warn!(
                 "Failed to save default federation client configuration: {}",
                 e

--- a/gateway/tests/tests/fixtures.rs
+++ b/gateway/tests/tests/fixtures.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -7,7 +10,7 @@ use fedimint_api::task::TaskGroup;
 use fedimint_ln::contracts::Preimage;
 use lightning_invoice::Invoice;
 use ln_gateway::{
-    client::{GatewayClientBuilder, MemoryDbGatewayClientBuilder},
+    client::{GatewayClientBuilder, MemDbFactory, StandardGatewayClientBuilder},
     config::GatewayConfig,
     ln::{LightningError, LnRpc},
     rpc::GatewayRequest,
@@ -26,7 +29,8 @@ pub async fn fixtures(gw_cfg: GatewayConfig) -> Result<Fixtures> {
 
     let ln_rpc = Arc::new(MockLnRpc::new());
 
-    let client_builder: GatewayClientBuilder = MemoryDbGatewayClientBuilder {}.into();
+    let client_builder: GatewayClientBuilder =
+        StandardGatewayClientBuilder::new(PathBuf::new(), MemDbFactory.into()).into();
     let (tx, rx) = mpsc::channel::<GatewayRequest>(100);
 
     let gateway = LnGateway::new(gw_cfg, ln_rpc, client_builder, tx, rx, task_group.clone()).await;

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -56,7 +56,7 @@ use itertools::Itertools;
 use lightning_invoice::Invoice;
 use ln_gateway::{
     actor::GatewayActor,
-    client::{GatewayClientBuilder, MemoryDbGatewayClientBuilder},
+    client::{GatewayClientBuilder, MemDbFactory, StandardGatewayClientBuilder},
     config::GatewayConfig,
     rpc::GatewayRequest,
     LnGateway,
@@ -399,7 +399,8 @@ impl GatewayTest {
         };
 
         // Create federation client builder for the gateway
-        let client_builder: GatewayClientBuilder = MemoryDbGatewayClientBuilder {}.into();
+        let client_builder: GatewayClientBuilder =
+            StandardGatewayClientBuilder::new(PathBuf::new(), MemDbFactory.into()).into();
 
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
         let adapter = Arc::new(ln_client_adapter);


### PR DESCRIPTION
Define a standard client builder with
1) Composed  DB factories for behaviour adaptation.
- The client builder pattern supports standard client generation with shared logic to save / load gateway client configurations. This allows for easy swap out the db factory, determining what db the client builder provisions for clients. Example use case: [Quickly swap out rocks db for sled](https://github.com/okjodom/fedimint/pull/71/commits) to test deployments.

2) Generate client config from the builder
- Composing the config logic within client builder would allows us to mock gateway - federation network layer simply by swapping out the client builder. The client builder we use in production by default generates client configs and builds clients that hold a websocket connection between gateway and federation. In contrast, we can implement a client builder that uses a fake federation api, and use this in test scenarios
