### PR TITLE
Implement message buffering to make sending non-blocking

### DIFF
--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -29,7 +29,7 @@ use crate::fedimint_api::NumPeers;
 use crate::net::connect::TlsConfig;
 use crate::net::connect::{parse_host_port, Connector};
 use crate::net::peers::NetworkConfig;
-use crate::{ReconnectPeerConnections, TlsTcpConnector};
+use crate::{MaybeEpochMessage, ReconnectPeerConnections, TlsTcpConnector};
 
 /// Default port for communication with peers when not specified (0x1FED)
 pub const DEFAULT_P2P_PORT: u16 = 8173;
@@ -658,7 +658,15 @@ pub async fn connect<T>(
     task_group: &mut TaskGroup,
 ) -> PeerConnections<T>
 where
-    T: std::fmt::Debug + Clone + Serialize + DeserializeOwned + Unpin + Send + Sync + 'static,
+    T: std::fmt::Debug
+        + Clone
+        + Serialize
+        + DeserializeOwned
+        + MaybeEpochMessage
+        + Unpin
+        + Send
+        + Sync
+        + 'static,
 {
     let connector = TlsTcpConnector::new(certs).into_dyn();
     ReconnectPeerConnections::new(network, connector, task_group)

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -51,6 +51,15 @@ impl MaybeEpochMessage for HbbftMessage {
     }
 }
 
+// FIXME: implement alternative anti-DoS measure during DKG
+/// We don't care about epochs during DKG, we don't enforce an upper limit on caching messages since
+/// DKG is assumed to only happen under supervision.
+impl MaybeEpochMessage for fedimint_api::config::DkgPeerMsg {
+    fn message_epoch(&self) -> Option<u64> {
+        None
+    }
+}
+
 // TODO remove HBBFT `Batch` from `ConsensusOutcome`
 #[derive(Debug, Clone)]
 pub struct ConsensusOutcomeConversion(pub HbbftConsensusOutcome);

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -39,6 +39,18 @@ pub type HbbftSerdeConsensusOutcome = hbbft::honey_badger::Batch<Vec<SerdeConsen
 pub type HbbftConsensusOutcome = hbbft::honey_badger::Batch<Vec<ConsensusItem>, PeerId>;
 pub type HbbftMessage = hbbft::honey_badger::Message<PeerId>;
 
+/// A message sent by a consensus protocol that might belong to a specific epoch
+pub trait MaybeEpochMessage {
+    /// Return the epoch the message belongs to, if any
+    fn message_epoch(&self) -> Option<u64>;
+}
+
+impl MaybeEpochMessage for HbbftMessage {
+    fn message_epoch(&self) -> Option<u64> {
+        Some(self.epoch())
+    }
+}
+
 // TODO remove HBBFT `Batch` from `ConsensusOutcome`
 #[derive(Debug, Clone)]
 pub struct ConsensusOutcomeConversion(pub HbbftConsensusOutcome);

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -27,6 +27,7 @@ use tracing::{info, warn};
 
 use crate::consensus::{
     ConsensusProposal, FedimintConsensus, HbbftConsensusOutcome, HbbftSerdeConsensusOutcome,
+    MaybeEpochMessage,
 };
 use crate::db::LastEpochKey;
 use crate::fedimint_api::net::peers::IPeerConnections;
@@ -63,6 +64,15 @@ const NUM_EPOCHS_REJOIN_AHEAD: u64 = 10;
 pub enum EpochMessage {
     Continue(Message<PeerId>),
     RejoinRequest(u64),
+}
+
+impl MaybeEpochMessage for EpochMessage {
+    fn message_epoch(&self) -> Option<u64> {
+        match self {
+            EpochMessage::Continue(msg) => msg.message_epoch(),
+            EpochMessage::RejoinRequest(_) => None,
+        }
+    }
 }
 
 type EpochStep = Step<Vec<SerdeConsensusItem>, PeerId>;

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -13,7 +13,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::{sync::Mutex, time::sleep};
 use tracing::{debug, error};
 
-use crate::PeerId;
+use crate::{MaybeEpochMessage, PeerId};
 
 /// TODO: Use proper ModuleId after modularization is complete
 pub type ModuleId = String;
