### PR TITLE
Make insert_entry and insert_new_entry asynchronous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ dependencies = [
  "bitcoin",
  "fedimint-api",
  "fedimint-bitcoind",
+ "fedimint-wallet",
  "futures",
  "rand",
  "secp256k1-zkp",

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -370,7 +370,7 @@ async fn main() {
 
         let rng = rand::rngs::OsRng;
 
-        let client = Client::new(cfg.clone(), db, Default::default());
+        let client = Client::new(cfg.clone(), db, Default::default()).await;
 
         let cli_result = handle_command(cli, client, rng).await;
 

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -109,7 +109,7 @@ pub trait IServerModule: Debug {
     /// This function may only be called after `begin_consensus_epoch` and before
     /// `end_consensus_epoch`. Data is only written to the database once all transaction have been
     /// processed.
-    fn apply_input<'a, 'b, 'c>(
+    async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
         dbtx: &mut DatabaseTransaction<'c>,
@@ -332,7 +332,7 @@ where
     /// This function may only be called after `begin_consensus_epoch` and before
     /// `end_consensus_epoch`. Data is only written to the database once all transaction have been
     /// processed.
-    fn apply_input<'a, 'b, 'c>(
+    async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
         dbtx: &mut DatabaseTransaction<'c>,
@@ -352,6 +352,7 @@ where
                 .downcast_ref::<<Self as ServerModulePlugin>::VerificationCache>()
                 .expect("incorrect verification cache type passed to module plugin"),
         )
+        .await
         .map(Into::into)
     }
 

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -67,7 +67,7 @@ impl IDatabase for MemDatabase {
 // as it doesn't properly implement MVCC
 #[async_trait]
 impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
-    fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
+    async fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let val = self.raw_get_bytes(key);
         // Insert data from copy so we can read our own writes
         self.tx_data.insert(key.to_vec(), value.clone());
@@ -173,14 +173,14 @@ mod tests {
         fedimint_api::db::verify_remove_nonexisting(MemDatabase::new().into()).await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_read_own_writes() {
-        fedimint_api::db::verify_read_own_writes(MemDatabase::new().into());
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_read_own_writes() {
+        fedimint_api::db::verify_read_own_writes(MemDatabase::new().into()).await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_prevent_dirty_reads() {
-        fedimint_api::db::verify_prevent_dirty_reads(MemDatabase::new().into());
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_prevent_dirty_reads() {
+        fedimint_api::db::verify_prevent_dirty_reads(MemDatabase::new().into()).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -262,7 +262,7 @@ pub trait ServerModulePlugin: Debug + Sized {
     /// This function may only be called after `begin_consensus_epoch` and before
     /// `end_consensus_epoch`. Data is only written to the database once all transaction have been
     /// processed.
-    fn apply_input<'a, 'b, 'c>(
+    async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
         dbtx: &mut DatabaseTransaction<'c>,

--- a/fedimint-api/src/tiered_multi.rs
+++ b/fedimint-api/src/tiered_multi.rs
@@ -166,10 +166,10 @@ impl<C> FromIterator<(Amount, C)> for TieredMulti<C> {
 
 impl<C> IntoIterator for TieredMulti<C>
 where
-    C: 'static,
+    C: 'static + Send,
 {
     type Item = (Amount, C);
-    type IntoIter = Box<dyn Iterator<Item = (Amount, C)>>;
+    type IntoIter = Box<dyn Iterator<Item = (Amount, C)> + Send>;
 
     fn into_iter(self) -> Self::IntoIter {
         Box::new(

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -65,7 +65,7 @@ impl IDatabase for RocksDb {
 
 #[async_trait]
 impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
-    fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
+    async fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let val = self.0.get(key).unwrap();
         self.0.put(key, value)?;
         Ok(val)
@@ -122,7 +122,7 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
 
 #[async_trait]
 impl IDatabaseTransaction<'_> for RocksDbReadOnly {
-    fn raw_insert_bytes(&mut self, _key: &[u8], _value: Vec<u8>) -> Result<Option<Vec<u8>>> {
+    async fn raw_insert_bytes(&mut self, _key: &[u8], _value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         panic!("Cannot insert into a read only transaction");
     }
 
@@ -200,18 +200,20 @@ mod fedimint_rocksdb_tests {
         .await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_read_own_writes() {
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_read_own_writes() {
         fedimint_api::db::verify_read_own_writes(
             open_temp_db("fcb-rocksdb-test-read-own-writes").into(),
-        );
+        )
+        .await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_prevent_dirty_reads() {
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_prevent_dirty_reads() {
         fedimint_api::db::verify_prevent_dirty_reads(
             open_temp_db("fcb-rocksdb-test-prevent-dirty-reads").into(),
-        );
+        )
+        .await;
     }
 
     #[test_log::test(tokio::test)]

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -69,7 +69,7 @@ impl IDatabase for SledDb {
 // as it doesn't properly implement MVCC
 #[async_trait]
 impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
-    fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
+    async fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let val = self.raw_get_bytes(key);
         self.operations
             .push(DatabaseOperation::Insert(DatabaseInsertOperation {
@@ -231,18 +231,20 @@ mod fedimint_sled_tests {
         .await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_read_own_writes() {
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_read_own_writes() {
         fedimint_api::db::verify_read_own_writes(
             open_temp_db("fcb-sled-test-read-own-writes").into(),
-        );
+        )
+        .await;
     }
 
-    #[test_log::test]
-    fn test_dbtx_prevent_dirty_reads() {
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_prevent_dirty_reads() {
         fedimint_api::db::verify_prevent_dirty_reads(
             open_temp_db("fcb-sled-test-prevent-dirty-reads").into(),
-        );
+        )
+        .await;
     }
 
     #[test_log::test(tokio::test)]

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -18,6 +18,7 @@ async-trait = "*"
 bitcoin = "0.29.2"
 fedimint-api  = { path = "../fedimint-api" }
 fedimint-bitcoind = { path = "../fedimint-bitcoind" }
+fedimint-wallet  = { path = "../modules/fedimint-wallet" }
 futures = "0.3"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
 serde = "1.0.147"

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -86,6 +86,7 @@ impl LnGateway {
                 let client = self
                     .client_builder
                     .build(config.clone())
+                    .await
                     .expect("Could not build federation client");
 
                 if let Err(e) = self.register_federation(Arc::new(client)).await {
@@ -162,7 +163,7 @@ impl LnGateway {
             api: self.config.announce_address.clone(),
         };
 
-        let client = self.client_builder.build(gw_client_cfg.clone())?;
+        let client = self.client_builder.build(gw_client_cfg.clone()).await?;
 
         if let Err(e) = self.register_federation(Arc::new(client)).await {
             error!("Failed to register federation: {}", e);

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -181,7 +181,7 @@ pub async fn fixtures(num_peers: u16, amount_tiers: &[Amount]) -> anyhow::Result
 
             let user_db = rocks(dir.clone()).into();
             let user_cfg = UserClientConfig(client_config.clone());
-            let user = UserTest::new(Arc::new(create_user_client(user_cfg, peers, user_db)));
+            let user = UserTest::new(Arc::new(create_user_client(user_cfg, peers, user_db).await));
             user.client.await_consensus_block_height(0).await?;
 
             let gateway = GatewayTest::new(
@@ -226,7 +226,7 @@ pub async fn fixtures(num_peers: u16, amount_tiers: &[Amount]) -> anyhow::Result
 
             let user_db = MemDatabase::new().into();
             let user_cfg = UserClientConfig(client_config.clone());
-            let user = UserTest::new(Arc::new(create_user_client(user_cfg, peers, user_db)));
+            let user = UserTest::new(Arc::new(create_user_client(user_cfg, peers, user_db).await));
             user.client.await_consensus_block_height(0).await?;
 
             let gateway = GatewayTest::new(
@@ -257,7 +257,7 @@ pub fn peers(peers: &[u16]) -> Vec<PeerId> {
 }
 
 /// Creates a new user client connected to the given peers
-pub fn create_user_client(
+pub async fn create_user_client(
     config: UserClientConfig,
     peers: Vec<PeerId>,
     db: Database,
@@ -274,7 +274,7 @@ pub fn create_user_client(
     )
     .into();
 
-    UserClient::new_with_api(config, db, api, Default::default())
+    UserClient::new_with_api(config, db, api, Default::default()).await
 }
 
 async fn distributed_config(
@@ -425,6 +425,7 @@ impl GatewayTest {
         let client = Arc::new(
             client_builder
                 .build(gw_client_cfg.clone())
+                .await
                 .expect("Could not build gateway client"),
         );
 
@@ -658,6 +659,7 @@ impl FederationTest {
                         amount: bitcoin::Amount::from_sat(input.tx_output().value),
                     },
                 )
+                .await
                 .expect("DB Error");
                 dbtx.commit_tx().await.expect("DB Error");
             });
@@ -713,6 +715,7 @@ impl FederationTest {
                             transaction,
                         },
                     )
+                    .await
                     .expect("DB Error");
 
                     svr.fedimint


### PR DESCRIPTION
This PR makes insert_entry and insert_new_entry asynchronous. This is part of the effort to move the database transaction trait to be entirely asychronous. https://github.com/fedimint/fedimint/issues/848