### PR TITLE
Unify `*Registry` types with a common macro 

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -195,7 +195,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             config: self
                 .config
                 .as_ref()
-                .get_module_by_kind::<LightningModuleClientConfig>("ln")
+                .get_first_module_by_kind::<LightningModuleClientConfig>("ln")
                 .expect("needs lightning module client config")
                 .1,
             context: self.context.clone(),
@@ -207,7 +207,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             config: self
                 .config
                 .as_ref()
-                .get_module_by_kind::<MintClientConfig>("mint")
+                .get_first_module_by_kind::<MintClientConfig>("mint")
                 .expect("needs mint module client config")
                 .1,
             epoch_pk: self.config.as_ref().epoch_pk,
@@ -221,7 +221,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             config: self
                 .config
                 .as_ref()
-                .get_module_by_kind::<WalletClientConfig>("wallet")
+                .get_first_module_by_kind::<WalletClientConfig>("wallet")
                 .expect("needs wallet module client config")
                 .1,
 
@@ -426,7 +426,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
         let funding_amount = self
             .config
             .as_ref()
-            .get_module_by_kind::<WalletClientConfig>("wallet")
+            .get_first_module_by_kind::<WalletClientConfig>("wallet")
             .expect("missing wallet module config")
             .1
             .fee_consensus
