### PR TITLE
Removes the port offsets from DKG

### DIFF
--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -54,16 +54,13 @@ pub async fn run_server(
         attach_endpoints_erased(&mut rpc_module, module);
     }
 
-    debug!(
-        addr = cfg.local.api_bind_addr.to_string(),
-        "Starting WSServer"
-    );
+    debug!(addr = cfg.local.api_bind.to_string(), "Starting WSServer");
     let server = ServerBuilder::new()
         .max_connections(cfg.local.max_connections)
         .ping_interval(Duration::from_secs(10))
-        .build(&cfg.local.api_bind_addr.to_string())
+        .build(&cfg.local.api_bind.to_string())
         .await
-        .context(format!("Bind address: {}", cfg.local.api_bind_addr))
+        .context(format!("Bind address: {}", cfg.local.api_bind))
         .expect("Could not start API server");
 
     let server_handle = server

--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -223,7 +223,7 @@ where
 }
 
 /// Parses the host and port from a url
-fn parse_host_port(url: Url) -> String {
+pub fn parse_host_port(url: Url) -> String {
     let host = url.host_str().expect("Expected host to exist");
     let port = url.port().expect("Expected port to exist");
 

--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -158,10 +158,10 @@ fn trusted_dealer_gen(
                 },
                 local: ServerConfigLocal {
                     identity: id,
-                    hbbft_bind_addr: format!("0.0.0.0:{}", hbbft_base_port + id_u16)
+                    fed_bind: format!("0.0.0.0:{}", hbbft_base_port + id_u16)
                         .parse()
                         .expect("Could not parse address"),
-                    api_bind_addr: format!("0.0.0.0:{}", api_base_port + id_u16)
+                    api_bind: format!("0.0.0.0:{}", api_base_port + id_u16)
                         .parse()
                         .expect("Could not parse address"),
                     tls_cert: tls_keys[&id].0.clone(),

--- a/integrationtests/README.md
+++ b/integrationtests/README.md
@@ -10,7 +10,7 @@ Tests cases begin by initializing test fixtures with the number of federation no
 let (fed, user, bitcoin, gateway, ln) = fixtures(2, &[sats(100), sats(1000)]).await;
 ```
 
-Initialization will spawn API and HBBFT consensus threads for federation nodes starting at port `4000` then give you access to the following:
+Initialization will spawn API and HBBFT consensus threads for federation nodes starting at port `8173` then give you access to the following:
 - `fed`- control and inspect federation nodes and consensus
 - `user`- calls functions in the user client API to simulate fedimint users
 - `bitcoin`- manipulate the shared Bitcoin network

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -36,7 +36,7 @@ use fedimint_bitcoind::BitcoindRpc;
 use fedimint_ln::LightningModule;
 use fedimint_ln::{LightningGateway, LightningModuleConfigGen};
 use fedimint_mint::{Mint, MintConfigGenerator, MintOutput};
-use fedimint_server::config::{connect, ServerConfig};
+use fedimint_server::config::{connect, ServerConfig, DEFAULT_P2P_PORT};
 use fedimint_server::config::{ModuleConfigGens, ServerConfigParams};
 use fedimint_server::consensus::{ConsensusProposal, HbbftConsensusOutcome};
 use fedimint_server::consensus::{FedimintConsensus, TransactionSubmissionError};
@@ -82,7 +82,7 @@ mod fake;
 mod real;
 mod utils;
 
-static BASE_PORT: AtomicU16 = AtomicU16::new(4000_u16);
+static BASE_PORT: AtomicU16 = AtomicU16::new(DEFAULT_P2P_PORT);
 
 // Helper functions for easier test writing
 pub fn rng() -> OsRng {
@@ -135,13 +135,13 @@ where
 }
 
 /// Generates the fixtures for an integration test and spawns API and HBBFT consensus threads for
-/// federation nodes starting at port 4000.
+/// federation nodes starting at port DEFAULT_P2P_PORT.
 pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
     let mut task_group = TaskGroup::new();
     let base_port = BASE_PORT.fetch_add(num_peers * 10, Ordering::Relaxed);
 
     // in case we need to output logs using 'cargo test -- --nocapture'
-    if base_port == 4000 {
+    if base_port == DEFAULT_P2P_PORT {
         tracing_subscriber::fmt()
             .with_env_filter(
                 EnvFilter::try_from_default_env()
@@ -347,7 +347,7 @@ async fn distributed_config(
         async move {
             let our_params = params[peer].clone();
             let server_conn = connect(
-                our_params.server_dkg.clone(),
+                our_params.fed_network.clone(),
                 our_params.tls.clone(),
                 &mut task_group,
             )


### PR DESCRIPTION
Now the URLs / bind addresses for the server and API endpoints will be independently configurable, using default ports `4000` and `4001`.  DKG will use the server endpoints.

Fix #1188