### PR TITLE
replit: add lld package

### DIFF
--- a/replit.nix
+++ b/replit.nix
@@ -9,6 +9,7 @@
     pkgs.rust-analyzer
     pkgs.clang
     pkgs.libclang.lib
+    pkgs.lld
     pkgs.pkg-config
     pkgs.openssl
     pkgs.nix


### PR DESCRIPTION
without this, it was failing with

  invalid linker name in argument '-fuse-ld=lld'

Hi, I saw your tweet https://twitter.com/_JustinMoon_/status/1602728750617169920 . I tried out importing this into Replit and I found this problem. Looks like there are still more problems though because it gets a lot further and then I see:

```
    Checking mint-client v0.1.0 (/home/runner/fedimint/client/client-lib)
error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> client/client-lib/src/api.rs:285:24
    |
285 |             .request::<_, SerdeEpochHistory>("/fetch_epoch_history", epoch, qs)
    |                        ^  ^^^^^^^^^^^^^^^^^ explicit generic argument not allowed
    |                        |
    |                        explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

For more information about this error, try `rustc --explain E0632`.
error: could not compile `mint-client` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
exit status 101
```