@@ -815,7 +815,7 @@ impl Client<UserClientConfig> {
         let invoice = InvoiceBuilder::new(network_to_currency(
             self.config
                 .0
-                .get_module_by_kind::<WalletClientConfig>("wallet")
+                .get_first_module_by_kind::<WalletClientConfig>("wallet")
                 .expect("must have wallet config available")
                 .1
                 .network,

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::io::Write;
-use std::ops::{self, Mul};
+use std::ops::Mul;
 use std::str::FromStr;
 
 use anyhow::bail;
@@ -58,14 +58,6 @@ impl JsonWithKind {
     }
     pub fn is_kind(&self, kind: &ModuleKind) -> bool {
         &self.kind == kind
-    }
-}
-
-impl ops::Deref for JsonWithKind {
-    type Target = serde_json::Value;
-
-    fn deref(&self) -> &Self::Target {
-        &self.value
     }
 }
 
@@ -143,13 +135,18 @@ impl ClientConfig {
         }
     }
 
-    pub fn get_module_by_kind<T: DeserializeOwned>(
+    /// (soft-deprecated): Get the first instance of a module of a given kind in defined in config
+    ///
+    /// Since module ids are numerical and for time being we only support 1:1 mint, wallet, ln
+    /// module code in the client, this is useful, but please write any new code that avoids
+    /// assumptions about available modules.
+    pub fn get_first_module_by_kind<T: DeserializeOwned>(
         &self,
         kind: impl Into<ModuleKind>,
     ) -> anyhow::Result<(ModuleInstanceId, T)> {
         let kind: ModuleKind = kind.into();
         let Some((id, module_cfg)) = self.modules.iter().find(|(_, v)| v.is_kind(&kind)) else {
-            anyhow::bail!("Module kind {kind:?} not found")
+            anyhow::bail!("Module kind {kind} not found")
         };
 
         Ok((*id, serde_json::from_value(module_cfg.0.value().clone())?))
@@ -208,13 +205,17 @@ impl ClientModuleConfig {
     pub fn new(kind: ModuleKind, value: serde_json::Value) -> Self {
         Self(JsonWithKind::new(kind, value))
     }
-}
 
-impl ops::Deref for ClientModuleConfig {
-    type Target = JsonWithKind;
+    pub fn is_kind(&self, kind: &ModuleKind) -> bool {
+        self.0.is_kind(kind)
+    }
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    pub fn kind(&self) -> &ModuleKind {
+        self.0.kind()
+    }
+
+    pub fn value(&self) -> &serde_json::Value {
+        self.0.value()
     }
 }
 
@@ -229,17 +230,13 @@ impl ClientModuleConfig {
 /// See [`ClientModuleConfig`].
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ServerModuleConfig {
-    pub local: serde_json::Value,
-    pub private: serde_json::Value,
+    pub local: JsonWithKind,
+    pub private: JsonWithKind,
     pub consensus: JsonWithKind,
 }
 
 impl ServerModuleConfig {
-    pub fn from(
-        local: serde_json::Value,
-        private: serde_json::Value,
-        consensus: JsonWithKind,
-    ) -> Self {
+    pub fn from(local: JsonWithKind, private: JsonWithKind, consensus: JsonWithKind) -> Self {
         Self {
             local,
             private,
@@ -248,8 +245,8 @@ impl ServerModuleConfig {
     }
 
     pub fn to_typed<T: TypedServerModuleConfig>(&self) -> anyhow::Result<T> {
-        let local = serde_json::from_value(self.local.clone())?;
-        let private = serde_json::from_value(self.private.clone())?;
+        let local = serde_json::from_value(self.local.value().clone())?;
+        let private = serde_json::from_value(self.private.value().clone())?;
         let consensus = serde_json::from_value(self.consensus.value().clone())?;
 
         Ok(TypedServerModuleConfig::from_parts(
@@ -284,8 +281,14 @@ pub trait TypedServerModuleConfig: DeserializeOwned + Serialize {
         let (kind, local, private, consensus) = self.to_parts();
 
         ServerModuleConfig {
-            local: serde_json::to_value(local).expect("serialization can't fail"),
-            private: serde_json::to_value(private).expect("serialization can't fail"),
+            local: JsonWithKind::new(
+                kind.clone(),
+                serde_json::to_value(local).expect("serialization can't fail"),
+            ),
+            private: JsonWithKind::new(
+                kind.clone(),
+                serde_json::to_value(private).expect("serialization can't fail"),
+            ),
             consensus: JsonWithKind::new(
                 kind,
                 serde_json::to_value(consensus).expect("serialization can't fail"),

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -145,8 +145,6 @@ macro_rules! __api_endpoint {
 
 pub use __api_endpoint as api_endpoint;
 
-use crate::module::registry::ModuleKey;
-
 type HandlerFnReturn<'a> = BoxFuture<'a, Result<serde_json::Value, ApiError>>;
 type HandlerFn<M> = Box<
     dyn for<'a> Fn(
@@ -224,7 +222,7 @@ pub trait ModuleInit {
 
     async fn distributed_gen(
         &self,
-        connections: &MuxPeerConnections<ModuleKey, DkgPeerMsg>,
+        connections: &MuxPeerConnections<ModuleInstanceId, DkgPeerMsg>,
         our_id: &PeerId,
         module_id: ModuleInstanceId,
         peers: &[PeerId],

--- a/fedimint-api/src/module/registry.rs
+++ b/fedimint-api/src/module/registry.rs
@@ -1,11 +1,8 @@
 use std::collections::BTreeMap;
 
-use crate::core::{Decoder, ModuleInstanceId};
+use crate::core::Decoder;
+pub use crate::core::ModuleInstanceId;
 use crate::server::DynServerModule;
-
-// TODO: unify and/or make a newtype?
-/// Fedimint module identifier
-pub type ModuleKey = u16;
 
 #[derive(Debug, Clone)]
 pub struct ModuleRegistry<M>(BTreeMap<ModuleInstanceId, M>);
@@ -16,14 +13,14 @@ impl<M> Default for ModuleRegistry<M> {
     }
 }
 
-impl<M> From<BTreeMap<ModuleKey, M>> for ModuleRegistry<M> {
-    fn from(value: BTreeMap<ModuleKey, M>) -> Self {
+impl<M> From<BTreeMap<ModuleInstanceId, M>> for ModuleRegistry<M> {
+    fn from(value: BTreeMap<ModuleInstanceId, M>) -> Self {
         Self(value)
     }
 }
 
 impl<M> ModuleRegistry<M> {
-    pub fn new(decoders: impl IntoIterator<Item = (ModuleKey, M)>) -> Self {
+    pub fn new(decoders: impl IntoIterator<Item = (ModuleInstanceId, M)>) -> Self {
         Self(decoders.into_iter().collect())
     }
 
@@ -32,7 +29,7 @@ impl<M> ModuleRegistry<M> {
         self.0.iter().map(|(id, m)| (*id, m))
     }
 
-    pub fn get_mut(&mut self, key: &ModuleKey) -> Option<&mut M> {
+    pub fn get_mut(&mut self, key: &ModuleInstanceId) -> Option<&mut M> {
         self.0.get_mut(key)
     }
 
@@ -40,7 +37,7 @@ impl<M> ModuleRegistry<M> {
     ///
     /// # Panics
     /// If the module isn't in the registry
-    pub fn get(&self, module_key: ModuleKey) -> &M {
+    pub fn get(&self, module_key: ModuleInstanceId) -> &M {
         self.0
             .get(&module_key)
             .expect("CIs were decoded, so the module exists")
@@ -69,20 +66,20 @@ impl ServerModuleRegistry {
 
 /// Collection of decoders belonging to modules, typically obtained from a `ModuleRegistry`
 #[derive(Debug, Default, Clone)]
-pub struct ModuleDecoderRegistry(BTreeMap<ModuleKey, Decoder>);
+pub struct ModuleDecoderRegistry(BTreeMap<ModuleInstanceId, Decoder>);
 
 impl ModuleDecoderRegistry {
     /// Return the decoder belonging to the module identified by the supplied `module_key`
     ///
     /// # Panics
     /// If the decoder isn't in the registry
-    pub fn get(&self, module_key: ModuleKey) -> &Decoder {
+    pub fn get(&self, module_key: ModuleInstanceId) -> &Decoder {
         self.0.get(&module_key).expect("Module not found")
     }
 }
 
-impl FromIterator<(ModuleKey, Decoder)> for ModuleDecoderRegistry {
-    fn from_iter<T: IntoIterator<Item = (ModuleKey, Decoder)>>(iter: T) -> Self {
+impl FromIterator<(ModuleInstanceId, Decoder)> for ModuleDecoderRegistry {
+    fn from_iter<T: IntoIterator<Item = (ModuleInstanceId, Decoder)>>(iter: T) -> Self {
         ModuleDecoderRegistry(iter.into_iter().collect())
     }
 }

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -14,7 +14,7 @@ use fedimint_api::core::{
     MODULE_INSTANCE_ID_GLOBAL,
 };
 use fedimint_api::db::Database;
-use fedimint_api::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
+use fedimint_api::module::registry::{ModuleDecoderRegistry, Registry};
 use fedimint_api::module::ModuleInit;
 use fedimint_api::net::peers::{IPeerConnections, MuxPeerConnections, PeerConnections};
 use fedimint_api::task::TaskGroup;
@@ -238,7 +238,7 @@ impl ModuleInitRegistry {
         cfg: &ServerConfig,
         db: &Database,
         task_group: &mut TaskGroup,
-    ) -> anyhow::Result<ModuleRegistry<fedimint_api::server::DynServerModule>> {
+    ) -> anyhow::Result<Registry<fedimint_api::server::DynServerModule>> {
         let mut modules = BTreeMap::new();
 
         for (module_id, module_cfg) in &cfg.consensus.modules {
@@ -253,7 +253,7 @@ impl ModuleInitRegistry {
                 .await?;
             modules.insert(*module_id, module);
         }
-        Ok(ModuleRegistry::from(modules))
+        Ok(Registry::from(modules))
     }
 }
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -11,7 +11,7 @@ use fedimint_api::core::ModuleInstanceId;
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
-use fedimint_api::module::registry::{ModuleDecoderRegistry, ModuleRegistry, ServerModuleRegistry};
+use fedimint_api::module::registry::{ModuleDecoderRegistry, Registry, ServerModuleRegistry};
 use fedimint_api::module::{ModuleError, TransactionItemAmount};
 use fedimint_api::server::{DynServerModule, DynVerificationCache};
 use fedimint_api::task::TaskGroup;
@@ -123,7 +123,7 @@ impl FedimintConsensus {
         cfg: ServerConfig,
         db: Database,
         module_inits: ModuleInitRegistry,
-        modules: ModuleRegistry<DynServerModule>,
+        modules: Registry<DynServerModule>,
     ) -> Self {
         Self {
             rng_gen: Box::new(OsRngGen),

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -126,7 +126,7 @@ async fn main() -> anyhow::Result<()> {
         Arc::new(LightningModuleConfigGen),
     ]);
 
-    let decoders = module_inits.decoders(cfg.module_kinds_iter())?;
+    let decoders = module_inits.decoders(cfg.iter_module_instances())?;
 
     let db =
         fedimint_rocksdb::RocksDb::open(opts.data_dir.join(DB_FILE)).expect("Error opening DB");

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -1025,7 +1025,7 @@ impl FederationTest {
     ) -> Self {
         let servers = join_all(server_config.values().map(|cfg| async {
             let btc_rpc = bitcoin_gen();
-            let decoders = module_inits.decoders(cfg.module_kinds_iter()).unwrap();
+            let decoders = module_inits.decoders(cfg.iter_module_instances()).unwrap();
             let db = database_gen(decoders.clone());
             let mut task_group = task_group.clone();
 
@@ -1103,7 +1103,7 @@ impl FederationTest {
             servers,
             max_balance_sheet,
             last_consensus,
-            decoders: module_inits.decoders(cfg.module_kinds_iter()).unwrap(),
+            decoders: module_inits.decoders(cfg.iter_module_instances()).unwrap(),
             cfg,
             wallet,
         }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -27,7 +27,7 @@ use fedimint_api::core::{
 };
 use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::Database;
-use fedimint_api::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
+use fedimint_api::module::registry::{ModuleDecoderRegistry, Registry};
 use fedimint_api::module::ModuleInit;
 use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::server::DynServerModule;
@@ -1056,7 +1056,7 @@ impl FederationTest {
                 cfg.clone(),
                 db.clone(),
                 module_inits.clone(),
-                ModuleRegistry::from(modules),
+                Registry::from(modules),
             );
             let decoders = consensus.decoders();
 


### PR DESCRIPTION
So they can maintain consistent apis (where desired).


On top of #1285. Please review that first, then click Update here. :)