### PR TITLE
Add and verify consensus config hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,6 +1081,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bitcoin_hashes 0.11.0",
  "fedimint-api",
  "futures",
  "impl-tools",
@@ -1174,6 +1175,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bitcoin",
+ "bitcoin_hashes 0.11.0",
  "bytes",
  "fedimint-api",
  "fedimint-build",
@@ -1624,6 +1626,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitcoin",
+ "bitcoin_hashes 0.11.0",
  "fedimint-api",
  "fedimint-core",
  "fedimint-ln",

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -97,6 +97,9 @@ pub trait IFederationApi: Debug + Send + Sync {
         &self,
         id: &secp256k1::XOnlyPublicKey,
     ) -> Result<Vec<ECashUserBackupSnapshot>>;
+
+    /// Returns a hash of the consensus configs from peers
+    async fn fetch_consensus_hash(&self) -> Result<Sha256Hash>;
 }
 
 dyn_newtype_define! {
@@ -406,6 +409,15 @@ impl<C: JsonRpcClient + Debug + Send + Sync> IFederationApi for WsFederationApi<
             .into_iter()
             .flatten()
             .collect())
+    }
+
+    async fn fetch_consensus_hash(&self) -> Result<Sha256Hash> {
+        self.request(
+            "/consensus_hash",
+            (),
+            EventuallyConsistent::new(self.peers().one_honest()),
+        )
+        .await
     }
 }
 

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -341,6 +341,7 @@ mod tests {
     use async_trait::async_trait;
     use bitcoin::hashes::{sha256, Hash};
     use bitcoin::Address;
+    use bitcoin_hashes::sha256::Hash as Sha256Hash;
     use fedimint_api::config::ConfigGenParams;
     use fedimint_api::core::OutputOutcome;
     use fedimint_api::db::mem_impl::MemDatabase;
@@ -475,6 +476,10 @@ mod tests {
             _id: &secp256k1::XOnlyPublicKey,
         ) -> crate::api::Result<Vec<ECashUserBackupSnapshot>> {
             unimplemented!()
+        }
+
+        async fn fetch_consensus_hash(&self) -> crate::api::Result<Sha256Hash> {
+            todo!()
         }
     }
 

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -669,6 +669,7 @@ mod tests {
     use async_trait::async_trait;
     use bitcoin::hashes::Hash;
     use bitcoin::Address;
+    use bitcoin_hashes::sha256::Hash as Sha256Hash;
     use fedimint_api::config::ConfigGenParams;
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::db::Database;
@@ -799,6 +800,10 @@ mod tests {
             _id: &secp256k1::XOnlyPublicKey,
         ) -> crate::api::Result<Vec<ECashUserBackupSnapshot>> {
             unimplemented!()
+        }
+
+        async fn fetch_consensus_hash(&self) -> crate::api::Result<Sha256Hash> {
+            todo!()
         }
     }
 

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -197,6 +197,7 @@ mod tests {
     use async_trait::async_trait;
     use bitcoin::hashes::sha256;
     use bitcoin::{Address, Txid};
+    use bitcoin_hashes::sha256::Hash as Sha256Hash;
     use bitcoin_hashes::Hash;
     use fedimint_api::config::{BitcoindRpcCfg, ConfigGenParams};
     use fedimint_api::db::mem_impl::MemDatabase;
@@ -317,6 +318,10 @@ mod tests {
             _id: &secp256k1::XOnlyPublicKey,
         ) -> crate::api::Result<Vec<ECashUserBackupSnapshot>> {
             unimplemented!()
+        }
+
+        async fn fetch_consensus_hash(&self) -> crate::api::Result<Sha256Hash> {
+            todo!()
         }
     }
 

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -10,6 +10,7 @@ use anyhow::format_err;
 use bitcoin::secp256k1;
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::sha256::HashEngine;
+use fedimint_api::encoding::Encodable;
 use fedimint_api::BitcoinHash;
 use hbbft::crypto::group::Curve;
 use hbbft::crypto::group::GroupEncoding;
@@ -32,7 +33,7 @@ use crate::core::ModuleKey;
 use crate::net::peers::MuxPeerConnections;
 use crate::PeerId;
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable)]
 pub struct ApiEndpoint {
     /// The peer's API websocket network address and port (e.g. `ws://10.42.0.10:5000`)
     pub url: Url,

--- a/fedimint-api/src/encoding/mod.rs
+++ b/fedimint-api/src/encoding/mod.rs
@@ -78,6 +78,12 @@ pub trait Decodable: Sized {
     ) -> Result<Self, DecodeError>;
 }
 
