### PR TITLE
Add testing infra. and first unit-test for e-cash recovery 

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -188,6 +188,12 @@ impl PaymentParameters {
     }
 }
 
+impl<T> Client<T> {
+    pub fn mint_secret_static(root_secret: &DerivableSecret) -> DerivableSecret {
+        root_secret.child_key(MINT_SECRET_CHILD_ID)
+    }
+}
+
 // TODO: `get_module` is parsing `serde_json::Value` every time, which is not best for performance
 impl<T: AsRef<ClientConfig> + Clone> Client<T> {
     pub fn api_client(&self) -> &FederationApi {
@@ -218,7 +224,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
                 .expect("needs mint module client config"),
             epoch_pk: self.config.as_ref().epoch_pk,
             context: self.context.clone(),
-            secret: self.root_secret.child_key(MINT_SECRET_CHILD_ID),
+            secret: Self::mint_secret_static(&self.root_secret),
         }
     }
 

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -667,7 +667,7 @@ impl EcashRecoveryTracker {
                 .expect("must be in the map already");
 
             for (item_i, (item_amt, item)) in output_data.iter_items().enumerate() {
-                let iss_request = if let Some(iss_request) = item.1.clone() {
+                let iss_request = if let Some(iss_request) = item.1 {
                     iss_request
                 } else {
                     // Items without issuance request are ones we don't consider ours

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -90,7 +90,7 @@ impl MicroMintClient {
             )),
             tiered
                 .iter_items()
-                .map(|(amount, (bn, iss_req))| (amount, *bn, iss_req.clone()))
+                .map(|(amount, (bn, iss_req))| (amount, *bn, *iss_req))
                 .collect(),
         )
     }
@@ -131,11 +131,11 @@ impl MicroMintFed {
                 let peer_id = PeerId::from(peer_i as u16);
                 pub_key_shares
                     .entry(peer_id)
-                    .or_insert(Tiered::default())
+                    .or_default()
                     .insert(amount, pub_keys[peer_i as usize]);
                 sec_key_shares
                     .entry(peer_id)
-                    .or_insert(Tiered::default())
+                    .or_default()
                     .insert(amount, sec_keys[peer_i as usize]);
             }
         }
