### PR TITLE
Update `crane` to include multi-threaded `zstd` compression

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,20 +22,21 @@
         "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1664412889,
-        "narHash": "sha256-gyVtTQf3CiXLe1cwNRFxqUqYl9BCmIDvK7hIpzR/oQU=",
+        "lastModified": 1670541416,
+        "narHash": "sha256-S33bhME0zPHPEZyZPCsrdQL/4WW/A020PwN+a3z7Q+I=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "755acd231a7de182fdc772bee1b2a1f21d4ec9ed",
+        "rev": "5f353e7a4ff785d38ff0f0f2b80f29a65b6f14cb",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "755acd231a7de182fdc772bee1b2a1f21d4ec9ed",
+        "rev": "5f353e7a4ff785d38ff0f0f2b80f29a65b6f14cb",
         "type": "github"
       }
     },
@@ -162,6 +163,31 @@
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1670466538,
+        "narHash": "sha256-qz3MwPVTHJb62vPRJMXJ+waqjEUHrjTyjXyLHqF0DrE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "073959f0687277a54bfaa3ac7a77feb072f88186",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
-    crane.url = "github:ipetkov/crane?rev=755acd231a7de182fdc772bee1b2a1f21d4ec9ed"; # https://github.com/ipetkov/crane/releases/tag/v0.7.0
+    crane.url = "github:ipetkov/crane?rev=5f353e7a4ff785d38ff0f0f2b80f29a65b6f14cb"; # https://github.com/ipetkov/crane/pull/183
     crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     fenix = {
@@ -313,6 +313,9 @@
               cp -r ${./.cargo} -T $out/.cargo
             '';
           };
+
+          # https://github.com/ipetkov/crane/issues/76#issuecomment-1296025495
+          installCargoArtifactsMode = "use-zstd";
 
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib/";
           ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib/";


### PR DESCRIPTION
This should improve Nix build speed when compressing artifacts, especially on machines with a lot of CPU cores. Nothing major, but these seconds add up.

In addition, this upgrades us from v0.7 to v0.10, which had some minor improvements ([including perf improvements](https://github.com/ipetkov/crane/issues/161)) along the way.
