### PR TITLE
request payment of multiple invoices in a stream

### DIFF
--- a/gateway/ln-gateway/proto/gatewaylnrpc.proto
+++ b/gateway/ln-gateway/proto/gatewaylnrpc.proto
@@ -8,9 +8,11 @@ service GatewayLightning {
   /* GetPubKey returns the public key of the associated lightning node */
   rpc GetPubKey(GetPubKeyRequest) returns (GetPubKeyResponse) {}
 
-  /* PayInvoice attempts to pay an invoice using the associated lightning node
+  /* PayInvoice allows a client to stream requests to to pay any number of
+   * invoices using the associated lightning node
    */
-  rpc PayInvoice(PayInvoiceRequest) returns (PayInvoiceResponse) {}
+  rpc PayInvoice(stream PayInvoiceRequest) returns (stream PayInvoiceResponse) {
+  }
 
   /* SubscribeInterceptHtlcs opens a stream that intercepts specific HTLCs to be
    * handled by the gateway  */


### PR DESCRIPTION
Inspired by [this discussion](https://github.com/fedimint/fedimint/pull/1224#discussion_r1064215899). Allows lnrpc clients used by `gatewayd` to batch pay invoice operations and stream them to `pay_invoice`