@@ -212,7 +212,7 @@ impl MicroMintFed {
         assert_eq!(confs_by_order.len(), note_iss_requests.len());
 
         note_iss_requests
-            .into_iter()
+            .iter()
             .zip(confs_by_order.into_iter())
             .map(|((amount, _bn, iss_req), sigs_by_peer)| {
                 let bsig = tbs::combine_valid_shares(
@@ -403,7 +403,7 @@ fn sanity_check_recovery_backup() {
     // Spend the notes, which should remove them from the tracker
     let tx_b = Transaction {
         inputs: vec![c1.generate_input(notes_c1_a).into()],
-        outputs: vec![output_c1_a.clone().into()],
+        outputs: vec![output_c1_a.into()],
         signature: None,
     };
 

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -1,6 +1,236 @@
-use anyhow::Result;
+use std::collections::{BTreeMap, HashMap};
 
-use super::*;
+use anyhow::Result;
+use fedimint_api::{msats, Amount, OutPoint, PeerId, Tiered, TieredMulti};
+use fedimint_core::{
+    epoch::ConsensusItem,
+    modules::mint::{
+        BlindNonce, MintInput, MintOutput, MintOutputConfirmation, OutputConfirmationSignatures,
+    },
+    transaction::Transaction,
+};
+use tbs::{AggregatePublicKey, BlindedSignatureShare, PublicKeyShare, SecretKeyShare};
+
+use super::{EcashRecoveryTracker, PlaintextEcashBackup};
+use crate::{
+    mint::{
+        db::OutputFinalizationKey, MintClient, NoteIndex, NoteIssuanceRequest,
+        NoteIssuanceRequests, SpendableNote,
+    },
+    secrets::DerivableSecret,
+    Client,
+};
+
+/// Simplest in-memory mint client for the purpose of writting tests
+/// (at least e-cash recovery ones).
+///
+/// It only tracks state of deterministic e-cash notes creation,
+/// and provide couple of functions to help manipulate them.
+///
+/// State management is left for the user (which in tests is usually
+/// bunch of variables tracking things).
+struct MicroMintClient {
+    next_note_idx: Tiered<NoteIndex>,
+    secret: DerivableSecret,
+}
+
+impl MicroMintClient {
+    fn from_short_seed(id: u8) -> Self {
+        let root_secret = DerivableSecret::new_root(&[id; 32], &[0; 32]);
+        Self::new(Client::<()>::mint_secret_static(&root_secret))
+    }
+
+    fn new(secret: DerivableSecret) -> Self {
+        Self {
+            next_note_idx: Tiered::default(),
+            secret,
+        }
+    }
+
+    fn make_backup(
+        &self,
+        spendable_notes: impl IntoIterator<Item = (Amount, SpendableNote)>,
+        pending_notes: impl IntoIterator<Item = (OutputFinalizationKey, NoteIssuanceRequests)>,
+    ) -> PlaintextEcashBackup {
+        PlaintextEcashBackup {
+            notes: TieredMulti::from_iter(spendable_notes.into_iter()),
+            pending_notes: pending_notes.into_iter().collect(),
+            epoch: 0,
+            next_note_idx: self.next_note_idx.clone(),
+        }
+    }
+
+    fn generate_pending_note(&mut self, amount: Amount) -> (NoteIssuanceRequest, BlindNonce) {
+        let note_idx_ref = self.next_note_idx.get_mut_or_default(amount);
+        let note_idx = *note_idx_ref;
+        note_idx_ref.advance();
+
+        NoteIssuanceRequest::new(
+            secp256k1::SECP256K1,
+            MintClient::new_note_secret_static(&self.secret, amount, note_idx),
+        )
+    }
+
+    fn generate_output(
+        &mut self,
+        note_amounts: impl IntoIterator<Item = u64>,
+    ) -> (MintOutput, Vec<(Amount, BlindNonce, NoteIssuanceRequest)>) {
+        let tiered = TieredMulti::from_iter(note_amounts.into_iter().map(|amount| {
+            let amount = Amount::from_msats(amount);
+            let (iss_req, bn) = self.generate_pending_note(amount);
+
+            (amount, (bn, iss_req))
+        }));
+
+        (
+            MintOutput(TieredMulti::from_iter(
+                tiered
+                    .iter_items()
+                    .map(|(amount, (bn, _iss_req))| (amount, *bn)),
+            )),
+            tiered
+                .iter_items()
+                .map(|(amount, (bn, iss_req))| (amount, *bn, iss_req.clone()))
+                .collect(),
+        )
+    }
+
+    fn generate_input(
+        &self,
+        spendable_notes: impl IntoIterator<Item = (Amount, SpendableNote)>,
+    ) -> MintInput {
+        MintInput(TieredMulti::from_iter(
+            spendable_notes
+                .into_iter()
+                .map(|(amount, snote)| (amount, snote.note)),
+        ))
+    }
+}
+
+/// Minimal mint-only federation
+///
+/// This is just bunch of functions to make it more convenient to
+/// simulate what a w real federation would do w.r.t. handling
+/// mint notes.
+struct MicroMintFed {
+    pub tbs_pks: Tiered<AggregatePublicKey>,
+    pub pub_key_shares: BTreeMap<PeerId, Tiered<PublicKeyShare>>,
+    pub sec_key_shares: BTreeMap<PeerId, Tiered<SecretKeyShare>>,
+    pub threshold: usize,
+}
+
+impl MicroMintFed {
+    fn new(threshold: usize, peers_num: usize, amount_tiers: &[Amount]) -> Self {
+        let mut tbs_pks: Tiered<AggregatePublicKey> = Tiered::default();
+        let mut pub_key_shares: BTreeMap<PeerId, Tiered<PublicKeyShare>> = BTreeMap::default();
+        let mut sec_key_shares: BTreeMap<PeerId, Tiered<SecretKeyShare>> = BTreeMap::default();
+        for &amount in amount_tiers {
+            let (agg_pk, pub_keys, sec_keys) = tbs::dealer_keygen(threshold, peers_num);
+            tbs_pks.insert(amount, agg_pk);
+            for peer_i in 0..peers_num {
+                let peer_id = PeerId::from(peer_i as u16);
+                pub_key_shares
+                    .entry(peer_id)
+                    .or_insert(Tiered::default())
+                    .insert(amount, pub_keys[peer_i as usize]);
+                sec_key_shares
+                    .entry(peer_id)
+                    .or_insert(Tiered::default())
+                    .insert(amount, sec_keys[peer_i as usize]);
+            }
+        }
+        Self {
+            tbs_pks,
+            pub_key_shares,
+            sec_key_shares,
+            threshold,
+        }
+    }
+
+    /// Generate [`MintOutputconfirmation`]s for each peer in the federation
+    fn confirm_mint_output(
+        &self,
+        out_point: OutPoint,
+        output: &MintOutput,
+    ) -> Vec<(PeerId, MintOutputConfirmation)> {
+        self.sec_key_shares
+            .iter()
+            .map(|(peer_id, sec_keys)| {
+                (
+                    *peer_id,
+                    MintOutputConfirmation {
+                        out_point,
+                        signatures: OutputConfirmationSignatures(TieredMulti::from_iter(
+                            output.0.iter_items().map(|(amount, blind_nonce)| {
+                                let blind_message = blind_nonce.0;
+
+                                (
+                                    amount,
+                                    (
+                                        blind_message,
+                                        tbs::sign_blinded_msg(
+                                            blind_message,
+                                            *sec_keys
+                                                .get(amount)
+                                                .expect("key for amount must be there"),
+                                        ),
+                                    ),
+                                )
+                            }),
+                        )),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Combine multiple mint consensus item output confirmations into
+    /// actual spendable notes.
+    ///
+    /// This is actually client-side operation, but given that it uses
+    /// keys and other data the `self` has already, it makes sense to
+    /// just do it here.
+    fn combine_output_confirmations(
+        &self,
+        note_iss_requests: &[(Amount, BlindNonce, NoteIssuanceRequest)],
+        confirmations: &[(PeerId, MintOutputConfirmation)],
+    ) -> Vec<(Amount, SpendableNote)> {
+        let mut confs_by_order: Vec<HashMap<PeerId, BlindedSignatureShare>> = vec![];
+
+        for (peer_id, mint_output_conf) in confirmations {
+            for (i, (_amount, (_bn, sig_share))) in
+                mint_output_conf.signatures.0.iter_items().enumerate()
+            {
+                if confs_by_order.len() <= i {
+                    assert_eq!(i, confs_by_order.len());
+                    confs_by_order.push(HashMap::new());
+                }
+                confs_by_order[i].insert(*peer_id, *sig_share);
+            }
+        }
+
+        assert_eq!(confs_by_order.len(), note_iss_requests.len());
+
+        note_iss_requests
+            .into_iter()
+            .zip(confs_by_order.into_iter())
+            .map(|((amount, _bn, iss_req), sigs_by_peer)| {
+                let bsig = tbs::combine_valid_shares(
+                    sigs_by_peer
+                        .iter()
+                        .map(|(peer_id, bsig)| (peer_id.to_usize(), *bsig)),
+                    self.threshold,
+                );
+                (
+                    *amount,
+                    iss_req
+                        .finalize(bsig, *self.tbs_pks.tier(amount).expect("Must have it"))
+                        .expect("all sigshares must be valid"),
+                )
+            })
+            .collect()
+    }
+}
 
 #[test]
 fn sanity_ecash_backup_align() {
@@ -19,6 +249,7 @@ fn sanity_ecash_backup_align() {
 fn sanity_ecash_backup_decode_encode() -> Result<()> {
     let orig = PlaintextEcashBackup {
         notes: TieredMulti::from_iter([]),
+        pending_notes: vec![],
         next_note_idx: Tiered::from_iter(
             [(Amount::from_msats(1), NoteIndex::from_u64(3))].into_iter(),
         ),
@@ -36,6 +267,7 @@ fn sanity_ecash_backup_decode_encode() -> Result<()> {
 fn sanity_ecash_backup_encrypt_decrypt() -> Result<()> {
     let orig = PlaintextEcashBackup {
         notes: TieredMulti::from_iter([]),
+        pending_notes: vec![],
         next_note_idx: Tiered::from_iter(
             [(Amount::from_msats(1), NoteIndex::from_u64(3))].into_iter(),
         ),
@@ -52,4 +284,129 @@ fn sanity_ecash_backup_encrypt_decrypt() -> Result<()> {
     assert_eq!(orig, decrypted);
 
     Ok(())
+}
+
+// A sanity test that simulates a simplest mint note lifecycle,
+// and confirms that backup recovery is tracking it correctly.
+//
+// It very much uses the knowledge of how recovery is implemented,
+// but given that recovery code is inherently complex, it makes
+// sense to validate things this way.
+//
+// In addition, opportunistically multiple checks are being done
+// here in sequnce. Ideally a test would exercise just one thing,
+// but given the amount of boilerplate and sequential nature of
+// the process, it really does pay off to check multiple things.
+#[test]
+fn sanity_check_recovery_backup() {
+    let peers_num = 3;
+    let threshold = 2;
+    let gap_limit = 10;
+    let amount_tiers = [msats(1), msats(2), msats(4)];
+
+    let fed = MicroMintFed::new(threshold, peers_num, &amount_tiers);
+
+    // Client 1
+    let mut c1 = MicroMintClient::from_short_seed(0);
+
+    // Make an empty backup of client1
+    let empty_backup_c1 = c1.make_backup(vec![], vec![]);
+
+    // Start a recovery nonce tracker from the backup.
+    // This simulates the simplest (yet corner) case, where we start from
+    // nothing.
+    let mut tracker = EcashRecoveryTracker::from_backup(
+        empty_backup_c1,
+        c1.secret.clone(),
+        gap_limit,
+        fed.tbs_pks.clone(),
+        fed.pub_key_shares.clone(),
+    );
+
+    let (output_c1_a, iss_reqs_c1_a) = c1.generate_output([1, 2, 4]);
+
+    let tx_a = Transaction {
+        inputs: vec![],
+        outputs: vec![output_c1_a.clone().into()],
+        signature: None,
+    };
+
+    let output_c1_a_out_point = OutPoint {
+        txid: tx_a.tx_hash(),
+        out_idx: 0,
+    };
+
+    tracker.handle_consensus_item(PeerId::from(0), &ConsensusItem::Transaction(tx_a));
+
+    // At this point tracker should recognize c1's blind nonces are mined and move them
+    // into `pending_outputs` to start matching against consensus items.
+    assert_eq!(tracker.pending_outputs.len(), 1);
+    assert!(tracker.pending_outputs.contains_key(&output_c1_a_out_point));
+
+    // Generate mint consensus items to confirm
+    let confirmations_c1_a = fed.confirm_mint_output(output_c1_a_out_point, &output_c1_a);
+
+    // The tracker will deduplicate/ignore redundant confirmations
+    for _ in 0..3 {
+        tracker.handle_consensus_item(
+            confirmations_c1_a[0].0,
+            &ConsensusItem::Module(confirmations_c1_a[0].1.clone().into()),
+        );
+
+        assert_eq!(
+            tracker
+                .pending_outputs
+                .get(&output_c1_a_out_point)
+                .unwrap()
+                .1
+                .len(),
+            1
+        );
+    }
+
+    // The tracker will reject incorrect confirmations (here: mismatch between peer and confirmation data)
+    for wrong_peer_i in 1..2 {
+        tracker.handle_consensus_item(
+            confirmations_c1_a[wrong_peer_i].0,
+            &ConsensusItem::Module(confirmations_c1_a[0].1.clone().into()),
+        );
+
+        assert_eq!(
+            tracker
+                .pending_outputs
+                .get(&output_c1_a_out_point)
+                .unwrap()
+                .1
+                .len(),
+            1
+        );
+    }
+
+    // After enough correct confirmations, the tracker convert tracked output into spendable notes
+    for (peer_id, mint_output_confirmation) in &confirmations_c1_a {
+        tracker.handle_consensus_item(
+            *peer_id,
+            &ConsensusItem::Module(mint_output_confirmation.clone().into()),
+        );
+    }
+
+    let notes_c1_a = fed.combine_output_confirmations(&iss_reqs_c1_a, &confirmations_c1_a);
+
+    assert_eq!(
+        tracker.spendable_note_by_nonce,
+        notes_c1_a
+            .iter()
+            .map(|(amount, spendable_note)| (spendable_note.note.0, (*amount, *spendable_note)))
+            .collect()
+    );
+
+    // Spend the notes, which should remove them from the tracker
+    let tx_b = Transaction {
+        inputs: vec![c1.generate_input(notes_c1_a).into()],
+        outputs: vec![output_c1_a.clone().into()],
+        signature: None,
+    };
+
+    tracker.handle_consensus_item(PeerId::from(0), &ConsensusItem::Transaction(tx_b));
+    assert!(tracker.spendable_note_by_nonce.is_empty());
 }

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -2,7 +2,7 @@ use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{Amount, OutPoint, TieredMulti, TransactionId};
 use fedimint_core::modules::mint::Nonce;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
 use crate::mint::{NoteIssuanceRequests, SpendableNote};
@@ -61,7 +61,7 @@ impl DatabaseKeyPrefixConst for PendingCoinsKeyPrefix {
     type Value = TieredMulti<SpendableNote>;
 }
 
-#[derive(Debug, Clone, Encodable, Decodable, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct OutputFinalizationKey(pub OutPoint);
 
 impl DatabaseKeyPrefixConst for OutputFinalizationKey {

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -94,7 +94,7 @@ impl NoteIndex {
 ///
 /// Keeps the data to generate [`SpendableNote`] once the
 /// mint successfully processed the transaction signing the corresponding [`BlindNonce`].
-#[derive(Debug, Clone, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Encodable, Decodable)]
 pub struct NoteIssuanceRequest {
     /// Spend key from which the coin nonce (corresponding public key) is derived
     spend_key: KeyPair,
@@ -131,14 +131,14 @@ impl NoteIssuanceRequest {
 ///
 /// Keeps all the data to generate [`SpendableNote`]s once the
 /// mint successfully processed corresponding [`NoteIssuanceRequest`]s.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, Encodable, Decodable)]
 pub struct NoteIssuanceRequests {
     /// Finalization data for all coin outputs in this request
     coins: TieredMulti<NoteIssuanceRequest>,
 }
 
 /// A [`Note`] with associated secret key that allows to proof ownership (spend it)
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct SpendableNote {
     pub note: Note,
     #[serde(deserialize_with = "deserialize_key_pair")]

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -101,7 +101,7 @@ pub struct OutputOutcome(pub TieredMulti<tbs::BlindedSignature>);
 ///
 /// In this form it can only be validated, not spent since for that the corresponding secret
 /// spend key is required.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct Note(pub Nonce, pub tbs::Signature);
 
 /// Unique ID of a mint note.
@@ -119,7 +119,7 @@ pub struct Nonce(pub secp256k1_zkp::XOnlyPublicKey);
 ///
 /// By signing it, the mint commits to the underlying (unblinded) [`Nonce`] as valid
 /// (until eventually spent).
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct BlindNonce(pub tbs::BlindedMessage);
 
 #[derive(Debug, Clone)]

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -378,7 +378,7 @@ impl ServerModulePlugin for Mint {
             .filter_map(|(amount, coin)| {
                 let amount_key = self.pub_key.get(&amount)?;
                 if coin.verify(*amount_key) {
-                    Some((coin.clone(), amount))
+                    Some((*coin, amount))
                 } else {
                     None
                 }


### PR DESCRIPTION
Follow-up to #1015 

Add some basic infra to allow reasonable code to test recovery logic, and a first test to validate the approach.

Also, store unsigned notes in the backup and add code to handle them during recovery.