### PR TITLE
Fix: Gateway fails to save federation config if one already exists #1056

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -129,7 +129,7 @@ impl FromStr for FederationId {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UserClientConfig(pub ClientConfig);
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct GatewayClientConfig {
     pub client_config: ClientConfig,
     #[serde(with = "serde_keypair")]

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -127,10 +127,9 @@ impl LnGateway {
 
     // Webserver handler for requests to register a federation
     async fn handle_connect_federation(&self, payload: ConnectFedPayload) -> Result<()> {
-        let connect: WsFederationConnect =
-            serde_json::from_str(&payload.connect).map_err(|_| {
-                LnGatewayError::Other(anyhow::anyhow!("Invalid federation member string"))
-            })?;
+        let connect: WsFederationConnect = serde_json::from_str(&payload.connect).map_err(|e| {
+            LnGatewayError::Other(anyhow::anyhow!("Invalid federation member string {}", e))
+        })?;
 
         let node_pub_key = self
             .ln_rpc


### PR DESCRIPTION
Gateway save federation config would `File::open` an existing config in readonly mode, then fail to ovewrite the content.
This fix introduces an explicit panic on attempts to re-register the same federation with a changed config.

Long term, we should look into [Safe persistence and migration of gateway federation config](https://github.com/fedimint/fedimint/issues/1057)