### PR TITLE
Rename intercepted HTLC handler function

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -205,7 +205,9 @@ impl LnGateway {
         })
     }
 
-    async fn handle_receive_invoice_msg(&self, payload: ReceivePaymentPayload) -> Result<Preimage> {
+    /// Handles an intercepted HTLC that might be an incoming payment we are receiving on behalf of
+    /// a federation user.
+    async fn handle_receive_payment(&self, payload: ReceivePaymentPayload) -> Result<Preimage> {
         let ReceivePaymentPayload { htlc_accepted } = payload;
 
         let invoice_amount = htlc_accepted.htlc.amount;
@@ -319,7 +321,7 @@ impl LnGateway {
                     }
                     GatewayRequest::ReceivePayment(inner) => {
                         inner
-                            .handle(|payload| self.handle_receive_invoice_msg(payload))
+                            .handle(|payload| self.handle_receive_payment(payload))
                             .await;
                     }
                     GatewayRequest::PayInvoice(inner) => {


### PR DESCRIPTION
It's definitely not an incoming invoice that this fn processes. I'd like to call it `handle_intercepted_htlc`, but I see how that might not get the high level functionality across as well (and would require more renames of structs).