+impl Encodable for hbbft::crypto::PublicKeySet {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        SerdeEncodable(self.clone()).consensus_encode(writer)
+    }
+}
+
 impl Encodable for Url {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         self.to_string().consensus_encode(writer)
@@ -131,6 +137,7 @@ impl_encode_decode_num!(u64);
 impl_encode_decode_num!(u32);
 impl_encode_decode_num!(u16);
 impl_encode_decode_num!(u8);
+impl_encode_decode_num!(usize);
 
 macro_rules! impl_encode_decode_tuple {
     ($($x:ident),*) => (
@@ -505,7 +512,7 @@ where
 }
 /// Wrappers for `T` that are `De-Serializable`, while we need them in `Encodable` contex
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]
-pub struct SerdeEncodable<T>(T);
+pub struct SerdeEncodable<T>(pub T);
 
 impl<T> Encodable for SerdeEncodable<T>
 where

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -6,6 +6,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
 
 use async_trait::async_trait;
+use bitcoin_hashes::sha256::HashEngine;
 use futures::future::BoxFuture;
 use secp256k1_zkp::XOnlyPublicKey;
 use thiserror::Error;
@@ -237,6 +238,12 @@ pub trait ModuleInit {
     ) -> anyhow::Result<ClientModuleConfig>;
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()>;
+
+    fn hash_consensus_config(
+        &self,
+        engine: &mut HashEngine,
+        config: serde_json::Value,
+    ) -> anyhow::Result<()>;
 }
 
 #[async_trait]

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0.66"
 async-trait = "0.1.59"
 bincode = "1.3.1"
 bitcoin = "0.29.2"
+bitcoin_hashes = "0.11.0"
 bytes = "1.3.0"
 hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
 futures = "0.3.24"

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
+use bitcoin_hashes::sha256;
 use fedimint_api::server::ServerModule;
 use fedimint_api::{
     config::ClientConfig,
@@ -223,6 +224,12 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
             "/config",
             async |fedimint: &FedimintConsensus, _dbtx, _v: ()| -> ClientConfig {
                 Ok(fedimint.cfg.consensus.to_client_config(&fedimint.module_inits))
+            }
+        },
+        api_endpoint! {
+            "/consensus_hash",
+            async |fedimint: &FedimintConsensus, _dbtx, _v: ()| -> sha256::Hash {
+                Ok(fedimint.cfg.consensus.hash)
             }
         },
     ]

--- a/gateway/tests/Cargo.toml
+++ b/gateway/tests/Cargo.toml
@@ -14,6 +14,7 @@ path = "tests/tests.rs"
 anyhow = "1.0.66"
 async-trait = "0.1.59"
 bitcoin = "0.29.2"
+bitcoin_hashes = "0.11.0"
 fedimint-api = { path = "../../fedimint-api" }
 fedimint-core = { path = "../../fedimint-core" }
 fedimint-ln = { path = "../../modules/fedimint-ln" }

--- a/gateway/tests/tests/fixtures/fed.rs
+++ b/gateway/tests/tests/fixtures/fed.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use bitcoin::{secp256k1, Address};
+use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use fedimint_api::TransactionId;
 use fedimint_core::{
     epoch::SignedEpochOutcome,
@@ -109,5 +110,9 @@ impl IFederationApi for MockApi {
         _id: &secp256k1::XOnlyPublicKey,
     ) -> Result<Vec<ECashUserBackupSnapshot>, ApiError> {
         unimplemented!()
+    }
+
+    async fn fetch_consensus_hash(&self) -> mint_client::api::Result<Sha256Hash> {
+        todo!()
     }
 }

--- a/modules/fedimint-dummy/Cargo.toml
+++ b/modules/fedimint-dummy/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1"
+bitcoin_hashes = "0.11.0"
 futures = "0.3"
 fedimint-api = { path = "../../fedimint-api" }
 rand = "0.8"

--- a/modules/fedimint-dummy/src/config.rs
+++ b/modules/fedimint-dummy/src/config.rs
@@ -2,6 +2,7 @@ use fedimint_api::config::{
     ClientModuleConfig, TypedClientModuleConfig, TypedServerModuleConfig,
     TypedServerModuleConsensusConfig,
 };
