### PR TITLE
Redefine htlc intercept and processing spec

### DIFF
--- a/gateway/ln-gateway/proto/gatewaylnrpc.proto
+++ b/gateway/ln-gateway/proto/gatewaylnrpc.proto
@@ -12,10 +12,12 @@ service GatewayLightning {
    */
   rpc PayInvoice(PayInvoiceRequest) returns (PayInvoiceResponse) {}
 
-  /* SubscribeInterceptHtlcs opens a stream that intercepts specific HTLCs to be
-   * handled by the gateway  */
-  rpc SubscribeInterceptHtlcs(SubscribeInterceptHtlcsRequest)
-      returns (stream SubscribeInterceptHtlcsResponse) {}
+  /* InterceptHtlcs opens a stream for a client to receive specific HTLCs
+   * that have a specific short channel id. For every HTLC intercepted and
+   * processed, the client should stream back a Success or Failure response.
+   */
+  rpc InterceptHtlcs(stream InterceptHtlcsRequest)
+      returns (stream InterceptedHtlcResponse) {}
 }
 
 message GetPubKeyRequest {}
@@ -38,21 +40,73 @@ message PayInvoiceResponse {
   bytes preimage = 1;
 }
 
-message SubscribeInterceptHtlcsRequest {
-  // Subscribe to intercepted HTLCs with this short channel id
-  uint64 short_channel_id = 1;
+message InterceptHtlcsRequest {
+  message Subscribe {
+    // The short channel id of HTLCs to intercept
+    uint64 short_channel_id = 1;
+  }
+
+  message Settle {
+    // The preimage for settling an intercepted HTLC
+    bytes preimage = 1;
+  }
+
+  message Cancel {
+    // The reason for the cancellation of an intercepted HTLC
+    string reason = 1;
+  }
+
+  oneof action {
+    // Request to subscribe to HTLCs with a specific short channel id
+    //
+    // Send this request when the gateway just assigned a new channel id to a
+    // newly connected federation. GatewayLightning will respond with a stream
+    // of intercept HTLCs for the gateway to process
+    Subscribe subscribe = 1;
+
+    // Request to complete an intercepted HTLC with success result after
+    // processing
+    //
+    // Send this request when the gateway successfully processed intercepted
+    // HTLC GatewayLightning will settle/resolve the intercepted HTLC with
+    // reason provided.
+    Settle settle = 2;
+
+    // Request to complete an intercepted HTLC with failure result after
+    // processing
+    //
+    // Send this request when the gateway failed or canceled processing of
+    // intercepted HTLC. GatewayLightning will fail/cancel the intercepted HTLC
+    // with reason provided.
+    Cancel cancel = 3;
+  }
 }
 
-message SubscribeInterceptHtlcsResponse {
-  // The payment hash of the invoice
+message InterceptedHtlcResponse {
+
+  // The HTLC payment hash.
+  // Value is not guaranteed to be unique per intercepted HTLC
   bytes payment_hash = 1;
 
-  // The amount of the invoice
-  uint64 amount = 2;
+  // The incoming HTLC amount in millisatoshi.
+  // This amount minus the `outgoing_amount_msat` is the fee paid for processing
+  // this intercepted HTLC
+  uint64 incoming_amount_msat = 2;
 
-  // The denomination units of the invoice
-  string units = 3;
+  // The outgoing HTLC amount in millisatoshi
+  // This is the amount we should forward to the Federation if we successfully
+  // process this intercepted HTLC
+  uint64 outgoing_amount_msat = 3;
 
-  // The expiry of the invoice
-  uint64 expiry = 4;
+  // The incoming HTLC expiry
+  // Determines block height when the node will automatically cancel and revert
+  // the intercepted HTLC to sender if it is not settled.
+  uint32 incoming_expiry = 4;
+
+  // Reserved for getting more details about intercepted HTLC
+  reserved 5 to 9;
+
+  // The short channel id of the HTLC.
+  // Use this value to confirm relevance of the intercepted HTLC
+  uint64 short_channel_id = 10;
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -6,6 +6,10 @@ pub mod ln;
 pub mod rpc;
 pub mod utils;
 
+pub mod gatewaylnrpc {
+    tonic::include_proto!("gatewaylnrpc");
+}
+
 use std::{
     borrow::Cow,
     collections::HashMap,


### PR DESCRIPTION
Improve upon [GatewayLightning](https://github.com/fedimint/fedimint/blob/master/gateway/ln-gateway/proto/gatewaylnrpc.proto#L17:L19) `subscribe_intercept_htlcs` by defining a [bi-directional rpc](https://grpc.io/docs/what-is-grpc/core-concepts/#bidirectional-streaming-rpc) pattern for subscribing to intercept htlcs and responding after complete htlc processing by the client.

- For every new federation connected, the gateway **sends a request for HTLC interception**:
```
// example
let request = InterceptHtlcsRequest { action: Some(Action::Subscribe(Subscribe { short_channel_id: u64 })) };
let stream = client.intercept_htlcs(request).await?;
```
- For every HTLC intercepted and processed by the gateway:
  - Use this RPC to **send a request to settle the HTLC** if HTLC processing was successful
  ```
  // example
  let request = InterceptHtlcsRequest { action: Some(Action::Settle(Settle { preimage: [] })) };
  let stream = client.intercept_htlcs(request).await?;
  ```
  - Use this RPC to **send a request to cancel the HTLC** if HTLC processing failed, timed-out or was rejected for some other reason
  ```
  // example
  let request = InterceptHtlcsRequest { action: Some(Action::Cancel(Cancel { reason: "" })) };
  let stream = client.intercept_htlcs(request).await?;
  ```

The RPC action types applied here are defined in protobuf message types as `InterceptHtlcsRequest`

