### PR TITLE
Track DerivableSecret's derivation level

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -1228,7 +1228,7 @@ impl Distribution<ClientSecret> for Standard {
 impl ClientSecret {
     fn into_root_secret(self) -> DerivableSecret {
         const FEDIMINT_CLIENT_NONCE: &[u8] = b"Fedimint Client Salt";
-        DerivableSecret::new(&self.0, FEDIMINT_CLIENT_NONCE)
+        DerivableSecret::new_root(&self.0, FEDIMINT_CLIENT_NONCE)
     }
 }
 

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -42,7 +42,7 @@ fn sanity_ecash_backup_encrypt_decrypt() -> Result<()> {
         epoch: 1,
     };
 
-    let secret = DerivableSecret::new(&[1; 32], &[1, 32]);
+    let secret = DerivableSecret::new_root(&[1; 32], &[1, 32]);
     let key = MintClient::get_derived_backup_encryption_key_static(&secret);
 
     let encrypted = orig.encrypt_to(&key)?;

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -782,7 +782,7 @@ mod tests {
             epoch_pk: threshold_crypto::SecretKey::random().public_key(),
             config: client_config,
             context: context.clone(),
-            secret: DerivableSecret::new(&[], &[]),
+            secret: DerivableSecret::new_root(&[], &[]),
         };
 
         const ISSUE_AMOUNT: Amount = Amount::from_sat(12);
@@ -802,7 +802,7 @@ mod tests {
             epoch_pk: threshold_crypto::SecretKey::random().public_key(),
             config: client_config,
             context: context.clone(),
-            secret: DerivableSecret::new(&[], &[]),
+            secret: DerivableSecret::new_root(&[], &[]),
         };
 
         issue_tokens(&fed, &client, &context.db, SPEND_AMOUNT * 2).await;
@@ -899,7 +899,7 @@ mod tests {
                 api: WsFederationApi::new(vec![]).into(),
                 secp: Default::default(),
             }),
-            secret: DerivableSecret::new(&[], &[]),
+            secret: DerivableSecret::new_root(&[], &[]),
         };
         let client_copy = client.clone();
         let amount = Amount::from_milli_sats(1);


### PR DESCRIPTION
In recovery code in certain functions I need a secret derived for the mint, and not the root secret. It's easy to mess up. Tracking the derivation level is an easy way to assert it in various places and avoid a mistake.