### PR TITLE
Persist the code version when fedimintd starts up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,8 @@ dependencies = [
  "secp256k1-zkp",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "tbs",
  "test-log",
  "thiserror",

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -26,6 +26,8 @@ rand = "0.8.5"
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.89"
+strum = "0.24"
+strum_macros = "0.24"
 tbs = { path = "../crypto/tbs"}
 thiserror = "1.0.37"
 threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use serde::Serialize;
+use strum_macros::EnumIter;
 use thiserror::Error;
 use tracing::{trace, warn};
 
@@ -66,6 +68,27 @@ dyn_newtype_define! {
     /// A handle to a type-erased database implementation
     #[derive(Clone)]
     pub Database(Arc<IDatabase>)
+}
+
+#[repr(u8)]
+#[derive(Clone, EnumIter, Debug)]
+pub enum DbKeyPrefix {
+    DatabaseVersion = 0x50,
+}
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct DatabaseVersionKey;
+
+impl DatabaseKeyPrefixConst for DatabaseVersionKey {
+    const DB_PREFIX: u8 = DbKeyPrefix::DatabaseVersion as u8;
+    type Key = Self;
+    type Value = String;
+}
+
+impl std::fmt::Display for DbKeyPrefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 /// Fedimint requires that the database implementation implement Snapshot Isolation.


### PR DESCRIPTION
In preparation for [Database Migrations](https://github.com/fedimint/fedimint/pull/1229/files), we will need a mechanism for determining when the code version of fedimintd has changed. We already have the code version in the config file, this PR modifies fedimintd so that value is persisted in the database.

Currently, if the code version already exists in the database, we don't do anything and simply output a log message. This is when we'll need to perform the migration. If the code version is not in the database, we persist it. If it is in the database and it matches the current code version, we also just log and continue.

Used dbdump and tmuxinator to verify that the value is persisted correctly.