### PR TITLE
Fix failing cli-test.sh

### DIFF
--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -49,8 +49,8 @@ await_cln_block_processing
 $FM_MINT_CLIENT ln-pay $INVOICE
 # Check that ln-gateway has received the ecash notes from the user payment
 # 100,000 sats + 100 sats without processing fee
-FED_NAME="$(get_federation_name)"
-LN_GATEWAY_BALANCE="$($FM_GATEWAY_CLI balance $FED_NAME | jq -r '.balance_msat')"
+FED_ID="$(get_federation_id)"
+LN_GATEWAY_BALANCE="$($FM_GATEWAY_CLI balance $FED_ID | jq -r '.balance_msat')"
 [[ "$LN_GATEWAY_BALANCE" = "100100000" ]]
 INVOICE_RESULT="$($FM_LN2 waitinvoice test)"
 INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -115,8 +115,8 @@ function get_raw_transaction() {
     echo $TRANSACTION
 }
 
-function get_federation_name() {
-    cat $FM_CFG_DIR/client.json | jq -r '.federation_name'
+function get_federation_id() {
+    cat $FM_CFG_DIR/client.json | jq -r '.federation_id'
 }
 
 function show_verbose_output()

--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -16,10 +16,10 @@ USE_GATEWAY=${2:-0}
 FINALITY_DELAY=$(get_finality_delay)
 echo "Pegging in $PEG_IN_AMOUNT with confirmation in $FINALITY_DELAY blocks"
 
-FED_NAME="$(get_federation_name)"
+FED_ID="$(get_federation_id)"
 
 # get a peg-in address from either the gateway or the client
-if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($FM_GATEWAY_CLI address "$FED_NAME" | jq -r '.address')"; else ADDR="$($FM_MINT_CLIENT peg-in-address | jq -r '.address')"; fi
+if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($FM_GATEWAY_CLI address "$FED_ID" | jq -r '.address')"; else ADDR="$($FM_MINT_CLIENT peg-in-address | jq -r '.address')"; fi
 # send bitcoin to that address and save the txid
 TX_ID=$(send_bitcoin $ADDR $PEG_IN_AMOUNT)
 # wait for confirmation and wait for the fed to sync
@@ -31,7 +31,7 @@ TRANSACTION=$(get_raw_transaction $TX_ID)
 
 # With these proofs we can instruct the client to start the peg-in process. Our client will add the tweak used to derive
 # the peg-in address to the request so that the federation can claim the funds later.
-if [ "$USE_GATEWAY" == 1 ]; then $FM_GATEWAY_CLI deposit "$FED_NAME" "$TXOUT_PROOF" "$TRANSACTION"; else $FM_MINT_CLIENT peg-in "$TXOUT_PROOF" "$TRANSACTION"; fi
+if [ "$USE_GATEWAY" == 1 ]; then $FM_GATEWAY_CLI deposit "$FED_ID" "$TXOUT_PROOF" "$TRANSACTION"; else $FM_MINT_CLIENT peg-in "$TXOUT_PROOF" "$TRANSACTION"; fi
 
 # Since the process is asynchronous have to come back to fetch the result later. We choose to do this right away and
 # just block till we get our tokens.


### PR DESCRIPTION
@NicolaLS discovered `cli-test.sh` was silently failing due to passing in the fed name as id (which now needs to be a hex pubkey).