### PR TITLE
Move URLs into consensus config

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -128,14 +128,14 @@ impl FedimintServer {
             cfg.local.identity,
             cfg.private.hbbft_sks.inner().clone(),
             cfg.consensus.hbbft_pk_set.clone(),
-            cfg.local.peers.keys().copied(),
+            cfg.consensus.peers.keys().copied(),
         );
 
         let hbbft: HoneyBadger<Vec<SerdeConsensusItem>, _> =
             HoneyBadger::builder(Arc::new(net_info)).build();
 
         let api_endpoints = cfg
-            .local
+            .consensus
             .peers
             .clone()
             .into_iter()
@@ -148,7 +148,7 @@ impl FedimintServer {
             consensus: Arc::new(consensus),
             cfg: cfg.clone(),
             api,
-            peers: cfg.local.peers.keys().cloned().collect(),
+            peers: cfg.consensus.peers.keys().cloned().collect(),
             rejoin_at_epoch: None,
             run_empty_epochs: 0,
             last_processed_epoch: None,
@@ -294,7 +294,7 @@ impl FedimintServer {
         rng: &mut (impl RngCore + CryptoRng + Clone + 'static),
     ) -> Cancellable<Vec<HbbftConsensusOutcome>> {
         // for testing federations with one peer
-        if self.cfg.local.peers.len() == 1 {
+        if self.cfg.consensus.peers.len() == 1 {
             tokio::select! {
               () = self.consensus.transaction_notify.notified() => (),
               () = self.consensus.await_consensus_proposal() => (),

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -54,11 +54,14 @@ pub async fn run_server(
         attach_endpoints_erased(&mut rpc_module, module);
     }
 
-    debug!(addr = cfg.local.api_bind_addr, "Starting WSServer");
+    debug!(
+        addr = cfg.local.api_bind_addr.to_string(),
+        "Starting WSServer"
+    );
     let server = ServerBuilder::new()
         .max_connections(cfg.local.max_connections)
         .ping_interval(Duration::from_secs(10))
-        .build(&cfg.local.api_bind_addr)
+        .build(&cfg.local.api_bind_addr.to_string())
         .await
         .context(format!("Bind address: {}", cfg.local.api_bind_addr))
         .expect("Could not start API server");

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -284,7 +284,7 @@ async fn run_dkg(
 }
 
 fn parse_peer_params(url: String) -> PeerServerParams {
-    let split: Vec<&str> = url.split(':').collect();
+    let split: Vec<&str> = url.split('@').collect();
     assert_eq!(split.len(), 4, "Cannot parse cert string");
     let base_port = split[1].parse().expect("could not parse base port");
     let hex_cert = hex::decode(split[3]).expect("cert was not hex encoded");
@@ -308,7 +308,7 @@ fn gen_tls(
 
     rustls::ServerName::try_from(name.as_str()).expect("Valid DNS name");
     // TODO Base64 encode name, hash fingerprint cert_string
-    let cert_url = format!("{}:{}:{}:{}", address, base_port, name, hex::encode(cert.0));
+    let cert_url = format!("{}@{}@{}@{}", address, base_port, name, hex::encode(cert.0));
     fs::write(dir_out_path.join(TLS_CERT), &cert_url).unwrap();
     cert_url
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,7 +34,7 @@ for ((ID=0; ID<FM_FED_SIZE; ID++));
 do
   mkdir $FM_CFG_DIR/server-$ID
   base_port=$(echo "4000 + $ID * 10" | bc -l)
-  $FM_BIN_DIR/distributedgen create-cert --announce-address localhost --out-dir $FM_CFG_DIR/server-$ID --base-port $base_port --name "Server-$ID" --password "pass$ID"
+  $FM_BIN_DIR/distributedgen create-cert --announce-address ws://localhost --out-dir $FM_CFG_DIR/server-$ID --base-port $base_port --name "Server-$ID" --password "pass$ID"
   CERTS="$CERTS,$(cat $FM_CFG_DIR/server-$ID/tls-cert)"
 done
 CERTS=${CERTS:1}


### PR DESCRIPTION
Moving URLs into consensus config, so that we can generate the client configs from the consensus configs.

The only disadvantage is that we cannot do rolling updates of the URL values, instead we need to update all at once, but that's an ability we'll need anyway since we will inevitably have to handle consensus-breaking code updates on a regular basis and once we have a P2P DNS we won't have to worry about domains at all