### PR TITLE
Splits configs into local, private, and consensus files

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -392,7 +392,7 @@ impl FedimintConsensus {
 
         // validate and update sigs on prev epoch
         if let Some(prev_epoch) = maybe_prev_epoch {
-            let pks = &self.cfg.epoch_pk_set;
+            let pks = &self.cfg.consensus.epoch_pk_set;
 
             match current.add_sig_to_prev(pks, prev_epoch) {
                 Ok(prev_epoch) => {
@@ -471,7 +471,7 @@ impl FedimintConsensus {
 
         if let Some(epoch) = dbtx.get_value(&LastEpochKey).await.unwrap() {
             let last_epoch = dbtx.get_value(&epoch).await.unwrap().unwrap();
-            let sig = self.cfg.epoch_sks.0.sign(last_epoch.hash);
+            let sig = self.cfg.private.epoch_sks.0.sign(last_epoch.hash);
             let item = ConsensusItem::EpochOutcomeSignatureShare(EpochOutcomeSignatureShare(sig));
             items.push(item);
         };

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -54,13 +54,13 @@ pub async fn run_server(
         attach_endpoints_erased(&mut rpc_module, module);
     }
 
-    debug!(addr = cfg.api_bind_addr, "Starting WSServer");
+    debug!(addr = cfg.local.api_bind_addr, "Starting WSServer");
     let server = ServerBuilder::new()
-        .max_connections(cfg.max_connections)
+        .max_connections(cfg.local.max_connections)
         .ping_interval(Duration::from_secs(10))
-        .build(&cfg.api_bind_addr)
+        .build(&cfg.local.api_bind_addr)
         .await
-        .context(format!("Bind address: {}", cfg.api_bind_addr))
+        .context(format!("Bind address: {}", cfg.local.api_bind_addr))
         .expect("Could not start API server");
 
     let server_handle = server

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -11,6 +11,7 @@ use fedimint_api::{Amount, PeerId};
 use fedimint_server::config::{PeerServerParams, ServerConfig, ServerConfigParams};
 use fedimint_server::multiplexed::PeerConnectionMultiplexer;
 use fedimintd::encrypt::*;
+use fedimintd::*;
 use itertools::Itertools;
 use rand::rngs::OsRng;
 use ring::aead::LessSafeKey;
@@ -180,13 +181,8 @@ async fn main() {
                 return;
             };
 
-            let server_path = dir_out_path.join(CONFIG_FILE);
-            let config_bytes = serde_json::to_string(&server).unwrap().into_bytes();
-            encrypted_write(config_bytes, &key, server_path);
-
-            let client_path: PathBuf = dir_out_path.join("client.json");
-            let client_file = fs::File::create(client_path).expect("Could not create cfg file");
-            serde_json::to_writer_pretty(client_file, &server.to_client_config()).unwrap();
+            encrypted_json_write(&server.private, &key, dir_out_path.join(PRIVATE_CONFIG));
+            write_nonprivate_configs(&server, dir_out_path);
         }
         Command::VersionHash => {
             println!("{}", env!("GIT_HASH"));

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -5,13 +5,13 @@ use fedimint_api::db::Database;
 use fedimint_api::task::TaskGroup;
 use fedimint_core::all_decoders;
 use fedimint_core::modules::ln::LightningModule;
-use fedimint_server::config::ServerConfig;
 use fedimint_server::consensus::FedimintConsensus;
 use fedimint_server::FedimintServer;
 use fedimint_wallet::config::WalletConfig;
 use fedimint_wallet::Wallet;
 use fedimintd::encrypt::*;
 use fedimintd::ui::run_ui;
+use fedimintd::*;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer;
@@ -77,9 +77,7 @@ async fn main() -> anyhow::Result<()> {
 
     let salt_path = opts.cfg_path.join(SALT_FILE);
     let key = get_key(opts.password, salt_path);
-    let decrypted = encrypted_read(&key, opts.cfg_path.join(CONFIG_FILE));
-    let cfg_string = String::from_utf8(decrypted).expect("is not correctly encoded");
-    let cfg: ServerConfig = serde_json::from_str(&cfg_string).expect("could not parse config");
+    let cfg = read_server_configs(&key, opts.cfg_path.clone());
 
     let mut task_group = TaskGroup::new();
 

--- a/fedimintd/src/encrypt.rs
+++ b/fedimintd/src/encrypt.rs
@@ -23,13 +23,6 @@ use ring::{aead, digest, pbkdf2};
 const ITERATIONS_PROD: Option<NonZeroU32> = NonZeroU32::new(1_000_000);
 const ITERATIONS_DEBUG: Option<NonZeroU32> = NonZeroU32::new(1);
 
-// server files
-pub const SALT_FILE: &str = "salt";
-pub const CONFIG_FILE: &str = "config";
-pub const DB_FILE: &str = "database";
-pub const TLS_PK: &str = "tls-pk";
-pub const TLS_CERT: &str = "tls-cert";
-
 /// Write `data` encrypted to a `file` with a random `nonce` that will be encoded in the file
 pub fn encrypted_write(mut data: Vec<u8>, key: &LessSafeKey, file: PathBuf) {
     let nonce_bytes: [u8; NONCE_LEN] = rand::random();
@@ -43,6 +36,7 @@ pub fn encrypted_write(mut data: Vec<u8>, key: &LessSafeKey, file: PathBuf) {
 
 /// Reads encrypted data from a file
 pub fn encrypted_read(key: &LessSafeKey, file: PathBuf) -> Vec<u8> {
+    tracing::warn!("READ {:?}", file);
     let hex = fs::read_to_string(file).expect("Can't read file.");
     let mut bytes = hex::decode(hex).expect("not hex encoded");
     let (nonce_bytes, encrypted_bytes) = bytes.split_at_mut(NONCE_LEN);

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -1,2 +1,84 @@
+use std::fs;
+use std::path::PathBuf;
+
+use fedimint_server::config::ServerConfig;
+use ring::aead::LessSafeKey;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::encrypt::{encrypted_read, encrypted_write};
+
 pub mod encrypt;
 pub mod ui;
+
+/// Client configuration file
+pub const CLIENT_CONFIG: &str = "client";
+
+/// Server encrypted private keys file
+pub const PRIVATE_CONFIG: &str = "private";
+
+/// Server locally configurable file
+pub const LOCAL_CONFIG: &str = "local";
+
+/// Server consensus-only configurable file
+pub const CONSENSUS_CONFIG: &str = "consensus";
+
+/// Salt backup for combining with the private key
+pub const SALT_FILE: &str = "private.salt";
+
+/// Database file name
+pub const DB_FILE: &str = "database";
+
+/// Encrypted TLS private keys
+pub const TLS_PK: &str = "tls-pk";
+
+/// TLS public cert
+pub const TLS_CERT: &str = "tls-cert";
+
+const JSON_EXT: &str = "json";
+const ENCRYPTED_EXT: &str = "encrypt";
+
+/// Reads the server from the local, private, and consensus cfg files (private file encrypted)
+pub fn read_server_configs(key: &LessSafeKey, path: PathBuf) -> ServerConfig {
+    ServerConfig {
+        consensus: plaintext_json_read(path.join(CONSENSUS_CONFIG)),
+        local: plaintext_json_read(path.join(LOCAL_CONFIG)),
+        private: encrypted_json_read(key, path.join(PRIVATE_CONFIG)),
+    }
+}
+
+/// Reads a plaintext json file into a struct
+pub fn plaintext_json_read<T: Serialize + DeserializeOwned>(path: PathBuf) -> T {
+    let string = fs::read_to_string(path.with_extension(JSON_EXT)).expect("Can't read file.");
+    serde_json::from_str(&string).expect("could not parse config")
+}
+
+/// Reads an encrypted json file into a struct
+pub fn encrypted_json_read<T: Serialize + DeserializeOwned>(key: &LessSafeKey, path: PathBuf) -> T {
+    let decrypted = encrypted_read(key, path.with_extension(ENCRYPTED_EXT));
+    let string = String::from_utf8(decrypted).expect("is not correctly encoded");
+    serde_json::from_str(&string).expect("could not parse config")
+}
+
+/// Writes the server into plaintext json configuration files (private keys not serialized)
+pub fn write_nonprivate_configs(server: &ServerConfig, path: PathBuf) {
+    plaintext_json_write(&server.local, path.join(LOCAL_CONFIG));
+    plaintext_json_write(&server.consensus, path.join(CONSENSUS_CONFIG));
+    plaintext_json_write(&server.to_client_config(), path.join(CLIENT_CONFIG));
+}
+
+/// Writes struct into a plaintext json file
+pub fn plaintext_json_write<T: Serialize + DeserializeOwned>(obj: &T, path: PathBuf) {
+    let file = fs::File::create(path.with_extension(JSON_EXT)).expect("Could not create cfg file");
+    serde_json::to_writer_pretty(file, obj).unwrap();
+}
+
+/// Writes struct into an encrypted json file
+pub fn encrypted_json_write<T: Serialize + DeserializeOwned>(
+    obj: &T,
+    key: &LessSafeKey,
+    path: PathBuf,
+) {
+    let bytes = serde_json::to_string(obj).unwrap().into_bytes();
+    encrypted_write(bytes, key, path.with_extension(ENCRYPTED_EXT));
+}

--- a/fedimintd/src/ui/mod.rs
+++ b/fedimintd/src/ui/mod.rs
@@ -196,7 +196,7 @@ async fn receive_configs(
 
     // update state
     state.client_config = Some(client_config);
-    state.federation_name = server_config.federation_name;
+    state.federation_name = server_config.consensus.federation_name;
 
     // run fedimint
     run_fedimint(&mut state);

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -231,7 +231,8 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
             let ln_rpc_adapter = LnRpcAdapter::new(Box::new(lightning.clone()));
             let net = MockNetwork::new();
             let net_ref = &net;
-            let connect_gen = move |cfg: &ServerConfig| net_ref.connector(cfg.identity).into_dyn();
+            let connect_gen =
+                move |cfg: &ServerConfig| net_ref.connector(cfg.local.identity).into_dyn();
 
             let fed_db = || MemDatabase::new().into();
             let fed = FederationTest::new(
@@ -587,7 +588,7 @@ impl FederationTest {
             servers: self
                 .servers
                 .iter()
-                .filter(|s| peers.contains(&s.as_ref().borrow().fedimint.cfg.identity))
+                .filter(|s| peers.contains(&s.as_ref().borrow().fedimint.cfg.local.identity))
                 .map(Rc::clone)
                 .collect(),
             wallet: self.wallet.clone(),

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -908,7 +908,7 @@ async fn can_get_signed_epoch_history() -> Result<()> {
         fed.mine_and_mint(&user, &*bitcoin, sats(1000)).await;
         fed.mine_and_mint(&user, &*bitcoin, sats(1000)).await;
 
-        let pubkey = fed.cfg.epoch_pk_set.public_key();
+        let pubkey = fed.cfg.consensus.epoch_pk_set.public_key();
         let epoch0 = user.client.fetch_epoch_history(0, pubkey).await.unwrap();
         let epoch1 = user.client.fetch_epoch_history(1, pubkey).await.unwrap();
 

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -8,9 +8,7 @@ export PEG_IN_AMOUNT=10000
 source ./scripts/setup-tests.sh
 
 # Test config en/decryption tool
-$FM_DISTRIBUTEDGEN config-decrypt --in-file $FM_CFG_DIR/server-0/config --out-file $FM_CFG_DIR/server-0/config-plaintext.json --password pass0
-[[ "$(jq -r '.federation_name' $FM_CFG_DIR/server-0/config-plaintext.json)" = "Hals_trusty_mint" ]]
-
+$FM_DISTRIBUTEDGEN config-decrypt --in-file $FM_CFG_DIR/server-0/private.encrypt --out-file $FM_CFG_DIR/server-0/config-plaintext.json --password pass0
 $FM_DISTRIBUTEDGEN config-encrypt --in-file $FM_CFG_DIR/server-0/config-plaintext.json --out-file $FM_CFG_DIR/server-0/config-2 --password pass-foo
 $FM_DISTRIBUTEDGEN config-decrypt --in-file $FM_CFG_DIR/server-0/config-2 --out-file $FM_CFG_DIR/server-0/config-plaintext-2.json --password pass-foo
 cmp --silent $FM_CFG_DIR/server-0/config-plaintext.json $FM_CFG_DIR/server-0/config-plaintext-2.json


### PR DESCRIPTION
Splits the `ServerConfig` into local, private, and consensus files, with only the private file encrypted.

Leaving the modules for another PR.