### PR TITLE
tmuxinator: Fix nix shell env detection

### DIFF
--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -7,8 +7,8 @@ if [[ -n "${TMUX:-}" ]]; then
   exit 1
 fi
 
-if [[ -z "$IN_NIX_SHELL" ]]; then
-  echo "It is recommended to run this command from a Nix dev shell. Use `nix develop` first"
+if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+  echo "It is recommended to run this command from a Nix dev shell. Use 'nix develop' first"
   sleep 3
 fi
 


### PR DESCRIPTION
`set -u` causes expansion of unset variable to fail completely, instead of printing a message.

Using `...` causes `nix develop` to be actually run, which is confusing.