### PR TITLE
Derive detereministic BlindNonces independently for each amount tier 

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -376,7 +376,11 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             .receive_coins(
                 amount,
                 &mut dbtx,
-                || async { self.mint_client().new_ecash_note(&self.context.secp).await },
+                |note_amount| async move {
+                    self.mint_client()
+                        .new_ecash_note(&self.context.secp, note_amount)
+                        .await
+                },
                 create_tx,
             )
             .await;
@@ -465,7 +469,11 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             tx.input_coins(coins.clone())?;
             tx.output_coins(
                 amount,
-                move || async { self.mint_client().new_ecash_note(&self.context.secp).await },
+                |note_amount| async move {
+                    self.mint_client()
+                        .new_ecash_note(&self.context.secp, note_amount)
+                        .await
+                },
                 &self.mint_client().config.tbs_pks,
             )
             .await;

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -121,7 +121,12 @@ impl MintClient {
 
         let mut dbtx = self.start_dbtx();
         let notes = self.get_available_notes(&mut dbtx);
-        let last_idx = self.get_last_note_index(&mut dbtx);
+        let last_idx = Tiered::from_iter(
+            self.config
+                .tbs_pks
+                .tiers()
+                .map(|&amount| (amount, self.get_last_note_index(&mut dbtx, amount))),
+        );
 
         Ok(PlaintextEcashBackup {
             notes,
@@ -153,7 +158,7 @@ impl MintClient {
 pub struct PlaintextEcashBackup {
     notes: TieredMulti<SpendableNote>,
     epoch: u64,
-    last_idx: NoteIndex,
+    last_idx: Tiered<NoteIndex>,
 }
 
 impl PlaintextEcashBackup {

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -19,7 +19,9 @@ fn sanity_ecash_backup_align() {
 fn sanity_ecash_backup_decode_encode() -> Result<()> {
     let orig = PlaintextEcashBackup {
         notes: TieredMulti::from_iter([]),
-        last_idx: NoteIndex::from_u64(3),
+        last_idx: Tiered::from_iter(
+            [(Amount::from_milli_sats(1), NoteIndex::from_u64(3))].into_iter(),
+        ),
         epoch: 0,
     };
 
@@ -34,7 +36,9 @@ fn sanity_ecash_backup_decode_encode() -> Result<()> {
 fn sanity_ecash_backup_encrypt_decrypt() -> Result<()> {
     let orig = PlaintextEcashBackup {
         notes: TieredMulti::from_iter([]),
-        last_idx: NoteIndex::from_u64(3),
+        last_idx: Tiered::from_iter(
+            [(Amount::from_milli_sats(1), NoteIndex::from_u64(3))].into_iter(),
+        ),
         epoch: 1,
     };
 

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -79,8 +79,17 @@ impl DatabaseKeyPrefixConst for OutputFinalizationKeyPrefix {
     type Value = NoteIssuanceRequests;
 }
 
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct LastECashNoteIndexKeyPrefix;
+
+impl DatabaseKeyPrefixConst for LastECashNoteIndexKeyPrefix {
+    const DB_PREFIX: u8 = DbKeyPrefix::LastECashNoteIndex as u8;
+    type Key = LastECashNoteIndexKey;
+    type Value = u64;
+}
+
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
-pub struct LastECashNoteIndexKey;
+pub struct LastECashNoteIndexKey(pub Amount);
 
 impl DatabaseKeyPrefixConst for LastECashNoteIndexKey {
     const DB_PREFIX: u8 = DbKeyPrefix::LastECashNoteIndex as u8;

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -137,7 +137,7 @@ impl TransactionBuilder {
         coin_gen: F,
         tbs_pks: &Tiered<AggregatePublicKey>,
     ) where
-        F: FnMut() -> Fut,
+        F: FnMut(Amount) -> Fut,
         Fut: futures::Future<Output = (NoteIssuanceRequest, BlindNonce)>,
     {
         let (coin_finalization_data, coin_output) =
@@ -158,13 +158,13 @@ impl TransactionBuilder {
         tbs_pks: &Tiered<AggregatePublicKey>,
     ) -> (NoteIssuanceRequests, TieredMulti<BlindNonce>)
     where
-        F: FnMut() -> Fut,
+        F: FnMut(Amount) -> Fut,
         Fut: futures::Future<Output = (NoteIssuanceRequest, BlindNonce)>,
     {
         let mut amount_requests: Vec<((Amount, NoteIssuanceRequest), (Amount, BlindNonce))> =
             Vec::new();
         for (amt, ()) in TieredMulti::represent_amount(amount, tbs_pks).into_iter() {
-            let (request, blind_nonce) = coin_gen().await;
+            let (request, blind_nonce) = coin_gen(amt).await;
             amount_requests.push(((amt, request), (amt, blind_nonce)));
         }
         let (coin_finalization_data, sig_req): (NoteIssuanceRequests, MintOutput) =
@@ -190,7 +190,7 @@ impl TransactionBuilder {
         mut rng: R,
     ) -> Transaction
     where
-        F: FnMut() -> Fut,
+        F: FnMut(Amount) -> Fut,
         Fut: futures::Future<Output = (NoteIssuanceRequest, BlindNonce)>,
     {
         // add change

--- a/fedimint-api/src/tiered_multi.rs
+++ b/fedimint-api/src/tiered_multi.rs
@@ -199,13 +199,7 @@ where
     C: Encodable,
 {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        let mut len = 0;
-        len += (self.iter_items().count() as u64).consensus_encode(writer)?;
-        for (amount, i) in self.iter_items() {
-            len += amount.consensus_encode(writer)?;
-            len += i.consensus_encode(writer)?;
-        }
-        Ok(len)
+        self.0.consensus_encode(writer)
     }
 }
 
@@ -220,14 +214,7 @@ where
     where
         M: ModuleDecode,
     {
-        let mut res = BTreeMap::new();
-        let len = u64::consensus_decode(d, modules)?;
-        for _ in 0..len {
-            let amt = Amount::consensus_decode(d, modules)?;
-            let v = C::consensus_decode(d, modules)?;
-            res.entry(amt).or_insert_with(Vec::new).push(v);
-        }
-        Ok(TieredMulti(res))
+        Ok(TieredMulti(BTreeMap::consensus_decode(d, modules)?))
     }
 }
 

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -534,16 +534,14 @@ impl<'a> DatabaseDump<'a> {
                     );
                 }
                 ClientMintRange::DbKeyPrefix::LastECashNoteIndex => {
-                    let last_ecash_note = self
-                        .read_only
-                        .get_value(&ClientMintRange::LastECashNoteIndexKey)
-                        .unwrap();
-                    if let Some(last_ecash_note) = last_ecash_note {
-                        mint_client.insert(
-                            "Last e-cash note index".to_string(),
-                            Box::new(last_ecash_note),
-                        );
-                    }
+                    push_db_pair_items!(
+                        self,
+                        ClientMintRange::LastECashNoteIndexKeyPrefix,
+                        ClientMintRange::LastECashNoteIndexKey,
+                        u64,
+                        mint_client,
+                        "Last e-cash note index"
+                    );
                 }
             }
         }

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -823,11 +823,12 @@ async fn receive_lightning_payment_invalid_preimage() -> Result<()> {
         .tbs_pks;
     let context = &user.client.mint_client().context;
     let mut dbtx = context.db.begin_transaction(all_decoders());
+    let client = &user.client;
     let tx = builder
         .build(
             sats(0),
             &mut dbtx,
-            || async { user.client.mint_client().new_ecash_note(&secp()).await },
+            |amount| async move { client.mint_client().new_ecash_note(&secp(), amount).await },
             &secp(),
             tbs_pks,
             rng(),


### PR DESCRIPTION
This is to help e-cash recovery code to avoid problems with potential
attacks where an evil guardian could mint a different note
(with smaller) value using the same `BlindNonce`.

Previous the recovery code could derive nonces, but wouldn't know
what amount to expect for each of them, so would either have to
use the first occurence of a given nonce (possibly malicious) blindly,
or explicitily track possiblities of there being multiple ones,
and use the one with the higest value after some delay.

By deriving `BlindNonce`s independently for each amount, when generating
them we know exactly what amount to expect.

TODO:

* [ ] If this look OK, I should probably update the docs too.

First couple of commits are already in #1033 and can be landed independently.