### PR TITLE
Add verbose output flag

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -118,3 +118,13 @@ function get_raw_transaction() {
 function get_federation_name() {
     cat $FM_CFG_DIR/client.json | jq -r '.federation_name'
 }
+
+function show_verbose_output()
+{
+    if [[ $FM_VERBOSE_OUTPUT -ne 1 ]] 
+    then
+        cat > /dev/null 2>&1
+    else
+        cat
+    fi
+}

--- a/scripts/tmux-user-shell.sh
+++ b/scripts/tmux-user-shell.sh
@@ -9,24 +9,24 @@ POLL_INTERVAL=0.5
 export POLL_INTERVAL
 
 echo Setting up bitcoind ...
-btc_client createwallet default > /dev/null 2>&1
-mine_blocks 101 > /dev/null 2>&1
+btc_client createwallet default | show_verbose_output
+mine_blocks 101 | show_verbose_output
 
 # Wait for the lightning clients to start (ln1 and ln2 are started with a 5s delay after bitcoind and deferation start)
 # FIXME: After tackling https://github.com/fedimint/fedimint/issues/699, this can be removed
 await_block_sync
 
 echo Setting up lightning channel ...
-open_channel > /dev/null 2>&1
+open_channel | show_verbose_output
 
 echo Funding user e-cash wallet ...
-scripts/pegin.sh 10000.0 > /dev/null 2>&1
+scripts/pegin.sh 10000.0 | show_verbose_output
 
 echo Connecting federation to gateway
 gw_connect_fed
 
 echo Funding gateway e-cash wallet ...
-scripts/pegin.sh 20000.0 1 > /dev/null 2>&1
+scripts/pegin.sh 20000.0 1 | show_verbose_output
 
 echo Done!
 echo

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -12,6 +12,9 @@ if [[ -z "${IN_NIX_SHELL:-}" ]]; then
   sleep 3
 fi
 
+# Flag to enable verbose build output from depndent processes (disabled by default)
+export FM_VERBOSE_OUTPUT=0
+
 source scripts/build.sh
 echo "Running in temporary directory $FM_TEST_DIR"
 


### PR DESCRIPTION
When running the repo locally using ./scripts/tmuxinator.sh script, I noticed that it it did not work and got stuck in the lightning channel setup. Diagnosing the issue needed me to remove the /dev/null output redirection in the scripts, so I could see what is going on under the hood.

Besides diagnosis, I believe it might also be useful for new people, unfamiliar with the underlying lightning interactions, to be able to see more verbose output of what the scripts are doing for learning purposes.

This PR adds a flag that conditionally shows or suppresses this output from dependent processes.