### PR TITLE
database: store module decoders inside database

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -8,6 +8,7 @@ use std::process::exit;
 use bitcoin::{secp256k1, Address, Transaction};
 use clap::{Parser, Subcommand};
 use fedimint_api::config::ClientConfig;
+use fedimint_api::db::Database;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, NumPeers, OutPoint, TieredMulti, TransactionId};
 use fedimint_core::config::load_from_file;
@@ -20,7 +21,7 @@ use mint_client::utils::{
     from_hex, parse_bitcoin_amount, parse_ecash, parse_fedimint_amount, parse_node_pub_key,
     serialize_ecash,
 };
-use mint_client::{Client, UserClientConfig};
+use mint_client::{module_decode_stubs, Client, UserClientConfig};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing_subscriber::EnvFilter;
@@ -390,8 +391,8 @@ async fn main() {
         let db_path = cli.workdir.join("client.db");
         let cfg: UserClientConfig = load_from_file(&cfg_path).expect("Failed to parse config");
         let db = fedimint_rocksdb::RocksDb::open(db_path)
-            .or_terminate(CliErrorKind::IOError, "could not open transaction db")
-            .into();
+            .or_terminate(CliErrorKind::IOError, "could not open transaction db");
+        let db = Database::new(db, module_decode_stubs());
 
         let rng = rand::rngs::OsRng;
 

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -685,9 +685,10 @@ async fn main() {
     ]);
 
     let serialized: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
