### PR TITLE
Remove polling

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -681,7 +681,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
 
         let stream = stream::iter(pending)
             .map(|(key, notes)| async move {
-                match self.context.api.fetch_tx_outcome(&key.0).await {
+                match self.context.api.await_tx_outcome(&key.0).await {
                     Ok(TransactionStatus::Rejected(_)) => Ok((key, notes)),
                     Ok(TransactionStatus::Accepted { .. }) => {
                         Ok((key, TieredMulti::<SpendableNote>::default()))

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -371,6 +371,24 @@ mod tests {
                 "/fetch_transaction",
                 move |mint: Arc<Mutex<FakeFed<Lightning>>>, tx: TransactionId| async move {
                     let mint = mint.lock().await;
+                    Ok(Some(TransactionStatus::Accepted {
+                        epoch: 0,
+                        outputs: vec![SerdeOutputOutcome::from(&DynOutputOutcome::from_typed(
+                            module_id,
+                            mint.output_outcome(OutPoint {
+                                txid: tx,
+                                out_idx: 0,
+                            })
+                            .await
+                            .unwrap(),
+                        ))],
+                    }))
+                },
+            )
+            .with(
+                "/wait_transaction",
+                move |mint: Arc<Mutex<FakeFed<Lightning>>>, tx: TransactionId| async move {
+                    let mint = mint.lock().await;
                     Ok(TransactionStatus::Accepted {
                         epoch: 0,
                         outputs: vec![SerdeOutputOutcome::from(&DynOutputOutcome::from_typed(

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -236,18 +236,31 @@ mod tests {
             .iter()
             .map(|(peer_id, _, _, _)| *peer_id)
             .collect();
-        FederationApiFaker::new(fed, members).with(
-            "/fetch_transaction",
-            move |_mint: Arc<Mutex<FakeFed<Wallet>>>, _tx: TransactionId| async move {
-                Ok(TransactionStatus::Accepted {
-                    epoch: 0,
-                    outputs: vec![SerdeOutputOutcome::from(&DynOutputOutcome::from_typed(
-                        module_id,
-                        WalletOutputOutcome(Txid::from_slice([0; 32].as_slice()).unwrap()),
-                    ))],
-                })
-            },
-        )
+        FederationApiFaker::new(fed, members)
+            .with(
+                "/fetch_transaction",
+                move |_mint: Arc<Mutex<FakeFed<Wallet>>>, _tx: TransactionId| async move {
+                    Ok(Some(TransactionStatus::Accepted {
+                        epoch: 0,
+                        outputs: vec![SerdeOutputOutcome::from(&DynOutputOutcome::from_typed(
+                            module_id,
+                            WalletOutputOutcome(Txid::from_slice([0; 32].as_slice()).unwrap()),
+                        ))],
+                    }))
+                },
+            )
+            .with(
+                "/wait_transaction",
+                move |_mint: Arc<Mutex<FakeFed<Wallet>>>, _tx: TransactionId| async move {
+                    Ok(TransactionStatus::Accepted {
+                        epoch: 0,
+                        outputs: vec![SerdeOutputOutcome::from(&DynOutputOutcome::from_typed(
+                            module_id,
+                            WalletOutputOutcome(Txid::from_slice([0; 32].as_slice()).unwrap()),
+                        ))],
+                    })
+                },
+            )
     }
 
     async fn new_mint_and_client(

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -787,7 +787,7 @@ impl FedimintConsensus {
                     output.module_instance_id(),
                 )
                 .await
-                .expect("the transaction was processed, so should be known");
+                .expect("the transaction was processed, so must be known");
             outputs.push((&outcome).into())
         }
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -766,6 +766,52 @@ impl FedimintConsensus {
         Ok(())
     }
 
+    async fn accepted_transaction_status(
+        &self,
+        txid: TransactionId,
+        accepted: AcceptedTransaction,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> TransactionStatus {
+        let mut outputs = Vec::new();
+        for (out_idx, output) in accepted.transaction.outputs.iter().enumerate() {
+            let outpoint = OutPoint {
+                txid,
+                out_idx: out_idx as u64,
+            };
+            let outcome = self
+                .modules
+                .get_expect(output.module_instance_id())
+                .output_status(
+                    &mut dbtx.with_module_prefix(output.module_instance_id()),
+                    outpoint,
+                    output.module_instance_id(),
+                )
+                .await
+                .expect("the transaction was processed, so should be known");
+            outputs.push((&outcome).into())
+        }
+
+        TransactionStatus::Accepted {
+            epoch: accepted.epoch,
+            outputs,
+        }
+    }
+
+    pub async fn wait_transaction_status(
+        &self,
+        txid: TransactionId,
+    ) -> crate::outcome::TransactionStatus {
+        let accepted_key = AcceptedTransactionKey(txid);
+        let rejected_key = RejectedTransactionKey(txid);
+        tokio::select! {
+            (accepted, mut dbtx) = self.db.wait_key_check(&accepted_key, std::convert::identity) => {
+                self.accepted_transaction_status(txid, accepted, &mut dbtx).await
+            }
+            rejected = self.db.wait_key_exists(&rejected_key) => {
+                TransactionStatus::Rejected(rejected)
+            }
+        }
+    }
     pub async fn transaction_status(
         &self,
         txid: TransactionId,
@@ -775,30 +821,11 @@ impl FedimintConsensus {
         let accepted: Option<AcceptedTransaction> =
             dbtx.get_value(&AcceptedTransactionKey(txid)).await;
 
-        if let Some(accepted_tx) = accepted {
-            let mut outputs = Vec::new();
-            for (out_idx, output) in accepted_tx.transaction.outputs.iter().enumerate() {
-                let outpoint = OutPoint {
-                    txid,
-                    out_idx: out_idx as u64,
-                };
-                let outcome = self
-                    .modules
-                    .get_expect(output.module_instance_id())
-                    .output_status(
-                        &mut dbtx.with_module_prefix(output.module_instance_id()),
-                        outpoint,
-                        output.module_instance_id(),
-                    )
-                    .await
-                    .expect("the transaction was processed, so should be known");
-                outputs.push((&outcome).into())
-            }
-
-            return Some(crate::outcome::TransactionStatus::Accepted {
-                epoch: accepted_tx.epoch,
-                outputs,
-            });
+        if let Some(accepted) = accepted {
+            return Some(
+                self.accepted_transaction_status(txid, accepted, &mut dbtx)
+                    .await,
+            );
         }
 
         let rejected: Option<String> = self

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -39,6 +39,7 @@ impl_db_record!(
     key = AcceptedTransactionKey,
     value = AcceptedTransaction,
     db_prefix = DbKeyPrefix::AcceptedTransaction,
+    notify_on_modify = true,
 );
 impl_db_lookup!(
     key = AcceptedTransactionKey,
@@ -55,6 +56,7 @@ impl_db_record!(
     key = RejectedTransactionKey,
     value = String,
     db_prefix = DbKeyPrefix::RejectedTransaction,
+    notify_on_modify = true,
 );
 impl_db_lookup!(
     key = RejectedTransactionKey,

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -204,10 +204,23 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
         },
         api_endpoint! {
             "/fetch_transaction",
+            async |fedimint: &FedimintConsensus, _dbtx, tx_hash: TransactionId| -> Option<TransactionStatus> {
+                debug!(transaction = %tx_hash, "Recieved request");
+
+                let tx_status = fedimint.transaction_status(tx_hash)
+                    .await;
+
+                debug!(transaction = %tx_hash, "Sending outcome");
+                Ok(tx_status)
+            }
+        },
+        api_endpoint! {
+            "/wait_transaction",
             async |fedimint: &FedimintConsensus, _dbtx, tx_hash: TransactionId| -> TransactionStatus {
                 debug!(transaction = %tx_hash, "Recieved request");
 
-                let tx_status = fedimint.transaction_status(tx_hash).await.ok_or_else(|| ApiError::not_found(String::from("transaction not found")))?;
+                let tx_status = fedimint.wait_transaction_status(tx_hash)
+                    .await;
 
                 debug!(transaction = %tx_hash, "Sending outcome");
                 Ok(tx_status)


### PR DESCRIPTION
Remain tasks:
- [x] debug test running forever
- [x] unit tests
- [x] docs
- [x] integrating task groups
---

Currently, we use polling to check for updates(say "fetch_transaction").

What we need is to subscribe for change in web server task, and push notification for these changes in the main task.
But we can't immediately notify the web server task because the transaction is not yet committed. And the database won't contain the value. 

So mainly I see two solution:
- have "post commit hooks", function that get called after transaction is committed. But then we don't access to the state of the module.
- build notifications into the database using database keys, which is much more clean.

Another Attempt #273 