### PR TITLE
Avoid setup UI port collisions

### DIFF
--- a/fedimintd/templates/params.html
+++ b/fedimintd/templates/params.html
@@ -35,11 +35,11 @@
     </div>
     <div class="form-group">
       <label for="guardians_count" class="col-form-label">Number of Guardians Including You</label>
-      <input class="form-control" type="number" name="guardians_count" required placeholder="4" min="1" oninput="this.value = Math.abs(this.value)" />
+      <input class="form-control" type="number" name="guardians_count" required placeholder="4" min="1" />
     </div>
     <div class="form-group">
       <label for="finality_delay" class="col-form-label">Finality delay</label>
-      <input class="form-control" type="number" name="finality_delay" required value="10" min="1" oninput="this.value = Math.abs(this.value)" />
+      <input class="form-control" type="number" name="finality_delay" required value="10" min="1" />
     </div>
     <div class="form-group">
       <label for="network1" class="col-form-label">Choose network</label><br>


### PR DESCRIPTION
Have had a problem where setup UI can spawn 2 instances of DKG if the "/post_federation_params" form needs to be submitted multiple times (e.g. you realize that someone pasted in the wrong set of connection strings). Second one will fail to bind to the port, because DKG server from first one is still running there.

Not sure if this is the best approach, but it does fix this particular problem.

In a perfect world we'd start DKG server without yet telling it what connection strings to use. Then we could send it connection strings -- multiple times if necessary. So there wouldn't be any risk of binding to the port twice.