+    let decoders = module_inits.decoders();
     let mut dbdump = DatabaseDump {
         serialized,
-        read_only: DatabaseTransaction::new(read_only, module_inits.decoders()),
+        read_only: DatabaseTransaction::new(Box::new(read_only), &decoders),
         ranges,
         prefixes,
         include_all_prefixes: csv_prefix == "All",

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -150,7 +150,7 @@ impl FedimintConsensus {
     }
 
     pub async fn database_transaction(&self) -> DatabaseTransaction<'_> {
-        self.db.begin_transaction(self.decoders()).await
+        self.db.begin_transaction().await
     }
 
     pub async fn submit_transaction(
@@ -174,7 +174,7 @@ impl FedimintConsensus {
         let mut pub_keys = Vec::new();
 
         // Create read-only DB tx so that the read state is consistent
-        let mut dbtx = self.db.begin_transaction(self.decoders()).await;
+        let mut dbtx = self.db.begin_transaction().await;
 
         for input in &transaction.inputs {
             let module = self.modules.get(input.module_key());
@@ -254,7 +254,7 @@ impl FedimintConsensus {
                 .into_iter()
                 .into_group_map_by(|(_peer, mci)| mci.module_key());
 
-            let mut dbtx = self.db.begin_transaction(self.decoders()).await;
+            let mut dbtx = self.db.begin_transaction().await;
             for (module_key, module_cis) in per_module_cis {
                 self.modules
                     .get(module_key)
@@ -268,7 +268,7 @@ impl FedimintConsensus {
         // Process transactions
         let mut rejected_txs: BTreeSet<TransactionId> = BTreeSet::new();
         {
-            let mut dbtx = self.db.begin_transaction(self.decoders()).await;
+            let mut dbtx = self.db.begin_transaction().await;
 
             let caches = self.build_verification_caches(transaction_cis.iter().map(|(_, tx)| tx));
             let mut processed_txs: HashSet<TransactionId> = HashSet::new();
@@ -334,7 +334,7 @@ impl FedimintConsensus {
 
         // End consensus epoch
         let epoch_history = {
-            let mut dbtx = self.db.begin_transaction(self.decoders()).await;
+            let mut dbtx = self.db.begin_transaction().await;
             let mut drop_peers = Vec::<PeerId>::new();
 
             let epoch_history = self
@@ -370,7 +370,7 @@ impl FedimintConsensus {
 
     pub async fn get_last_epoch(&self) -> Option<u64> {
         self.db
-            .begin_transaction(self.decoders())
+            .begin_transaction()
             .await
             .get_value(&LastEpochKey)
             .await
@@ -380,7 +380,7 @@ impl FedimintConsensus {
 
     pub async fn epoch_history(&self, epoch: u64) -> Option<SignedEpochOutcome> {
         self.db
-            .begin_transaction(self.decoders())
+            .begin_transaction()
             .await
             .get_value(&EpochHistoryKey(epoch))
             .await
@@ -398,7 +398,7 @@ impl FedimintConsensus {
         let peers: Vec<PeerId> = outcome.contributions.keys().cloned().collect();
         let maybe_prev_epoch = self
             .db
-            .begin_transaction(self.decoders())
+            .begin_transaction()
             .await
             .get_value(&prev_epoch_key)
             .await
@@ -582,7 +582,7 @@ impl FedimintConsensus {
 
         let rejected: Option<String> = self
             .db
-            .begin_transaction(self.decoders())
+            .begin_transaction()
             .await
             .get_value(&RejectedTransactionKey(txid))
             .await

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -193,7 +193,7 @@ impl FedimintServer {
     /// Starts consensus by skipping to the last saved epoch history  and triggering a new epoch
     pub async fn start_consensus(&mut self) {
         let db = self.consensus.db.clone();
-        let mut tx = db.begin_transaction(self.consensus.decoders()).await;
+        let mut tx = db.begin_transaction().await;
 
         if let Some(key) = tx.get_value(&LastEpochKey).await.expect("DB error") {
             self.last_processed_epoch = tx.get_value(&key).await.expect("DB error");

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -115,10 +115,6 @@ async fn main() -> anyhow::Result<()> {
     let key = get_key(opts.password, salt_path);
     let cfg = read_server_configs(&key, opts.data_dir.clone());
 
-    let db: Database = fedimint_rocksdb::RocksDb::open(opts.data_dir.join(DB_FILE))
-        .expect("Error opening DB")
-        .into();
-
     let local_task_set = tokio::task::LocalSet::new();
     let _guard = local_task_set.enter();
 
@@ -134,6 +130,10 @@ async fn main() -> anyhow::Result<()> {
     ]);
 
     let decoders = module_inits.decoders();
+
+    let db =
+        fedimint_rocksdb::RocksDb::open(opts.data_dir.join(DB_FILE)).expect("Error opening DB");
+    let db = Database::new(db, decoders.clone());
 
     let consensus = FedimintConsensus::new(cfg.clone(), db, module_inits, &mut task_group).await?;
 

--- a/gateway/tests/tests/fixtures/client.rs
+++ b/gateway/tests/tests/fixtures/client.rs
@@ -9,7 +9,7 @@ use ln_gateway::{
 };
 use mint_client::{
     api::{FederationApi, WsFederationConnect},
-    Client, GatewayClient, GatewayClientConfig,
+    module_decode_stubs, Client, GatewayClient, GatewayClientConfig,
 };
 use secp256k1::{PublicKey, Secp256k1};
 use url::Url;
@@ -36,9 +36,11 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
         let federation_id = config.client_config.federation_id.clone();
 
         let api: FederationApi = MockApi::new().into();
-        let db = self
-            .db_factory
-            .create_database(federation_id, PathBuf::new())?;
+        let db = self.db_factory.create_database(
+            federation_id,
+            PathBuf::new(),
+            module_decode_stubs(),
+        )?;
 
         Ok(GatewayClient::new_with_api(config, db, api, Default::default()).await)
     }

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -1,8 +1,6 @@
 use bitcoin_hashes::sha256;
 use bitcoin_hashes::Hash as BitcoinHash;
 use fedimint_api::config::ConfigGenParams;
-use fedimint_api::core::{Decoder, MODULE_KEY_LN};
-use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::{Amount, OutPoint};
 use fedimint_ln::config::LightningModuleClientConfig;
 use fedimint_ln::contracts::account::AccountContract;
@@ -19,13 +17,6 @@ use fedimint_ln::{
 };
 use fedimint_testing::FakeFed;
 use secp256k1::KeyPair;
-
-fn ln_decoders() -> ModuleDecoderRegistry {
-    ModuleDecoderRegistry::from_iter([(
-        MODULE_KEY_LN,
-        Decoder::from_typed(&fedimint_ln::common::LightningModuleDecoder),
-    )])
-}
 
 #[test_log::test(tokio::test)]
 async fn test_account() {
@@ -216,10 +207,7 @@ async fn test_incoming() {
     fed.consensus_round(&[], &[(offer_out_point, offer_output)])
         .await;
     let offers = fed
-        .fetch_from_all(|m, db| async {
-            m.get_offers(&mut db.begin_transaction(ln_decoders()).await)
-                .await
-        })
+        .fetch_from_all(|m, db| async { m.get_offers(&mut db.begin_transaction().await).await })
         .await;
     assert_eq!(offers, vec![offer.clone()]);
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -1495,15 +1495,7 @@ pub fn is_address_valid_for_network(address: &Address, network: Network) -> bool
 #[instrument(level = "debug", skip_all)]
 pub async fn run_broadcast_pending_tx(db: Database, rpc: BitcoindRpc, tg_handle: &TaskHandle) {
     while !tg_handle.is_shutting_down() {
-        broadcast_pending_tx(
-            db.begin_transaction(
-                /* we do not expect any module-specific types here, so no decoders should be OK */
-                Default::default(),
-            )
-            .await,
-            &rpc,
-        )
-        .await;
+        broadcast_pending_tx(db.begin_transaction().await, &rpc).await;
         // FIXME: remove after modularization finishes
         #[cfg(not(target_family = "wasm"))]
         fedimint_api::task::sleep(Duration::from_secs(10)).await;


### PR DESCRIPTION
Store ModuleDecoderRegistry inside Database, so it doesn't need to be supplied begin_transaction.

Split off from #1197 