### PR TITLE
Client exposes reference to it's database

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -193,6 +193,10 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         &self.context.api
     }
 
+    pub fn db(&self) -> &Database {
+        &self.context.db
+    }
+
     pub fn ln_client(&self) -> LnClient {
         LnClient {
             config: self


### PR DESCRIPTION
This is useful for clients like Fluttermint to implement extra functionality without needing to modify Fedimint.