### PR TITLE
Add `10000` to test setup base port to avoid conflicts

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -82,7 +82,7 @@ mod fake;
 mod real;
 mod utils;
 
-static BASE_PORT: AtomicU16 = AtomicU16::new(DEFAULT_P2P_PORT);
+static BASE_PORT: AtomicU16 = AtomicU16::new(DEFAULT_P2P_PORT + 10000);
 
 // Helper functions for easier test writing
 pub fn rng() -> OsRng {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,7 @@ echo "Run with 'source ./scripts/build.sh [fed_size] [dir]"
 
 # allow for overriding arguments
 export FM_FED_SIZE=${1:-4}
-BASE_PORT=8173
+BASE_PORT=$((8173 + 10000))
 
 # If $TMP contains '/nix-shell.' it is already unique to the
 # nix shell instance, and appending more characters to it is


### PR DESCRIPTION
Avoids conflicts with `fedimintd` itself, which someone might want to run locally while running tmuxinator/tests, and with other random apps (currently we are hitting `syncthing` ports).