### PR TITLE
Change get_value and find_by_prefix to be async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "tokio",
 ]
 
 [[package]]

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -468,7 +468,7 @@ async fn handle_command(
             }
         }
         Command::Info => {
-            let coins = client.coins();
+            let coins = client.coins().await;
             let details_vec = coins
                 .iter_tiers()
                 .map(|(amount, coins)| (amount.to_owned(), coins.len()))

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -370,7 +370,8 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
 
         let input_coins = self
             .mint_client()
-            .select_coins(blind_nonces.total_amount())?;
+            .select_coins(blind_nonces.total_amount())
+            .await?;
         tx.input_coins(input_coins)?;
         tx.output(Output::Mint(MintOutput(blind_nonces)));
         let txid = self.submit_tx_with_change(tx, &mut rng).await?;
@@ -428,7 +429,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             .fee_consensus
             .peg_out_abs
             + (peg_out.amount + peg_out.fees.amount()).into();
-        let coins = self.mint_client().select_coins(funding_amount)?;
+        let coins = self.mint_client().select_coins(funding_amount).await?;
         tx.input_coins(coins)?;
         let peg_out_idx = tx.output(Output::Wallet(WalletOutput(peg_out)));
 
@@ -467,7 +468,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         amount: Amount,
         rng: R,
     ) -> Result<TieredMulti<SpendableNote>> {
-        let coins = self.mint_client().select_coins(amount)?;
+        let coins = self.mint_client().select_coins(amount).await?;
 
         let final_coins = if coins.total_amount() == amount {
             coins
@@ -484,7 +485,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
 
             self.submit_tx_with_change(tx, rng).await?;
             self.fetch_all_coins().await;
-            self.mint_client().select_coins(amount)?
+            self.mint_client().select_coins(amount).await?
         };
         assert_eq!(
             final_coins.total_amount(),
@@ -519,9 +520,10 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     /// Should be called after any transaction that might have failed in order to get any coin
     /// inputs back.
     pub async fn reissue_pending_coins<R: RngCore + CryptoRng>(&self, rng: R) -> Result<OutPoint> {
-        let dbtx = self.context.db.begin_transaction(ModuleRegistry::default());
+        let mut dbtx = self.context.db.begin_transaction(ModuleRegistry::default());
         let pending = dbtx
             .find_by_prefix(&PendingCoinsKeyPrefix)
+            .await
             .map(|res| res.expect("DB error"));
 
         let stream = pending
@@ -576,12 +578,12 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             .collect()
     }
 
-    pub fn coins(&self) -> TieredMulti<SpendableNote> {
-        self.mint_client().coins()
+    pub async fn coins(&self) -> TieredMulti<SpendableNote> {
+        self.mint_client().coins().await
     }
 
-    pub fn list_active_issuances(&self) -> Vec<(OutPoint, NoteIssuanceRequests)> {
-        self.mint_client().list_active_issuances()
+    pub async fn list_active_issuances(&self) -> Vec<(OutPoint, NoteIssuanceRequests)> {
+        self.mint_client().list_active_issuances().await
     }
 
     pub async fn fetch_epoch_history(
@@ -686,7 +688,7 @@ impl Client<UserClientConfig> {
             } // FIXME: impl TryFrom
         };
 
-        let coins = self.mint_client().select_coins(amount)?;
+        let coins = self.mint_client().select_coins(amount).await?;
         tx.input_coins(coins)?;
         tx.output(Output::LN(contract));
         let txid = self.submit_tx_with_change(tx, &mut rng).await?;
@@ -1010,11 +1012,12 @@ impl Client<GatewayClientConfig> {
     }
 
     /// Lists all previously saved transactions that have not been driven to completion so far
-    pub fn list_pending_outgoing(&self) -> Vec<OutgoingContractAccount> {
+    pub async fn list_pending_outgoing(&self) -> Vec<OutgoingContractAccount> {
         self.context
             .db
             .begin_transaction(ModuleRegistry::default())
             .find_by_prefix(&OutgoingContractAccountKeyPrefix)
+            .await
             .map(|res| res.expect("DB error").1)
             .collect()
     }
@@ -1106,7 +1109,7 @@ impl Client<GatewayClientConfig> {
 
         // Inputs
         let mut builder = TransactionBuilder::default();
-        let coins = self.mint_client().select_coins(offer.amount)?;
+        let coins = self.mint_client().select_coins(offer.amount).await?;
         builder.input_coins(coins)?;
 
         // Outputs
@@ -1154,11 +1157,12 @@ impl Client<GatewayClientConfig> {
 
     /// Lists all claim transactions for outgoing contracts that we have submitted but were not part
     /// of the consensus yet.
-    pub fn list_pending_claimed_outgoing(&self) -> Vec<ContractId> {
+    pub async fn list_pending_claimed_outgoing(&self) -> Vec<ContractId> {
         self.context
             .db
             .begin_transaction(ModuleRegistry::default())
             .find_by_prefix(&OutgoingPaymentClaimKeyPrefix)
+            .await
             .map(|res| res.expect("DB error").0 .0)
             .collect()
     }
@@ -1197,9 +1201,10 @@ impl Client<GatewayClientConfig> {
         Ok(())
     }
 
-    pub fn list_fetchable_coins(&self) -> Vec<OutPoint> {
+    pub async fn list_fetchable_coins(&self) -> Vec<OutPoint> {
         self.mint_client()
             .list_active_issuances()
+            .await
             .into_iter()
             .map(|(outpoint, _)| outpoint)
             .collect()

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -265,7 +265,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     /// Fetches the client secret from the database or generates a new one if none is present
     async fn get_secret(db: &Database) -> DerivableSecret {
         let mut tx = db.begin_transaction(ModuleRegistry::default());
-        let client_secret = tx.get_value(&ClientSecretKey).expect("DB error");
+        let client_secret = tx.get_value(&ClientSecretKey).await.expect("DB error");
         let secret = if let Some(client_secret) = client_secret {
             client_secret
         } else {
@@ -294,7 +294,8 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
 
         let (peg_in_key, peg_in_proof) = self
             .wallet_client()
-            .create_pegin_input(txout_proof, btc_transaction)?;
+            .create_pegin_input(txout_proof, btc_transaction)
+            .await?;
 
         tx.input(
             &mut vec![peg_in_key],
@@ -606,6 +607,7 @@ impl Client<UserClientConfig> {
             .db
             .begin_transaction(ModuleRegistry::default())
             .get_value(&LightningGatewayKey)
+            .await
             .expect("DB error")
         {
             Ok(gateway)
@@ -708,6 +710,7 @@ impl Client<UserClientConfig> {
             .db
             .begin_transaction(ModuleRegistry::default())
             .get_value(&OutgoingPaymentKey(contract_id))
+            .await
             .expect("DB error")
             .ok_or(ClientError::RefundUnknownOutgoingContract)?;
 
@@ -866,7 +869,7 @@ impl Client<UserClientConfig> {
     ) -> Result<OutPoint> {
         // Lookup contract and "confirmed invoice"
         let contract = self.ln_client().get_incoming_contract(contract_id).await?;
-        let ci = self.ln_client().get_confirmed_invoice(contract_id)?;
+        let ci = self.ln_client().get_confirmed_invoice(contract_id).await?;
 
         // Input claims this contract
         let mut tx = TransactionBuilder::default();

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -362,22 +362,21 @@ mod tests {
             &self,
             tx: TransactionId,
         ) -> crate::api::Result<TransactionStatus> {
-            // TODO: output_outcome is not Send
-            /*
             let mint = self.mint.lock().await;
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
                 outputs: vec![SerdeOutputOutcome::from(&OutputOutcome::from(
-                    mint.output_outcome(OutPoint {
-                        txid: tx,
-                        out_idx: 0,
-                    })
-                    .await
-                    .unwrap(),
+                    // FIXME: Need to block on this future because output_outcome is not send
+                    futures::executor::block_on(async {
+                        mint.output_outcome(OutPoint {
+                            txid: tx,
+                            out_idx: 0,
+                        })
+                        .await
+                        .unwrap()
+                    }),
                 ))],
             })
-            */
-            todo!();
         }
 
         async fn submit_transaction(

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -191,12 +191,16 @@ impl<'c> LnClient<'c> {
             _ => Err(LnClientError::WrongAccountType),
         }
     }
-    pub fn refundable_outgoing_contracts(&self, block_height: u64) -> Vec<OutgoingContractData> {
+    pub async fn refundable_outgoing_contracts(
+        &self,
+        block_height: u64,
+    ) -> Vec<OutgoingContractData> {
         // TODO: unify block height type
         self.context
             .db
             .begin_transaction(ModuleRegistry::default())
             .find_by_prefix(&OutgoingPaymentKeyPrefix)
+            .await
             .filter_map(|res| {
                 let (_key, outgoing_data) = res.expect("DB error");
                 let cancelled = outgoing_data.contract_account.contract.cancelled;
@@ -572,8 +576,11 @@ mod tests {
 
         assert!(client
             .refundable_outgoing_contracts((timelock - 1) as u64)
+            .await
             .is_empty());
-        let refund_inputs = client.refundable_outgoing_contracts((timelock) as u64);
+        let refund_inputs = client
+            .refundable_outgoing_contracts((timelock) as u64)
+            .await;
         assert_eq!(refund_inputs.len(), 1);
         let contract_data = refund_inputs.into_iter().next().unwrap();
         let (refund_key, refund_input) =

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -327,12 +327,11 @@ mod tests {
     use bitcoin::Address;
     use fedimint_api::backup::SignedBackupRequest;
     use fedimint_api::config::ModuleConfigGenParams;
-    use fedimint_api::core::{Decoder, OutputOutcome, MODULE_KEY_LN};
+    use fedimint_api::core::OutputOutcome;
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::encoding::ModuleRegistry;
     use fedimint_api::{Amount, OutPoint, TransactionId};
     use fedimint_core::epoch::EpochHistory;
-    use fedimint_core::modules::ln::common::LightningModuleDecoder;
     use fedimint_core::modules::ln::config::LightningModuleClientConfig;
     use fedimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
     use fedimint_core::modules::ln::contracts::{ContractId, IdentifyableContract};
@@ -460,30 +459,21 @@ mod tests {
         }
     }
 
-    fn ln_decoders() -> ModuleRegistry {
-        vec![(MODULE_KEY_LN, Decoder::from_typed(LightningModuleDecoder))]
-            .into_iter()
-            .collect()
-    }
-
     async fn new_mint_and_client() -> (
         Arc<tokio::sync::Mutex<Fed>>,
         LightningModuleClientConfig,
         ClientContext,
     ) {
-        let fed =
-            Arc::new(tokio::sync::Mutex::new(
-                FakeFed::<LightningModule>::new(
-                    4,
-                    |cfg, db| async move {
-                        Ok(LightningModule::new(cfg.to_typed()?, db, ln_decoders()))
-                    },
-                    &ModuleConfigGenParams::fake_config_gen_params(),
-                    &LightningModuleConfigGen,
-                )
-                .await
-                .unwrap(),
-            ));
+        let fed = Arc::new(tokio::sync::Mutex::new(
+            FakeFed::<LightningModule>::new(
+                4,
+                |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
+                &ModuleConfigGenParams::fake_config_gen_params(),
+                &LightningModuleConfigGen,
+            )
+            .await
+            .unwrap(),
+        ));
         let api = FakeApi { mint: fed.clone() };
         let client_config = fed.lock().await.client_cfg().clone();
 

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -265,12 +265,13 @@ impl<'c> LnClient<'c> {
         dbtx.commit_tx().await.expect("DB Error");
     }
 
-    pub fn get_confirmed_invoice(&self, contract_id: ContractId) -> Result<ConfirmedInvoice> {
+    pub async fn get_confirmed_invoice(&self, contract_id: ContractId) -> Result<ConfirmedInvoice> {
         let confirmed_invoice = self
             .context
             .db
             .begin_transaction(ModuleRegistry::default())
             .get_value(&ConfirmedInvoiceKey(contract_id))
+            .await
             .expect("Db error")
             .ok_or(LnClientError::NoConfirmedInvoice(contract_id))?;
         Ok(confirmed_invoice)
@@ -361,6 +362,8 @@ mod tests {
             &self,
             tx: TransactionId,
         ) -> crate::api::Result<TransactionStatus> {
+            // TODO: output_outcome is not Send
+            /*
             let mint = self.mint.lock().await;
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
@@ -369,9 +372,12 @@ mod tests {
                         txid: tx,
                         out_idx: 0,
                     })
+                    .await
                     .unwrap(),
                 ))],
             })
+            */
+            todo!();
         }
 
         async fn submit_transaction(
@@ -385,17 +391,19 @@ mod tests {
             &self,
             contract: ContractId,
         ) -> crate::api::Result<ContractAccount> {
-            Ok(self
-                .mint
-                .lock()
-                .await
-                .fetch_from_all(|m, db| {
-                    m.get_contract_account(
-                        &db.begin_transaction(ModuleRegistry::default()),
-                        contract,
-                    )
-                })
-                .unwrap())
+            let mut results = Vec::new();
+            for (_, member, db) in self.mint.lock().await.members.iter_mut() {
+                results.push(
+                    member
+                        .get_contract_account(
+                            &mut db.begin_transaction(ModuleRegistry::default()),
+                            contract,
+                        )
+                        .await,
+                );
+            }
+            let contract_account = fedimint_testing::assert_all_equal(results.into_iter());
+            Ok(contract_account.unwrap())
         }
 
         async fn fetch_consensus_block_height(&self) -> crate::api::Result<u64> {

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -581,12 +581,12 @@ mod tests {
         let contract_data = refund_inputs.into_iter().next().unwrap();
         let (refund_key, refund_input) =
             client.create_refund_outgoing_contract_input(&contract_data);
-        assert!(fed.lock().await.verify_input(&refund_input).is_err());
+        assert!(fed.lock().await.verify_input(&refund_input).await.is_err());
 
         // We need to compensate for the wallet's confirmation target
         fed.lock().await.set_block_height(timelock as u64);
 
-        let meta = fed.lock().await.verify_input(&refund_input).unwrap();
+        let meta = fed.lock().await.verify_input(&refund_input).await.unwrap();
         let refund_pk = secp256k1_zkp::XOnlyPublicKey::from_keypair(refund_key).0;
         assert_eq!(meta.keys, vec![refund_pk]);
         assert_eq!(meta.amount.amount, expected_amount);

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -121,7 +121,7 @@ impl<'c> MintClient<'c> {
 
         let mut dbtx = self.start_dbtx();
         let notes = self.get_available_notes(&mut dbtx);
-        let last_idx = self.get_last_note_index(&mut dbtx);
+        let last_idx = self.get_last_note_index(&mut dbtx).await;
 
         Ok(PlaintextEcashBackup {
             notes,

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -120,7 +120,7 @@ impl<'c> MintClient<'c> {
         let epoch = self.context.api.fetch_last_epoch().await?;
 
         let mut dbtx = self.start_dbtx();
-        let notes = self.get_available_notes(&mut dbtx);
+        let notes = self.get_available_notes(&mut dbtx).await;
         let last_idx = self.get_last_note_index(&mut dbtx).await;
 
         Ok(PlaintextEcashBackup {

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -490,7 +490,6 @@ mod tests {
     use bitcoin::Address;
     use fedimint_api::backup::SignedBackupRequest;
     use fedimint_api::config::ModuleConfigGenParams;
-    use fedimint_api::core::{Decoder, MODULE_KEY_MINT};
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::db::Database;
     use fedimint_api::encoding::ModuleRegistry;
@@ -499,7 +498,6 @@ mod tests {
     use fedimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
     use fedimint_core::modules::ln::contracts::ContractId;
     use fedimint_core::modules::ln::{ContractAccount, LightningGateway};
-    use fedimint_core::modules::mint::common::MintModuleDecoder;
     use fedimint_core::modules::mint::config::MintClientConfig;
     use fedimint_core::modules::mint::{Mint, MintConfigGenerator, MintOutput};
     use fedimint_core::modules::wallet::PegOutFees;
@@ -618,35 +616,24 @@ mod tests {
         }
     }
 
-    fn mint_decoders() -> ModuleRegistry {
-        vec![(MODULE_KEY_MINT, Decoder::from_typed(MintModuleDecoder))]
-            .into_iter()
-            .collect()
-    }
-
     async fn new_mint_and_client() -> (
         Arc<tokio::sync::Mutex<Fed>>,
         MintClientConfig,
         ClientContext,
     ) {
-        let fed =
-            Arc::new(
-                tokio::sync::Mutex::new(
-                    FakeFed::<Mint>::new(
-                        4,
-                        |cfg, db| async move {
-                            Ok(Mint::new(cfg.to_typed().unwrap(), db, mint_decoders()))
-                        },
-                        &ModuleConfigGenParams {
-                            mint_amounts: vec![Amount::from_sat(1), Amount::from_sat(10)],
-                            ..ModuleConfigGenParams::fake_config_gen_params()
-                        },
-                        &MintConfigGenerator,
-                    )
-                    .await
-                    .unwrap(),
-                ),
-            );
+        let fed = Arc::new(tokio::sync::Mutex::new(
+            FakeFed::<Mint>::new(
+                4,
+                |cfg, _db| async move { Ok(Mint::new(cfg.to_typed().unwrap())) },
+                &ModuleConfigGenParams {
+                    mint_amounts: vec![Amount::from_sat(1), Amount::from_sat(10)],
+                    ..ModuleConfigGenParams::fake_config_gen_params()
+                },
+                &MintConfigGenerator,
+            )
+            .await
+            .unwrap(),
+        ));
 
         let api = FakeApi { mint: fed.clone() };
 

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -154,9 +154,10 @@ impl<'c> MintClient<'c> {
             .collect()
     }
 
-    pub fn get_last_note_index(&self, dbtx: &mut DatabaseTransaction<'_>) -> NoteIndex {
+    pub async fn get_last_note_index(&self, dbtx: &mut DatabaseTransaction<'_>) -> NoteIndex {
         NoteIndex(
             dbtx.get_value(&LastECashNoteIndexKey)
+                .await
                 .expect("DB error")
                 .unwrap_or(0),
         )
@@ -166,7 +167,7 @@ impl<'c> MintClient<'c> {
         let mut new_idx;
         loop {
             let mut dbtx = self.start_dbtx();
-            new_idx = self.get_last_note_index(&mut dbtx).next();
+            new_idx = self.get_last_note_index(&mut dbtx).await.next();
             dbtx.insert_entry(&LastECashNoteIndexKey, &new_idx.as_u64())
                 .await
                 .expect("DB error");
@@ -263,6 +264,7 @@ impl<'c> MintClient<'c> {
             .db
             .begin_transaction(ModuleRegistry::default())
             .get_value(&OutputFinalizationKey(outpoint))
+            .await
             .expect("DB error")
             .ok_or(MintClientError::FinalizationError(
                 CoinFinalizationError::UnknownIssuance,
@@ -526,6 +528,8 @@ mod tests {
             &self,
             tx: TransactionId,
         ) -> crate::api::Result<TransactionStatus> {
+            // TODO: output_outcome is not Send
+            /*
             let mint = self.mint.lock().await;
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
@@ -535,10 +539,13 @@ mod tests {
                             txid: tx,
                             out_idx: 0,
                         })
+                        .await
                         .unwrap()
                         .into()),
                 )],
             })
+            */
+            todo!()
         }
 
         async fn submit_transaction(
@@ -847,6 +854,7 @@ mod tests {
             .db
             .begin_transaction(ModuleRegistry::default())
             .get_value(&LastECashNoteIndexKey)
+            .await
             .expect("DB error")
             .unwrap_or(0);
         // Ensure we didn't skip any keys

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -131,9 +131,10 @@ impl<'c> MintClient<'c> {
         self.context.db.begin_transaction(ModuleRegistry::default())
     }
 
-    pub fn coins(&self) -> TieredMulti<SpendableNote> {
+    pub async fn coins(&self) -> TieredMulti<SpendableNote> {
         self.start_dbtx()
             .find_by_prefix(&CoinKeyPrefix)
+            .await
             .map(|res| {
                 let (key, spendable_coin) = res.expect("DB error");
                 (key.amount, spendable_coin)
@@ -142,11 +143,12 @@ impl<'c> MintClient<'c> {
     }
 
     /// Get available spendable notes with a db transaction already opened
-    pub fn get_available_notes(
+    pub async fn get_available_notes(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
     ) -> TieredMulti<SpendableNote> {
         dbtx.find_by_prefix(&CoinKeyPrefix)
+            .await
             .map(|res| {
                 let (key, spendable_coin) = res.expect("DB error");
                 (key.amount, spendable_coin)
@@ -189,9 +191,10 @@ impl<'c> MintClient<'c> {
         NoteIssuanceRequest::new(ctx, secret)
     }
 
-    pub fn select_coins(&self, amount: Amount) -> Result<TieredMulti<SpendableNote>> {
+    pub async fn select_coins(&self, amount: Amount) -> Result<TieredMulti<SpendableNote>> {
         let coins = self
             .coins()
+            .await
             .select_coins(amount)
             .ok_or(MintClientError::NotEnoughCoins)?;
 
@@ -296,11 +299,12 @@ impl<'c> MintClient<'c> {
         Ok(())
     }
 
-    pub fn list_active_issuances(&self) -> Vec<(OutPoint, NoteIssuanceRequests)> {
+    pub async fn list_active_issuances(&self) -> Vec<(OutPoint, NoteIssuanceRequests)> {
         self.context
             .db
             .begin_transaction(ModuleRegistry::default())
             .find_by_prefix(&OutputFinalizationKeyPrefix)
+            .await
             .map(|res| {
                 let (OutputFinalizationKey(outpoint), cfd) = res.expect("DB error");
                 (outpoint, cfd)
@@ -309,7 +313,7 @@ impl<'c> MintClient<'c> {
     }
 
     pub async fn fetch_all_coins(&self) -> Vec<Result<OutPoint>> {
-        let active_issuances = self.list_active_issuances();
+        let active_issuances = self.list_active_issuances().await;
         if active_issuances.is_empty() {
             return Vec::new();
         }
@@ -696,7 +700,7 @@ mod tests {
         const ISSUE_AMOUNT: Amount = Amount::from_sat(12);
         issue_tokens(&fed, &client, &client_context.db, ISSUE_AMOUNT).await;
 
-        assert_eq!(client.coins().total_amount(), ISSUE_AMOUNT)
+        assert_eq!(client.coins().await.total_amount(), ISSUE_AMOUNT)
     }
 
     #[test_log::test(tokio::test)]
@@ -721,7 +725,7 @@ mod tests {
         let secp = &client.context.secp;
         let tbs_pks = &client.config.tbs_pks;
         let rng = rand::rngs::OsRng;
-        let coins = client.select_coins(SPEND_AMOUNT).unwrap();
+        let coins = client.select_coins(SPEND_AMOUNT).await.unwrap();
         let (spend_keys, input) = builder.create_input_from_coins(coins.clone()).unwrap();
         builder.input_coins(coins).unwrap();
         builder
@@ -752,7 +756,7 @@ mod tests {
             .await;
 
         // The right amount of money is left
-        assert_eq!(client.coins().total_amount(), SPEND_AMOUNT);
+        assert_eq!(client.coins().await.total_amount(), SPEND_AMOUNT);
 
         // Double spends aren't possible
         assert!(fed.lock().await.verify_input(&input).await.is_err());
@@ -763,7 +767,7 @@ mod tests {
             .db
             .begin_transaction(ModuleRegistry::default());
         let mut builder = TransactionBuilder::default();
-        let coins = client.select_coins(SPEND_AMOUNT).unwrap();
+        let coins = client.select_coins(SPEND_AMOUNT).await.unwrap();
         let rng = rand::rngs::OsRng;
         let (spend_keys, input) = builder.create_input_from_coins(coins.clone()).unwrap();
         builder.input_coins(coins).unwrap();
@@ -790,7 +794,7 @@ mod tests {
         );
 
         // No money is left
-        assert_eq!(client.coins().total_amount(), Amount::ZERO);
+        assert_eq!(client.coins().await.total_amount(), Amount::ZERO);
     }
 
     #[allow(clippy::needless_collect)]

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -745,7 +745,7 @@ mod tests {
             .await;
         dbtx.commit_tx().await.expect("DB Error");
 
-        let meta = fed.lock().await.verify_input(&input).unwrap();
+        let meta = fed.lock().await.verify_input(&input).await.unwrap();
         assert_eq!(meta.amount.amount, SPEND_AMOUNT);
         assert_eq!(
             meta.keys,
@@ -764,7 +764,7 @@ mod tests {
         assert_eq!(client.coins().total_amount(), SPEND_AMOUNT);
 
         // Double spends aren't possible
-        assert!(fed.lock().await.verify_input(&input).is_err());
+        assert!(fed.lock().await.verify_input(&input).await.is_err());
 
         // We can exactly spend the remainder
         let mut dbtx = client
@@ -788,7 +788,7 @@ mod tests {
             .await;
         dbtx.commit_tx().await.expect("DB Error");
 
-        let meta = fed.lock().await.verify_input(&input).unwrap();
+        let meta = fed.lock().await.verify_input(&input).await.unwrap();
         assert_eq!(meta.amount.amount, SPEND_AMOUNT);
         assert_eq!(
             meta.keys,

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -528,24 +528,21 @@ mod tests {
             &self,
             tx: TransactionId,
         ) -> crate::api::Result<TransactionStatus> {
-            // TODO: output_outcome is not Send
-            /*
             let mint = self.mint.lock().await;
+            // FIXME: Need to block on this future because output_outcome is not send
+            let output_outcome = futures::executor::block_on(async {
+                mint.output_outcome(OutPoint {
+                    txid: tx,
+                    out_idx: 0,
+                })
+                .await
+                .unwrap()
+            });
+
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
-                outputs: vec![SerdeOutputOutcome::from(
-                    &(mint
-                        .output_outcome(OutPoint {
-                            txid: tx,
-                            out_idx: 0,
-                        })
-                        .await
-                        .unwrap()
-                        .into()),
-                )],
+                outputs: vec![SerdeOutputOutcome::from(&(output_outcome.into()))],
             })
-            */
-            todo!()
         }
 
         async fn submit_transaction(

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -96,27 +96,35 @@ impl<'c> WalletClient<'c> {
         address
     }
 
-    pub fn create_pegin_input(
+    pub async fn create_pegin_input(
         &self,
         txout_proof: TxOutProof,
         btc_transaction: bitcoin::Transaction,
     ) -> Result<(KeyPair, PegInProof)> {
-        let (output_idx, secret_tweak_key_bytes) = btc_transaction
-            .output
-            .iter()
-            .enumerate()
-            .find_map(|(idx, out)| {
+        let output_function = || async {
+            for (idx, out) in btc_transaction.output.iter().enumerate() {
                 debug!(output_script = ?out.script_pubkey);
-                self.context
+                let result = self
+                    .context
                     .db
                     .begin_transaction(ModuleRegistry::default())
                     .get_value(&PegInKey {
                         peg_in_script: out.script_pubkey.clone(),
                     })
+                    .await
                     .expect("DB error")
-                    .map(|tweak_secret| (idx, tweak_secret))
-            })
+                    .map(|tweak_secret| (idx, tweak_secret));
+                if !result.is_none() {
+                    return result;
+                }
+            }
+            None
+        };
+
+        let (output_idx, secret_tweak_key_bytes) = output_function()
+            .await
             .ok_or(WalletClientError::NoMatchingPegInFound)?;
+
         let secret_tweak_key =
             bitcoin::KeyPair::from_seckey_slice(&self.context.secp, &secret_tweak_key_bytes)
                 .expect("sec key was generated and saved by us");

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -428,9 +428,15 @@ mod tests {
         fedimint_api::task::sleep(Duration::from_secs(12)).await;
         assert!(btc_rpc.is_btc_sent_to(amount, addr).await);
 
-        let wallet_value = fed.lock().await.fetch_from_all(|wallet, db| {
-            wallet.get_wallet_value(&db.begin_transaction(ModuleRegistry::default()))
-        });
+        let mut results = Vec::new();
+        for (_, member, db) in fed.lock().await.members.iter_mut() {
+            results.push(
+                member
+                    .get_wallet_value(&mut db.begin_transaction(ModuleRegistry::default()))
+                    .await,
+            );
+        }
+        let wallet_value = fedimint_testing::assert_all_equal(results.into_iter());
         assert_eq!(wallet_value, bitcoin::Amount::from_sat(0));
 
         // test change recognition, wallet should hold some sats
@@ -438,9 +444,15 @@ mod tests {
         btc_rpc.set_block_height(301).await;
         fed.lock().await.consensus_round(&[], &[]).await;
 
-        let wallet_value = fed.lock().await.fetch_from_all(|wallet, db| {
-            wallet.get_wallet_value(&db.begin_transaction(ModuleRegistry::default()))
-        });
+        let mut results = Vec::new();
+        for (_, member, db) in fed.lock().await.members.iter_mut() {
+            results.push(
+                member
+                    .get_wallet_value(&mut db.begin_transaction(ModuleRegistry::default()))
+                    .await,
+            );
+        }
+        let wallet_value = fedimint_testing::assert_all_equal(results.into_iter());
         assert!(wallet_value > bitcoin::Amount::from_sat(0));
     }
 }

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -94,10 +94,10 @@ pub trait IServerModule: Debug {
     /// function has no side effects and may be called at any time. False positives due to outdated
     /// database state are ok since they get filtered out after consensus has been reached on them
     /// and merely generate a warning.
-    fn validate_input<'a>(
+    async fn validate_input<'a>(
         &self,
-        interconnect: &dyn ModuleInterconect,
-        dbtx: &DatabaseTransaction<'a>,
+        interconnect: &'a dyn ModuleInterconect,
+        dbtx: &mut DatabaseTransaction<'_>,
         verification_cache: &VerificationCache,
         input: &Input,
     ) -> Result<InputMeta, ModuleError>;
@@ -306,10 +306,10 @@ where
     /// function has no side effects and may be called at any time. False positives due to outdated
     /// database state are ok since they get filtered out after consensus has been reached on them
     /// and merely generate a warning.
-    fn validate_input<'a>(
+    async fn validate_input<'a>(
         &self,
-        interconnect: &dyn ModuleInterconect,
-        dbtx: &DatabaseTransaction<'a>,
+        interconnect: &'a dyn ModuleInterconect,
+        dbtx: &mut DatabaseTransaction<'_>,
         verification_cache: &VerificationCache,
         input: &Input,
     ) -> Result<InputMeta, ModuleError> {
@@ -326,6 +326,7 @@ where
                 .downcast_ref::<<Self as ServerModulePlugin>::Input>()
                 .expect("incorrect input type passed to module plugin"),
         )
+        .await
         .map(Into::into)
     }
 
@@ -448,13 +449,17 @@ where
             .into_iter()
             .map(|ApiEndpoint { path, handler }| ApiEndpoint {
                 path,
-                handler: Box::new(move |module: &ServerModule, value: serde_json::Value| {
-                    let typed_module = module
-                        .as_any()
-                        .downcast_ref::<T>()
-                        .expect("the dispatcher should always call with the right module");
-                    Box::pin(handler(typed_module, value))
-                }),
+                handler: Box::new(
+                    move |module: &ServerModule,
+                          dbtx: fedimint_api::db::DatabaseTransaction<'_>,
+                          value: serde_json::Value| {
+                        let typed_module = module
+                            .as_any()
+                            .downcast_ref::<T>()
+                            .expect("the dispatcher should always call with the right module");
+                        Box::pin(handler(typed_module, dbtx, value))
+                    },
+                ),
             })
             .collect()
     }

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -69,10 +69,10 @@ pub trait IServerModule: Debug {
     fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self);
+    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>);
 
     /// This module's contribution to the next consensus proposal
-    async fn consensus_proposal(&self) -> Vec<ConsensusItem>;
+    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<ConsensusItem>;
 
     /// This function is called once before transaction processing starts. All module consensus
     /// items of this round are supplied as `consensus_items`. The batch will be committed to the
@@ -158,13 +158,17 @@ pub trait IServerModule: Debug {
     /// Retrieve the current status of the output. Depending on the module this might contain data
     /// needed by the client to access funds or give an estimate of when funds will be available.
     /// Returns `None` if the output is unknown, **NOT** if it is just not ready yet.
-    fn output_status(&self, out_point: OutPoint) -> Option<OutputOutcome>;
+    fn output_status(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        out_point: OutPoint,
+    ) -> Option<OutputOutcome>;
 
     /// Queries the database and returns all assets and liabilities of the module.
     ///
     /// Summing over all modules, if liabilities > assets then an error has occurred in the database
     /// and consensus should halt.
-    fn audit(&self, audit: &mut Audit);
+    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit);
 
     /// Defines the prefix for API endpoints defined by the module.
     ///
@@ -240,13 +244,13 @@ where
     }
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self) {
-        <Self as ServerModulePlugin>::await_consensus_proposal(self).await
+    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
+        <Self as ServerModulePlugin>::await_consensus_proposal(self, dbtx).await
     }
 
     /// This module's contribution to the next consensus proposal
-    async fn consensus_proposal(&self) -> Vec<ConsensusItem> {
-        <Self as ServerModulePlugin>::consensus_proposal(self)
+    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<ConsensusItem> {
+        <Self as ServerModulePlugin>::consensus_proposal(self, dbtx)
             .await
             .into_iter()
             .map(Into::into)
@@ -419,16 +423,20 @@ where
     /// Retrieve the current status of the output. Depending on the module this might contain data
     /// needed by the client to access funds or give an estimate of when funds will be available.
     /// Returns `None` if the output is unknown, **NOT** if it is just not ready yet.
-    fn output_status(&self, out_point: OutPoint) -> Option<OutputOutcome> {
-        <Self as ServerModulePlugin>::output_status(self, out_point).map(Into::into)
+    fn output_status(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        out_point: OutPoint,
+    ) -> Option<OutputOutcome> {
+        <Self as ServerModulePlugin>::output_status(self, dbtx, out_point).map(Into::into)
     }
 
     /// Queries the database and returns all assets and liabilities of the module.
     ///
     /// Summing over all modules, if liabilities > assets then an error has occurred in the database
     /// and consensus should halt.
-    fn audit(&self, audit: &mut Audit) {
-        <Self as ServerModulePlugin>::audit(self, audit)
+    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
+        <Self as ServerModulePlugin>::audit(self, dbtx, audit)
     }
 
     fn api_base_name(&self) -> &'static str {

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -168,7 +168,7 @@ pub trait IServerModule: Debug {
     ///
     /// Summing over all modules, if liabilities > assets then an error has occurred in the database
     /// and consensus should halt.
-    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit);
+    async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit);
 
     /// Defines the prefix for API endpoints defined by the module.
     ///
@@ -439,8 +439,8 @@ where
     ///
     /// Summing over all modules, if liabilities > assets then an error has occurred in the database
     /// and consensus should halt.
-    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
-        <Self as ServerModulePlugin>::audit(self, dbtx, audit)
+    async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit) {
+        <Self as ServerModulePlugin>::audit(self, dbtx, audit).await
     }
 
     fn api_base_name(&self) -> &'static str {

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -69,7 +69,7 @@ pub trait IServerModule: Debug {
     fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>);
+    async fn await_consensus_proposal(&self, mut dbtx: DatabaseTransaction<'_>);
 
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) -> Vec<ConsensusItem>;
@@ -244,7 +244,7 @@ where
     }
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
+    async fn await_consensus_proposal(&self, dbtx: DatabaseTransaction<'_>) {
         <Self as ServerModulePlugin>::await_consensus_proposal(self, dbtx).await
     }
 

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -69,10 +69,10 @@ pub trait IServerModule: Debug {
     fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>);
+    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>);
 
     /// This module's contribution to the next consensus proposal
-    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<ConsensusItem>;
+    async fn consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) -> Vec<ConsensusItem>;
 
     /// This function is called once before transaction processing starts. All module consensus
     /// items of this round are supplied as `consensus_items`. The batch will be committed to the
@@ -121,9 +121,9 @@ pub trait IServerModule: Debug {
     /// function has no side effects and may be called at any time. False positives due to outdated
     /// database state are ok since they get filtered out after consensus has been reached on them
     /// and merely generate a warning.
-    fn validate_output(
+    async fn validate_output(
         &self,
-        dbtx: &DatabaseTransaction,
+        dbtx: &mut DatabaseTransaction<'_>,
         output: &Output,
     ) -> Result<TransactionItemAmount, ModuleError>;
 
@@ -158,7 +158,7 @@ pub trait IServerModule: Debug {
     /// Retrieve the current status of the output. Depending on the module this might contain data
     /// needed by the client to access funds or give an estimate of when funds will be available.
     /// Returns `None` if the output is unknown, **NOT** if it is just not ready yet.
-    fn output_status(
+    async fn output_status(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
@@ -244,12 +244,12 @@ where
     }
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
+    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
         <Self as ServerModulePlugin>::await_consensus_proposal(self, dbtx).await
     }
 
     /// This module's contribution to the next consensus proposal
-    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<ConsensusItem> {
+    async fn consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) -> Vec<ConsensusItem> {
         <Self as ServerModulePlugin>::consensus_proposal(self, dbtx)
             .await
             .into_iter()
@@ -365,9 +365,9 @@ where
     /// function has no side effects and may be called at any time. False positives due to outdated
     /// database state are ok since they get filtered out after consensus has been reached on them
     /// and merely generate a warning.
-    fn validate_output(
+    async fn validate_output(
         &self,
-        dbtx: &DatabaseTransaction,
+        dbtx: &mut DatabaseTransaction<'_>,
         output: &Output,
     ) -> Result<TransactionItemAmount, ModuleError> {
         <Self as ServerModulePlugin>::validate_output(
@@ -378,6 +378,7 @@ where
                 .downcast_ref::<<Self as ServerModulePlugin>::Output>()
                 .expect("incorrect output type passed to module plugin"),
         )
+        .await
     }
 
     /// Try to create an output (e.g. issue coins, peg-out BTC, …). On success all necessary updates
@@ -424,12 +425,14 @@ where
     /// Retrieve the current status of the output. Depending on the module this might contain data
     /// needed by the client to access funds or give an estimate of when funds will be available.
     /// Returns `None` if the output is unknown, **NOT** if it is just not ready yet.
-    fn output_status(
+    async fn output_status(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<OutputOutcome> {
-        <Self as ServerModulePlugin>::output_status(self, dbtx, out_point).map(Into::into)
+        <Self as ServerModulePlugin>::output_status(self, dbtx, out_point)
+            .await
+            .map(Into::into)
     }
 
     /// Queries the database and returns all assets and liabilities of the module.

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -80,7 +80,7 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
         val
     }
 
-    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.tx_data.get(key).cloned())
     }
 

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -68,7 +68,7 @@ impl IDatabase for MemDatabase {
 #[async_trait]
 impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
     async fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
-        let val = self.raw_get_bytes(key);
+        let val = self.raw_get_bytes(key).await;
         // Insert data from copy so we can read our own writes
         self.tx_data.insert(key.to_vec(), value.clone());
         self.operations
@@ -80,7 +80,7 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
         val
     }
 
-    fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.tx_data.get(key).cloned())
     }
 

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -95,7 +95,7 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
         Ok(ret)
     }
 
-    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_> {
+    async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixIter<'_> {
         let mut data = self
             .tx_data
             .range::<Vec<u8>, _>((key_prefix.to_vec())..)

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -80,7 +80,7 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
         val
     }
 
-    async fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.tx_data.get(key).cloned())
     }
 

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -103,7 +103,7 @@ dyn_newtype_define! {
 pub trait IDatabaseTransaction<'a>: 'a + Send {
     async fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>>;
 
-    async fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -107,7 +107,7 @@ pub trait IDatabaseTransaction<'a>: 'a + Send {
 
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
-    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_>;
+    async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixIter<'_>;
 
     async fn commit_tx(self: Box<Self>) -> Result<()>;
 
@@ -232,27 +232,29 @@ impl<'a> DatabaseTransaction<'a> {
         Ok(Some(K::Value::from_bytes(&value_bytes, &self.1)?))
     }
 
-    pub fn find_by_prefix<KP>(
-        &self,
+    pub async fn find_by_prefix<KP>(
+        &mut self,
         key_prefix: &KP,
     ) -> impl Iterator<Item = Result<(KP::Key, KP::Value)>> + '_
     where
         KP: DatabaseKeyPrefix + DatabaseKeyPrefixConst,
     {
-        let decoders = &self.1;
+        let decoders = self.1.clone();
         let prefix_bytes = key_prefix.to_bytes();
-        self.raw_find_by_prefix(&prefix_bytes).map(|res| {
-            res.and_then(|(key_bytes, value_bytes)| {
-                let key = KP::Key::from_bytes(&key_bytes, decoders)?;
-                trace!(
-                    "find by prefix: Decoding {} from bytes {:?}",
-                    std::any::type_name::<KP::Value>(),
-                    value_bytes
-                );
-                let value = KP::Value::from_bytes(&value_bytes, decoders)?;
-                Ok((key, value))
+        self.raw_find_by_prefix(&prefix_bytes)
+            .await
+            .map(move |res| {
+                res.and_then(|(key_bytes, value_bytes)| {
+                    let key = KP::Key::from_bytes(&key_bytes, &decoders)?;
+                    trace!(
+                        "find by prefix: Decoding {} from bytes {:?}",
+                        std::any::type_name::<KP::Value>(),
+                        value_bytes
+                    );
+                    let value = KP::Value::from_bytes(&value_bytes, &decoders)?;
+                    Ok((key, value))
+                })
             })
-        })
     }
 }
 
@@ -484,10 +486,10 @@ mod tests {
         dbtx.commit_tx().await.expect("DB Error");
 
         // Verify finding by prefix returns the correct set of key pairs
-        let dbtx = db.begin_transaction(ModuleRegistry::default());
+        let mut dbtx = db.begin_transaction(ModuleRegistry::default());
         let mut returned_keys = 0;
         let expected_keys = 2;
-        for res in dbtx.find_by_prefix(&DbPrefixTestPrefix) {
+        for res in dbtx.find_by_prefix(&DbPrefixTestPrefix).await {
             match res.as_ref().unwrap().0 {
                 TestKey(55) => {
                     assert!(res.unwrap().1.eq(&TestVal(9999)));
@@ -507,7 +509,7 @@ mod tests {
 
         let mut returned_keys = 0;
         let expected_keys = 2;
-        for res in dbtx.find_by_prefix(&AltDbPrefixTestPrefix) {
+        for res in dbtx.find_by_prefix(&AltDbPrefixTestPrefix).await {
             match res.as_ref().unwrap().0 {
                 AltTestKey(55) => {
                     assert!(res.unwrap().1.eq(&TestVal(7777)));
@@ -599,7 +601,7 @@ mod tests {
 
         let mut returned_keys = 0;
         let expected_keys = 0;
-        for res in dbtx.find_by_prefix(&DbPrefixTestPrefix) {
+        for res in dbtx.find_by_prefix(&DbPrefixTestPrefix).await {
             match res.as_ref().unwrap().0 {
                 TestKey(100) => {
                     assert!(res.unwrap().1.eq(&TestVal(101)));
@@ -629,10 +631,10 @@ mod tests {
 
         dbtx.commit_tx().await.expect("DB Error");
 
-        let dbtx = db.begin_transaction(ModuleRegistry::default());
+        let mut dbtx = db.begin_transaction(ModuleRegistry::default());
         let mut returned_keys = 0;
         let expected_keys = 2;
-        for res in dbtx.find_by_prefix(&DbPrefixTestPrefix) {
+        for res in dbtx.find_by_prefix(&DbPrefixTestPrefix).await {
             match res.as_ref().unwrap().0 {
                 TestKey(100) => {
                     assert!(res.unwrap().1.eq(&TestVal(101)));
@@ -660,7 +662,7 @@ mod tests {
         dbtx2.commit_tx().await.expect("DB Error");
 
         let mut returned_keys = 0;
-        for res in dbtx.find_by_prefix(&DbPrefixTestPrefix) {
+        for res in dbtx.find_by_prefix(&DbPrefixTestPrefix).await {
             match res.as_ref().unwrap().0 {
                 TestKey(100) => {
                     assert!(res.unwrap().1.eq(&TestVal(101)));

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -103,7 +103,7 @@ dyn_newtype_define! {
 pub trait IDatabaseTransaction<'a>: 'a + Send {
     async fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>>;
 
-    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
+    async fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -103,7 +103,7 @@ dyn_newtype_define! {
 pub trait IDatabaseTransaction<'a>: 'a + Send {
     async fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>>;
 
-    fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
@@ -201,12 +201,12 @@ impl<'a> DatabaseTransaction<'a> {
         }
     }
 
-    pub fn get_value<K>(&self, key: &K) -> Result<Option<K::Value>>
+    pub async fn get_value<K>(&mut self, key: &K) -> Result<Option<K::Value>>
     where
         K: DatabaseKey + DatabaseKeyPrefixConst,
     {
         let key_bytes = key.to_bytes();
-        let value_bytes = match self.raw_get_bytes(&key_bytes)? {
+        let value_bytes = match self.raw_get_bytes(&key_bytes).await? {
             Some(value) => value,
             None => return Ok(None),
         };
@@ -414,7 +414,7 @@ mod tests {
 
     pub async fn verify_remove_nonexisting(db: Database) {
         let mut dbtx = db.begin_transaction(ModuleRegistry::default());
-        assert_eq!(dbtx.get_value(&TestKey(1)).unwrap(), None);
+        assert_eq!(dbtx.get_value(&TestKey(1)).await.unwrap(), None);
         let removed = dbtx.remove_entry(&TestKey(1)).await;
         assert!(removed.is_ok());
     }
@@ -428,12 +428,12 @@ mod tests {
             .unwrap()
             .is_none());
 
-        assert_eq!(dbtx.get_value(&TestKey(1)).unwrap(), Some(TestVal(2)));
+        assert_eq!(dbtx.get_value(&TestKey(1)).await.unwrap(), Some(TestVal(2)));
 
         let removed = dbtx.remove_entry(&TestKey(1)).await;
         assert!(removed.is_ok());
         assert_eq!(removed.unwrap(), Some(TestVal(2)));
-        assert_eq!(dbtx.get_value(&TestKey(1)).unwrap(), None);
+        assert_eq!(dbtx.get_value(&TestKey(1)).await.unwrap(), None);
     }
 
     pub async fn verify_read_own_writes(db: Database) {
@@ -445,7 +445,7 @@ mod tests {
             .unwrap()
             .is_none());
 
-        assert_eq!(dbtx.get_value(&TestKey(1)).unwrap(), Some(TestVal(2)));
+        assert_eq!(dbtx.get_value(&TestKey(1)).await.unwrap(), Some(TestVal(2)));
     }
 
     pub async fn verify_prevent_dirty_reads(db: Database) {
@@ -458,8 +458,8 @@ mod tests {
             .is_none());
 
         // dbtx2 should not be able to see uncommitted changes
-        let dbtx2 = db.begin_transaction(ModuleRegistry::default());
-        assert_eq!(dbtx2.get_value(&TestKey(1)).unwrap(), None);
+        let mut dbtx2 = db.begin_transaction(ModuleRegistry::default());
+        assert_eq!(dbtx2.get_value(&TestKey(1)).await.unwrap(), None);
     }
 
     pub async fn verify_find_by_prefix(db: Database) {
@@ -537,8 +537,11 @@ mod tests {
         dbtx.commit_tx().await.expect("DB Error");
 
         // Verify dbtx2 can see committed transactions
-        let dbtx2 = db.begin_transaction(ModuleRegistry::default());
-        assert_eq!(dbtx2.get_value(&TestKey(1)).unwrap(), Some(TestVal(2)));
+        let mut dbtx2 = db.begin_transaction(ModuleRegistry::default());
+        assert_eq!(
+            dbtx2.get_value(&TestKey(1)).await.unwrap(),
+            Some(TestVal(2))
+        );
     }
 
     pub async fn verify_rollback_to_savepoint(db: Database) {
@@ -557,27 +560,27 @@ mod tests {
             .is_ok());
 
         assert_eq!(
-            dbtx_rollback.get_value(&TestKey(20)).unwrap(),
+            dbtx_rollback.get_value(&TestKey(20)).await.unwrap(),
             Some(TestVal(2000))
         );
         assert_eq!(
-            dbtx_rollback.get_value(&TestKey(21)).unwrap(),
+            dbtx_rollback.get_value(&TestKey(21)).await.unwrap(),
             Some(TestVal(2001))
         );
 
         dbtx_rollback.rollback_tx_to_savepoint().await;
 
         assert_eq!(
-            dbtx_rollback.get_value(&TestKey(20)).unwrap(),
+            dbtx_rollback.get_value(&TestKey(20)).await.unwrap(),
             Some(TestVal(2000))
         );
 
-        assert_eq!(dbtx_rollback.get_value(&TestKey(21)).unwrap(), None);
+        assert_eq!(dbtx_rollback.get_value(&TestKey(21)).await.unwrap(), None);
     }
 
     pub async fn verify_prevent_nonrepeatable_reads(db: Database) {
-        let dbtx = db.begin_transaction(ModuleRegistry::default());
-        assert_eq!(dbtx.get_value(&TestKey(100)).unwrap(), None);
+        let mut dbtx = db.begin_transaction(ModuleRegistry::default());
+        assert_eq!(dbtx.get_value(&TestKey(100)).await.unwrap(), None);
 
         let mut dbtx2 = db.begin_transaction(ModuleRegistry::default());
 
@@ -586,13 +589,13 @@ mod tests {
             .await
             .is_ok());
 
-        assert_eq!(dbtx.get_value(&TestKey(100)).unwrap(), None);
+        assert_eq!(dbtx.get_value(&TestKey(100)).await.unwrap(), None);
 
         dbtx2.commit_tx().await.expect("DB Error");
 
         // dbtx should still read None because it is operating over a snapshot
         // of the data when the transaction started
-        assert_eq!(dbtx.get_value(&TestKey(100)).unwrap(), None);
+        assert_eq!(dbtx.get_value(&TestKey(100)).await.unwrap(), None);
 
         let mut returned_keys = 0;
         let expected_keys = 0;

--- a/fedimint-api/src/module/audit.rs
+++ b/fedimint-api/src/module/audit.rs
@@ -20,13 +20,18 @@ impl Audit {
         }
     }
 
-    pub fn add_items<KP, F>(&mut self, dbtx: &DatabaseTransaction, key_prefix: &KP, to_milli_sat: F)
-    where
+    pub async fn add_items<KP, F>(
+        &mut self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        key_prefix: &KP,
+        to_milli_sat: F,
+    ) where
         KP: DatabaseKeyPrefix + DatabaseKeyPrefixConst + 'static,
         F: Fn(KP::Key, KP::Value) -> i64,
     {
         let mut new_items = dbtx
             .find_by_prefix(key_prefix)
+            .await
             .map(|res| {
                 let (key, value) = res.expect("DB error");
                 let name = format!("{:?}", key);

--- a/fedimint-api/src/module/interconnect.rs
+++ b/fedimint-api/src/module/interconnect.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use super::ApiError;
 
 /// Provides an interface to call APIs of other modules
-#[async_trait]
-pub trait ModuleInterconect {
+#[async_trait(?Send)]
+pub trait ModuleInterconect: Sync + Send {
     /// Simulates a call to an API endpoint of another module.
     /// This has lower latency.
     async fn call(

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -117,7 +117,7 @@ macro_rules! __api_endpoint {
 
             async fn handle<'a, 'b>(
                 $state: &'a Self::State,
-                $dbtx: fedimint_api::db::DatabaseTransaction<'b>,
+                mut $dbtx: fedimint_api::db::DatabaseTransaction<'b>,
                 $param: Self::Param,
             ) -> ::std::result::Result<Self::Response, $crate::module::ApiError> {
                 $body

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -232,12 +232,12 @@ pub trait ServerModulePlugin: Debug + Sized {
     fn decoder(&self) -> Self::Decoder;
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal<'a>(&'a self, dbtx: &DatabaseTransaction<'_>);
+    async fn await_consensus_proposal<'a>(&'a self, dbtx: &mut DatabaseTransaction<'_>);
 
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal<'a>(
         &'a self,
-        dbtx: &DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
     ) -> Vec<Self::ConsensusItem>;
 
     /// This function is called once before transaction processing starts. All module consensus
@@ -290,9 +290,9 @@ pub trait ServerModulePlugin: Debug + Sized {
     /// function has no side effects and may be called at any time. False positives due to outdated
     /// database state are ok since they get filtered out after consensus has been reached on them
     /// and merely generate a warning.
-    fn validate_output(
+    async fn validate_output(
         &self,
-        dbtx: &DatabaseTransaction,
+        dbtx: &mut DatabaseTransaction<'_>,
         output: &Self::Output,
     ) -> Result<TransactionItemAmount, ModuleError>;
 
@@ -327,7 +327,7 @@ pub trait ServerModulePlugin: Debug + Sized {
     /// Retrieve the current status of the output. Depending on the module this might contain data
     /// needed by the client to access funds or give an estimate of when funds will be available.
     /// Returns `None` if the output is unknown, **NOT** if it is just not ready yet.
-    fn output_status(
+    async fn output_status(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -337,7 +337,7 @@ pub trait ServerModulePlugin: Debug + Sized {
     ///
     /// Summing over all modules, if liabilities > assets then an error has occurred in the database
     /// and consensus should halt.
-    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit);
+    async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit);
 
     /// Defines the prefix for API endpoints defined by the module.
     ///

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -232,7 +232,7 @@ pub trait ServerModulePlugin: Debug + Sized {
     fn decoder(&self) -> Self::Decoder;
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal<'a>(&'a self, dbtx: &mut DatabaseTransaction<'_>);
+    async fn await_consensus_proposal<'a>(&'a self, mut dbtx: DatabaseTransaction<'_>);
 
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal<'a>(

--- a/fedimint-dbdump/Cargo.toml
+++ b/fedimint-dbdump/Cargo.toml
@@ -24,3 +24,4 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.89"
 strum = "0.24"
 strum_macros = "0.24"
+tokio = { version = "1.22.0", features = ["full"] }

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -92,23 +92,23 @@ impl<'a> DatabaseDump<'a> {
 
     /// Iterates through all the specified ranges in the database and retrieves the
     /// data for each range. Prints serialized contents at the end.
-    pub fn dump_database(&mut self) {
+    pub async fn dump_database(&mut self) {
         for range in self.ranges.clone() {
             match range.as_str() {
                 "consensus" => {
-                    self.get_consensus_data();
+                    self.get_consensus_data().await;
                 }
                 "mint" => {
                     self.get_mint_data();
                 }
                 "wallet" => {
-                    self.get_wallet_data();
+                    self.get_wallet_data().await;
                 }
                 "lightning" => {
                     self.get_lightning_data();
                 }
                 "mintclient" => {
-                    self.get_mint_client_data();
+                    self.get_mint_client_data().await;
                 }
                 "lightningclient" => {
                     self.get_ln_client_data();
@@ -117,7 +117,7 @@ impl<'a> DatabaseDump<'a> {
                     self.get_wallet_client_data();
                 }
                 "client" => {
-                    self.get_client_data();
+                    self.get_client_data().await;
                 }
                 _ => {}
             }
@@ -128,7 +128,7 @@ impl<'a> DatabaseDump<'a> {
 
     /// Iterates through each of the prefixes within the consensus range and retrieves
     /// the corresponding data.
-    fn get_consensus_data(&mut self) {
+    async fn get_consensus_data(&mut self) {
         let mut consensus: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
 
         for table in ConsensusRange::DbKeyPrefix::iter() {
@@ -188,6 +188,7 @@ impl<'a> DatabaseDump<'a> {
                     let last_epoch = self
                         .read_only
                         .get_value(&ConsensusRange::LastEpochKey)
+                        .await
                         .unwrap();
                     if let Some(last_epoch) = last_epoch {
                         consensus.insert("LastEpoch".to_string(), Box::new(last_epoch));
@@ -275,7 +276,7 @@ impl<'a> DatabaseDump<'a> {
 
     /// Iterates through each of the prefixes within the wallet range and retrieves
     /// the corresponding data.
-    fn get_wallet_data(&mut self) {
+    async fn get_wallet_data(&mut self) {
         let mut wallet: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
         for table in WalletRange::DbKeyPrefix::iter() {
             filter_prefixes!(table, self);
@@ -324,6 +325,7 @@ impl<'a> DatabaseDump<'a> {
                     let round_consensus = self
                         .read_only
                         .get_value(&WalletRange::RoundConsensusKey)
+                        .await
                         .unwrap();
                     if let Some(round_consensus) = round_consensus {
                         wallet.insert("Round Consensus".to_string(), Box::new(round_consensus));
@@ -497,7 +499,7 @@ impl<'a> DatabaseDump<'a> {
 
     /// Iterates through each of the prefixes within the mint client range and retrieves
     /// the corresponding data.
-    fn get_mint_client_data(&mut self) {
+    async fn get_mint_client_data(&mut self) {
         let mut mint_client: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
         for table in ClientMintRange::DbKeyPrefix::iter() {
             filter_prefixes!(table, self);
@@ -537,6 +539,7 @@ impl<'a> DatabaseDump<'a> {
                     let last_ecash_note = self
                         .read_only
                         .get_value(&ClientMintRange::LastECashNoteIndexKey)
+                        .await
                         .unwrap();
                     if let Some(last_ecash_note) = last_ecash_note {
                         mint_client.insert(
@@ -577,7 +580,7 @@ impl<'a> DatabaseDump<'a> {
             .insert("Client Wallet".to_string(), Box::new(wallet_client));
     }
 
-    fn get_client_data(&mut self) {
+    async fn get_client_data(&mut self) {
         let mut client: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
 
         for table in ClientRange::DbKeyPrefix::iter() {
@@ -588,6 +591,7 @@ impl<'a> DatabaseDump<'a> {
                     let secret = self
                         .read_only
                         .get_value(&ClientRange::ClientSecretKey)
+                        .await
                         .unwrap();
                     if let Some(secret) = secret {
                         client.insert("Client Secret".to_string(), Box::new(secret));
@@ -630,7 +634,8 @@ struct Args {
     flag_prefix: String,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());
@@ -670,5 +675,5 @@ fn main() {
         include_all_prefixes: csv_prefix == "All",
     };
 
-    dbdump.dump_database();
+    dbdump.dump_database().await;
 }

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -29,7 +29,7 @@ macro_rules! filter_prefixes {
 
 macro_rules! push_db_pair_items {
     ($self:ident, $prefix_type:expr, $key_type:ty, $value_type:ty, $map:ident, $key_literal:literal) => {
-        let db_items = $self.read_only.find_by_prefix(&$prefix_type);
+        let db_items = $self.read_only.find_by_prefix(&$prefix_type).await;
         let mut items: Vec<($key_type, $value_type)> = Vec::new();
         for item in db_items {
             items.push(item.unwrap());
@@ -52,7 +52,7 @@ impl SerdeWrapper {
 
 macro_rules! push_db_pair_items_no_serde {
     ($self:ident, $prefix_type:expr, $key_type:ty, $value_type:ty, $map:ident, $key_literal:literal) => {
-        let db_items = $self.read_only.find_by_prefix(&$prefix_type);
+        let db_items = $self.read_only.find_by_prefix(&$prefix_type).await;
         let mut items: Vec<($key_type, SerdeWrapper)> = Vec::new();
         for item in db_items {
             let (k, v) = item.unwrap();
@@ -64,7 +64,7 @@ macro_rules! push_db_pair_items_no_serde {
 
 macro_rules! push_db_key_items {
     ($self:ident, $prefix_type:expr, $key_type:ty, $map:ident, $key_literal:literal) => {
-        let db_items = $self.read_only.find_by_prefix(&$prefix_type);
+        let db_items = $self.read_only.find_by_prefix(&$prefix_type).await;
         let mut items: Vec<$key_type> = Vec::new();
         for item in db_items {
             items.push(item.unwrap().0);
@@ -99,22 +99,22 @@ impl<'a> DatabaseDump<'a> {
                     self.get_consensus_data().await;
                 }
                 "mint" => {
-                    self.get_mint_data();
+                    self.get_mint_data().await;
                 }
                 "wallet" => {
                     self.get_wallet_data().await;
                 }
                 "lightning" => {
-                    self.get_lightning_data();
+                    self.get_lightning_data().await;
                 }
                 "mintclient" => {
                     self.get_mint_client_data().await;
                 }
                 "lightningclient" => {
-                    self.get_ln_client_data();
+                    self.get_ln_client_data().await;
                 }
                 "walletclient" => {
-                    self.get_wallet_client_data();
+                    self.get_wallet_client_data().await;
                 }
                 "client" => {
                     self.get_client_data().await;
@@ -203,7 +203,7 @@ impl<'a> DatabaseDump<'a> {
 
     /// Iterates through each of the prefixes within the mint range and retrieves
     /// the corresponding data.
-    fn get_mint_data(&mut self) {
+    async fn get_mint_data(&mut self) {
         let mut mint: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
         for table in MintRange::DbKeyPrefix::iter() {
             filter_prefixes!(table, self);
@@ -360,7 +360,7 @@ impl<'a> DatabaseDump<'a> {
 
     /// Iterates through each of the prefixes within the lightning range and retrieves
     /// the corresponding data.
-    fn get_lightning_data(&mut self) {
+    async fn get_lightning_data(&mut self) {
         let mut lightning: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
         for table in LightningRange::DbKeyPrefix::iter() {
             filter_prefixes!(table, self);
@@ -435,7 +435,7 @@ impl<'a> DatabaseDump<'a> {
 
     /// Iterates through each of the prefixes within the lightning client range and retrieves
     /// the corresponding data.
-    fn get_ln_client_data(&mut self) {
+    async fn get_ln_client_data(&mut self) {
         let mut ln_client: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
         for table in ClientLightningRange::DbKeyPrefix::iter() {
             filter_prefixes!(table, self);
@@ -557,7 +557,7 @@ impl<'a> DatabaseDump<'a> {
 
     /// Iterates through each of the prefixes within the wallet client range and retrieves
     /// the corresponding data.
-    fn get_wallet_client_data(&mut self) {
+    async fn get_wallet_client_data(&mut self) {
         let mut wallet_client: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
         for table in ClientWalletRange::DbKeyPrefix::iter() {
             filter_prefixes!(table, self);

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -71,7 +71,7 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
         Ok(val)
     }
 
-    fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.snapshot().get(key)?)
     }
 
@@ -126,7 +126,7 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
         panic!("Cannot insert into a read only transaction");
     }
 
-    fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.get(key)?)
     }
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -81,7 +81,7 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
         Ok(val)
     }
 
-    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_> {
+    async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixIter<'_> {
         let prefix = key_prefix.to_vec();
         let mut options = rocksdb::ReadOptions::default();
         options.set_iterate_range(rocksdb::PrefixRange(prefix.clone()));
@@ -134,7 +134,7 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
         panic!("Cannot remove from a read only transaction");
     }
 
-    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_> {
+    async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixIter<'_> {
         let prefix = key_prefix.to_vec();
         Box::new(
             self.0

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -71,10 +71,8 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
         Ok(val)
     }
 
-    async fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        //let snap = self.0.snapshot();
-        //Ok(self.0.snapshot().get(key)?)
-        todo!()
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        Ok(self.0.snapshot().get(key)?)
     }
 
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
@@ -128,7 +126,7 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
         panic!("Cannot insert into a read only transaction");
     }
 
-    async fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.get(key)?)
     }
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -71,8 +71,10 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
         Ok(val)
     }
 
-    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        Ok(self.0.snapshot().get(key)?)
+    async fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        //let snap = self.0.snapshot();
+        //Ok(self.0.snapshot().get(key)?)
+        todo!()
     }
 
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
@@ -126,7 +128,7 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
         panic!("Cannot insert into a read only transaction");
     }
 
-    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.get(key)?)
     }
 

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -9,7 +9,7 @@ pub struct FedimintInterconnect<'a> {
     pub fedimint: &'a FedimintConsensus,
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
     async fn call(
         &self,
@@ -25,7 +25,8 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
                     .find(|endpoint| endpoint.path == path)
                     .ok_or_else(|| ApiError::not_found(String::from("Method not found")))?;
 
-                return (endpoint.handler)(module, data).await;
+                return (endpoint.handler)(module, self.fedimint.database_transaction(), data)
+                    .await;
             }
         }
         panic!("Module not registered: {}", module_name);

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -318,7 +318,7 @@ impl FedimintConsensus {
             dbtx.commit_tx().await.expect("DB Error");
         }
 
-        let audit = self.audit();
+        let audit = self.audit().await;
         if audit.sum().milli_sat < 0 {
             panic!(
                 "Balance sheet of the fed has gone negative, this should never happen! {}",
@@ -406,6 +406,7 @@ impl FedimintConsensus {
 
         let drop_peers = dbtx
             .find_by_prefix(&DropPeerKeyPrefix)
+            .await
             .map(|res| {
                 let key = res.expect("DB error").0;
                 key.0
@@ -414,6 +415,7 @@ impl FedimintConsensus {
 
         let mut items: Vec<ConsensusItem> = dbtx
             .find_by_prefix(&ProposedTransactionKeyPrefix)
+            .await
             .map(|res| {
                 let (_key, value) = res.expect("DB error");
                 ConsensusItem::Transaction(value)
@@ -566,11 +568,11 @@ impl FedimintConsensus {
         VerificationCaches { caches }
     }
 
-    pub fn audit(&self) -> Audit {
-        let dbtx = self.database_transaction();
+    pub async fn audit(&self) -> Audit {
+        let mut dbtx = self.database_transaction();
         let mut audit = Audit::default();
         for module in self.modules.values() {
-            module.audit(&dbtx, &mut audit)
+            module.audit(&mut dbtx, &mut audit).await
         }
         audit
     }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -392,24 +392,13 @@ impl FedimintConsensus {
             .expect("DB Error");
     }
 
-    pub async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
-        /*
-        let proposal_futures = self
-            .modules
-            .iter()
-            .map(|(_, module)| {
-                //let mut dbtx = self.database_transaction();
-                module.await_consensus_proposal(dbtx)
-            })
-            .collect::<Vec<_>>();
-
-        select_all(proposal_futures).await;
-        */
+    pub async fn await_consensus_proposal(&self) {
         let mut futures = Vec::new();
         for (_, module) in self.modules.iter() {
-            //let mut dbtx = self.database_transaction();
+            let dbtx = self.database_transaction();
             futures.push(module.await_consensus_proposal(dbtx));
         }
+        select_all(futures).await;
     }
 
     pub async fn get_consensus_proposal(&self) -> ConsensusProposal {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -392,24 +392,24 @@ impl FedimintConsensus {
             .expect("DB Error");
     }
 
-    pub async fn await_consensus_proposal(&self) {
-        // TODO: FIXME
+    pub async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
         /*
-        let mut proposal_futures = Vec::new();
-        for (_, module) in self.modules.iter() {
-            proposal_futures.push(module.await_consensus_proposal(&mut dbtx));
-        }
-        let mut dbtx = self.database_transaction();
         let proposal_futures = self
             .modules
             .iter()
             .map(|(_, module)| {
-                module.await_consensus_proposal(&mut dbtx)
+                //let mut dbtx = self.database_transaction();
+                module.await_consensus_proposal(dbtx)
             })
             .collect::<Vec<_>>();
 
         select_all(proposal_futures).await;
-            */
+        */
+        let mut futures = Vec::new();
+        for (_, module) in self.modules.iter() {
+            //let mut dbtx = self.database_transaction();
+            futures.push(module.await_consensus_proposal(dbtx));
+        }
     }
 
     pub async fn get_consensus_proposal(&self) -> ConsensusProposal {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -141,7 +141,11 @@ impl FedimintConsensus {
         transaction: Transaction,
     ) -> Result<(), TransactionSubmissionError> {
         // we already processed the transaction before the request was received
-        if self.transaction_status(transaction.tx_hash()).is_some() {
+        if self
+            .transaction_status(transaction.tx_hash())
+            .await
+            .is_some()
+        {
             return Ok(());
         }
 
@@ -179,7 +183,8 @@ impl FedimintConsensus {
                 .get(&output.module_key())
                 .expect("Parsing the input should fail if the module doesn't exist");
             let amount = module
-                .validate_output(&dbtx, output)
+                .validate_output(&mut dbtx, output)
+                .await
                 .map_err(|e| TransactionSubmissionError::ModuleError(tx_hash, e))?;
             funding_verifier.add_output(amount);
         }
@@ -322,18 +327,20 @@ impl FedimintConsensus {
         }
     }
 
-    pub fn get_last_epoch(&self) -> Option<u64> {
+    pub async fn get_last_epoch(&self) -> Option<u64> {
         self.db
             .begin_transaction(self.decoders())
             .get_value(&LastEpochKey)
+            .await
             .expect("db query must not fail")
             .map(|e| e.0)
     }
 
-    pub fn epoch_history(&self, epoch: u64) -> Option<EpochHistory> {
+    pub async fn epoch_history(&self, epoch: u64) -> Option<EpochHistory> {
         self.db
             .begin_transaction(self.decoders())
             .get_value(&EpochHistoryKey(epoch))
+            .await
             .unwrap()
     }
 
@@ -349,6 +356,7 @@ impl FedimintConsensus {
             .db
             .begin_transaction(self.decoders())
             .get_value(&prev_epoch_key)
+            .await
             .expect("DB error");
 
         let current = EpochHistory::new(outcome.epoch, outcome.contributions, &maybe_prev_epoch);
@@ -385,18 +393,27 @@ impl FedimintConsensus {
     }
 
     pub async fn await_consensus_proposal(&self) {
-        let dbtx = self.database_transaction();
+        // TODO: FIXME
+        /*
+        let mut proposal_futures = Vec::new();
+        for (_, module) in self.modules.iter() {
+            proposal_futures.push(module.await_consensus_proposal(&mut dbtx));
+        }
+        let mut dbtx = self.database_transaction();
         let proposal_futures = self
             .modules
             .iter()
-            .map(|(_, module)| module.await_consensus_proposal(&dbtx))
+            .map(|(_, module)| {
+                module.await_consensus_proposal(&mut dbtx)
+            })
             .collect::<Vec<_>>();
 
         select_all(proposal_futures).await;
+            */
     }
 
     pub async fn get_consensus_proposal(&self) -> ConsensusProposal {
-        let dbtx = self.database_transaction();
+        let mut dbtx = self.database_transaction();
 
         let drop_peers = dbtx
             .find_by_prefix(&DropPeerKeyPrefix)
@@ -417,15 +434,15 @@ impl FedimintConsensus {
         for module in self.modules.values() {
             items.extend(
                 module
-                    .consensus_proposal(&dbtx)
+                    .consensus_proposal(&mut dbtx)
                     .await
                     .into_iter()
                     .map(ConsensusItem::Module),
             );
         }
 
-        if let Some(epoch) = dbtx.get_value(&LastEpochKey).unwrap() {
-            let last_epoch = dbtx.get_value(&epoch).unwrap().unwrap();
+        if let Some(epoch) = dbtx.get_value(&LastEpochKey).await.unwrap() {
+            let last_epoch = dbtx.get_value(&epoch).await.unwrap().unwrap();
             let sig = self.cfg.epoch_sks.0.sign(last_epoch.hash);
             let item = ConsensusItem::EpochInfo(EpochSignatureShare(sig));
             items.push(item);
@@ -486,36 +503,35 @@ impl FedimintConsensus {
         Ok(())
     }
 
-    pub fn transaction_status(
+    pub async fn transaction_status(
         &self,
         txid: TransactionId,
     ) -> Option<crate::outcome::TransactionStatus> {
         let mut dbtx = self.database_transaction();
 
-        let accepted: Option<AcceptedTransaction> = dbtx
+        let accepted: Option<AcceptedTransaction> = self
+            .db
+            .begin_transaction(self.decoders())
             .get_value(&AcceptedTransactionKey(txid))
+            .await
             .expect("DB error");
 
         if let Some(accepted_tx) = accepted {
-            let outputs = accepted_tx
-                .transaction
-                .outputs
-                .iter()
-                .enumerate()
-                .map(|(out_idx, output)| {
-                    let outpoint = OutPoint {
-                        txid,
-                        out_idx: out_idx as u64,
-                    };
-                    let outcome = self
-                        .modules
-                        .get(&output.module_key())
-                        .expect("Module exists because parsing succeeded")
-                        .output_status(&mut dbtx, outpoint)
-                        .expect("the transaction was processed, so should be known");
-                    (&outcome).into()
-                })
-                .collect();
+            let mut outputs = Vec::new();
+            for (out_idx, output) in accepted_tx.transaction.outputs.iter().enumerate() {
+                let outpoint = OutPoint {
+                    txid,
+                    out_idx: out_idx as u64,
+                };
+                let outcome = self
+                    .modules
+                    .get(&output.module_key())
+                    .expect("Module exists because parsing succeeded")
+                    .output_status(&mut dbtx, outpoint)
+                    .await
+                    .expect("the transaction was processed, so should be known");
+                outputs.push((&outcome).into())
+            }
 
             return Some(crate::outcome::TransactionStatus::Accepted {
                 epoch: accepted_tx.epoch,
@@ -527,6 +543,7 @@ impl FedimintConsensus {
             .db
             .begin_transaction(self.decoders())
             .get_value(&RejectedTransactionKey(txid))
+            .await
             .expect("DB error");
 
         if let Some(message) = rejected {

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -199,6 +199,7 @@ impl FedimintServer {
             .db
             .begin_transaction(self.consensus.decoders())
             .get_value(&LastEpochKey)
+            .await
             .expect("DB error");
         let last_saved_epoch = last_saved_response.map(|e| e.0);
 
@@ -236,16 +237,20 @@ impl FedimintServer {
             .db
             .begin_transaction(self.consensus.decoders())
             .get_value(&LastEpochKey)
+            .await
             .unwrap();
 
         let download_epoch_num = saved_epoch_key.map(|e| e.0 + 1).unwrap_or(0);
-        let mut prev_epoch = saved_epoch_key.and_then(|e| {
-            self.consensus
+        let mut prev_epoch = None;
+        if saved_epoch_key.is_some() {
+            prev_epoch = self
+                .consensus
                 .db
                 .begin_transaction(self.consensus.decoders())
-                .get_value(&e)
+                .get_value(&saved_epoch_key.unwrap())
+                .await
                 .unwrap()
-        });
+        }
 
         for epoch_num in download_epoch_num..=last_outcome.epoch {
             let current_epoch = if epoch_num == last_outcome.epoch {
@@ -298,7 +303,8 @@ impl FedimintServer {
             .consensus
             .db
             .begin_transaction(self.consensus.decoders())
-            .get_value(&LastEpochKey);
+            .get_value(&LastEpochKey)
+            .await;
         let next_epoch = last_saved.expect("DB error").map(|e| e.0 + 1).unwrap_or(0);
         consensus_peers.insert(self.cfg.identity, next_epoch);
 
@@ -349,7 +355,9 @@ impl FedimintServer {
                 }
                 Ok(Ok((peer, EpochMessage::RejoinRequest))) => {
                     let msg = EpochMessage::Rejoin(
-                        self.last_signed_epoch(next_epoch).map(|eh| (&eh).into()),
+                        self.last_signed_epoch(next_epoch)
+                            .await
+                            .map(|eh| (&eh).into()),
                         next_epoch,
                     );
                     self.connections.send(&[peer], msg).await?;
@@ -467,7 +475,7 @@ impl FedimintServer {
         match msg {
             (_, EpochMessage::Rejoin(_, _)) => Ok(vec![]),
             (peer, EpochMessage::RejoinRequest) => {
-                let last_signed = self.last_signed_epoch(self.hbbft.epoch());
+                let last_signed = self.last_signed_epoch(self.hbbft.epoch()).await;
 
                 let msg = EpochMessage::Rejoin(
                     last_signed.map(|eh| (&eh).into()),
@@ -510,13 +518,14 @@ impl FedimintServer {
     }
 
     /// Searches back in saved epoch history for the last signed epoch
-    fn last_signed_epoch(&self, mut epoch: u64) -> Option<EpochHistory> {
+    async fn last_signed_epoch(&self, mut epoch: u64) -> Option<EpochHistory> {
         loop {
             let query = self
                 .consensus
                 .db
                 .begin_transaction(self.consensus.decoders())
-                .get_value(&EpochHistoryKey(epoch));
+                .get_value(&EpochHistoryKey(epoch))
+                .await;
             match query.expect("DB error") {
                 Some(result) if result.signature.is_some() => break Some(result),
                 _ if epoch == 0 => break None,

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -214,7 +214,7 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
             async |fedimint: &FedimintConsensus, _dbtx, tx_hash: TransactionId| -> TransactionStatus {
                 debug!(transaction = %tx_hash, "Recieved request");
 
-                let tx_status = fedimint.transaction_status(tx_hash).ok_or_else(|| ApiError::not_found(String::from("transaction not found")))?;
+                let tx_status = fedimint.transaction_status(tx_hash).await.ok_or_else(|| ApiError::not_found(String::from("transaction not found")))?;
 
                 debug!(transaction = %tx_hash, "Sending outcome");
                 Ok(tx_status)
@@ -223,14 +223,14 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
         api_endpoint! {
             "/fetch_epoch_history",
             async |fedimint: &FedimintConsensus, _dbtx, epoch: u64| -> SerdeEpochHistory {
-                let epoch = fedimint.epoch_history(epoch).ok_or_else(|| ApiError::not_found(String::from("epoch not found")))?;
+                let epoch = fedimint.epoch_history(epoch).await.ok_or_else(|| ApiError::not_found(String::from("epoch not found")))?;
                 Ok((&epoch).into())
             }
         },
         api_endpoint! {
             "/epoch",
             async |fedimint: &FedimintConsensus, _dbtx, _v: ()| -> u64 {
-                Ok(fedimint.get_last_epoch().ok_or_else(|| ApiError::not_found(String::from("epoch not found")))?)
+                Ok(fedimint.get_last_epoch().await.ok_or_else(|| ApiError::not_found(String::from("epoch not found")))?)
             }
         },
         api_endpoint! {

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -123,7 +123,7 @@ impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
         ret
     }
 
-    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_> {
+    async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixIter<'_> {
         let mut val = BTreeMap::new();
         // First iterate through pending writes to support "read our own writes"
         for op in &self.operations {

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -70,7 +70,7 @@ impl IDatabase for SledDb {
 #[async_trait]
 impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
     async fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
-        let val = self.raw_get_bytes(key);
+        let val = self.raw_get_bytes(key).await;
         self.operations
             .push(DatabaseOperation::Insert(DatabaseInsertOperation {
                 key: key.to_vec(),
@@ -80,7 +80,7 @@ impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
         val
     }
 
-    fn raw_get_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         let mut val: Option<Vec<u8>> = None;
         let mut deleted = false;
         // First iterate through pending writes to support "read our own writes"
@@ -114,7 +114,7 @@ impl<'a> IDatabaseTransaction<'a> for SledTransaction<'a> {
     }
 
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        let ret = self.raw_get_bytes(key);
+        let ret = self.raw_get_bytes(key).await;
         self.operations
             .push(DatabaseOperation::Delete(DatabaseDeleteOperation {
                 key: key.to_vec(),

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -119,13 +119,14 @@ where
         <Module as ServerModulePlugin>::Input: Send + Sync,
     {
         let fake_ic = FakeInterconnect::new_block_height_responder(self.block_height.clone());
+        let decoders = self.decoders();
 
         // TODO: only include some of the proposals for realism
         let mut consensus = vec![];
-        for (id, member, _db) in &mut self.members {
+        for (id, member, db) in &mut self.members {
             consensus.extend(
                 member
-                    .consensus_proposal()
+                    .consensus_proposal(&db.begin_transaction(decoders.clone()))
                     .await
                     .into_iter()
                     .map(|ci| (*id, ci)),
@@ -171,11 +172,9 @@ where
         // in terms of outcomes. This may change later once end_consensus_epoch is pulled out of the
         // main consensus loop into another thread to optimize latency. This test will probably fail
         // then.
-        assert_all_equal(
-            self.members
-                .iter()
-                .map(|(_, member, _)| member.output_status(out_point)),
-        )
+        assert_all_equal(self.members.iter().map(|(_, member, db)| {
+            member.output_status(&mut db.begin_transaction(self.decoders()), out_point)
+        }))
     }
 
     pub async fn patch_dbs<U>(&mut self, update: U)

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -21,7 +21,7 @@ pub mod btc;
 
 #[derive(Debug)]
 pub struct FakeFed<Module> {
-    members: Vec<(PeerId, Module, Database)>,
+    pub members: Vec<(PeerId, Module, Database)>,
     client_cfg: ClientModuleConfig,
     block_height: Arc<std::sync::atomic::AtomicU64>,
 }
@@ -104,13 +104,17 @@ where
         assert_all_equal_result(results.into_iter())
     }
 
-    pub fn verify_output(&self, output: &Module::Output) -> bool {
-        let results = self.members.iter().map(|(_, member, db)| {
-            member
-                .validate_output(&db.begin_transaction(self.decoders()), output)
-                .is_err()
-        });
-        assert_all_equal(results)
+    pub async fn verify_output(&self, output: &Module::Output) -> bool {
+        let mut results = Vec::new();
+        for (_, member, db) in self.members.iter() {
+            results.push(
+                member
+                    .validate_output(&mut db.begin_transaction(self.decoders()), output)
+                    .await
+                    .is_err(),
+            );
+        }
+        assert_all_equal(results.into_iter())
     }
 
     fn decoders(&self) -> ModuleRegistry<Decoder> {
@@ -134,7 +138,7 @@ where
         for (id, member, db) in &mut self.members {
             consensus.extend(
                 member
-                    .consensus_proposal(&db.begin_transaction(decoders.clone()))
+                    .consensus_proposal(&mut db.begin_transaction(decoders.clone()))
                     .await
                     .into_iter()
                     .map(|ci| (*id, ci)),
@@ -175,14 +179,20 @@ where
         }
     }
 
-    pub fn output_outcome(&self, out_point: OutPoint) -> Option<Module::OutputOutcome> {
+    pub async fn output_outcome(&self, out_point: OutPoint) -> Option<Module::OutputOutcome> {
         // Since every member is in the same epoch they should have the same internal state, even
         // in terms of outcomes. This may change later once end_consensus_epoch is pulled out of the
         // main consensus loop into another thread to optimize latency. This test will probably fail
         // then.
-        assert_all_equal(self.members.iter().map(|(_, member, db)| {
-            member.output_status(&mut db.begin_transaction(self.decoders()), out_point)
-        }))
+        let mut results = Vec::new();
+        for (_, member, db) in self.members.iter() {
+            results.push(
+                member
+                    .output_status(&mut db.begin_transaction(self.decoders()), out_point)
+                    .await,
+            );
+        }
+        assert_all_equal(results.into_iter())
     }
 
     pub async fn patch_dbs<U>(&mut self, update: U)
@@ -247,7 +257,7 @@ where
     }
 }
 
-fn assert_all_equal<I>(mut iter: I) -> I::Item
+pub fn assert_all_equal<I>(mut iter: I) -> I::Item
 where
     I: Iterator,
     I::Item: Eq + Debug,

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -96,11 +96,7 @@ async fn main() -> anyhow::Result<()> {
 
     task_group.install_kill_handler();
 
-    let mint = fedimint_core::modules::mint::Mint::new(
-        cfg.get_module_config("mint")?,
-        db.clone(),
-        all_decoders(),
-    );
+    let mint = fedimint_core::modules::mint::Mint::new(cfg.get_module_config("mint")?);
 
     let wallet = Wallet::new_with_bitcoind(
         cfg.get_module_config("wallet")?,

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
     .await
     .expect("Couldn't create wallet");
 
-    let ln = LightningModule::new(cfg.get_module_config("ln")?, db.clone(), all_decoders());
+    let ln = LightningModule::new(cfg.get_module_config("ln")?);
 
     let mut consensus = FedimintConsensus::new(cfg.clone(), db);
     consensus.register_module(mint.into());

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -234,6 +234,6 @@ impl GatewayActor {
     pub async fn get_balance(&self) -> Result<Amount> {
         self.fetch_all_coins().await;
 
-        Ok(self.client.coins().total_amount())
+        Ok(self.client.coins().await.total_amount())
     }
 }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -535,13 +535,15 @@ impl FederationTest {
     }
 
     /// Submit a fedimint transaction to all federation servers
-    pub fn submit_transaction(&self, transaction: fedimint_server::transaction::Transaction) {
+    #[allow(clippy::await_holding_refcell_ref)] // TODO: fix, it's just a test
+    pub async fn submit_transaction(&self, transaction: fedimint_server::transaction::Transaction) {
         for server in &self.servers {
             server
                 .borrow_mut()
                 .fedimint
                 .consensus
                 .submit_transaction(transaction.clone())
+                .await
                 .unwrap();
         }
     }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -910,11 +910,7 @@ impl FederationTest {
             .await
             .expect("Couldn't create wallet");
 
-            let ln = LightningModule::new(
-                cfg.get_module_config("ln").unwrap(),
-                db.clone(),
-                all_decoders(),
-            );
+            let ln = LightningModule::new(cfg.get_module_config("ln").unwrap());
 
             let mut consensus = FedimintConsensus::new(cfg.clone(), db.clone());
             consensus.register_module(mint.into());

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -453,9 +453,10 @@ impl<T: AsRef<ClientConfig> + Clone> UserTest<T> {
     }
 
     /// Returns the amount denominations of all coins from lowest to highest
-    pub fn coin_amounts(&self) -> Vec<Amount> {
+    pub async fn coin_amounts(&self) -> Vec<Amount> {
         self.client
             .coins()
+            .await
             .iter_tiers()
             .flat_map(|(a, c)| repeat(*a).take(c.len()))
             .sorted()
@@ -463,17 +464,17 @@ impl<T: AsRef<ClientConfig> + Clone> UserTest<T> {
     }
 
     /// Returns sum total of all coins
-    pub fn total_coins(&self) -> Amount {
-        self.client.coins().total_amount()
+    pub async fn total_coins(&self) -> Amount {
+        self.client.coins().await.total_amount()
     }
 
     pub async fn assert_total_coins(&self, amount: Amount) {
         self.client.fetch_all_coins().await;
-        assert_eq!(self.total_coins(), amount);
+        assert_eq!(self.total_coins().await, amount);
     }
     pub async fn assert_coin_amounts(&self, amounts: Vec<Amount>) {
         self.client.fetch_all_coins().await;
-        assert_eq!(self.coin_amounts(), amounts);
+        assert_eq!(self.coin_amounts().await, amounts);
     }
 }
 
@@ -576,7 +577,12 @@ impl FederationTest {
         user: &UserTest<C>,
         amount: Amount,
     ) -> TieredMulti<SpendableNote> {
-        let coins = user.client.mint_client().select_coins(amount).unwrap();
+        let coins = user
+            .client
+            .mint_client()
+            .select_coins(amount)
+            .await
+            .unwrap();
         if coins.total_amount() == amount {
             return user.client.spend_ecash(amount, rng()).await.unwrap();
         }
@@ -761,7 +767,7 @@ impl FederationTest {
             {
                 maybe_cancelled?;
             }
-            self.update_last_consensus();
+            self.update_last_consensus().await;
         }
         Ok(())
     }
@@ -822,7 +828,7 @@ impl FederationTest {
 
             res.0?;
         }
-        self.update_last_consensus();
+        self.update_last_consensus().await;
         Ok(())
     }
 
@@ -860,7 +866,7 @@ impl FederationTest {
         Ok(())
     }
 
-    fn update_last_consensus(&self) {
+    async fn update_last_consensus(&self) {
         let new_consensus = self
             .servers
             .iter()
@@ -875,7 +881,8 @@ impl FederationTest {
             .borrow()
             .fedimint
             .consensus
-            .audit();
+            .audit()
+            .await;
 
         if last_consensus.is_empty() || last_consensus.epoch < new_consensus.epoch {
             info!("{}", consensus::debug::epoch_message(&new_consensus));

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -894,11 +894,7 @@ impl FederationTest {
             let db = database_gen();
             let mut task_group = task_group.clone();
 
-            let mint = Mint::new(
-                cfg.get_module_config("mint").unwrap(),
-                db.clone(),
-                all_decoders(),
-            );
+            let mint = Mint::new(cfg.get_module_config("mint").unwrap());
 
             let wallet = Wallet::new_with_bitcoind(
                 cfg.get_module_config("wallet").unwrap(),

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -628,6 +628,7 @@ impl FederationTest {
             .client
             .wallet_client()
             .create_pegin_input(txout_proof, btc_transaction)
+            .await
             .unwrap();
 
         for server in &self.servers {
@@ -732,11 +733,13 @@ impl FederationTest {
     /// If the epoch has empty proposals (no new information) then panic
     pub async fn run_consensus_epochs(&self, epochs: usize) {
         for _ in 0..(epochs) {
-            if self
-                .servers
-                .iter()
-                .all(|s| Self::empty_proposal(&s.borrow().fedimint))
-            {
+            let mut empty_proposal = true;
+            for serv in self.servers.iter() {
+                empty_proposal =
+                    empty_proposal && Self::empty_proposal(&serv.borrow().fedimint).await;
+            }
+
+            if empty_proposal {
                 panic!("Empty proposals, fed might wait forever");
             }
 
@@ -764,7 +767,7 @@ impl FederationTest {
     }
 
     /// Returns true if the fed would produce an empty epoch proposal (no new information)
-    fn empty_proposal(server: &FedimintServer) -> bool {
+    async fn empty_proposal(server: &FedimintServer) -> bool {
         let height = server
             .consensus
             .modules
@@ -773,7 +776,8 @@ impl FederationTest {
             .as_any()
             .downcast_ref::<Wallet>()
             .unwrap()
-            .consensus_height(&server.consensus.db.begin_transaction(all_decoders()))
+            .consensus_height(&mut server.consensus.db.begin_transaction(all_decoders()))
+            .await
             .unwrap_or(0);
         let proposal = block_on(server.consensus.get_consensus_proposal());
 

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -196,8 +196,8 @@ async fn ecash_can_be_exchanged_directly_between_users() -> Result<()> {
     ));
 
     fed.mine_and_mint(&user_send, &*bitcoin, sats(5000)).await;
-    assert_eq!(user_send.total_coins(), sats(5000));
-    assert_eq!(user_receive.total_coins(), sats(0));
+    assert_eq!(user_send.total_coins().await, sats(5000));
+    assert_eq!(user_receive.total_coins().await, sats(0));
 
     let ecash = fed.spend_ecash(&user_send, sats(3500)).await;
     user_receive.client.reissue(ecash, rng()).await.unwrap();
@@ -237,7 +237,10 @@ async fn ecash_cannot_double_spent_with_different_nodes() -> Result<()> {
     let res2 = user2.client.fetch_coins(out2).await;
     let res3 = user3.client.fetch_coins(out3).await;
     assert!(res2.is_err() || res3.is_err()); //no double spend
-    assert_eq!(user2.total_coins() + user3.total_coins(), sats(2000));
+    assert_eq!(
+        user2.total_coins().await + user3.total_coins().await,
+        sats(2000)
+    );
     assert_eq!(fed.max_balance_sheet(), 0);
 
     task_group.shutdown_join_all().await
@@ -264,7 +267,7 @@ async fn ecash_in_wallet_can_sent_through_a_tx() -> Result<()> {
 
     fed.mine_and_mint(&user_send, &*bitcoin, sats(1100)).await;
     assert_eq!(
-        user_send.coin_amounts(),
+        user_send.coin_amounts().await,
         vec![sats(100), sats(500), sats(500)]
     );
 
@@ -726,8 +729,8 @@ async fn receive_lightning_payment_valid_preimage() -> Result<()> {
     } = fixtures(2, &[sats(1000), sats(100)]).await?;
     fed.mine_and_mint(&gateway.user, &*bitcoin, starting_balance)
         .await;
-    assert_eq!(user.total_coins(), sats(0));
-    assert_eq!(gateway.user.total_coins(), starting_balance);
+    assert_eq!(user.total_coins().await, sats(0));
+    assert_eq!(gateway.user.total_coins().await, starting_balance);
 
     // Create lightning invoice whose associated "offer" is accepted by federation consensus
     let invoice = tokio::join!(
@@ -802,8 +805,8 @@ async fn receive_lightning_payment_invalid_preimage() -> Result<()> {
     } = fixtures(2, &[sats(1000), sats(100)]).await?;
     fed.mine_and_mint(&gateway.user, &*bitcoin, starting_balance)
         .await;
-    assert_eq!(user.total_coins(), sats(0));
-    assert_eq!(gateway.user.total_coins(), starting_balance);
+    assert_eq!(user.total_coins().await, sats(0));
+    assert_eq!(gateway.user.total_coins().await, starting_balance);
 
     // Manually construct offer where sha256(preimage) != hash
     let kp = KeyPair::new(&secp(), &mut rng());
@@ -972,7 +975,7 @@ async fn lightning_gateway_can_abort_payment_to_return_user_funds() -> Result<()
         .unwrap();
     fed.run_consensus_epochs(2).await;
     user.client.fetch_coins(outpoint).await.unwrap();
-    assert_eq!(user.total_coins(), sats(1010));
+    assert_eq!(user.total_coins().await, sats(1010));
     assert_eq!(fed.max_balance_sheet(), 0);
 
     task_group.shutdown_join_all().await

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -837,7 +837,7 @@ async fn receive_lightning_payment_invalid_preimage() -> Result<()> {
             rng(),
         )
         .await;
-    fed.submit_transaction(tx.into_type_erased());
+    fed.submit_transaction(tx.into_type_erased()).await;
     fed.run_consensus_epochs(1).await; // process offer
 
     // Gateway escrows ecash to trigger preimage decryption by the federation

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -271,8 +271,8 @@ impl ServerModulePlugin for LightningModule {
         LightningModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
-        if self.consensus_proposal(dbtx).await.is_empty() {
+    async fn await_consensus_proposal(&self, mut dbtx: DatabaseTransaction<'_>) {
+        if self.consensus_proposal(&mut dbtx).await.is_empty() {
             std::future::pending().await
         }
     }

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -274,13 +274,16 @@ impl ServerModulePlugin for LightningModule {
         LightningModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self) {
-        if self.consensus_proposal().await.is_empty() {
+    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
+        if self.consensus_proposal(dbtx).await.is_empty() {
             std::future::pending().await
         }
     }
 
-    async fn consensus_proposal(&self) -> Vec<Self::ConsensusItem> {
+    async fn consensus_proposal(
+        &self,
+        _dbtx: &DatabaseTransaction<'_>,
+    ) -> Vec<Self::ConsensusItem> {
         self.non_consensus_db
             .begin_transaction(self.decoders.clone())
             .find_by_prefix(&ProposeDecryptionShareKeyPrefix)
@@ -746,14 +749,18 @@ impl ServerModulePlugin for LightningModule {
         bad_peers
     }
 
-    fn output_status(&self, out_point: OutPoint) -> Option<Self::OutputOutcome> {
+    fn output_status(
+        &self,
+        _dbtx: &mut DatabaseTransaction<'_>,
+        out_point: OutPoint,
+    ) -> Option<Self::OutputOutcome> {
         self.non_consensus_db
             .begin_transaction(self.decoders.clone())
             .get_value(&ContractUpdateKey(out_point))
             .expect("DB error")
     }
 
-    fn audit(&self, audit: &mut Audit) {
+    fn audit(&self, _dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
         audit.add_items(
             &self
                 .non_consensus_db

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -27,9 +27,9 @@ use fedimint_api::config::{
     ClientModuleConfig, DkgPeerMsg, DkgRunner, ModuleConfigGenParams, ServerModuleConfig,
     TypedServerModuleConfig,
 };
-use fedimint_api::core::{Decoder, ModuleKey, MODULE_KEY_LN};
-use fedimint_api::db::{Database, DatabaseTransaction};
-use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
+use fedimint_api::core::{ModuleKey, MODULE_KEY_LN};
+use fedimint_api::db::DatabaseTransaction;
+use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
@@ -83,9 +83,6 @@ use crate::db::{
 #[derive(Debug)]
 pub struct LightningModule {
     cfg: LightningModuleConfig,
-    // TODO: remove DB all together
-    non_consensus_db: Database,
-    decoders: ModuleRegistry<Decoder>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
@@ -280,13 +277,8 @@ impl ServerModulePlugin for LightningModule {
         }
     }
 
-    async fn consensus_proposal(
-        &self,
-        _dbtx: &DatabaseTransaction<'_>,
-    ) -> Vec<Self::ConsensusItem> {
-        self.non_consensus_db
-            .begin_transaction(self.decoders.clone())
-            .find_by_prefix(&ProposeDecryptionShareKeyPrefix)
+    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<Self::ConsensusItem> {
+        dbtx.find_by_prefix(&ProposeDecryptionShareKeyPrefix)
             .map(|res| {
                 let (ProposeDecryptionShareKey(contract_id), share) = res.expect("DB error");
                 LightningConsensusItem { contract_id, share }
@@ -753,23 +745,17 @@ impl ServerModulePlugin for LightningModule {
 
     fn output_status(
         &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<Self::OutputOutcome> {
-        self.non_consensus_db
-            .begin_transaction(self.decoders.clone())
-            .get_value(&ContractUpdateKey(out_point))
+        dbtx.get_value(&ContractUpdateKey(out_point))
             .expect("DB error")
     }
 
-    fn audit(&self, _dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
-        audit.add_items(
-            &self
-                .non_consensus_db
-                .begin_transaction(self.decoders.clone()),
-            &ContractKeyPrefix,
-            |_, v| -(v.amount.milli_sat as i64),
-        );
+    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
+        audit.add_items(dbtx, &ContractKeyPrefix, |_, v| {
+            -(v.amount.milli_sat as i64)
+        });
     }
 
     fn api_base_name(&self) -> &'static str {
@@ -780,23 +766,23 @@ impl ServerModulePlugin for LightningModule {
         vec![
             api_endpoint! {
                 "/account",
-                async |module: &LightningModule, _dbtx, contract_id: ContractId| -> ContractAccount {
+                async |module: &LightningModule, dbtx, contract_id: ContractId| -> ContractAccount {
                     module
-                        .get_contract_account(&module.non_consensus_db.begin_transaction(module.decoders.clone()), contract_id)
+                        .get_contract_account(&dbtx, contract_id)
                         .ok_or_else(|| ApiError::not_found(String::from("Contract not found")))
                 }
             },
             api_endpoint! {
                 "/offers",
-                async |module: &LightningModule, _dbtx, _params: ()| -> Vec<IncomingContractOffer> {
-                    Ok(module.get_offers(&module.non_consensus_db.begin_transaction(module.decoders.clone())))
+                async |module: &LightningModule, dbtx, _params: ()| -> Vec<IncomingContractOffer> {
+                    Ok(module.get_offers(&dbtx))
                 }
             },
             api_endpoint! {
                 "/offer",
-                async |module: &LightningModule, _dbtx, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
+                async |module: &LightningModule, dbtx, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
                     let offer = module
-                        .get_offer(&module.non_consensus_db.begin_transaction(module.decoders.clone()), payment_hash)
+                        .get_offer(&dbtx, payment_hash)
                         .ok_or_else(|| ApiError::not_found(String::from("Offer not found")))?;
 
                     debug!(%payment_hash, "Sending offer info");
@@ -805,16 +791,15 @@ impl ServerModulePlugin for LightningModule {
             },
             api_endpoint! {
                 "/list_gateways",
-                async |module: &LightningModule, _dbtx, _v: ()| -> Vec<LightningGateway> {
-                    Ok(module.list_gateways(&module.non_consensus_db.begin_transaction(module.decoders.clone())))
+                async |module: &LightningModule, dbtx, _v: ()| -> Vec<LightningGateway> {
+                    Ok(module.list_gateways(&dbtx))
                 }
             },
             api_endpoint! {
                 "/register_gateway",
-                async |module: &LightningModule, _dbtx, gateway: LightningGateway| -> () {
-                    futures::executor::block_on( async {
-                       module.register_gateway(gateway).await;
-                    });
+                async |module: &LightningModule, dbtx, gateway: LightningGateway| -> () {
+                    module.register_gateway(&mut dbtx, gateway).await;
+                    dbtx.commit_tx().await.expect("DB Error");
                     Ok(())
                 }
             },
@@ -823,16 +808,8 @@ impl ServerModulePlugin for LightningModule {
 }
 
 impl LightningModule {
-    pub fn new(
-        cfg: LightningModuleConfig,
-        db: Database,
-        decoders: ModuleRegistry<Decoder>,
-    ) -> Self {
-        LightningModule {
-            cfg,
-            non_consensus_db: db,
-            decoders,
-        }
+    pub fn new(cfg: LightningModuleConfig) -> Self {
+        LightningModule { cfg }
     }
 
     fn validate_decryption_share(
@@ -875,14 +852,14 @@ impl LightningModule {
             .collect()
     }
 
-    pub async fn register_gateway(&self, gateway: LightningGateway) {
-        let mut dbtx = self
-            .non_consensus_db
-            .begin_transaction(self.decoders.clone());
+    pub async fn register_gateway(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        gateway: LightningGateway,
+    ) {
         dbtx.insert_entry(&LightningGatewayKey(gateway.node_pub_key), &gateway)
             .await
             .expect("DB error");
-        dbtx.commit_tx().await.expect("DB Error");
     }
 }
 

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -282,6 +282,7 @@ impl ServerModulePlugin for LightningModule {
         dbtx: &mut DatabaseTransaction<'_>,
     ) -> Vec<Self::ConsensusItem> {
         dbtx.find_by_prefix(&ProposeDecryptionShareKeyPrefix)
+            .await
             .map(|res| {
                 let (ProposeDecryptionShareKey(contract_id), share) = res.expect("DB error");
                 LightningConsensusItem { contract_id, share }
@@ -598,6 +599,7 @@ impl ServerModulePlugin for LightningModule {
         // Decrypt preimages
         let preimage_decryption_shares = dbtx
             .find_by_prefix(&AgreedDecryptionShareKeyPrefix)
+            .await
             .map(|res| {
                 let (key, value) = res.expect("DB error");
                 (key.0, (key.1, value))
@@ -766,10 +768,12 @@ impl ServerModulePlugin for LightningModule {
             .expect("DB error")
     }
 
-    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
-        audit.add_items(dbtx, &ContractKeyPrefix, |_, v| {
-            -(v.amount.milli_sat as i64)
-        });
+    async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit) {
+        audit
+            .add_items(dbtx, &ContractKeyPrefix, |_, v| {
+                -(v.amount.milli_sat as i64)
+            })
+            .await;
     }
 
     fn api_base_name(&self) -> &'static str {
@@ -790,7 +794,7 @@ impl ServerModulePlugin for LightningModule {
             api_endpoint! {
                 "/offers",
                 async |module: &LightningModule, dbtx, _params: ()| -> Vec<IncomingContractOffer> {
-                    Ok(module.get_offers(&dbtx))
+                    Ok(module.get_offers(&mut dbtx).await)
                 }
             },
             api_endpoint! {
@@ -808,7 +812,7 @@ impl ServerModulePlugin for LightningModule {
             api_endpoint! {
                 "/list_gateways",
                 async |module: &LightningModule, dbtx, _v: ()| -> Vec<LightningGateway> {
-                    Ok(module.list_gateways(&dbtx))
+                    Ok(module.list_gateways(&mut dbtx).await)
                 }
             },
             api_endpoint! {
@@ -850,8 +854,12 @@ impl LightningModule {
             .expect("DB error")
     }
 
-    pub fn get_offers(&self, dbtx: &DatabaseTransaction) -> Vec<IncomingContractOffer> {
+    pub async fn get_offers(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> Vec<IncomingContractOffer> {
         dbtx.find_by_prefix(&OfferKeyPrefix)
+            .await
             .map(|res| res.expect("DB error").1)
             .collect()
     }
@@ -866,8 +874,9 @@ impl LightningModule {
             .expect("DB error")
     }
 
-    pub fn list_gateways(&self, dbtx: &DatabaseTransaction) -> Vec<LightningGateway> {
+    pub async fn list_gateways(&self, dbtx: &mut DatabaseTransaction<'_>) -> Vec<LightningGateway> {
         dbtx.find_by_prefix(&LightningGatewayKeyPrefix)
+            .await
             .map(|res| res.expect("DB error").1)
             .collect()
     }

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -271,13 +271,16 @@ impl ServerModulePlugin for LightningModule {
         LightningModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
+    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
         if self.consensus_proposal(dbtx).await.is_empty() {
             std::future::pending().await
         }
     }
 
-    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<Self::ConsensusItem> {
+    async fn consensus_proposal(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> Vec<Self::ConsensusItem> {
         dbtx.find_by_prefix(&ProposeDecryptionShareKeyPrefix)
             .map(|res| {
                 let (ProposeDecryptionShareKey(contract_id), share) = res.expect("DB error");
@@ -320,6 +323,7 @@ impl ServerModulePlugin for LightningModule {
     ) -> Result<InputMeta, ModuleError> {
         let account: ContractAccount = self
             .get_contract_account(dbtx, input.contract_id)
+            .await
             .ok_or(LightningModuleError::UnknownContract(input.contract_id))
             .into_module_error_other()?;
 
@@ -398,6 +402,7 @@ impl ServerModulePlugin for LightningModule {
         let account_db_key = ContractKey(input.contract_id);
         let mut contract_account = dbtx
             .get_value(&account_db_key)
+            .await
             .expect("DB error")
             .expect("Should fail validation if contract account doesn't exist");
         contract_account.amount -= meta.amount.amount;
@@ -408,9 +413,9 @@ impl ServerModulePlugin for LightningModule {
         Ok(meta)
     }
 
-    fn validate_output(
+    async fn validate_output(
         &self,
-        dbtx: &DatabaseTransaction,
+        dbtx: &mut DatabaseTransaction<'_>,
         output: &Self::Output,
     ) -> Result<TransactionItemAmount, ModuleError> {
         match output {
@@ -419,6 +424,7 @@ impl ServerModulePlugin for LightningModule {
                 if let Contract::Incoming(incoming) = &contract.contract {
                     let offer = dbtx
                         .get_value(&OfferKey(incoming.hash))
+                        .await
                         .expect("DB error")
                         .ok_or(LightningModuleError::NoOffer(incoming.hash))
                         .into_module_error_other()?;
@@ -455,6 +461,7 @@ impl ServerModulePlugin for LightningModule {
             } => {
                 let contract_account = dbtx
                     .get_value(&ContractKey(*contract))
+                    .await
                     .expect("DB error")
                     .ok_or(LightningModuleError::UnknownContract(*contract))
                     .into_module_error_other()?;
@@ -487,13 +494,14 @@ impl ServerModulePlugin for LightningModule {
         output: &'a Self::Output,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
-        let amount = self.validate_output(dbtx, output)?;
+        let amount = self.validate_output(dbtx, output).await?;
 
         match output {
             LightningOutput::Contract(contract) => {
                 let contract_db_key = ContractKey(contract.contract.contract_id());
                 let updated_contract_account = dbtx
                     .get_value(&contract_db_key)
+                    .await
                     .expect("DB error")
                     .map(|mut value: ContractAccount| {
                         value.amount += amount.amount;
@@ -520,6 +528,7 @@ impl ServerModulePlugin for LightningModule {
                 if let Contract::Incoming(incoming) = &contract.contract {
                     let offer = dbtx
                         .get_value(&OfferKey(incoming.hash))
+                        .await
                         .expect("DB error")
                         .expect("offer exists if output is valid");
 
@@ -555,6 +564,7 @@ impl ServerModulePlugin for LightningModule {
                 let updated_contract_account = {
                     let mut contract_account = dbtx
                         .get_value(&ContractKey(*contract))
+                        .await
                         .expect("DB error")
                         .expect("Contract exists if output is valid");
 
@@ -600,7 +610,7 @@ impl ServerModulePlugin for LightningModule {
             let span = info_span!("decrypt_preimage", %contract_id);
             let _gaurd = span.enter();
 
-            let incoming_contract = match self.get_contract_account(dbtx, contract_id) {
+            let incoming_contract = match self.get_contract_account(dbtx, contract_id).await {
                 Some(ContractAccount {
                     contract: FundedContract::Incoming(incoming),
                     ..
@@ -644,6 +654,7 @@ impl ServerModulePlugin for LightningModule {
 
             let contract = self
                 .get_contract_account(dbtx, contract_id)
+                .await
                 .expect("decryption shares without contracts should be discarded earlier"); // FIXME: verify
 
             let (incoming_contract, out_point) = match contract.contract {
@@ -709,6 +720,7 @@ impl ServerModulePlugin for LightningModule {
             let contract_db_key = ContractKey(contract_id);
             let mut contract_account = dbtx
                 .get_value(&contract_db_key)
+                .await
                 .expect("DB error")
                 .expect("checked before that it exists");
             let mut incoming = match &mut contract_account.contract {
@@ -725,6 +737,7 @@ impl ServerModulePlugin for LightningModule {
             let outcome_db_key = ContractUpdateKey(out_point);
             let mut outcome = dbtx
                 .get_value(&outcome_db_key)
+                .await
                 .expect("DB error")
                 .expect("outcome was created on funding");
             let incoming_contract_outcome_preimage = match &mut outcome {
@@ -743,12 +756,13 @@ impl ServerModulePlugin for LightningModule {
         bad_peers
     }
 
-    fn output_status(
+    async fn output_status(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<Self::OutputOutcome> {
         dbtx.get_value(&ContractUpdateKey(out_point))
+            .await
             .expect("DB error")
     }
 
@@ -768,7 +782,8 @@ impl ServerModulePlugin for LightningModule {
                 "/account",
                 async |module: &LightningModule, dbtx, contract_id: ContractId| -> ContractAccount {
                     module
-                        .get_contract_account(&dbtx, contract_id)
+                        .get_contract_account(&mut dbtx, contract_id)
+                        .await
                         .ok_or_else(|| ApiError::not_found(String::from("Contract not found")))
                 }
             },
@@ -782,7 +797,8 @@ impl ServerModulePlugin for LightningModule {
                 "/offer",
                 async |module: &LightningModule, dbtx, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
                     let offer = module
-                        .get_offer(&dbtx, payment_hash)
+                        .get_offer(&mut dbtx, payment_hash)
+                        .await
                         .ok_or_else(|| ApiError::not_found(String::from("Offer not found")))?;
 
                     debug!(%payment_hash, "Sending offer info");
@@ -824,12 +840,14 @@ impl LightningModule {
             .verify_decryption_share(&share.0, &message.0)
     }
 
-    pub fn get_offer(
+    pub async fn get_offer(
         &self,
-        dbtx: &DatabaseTransaction,
+        dbtx: &mut DatabaseTransaction<'_>,
         payment_hash: bitcoin_hashes::sha256::Hash,
     ) -> Option<IncomingContractOffer> {
-        dbtx.get_value(&OfferKey(payment_hash)).expect("DB error")
+        dbtx.get_value(&OfferKey(payment_hash))
+            .await
+            .expect("DB error")
     }
 
     pub fn get_offers(&self, dbtx: &DatabaseTransaction) -> Vec<IncomingContractOffer> {
@@ -838,12 +856,14 @@ impl LightningModule {
             .collect()
     }
 
-    pub fn get_contract_account(
+    pub async fn get_contract_account(
         &self,
-        dbtx: &DatabaseTransaction,
+        dbtx: &mut DatabaseTransaction<'_>,
         contract_id: ContractId,
     ) -> Option<ContractAccount> {
-        dbtx.get_value(&ContractKey(contract_id)).expect("DB error")
+        dbtx.get_value(&ContractKey(contract_id))
+            .await
+            .expect("DB error")
     }
 
     pub fn list_gateways(&self, dbtx: &DatabaseTransaction) -> Vec<LightningGateway> {

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -319,10 +319,10 @@ impl ServerModulePlugin for LightningModule {
         LightningVerificationCache
     }
 
-    fn validate_input<'a, 'b>(
+    async fn validate_input<'a, 'b>(
         &self,
         interconnect: &dyn ModuleInterconect,
-        dbtx: &DatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransaction<'b>,
         _verification_cache: &Self::VerificationCache,
         input: &'a Self::Input,
     ) -> Result<InputMeta, ModuleError> {
@@ -341,7 +341,7 @@ impl ServerModulePlugin for LightningModule {
 
         let pub_key = match account.contract {
             FundedContract::Outgoing(outgoing) => {
-                if outgoing.timelock > block_height(interconnect) && !outgoing.cancelled {
+                if outgoing.timelock > block_height(interconnect).await && !outgoing.cancelled {
                     // If the timelock hasn't expired yet …
                     let preimage_hash = bitcoin_hashes::sha256::Hash::hash(
                         &input
@@ -399,7 +399,9 @@ impl ServerModulePlugin for LightningModule {
         input: &'b Self::Input,
         cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
-        let meta = self.validate_input(interconnect, dbtx, cache, input)?;
+        let meta = self
+            .validate_input(interconnect, dbtx, cache, input)
+            .await?;
 
         let account_db_key = ContractKey(input.contract_id);
         let mut contract_account = dbtx
@@ -778,7 +780,7 @@ impl ServerModulePlugin for LightningModule {
         vec![
             api_endpoint! {
                 "/account",
-                async |module: &LightningModule, contract_id: ContractId| -> ContractAccount {
+                async |module: &LightningModule, _dbtx, contract_id: ContractId| -> ContractAccount {
                     module
                         .get_contract_account(&module.non_consensus_db.begin_transaction(module.decoders.clone()), contract_id)
                         .ok_or_else(|| ApiError::not_found(String::from("Contract not found")))
@@ -786,13 +788,13 @@ impl ServerModulePlugin for LightningModule {
             },
             api_endpoint! {
                 "/offers",
-                async |module: &LightningModule, _params: ()| -> Vec<IncomingContractOffer> {
+                async |module: &LightningModule, _dbtx, _params: ()| -> Vec<IncomingContractOffer> {
                     Ok(module.get_offers(&module.non_consensus_db.begin_transaction(module.decoders.clone())))
                 }
             },
             api_endpoint! {
                 "/offer",
-                async |module: &LightningModule, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
+                async |module: &LightningModule, _dbtx, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
                     let offer = module
                         .get_offer(&module.non_consensus_db.begin_transaction(module.decoders.clone()), payment_hash)
                         .ok_or_else(|| ApiError::not_found(String::from("Offer not found")))?;
@@ -803,13 +805,13 @@ impl ServerModulePlugin for LightningModule {
             },
             api_endpoint! {
                 "/list_gateways",
-                async |module: &LightningModule, _v: ()| -> Vec<LightningGateway> {
+                async |module: &LightningModule, _dbtx, _v: ()| -> Vec<LightningGateway> {
                     Ok(module.list_gateways(&module.non_consensus_db.begin_transaction(module.decoders.clone())))
                 }
             },
             api_endpoint! {
                 "/register_gateway",
-                async |module: &LightningModule, gateway: LightningGateway| -> () {
+                async |module: &LightningModule, _dbtx, gateway: LightningGateway| -> () {
                     futures::executor::block_on( async {
                        module.register_gateway(gateway).await;
                     });
@@ -893,15 +895,13 @@ plugin_types_trait_impl!(
     LightningVerificationCache
 );
 
-fn block_height(interconnect: &dyn ModuleInterconect) -> u32 {
+async fn block_height(interconnect: &dyn ModuleInterconect) -> u32 {
     // This is a future because we are normally reading from a network socket. But for internal
     // calls the data is available instantly in one go, so we can just block on it.
-    let body = futures::executor::block_on(interconnect.call(
-        "wallet",
-        "/block_height".to_owned(),
-        Default::default(),
-    ))
-    .expect("Wallet module not present or malfunctioning!");
+    let body = interconnect
+        .call("wallet", "/block_height".to_owned(), Default::default())
+        .await
+        .expect("Wallet module not present or malfunctioning!");
 
     serde_json::from_value(body).expect("Malformed block height response from wallet module!")
 }

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -35,7 +35,7 @@ async fn test_account() {
 
     let mut fed = FakeFed::<LightningModule>::new(
         4,
-        |cfg, db| async move { Ok(LightningModule::new(cfg.to_typed()?, db, ln_decoders())) },
+        |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
         &ModuleConfigGenParams::fake_config_gen_params(),
         &LightningModuleConfigGen,
     )
@@ -85,7 +85,7 @@ async fn test_outgoing() {
 
     let mut fed = FakeFed::<LightningModule>::new(
         4,
-        |cfg, db| async move { Ok(LightningModule::new(cfg.to_typed()?, db, ln_decoders())) },
+        |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
         &ModuleConfigGenParams::fake_config_gen_params(),
         &LightningModuleConfigGen,
     )
@@ -184,7 +184,7 @@ async fn test_incoming() {
 
     let mut fed = FakeFed::<LightningModule>::new(
         4,
-        |cfg, db| async move { Ok(LightningModule::new(cfg.to_typed()?, db, ln_decoders())) },
+        |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
         &ModuleConfigGenParams::fake_config_gen_params(),
         &LightningModuleConfigGen,
     )

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -71,12 +71,12 @@ async fn test_account() {
         amount: Amount::from_sat(42),
         witness: None,
     };
-    let meta = fed.verify_input(&account_input).unwrap();
+    let meta = fed.verify_input(&account_input).await.unwrap();
     assert_eq!(meta.keys, vec![kp.x_only_public_key().0]);
 
     fed.consensus_round(&[account_input.clone()], &[]).await;
 
-    assert!(fed.verify_input(&account_input).is_err());
+    assert!(fed.verify_input(&account_input).await.is_err());
 }
 
 #[test_log::test(tokio::test)]
@@ -152,7 +152,10 @@ j5r6drg6k6zcqj0fcwg"
         amount: Amount::from_sat(42),
         witness: None,
     };
-    let err = fed.verify_input(&account_input_no_witness).unwrap_err();
+    let err = fed
+        .verify_input(&account_input_no_witness)
+        .await
+        .unwrap_err();
     assert_eq!(
         format!("{err}"),
         format!("{}", LightningModuleError::MissingPreimage)
@@ -164,12 +167,12 @@ j5r6drg6k6zcqj0fcwg"
         amount: Amount::from_sat(42),
         witness: Some(preimage),
     };
-    let meta = fed.verify_input(&account_input_witness).unwrap();
+    let meta = fed.verify_input(&account_input_witness).await.unwrap();
     assert_eq!(meta.keys, vec![gw_pk]);
 
     // Test case 2: after timeout
     fed.set_block_height(42);
-    let meta = fed.verify_input(&account_input_no_witness).unwrap();
+    let meta = fed.verify_input(&account_input_no_witness).await.unwrap();
     assert_eq!(meta.keys, vec![user_pk]);
 
     fed.consensus_round(&[account_input_no_witness], &[]).await;
@@ -249,7 +252,7 @@ async fn test_incoming() {
         amount: Amount::from_sat(42),
         witness: None,
     };
-    let error = fed.verify_input(&incoming_input).unwrap_err();
+    let error = fed.verify_input(&incoming_input).await.unwrap_err();
     assert_eq!(
         format!("{error}"),
         format!("{}", LightningModuleError::ContractNotReady)
@@ -266,7 +269,7 @@ async fn test_incoming() {
         _ => panic!(),
     };
 
-    let meta = fed.verify_input(&incoming_input).unwrap();
+    let meta = fed.verify_input(&incoming_input).await.unwrap();
     assert_eq!(meta.keys, vec![user_pk]);
 
     // TODO: test faulty encrypted preimage

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -217,7 +217,15 @@ async fn test_incoming() {
 
     fed.consensus_round(&[], &[(offer_out_point, offer_output)])
         .await;
-    let offers = fed.fetch_from_all(|m, db| m.get_offers(&db.begin_transaction(ln_decoders())));
+    let mut results = Vec::new();
+    for (_, member, db) in fed.members.iter_mut() {
+        results.push(
+            member
+                .get_offers(&mut db.begin_transaction(ln_decoders()))
+                .await,
+        );
+    }
+    let offers = fedimint_testing::assert_all_equal(results.into_iter());
     assert_eq!(offers, vec![offer.clone()]);
 
     let contract = Contract::Incoming(IncomingContract {

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -59,7 +59,7 @@ async fn test_account() {
     let outputs = [(account_out_point, account_output)];
 
     fed.consensus_round(&[], &outputs).await;
-    match fed.output_outcome(account_out_point).unwrap() {
+    match fed.output_outcome(account_out_point).await.unwrap() {
         LightningOutputOutcome::Contract { outcome, .. } => {
             assert_eq!(outcome, ContractOutcome::Account(AccountContractOutcome {}));
         }
@@ -133,7 +133,7 @@ j5r6drg6k6zcqj0fcwg"
     let outputs = [(outgoing_out_point, outgoing_output)];
 
     fed.consensus_round(&[], &outputs).await;
-    match fed.output_outcome(outgoing_out_point).unwrap() {
+    match fed.output_outcome(outgoing_out_point).await.unwrap() {
         LightningOutputOutcome::Contract { outcome, .. } => {
             assert_eq!(
                 outcome,
@@ -237,7 +237,7 @@ async fn test_incoming() {
     let outputs = [(incoming_out_point, incoming_output)];
 
     fed.consensus_round(&[], &outputs).await;
-    match fed.output_outcome(incoming_out_point).unwrap() {
+    match fed.output_outcome(incoming_out_point).await.unwrap() {
         LightningOutputOutcome::Contract { outcome, .. } => {
             assert_eq!(
                 outcome,
@@ -259,7 +259,7 @@ async fn test_incoming() {
     );
 
     fed.consensus_round(&[], &[]).await;
-    match fed.output_outcome(incoming_out_point).unwrap() {
+    match fed.output_outcome(incoming_out_point).await.unwrap() {
         LightningOutputOutcome::Contract { outcome, .. } => {
             assert_eq!(
                 outcome,

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -45,7 +45,7 @@ impl DatabaseKeyPrefixConst for NonceKeyPrefix {
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ProposedPartialSignatureKey {
-    pub request_id: OutPoint, // tx + output idx
+    pub out_point: OutPoint, // tx + output idx
 }
 
 impl DatabaseKeyPrefixConst for ProposedPartialSignatureKey {

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -12,9 +12,9 @@ use fedimint_api::config::{
     scalar, ClientModuleConfig, DkgPeerMsg, DkgRunner, ModuleConfigGenParams, ServerModuleConfig,
     TypedServerModuleConfig,
 };
-use fedimint_api::core::{Decoder, ModuleKey, MODULE_KEY_MINT};
-use fedimint_api::db::{Database, DatabaseTransaction};
-use fedimint_api::encoding::{Decodable, Encodable, ModuleRegistry};
+use fedimint_api::core::{ModuleKey, MODULE_KEY_MINT};
+use fedimint_api::db::DatabaseTransaction;
+use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
@@ -65,8 +65,6 @@ pub struct Mint {
     sec_key: Tiered<SecretKeyShare>,
     pub_key_shares: BTreeMap<PeerId, Tiered<PublicKeyShare>>,
     pub_key: HashMap<Amount, AggregatePublicKey>,
-    non_consensus_db: Database,
-    decoders: ModuleRegistry<Decoder>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
@@ -314,13 +312,8 @@ impl ServerModulePlugin for Mint {
         }
     }
 
-    async fn consensus_proposal(
-        &self,
-        _dbtx: &DatabaseTransaction<'_>,
-    ) -> Vec<Self::ConsensusItem> {
-        self.non_consensus_db
-            .begin_transaction(self.decoders.clone())
-            .find_by_prefix(&ProposedPartialSignaturesKeyPrefix)
+    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<Self::ConsensusItem> {
+        dbtx.find_by_prefix(&ProposedPartialSignaturesKeyPrefix)
             .map(|res| {
                 let (key, partial_signature) = res.expect("DB error");
                 MintConsensusItem(PartiallySignedRequest {
@@ -608,12 +601,9 @@ impl ServerModulePlugin for Mint {
 
     fn output_status(
         &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<Self::OutputOutcome> {
-        let dbtx = self
-            .non_consensus_db
-            .begin_transaction(self.decoders.clone());
         let we_proposed = dbtx
             .get_value(&ProposedPartialSignatureKey { out_point })
             .expect("DB error")
@@ -637,19 +627,13 @@ impl ServerModulePlugin for Mint {
         }
     }
 
-    fn audit(&self, _dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
-        audit.add_items(
-            &self
-                .non_consensus_db
-                .begin_transaction(self.decoders.clone()),
-            &MintAuditItemKeyPrefix,
-            |k, v| match k {
-                MintAuditItemKey::Issuance(_) => -(v.milli_sat as i64),
-                MintAuditItemKey::IssuanceTotal => -(v.milli_sat as i64),
-                MintAuditItemKey::Redemption(_) => v.milli_sat as i64,
-                MintAuditItemKey::RedemptionTotal => v.milli_sat as i64,
-            },
-        );
+    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
+        audit.add_items(dbtx, &MintAuditItemKeyPrefix, |k, v| match k {
+            MintAuditItemKey::Issuance(_) => -(v.milli_sat as i64),
+            MintAuditItemKey::IssuanceTotal => -(v.milli_sat as i64),
+            MintAuditItemKey::Redemption(_) => v.milli_sat as i64,
+            MintAuditItemKey::RedemptionTotal => v.milli_sat as i64,
+        });
     }
 
     fn api_base_name(&self) -> &'static str {
@@ -660,16 +644,18 @@ impl ServerModulePlugin for Mint {
         vec![
             api_endpoint! {
                 "/backup",
-                async |module: &Mint, _dbtx, request: SignedBackupRequest| -> () {
+                async |module: &Mint, dbtx, request: SignedBackupRequest| -> () {
                     module
-                        .handle_backup_request(request).await
+                        .handle_backup_request(&mut dbtx, request).await?;
+                    dbtx.commit_tx().await.map_err(|e| ApiError::new(1000, format!("Transaction error: {}", e)))?;
+                    Ok(())
                 }
             },
             api_endpoint! {
                 "/recover",
-                async |module: &Mint, _dbtx, id: secp256k1_zkp::XOnlyPublicKey| -> Vec<u8> {
+                async |module: &Mint, dbtx, id: secp256k1_zkp::XOnlyPublicKey| -> Vec<u8> {
                     module
-                        .handle_recover_request(id).await
+                        .handle_recover_request(&dbtx, id).await
                         .ok_or_else(|| ApiError::not_found(String::from("Backup not found")))
                 }
             },
@@ -678,14 +664,14 @@ impl ServerModulePlugin for Mint {
 }
 
 impl Mint {
-    async fn handle_backup_request(&self, request: SignedBackupRequest) -> Result<(), ApiError> {
+    async fn handle_backup_request(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        request: SignedBackupRequest,
+    ) -> Result<(), ApiError> {
         let request = request
             .verify_valid(SECP256K1)
             .map_err(|_| ApiError::bad_request("invalid request".into()))?;
-
-        let mut dbtx = self
-            .non_consensus_db
-            .begin_transaction(self.decoders.clone());
 
         if let Some(prev) = dbtx
             .get_value(&EcashBackupKey(request.id))
@@ -709,10 +695,12 @@ impl Mint {
         Ok(())
     }
 
-    async fn handle_recover_request(&self, id: secp256k1_zkp::XOnlyPublicKey) -> Option<Vec<u8>> {
-        self.non_consensus_db
-            .begin_transaction(self.decoders.clone())
-            .get_value(&EcashBackupKey(id))
+    async fn handle_recover_request(
+        &self,
+        dbtx: &DatabaseTransaction<'_>,
+        id: secp256k1_zkp::XOnlyPublicKey,
+    ) -> Option<Vec<u8>> {
+        dbtx.get_value(&EcashBackupKey(id))
             .expect("DB error")
             .map(|res| res.data)
     }
@@ -725,7 +713,7 @@ impl Mint {
     /// * If there are no amount tiers
     /// * If the amount tiers for secret and public keys are inconsistent
     /// * If the pub key belonging to the secret key share is not in the pub key list.
-    pub fn new(cfg: MintConfig, db: Database, decoders: ModuleRegistry<Decoder>) -> Mint {
+    pub fn new(cfg: MintConfig) -> Mint {
         assert!(cfg.tbs_sks.tiers().count() > 0);
 
         // The amount tiers are implicitly provided by the key sets, make sure they are internally
@@ -770,8 +758,6 @@ impl Mint {
             sec_key: cfg.tbs_sks,
             pub_key_shares: cfg.peer_tbs_pks,
             pub_key: aggregate_pub_keys,
-            non_consensus_db: db,
-            decoders,
         }
     }
 
@@ -1054,18 +1040,12 @@ impl From<InvalidAmountTierError> for MintError {
 #[cfg(test)]
 mod test {
     use fedimint_api::config::{ClientModuleConfig, ModuleConfigGenParams, ServerModuleConfig};
-    use fedimint_api::core::{Decoder, MODULE_KEY_MINT};
-    use fedimint_api::db::mem_impl::MemDatabase;
-    use fedimint_api::encoding::ModuleRegistry;
     use fedimint_api::module::FederationModuleConfigGen;
     use fedimint_api::{Amount, PeerId, TieredMulti};
     use tbs::{blind_message, unblind_signature, verify, AggregatePublicKey, BlindingKey, Message};
 
     use crate::config::{FeeConsensus, MintClientConfig};
-    use crate::{
-        BlindNonce, CombineError, Mint, MintConfig, MintConfigGenerator, MintModuleDecoder,
-        PeerErrorType,
-    };
+    use crate::{BlindNonce, CombineError, Mint, MintConfig, MintConfigGenerator, PeerErrorType};
 
     const THRESHOLD: usize = 1;
     const MINTS: usize = 5;
@@ -1087,15 +1067,7 @@ mod test {
         let (mint_cfg, client_cfg) = build_configs();
         let mints = mint_cfg
             .into_iter()
-            .map(|config| {
-                Mint::new(
-                    config.to_typed().unwrap(),
-                    MemDatabase::new().into(),
-                    vec![(MODULE_KEY_MINT, Decoder::from_typed(MintModuleDecoder))]
-                        .into_iter()
-                        .collect(),
-                )
-            })
+            .map(|config| Mint::new(config.to_typed().unwrap()))
             .collect::<Vec<_>>();
 
         let agg_pk = *client_cfg
@@ -1257,21 +1229,17 @@ mod test {
         let (mint_server_cfg1, _) = build_configs();
         let (mint_server_cfg2, _) = build_configs();
 
-        Mint::new(
-            MintConfig {
-                threshold: THRESHOLD,
-                tbs_sks: mint_server_cfg1[0]
-                    .to_typed::<MintConfig>()
-                    .unwrap()
-                    .tbs_sks,
-                peer_tbs_pks: mint_server_cfg2[0]
-                    .to_typed::<MintConfig>()
-                    .unwrap()
-                    .peer_tbs_pks,
-                fee_consensus: FeeConsensus::default(),
-            },
-            MemDatabase::new().into(),
-            ModuleRegistry::default(),
-        );
+        Mint::new(MintConfig {
+            threshold: THRESHOLD,
+            tbs_sks: mint_server_cfg1[0]
+                .to_typed::<MintConfig>()
+                .unwrap()
+                .tbs_sks,
+            peer_tbs_pks: mint_server_cfg2[0]
+                .to_typed::<MintConfig>()
+                .unwrap()
+                .peer_tbs_pks,
+            fee_consensus: FeeConsensus::default(),
+        });
     }
 }

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -370,10 +370,10 @@ impl ServerModulePlugin for Mint {
         VerificationCache { valid_coins }
     }
 
-    fn validate_input<'a, 'b>(
+    async fn validate_input<'a, 'b>(
         &self,
         _interconnect: &dyn ModuleInterconect,
-        dbtx: &DatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransaction<'b>,
         verification_cache: &Self::VerificationCache,
         input: &'a Self::Input,
     ) -> Result<InputMeta, ModuleError> {
@@ -421,7 +421,9 @@ impl ServerModulePlugin for Mint {
         input: &'b Self::Input,
         cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
-        let meta = self.validate_input(interconnect, dbtx, cache, input)?;
+        let meta = self
+            .validate_input(interconnect, dbtx, cache, input)
+            .await?;
 
         for (amount, coin) in input.iter_items() {
             let key = NonceKey(coin.0.clone());
@@ -658,14 +660,14 @@ impl ServerModulePlugin for Mint {
         vec![
             api_endpoint! {
                 "/backup",
-                async |module: &Mint, request: SignedBackupRequest| -> () {
+                async |module: &Mint, _dbtx, request: SignedBackupRequest| -> () {
                     module
                         .handle_backup_request(request).await
                 }
             },
             api_endpoint! {
                 "/recover",
-                async |module: &Mint, id: secp256k1_zkp::XOnlyPublicKey| -> Vec<u8> {
+                async |module: &Mint, _dbtx, id: secp256k1_zkp::XOnlyPublicKey| -> Vec<u8> {
                     module
                         .handle_recover_request(id).await
                         .ok_or_else(|| ApiError::not_found(String::from("Backup not found")))

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -321,7 +321,7 @@ impl ServerModulePlugin for Mint {
             .map(|res| {
                 let (key, partial_signature) = res.expect("DB error");
                 MintConsensusItem(PartiallySignedRequest {
-                    out_point: key.request_id,
+                    out_point: key.out_point,
                     partial_signature,
                 })
             })
@@ -466,14 +466,9 @@ impl ServerModulePlugin for Mint {
             .blind_sign(output.clone().0)
             .into_module_error_other()?;
 
-        dbtx.insert_new_entry(
-            &ProposedPartialSignatureKey {
-                request_id: out_point,
-            },
-            &partial_sig,
-        )
-        .await
-        .expect("DB Error");
+        dbtx.insert_new_entry(&ProposedPartialSignatureKey { out_point }, &partial_sig)
+            .await
+            .expect("DB Error");
         dbtx.insert_new_entry(
             &MintAuditItemKey::Issuance(out_point),
             &output.total_amount(),
@@ -509,9 +504,7 @@ impl ServerModulePlugin for Mint {
             .into_group_map()
             .into_iter()
             .map(|(out_point, signature_shares)| {
-                let proposal_key = ProposedPartialSignatureKey {
-                    request_id: out_point,
-                };
+                let proposal_key = ProposedPartialSignatureKey { out_point };
                 let our_contribution = dbtx.get_value(&proposal_key).expect("DB error");
 
                 IssuanceData {
@@ -557,7 +550,7 @@ impl ServerModulePlugin for Mint {
                     }
 
                     dbtx.remove_entry(&ProposedPartialSignatureKey {
-                        request_id: issuance_data.out_point,
+                        out_point: issuance_data.out_point,
                     })
                     .await
                     .expect("DB Error");
@@ -613,9 +606,7 @@ impl ServerModulePlugin for Mint {
             .non_consensus_db
             .begin_transaction(self.decoders.clone());
         let we_proposed = dbtx
-            .get_value(&ProposedPartialSignatureKey {
-                request_id: out_point,
-            })
+            .get_value(&ProposedPartialSignatureKey { out_point })
             .expect("DB error")
             .is_some();
         let was_consensus_outcome = dbtx

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::ops::Sub;
@@ -32,7 +32,7 @@ use fedimint_api::{
 use impl_tools::autoimpl;
 use itertools::Itertools;
 use rand::rngs::OsRng;
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 use secp256k1_zkp::SECP256K1;
 use serde::{Deserialize, Serialize};
 use tbs::{
@@ -489,75 +489,94 @@ impl ServerModulePlugin for Mint {
         consensus_peers: &HashSet<PeerId>,
         dbtx: &mut DatabaseTransaction<'b>,
     ) -> Vec<PeerId> {
+        struct IssuanceData {
+            out_point: OutPoint,
+            // TODO: remove Option, make it mandatory
+            // TODO: make it only the message, remove msg from PartialSigResponse
+            our_contribution: Option<PartialSigResponse>,
+            signature_shares: Vec<(PeerId, PartialSigResponse)>,
+        }
+
+        let mut drop_peers = BTreeSet::new();
+
         // Finalize partial signatures for which we now have enough shares
-        let req_psigs = dbtx
+        let issuance_requests = dbtx
             .find_by_prefix(&ReceivedPartialSignaturesKeyPrefix)
             .map(|entry_res| {
                 let (key, partial_sig) = entry_res.expect("DB error");
                 (key.request_id, (key.peer_id, partial_sig))
             })
-            .into_group_map();
-
-        // TODO: use own par iter impl that allows efficient use of accumulators or just decouple it entirely (doesn't need consensus)
-        let par_map = req_psigs
+            .into_group_map()
             .into_iter()
-            .map(|(issuance_id, shares)| async move {
-                let mut drop_peers = Vec::<PeerId>::new();
-                // FIXME: this specific instance is safe, but we should never directly read from the DB
-                let mut dbtx = self
-                    .non_consensus_db
-                    .begin_transaction(self.decoders.clone());
+            .map(|(out_point, signature_shares)| {
                 let proposal_key = ProposedPartialSignatureKey {
-                    request_id: issuance_id,
+                    request_id: out_point,
                 };
                 let our_contribution = dbtx.get_value(&proposal_key).expect("DB error");
-                let (bsig, errors) = self.combine(our_contribution, shares.clone());
 
-                // FIXME: validate shares before writing to DB to make combine infallible
-                errors.0.iter().for_each(|(peer, error)| {
-                    error!("Dropping {:?} for {:?}", peer, error);
-                    drop_peers.push(*peer);
-                });
-
-                match bsig {
-                    Ok(blind_signature) => {
-                        debug!(
-                            %issuance_id,
-                            "Successfully combined signature shares",
-                        );
-
-                        for (peer, _) in shares.into_iter() {
-                            dbtx.remove_entry(&ReceivedPartialSignatureKey {
-                                request_id: issuance_id,
-                                peer_id: peer,
-                            })
-                            .await
-                            .expect("DB Error");
-                        }
-
-                        dbtx.remove_entry(&proposal_key).await.expect("DB Error");
-
-                        dbtx.insert_entry(&OutputOutcomeKey(issuance_id), &blind_signature)
-                            .await
-                            .expect("DB Error");
-                    }
-                    Err(CombineError::TooFewShares(got, _)) => {
-                        for peer in consensus_peers.sub(&HashSet::from_iter(got)) {
-                            error!("Dropping {:?} for not contributing shares", peer);
-                            drop_peers.push(peer);
-                        }
-                    }
-                    Err(error) => {
-                        warn!(%error, "Could not combine shares");
-                    }
+                IssuanceData {
+                    out_point,
+                    our_contribution,
+                    signature_shares,
                 }
+            })
+            .collect::<Vec<_>>();
 
-                dbtx.commit_tx().await.expect("DB Error");
-                drop_peers
+        let issuance_results = issuance_requests
+            .into_par_iter()
+            .map(|issuance_data| {
+                let (bsig, errors) = self.combine(
+                    issuance_data.our_contribution.clone(),
+                    issuance_data.signature_shares.clone(),
+                );
+                (issuance_data, bsig, errors)
+            })
+            .collect::<Vec<_>>();
+
+        for (issuance_data, bsig_res, errors) in issuance_results {
+            // FIXME: validate shares before writing to DB to make combine infallible
+            errors.0.iter().for_each(|(peer, error)| {
+                error!("Dropping {:?} for {:?}", peer, error);
+                drop_peers.insert(*peer);
             });
 
-        let par_batches = futures::future::join_all(par_map).await;
-        let dropped_peers = par_batches.iter().flatten().copied().collect();
+            match bsig_res {
+                Ok(blind_signature) => {
+                    debug!(
+                        out_point = %issuance_data.out_point,
+                        "Successfully combined signature shares",
+                    );
+
+                    for (peer, _) in issuance_data.signature_shares.into_iter() {
+                        dbtx.remove_entry(&ReceivedPartialSignatureKey {
+                            request_id: issuance_data.out_point,
+                            peer_id: peer,
+                        })
+                        .await
+                        .expect("DB Error");
+                    }
+
+                    dbtx.remove_entry(&ProposedPartialSignatureKey {
+                        request_id: issuance_data.out_point,
+                    })
+                    .await
+                    .expect("DB Error");
+
+                    dbtx.insert_entry(&OutputOutcomeKey(issuance_data.out_point), &blind_signature)
+                        .await
+                        .expect("DB Error");
+                }
+                Err(CombineError::TooFewShares(got, _)) => {
+                    for peer in consensus_peers.sub(&HashSet::from_iter(got)) {
+                        error!("Dropping {:?} for not contributing shares", peer);
+                        drop_peers.insert(peer);
+                    }
+                }
+                Err(error) => {
+                    warn!(%error, "Could not combine shares");
+                }
+            }
+        }
 
         let mut redemptions = Amount::from_sat(0);
         let mut issuances = Amount::from_sat(0);
@@ -586,7 +605,7 @@ impl ServerModulePlugin for Mint {
             .await
             .expect("DB Error");
 
-        dropped_peers
+        drop_peers.into_iter().collect()
     }
 
     fn output_status(&self, out_point: OutPoint) -> Option<Self::OutputOutcome> {

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -306,8 +306,8 @@ impl ServerModulePlugin for Mint {
         MintModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
-        if self.consensus_proposal(dbtx).await.is_empty() {
+    async fn await_consensus_proposal(&self, mut dbtx: DatabaseTransaction<'_>) {
+        if self.consensus_proposal(&mut dbtx).await.is_empty() {
             std::future::pending().await
         }
     }

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -317,6 +317,7 @@ impl ServerModulePlugin for Mint {
         dbtx: &mut DatabaseTransaction<'_>,
     ) -> Vec<Self::ConsensusItem> {
         dbtx.find_by_prefix(&ProposedPartialSignaturesKeyPrefix)
+            .await
             .map(|res| {
                 let (key, partial_signature) = res.expect("DB error");
                 MintConsensusItem(PartiallySignedRequest {
@@ -494,6 +495,7 @@ impl ServerModulePlugin for Mint {
         // Finalize partial signatures for which we now have enough shares
         let issuance_requests_iter = dbtx
             .find_by_prefix(&ReceivedPartialSignaturesKeyPrefix)
+            .await
             .map(|entry_res| {
                 let (key, partial_sig) = entry_res.expect("DB error");
                 (key.request_id, (key.peer_id, partial_sig))
@@ -572,6 +574,7 @@ impl ServerModulePlugin for Mint {
         let mut issuances = Amount::from_sat(0);
         let remove_audit_keys = dbtx
             .find_by_prefix(&MintAuditItemKeyPrefix)
+            .await
             .map(|res| {
                 let (key, amount) = res.expect("DB error");
                 match key {
@@ -612,6 +615,7 @@ impl ServerModulePlugin for Mint {
             .find_by_prefix(&ReceivedPartialSignatureKeyOutputPrefix {
                 request_id: out_point,
             })
+            .await
             .any(|res| res.is_ok());
 
         let final_sig = dbtx
@@ -628,13 +632,15 @@ impl ServerModulePlugin for Mint {
         }
     }
 
-    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
-        audit.add_items(dbtx, &MintAuditItemKeyPrefix, |k, v| match k {
-            MintAuditItemKey::Issuance(_) => -(v.milli_sat as i64),
-            MintAuditItemKey::IssuanceTotal => -(v.milli_sat as i64),
-            MintAuditItemKey::Redemption(_) => v.milli_sat as i64,
-            MintAuditItemKey::RedemptionTotal => v.milli_sat as i64,
-        });
+    async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit) {
+        audit
+            .add_items(dbtx, &MintAuditItemKeyPrefix, |k, v| match k {
+                MintAuditItemKey::Issuance(_) => -(v.milli_sat as i64),
+                MintAuditItemKey::IssuanceTotal => -(v.milli_sat as i64),
+                MintAuditItemKey::Redemption(_) => v.milli_sat as i64,
+                MintAuditItemKey::RedemptionTotal => v.milli_sat as i64,
+            })
+            .await;
     }
 
     fn api_base_name(&self) -> &'static str {

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -308,13 +308,16 @@ impl ServerModulePlugin for Mint {
         MintModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self) {
-        if self.consensus_proposal().await.is_empty() {
+    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
+        if self.consensus_proposal(dbtx).await.is_empty() {
             std::future::pending().await
         }
     }
 
-    async fn consensus_proposal(&self) -> Vec<Self::ConsensusItem> {
+    async fn consensus_proposal(
+        &self,
+        _dbtx: &DatabaseTransaction<'_>,
+    ) -> Vec<Self::ConsensusItem> {
         self.non_consensus_db
             .begin_transaction(self.decoders.clone())
             .find_by_prefix(&ProposedPartialSignaturesKeyPrefix)
@@ -601,7 +604,11 @@ impl ServerModulePlugin for Mint {
         drop_peers.into_iter().collect()
     }
 
-    fn output_status(&self, out_point: OutPoint) -> Option<Self::OutputOutcome> {
+    fn output_status(
+        &self,
+        _dbtx: &mut DatabaseTransaction<'_>,
+        out_point: OutPoint,
+    ) -> Option<Self::OutputOutcome> {
         let dbtx = self
             .non_consensus_db
             .begin_transaction(self.decoders.clone());
@@ -628,7 +635,7 @@ impl ServerModulePlugin for Mint {
         }
     }
 
-    fn audit(&self, audit: &mut Audit) {
+    fn audit(&self, _dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
         audit.add_items(
             &self
                 .non_consensus_db

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -306,13 +306,16 @@ impl ServerModulePlugin for Mint {
         MintModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
+    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
         if self.consensus_proposal(dbtx).await.is_empty() {
             std::future::pending().await
         }
     }
 
-    async fn consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) -> Vec<Self::ConsensusItem> {
+    async fn consensus_proposal(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> Vec<Self::ConsensusItem> {
         dbtx.find_by_prefix(&ProposedPartialSignaturesKeyPrefix)
             .map(|res| {
                 let (key, partial_signature) = res.expect("DB error");
@@ -370,30 +373,26 @@ impl ServerModulePlugin for Mint {
         verification_cache: &Self::VerificationCache,
         input: &'a Self::Input,
     ) -> Result<InputMeta, ModuleError> {
-        input
-            .iter_items()
-            .try_for_each(|(amount, coin)| {
-                let coin_valid = verification_cache
-                    .valid_coins
-                    .get(coin) // We validated the coin
-                    .map(|coint_amount| *coint_amount == amount) // It has the right amount tier
-                    .unwrap_or(false); // If we didn't validate the coin return false
+        for (amount, coin) in input.iter_items() {
+            let coin_valid = verification_cache
+                .valid_coins
+                .get(coin) // We validated the coin
+                .map(|coint_amount| *coint_amount == amount) // It has the right amount tier
+                .unwrap_or(false); // If we didn't validate the coin return false
 
-                if !coin_valid {
-                    return Err(MintError::InvalidSignature);
-                }
+            if !coin_valid {
+                return Err(MintError::InvalidSignature).into_module_error_other();
+            }
 
-                if dbtx
-                    .get_value(&NonceKey(coin.0.clone()))
-                    .expect("DB error")
-                    .is_some()
-                {
-                    return Err(MintError::SpentCoin);
-                }
-
-                Ok(())
-            })
-            .into_module_error_other()?;
+            if dbtx
+                .get_value(&NonceKey(coin.0.clone()))
+                .await
+                .expect("DB error")
+                .is_some()
+            {
+                return Err(MintError::SpentCoin).into_module_error_other();
+            }
+        }
 
         Ok(InputMeta {
             amount: TransactionItemAmount {
@@ -429,9 +428,9 @@ impl ServerModulePlugin for Mint {
         Ok(meta)
     }
 
-    fn validate_output(
+    async fn validate_output(
         &self,
-        _dbtx: &DatabaseTransaction,
+        _dbtx: &mut DatabaseTransaction<'_>,
         output: &Self::Output,
     ) -> Result<TransactionItemAmount, ModuleError> {
         if let Some(amount) = output.iter_items().find_map(|(amount, _)| {
@@ -456,7 +455,7 @@ impl ServerModulePlugin for Mint {
         output: &'a Self::Output,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
-        let amount = self.validate_output(dbtx, output)?;
+        let amount = self.validate_output(dbtx, output).await?;
 
         // TODO: move actual signing to worker thread
         // TODO: get rid of clone
@@ -493,25 +492,25 @@ impl ServerModulePlugin for Mint {
         let mut drop_peers = BTreeSet::new();
 
         // Finalize partial signatures for which we now have enough shares
-        let issuance_requests = dbtx
+        let issuance_requests_iter = dbtx
             .find_by_prefix(&ReceivedPartialSignaturesKeyPrefix)
             .map(|entry_res| {
                 let (key, partial_sig) = entry_res.expect("DB error");
                 (key.request_id, (key.peer_id, partial_sig))
             })
             .into_group_map()
-            .into_iter()
-            .map(|(out_point, signature_shares)| {
-                let proposal_key = ProposedPartialSignatureKey { out_point };
-                let our_contribution = dbtx.get_value(&proposal_key).expect("DB error");
+            .into_iter();
+        let mut issuance_requests = Vec::new();
+        for (out_point, signature_shares) in issuance_requests_iter {
+            let proposal_key = ProposedPartialSignatureKey { out_point };
+            let our_contribution = dbtx.get_value(&proposal_key).await.expect("DB error");
 
-                IssuanceData {
-                    out_point,
-                    our_contribution,
-                    signature_shares,
-                }
-            })
-            .collect::<Vec<_>>();
+            issuance_requests.push(IssuanceData {
+                out_point,
+                our_contribution,
+                signature_shares,
+            });
+        }
 
         let issuance_results = issuance_requests
             .into_par_iter()
@@ -599,13 +598,14 @@ impl ServerModulePlugin for Mint {
         drop_peers.into_iter().collect()
     }
 
-    fn output_status(
+    async fn output_status(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<Self::OutputOutcome> {
         let we_proposed = dbtx
             .get_value(&ProposedPartialSignatureKey { out_point })
+            .await
             .expect("DB error")
             .is_some();
         let was_consensus_outcome = dbtx
@@ -616,6 +616,7 @@ impl ServerModulePlugin for Mint {
 
         let final_sig = dbtx
             .get_value(&OutputOutcomeKey(out_point))
+            .await
             .expect("DB error");
 
         if final_sig.is_some() {
@@ -655,7 +656,7 @@ impl ServerModulePlugin for Mint {
                 "/recover",
                 async |module: &Mint, dbtx, id: secp256k1_zkp::XOnlyPublicKey| -> Vec<u8> {
                     module
-                        .handle_recover_request(&dbtx, id).await
+                        .handle_recover_request(&mut dbtx, id).await
                         .ok_or_else(|| ApiError::not_found(String::from("Backup not found")))
                 }
             },
@@ -675,6 +676,7 @@ impl Mint {
 
         if let Some(prev) = dbtx
             .get_value(&EcashBackupKey(request.id))
+            .await
             .expect("DB error")
         {
             if request.timestamp <= prev.timestamp {
@@ -697,10 +699,11 @@ impl Mint {
 
     async fn handle_recover_request(
         &self,
-        dbtx: &DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         id: secp256k1_zkp::XOnlyPublicKey,
     ) -> Option<Vec<u8>> {
         dbtx.get_value(&EcashBackupKey(id))
+            .await
             .expect("DB error")
             .map(|res| res.data)
     }
@@ -914,6 +917,7 @@ impl Mint {
     ) {
         if dbtx
             .get_value(&OutputOutcomeKey(output_id))
+            .await
             .expect("DB error")
             .is_some()
         {

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -105,10 +105,6 @@ pub struct Wallet {
     cfg: WalletConfig,
     secp: Secp256k1<All>,
     btc_rpc: BitcoindRpc,
-    // TODO: remove DB altogether
-    // Only to be used for non-consensus read operations
-    non_consensus_db: Database,
-    decoders: ModuleRegistry<Decoder>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Encodable, Decodable)]
@@ -379,18 +375,14 @@ impl ServerModulePlugin for Wallet {
 
     async fn consensus_proposal<'a>(
         &'a self,
-        _dbtx: &DatabaseTransaction<'_>,
+        dbtx: &DatabaseTransaction<'_>,
     ) -> Vec<Self::ConsensusItem> {
-        let dbtx = self
-            .non_consensus_db
-            .begin_transaction(self.decoders.clone());
-
         // TODO: implement retry logic in case bitcoind is temporarily unreachable
         let our_target_height = self.target_height().await;
 
         // In case the wallet just got created the height is not committed to the DB yet but will
         // be set to 0 first, so we can assume that here.
-        let last_consensus_height = self.consensus_height(&dbtx).unwrap_or(0);
+        let last_consensus_height = self.consensus_height(dbtx).unwrap_or(0);
 
         let proposed_height = if our_target_height >= last_consensus_height {
             our_target_height
@@ -705,26 +697,19 @@ impl ServerModulePlugin for Wallet {
 
     fn output_status(
         &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<Self::OutputOutcome> {
-        self.non_consensus_db
-            .begin_transaction(self.decoders.clone())
-            .get_value(&PegOutBitcoinTransaction(out_point))
+        dbtx.get_value(&PegOutBitcoinTransaction(out_point))
             .expect("DB error")
     }
 
-    fn audit(&self, _dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
-        let dbtx = self
-            .non_consensus_db
-            .begin_transaction(self.decoders.clone());
-        audit.add_items(&dbtx, &UTXOPrefixKey, |_, v| {
-            v.amount.to_sat() as i64 * 1000
-        });
-        audit.add_items(&dbtx, &UnsignedTransactionPrefixKey, |_, v| {
+    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
+        audit.add_items(dbtx, &UTXOPrefixKey, |_, v| v.amount.to_sat() as i64 * 1000);
+        audit.add_items(dbtx, &UnsignedTransactionPrefixKey, |_, v| {
             v.change.to_sat() as i64 * 1000
         });
-        audit.add_items(&dbtx, &PendingTransactionPrefixKey, |_, v| {
+        audit.add_items(dbtx, &PendingTransactionPrefixKey, |_, v| {
             v.change.to_sat() as i64 * 1000
         });
     }
@@ -737,14 +722,13 @@ impl ServerModulePlugin for Wallet {
         vec![
             api_endpoint! {
                 "/block_height",
-                async |module: &Wallet, _dbtx, _params: ()| -> u32 {
-                    Ok(module.consensus_height(&module.non_consensus_db.begin_transaction(module.decoders.clone())).unwrap_or(0))
+                async |module: &Wallet, dbtx, _params: ()| -> u32 {
+                    Ok(module.consensus_height(&dbtx).unwrap_or(0))
                 }
             },
             api_endpoint! {
                 "/peg_out_fees",
-                async |module: &Wallet, _dbtx, params: (Address, u64)| -> Option<PegOutFees> {
-                    let dbtx = module.non_consensus_db.begin_transaction(module.decoders.clone());
+                async |module: &Wallet, dbtx, params: (Address, u64)| -> Option<PegOutFees> {
                     let (address, sats) = params;
                     let consensus = module.current_round_consensus(&dbtx).unwrap();
                     let tx = module.offline_wallet().create_tx(
@@ -800,8 +784,6 @@ impl Wallet {
             cfg,
             secp: Default::default(),
             btc_rpc: bitcoind_rpc,
-            non_consensus_db: db,
-            decoders,
         };
 
         Ok(wallet)

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -486,10 +486,10 @@ impl ServerModulePlugin for Wallet {
         WalletVerificationCache
     }
 
-    fn validate_input<'a, 'b>(
+    async fn validate_input<'a, 'b>(
         &self,
         _interconnect: &dyn ModuleInterconect,
-        dbtx: &DatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransaction<'b>,
         _verification_cache: &Self::VerificationCache,
         input: &'a Self::Input,
     ) -> Result<InputMeta, ModuleError> {
@@ -526,7 +526,9 @@ impl ServerModulePlugin for Wallet {
         input: &'b Self::Input,
         cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
-        let meta = self.validate_input(interconnect, dbtx, cache, input)?;
+        let meta = self
+            .validate_input(interconnect, dbtx, cache, input)
+            .await?;
         debug!(outpoint = %input.outpoint(), amount = %meta.amount.amount, "Claiming peg-in");
 
         dbtx.insert_new_entry(
@@ -735,13 +737,13 @@ impl ServerModulePlugin for Wallet {
         vec![
             api_endpoint! {
                 "/block_height",
-                async |module: &Wallet, _params: ()| -> u32 {
+                async |module: &Wallet, _dbtx, _params: ()| -> u32 {
                     Ok(module.consensus_height(&module.non_consensus_db.begin_transaction(module.decoders.clone())).unwrap_or(0))
                 }
             },
             api_endpoint! {
                 "/peg_out_fees",
-                async |module: &Wallet, params: (Address, u64)| -> Option<PegOutFees> {
+                async |module: &Wallet, _dbtx, params: (Address, u64)| -> Option<PegOutFees> {
                     let dbtx = module.non_consensus_db.begin_transaction(module.decoders.clone());
                     let (address, sats) = params;
                     let consensus = module.current_round_consensus(&dbtx).unwrap();

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -409,6 +409,7 @@ impl ServerModulePlugin for Wallet {
         });
 
         dbtx.find_by_prefix(&PegOutTxSignatureCIPrefix)
+            .await
             .map(|res| {
                 let (key, val) = res.expect("FB error");
                 WalletConsensusItem::PegOutSignature(PegOutSignatureItem {
@@ -645,6 +646,7 @@ impl ServerModulePlugin for Wallet {
         // Sign and finalize any unsigned transactions that have signatures
         let unsigned_txs: Vec<(UnsignedTransactionKey, UnsignedTransaction)> = dbtx
             .find_by_prefix(&UnsignedTransactionPrefixKey)
+            .await
             .map(|res| res.expect("DB error"))
             .filter(|(_, unsigned)| !unsigned.signatures.is_empty())
             .collect();
@@ -707,14 +709,20 @@ impl ServerModulePlugin for Wallet {
             .expect("DB error")
     }
 
-    fn audit(&self, dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
-        audit.add_items(dbtx, &UTXOPrefixKey, |_, v| v.amount.to_sat() as i64 * 1000);
-        audit.add_items(dbtx, &UnsignedTransactionPrefixKey, |_, v| {
-            v.change.to_sat() as i64 * 1000
-        });
-        audit.add_items(dbtx, &PendingTransactionPrefixKey, |_, v| {
-            v.change.to_sat() as i64 * 1000
-        });
+    async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit) {
+        audit
+            .add_items(dbtx, &UTXOPrefixKey, |_, v| v.amount.to_sat() as i64 * 1000)
+            .await;
+        audit
+            .add_items(dbtx, &UnsignedTransactionPrefixKey, |_, v| {
+                v.change.to_sat() as i64 * 1000
+            })
+            .await;
+        audit
+            .add_items(dbtx, &PendingTransactionPrefixKey, |_, v| {
+                v.change.to_sat() as i64 * 1000
+            })
+            .await;
     }
 
     fn api_base_name(&self) -> &'static str {
@@ -737,7 +745,7 @@ impl ServerModulePlugin for Wallet {
                     let tx = module.offline_wallet().create_tx(
                         bitcoin::Amount::from_sat(sats),
                         address.script_pubkey(),
-                        module.available_utxos(&dbtx),
+                        module.available_utxos(&mut dbtx).await,
                         consensus.fee_rate,
                         &consensus.randomness_beacon
                     );
@@ -808,6 +816,7 @@ impl Wallet {
     ) {
         let mut cache: BTreeMap<Txid, UnsignedTransaction> = dbtx
             .find_by_prefix(&UnsignedTransactionPrefixKey)
+            .await
             .map(|res| {
                 let (key, val) = res.expect("DB error");
                 (key.0, val)
@@ -1031,6 +1040,7 @@ impl Wallet {
 
             let pending_transactions = dbtx
                 .find_by_prefix(&PendingTransactionPrefixKey)
+                .await
                 .map(|res| {
                     let (key, transaction) = res.expect("DB error");
                     (key.0, transaction)
@@ -1113,21 +1123,26 @@ impl Wallet {
         self.offline_wallet().create_tx(
             peg_out.amount,
             peg_out.recipient.script_pubkey(),
-            self.available_utxos(dbtx),
+            self.available_utxos(dbtx).await,
             peg_out.fees.fee_rate,
             &change_tweak,
         )
     }
 
-    fn available_utxos(&self, dbtx: &DatabaseTransaction) -> Vec<(UTXOKey, SpendableUTXO)> {
+    async fn available_utxos(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> Vec<(UTXOKey, SpendableUTXO)> {
         dbtx.find_by_prefix(&UTXOPrefixKey)
+            .await
             .collect::<Result<_, _>>()
             .expect("DB error")
     }
 
-    pub fn get_wallet_value(&self, dbtx: &DatabaseTransaction) -> bitcoin::Amount {
+    pub async fn get_wallet_value(&self, dbtx: &mut DatabaseTransaction<'_>) -> bitcoin::Amount {
         let sat_sum = self
             .available_utxos(dbtx)
+            .await
             .into_iter()
             .map(|(_, utxo)| utxo.amount.to_sat())
             .sum();
@@ -1440,9 +1455,10 @@ pub async fn run_broadcast_pending_tx(
     }
 }
 
-pub async fn broadcast_pending_tx(dbtx: DatabaseTransaction<'_>, rpc: &BitcoindRpc) {
+pub async fn broadcast_pending_tx(mut dbtx: DatabaseTransaction<'_>, rpc: &BitcoindRpc) {
     let pending_tx = dbtx
         .find_by_prefix(&PendingTransactionPrefixKey)
+        .await
         .collect::<Result<Vec<_>, _>>()
         .expect("DB error");
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -365,17 +365,11 @@ impl ServerModulePlugin for Wallet {
         WalletModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self) {
+    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
         let mut our_target_height = self.target_height().await;
-        let last_consensus_height = self
-            .consensus_height(
-                &self
-                    .non_consensus_db
-                    .begin_transaction(self.decoders.clone()),
-            )
-            .unwrap_or(0);
+        let last_consensus_height = self.consensus_height(dbtx).unwrap_or(0);
 
-        if self.consensus_proposal().await.len() == 1 {
+        if self.consensus_proposal(dbtx).await.len() == 1 {
             while our_target_height <= last_consensus_height {
                 our_target_height = self.target_height().await;
                 sleep(Duration::from_millis(1000)).await;
@@ -383,7 +377,10 @@ impl ServerModulePlugin for Wallet {
         }
     }
 
-    async fn consensus_proposal<'a>(&'a self) -> Vec<Self::ConsensusItem> {
+    async fn consensus_proposal<'a>(
+        &'a self,
+        _dbtx: &DatabaseTransaction<'_>,
+    ) -> Vec<Self::ConsensusItem> {
         let dbtx = self
             .non_consensus_db
             .begin_transaction(self.decoders.clone());
@@ -704,14 +701,18 @@ impl ServerModulePlugin for Wallet {
         drop_peers
     }
 
-    fn output_status(&self, out_point: OutPoint) -> Option<Self::OutputOutcome> {
+    fn output_status(
+        &self,
+        _dbtx: &mut DatabaseTransaction<'_>,
+        out_point: OutPoint,
+    ) -> Option<Self::OutputOutcome> {
         self.non_consensus_db
             .begin_transaction(self.decoders.clone())
             .get_value(&PegOutBitcoinTransaction(out_point))
             .expect("DB error")
     }
 
-    fn audit(&self, audit: &mut Audit) {
+    fn audit(&self, _dbtx: &DatabaseTransaction<'_>, audit: &mut Audit) {
         let dbtx = self
             .non_consensus_db
             .begin_transaction(self.decoders.clone());

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -361,11 +361,11 @@ impl ServerModulePlugin for Wallet {
         WalletModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
+    async fn await_consensus_proposal(&self, mut dbtx: DatabaseTransaction<'_>) {
         let mut our_target_height = self.target_height().await;
-        let last_consensus_height = self.consensus_height(dbtx).await.unwrap_or(0);
+        let last_consensus_height = self.consensus_height(&mut dbtx).await.unwrap_or(0);
 
-        if self.consensus_proposal(dbtx).await.len() == 1 {
+        if self.consensus_proposal(&mut dbtx).await.len() == 1 {
             while our_target_height <= last_consensus_height {
                 our_target_height = self.target_height().await;
                 sleep(Duration::from_millis(1000)).await;

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -361,9 +361,9 @@ impl ServerModulePlugin for Wallet {
         WalletModuleDecoder
     }
 
-    async fn await_consensus_proposal(&self, dbtx: &DatabaseTransaction<'_>) {
+    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
         let mut our_target_height = self.target_height().await;
-        let last_consensus_height = self.consensus_height(dbtx).unwrap_or(0);
+        let last_consensus_height = self.consensus_height(dbtx).await.unwrap_or(0);
 
         if self.consensus_proposal(dbtx).await.len() == 1 {
             while our_target_height <= last_consensus_height {
@@ -375,14 +375,14 @@ impl ServerModulePlugin for Wallet {
 
     async fn consensus_proposal<'a>(
         &'a self,
-        dbtx: &DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
     ) -> Vec<Self::ConsensusItem> {
         // TODO: implement retry logic in case bitcoind is temporarily unreachable
         let our_target_height = self.target_height().await;
 
         // In case the wallet just got created the height is not committed to the DB yet but will
         // be set to 0 first, so we can assume that here.
-        let last_consensus_height = self.consensus_height(dbtx).unwrap_or(0);
+        let last_consensus_height = self.consensus_height(dbtx).await.unwrap_or(0);
 
         let proposed_height = if our_target_height >= last_consensus_height {
             our_target_height
@@ -485,7 +485,7 @@ impl ServerModulePlugin for Wallet {
         _verification_cache: &Self::VerificationCache,
         input: &'a Self::Input,
     ) -> Result<InputMeta, ModuleError> {
-        if !self.block_is_known(dbtx, input.proof_block()) {
+        if !self.block_is_known(dbtx, input.proof_block()).await {
             return Err(WalletError::UnknownPegInProofBlock(input.proof_block()))
                 .into_module_error_other();
         }
@@ -496,6 +496,7 @@ impl ServerModulePlugin for Wallet {
 
         if dbtx
             .get_value(&UTXOKey(input.outpoint()))
+            .await
             .expect("DB error")
             .is_some()
         {
@@ -536,9 +537,9 @@ impl ServerModulePlugin for Wallet {
         Ok(meta)
     }
 
-    fn validate_output(
+    async fn validate_output(
         &self,
-        dbtx: &DatabaseTransaction,
+        dbtx: &mut DatabaseTransaction<'_>,
         output: &Self::Output,
     ) -> Result<TransactionItemAmount, ModuleError> {
         if !is_address_valid_for_network(&output.recipient, self.cfg.network) {
@@ -548,7 +549,7 @@ impl ServerModulePlugin for Wallet {
             ))
             .into_module_error_other();
         }
-        let consensus_fee_rate = self.current_round_consensus(dbtx).unwrap().fee_rate;
+        let consensus_fee_rate = self.current_round_consensus(dbtx).await.unwrap().fee_rate;
         if output.fees.fee_rate < consensus_fee_rate {
             return Err(WalletError::PegOutFeeRate(
                 output.fees.fee_rate,
@@ -556,7 +557,7 @@ impl ServerModulePlugin for Wallet {
             ))
             .into_module_error_other();
         }
-        if self.create_peg_out_tx(dbtx, output).is_none() {
+        if self.create_peg_out_tx(dbtx, output).await.is_none() {
             return Err(WalletError::NotEnoughSpendableUTXO).into_module_error_other();
         }
         Ok(TransactionItemAmount {
@@ -571,7 +572,7 @@ impl ServerModulePlugin for Wallet {
         output: &'a Self::Output,
         out_point: fedimint_api::OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
-        let amount = self.validate_output(dbtx, output)?;
+        let amount = self.validate_output(dbtx, output).await?;
         debug!(
             amount = %output.amount, recipient = %output.recipient,
             "Queuing peg-out",
@@ -579,6 +580,7 @@ impl ServerModulePlugin for Wallet {
 
         let mut tx = self
             .create_peg_out_tx(dbtx, output)
+            .await
             .expect("Should have been validated");
         self.offline_wallet().sign_psbt(&mut tx.psbt);
         let txid = tx.psbt.unsigned_tx.txid();
@@ -695,12 +697,13 @@ impl ServerModulePlugin for Wallet {
         drop_peers
     }
 
-    fn output_status(
+    async fn output_status(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<Self::OutputOutcome> {
         dbtx.get_value(&PegOutBitcoinTransaction(out_point))
+            .await
             .expect("DB error")
     }
 
@@ -723,14 +726,14 @@ impl ServerModulePlugin for Wallet {
             api_endpoint! {
                 "/block_height",
                 async |module: &Wallet, dbtx, _params: ()| -> u32 {
-                    Ok(module.consensus_height(&dbtx).unwrap_or(0))
+                    Ok(module.consensus_height(&mut dbtx).await.unwrap_or(0))
                 }
             },
             api_endpoint! {
                 "/peg_out_fees",
                 async |module: &Wallet, dbtx, params: (Address, u64)| -> Option<PegOutFees> {
                     let (address, sats) = params;
-                    let consensus = module.current_round_consensus(&dbtx).unwrap();
+                    let consensus = module.current_round_consensus(&mut dbtx).await.unwrap();
                     let tx = module.offline_wallet().create_tx(
                         bitcoin::Amount::from_sat(sats),
                         address.script_pubkey(),
@@ -947,7 +950,7 @@ impl Wallet {
         proposals.sort_unstable();
         let median_proposal = proposals[proposals.len() / 2];
 
-        let consensus_height = self.consensus_height(dbtx).unwrap_or(0);
+        let consensus_height = self.consensus_height(dbtx).await.unwrap_or(0);
 
         if median_proposal >= consensus_height {
             debug!("Setting consensus block height to {}", median_proposal);
@@ -963,8 +966,11 @@ impl Wallet {
         median_proposal
     }
 
-    pub fn current_round_consensus(&self, dbtx: &DatabaseTransaction) -> Option<RoundConsensus> {
-        dbtx.get_value(&RoundConsensusKey).expect("DB error")
+    pub async fn current_round_consensus(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> Option<RoundConsensus> {
+        dbtx.get_value(&RoundConsensusKey).await.expect("DB error")
     }
 
     pub async fn target_height(&self) -> u32 {
@@ -976,8 +982,10 @@ impl Wallet {
         our_network_height.saturating_sub(self.cfg.finality_delay)
     }
 
-    pub fn consensus_height(&self, dbtx: &DatabaseTransaction) -> Option<u32> {
-        self.current_round_consensus(dbtx).map(|rc| rc.block_height)
+    pub async fn consensus_height(&self, dbtx: &mut DatabaseTransaction<'_>) -> Option<u32> {
+        self.current_round_consensus(dbtx)
+            .await
+            .map(|rc| rc.block_height)
     }
 
     async fn sync_up_to_consensus_height<'a>(
@@ -987,6 +995,7 @@ impl Wallet {
     ) {
         let old_height = self
             .consensus_height(dbtx)
+            .await
             .unwrap_or_else(|| new_height.saturating_sub(10));
         if new_height < old_height {
             info!(
@@ -1080,19 +1089,25 @@ impl Wallet {
         }
     }
 
-    fn block_is_known(&self, dbtx: &DatabaseTransaction, block_hash: BlockHash) -> bool {
+    async fn block_is_known(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        block_hash: BlockHash,
+    ) -> bool {
         dbtx.get_value(&BlockHashKey(block_hash))
+            .await
             .expect("DB error")
             .is_some()
     }
 
-    fn create_peg_out_tx(
+    async fn create_peg_out_tx(
         &self,
-        dbtx: &DatabaseTransaction,
+        dbtx: &mut DatabaseTransaction<'_>,
         peg_out: &PegOut,
     ) -> Option<UnsignedTransaction> {
         let change_tweak = self
             .current_round_consensus(dbtx)
+            .await
             .unwrap()
             .randomness_beacon;
         self.offline_wallet().create_tx(


### PR DESCRIPTION
This PR changes the get_value and find_by_prefix functions of the database transaction trait to be asynchronous. This PR builds on top of https://github.com/fedimint/fedimint/pull/975 to work around issues of some futures not being Send.