### PR TITLE
Streamline `Amount` usage

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -183,7 +183,7 @@ impl PaymentParameters {
     // FIXME: change to absolute fee to avoid rounding errors
     pub fn max_fee_percent(&self) -> f64 {
         let max_absolute_fee = self.max_send_amount - self.invoice_amount;
-        (max_absolute_fee.milli_sat as f64) / (self.invoice_amount.milli_sat as f64)
+        (max_absolute_fee.msats as f64) / (self.invoice_amount.msats as f64)
     }
 }
 
@@ -814,7 +814,7 @@ impl Client<UserClientConfig> {
                 .expect("must have wallet config available")
                 .network,
         ))
-        .amount_milli_satoshis(amount.milli_sat)
+        .amount_milli_satoshis(amount.msats)
         .description(description)
         .payment_hash(payment_hash)
         .payment_secret(payment_secret)
@@ -953,7 +953,7 @@ impl Client<GatewayClientConfig> {
         }
 
         let invoice: Invoice = account.contract.invoice.clone();
-        let invoice_amount = Amount::from_msat(
+        let invoice_amount = Amount::from_msats(
             invoice
                 .amount_milli_satoshis()
                 .ok_or(ClientError::InvoiceMissingAmount)?,

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -98,7 +98,7 @@ impl LnClient {
             // TODO: better define fee handling
             // Add 1% fee margin
             let contract_amount_msat = invoice_amount_msat + (invoice_amount_msat / 100);
-            Amount::from_msat(contract_amount_msat)
+            Amount::from_msats(contract_amount_msat)
         };
 
         let user_sk = bitcoin::KeyPair::new(&self.context.secp, &mut rng);
@@ -566,7 +566,7 @@ mod tests {
         // TODO: test that the client has its key
 
         let expected_amount_msat = invoice_amt_msat + (invoice_amt_msat / 100);
-        let expected_amount = Amount::from_msat(expected_amount_msat);
+        let expected_amount = Amount::from_msats(expected_amount_msat);
         assert_eq!(contract_acc.amount, expected_amount);
 
         // We need to compensate for the wallet's confirmation target

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -20,7 +20,7 @@ fn sanity_ecash_backup_decode_encode() -> Result<()> {
     let orig = PlaintextEcashBackup {
         notes: TieredMulti::from_iter([]),
         next_note_idx: Tiered::from_iter(
-            [(Amount::from_milli_sats(1), NoteIndex::from_u64(3))].into_iter(),
+            [(Amount::from_msats(1), NoteIndex::from_u64(3))].into_iter(),
         ),
         epoch: 0,
     };
@@ -37,7 +37,7 @@ fn sanity_ecash_backup_encrypt_decrypt() -> Result<()> {
     let orig = PlaintextEcashBackup {
         notes: TieredMulti::from_iter([]),
         next_note_idx: Tiered::from_iter(
-            [(Amount::from_milli_sats(1), NoteIndex::from_u64(3))].into_iter(),
+            [(Amount::from_msats(1), NoteIndex::from_u64(3))].into_iter(),
         ),
         epoch: 1,
     };

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -338,9 +338,9 @@ impl MintClient {
     ) -> DerivableSecret {
         secret
             .child_key(MINT_E_CASH_TYPE_CHILD_ID) // TODO: cache
-            .child_key(ChildId(amount.milli_sat))
+            .child_key(ChildId(amount.msats))
             .child_key(ChildId(note_idx.as_u64()))
-            .child_key(ChildId(amount.milli_sat))
+            .child_key(ChildId(amount.msats))
     }
 
     pub async fn new_ecash_note<C: Signing>(
@@ -753,7 +753,7 @@ mod tests {
                 4,
                 |cfg, _db| async move { Ok(Mint::new(cfg.to_typed().unwrap())) },
                 &ModuleConfigGenParams {
-                    mint_amounts: vec![Amount::from_sat(1), Amount::from_sat(10)],
+                    mint_amounts: vec![Amount::from_sats(1), Amount::from_sats(10)],
                     ..ModuleConfigGenParams::fake_config_gen_params()
                 },
                 &MintConfigGenerator,
@@ -813,7 +813,7 @@ mod tests {
             secret: DerivableSecret::new_root(&[], &[]),
         };
 
-        const ISSUE_AMOUNT: Amount = Amount::from_sat(12);
+        const ISSUE_AMOUNT: Amount = Amount::from_sats(12);
         issue_tokens(&fed, &client, &context.db, ISSUE_AMOUNT).await;
 
         assert_eq!(client.coins().await.total_amount(), ISSUE_AMOUNT)
@@ -821,7 +821,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn create_input() {
-        const SPEND_AMOUNT: Amount = Amount::from_sat(21);
+        const SPEND_AMOUNT: Amount = Amount::from_sats(21);
 
         let (fed, client_config, client_context) = new_mint_and_client().await;
 
@@ -850,7 +850,7 @@ mod tests {
         builder.input(&mut spend_keys.clone(), ecash_input.clone());
         let client = &client;
         builder
-            .build_with_change(client.clone(), rng, vec![Amount::from_sat(0)], secp)
+            .build_with_change(client.clone(), rng, vec![Amount::from_sats(0)], secp)
             .await;
         dbtx.commit_tx().await.expect("DB Error");
 
@@ -889,7 +889,7 @@ mod tests {
 
         builder.input(&mut spend_keys.clone(), ecash_input.clone());
         builder
-            .build_with_change(client.clone(), rng, vec![Amount::from_sat(0)], secp)
+            .build_with_change(client.clone(), rng, vec![Amount::from_sats(0)], secp)
             .await;
         dbtx.commit_tx().await.expect("DB Error");
 
@@ -930,7 +930,7 @@ mod tests {
             secret: DerivableSecret::new_root(&[], &[]),
         };
         let client_copy = client.clone();
-        let amount = Amount::from_milli_sats(1);
+        let amount = Amount::from_msats(1);
 
         let issuance_thread = move || {
             (0..ITERATIONS)

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -41,7 +41,7 @@ impl ClientModulePlugin for WalletClient {
         input: &<Self::Module as ServerModulePlugin>::Input,
     ) -> TransactionItemAmount {
         TransactionItemAmount {
-            amount: Amount::from_sat(input.tx_output().value),
+            amount: Amount::from_sats(input.tx_output().value),
             fee: self.config.fee_consensus.peg_in_abs,
         }
     }
@@ -143,7 +143,7 @@ impl WalletClient {
             .verify(&self.context.secp, &self.config.peg_in_descriptor)
             .map_err(WalletClientError::PegInProofError)?;
 
-        let amount = Amount::from_sat(peg_in_proof.tx_output().value)
+        let amount = Amount::from_sats(peg_in_proof.tx_output().value)
             .saturating_sub(self.config.fee_consensus.peg_in_abs);
         if amount == Amount::ZERO {
             return Err(WalletClientError::PegInAmountTooSmall);

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -80,7 +80,7 @@ impl ModuleConfigGenParams {
         ModuleConfigGenParams {
             mint_amounts: [1, 10, 100, 1000, 10000, 100000, 1000000]
                 .into_iter()
-                .map(Amount::from_milli_sats)
+                .map(Amount::from_msats)
                 .collect(),
             bitcoin_rpc: fedimint_api::config::BitcoindRpcCfg {
                 btc_rpc_address: "localhost".into(),

--- a/fedimint-api/src/tiered_multi.rs
+++ b/fedimint-api/src/tiered_multi.rs
@@ -27,9 +27,9 @@ impl<T> TieredMulti<T> {
         let milli_sat = self
             .0
             .iter()
-            .map(|(tier, coins)| tier.milli_sat * (coins.len() as u64))
+            .map(|(tier, coins)| tier.msats * (coins.len() as u64))
             .sum();
-        Amount { milli_sat }
+        Amount { msats: milli_sat }
     }
 
     pub fn item_count(&self) -> usize {
@@ -283,35 +283,35 @@ mod test {
     #[test]
     fn select_coins_returns_exact_amount() {
         let starting = coins(vec![
-            (Amount::from_sat(1), 5),
-            (Amount::from_sat(5), 5),
-            (Amount::from_sat(20), 5),
+            (Amount::from_sats(1), 5),
+            (Amount::from_sats(5), 5),
+            (Amount::from_sats(20), 5),
         ]);
 
         assert_eq!(
-            starting.select_coins(Amount::from_sat(7)),
+            starting.select_coins(Amount::from_sats(7)),
             Some(coins(vec![
-                (Amount::from_sat(1), 2),
-                (Amount::from_sat(5), 1)
+                (Amount::from_sats(1), 2),
+                (Amount::from_sats(5), 1)
             ]))
         );
     }
 
     #[test]
     fn select_coins_uses_smaller_denominations() {
-        let starting = coins(vec![(Amount::from_sat(5), 5), (Amount::from_sat(20), 5)]);
+        let starting = coins(vec![(Amount::from_sats(5), 5), (Amount::from_sats(20), 5)]);
 
         assert_eq!(
-            starting.select_coins(Amount::from_sat(7)),
-            Some(coins(vec![(Amount::from_sat(5), 2)]))
+            starting.select_coins(Amount::from_sats(7)),
+            Some(coins(vec![(Amount::from_sats(5), 2)]))
         );
     }
 
     #[test]
     fn select_coins_returns_none_if_amount_is_too_large() {
-        let starting = coins(vec![(Amount::from_sat(10), 1)]);
+        let starting = coins(vec![(Amount::from_sats(10), 1)]);
 
-        assert_eq!(starting.select_coins(Amount::from_sat(100)), None);
+        assert_eq!(starting.select_coins(Amount::from_sats(100)), None);
     }
 
     fn coins(coins: Vec<(Amount, usize)>) -> TieredMulti<usize> {

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -411,7 +411,7 @@ impl ServerConfigParams {
     pub fn gen_denominations(max: Amount) -> Vec<Amount> {
         let mut amounts = vec![];
 
-        let mut denomination = Amount::from_msat(1);
+        let mut denomination = Amount::from_msats(1);
         while denomination < max {
             amounts.push(denomination);
             denomination = denomination * 2;

--- a/fedimint-testing/src/btc/fixtures.rs
+++ b/fedimint-testing/src/btc/fixtures.rs
@@ -132,7 +132,7 @@ impl BitcoinTest for FakeBitcoinTest {
             .find(|out| out.script_pubkey == address.payload.script_pubkey())
             .map(|tx| tx.value)
             .unwrap_or(0);
-        Amount::from_sat(sats)
+        Amount::from_sats(sats)
     }
 }
 

--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -21,7 +21,7 @@ pub fn configgen(
     btc_rpc: BitcoindRpcCfg,
 ) -> (Vec<(Guardian, ServerConfig)>, ClientConfig) {
     let amount_tiers = (1..12)
-        .map(|amount| Amount::from_sat(10 * amount))
+        .map(|amount| Amount::from_sats(10 * amount))
         .collect();
     let rng = OsRng;
     let num_peers = guardians.len() as u16;

--- a/gateway/ln-gateway/src/cln.rs
+++ b/gateway/ln-gateway/src/cln.rs
@@ -24,7 +24,7 @@ where
     D: Deserializer<'de>,
 {
     let amount = String::deserialize(amount)?;
-    Ok(Amount::from_msat(
+    Ok(Amount::from_msats(
         amount[0..amount.len() - 4].parse::<u64>().unwrap(),
     ))
 }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -64,7 +64,7 @@ async fn balance(
     Json(payload): Json<BalancePayload>,
 ) -> Result<impl IntoResponse, LnGatewayError> {
     let amount = rpc.send(payload).await?;
-    Ok(Json(json!({ "balance_msat": amount.milli_sat })))
+    Ok(Json(json!({ "balance_msat": amount.msats })))
 }
 
 /// Generate deposit address

--- a/integrationtests/tests/fixtures/fake.rs
+++ b/integrationtests/tests/fixtures/fake.rs
@@ -48,7 +48,7 @@ impl LightningTest for FakeLightningTest {
             .current_timestamp()
             .min_final_cltv_expiry(0)
             .payment_secret(PaymentSecret([0; 32]))
-            .amount_milli_satoshis(amount.milli_sat)
+            .amount_milli_satoshis(amount.msats)
             .expiry_time(Duration::from_secs(
                 expiry_time.unwrap_or(DEFAULT_EXPIRY_TIME),
             ))
@@ -57,7 +57,7 @@ impl LightningTest for FakeLightningTest {
     }
 
     async fn amount_sent(&self) -> Amount {
-        Amount::from_msat(*self.amount_sent.lock().unwrap())
+        Amount::from_msats(*self.amount_sent.lock().unwrap())
     }
 }
 

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -34,7 +34,7 @@ impl LightningTest for RealLightningTest {
     async fn invoice(&self, amount: Amount, expiry_time: Option<u64>) -> Invoice {
         let random: u64 = rand::random();
         let invoice_req = requests::InvoiceRequest {
-            amount_msat: AmountOrAny::Amount(ClnRpcAmount::from_msat(amount.milli_sat)),
+            amount_msat: AmountOrAny::Amount(ClnRpcAmount::from_msat(amount.msats)),
             description: "".to_string(),
             label: random.to_string(),
             expiry: expiry_time,
@@ -117,7 +117,7 @@ impl RealLightningTest {
             .filter(|channel| channel.short_channel_id.is_some() && channel.connected)
             .map(|channel| channel.our_amount_msat.msat())
             .sum();
-        Amount::from_msat(funds)
+        Amount::from_msats(funds)
     }
 }
 

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -9,7 +9,7 @@ use bitcoin::{Amount, KeyPair};
 use fedimint_api::cancellable::Cancellable;
 use fedimint_api::core::MODULE_KEY_LN;
 use fedimint_api::db::mem_impl::MemDatabase;
-use fedimint_api::TieredMulti;
+use fedimint_api::{msats, sats, TieredMulti};
 use fedimint_ln::contracts::{Preimage, PreimageDecryptionShare};
 use fedimint_ln::LightningConsensusItem;
 use fedimint_mint::{MintOutputConfirmation, OutputConfirmationSignatures};
@@ -19,7 +19,7 @@ use fedimint_server::transaction::legacy::Output;
 use fedimint_server::transaction::TransactionError::UnbalancedTransaction;
 use fedimint_wallet::PegOutSignatureItem;
 use fedimint_wallet::WalletConsensusItem::PegOutSignature;
-use fixtures::{fixtures, rng, sats, secp, sha256, Fixtures};
+use fixtures::{fixtures, rng, secp, sha256, Fixtures};
 use futures::future::{join_all, Either};
 use mint_client::mint::MintClient;
 use mint_client::transaction::TransactionBuilder;
@@ -28,7 +28,7 @@ use threshold_crypto::{SecretKey, SecretKeyShare};
 use tokio::time::timeout;
 use tracing::debug;
 
-use crate::fixtures::{assert_ci, create_user_client, msats, peers, FederationTest, UserTest};
+use crate::fixtures::{assert_ci, create_user_client, peers, FederationTest, UserTest};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_in_and_peg_out_with_fees() -> anyhow::Result<()> {

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -819,9 +819,7 @@ impl ServerModulePlugin for LightningModule {
 
     async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit) {
         audit
-            .add_items(dbtx, &ContractKeyPrefix, |_, v| {
-                -(v.amount.milli_sat as i64)
-            })
+            .add_items(dbtx, &ContractKeyPrefix, |_, v| -(v.amount.msats as i64))
             .await;
     }
 

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -49,7 +49,7 @@ async fn test_account() {
     });
 
     let account_output = LightningOutput::Contract(ContractOutput {
-        amount: Amount::from_sat(42),
+        amount: Amount::from_sats(42),
         contract: contract.clone(),
     });
     let account_out_point = OutPoint {
@@ -68,7 +68,7 @@ async fn test_account() {
 
     let account_input = LightningInput {
         contract_id: contract.contract_id(),
-        amount: Amount::from_sat(42),
+        amount: Amount::from_sats(42),
         witness: None,
     };
     let meta = fed.verify_input(&account_input).await.unwrap();
@@ -123,7 +123,7 @@ j5r6drg6k6zcqj0fcwg"
     });
 
     let outgoing_output = LightningOutput::Contract(ContractOutput {
-        amount: Amount::from_sat(42),
+        amount: Amount::from_sats(42),
         contract: contract.clone(),
     });
     let outgoing_out_point = OutPoint {
@@ -149,7 +149,7 @@ j5r6drg6k6zcqj0fcwg"
     // Error: Missing preimage
     let account_input_no_witness = LightningInput {
         contract_id: contract.contract_id(),
-        amount: Amount::from_sat(42),
+        amount: Amount::from_sats(42),
         witness: None,
     };
     let err = fed
@@ -164,7 +164,7 @@ j5r6drg6k6zcqj0fcwg"
     // Ok
     let account_input_witness = LightningInput {
         contract_id: contract.contract_id(),
-        amount: Amount::from_sat(42),
+        amount: Amount::from_sats(42),
         witness: Some(preimage),
     };
     let meta = fed.verify_input(&account_input_witness).await.unwrap();
@@ -199,7 +199,7 @@ async fn test_incoming() {
     let hash = secp256k1::hashes::sha256::Hash::hash(&preimage.0);
 
     let offer = IncomingContractOffer {
-        amount: Amount::from_sat(42),
+        amount: Amount::from_sats(42),
         hash,
         encrypted_preimage: EncryptedPreimage::new(
             preimage.clone(),
@@ -231,7 +231,7 @@ async fn test_incoming() {
         gateway_key: gw_pk,
     });
     let incoming_output = LightningOutput::Contract(ContractOutput {
-        amount: Amount::from_sat(42),
+        amount: Amount::from_sats(42),
         contract: contract.clone(),
     });
     let incoming_out_point = OutPoint {
@@ -253,7 +253,7 @@ async fn test_incoming() {
 
     let incoming_input = LightningInput {
         contract_id: contract.contract_id(),
-        amount: Amount::from_sat(42),
+        amount: Amount::from_sats(42),
         witness: None,
     };
     let error = fed.verify_input(&incoming_input).await.unwrap_err();

--- a/modules/fedimint-mint/src/config.rs
+++ b/modules/fedimint-mint/src/config.rs
@@ -59,7 +59,7 @@ impl TypedServerModuleConfig for MintConfig {
         if sks != pks {
             bail!("Mint private key doesn't match pubkey share");
         }
-        if !sks.keys().contains(&Amount::from_msat(1)) {
+        if !sks.keys().contains(&Amount::from_msats(1)) {
             bail!("No msat 1 denomination");
         }
 

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -591,8 +591,8 @@ impl ServerModulePlugin for Mint {
             }
         }
 
-        let mut redemptions = Amount::from_sat(0);
-        let mut issuances = Amount::from_sat(0);
+        let mut redemptions = Amount::from_sats(0);
+        let mut issuances = Amount::from_sats(0);
         let remove_audit_keys = dbtx
             .find_by_prefix(&MintAuditItemKeyPrefix)
             .await
@@ -656,10 +656,10 @@ impl ServerModulePlugin for Mint {
     async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit) {
         audit
             .add_items(dbtx, &MintAuditItemKeyPrefix, |k, v| match k {
-                MintAuditItemKey::Issuance(_) => -(v.milli_sat as i64),
-                MintAuditItemKey::IssuanceTotal => -(v.milli_sat as i64),
-                MintAuditItemKey::Redemption(_) => v.milli_sat as i64,
-                MintAuditItemKey::RedemptionTotal => v.milli_sat as i64,
+                MintAuditItemKey::Issuance(_) => -(v.msats as i64),
+                MintAuditItemKey::IssuanceTotal => -(v.msats as i64),
+                MintAuditItemKey::Redemption(_) => v.msats as i64,
+                MintAuditItemKey::RedemptionTotal => v.msats as i64,
             })
             .await;
     }
@@ -1089,7 +1089,7 @@ mod test {
         let (mint_cfg, client_cfg) = MintConfigGenerator.trusted_dealer_gen(
             &peers,
             &ModuleConfigGenParams {
-                mint_amounts: vec![Amount::from_sat(1)],
+                mint_amounts: vec![Amount::from_sats(1)],
                 ..ModuleConfigGenParams::fake_config_gen_params()
             },
         );
@@ -1108,7 +1108,7 @@ mod test {
             .cast::<MintClientConfig>()
             .unwrap()
             .tbs_pks
-            .get(Amount::from_sat(1))
+            .get(Amount::from_sats(1))
             .unwrap();
 
         (agg_pk, mints)
@@ -1123,7 +1123,7 @@ mod test {
         let bmsg = blind_message(nonce, bkey);
         let blind_tokens = TieredMulti::new(
             vec![(
-                Amount::from_sat(1),
+                Amount::from_sats(1),
                 vec![BlindNonce(bmsg), BlindNonce(bmsg)],
             )]
             .into_iter()
@@ -1149,7 +1149,7 @@ mod test {
         assert!(errors.0.is_empty());
 
         let bsig = bsig_res.unwrap();
-        assert_eq!(bsig.0.total_amount(), Amount::from_sat(2));
+        assert_eq!(bsig.0.total_amount(), Amount::from_sats(2));
 
         bsig.0.iter_items().for_each(|(_, bs)| {
             let sig = unblind_signature(bkey, *bs);
@@ -1207,7 +1207,7 @@ mod test {
                 .cloned()
                 .map(|(peer, mut psigs)| {
                     if peer == PeerId::from(1) {
-                        psigs.0.get_mut(Amount::from_sat(1)).unwrap().pop();
+                        psigs.0.get_mut(Amount::from_sats(1)).unwrap().pop();
                     }
                     (peer, psigs)
                 })
@@ -1225,8 +1225,8 @@ mod test {
                 .cloned()
                 .map(|(peer, mut psig)| {
                     if peer == PeerId::from(2) {
-                        psig.0.get_mut(Amount::from_sat(1)).unwrap()[0].1 =
-                            psigs[0].1 .0.get(Amount::from_sat(1)).unwrap()[0].1;
+                        psig.0.get_mut(Amount::from_sats(1)).unwrap()[0].1 =
+                            psigs[0].1 .0.get(Amount::from_sats(1)).unwrap()[0].1;
                     }
                     (peer, psig)
                 })
@@ -1245,7 +1245,7 @@ mod test {
                 .cloned()
                 .map(|(peer, mut psig)| {
                     if peer == PeerId::from(3) {
-                        psig.0.get_mut(Amount::from_sat(1)).unwrap()[0].0 = bmsg;
+                        psig.0.get_mut(Amount::from_sats(1)).unwrap()[0].0 = bmsg;
                     }
                     (peer, psig)
                 })

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -539,7 +539,7 @@ impl ServerModulePlugin for Wallet {
 
         Ok(InputMeta {
             amount: TransactionItemAmount {
-                amount: fedimint_api::Amount::from_sat(input.tx_output().value),
+                amount: fedimint_api::Amount::from_sats(input.tx_output().value),
                 fee: self.cfg.fee_consensus.peg_in_abs,
             },
             puk_keys: vec![*input.tweak_contract_key()],


### PR DESCRIPTION
Get rid of very long `Amount::from_millis_sat`.

Make the `from_msats` and `from_sats` plural. Just like e.g. [Duration::from_secs](https://doc.rust-lang.org/std/time/struct.Duration.html#method.from_secs) .

Move `msats` and `sats` to `fedimint-api`. Seem commonly needed in all test code, to justify it.

Did NOT go around the code and change existing `Amount::from_x` usage. Maybe some other time.

Pushback and bikeshedding welcome and appreciated.