### PR TITLE
tmuxinator: Keep $TMP shorter when in nix shell

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,17 @@ echo "Run with 'source ./scripts/build.sh [fed_size] [dir]"
 
 # allow for overriding arguments
 export FM_FED_SIZE=${1:-4}
-export FM_TMP_DIR=${2-"$(mktemp -d)"}
+
+# If $TMP contains '/nix-shell.' it is already unique to the
+# nix shell instance, and appending more characters to it is
+# pointless. It only gets us closer to the 108 character limit
+# for named unix sockets (https://stackoverflow.com/a/34833072),
+# so let's not do it.
+if [[ "$TMP" == *"/nix-shell."* ]]; then
+  export FM_TMP_DIR=${2-$TMP}
+else
+  export FM_TMP_DIR=${2-"$(mktemp -d)"}
+fi
 export FM_TEST_FAST_WEAK_CRYPTO="1"
 
 echo "Setting up env variables in $FM_TMP_DIR"


### PR DESCRIPTION
We have a user reporting problems that look
like hitting the unix named socket limit:

```
thread 'main' panicked at 'connect to ln_socket: path must be shorter than libc::sockaddr_un.sun_path'
```

It's unclear why exactly would they hit the limit - there
still seems to be some room left, but one way or another,
it seems like a good idea to keep the $TMP as short as possible,
even if just for more compact debug outputs.