### PR TITLE
Move aead wrappers around ring to separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "rand",
+ "ring",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2257,7 @@ dependencies = [
 name = "mint-client"
 version = "0.1.0"
 dependencies = [
+ "aead",
  "anyhow",
  "async-trait",
  "base64 0.20.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,7 @@ dependencies = [
 name = "fedimintd"
 version = "0.1.0"
 dependencies = [
+ "aead",
  "anyhow",
  "askama",
  "askama_axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crypto/aead",
     "crypto/hkdf",
     "crypto/tbs",
     "gateway/ln-gateway",

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 
 
 [dependencies]
+aead = { path = "../../crypto/aead" }
 anyhow = "1.0.66"
 async-trait = "0.1.59"
 base64 = "0.20.0"

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -31,56 +31,6 @@ use tracing::{error, info};
 use super::{db::NextECashNoteIndexKeyPrefix, *};
 use crate::api;
 
-/// Some helpers to make `ring::aead` usable
-mod aead {
-    use anyhow::{bail, Result};
-    use rand::rngs::OsRng;
-    use rand::Rng;
-    use ring::aead::Nonce;
-    pub use ring::aead::{Aad, LessSafeKey, UnboundKey, NONCE_LEN};
-
-    /// Get a random nonce.
-    pub fn get_random_nonce() -> ring::aead::Nonce {
-        Nonce::assume_unique_for_key(OsRng.gen())
-    }
-
-    /// Encrypt `plaintext` using `key`.
-    ///
-    /// Prefixes the ciphertext with a nonce.
-    pub fn encrypt(mut plaintext: Vec<u8>, key: &LessSafeKey) -> Result<Vec<u8>> {
-        let nonce = get_random_nonce();
-        // prefix ciphertext with nonce
-        let mut ciphertext: Vec<u8> = nonce.as_ref().to_vec();
-
-        key.seal_in_place_append_tag(nonce, Aad::empty(), &mut plaintext)
-            .map_err(|_| anyhow::format_err!("Encryption failed due to unspecified aead error"))?;
-
-        ciphertext.append(&mut plaintext);
-
-        Ok(ciphertext)
-    }
-
-    /// Decrypts a `ciphertext` using `key`.
-    ///
-    /// Expect nonce in the prefix, like [`encrypt`] produces.
-    pub fn decrypt<'c>(ciphertext: &'c mut [u8], key: &LessSafeKey) -> Result<&'c [u8]> {
-        if ciphertext.len() < NONCE_LEN {
-            bail!("Ciphertext too short: {}", ciphertext.len());
-        }
-
-        let (nonce_bytes, encrypted_bytes) = ciphertext.split_at_mut(NONCE_LEN);
-
-        key.open_in_place(
-            Nonce::assume_unique_for_key(nonce_bytes.try_into().expect("nonce size known")),
-            Aad::empty(),
-            encrypted_bytes,
-        )
-        .map_err(|_| anyhow::format_err!("Decryption failed due to unspecified aead error"))?;
-
-        Ok(encrypted_bytes)
-    }
-}
-
 impl MintClient {
     /// Prepare an encrypted backup and send it to federation for storing
     pub async fn back_up_ecash_to_federation(&self) -> Result<()> {

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aead"
+version = "0.1.0"
+authors = ["The Fedimint Developers"]
+edition = "2021"
+description = "aead utilities on top of ring "
+license = "MIT"
+
+[lib]
+name = "aead"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "1.0.65"
+ring = "0.16.20"
+rand = "0.8"

--- a/crypto/aead/src/lib.rs
+++ b/crypto/aead/src/lib.rs
@@ -1,0 +1,46 @@
+use anyhow::{bail, Result};
+use rand::rngs::OsRng;
+use rand::Rng;
+use ring::aead::Nonce;
+pub use ring::aead::{Aad, LessSafeKey, UnboundKey, NONCE_LEN};
+
+/// Get a random nonce.
+pub fn get_random_nonce() -> ring::aead::Nonce {
+    Nonce::assume_unique_for_key(OsRng.gen())
+}
+
+/// Encrypt `plaintext` using `key`.
+///
+/// Prefixes the ciphertext with a nonce.
+pub fn encrypt(mut plaintext: Vec<u8>, key: &LessSafeKey) -> Result<Vec<u8>> {
+    let nonce = get_random_nonce();
+    // prefix ciphertext with nonce
+    let mut ciphertext: Vec<u8> = nonce.as_ref().to_vec();
+
+    key.seal_in_place_append_tag(nonce, Aad::empty(), &mut plaintext)
+        .map_err(|_| anyhow::format_err!("Encryption failed due to unspecified aead error"))?;
+
+    ciphertext.append(&mut plaintext);
+
+    Ok(ciphertext)
+}
+
+/// Decrypts a `ciphertext` using `key`.
+///
+/// Expect nonce in the prefix, like [`encrypt`] produces.
+pub fn decrypt<'c>(ciphertext: &'c mut [u8], key: &LessSafeKey) -> Result<&'c [u8]> {
+    if ciphertext.len() < NONCE_LEN {
+        bail!("Ciphertext too short: {}", ciphertext.len());
+    }
+
+    let (nonce_bytes, encrypted_bytes) = ciphertext.split_at_mut(NONCE_LEN);
+
+    key.open_in_place(
+        Nonce::assume_unique_for_key(nonce_bytes.try_into().expect("nonce size known")),
+        Aad::empty(),
+        encrypted_bytes,
+    )
+    .map_err(|_| anyhow::format_err!("Decryption failed due to unspecified aead error"))?;
+
+    Ok(encrypted_bytes)
+}

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -23,6 +23,7 @@ name = "distributedgen"
 path  = "src/bin/distributedgen.rs"
 
 [dependencies]
+aead = { path = "../crypto/aead" }
 ring = "0.16.20"
 rpassword = "7.2.0"
 anyhow = "1.0.66"

--- a/flake.nix
+++ b/flake.nix
@@ -480,6 +480,7 @@
           bin = "fedimintd";
           dirs = [
             "client/client-lib"
+            "crypto/aead"
             "crypto/hkdf"
             "crypto/tbs"
             "fedimintd"
@@ -506,6 +507,7 @@
           name = "ln-gateway";
           bin = "ln-gateway";
           dirs = [
+            "crypto/aead"
             "crypto/tbs"
             "crypto/hkdf"
             "client/client-lib"
@@ -531,6 +533,7 @@
           name = "gateway-cli";
           bin = "gateway-cli";
           dirs = [
+            "crypto/aead"
             "crypto/tbs"
             "crypto/hkdf"
             "client/client-lib"
@@ -559,6 +562,7 @@
           dirs = [
             "client/client-lib"
             "client/cli"
+            "crypto/aead"
             "crypto/tbs"
             "crypto/hkdf"
             "fedimint-api"
@@ -581,6 +585,7 @@
           inherit target;
           dirs = [
             "client/client-lib"
+            "crypto/aead"
             "crypto/tbs"
             "crypto/hkdf"
             "fedimint-api"
@@ -602,6 +607,7 @@
           dirs = [
             "client/cli"
             "client/client-lib"
+            "crypto/aead"
             "crypto/tbs"
             "crypto/hkdf"
             "gateway/ln-gateway"


### PR DESCRIPTION
I'm going to need to use it another place soon, so it makes sense to unify now.

Since it's being used from unrelated places, I don't see any other way than a separate crate.