### PR TITLE
safe attempt to load previous gateway federation configs

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -81,20 +81,19 @@ impl LnGateway {
     }
 
     async fn load_federation_actors(&self) {
-        // TODO: handle error better
-        for config in self
-            .client_builder
-            .load_configs()
-            .expect("Could not read configs")
-        {
-            let client = self
-                .client_builder
-                .build(config.clone())
-                .expect("Could not build federation client");
+        if let Ok(configs) = self.client_builder.load_configs() {
+            for config in configs {
+                let client = self
+                    .client_builder
+                    .build(config.clone())
+                    .expect("Could not build federation client");
 
-            if let Err(e) = self.register_federation(Arc::new(client)).await {
-                error!("Failed to register federation: {}", e);
+                if let Err(e) = self.register_federation(Arc::new(client)).await {
+                    error!("Failed to register federation: {}", e);
+                }
             }
+        } else {
+            warn!("Could not load any previous federation configs");
         }
     }
 


### PR DESCRIPTION
Handle errors from gateway attempt to load configs. Better error handling allows gateway startup to survive errors on attempt to load config