@@ -30,6 +30,15 @@ pub const MAX_PEER_OUT_OF_ORDER_MESSAGES: u64 = 10000;
 pub struct ModuleMultiplexed<MuxKey, Msg> {
     pub key: MuxKey,
     pub msg: Msg,
+}
+
+impl<MuxKey, Msg> MaybeEpochMessage for ModuleMultiplexed<MuxKey, Msg>
+where
+    Msg: MaybeEpochMessage,
+{
+    fn message_epoch(&self) -> Option<u64> {
+        self.msg.message_epoch()
+    }
 }
 
 struct ModuleMultiplexerOutOfOrder<MuxKey, Msg> {

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -29,11 +29,16 @@ use url::Url;
 use crate::net::connect::{AnyConnector, SharedAnyConnector};
 use crate::net::framed::AnyFramedTransport;
 use crate::net::queue::{MessageId, MessageQueue, UniqueMessage};
+use crate::MaybeEpochMessage;
 
 /// Maximum connection failures we consider for our back-off strategy
 const MAX_FAIL_RECONNECT_COUNTER: u64 = 300;
 
+/// How many unsent messages will be buffered before a connection is re-established
 const MAX_UNSENT_MESSAGES: usize = 4096;
+
+/// Messages for how many epochs the resend buffer will hold before the session is reset
+const MAX_BUFFERED_EPOCHS: u64 = 100;
 
 /// Owned [`Connector`](crate::net::connect::Connector) trait object used by
 /// [`ReconnectPeerConnections`]
@@ -120,7 +125,14 @@ enum PeerConnectionState<M> {
 
 impl<T: 'static> ReconnectPeerConnections<T>
 where
-    T: std::fmt::Debug + Clone + Serialize + DeserializeOwned + Unpin + Send + Sync,
+    T: std::fmt::Debug
+        + Clone
+        + Serialize
+        + DeserializeOwned
+        + MaybeEpochMessage
+        + Unpin
+        + Send
+        + Sync,
 {
     /// Creates a new `ReconnectPeerConnections` connection manager from a network config and a
     /// [`Connector`](crate::net::connect::Connector). See [`ReconnectPeerConnections`] for
@@ -227,7 +239,15 @@ impl PeerSlice for Target<PeerId> {
 #[async_trait]
 impl<T> IPeerConnections<T> for ReconnectPeerConnections<T>
 where
-    T: std::fmt::Debug + Serialize + DeserializeOwned + Clone + Unpin + Send + Sync + 'static,
+    T: std::fmt::Debug
+        + Serialize
+        + DeserializeOwned
+        + Clone
+        + MaybeEpochMessage
+        + Unpin
+        + Send
+        + Sync
+        + 'static,
 {
     #[must_use]
     async fn send(&mut self, peers: &[PeerId], msg: T) -> Cancellable<()> {
@@ -266,7 +286,7 @@ where
 
 impl<M> PeerConnectionStateMachine<M>
 where
-    M: Debug + Clone,
+    M: Debug + Clone + MaybeEpochMessage,
 {
     async fn run(mut self, task_handle: &TaskHandle) {
         // Note: `state_transition` internally uses channel operations (`send` and `recv`)
@@ -301,7 +321,7 @@ where
 
 impl<M> CommonPeerConnectionState<M>
 where
-    M: Debug + Clone,
+    M: Debug + Clone + MaybeEpochMessage,
 {
     async fn state_transition_connected(
         &mut self,
@@ -474,9 +494,16 @@ where
     ) -> Option<PeerConnectionState<M>> {
         Some(tokio::select! {
             maybe_msg = self.outgoing.recv() => {
+                let buffer_ready = self.message_buffer.buffered_epochs() < MAX_BUFFERED_EPOCHS;
                 match maybe_msg {
-                    Some(msg) => {
+                    Some(msg)if buffer_ready  => {
                         self.message_buffer.queue_message(msg);
+                        PeerConnectionState::Disconnected(disconnected)
+                    }
+                    Some(_) => {
+                        // FIXME: only begin buffering again once we have a new connection
+                        // Drop buffer if it gets too big, now the peer will have to rejoin consensus
+                        self.message_buffer = Default::default();
                         PeerConnectionState::Disconnected(disconnected)
                     }
                     None => {
@@ -530,7 +557,7 @@ where
 
 impl<M> PeerConnection<M>
 where
-    M: Debug + Clone + Send + Sync + 'static,
+    M: Debug + Clone + MaybeEpochMessage + Send + Sync + 'static,
 {
     fn new(
         id: PeerId,
@@ -612,10 +639,12 @@ mod tests {
     use fedimint_api::task::TaskGroup;
     use fedimint_api::PeerId;
     use futures::Future;
+    use serde::{Deserialize, Serialize};
 
     use crate::net::connect::mock::MockNetwork;
     use crate::net::connect::Connector;
     use crate::net::peers::{IPeerConnections, NetworkConfig, ReconnectPeerConnections};
+    use crate::MaybeEpochMessage;
 
     async fn timeout<F, T>(f: F) -> Option<T>
     where
@@ -626,6 +655,15 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_connect() {
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        struct TestMessage(u64);
+
+        impl MaybeEpochMessage for TestMessage {
+            fn message_epoch(&self) -> Option<u64> {
+                None
+            }
+        }
+
         let task_group = TaskGroup::new();
 
         {
@@ -653,23 +691,29 @@ mod tests {
                     peers: peers_ref.clone(),
                 };
                 let connect = net_ref.connector(cfg.identity).into_dyn();
-                ReconnectPeerConnections::<u64>::new(cfg, connect, &mut task_group).await
+                ReconnectPeerConnections::<TestMessage>::new(cfg, connect, &mut task_group).await
             };
 
             let mut peers_a = build_peers("127.0.0.1:1000", 1, task_group.clone()).await;
             let mut peers_b = build_peers("127.0.0.1:2000", 2, task_group.clone()).await;
 
-            peers_a.send(&[PeerId::from(2)], 42).await.unwrap();
+            peers_a
+                .send(&[PeerId::from(2)], TestMessage(42))
+                .await
+                .unwrap();
             let recv = timeout(peers_b.receive()).await.unwrap().unwrap();
             assert_eq!(recv.0, PeerId::from(1));
-            assert_eq!(recv.1, 42);
+            assert_eq!(recv.1 .0, 42);
 
-            peers_a.send(&[PeerId::from(3)], 21).await.unwrap();
+            peers_a
+                .send(&[PeerId::from(3)], TestMessage(21))
+                .await
+                .unwrap();
 
             let mut peers_c = build_peers("127.0.0.1:3000", 3, task_group.clone()).await;
             let recv = timeout(peers_c.receive()).await.unwrap().unwrap();
             assert_eq!(recv.0, PeerId::from(1));
-            assert_eq!(recv.1, 21);
+            assert_eq!(recv.1 .0, 21);
         }
 
         task_group.shutdown().await;

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -110,8 +110,13 @@ struct CommonPeerConnectionState<M> {
 }
 
 struct DisconnectedPeerConnectionState {
+    /// Time at which we will try another connection attempt
     reconnect_at: Instant,
+    /// Number used to calculate time till next reconnect attempt
     failed_reconnect_counter: u64,
+    /// If a connection was dropped because of a full `message_buffer` we do not need to buffer any
+    /// messages till there is a new TCP connection.
+    session_active: bool,
 }
 
 struct ConnectedPeerConnectionState<M> {
@@ -430,6 +435,7 @@ where
         PeerConnectionState::Disconnected(DisconnectedPeerConnectionState {
             reconnect_at,
             failed_reconnect_counter: min(disconnect_count, MAX_FAIL_RECONNECT_COUNTER),
+            session_active: true,
         })
     }
 
@@ -494,17 +500,19 @@ where
     ) -> Option<PeerConnectionState<M>> {
         Some(tokio::select! {
             maybe_msg = self.outgoing.recv() => {
-                let buffer_ready = self.message_buffer.buffered_epochs() < MAX_BUFFERED_EPOCHS;
+                let buffer_ready = (self.message_buffer.buffered_epochs() < MAX_BUFFERED_EPOCHS) && disconnected.session_active;
                 match maybe_msg {
-                    Some(msg)if buffer_ready  => {
+                    Some(msg) if buffer_ready  => {
                         self.message_buffer.queue_message(msg);
                         PeerConnectionState::Disconnected(disconnected)
                     }
                     Some(_) => {
-                        // FIXME: only begin buffering again once we have a new connection
                         // Drop buffer if it gets too big, now the peer will have to rejoin consensus
                         self.message_buffer = Default::default();
-                        PeerConnectionState::Disconnected(disconnected)
+                        PeerConnectionState::Disconnected(DisconnectedPeerConnectionState {
+                            session_active: false,
+                            ..disconnected
+                        })
                     }
                     None => {
                         debug!("Exiting peer connection IO task - parent disconnected");

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -574,7 +574,7 @@ where
         incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,
         task_group: &mut TaskGroup,
     ) -> PeerConnection<M> {
-        let (outgoing_sender, outgoing_receiver) = tokio::sync::mpsc::channel::<M>(1024);
+        let (outgoing_sender, outgoing_receiver) = tokio::sync::mpsc::channel::<M>(1);
         let (incoming_sender, incoming_receiver) = tokio::sync::mpsc::channel::<M>(1024);
 
         futures::executor::block_on(task_group.spawn(

--- a/fedimint-server/src/net/queue.rs
+++ b/fedimint-server/src/net/queue.rs
@@ -133,6 +133,11 @@ where
             Some((oldest, newest))
         }
     }
+
+    /// Return the number of unsent messages
+    pub fn unsent_len(&self) -> usize {
+        self.unsent_messages as usize
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Previously the network stack could block when trying to send too many messages to a TCP connection that could not send them out quickly enough. In theory that could lead to deadlocks, in practice it was hidden by the channels sending messages between main and io threads being large.

This PR makes sending messages non-blocking by buffering them inside the io thread. To avoid DoS two two limits are introduced:

1. Maximum number of unsent messages: if a connection can't send messages quickly enough and messages pile up it gets closed and re-established, hopefully this helps.
2. Maximum queued epochs: while there is no connection we still queue messages in the hope it gets re-established quickly. If there are messages from too many epochs in the buffer we drop it and won't buffer anything till there is a new connection. 

TODO:
- [x] Implement message buffer
- [x] Drop connections with overfull send buffers
- [x] Drop sessions with overfull resend buffers
- [x] Keep them dropped till reconnect
- [ ] Tests