### PR TITLE
Decoder cleanup

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -1310,9 +1310,9 @@ impl Debug for ClientSecret {
 /// modularized yet but we need the decoding functionality.
 fn module_decode_stubs() -> ModuleDecoderRegistry {
     ModuleDecoderRegistry::new([
-        (MODULE_KEY_LN, Decoder::from_typed(LightningModuleDecoder)),
-        (MODULE_KEY_WALLET, Decoder::from_typed(WalletModuleDecoder)),
-        (MODULE_KEY_MINT, Decoder::from_typed(MintModuleDecoder)),
+        (MODULE_KEY_LN, Decoder::from_typed(&LightningModuleDecoder)),
+        (MODULE_KEY_WALLET, Decoder::from_typed(&WalletModuleDecoder)),
+        (MODULE_KEY_MINT, Decoder::from_typed(&MintModuleDecoder)),
     ])
 }
 

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -14,6 +14,7 @@ use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::task::timeout;
 use fedimint_api::{Amount, ServerModulePlugin};
+use fedimint_core::modules::ln::common::LightningModuleDecoder;
 use fedimint_core::modules::ln::config::LightningModuleClientConfig;
 use fedimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
 use fedimint_core::modules::ln::contracts::outgoing::OutgoingContract;
@@ -48,6 +49,10 @@ impl ClientModulePlugin for LnClient {
     type Decoder = <LightningModule as ServerModulePlugin>::Decoder;
     type Module = LightningModule;
     const MODULE_KEY: ModuleKey = MODULE_KEY_LN;
+
+    fn decoder(&self) -> &'static Self::Decoder {
+        &LightningModuleDecoder
+    }
 
     fn input_amount(
         &self,

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -30,7 +30,7 @@ use tracing::{debug, trace, warn};
 use crate::api::ApiError;
 use crate::mint::db::{NextECashNoteIndexKey, PendingCoinsKey};
 use crate::utils::ClientContext;
-use crate::{ChildId, DerivableSecret};
+use crate::{ChildId, DerivableSecret, MintModuleDecoder};
 
 pub mod backup;
 
@@ -149,6 +149,10 @@ impl ClientModulePlugin for MintClient {
     type Decoder = <Mint as ServerModulePlugin>::Decoder;
     type Module = Mint;
     const MODULE_KEY: ModuleKey = MODULE_KEY_MINT;
+
+    fn decoder(&self) -> &'static Self::Decoder {
+        &MintModuleDecoder
+    }
 
     fn input_amount(
         &self,

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -9,6 +9,7 @@ use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::{Amount, ServerModulePlugin};
+use fedimint_core::modules::wallet::common::WalletModuleDecoder;
 use fedimint_core::modules::wallet::config::WalletClientConfig;
 use fedimint_core::modules::wallet::tweakable::Tweakable;
 use fedimint_core::modules::wallet::txoproof::{PegInProof, PegInProofError, TxOutProof};
@@ -34,6 +35,10 @@ impl ClientModulePlugin for WalletClient {
     type Decoder = <Wallet as ServerModulePlugin>::Decoder;
     type Module = Wallet;
     const MODULE_KEY: ModuleKey = MODULE_KEY_WALLET;
+
+    fn decoder(&self) -> &'static Self::Decoder {
+        &WalletModuleDecoder
+    }
 
     fn input_amount(
         &self,

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -317,7 +317,7 @@ mod tests {
     }
 
     fn wallet_decoders() -> ModuleDecoderRegistry {
-        ModuleDecoderRegistry::new([(MODULE_KEY_WALLET, Decoder::from_typed(WalletModuleDecoder))])
+        ModuleDecoderRegistry::new([(MODULE_KEY_WALLET, Decoder::from_typed(&WalletModuleDecoder))])
     }
 
     async fn new_mint_and_client(

--- a/fedimint-api/src/core/client.rs
+++ b/fedimint-api/src/core/client.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::core::{ConsensusItem, Decoder, Input, Output, OutputOutcome};
+use crate::core::{ConsensusItem, Input, Output, OutputOutcome};
 use crate::core::{ModuleKey, PluginDecode};
 use crate::module::TransactionItemAmount;
 use crate::{dyn_newtype_define, DecodeError, ModuleDecode, ServerModulePlugin};
@@ -80,10 +80,6 @@ where
 }
 
 impl ModuleDecode for ClientModule {
-    fn clone_decoder(&self) -> Decoder {
-        unimplemented!()
-    }
-
     fn decode_input(&self, r: &mut dyn io::Read) -> Result<Input, DecodeError> {
         (**self).decode_input(r)
     }

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -56,17 +56,10 @@ where
 pub trait IServerModule: Debug {
     fn module_key(&self) -> ModuleKey;
 
+    /// Returns the decoder belonging to the server module
     fn decoder(&self) -> Decoder;
 
     fn as_any(&self) -> &(dyn Any + 'static);
-
-    fn decode_input(&self, r: &mut dyn io::Read) -> Result<Input, DecodeError>;
-
-    fn decode_output(&self, r: &mut dyn io::Read) -> Result<Output, DecodeError>;
-
-    fn decode_output_outcome(&self, r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError>;
-
-    fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
 
     /// Blocks until a new `consensus_proposal` is available.
     async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>);
@@ -187,24 +180,6 @@ dyn_newtype_define!(
     pub ServerModule(Arc<IServerModule>)
 );
 
-impl ModuleDecode for ServerModule {
-    fn decode_input(&self, r: &mut dyn io::Read) -> Result<Input, DecodeError> {
-        (**self).decode_input(r)
-    }
-
-    fn decode_output(&self, r: &mut dyn io::Read) -> Result<Output, DecodeError> {
-        (**self).decode_output(r)
-    }
-
-    fn decode_output_outcome(&self, r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError> {
-        (**self).decode_output_outcome(r)
-    }
-
-    fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError> {
-        (**self).decode_consensus_item(r)
-    }
-}
-
 #[async_trait]
 impl<T> IServerModule for T
 where
@@ -221,22 +196,6 @@ where
 
     fn as_any(&self) -> &(dyn Any + 'static) {
         self
-    }
-
-    fn decode_input(&self, r: &mut dyn io::Read) -> Result<Input, DecodeError> {
-        <<Self as ServerModulePlugin>::Decoder as PluginDecode>::decode_input(r)
-    }
-
-    fn decode_output(&self, r: &mut dyn io::Read) -> Result<Output, DecodeError> {
-        <<Self as ServerModulePlugin>::Decoder as PluginDecode>::decode_output(r)
-    }
-
-    fn decode_output_outcome(&self, r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError> {
-        <<Self as ServerModulePlugin>::Decoder as PluginDecode>::decode_output_outcome(r)
-    }
-
-    fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError> {
-        <<Self as ServerModulePlugin>::Decoder as PluginDecode>::decode_consensus_item(r)
     }
 
     /// Blocks until a new `consensus_proposal` is available.

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -188,10 +188,6 @@ dyn_newtype_define!(
 );
 
 impl ModuleDecode for ServerModule {
-    fn clone_decoder(&self) -> Decoder {
-        self.decoder()
-    }
-
     fn decode_input(&self, r: &mut dyn io::Read) -> Result<Input, DecodeError> {
         (**self).decode_input(r)
     }

--- a/fedimint-api/src/lib.rs
+++ b/fedimint-api/src/lib.rs
@@ -16,7 +16,6 @@ pub use tiered::Tiered;
 pub use tiered_multi::*;
 
 pub use crate::core::server;
-use crate::core::ModuleDecode;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -231,7 +231,7 @@ pub trait ServerModulePlugin: Debug + Sized {
 
     fn module_key(&self) -> ModuleKey;
 
-    fn decoder(&self) -> Self::Decoder;
+    fn decoder(&self) -> &'static Self::Decoder;
 
     /// Blocks until a new `consensus_proposal` is available.
     async fn await_consensus_proposal<'a>(&'a self, dbtx: &mut DatabaseTransaction<'_>);

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -34,8 +34,8 @@ impl CoreError {
 
 pub fn all_decoders() -> ModuleDecoderRegistry {
     ModuleDecoderRegistry::new([
-        (MODULE_KEY_LN, Decoder::from_typed(LightningModuleDecoder)),
-        (MODULE_KEY_MINT, Decoder::from_typed(MintModuleDecoder)),
-        (MODULE_KEY_WALLET, Decoder::from_typed(WalletModuleDecoder)),
+        (MODULE_KEY_LN, Decoder::from_typed(&LightningModuleDecoder)),
+        (MODULE_KEY_MINT, Decoder::from_typed(&MintModuleDecoder)),
+        (MODULE_KEY_WALLET, Decoder::from_typed(&WalletModuleDecoder)),
     ])
 }

--- a/modules/fedimint-ln/src/common.rs
+++ b/modules/fedimint-ln/src/common.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use fedimint_api::core::{ConsensusItem, Decoder, Input, Output, OutputOutcome, PluginDecode};
+use fedimint_api::core::{ConsensusItem, Input, Output, OutputOutcome, PluginDecode};
 use fedimint_api::encoding::Decodable;
 use fedimint_api::encoding::DecodeError;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -11,10 +11,6 @@ use crate::{LightningConsensusItem, LightningInput, LightningOutput, LightningOu
 pub struct LightningModuleDecoder;
 
 impl PluginDecode for LightningModuleDecoder {
-    fn clone_decoder() -> Decoder {
-        Decoder::from_typed(LightningModuleDecoder)
-    }
-
     fn decode_input(mut d: &mut dyn io::Read) -> Result<Input, DecodeError> {
         Ok(Input::from(LightningInput::consensus_decode(
             &mut d,

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -316,8 +316,8 @@ impl ServerModulePlugin for LightningModule {
         MODULE_KEY_LN
     }
 
-    fn decoder(&self) -> Self::Decoder {
-        LightningModuleDecoder
+    fn decoder(&self) -> &'static Self::Decoder {
+        &LightningModuleDecoder
     }
 
     async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -23,7 +23,7 @@ use secp256k1::KeyPair;
 fn ln_decoders() -> ModuleDecoderRegistry {
     ModuleDecoderRegistry::new([(
         MODULE_KEY_LN,
-        Decoder::from_typed(fedimint_ln::common::LightningModuleDecoder),
+        Decoder::from_typed(&fedimint_ln::common::LightningModuleDecoder),
     )])
 }
 

--- a/modules/fedimint-mint/src/common.rs
+++ b/modules/fedimint-mint/src/common.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::io;
 
-use fedimint_api::core::{ConsensusItem, Decoder, Input, Output, OutputOutcome, PluginDecode};
+use fedimint_api::core::{ConsensusItem, Input, Output, OutputOutcome, PluginDecode};
 use fedimint_api::encoding::Decodable;
 use fedimint_api::encoding::DecodeError;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -12,10 +12,6 @@ use crate::{MintInput, MintOutput, MintOutputConfirmation, MintOutputOutcome};
 pub struct MintModuleDecoder;
 
 impl PluginDecode for MintModuleDecoder {
-    fn clone_decoder() -> Decoder {
-        Decoder::from_typed(MintModuleDecoder)
-    }
-
     fn decode_input(mut d: &mut dyn io::Read) -> Result<Input, DecodeError> {
         Ok(Input::from(MintInput::consensus_decode(
             &mut d,

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -323,8 +323,8 @@ impl ServerModulePlugin for Mint {
         MODULE_KEY_MINT
     }
 
-    fn decoder(&self) -> Self::Decoder {
-        MintModuleDecoder
+    fn decoder(&self) -> &'static Self::Decoder {
+        &MintModuleDecoder
     }
 
     async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {

--- a/modules/fedimint-wallet/src/common.rs
+++ b/modules/fedimint-wallet/src/common.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use fedimint_api::core::{ConsensusItem, Decoder, Input, Output, OutputOutcome, PluginDecode};
+use fedimint_api::core::{ConsensusItem, Input, Output, OutputOutcome, PluginDecode};
 use fedimint_api::encoding::{Decodable, DecodeError};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 
@@ -10,10 +10,6 @@ use crate::{WalletConsensusItem, WalletInput, WalletOutput, WalletOutputOutcome}
 pub struct WalletModuleDecoder;
 
 impl PluginDecode for WalletModuleDecoder {
-    fn clone_decoder() -> Decoder {
-        Decoder::from_typed(WalletModuleDecoder)
-    }
-
     fn decode_input(mut d: &mut dyn io::Read) -> Result<Input, DecodeError> {
         Ok(Input::from(WalletInput::consensus_decode(
             &mut d,

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -389,8 +389,8 @@ impl ServerModulePlugin for Wallet {
         MODULE_KEY_WALLET
     }
 
-    fn decoder(&self) -> Self::Decoder {
-        WalletModuleDecoder
+    fn decoder(&self) -> &'static Self::Decoder {
+        &WalletModuleDecoder
     }
 
     async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {


### PR DESCRIPTION
* Don't pollute heap with many small allocations of decoders, make them `&'static dyn` instead (easy since they are ZSTs)
* Remove decode impl from `IServerModule` and `IClientModule`
* Add `decoder` fn to `IClientModule` the get the module's decoder