### PR TITLE
Extend gateway config to support LN RPC

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -31,10 +31,12 @@ pub enum Commands {
     /// Ganerate gateway configuration
     /// NOTE: This command can only be used on a local gateway
     GenerateConfig {
+        /// Address to which the LN rpc webserver will bind
+        lnrpc_bind_address: SocketAddr,
         /// Address to which the API webserver will bind
-        bind_address: SocketAddr,
+        webserver_bind_address: SocketAddr,
         /// URL under which the API will be reachable
-        announce_address: Url,
+        api_announce_address: Url,
         /// The gateway configuration directory
         out_dir: PathBuf,
     },
@@ -77,8 +79,9 @@ async fn main() {
 
     match cli.command {
         Commands::GenerateConfig {
-            bind_address: address,
-            announce_address,
+            lnrpc_bind_address,
+            webserver_bind_address,
+            api_announce_address,
             mut out_dir,
         } => {
             // Recursively create config directory if it doesn't exist
@@ -91,10 +94,15 @@ async fn main() {
             serde_json::to_writer_pretty(
                 cfg_file,
                 &GatewayConfig {
-                    bind_address: address,
-                    announce_address,
-                    // TODO: Generate a strong random password
-                    password: source_password(cli.rpcpassword),
+                    /* LN RPC config */
+                    lnrpc_bind_address,
+                    lnd_rpc_connect: None,
+
+                    /* Webserver config */
+                    webserver_bind_address,
+                    webserver_password: source_password(cli.rpcpassword), // TODO: Generate a strong random password
+                    api_announce_address,
+
                     // TODO: Remove this field with hardcoded value once we have fixed Issue 664:
                     default_federation: FederationId("Hals_trusty_mint".into()),
                 },

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -6,13 +6,33 @@ use url::Url;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GatewayConfig {
-    /// API webserver bind address
-    pub bind_address: SocketAddr,
-    /// URL under which the API will be reachable
-    pub announce_address: Url,
-    /// webserver authentication password
-    pub password: String,
+    /* lightning configs */
+    /// Lightning RPC bind address
+    pub lnrpc_bind_address: SocketAddr,
+    /// RPC connection config when using LND nodes
+    pub lnd_rpc_connect: Option<LndRpcConfig>,
+
+    /* webserver configs */
+    /// Webserver bind address
+    pub webserver_bind_address: SocketAddr,
+    /// Webserver authentication password
+    pub webserver_password: String,
+    /// URL under which the Gateway API will be reachable
+    pub api_announce_address: Url,
+
     // FIXME: Issue 664: We should avoid having a special reference to a federation
     // all requests, including `ReceivePaymentPayload`, should contain the federation id
     pub default_federation: FederationId,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LndRpcConfig {
+    // LND node host
+    pub node_host: String,
+    // LND node port
+    pub node_port: u32,
+    // LND node tls certificate path
+    pub tls_cert_path: String,
+    // LND node macaroon path. Usually path to admin.macaroon
+    pub macaroon_path: String,
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -139,7 +139,11 @@ impl LnGateway {
 
         let gw_client_cfg = self
             .client_builder
-            .create_config(connect, node_pub_key, self.config.announce_address.clone())
+            .create_config(
+                connect,
+                node_pub_key,
+                self.config.api_announce_address.clone(),
+            )
             .await
             .expect("Failed to create gateway client config");
 
@@ -256,8 +260,8 @@ impl LnGateway {
         let sender = GatewayRpcSender::new(self.sender.clone());
         tg.spawn("Gateway Webserver", move |server_ctrl| async move {
             let mut webserver = tokio::spawn(run_webserver(
-                cfg.password.clone(),
-                cfg.bind_address,
+                cfg.webserver_password.clone(),
+                cfg.webserver_bind_address,
                 sender,
             ));
 

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -21,18 +21,28 @@ use url::Url;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_authentication() -> Result<()> {
-    let gw_password = "password".to_string();
-    let gw_port = portpicker::pick_unused_port().expect("Failed to pick port");
-    let gw_bind_address = SocketAddr::from(([127, 0, 0, 1], gw_port));
+    let gw_lnrpc_port = portpicker::pick_unused_port().expect("Failed to pick lnrpc port");
+    let gw_server_port = portpicker::pick_unused_port().expect("Failed to pick webserver port");
+
+    let gw_bind_address = SocketAddr::from(([127, 0, 0, 1], gw_server_port));
     let gw_announce_address =
         Url::parse(&format!("http://{}", gw_bind_address)).expect("Invalid gateway address");
+    let gw_password = "password".to_string();
+
     let federation_id = FederationId("test_fed".into());
 
     let cfg = GatewayConfig {
-        password: gw_password.clone(),
+        /* LN RPC config */
+        lnrpc_bind_address: SocketAddr::from(([127, 0, 0, 1], gw_lnrpc_port)),
+        lnd_rpc_connect: None,
+
+        /* Webserver config */
+        webserver_bind_address: gw_bind_address,
+        webserver_password: gw_password.clone(),
+        api_announce_address: gw_announce_address.clone(),
+
+        // Additional <temporary configs>
         default_federation: federation_id.clone(),
-        bind_address: gw_bind_address,
-        announce_address: gw_announce_address.clone(),
     };
 
     let Fixtures {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -405,9 +405,13 @@ impl GatewayTest {
         let ln_rpc = Arc::clone(&adapter);
 
         let gw_cfg = GatewayConfig {
-            bind_address: bind_addr,
-            announce_address: announce_addr,
-            password: "abc".into(),
+            lnrpc_bind_address: bind_addr, // TODO: Use a nunique lnrpc address
+            lnd_rpc_connect: None,
+
+            webserver_bind_address: bind_addr,
+            webserver_password: "abc".into(),
+            api_announce_address: announce_addr,
+
             default_federation: FederationId(gw_client_cfg.client_config.federation_name.clone()),
         };
 


### PR DESCRIPTION
Extends `GatewayConfig` definition to support gateway <> node implementation via RPC interface proposed in #1143 
- `LndRpcConfig` contains specific config fields that allow connecting to a remote LND node via RPC