### PR TITLE
Use chat.fedimint.org for the discord link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/fedimint/fedimint/actions/workflows/ci-nix.yml">
       <img src="https://github.com/fedimint/fedimint/actions/workflows/ci-nix.yml/badge.svg" alt="Github Actions CI Build Status">
   </a>
-  <a href="https://discord.com/channels/990354215060795454"><img alt="Chat for developers on Discord" src="https://img.shields.io/discord/990354215060795454?label=dev%20chat"></a>
+  <a href="https://chat.fedimint.org"><img alt="Chat for developers on Discord" src="https://img.shields.io/discord/990354215060795454?label=dev%20chat"></a>
   <a href="https://github.com/fedimint/fedimint/discussions">
     <img src="https://img.shields.io/badge/commmunity-discussion-blue" alt="github discussion">
   </a>


### PR DESCRIPTION
This way we don't need to think about multiple links. Just keep that one redirect working.