### PR TITLE
Fix clippy warning that somehow only appears in the mac builds

### DIFF
--- a/fedimint-api/src/tiered_multi.rs
+++ b/fedimint-api/src/tiered_multi.rs
@@ -33,7 +33,7 @@ impl<T> TieredMulti<T> {
     }
 
     pub fn item_count(&self) -> usize {
-        self.0.iter().map(|(_, coins)| coins.len()).sum()
+        self.0.values().map(|coins| coins.len()).sum()
     }
 
     pub fn tier_count(&self) -> usize {


### PR DESCRIPTION
https://github.com/fedimint/fedimint/actions/runs/3742643786/jobs/6353843599