### PR TITLE
Refactor the configs to be prepared for splitting them

### DIFF
--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -139,7 +139,8 @@ fn trusted_dealer_gen(
             let epoch_keys = epochinfo
                 .get(&id)
                 .expect("Could not get keys from epoch info");
-            let config = ServerConfig {
+
+            let mut config = ServerConfig {
                 federation_name: params.federation_name.clone(),
                 identity: id,
                 hbbft_bind_addr: format!("0.0.0.0:{}", hbbft_base_port + id_u16),
@@ -157,12 +158,19 @@ fn trusted_dealer_gen(
                 epoch_sks: SerdeSecret(epoch_keys.secret_key_share().unwrap().clone()),
                 epoch_pk_set: epoch_keys.public_key_set().clone(),
 
-                modules: module_configs
+                modules_local: Default::default(),
+                modules_private: Default::default(),
+                modules_consensus: Default::default(),
+                max_connections: 1000,
+            };
+
+            config.add_modules(
+                module_configs
                     .iter()
                     .map(|(name, cfgs)| (name.to_string(), cfgs.0[&id].clone()))
                     .collect(),
-                max_connections: 1000,
-            };
+            );
+
             (id, config)
         })
         .collect();

--- a/modules/fedimint-ln/src/config.rs
+++ b/modules/fedimint-ln/src/config.rs
@@ -22,6 +22,22 @@ pub struct LightningModuleClientConfig {
 }
 
 impl TypedServerModuleConfig for LightningModuleConfig {
+    type Local = LightningModuleConfig;
+    type Private = ();
+    type Consensus = ();
+
+    fn from_parts(
+        local: Self::Local,
+        _private: Self::Private,
+        _consensus: Self::Consensus,
+    ) -> Self {
+        local
+    }
+
+    fn to_parts(self) -> (Self::Local, Self::Private, Self::Consensus) {
+        (self, (), ())
+    }
+
     fn to_client_config(&self) -> ClientModuleConfig {
         serde_json::to_value(&LightningModuleClientConfig {
             threshold_pub_key: self.threshold_pub_keys.public_key(),

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -241,14 +241,13 @@ impl FederationModuleConfigGen for LightningModuleConfigGen {
 
                 (
                     peer,
-                    serde_json::to_value(&LightningModuleConfig {
+                    LightningModuleConfig {
                         threshold_pub_keys: pks.clone(),
                         threshold_sec_key: threshold_crypto::serde_impl::SerdeSecret(sk),
                         threshold: peers.threshold(),
                         fee_consensus: FeeConsensus::default(),
-                    })
-                    .expect("serialization can't fail here")
-                    .into(),
+                    }
+                    .to_erased(),
                 )
             })
             .collect();

--- a/modules/fedimint-mint/src/config.rs
+++ b/modules/fedimint-mint/src/config.rs
@@ -27,6 +27,22 @@ pub struct MintClientConfig {
 impl TypedClientModuleConfig for MintClientConfig {}
 
 impl TypedServerModuleConfig for MintConfig {
+    type Local = MintConfig;
+    type Private = ();
+    type Consensus = ();
+
+    fn from_parts(
+        local: Self::Local,
+        _private: Self::Private,
+        _consensus: Self::Consensus,
+    ) -> Self {
+        local
+    }
+
+    fn to_parts(self) -> (Self::Local, Self::Private, Self::Consensus) {
+        (self, (), ())
+    }
+
     fn to_client_config(&self) -> ClientModuleConfig {
         let pub_key: HashMap<Amount, AggregatePublicKey> = TieredMultiZip::new(
             self.peer_tbs_pks

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -194,14 +194,7 @@ impl FederationModuleConfigGen for MintConfigGenerator {
         (
             mint_cfg
                 .into_iter()
-                .map(|(k, v)| {
-                    (
-                        k,
-                        serde_json::to_value(v)
-                            .expect("serialization can't fail")
-                            .into(),
-                    )
-                })
+                .map(|(k, v)| (k, v.to_erased()))
                 .collect(),
             serde_json::to_value(client_cfg)
                 .expect("serialization can't fail")

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -57,6 +57,22 @@ impl Default for FeeConsensus {
 }
 
 impl TypedServerModuleConfig for WalletConfig {
+    type Local = WalletConfig;
+    type Private = ();
+    type Consensus = ();
+
+    fn from_parts(
+        local: Self::Local,
+        _private: Self::Private,
+        _consensus: Self::Consensus,
+    ) -> Self {
+        local
+    }
+
+    fn to_parts(self) -> (Self::Local, Self::Private, Self::Consensus) {
+        (self, (), ())
+    }
+
     fn to_client_config(&self) -> ClientModuleConfig {
         serde_json::to_value(&WalletClientConfig {
             peg_in_descriptor: self.peg_in_descriptor.clone(),

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -257,14 +257,7 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
         (
             wallet_cfg
                 .into_iter()
-                .map(|(k, v)| {
-                    (
-                        k,
-                        serde_json::to_value(v)
-                            .expect("serialization can't fail")
-                            .into(),
-                    )
-                })
+                .map(|(k, v)| (k, v.to_erased()))
                 .collect(),
             serde_json::to_value(client_cfg)
                 .expect("serialization can't fail")


### PR DESCRIPTION
In preparation for #960 I will first add the local, private, and consensus types to all the configs and json logic.

Next step will be to break the configs up into structs representating those fields and write them to different files.  I'd like to do this in a separate PR since it will involve a large refactor.