### PR TITLE
Rename/tweak mint module types

### DIFF
--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -15,7 +15,9 @@ use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::tiered::InvalidAmountTierError;
 use fedimint_api::{Amount, OutPoint, ServerModulePlugin, Tiered, TieredMulti, TransactionId};
 use fedimint_core::modules::mint::config::MintClientConfig;
-use fedimint_core::modules::mint::{BlindNonce, Mint, MintOutputOutcome, Nonce, Note, SigResponse};
+use fedimint_core::modules::mint::{
+    BlindNonce, Mint, MintOutputOutcome, Nonce, Note, OutputOutcome,
+};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use rand::{CryptoRng, RngCore};
@@ -347,12 +349,12 @@ impl Extend<(Amount, NoteIssuanceRequest)> for NoteIssuanceRequests {
 }
 
 impl NoteIssuanceRequests {
-    /// Finalize the issuance request using a [`SigResponse`] from the mint containing the blind
+    /// Finalize the issuance request using a [`OutputOutcome`] from the mint containing the blind
     /// signatures for all coins in this `IssuanceRequest`. It also takes the mint's
     /// [`AggregatePublicKey`] to validate the supplied blind signatures.
     pub fn finalize(
         &self,
-        bsigs: SigResponse,
+        bsigs: OutputOutcome,
         mint_pub_key: &Tiered<AggregatePublicKey>,
     ) -> std::result::Result<TieredMulti<SpendableNote>, CoinFinalizationError> {
         if !self.coins.structural_eq(&bsigs.0) {

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -6,7 +6,7 @@ use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::{Amount, OutPoint, Tiered, TieredMulti};
 use fedimint_core::modules::ln::contracts::ContractOutcome;
 use fedimint_core::modules::ln::LightningOutputOutcome;
-use fedimint_core::modules::mint::{BlindNonce, MintInput, MintOutput, SignRequest};
+use fedimint_core::modules::mint::{BlindNonce, MintInput, MintOutput};
 use fedimint_core::outcome::legacy::OutputOutcome;
 use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::transaction::legacy::{Input, Output, Transaction};
@@ -167,7 +167,7 @@ impl TransactionBuilder {
             let (request, blind_nonce) = coin_gen().await;
             amount_requests.push(((amt, request), (amt, blind_nonce)));
         }
-        let (coin_finalization_data, sig_req): (NoteIssuanceRequests, SignRequest) =
+        let (coin_finalization_data, sig_req): (NoteIssuanceRequests, MintOutput) =
             amount_requests.into_iter().unzip();
 
         debug!(

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -232,7 +232,7 @@ impl<'a> DatabaseDump<'a> {
                         self,
                         MintRange::OutputOutcomeKeyPrefix,
                         MintRange::OutputOutcomeKey,
-                        fedimint_mint::SigResponse,
+                        fedimint_mint::OutputOutcome,
                         mint,
                         "Output Outcomes"
                     );
@@ -242,7 +242,7 @@ impl<'a> DatabaseDump<'a> {
                         self,
                         MintRange::ProposedPartialSignaturesKeyPrefix,
                         MintRange::ProposedPartialSignatureKey,
-                        fedimint_mint::PartialSigResponse,
+                        fedimint_mint::OutputConfirmationSignatures,
                         mint,
                         "Proposed Signature Shares"
                     );
@@ -252,7 +252,7 @@ impl<'a> DatabaseDump<'a> {
                         self,
                         MintRange::ReceivedPartialSignaturesKeyPrefix,
                         MintRange::ReceivedPartialSignatureKey,
-                        fedimint_mint::PartialSigResponse,
+                        fedimint_mint::OutputConfirmationSignatures,
                         mint,
                         "User Ecash Backup"
                     );

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -13,7 +13,7 @@ use fedimint_api::TieredMulti;
 use fedimint_ln::contracts::{Preimage, PreimageDecryptionShare};
 use fedimint_ln::LightningConsensusItem;
 use fedimint_mint::config::MintClientConfig;
-use fedimint_mint::{MintConsensusItem, PartialSigResponse, PartiallySignedRequest};
+use fedimint_mint::{MintOutputConfirmation, OutputConfirmationSignatures};
 use fedimint_server::all_decoders;
 use fedimint_server::epoch::ConsensusItem;
 use fedimint_server::transaction::legacy::Output;
@@ -438,10 +438,10 @@ async fn drop_peers_who_contribute_bad_sigs() -> Result<()> {
         .await;
     let out_point = fed.database_add_coins_for_user(&user, sats(2000)).await;
     let bad_proposal = vec![ConsensusItem::Module(
-        MintConsensusItem(PartiallySignedRequest {
+        MintOutputConfirmation {
             out_point,
-            partial_signature: PartialSigResponse(TieredMulti::default()),
-        })
+            signatures: OutputConfirmationSignatures(TieredMulti::default()),
+        }
         .into(),
     )];
 

--- a/modules/fedimint-mint/src/common.rs
+++ b/modules/fedimint-mint/src/common.rs
@@ -6,7 +6,7 @@ use fedimint_api::core::{ConsensusItem, Decoder, Input, Output, OutputOutcome, P
 use fedimint_api::encoding::Decodable;
 use fedimint_api::encoding::DecodeError;
 
-use crate::{MintConsensusItem, MintInput, MintOutput, MintOutputOutcome};
+use crate::{MintInput, MintOutput, MintOutputConfirmation, MintOutputOutcome};
 
 #[derive(Debug, Default, Clone)]
 pub struct MintModuleDecoder;
@@ -39,9 +39,8 @@ impl PluginDecode for MintModuleDecoder {
     fn decode_consensus_item(
         mut r: &mut dyn io::Read,
     ) -> Result<fedimint_api::core::ConsensusItem, DecodeError> {
-        Ok(ConsensusItem::from(MintConsensusItem::consensus_decode(
-            &mut r,
-            &BTreeMap::<_, Decoder>::new(),
-        )?))
+        Ok(ConsensusItem::from(
+            MintOutputConfirmation::consensus_decode(&mut r, &BTreeMap::<_, Decoder>::new())?,
+        ))
     }
 }

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -6,7 +6,7 @@ use fedimint_api::{Amount, OutPoint, PeerId};
 use serde::Serialize;
 use strum_macros::EnumIter;
 
-use crate::{Nonce, PartialSigResponse, SigResponse};
+use crate::{Nonce, OutputConfirmationSignatures, OutputOutcome};
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -51,7 +51,7 @@ pub struct ProposedPartialSignatureKey {
 impl DatabaseKeyPrefixConst for ProposedPartialSignatureKey {
     const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
     type Key = Self;
-    type Value = PartialSigResponse;
+    type Value = OutputConfirmationSignatures;
 }
 
 #[derive(Debug, Encodable, Decodable)]
@@ -60,7 +60,7 @@ pub struct ProposedPartialSignaturesKeyPrefix;
 impl DatabaseKeyPrefixConst for ProposedPartialSignaturesKeyPrefix {
     const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
     type Key = ProposedPartialSignatureKey;
-    type Value = PartialSigResponse;
+    type Value = OutputConfirmationSignatures;
 }
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -72,7 +72,7 @@ pub struct ReceivedPartialSignatureKey {
 impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKey {
     const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = Self;
-    type Value = PartialSigResponse;
+    type Value = OutputConfirmationSignatures;
 }
 
 #[derive(Debug, Encodable, Decodable)]
@@ -83,7 +83,7 @@ pub struct ReceivedPartialSignatureKeyOutputPrefix {
 impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKeyOutputPrefix {
     const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = ReceivedPartialSignatureKey;
-    type Value = PartialSigResponse;
+    type Value = OutputConfirmationSignatures;
 }
 
 #[derive(Debug, Encodable, Decodable)]
@@ -92,7 +92,7 @@ pub struct ReceivedPartialSignaturesKeyPrefix;
 impl DatabaseKeyPrefixConst for ReceivedPartialSignaturesKeyPrefix {
     const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = ReceivedPartialSignatureKey;
-    type Value = PartialSigResponse;
+    type Value = OutputConfirmationSignatures;
 }
 
 /// Transaction id and output index identifying an output outcome
@@ -102,7 +102,7 @@ pub struct OutputOutcomeKey(pub OutPoint);
 impl DatabaseKeyPrefixConst for OutputOutcomeKey {
     const DB_PREFIX: u8 = DbKeyPrefix::OutputOutcome as u8;
     type Key = Self;
-    type Value = SigResponse;
+    type Value = OutputOutcome;
 }
 
 #[derive(Debug, Encodable, Decodable)]
@@ -111,7 +111,7 @@ pub struct OutputOutcomeKeyPrefix;
 impl DatabaseKeyPrefixConst for OutputOutcomeKeyPrefix {
     const DB_PREFIX: u8 = DbKeyPrefix::OutputOutcome as u8;
     type Key = OutputOutcomeKey;
-    type Value = SigResponse;
+    type Value = OutputOutcome;
 }
 
 /// Represents the amounts of issued (signed) and redeemed (verified) coins for auditing


### PR DESCRIPTION
I find the existing naming around the mint module output / consesus items confusing. In particular the request/response part, as this really isn't a request-response system.

* Add some comments.
* Avoid request/response names.
* Remove some redundant types