### PR TITLE
remove_by_prefix for SQLite

### DIFF
--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -207,4 +207,9 @@ mod tests {
     async fn test_dbtx_phantom_entry() {
         fedimint_api::db::verify_phantom_entry(MemDatabase::new().into()).await;
     }
+
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_remove_by_prefix() {
+        fedimint_api::db::verify_remove_by_prefix(MemDatabase::new().into()).await;
+    }
 }

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -260,4 +260,12 @@ mod fedimint_rocksdb_tests {
         )
         .await;
     }
+
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_remove_by_prefix() {
+        fedimint_api::db::verify_remove_by_prefix(
+            open_temp_db("fcb-rocksdb-test-remove-by-prefix").into(),
+        )
+        .await;
+    }
 }

--- a/fedimint-sled/src/lib.rs
+++ b/fedimint-sled/src/lib.rs
@@ -267,4 +267,12 @@ mod fedimint_sled_tests {
         )
         .await;
     }
+
+    #[test_log::test(tokio::test)]
+    async fn test_dbtx_remove_by_prefix() {
+        fedimint_api::db::verify_remove_by_prefix(
+            open_temp_db("fcb-sled-test-remove-by-prefix").into(),
+        )
+        .await;
+    }
 }


### PR DESCRIPTION
Small PR that introduces tests for remove_by_prefix and a native implementation for SQLite.

It looks like the existing default implementation for Rocksdb is the most efficient it currently supports. See comment here: https://github.com/fedimint/fedimint/issues/1111