### PR TITLE
WIP: Add Module Prefix and Check Database Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,8 @@ dependencies = [
  "secp256k1-zkp",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "tbs",
  "test-log",
  "thiserror",

--- a/client/client-lib/src/db.rs
+++ b/client/client-lib/src/db.rs
@@ -1,3 +1,4 @@
+use fedimint_api::core::CLIENT_KEY;
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use serde::Serialize;
@@ -21,6 +22,7 @@ impl std::fmt::Display for DbKeyPrefix {
 pub struct ClientSecretKey;
 
 impl DatabaseKeyPrefixConst for ClientSecretKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::ClientSecret as u8;
     type Key = ClientSecretKey;
     type Value = ClientSecret;

--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -1,3 +1,4 @@
+use fedimint_api::core::CLIENT_KEY;
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_core::modules::ln::contracts::ContractId;
@@ -29,6 +30,7 @@ impl std::fmt::Display for DbKeyPrefix {
 pub struct OutgoingPaymentKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for OutgoingPaymentKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPayment as u8;
     type Key = Self;
     type Value = OutgoingContractData;
@@ -38,6 +40,7 @@ impl DatabaseKeyPrefixConst for OutgoingPaymentKey {
 pub struct OutgoingPaymentKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OutgoingPaymentKeyPrefix {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPayment as u8;
     type Key = OutgoingPaymentKey;
     type Value = OutgoingContractData;
@@ -47,6 +50,7 @@ impl DatabaseKeyPrefixConst for OutgoingPaymentKeyPrefix {
 pub struct OutgoingPaymentClaimKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPaymentClaim as u8;
     type Key = Self;
     type Value = ();
@@ -56,6 +60,7 @@ impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKey {
 pub struct OutgoingPaymentClaimKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKeyPrefix {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPaymentClaim as u8;
     type Key = OutgoingPaymentClaimKey;
     type Value = ();
@@ -65,6 +70,7 @@ impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKeyPrefix {
 pub struct OutgoingContractAccountKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for OutgoingContractAccountKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::OutgoingContractAccount as u8;
     type Key = Self;
     type Value = OutgoingContractAccount;
@@ -74,6 +80,7 @@ impl DatabaseKeyPrefixConst for OutgoingContractAccountKey {
 pub struct OutgoingContractAccountKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OutgoingContractAccountKeyPrefix {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::OutgoingContractAccount as u8;
     type Key = OutgoingContractAccountKey;
     type Value = OutgoingContractAccount;
@@ -83,6 +90,7 @@ impl DatabaseKeyPrefixConst for OutgoingContractAccountKeyPrefix {
 pub struct ConfirmedInvoiceKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for ConfirmedInvoiceKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::ConfirmedInvoice as u8;
     type Key = Self;
     type Value = ConfirmedInvoice;
@@ -92,6 +100,7 @@ impl DatabaseKeyPrefixConst for ConfirmedInvoiceKey {
 pub struct ConfirmedInvoiceKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ConfirmedInvoiceKeyPrefix {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::ConfirmedInvoice as u8;
     type Key = ConfirmedInvoiceKey;
     type Value = ConfirmedInvoice;
@@ -101,6 +110,7 @@ impl DatabaseKeyPrefixConst for ConfirmedInvoiceKeyPrefix {
 pub struct LightningGatewayKey;
 
 impl DatabaseKeyPrefixConst for LightningGatewayKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
     type Key = Self;
     type Value = LightningGateway;
@@ -110,6 +120,7 @@ impl DatabaseKeyPrefixConst for LightningGatewayKey {
 pub struct LightningGatewayKeyPrefix;
 
 impl DatabaseKeyPrefixConst for LightningGatewayKeyPrefix {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
     type Key = LightningGatewayKey;
     type Value = LightningGateway;

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -1,3 +1,4 @@
+use fedimint_api::core::CLIENT_KEY;
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{Amount, OutPoint, TieredMulti, TransactionId};
@@ -30,6 +31,7 @@ pub struct CoinKey {
 }
 
 impl DatabaseKeyPrefixConst for CoinKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::Coin as u8;
     type Key = Self;
     type Value = SpendableNote;
@@ -39,6 +41,7 @@ impl DatabaseKeyPrefixConst for CoinKey {
 pub struct CoinKeyPrefix;
 
 impl DatabaseKeyPrefixConst for CoinKeyPrefix {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::Coin as u8;
     type Key = CoinKey;
     type Value = SpendableNote;
@@ -48,6 +51,7 @@ impl DatabaseKeyPrefixConst for CoinKeyPrefix {
 pub struct PendingCoinsKey(pub TransactionId);
 
 impl DatabaseKeyPrefixConst for PendingCoinsKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::PendingCoins as u8;
     type Key = Self;
     type Value = TieredMulti<SpendableNote>;
@@ -57,6 +61,7 @@ impl DatabaseKeyPrefixConst for PendingCoinsKey {
 pub struct PendingCoinsKeyPrefix;
 
 impl DatabaseKeyPrefixConst for PendingCoinsKeyPrefix {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::PendingCoins as u8;
     type Key = PendingCoinsKey;
     type Value = TieredMulti<SpendableNote>;
@@ -66,6 +71,7 @@ impl DatabaseKeyPrefixConst for PendingCoinsKeyPrefix {
 pub struct OutputFinalizationKey(pub OutPoint);
 
 impl DatabaseKeyPrefixConst for OutputFinalizationKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::OutputFinalizationData as u8;
     type Key = Self;
     type Value = NoteIssuanceRequests;
@@ -75,6 +81,7 @@ impl DatabaseKeyPrefixConst for OutputFinalizationKey {
 pub struct OutputFinalizationKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OutputFinalizationKeyPrefix {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::OutputFinalizationData as u8;
     type Key = OutputFinalizationKey;
     type Value = NoteIssuanceRequests;
@@ -84,6 +91,7 @@ impl DatabaseKeyPrefixConst for OutputFinalizationKeyPrefix {
 pub struct NextECashNoteIndexKeyPrefix;
 
 impl DatabaseKeyPrefixConst for NextECashNoteIndexKeyPrefix {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::NextECashNoteIndex as u8;
     type Key = NextECashNoteIndexKey;
     type Value = u64;
@@ -93,6 +101,7 @@ impl DatabaseKeyPrefixConst for NextECashNoteIndexKeyPrefix {
 pub struct NextECashNoteIndexKey(pub Amount);
 
 impl DatabaseKeyPrefixConst for NextECashNoteIndexKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::NextECashNoteIndex as u8;
     type Key = Self;
     type Value = u64;
@@ -102,6 +111,7 @@ impl DatabaseKeyPrefixConst for NextECashNoteIndexKey {
 pub struct NotesPerDenominationKey;
 
 impl DatabaseKeyPrefixConst for NotesPerDenominationKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = 0;
     type Key = Self;
     type Value = u16;

--- a/client/client-lib/src/wallet/db.rs
+++ b/client/client-lib/src/wallet/db.rs
@@ -1,4 +1,5 @@
 use bitcoin::Script;
+use fedimint_api::core::CLIENT_KEY;
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use serde::Serialize;
@@ -22,6 +23,7 @@ pub struct PegInKey {
 }
 
 impl DatabaseKeyPrefixConst for PegInKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::PegIn as u8;
     type Key = Self;
     type Value = [u8; 32]; // TODO: introduce newtype
@@ -31,6 +33,7 @@ impl DatabaseKeyPrefixConst for PegInKey {
 pub struct PegInPrefixKey;
 
 impl DatabaseKeyPrefixConst for PegInPrefixKey {
+    const MODULE_PREFIX: u16 = CLIENT_KEY;
     const DB_PREFIX: u8 = DbKeyPrefix::PegIn as u8;
     type Key = PegInKey;
     type Value = [u8; 32];

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -26,6 +26,8 @@ rand = "0.8.5"
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.89"
+strum = "0.24"
+strum_macros = "0.24"
 tbs = { path = "../crypto/tbs"}
 thiserror = "1.0.37"
 threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -36,6 +36,8 @@ pub const MODULE_KEY_MINT: u16 = 1;
 pub const MODULE_KEY_LN: u16 = 2;
 // not really a module
 pub const MODULE_KEY_GLOBAL: u16 = 1024;
+// need a key for the client
+pub const CLIENT_KEY: u16 = 3;
 
 /// Implement `Encodable` and `Decodable` for a "module dyn newtype"
 ///

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -14,8 +14,9 @@ use fedimint_api::{
 };
 
 use super::*;
-use crate::module::{
-    ApiEndpoint, InputMeta, ModuleError, ServerModulePlugin, TransactionItemAmount,
+use crate::{
+    db::DatabaseVersion,
+    module::{ApiEndpoint, InputMeta, ModuleError, ServerModulePlugin, TransactionItemAmount},
 };
 
 pub trait ModuleVerificationCache: Debug {
@@ -55,6 +56,8 @@ where
 #[async_trait]
 pub trait IServerModule: Debug {
     fn module_key(&self) -> ModuleKey;
+
+    fn db_module_version(&self) -> DatabaseVersion;
 
     /// Returns the decoder belonging to the server module
     fn decoder(&self) -> Decoder;
@@ -187,6 +190,10 @@ where
 {
     fn module_key(&self) -> ModuleKey {
         <Self as ServerModulePlugin>::module_key(self)
+    }
+
+    fn db_module_version(&self) -> DatabaseVersion {
+        <Self as ServerModulePlugin>::db_module_version(self)
     }
 
     fn decoder(&self) -> Decoder {

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -15,7 +15,7 @@ use crate::config::{ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ServerModul
 use crate::core::{
     Decoder, PluginConsensusItem, PluginDecode, PluginInput, PluginOutput, PluginOutputOutcome,
 };
-use crate::db::{Database, DatabaseTransaction};
+use crate::db::{Database, DatabaseTransaction, DatabaseVersion};
 use crate::module::audit::Audit;
 use crate::module::interconnect::ModuleInterconect;
 use crate::net::peers::MuxPeerConnections;
@@ -249,6 +249,8 @@ pub trait ServerModulePlugin: Debug + Sized {
     type VerificationCache: PluginVerificationCache;
 
     fn module_key(&self) -> ModuleKey;
+
+    fn db_module_version(&self) -> DatabaseVersion;
 
     fn decoder(&self) -> &'static Self::Decoder;
 

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -9,7 +9,9 @@ use fedimint_api::config::{
     FederationId, ServerModuleConfig, ThresholdKeys, TypedServerModuleConfig,
 };
 use fedimint_api::core::{ModuleKey, MODULE_KEY_GLOBAL};
-use fedimint_api::db::Database;
+use fedimint_api::db::{
+    Database, DatabaseTransaction, DatabaseVersion, DatabaseVersionKey, GLOBAL_DATABASE_VERSION,
+};
 use fedimint_api::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use fedimint_api::module::ModuleInit;
 use fedimint_api::net::peers::{IPeerConnections, MuxPeerConnections, PeerConnections};
@@ -191,9 +193,60 @@ impl ModuleInitRegistry {
             let module = v
                 .init(cfg.get_module_config(k)?, db.clone(), task_group)
                 .await?;
+            self.check_module_db_version(
+                module.module_key(),
+                module.db_module_version(),
+                db.begin_transaction(ModuleDecoderRegistry::default()).await,
+            )
+            .await?;
             modules.insert(module.module_key(), module);
         }
+
+        self.check_module_db_version(
+            MODULE_KEY_GLOBAL,
+            GLOBAL_DATABASE_VERSION,
+            db.begin_transaction(ModuleDecoderRegistry::default()).await,
+        )
+        .await?;
+
         Ok(ModuleRegistry::from(modules))
+    }
+
+    async fn check_module_db_version(
+        &self,
+        module_key: ModuleKey,
+        db_code_version: DatabaseVersion,
+        mut dbtx: DatabaseTransaction<'_>,
+    ) -> Result<(), anyhow::Error> {
+        // Get database version of module from database
+        if let Some(db_version) = dbtx.get_value(&DatabaseVersionKey { module_key }).await? {
+            // Compare db version from db against the version in the code
+            if db_version.version == db_code_version.version {
+                tracing::info!(
+                    "Database version for module {} matches the code version {}",
+                    module_key,
+                    db_version
+                );
+            } else {
+                tracing::info!(
+                    "Database version {} for module {} does not match the code version {}",
+                    db_version,
+                    module_key,
+                    db_code_version
+                );
+            }
+        } else {
+            tracing::info!(
+                "Persisting database version {} for module {}",
+                db_code_version,
+                module_key
+            );
+            dbtx.insert_new_entry(&DatabaseVersionKey { module_key }, &db_code_version)
+                .await?;
+            dbtx.commit_tx().await?;
+        }
+
+        Ok(())
     }
 }
 

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use fedimint_api::core::MODULE_KEY_GLOBAL;
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{PeerId, TransactionId};
@@ -31,6 +32,7 @@ impl std::fmt::Display for DbKeyPrefix {
 pub struct ProposedTransactionKey(pub TransactionId);
 
 impl DatabaseKeyPrefixConst for ProposedTransactionKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::ProposedTransaction as u8;
     type Key = Self;
     type Value = Transaction;
@@ -40,6 +42,7 @@ impl DatabaseKeyPrefixConst for ProposedTransactionKey {
 pub struct ProposedTransactionKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ProposedTransactionKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::ProposedTransaction as u8;
     type Key = ProposedTransactionKey;
     type Value = Transaction;
@@ -49,6 +52,7 @@ impl DatabaseKeyPrefixConst for ProposedTransactionKeyPrefix {
 pub struct AcceptedTransactionKey(pub TransactionId);
 
 impl DatabaseKeyPrefixConst for AcceptedTransactionKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::AcceptedTransaction as u8;
     type Key = Self;
     type Value = AcceptedTransaction;
@@ -58,6 +62,7 @@ impl DatabaseKeyPrefixConst for AcceptedTransactionKey {
 pub struct AcceptedTransactionKeyPrefix;
 
 impl DatabaseKeyPrefixConst for AcceptedTransactionKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::AcceptedTransaction as u8;
     type Key = AcceptedTransactionKey;
     type Value = AcceptedTransaction;
@@ -67,6 +72,7 @@ impl DatabaseKeyPrefixConst for AcceptedTransactionKeyPrefix {
 pub struct RejectedTransactionKey(pub TransactionId);
 
 impl DatabaseKeyPrefixConst for RejectedTransactionKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::RejectedTransaction as u8;
     type Key = Self;
     type Value = String;
@@ -76,6 +82,7 @@ impl DatabaseKeyPrefixConst for RejectedTransactionKey {
 pub struct RejectedTransactionKeyPrefix;
 
 impl DatabaseKeyPrefixConst for RejectedTransactionKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::RejectedTransaction as u8;
     type Key = RejectedTransactionKey;
     type Value = String;
@@ -85,6 +92,7 @@ impl DatabaseKeyPrefixConst for RejectedTransactionKeyPrefix {
 pub struct DropPeerKey(pub PeerId);
 
 impl DatabaseKeyPrefixConst for DropPeerKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::DropPeer as u8;
     type Key = Self;
     type Value = ();
@@ -94,6 +102,7 @@ impl DatabaseKeyPrefixConst for DropPeerKey {
 pub struct DropPeerKeyPrefix;
 
 impl DatabaseKeyPrefixConst for DropPeerKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::DropPeer as u8;
     type Key = DropPeerKey;
     type Value = ();
@@ -103,6 +112,7 @@ impl DatabaseKeyPrefixConst for DropPeerKeyPrefix {
 pub struct EpochHistoryKey(pub u64);
 
 impl DatabaseKeyPrefixConst for EpochHistoryKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::EpochHistory as u8;
     type Key = Self;
     type Value = SignedEpochOutcome;
@@ -112,6 +122,7 @@ impl DatabaseKeyPrefixConst for EpochHistoryKey {
 pub struct EpochHistoryKeyPrefix;
 
 impl DatabaseKeyPrefixConst for EpochHistoryKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::EpochHistory as u8;
     type Key = EpochHistoryKey;
     type Value = SignedEpochOutcome;
@@ -121,6 +132,7 @@ impl DatabaseKeyPrefixConst for EpochHistoryKeyPrefix {
 pub struct LastEpochKey;
 
 impl DatabaseKeyPrefixConst for LastEpochKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_GLOBAL;
     const DB_PREFIX: u8 = DbKeyPrefix::LastEpoch as u8;
     type Key = Self;
     type Value = EpochHistoryKey;

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -137,6 +137,8 @@ async fn main() -> anyhow::Result<()> {
 
     let consensus = FedimintConsensus::new(cfg.clone(), db, module_inits, &mut task_group).await?;
 
+    consensus.check_database_versions().await?;
+
     FedimintServer::run(cfg, consensus, decoders, &mut task_group).await?;
 
     local_task_set.await;

--- a/modules/fedimint-dummy/src/db.rs
+++ b/modules/fedimint-dummy/src/db.rs
@@ -1,7 +1,11 @@
-use fedimint_api::db::DatabaseKeyPrefixConst;
+use fedimint_api::db::{DatabaseKeyPrefixConst, DatabaseVersion};
 use fedimint_api::encoding::{Decodable, Encodable};
 use serde::Serialize;
 use strum_macros::EnumIter;
+
+use crate::MODULE_KEY_DUMMY;
+
+pub const DATABASE_VERSION: DatabaseVersion = DatabaseVersion { version: 1 };
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -20,6 +24,7 @@ impl std::fmt::Display for DbKeyPrefix {
 pub struct ExampleKey(pub u64);
 
 impl DatabaseKeyPrefixConst for ExampleKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_DUMMY;
     const DB_PREFIX: u8 = DbKeyPrefix::Example as u8;
     type Key = Self;
     type Value = ();
@@ -29,6 +34,7 @@ impl DatabaseKeyPrefixConst for ExampleKey {
 pub struct ExampleKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ExampleKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_DUMMY;
     const DB_PREFIX: u8 = DbKeyPrefix::Example as u8;
     type Key = ExampleKey;
     type Value = ();

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 use async_trait::async_trait;
 use common::DummyModuleDecoder;
+use db::DATABASE_VERSION;
 use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::TypedServerModuleConsensusConfig;
 use fedimint_api::config::{
@@ -10,7 +11,7 @@ use fedimint_api::config::{
     TypedServerModuleConfig,
 };
 use fedimint_api::core::{Decoder, ModuleKey};
-use fedimint_api::db::{Database, DatabaseTransaction};
+use fedimint_api::db::{Database, DatabaseTransaction, DatabaseVersion};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
@@ -185,6 +186,10 @@ impl ServerModulePlugin for Dummy {
 
     fn module_key(&self) -> ModuleKey {
         MODULE_KEY_DUMMY
+    }
+
+    fn db_module_version(&self) -> DatabaseVersion {
+        DATABASE_VERSION
     }
 
     fn decoder(&self) -> &'static Self::Decoder {

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -1,4 +1,5 @@
-use fedimint_api::db::DatabaseKeyPrefixConst;
+use fedimint_api::core::MODULE_KEY_LN;
+use fedimint_api::db::{DatabaseKeyPrefixConst, DatabaseVersion};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{OutPoint, PeerId};
 use secp256k1::PublicKey;
@@ -7,6 +8,8 @@ use strum_macros::EnumIter;
 
 use crate::contracts::{incoming::IncomingContractOffer, ContractId, PreimageDecryptionShare};
 use crate::{ContractAccount, LightningGateway, LightningOutputOutcome};
+
+pub const DATABASE_VERSION: DatabaseVersion = DatabaseVersion { version: 1 };
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -29,6 +32,7 @@ impl std::fmt::Display for DbKeyPrefix {
 pub struct ContractKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for ContractKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::Contract as u8;
     type Key = Self;
     type Value = ContractAccount;
@@ -38,6 +42,7 @@ impl DatabaseKeyPrefixConst for ContractKey {
 pub struct ContractKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ContractKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::Contract as u8;
     type Key = ContractKey;
     type Value = ContractAccount;
@@ -47,6 +52,7 @@ impl DatabaseKeyPrefixConst for ContractKeyPrefix {
 pub struct ContractUpdateKey(pub OutPoint);
 
 impl DatabaseKeyPrefixConst for ContractUpdateKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::ContractUpdate as u8;
     type Key = Self;
     type Value = LightningOutputOutcome;
@@ -56,6 +62,7 @@ impl DatabaseKeyPrefixConst for ContractUpdateKey {
 pub struct ContractUpdateKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ContractUpdateKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::ContractUpdate as u8;
     type Key = ContractUpdateKey;
     type Value = LightningOutputOutcome;
@@ -65,6 +72,7 @@ impl DatabaseKeyPrefixConst for ContractUpdateKeyPrefix {
 pub struct OfferKey(pub bitcoin_hashes::sha256::Hash);
 
 impl DatabaseKeyPrefixConst for OfferKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::Offer as u8;
     type Key = Self;
     type Value = IncomingContractOffer;
@@ -74,6 +82,7 @@ impl DatabaseKeyPrefixConst for OfferKey {
 pub struct OfferKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OfferKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::Offer as u8;
     type Key = OfferKey;
     type Value = IncomingContractOffer;
@@ -84,6 +93,7 @@ impl DatabaseKeyPrefixConst for OfferKeyPrefix {
 pub struct ProposeDecryptionShareKey(pub ContractId);
 
 impl DatabaseKeyPrefixConst for ProposeDecryptionShareKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::ProposeDecryptionShare as u8;
     type Key = Self;
     type Value = PreimageDecryptionShare;
@@ -94,6 +104,7 @@ impl DatabaseKeyPrefixConst for ProposeDecryptionShareKey {
 pub struct ProposeDecryptionShareKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ProposeDecryptionShareKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::ProposeDecryptionShare as u8;
     type Key = ProposeDecryptionShareKey;
     type Value = PreimageDecryptionShare;
@@ -104,6 +115,7 @@ impl DatabaseKeyPrefixConst for ProposeDecryptionShareKeyPrefix {
 pub struct AgreedDecryptionShareKey(pub ContractId, pub PeerId);
 
 impl DatabaseKeyPrefixConst for AgreedDecryptionShareKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::AgreedDecryptionShare as u8;
     type Key = Self;
     type Value = PreimageDecryptionShare;
@@ -114,6 +126,7 @@ impl DatabaseKeyPrefixConst for AgreedDecryptionShareKey {
 pub struct AgreedDecryptionShareKeyPrefix;
 
 impl DatabaseKeyPrefixConst for AgreedDecryptionShareKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::AgreedDecryptionShare as u8;
     type Key = AgreedDecryptionShareKey;
     type Value = PreimageDecryptionShare;
@@ -123,6 +136,7 @@ impl DatabaseKeyPrefixConst for AgreedDecryptionShareKeyPrefix {
 pub struct LightningGatewayKey(pub PublicKey);
 
 impl DatabaseKeyPrefixConst for LightningGatewayKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
     type Key = Self;
     type Value = LightningGateway;
@@ -132,6 +146,7 @@ impl DatabaseKeyPrefixConst for LightningGatewayKey {
 pub struct LightningGatewayKeyPrefix;
 
 impl DatabaseKeyPrefixConst for LightningGatewayKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_LN;
     const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
     type Key = LightningGatewayKey;
     type Value = LightningGateway;

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -20,7 +20,7 @@ use std::ops::Sub;
 use async_trait::async_trait;
 use bitcoin_hashes::Hash as BitcoinHash;
 use config::FeeConsensus;
-use db::{LightningGatewayKey, LightningGatewayKeyPrefix};
+use db::{LightningGatewayKey, LightningGatewayKeyPrefix, DATABASE_VERSION};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::TypedServerModuleConsensusConfig;
 use fedimint_api::config::{
@@ -28,7 +28,7 @@ use fedimint_api::config::{
     TypedServerModuleConfig,
 };
 use fedimint_api::core::{Decoder, ModuleKey, MODULE_KEY_LN};
-use fedimint_api::db::{Database, DatabaseTransaction};
+use fedimint_api::db::{Database, DatabaseTransaction, DatabaseVersion};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
@@ -339,6 +339,10 @@ impl ServerModulePlugin for LightningModule {
 
     fn module_key(&self) -> ModuleKey {
         MODULE_KEY_LN
+    }
+
+    fn db_module_version(&self) -> DatabaseVersion {
+        DATABASE_VERSION
     }
 
     fn decoder(&self) -> &'static Self::Decoder {

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -1,12 +1,15 @@
 use std::time::SystemTime;
 
-use fedimint_api::db::DatabaseKeyPrefixConst;
+use fedimint_api::core::MODULE_KEY_MINT;
+use fedimint_api::db::{DatabaseKeyPrefixConst, DatabaseVersion};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{Amount, OutPoint, PeerId};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
 use crate::{Nonce, OutputConfirmationSignatures, OutputOutcome};
+
+pub const DATABASE_VERSION: DatabaseVersion = DatabaseVersion { version: 1 };
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -29,6 +32,7 @@ impl std::fmt::Display for DbKeyPrefix {
 pub struct NonceKey(pub Nonce);
 
 impl DatabaseKeyPrefixConst for NonceKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::CoinNonce as u8;
     type Key = Self;
     type Value = ();
@@ -38,6 +42,7 @@ impl DatabaseKeyPrefixConst for NonceKey {
 pub struct NonceKeyPrefix;
 
 impl DatabaseKeyPrefixConst for NonceKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::CoinNonce as u8;
     type Key = NonceKey;
     type Value = ();
@@ -49,6 +54,7 @@ pub struct ProposedPartialSignatureKey {
 }
 
 impl DatabaseKeyPrefixConst for ProposedPartialSignatureKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
     type Key = Self;
     type Value = OutputConfirmationSignatures;
@@ -58,6 +64,7 @@ impl DatabaseKeyPrefixConst for ProposedPartialSignatureKey {
 pub struct ProposedPartialSignaturesKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ProposedPartialSignaturesKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
     type Key = ProposedPartialSignatureKey;
     type Value = OutputConfirmationSignatures;
@@ -70,6 +77,7 @@ pub struct ReceivedPartialSignatureKey {
 }
 
 impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = Self;
     type Value = OutputConfirmationSignatures;
@@ -81,6 +89,7 @@ pub struct ReceivedPartialSignatureKeyOutputPrefix {
 }
 
 impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKeyOutputPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = ReceivedPartialSignatureKey;
     type Value = OutputConfirmationSignatures;
@@ -90,6 +99,7 @@ impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKeyOutputPrefix {
 pub struct ReceivedPartialSignaturesKeyPrefix;
 
 impl DatabaseKeyPrefixConst for ReceivedPartialSignaturesKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = ReceivedPartialSignatureKey;
     type Value = OutputConfirmationSignatures;
@@ -100,6 +110,7 @@ impl DatabaseKeyPrefixConst for ReceivedPartialSignaturesKeyPrefix {
 pub struct OutputOutcomeKey(pub OutPoint);
 
 impl DatabaseKeyPrefixConst for OutputOutcomeKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::OutputOutcome as u8;
     type Key = Self;
     type Value = OutputOutcome;
@@ -109,6 +120,7 @@ impl DatabaseKeyPrefixConst for OutputOutcomeKey {
 pub struct OutputOutcomeKeyPrefix;
 
 impl DatabaseKeyPrefixConst for OutputOutcomeKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::OutputOutcome as u8;
     type Key = OutputOutcomeKey;
     type Value = OutputOutcome;
@@ -124,6 +136,7 @@ pub enum MintAuditItemKey {
 }
 
 impl DatabaseKeyPrefixConst for MintAuditItemKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::MintAuditItem as u8;
     type Key = Self;
     type Value = Amount;
@@ -133,6 +146,7 @@ impl DatabaseKeyPrefixConst for MintAuditItemKey {
 pub struct MintAuditItemKeyPrefix;
 
 impl DatabaseKeyPrefixConst for MintAuditItemKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::MintAuditItem as u8;
     type Key = MintAuditItemKey;
     type Value = Amount;
@@ -146,6 +160,7 @@ pub struct EcashBackupKeyPrefix;
 pub struct EcashBackupKey(pub secp256k1_zkp::XOnlyPublicKey);
 
 impl DatabaseKeyPrefixConst for EcashBackupKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::EcashBackup as u8;
     type Key = EcashBackupKey;
     type Value = ECashUserBackupSnapshot;
@@ -160,6 +175,7 @@ pub struct ECashUserBackupSnapshot {
 }
 
 impl DatabaseKeyPrefixConst for EcashBackupKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_MINT;
     const DB_PREFIX: u8 = DbKeyPrefix::EcashBackup as u8;
     type Key = Self;
     type Value = ECashUserBackupSnapshot;

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -6,7 +6,7 @@ use std::ops::Sub;
 use async_trait::async_trait;
 pub use common::{BackupRequest, SignedBackupRequest};
 use config::FeeConsensus;
-use db::{ECashUserBackupSnapshot, EcashBackupKey};
+use db::{ECashUserBackupSnapshot, EcashBackupKey, DATABASE_VERSION};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::TypedServerModuleConsensusConfig;
 use fedimint_api::config::{
@@ -14,7 +14,7 @@ use fedimint_api::config::{
     ServerModuleConfig, TypedServerModuleConfig,
 };
 use fedimint_api::core::{Decoder, ModuleKey, MODULE_KEY_MINT};
-use fedimint_api::db::{Database, DatabaseTransaction};
+use fedimint_api::db::{Database, DatabaseTransaction, DatabaseVersion};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
@@ -358,6 +358,10 @@ impl ServerModulePlugin for Mint {
 
     fn module_key(&self) -> ModuleKey {
         MODULE_KEY_MINT
+    }
+
+    fn db_module_version(&self) -> DatabaseVersion {
+        DATABASE_VERSION
     }
 
     fn decoder(&self) -> &'static Self::Decoder {

--- a/modules/fedimint-wallet/src/db.rs
+++ b/modules/fedimint-wallet/src/db.rs
@@ -1,5 +1,6 @@
 use bitcoin::{BlockHash, Txid};
-use fedimint_api::db::DatabaseKeyPrefixConst;
+use fedimint_api::core::MODULE_KEY_WALLET;
+use fedimint_api::db::{DatabaseKeyPrefixConst, DatabaseVersion};
 use fedimint_api::encoding::{Decodable, Encodable};
 use secp256k1::ecdsa::Signature;
 use serde::Serialize;
@@ -8,6 +9,8 @@ use strum_macros::EnumIter;
 use crate::{
     PendingTransaction, RoundConsensus, SpendableUTXO, UnsignedTransaction, WalletOutputOutcome,
 };
+
+pub const DATABASE_VERSION: DatabaseVersion = DatabaseVersion { version: 1 };
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -31,6 +34,7 @@ impl std::fmt::Display for DbKeyPrefix {
 pub struct BlockHashKey(pub BlockHash);
 
 impl DatabaseKeyPrefixConst for BlockHashKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::BlockHash as u8;
     type Key = Self;
     type Value = ();
@@ -40,6 +44,7 @@ impl DatabaseKeyPrefixConst for BlockHashKey {
 pub struct BlockHashKeyPrefix;
 
 impl DatabaseKeyPrefixConst for BlockHashKeyPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::BlockHash as u8;
     type Key = BlockHashKey;
     type Value = ();
@@ -49,6 +54,7 @@ impl DatabaseKeyPrefixConst for BlockHashKeyPrefix {
 pub struct UTXOKey(pub bitcoin::OutPoint);
 
 impl DatabaseKeyPrefixConst for UTXOKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::Utxo as u8;
     type Key = Self;
     type Value = SpendableUTXO;
@@ -58,6 +64,7 @@ impl DatabaseKeyPrefixConst for UTXOKey {
 pub struct UTXOPrefixKey;
 
 impl DatabaseKeyPrefixConst for UTXOPrefixKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::Utxo as u8;
     type Key = UTXOKey;
     type Value = SpendableUTXO;
@@ -67,6 +74,7 @@ impl DatabaseKeyPrefixConst for UTXOPrefixKey {
 pub struct RoundConsensusKey;
 
 impl DatabaseKeyPrefixConst for RoundConsensusKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::RoundConsensus as u8;
     type Key = Self;
     type Value = RoundConsensus;
@@ -76,6 +84,7 @@ impl DatabaseKeyPrefixConst for RoundConsensusKey {
 pub struct UnsignedTransactionKey(pub Txid);
 
 impl DatabaseKeyPrefixConst for UnsignedTransactionKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::UnsignedTransaction as u8;
     type Key = Self;
     type Value = UnsignedTransaction;
@@ -85,6 +94,7 @@ impl DatabaseKeyPrefixConst for UnsignedTransactionKey {
 pub struct UnsignedTransactionPrefixKey;
 
 impl DatabaseKeyPrefixConst for UnsignedTransactionPrefixKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::UnsignedTransaction as u8;
     type Key = UnsignedTransactionKey;
     type Value = UnsignedTransaction;
@@ -94,6 +104,7 @@ impl DatabaseKeyPrefixConst for UnsignedTransactionPrefixKey {
 pub struct PendingTransactionKey(pub Txid);
 
 impl DatabaseKeyPrefixConst for PendingTransactionKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::PendingTransaction as u8;
     type Key = Self;
     type Value = PendingTransaction;
@@ -103,6 +114,7 @@ impl DatabaseKeyPrefixConst for PendingTransactionKey {
 pub struct PendingTransactionPrefixKey;
 
 impl DatabaseKeyPrefixConst for PendingTransactionPrefixKey {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::PendingTransaction as u8;
     type Key = PendingTransactionKey;
     type Value = PendingTransaction;
@@ -112,6 +124,7 @@ impl DatabaseKeyPrefixConst for PendingTransactionPrefixKey {
 pub struct PegOutTxSignatureCI(pub Txid);
 
 impl DatabaseKeyPrefixConst for PegOutTxSignatureCI {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::PegOutTxSigCi as u8;
     type Key = Self;
     type Value = Vec<Signature>; // TODO: define newtype
@@ -121,6 +134,7 @@ impl DatabaseKeyPrefixConst for PegOutTxSignatureCI {
 pub struct PegOutTxSignatureCIPrefix;
 
 impl DatabaseKeyPrefixConst for PegOutTxSignatureCIPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::PegOutTxSigCi as u8;
     type Key = PegOutTxSignatureCI;
     type Value = Vec<Signature>;
@@ -130,6 +144,7 @@ impl DatabaseKeyPrefixConst for PegOutTxSignatureCIPrefix {
 pub struct PegOutBitcoinTransaction(pub fedimint_api::OutPoint);
 
 impl DatabaseKeyPrefixConst for PegOutBitcoinTransaction {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::PegOutBitcoinOutPoint as u8;
     type Key = Self;
     type Value = WalletOutputOutcome;
@@ -139,6 +154,7 @@ impl DatabaseKeyPrefixConst for PegOutBitcoinTransaction {
 pub struct PegOutBitcoinTransactionPrefix;
 
 impl DatabaseKeyPrefixConst for PegOutBitcoinTransactionPrefix {
+    const MODULE_PREFIX: u16 = MODULE_KEY_WALLET;
     const DB_PREFIX: u8 = DbKeyPrefix::PegOutBitcoinOutPoint as u8;
     type Key = PegOutBitcoinTransaction;
     type Value = WalletOutputOutcome;

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -18,6 +18,7 @@ use bitcoin::{
 };
 use bitcoin::{PackedLockTime, Sequence};
 use config::WalletConfigConsensus;
+use db::DATABASE_VERSION;
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::TypedServerModuleConsensusConfig;
 use fedimint_api::config::{
@@ -25,7 +26,7 @@ use fedimint_api::config::{
     ServerModuleConfig, TypedServerModuleConfig,
 };
 use fedimint_api::core::{Decoder, ModuleKey, MODULE_KEY_WALLET};
-use fedimint_api::db::{Database, DatabaseTransaction};
+use fedimint_api::db::{Database, DatabaseTransaction, DatabaseVersion};
 use fedimint_api::encoding::{Decodable, Encodable, UnzipConsensus};
 use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
@@ -394,6 +395,10 @@ impl ServerModulePlugin for Wallet {
 
     fn module_key(&self) -> ModuleKey {
         MODULE_KEY_WALLET
+    }
+
+    fn db_module_version(&self) -> DatabaseVersion {
+        DATABASE_VERSION
     }
 
     fn decoder(&self) -> &'static Self::Decoder {


### PR DESCRIPTION
This PR adds a module prefix to each database key and adds some initialization code when each module is initialized that check's the database version for each module.

This PR is dependent on the decision to split the Module Key into ModuleInstanceId and ModuleKind, so if that is merged then some things in this PR will need to change.