### PR TITLE
replit: bump nix channel

### DIFF
--- a/.replit
+++ b/.replit
@@ -57,7 +57,7 @@ start = "nix --extra-experimental-features nix-command --extra-experimental-feat
 
 [nix]
 # this must be kept in sync with `nixpkgs` channel in `flake.nix`
-channel = "stable-22_05"
+channel = "stable-22_11"
 
 [gitHubImport]
 requiredFiles = [".replit", "replit.nix"]


### PR DESCRIPTION
Using the latest nix channel on replit gives a newer version of the rust compiler, which makes it further along in the build process past the error mentioned in https://github.com/fedimint/fedimint/pull/1112. Unfortunately, it runs out of disk space even after this change.