### PR TITLE
Use `FederationModuleConfigGen` to manipulate module configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,8 @@ dependencies = [
  "fedimint-bitcoind",
  "fedimint-build",
  "fedimint-core",
+ "fedimint-ln",
+ "fedimint-mint",
  "fedimint-rocksdb",
  "fedimint-server",
  "fedimint-wallet",

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -217,6 +217,12 @@ pub trait FederationModuleConfigGen {
 
     fn to_client_config(&self, config: ServerModuleConfig) -> anyhow::Result<ClientModuleConfig>;
 
+    // TODO: There's a bit of confusion here between whole config as one value, `ServerModuleConfig`, and just consensus part
+    fn to_client_config_from_consensus_value(
+        &self,
+        config: serde_json::Value,
+    ) -> anyhow::Result<ClientModuleConfig>;
+
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()>;
 }
 

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -161,7 +161,7 @@ impl ServerConfigConsensus {
     }
 }
 
-pub type ModuleConfigGens = Vec<(&'static str, Arc<dyn FederationModuleConfigGen>)>;
+pub type ModuleConfigGens = BTreeMap<&'static str, Arc<dyn FederationModuleConfigGen>>;
 
 impl ServerConfig {
     /// Creates a new config from the results of a trusted or distributed key setup
@@ -283,7 +283,7 @@ impl ServerConfig {
 
         let peer0 = &params[&PeerId::from(0)];
 
-        let module_configs: Vec<_> = module_config_gens
+        let module_configs: BTreeMap<_, _> = module_config_gens
             .iter()
             .map(|(name, gen)| (name, gen.trusted_dealer_gen(peers, &peer0.modules)))
             .collect();

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use tokio::sync::Notify;
 use tracing::{debug, error, info_span, instrument, trace, warn, Instrument};
 
-use crate::config::ServerConfig;
+use crate::config::{ModuleConfigGens, ServerConfig};
 use crate::consensus::interconnect::FedimintInterconnect;
 use crate::db::{
     AcceptedTransactionKey, DropPeerKey, DropPeerKeyPrefix, EpochHistoryKey, LastEpochKey,
@@ -73,6 +73,8 @@ pub struct FedimintConsensus {
     /// Configuration describing the federation and containing our secrets
     pub cfg: ServerConfig,
 
+    pub module_config_gens: ModuleConfigGens,
+
     pub modules: ServerModuleRegistry,
     /// KV Database into which all state is persisted to recover from in case of a crash
     pub db: Database,
@@ -99,10 +101,11 @@ struct FundingVerifier {
 }
 
 impl FedimintConsensus {
-    pub fn new(cfg: ServerConfig, db: Database) -> Self {
+    pub fn new(cfg: ServerConfig, db: Database, module_config_gens: ModuleConfigGens) -> Self {
         Self {
             rng_gen: Box::new(OsRngGen),
             cfg,
+            module_config_gens,
             modules: ServerModuleRegistry::default(),
             db,
             transaction_notify: Arc::new(Notify::new()),

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -116,7 +116,7 @@ impl FedimintServer {
         connector: PeerConnector<EpochMessage>,
         task_group: &mut TaskGroup,
     ) -> Self {
-        cfg.validate_config(&cfg.local.identity)
+        cfg.validate_config(&cfg.local.identity, &consensus.module_config_gens)
             .expect("invalid config");
 
         let connections =

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -225,7 +225,7 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
         api_endpoint! {
             "/config",
             async |fedimint: &FedimintConsensus, _dbtx, _v: ()| -> ClientConfig {
-                Ok(fedimint.cfg.consensus.to_client_config())
+                Ok(fedimint.cfg.consensus.to_client_config(&fedimint.module_config_gens))
             }
         },
     ]

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -43,6 +43,8 @@ fedimint-core = { path = "../fedimint-core" }
 fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 fedimint-server = { path = "../fedimint-server" }
 fedimint-wallet = { path = "../modules/fedimint-wallet", features = ["native"] }
+fedimint-mint= { path = "../modules/fedimint-mint" }
+fedimint-ln = { path = "../modules/fedimint-ln" }
 fedimint-bitcoind = { path = "../fedimint-bitcoind", features = [ "bitcoincore-rpc" ]}
 opentelemetry = { version = "0.18.0", optional = true }
 opentelemetry-jaeger = { version = "0.17.0", optional = true }

--- a/fedimintd/src/bin/configgen.rs
+++ b/fedimintd/src/bin/configgen.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::{fs, sync::Arc};
 
@@ -81,14 +82,14 @@ fn main() {
                 &federation_name,
                 &bitcoind_rpc,
             );
-            let module_config_gens: ModuleConfigGens = vec![
+            let module_config_gens: ModuleConfigGens = BTreeMap::from([
                 (
                     "wallet",
                     Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen>,
                 ),
                 ("mint", Arc::new(MintConfigGenerator)),
                 ("ln", Arc::new(LightningModuleConfigGen)),
-            ];
+            ]);
 
             let server_cfg = ServerConfig::trusted_dealer_gen(
                 CODE_VERSION,

--- a/fedimintd/src/bin/configgen.rs
+++ b/fedimintd/src/bin/configgen.rs
@@ -85,7 +85,8 @@ fn main() {
             let module_config_gens: ModuleConfigGens = BTreeMap::from([
                 (
                     "wallet",
-                    Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen>,
+                    Arc::new(WalletConfigGenerator)
+                        as Arc<dyn FederationModuleConfigGen + Send + Sync>,
                 ),
                 ("mint", Arc::new(MintConfigGenerator)),
                 ("ln", Arc::new(LightningModuleConfigGen)),
@@ -95,14 +96,14 @@ fn main() {
                 CODE_VERSION,
                 &peers,
                 &params,
-                module_config_gens,
+                module_config_gens.clone(),
                 rng,
             );
 
             for (id, server) in server_cfg {
                 let path = cfg_path.join(id.to_string());
                 fs::create_dir_all(path.clone()).expect("Could not create cfg dir");
-                write_nonprivate_configs(&server, path.clone());
+                write_nonprivate_configs(&server, path.clone(), &module_config_gens);
                 plaintext_json_write(&server.private, path.join(PRIVATE_CONFIG));
             }
         }

--- a/fedimintd/src/bin/configgen.rs
+++ b/fedimintd/src/bin/configgen.rs
@@ -1,9 +1,11 @@
-use std::fs;
 use std::path::PathBuf;
+use std::{fs, sync::Arc};
 
 use clap::{Parser, Subcommand};
-use fedimint_api::{Amount, NumPeers, PeerId};
-use fedimint_server::config::{ServerConfig, ServerConfigParams};
+use fedimint_api::{module::FederationModuleConfigGen, Amount, NumPeers, PeerId};
+use fedimint_core::modules::{ln::LightningModuleConfigGen, mint::MintConfigGenerator};
+use fedimint_server::config::{ModuleConfigGens, ServerConfig, ServerConfigParams};
+use fedimint_wallet::WalletConfigGenerator;
 use fedimintd::{plaintext_json_write, write_nonprivate_configs, CODE_VERSION, PRIVATE_CONFIG};
 use rand::rngs::OsRng;
 
@@ -79,8 +81,22 @@ fn main() {
                 &federation_name,
                 &bitcoind_rpc,
             );
+            let module_config_gens: ModuleConfigGens = vec![
+                (
+                    "wallet",
+                    Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen>,
+                ),
+                ("mint", Arc::new(MintConfigGenerator)),
+                ("ln", Arc::new(LightningModuleConfigGen)),
+            ];
 
-            let server_cfg = ServerConfig::trusted_dealer_gen(CODE_VERSION, &peers, &params, rng);
+            let server_cfg = ServerConfig::trusted_dealer_gen(
+                CODE_VERSION,
+                &peers,
+                &params,
+                module_config_gens,
+                rng,
+            );
 
             for (id, server) in server_cfg {
                 let path = cfg_path.join(id.to_string());

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -278,14 +278,14 @@ async fn run_dkg(
             .await;
     let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
 
-    let module_config_gens: ModuleConfigGens = vec![
+    let module_config_gens: ModuleConfigGens = BTreeMap::from([
         (
             "wallet",
             Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen>,
         ),
         ("mint", Arc::new(MintConfigGenerator)),
         ("ln", Arc::new(LightningModuleConfigGen)),
-    ];
+    ]);
 
     ServerConfig::distributed_gen(
         CODE_VERSION,

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -138,6 +138,15 @@ async fn main() {
         )
         .init();
 
+    let module_config_gens: ModuleConfigGens = BTreeMap::from([
+        (
+            "wallet",
+            Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen + Send + Sync>,
+        ),
+        ("mint", Arc::new(MintConfigGenerator)),
+        ("ln", Arc::new(LightningModuleConfigGen)),
+    ]);
+
     let mut task_group = TaskGroup::new();
 
     let command: Command = Cli::parse().command;
@@ -189,7 +198,7 @@ async fn main() {
             };
 
             encrypted_json_write(&server.private, &key, dir_out_path.join(PRIVATE_CONFIG));
-            write_nonprivate_configs(&server, dir_out_path);
+            write_nonprivate_configs(&server, dir_out_path, &module_config_gens);
         }
         Command::VersionHash => {
             println!("{}", CODE_VERSION);
@@ -281,7 +290,7 @@ async fn run_dkg(
     let module_config_gens: ModuleConfigGens = BTreeMap::from([
         (
             "wallet",
-            Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen>,
+            Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen + Send + Sync>,
         ),
         ("mint", Arc::new(MintConfigGenerator)),
         ("ln", Arc::new(LightningModuleConfigGen)),

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use fedimint_server::config::ServerConfig;
+use fedimint_server::config::{ModuleConfigGens, ServerConfig};
 use ring::aead::LessSafeKey;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -64,11 +64,15 @@ pub fn encrypted_json_read<T: Serialize + DeserializeOwned>(key: &LessSafeKey, p
 }
 
 /// Writes the server into plaintext json configuration files (private keys not serialized)
-pub fn write_nonprivate_configs(server: &ServerConfig, path: PathBuf) {
+pub fn write_nonprivate_configs(
+    server: &ServerConfig,
+    path: PathBuf,
+    module_config_gens: &ModuleConfigGens,
+) {
     plaintext_json_write(&server.local, path.join(LOCAL_CONFIG));
     plaintext_json_write(&server.consensus, path.join(CONSENSUS_CONFIG));
     plaintext_json_write(
-        &server.consensus.to_client_config(),
+        &server.consensus.to_client_config(module_config_gens),
         path.join(CLIENT_CONFIG),
     );
 }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -154,14 +154,14 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
         ServerConfigParams::gen_local(&peers, sats(100000), base_port, "test", "127.0.0.1:18443");
     let max_evil = hbbft::util::max_faulty(peers.len());
 
-    let module_config_gens: ModuleConfigGens = vec![
+    let module_config_gens: ModuleConfigGens = BTreeMap::from([
         (
             "wallet",
             Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen>,
         ),
         ("mint", Arc::new(MintConfigGenerator)),
         ("ln", Arc::new(LightningModuleConfigGen)),
-    ];
+    ]);
 
     match env::var("FM_TEST_DISABLE_MOCKS") {
         Ok(s) if s == "1" => {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -157,7 +157,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
     let module_config_gens: ModuleConfigGens = BTreeMap::from([
         (
             "wallet",
-            Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen>,
+            Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen + Send + Sync>,
         ),
         ("mint", Arc::new(MintConfigGenerator)),
         ("ln", Arc::new(LightningModuleConfigGen)),
@@ -170,7 +170,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
                 "",
                 &peers,
                 params,
-                module_config_gens,
+                module_config_gens.clone(),
                 max_evil,
                 &mut task_group,
             )
@@ -183,7 +183,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
                 .last()
                 .unwrap()
                 .1
-                .get_module_config("wallet")
+                .get_module_config_typed("wallet")
                 .unwrap();
             let bitcoin_rpc = fedimint_bitcoind::bitcoincore_rpc::make_bitcoind_rpc(
                 &wallet_config.local.btc_rpc,
@@ -210,6 +210,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
                 &fed_db,
                 &|| bitcoin_rpc.clone(),
                 &connect_gen,
+                module_config_gens,
                 &mut task_group,
             )
             .await;
@@ -244,9 +245,16 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
         }
         _ => {
             info!("Testing with FAKE Bitcoin and Lightning services");
-            let server_config =
-                ServerConfig::trusted_dealer_gen("", &peers, &params, module_config_gens, OsRng);
-            let client_config = server_config[&PeerId::from(0)].consensus.to_client_config();
+            let server_config = ServerConfig::trusted_dealer_gen(
+                "",
+                &peers,
+                &params,
+                module_config_gens.clone(),
+                OsRng,
+            );
+            let client_config = server_config[&PeerId::from(0)]
+                .consensus
+                .to_client_config(&module_config_gens);
 
             let bitcoin = FakeBitcoinTest::new();
             let bitcoin_rpc = || bitcoin.clone().into();
@@ -263,6 +271,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
                 &fed_db,
                 &bitcoin_rpc,
                 &connect_gen,
+                module_config_gens,
                 &mut task_group,
             )
             .await;
@@ -370,7 +379,7 @@ async fn distributed_config(
 
     Ok((
         configs.into_iter().collect(),
-        config.consensus.to_client_config(),
+        config.consensus.to_client_config(&module_config_gens),
     ))
 }
 
@@ -958,6 +967,7 @@ impl FederationTest {
         database_gen: &impl Fn() -> Database,
         bitcoin_gen: &impl Fn() -> BitcoindRpc,
         connect_gen: &impl Fn(&ServerConfig) -> PeerConnector<EpochMessage>,
+        module_config_gens: ModuleConfigGens,
         task_group: &mut TaskGroup,
     ) -> Self {
         let servers = join_all(server_config.values().map(|cfg| async {
@@ -965,10 +975,10 @@ impl FederationTest {
             let db = database_gen();
             let mut task_group = task_group.clone();
 
-            let mint = Mint::new(cfg.get_module_config("mint").unwrap());
+            let mint = Mint::new(cfg.get_module_config_typed("mint").unwrap());
 
             let wallet = Wallet::new_with_bitcoind(
-                cfg.get_module_config("wallet").unwrap(),
+                cfg.get_module_config_typed("wallet").unwrap(),
                 db.clone(),
                 btc_rpc.clone(),
                 &mut task_group.clone(),
@@ -977,9 +987,10 @@ impl FederationTest {
             .await
             .expect("Couldn't create wallet");
 
-            let ln = LightningModule::new(cfg.get_module_config("ln").unwrap());
+            let ln = LightningModule::new(cfg.get_module_config_typed("ln").unwrap());
 
-            let mut consensus = FedimintConsensus::new(cfg.clone(), db.clone());
+            let mut consensus =
+                FedimintConsensus::new(cfg.clone(), db.clone(), module_config_gens.clone());
             consensus.register_module(mint.into());
             consensus.register_module(wallet.into());
             consensus.register_module(ln.into());
@@ -1009,7 +1020,7 @@ impl FederationTest {
 
         // Consumes the empty epoch 0 outcome from all servers
         let cfg = server_config.iter().last().unwrap().1.clone();
-        let wallet = cfg.get_module_config("wallet").unwrap();
+        let wallet = cfg.get_module_config_typed("wallet").unwrap();
         let last_consensus = Rc::new(RefCell::new(Batch {
             epoch: 0,
             contributions: BTreeMap::new(),

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -25,6 +25,7 @@ use fedimint_api::core::{
 };
 use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::Database;
+use fedimint_api::module::FederationModuleConfigGen;
 use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::task::{timeout, TaskGroup};
 use fedimint_api::OutPoint;
@@ -32,11 +33,11 @@ use fedimint_api::PeerId;
 use fedimint_api::TieredMulti;
 use fedimint_api::{sats, Amount};
 use fedimint_bitcoind::BitcoindRpc;
-use fedimint_ln::LightningGateway;
 use fedimint_ln::LightningModule;
-use fedimint_mint::{Mint, MintOutput};
-use fedimint_server::config::ServerConfigParams;
+use fedimint_ln::{LightningGateway, LightningModuleConfigGen};
+use fedimint_mint::{Mint, MintConfigGenerator, MintOutput};
 use fedimint_server::config::{connect, ServerConfig};
+use fedimint_server::config::{ModuleConfigGens, ServerConfigParams};
 use fedimint_server::consensus::{ConsensusProposal, HbbftConsensusOutcome};
 use fedimint_server::consensus::{FedimintConsensus, TransactionSubmissionError};
 use fedimint_server::multiplexed::PeerConnectionMultiplexer;
@@ -47,9 +48,9 @@ use fedimint_server::{all_decoders, consensus, EpochMessage, FedimintServer};
 use fedimint_testing::btc::{fixtures::FakeBitcoinTest, BitcoinTest};
 use fedimint_wallet::config::WalletConfig;
 use fedimint_wallet::db::UTXOKey;
-use fedimint_wallet::SpendableUTXO;
 use fedimint_wallet::Wallet;
 use fedimint_wallet::WalletConsensusItem;
+use fedimint_wallet::{SpendableUTXO, WalletConfigGenerator};
 use futures::executor::block_on;
 use futures::future::{join_all, select_all};
 use hbbft::honey_badger::Batch;
@@ -153,13 +154,28 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
         ServerConfigParams::gen_local(&peers, sats(100000), base_port, "test", "127.0.0.1:18443");
     let max_evil = hbbft::util::max_faulty(peers.len());
 
+    let module_config_gens: ModuleConfigGens = vec![
+        (
+            "wallet",
+            Arc::new(WalletConfigGenerator) as Arc<dyn FederationModuleConfigGen>,
+        ),
+        ("mint", Arc::new(MintConfigGenerator)),
+        ("ln", Arc::new(LightningModuleConfigGen)),
+    ];
+
     match env::var("FM_TEST_DISABLE_MOCKS") {
         Ok(s) if s == "1" => {
             info!("Testing with REAL Bitcoin and Lightning services");
-            let (server_config, client_config) =
-                distributed_config("", &peers, params, max_evil, &mut task_group)
-                    .await
-                    .expect("distributed config should not be canceled");
+            let (server_config, client_config) = distributed_config(
+                "",
+                &peers,
+                params,
+                module_config_gens,
+                max_evil,
+                &mut task_group,
+            )
+            .await
+            .expect("distributed config should not be canceled");
 
             let dir = env::var("FM_TEST_DIR").expect("Must have test dir defined for real tests");
             let wallet_config: WalletConfig = server_config
@@ -228,7 +244,8 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
         }
         _ => {
             info!("Testing with FAKE Bitcoin and Lightning services");
-            let server_config = ServerConfig::trusted_dealer_gen("", &peers, &params, OsRng);
+            let server_config =
+                ServerConfig::trusted_dealer_gen("", &peers, &params, module_config_gens, OsRng);
             let client_config = server_config[&PeerId::from(0)].consensus.to_client_config();
 
             let bitcoin = FakeBitcoinTest::new();
@@ -307,6 +324,7 @@ async fn distributed_config(
     code_version: &str,
     peers: &[PeerId],
     params: HashMap<PeerId, ServerConfigParams>,
+    module_config_gens: ModuleConfigGens,
     _max_evil: usize,
     task_group: &mut TaskGroup,
 ) -> Cancellable<(BTreeMap<PeerId, ServerConfig>, ClientConfig)> {
@@ -315,6 +333,7 @@ async fn distributed_config(
         let peers = peers.to_vec();
 
         let mut task_group = task_group.clone();
+        let module_config_gens = module_config_gens.clone();
 
         async move {
             let our_params = params[peer].clone();
@@ -333,6 +352,7 @@ async fn distributed_config(
                 peer,
                 &peers,
                 &our_params,
+                module_config_gens,
                 rng,
                 &mut task_group,
             );

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -297,6 +297,13 @@ impl FederationModuleConfigGen for LightningModuleConfigGen {
             .to_client_config())
     }
 
+    fn to_client_config_from_consensus_value(
+        &self,
+        config: serde_json::Value,
+    ) -> anyhow::Result<ClientModuleConfig> {
+        Ok(serde_json::from_value::<LightningConfigConsensus>(config)?.to_client_config())
+    }
+
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
         config
             .to_typed::<LightningConfig>()?

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -16,6 +16,7 @@ use fedimint_api::config::{
 use fedimint_api::core::{ModuleKey, MODULE_KEY_MINT};
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
@@ -257,6 +258,13 @@ impl FederationModuleConfigGen for MintConfigGenerator {
             .to_typed::<MintConfig>()?
             .consensus
             .to_client_config())
+    }
+
+    fn to_client_config_from_consensus_value(
+        &self,
+        config: serde_json::Value,
+    ) -> anyhow::Result<ClientModuleConfig> {
+        Ok(serde_json::from_value::<MintConfigConsensus>(config)?.to_client_config())
     }
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -17,6 +17,7 @@ use bitcoin::{
     Transaction, TxIn, TxOut, Txid,
 };
 use bitcoin::{PackedLockTime, Sequence};
+use config::WalletConfigConsensus;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::TypedServerModuleConsensusConfig;
 use fedimint_api::config::{
@@ -26,6 +27,7 @@ use fedimint_api::config::{
 use fedimint_api::core::{ModuleKey, MODULE_KEY_WALLET};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable, UnzipConsensus};
+use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -315,6 +317,13 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
             .to_typed::<WalletConfig>()?
             .consensus
             .to_client_config())
+    }
+
+    fn to_client_config_from_consensus_value(
+        &self,
+        config: serde_json::Value,
+    ) -> anyhow::Result<ClientModuleConfig> {
+        Ok(serde_json::from_value::<WalletConfigConsensus>(config)?.to_client_config())
     }
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {


### PR DESCRIPTION
Get rid of some hardcodings listing federation modules deep inside generic code, and move toward edges (final binaries), so it's easier to customize/inject new modules.

There's probably a lot more work to do around it, but it's a step towards the goal, I think.