### PR TITLE
Update developer discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Fedimint is alpha software. Use cautiously, with small amounts of money. There a
 
 * <a id="community" />Community:
   * [Telegram group](https://t.me/fedimint) for high-level non-technical discussion
-  * [Developer discord](https://discord.gg/dZYajBMsEB) for technical discussion
+  * [Developer discord](https://chat.fedimint.org) for technical discussion
 * For developers:
   * [Introduction for contributors](./docs/contributing.md)
   * [Setting up dev environment](./docs/dev-env.md)


### PR DESCRIPTION
I just noticed that the discord link under the bullet points does not work. (the badge works). 
I changed it to the same URL as in the badge: chat.fedimint.org