### PR TITLE
Fix incorrect string serialization of bitcoin::Network::Bitcoin

### DIFF
--- a/fedimintd/templates/params.html
+++ b/fedimintd/templates/params.html
@@ -42,7 +42,7 @@
           <label for="network1">Regtest</label>
           <input type="radio" id="network2" name="network" value="testnet">
           <label for="network2">Testnet</label>
-          <input type="radio" id="network3" name="network" value="mainnet">
+          <input type="radio" id="network3" name="network" value="bitcoin">
           <label for="network3">Mainnet</label>
         </div>
       </div>


### PR DESCRIPTION
String serialization of `bitcoin::Network::Bitcoin` is `bitcoin`, not `mainnet`. When setting up our test federation yesterday @m1sterc001guy and I had to edit the HTML manually to `bitcoin` but then it worked.