### PR TITLE
Don't inject a default port into API URLs

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -38,7 +38,7 @@ use fedimint_api::{sats, Amount};
 use fedimint_bitcoind::BitcoindRpc;
 use fedimint_ln::{LightningGateway, LightningModuleConfigGen};
 use fedimint_mint::{MintConfigGenerator, MintOutput};
-use fedimint_server::config::{connect, ServerConfig, DEFAULT_P2P_PORT};
+use fedimint_server::config::{connect, ServerConfig};
 use fedimint_server::config::{ModuleInitRegistry, ServerConfigParams};
 use fedimint_server::consensus::{ConsensusProposal, HbbftConsensusOutcome};
 use fedimint_server::consensus::{FedimintConsensus, TransactionSubmissionError};
@@ -84,6 +84,7 @@ mod fake;
 mod real;
 mod utils;
 
+const DEFAULT_P2P_PORT: u16 = 8173;
 const BASE_PORT_INIT: u16 = DEFAULT_P2P_PORT + 10000;
 static BASE_PORT: AtomicU16 = AtomicU16::new(BASE_PORT_INIT);
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,12 +49,7 @@ do
   fed_port=$(echo "$BASE_PORT + $ID * 10" | bc -l)
   api_port=$(echo "$BASE_PORT + $ID * 10 + 1" | bc -l)
   export FM_PASSWORD="pass$ID"
-  if [ $ID -eq 0 ]; then
-    # Test that the ports will default to $BASE_PORT and $BASE_PORT+1 if unspecified
-    $FM_BIN_DIR/distributedgen create-cert --p2p-url ws://localhost --api-url ws://localhost --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID"
-  else
-    $FM_BIN_DIR/distributedgen create-cert --p2p-url ws://localhost:$fed_port --api-url ws://localhost:$api_port --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID"
-  fi
+  $FM_BIN_DIR/distributedgen create-cert --p2p-url ws://localhost:$fed_port --api-url ws://localhost:$api_port --out-dir $FM_CFG_DIR/server-$ID --name "Server-$ID"
   CERTS="$CERTS,$(cat $FM_CFG_DIR/server-$ID/tls-cert)"
 done
 CERTS=${CERTS:1}


### PR DESCRIPTION
Closes #1263

I just don't think injecting a default port is useful or needed. Eric and I just setup a federation via UI and were surprised that a port was injected into the URL we put into the UI.