### PR TITLE
Remove unnecessary static bound

### DIFF
--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -96,7 +96,7 @@ macro_rules! module_plugin_trait_define {
         where
             T: $plugin_ty + DynEncodable + 'static + Send + Sync,
         {
-            fn as_any(&self) -> &(dyn Any + 'static + Send + Sync) {
+            fn as_any(&self) -> &(dyn Any + Send + Sync) {
                 self
             }
 
@@ -310,7 +310,7 @@ impl Decoder {
 ///
 /// General purpose code should use [`Input`] instead
 pub trait ModuleInput: Debug + Display + DynEncodable {
-    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync);
+    fn as_any(&self) -> &(dyn Any + Send + Sync);
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> Input;
     fn dyn_hash(&self) -> u64;
@@ -342,7 +342,7 @@ newtype_impl_display_passthrough!(Input);
 ///
 /// General purpose code should use [`Output`] instead
 pub trait ModuleOutput: Debug + Display + DynEncodable {
-    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync);
+    fn as_any(&self) -> &(dyn Any + Send + Sync);
     fn module_key(&self) -> ModuleKey;
 
     fn clone(&self) -> Output;
@@ -375,7 +375,7 @@ pub enum FinalizationError {
 }
 
 pub trait ModuleOutputOutcome: Debug + Display + DynEncodable {
-    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync);
+    fn as_any(&self) -> &(dyn Any + Send + Sync);
     /// Module key
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> OutputOutcome;
@@ -415,7 +415,7 @@ newtype_impl_eq_passthrough!(OutputOutcome);
 newtype_impl_display_passthrough!(OutputOutcome);
 
 pub trait ModuleConsensusItem: Debug + Display + DynEncodable {
-    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync);
+    fn as_any(&self) -> &(dyn Any + Send + Sync);
     /// Module key
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> ConsensusItem;

--- a/fedimint-api/src/core/client.rs
+++ b/fedimint-api/src/core/client.rs
@@ -34,7 +34,7 @@ pub trait ClientModulePlugin: Debug {
 pub trait IClientModule: Debug {
     fn module_key(&self) -> ModuleKey;
 
-    fn as_any(&self) -> &(dyn Any + 'static);
+    fn as_any(&self) -> &dyn Any;
 
     /// Return the type-erased decoder of the module
     fn decoder(&self) -> Decoder;
@@ -54,7 +54,7 @@ where
         <T as ClientModulePlugin>::MODULE_KEY
     }
 
-    fn as_any(&self) -> &(dyn Any + 'static) {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -19,7 +19,7 @@ use crate::module::{
 };
 
 pub trait ModuleVerificationCache: Debug {
-    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync);
+    fn as_any(&self) -> &(dyn Any + Send + Sync);
     fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> VerificationCache;
 }
@@ -37,7 +37,7 @@ impl<T> ModuleVerificationCache for T
 where
     T: PluginVerificationCache + 'static,
 {
-    fn as_any(&self) -> &(dyn Any + 'static + Send + Sync) {
+    fn as_any(&self) -> &(dyn Any + Send + Sync) {
         self
     }
 
@@ -59,7 +59,7 @@ pub trait IServerModule: Debug {
     /// Returns the decoder belonging to the server module
     fn decoder(&self) -> Decoder;
 
-    fn as_any(&self) -> &(dyn Any + 'static);
+    fn as_any(&self) -> &dyn Any;
 
     /// Blocks until a new `consensus_proposal` is available.
     async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>);
@@ -194,7 +194,7 @@ where
         Decoder::from_typed(ServerModulePlugin::decoder(self))
     }
 
-    fn as_any(&self) -> &(dyn Any + 'static) {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 


### PR DESCRIPTION
`'static` is already required by `Any`.

If there was a deeper thought behind stating this explicitly, please tell