### PR TITLE
Don't generate client config in configgen

### DIFF
--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -198,7 +198,7 @@ pub trait FederationModuleConfigGen {
         peers: &[PeerId],
         params: &ModuleConfigGenParams,
         task_group: &mut TaskGroup,
-    ) -> anyhow::Result<Cancellable<(ServerModuleConfig, ClientModuleConfig)>>;
+    ) -> anyhow::Result<Cancellable<ServerModuleConfig>>;
 
     fn to_client_config(&self, config: ServerModuleConfig) -> anyhow::Result<ClientModuleConfig>;
 

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -206,7 +206,7 @@ impl FederationModuleConfigGen for MintConfigGenerator {
         peers: &[PeerId],
         params: &ModuleConfigGenParams,
         _task_group: &mut TaskGroup,
-    ) -> anyhow::Result<Cancellable<(ServerModuleConfig, ClientModuleConfig)>> {
+    ) -> anyhow::Result<Cancellable<ServerModuleConfig>> {
         let mut dkg = DkgRunner::multi(
             params.mint_amounts.to_vec(),
             peers.threshold(),
@@ -247,24 +247,7 @@ impl FederationModuleConfigGen for MintConfigGenerator {
             threshold: peers.threshold(),
         };
 
-        let client = MintClientConfig {
-            tbs_pks: amounts_keys
-                .iter()
-                .map(|(amount, (pks, _))| {
-                    (*amount, AggregatePublicKey(pks.evaluate(0).to_affine()))
-                })
-                .collect(),
-            fee_consensus: Default::default(),
-        };
-
-        Ok(Ok((
-            serde_json::to_value(server)
-                .expect("serialization can't fail")
-                .into(),
-            serde_json::to_value(client)
-                .expect("serialization can't fail")
-                .into(),
-        )))
+        Ok(Ok(server.to_erased()))
     }
 
     fn to_client_config(&self, config: ServerModuleConfig) -> anyhow::Result<ClientModuleConfig> {

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -20,7 +20,7 @@ use config::WalletClientConfig;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
     ClientModuleConfig, DkgPeerMsg, ModuleConfigGenParams, ServerModuleConfig,
-    TypedClientModuleConfig, TypedServerModuleConfig,
+    TypedServerModuleConfig,
 };
 use fedimint_api::core::{Decoder, ModuleKey, MODULE_KEY_WALLET};
 use fedimint_api::db::{Database, DatabaseTransaction};
@@ -265,7 +265,7 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
         peers: &[PeerId],
         params: &ModuleConfigGenParams,
         _task_group: &mut TaskGroup,
-    ) -> anyhow::Result<Cancellable<(ServerModuleConfig, ClientModuleConfig)>> {
+    ) -> anyhow::Result<Cancellable<ServerModuleConfig>> {
         let secp = secp256k1::Secp256k1::new();
         let (sk, pk) = secp.generate_keypair(&mut OsRng);
         let our_key = CompressedPublicKey { key: pk };
@@ -319,13 +319,8 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
             network,
             finality_delay,
         );
-        let client_cfg = WalletClientConfig::new(
-            wallet_cfg.peg_in_descriptor.clone(),
-            network,
-            finality_delay,
-        );
 
-        Ok(Ok((wallet_cfg.to_erased(), client_cfg.to_erased())))
+        Ok(Ok(wallet_cfg.to_erased()))
     }
 
     fn to_client_config(&self, config: ServerModuleConfig) -> anyhow::Result<ClientModuleConfig> {


### PR DESCRIPTION
Removes client config from DKG and fixes the peer names.

Fixes  #1016.