### PR TITLE
Renames in lightning module and ModuleInit

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -31,7 +31,7 @@ use fedimint_api::{Amount, OutPoint, TransactionId};
 use fedimint_api::{ServerModule, TieredMulti};
 use fedimint_core::epoch::SignedEpochOutcome;
 use fedimint_core::modules::ln::common::LightningDecoder;
-use fedimint_core::modules::ln::config::LightningModuleClientConfig;
+use fedimint_core::modules::ln::config::LightningClientConfig;
 use fedimint_core::modules::mint::common::MintDecoder;
 use fedimint_core::modules::mint::config::MintClientConfig;
 use fedimint_core::modules::mint::{MintOutput, MintOutputOutcome};
@@ -195,7 +195,7 @@ impl<T: AsRef<ClientConfig> + Clone> Client<T> {
             config: self
                 .config
                 .as_ref()
-                .get_first_module_by_kind::<LightningModuleClientConfig>("ln")
+                .get_first_module_by_kind::<LightningClientConfig>("ln")
                 .expect("needs lightning module client config")
                 .1,
             context: self.context.clone(),

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -198,11 +198,16 @@ where
     }
 }
 
-/// Logic responsible for module's initialization, config generation and validation
+/// Module Generation
 ///
-/// Once the module config is ready, the module can be instantiated via `[Self::init]`.
+/// This trait contains the methods responsible for the module's
+/// - initialization
+/// - config generation
+/// - config validation
+///
+/// Once the module configuration is ready, the module can be instantiated via `[Self::init]`.
 #[async_trait]
