### PR TITLE
Split `ModuleKey` into `ModuleInstanceId` & `ModuleKind`

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -7,6 +7,10 @@ use async_trait::async_trait;
 use bitcoin::{Address, Amount};
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use fedimint_api::config::ClientConfig;
+use fedimint_api::core::{
+    LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+    LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::task::{sleep, RwLock, RwLockWriteGuard};
 use fedimint_api::{dyn_newtype_define, NumPeers, OutPoint, PeerId, TransactionId};
@@ -306,7 +310,7 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
 
     async fn fetch_contract(&self, contract: ContractId) -> Result<ContractAccount> {
         self.request(
-            "/ln/account",
+            &format!("/module/{}/account", LEGACY_HARDCODED_INSTANCE_ID_LN),
             contract,
             Retry404::new(self.peers().one_honest()),
         )
@@ -315,7 +319,10 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
 
     async fn fetch_consensus_block_height(&self) -> Result<u64> {
         self.request(
-            "/wallet/block_height",
+            &format!(
+                "/module/{}/block_height",
+                LEGACY_HARDCODED_INSTANCE_ID_WALLET
+            ),
             (),
             EventuallyConsistent::new(self.peers().one_honest()),
         )
@@ -328,7 +335,10 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
         amount: &Amount,
     ) -> Result<Option<PegOutFees>> {
         self.request(
-            "/wallet/peg_out_fees",
+            &format!(
+                "/module/{}/peg_out_fees",
+                LEGACY_HARDCODED_INSTANCE_ID_WALLET
+            ),
             (address, amount.to_sat()),
             EventuallyConsistent::new(self.peers().one_honest()),
         )
@@ -337,7 +347,7 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
 
     async fn fetch_offer(&self, payment_hash: Sha256Hash) -> Result<IncomingContractOffer> {
         self.request(
-            "/ln/offer",
+            &format!("/module/{}/offer", LEGACY_HARDCODED_INSTANCE_ID_LN),
             payment_hash,
             Retry404::new(self.peers().one_honest()),
         )
@@ -346,7 +356,7 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
 
     async fn fetch_gateways(&self) -> Result<Vec<LightningGateway>> {
         self.request(
-            "/ln/list_gateways",
+            &format!("/module/{}/list_gateways", LEGACY_HARDCODED_INSTANCE_ID_LN),
             (),
             UnionResponses::new(self.peers().one_honest()),
         )
@@ -355,7 +365,10 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
 
     async fn register_gateway(&self, gateway: LightningGateway) -> Result<()> {
         self.request(
-            "/ln/register_gateway",
+            &format!(
+                "/module/{}/register_gateway",
+                LEGACY_HARDCODED_INSTANCE_ID_LN
+            ),
             gateway,
             CurrentConsensus::new(self.peers().threshold()),
         )
@@ -365,7 +378,7 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
     async fn offer_exists(&self, payment_hash: Sha256Hash) -> Result<bool> {
         let res: Result<IncomingContractOffer> = self
             .request(
-                "/ln/offer",
+                &format!("/module/{}/offer", LEGACY_HARDCODED_INSTANCE_ID_LN),
                 payment_hash,
                 CurrentConsensus::new(self.peers().one_honest()),
             )
@@ -383,7 +396,7 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
         request: &fedimint_mint::SignedBackupRequest,
     ) -> Result<()> {
         self.request(
-            "/mint/backup",
+            &format!("/module/{}/backup", LEGACY_HARDCODED_INSTANCE_ID_MINT),
             request,
             CurrentConsensus::new(self.peers().threshold()),
         )
@@ -396,7 +409,7 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
     ) -> Result<Vec<ECashUserBackupSnapshot>> {
         Ok(self
             .request_complex(
-                "/mint/recover",
+                &format!("/module/{}/recover", LEGACY_HARDCODED_INSTANCE_ID_MINT),
                 id,
                 UnionResponsesSingle::<Option<ECashUserBackupSnapshot>>::new(
                     self.peers().one_honest(),

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -376,15 +376,15 @@ mod tests {
             let mint = self.mint.lock().await;
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
-                outputs: vec![SerdeOutputOutcome::from(&OutputOutcome::from((
+                outputs: vec![SerdeOutputOutcome::from(&OutputOutcome::from_typed(
+                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
                     mint.output_outcome(OutPoint {
                         txid: tx,
                         out_idx: 0,
                     })
                     .await
                     .unwrap(),
-                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                )))],
+                ))],
             })
         }
 

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -16,6 +16,7 @@ use std::{
 use anyhow::Result;
 use fedimint_api::{
     cancellable::{Cancellable, Cancelled},
+    core::LEGACY_HARDCODED_INSTANCE_ID_MINT,
     task::{TaskGroup, TaskHandle},
     NumPeers, PeerId,
 };
@@ -801,7 +802,7 @@ impl EcashRecoveryTracker {
                 }
 
                 for input in &tx.inputs {
-                    if input.module_key() == MODULE_KEY_MINT {
+                    if input.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_MINT {
                         let input = input
                             .as_any()
                             .downcast_ref::<MintInput>()
@@ -812,7 +813,7 @@ impl EcashRecoveryTracker {
                 }
 
                 for (out_idx, output) in tx.outputs.iter().enumerate() {
-                    if output.module_key() == MODULE_KEY_MINT {
+                    if output.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_MINT {
                         let output = output
                             .as_any()
                             .downcast_ref::<MintOutput>()
@@ -829,7 +830,7 @@ impl EcashRecoveryTracker {
                 }
             }
             ConsensusItem::Module(module_item) => {
-                if module_item.module_key() == MODULE_KEY_MINT {
+                if module_item.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_MINT {
                     let mint_item = module_item
                         .as_any()
                         .downcast_ref::<MintOutputConfirmation>()

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
-use fedimint_api::{msats, Amount, OutPoint, PeerId, Tiered, TieredMulti};
+use fedimint_api::{
+    core::LEGACY_HARDCODED_INSTANCE_ID_MINT, msats, Amount, OutPoint, PeerId, Tiered, TieredMulti,
+};
 use fedimint_core::{
     epoch::ConsensusItem,
     modules::mint::{
@@ -341,7 +343,7 @@ fn sanity_check_recovery_fresh_backup() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![output_c1_a.clone().into()],
+        outputs: vec![(output_c1_a.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
         signature: None,
     };
 
@@ -369,7 +371,13 @@ fn sanity_check_recovery_fresh_backup() {
     for _ in 0..3 {
         tracker.handle_consensus_item(
             confirmations_c1_a[0].0,
-            &ConsensusItem::Module(confirmations_c1_a[0].1.clone().into()),
+            &ConsensusItem::Module(
+                (
+                    confirmations_c1_a[0].1.clone(),
+                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                )
+                    .into(),
+            ),
             &mut Default::default(),
             &Default::default(),
         );
@@ -389,7 +397,13 @@ fn sanity_check_recovery_fresh_backup() {
     for wrong_peer_i in 1..2 {
         tracker.handle_consensus_item(
             confirmations_c1_a[wrong_peer_i].0,
-            &ConsensusItem::Module(confirmations_c1_a[0].1.clone().into()),
+            &ConsensusItem::Module(
+                (
+                    confirmations_c1_a[0].1.clone(),
+                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                )
+                    .into(),
+            ),
             &mut Default::default(),
             &Default::default(),
         );
@@ -409,7 +423,13 @@ fn sanity_check_recovery_fresh_backup() {
     for (peer_id, mint_output_confirmation) in &confirmations_c1_a {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(mint_output_confirmation.clone().into()),
+            &ConsensusItem::Module(
+                (
+                    mint_output_confirmation.clone(),
+                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                )
+                    .into(),
+            ),
             &mut Default::default(),
             &Default::default(),
         );
@@ -427,8 +447,12 @@ fn sanity_check_recovery_fresh_backup() {
 
     // Spend the notes, which should remove them from the tracker
     let tx_b = Transaction {
-        inputs: vec![c1.generate_input(notes_c1_a).into()],
-        outputs: vec![output_c1_a.into()],
+        inputs: vec![(
+            c1.generate_input(notes_c1_a),
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
+        )
+            .into()],
+        outputs: vec![(output_c1_a, LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
         signature: None,
     };
 
@@ -461,7 +485,10 @@ fn sanity_check_recovery_non_empty_backup() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![output_c1_a0.clone().into(), output_c1_a1.clone().into()],
+        outputs: vec![
+            (output_c1_a0.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
+            (output_c1_a1.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
+        ],
         signature: None,
     };
 
@@ -500,7 +527,11 @@ fn sanity_check_recovery_non_empty_backup() {
 
     // Spend the notes, which should remove them from the tracker
     let tx_b = Transaction {
-        inputs: vec![c1.generate_input(notes_c1_a0).into()],
+        inputs: vec![(
+            c1.generate_input(notes_c1_a0),
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
+        )
+            .into()],
         outputs: vec![],
         signature: None,
     };
@@ -516,7 +547,13 @@ fn sanity_check_recovery_non_empty_backup() {
     for (peer_id, mint_output_confirmation) in &confirmations_c1_a1 {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(mint_output_confirmation.clone().into()),
+            &ConsensusItem::Module(
+                (
+                    mint_output_confirmation.clone(),
+                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                )
+                    .into(),
+            ),
             &mut Default::default(),
             &Default::default(),
         );
@@ -567,7 +604,7 @@ fn sanity_check_recovery_bn_reuse_with_invalid_amount() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![output_c2_a.clone().into()],
+        outputs: vec![(output_c2_a.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
         signature: None,
     };
     let output_c1_a_out_point = OutPoint {
@@ -577,7 +614,7 @@ fn sanity_check_recovery_bn_reuse_with_invalid_amount() {
 
     let tx_b = Transaction {
         inputs: vec![],
-        outputs: vec![output_c1_b.into()],
+        outputs: vec![(output_c1_b, LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
         signature: None,
     };
     let output_c1_b_out_point = OutPoint {
@@ -643,7 +680,7 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![output_c2_a.clone().into()],
+        outputs: vec![(output_c2_a.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
         signature: None,
     };
     let output_c2_a_out_point = OutPoint {
@@ -653,7 +690,7 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
 
     let tx_b = Transaction {
         inputs: vec![],
-        outputs: vec![output_c1_b.clone().into()],
+        outputs: vec![(output_c1_b.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
         signature: None,
     };
     let output_c1_b_out_point = OutPoint {
@@ -686,7 +723,13 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
     for (peer_id, mint_output_confirmation) in &confirmations_c2_a {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(mint_output_confirmation.clone().into()),
+            &ConsensusItem::Module(
+                (
+                    mint_output_confirmation.clone(),
+                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                )
+                    .into(),
+            ),
             &mut Default::default(),
             &Default::default(),
         );
@@ -699,7 +742,13 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
     for (peer_id, mint_output_confirmation) in &confirmations_c1_b {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(mint_output_confirmation.clone().into()),
+            &ConsensusItem::Module(
+                (
+                    mint_output_confirmation.clone(),
+                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                )
+                    .into(),
+            ),
             &mut Default::default(),
             &Default::default(),
         );

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
 use fedimint_api::{
-    core::LEGACY_HARDCODED_INSTANCE_ID_MINT, msats, Amount, OutPoint, PeerId, Tiered, TieredMulti,
+    core::{self, Output, LEGACY_HARDCODED_INSTANCE_ID_MINT},
+    msats, Amount, OutPoint, PeerId, Tiered, TieredMulti,
 };
 use fedimint_core::{
     epoch::ConsensusItem,
@@ -343,7 +344,10 @@ fn sanity_check_recovery_fresh_backup() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![(output_c1_a.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
+        outputs: vec![Output::from_typed(
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
+            output_c1_a.clone(),
+        )],
         signature: None,
     };
 
@@ -371,13 +375,10 @@ fn sanity_check_recovery_fresh_backup() {
     for _ in 0..3 {
         tracker.handle_consensus_item(
             confirmations_c1_a[0].0,
-            &ConsensusItem::Module(
-                (
-                    confirmations_c1_a[0].1.clone(),
-                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                )
-                    .into(),
-            ),
+            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+                LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                confirmations_c1_a[0].1.clone(),
+            )),
             &mut Default::default(),
             &Default::default(),
         );
@@ -397,13 +398,10 @@ fn sanity_check_recovery_fresh_backup() {
     for wrong_peer_i in 1..2 {
         tracker.handle_consensus_item(
             confirmations_c1_a[wrong_peer_i].0,
-            &ConsensusItem::Module(
-                (
-                    confirmations_c1_a[0].1.clone(),
-                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                )
-                    .into(),
-            ),
+            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+                LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                confirmations_c1_a[0].1.clone(),
+            )),
             &mut Default::default(),
             &Default::default(),
         );
@@ -423,13 +421,10 @@ fn sanity_check_recovery_fresh_backup() {
     for (peer_id, mint_output_confirmation) in &confirmations_c1_a {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(
-                (
-                    mint_output_confirmation.clone(),
-                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                )
-                    .into(),
-            ),
+            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+                LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                mint_output_confirmation.clone(),
+            )),
             &mut Default::default(),
             &Default::default(),
         );
@@ -447,12 +442,14 @@ fn sanity_check_recovery_fresh_backup() {
 
     // Spend the notes, which should remove them from the tracker
     let tx_b = Transaction {
-        inputs: vec![(
-            c1.generate_input(notes_c1_a),
+        inputs: vec![core::Input::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
-        )
-            .into()],
-        outputs: vec![(output_c1_a, LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
+            c1.generate_input(notes_c1_a),
+        )],
+        outputs: vec![core::Output::from_typed(
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
+            output_c1_a,
+        )],
         signature: None,
     };
 
@@ -486,8 +483,8 @@ fn sanity_check_recovery_non_empty_backup() {
     let tx_a = Transaction {
         inputs: vec![],
         outputs: vec![
-            (output_c1_a0.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
-            (output_c1_a1.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
+            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, output_c1_a0.clone()),
+            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, output_c1_a1.clone()),
         ],
         signature: None,
     };
@@ -527,11 +524,10 @@ fn sanity_check_recovery_non_empty_backup() {
 
     // Spend the notes, which should remove them from the tracker
     let tx_b = Transaction {
-        inputs: vec![(
-            c1.generate_input(notes_c1_a0),
+        inputs: vec![core::Input::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
-        )
-            .into()],
+            c1.generate_input(notes_c1_a0),
+        )],
         outputs: vec![],
         signature: None,
     };
@@ -547,13 +543,10 @@ fn sanity_check_recovery_non_empty_backup() {
     for (peer_id, mint_output_confirmation) in &confirmations_c1_a1 {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(
-                (
-                    mint_output_confirmation.clone(),
-                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                )
-                    .into(),
-            ),
+            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+                LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                mint_output_confirmation.clone(),
+            )),
             &mut Default::default(),
             &Default::default(),
         );
@@ -604,7 +597,10 @@ fn sanity_check_recovery_bn_reuse_with_invalid_amount() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![(output_c2_a.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
+        outputs: vec![core::Output::from_typed(
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
+            output_c2_a.clone(),
+        )],
         signature: None,
     };
     let output_c1_a_out_point = OutPoint {
@@ -614,7 +610,10 @@ fn sanity_check_recovery_bn_reuse_with_invalid_amount() {
 
     let tx_b = Transaction {
         inputs: vec![],
-        outputs: vec![(output_c1_b, LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
+        outputs: vec![core::Output::from_typed(
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
+            output_c1_b,
+        )],
         signature: None,
     };
     let output_c1_b_out_point = OutPoint {
@@ -680,7 +679,10 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![(output_c2_a.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
+        outputs: vec![core::Output::from_typed(
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
+            output_c2_a.clone(),
+        )],
         signature: None,
     };
     let output_c2_a_out_point = OutPoint {
@@ -690,7 +692,10 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
 
     let tx_b = Transaction {
         inputs: vec![],
-        outputs: vec![(output_c1_b.clone(), LEGACY_HARDCODED_INSTANCE_ID_MINT).into()],
+        outputs: vec![core::Output::from_typed(
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
+            output_c1_b.clone(),
+        )],
         signature: None,
     };
     let output_c1_b_out_point = OutPoint {
@@ -723,13 +728,10 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
     for (peer_id, mint_output_confirmation) in &confirmations_c2_a {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(
-                (
-                    mint_output_confirmation.clone(),
-                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                )
-                    .into(),
-            ),
+            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+                LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                mint_output_confirmation.clone(),
+            )),
             &mut Default::default(),
             &Default::default(),
         );
@@ -742,13 +744,10 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
     for (peer_id, mint_output_confirmation) in &confirmations_c1_b {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(
-                (
-                    mint_output_confirmation.clone(),
-                    LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                )
-                    .into(),
-            ),
+            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+                LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                mint_output_confirmation.clone(),
+            )),
             &mut Default::default(),
             &Default::default(),
         );

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -707,16 +707,15 @@ mod tests {
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
                 outputs: vec![SerdeOutputOutcome::from(
-                    &((
+                    &(fedimint_api::core::OutputOutcome::from_typed(
+                        LEGACY_HARDCODED_INSTANCE_ID_MINT,
                         mint.output_outcome(OutPoint {
                             txid: tx,
                             out_idx: 0,
                         })
                         .await
                         .unwrap(),
-                        LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                    )
-                        .into()),
+                    )),
                 )],
             })
         }

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -239,11 +239,10 @@ mod tests {
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
                 outputs: vec![SerdeOutputOutcome::from(
-                    &(
-                        (WalletOutputOutcome(Txid::from_slice([0; 32].as_slice()).unwrap())),
+                    &fedimint_api::core::OutputOutcome::from_typed(
                         LEGACY_HARDCODED_INSTANCE_ID_WALLET,
-                    )
-                        .into(),
+                        WalletOutputOutcome(Txid::from_slice([0; 32].as_slice()).unwrap()),
+                    ),
                 )],
             })
         }

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -4,7 +4,6 @@ use bitcoin::Address;
 use bitcoin::KeyPair;
 use db::PegInKey;
 use fedimint_api::core::client::ClientModulePlugin;
-use fedimint_api::core::{ModuleKey, MODULE_KEY_WALLET};
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::{Amount, ServerModulePlugin};
@@ -31,12 +30,12 @@ pub struct WalletClient {
 }
 
 impl ClientModulePlugin for WalletClient {
+    const KIND: &'static str = "wallet";
     type Decoder = <Wallet as ServerModulePlugin>::Decoder;
     type Module = Wallet;
-    const MODULE_KEY: ModuleKey = MODULE_KEY_WALLET;
 
-    fn decoder(&self) -> &'static Self::Decoder {
-        &WalletModuleDecoder
+    fn decoder(&self) -> Self::Decoder {
+        WalletModuleDecoder
     }
 
     fn input_amount(
@@ -198,6 +197,7 @@ mod tests {
     use bitcoin::{Address, Txid};
     use bitcoin_hashes::Hash;
     use fedimint_api::config::{BitcoindRpcCfg, ConfigGenParams};
+    use fedimint_api::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::db::Database;
     use fedimint_api::task::TaskGroup;
@@ -239,7 +239,11 @@ mod tests {
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
                 outputs: vec![SerdeOutputOutcome::from(
-                    &(WalletOutputOutcome(Txid::from_slice([0; 32].as_slice()).unwrap()).into()),
+                    &(
+                        (WalletOutputOutcome(Txid::from_slice([0; 32].as_slice()).unwrap())),
+                        LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+                    )
+                        .into(),
                 )],
             })
         }
@@ -356,6 +360,7 @@ mod tests {
                     finality_delay: 10,
                 }),
                 &WalletConfigGenerator,
+                LEGACY_HARDCODED_INSTANCE_ID_WALLET,
             )
             .await
             .unwrap(),

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -157,7 +157,7 @@ macro_rules! module_plugin_trait_define{
             }
 
             fn clone(&self, instance_id: ::fedimint_api::core::ModuleInstanceId) -> $newtype_ty {
-                (<Self as Clone>::clone(self), instance_id).into()
+                $newtype_ty::from_typed(instance_id, <Self as Clone>::clone(self))
             }
 
             fn dyn_hash(&self) -> u64 {
@@ -327,7 +327,10 @@ where
         r: &mut dyn Read,
         instance_id: ModuleInstanceId,
     ) -> Result<Input, DecodeError> {
-        Ok((<Self as PluginDecode>::decode_input(self, r)?, instance_id).into())
+        Ok(Input::from_typed(
+            instance_id,
+            <Self as PluginDecode>::decode_input(self, r)?,
+        ))
     }
 
     fn decode_output(
@@ -335,7 +338,10 @@ where
         r: &mut dyn Read,
         instance_id: ModuleInstanceId,
     ) -> Result<Output, DecodeError> {
-        Ok((<Self as PluginDecode>::decode_output(self, r)?, instance_id).into())
+        Ok(Output::from_typed(
+            instance_id,
+            <Self as PluginDecode>::decode_output(self, r)?,
+        ))
     }
 
     fn decode_output_outcome(
@@ -344,11 +350,10 @@ where
 
         instance_id: ModuleInstanceId,
     ) -> Result<OutputOutcome, DecodeError> {
-        Ok((
-            <Self as PluginDecode>::decode_output_outcome(self, r)?,
+        Ok(OutputOutcome::from_typed(
             instance_id,
-        )
-            .into())
+            <Self as PluginDecode>::decode_output_outcome(self, r)?,
+        ))
     }
 
     fn decode_consensus_item(
@@ -356,11 +361,10 @@ where
         r: &mut dyn Read,
         instance_id: ModuleInstanceId,
     ) -> Result<ConsensusItem, DecodeError> {
-        Ok((
-            <Self as PluginDecode>::decode_consensus_item(self, r)?,
+        Ok(ConsensusItem::from_typed(
             instance_id,
-        )
-            .into())
+            <Self as PluginDecode>::decode_consensus_item(self, r)?,
+        ))
     }
 }
 

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -4,38 +4,95 @@
 //!
 //! This (Rust) module defines common interoperability types
 //! and functionality that is used on both client and sever side.
+use core::fmt;
 use std::any::Any;
+use std::borrow::Cow;
 use std::fmt::{Debug, Display};
-use std::io;
 use std::io::Read;
+use std::sync::Arc;
+use std::{io, ops};
 
 pub use bitcoin::KeyPair;
 use fedimint_api::{
-    dyn_newtype_define, dyn_newtype_impl_dyn_clone_passhthrough,
+    dyn_newtype_define,
     encoding::{Decodable, DecodeError, DynEncodable, Encodable},
 };
+use serde::{Deserialize, Serialize};
 
-use crate::ModuleDecoderRegistry;
+use crate::{
+    dyn_newtype_define_with_instance_id, dyn_newtype_impl_dyn_clone_passhthrough_with_instance_id,
+    ModuleDecoderRegistry,
+};
 
 pub mod encode;
 
 pub mod client;
 pub mod server;
 
-/// A module key identifing a module
+/// Module instance ID
 ///
-/// Used as an unique ID, and also as prefix in serialization
-/// of module-specific data.
-pub type ModuleKey = u16;
+/// This value uniquely identifies a single instance of a module in a federation.
+///
+/// In case a single [`ModuleKind`] is instantiated twice (rare, but possible),
+/// each instance will have a different id.
+///
+/// Note: We have used this type differently before, assuming each `u16`
+/// uniquly identifies a type of module in question. This function will move
+/// to a `ModuleKind` type which only identifies type of a module (mint vs wallet vs ln, etc)
+// TODO: turn in a newtype
+pub type ModuleInstanceId = u16;
 
-/// Temporary constant for the modules we already have
+/// Special ID we use for global dkg
+pub const MODULE_INSTANCE_ID_GLOBAL: u16 = u16::MAX;
+
+// Note: needs to be in alphabetical order of ModuleKind of each module,
+// as this is the ordering we currently harcoded.
+// Should be used only for pre-modularization code we still have  left
+pub const LEGACY_HARDCODED_INSTANCE_ID_LN: ModuleInstanceId = 0;
+pub const LEGACY_HARDCODED_INSTANCE_ID_MINT: ModuleInstanceId = 1;
+pub const LEGACY_HARDCODED_INSTANCE_ID_WALLET: ModuleInstanceId = 2;
+
+/// A type of a module
 ///
-/// To be removed after modularization is complete.
-pub const MODULE_KEY_WALLET: u16 = 0;
-pub const MODULE_KEY_MINT: u16 = 1;
-pub const MODULE_KEY_LN: u16 = 2;
-// not really a module
-pub const MODULE_KEY_GLOBAL: u16 = 1024;
+/// This is a short string that identifies type of a module.
+/// Authors of 3rd party modules are free to come up with a string,
+/// long enough to avoid conflicts with similiar modules.
+#[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ModuleKind(Cow<'static, str>);
+
+impl ModuleKind {
+    pub fn clone_from_str(s: &str) -> Self {
+        Self(Cow::from(s.to_owned()))
+    }
+
+    pub const fn from_static_str(s: &'static str) -> Self {
+        Self(Cow::Borrowed(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ModuleKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl From<&'static str> for ModuleKind {
+    fn from(val: &'static str) -> Self {
+        ModuleKind::from_static_str(val)
+    }
+}
+
+impl ops::Deref for ModuleKind {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// Implement `Encodable` and `Decodable` for a "module dyn newtype"
 ///
@@ -51,7 +108,7 @@ macro_rules! module_dyn_newtype_impl_encode_decode {
                 &self,
                 writer: &mut W,
             ) -> Result<usize, std::io::Error> {
-                self.0.module_key().consensus_encode(writer)?;
+                self.1.consensus_encode(writer)?;
                 self.0.consensus_encode_dyn(writer)
             }
         }
@@ -61,14 +118,15 @@ macro_rules! module_dyn_newtype_impl_encode_decode {
                 r: &mut R,
                 modules: &$crate::module::registry::ModuleDecoderRegistry,
             ) -> Result<Self, DecodeError> {
-                $crate::core::encode::module_decode_key_prefixed_decodable(r, modules, |r, m| {
-                    m.$decode_fn(r)
-                })
+                $crate::core::encode::module_decode_key_prefixed_decodable(
+                    r,
+                    modules,
+                    |r, m, id| m.$decode_fn(r, id),
+                )
             }
         }
     };
 }
-
 /// Define a "plugin" trait
 ///
 /// "Plugin trait" is a trait that a developer of a mint module
@@ -80,15 +138,13 @@ macro_rules! module_dyn_newtype_impl_encode_decode {
 /// "module dyn newtypes", erasing the exact type and used in a common
 /// Fedimint code.
 #[macro_export]
-macro_rules! module_plugin_trait_define {
+macro_rules! module_plugin_trait_define{
     (   $(#[$outer:meta])*
         $newtype_ty:ident, $plugin_ty:ident, $module_ty:ident, { $($extra_methods:tt)*  } { $($extra_impls:tt)* }
     ) => {
         pub trait $plugin_ty:
             std::fmt::Debug + std::fmt::Display + std::cmp::PartialEq + std::hash::Hash + DynEncodable + Decodable + Encodable + Clone + Send + Sync + 'static
         {
-            fn module_key(&self) -> ModuleKey;
-
             $($extra_methods)*
         }
 
@@ -100,12 +156,8 @@ macro_rules! module_plugin_trait_define {
                 self
             }
 
-            fn module_key(&self) -> ModuleKey {
-                <Self as $plugin_ty>::module_key(self)
-            }
-
-            fn clone(&self) -> $newtype_ty {
-                <Self as Clone>::clone(self).into()
+            fn clone(&self, instance_id: ::fedimint_api::core::ModuleInstanceId) -> $newtype_ty {
+                (<Self as Clone>::clone(self), instance_id).into()
             }
 
             fn dyn_hash(&self) -> u64 {
@@ -122,8 +174,7 @@ macro_rules! module_plugin_trait_define {
             where
                 H: std::hash::Hasher
             {
-                let module_key = self.module_key();
-                module_key.hash(state);
+                self.1.hash(state);
                 self.0.dyn_hash().hash(state);
             }
         }
@@ -134,44 +185,25 @@ macro_rules! module_plugin_trait_define {
 #[macro_export]
 macro_rules! plugin_types_trait_impl {
     ($key:expr, $input:ty, $output:ty, $outcome:ty, $ci:ty, $cache:ty) => {
-        impl fedimint_api::core::PluginInput for $input {
-            fn module_key(&self) -> ModuleKey {
-                $key
-            }
-        }
+        impl fedimint_api::core::PluginInput for $input {}
 
-        impl fedimint_api::core::PluginOutput for $output {
-            fn module_key(&self) -> ModuleKey {
-                $key
-            }
-        }
+        impl fedimint_api::core::PluginOutput for $output {}
 
-        impl fedimint_api::core::PluginOutputOutcome for $outcome {
-            fn module_key(&self) -> ModuleKey {
-                $key
-            }
-        }
+        impl fedimint_api::core::PluginOutputOutcome for $outcome {}
 
-        impl fedimint_api::core::PluginConsensusItem for $ci {
-            fn module_key(&self) -> ModuleKey {
-                $key
-            }
-        }
+        impl fedimint_api::core::PluginConsensusItem for $ci {}
 
-        impl fedimint_api::server::PluginVerificationCache for $cache {
-            fn module_key(&self) -> ModuleKey {
-                $key
-            }
-        }
+        impl fedimint_api::server::PluginVerificationCache for $cache {}
     };
 }
 
 macro_rules! erased_eq {
     ($newtype:ty) => {
         fn erased_eq(&self, other: &$newtype) -> bool {
-            if self.module_key() != other.module_key() {
-                return false;
-            }
+            // TODO:?
+            // if self.module_key() != other.module_key() {
+            //     return false;
+            // }
 
             let other: &T = other
                 .as_any()
@@ -211,45 +243,72 @@ macro_rules! newtype_impl_display_passthrough {
 /// Static-polymorphism version of [`ModuleDecode`]
 ///
 /// All methods are static, as the decoding code is supposed to be instance-independent,
-/// at least until we start to support modules with overriden [`ModuleKey`]s
+/// at least until we start to support modules with overriden [`ModuleInstanceId`]s
 pub trait PluginDecode: Debug + Send + Sync + 'static {
+    type Input: PluginInput;
+    type Output: PluginOutput;
+    type OutputOutcome: PluginOutputOutcome;
+    type ConsensusItem: PluginConsensusItem;
+
     /// Decode `Input` compatible with this module, after the module key prefix was already decoded
-    fn decode_input(r: &mut dyn io::Read) -> Result<Input, DecodeError>;
+    fn decode_input(&self, r: &mut dyn io::Read) -> Result<Self::Input, DecodeError>;
 
     /// Decode `Output` compatible with this module, after the module key prefix was already decoded
-    fn decode_output(r: &mut dyn io::Read) -> Result<Output, DecodeError>;
+    fn decode_output(&self, r: &mut dyn io::Read) -> Result<Self::Output, DecodeError>;
 
     /// Decode `OutputOutcome` compatible with this module, after the module key prefix was already decoded
-    fn decode_output_outcome(r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError>;
+    fn decode_output_outcome(
+        &self,
+        r: &mut dyn io::Read,
+    ) -> Result<Self::OutputOutcome, DecodeError>;
 
     /// Decode `ConsensusItem` compatible with this module, after the module key prefix was already decoded
-    fn decode_consensus_item(r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
+    fn decode_consensus_item(
+        &self,
+        r: &mut dyn io::Read,
+    ) -> Result<Self::ConsensusItem, DecodeError>;
 }
 
 pub trait ModuleDecode: Debug {
     /// Decode `Input` compatible with this module, after the module key prefix was already decoded
-    fn decode_input(&self, r: &mut dyn io::Read) -> Result<Input, DecodeError>;
+    fn decode_input(
+        &self,
+        r: &mut dyn io::Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<Input, DecodeError>;
 
     /// Decode `Output` compatible with this module, after the module key prefix was already decoded
-    fn decode_output(&self, r: &mut dyn io::Read) -> Result<Output, DecodeError>;
+    fn decode_output(
+        &self,
+        r: &mut dyn io::Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<Output, DecodeError>;
 
     /// Decode `OutputOutcome` compatible with this module, after the module key prefix was already decoded
-    fn decode_output_outcome(&self, r: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError>;
+    fn decode_output_outcome(
+        &self,
+        r: &mut dyn io::Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<OutputOutcome, DecodeError>;
 
     /// Decode `ConsensusItem` compatible with this module, after the module key prefix was already decoded
-    fn decode_consensus_item(&self, r: &mut dyn io::Read) -> Result<ConsensusItem, DecodeError>;
+    fn decode_consensus_item(
+        &self,
+        r: &mut dyn io::Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<ConsensusItem, DecodeError>;
 }
 
 // TODO: use macro again
 /// Decoder for module associated types
 #[derive(Clone)]
-pub struct Decoder(&'static (dyn ModuleDecode + Send + Sync));
+pub struct Decoder(Arc<dyn ModuleDecode + Send + Sync>);
 
 impl std::ops::Deref for Decoder {
     type Target = dyn ModuleDecode + Send + Sync + 'static;
 
     fn deref(&self) -> &<Self as std::ops::Deref>::Target {
-        self.0
+        &*self.0
     }
 }
 
@@ -263,55 +322,87 @@ impl<T> ModuleDecode for T
 where
     T: PluginDecode + 'static,
 {
-    fn decode_input(&self, r: &mut dyn Read) -> Result<Input, DecodeError> {
-        <Self as PluginDecode>::decode_input(r)
+    fn decode_input(
+        &self,
+        r: &mut dyn Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<Input, DecodeError> {
+        Ok((<Self as PluginDecode>::decode_input(self, r)?, instance_id).into())
     }
 
-    fn decode_output(&self, r: &mut dyn Read) -> Result<Output, DecodeError> {
-        <Self as PluginDecode>::decode_output(r)
+    fn decode_output(
+        &self,
+        r: &mut dyn Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<Output, DecodeError> {
+        Ok((<Self as PluginDecode>::decode_output(self, r)?, instance_id).into())
     }
 
-    fn decode_output_outcome(&self, r: &mut dyn Read) -> Result<OutputOutcome, DecodeError> {
-        <Self as PluginDecode>::decode_output_outcome(r)
+    fn decode_output_outcome(
+        &self,
+        r: &mut dyn Read,
+
+        instance_id: ModuleInstanceId,
+    ) -> Result<OutputOutcome, DecodeError> {
+        Ok((
+            <Self as PluginDecode>::decode_output_outcome(self, r)?,
+            instance_id,
+        )
+            .into())
     }
 
-    fn decode_consensus_item(&self, r: &mut dyn Read) -> Result<ConsensusItem, DecodeError> {
-        <Self as PluginDecode>::decode_consensus_item(r)
+    fn decode_consensus_item(
+        &self,
+        r: &mut dyn Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<ConsensusItem, DecodeError> {
+        Ok((
+            <Self as PluginDecode>::decode_consensus_item(self, r)?,
+            instance_id,
+        )
+            .into())
     }
 }
 
 impl ModuleDecode for Decoder {
-    fn decode_input(&self, r: &mut dyn Read) -> Result<Input, DecodeError> {
-        self.0.decode_input(r)
+    fn decode_input(
+        &self,
+        r: &mut dyn Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<Input, DecodeError> {
+        self.0.decode_input(r, instance_id)
     }
 
-    fn decode_output(&self, r: &mut dyn Read) -> Result<Output, DecodeError> {
-        self.0.decode_output(r)
+    fn decode_output(
+        &self,
+        r: &mut dyn Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<Output, DecodeError> {
+        self.0.decode_output(r, instance_id)
     }
 
-    fn decode_output_outcome(&self, r: &mut dyn Read) -> Result<OutputOutcome, DecodeError> {
-        self.0.decode_output_outcome(r)
+    fn decode_output_outcome(
+        &self,
+        r: &mut dyn Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<OutputOutcome, DecodeError> {
+        self.0.decode_output_outcome(r, instance_id)
     }
 
-    fn decode_consensus_item(&self, r: &mut dyn Read) -> Result<ConsensusItem, DecodeError> {
-        self.0.decode_consensus_item(r)
+    fn decode_consensus_item(
+        &self,
+        r: &mut dyn Read,
+        instance_id: ModuleInstanceId,
+    ) -> Result<ConsensusItem, DecodeError> {
+        self.0.decode_consensus_item(r, instance_id)
     }
 }
 
 impl Decoder {
     /// Creates a static, type-erased decoder. Only call this a limited amout of times since it uses
     /// `Box::leak` internally.
-    pub fn from_typed(decoder: &'static (impl PluginDecode + Send + Sync + 'static)) -> Decoder {
-        Decoder(decoder)
-    }
-}
-
-impl<T> From<&'static T> for Decoder
-where
-    T: PluginDecode + Send + Sync + 'static,
-{
-    fn from(value: &'static T) -> Self {
-        Decoder(value)
+    pub fn from_typed(decoder: impl PluginDecode + Send + Sync + 'static) -> Decoder {
+        Decoder(Arc::new(decoder))
     }
 }
 
@@ -320,8 +411,7 @@ where
 /// General purpose code should use [`Input`] instead
 pub trait ModuleInput: Debug + Display + DynEncodable {
     fn as_any(&self) -> &(dyn Any + Send + Sync);
-    fn module_key(&self) -> ModuleKey;
-    fn clone(&self) -> Input;
+    fn clone(&self, instance_id: ModuleInstanceId) -> Input;
     fn dyn_hash(&self) -> u64;
     fn erased_eq(&self, other: &Input) -> bool;
 }
@@ -334,14 +424,14 @@ module_plugin_trait_define! {
     }
 }
 
-dyn_newtype_define! {
+dyn_newtype_define_with_instance_id! {
     /// An owned, immutable input to a [`Transaction`]
     pub Input(Box<ModuleInput>)
 }
 module_dyn_newtype_impl_encode_decode! {
     Input, decode_input
 }
-dyn_newtype_impl_dyn_clone_passhthrough!(Input);
+dyn_newtype_impl_dyn_clone_passhthrough_with_instance_id!(Input);
 
 newtype_impl_eq_passthrough!(Input);
 
@@ -352,14 +442,12 @@ newtype_impl_display_passthrough!(Input);
 /// General purpose code should use [`Output`] instead
 pub trait ModuleOutput: Debug + Display + DynEncodable {
     fn as_any(&self) -> &(dyn Any + Send + Sync);
-    fn module_key(&self) -> ModuleKey;
-
-    fn clone(&self) -> Output;
+    fn clone(&self, instance_id: ModuleInstanceId) -> Output;
     fn dyn_hash(&self) -> u64;
     fn erased_eq(&self, other: &Output) -> bool;
 }
 
-dyn_newtype_define! {
+dyn_newtype_define_with_instance_id! {
     /// An owned, immutable output of a [`Transaction`]
     pub Output(Box<ModuleOutput>)
 }
@@ -373,7 +461,7 @@ module_plugin_trait_define! {
 module_dyn_newtype_impl_encode_decode! {
     Output, decode_output
 }
-dyn_newtype_impl_dyn_clone_passhthrough!(Output);
+dyn_newtype_impl_dyn_clone_passhthrough_with_instance_id!(Output);
 
 newtype_impl_eq_passthrough!(Output);
 
@@ -385,14 +473,12 @@ pub enum FinalizationError {
 
 pub trait ModuleOutputOutcome: Debug + Display + DynEncodable {
     fn as_any(&self) -> &(dyn Any + Send + Sync);
-    /// Module key
-    fn module_key(&self) -> ModuleKey;
-    fn clone(&self) -> OutputOutcome;
+    fn clone(&self, module_instance_id: ModuleInstanceId) -> OutputOutcome;
     fn dyn_hash(&self) -> u64;
     fn erased_eq(&self, other: &OutputOutcome) -> bool;
 }
 
-dyn_newtype_define! {
+dyn_newtype_define_with_instance_id! {
     /// An owned, immutable output of a [`Transaction`] before it was finalized
     pub OutputOutcome(Box<ModuleOutputOutcome>)
 }
@@ -400,24 +486,13 @@ module_plugin_trait_define! {
     OutputOutcome, PluginOutputOutcome, ModuleOutputOutcome,
     { }
     {
-        fn erased_eq(&self, other: &OutputOutcome) -> bool {
-            if self.module_key() != other.module_key() {
-                return false;
-            }
-
-            let other = other
-                .as_any()
-                .downcast_ref::<T>()
-                .expect("Type is ensured in previous step");
-
-            self == other
-        }
+        erased_eq!(OutputOutcome);
     }
 }
 module_dyn_newtype_impl_encode_decode! {
     OutputOutcome, decode_output_outcome
 }
-dyn_newtype_impl_dyn_clone_passhthrough!(OutputOutcome);
+dyn_newtype_impl_dyn_clone_passhthrough_with_instance_id!(OutputOutcome);
 
 newtype_impl_eq_passthrough!(OutputOutcome);
 
@@ -425,15 +500,13 @@ newtype_impl_display_passthrough!(OutputOutcome);
 
 pub trait ModuleConsensusItem: Debug + Display + DynEncodable {
     fn as_any(&self) -> &(dyn Any + Send + Sync);
-    /// Module key
-    fn module_key(&self) -> ModuleKey;
-    fn clone(&self) -> ConsensusItem;
+    fn clone(&self, module_instance_id: ModuleInstanceId) -> ConsensusItem;
     fn dyn_hash(&self) -> u64;
 
     fn erased_eq(&self, other: &ConsensusItem) -> bool;
 }
 
-dyn_newtype_define! {
+dyn_newtype_define_with_instance_id! {
     /// An owned, immutable output of a [`Transaction`] before it was finalized
     pub ConsensusItem(Box<ModuleConsensusItem>)
 }
@@ -447,7 +520,7 @@ module_plugin_trait_define! {
 module_dyn_newtype_impl_encode_decode! {
     ConsensusItem, decode_consensus_item
 }
-dyn_newtype_impl_dyn_clone_passhthrough!(ConsensusItem);
+dyn_newtype_impl_dyn_clone_passhthrough_with_instance_id!(ConsensusItem);
 
 newtype_impl_eq_passthrough!(ConsensusItem);
 
@@ -478,84 +551,5 @@ where
             outputs: Decodable::consensus_decode(r, modules)?,
             signature: Decodable::consensus_decode(r, modules)?,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    use fedimint_api::core::PluginConsensusItem;
-    use fedimint_api::encoding::{Decodable, Encodable};
-
-    use crate::core::{
-        ConsensusItem, Input, ModuleKey, Output, OutputOutcome, PluginInput, PluginOutput,
-        PluginOutputOutcome,
-    };
-
-    macro_rules! test_newtype_eq_hash {
-        ($newtype:ty, $trait:ty) => {
-            #[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
-            struct Foo {
-                key: u16,
-                data: u16,
-            }
-
-            impl std::fmt::Display for Foo {
-                fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                    unimplemented!();
-                }
-            }
-
-            impl $trait for Foo {
-                fn module_key(&self) -> ModuleKey {
-                    self.key
-                }
-            }
-
-            let a: $newtype = Foo { key: 42, data: 0 }.into();
-            let b: $newtype = Foo { key: 21, data: 0 }.into();
-            let c: $newtype = Foo { key: 42, data: 1 }.into();
-
-            assert_eq!(a, a);
-            assert_ne!(a, b);
-            assert_ne!(a, c);
-            assert_ne!(b, c);
-
-            assert_eq!(hash(&a), hash(&a));
-            assert_ne!(hash(&a), hash(&b));
-            assert_ne!(hash(&a), hash(&c));
-            assert_ne!(hash(&b), hash(&c));
-        };
-    }
-
-    fn hash<T>(item: &T) -> u64
-    where
-        T: Hash,
-    {
-        let mut hasher = DefaultHasher::new();
-        item.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    #[test]
-    fn test_dyn_eq_hash_input() {
-        test_newtype_eq_hash!(Input, PluginInput);
-    }
-
-    #[test]
-    fn test_dyn_eq_hash_output() {
-        test_newtype_eq_hash!(Output, PluginOutput);
-    }
-
-    #[test]
-    fn test_dyn_eq_hash_outcome() {
-        test_newtype_eq_hash!(OutputOutcome, PluginOutputOutcome);
-    }
-
-    #[test]
-    fn test_dyn_eq_hash_ci() {
-        test_newtype_eq_hash!(ConsensusItem, PluginConsensusItem);
     }
 }

--- a/fedimint-api/src/core/encode.rs
+++ b/fedimint-api/src/core/encode.rs
@@ -2,8 +2,9 @@ use std::io;
 
 use fedimint_api::encoding::{Decodable, DecodeError};
 
+use super::ModuleInstanceId;
 use crate::core::Decoder;
-use crate::module::registry::{ModuleDecoderRegistry, ModuleKey};
+use crate::module::registry::ModuleDecoderRegistry;
 
 pub fn module_decode_key_prefixed_decodable<T, F, R>(
     mut d: &mut R,
@@ -12,9 +13,9 @@ pub fn module_decode_key_prefixed_decodable<T, F, R>(
 ) -> Result<T, DecodeError>
 where
     R: io::Read,
-    F: FnOnce(&mut R, &Decoder) -> Result<T, DecodeError>,
+    F: FnOnce(&mut R, &Decoder, ModuleInstanceId) -> Result<T, DecodeError>,
 {
-    let key = ModuleKey::consensus_decode(&mut d, modules)?;
+    let key = ModuleInstanceId::consensus_decode(&mut d, modules)?;
 
-    decode_fn(d, modules.get(key))
+    decode_fn(d, modules.get(key), key)
 }

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -198,7 +198,7 @@ where
         <Self as ServerModulePlugin>::consensus_proposal(self, dbtx)
             .await
             .into_iter()
-            .map(|v| (v, module_instance_id).into())
+            .map(|v| ConsensusItem::from_typed(module_instance_id, v))
             .collect()
     }
 
@@ -378,7 +378,7 @@ where
     ) -> Option<OutputOutcome> {
         <Self as ServerModulePlugin>::output_status(self, dbtx, out_point)
             .await
-            .map(|v| (v, module_instance_id).into())
+            .map(|v| OutputOutcome::from_typed(module_instance_id, v))
     }
 
     /// Queries the database and returns all assets and liabilities of the module.

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -20,7 +20,6 @@ use crate::module::{
 
 pub trait ModuleVerificationCache: Debug {
     fn as_any(&self) -> &(dyn Any + Send + Sync);
-    fn module_key(&self) -> ModuleKey;
     fn clone(&self) -> VerificationCache;
 }
 
@@ -29,9 +28,7 @@ dyn_newtype_define! {
 }
 
 // TODO: make macro impl that doesn't force en/decodable
-pub trait PluginVerificationCache: Clone + Debug + Send + Sync + 'static {
-    fn module_key(&self) -> ModuleKey;
-}
+pub trait PluginVerificationCache: Clone + Debug + Send + Sync + 'static {}
 
 impl<T> ModuleVerificationCache for T
 where
@@ -41,21 +38,16 @@ where
         self
     }
 
-    fn module_key(&self) -> ModuleKey {
-        <Self as PluginVerificationCache>::module_key(self)
-    }
-
     fn clone(&self) -> VerificationCache {
         <Self as Clone>::clone(self).into()
     }
 }
+
 /// Backend side module interface
 ///
 /// Server side Fedimint module needs to implement this trait.
 #[async_trait]
 pub trait IServerModule: Debug {
-    fn module_key(&self) -> ModuleKey;
-
     /// Returns the decoder belonging to the server module
     fn decoder(&self) -> Decoder;
 
@@ -65,7 +57,11 @@ pub trait IServerModule: Debug {
     async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>);
 
     /// This module's contribution to the next consensus proposal
-    async fn consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) -> Vec<ConsensusItem>;
+    async fn consensus_proposal(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        module_instance_id: ModuleInstanceId,
+    ) -> Vec<ConsensusItem>;
 
     /// This function is called once before transaction processing starts. All module consensus
     /// items of this round are supplied as `consensus_items`. The batch will be committed to the
@@ -155,6 +151,7 @@ pub trait IServerModule: Debug {
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
+        module_instance_id: ModuleInstanceId,
     ) -> Option<OutputOutcome>;
 
     /// Queries the database and returns all assets and liabilities of the module.
@@ -162,12 +159,6 @@ pub trait IServerModule: Debug {
     /// Summing over all modules, if liabilities > assets then an error has occurred in the database
     /// and consensus should halt.
     async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit);
-
-    /// Defines the prefix for API endpoints defined by the module.
-    ///
-    /// E.g. if the module's base path is `foo` and it defines API endpoints `bar` and `baz` then
-    /// these endpoints will be reachable under `/foo/bar` and `/foo/baz`.
-    fn api_base_name(&self) -> &'static str;
 
     /// Returns a list of custom API endpoints defined by the module. These are made available both
     /// to users as well as to other modules. They thus should be deterministic, only dependant on
@@ -185,10 +176,6 @@ impl<T> IServerModule for T
 where
     T: ServerModulePlugin + 'static + Sync,
 {
-    fn module_key(&self) -> ModuleKey {
-        <Self as ServerModulePlugin>::module_key(self)
-    }
-
     fn decoder(&self) -> Decoder {
         Decoder::from_typed(ServerModulePlugin::decoder(self))
     }
@@ -203,11 +190,15 @@ where
     }
 
     /// This module's contribution to the next consensus proposal
-    async fn consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) -> Vec<ConsensusItem> {
+    async fn consensus_proposal(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        module_instance_id: ModuleInstanceId,
+    ) -> Vec<ConsensusItem> {
         <Self as ServerModulePlugin>::consensus_proposal(self, dbtx)
             .await
             .into_iter()
-            .map(Into::into)
+            .map(|v| (v, module_instance_id).into())
             .collect()
     }
 
@@ -383,10 +374,11 @@ where
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
+        module_instance_id: ModuleInstanceId,
     ) -> Option<OutputOutcome> {
         <Self as ServerModulePlugin>::output_status(self, dbtx, out_point)
             .await
-            .map(Into::into)
+            .map(|v| (v, module_instance_id).into())
     }
 
     /// Queries the database and returns all assets and liabilities of the module.
@@ -395,10 +387,6 @@ where
     /// and consensus should halt.
     async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit) {
         <Self as ServerModulePlugin>::audit(self, dbtx, audit).await
-    }
-
-    fn api_base_name(&self) -> &'static str {
-        <Self as ServerModulePlugin>::api_base_name(self)
     }
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<ServerModule>> {

--- a/fedimint-api/src/macros.rs
+++ b/fedimint-api/src/macros.rs
@@ -160,14 +160,12 @@ macro_rules! _dyn_newtype_define_with_instance_id_inner {
             pub fn module_instance_id(&self) -> ::fedimint_api::core::ModuleInstanceId {
                 self.1
             }
-        }
 
-        impl<I> From<(I, ::fedimint_api::core::ModuleInstanceId)> for $name
-        where
-            I: $trait + Send + Sync + 'static,
-        {
-            fn from(v: (I, ::fedimint_api::core::ModuleInstanceId)) -> Self {
-                Self($container::new(v.0), v.1)
+            pub fn from_typed<I>(module_instance_id: ::fedimint_api::core::ModuleInstanceId, typed: I) -> Self
+            where
+                I: $trait + Send + Sync + 'static {
+
+                Self($container::new(typed), module_instance_id)
             }
         }
 
@@ -187,6 +185,13 @@ macro_rules! _dyn_newtype_define_with_instance_id_inner {
             pub fn module_instance_id(&self) -> ::fedimint_api::core::ModuleInstanceId {
                 self.1
             }
+
+            pub fn from_typed<I>(module_instance_id: ::fedimint_api::core::ModuleInstanceId, typed: I) -> Self
+            where
+                I: $trait + Send + Sync + 'static {
+
+                Self($container::new(typed), module_instance_id)
+            }
         }
 
         impl<$lifetime> std::ops::Deref for $name<$lifetime> {
@@ -194,15 +199,6 @@ macro_rules! _dyn_newtype_define_with_instance_id_inner {
 
             fn deref(&self) -> &<Self as std::ops::Deref>::Target {
                 &*self.0
-            }
-        }
-
-        impl<$lifetime, I> From<(I, ::fedimint_api::core::ModuleInstanceId)> for $name<$lifetime>
-        where
-            I: $trait<$lifetime> + Send + $lifetime,
-        {
-            fn from(v: (I, ::fedimint_api::core::ModuleInstanceId)) -> Self {
-                Self($container::new(v.0), v.1)
             }
         }
     };

--- a/fedimint-api/src/macros.rs
+++ b/fedimint-api/src/macros.rs
@@ -45,6 +45,44 @@ macro_rules! dyn_newtype_define {
 }
 
 #[macro_export]
+macro_rules! dyn_newtype_define_with_instance_id{
+    (   $(#[$outer:meta])*
+        $vis:vis $name:ident<$lifetime:lifetime>(Box<$trait:ident>)
+    ) => {
+        $crate::_dyn_newtype_define_with_instance_id_inner!{
+            $(#[$outer])*
+            $vis $name<$lifetime>(Box<$trait>)
+        }
+        $crate::_dyn_newtype_impl_deref_mut!($name<$lifetime>);
+    };
+    (   $(#[$outer:meta])*
+        $vis:vis $name:ident(Box<$trait:ident>)
+    ) => {
+        $crate::_dyn_newtype_define_with_instance_id_inner!{
+            $(#[$outer])*
+            $vis $name(Box<$trait>)
+        }
+        $crate::_dyn_newtype_impl_deref_mut!($name);
+    };
+    (   $(#[$outer:meta])*
+        $vis:vis $name:ident<$lifetime:lifetime>(Arc<$trait:ident>)
+    ) => {
+        $crate::_dyn_newtype_define_with_instance_id_inner!{
+            $(#[$outer])*
+            $vis $name<$lifetime>(Arc<$trait>)
+        }
+    };
+    (   $(#[$outer:meta])*
+        $vis:vis $name:ident(Arc<$trait:ident>)
+    ) => {
+        $crate::_dyn_newtype_define_with_instance_id_inner!{
+            $(#[$outer])*
+            $vis $name(Arc<$trait>)
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! _dyn_newtype_define_inner {
     (   $(#[$outer:meta])*
         $vis:vis $name:ident($container:ident<$trait:ident>)
@@ -60,6 +98,7 @@ macro_rules! _dyn_newtype_define_inner {
             }
 
         }
+
         impl<I> From<I> for $name
         where
             I: $trait + Send + Sync + 'static,
@@ -95,6 +134,75 @@ macro_rules! _dyn_newtype_define_inner {
         {
             fn from(i: I) -> Self {
                 Self($container::new(i))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! _dyn_newtype_define_with_instance_id_inner {
+    (   $(#[$outer:meta])*
+        $vis:vis $name:ident($container:ident<$trait:ident>)
+    ) => {
+        $(#[$outer])*
+        $vis struct $name($container<dyn $trait + Send + Sync + 'static>, ::fedimint_api::core::ModuleInstanceId);
+
+        impl std::ops::Deref for $name {
+            type Target = dyn $trait + Send + Sync + 'static;
+
+            fn deref(&self) -> &<Self as std::ops::Deref>::Target {
+                &*self.0
+            }
+
+        }
+
+        impl $name {
+            pub fn module_instance_id(&self) -> ::fedimint_api::core::ModuleInstanceId {
+                self.1
+            }
+        }
+
+        impl<I> From<(I, ::fedimint_api::core::ModuleInstanceId)> for $name
+        where
+            I: $trait + Send + Sync + 'static,
+        {
+            fn from(v: (I, ::fedimint_api::core::ModuleInstanceId)) -> Self {
+                Self($container::new(v.0), v.1)
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
+    };
+    (   $(#[$outer:meta])*
+        $vis:vis $name:ident<$lifetime:lifetime>($container:ident<$trait:ident>)
+    ) => {
+        $(#[$outer])*
+        $vis struct $name<$lifetime>($container<dyn $trait<$lifetime> + Send + $lifetime>, ModuleInstanceId);
+
+        impl $name {
+            pub fn module_instance_id(&self) -> ::fedimint_api::core::ModuleInstanceId {
+                self.1
+            }
+        }
+
+        impl<$lifetime> std::ops::Deref for $name<$lifetime> {
+            type Target = dyn $trait<$lifetime> + Send + $lifetime;
+
+            fn deref(&self) -> &<Self as std::ops::Deref>::Target {
+                &*self.0
+            }
+        }
+
+        impl<$lifetime, I> From<(I, ::fedimint_api::core::ModuleInstanceId)> for $name<$lifetime>
+        where
+            I: $trait<$lifetime> + Send + $lifetime,
+        {
+            fn from(v: (I, ::fedimint_api::core::ModuleInstanceId)) -> Self {
+                Self($container::new(v.0), v.1)
             }
         }
     };
@@ -138,6 +246,17 @@ macro_rules! dyn_newtype_impl_dyn_clone_passhthrough {
         impl Clone for $name {
             fn clone(&self) -> Self {
                 self.0.clone()
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! dyn_newtype_impl_dyn_clone_passhthrough_with_instance_id {
+    ($name:ident) => {
+        impl Clone for $name {
+            fn clone(&self) -> Self {
+                self.0.clone(self.1)
             }
         }
     };

--- a/fedimint-api/src/module/interconnect.rs
+++ b/fedimint-api/src/module/interconnect.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use super::ApiError;
+use crate::core::ModuleInstanceId;
 
 /// Provides an interface to call APIs of other modules
 #[async_trait]
@@ -9,7 +10,7 @@ pub trait ModuleInterconect: Sync + Send {
     /// This has lower latency.
     async fn call(
         &self,
-        module: &'static str,
+        module_id: ModuleInstanceId,
         path: String,
         data: serde_json::Value,
     ) -> Result<serde_json::Value, ApiError>;

--- a/fedimint-api/src/module/registry.rs
+++ b/fedimint-api/src/module/registry.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::core::Decoder;
+use crate::core::{Decoder, ModuleInstanceId};
 use crate::server::ServerModule;
 
 // TODO: unify and/or make a newtype?
@@ -8,7 +8,7 @@ use crate::server::ServerModule;
 pub type ModuleKey = u16;
 
 #[derive(Debug, Clone)]
-pub struct ModuleRegistry<M>(BTreeMap<ModuleKey, M>);
+pub struct ModuleRegistry<M>(BTreeMap<ModuleInstanceId, M>);
 
 impl<M> Default for ModuleRegistry<M> {
     fn default() -> Self {
@@ -28,8 +28,8 @@ impl<M> ModuleRegistry<M> {
     }
 
     /// Return an iterator over all modules
-    pub fn iter_modules(&self) -> impl Iterator<Item = &M> {
-        self.0.values()
+    pub fn iter_modules(&self) -> impl Iterator<Item = (ModuleInstanceId, &M)> {
+        self.0.iter().map(|(id, m)| (*id, m))
     }
 
     pub fn get_mut(&mut self, key: &ModuleKey) -> Option<&mut M> {
@@ -59,9 +59,9 @@ impl ServerModuleRegistry {
 
     // TODO: move into `ModuleRegistry` impl by splitting `module_key` fn into separate trait
     /// Add a module to the registry
-    pub fn register_module(&mut self, module: ServerModule) {
+    pub fn register_module(&mut self, id: ModuleInstanceId, module: ServerModule) {
         assert!(
-            self.0.insert(module.module_key(), module).is_none(),
+            self.0.insert(id, module).is_none(),
             "Module was already registered!"
         )
     }

--- a/fedimint-core/src/outcome.rs
+++ b/fedimint-core/src/outcome.rs
@@ -17,7 +17,10 @@ pub enum TransactionStatus {
 serde_module_encoding_wrapper!(SerdeOutputOutcome, fedimint_api::core::OutputOutcome);
 
 pub mod legacy {
-    use fedimint_api::core::{MODULE_KEY_LN, MODULE_KEY_MINT, MODULE_KEY_WALLET};
+    use fedimint_api::core::{
+        LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+        LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+    };
     use fedimint_api::encoding::{Decodable, Encodable};
     use fedimint_api::ServerModulePlugin;
     use fedimint_ln::contracts::incoming::OfferId;
@@ -40,20 +43,20 @@ pub mod legacy {
 
     impl From<fedimint_api::core::OutputOutcome> for OutputOutcome {
         fn from(oo: fedimint_api::core::OutputOutcome) -> Self {
-            match oo.module_key() {
-                MODULE_KEY_LN => OutputOutcome::LN(
+            match oo.module_instance_id() {
+                LEGACY_HARDCODED_INSTANCE_ID_LN => OutputOutcome::LN(
                     oo.as_any()
                         .downcast_ref::<LightningOutputOutcome>()
                         .expect("Module key matches")
                         .clone(),
                 ),
-                MODULE_KEY_MINT => OutputOutcome::Mint(
+                LEGACY_HARDCODED_INSTANCE_ID_MINT => OutputOutcome::Mint(
                     oo.as_any()
                         .downcast_ref::<MintOutputOutcome>()
                         .expect("Module key matches")
                         .clone(),
                 ),
-                MODULE_KEY_WALLET => OutputOutcome::Wallet(
+                LEGACY_HARDCODED_INSTANCE_ID_WALLET => OutputOutcome::Wallet(
                     oo.as_any()
                         .downcast_ref::<WalletOutputOutcome>()
                         .expect("Module key matches")

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -225,20 +225,27 @@ pub mod legacy {
 
         /// Generate the transaction hash.
         pub fn tx_hash_from_parts(inputs: &[Input], outputs: &[Output]) -> TransactionId {
+            use fedimint_api::core;
             let erased_inputs = inputs
                 .iter()
                 .map(|input| match input.clone() {
-                    Input::Mint(i) => (i, LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
-                    Input::Wallet(i) => (i, LEGACY_HARDCODED_INSTANCE_ID_WALLET).into(),
-                    Input::LN(i) => (i, LEGACY_HARDCODED_INSTANCE_ID_LN).into(),
+                    Input::Mint(i) => core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, i),
+                    Input::Wallet(i) => {
+                        core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, i)
+                    }
+                    Input::LN(i) => core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, i),
                 })
                 .collect::<Vec<fedimint_api::core::Input>>();
             let erased_outputs = outputs
                 .iter()
                 .map(|output| match output.clone() {
-                    Output::Mint(o) => (o, LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
-                    Output::Wallet(o) => (o, LEGACY_HARDCODED_INSTANCE_ID_WALLET).into(),
-                    Output::LN(o) => (o, LEGACY_HARDCODED_INSTANCE_ID_LN).into(),
+                    Output::Mint(o) => {
+                        core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, o)
+                    }
+                    Output::Wallet(o) => {
+                        core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, o)
+                    }
+                    Output::LN(o) => core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, o),
                 })
                 .collect::<Vec<fedimint_api::core::Output>>();
 
@@ -287,25 +294,36 @@ pub mod legacy {
         }
 
         pub fn into_type_erased(self) -> super::Transaction {
+            use fedimint_api::core;
             super::Transaction {
                 inputs: self
                     .inputs
                     .into_iter()
                     .map(|input| match input {
-                        Input::Mint(input) => (input, LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
-                        Input::Wallet(input) => (input, LEGACY_HARDCODED_INSTANCE_ID_WALLET).into(),
-                        Input::LN(input) => (input, LEGACY_HARDCODED_INSTANCE_ID_LN).into(),
+                        Input::Mint(input) => {
+                            core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, input)
+                        }
+                        Input::Wallet(input) => {
+                            core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, input)
+                        }
+                        Input::LN(input) => {
+                            core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, input)
+                        }
                     })
                     .collect(),
                 outputs: self
                     .outputs
                     .into_iter()
                     .map(|output| match output {
-                        Output::Mint(output) => (output, LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
-                        Output::Wallet(output) => {
-                            (output, LEGACY_HARDCODED_INSTANCE_ID_WALLET).into()
+                        Output::Mint(output) => {
+                            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, output)
                         }
-                        Output::LN(output) => (output, LEGACY_HARDCODED_INSTANCE_ID_LN).into(),
+                        Output::Wallet(output) => {
+                            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, output)
+                        }
+                        Output::LN(output) => {
+                            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, output)
+                        }
                     })
                     .collect(),
                 signature: self.signature,

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -167,6 +167,10 @@ pub enum TransactionError {
 /// Old transaction definition used by old client.
 pub mod legacy {
     use bitcoin_hashes::Hash;
+    use fedimint_api::core::{
+        LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+        LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+    };
     use fedimint_api::encoding::{Decodable, Encodable};
     use fedimint_api::{ServerModulePlugin, TransactionId};
     use secp256k1_zkp::{schnorr, XOnlyPublicKey};
@@ -224,17 +228,17 @@ pub mod legacy {
             let erased_inputs = inputs
                 .iter()
                 .map(|input| match input.clone() {
-                    Input::Mint(i) => i.into(),
-                    Input::Wallet(i) => i.into(),
-                    Input::LN(i) => i.into(),
+                    Input::Mint(i) => (i, LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
+                    Input::Wallet(i) => (i, LEGACY_HARDCODED_INSTANCE_ID_WALLET).into(),
+                    Input::LN(i) => (i, LEGACY_HARDCODED_INSTANCE_ID_LN).into(),
                 })
                 .collect::<Vec<fedimint_api::core::Input>>();
             let erased_outputs = outputs
                 .iter()
                 .map(|output| match output.clone() {
-                    Output::Mint(o) => o.into(),
-                    Output::Wallet(o) => o.into(),
-                    Output::LN(o) => o.into(),
+                    Output::Mint(o) => (o, LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
+                    Output::Wallet(o) => (o, LEGACY_HARDCODED_INSTANCE_ID_WALLET).into(),
+                    Output::LN(o) => (o, LEGACY_HARDCODED_INSTANCE_ID_LN).into(),
                 })
                 .collect::<Vec<fedimint_api::core::Output>>();
 
@@ -288,18 +292,20 @@ pub mod legacy {
                     .inputs
                     .into_iter()
                     .map(|input| match input {
-                        Input::Mint(input) => input.into(),
-                        Input::Wallet(input) => input.into(),
-                        Input::LN(input) => input.into(),
+                        Input::Mint(input) => (input, LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
+                        Input::Wallet(input) => (input, LEGACY_HARDCODED_INSTANCE_ID_WALLET).into(),
+                        Input::LN(input) => (input, LEGACY_HARDCODED_INSTANCE_ID_LN).into(),
                     })
                     .collect(),
                 outputs: self
                     .outputs
                     .into_iter()
                     .map(|output| match output {
-                        Output::Mint(output) => output.into(),
-                        Output::Wallet(output) => output.into(),
-                        Output::LN(output) => output.into(),
+                        Output::Mint(output) => (output, LEGACY_HARDCODED_INSTANCE_ID_MINT).into(),
+                        Output::Wallet(output) => {
+                            (output, LEGACY_HARDCODED_INSTANCE_ID_WALLET).into()
+                        }
+                        Output::LN(output) => (output, LEGACY_HARDCODED_INSTANCE_ID_LN).into(),
                     })
                     .collect(),
                 signature: self.signature,

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -675,17 +675,15 @@ async fn main() {
         }
     };
 
-    let module_inits = ModuleInitRegistry::from([
-        (
-            "wallet",
-            Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
-        ),
-        ("mint", Arc::new(MintConfigGenerator)),
-        ("ln", Arc::new(LightningModuleConfigGen)),
+    let _module_inits = ModuleInitRegistry::from(vec![
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(MintConfigGenerator),
+        Arc::new(LightningModuleConfigGen),
     ]);
 
+    let decoders = Default::default(); // TODO: read config and use it to create decoders
+
     let serialized: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
-    let decoders = module_inits.decoders();
     let mut dbdump = DatabaseDump {
         serialized,
         read_only: DatabaseTransaction::new(Box::new(read_only), &decoders),

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -6,9 +6,9 @@ use anyhow::{bail, format_err};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
     ApiEndpoint, BitcoindRpcCfg, ClientConfig, ConfigGenParams, DkgPeerMsg, DkgRunner,
-    FederationId, ServerModuleConfig, ThresholdKeys, TypedServerModuleConfig,
+    FederationId, JsonWithKind, ServerModuleConfig, ThresholdKeys, TypedServerModuleConfig,
 };
-use fedimint_api::core::{ModuleKey, MODULE_KEY_GLOBAL};
+use fedimint_api::core::{ModuleInstanceId, ModuleKind, MODULE_INSTANCE_ID_GLOBAL};
 use fedimint_api::db::Database;
 use fedimint_api::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use fedimint_api::module::ModuleInit;
@@ -47,6 +47,12 @@ pub struct ServerConfig {
     pub private: ServerConfigPrivate,
 }
 
+impl ServerConfig {
+    pub fn module_kinds_iter(&self) -> impl Iterator<Item = (ModuleInstanceId, &ModuleKind)> + '_ {
+        self.consensus.module_kinds_iter()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfigPrivate {
     /// Secret key for TLS communication, required for peer authentication
@@ -62,7 +68,7 @@ pub struct ServerConfigPrivate {
     #[serde(with = "serde_binary_human_readable")]
     pub epoch_sks: SerdeSecret<hbbft::crypto::SecretKeyShare>,
     /// Secret material from modules
-    pub modules: BTreeMap<String, serde_json::Value>,
+    pub modules: BTreeMap<ModuleInstanceId, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,7 +89,13 @@ pub struct ServerConfigConsensus {
     /// Network addresses and names for all peer APIs
     pub api: BTreeMap<PeerId, ApiEndpoint>,
     /// All configuration that needs to be the same for modules
-    pub modules: BTreeMap<String, serde_json::Value>,
+    pub modules: BTreeMap<ModuleInstanceId, JsonWithKind>,
+}
+
+impl ServerConfigConsensus {
+    pub fn module_kinds_iter(&self) -> impl Iterator<Item = (ModuleInstanceId, &ModuleKind)> + '_ {
+        self.modules.iter().map(|(k, v)| (*k, v.kind()))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,7 +114,7 @@ pub struct ServerConfigLocal {
     /// How many API connections we will accept
     pub max_connections: u32,
     /// Non-consensus, non-private configuration from modules
-    pub modules: BTreeMap<String, serde_json::Value>,
+    pub modules: BTreeMap<ModuleInstanceId, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -140,13 +152,16 @@ impl ServerConfigConsensus {
             modules: self
                 .modules
                 .iter()
-                .map(|(k, v)| {
+                .map(|(module_instance_id, v)| {
+                    let kind = v.kind();
                     Ok((
-                        k.clone(),
+                        *module_instance_id,
                         module_config_gens
-                            .get(&k.as_str())
-                            .ok_or_else(|| anyhow::format_err!("module config gen not found: {k}"))?
-                            .to_client_config_from_consensus_value(v.clone())?,
+                            .get(kind)
+                            .ok_or_else(|| {
+                                anyhow::format_err!("module config gen not found: {kind:?}")
+                            })?
+                            .to_client_config_from_consensus_value(v.value().clone())?,
                     ))
                 })
                 .collect::<anyhow::Result<_>>()?,
@@ -166,17 +181,30 @@ pub type DynModuleInit = Arc<dyn ModuleInit + Send + Sync>;
 // TODO: turn all registeries into `Registry<T>(BTreeMap<&'static str, T))` + type alias
 #[autoimpl(Deref using self.0)]
 #[derive(Clone)]
-pub struct ModuleInitRegistry(BTreeMap<&'static str, DynModuleInit>);
+pub struct ModuleInitRegistry(BTreeMap<ModuleKind, DynModuleInit>);
 
-impl<const N: usize> From<[(&'static str, DynModuleInit); N]> for ModuleInitRegistry {
-    fn from(value: [(&'static str, DynModuleInit); N]) -> Self {
-        Self(BTreeMap::from(value))
+impl From<Vec<DynModuleInit>> for ModuleInitRegistry {
+    fn from(value: Vec<DynModuleInit>) -> Self {
+        Self(BTreeMap::from_iter(
+            value.into_iter().map(|i| (i.module_kind(), i)),
+        ))
     }
 }
 
 impl ModuleInitRegistry {
-    pub fn decoders(&self) -> ModuleDecoderRegistry {
-        ModuleDecoderRegistry::from_iter(self.0.values().map(|v| v.decoder()))
+    pub fn decoders<'a>(
+        &self,
+        module_kinds: impl Iterator<Item = (ModuleInstanceId, &'a ModuleKind)>,
+    ) -> anyhow::Result<ModuleDecoderRegistry> {
+        let mut modules = BTreeMap::new();
+        for (id, kind) in module_kinds {
+            let Some(init) = self.0.get(kind) else {
+                anyhow::bail!("Detected configuration for unsupported module kind: {kind:?}")
+            };
+
+            modules.insert(id, init.decoder());
+        }
+        Ok(ModuleDecoderRegistry::from_iter(modules))
     }
 
     pub async fn init_all(
@@ -187,11 +215,16 @@ impl ModuleInitRegistry {
     ) -> anyhow::Result<ModuleRegistry<fedimint_api::server::ServerModule>> {
         let mut modules = BTreeMap::new();
 
-        for (k, v) in &self.0 {
-            let module = v
-                .init(cfg.get_module_config(k)?, db.clone(), task_group)
+        for (module_id, module_cfg) in &cfg.consensus.modules {
+            let kind = module_cfg.kind();
+            let Some(init) = self.0.get(kind) else {
+                anyhow::bail!("Detected configuration for unsupported module kind: {kind:?}")
+            };
+            info!(module_instance_id = *module_id, kind = %kind, "Init  module");
+            let module = init
+                .init(cfg.get_module_config(*module_id)?, db.clone(), task_group)
                 .await?;
-            modules.insert(module.module_key(), module);
+            modules.insert(*module_id, module);
         }
         Ok(ModuleRegistry::from(modules))
     }
@@ -207,7 +240,7 @@ impl ServerConfig {
         auth_keys: ThresholdKeys,
         epoch_keys: ThresholdKeys,
         hbbft_keys: ThresholdKeys,
-        modules: BTreeMap<String, ServerModuleConfig>,
+        modules: BTreeMap<ModuleInstanceId, ServerModuleConfig>,
     ) -> Self {
         let private = ServerConfigPrivate {
             tls_key: params.tls.our_private_key.clone(),
@@ -243,7 +276,7 @@ impl ServerConfig {
         cfg
     }
 
-    pub fn add_modules(&mut self, modules: BTreeMap<String, ServerModuleConfig>) {
+    pub fn add_modules(&mut self, modules: BTreeMap<ModuleInstanceId, ServerModuleConfig>) {
         for (name, config) in modules.into_iter() {
             let ServerModuleConfig {
                 local,
@@ -251,8 +284,8 @@ impl ServerConfig {
                 consensus,
             } = config;
 
-            self.local.modules.insert(name.clone(), local);
-            self.private.modules.insert(name.clone(), private);
+            self.local.modules.insert(name, local);
+            self.private.modules.insert(name, private);
             self.consensus.modules.insert(name, consensus);
         }
     }
@@ -260,30 +293,46 @@ impl ServerConfig {
     /// Constructs a module config by name
     pub fn get_module_config_typed<T: TypedServerModuleConfig>(
         &self,
-        name: &str,
+        id: ModuleInstanceId,
     ) -> anyhow::Result<T> {
-        let local = Self::get_or_error(&self.local.modules, name)?;
-        let private = Self::get_or_error(&self.private.modules, name)?;
-        let consensus = Self::get_or_error(&self.consensus.modules, name)?;
+        let local = Self::get_or_error(&self.local.modules, id)?;
+        let private = Self::get_or_error(&self.private.modules, id)?;
+        let consensus = Self::get_or_error(&self.consensus.modules, id)?;
         let module = ServerModuleConfig::from(local, private, consensus);
 
         module.to_typed()
     }
+    pub fn get_module_id_by_kind(
+        &self,
+        kind: impl Into<ModuleKind>,
+    ) -> anyhow::Result<ModuleInstanceId> {
+        let kind = kind.into();
+        Ok(*self
+            .consensus
+            .modules
+            .iter()
+            .find(|(_, v)| v.is_kind(&kind))
+            .ok_or_else(|| format_err!("Module {kind} not found"))?
+            .0)
+    }
 
     /// Constructs a module config by name
-    pub fn get_module_config(&self, name: &str) -> anyhow::Result<ServerModuleConfig> {
-        let local = Self::get_or_error(&self.local.modules, name)?;
-        let private = Self::get_or_error(&self.private.modules, name)?;
-        let consensus = Self::get_or_error(&self.consensus.modules, name)?;
+    pub fn get_module_config(&self, id: ModuleInstanceId) -> anyhow::Result<ServerModuleConfig> {
+        let local = Self::get_or_error(&self.local.modules, id)?;
+        let private = Self::get_or_error(&self.private.modules, id)?;
+        let consensus = Self::get_or_error(&self.consensus.modules, id)?;
         Ok(ServerModuleConfig::from(local, private, consensus))
     }
 
-    fn get_or_error(
-        json: &BTreeMap<String, serde_json::Value>,
-        name: &str,
-    ) -> anyhow::Result<serde_json::Value> {
-        json.get(name)
-            .ok_or_else(|| format_err!("Module {name} not found"))
+    fn get_or_error<T>(
+        json: &BTreeMap<ModuleInstanceId, T>,
+        id: ModuleInstanceId,
+    ) -> anyhow::Result<T>
+    where
+        T: Clone,
+    {
+        json.get(&id)
+            .ok_or_else(|| format_err!("Module {id} not found"))
             .cloned()
     }
 
@@ -310,20 +359,18 @@ impl ServerConfig {
             bail!("Peer ids are not indexed from 0");
         }
 
-        for module_name in self
-            .local
+        for (module_id, module_kind) in self
+            .consensus
             .modules
-            .keys()
-            .collect::<BTreeSet<_>>()
-            .union(&self.consensus.modules.keys().collect::<BTreeSet<_>>())
-            .copied()
-            .collect::<BTreeSet<_>>()
-            .union(&self.private.modules.keys().collect::<BTreeSet<_>>())
+            .iter()
+            .map(|(id, config)| Ok((*id, config.kind())))
+            .collect::<anyhow::Result<BTreeSet<_>>>()?
+            .iter()
         {
             module_config_gens
-                .get(module_name.as_str())
-                .ok_or_else(|| format_err!("module config gen not found {module_name}"))?
-                .validate_config(identity, self.get_module_config(module_name)?)?;
+                .get(module_kind)
+                .ok_or_else(|| format_err!("module config gen not found {module_kind}"))?
+                .validate_config(identity, self.get_module_config(*module_id)?)?;
         }
 
         Ok(())
@@ -346,10 +393,18 @@ impl ServerConfig {
 
         let peer0 = &params[&PeerId::from(0)];
 
+        // We assume user wants one module instance for every module kind
         let module_configs: BTreeMap<_, _> = module_config_gens
             .iter()
-            .map(|(name, gen)| (name, gen.trusted_dealer_gen(peers, &peer0.modules)))
+            .enumerate()
+            .map(|(module_id, (_kind, gen))| {
+                (
+                    u16::try_from(module_id).expect("Can't fail"),
+                    gen.trusted_dealer_gen(peers, &peer0.modules),
+                )
+            })
             .collect();
+
         let server_config: BTreeMap<_, _> = netinfo
             .iter()
             .map(|(&id, _netinf)| {
@@ -362,7 +417,7 @@ impl ServerConfig {
                     Self::extract_keys(netinfo.get(&id).expect("peer exists")),
                     module_configs
                         .iter()
-                        .map(|(name, cfgs)| (name.to_string(), cfgs[&id].clone()))
+                        .map(|(module_id, cfgs)| (*module_id, cfgs[&id].clone()))
                         .collect(),
                 );
                 (id, config)
@@ -382,7 +437,7 @@ impl ServerConfig {
     #[allow(clippy::too_many_arguments)]
     pub async fn distributed_gen(
         code_version: &str,
-        connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
+        connections: &MuxPeerConnections<ModuleInstanceId, DkgPeerMsg>,
         our_id: &PeerId,
         peers: &[PeerId],
         params: &ServerConfigParams,
@@ -409,7 +464,10 @@ impl ServerConfig {
         dkg.add(KeyType::Epoch, peers.threshold());
 
         // run DKG for epoch and hbbft keys
-        let keys = if let Ok(v) = dkg.run_g1(MODULE_KEY_GLOBAL, connections, &mut rng).await {
+        let keys = if let Ok(v) = dkg
+            .run_g1(MODULE_INSTANCE_ID_GLOBAL, connections, &mut rng)
+            .await
+        {
             v
         } else {
             return Ok(Err(Cancelled));
@@ -418,13 +476,25 @@ impl ServerConfig {
         let hbbft_keys = keys[&KeyType::Hbbft].threshold_crypto();
         let epoch_keys = keys[&KeyType::Epoch].threshold_crypto();
 
-        let mut module_cfgs: BTreeMap<String, ServerModuleConfig> = Default::default();
+        let mut module_cfgs: BTreeMap<ModuleInstanceId, ServerModuleConfig> = Default::default();
 
-        for (name, gen) in module_config_gens.iter() {
+        // NOTE: Currently we do not implement user-assisted module-kind to module-instance-id assignment
+        // We assume that user wants one instance of each module that was compiled in. This is how
+        // things were initially, where we consider "module as a code" as "module as an instance at runtime"
+        for (module_instance_id, (_kind, gen)) in module_config_gens.iter().enumerate() {
+            let module_instance_id = u16::try_from(module_instance_id)
+                .expect("64k module instances should be enough for everyone");
             module_cfgs.insert(
-                name.to_string(),
+                module_instance_id,
                 if let Ok(cfgs) = gen
-                    .distributed_gen(connections, our_id, peers, &params.modules, task_group)
+                    .distributed_gen(
+                        connections,
+                        our_id,
+                        module_instance_id,
+                        peers,
+                        &params.modules,
+                        task_group,
+                    )
                     .await?
                 {
                     cfgs

--- a/fedimint-server/src/consensus/debug.rs
+++ b/fedimint-server/src/consensus/debug.rs
@@ -23,7 +23,7 @@ fn item_message(item: &ConsensusItem) -> String {
         ConsensusItem::EpochOutcomeSignatureShare(_) => "Outcome Signature".to_string(),
         // TODO: make this nice again
         ConsensusItem::Module(mci) => {
-            format!("Module CI: module={} ci={}", mci.module_key(), mci)
+            format!("Module CI: module={} ci={}", mci.module_instance_id(), mci)
         }
         ConsensusItem::Transaction(Transaction {
             inputs, outputs, ..

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use fedimint_api::core::ModuleInstanceId;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::ApiError;
 use serde_json::Value;
@@ -13,12 +14,12 @@ pub struct FedimintInterconnect<'a> {
 impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
     async fn call(
         &self,
-        module_name: &'static str,
+        id: ModuleInstanceId,
         path: String,
         data: Value,
     ) -> Result<Value, ApiError> {
-        for module in self.fedimint.modules.iter_modules() {
-            if module.api_base_name() == module_name {
+        for (module_id, module) in self.fedimint.modules.iter_modules() {
+            if module_id == id {
                 let endpoint = module
                     .api_endpoints()
                     .into_iter()
@@ -33,6 +34,6 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
                 .await;
             }
         }
-        panic!("Module not registered: {}", module_name);
+        panic!("Module not registered: {}", id);
     }
 }

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -19,7 +19,6 @@ pub mod btc;
 #[derive(Debug)]
 pub struct FakeFed<Module> {
     members: Vec<(PeerId, Module, Database)>,
-    module_instance_id: ModuleInstanceId,
     client_cfg: ClientModuleConfig,
     block_height: Arc<std::sync::atomic::AtomicU64>,
 }
@@ -69,7 +68,6 @@ where
         Ok(FakeFed {
             members,
             client_cfg,
-            module_instance_id,
             block_height: Arc::new(AtomicU64::new(0)),
         })
     }

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use fedimint_api::config::{ClientModuleConfig, ConfigGenParams, ServerModuleConfig};
+use fedimint_api::core::{ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
 use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::module::interconnect::ModuleInterconect;
@@ -18,6 +19,7 @@ pub mod btc;
 #[derive(Debug)]
 pub struct FakeFed<Module> {
     members: Vec<(PeerId, Module, Database)>,
+    module_instance_id: ModuleInstanceId,
     client_cfg: ClientModuleConfig,
     block_height: Arc<std::sync::atomic::AtomicU64>,
 }
@@ -41,6 +43,7 @@ where
         constructor: F,
         params: &ConfigGenParams,
         conf_gen: &ConfGen,
+        module_instance_id: ModuleInstanceId,
     ) -> anyhow::Result<FakeFed<Module>>
     where
         ConfGen: ModuleInit,
@@ -57,7 +60,7 @@ where
         for (peer, cfg) in server_cfg {
             let db = Database::new(
                 MemDatabase::new(),
-                ModuleDecoderRegistry::from_iter([conf_gen.decoder()]),
+                ModuleDecoderRegistry::from_iter([(module_instance_id, conf_gen.decoder())]),
             );
             let member = constructor(cfg, db.clone()).await?;
             members.push((peer, member, db));
@@ -66,6 +69,7 @@ where
         Ok(FakeFed {
             members,
             client_cfg,
+            module_instance_id,
             block_height: Arc::new(AtomicU64::new(0)),
         })
     }
@@ -231,7 +235,7 @@ where
     }
 
     pub fn client_cfg_typed<T: serde::de::DeserializeOwned>(&self) -> anyhow::Result<T> {
-        Ok(serde_json::from_value(self.client_cfg.0.clone())?)
+        Ok(serde_json::from_value(self.client_cfg.value().clone())?)
     }
 
     pub async fn fetch_from_all<'a: 'b, 'b, O, F, Fut>(&'a mut self, fetch: F) -> O
@@ -306,7 +310,7 @@ where
 
 struct FakeInterconnect(
     Box<
-        dyn Fn(&'static str, String, serde_json::Value) -> Result<serde_json::Value, ApiError>
+        dyn Fn(ModuleInstanceId, String, serde_json::Value) -> Result<serde_json::Value, ApiError>
             + Sync
             + Send,
     >,
@@ -315,7 +319,7 @@ struct FakeInterconnect(
 impl FakeInterconnect {
     fn new_block_height_responder(bh: Arc<AtomicU64>) -> FakeInterconnect {
         FakeInterconnect(Box::new(move |module, path, _data| {
-            assert_eq!(module, "wallet");
+            assert_eq!(module, LEGACY_HARDCODED_INSTANCE_ID_WALLET);
             assert_eq!(path, "/block_height");
 
             let height = bh.load(Ordering::Relaxed);
@@ -328,10 +332,10 @@ impl FakeInterconnect {
 impl ModuleInterconect for FakeInterconnect {
     async fn call(
         &self,
-        module: &'static str,
+        module_id: ModuleInstanceId,
         path: String,
         data: serde_json::Value,
     ) -> Result<serde_json::Value, ApiError> {
-        (self.0)(module, path, data)
+        (self.0)(module_id, path, data)
     }
 }

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -136,13 +136,10 @@ async fn main() {
         )
         .init();
 
-    let module_config_gens = ModuleInitRegistry::from([
-        (
-            "wallet",
-            Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
-        ),
-        ("mint", Arc::new(MintConfigGenerator)),
-        ("ln", Arc::new(LightningModuleConfigGen)),
+    let module_config_gens = ModuleInitRegistry::from(vec![
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(MintConfigGenerator),
+        Arc::new(LightningModuleConfigGen),
     ]);
 
     let mut task_group = TaskGroup::new();

--- a/fedimintd/src/distributedgen.rs
+++ b/fedimintd/src/distributedgen.rs
@@ -86,13 +86,10 @@ pub async fn run_dkg(
     .await;
     let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
 
-    let module_config_gens = ModuleInitRegistry::from([
-        (
-            "wallet",
-            Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
-        ),
-        ("mint", Arc::new(MintConfigGenerator)),
-        ("ln", Arc::new(LightningModuleConfigGen)),
+    let module_config_gens = ModuleInitRegistry::from(vec![
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(MintConfigGenerator),
+        Arc::new(LightningModuleConfigGen),
     ]);
 
     let result = ServerConfig::distributed_gen(

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -133,13 +133,10 @@ async fn post_guardians(
     let pk_bytes = encrypted_read(&key, state.data_dir.join(TLS_PK));
     let max_denomination = Amount::from_msats(100000000000);
     let (dkg_sender, dkg_receiver) = tokio::sync::oneshot::channel::<UiMessage>();
-    let module_config_gens = ModuleInitRegistry::from([
-        (
-            "wallet",
-            Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
-        ),
-        ("mint", Arc::new(MintConfigGenerator)),
-        ("ln", Arc::new(LightningModuleConfigGen)),
+    let module_config_gens = ModuleInitRegistry::from(vec![
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(MintConfigGenerator),
+        Arc::new(LightningModuleConfigGen),
     ]);
     let dir_out_path = state.data_dir.clone();
     let fedimintd_sender = state.sender.clone();

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -1042,7 +1042,7 @@ impl FederationTest {
 
             let mut modules = BTreeMap::new();
 
-            for (kind, gen) in module_inits.iter() {
+            for (kind, gen) in module_inits.legacy_init_order_iter() {
                 let id = cfg.get_module_id_by_kind(kind.clone()).unwrap();
                 if let Some(module) = override_modules.remove(kind.as_str()) {
                     info!(module_instance_id = id, kind = %kind, "Use overriden module");

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -20,6 +20,7 @@ use cln_rpc::ClnRpc;
 use fake::FakeLightningTest;
 use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::ClientConfig;
+use fedimint_api::core;
 use fedimint_api::core::{
     ConsensusItem as PerModuleConsensusItem, PluginConsensusItem,
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
@@ -810,11 +811,10 @@ impl FederationTest {
                     let mut dbtx = svr.database.begin_transaction().await;
                     let transaction = fedimint_server::transaction::Transaction {
                         inputs: vec![],
-                        outputs: vec![(
-                            MintOutput(tokens.clone()),
+                        outputs: vec![core::Output::from_typed(
                             LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                        )
-                            .into()],
+                            MintOutput(tokens.clone()),
+                        )],
                         signature: None,
                     };
 
@@ -834,11 +834,10 @@ impl FederationTest {
                         .get(LEGACY_HARDCODED_INSTANCE_ID_MINT)
                         .apply_output(
                             &mut dbtx,
-                            &(
-                                MintOutput(tokens.clone()),
+                            &core::Output::from_typed(
                                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                            )
-                                .into(),
+                                MintOutput(tokens.clone()),
+                            ),
                             out_point,
                         )
                         .await

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -348,14 +348,13 @@ async fn drop_peers_who_dont_contribute_decryption_shares() -> Result<()> {
             .decrypt_share_no_verify(&SecretKey::random().public_key().encrypt(""));
         fed.subset_peers(&[3])
             .override_proposal(vec![ConsensusItem::Module(
-                (
+                fedimint_api::core::ConsensusItem::from_typed(
+                    LEGACY_HARDCODED_INSTANCE_ID_LN,
                     LightningConsensusItem {
                         contract_id,
                         share: PreimageDecryptionShare(share),
                     },
-                    LEGACY_HARDCODED_INSTANCE_ID_LN,
-                )
-                    .into(),
+                ),
             )]);
         drop_peer_3_during_epoch(&fed).await.unwrap(); // preimage decryption
 
@@ -395,14 +394,13 @@ async fn drop_peers_who_contribute_bad_sigs() -> Result<()> {
             .await;
         let out_point = fed.database_add_coins_for_user(&user, sats(2000)).await;
         let bad_proposal = vec![ConsensusItem::Module(
-            (
+            fedimint_api::core::ConsensusItem::from_typed(
+                LEGACY_HARDCODED_INSTANCE_ID_MINT,
                 MintOutputConfirmation {
                     out_point,
                     signatures: OutputConfirmationSignatures(TieredMulti::default()),
                 },
-                LEGACY_HARDCODED_INSTANCE_ID_MINT,
-            )
-                .into(),
+            ),
         )];
 
         fed.subset_peers(&[3]).override_proposal(bad_proposal);

--- a/modules/fedimint-dummy/src/common.rs
+++ b/modules/fedimint-dummy/src/common.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use fedimint_api::core::{ConsensusItem, Input, Output, OutputOutcome, PluginDecode};
+use fedimint_api::core::PluginDecode;
 use fedimint_api::encoding::{Decodable, DecodeError};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 
@@ -10,31 +10,30 @@ use crate::{DummyInput, DummyOutput, DummyOutputConfirmation, DummyOutputOutcome
 pub struct DummyModuleDecoder;
 
 impl PluginDecode for DummyModuleDecoder {
-    fn decode_input(mut d: &mut dyn io::Read) -> Result<Input, DecodeError> {
-        Ok(Input::from(DummyInput::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
-    }
-    fn decode_output(mut d: &mut dyn io::Read) -> Result<Output, DecodeError> {
-        Ok(Output::from(DummyOutput::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
+    type Input = DummyInput;
+    type Output = DummyOutput;
+    type OutputOutcome = DummyOutputOutcome;
+    type ConsensusItem = DummyOutputConfirmation;
+
+    fn decode_input(&self, mut d: &mut dyn io::Read) -> Result<DummyInput, DecodeError> {
+        DummyInput::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
     }
 
-    fn decode_output_outcome(mut d: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError> {
-        Ok(OutputOutcome::from(DummyOutputOutcome::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
+    fn decode_output(&self, mut d: &mut dyn io::Read) -> Result<DummyOutput, DecodeError> {
+        DummyOutput::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
+    }
+
+    fn decode_output_outcome(
+        &self,
+        mut d: &mut dyn io::Read,
+    ) -> Result<DummyOutputOutcome, DecodeError> {
+        DummyOutputOutcome::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
     }
 
     fn decode_consensus_item(
+        &self,
         mut r: &mut dyn io::Read,
-    ) -> Result<fedimint_api::core::ConsensusItem, DecodeError> {
-        Ok(ConsensusItem::from(
-            DummyOutputConfirmation::consensus_decode(&mut r, &ModuleDecoderRegistry::default())?,
-        ))
+    ) -> Result<DummyOutputConfirmation, DecodeError> {
+        DummyOutputConfirmation::consensus_decode(&mut r, &ModuleDecoderRegistry::default())
     }
 }

--- a/modules/fedimint-ln/src/common.rs
+++ b/modules/fedimint-ln/src/common.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use fedimint_api::core::{ConsensusItem, Input, Output, OutputOutcome, PluginDecode};
+use fedimint_api::core::PluginDecode;
 use fedimint_api::encoding::Decodable;
 use fedimint_api::encoding::DecodeError;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -11,30 +11,30 @@ use crate::{LightningConsensusItem, LightningInput, LightningOutput, LightningOu
 pub struct LightningModuleDecoder;
 
 impl PluginDecode for LightningModuleDecoder {
-    fn decode_input(mut d: &mut dyn io::Read) -> Result<Input, DecodeError> {
-        Ok(Input::from(LightningInput::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
-    }
-    fn decode_output(mut d: &mut dyn io::Read) -> Result<Output, DecodeError> {
-        Ok(Output::from(LightningOutput::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
+    type Input = LightningInput;
+    type Output = LightningOutput;
+    type OutputOutcome = LightningOutputOutcome;
+    type ConsensusItem = LightningConsensusItem;
+
+    fn decode_input(&self, mut d: &mut dyn io::Read) -> Result<LightningInput, DecodeError> {
+        LightningInput::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
     }
 
-    fn decode_output_outcome(mut d: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError> {
-        Ok(OutputOutcome::from(
-            LightningOutputOutcome::consensus_decode(&mut d, &ModuleDecoderRegistry::default())?,
-        ))
+    fn decode_output(&self, mut d: &mut dyn io::Read) -> Result<LightningOutput, DecodeError> {
+        LightningOutput::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
+    }
+
+    fn decode_output_outcome(
+        &self,
+        mut d: &mut dyn io::Read,
+    ) -> Result<LightningOutputOutcome, DecodeError> {
+        LightningOutputOutcome::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
     }
 
     fn decode_consensus_item(
+        &self,
         mut r: &mut dyn io::Read,
-    ) -> Result<fedimint_api::core::ConsensusItem, DecodeError> {
-        Ok(ConsensusItem::from(
-            LightningConsensusItem::consensus_decode(&mut r, &ModuleDecoderRegistry::default())?,
-        ))
+    ) -> Result<LightningConsensusItem, DecodeError> {
+        LightningConsensusItem::consensus_decode(&mut r, &ModuleDecoderRegistry::default())
     }
 }

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -27,6 +27,7 @@ async fn test_account() {
         |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
         &ConfigGenParams::new(),
         &LightningModuleConfigGen,
+        LEGACY_HARDCODED_INSTANCE_ID_LN,
     )
     .await
     .unwrap();
@@ -77,6 +78,7 @@ async fn test_outgoing() {
         |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
         &ConfigGenParams::new(),
         &LightningModuleConfigGen,
+        LEGACY_HARDCODED_INSTANCE_ID_LN,
     )
     .await
     .unwrap();
@@ -176,6 +178,7 @@ async fn test_incoming() {
         |cfg, _db| async move { Ok(LightningModule::new(cfg.to_typed()?)) },
         &ConfigGenParams::new(),
         &LightningModuleConfigGen,
+        LEGACY_HARDCODED_INSTANCE_ID_LN,
     )
     .await
     .unwrap();

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -1,6 +1,7 @@
 use bitcoin_hashes::sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
 use fedimint_api::config::ConfigGenParams;
+use fedimint_api::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
 use fedimint_api::{Amount, OutPoint};
 use fedimint_ln::config::LightningModuleClientConfig;
 use fedimint_ln::contracts::account::AccountContract;

--- a/modules/fedimint-mint/src/common.rs
+++ b/modules/fedimint-mint/src/common.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::io;
 
 use bitcoin_hashes::{sha256, Hash};
-use fedimint_api::core::{ConsensusItem, Input, Output, OutputOutcome, PluginDecode};
+use fedimint_api::core::PluginDecode;
 use fedimint_api::encoding::DecodeError;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -65,31 +65,30 @@ impl SignedBackupRequest {
 pub struct MintModuleDecoder;
 
 impl PluginDecode for MintModuleDecoder {
-    fn decode_input(mut d: &mut dyn io::Read) -> Result<Input, DecodeError> {
-        Ok(Input::from(MintInput::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
-    }
-    fn decode_output(mut d: &mut dyn io::Read) -> Result<Output, DecodeError> {
-        Ok(Output::from(MintOutput::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
+    type Input = MintInput;
+    type Output = MintOutput;
+    type OutputOutcome = MintOutputOutcome;
+    type ConsensusItem = MintOutputConfirmation;
+
+    fn decode_input(&self, mut d: &mut dyn io::Read) -> Result<MintInput, DecodeError> {
+        MintInput::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
     }
 
-    fn decode_output_outcome(mut d: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError> {
-        Ok(OutputOutcome::from(MintOutputOutcome::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
+    fn decode_output(&self, mut d: &mut dyn io::Read) -> Result<MintOutput, DecodeError> {
+        MintOutput::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
+    }
+
+    fn decode_output_outcome(
+        &self,
+        mut d: &mut dyn io::Read,
+    ) -> Result<MintOutputOutcome, DecodeError> {
+        MintOutputOutcome::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
     }
 
     fn decode_consensus_item(
+        &self,
         mut r: &mut dyn io::Read,
-    ) -> Result<fedimint_api::core::ConsensusItem, DecodeError> {
-        Ok(ConsensusItem::from(
-            MintOutputConfirmation::consensus_decode(&mut r, &ModuleDecoderRegistry::default())?,
-        ))
+    ) -> Result<MintOutputConfirmation, DecodeError> {
+        MintOutputConfirmation::consensus_decode(&mut r, &ModuleDecoderRegistry::default())
     }
 }

--- a/modules/fedimint-wallet/src/common.rs
+++ b/modules/fedimint-wallet/src/common.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use fedimint_api::core::{ConsensusItem, Input, Output, OutputOutcome, PluginDecode};
+use fedimint_api::core::PluginDecode;
 use fedimint_api::encoding::{Decodable, DecodeError};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 
@@ -10,32 +10,30 @@ use crate::{WalletConsensusItem, WalletInput, WalletOutput, WalletOutputOutcome}
 pub struct WalletModuleDecoder;
 
 impl PluginDecode for WalletModuleDecoder {
-    fn decode_input(mut d: &mut dyn io::Read) -> Result<Input, DecodeError> {
-        Ok(Input::from(WalletInput::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
-    }
-    fn decode_output(mut d: &mut dyn io::Read) -> Result<Output, DecodeError> {
-        Ok(Output::from(WalletOutput::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
+    type Input = WalletInput;
+    type Output = WalletOutput;
+    type OutputOutcome = WalletOutputOutcome;
+    type ConsensusItem = WalletConsensusItem;
+
+    fn decode_input(&self, mut d: &mut dyn io::Read) -> Result<WalletInput, DecodeError> {
+        WalletInput::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
     }
 
-    fn decode_output_outcome(mut d: &mut dyn io::Read) -> Result<OutputOutcome, DecodeError> {
-        Ok(OutputOutcome::from(WalletOutputOutcome::consensus_decode(
-            &mut d,
-            &ModuleDecoderRegistry::default(),
-        )?))
+    fn decode_output(&self, mut d: &mut dyn io::Read) -> Result<WalletOutput, DecodeError> {
+        WalletOutput::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
+    }
+
+    fn decode_output_outcome(
+        &self,
+        mut d: &mut dyn io::Read,
+    ) -> Result<WalletOutputOutcome, DecodeError> {
+        WalletOutputOutcome::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
     }
 
     fn decode_consensus_item(
+        &self,
         mut r: &mut dyn io::Read,
-    ) -> Result<fedimint_api::core::ConsensusItem, DecodeError> {
-        Ok(ConsensusItem::from(WalletConsensusItem::consensus_decode(
-            &mut r,
-            &ModuleDecoderRegistry::default(),
-        )?))
+    ) -> Result<WalletConsensusItem, DecodeError> {
+        WalletConsensusItem::consensus_decode(&mut r, &ModuleDecoderRegistry::default())
     }
 }


### PR DESCRIPTION
### Update

So I followed through and I think I'm almost done, but I've got tired

Missing pieces:

* [ ] ~~`fedimint-dbdump` needs to load the config to know instande ids to create all the decoders; easy~~ I would prefer doing it in a follow-up, as I think we will need to switch to clap, share some constants and logic of loading config between fedimintd-dbump and fedimimntd. 


Some thoughts:

* Quite a bit of changes, but mostly mechanical.
* Client and tests code is all non-modularized and in quite few places I had to hardcode the 1:1 mapping between kind and instance id. We know the initialization order.
* In some places doing this effort actually made things cleaner&better.


### Previous description

So far we've been conflating the two, thinking that a federation will run each module type exactly once, using a `u16` value as a "globally unique ID".

After the modularization is complete, it became more clear that actually we want a seprate id for a "module type" (named here "kind" to avoid confussion with Rust "type"), and a separate id for each module federation decided to "instantiate".

Each fedimint binary (like `fedimintd` will register all available module kinds) early in `main` function.

```rust
fn main() {
    FedimintServer::builder()
        .datadir("/var/lib/fedimintd")
        .with_module::<WalletInit>()
        .with_module::<MintInit>()
        .with_module::<LightningInit>()
        .build()
        .run()
        .await
}
```

The the users will define module instances they actually want to run as a part of the federation (we don't need this part yet, and we can just assume each module kind is insantiated exactly once).

The DKG will generate federation config that will have module configs keyed by the `ModuleInstanceId`, and containing `kind: ModuleKind` for each instance, so like:

```
{
  // ...

  modules: {
    1: {
      kind: "mint",
      // ..
    },
    2: {
      kind: "wallet",
    }
  }
  // ...
}
```

On start, when config is initialized `fedimintd` will use the config to know for which id, to instantiate what module with what config.

In the future we might want to implement ability to change the composition of module instances. So the Federation can disable certain module, and replace it with a different one, etc.

It's undecided yet, are we going to use it for module version change coordination, or just to give ability to run same module multiple times with different configs (might be useful for 3rd party modules).

One way or another the architecture seems better if the id of the instance is separate from it's "type".

This change only does the minimum rename and is to gather approval for the idea. In follow-up changes we will have to actually replace certain parts of code-base that are using strings, where they should be using ids, etc.