### PR TITLE
Move PluginDecode trait bounds to definition

### DIFF
--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -212,7 +212,7 @@ macro_rules! newtype_impl_display_passthrough {
 ///
 /// All methods are static, as the decoding code is supposed to be instance-independent,
 /// at least until we start to support modules with overriden [`ModuleKey`]s
-pub trait PluginDecode: Debug {
+pub trait PluginDecode: Debug + Send + Sync + 'static {
     /// Decode `Input` compatible with this module, after the module key prefix was already decoded
     fn decode_input(r: &mut dyn io::Read) -> Result<Input, DecodeError>;
 

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -184,7 +184,6 @@ dyn_newtype_define!(
 impl<T> IServerModule for T
 where
     T: ServerModulePlugin + 'static + Sync,
-    <T as ServerModulePlugin>::Decoder: Sync + Send + 'static,
 {
     fn module_key(&self) -> ModuleKey {
         <Self as ServerModulePlugin>::module_key(self)


### PR DESCRIPTION
`Decoder` is an associated type in `ServerModulePlugin` and refers to `PluginDecode`.

This only moves the bounds. There is not functionality added or removed.