### PR TITLE
Implement `fedimint-cli backup` and `restore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "counter",
  "fedimint-api",
  "futures",
+ "hex",
  "impl-tools",
  "itertools",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ secp256k1 = { opt-level = 2 }
 secp256k1-zkp = { opt-level = 2 }
 secp256k1-sys = { opt-level = 2 }
 secp256k1-zkp-sys = { opt-level = 2 }
+bitcoin_hashes = { opt-level = 2 }
 ff = { opt-level = 2 }
 group = { opt-level = 2 }
 pairing = { opt-level = 2 }

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -278,6 +278,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             );
             secret
         };
+        tx.commit_tx().await.expect("db failure");
         secret.into_root_secret()
     }
 

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -473,7 +473,7 @@ mod tests {
         async fn download_ecash_backup(
             &self,
             _id: &secp256k1::XOnlyPublicKey,
-        ) -> crate::api::Result<Vec<u8>> {
+        ) -> crate::api::Result<Option<Vec<u8>>> {
             unimplemented!()
         }
     }

--- a/client/client-lib/src/secrets.rs
+++ b/client/client-lib/src/secrets.rs
@@ -91,6 +91,15 @@ fn tagged_derive(tag: &[u8; 8], derivation: ChildId) -> [u8; 16] {
 
 impl std::fmt::Debug for DerivableSecret {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DerivableSecret")
+        write!(f, "DerivableSecret")?;
+        write!(
+            f,
+            "#{}",
+            // Note: bothers me that `hex` can't avoid allocating here :shrug:
+            hex::encode(
+                self.kdf
+                    .derive::<8>(b"just a debug fingerprint derivation salt")
+            )
+        )
     }
 }

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -316,7 +316,7 @@ mod tests {
         async fn download_ecash_backup(
             &self,
             _id: &secp256k1::XOnlyPublicKey,
-        ) -> crate::api::Result<Vec<u8>> {
+        ) -> crate::api::Result<Option<Vec<u8>>> {
             unimplemented!()
         }
     }

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -252,6 +252,24 @@ impl<'a> DatabaseTransaction<'a> {
                 })
             })
     }
+
+    // TODO: this function doesn't seem very optimal
+    pub async fn remove_by_prefix<KP>(&mut self, key_prefix: &KP) -> Result<()>
+    where
+        KP: DatabaseKeyPrefix + DatabaseKeyPrefixConst,
+    {
+        let prefix_bytes = key_prefix.to_bytes();
+        let mut keys = vec![];
+        for kv in self.raw_find_by_prefix(&prefix_bytes).await {
+            let (k, _) = kv?;
+            keys.push(k);
+        }
+
+        for keys in &keys {
+            self.raw_remove_entry(keys).await?;
+        }
+        Ok(())
+    }
 }
 
 impl<T> DatabaseKeyPrefix for T

--- a/fedimint-api/src/tiered_multi.rs
+++ b/fedimint-api/src/tiered_multi.rs
@@ -88,6 +88,12 @@ impl<T> TieredMulti<T> {
             .iter()
             .flat_map(|(amt, coins)| coins.iter().map(move |c| (*amt, c)))
     }
+    // Note: order of the elements is important here: from lowest tiers to highest, then in order of elements in the Vec
+    pub fn into_iter_items(self) -> impl Iterator<Item = (Amount, T)> + DoubleEndedIterator {
+        self.0
+            .into_iter()
+            .flat_map(|(amt, coins)| coins.into_iter().map(move |c| (amt, c)))
+    }
 
     pub fn check_tiers<K>(&self, keys: &Tiered<K>) -> Result<(), InvalidAmountTierError> {
         match self.0.keys().find(|&amt| keys.get(*amt).is_none()) {

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -255,7 +255,7 @@ impl<'a> DatabaseDump<'a> {
                         MintRange::ReceivedPartialSignatureKey,
                         fedimint_mint::OutputConfirmationSignatures,
                         mint,
-                        "User Ecash Backup"
+                        "Received Signature Shares"
                     );
                 }
                 MintRange::DbKeyPrefix::EcashBackup => {
@@ -265,7 +265,7 @@ impl<'a> DatabaseDump<'a> {
                         MintRange::EcashBackupKey,
                         fedimint_mint::db::EcashBackupValue,
                         mint,
-                        "Received Signature Shares"
+                        "User Ecash Backup"
                     );
                 }
             }

--- a/gateway/tests/tests/fixtures/fed.rs
+++ b/gateway/tests/tests/fixtures/fed.rs
@@ -103,7 +103,7 @@ impl IFederationApi for MockApi {
     async fn download_ecash_backup(
         &self,
         _id: &secp256k1::XOnlyPublicKey,
-    ) -> Result<Vec<u8>, ApiError> {
+    ) -> Result<Option<Vec<u8>>, ApiError> {
         unimplemented!()
     }
 }

--- a/modules/fedimint-mint/Cargo.toml
+++ b/modules/fedimint-mint/Cargo.toml
@@ -18,6 +18,7 @@ bincode = "1.3.1"
 bitcoin_hashes = "0.11.0"
 counter = "0.5.7"
 futures = "0.3"
+hex = "0.4.2"
 itertools = "0.10.5"
 fedimint-api = { path = "../../fedimint-api" }
 rand = "0.8"

--- a/modules/fedimint-mint/src/config.rs
+++ b/modules/fedimint-mint/src/config.rs
@@ -17,10 +17,11 @@ pub struct MintConfig {
     pub threshold: usize,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MintClientConfig {
     pub tbs_pks: Tiered<AggregatePublicKey>,
     pub fee_consensus: FeeConsensus,
+    pub peer_tbs_pks: BTreeMap<PeerId, Tiered<tbs::PublicKeyShare>>,
 }
 
 impl TypedClientModuleConfig for MintClientConfig {}
@@ -43,6 +44,7 @@ impl TypedServerModuleConfig for MintConfig {
         serde_json::to_value(&MintClientConfig {
             tbs_pks: Tiered::from_iter(pub_key.into_iter()),
             fee_consensus: self.fee_consensus.clone(),
+            peer_tbs_pks: self.peer_tbs_pks.clone(),
         })
         .expect("Serialization can't fail")
         .into()

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -154,6 +154,7 @@ impl DatabaseKeyPrefixConst for EcashBackupKeyPrefix {
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct EcashBackupValue {
     pub timestamp: SystemTime,
+    #[serde(with = "hex::serde")]
     pub data: Vec<u8>,
 }
 


### PR DESCRIPTION
This commit adds:

* `backup`
* `restore`
* `wipe-notes` (hidden)

I tested it in various sequences and it seems to work now.

[Things to follow-up with are being tracked](https://github.com/fedimint/fedimint/issues/502#issue-1363756545).

To give a feel how it works:

```
dpc@mutex:~/lab/fedimint.git/mod$ fedimint-cli info
{
  "total_amount": 80000000,
  "total_num_notes": 56,
  "details": {
    "1": 2,
    "2": 1,
    "4": 1,
    "8": 1,
    "16": 1,
    "32": 1,
    "64": 1,
    "128": 1,
    "256": 5,
    "512": 1,
    "1024": 5,
    "2048": 5,
    "4096": 1,
    "8192": 5,
    "16384": 1,
    "32768": 1,
    "65536": 5,
    "131072": 1,
    "262144": 1,
    "524288": 1,
    "1048576": 5,
    "2097152": 5,
    "4194304": 1,
    "8388608": 1,
    "16777216": 3
  }
}
dpc@mutex:~/lab/fedimint.git/mod$ fedimint-cli wipe-notes
null
dpc@mutex:~/lab/fedimint.git/mod$ fedimint-cli info
{
  "total_amount": 0,
  "total_num_notes": 0,
  "details": {}
}
dpc@mutex:~/lab/fedimint.git/mod$ fedimint-cli restore
2022-12-11T03:27:00.392042Z  INFO mint_client::mint::backup: Recovering from snapshot start_epoch=16 end_epoch=16
2022-12-11T03:27:00.392468Z  INFO mint_client::mint::backup: Fetching epoch epoch=16
2022-12-11T03:27:00.392641Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=1 msat count=100
2022-12-11T03:27:00.517242Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=2 msat count=100
2022-12-11T03:27:00.633808Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=4 msat count=100
2022-12-11T03:27:00.747895Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=8 msat count=100
2022-12-11T03:27:00.864534Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=16 msat count=100
2022-12-11T03:27:00.982019Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=32 msat count=100
2022-12-11T03:27:01.098951Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=64 msat count=100
2022-12-11T03:27:01.215123Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=128 msat count=100
2022-12-11T03:27:01.333288Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=256 msat count=100
2022-12-11T03:27:01.448584Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=512 msat count=100
2022-12-11T03:27:01.563172Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=1024 msat count=100
2022-12-11T03:27:01.679512Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=2048 msat count=100
2022-12-11T03:27:01.794700Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=4096 msat count=100
2022-12-11T03:27:01.910540Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=8192 msat count=100
2022-12-11T03:27:02.026569Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=16384 msat count=100
2022-12-11T03:27:02.141762Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=32768 msat count=100
2022-12-11T03:27:02.257279Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=65536 msat count=100
2022-12-11T03:27:02.373448Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=131072 msat count=100
2022-12-11T03:27:02.490648Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=262144 msat count=100
2022-12-11T03:27:02.607107Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=524288 msat count=100
2022-12-11T03:27:02.723075Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=1048576 msat count=100
2022-12-11T03:27:02.839143Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=2097152 msat count=100
2022-12-11T03:27:02.956344Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=4194304 msat count=100
2022-12-11T03:27:03.070984Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=8388608 msat count=100
2022-12-11T03:27:03.187870Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=16777216 msat count=100
2022-12-11T03:27:03.305385Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=33554432 msat count=100
2022-12-11T03:27:03.421754Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=67108864 msat count=100
2022-12-11T03:27:03.538113Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=134217728 msat count=100
2022-12-11T03:27:03.654884Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=268435456 msat count=100
2022-12-11T03:27:03.772152Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=536870912 msat count=100
2022-12-11T03:27:03.890238Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=1073741824 msat count=100
2022-12-11T03:27:04.005920Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=2147483648 msat count=100
2022-12-11T03:27:04.123123Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=4294967296 msat count=100
2022-12-11T03:27:04.240138Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=8589934592 msat count=100
2022-12-11T03:27:04.356502Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=17179869184 msat count=100
2022-12-11T03:27:04.475297Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=34359738368 msat count=100
2022-12-11T03:27:04.596397Z  INFO mint_client::mint::backup: Generating initial set of nones for amount tier amount=68719476736 msat count=100
2022-12-11T03:27:04.712092Z  INFO mint_client::mint::backup: Awaiting epoch epoch=16
2022-12-11T03:27:04.712133Z  INFO mint_client::mint::backup: Processing epoch epoch=16
2022-12-11T03:27:04.712523Z  INFO mint_client::mint::backup: Writting out the recovered state to the database
null
dpc@mutex:~/lab/fedimint.git/mod$ fedimint-cli info
{
  "total_amount": 80000000,
  "total_num_notes": 56,
  "details": {
    "1": 2,
    "2": 1,
    "4": 1,
    "8": 1,
    "16": 1,
    "32": 1,
    "64": 1,
    "128": 1,
    "256": 5,
    "512": 1,
    "1024": 5,
    "2048": 5,
    "4096": 1,
    "8192": 5,
    "16384": 1,
    "32768": 1,
    "65536": 5,
    "131072": 1,
    "262144": 1,
    "524288": 1,
    "1048576": 5,
    "2097152": 5,
    "4194304": 1,
    "8388608": 1,
    "16777216": 3
  }
}
```