### PR TITLE
Print warning to stderr

### DIFF
--- a/fedimintd/src/encrypt.rs
+++ b/fedimintd/src/encrypt.rs
@@ -47,7 +47,7 @@ pub fn get_key(password: Option<String>, salt_path: PathBuf) -> LessSafeKey {
     let password = match password {
         None => rpassword::prompt_password("Enter a password to encrypt configs: ").unwrap(),
         Some(password) => {
-            println!("WARNING: Passing in a password from the command line may be less secure!");
+            eprintln!("WARNING: Passing in a password from the command line may be less secure!");
             password
         }
     };


### PR DESCRIPTION
It currently interferes when trying set a variable on the command line:

```
$ CERTS=$(distributedgen create-cert --password password  ...)
$ echo $CERTS
WARNING: Passing in a password from the command line may be less secure! ws://hostname@5000@bravo@3082012c3081d3a003020102020900bd1e155b36b28c21300a06082a8648ce3d0403023010310e300c06035504030c05627261766f3020170d3735303130313030303030305a180f34303936303130313030303030305a3010310e300c06035504030c05627261766f3059301306072a8648ce3d020106082a8648ce3d0301070342000463bb130366f89390e559fe201726f29fc31dfdddf562d4e76183504adf711d322be1b03d61dfe54c13eaa7131fcc098dc7487da1cd7407e06ec5918501cfc465a314301230100603551d11040930078205627261766f300a06082a8648ce3d0403020348003045022100abd5a4ffefc7d707c224fda39596292430d8847cdbefc7f20dc71e7a4b2e936202204d272d1f9895a5260d5e6ff52a8a6872a8a4c213b4d4af477b3eeb1e5ee4c723
```

If printed to stderr this doesn't happen ...