### PR TITLE
enforce max notes per denominations

### DIFF
--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -14,6 +14,7 @@ pub enum DbKeyPrefix {
     OutputFinalizationData = 0x21,
     PendingCoins = 0x27,
     NextECashNoteIndex = 0x2a,
+    NotesPerDenomination = 0x2b,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -95,4 +96,13 @@ impl DatabaseKeyPrefixConst for NextECashNoteIndexKey {
     const DB_PREFIX: u8 = DbKeyPrefix::NextECashNoteIndex as u8;
     type Key = Self;
     type Value = u64;
+}
+
+#[derive(Debug, Clone, Encodable, Decodable, Serialize)]
+pub struct NotesPerDenominationKey;
+
+impl DatabaseKeyPrefixConst for NotesPerDenominationKey {
+    const DB_PREFIX: u8 = 0;
+    type Key = Self;
+    type Value = u16;
 }

--- a/docs/database.md
+++ b/docs/database.md
@@ -83,6 +83,7 @@ The Database is split into different key spaces based on prefixing that can be u
 | Coin                   | `0x20` | amount (8 bytes), nonce (32 bytes) | `SpendableCoin`              |
 | OutputFinalizationData | `0x21` | issuance_id (32 bytes)             | `NoteIssuanceRequests`       |
 | PendingCoins           | `0x27` | mint tx id (sha256 payment hash)   | `TieredMulti<SpendableCoin>` |
+| NotesPerDenomination   | `0x2b` | determines how many notes to issue | `u16`                        |
 
 ### WalletClient
 | Name                    | Prefix | Key        | Value                        |

--- a/fedimint-api/src/tiered_multi.rs
+++ b/fedimint-api/src/tiered_multi.rs
@@ -95,6 +95,11 @@ impl<T> TieredMulti<T> {
             .flat_map(|(amt, coins)| coins.into_iter().map(move |c| (amt, c)))
     }
 
+    /// Returns the max number of notes for any given denomination tier
+    pub fn max_tier_len(&self) -> usize {
+        self.0.values().map(|notes| notes.len()).max().unwrap_or(0)
+    }
+
     pub fn check_tiers<K>(&self, keys: &Tiered<K>) -> Result<(), InvalidAmountTierError> {
         match self.0.keys().find(|&amt| keys.get(*amt).is_none()) {
             Some(amt) => Err(InvalidAmountTierError(*amt)),

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -545,6 +545,16 @@ impl<'a> DatabaseDump<'a> {
                         "Last e-cash note index"
                     );
                 }
+                ClientMintRange::DbKeyPrefix::NotesPerDenomination => {
+                    let notes = self
+                        .read_only
+                        .get_value(&ClientMintRange::NotesPerDenominationKey)
+                        .await
+                        .unwrap();
+                    if let Some(notes) = notes {
+                        mint_client.insert("NotesPerDenomination".to_string(), Box::new(notes));
+                    }
+                }
             }
         }
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -150,7 +150,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
     }
     let peers = (0..num_peers).map(PeerId::from).collect::<Vec<_>>();
     let params =
-        ServerConfigParams::gen_local(&peers, sats(1000), base_port, "test", "127.0.0.1:18443");
+        ServerConfigParams::gen_local(&peers, sats(100000), base_port, "test", "127.0.0.1:18443");
     let max_evil = hbbft::util::max_faulty(peers.len());
 
     match env::var("FM_TEST_DISABLE_MOCKS") {

--- a/modules/fedimint-mint/src/config.rs
+++ b/modules/fedimint-mint/src/config.rs
@@ -26,8 +26,7 @@ pub struct MintConfigConsensus {
     /// Number of signers required
     pub threshold: usize,
     /// The maximum amount of change a client can request
-    /// TODO implement this restriction
-    pub max_target_denomination_sets: u16,
+    pub max_notes_per_denomination: u16,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -41,7 +40,7 @@ pub struct MintClientConfig {
     pub tbs_pks: Tiered<AggregatePublicKey>,
     pub fee_consensus: FeeConsensus,
     pub peer_tbs_pks: BTreeMap<PeerId, Tiered<tbs::PublicKeyShare>>,
-    pub target_denomination_sets: u16,
+    pub max_notes_per_denomination: u16,
 }
 
 impl TypedClientModuleConfig for MintClientConfig {}
@@ -78,7 +77,7 @@ impl TypedServerModuleConfig for MintConfig {
             tbs_pks: Tiered::from_iter(pub_key.into_iter()),
             fee_consensus: self.consensus.fee_consensus.clone(),
             peer_tbs_pks: self.consensus.peer_tbs_pks.clone(),
-            target_denomination_sets: self.consensus.max_target_denomination_sets,
+            max_notes_per_denomination: self.consensus.max_notes_per_denomination,
         })
         .expect("Serialization can't fail")
         .into()


### PR DESCRIPTION
Enforce max notes per denomination per output.  We should probably enforce max outputs per tx as well.

Lets clients configure the notes per denomination via a DB entry instead of the config file (which should be immutable).

Related to #1141