### PR TITLE
Derive the client config from consensus config

### DIFF
--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -149,10 +149,14 @@ impl ServerModuleConfig {
     }
 }
 
+pub trait TypedServerModuleConsensusConfig: DeserializeOwned + Serialize {
+    fn to_client_config(&self) -> ClientModuleConfig;
+}
+
 pub trait TypedServerModuleConfig: DeserializeOwned + Serialize {
     type Local: DeserializeOwned + Serialize;
     type Private: DeserializeOwned + Serialize;
-    type Consensus: DeserializeOwned + Serialize;
+    type Consensus: TypedServerModuleConsensusConfig;
 
     fn from_parts(local: Self::Local, private: Self::Private, consensus: Self::Consensus) -> Self;
 
@@ -167,8 +171,6 @@ pub trait TypedServerModuleConfig: DeserializeOwned + Serialize {
             consensus: serde_json::to_value(consensus).expect("serialization can't fail"),
         }
     }
-
-    fn to_client_config(&self) -> ClientModuleConfig;
 
     fn validate_config(&self, identity: &PeerId) -> anyhow::Result<()>;
 }

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -225,7 +225,7 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
         api_endpoint! {
             "/config",
             async |fedimint: &FedimintConsensus, _dbtx, _v: ()| -> ClientConfig {
-                Ok(fedimint.cfg.to_client_config())
+                Ok(fedimint.cfg.consensus.to_client_config())
             }
         },
     ]

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -67,7 +67,10 @@ pub fn encrypted_json_read<T: Serialize + DeserializeOwned>(key: &LessSafeKey, p
 pub fn write_nonprivate_configs(server: &ServerConfig, path: PathBuf) {
     plaintext_json_write(&server.local, path.join(LOCAL_CONFIG));
     plaintext_json_write(&server.consensus, path.join(CONSENSUS_CONFIG));
-    plaintext_json_write(&server.to_client_config(), path.join(CLIENT_CONFIG));
+    plaintext_json_write(
+        &server.consensus.to_client_config(),
+        path.join(CLIENT_CONFIG),
+    );
 }
 
 /// Writes struct into a plaintext json file

--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -188,7 +188,12 @@ fn trusted_dealer_gen(
         })
         .collect();
 
-    let client_config = server_config.values().next().unwrap().to_client_config();
+    let client_config = server_config
+        .values()
+        .next()
+        .unwrap()
+        .consensus
+        .to_client_config();
 
     (server_config, client_config)
 }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -223,7 +223,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
         _ => {
             info!("Testing with FAKE Bitcoin and Lightning services");
             let server_config = ServerConfig::trusted_dealer_gen("", &peers, &params, OsRng);
-            let client_config = server_config[&PeerId::from(0)].to_client_config();
+            let client_config = server_config[&PeerId::from(0)].consensus.to_client_config();
 
             let bitcoin = FakeBitcoinTest::new();
             let bitcoin_rpc = || bitcoin.clone().into();
@@ -342,7 +342,10 @@ async fn distributed_config(
 
     let (_, config) = configs.first().unwrap().clone();
 
-    Ok((configs.into_iter().collect(), config.to_client_config()))
+    Ok((
+        configs.into_iter().collect(),
+        config.consensus.to_client_config(),
+    ))
 }
 
 fn rocks(dir: String) -> fedimint_rocksdb::RocksDb {

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -8,6 +8,7 @@ use config::FeeConsensus;
 use db::{ECashUserBackupSnapshot, EcashBackupKey};
 use fedimint_api::backup::SignedBackupRequest;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
+use fedimint_api::config::TypedServerModuleConsensusConfig;
 use fedimint_api::config::{
     scalar, ClientModuleConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, ModuleConfigGenParams,
     ServerModuleConfig, TypedServerModuleConfig,
@@ -252,7 +253,10 @@ impl FederationModuleConfigGen for MintConfigGenerator {
     }
 
     fn to_client_config(&self, config: ServerModuleConfig) -> anyhow::Result<ClientModuleConfig> {
-        Ok(config.to_typed::<MintConfig>()?.to_client_config())
+        Ok(config
+            .to_typed::<MintConfig>()?
+            .consensus
+            .to_client_config())
     }
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
@@ -1099,7 +1103,7 @@ impl From<InvalidAmountTierError> for MintError {
 #[cfg(test)]
 mod test {
     use fedimint_api::config::{
-        ClientModuleConfig, ConfigGenParams, ServerModuleConfig, TypedServerModuleConfig,
+        ClientModuleConfig, ConfigGenParams, ServerModuleConfig, TypedServerModuleConsensusConfig,
     };
     use fedimint_api::module::FederationModuleConfigGen;
     use fedimint_api::{Amount, PeerId, TieredMulti};
@@ -1125,6 +1129,7 @@ mod test {
         let client_cfg = mint_cfg[&PeerId::from(0)]
             .to_typed::<MintConfig>()
             .unwrap()
+            .consensus
             .to_client_config();
 
         (mint_cfg.into_values().collect(), client_cfg)

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -18,6 +18,7 @@ use bitcoin::{
 };
 use bitcoin::{PackedLockTime, Sequence};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
+use fedimint_api::config::TypedServerModuleConsensusConfig;
 use fedimint_api::config::{
     BitcoindRpcCfg, ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ModuleConfigGenParams,
     ServerModuleConfig, TypedServerModuleConfig,
@@ -310,7 +311,10 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
     }
 
     fn to_client_config(&self, config: ServerModuleConfig) -> anyhow::Result<ClientModuleConfig> {
-        Ok(config.to_typed::<WalletConfig>()?.to_client_config())
+        Ok(config
+            .to_typed::<WalletConfig>()?
+            .consensus
+            .to_client_config())
     }
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {


### PR DESCRIPTION
Derives the client config from consensus config, so that we can be assured that the client config returned is the same for all guardians.