### PR TITLE
Build typed configgen parameters API

### DIFF
--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -342,7 +342,7 @@ mod tests {
     use bitcoin::hashes::{sha256, Hash};
     use bitcoin::Address;
     use fedimint_api::backup::SignedBackupRequest;
-    use fedimint_api::config::ModuleConfigGenParams;
+    use fedimint_api::config::ConfigGenParams;
     use fedimint_api::core::OutputOutcome;
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -487,7 +487,7 @@ mod tests {
             FakeFed::<LightningModule>::new(
                 4,
                 |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
-                &ModuleConfigGenParams::fake_config_gen_params(),
+                &ConfigGenParams::fake_config_gen_params(),
                 &LightningModuleConfigGen,
             )
             .await

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -487,7 +487,7 @@ mod tests {
             FakeFed::<LightningModule>::new(
                 4,
                 |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
-                &ConfigGenParams::fake_config_gen_params(),
+                &ConfigGenParams::new(),
                 &LightningModuleConfigGen,
             )
             .await

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -646,7 +646,7 @@ mod tests {
     use bitcoin::hashes::Hash;
     use bitcoin::Address;
     use fedimint_api::backup::SignedBackupRequest;
-    use fedimint_api::config::ModuleConfigGenParams;
+    use fedimint_api::config::ConfigGenParams;
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::db::Database;
     use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -784,9 +784,9 @@ mod tests {
             FakeFed::<Mint>::new(
                 4,
                 |cfg, _db| async move { Ok(Mint::new(cfg.to_typed().unwrap())) },
-                &ModuleConfigGenParams {
+                &ConfigGenParams {
                     mint_amounts: vec![Amount::from_sats(1), Amount::from_sats(10)],
-                    ..ModuleConfigGenParams::fake_config_gen_params()
+                    ..ConfigGenParams::fake_config_gen_params()
                 },
                 &MintConfigGenerator,
             )

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -656,7 +656,9 @@ mod tests {
     use fedimint_core::modules::ln::contracts::ContractId;
     use fedimint_core::modules::ln::{ContractAccount, LightningGateway};
     use fedimint_core::modules::mint::config::MintClientConfig;
-    use fedimint_core::modules::mint::{Mint, MintConfigGenerator, MintOutput};
+    use fedimint_core::modules::mint::{
+        Mint, MintConfigGenParams, MintConfigGenerator, MintOutput,
+    };
     use fedimint_core::modules::wallet::PegOutFees;
     use fedimint_core::outcome::{SerdeOutputOutcome, TransactionStatus};
     use fedimint_core::transaction::legacy::Input;
@@ -784,10 +786,9 @@ mod tests {
             FakeFed::<Mint>::new(
                 4,
                 |cfg, _db| async move { Ok(Mint::new(cfg.to_typed().unwrap())) },
-                &ConfigGenParams {
+                &ConfigGenParams::new().attach(MintConfigGenParams {
                     mint_amounts: vec![Amount::from_sats(1), Amount::from_sats(10)],
-                    ..ConfigGenParams::fake_config_gen_params()
-                },
+                }),
                 &MintConfigGenerator,
             )
             .await

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -199,7 +199,7 @@ mod tests {
     use bitcoin::{Address, Txid};
     use bitcoin_hashes::Hash;
     use fedimint_api::backup::SignedBackupRequest;
-    use fedimint_api::config::ModuleConfigGenParams;
+    use fedimint_api::config::ConfigGenParams;
     use fedimint_api::core::{Decoder, MODULE_KEY_WALLET};
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -353,7 +353,7 @@ mod tests {
                         .await?)
                     }
                 },
-                &ModuleConfigGenParams::fake_config_gen_params(),
+                &ConfigGenParams::fake_config_gen_params(),
                 &WalletConfigGenerator,
             )
             .await

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -199,7 +199,7 @@ mod tests {
     use bitcoin::{Address, Txid};
     use bitcoin_hashes::Hash;
     use fedimint_api::backup::SignedBackupRequest;
-    use fedimint_api::config::ConfigGenParams;
+    use fedimint_api::config::{BitcoindRpcCfg, ConfigGenParams};
     use fedimint_api::core::{Decoder, MODULE_KEY_WALLET};
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -212,7 +212,8 @@ mod tests {
     use fedimint_core::modules::wallet::common::WalletModuleDecoder;
     use fedimint_core::modules::wallet::config::WalletClientConfig;
     use fedimint_core::modules::wallet::{
-        PegOut, PegOutFees, Wallet, WalletConfigGenerator, WalletOutput, WalletOutputOutcome,
+        PegOut, PegOutFees, Wallet, WalletConfigGenParams, WalletConfigGenerator, WalletOutput,
+        WalletOutputOutcome,
     };
     use fedimint_core::outcome::{SerdeOutputOutcome, TransactionStatus};
     use fedimint_testing::btc::bitcoind::{FakeBitcoindRpc, FakeBitcoindRpcController};
@@ -353,7 +354,15 @@ mod tests {
                         .await?)
                     }
                 },
-                &ConfigGenParams::fake_config_gen_params(),
+                &ConfigGenParams::new().attach(WalletConfigGenParams {
+                    network: bitcoin::network::constants::Network::Regtest,
+                    bitcoin_rpc: BitcoindRpcCfg {
+                        btc_rpc_address: "localhst".to_string(),
+                        btc_rpc_user: "bitcoin".to_string(),
+                        btc_rpc_pass: "bitcoin".to_string(),
+                    },
+                    finality_delay: 10,
+                }),
                 &WalletConfigGenerator,
             )
             .await

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -26,7 +26,6 @@ use url::Url;
 use crate::cancellable::Cancellable;
 use crate::core::ModuleKey;
 use crate::net::peers::MuxPeerConnections;
-use crate::Amount;
 use crate::PeerId;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -64,32 +63,36 @@ impl ClientConfig {
 ///
 /// Candidate for re-designing when the modularization effort is
 /// complete.
-pub struct ConfigGenParams {
-    pub mint_amounts: Vec<Amount>,
-    pub bitcoin_rpc: BitcoindRpcCfg,
-
-    /// extra options for extra settings and modules
-    pub other: BTreeMap<String, serde_json::Value>,
-}
+#[derive(Debug, Clone, Default)]
+pub struct ConfigGenParams(BTreeMap<String, serde_json::Value>);
 
 impl ConfigGenParams {
-    /// Default & fake config gen params for things like tests
-    ///
-    /// TODO: Possibly this does not belong here.
-    pub fn fake_config_gen_params() -> ConfigGenParams {
-        ConfigGenParams {
-            mint_amounts: [1, 10, 100, 1000, 10000, 100000, 1000000]
-                .into_iter()
-                .map(Amount::from_msats)
-                .collect(),
-            bitcoin_rpc: fedimint_api::config::BitcoindRpcCfg {
-                btc_rpc_address: "localhost".into(),
-                btc_rpc_user: "bitcoin".into(),
-                btc_rpc_pass: "bitcoin".into(),
-            },
-            other: Default::default(),
-        }
+    pub fn new() -> ConfigGenParams {
+        ConfigGenParams::default()
     }
+
+    /// Add params for a module
+    pub fn attach<P: ModuleConfigGenParams>(mut self, module_params: P) -> Self {
+        self.0.insert(
+            P::MODULE_NAME.to_string(),
+            serde_json::to_value(&module_params).expect("Encoding to value doesn't fail"),
+        );
+        self
+    }
+
+    /// Retrieve a typed config generation parameters for a module
+    pub fn get<P: ModuleConfigGenParams>(&self) -> anyhow::Result<P> {
+        let value = self
+            .0
+            .get(P::MODULE_NAME)
+            .ok_or_else(|| anyhow::anyhow!("No params found for module {}", P::MODULE_NAME))?;
+        serde_json::from_value(value.clone())
+            .map_err(|e| anyhow::Error::new(e).context("Invalid module params"))
+    }
+}
+
+pub trait ModuleConfigGenParams: serde::Serialize + serde::de::DeserializeOwned {
+    const MODULE_NAME: &'static str;
 }
 
 /// Config for the client-side of a particular Federation module

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -64,7 +64,7 @@ impl ClientConfig {
 ///
 /// Candidate for re-designing when the modularization effort is
 /// complete.
-pub struct ModuleConfigGenParams {
+pub struct ConfigGenParams {
     pub mint_amounts: Vec<Amount>,
     pub bitcoin_rpc: BitcoindRpcCfg,
 
@@ -72,12 +72,12 @@ pub struct ModuleConfigGenParams {
     pub other: BTreeMap<String, serde_json::Value>,
 }
 
-impl ModuleConfigGenParams {
+impl ConfigGenParams {
     /// Default & fake config gen params for things like tests
     ///
     /// TODO: Possibly this does not belong here.
-    pub fn fake_config_gen_params() -> ModuleConfigGenParams {
-        ModuleConfigGenParams {
+    pub fn fake_config_gen_params() -> ConfigGenParams {
+        ConfigGenParams {
             mint_amounts: [1, 10, 100, 1000, 10000, 100000, 1000000]
                 .into_iter()
                 .map(Amount::from_msats)

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -11,7 +11,7 @@ use secp256k1_zkp::XOnlyPublicKey;
 use thiserror::Error;
 
 use crate::cancellable::Cancellable;
-use crate::config::{ClientModuleConfig, DkgPeerMsg, ModuleConfigGenParams, ServerModuleConfig};
+use crate::config::{ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ServerModuleConfig};
 use crate::core::{
     PluginConsensusItem, PluginDecode, PluginInput, PluginOutput, PluginOutputOutcome,
 };
@@ -203,7 +203,7 @@ pub trait FederationModuleConfigGen {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        params: &ModuleConfigGenParams,
+        params: &ConfigGenParams,
     ) -> (BTreeMap<PeerId, ServerModuleConfig>, ClientModuleConfig);
 
     async fn distributed_gen(
@@ -211,7 +211,7 @@ pub trait FederationModuleConfigGen {
         connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         our_id: &PeerId,
         peers: &[PeerId],
-        params: &ModuleConfigGenParams,
+        params: &ConfigGenParams,
         task_group: &mut TaskGroup,
     ) -> anyhow::Result<Cancellable<ServerModuleConfig>>;
 

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -15,9 +15,9 @@ pub use fedimint_core::config::*;
 use fedimint_core::modules::ln::config::LightningModuleConfig;
 use fedimint_core::modules::ln::LightningModuleConfigGen;
 use fedimint_core::modules::mint::config::MintConfig;
-use fedimint_core::modules::mint::MintConfigGenerator;
+use fedimint_core::modules::mint::{MintConfigGenParams, MintConfigGenerator};
 use fedimint_wallet::config::WalletConfig;
-use fedimint_wallet::WalletConfigGenerator;
+use fedimint_wallet::{WalletConfigGenParams, WalletConfigGenerator};
 use hbbft::crypto::serde_impl::SerdeSecret;
 use rand::{CryptoRng, RngCore};
 use serde::de::DeserializeOwned;
@@ -87,12 +87,10 @@ pub struct ServerConfigParams {
     pub hbbft: NetworkConfig,
     pub api: NetworkConfig,
     pub server_dkg: NetworkConfig,
-    pub max_denomination: Amount,
     pub federation_name: String,
-    pub bitcoind_rpc: String,
 
     /// extra options for extra settings and modules
-    pub other: BTreeMap<String, serde_json::Value>,
+    pub modules: ConfigGenParams,
 }
 
 impl ServerConfig {
@@ -192,16 +190,6 @@ impl ServerConfig {
 
         let peer0 = &params[&PeerId::from(0)];
 
-        let module_cfg_gen_params = ConfigGenParams {
-            mint_amounts: ServerConfigParams::gen_denominations(peer0.max_denomination),
-            // TODO: FIXME: meh
-            bitcoin_rpc: BitcoindRpcCfg {
-                btc_rpc_address: peer0.bitcoind_rpc.clone(),
-                btc_rpc_user: "bitcoin".into(),
-                btc_rpc_pass: "bitcoin".into(),
-            },
-            other: peer0.other.clone(),
-        };
         let module_config_gens: Vec<(&'static str, Box<dyn FederationModuleConfigGen>)> = vec![
             (
                 "wallet",
@@ -213,7 +201,7 @@ impl ServerConfig {
 
         let module_configs: Vec<_> = module_config_gens
             .iter()
-            .map(|(name, gen)| (name, gen.trusted_dealer_gen(peers, &module_cfg_gen_params)))
+            .map(|(name, gen)| (name, gen.trusted_dealer_gen(peers, &peer0.modules)))
             .collect();
 
         let server_config: BTreeMap<_, _> = netinfo
@@ -293,15 +281,6 @@ impl ServerConfig {
         let (hbbft_pks, hbbft_sks) = keys[&KeyType::Hbbft].threshold_crypto();
         let (epoch_pks, epoch_sks) = keys[&KeyType::Epoch].threshold_crypto();
 
-        let module_cfg_gen_params = ConfigGenParams {
-            mint_amounts: ServerConfigParams::gen_denominations(params.max_denomination),
-            bitcoin_rpc: BitcoindRpcCfg {
-                btc_rpc_address: params.bitcoind_rpc.clone(),
-                btc_rpc_user: "bitcoin".into(),
-                btc_rpc_pass: "bitcoin".into(),
-            },
-            other: params.other.clone(),
-        };
         let module_config_gens: Vec<(&'static str, Box<dyn FederationModuleConfigGen>)> = vec![
             (
                 "wallet",
@@ -317,13 +296,7 @@ impl ServerConfig {
             module_cfgs.push((
                 name,
                 if let Ok(cfgs) = gen
-                    .distributed_gen(
-                        connections,
-                        our_id,
-                        peers,
-                        &module_cfg_gen_params,
-                        task_group,
-                    )
+                    .distributed_gen(connections, our_id, peers, &params.modules, task_group)
                     .await?
                 {
                     cfgs
@@ -473,15 +446,20 @@ impl ServerConfigParams {
             hbbft: Self::gen_network(&bind_address, &our_id, 0, peers),
             api: Self::gen_network(&bind_address, &our_id, 1, peers),
             server_dkg: Self::gen_network(&bind_address, &our_id, 2, peers),
-            max_denomination,
             federation_name,
-            bitcoind_rpc,
-            other: vec![
-                ("network".into(), network.to_string().into()),
-                ("finality_delay".into(), finality_delay.into()),
-            ]
-            .into_iter()
-            .collect(),
+            modules: ConfigGenParams::new()
+                .attach(WalletConfigGenParams {
+                    network,
+                    bitcoin_rpc: BitcoindRpcCfg {
+                        btc_rpc_address: bitcoind_rpc,
+                        btc_rpc_user: "bitcoin".to_string(),
+                        btc_rpc_pass: "bitcoin".to_string(),
+                    },
+                    finality_delay,
+                })
+                .attach(MintConfigGenParams {
+                    mint_amounts: ServerConfigParams::gen_denominations(max_denomination),
+                }),
         }
     }
 

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -3,8 +3,8 @@ use std::collections::{BTreeMap, HashMap};
 use anyhow::{bail, format_err};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
-    BitcoindRpcCfg, ClientConfig, DkgPeerMsg, DkgRunner, ModuleConfigGenParams, Node,
-    ServerModuleConfig, TypedServerModuleConfig,
+    BitcoindRpcCfg, ClientConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, Node, ServerModuleConfig,
+    TypedServerModuleConfig,
 };
 use fedimint_api::core::{ModuleKey, MODULE_KEY_GLOBAL};
 use fedimint_api::module::FederationModuleConfigGen;
@@ -192,7 +192,7 @@ impl ServerConfig {
 
         let peer0 = &params[&PeerId::from(0)];
 
-        let module_cfg_gen_params = ModuleConfigGenParams {
+        let module_cfg_gen_params = ConfigGenParams {
             mint_amounts: ServerConfigParams::gen_denominations(peer0.max_denomination),
             // TODO: FIXME: meh
             bitcoin_rpc: BitcoindRpcCfg {
@@ -293,7 +293,7 @@ impl ServerConfig {
         let (hbbft_pks, hbbft_sks) = keys[&KeyType::Hbbft].threshold_crypto();
         let (epoch_pks, epoch_sks) = keys[&KeyType::Epoch].threshold_crypto();
 
-        let module_cfg_gen_params = ModuleConfigGenParams {
+        let module_cfg_gen_params = ConfigGenParams {
             mint_amounts: ServerConfigParams::gen_denominations(params.max_denomination),
             bitcoin_rpc: BitcoindRpcCfg {
                 btc_rpc_address: params.bitcoind_rpc.clone(),

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use fedimint_api::config::{ClientModuleConfig, ModuleConfigGenParams, ServerModuleConfig};
+use fedimint_api::config::{ClientModuleConfig, ConfigGenParams, ServerModuleConfig};
 use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::module::interconnect::ModuleInterconect;
@@ -42,7 +42,7 @@ where
     pub async fn new<ConfGen, F, FF>(
         members: usize,
         constructor: F,
-        params: &ModuleConfigGenParams,
+        params: &ConfigGenParams,
         conf_gen: &ConfGen,
     ) -> anyhow::Result<FakeFed<Module>>
     where

--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use fedimint_api::config::{BitcoindRpcCfg, ClientConfig, ModuleConfigGenParams};
+use fedimint_api::config::{BitcoindRpcCfg, ClientConfig, ConfigGenParams};
 use fedimint_api::module::FederationModuleConfigGen;
 use fedimint_api::{Amount, PeerId};
 use fedimint_core::modules::ln::LightningModuleConfigGen;
@@ -109,7 +109,7 @@ fn trusted_dealer_gen(
         })
         .collect::<BTreeMap<_, _>>();
 
-    let module_cfg_gen_params = ModuleConfigGenParams {
+    let module_cfg_gen_params = ConfigGenParams {
         mint_amounts: params.amount_tiers.clone(),
         bitcoin_rpc: params.btc_rpc.clone(),
         other: BTreeMap::new(),

--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -4,10 +4,10 @@ use fedimint_api::config::{BitcoindRpcCfg, ClientConfig, ConfigGenParams};
 use fedimint_api::module::FederationModuleConfigGen;
 use fedimint_api::{Amount, PeerId};
 use fedimint_core::modules::ln::LightningModuleConfigGen;
-use fedimint_core::modules::mint::MintConfigGenerator;
+use fedimint_core::modules::mint::{MintConfigGenParams, MintConfigGenerator};
 use fedimint_server::config::{gen_cert_and_key, Peer as ServerPeer, ServerConfig};
 use fedimint_server::net::peers::ConnectionConfig;
-use fedimint_wallet::WalletConfigGenerator;
+use fedimint_wallet::{WalletConfigGenParams, WalletConfigGenerator};
 use rand::rngs::OsRng;
 use rand::{CryptoRng, RngCore};
 use threshold_crypto::serde_impl::SerdeSecret;
@@ -109,11 +109,15 @@ fn trusted_dealer_gen(
         })
         .collect::<BTreeMap<_, _>>();
 
-    let module_cfg_gen_params = ConfigGenParams {
-        mint_amounts: params.amount_tiers.clone(),
-        bitcoin_rpc: params.btc_rpc.clone(),
-        other: BTreeMap::new(),
-    };
+    let module_cfg_gen_params = ConfigGenParams::new()
+        .attach(WalletConfigGenParams {
+            network: bitcoin::network::constants::Network::Regtest,
+            bitcoin_rpc: params.btc_rpc.clone(),
+            finality_delay: 10,
+        })
+        .attach(MintConfigGenParams {
+            mint_amounts: params.amount_tiers.clone(),
+        });
     let module_config_gens: Vec<(&'static str, Box<_>)> = vec![
         (
             "wallet",

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -24,7 +24,7 @@ use config::{FeeConsensus, LightningModuleClientConfig};
 use db::{LightningGatewayKey, LightningGatewayKeyPrefix};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
-    ClientModuleConfig, DkgPeerMsg, DkgRunner, ModuleConfigGenParams, ServerModuleConfig,
+    ClientModuleConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, ServerModuleConfig,
     TypedServerModuleConfig,
 };
 use fedimint_api::core::{ModuleKey, MODULE_KEY_LN};
@@ -229,7 +229,7 @@ impl FederationModuleConfigGen for LightningModuleConfigGen {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        _params: &ModuleConfigGenParams,
+        _params: &ConfigGenParams,
     ) -> (BTreeMap<PeerId, ServerModuleConfig>, ClientModuleConfig) {
         let sks = threshold_crypto::SecretKeySet::random(peers.degree(), &mut OsRng);
         let pks = sks.public_keys();
@@ -268,7 +268,7 @@ impl FederationModuleConfigGen for LightningModuleConfigGen {
         connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         our_id: &PeerId,
         peers: &[PeerId],
-        _params: &ModuleConfigGenParams,
+        _params: &ConfigGenParams,
         _task_group: &mut TaskGroup,
     ) -> anyhow::Result<Cancellable<ServerModuleConfig>> {
         let mut dkg = DkgRunner::new((), peers.threshold(), our_id, peers);

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -1,6 +1,6 @@
 use bitcoin_hashes::sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
-use fedimint_api::config::ModuleConfigGenParams;
+use fedimint_api::config::ConfigGenParams;
 use fedimint_api::core::{Decoder, MODULE_KEY_LN};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::{Amount, OutPoint};
@@ -34,7 +34,7 @@ async fn test_account() {
     let mut fed = FakeFed::<LightningModule>::new(
         4,
         |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
-        &ModuleConfigGenParams::fake_config_gen_params(),
+        &ConfigGenParams::fake_config_gen_params(),
         &LightningModuleConfigGen,
     )
     .await
@@ -84,7 +84,7 @@ async fn test_outgoing() {
     let mut fed = FakeFed::<LightningModule>::new(
         4,
         |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
-        &ModuleConfigGenParams::fake_config_gen_params(),
+        &ConfigGenParams::fake_config_gen_params(),
         &LightningModuleConfigGen,
     )
     .await
@@ -183,7 +183,7 @@ async fn test_incoming() {
     let mut fed = FakeFed::<LightningModule>::new(
         4,
         |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
-        &ModuleConfigGenParams::fake_config_gen_params(),
+        &ConfigGenParams::fake_config_gen_params(),
         &LightningModuleConfigGen,
     )
     .await

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -34,7 +34,7 @@ async fn test_account() {
     let mut fed = FakeFed::<LightningModule>::new(
         4,
         |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
-        &ConfigGenParams::fake_config_gen_params(),
+        &ConfigGenParams::new(),
         &LightningModuleConfigGen,
     )
     .await
@@ -84,7 +84,7 @@ async fn test_outgoing() {
     let mut fed = FakeFed::<LightningModule>::new(
         4,
         |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
-        &ConfigGenParams::fake_config_gen_params(),
+        &ConfigGenParams::new(),
         &LightningModuleConfigGen,
     )
     .await
@@ -183,7 +183,7 @@ async fn test_incoming() {
     let mut fed = FakeFed::<LightningModule>::new(
         4,
         |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
-        &ConfigGenParams::fake_config_gen_params(),
+        &ConfigGenParams::new(),
         &LightningModuleConfigGen,
     )
     .await

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -9,8 +9,8 @@ use db::{EcashBackupKey, EcashBackupValue};
 use fedimint_api::backup::SignedBackupRequest;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
-    scalar, ClientModuleConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, ServerModuleConfig,
-    TypedServerModuleConfig,
+    scalar, ClientModuleConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, ModuleConfigGenParams,
+    ServerModuleConfig, TypedServerModuleConfig,
 };
 use fedimint_api::core::{ModuleKey, MODULE_KEY_MINT};
 use fedimint_api::db::DatabaseTransaction;
@@ -136,6 +136,10 @@ impl FederationModuleConfigGen for MintConfigGenerator {
         peers: &[PeerId],
         params: &ConfigGenParams,
     ) -> (BTreeMap<PeerId, ServerModuleConfig>, ClientModuleConfig) {
+        let params = params
+            .get::<MintConfigGenParams>()
+            .expect("Invalid mint params");
+
         let tbs_keys = params
             .mint_amounts
             .iter()
@@ -206,6 +210,10 @@ impl FederationModuleConfigGen for MintConfigGenerator {
         params: &ConfigGenParams,
         _task_group: &mut TaskGroup,
     ) -> anyhow::Result<Cancellable<ServerModuleConfig>> {
+        let params = params
+            .get::<MintConfigGenParams>()
+            .expect("Invalid mint params");
+
         let mut dkg = DkgRunner::multi(
             params.mint_amounts.to_vec(),
             peers.threshold(),
@@ -256,6 +264,15 @@ impl FederationModuleConfigGen for MintConfigGenerator {
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
         config.to_typed::<MintConfig>()?.validate_config(identity)
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MintConfigGenParams {
+    pub mint_amounts: Vec<Amount>,
+}
+
+impl ModuleConfigGenParams for MintConfigGenParams {
+    const MODULE_NAME: &'static str = "mint";
 }
 
 #[autoimpl(Deref, DerefMut using self.0)]
@@ -1079,7 +1096,10 @@ mod test {
     use tbs::{blind_message, unblind_signature, verify, AggregatePublicKey, BlindingKey, Message};
 
     use crate::config::{FeeConsensus, MintClientConfig};
-    use crate::{BlindNonce, CombineError, Mint, MintConfig, MintConfigGenerator, PeerErrorType};
+    use crate::{
+        BlindNonce, CombineError, Mint, MintConfig, MintConfigGenParams, MintConfigGenerator,
+        PeerErrorType,
+    };
 
     const THRESHOLD: usize = 1;
     const MINTS: usize = 5;
@@ -1088,10 +1108,9 @@ mod test {
         let peers = (0..MINTS as u16).map(PeerId::from).collect::<Vec<_>>();
         let (mint_cfg, client_cfg) = MintConfigGenerator.trusted_dealer_gen(
             &peers,
-            &ConfigGenParams {
+            &ConfigGenParams::new().attach(MintConfigGenParams {
                 mint_amounts: vec![Amount::from_sats(1)],
-                ..ConfigGenParams::fake_config_gen_params()
-            },
+            }),
         );
 
         (mint_cfg.into_iter().map(|(_, c)| c).collect(), client_cfg)

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -9,7 +9,7 @@ use db::{EcashBackupKey, EcashBackupValue};
 use fedimint_api::backup::SignedBackupRequest;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
-    scalar, ClientModuleConfig, DkgPeerMsg, DkgRunner, ModuleConfigGenParams, ServerModuleConfig,
+    scalar, ClientModuleConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, ServerModuleConfig,
     TypedServerModuleConfig,
 };
 use fedimint_api::core::{ModuleKey, MODULE_KEY_MINT};
@@ -134,7 +134,7 @@ impl FederationModuleConfigGen for MintConfigGenerator {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        params: &ModuleConfigGenParams,
+        params: &ConfigGenParams,
     ) -> (BTreeMap<PeerId, ServerModuleConfig>, ClientModuleConfig) {
         let tbs_keys = params
             .mint_amounts
@@ -203,7 +203,7 @@ impl FederationModuleConfigGen for MintConfigGenerator {
         connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         our_id: &PeerId,
         peers: &[PeerId],
-        params: &ModuleConfigGenParams,
+        params: &ConfigGenParams,
         _task_group: &mut TaskGroup,
     ) -> anyhow::Result<Cancellable<ServerModuleConfig>> {
         let mut dkg = DkgRunner::multi(
@@ -1073,7 +1073,7 @@ impl From<InvalidAmountTierError> for MintError {
 
 #[cfg(test)]
 mod test {
-    use fedimint_api::config::{ClientModuleConfig, ModuleConfigGenParams, ServerModuleConfig};
+    use fedimint_api::config::{ClientModuleConfig, ConfigGenParams, ServerModuleConfig};
     use fedimint_api::module::FederationModuleConfigGen;
     use fedimint_api::{Amount, PeerId, TieredMulti};
     use tbs::{blind_message, unblind_signature, verify, AggregatePublicKey, BlindingKey, Message};
@@ -1088,9 +1088,9 @@ mod test {
         let peers = (0..MINTS as u16).map(PeerId::from).collect::<Vec<_>>();
         let (mint_cfg, client_cfg) = MintConfigGenerator.trusted_dealer_gen(
             &peers,
-            &ModuleConfigGenParams {
+            &ConfigGenParams {
                 mint_amounts: vec![Amount::from_sats(1)],
-                ..ModuleConfigGenParams::fake_config_gen_params()
+                ..ConfigGenParams::fake_config_gen_params()
             },
         );
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -19,8 +19,7 @@ use bitcoin::{PackedLockTime, Sequence};
 use config::WalletClientConfig;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
-    ClientModuleConfig, DkgPeerMsg, ModuleConfigGenParams, ServerModuleConfig,
-    TypedServerModuleConfig,
+    ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ServerModuleConfig, TypedServerModuleConfig,
 };
 use fedimint_api::core::{ModuleKey, MODULE_KEY_WALLET};
 use fedimint_api::db::{Database, DatabaseTransaction};
@@ -220,7 +219,7 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        params: &ModuleConfigGenParams,
+        params: &ConfigGenParams,
     ) -> (BTreeMap<PeerId, ServerModuleConfig>, ClientModuleConfig) {
         const FINALITY_DELAY: u32 = 10;
 
@@ -279,7 +278,7 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
         connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
         our_id: &PeerId,
         peers: &[PeerId],
-        params: &ModuleConfigGenParams,
+        params: &ConfigGenParams,
         _task_group: &mut TaskGroup,
     ) -> anyhow::Result<Cancellable<ServerModuleConfig>> {
         let secp = secp256k1::Secp256k1::new();


### PR DESCRIPTION
The config generation is not fully modularized yet. As a first step this PR builds a typed API to access configgen params from module configgen. 

- [x] Allow extracting typed params structs from module params
- [ ] Remove client cfg from trusted dealer gen return type
- [ ] Split configgen trait into typed+type erased version
- [ ] Add associated constants for param and cofig types to typed configgen trait