### PR TITLE
Get rid of bitcoind_rpc as configuration of `fedimint-wallet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,8 +961,8 @@ dependencies = [
  "fedimint-api",
  "rand",
  "serde",
- "thiserror",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -198,7 +198,7 @@ mod tests {
     use bitcoin::hashes::sha256;
     use bitcoin::{Address, Txid};
     use bitcoin_hashes::Hash;
-    use fedimint_api::config::{BitcoindRpcCfg, ConfigGenParams};
+    use fedimint_api::config::ConfigGenParams;
     use fedimint_api::core::{Decoder, MODULE_KEY_WALLET};
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -356,11 +356,6 @@ mod tests {
                 },
                 &ConfigGenParams::new().attach(WalletConfigGenParams {
                     network: bitcoin::network::constants::Network::Regtest,
-                    bitcoin_rpc: BitcoindRpcCfg {
-                        btc_rpc_address: "localhst".to_string(),
-                        btc_rpc_user: "bitcoin".to_string(),
-                        btc_rpc_pass: "bitcoin".to_string(),
-                    },
                     finality_delay: 10,
                 }),
                 &WalletConfigGenerator,

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -750,10 +750,3 @@ mod tests {
         keys
     }
 }
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct BitcoindRpcCfg {
-    pub btc_rpc_address: String,
-    pub btc_rpc_user: String,
-    pub btc_rpc_pass: String,
-}

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -24,5 +24,4 @@ fedimint-api  = { path = "../fedimint-api" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 tracing = "0.1.37"
-thiserror = "1.0.37"
-                   
+url = "2.3.1"                   

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -1,23 +1,41 @@
 use ::bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
 use ::bitcoincore_rpc::jsonrpc::error::RpcError;
 use ::bitcoincore_rpc::{jsonrpc, Auth, RpcApi};
-use fedimint_api::config::BitcoindRpcCfg;
+use anyhow::format_err;
 use fedimint_api::module::__reexports::serde_json::Value;
 use jsonrpc::error::Error as JsonError;
 use serde::Deserialize;
 use tracing::warn;
+use url::Url;
 
 use super::*;
 
 // <https://github.com/bitcoin/bitcoin/blob/ec0a4ad67769109910e3685da9c56c1b9f42414e/src/rpc/protocol.h#L48>
 const RPC_VERIFY_ALREADY_IN_CHAIN: i32 = -27;
 
-pub fn make_bitcoind_rpc(cfg: &BitcoindRpcCfg, task_handle: TaskHandle) -> Result<BitcoindRpc> {
-    let bitcoind_client = ::bitcoincore_rpc::Client::new(
-        &cfg.btc_rpc_address,
-        Auth::UserPass(cfg.btc_rpc_user.clone(), cfg.btc_rpc_pass.clone()),
-    )
-    .map_err(anyhow::Error::from)?;
+pub fn from_url_to_url_auth(url: &Url) -> Result<(String, Auth)> {
+    Ok((
+        (if let Some(port) = url.port() {
+            format!("{}:{port}", url.host_str().unwrap_or("127.0.0.1"))
+        } else {
+            url.host_str().unwrap_or("localhost").to_owned()
+        }),
+        if url.username().is_empty() {
+            Auth::None
+        } else {
+            Auth::UserPass(
+                url.username().to_owned(),
+                url.password()
+                    .ok_or_else(|| format_err!("Password missing for {}", url.username()))?
+                    .to_owned(),
+            )
+        },
+    ))
+}
+pub fn make_bitcoind_rpc(url: &Url, task_handle: TaskHandle) -> Result<BitcoindRpc> {
+    let (url, auth) = from_url_to_url_auth(url)?;
+    let bitcoind_client =
+        ::bitcoincore_rpc::Client::new(&url, auth).map_err(anyhow::Error::from)?;
     let retry_client = RetryClient::new(Client(ErrorReporting::new(bitcoind_client)), task_handle);
 
     Ok(retry_client.into())
@@ -122,7 +140,7 @@ where
                 code: RPC_VERIFY_ALREADY_IN_CHAIN,
                 ..
             }))) => Ok(()),
-            Err(e) => Err(anyhow::Error::from(e).into()),
+            Err(e) => Err(anyhow::Error::from(e)),
             Ok(_) => Ok(()),
         })
     }

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -3,22 +3,14 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub use anyhow::Result;
 use async_trait::async_trait;
 use bitcoin::{Block, BlockHash, Network, Transaction};
 use fedimint_api::{dyn_newtype_define, task::TaskHandle, Feerate};
-use thiserror::Error;
 use tracing::info;
 
 #[cfg(feature = "bitcoincore-rpc")]
 pub mod bitcoincore_rpc;
-
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("Rpc error")]
-    Rpc(#[from] anyhow::Error),
-}
-
-pub type Result<T> = std::result::Result<T, Error>;
 
 /// Trait that allows interacting with the Bitcoin blockchain
 ///

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::{bail, format_err};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
-    BitcoindRpcCfg, ClientConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, Node, ServerModuleConfig,
+    ClientConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, Node, ServerModuleConfig,
     TypedServerModuleConfig,
 };
 use fedimint_api::core::{ModuleKey, MODULE_KEY_GLOBAL};
@@ -505,7 +505,6 @@ impl ServerConfigParams {
         max_denomination: Amount,
         peers: &BTreeMap<PeerId, PeerServerParams>,
         federation_name: String,
-        bitcoind_rpc: String,
         network: bitcoin::network::constants::Network,
         finality_delay: u32,
     ) -> ServerConfigParams {
@@ -538,11 +537,6 @@ impl ServerConfigParams {
             modules: ConfigGenParams::new()
                 .attach(WalletConfigGenParams {
                     network,
-                    bitcoin_rpc: BitcoindRpcCfg {
-                        btc_rpc_address: bitcoind_rpc,
-                        btc_rpc_user: "bitcoin".to_string(),
-                        btc_rpc_pass: "bitcoin".to_string(),
-                    },
                     finality_delay,
                 })
                 .attach(MintConfigGenParams {
@@ -581,7 +575,6 @@ impl ServerConfigParams {
         max_denomination: Amount,
         base_port: u16,
         federation_name: &str,
-        bitcoind_rpc: &str,
     ) -> HashMap<PeerId, ServerConfigParams> {
         let keys: HashMap<PeerId, (rustls::Certificate, rustls::PrivateKey)> = peers
             .iter()
@@ -622,7 +615,6 @@ impl ServerConfigParams {
                     max_denomination,
                     &peer_params,
                     federation_name.to_string(),
-                    bitcoind_rpc.to_string(),
                     bitcoin::network::constants::Network::Regtest,
                     10,
                 );

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -32,7 +32,7 @@ bincode = "1.3.1"
 bitcoin = "0.29.2"
 bytes = "1.3.0"
 hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
-clap = { version = "4.0.29", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
+clap = { version = "4.0.29", features = ["derive", "env", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 futures = "0.3.24"
 hex = "0.4.2"
 itertools = "0.10.5"

--- a/fedimintd/src/bin/configgen.rs
+++ b/fedimintd/src/bin/configgen.rs
@@ -37,10 +37,6 @@ enum Command {
         #[arg(long = "base-port", default_value = "17240")]
         base_port: u16,
 
-        /// `bitcoind` json rpc endpoint
-        #[arg(long = "bitcoind-rpc", default_value = "127.0.0.1:18443")]
-        bitcoind_rpc: String,
-
         /// Max denomination of notes issued by the federation (in millisats)
         /// default = 1 BTC
         #[arg(long = "max_denomination", default_value = "100000000000")]
@@ -64,7 +60,6 @@ fn main() {
             base_port,
             max_denomination,
             federation_name,
-            bitcoind_rpc,
         } => {
             let rng = OsRng;
             // Recursively create config directory if it doesn't exist
@@ -80,7 +75,6 @@ fn main() {
                 max_denomination,
                 base_port,
                 &federation_name,
-                &bitcoind_rpc,
             );
             let module_config_gens: ModuleConfigGens = BTreeMap::from([
                 (

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -82,10 +82,6 @@ enum Command {
         #[arg(long = "certs", value_delimiter = ',')]
         certs: Vec<String>,
 
-        /// `bitcoind` json rpc endpoint
-        #[arg(long = "bitcoind-rpc", default_value = "127.0.0.1:18443")]
-        bitcoind_rpc: String,
-
         /// Max denomination of notes issued by the federation (in millisats)
         /// default = 1 BTC
         #[arg(long = "max_denomination", default_value = "100000000000")]
@@ -176,7 +172,6 @@ async fn main() {
             certs,
             bind_p2p,
             bind_api,
-            bitcoind_rpc,
             max_denomination,
             network,
             finality_delay,
@@ -191,7 +186,6 @@ async fn main() {
                 max_denomination,
                 federation_name,
                 certs,
-                bitcoind_rpc,
                 network,
                 finality_delay,
                 rustls::PrivateKey(pk_bytes),
@@ -258,7 +252,6 @@ async fn run_dkg(
     max_denomination: Amount,
     federation_name: String,
     certs: Vec<String>,
-    bitcoind_rpc: String,
     network: bitcoin::network::constants::Network,
     finality_delay: u32,
     pk: rustls::PrivateKey,
@@ -287,7 +280,6 @@ async fn run_dkg(
         max_denomination,
         &peers,
         federation_name,
-        bitcoind_rpc,
         network,
         finality_delay,
     );

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -13,7 +13,6 @@ use fedimint_mint::MintConfigGenerator;
 use fedimint_server::config::ModuleConfigGens;
 use fedimint_server::consensus::FedimintConsensus;
 use fedimint_server::FedimintServer;
-use fedimint_wallet::config::WalletConfig;
 use fedimint_wallet::Wallet;
 use fedimint_wallet::WalletConfigGenerator;
 use fedimintd::encrypt::*;
@@ -22,6 +21,7 @@ use fedimintd::*;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer;
+use url::Url;
 
 #[derive(Parser)]
 pub struct ServerOpts {
@@ -31,8 +31,11 @@ pub struct ServerOpts {
     #[arg(default_value = None)]
     pub ui_port: Option<u32>,
     #[cfg(feature = "telemetry")]
-    #[clap(long)]
+    #[arg(long)]
     pub with_telemetry: bool,
+
+    #[arg(long = "bitcoind-rpc", env = "FEDIMINT_BITCOIND_RPC")]
+    pub bitcoind_rpc: Url,
 }
 
 #[tokio::main]
@@ -92,9 +95,7 @@ async fn main() -> anyhow::Result<()> {
         .expect("Error opening DB")
         .into();
     let btc_rpc = fedimint_bitcoind::bitcoincore_rpc::make_bitcoind_rpc(
-        &cfg.get_module_config_typed::<WalletConfig>("wallet")?
-            .local
-            .btc_rpc,
+        &opts.bitcoind_rpc,
         task_group.make_handle(),
     )?;
 

--- a/fedimintd/src/ui/configgen.rs
+++ b/fedimintd/src/ui/configgen.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-use fedimint_api::config::{BitcoindRpcCfg, ClientConfig, ConfigGenParams};
+use fedimint_api::config::{ClientConfig, ConfigGenParams};
 use fedimint_api::module::FederationModuleConfigGen;
 use fedimint_api::{Amount, PeerId};
 use fedimint_core::modules::ln::LightningModuleConfigGen;
@@ -22,7 +22,6 @@ use crate::CODE_VERSION;
 pub fn configgen(
     federation_name: String,
     guardians: Vec<Guardian>,
-    btc_rpc: BitcoindRpcCfg,
 ) -> (Vec<(Guardian, ServerConfig)>, ClientConfig) {
     let amount_tiers = (1..12)
         .map(|amount| Amount::from_sats(10 * amount))
@@ -34,7 +33,6 @@ pub fn configgen(
         federation_name,
         guardians: guardians.clone(),
         amount_tiers,
-        btc_rpc,
     };
     let (config_map, client_config) = trusted_dealer_gen(&peers, &params, rng);
     let server_configs = guardians
@@ -53,7 +51,6 @@ pub struct SetupConfigParams {
     pub federation_name: String,
     pub guardians: Vec<Guardian>,
     pub amount_tiers: Vec<fedimint_api::Amount>,
-    pub btc_rpc: BitcoindRpcCfg,
 }
 
 fn trusted_dealer_gen(
@@ -116,7 +113,6 @@ fn trusted_dealer_gen(
     let module_cfg_gen_params = ConfigGenParams::new()
         .attach(WalletConfigGenParams {
             network: bitcoin::network::constants::Network::Regtest,
-            bitcoin_rpc: params.btc_rpc.clone(),
             finality_delay: 10,
         })
         .attach(MintConfigGenParams {

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -6,11 +6,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bitcoin::{secp256k1, Address, Transaction};
-use bitcoincore_rpc::{Auth, Client, RpcApi};
+use bitcoincore_rpc::{Client, RpcApi};
 use cln_rpc::model::requests;
 use cln_rpc::primitives::{Amount as ClnRpcAmount, AmountOrAny};
 use cln_rpc::{ClnRpc, Request, Response};
-use fedimint_api::config::BitcoindRpcCfg;
 use fedimint_api::encoding::Decodable;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::Amount;
@@ -18,6 +17,7 @@ use fedimint_testing::btc::BitcoinTest;
 use fedimint_wallet::txoproof::TxOutProof;
 use futures::lock::Mutex;
 use lightning_invoice::Invoice;
+use url::Url;
 
 use crate::fixtures::LightningTest;
 
@@ -127,12 +127,10 @@ pub struct RealBitcoinTest {
 impl RealBitcoinTest {
     const ERROR: &'static str = "Bitcoin RPC returned an error";
 
-    pub fn new(rpc_cfg: &BitcoindRpcCfg) -> Self {
-        let client = Client::new(
-            &(rpc_cfg.btc_rpc_address),
-            Auth::UserPass(rpc_cfg.btc_rpc_user.clone(), rpc_cfg.btc_rpc_pass.clone()),
-        )
-        .expect(Self::ERROR);
+    pub fn new(bitcoind_rpc: &Url) -> Self {
+        let (url, auth) = fedimint_bitcoind::bitcoincore_rpc::from_url_to_url_auth(bitcoind_rpc)
+            .expect("requires a correct url");
+        let client = Client::new(&url, auth).expect(Self::ERROR);
 
         Self { client }
     }

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use anyhow::bail;
 use anyhow::format_err;
 use bitcoin::Network;
+use fedimint_api::config::ClientModuleConfig;
 use fedimint_api::config::TypedServerModuleConfig;
-use fedimint_api::config::{BitcoindRpcCfg, ClientModuleConfig};
 use fedimint_api::config::{TypedClientModuleConfig, TypedServerModuleConsensusConfig};
 use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::{Feerate, PeerId};
@@ -26,11 +26,7 @@ pub struct WalletConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct WalletConfigLocal {
-    #[serde(flatten)]
-    /// Configuration for connecting to our Bitcoin node
-    pub btc_rpc: BitcoindRpcCfg,
-}
+pub struct WalletConfigLocal;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WalletConfigPrivate {
@@ -134,7 +130,6 @@ impl WalletConfig {
         pubkeys: BTreeMap<PeerId, CompressedPublicKey>,
         sk: SecretKey,
         threshold: usize,
-        btc_rpc: BitcoindRpcCfg,
         network: Network,
         finality_delay: u32,
     ) -> Self {
@@ -143,7 +138,7 @@ impl WalletConfig {
         );
 
         Self {
-            local: WalletConfigLocal { btc_rpc },
+            local: WalletConfigLocal,
             private: WalletConfigPrivate { peg_in_key: sk },
             consensus: WalletConfigConsensus {
                 network,

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -21,8 +21,8 @@ use config::WalletConfigConsensus;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::TypedServerModuleConsensusConfig;
 use fedimint_api::config::{
-    BitcoindRpcCfg, ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ModuleConfigGenParams,
-    ServerModuleConfig, TypedServerModuleConfig,
+    ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ModuleConfigGenParams, ServerModuleConfig,
+    TypedServerModuleConfig,
 };
 use fedimint_api::core::{ModuleKey, MODULE_KEY_WALLET};
 use fedimint_api::db::{Database, DatabaseTransaction};
@@ -247,7 +247,6 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
                         .collect(),
                     *sk,
                     peers.threshold(),
-                    params.bitcoin_rpc.clone(),
                     params.network,
                     params.finality_delay,
                 );
@@ -304,7 +303,6 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
             peer_peg_in_keys,
             sk,
             peers.threshold(),
-            params.bitcoin_rpc.clone(),
             params.network,
             params.finality_delay,
         );
@@ -334,7 +332,6 @@ impl FederationModuleConfigGen for WalletConfigGenerator {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletConfigGenParams {
     pub network: bitcoin::network::constants::Network,
-    pub bitcoin_rpc: BitcoindRpcCfg,
     pub finality_delay: u32,
 }
 
@@ -814,7 +811,7 @@ impl Wallet {
         let bitcoind_net = bitcoind_rpc
             .get_network()
             .await
-            .map_err(|e| WalletError::RpcError(e.into()))?;
+            .map_err(WalletError::RpcError)?;
         if bitcoind_net != cfg.consensus.network {
             return Err(WalletError::WrongNetwork(
                 cfg.consensus.network,

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -20,6 +20,7 @@ echo "Running in temporary directory $FM_TEST_DIR"
 
 env | sed -En 's/(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
 
+export FEDIMINT_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443" # default bitcoind rpc port for regtest
 SHELL=$(which bash) tmuxinator local
 tmux -L fedimint-dev kill-session -t fedimint-dev || true
 pkill bitcoind


### PR DESCRIPTION
The wallet module already gets the API (`dyn Trait`) injected. It does not need to know by itself where is the bitcoin data comming from. It simplifies a lot of other things, where we don't need to fake things we don't need anyway.

The end application is responsible for providing wallet module with blockchain data: be that bitcoind rpc client, or (in the future) electrum client or something entirely different.

From an operational PoV, the bitcoind rpc port is also so important, that it's best to bring it upfront instead of hidding in a module config.