### PR TITLE
increase number of client connections allowed

### DIFF
--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -32,6 +32,8 @@ use crate::net::connect::TlsConfig;
 use crate::net::peers::{ConnectionConfig, NetworkConfig};
 use crate::{ReconnectPeerConnections, TlsTcpConnector};
 
+const DEFAULT_MAX_CLIENT_CONNECTIONS: u32 = 1000;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
     pub federation_name: String,
@@ -55,6 +57,7 @@ pub struct ServerConfig {
     pub epoch_pk_set: hbbft::crypto::PublicKeySet,
 
     pub modules: BTreeMap<String, ServerModuleConfig>,
+    pub max_connections: u32,
 }
 
 impl ServerConfig {
@@ -241,6 +244,7 @@ impl ServerConfig {
                         .iter()
                         .map(|(name, cfgs)| (name.to_string(), cfgs.0[&id].clone()))
                         .collect(),
+                    max_connections: DEFAULT_MAX_CLIENT_CONNECTIONS,
                 };
                 (id, config)
             })
@@ -348,6 +352,7 @@ impl ServerConfig {
                 .iter()
                 .map(|(name, cfgs)| (name.to_string(), cfgs.0.clone()))
                 .collect(),
+            max_connections: DEFAULT_MAX_CLIENT_CONNECTIONS,
         };
 
         let client = ClientConfig {

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -2,6 +2,7 @@
 use std::fmt::Formatter;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use fedimint_api::server::ServerModule;
@@ -55,6 +56,8 @@ pub async fn run_server(
 
     debug!(addr = cfg.api_bind_addr, "Starting WSServer");
     let server = ServerBuilder::new()
+        .max_connections(cfg.max_connections)
+        .ping_interval(Duration::from_secs(10))
         .build(&cfg.api_bind_addr)
         .await
         .context(format!("Bind address: {}", cfg.api_bind_addr))

--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -157,6 +157,7 @@ fn trusted_dealer_gen(
                     .iter()
                     .map(|(name, cfgs)| (name.to_string(), cfgs.0[&id].clone()))
                     .collect(),
+                max_connections: 1000,
             };
             (id, config)
         })


### PR DESCRIPTION
Fixes #983 by increasing number of connections from 100 to 1000 and allowing them to be configurable.  Decreases the ping time to 10 sec to close dead connections.