### PR TITLE
Fix nix-ci not running `cargo test`

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -97,7 +97,7 @@ jobs:
         continue-on-error: true
 
       - name: Build and run tests with Code Coverage
-        run: nix build -L .#debug.workspaceCov
+        run: nix build -L .#debug.workspaceTestCov
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
I think this got broken when I've upgraded crane in #1081 as the behavior of `doCheck` have changed between releases.