### PR TITLE
small improvement to DKG logging

### DIFF
--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -364,6 +364,8 @@ impl ServerConfig {
                 .collect(),
         };
 
+        info!("Distributed key generation has completed successfully!");
+
         Ok(Ok((server, client)))
     }
 }

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -387,7 +387,7 @@ where
     }
 
     fn disconnect_err(&self, err: anyhow::Error, disconnect_count: u64) -> PeerConnectionState<M> {
-        info!(peer = ?self.peer, %err, %disconnect_count, "Peer disconnected");
+        debug!(peer = ?self.peer, %err, %disconnect_count, "Peer disconnected");
         self.disconnect(disconnect_count)
     }
 


### PR DESCRIPTION
Figured I might as well do this tiny change, new logs look like:

```
022-11-29T18:56:14.350802Z  INFO fedimint_server::config: Peer 0 running distributed key generation...
2022-11-29T18:56:14.350802Z  INFO fedimint_server::config: Peer 1 running distributed key generation...
2022-11-29T18:56:14.355727Z  INFO fedimint_server::config: Peer 3 running distributed key generation...
2022-11-29T18:56:14.355728Z  INFO fedimint_server::config: Peer 2 running distributed key generation...
2022-11-29T18:56:18.336322Z  INFO fedimint_server::config: Distributed key generation has completed successfully!
2022-11-29T18:56:18.336469Z  INFO fedimint_server::config: Distributed key generation has completed successfully!
2022-11-29T18:56:18.336597Z  INFO fedimint_server::config: Distributed key generation has completed successfully!
2022-11-29T18:56:18.336714Z  INFO fedimint_server::config: Distributed key generation has completed successfully!
```

Fixes #976