### PR TITLE
More consistent address and port variable naming

### DIFF
--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -54,13 +54,13 @@ pub async fn run_server(
         attach_endpoints_erased(&mut rpc_module, module);
     }
 
-    debug!(addr = cfg.local.api_bind.to_string(), "Starting WSServer");
+    debug!(addr = cfg.local.listen_api.to_string(), "Starting WSServer");
     let server = ServerBuilder::new()
         .max_connections(cfg.local.max_connections)
         .ping_interval(Duration::from_secs(10))
-        .build(&cfg.local.api_bind.to_string())
+        .build(&cfg.local.listen_api.to_string())
         .await
-        .context(format!("Bind address: {}", cfg.local.api_bind))
+        .context(format!("Bind address: {}", cfg.local.listen_api))
         .expect("Could not start API server");
 
     let server_handle = server

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -37,12 +37,12 @@ enum Command {
         dir_out_path: PathBuf,
 
         /// Our API address for clients to connect to us
-        #[arg(long = "api-url")]
-        api_url: Url,
+        #[arg(long = "url-p2p")]
+        url_api: Url,
 
         /// Our external address for communicating with our peers
-        #[arg(long = "p2p-url")]
-        p2p_url: Url,
+        #[arg(long = "url-p2p")]
+        url_p2p: Url,
 
         /// Our node name, must be unique among peers
         #[arg(long = "name")]
@@ -59,12 +59,12 @@ enum Command {
         dir_out_path: PathBuf,
 
         /// Address we bind to for federation communication
-        #[arg(long = "bind-p2p", default_value = "127.0.0.1:8173")]
-        bind_p2p: SocketAddr,
+        #[arg(long = "listen-p2p", default_value = "127.0.0.1:8173")]
+        listen_p2p: SocketAddr,
 
         /// Address we bind to for exposing the API
-        #[arg(long = "bind-api", default_value = "127.0.0.1:8174")]
-        bind_api: SocketAddr,
+        #[arg(long = "listen-api", default_value = "127.0.0.1:8174")]
+        listen_api: SocketAddr,
 
         /// Federation name, same for all peers
         #[arg(long = "federation-name", default_value = "Hals_trusty_mint")]
@@ -151,20 +151,20 @@ async fn main() {
     match command {
         Command::CreateCert {
             dir_out_path,
-            p2p_url,
-            api_url,
+            url_p2p,
+            url_api,
             name,
             password,
         } => {
-            let config_str = create_cert(dir_out_path, p2p_url, api_url, name, password);
+            let config_str = create_cert(dir_out_path, url_p2p, url_api, name, password);
             println!("{}", config_str);
         }
         Command::Run {
             dir_out_path,
             federation_name,
             certs,
-            bind_p2p,
-            bind_api,
+            listen_p2p,
+            listen_api,
             bitcoind_rpc,
             max_denomination,
             network,
@@ -174,8 +174,8 @@ async fn main() {
             let key = get_key(password, dir_out_path.join(SALT_FILE));
             let pk_bytes = encrypted_read(&key, dir_out_path.join(TLS_PK));
             let server = if let Ok(v) = run_dkg(
-                bind_p2p,
-                bind_api,
+                listen_p2p,
+                listen_api,
                 &dir_out_path,
                 max_denomination,
                 federation_name,

--- a/fedimintd/templates/params.html
+++ b/fedimintd/templates/params.html
@@ -14,20 +14,20 @@
       <input type="text" class="form-control" id="federation_name" name="federation_name" placeholder="Cypherpunk Federation">
     </div>
     <div class="form-group">
-      <label for="bind_p2p">P2P Listen Address</label>
-      <input type="text" class="form-control" id="bind_p2p" name="bind_p2p" placeholder="127.0.0.1:8173" />
+      <label for="listen_p2p">P2P Listen Address</label>
+      <input type="text" class="form-control" id="listen_p2p" name="listen_p2p" placeholder="127.0.0.1:8173" />
     </div>
     <div class="form-group">
-      <label for="p2p_url">P2P Public URL</label>
-      <input type="text" class="form-control" id="p2p_url" name="p2p_url" placeholder="wss://p2p.your-website.com" />
+      <label for="url_p2p">P2P Public URL</label>
+      <input type="text" class="form-control" id="url_p2p" name="url_p2p" placeholder="wss://p2p.your-website.com" />
     </div>
     <div class="form-group">
-      <label for="bind_api">API Listen Address</label>
-      <input type="text" class="form-control" id="bind_api" name="bind_api" placeholder="127.0.0.1:8174" />
+      <label for="listen_api">API Listen Address</label>
+      <input type="text" class="form-control" id="listen_api" name="listen_api" placeholder="127.0.0.1:8174" />
     </div>
     <div class="form-group">
-      <label for="api_url">API Public URL</label>
-      <input type="text" class="form-control" id="api_url" name="api_url" placeholder="wss://api.your-website.com" />
+      <label for="url_api">API Public URL</label>
+      <input type="text" class="form-control" id="url_api" name="url_api" placeholder="wss://api.your-website.com" />
     </div>
     <div class="form-group">
       <label for="bitcoind_rpc">Bitcoin RPC Addr and Port</label>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -51,9 +51,9 @@ do
   export FM_PASSWORD="pass$ID"
   if [ $ID -eq 0 ]; then
     # Test that the ports will default to $BASE_PORT and $BASE_PORT+1 if unspecified
-    $FM_BIN_DIR/distributedgen create-cert --p2p-url ws://localhost --api-url ws://localhost --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID"
+    $FM_BIN_DIR/distributedgen create-cert --url-p2p ws://localhost --url-api ws://localhost --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID"
   else
-    $FM_BIN_DIR/distributedgen create-cert --p2p-url ws://localhost:$fed_port --api-url ws://localhost:$api_port --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID"
+    $FM_BIN_DIR/distributedgen create-cert --url-p2p ws://localhost:$fed_port --url-api ws://localhost:$api_port --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID"
   fi
   CERTS="$CERTS,$(cat $FM_CFG_DIR/server-$ID/tls-cert)"
 done


### PR DESCRIPTION
For public APIs, use the word "listen" instead of "bind". Inspired by `--listen` comment here https://github.com/fedimint/fedimint/issues/1251.

We had `api_bind` and `bind_p2p` which was kind of confusing because they were ordered in reverse. Switched to `listen_api` and `listen_p2p`. Inspired by https://github.com/fedimint/fedimint/pull/1261#discussion_r1065034821

 Some internal structs still called "bind" and gateway config still uses "bind. Should I change them, too?