### PR TITLE
Convert the password to an env var

### DIFF
--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -32,7 +32,7 @@ bincode = "1.3.1"
 bitcoin = "0.29.2"
 bytes = "1.3.0"
 hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
-clap = { version = "4.0.29", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
+clap = { version = "4.0.29", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
 futures = "0.3.24"
 hex = "0.4.2"
 itertools = "0.10.5"

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -57,7 +57,7 @@ enum Command {
         name: String,
 
         /// The password that encrypts the configs, will prompt if not passed in
-        #[arg(long = "password")]
+        #[arg(env = "FM_PASSWORD")]
         password: Option<String>,
     },
     /// All peers must run distributed key gen at the same time to create configs
@@ -101,7 +101,7 @@ enum Command {
         finality_delay: u32,
 
         /// The password that encrypts the configs, will prompt if not passed in
-        #[arg(long = "password")]
+        #[arg(env = "FM_PASSWORD")]
         password: Option<String>,
     },
 
@@ -116,7 +116,7 @@ enum Command {
         #[arg(long = "salt-file")]
         salt_file: Option<PathBuf>,
         /// The password that encrypts the configs, will prompt if not passed in
-        #[arg(long = "password")]
+        #[arg(env = "FM_PASSWORD")]
         password: Option<String>,
     },
 
@@ -131,7 +131,7 @@ enum Command {
         #[arg(long = "salt-file")]
         salt_file: Option<PathBuf>,
         /// The password that encrypts the configs, will prompt if not passed in
-        #[arg(long = "password")]
+        #[arg(env = "FM_PASSWORD")]
         password: Option<String>,
     },
 }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -26,7 +26,7 @@ use tracing_subscriber::Layer;
 #[derive(Parser)]
 pub struct ServerOpts {
     pub cfg_path: PathBuf,
-    #[arg(default_value = None)]
+    #[arg(env = "FM_PASSWORD")]
     pub password: Option<String>,
     #[arg(default_value = None)]
     pub ui_port: Option<u32>,

--- a/fedimintd/src/encrypt.rs
+++ b/fedimintd/src/encrypt.rs
@@ -46,10 +46,7 @@ pub fn encrypted_read(key: &LessSafeKey, file: PathBuf) -> Vec<u8> {
 pub fn get_key(password: Option<String>, salt_path: PathBuf) -> LessSafeKey {
     let password = match password {
         None => rpassword::prompt_password("Enter a password to encrypt configs: ").unwrap(),
-        Some(password) => {
-            eprintln!("WARNING: Passing in a password from the command line may be less secure!");
-            password
-        }
+        Some(password) => password,
     };
 
     let salt_str = fs::read_to_string(salt_path).expect("Can't read salt file");

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,11 +46,12 @@ do
   mkdir $FM_CFG_DIR/server-$ID
   fed_port=$(echo "$BASE_PORT + $ID * 10" | bc -l)
   api_port=$(echo "$BASE_PORT + $ID * 10 + 1" | bc -l)
+  export FM_PASSWORD="pass$ID"
   if [ $ID -eq 0 ]; then
     # Test that the ports will default to $BASE_PORT and $BASE_PORT+1 if unspecified
-    $FM_BIN_DIR/distributedgen create-cert --p2p-url ws://localhost --api-url ws://localhost --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID" --password "pass$ID"
+    $FM_BIN_DIR/distributedgen create-cert --p2p-url ws://localhost --api-url ws://localhost --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID"
   else
-    $FM_BIN_DIR/distributedgen create-cert --p2p-url ws://localhost:$fed_port --api-url ws://localhost:$api_port --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID" --password "pass$ID"
+    $FM_BIN_DIR/distributedgen create-cert --p2p-url ws://localhost:$fed_port --api-url ws://localhost:$api_port --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID"
   fi
   CERTS="$CERTS,$(cat $FM_CFG_DIR/server-$ID/tls-cert)"
 done
@@ -59,9 +60,10 @@ echo "Running DKG with certs: $CERTS"
 
 for ((ID=0; ID<FM_FED_SIZE; ID++));
 do
+  export FM_PASSWORD="pass$ID"
   fed_port=$(echo "$BASE_PORT + $ID * 10" | bc -l)
   api_port=$(echo "$BASE_PORT + $ID * 10 + 1" | bc -l)
-  $FM_BIN_DIR/distributedgen run  --bind-p2p 127.0.0.1:$fed_port --bind-api 127.0.0.1:$api_port --out-dir $FM_CFG_DIR/server-$ID --certs $CERTS --password "pass$ID" &
+  $FM_BIN_DIR/distributedgen run  --bind-p2p 127.0.0.1:$fed_port --bind-api 127.0.0.1:$api_port --out-dir $FM_CFG_DIR/server-$ID --certs $CERTS &
 done
 wait
 

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -8,9 +8,11 @@ export PEG_IN_AMOUNT=10000
 source ./scripts/setup-tests.sh
 
 # Test config en/decryption tool
-$FM_DISTRIBUTEDGEN config-decrypt --in-file $FM_CFG_DIR/server-0/private.encrypt --out-file $FM_CFG_DIR/server-0/config-plaintext.json --password pass0
-$FM_DISTRIBUTEDGEN config-encrypt --in-file $FM_CFG_DIR/server-0/config-plaintext.json --out-file $FM_CFG_DIR/server-0/config-2 --password pass-foo
-$FM_DISTRIBUTEDGEN config-decrypt --in-file $FM_CFG_DIR/server-0/config-2 --out-file $FM_CFG_DIR/server-0/config-plaintext-2.json --password pass-foo
+export FM_PASSWORD=pass0
+$FM_DISTRIBUTEDGEN config-decrypt --in-file $FM_CFG_DIR/server-0/private.encrypt --out-file $FM_CFG_DIR/server-0/config-plaintext.json
+export FM_PASSWORD=pass-foo
+$FM_DISTRIBUTEDGEN config-encrypt --in-file $FM_CFG_DIR/server-0/config-plaintext.json --out-file $FM_CFG_DIR/server-0/config-2
+$FM_DISTRIBUTEDGEN config-decrypt --in-file $FM_CFG_DIR/server-0/config-2 --out-file $FM_CFG_DIR/server-0/config-plaintext-2.json
 cmp --silent $FM_CFG_DIR/server-0/config-plaintext.json $FM_CFG_DIR/server-0/config-plaintext-2.json
 
 ./scripts/start-fed.sh

--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -13,7 +13,8 @@ function generate_certs() {
     do
         mkdir -p $1/server-$ID
         base_port=$(echo "$BASE_PORT + $ID * 10" | bc -l)
-        docker run -v $1/server-$ID:/var/fedimint $2 distributedgen create-cert --announce-address ws://server-$ID --out-dir /var/fedimint --base-port $base_port --name "Server-$ID" --password "pass$ID"
+        export FM_PASSWORD="pass$ID"
+        docker run -v $1/server-$ID:/var/fedimint $2 distributedgen create-cert --announce-address ws://server-$ID --out-dir /var/fedimint --base-port $base_port --name "Server-$ID"
         CERTS="$CERTS,$(cat $1/server-$ID/tls-cert)"
     done
     export CERTS=${CERTS:1}
@@ -29,7 +30,7 @@ function run_dkg() {
         next_port=$(echo "$BASE_PORT + $ID * 10 + 1" | bc -l)
         echo "  server-$ID:" >> $3
         echo "    image: $2" >> $3
-        echo "    command: distributedgen run --out-dir /var/fedimint --certs $CERTS --password "pass$ID" --bind_address 0.0.0.0 --bitcoind-rpc bitcoind:18443" >> $3
+        echo "    command: distributedgen run --out-dir /var/fedimint --certs $CERTS --bind_address 0.0.0.0 --bitcoind-rpc bitcoind:18443" >> $3
         echo "    ports:" >> $3
         echo "      - $base_port:$base_port" >> $3
         echo "      - $next_port:$next_port" >> $3
@@ -37,6 +38,7 @@ function run_dkg() {
         echo "      - $1/server-$ID:/var/fedimint" >> $3
         echo "    environment:" >> $3
         echo "      - CERTS=$CERTS" >> $3
+        echo "      - FM_PASSWORD=pass$ID" >> $3
         echo "" >> $3
     done
 

--- a/scripts/start-fed.sh
+++ b/scripts/start-fed.sh
@@ -9,6 +9,7 @@ END_SERVER=${2:-$FM_FED_SIZE}
 # Start the federation members inside the temporary directory
 for ((ID=START_SERVER; ID<END_SERVER; ID++)); do
   echo "starting mint $ID"
-  ( ($FM_BIN_DIR/fedimintd $FM_CFG_DIR/server-$ID "pass$ID" 2>&1 & echo $! >&3 ) 3>>$FM_PID_FILE | sed -e "s/^/mint $ID: /" ) &
+  export FM_PASSWORD="pass$ID"
+  ( ($FM_BIN_DIR/fedimintd $FM_CFG_DIR/server-$ID 2>&1 & echo $! >&3 ) 3>>$FM_PID_FILE | sed -e "s/^/mint $ID: /" ) &
 done
 


### PR DESCRIPTION
Supports passing in passwords with environment variables which is safer than command-line.  Can still prompt users if the environment var is not set.

Fix #1176