### PR TITLE
Bash script to start federation with containers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -829,6 +829,7 @@
                 (hiPrio pkgs.bashInteractive)
                 tmux
                 tmuxinator
+                docker-compose
 
                 # Nix
                 pkgs.nixpkgs-fmt

--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+BUILD_IMAGES=${1:-0}
+FM_FED_SIZE=${2:-2}
+export DOCKER_DIR=${3-"$(mktemp -d)"}
+
+function generate_certs() {
+    echo "Generating certificates..."
+
+    CERTS=""
+    for ((ID=0; ID<FM_FED_SIZE; ID++));
+    do
+        mkdir -p $1/server-$ID
+        base_port=$(echo "4000 + $ID * 10" | bc -l)
+        docker run -v $1/server-$ID:/var/fedimint $2 distributedgen create-cert --announce-address ws://server-$ID --out-dir /var/fedimint --base-port $base_port --name "Server-$ID" --password "pass$ID"
+        CERTS="$CERTS,$(cat $1/server-$ID/tls-cert)"
+    done
+    export CERTS=${CERTS:1}
+}
+
+function run_dkg() {
+    echo "version: \"3.9\"" >> $3
+    echo "services:" >> $3
+
+    for ((ID=0; ID<FM_FED_SIZE; ID++));
+    do
+        base_port=$(echo "4000 + $ID * 10" | bc -l)
+        next_port=$(echo "4000 + $ID * 10 + 1" | bc -l)
+        echo "  server-$ID:" >> $3
+        echo "    image: $2" >> $3
+        echo "    command: distributedgen run --out-dir /var/fedimint --certs $CERTS --password "pass$ID" --bind_address 0.0.0.0 --bitcoind-rpc bitcoind:18443" >> $3
+        echo "    ports:" >> $3
+        echo "      - $base_port:$base_port" >> $3
+        echo "      - $next_port:$next_port" >> $3
+        echo "    volumes:" >> $3
+        echo "      - $1/server-$ID:/var/fedimint" >> $3
+        echo "    environment:" >> $3
+        echo "      - CERTS=$CERTS" >> $3
+        echo "" >> $3
+    done
+
+    echo "Running DKG with certs: $CERTS"
+    docker-compose -f $3 up -d
+    wait_for_dkg
+}
+
+function wait_for_dkg() {
+    while [ "$(docker ps | grep fedimint | wc -l)" -ne 0 ]
+    do
+        sleep 1
+    done
+}
+
+function generate_docker_compose() {
+    echo "Generating docker-compose..."
+
+    echo "version: \"3.9\"" >> $3
+    echo "services:" >> $3
+
+    generate_bitcoind_container_def $3
+
+    for ((ID=0; ID<FM_FED_SIZE; ID++)); do
+        base_port=$(echo "4000 + $ID * 10" | bc -l)
+        api_port=$(echo "4000 + $ID * 10 + 1" | bc -l)
+        generate_fedimintd_container_def $ID $base_port $api_port $1 $2 $3
+    done
+}
+
+function generate_bitcoind_container_def() {
+    echo "  bitcoind:" >> $1
+    echo "    image: ruimarinho/bitcoin-core:23.0" >> $1
+    echo "    environment:" >> $1
+    echo "      - BITCOIN_DATA=/var/fedimint/bitcoind" >> $1
+    echo "    command: bitcoind -printtoconsole -regtest=1 -rpcbind=0.0.0.0 -rpcallowip=0.0.0.0/0 -rpcport=18443 -rpcuser=bitcoin -rpcpassword=bitcoin" >> $1
+    echo "    ports:" >> $1
+    echo "      - 18443:18443" >> $1
+}
+
+function generate_fedimintd_container_def() {
+    echo "  server-$1:" >> $6
+    echo "    image: $5" >> $6
+    echo "    command: fedimintd /var/fedimint "pass$1"" >> $6
+    echo "    ports:" >> $6
+    echo "      - $2:$2" >> $6
+    echo "      - $3:$3" >> $6
+    echo "    volumes:" >> $6
+    echo "      - $4/server-$1:/var/fedimint" >> $6
+    echo "" >> $6
+}
+
+echo "Run with 'source ./scripts/start-containers.sh [build-images] [fed_size] [dir]"
+rm -rf $DOCKER_DIR
+init="$DOCKER_DIR/init"
+mkdir -p $init
+fed="$DOCKER_DIR/fed"
+mkdir -p $fed
+
+if [[ "$BUILD_IMAGES" != "0" ]]; then
+    echo "Building the containers..."
+    container=$(nix build .\#container.fedimintd && docker load < ./result)
+    container_image=$(echo "${container/Loaded image: /}")
+else
+    echo "Pulling containers from dockerhub"
+    container_image="fedimint/fedimintd:master"
+fi
+
+echo "Generating certificates..."
+generate_certs $DOCKER_DIR $container_image
+
+echo "Running DKG"
+run_dkg $DOCKER_DIR $container_image "$init/docker-compose.yaml"
+
+generate_docker_compose $DOCKER_DIR $container_image "$fed/docker-compose.yaml"
+cat "$fed/docker-compose.yaml"
+docker-compose -f "$fed/docker-compose.yaml" up -d


### PR DESCRIPTION
This PR is an extension of https://github.com/fedimint/fedimint/pull/702/files that adds a docker compose file to start a federation. This PR adds a simple bash script to generate the docker compose files that do DKG and run the federation.

Right now, for developer environment there is not much advantage to creating a federation this way vs tmux. The main advantage is not needing to download the build tools (nix) in an environment where bandwidth might be an issue (such as tabconf). Pulling the containers might not be much faster though. Images can optionally be built using nix.

I mainly did this as an exercise to practice the steps necessary for setting up a federation, and since docker creates its own virtual network, its a bit more "real" since it doesn't rely on localhost.

Currently the script does not contain the lightning gateway or any of the nice setup that the tmuxinator script has. I can add that next if this is deemed useful. If this script and tmuxinator are too much to maintain, feel free to reject.