### PR TITLE
Initial one-"docker run"-command docker image

### DIFF
--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -33,7 +33,7 @@ enum Command {
     /// Creates a connection cert string that must be shared with all other peers
     CreateCert {
         /// Directory to output all the generated config files
-        #[arg(long = "out-dir")]
+        #[arg(long = "out-dir", env = "FM_DATA_DIR")]
         dir_out_path: PathBuf,
 
         /// Our API address for clients to connect to us

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -30,7 +30,7 @@ pub struct ServerOpts {
     #[arg(env = "FM_PASSWORD")]
     pub password: Option<String>,
     /// Port to run admin UI on
-    #[arg(long = "ui-bind", default_value = None)]
+    #[arg(long = "ui-bind", env = "FM_LISTEN_UI")]
     pub ui_bind: Option<SocketAddr>,
     #[cfg(feature = "telemetry")]
     #[clap(long)]

--- a/misc/fedimintd-container-entrypoint.sh
+++ b/misc/fedimintd-container-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# if command specified - run it inside
+if [ -n "$*" ]; then
+ exec "$@"
+fi
+
+if [ -z "$FM_DATA_DIR" ]; then
+  1>&2 echo "Must provide FM_DATA_DIR environment variable"
+  exit 1
+fi
+
+if [ -z "$FM_PASSWORD" ]; then
+  1>&2 echo "Must provide FM_PASSWORD environment variable"
+  exit 1
+fi
+
+if [ ! -e "$FM_DATA_DIR" ]; then
+  1>&2 echo "Creating $FM_DATA_DIR"
+  mkdir -p "$FM_DATA_DIR" && chmod 0600 "$FM_DATA_DIR"
+fi
+
+mkdir -p "$FM_DATA_DIR"
+
+export FM_LISTEN_UI=0.0.0.0:8175
+
+1>&2 echo 'Starting fedimintd'
+env RUST_LOG=debug fedimintd "$FM_DATA_DIR/"


### PR DESCRIPTION
Test with:

```sh
nix build .#container.fedimintd
docker load < result
docker run -e FM_PASSWORD=password -e FM_DATA_DIR=/data -v $PWD/data:/data -p 8173:8173 -p 8174:8174 -p 8175:8175 -it fedimintd:container-tag-from-previous-command

xdg-open http://localhost:8175/
```

Once it lands it should be just:

```sh
docker run -e FM_PASSWORD=password -e FM_DATA_DIR=/data -v $PWD/data:/data -p 8173:8173 -p 8174:8174 -p 8175:8175 -it fedimint/fedimintd:master
```

Seems to work, but there's bunch of things I'd like to do before this works well.

Created #1251 for some follow-ups.