### PR TITLE
Common lnrpc client for gateway calls into LN node

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -20,11 +20,12 @@ use std::{
     time::{Duration, Instant},
 };
 
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
 use bitcoin::Address;
-use fedimint_api::config::FederationId;
-use fedimint_api::{task::TaskGroup, Amount, TransactionId};
+use fedimint_api::{config::FederationId, task::TaskGroup, Amount, TransactionId};
 use fedimint_server::modules::ln::contracts::Preimage;
 use mint_client::{
     api::WsFederationConnect, ln::PayInvoicePayload, mint::MintClientError, ClientError,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -135,6 +135,8 @@ impl LnGateway {
                 .expect("Failed to create actor"),
         );
 
+        // TODO: Subscribe for HTLC intercept on behalf of this federation
+
         self.actors.lock().await.insert(
             client.config().client_config.federation_id.to_string(),
             actor.clone(),

--- a/gateway/ln-gateway/src/rpc/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/lnrpc_client.rs
@@ -214,7 +214,16 @@ impl ILnRpcClient for NetworkLnRpcClient {
                         htlc_outcomes.push(outcome);
                     }
 
-                    // TODO: Send HTLC outcomes to gateway lightning rpc server
+                    if let Err(e) = client
+                        .complete_htlcs(Request::new(stream::iter(htlc_outcomes)))
+                        .await
+                    {
+                        // Note: This is a potential loss of funds for the gateway
+                        error!(
+                            "Failed to send request completing the processed HTLCs: {:?}",
+                            e
+                        );
+                    }
                 }
             },
         )

--- a/gateway/ln-gateway/src/rpc/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/lnrpc_client.rs
@@ -1,0 +1,126 @@
+use std::{fmt::Debug, net::SocketAddr, sync::Arc};
+
+use async_trait::async_trait;
+use fedimint_api::{dyn_newtype_define, task::TaskGroup};
+use fedimint_server::modules::ln::contracts::Preimage;
+use lightning_invoice::Invoice;
+use secp256k1::PublicKey;
+use tokio::sync::{mpsc, Mutex};
+use tonic::transport::Channel;
+
+use super::HtlcInterceptPayload;
+use crate::{gatewaylnrpc::gateway_lightning_client::GatewayLightningClient, Result};
+
+#[derive(Debug, Clone)]
+
+pub struct InvoiceInfo {
+    pub invoice: Invoice,
+    pub max_delay: u64,
+    pub max_fee_percent: f64,
+}
+
+/**
+ * Convenience wrapper around `GatewayLightningClient` protocol spec
+ * This provides ease in constructing rpc requests and parsing responses.
+ */
+#[async_trait]
+pub trait ILnRpcClient: Debug + Send + Sync {
+    // Get the public key of the lightning node
+    async fn get_pubkey(&self) -> Result<PublicKey>;
+
+    // Attempt to pay an invoice using the lightning node
+    async fn pay_invoice(&self, invoices: Vec<InvoiceInfo>) -> Result<Vec<Result<Preimage>>>;
+
+    // Subscribe to intercept htlcs that belong to a specific mint identified by `short_channel_id`
+    async fn subscribe_intercept_htlcs(
+        &self,
+        short_channel_id: u64,
+    ) -> Result<mpsc::Receiver<HtlcInterceptPayload>>;
+}
+
+dyn_newtype_define!(
+    /// Arc reference to a gateway lightning rpc client
+    #[derive(Clone)]
+    pub LnRpcClient(Arc<ILnRpcClient>)
+);
+
+impl LnRpcClient {
+    pub fn new(client: Arc<dyn ILnRpcClient + Send + Sync>) -> Self {
+        LnRpcClient(client)
+    }
+}
+
+/**
+ * An `ILnRpcClient` that wraps around `GatewayLightningClient` for convenience,
+ * and makes real RPC requests over the wire to a remote lightning node.
+ * The lightnign node is exposed via a corresponding `GatewayLightningServer`.
+ */
+#[derive(Debug)]
+pub struct NetworkLnRpcClient {
+    client: Mutex<GatewayLightningClient<Channel>>,
+    task_group: TaskGroup,
+}
+
+impl NetworkLnRpcClient {
+    pub async fn new(address: SocketAddr, task_group: TaskGroup) -> Result<Self> {
+        // TODO: Use secure connections to `GatewayLightningServer`
+        let url = format!("http://{}", address);
+
+        let client = GatewayLightningClient::connect(url)
+            .await
+            .expect("Failed to construct gateway lightning rpc client");
+
+        Ok(Self {
+            client: Mutex::new(client),
+            task_group,
+        })
+    }
+}
+
+#[async_trait]
+impl ILnRpcClient for NetworkLnRpcClient {
+    async fn get_pubkey(&self) -> Result<PublicKey> {
+        unimplemented!()
+    }
+
+    async fn pay_invoice(&self, _invoices: Vec<InvoiceInfo>) -> Result<Vec<Result<Preimage>>> {
+        unimplemented!()
+    }
+
+    async fn subscribe_intercept_htlcs(
+        &self,
+        _short_channel_id: u64,
+    ) -> Result<mpsc::Receiver<HtlcInterceptPayload>> {
+        unimplemented!()
+    }
+}
+
+/**
+ * A generic factory trait for creating `LnRpcClient` instances.
+ */
+#[async_trait]
+pub trait ILnRpcClientFactory: Debug {
+    async fn create(&self, address: SocketAddr, task_group: TaskGroup) -> Result<LnRpcClient>;
+}
+
+dyn_newtype_define!(
+    /// Arc reference to a gateway lightning rpc client factory
+    #[derive(Clone)]
+    pub LnRpcClientFactory(Arc<ILnRpcClientFactory>)
+);
+
+/**
+ * An `ILnRpcClientFactory` that creates `NetworkLnRpcClient` instances.
+ */
+#[derive(Debug, Default)]
+pub struct NetworkLnRpcClientFactory;
+
+#[async_trait]
+impl ILnRpcClientFactory for NetworkLnRpcClientFactory {
+    async fn create(&self, address: SocketAddr, task_group: TaskGroup) -> Result<LnRpcClient> {
+        let client = NetworkLnRpcClient::new(address, task_group)
+            .await
+            .expect("Failed to build network ln rpc client");
+        Ok(LnRpcClient(Arc::new(client)))
+    }
+}

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -1,3 +1,4 @@
+pub mod lnrpc_client;
 pub mod rpc_client;
 pub mod rpc_server;
 
@@ -208,4 +209,9 @@ pub fn serde_hex_serialize<T: bitcoin::consensus::Encodable, S: Serializer>(
     } else {
         s.serialize_bytes(&bytes)
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HtlcInterceptPayload {
+    pub invoice_amount: Amount,
 }


### PR DESCRIPTION
Gateway defines a unified lnrpc client implementation that calls into a [GatewayLightning](https://github.com/fedimint/fedimint/blob/master/gateway/ln-gateway/proto/gatewaylnrpc.proto#L7:L19) extension instance.
- The clients calls in for the following functions:
  - get node pubkey for constructing invoices
  - pay invoice on behalf of user
  - subscribe to htlcs directed at a federation
  - process and respond to htlcs intercepted
- RPC calls are agnostic of the lightning node implementation
- #1224 is an example of gateway lightning extension this client can call into

![image](https://user-images.githubusercontent.com/11217077/211143809-c87d59db-80ba-41c1-8534-a0ab2a28bae7.png)
