### PR TITLE
 Add a method to recover BlindNonce from NoteIssuanceRequest 

### DIFF
--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -102,6 +102,11 @@ pub struct NoteIssuanceRequest {
 }
 
 impl NoteIssuanceRequest {
+    pub fn recover_blind_nonce(&self) -> BlindNonce {
+        let message = Nonce(self.spend_key.x_only_public_key().0).to_message();
+        BlindNonce(tbs::blind_message(message, self.blinding_key))
+    }
+
     pub fn finalize(
         &self,
         bsig: BlindedSignature,


### PR DESCRIPTION
I need it for e-cash recovery. I initially thought that I'll have to store it as an extra field, but Eric told me that it can be calculated, which is even better.