### PR TITLE
Rename: Differentiate connect federation  from gateway `register_with_federation`

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -58,7 +58,7 @@ Commands:
   address          Generate a new peg-in address, funds sent to it can later be claimed
   deposit          Deposit funds into a gateway federation
   withdraw         Claim funds from a gateway federation
-  register-fed     Register federation with the gateway
+  connect-fed      Connect federation with the gateway
   help             Print this message or the help of the given subcommand(s)
 
 Options:

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -6,8 +6,8 @@ use fedimint_server::modules::wallet::txoproof::TxOutProof;
 use ln_gateway::{
     config::GatewayConfig,
     rpc::{
-        rpc_client::RpcClient, BalancePayload, DepositAddressPayload, DepositPayload,
-        RegisterFedPayload, WithdrawPayload,
+        rpc_client::RpcClient, BalancePayload, ConnectFedPayload, DepositAddressPayload,
+        DepositPayload, WithdrawPayload,
     },
 };
 use mint_client::{utils::from_hex, FederationId};
@@ -64,7 +64,7 @@ pub enum Commands {
         address: Address,
     },
     /// Register federation with the gateway
-    RegisterFed {
+    ConnectFed {
         /// ConnectInfo code to connect to the federation
         connect: String,
     },
@@ -172,14 +172,14 @@ async fn main() {
 
             print_response(response).await;
         }
-        Commands::RegisterFed { connect } => {
+        Commands::ConnectFed { connect } => {
             let response = client
-                .register_federation(
+                .connect_federation(
                     source_password(cli.rpcpassword),
-                    RegisterFedPayload { connect },
+                    ConnectFedPayload { connect },
                 )
                 .await
-                .expect("Failed to register federation");
+                .expect("Failed to connect federation");
 
             print_response(response).await;
         }

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -27,15 +27,15 @@ impl GatewayActor {
                 Ok(client
                     .register_with_federation(client.config().into())
                     .await
-                    .expect("Failed to register with federation"))
+                    .expect("Failed to connect with federation"))
             },
             Duration::from_secs(1),
             5,
         )
         .await
         {
-            Ok(_) => info!("Registered with federation"),
-            Err(e) => warn!("Failed to register with federation: {}", e),
+            Ok(_) => info!("Connected with federation"),
+            Err(e) => warn!("Failed to connect with federation: {}", e),
         }
 
         Ok(Self { client })

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -43,7 +43,7 @@ impl GatewayRpcSender {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct RegisterFedPayload {
+pub struct ConnectFedPayload {
     pub connect: String,
 }
 
@@ -101,7 +101,7 @@ pub struct GatewayInfo {
 #[derive(Debug)]
 pub enum GatewayRequest {
     Info(GatewayRequestInner<InfoPayload>),
-    RegisterFederation(GatewayRequestInner<RegisterFedPayload>),
+    ConnectFederation(GatewayRequestInner<ConnectFedPayload>),
     ReceivePayment(GatewayRequestInner<ReceivePaymentPayload>),
     PayInvoice(GatewayRequestInner<PayInvoicePayload>),
     Balance(GatewayRequestInner<BalancePayload>),
@@ -137,7 +137,7 @@ macro_rules! impl_gateway_request_trait {
 }
 
 impl_gateway_request_trait!(InfoPayload, GatewayInfo, GatewayRequest::Info);
-impl_gateway_request_trait!(RegisterFedPayload, (), GatewayRequest::RegisterFederation);
+impl_gateway_request_trait!(ConnectFedPayload, (), GatewayRequest::ConnectFederation);
 impl_gateway_request_trait!(
     ReceivePaymentPayload,
     Preimage,

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use url::Url;
 
 use super::{
-    BalancePayload, DepositAddressPayload, DepositPayload, RegisterFedPayload, WithdrawPayload,
+    BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload, WithdrawPayload,
 };
 
 pub struct RpcClient {
@@ -64,12 +64,12 @@ impl RpcClient {
         self.call(url, password, payload).await
     }
 
-    pub async fn register_federation(
+    pub async fn connect_federation(
         &self,
         password: String,
-        payload: RegisterFedPayload,
+        payload: ConnectFedPayload,
     ) -> Result<Response, Error> {
-        let url = self.base_url.join("/register").expect("invalid base url");
+        let url = self.base_url.join("/connect").expect("invalid base url");
         self.call(url, password, payload).await
     }
 

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -8,8 +8,8 @@ use tower_http::{auth::RequireAuthorizationLayer, cors::CorsLayer};
 use tracing::instrument;
 
 use super::{
-    BalancePayload, DepositAddressPayload, DepositPayload, GatewayRpcSender, InfoPayload,
-    RegisterFedPayload, WithdrawPayload,
+    BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload, GatewayRpcSender,
+    InfoPayload, WithdrawPayload,
 };
 use crate::LnGatewayError;
 
@@ -28,7 +28,7 @@ pub async fn run_webserver(
         .route("/address", post(address))
         .route("/deposit", post(deposit))
         .route("/withdraw", post(withdraw))
-        .route("/register", post(register))
+        .route("/connect", post(connect))
         .layer(RequireAuthorizationLayer::bearer(&authkey));
 
     let app = Router::new()
@@ -109,11 +109,11 @@ async fn pay_invoice(
     Ok(())
 }
 
-/// Register a new federation
+/// Connect a new federation
 #[instrument(skip_all, err)]
-async fn register(
+async fn connect(
     Extension(rpc): Extension<GatewayRpcSender>,
-    Json(payload): Json<RegisterFedPayload>,
+    Json(payload): Json<ConnectFedPayload>,
 ) -> Result<impl IntoResponse, LnGatewayError> {
     rpc.send(payload).await?;
     Ok(())

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -10,8 +10,8 @@ use ln_gateway::rpc::rpc_client::{Error, Response};
 use ln_gateway::{
     config::GatewayConfig,
     rpc::{
-        rpc_client::RpcClient, BalancePayload, DepositAddressPayload, DepositPayload,
-        RegisterFedPayload, WithdrawPayload,
+        rpc_client::RpcClient, BalancePayload, ConnectFedPayload, DepositAddressPayload,
+        DepositPayload, WithdrawPayload,
     },
     utils::retry,
 };
@@ -51,14 +51,14 @@ async fn test_gateway_authentication() -> Result<()> {
     // Create an RPC client reference
     let client_ref = &RpcClient::new(gw_announce_address);
 
-    // Test gateway authentication on `register_federation` function
-    // *  `register_federation` with correct password succeeds
-    // *  `register_federation` with incorrect password fails
-    let payload = RegisterFedPayload {
+    // Test gateway authentication on `connect_federation` function
+    // *  `connect_federation` with correct password succeeds
+    // *  `connect_federation` with incorrect password fails
+    let payload = ConnectFedPayload {
         connect: serde_json::to_string(&WsFederationConnect { members: vec![] })?,
     };
     test_auth(&gw_password, move |pw| {
-        client_ref.register_federation(pw, payload.clone())
+        client_ref.connect_federation(pw, payload.clone())
     })
     .await?;
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -398,9 +398,9 @@ impl GatewayTest {
         );
 
         let actor = gateway
-            .register_federation(client.clone())
+            .connect_federation(client.clone())
             .await
-            .expect("Could not register federation");
+            .expect("Could not connect federation");
         // Note: We don't run the gateway in test scenarios
 
         // Create a user test from gateway federation client

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -68,13 +68,13 @@ function start_gateway() {
   $FM_GATEWAY_CLI generate-config '127.0.0.1:8080' 'http://127.0.0.1:8080' $FM_CFG_DIR # generate gateway config
   $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR &
   sleep 5 # wait for plugin to start
-  gw_register_fed
+  gw_connect_fed
 }
 
-function gw_register_fed() {
-  # register federation on the gateway
+function gw_connect_fed() {
+  # connect federation with the gateway
   FM_CONNECT_STR="$($FM_MINT_CLIENT connect-info | jq -r '.connect_info')"
-  $FM_GATEWAY_CLI register-fed "$FM_CONNECT_STR"
+  $FM_GATEWAY_CLI connect-fed "$FM_CONNECT_STR"
 }
 
 function get_finality_delay() {

--- a/scripts/tmux-user-shell.sh
+++ b/scripts/tmux-user-shell.sh
@@ -23,7 +23,7 @@ echo Funding user e-cash wallet ...
 scripts/pegin.sh 10000.0 > /dev/null 2>&1
 
 echo Connecting federation to gateway
-gw_register_fed
+gw_connect_fed
 
 echo Funding gateway e-cash wallet ...
 scripts/pegin.sh 20000.0 1 > /dev/null 2>&1


### PR DESCRIPTION
Differentiate the gateway api used to connect a federation, from the federation api used to register a connected gateway client
- `connect_federation()` is a public gateway API : It can be used by authorised person gateway admin to propose a federation to the gateway
- `register_with_federation()` is a gateway client API that calls back into the federation when connect federation api is used