-pub trait ModuleInit {
+pub trait ModuleGen {
     fn decoder(&self) -> DynDecoder;
 
     fn module_kind(&self) -> ModuleKind;

--- a/fedimint-core/src/outcome.rs
+++ b/fedimint-core/src/outcome.rs
@@ -28,7 +28,7 @@ pub mod legacy {
         AccountContractOutcome, ContractOutcome, DecryptedPreimage, OutgoingContractOutcome,
         Preimage,
     };
-    use fedimint_ln::{LightningModule, LightningOutputOutcome};
+    use fedimint_ln::{Lightning, LightningOutputOutcome};
     use fedimint_mint::{Mint, MintOutputOutcome};
     use fedimint_wallet::{Wallet, WalletOutputOutcome};
 
@@ -38,7 +38,7 @@ pub mod legacy {
     pub enum OutputOutcome {
         Mint(<Mint as ServerModule>::OutputOutcome),
         Wallet(<Wallet as ServerModule>::OutputOutcome),
-        LN(<LightningModule as ServerModule>::OutputOutcome),
+        LN(<Lightning as ServerModule>::OutputOutcome),
     }
 
     impl From<fedimint_api::core::DynOutputOutcome> for OutputOutcome {

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -202,7 +202,7 @@ pub mod legacy {
         // TODO: maybe treat every coin as a seperate input?
         Mint(<fedimint_mint::Mint as ServerModule>::Input),
         Wallet(<fedimint_wallet::Wallet as ServerModule>::Input),
-        LN(<fedimint_ln::LightningModule as ServerModule>::Input),
+        LN(<fedimint_ln::Lightning as ServerModule>::Input),
     }
 
     // TODO: check if clippy is right
@@ -211,7 +211,7 @@ pub mod legacy {
     pub enum Output {
         Mint(<fedimint_mint::Mint as ServerModule>::Output),
         Wallet(<fedimint_wallet::Wallet as ServerModule>::Output),
-        LN(<fedimint_ln::LightningModule as ServerModule>::Output),
+        LN(<fedimint_ln::Lightning as ServerModule>::Output),
     }
 
     impl Transaction {

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -5,7 +5,7 @@ use docopt::Docopt;
 use erased_serde::Serialize;
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::encoding::Encodable;
-use fedimint_api::module::ModuleInit;
+use fedimint_api::module::ModuleGen;
 use fedimint_ln::{db as LightningRange, LightningModuleConfigGen};
 use fedimint_mint::{db as MintRange, MintConfigGenerator};
 use fedimint_rocksdb::RocksDbReadOnly;
@@ -617,7 +617,7 @@ impl<'a> DatabaseDump<'a> {
 const USAGE: &str = "
 Usage:
     fedimint-dbdump <path> [--range=<range>] [--prefix=<prefix>]
-    
+
 Options:
     --range=<range>    A CSV list of the ranges of the database to dump [default: All].
     --prefix=<prefix>  A CSV list of he prefixes within the range of the database to dump [default: All].
@@ -676,7 +676,7 @@ async fn main() {
     };
 
     let _module_inits = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
         Arc::new(LightningModuleConfigGen),
     ]);

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -6,7 +6,7 @@ use erased_serde::Serialize;
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::encoding::Encodable;
 use fedimint_api::module::ModuleGen;
-use fedimint_ln::{db as LightningRange, LightningModuleConfigGen};
+use fedimint_ln::{db as LightningRange, LightningConfigGenerator};
 use fedimint_mint::{db as MintRange, MintConfigGenerator};
 use fedimint_rocksdb::RocksDbReadOnly;
 use fedimint_server::config::ModuleInitRegistry;
@@ -678,7 +678,7 @@ async fn main() {
     let _module_inits = ModuleInitRegistry::from(vec![
         Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
-        Arc::new(LightningModuleConfigGen),
+        Arc::new(LightningConfigGenerator),
     ]);
 
     let decoders = Default::default(); // TODO: read config and use it to create decoders

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -11,7 +11,7 @@ use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
-use fedimint_api::module::{ApiError, InputMeta, ModuleError, ModuleInit, TransactionItemAmount};
+use fedimint_api::module::{ApiError, InputMeta, ModuleError, ModuleGen, TransactionItemAmount};
 use fedimint_api::{OutPoint, PeerId, ServerModule};
 
 pub mod btc;
@@ -45,7 +45,7 @@ where
         module_instance_id: ModuleInstanceId,
     ) -> anyhow::Result<FakeFed<Module>>
     where
-        ConfGen: ModuleInit,
+        ConfGen: ModuleGen,
         F: Fn(ServerModuleConfig, Database) -> FF,
         FF: Future<Output = anyhow::Result<Module>>,
     {

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 use fedimint_api::module::ModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
-use fedimint_ln::LightningModuleConfigGen;
+use fedimint_ln::LightningConfigGenerator;
 use fedimint_mint::MintConfigGenerator;
 use fedimint_server::config::ModuleInitRegistry;
 use fedimint_wallet::WalletConfigGenerator;
@@ -135,7 +135,7 @@ async fn main() -> anyhow::Result<()> {
     let module_config_gens = ModuleInitRegistry::from(vec![
         Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
-        Arc::new(LightningModuleConfigGen),
+        Arc::new(LightningConfigGenerator),
     ]);
 
     let mut task_group = TaskGroup::new();

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use clap::{Parser, Subcommand};
-use fedimint_api::module::ModuleInit;
+use fedimint_api::module::ModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
 use fedimint_ln::LightningModuleConfigGen;
@@ -133,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let module_config_gens = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
         Arc::new(LightningModuleConfigGen),
     ]);

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use fedimint_api::db::Database;
-use fedimint_api::module::ModuleInit;
+use fedimint_api::module::ModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_ln::LightningModuleConfigGen;
 use fedimint_mint::MintConfigGenerator;
@@ -121,7 +121,7 @@ async fn main() -> anyhow::Result<()> {
     task_group.install_kill_handler();
 
     let module_inits = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
         Arc::new(LightningModuleConfigGen),
     ]);

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use fedimint_api::db::Database;
 use fedimint_api::module::ModuleGen;
 use fedimint_api::task::TaskGroup;
-use fedimint_ln::LightningModuleConfigGen;
+use fedimint_ln::LightningConfigGenerator;
 use fedimint_mint::MintConfigGenerator;
 use fedimint_server::config::ModuleInitRegistry;
 use fedimint_server::consensus::FedimintConsensus;
@@ -123,7 +123,7 @@ async fn main() -> anyhow::Result<()> {
     let module_inits = ModuleInitRegistry::from(vec![
         Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
-        Arc::new(LightningModuleConfigGen),
+        Arc::new(LightningConfigGenerator),
     ]);
 
     let decoders = module_inits.decoders(cfg.iter_module_instances())?;

--- a/fedimintd/src/distributedgen.rs
+++ b/fedimintd/src/distributedgen.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::ensure;
-use fedimint_api::module::ModuleInit;
+use fedimint_api::module::ModuleGen;
 use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
@@ -85,7 +85,7 @@ pub async fn run_dkg(
     let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
 
     let module_config_gens = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
         Arc::new(LightningModuleConfigGen),
     ]);

--- a/fedimintd/src/distributedgen.rs
+++ b/fedimintd/src/distributedgen.rs
@@ -9,7 +9,7 @@ use fedimint_api::module::ModuleGen;
 use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
-use fedimint_ln::LightningModuleConfigGen;
+use fedimint_ln::LightningConfigGenerator;
 use fedimint_mint::MintConfigGenerator;
 use fedimint_server::config::{PeerServerParams, ServerConfig, ServerConfigParams};
 use fedimint_server::multiplexed::PeerConnectionMultiplexer;
@@ -87,7 +87,7 @@ pub async fn run_dkg(
     let module_config_gens = ModuleInitRegistry::from(vec![
         Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
-        Arc::new(LightningModuleConfigGen),
+        Arc::new(LightningConfigGenerator),
     ]);
 
     let result = ServerConfig::distributed_gen(

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -13,7 +13,7 @@ use axum::{
 use axum_macros::debug_handler;
 use bitcoin::Network;
 use fedimint_api::config::ClientConfig;
-use fedimint_api::module::ModuleInit;
+use fedimint_api::module::ModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
 use fedimint_ln::LightningModuleConfigGen;
@@ -135,7 +135,7 @@ async fn post_guardians(
     let max_denomination = Amount::from_msats(100000000000);
     let (dkg_sender, dkg_receiver) = tokio::sync::oneshot::channel::<UiMessage>();
     let module_config_gens = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
         Arc::new(LightningModuleConfigGen),
     ]);

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -16,7 +16,7 @@ use fedimint_api::config::ClientConfig;
 use fedimint_api::module::ModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
-use fedimint_ln::LightningModuleConfigGen;
+use fedimint_ln::LightningConfigGenerator;
 use fedimint_mint::MintConfigGenerator;
 use fedimint_server::config::ModuleInitRegistry;
 use fedimint_wallet::WalletConfigGenerator;
@@ -137,7 +137,7 @@ async fn post_guardians(
     let module_config_gens = ModuleInitRegistry::from(vec![
         Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
-        Arc::new(LightningModuleConfigGen),
+        Arc::new(LightningConfigGenerator),
     ]);
     let dir_out_path = state.data_dir.clone();
     let fedimintd_sender = state.sender.clone();

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -29,7 +29,7 @@ use fedimint_api::core::{
 use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::Database;
 use fedimint_api::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
-use fedimint_api::module::ModuleInit;
+use fedimint_api::module::ModuleGen;
 use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::server::DynServerModule;
 use fedimint_api::task::{timeout, TaskGroup};
@@ -161,7 +161,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
     let max_evil = hbbft::util::max_faulty(peers.len());
 
     let module_inits = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleInit + Send + Sync>,
+        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
         Arc::new(LightningModuleConfigGen),
     ]);

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -38,7 +38,7 @@ use fedimint_api::PeerId;
 use fedimint_api::TieredMulti;
 use fedimint_api::{sats, Amount};
 use fedimint_bitcoind::DynBitcoindRpc;
-use fedimint_ln::{LightningGateway, LightningModuleConfigGen};
+use fedimint_ln::{LightningConfigGenerator, LightningGateway};
 use fedimint_mint::{MintConfigGenerator, MintOutput};
 use fedimint_server::config::{connect, ServerConfig};
 use fedimint_server::config::{ModuleInitRegistry, ServerConfigParams};
@@ -163,7 +163,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
     let module_inits = ModuleInitRegistry::from(vec![
         Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
         Arc::new(MintConfigGenerator),
-        Arc::new(LightningModuleConfigGen),
+        Arc::new(LightningConfigGenerator),
     ]);
 
     match env::var("FM_TEST_DISABLE_MOCKS") {

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -17,7 +17,7 @@ use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
-    api_endpoint, ApiEndpoint, InputMeta, ModuleError, ModuleInit, TransactionItemAmount,
+    api_endpoint, ApiEndpoint, InputMeta, ModuleError, ModuleGen, TransactionItemAmount,
 };
 use fedimint_api::net::peers::MuxPeerConnections;
 use fedimint_api::server::DynServerModule;
@@ -49,7 +49,7 @@ pub struct DummyVerificationCache;
 pub struct DummyConfigGenerator;
 
 #[async_trait]
-impl ModuleInit for DummyConfigGenerator {
+impl ModuleGen for DummyConfigGenerator {
     fn decoder(&self) -> DynDecoder {
         DynDecoder::from_typed(DummyDecoder)
     }

--- a/modules/fedimint-ln/src/config.rs
+++ b/modules/fedimint-ln/src/config.rs
@@ -35,14 +35,14 @@ pub struct LightningConfigPrivate {
     pub threshold_sec_key: SerdeSecret<threshold_crypto::SecretKeyShare>,
 }
 
-impl TypedClientModuleConfig for LightningModuleClientConfig {
+impl TypedClientModuleConfig for LightningClientConfig {
     fn kind(&self) -> ModuleKind {
         KIND
     }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct LightningModuleClientConfig {
+pub struct LightningClientConfig {
     pub threshold_pub_key: threshold_crypto::PublicKey,
     pub fee_consensus: FeeConsensus,
 }
@@ -51,7 +51,7 @@ impl TypedServerModuleConsensusConfig for LightningConfigConsensus {
     fn to_client_config(&self) -> ClientModuleConfig {
         ClientModuleConfig::new(
             KIND,
-            serde_json::to_value(&LightningModuleClientConfig {
+            serde_json::to_value(&LightningClientConfig {
                 threshold_pub_key: self.threshold_pub_keys.public_key(),
                 fee_consensus: self.fee_consensus.clone(),
             })

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -36,7 +36,7 @@ use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
-    api_endpoint, ApiEndpoint, ApiError, InputMeta, IntoModuleError, ModuleError, ModuleInit,
+    api_endpoint, ApiEndpoint, ApiError, InputMeta, IntoModuleError, ModuleError, ModuleGen,
     TransactionItemAmount,
 };
 use fedimint_api::net::peers::MuxPeerConnections;
@@ -234,7 +234,7 @@ pub struct LightningVerificationCache;
 pub struct LightningModuleConfigGen;
 
 #[async_trait]
-impl ModuleInit for LightningModuleConfigGen {
+impl ModuleGen for LightningModuleConfigGen {
     fn decoder(&self) -> DynDecoder {
         DynDecoder::from_typed(LightningDecoder)
     }

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -21,7 +21,7 @@ use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
-    api_endpoint, ApiEndpoint, ApiError, InputMeta, IntoModuleError, ModuleError, ModuleInit,
+    api_endpoint, ApiEndpoint, ApiError, InputMeta, IntoModuleError, ModuleError, ModuleGen,
     TransactionItemAmount,
 };
 use fedimint_api::net::peers::MuxPeerConnections;
@@ -138,7 +138,7 @@ pub struct VerifiedNotes {
 pub struct MintConfigGenerator;
 
 #[async_trait]
-impl ModuleInit for MintConfigGenerator {
+impl ModuleGen for MintConfigGenerator {
     fn decoder(&self) -> DynDecoder {
         DynDecoder::from_typed(MintDecoder)
     }
@@ -1132,7 +1132,7 @@ mod test {
     use fedimint_api::config::{
         ClientModuleConfig, ConfigGenParams, ServerModuleConfig, TypedServerModuleConsensusConfig,
     };
-    use fedimint_api::module::ModuleInit;
+    use fedimint_api::module::ModuleGen;
     use fedimint_api::{Amount, PeerId, TieredMulti};
     use tbs::{blind_message, unblind_signature, verify, AggregatePublicKey, BlindingKey, Message};
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -33,7 +33,7 @@ use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
-    api_endpoint, InputMeta, IntoModuleError, ModuleInit, TransactionItemAmount,
+    api_endpoint, InputMeta, IntoModuleError, ModuleGen, TransactionItemAmount,
 };
 use fedimint_api::module::{ApiEndpoint, ModuleError};
 use fedimint_api::net::peers::MuxPeerConnections;
@@ -222,7 +222,7 @@ impl std::fmt::Display for WalletOutputOutcome {
 pub struct WalletConfigGenerator;
 
 #[async_trait]
-impl ModuleInit for WalletConfigGenerator {
+impl ModuleGen for WalletConfigGenerator {
     fn decoder(&self) -> DynDecoder {
         DynDecoder::from_typed(WalletDecoder)
     }


### PR DESCRIPTION
part of #1232

First commit renames `ModuleInit` to `ModuleGen` and moves the `try` to the front of the function `try_to_client_config`.

Second commit removes `Module` from `Lightning*` symbols. 

Happy to change or revert anything.

