### PR TITLE
modify change algorithm to favor denomination sets

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -388,6 +388,11 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         Ok(OutPoint { txid, out_idx: 0 })
     }
 
+    /// Receive e-cash directly from another user when online (vs. offline transfer)
+    ///
+    /// Generates coins that another user will pay for and let us know the OutPoint in `create_tx`
+    /// Payer can use the `pay_to_blind_nonces` function
+    /// Allows transfer of e-cash without risk of double-spend or not having exact change
     pub async fn receive_coins<F, Fut>(&self, amount: Amount, create_tx: F)
     where
         F: FnMut(TieredMulti<BlindNonce>) -> Fut,

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -41,7 +41,7 @@ gloo-timers = { version = "0.2.5", features = ["futures"] }
 wasm-bindgen-futures = "0.4.33"
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-tokio = { version = "1.23.0", features = ["rt", "rt-multi-thread", "sync", "time", "signal"] }
+tokio = { version = "1.23.0", features = ["full"] }
 
 [dev-dependencies]
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }

--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -3,9 +3,9 @@
 
 set -eu
 FM_FED_SIZE=${1:-4}
-ITERATIONS=${2:-5}
+ITERATIONS=${2:-10}
 export RUST_LOG=error,ln_gateway=off
-export PEG_IN_AMOUNT=99999
+export PEG_IN_AMOUNT=10000000
 
 source ./scripts/setup-tests.sh $FM_FED_SIZE
 ./scripts/start-fed.sh
@@ -20,7 +20,7 @@ time1=$(date +%s.%N)
 for i in $( seq 1 $ITERATIONS )
 do
   echo "REISSUE $i"
-  TOKENS=$($FM_MINT_CLIENT spend 1000 | jq -r '.token')
+  TOKENS=$($FM_MINT_CLIENT spend 50000 | jq -r '.token')
   $FM_MINT_CLIENT reissue $TOKENS
   $FM_MINT_CLIENT fetch
 done
@@ -31,7 +31,7 @@ for i in $( seq 1 $ITERATIONS )
 do
   echo "LN SEND $i"
   LABEL=test$RANDOM$RANDOM
-  INVOICE="$($FM_LN2 invoice 500000 $LABEL $LABEL 1m | jq -r '.bolt11')"
+  INVOICE="$($FM_LN2 invoice 50000000 $LABEL $LABEL 1m | jq -r '.bolt11')"
   $FM_MINT_CLIENT ln-pay $INVOICE
   INVOICE_RESULT="$($FM_LN2 waitinvoice $LABEL)"
   INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"
@@ -44,7 +44,7 @@ time3=$(date +%s.%N)
 for i in $( seq 1 $ITERATIONS )
 do
   echo "LN RECEIVE $i"
-  INVOICE="$($FM_MINT_CLIENT ln-invoice '500000msat' '$RANDOM' | jq -r '.invoice')"
+  INVOICE="$($FM_MINT_CLIENT ln-invoice '50000000msat' '$RANDOM' | jq -r '.invoice')"
   INVOICE_RESULT=$($FM_LN2 pay $INVOICE)
   INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"
   echo "RESULT $INVOICE_STATUS"


### PR DESCRIPTION
Modifies the algorithm for picking ecash denominations so that we try to target having 1 sets of every denomination.  This makes it easier to send ecash offline and also improves the anonymity sets.  There is an increase in tx time given the number of notes to sign:

> Greedy algorithm
> AVG REISSUE TIME: 1.749 seconds
> AVG LN SEND TIME: 1.853 seconds
> AVG LN RECEIVE TIME: 2.456 seconds
> 
> Denom sets = 1
> AVG REISSUE TIME: 1.693 seconds
> AVG LN SEND TIME: 3.822 seconds
> AVG LN RECEIVE TIME: 3.333 seconds
> 
> Denom sets = 2
> AVG REISSUE TIME: 1.960 seconds
> AVG LN SEND TIME: 4.343 seconds
> AVG LN RECEIVE TIME: 3.742 seconds
> 
> Denom sets = 3
> AVG REISSUE TIME: 2.243 seconds
> AVG LN SEND TIME: 5.475 seconds
> AVG LN RECEIVE TIME: 3.965 seconds

Fixes #962