+use fedimint_api::encoding::Encodable;
 use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::PeerId;
 use serde::{Deserialize, Serialize};
@@ -14,7 +15,7 @@ pub struct DummyConfig {
     pub consensus: DummyConfigConsensus,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Encodable)]
 pub struct DummyConfigConsensus {
     pub something: u64,
 }

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 
 use async_trait::async_trait;
+use bitcoin_hashes::sha256::HashEngine;
 use common::DummyModuleDecoder;
 use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::TypedServerModuleConsensusConfig;
@@ -126,6 +127,15 @@ impl ModuleInit for DummyConfigGenerator {
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
         config.to_typed::<DummyConfig>()?.validate_config(identity)
+    }
+
+    fn hash_consensus_config(
+        &self,
+        engine: &mut HashEngine,
+        config: serde_json::Value,
+    ) -> anyhow::Result<()> {
+        serde_json::from_value::<DummyConfigConsensus>(config)?.consensus_encode(engine)?;
+        Ok(())
     }
 }
 

--- a/modules/fedimint-ln/src/config.rs
+++ b/modules/fedimint-ln/src/config.rs
@@ -3,6 +3,7 @@ use fedimint_api::config::{
     ClientModuleConfig, TypedClientModuleConfig, TypedServerModuleConfig,
     TypedServerModuleConsensusConfig,
 };
+use fedimint_api::encoding::Encodable;
 use fedimint_api::PeerId;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::serde_impl::SerdeSecret;
@@ -15,7 +16,7 @@ pub struct LightningConfig {
     pub consensus: LightningConfigConsensus,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encodable)]
 pub struct LightningConfigConsensus {
     /// The threshold public keys for encrypting the LN preimage
     pub threshold_pub_keys: threshold_crypto::PublicKeySet,
@@ -77,7 +78,7 @@ impl TypedServerModuleConfig for LightningConfig {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable)]
 pub struct FeeConsensus {
     pub contract_input: fedimint_api::Amount,
     pub contract_output: fedimint_api::Amount,

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -18,6 +18,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Sub;
 
 use async_trait::async_trait;
+use bitcoin_hashes::sha256::HashEngine;
 use bitcoin_hashes::Hash as BitcoinHash;
 use config::FeeConsensus;
 use db::{LightningGatewayKey, LightningGatewayKeyPrefix};
@@ -325,6 +326,15 @@ impl ModuleInit for LightningModuleConfigGen {
         config
             .to_typed::<LightningConfig>()?
             .validate_config(identity)
+    }
+
+    fn hash_consensus_config(
+        &self,
+        engine: &mut HashEngine,
+        config: serde_json::Value,
+    ) -> anyhow::Result<()> {
+        serde_json::from_value::<LightningConfigConsensus>(config)?.consensus_encode(engine)?;
+        Ok(())
     }
 }
 

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -6,6 +6,7 @@ use bitcoin::Network;
 use fedimint_api::config::TypedServerModuleConfig;
 use fedimint_api::config::{BitcoindRpcCfg, ClientModuleConfig};
 use fedimint_api::config::{TypedClientModuleConfig, TypedServerModuleConsensusConfig};
+use fedimint_api::encoding::Encodable;
 use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::{Feerate, PeerId};
 use miniscript::descriptor::Wsh;
@@ -67,7 +68,7 @@ pub struct WalletClientConfig {
 
 impl TypedClientModuleConfig for WalletClientConfig {}
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable)]
 pub struct FeeConsensus {
     pub peg_in_abs: fedimint_api::Amount,
     pub peg_out_abs: fedimint_api::Amount,

--- a/modules/fedimint-wallet/src/keys.rs
+++ b/modules/fedimint-wallet/src/keys.rs
@@ -3,12 +3,15 @@ use std::str::FromStr;
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{Secp256k1, Verification};
 use bitcoin::PublicKey;
+use fedimint_api::encoding::Encodable;
 use miniscript::{MiniscriptKey, ToPublicKey};
 use serde::{Deserialize, Serialize};
 
 use crate::tweakable::{Contract, Tweakable};
 
-#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable,
+)]
 pub struct CompressedPublicKey {
     pub key: secp256k1::PublicKey,
 }


### PR DESCRIPTION
Adds a SHA256 hash to the consensus config and has peers validate the hash against each other on startup.

Fixes #950