### PR TITLE
Change gateway webserver default port to 8175

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -27,7 +27,7 @@ windows:
           - fg
         - ln1:
           - sleep 5 # wait for bitcoind and federation
-          - gateway-cli generate-config 127.0.0.1:8080 'http://127.0.0.1:8080' $FM_CFG_DIR #generate gateway config
+          - gateway-cli generate-config 127.0.0.1:8175 'http://127.0.0.1:8175' $FM_CFG_DIR #generate gateway config
           - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 --plugin=$FM_BIN_DIR/ln_gateway --fedimint-cfg=$FM_CFG_DIR &
           - echo $! >> $FM_PID_FILE
           - fg

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -62,7 +62,7 @@ Commands:
   help             Print this message or the help of the given subcommand(s)
 
 Options:
-  -a, --address <ADDRESS>          The address of the gateway webserver [default: http://127.0.0.1:8080]
+  -a, --address <ADDRESS>          The address of the gateway webserver [default: http://127.0.0.1:8175]
       --rpcpassword <RPCPASSWORD>  WARNING: Passing in a password from the command line may be less secure!
   -h, --help                       Print help information
   -V, --version                    Print version information

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -17,7 +17,7 @@ use url::Url;
 #[command(version)]
 struct Cli {
     /// The address of the gateway webserver
-    #[clap(short, long, default_value = "http://127.0.0.1:8080")]
+    #[clap(short, long, default_value = "http://127.0.0.1:8175")]
     address: Url,
     #[command(subcommand)]
     command: Commands,

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -65,7 +65,7 @@ function kill_fedimint_processes {
 }
 
 function start_gateway() {
-  $FM_GATEWAY_CLI generate-config '127.0.0.1:8080' 'http://127.0.0.1:8080' $FM_CFG_DIR # generate gateway config
+  $FM_GATEWAY_CLI generate-config '127.0.0.1:8175' 'http://127.0.0.1:8175' $FM_CFG_DIR # generate gateway config
   $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR &
   sleep 5 # wait for plugin to start
   gw_connect_fed


### PR DESCRIPTION
Port 8080 is somewhat common. Helps with  #1199. 8175 is one above the defaults ports used by `distributedgen`. I didn't test this manually at all.