### PR TITLE
Prefer PublicKey instead of XOnlyPublicKey for gateway references

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -143,7 +143,7 @@ pub struct GatewayClientConfig {
 impl From<GatewayClientConfig> for LightningGateway {
     fn from(config: GatewayClientConfig) -> Self {
         LightningGateway {
-            mint_pub_key: config.redeem_key.x_only_public_key().0,
+            mint_pub_key: config.redeem_key.public_key(),
             node_pub_key: config.node_pub_key,
             api: config.api,
         }

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -532,7 +532,7 @@ mod tests {
                 .unwrap();
         let invoice_amt_msat = invoice.amount_milli_satoshis().unwrap();
         let gateway = {
-            let mint_pub_key = secp256k1_zkp::XOnlyPublicKey::from_slice(&[42; 32][..]).unwrap();
+            let mint_pub_key = secp256k1_zkp::PublicKey::from_slice(&[42; 32][..]).unwrap();
             let node_pub_key = secp256k1_zkp::PublicKey::from_slice(&[2; 33][..]).unwrap();
             LightningGateway {
                 mint_pub_key,

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -202,7 +202,7 @@ impl std::fmt::Display for LightningOutputOutcome {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable, PartialEq, Eq, Hash)]
 pub struct LightningGateway {
-    pub mint_pub_key: secp256k1::XOnlyPublicKey,
+    pub mint_pub_key: secp256k1::PublicKey,
     pub node_pub_key: secp256k1::PublicKey,
     pub api: Url,
 }


### PR DESCRIPTION
As inspired by https://github.com/jonasnick/bips/issues/32 and the fact that I need tke `mint_pub_key` in `PublicKey` but don't know the parity with which I can type convert it