### PR TITLE
Add epoch_pk to ClientConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
  "tbs",
  "test-log",
  "thiserror",
+ "threshold_crypto",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -215,6 +215,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
                 .as_ref()
                 .get_module::<MintClientConfig>("mint")
                 .expect("needs mint module client config"),
+            epoch_pk: self.config.as_ref().epoch_pk,
             context: self.context.clone(),
             secret: self.root_secret.child_key(MINT_SECRET_CHILD_ID),
         }

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -42,6 +42,7 @@ const MINT_E_CASH_TYPE_CHILD_ID: ChildId = ChildId(0);
 /// of the mint type.
 #[derive(Debug, Clone)]
 pub struct MintClient {
+    pub epoch_pk: threshold_crypto::PublicKey,
     pub config: MintClientConfig,
     pub context: Arc<ClientContext>,
     pub secret: DerivableSecret,
@@ -705,6 +706,7 @@ mod tests {
 
         let context = Arc::new(client_context);
         let client = MintClient {
+            epoch_pk: threshold_crypto::SecretKey::random().public_key(),
             config: client_config,
             context: context.clone(),
             secret: DerivableSecret::new(&[], &[]),
@@ -724,6 +726,7 @@ mod tests {
 
         let context = Arc::new(client_context);
         let client = MintClient {
+            epoch_pk: threshold_crypto::SecretKey::random().public_key(),
             config: client_config,
             context: context.clone(),
             secret: DerivableSecret::new(&[], &[]),
@@ -821,6 +824,7 @@ mod tests {
         let db = fedimint_rocksdb::RocksDb::open(tempfile::tempdir().unwrap()).unwrap();
 
         let client: MintClient = MintClient {
+            epoch_pk: threshold_crypto::SecretKey::random().public_key(),
             config: MintClientConfig {
                 tbs_pks: Tiered::from_iter([]),
                 fee_consensus: Default::default(),

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.147", features = [ "derive" ] }
 serde_json = "1.0.89"
 tbs = { path = "../crypto/tbs"}
 thiserror = "1.0.37"
+threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
 tracing ="0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -42,6 +42,7 @@ pub struct Node {
 pub struct ClientConfig {
     pub federation_name: String,
     pub nodes: Vec<Node>,
+    pub epoch_pk: threshold_crypto::PublicKey,
     pub modules: BTreeMap<String, ClientModuleConfig>,
 }
 

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -108,6 +108,7 @@ impl ServerConfig {
 
         ClientConfig {
             federation_name: self.federation_name.clone(),
+            epoch_pk: self.epoch_pk_set.public_key(),
             nodes,
             modules: self
                 .modules
@@ -215,7 +216,7 @@ impl ServerConfig {
             .map(|(name, gen)| (name, gen.trusted_dealer_gen(peers, &module_cfg_gen_params)))
             .collect();
 
-        let server_config = netinfo
+        let server_config: BTreeMap<_, _> = netinfo
             .iter()
             .map(|(&id, netinf)| {
                 let epoch_keys = epochinfo.get(&id).unwrap();
@@ -249,6 +250,11 @@ impl ServerConfig {
         let client_config = ClientConfig {
             federation_name: peer0.federation_name.clone(),
             nodes: peer0.api.nodes("ws://", names),
+            epoch_pk: server_config
+                .get(&peers[0])
+                .expect("must have at least one peer")
+                .epoch_pk_set
+                .public_key(),
             modules: module_configs
                 .iter()
                 .map(|(name, cfgs)| (name.to_string(), cfgs.1.clone()))

--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -128,7 +128,7 @@ fn trusted_dealer_gen(
         .map(|(name, gen)| (name, gen.trusted_dealer_gen(peers, &module_cfg_gen_params)))
         .collect();
 
-    let server_config = netinfo
+    let server_config: BTreeMap<_, _> = netinfo
         .iter()
         .map(|(&id, netinf)| {
             let id_u16: u16 = id.into();
@@ -181,6 +181,11 @@ fn trusted_dealer_gen(
                 }
             })
             .collect(),
+        epoch_pk: server_config
+            .get(&peers[0])
+            .expect("must have at least one peer")
+            .epoch_pk_set
+            .public_key(),
         modules: module_configs
             .iter()
             .map(|(name, cfgs)| (name.to_string(), cfgs.1.clone()))

--- a/gateway/tests/tests/fixtures/client.rs
+++ b/gateway/tests/tests/fixtures/client.rs
@@ -54,6 +54,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
         // Using some of the info in provided web socket connect info
         let client_config = ClientConfig {
             federation_name: "".to_string(),
+            epoch_pk: threshold_crypto::SecretKey::random().public_key(),
             nodes: [].into(),
             modules: [].into(),
         };


### PR DESCRIPTION
When downloading epochs, the client needs a `epoch_pk` to verify the epochs.