### PR TITLE
Rename LastEcashNoteIndex to NextEcashNoteIndex

### DIFF
--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -123,7 +123,7 @@ impl MintClient {
         let notes = self.get_available_notes(&mut dbtx).await;
         let mut note_idxs = Vec::new();
         for &amount in self.config.tbs_pks.tiers() {
-            note_idxs.push((amount, self.get_last_note_index(&mut dbtx, amount).await));
+            note_idxs.push((amount, self.get_next_note_index(&mut dbtx, amount).await));
         }
         let last_idx = Tiered::from_iter(note_idxs.into_iter());
 

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -13,7 +13,7 @@ pub enum DbKeyPrefix {
     Coin = 0x20,
     OutputFinalizationData = 0x21,
     PendingCoins = 0x27,
-    LastECashNoteIndex = 0x2a,
+    NextECashNoteIndex = 0x2a,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -80,19 +80,19 @@ impl DatabaseKeyPrefixConst for OutputFinalizationKeyPrefix {
 }
 
 #[derive(Debug, Clone, Encodable, Decodable)]
-pub struct LastECashNoteIndexKeyPrefix;
+pub struct NextECashNoteIndexKeyPrefix;
 
-impl DatabaseKeyPrefixConst for LastECashNoteIndexKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::LastECashNoteIndex as u8;
-    type Key = LastECashNoteIndexKey;
+impl DatabaseKeyPrefixConst for NextECashNoteIndexKeyPrefix {
+    const DB_PREFIX: u8 = DbKeyPrefix::NextECashNoteIndex as u8;
+    type Key = NextECashNoteIndexKey;
     type Value = u64;
 }
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
-pub struct LastECashNoteIndexKey(pub Amount);
+pub struct NextECashNoteIndexKey(pub Amount);
 
-impl DatabaseKeyPrefixConst for LastECashNoteIndexKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::LastECashNoteIndex as u8;
+impl DatabaseKeyPrefixConst for NextECashNoteIndexKey {
+    const DB_PREFIX: u8 = DbKeyPrefix::NextECashNoteIndex as u8;
     type Key = Self;
     type Value = u64;
 }

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -535,11 +535,11 @@ impl<'a> DatabaseDump<'a> {
                         "Pending Coins"
                     );
                 }
-                ClientMintRange::DbKeyPrefix::LastECashNoteIndex => {
+                ClientMintRange::DbKeyPrefix::NextECashNoteIndex => {
                     push_db_pair_items!(
                         self,
-                        ClientMintRange::LastECashNoteIndexKeyPrefix,
-                        ClientMintRange::LastECashNoteIndexKey,
+                        ClientMintRange::NextECashNoteIndexKeyPrefix,
+                        ClientMintRange::NextECashNoteIndexKey,
                         u64,
                         mint_client,
                         "Last e-cash note index"


### PR DESCRIPTION
This avoids skipping the note of the index 0, and aligns the "missing value" with `0`.