### PR TITLE
fix issue that causes MissingPreviousEpoch error in CI

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -565,6 +566,7 @@ impl<C: JsonRpcClient> WsFederationApi<C> {
         // Delegates the response handling to the `QueryStrategy` with an exponential back-off
         // with every new set of requests
         let mut delay_ms = 10;
+        let max_delay_ms = 1000;
         loop {
             match futures.next().await {
                 Some(result) => match strategy.process(result) {
@@ -575,7 +577,7 @@ impl<C: JsonRpcClient> WsFederationApi<C> {
                             }
                         }
                         sleep(Duration::from_millis(delay_ms)).await;
-                        delay_ms *= 2;
+                        delay_ms = min(max_delay_ms, delay_ms * 2);
                     }
                     QueryStep::Continue => {}
                     QueryStep::Finished(result) => return result,

--- a/client/client-lib/src/query.rs
+++ b/client/client-lib/src/query.rs
@@ -7,7 +7,7 @@ use fedimint_core::epoch::EpochHistory;
 use jsonrpsee_core::Error as JsonRpcError;
 use jsonrpsee_types::error::CallError as RpcCallError;
 use threshold_crypto::PublicKey;
-use tracing::warn;
+use tracing::debug;
 
 use crate::api::{FedResponse, Result};
 use crate::ApiError;
@@ -187,7 +187,7 @@ impl<R: Eq + Clone + Debug> QueryStrategy<R> for CurrentConsensus<R> {
                     .find(|(prev_result, _)| prev_result == &result)
                 {
                     if peers.contains(&peer) {
-                        warn!(prev = ?prev_result, new = ?result, peer = %peer, "Ignoring duplicate response from peer");
+                        debug!(prev = ?prev_result, new = ?result, peer = %peer, "Ignoring duplicate response from peer");
                     } else {
                         peers.insert(peer);
                     }

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -253,8 +253,10 @@ impl FedimintServer {
                 EpochHistory::new(last_outcome.epoch, contributions, &prev_epoch)
             } else {
                 let epoch_pk = self.cfg.epoch_pk_set.public_key();
-                let result = self.api.fetch_epoch_history(epoch_num, epoch_pk).await;
-                result.map_err(|_| EpochVerifyError::MissingPreviousEpoch)?
+                self.api
+                    .fetch_epoch_history(epoch_num, epoch_pk)
+                    .await
+                    .expect("fetches history")
             };
 
             current_epoch.verify_hash(&prev_epoch)?;

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -27,6 +27,10 @@ function await_block_sync() {
   echo "Mint at ${EXPECTED_BLOCK_HEIGHT}H"
 }
 
+function await_all_peers() {
+  $FM_MINT_CLIENT api /wallet/block_height
+}
+
 function await_server_on_port() {
   until nc -z 127.0.0.1 $1
   do


### PR DESCRIPTION
There was a lot of flakiness in the reconnect tests that this should address, while also making them faster.  Also sets a max delay on client requests to 1sec.

Fixes #860 or at least improves it...if anyone encounters again please ping me.