### PR TITLE
Make NotEnoughCoins error more desriptive

### DIFF
--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -325,15 +325,11 @@ impl MintClient {
 
     pub async fn select_coins(&self, amount: Amount) -> Result<TieredMulti<SpendableNote>> {
         let coins = self.coins().await;
+        let selected_coins = coins.select_coins(amount).ok_or_else(|| {
+            MintClientError::InsufficientBalance(amount, TieredMulti::total_amount(&coins))
+        })?;
 
-        coins
-            .select_coins(amount)
-            .ok_or(MintClientError::InsufficientBalance(
-                amount,
-                TieredMulti::total_amount(&coins),
-            ))?;
-
-        Ok(coins)
+        Ok(selected_coins)
     }
 
     pub async fn receive_coins<'a, F, Fut>(

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -324,14 +324,14 @@ impl MintClient {
     }
 
     pub async fn select_coins(&self, amount: Amount) -> Result<TieredMulti<SpendableNote>> {
-        let coins =
-            self.coins()
-                .await
-                .select_coins(amount)
-                .ok_or(MintClientError::InsufficientBalance(
-                    amount,
-                    TieredMulti::total_amount(&self.coins().await),
-                ))?;
+        let coins = self.coins().await;
+
+        coins
+            .select_coins(amount)
+            .ok_or(MintClientError::InsufficientBalance(
+                amount,
+                TieredMulti::total_amount(&coins),
+            ))?;
 
         Ok(coins)
     }


### PR DESCRIPTION
Rename NotEnoughCoins to InsufficientBalance and include the requested amount and total balance in the error message.