### PR TITLE
Fix `decrypt` in the new `crypto/aead` crate

### DIFF
--- a/crypto/aead/src/lib.rs
+++ b/crypto/aead/src/lib.rs
@@ -42,5 +42,5 @@ pub fn decrypt<'c>(ciphertext: &'c mut [u8], key: &LessSafeKey) -> Result<&'c [u
     )
     .map_err(|_| anyhow::format_err!("Decryption failed due to unspecified aead error"))?;
 
-    Ok(encrypted_bytes)
+    Ok(&encrypted_bytes[..encrypted_bytes.len() - key.algorithm().tag_len()])
 }


### PR DESCRIPTION
I have forgot to remove the tag at the end and somehow this is revealed only when using tmuxinator. Possibly because most of the stuff we use it for uses encoding that tolerate trailing bytes.