### PR TITLE
switch ecash denominations to powers of 2

### DIFF
--- a/fedimintd/src/bin/configgen.rs
+++ b/fedimintd/src/bin/configgen.rs
@@ -36,14 +36,10 @@ enum Command {
         #[arg(long = "bitcoind-rpc", default_value = "127.0.0.1:18443")]
         bitcoind_rpc: String,
 
-        /// Available denominations of notes issues by the federation (comma separated)
-        #[arg(
-            long = "denominations",
-            value_delimiter = ',',
-            num_args = 1..,
-            required = true
-        )]
-        denominations: Vec<Amount>,
+        /// Max denomination of notes issued by the federation (in millisats)
+        /// default = 1 BTC
+        #[arg(long = "max_denomination", default_value = "100000000000")]
+        max_denomination: Amount,
 
         /// Federation name
         #[arg(long = "federation-name", default_value = "Hals_trusty_mint")]
@@ -61,7 +57,7 @@ fn main() {
             dir_out_path: cfg_path,
             num_nodes: nodes,
             base_port,
-            denominations: amount_tiers,
+            max_denomination,
             federation_name,
             bitcoind_rpc,
         } => {
@@ -76,7 +72,7 @@ fn main() {
             );
             let params = ServerConfigParams::gen_local(
                 &peers,
-                amount_tiers.to_vec(),
+                max_denomination,
                 base_port,
                 &federation_name,
                 &bitcoind_rpc,

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -72,15 +72,10 @@ enum Command {
         #[arg(long = "bitcoind-rpc", default_value = "127.0.0.1:18443")]
         bitcoind_rpc: String,
 
-        /// Available denominations of notes issues by the federation (comma separated)
-        /// default = 1 msat - 1M sats by powers of 10
-        #[arg(
-        long = "denominations",
-        value_delimiter = ',',
-        num_args = 1..,
-        default_value = "1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000"
-        )]
-        denominations: Vec<Amount>,
+        /// Max denomination of notes issued by the federation (in millisats)
+        /// default = 1 BTC
+        #[arg(long = "max_denomination", default_value = "100000000000")]
+        max_denomination: Amount,
 
         /// The bitcoin network that fedimint will be running on
         #[arg(long = "network", default_value = "regtest")]
@@ -158,7 +153,7 @@ async fn main() {
             certs,
             bind_address,
             bitcoind_rpc,
-            denominations,
+            max_denomination,
             network,
             finality_delay,
             password,
@@ -168,7 +163,7 @@ async fn main() {
             let server = if let Ok(v) = run_dkg(
                 bind_address,
                 &dir_out_path,
-                denominations,
+                max_denomination,
                 federation_name,
                 certs,
                 bitcoind_rpc,
@@ -239,7 +234,7 @@ fn salt_file_path_from_file_path(file_path: &Path) -> PathBuf {
 async fn run_dkg(
     bind_address: String,
     dir_out_path: &Path,
-    denominations: Vec<Amount>,
+    max_denomination: Amount,
     federation_name: String,
     certs: Vec<String>,
     bitcoind_rpc: String,
@@ -267,7 +262,7 @@ async fn run_dkg(
         bind_address,
         pk,
         our_id,
-        denominations,
+        max_denomination,
         &peers,
         federation_name,
         bitcoind_rpc,

--- a/modules/fedimint-mint/src/config.rs
+++ b/modules/fedimint-mint/src/config.rs
@@ -5,6 +5,7 @@ use anyhow::bail;
 use fedimint_api::config::{ClientModuleConfig, TypedClientModuleConfig, TypedServerModuleConfig};
 use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::{Amount, PeerId, Tiered, TieredMultiZip};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tbs::{Aggregatable, AggregatePublicKey, PublicKeyShare};
 
@@ -57,6 +58,9 @@ impl TypedServerModuleConfig for MintConfig {
             self.peer_tbs_pks.get(identity).unwrap().as_map().clone();
         if sks != pks {
             bail!("Mint private key doesn't match pubkey share");
+        }
+        if !sks.keys().contains(&Amount::from_msat(1)) {
+            bail!("No msat 1 denomination");
         }
 
         Ok(())


### PR DESCRIPTION
Switching to denominations as powers of 2 to simplify code and reduce chance of errors.  More reasoning explained here https://github.com/fedimint/fedimint/issues/116#issuecomment-1332598851

Fixes #332, fixes #674