### PR TITLE
Introduce gateway channel IDs for federations

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -138,11 +138,16 @@ pub struct GatewayClientConfig {
     pub timelock_delta: u64,
     pub api: Url,
     pub node_pub_key: bitcoin::secp256k1::PublicKey,
+    /// Channel identifier assigned to the mint by the gateway.
+    /// All clients in this federation should use this value as `short_channel_id`
+    /// when creating invoices to be settled by this gateway.
+    pub mint_channel_id: u64,
 }
 
 impl From<GatewayClientConfig> for LightningGateway {
     fn from(config: GatewayClientConfig) -> Self {
         LightningGateway {
+            mint_channel_id: config.mint_channel_id,
             mint_pub_key: config.redeem_key.x_only_public_key().0,
             node_pub_key: config.node_pub_key,
             api: config.api,

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -845,7 +845,7 @@ impl Client<UserClientConfig> {
         // Route hint instructing payer how to route to gateway
         let gateway_route_hint = RouteHint(vec![RouteHintHop {
             src_node_id: gateway.node_pub_key,
-            short_channel_id: 8,
+            short_channel_id: gateway.mint_channel_id,
             fees: RoutingFees {
                 base_msat: 0,
                 proportional_millionths: 0,

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -534,6 +534,7 @@ mod tests {
             let mint_pub_key = secp256k1_zkp::XOnlyPublicKey::from_slice(&[42; 32][..]).unwrap();
             let node_pub_key = secp256k1_zkp::PublicKey::from_slice(&[2; 33][..]).unwrap();
             LightningGateway {
+                mint_channel_id: 0,
                 mint_pub_key,
                 node_pub_key,
                 api: Url::parse("http://example.com")

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -67,6 +67,7 @@ pub trait IGatewayClientBuilder: Debug {
     async fn create_config(
         &self,
         connect: WsFederationConnect,
+        mint_channel_id: u64,
         node_pubkey: PublicKey,
         announce_address: Url,
     ) -> Result<GatewayClientConfig>;
@@ -115,6 +116,7 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
     async fn create_config(
         &self,
         connect: WsFederationConnect,
+        mint_channel_id: u64,
         node_pubkey: PublicKey,
         announce_address: Url,
     ) -> Result<GatewayClientConfig> {
@@ -134,6 +136,7 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
         let kp_fed = KeyPair::new(&ctx, &mut rng);
 
         Ok(GatewayClientConfig {
+            mint_channel_id,
             client_config: client_cfg,
             redeem_key: kp_fed,
             timelock_delta: 10,

--- a/gateway/tests/tests/fixtures/client.rs
+++ b/gateway/tests/tests/fixtures/client.rs
@@ -46,6 +46,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
     async fn create_config(
         &self,
         _connect: WsFederationConnect,
+        mint_channel_id: u64,
         node_pubkey: PublicKey,
         announce_address: Url,
     ) -> Result<GatewayClientConfig, LnGatewayError> {
@@ -64,6 +65,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
         let kp_fed = KeyPair::new(&ctx, &mut rng);
 
         Ok(GatewayClientConfig {
+            mint_channel_id,
             client_config,
             redeem_key: kp_fed,
             timelock_delta: 10,

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -423,7 +423,10 @@ impl GatewayTest {
         let ctx = bitcoin::secp256k1::Secp256k1::new();
         let kp = KeyPair::new(&ctx, &mut rng);
 
+        let mint_channel_id: u64 = 0;
+
         let keys = LightningGateway {
+            mint_channel_id: mint_channel_id.clone(),
             mint_pub_key: kp.x_only_public_key().0,
             node_pub_key,
             api: Url::parse("http://example.com")
@@ -434,6 +437,7 @@ impl GatewayTest {
         let announce_addr = Url::parse(format!("http://{}", bind_addr).as_str())
             .expect("Could not parse URL to generate GatewayClientConfig API endpoint");
         let gw_client_cfg = GatewayClientConfig {
+            mint_channel_id,
             client_config: client_config.clone(),
             redeem_key: kp,
             timelock_delta: 10,

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -426,7 +426,7 @@ impl GatewayTest {
         let mint_channel_id: u64 = 0;
 
         let keys = LightningGateway {
-            mint_channel_id: mint_channel_id.clone(),
+            mint_channel_id,
             mint_pub_key: kp.x_only_public_key().0,
             node_pub_key,
             api: Url::parse("http://example.com")

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -202,6 +202,10 @@ impl std::fmt::Display for LightningOutputOutcome {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable, PartialEq, Eq, Hash)]
 pub struct LightningGateway {
+    /// Channel identifier assigned to the mint by the gateway.
+    /// All clients in this federation should use this value as `short_channel_id`
+    /// when creating invoices to be settled by this gateway.
+    pub mint_channel_id: u64,
     pub mint_pub_key: secp256k1::XOnlyPublicKey,
     pub node_pub_key: secp256k1::PublicKey,
     pub api: Url,


### PR DESCRIPTION
For every Federation connected, the gateway deterministically generates and assigns a channel identifier. Clients within these federations use the channel id as `short_channel_id` in every generated invoice, thus allowing the Gateway to easily identify which federation it should settle a payment on behalf of.

For full context, see these discussions:
- https://discord.com/channels/915026692102316113/915026887066132481/1058487466786574389
- https://discord.com/channels/990354215060795454/996329365329686559/1058247253594218618
