### PR TITLE
Rename symbols around modules

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -19,7 +19,7 @@ use bitcoin::{secp256k1, Address, Transaction as BitcoinTransaction};
 use bitcoin_hashes::{sha256, Hash};
 use fedimint_api::config::ClientConfig;
 use fedimint_api::core::{
-    Decoder, LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+    DynDecoder, LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_api::db::Database;
@@ -1251,15 +1251,15 @@ pub fn module_decode_stubs() -> ModuleDecoderRegistry {
     ModuleDecoderRegistry::from_iter([
         (
             LEGACY_HARDCODED_INSTANCE_ID_LN,
-            Decoder::from_typed(LightningDecoder),
+            DynDecoder::from_typed(LightningDecoder),
         ),
         (
             LEGACY_HARDCODED_INSTANCE_ID_WALLET,
-            Decoder::from_typed(WalletDecoder),
+            DynDecoder::from_typed(WalletDecoder),
         ),
         (
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
-            Decoder::from_typed(MintDecoder),
+            DynDecoder::from_typed(MintDecoder),
         ),
     ])
 }

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -334,7 +334,7 @@ mod tests {
     use bitcoin::Address;
     use fedimint_api::config::ConfigGenParams;
     use fedimint_api::core::{
-        OutputOutcome, LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+        DynOutputOutcome, LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     };
     use fedimint_api::db::mem_impl::MemDatabase;
     use fedimint_api::db::Database;
@@ -373,7 +373,7 @@ mod tests {
             let mint = self.mint.lock().await;
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
-                outputs: vec![SerdeOutputOutcome::from(&OutputOutcome::from_typed(
+                outputs: vec![SerdeOutputOutcome::from(&DynOutputOutcome::from_typed(
                     LEGACY_HARDCODED_INSTANCE_ID_MINT,
                     mint.output_outcome(OutPoint {
                         txid: tx,

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
 use fedimint_api::{
-    core::{self, Output, LEGACY_HARDCODED_INSTANCE_ID_MINT},
+    core::{self, DynOutput, LEGACY_HARDCODED_INSTANCE_ID_MINT},
     msats, Amount, OutPoint, PeerId, Tiered, TieredMulti,
 };
 use fedimint_core::{
@@ -344,7 +344,7 @@ fn sanity_check_recovery_fresh_backup() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![Output::from_typed(
+        outputs: vec![DynOutput::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
             output_c1_a.clone(),
         )],
@@ -446,7 +446,7 @@ fn sanity_check_recovery_fresh_backup() {
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
             c1.generate_input(notes_c1_a),
         )],
-        outputs: vec![core::Output::from_typed(
+        outputs: vec![core::DynOutput::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
             output_c1_a,
         )],
@@ -483,8 +483,8 @@ fn sanity_check_recovery_non_empty_backup() {
     let tx_a = Transaction {
         inputs: vec![],
         outputs: vec![
-            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, output_c1_a0.clone()),
-            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, output_c1_a1.clone()),
+            core::DynOutput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, output_c1_a0.clone()),
+            core::DynOutput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, output_c1_a1.clone()),
         ],
         signature: None,
     };
@@ -597,7 +597,7 @@ fn sanity_check_recovery_bn_reuse_with_invalid_amount() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![core::Output::from_typed(
+        outputs: vec![core::DynOutput::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
             output_c2_a.clone(),
         )],
@@ -610,7 +610,7 @@ fn sanity_check_recovery_bn_reuse_with_invalid_amount() {
 
     let tx_b = Transaction {
         inputs: vec![],
-        outputs: vec![core::Output::from_typed(
+        outputs: vec![core::DynOutput::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
             output_c1_b,
         )],
@@ -679,7 +679,7 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
 
     let tx_a = Transaction {
         inputs: vec![],
-        outputs: vec![core::Output::from_typed(
+        outputs: vec![core::DynOutput::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
             output_c2_a.clone(),
         )],
@@ -692,7 +692,7 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
 
     let tx_b = Transaction {
         inputs: vec![],
-        outputs: vec![core::Output::from_typed(
+        outputs: vec![core::DynOutput::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
             output_c1_b.clone(),
         )],

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -442,7 +442,7 @@ fn sanity_check_recovery_fresh_backup() {
 
     // Spend the notes, which should remove them from the tracker
     let tx_b = Transaction {
-        inputs: vec![core::Input::from_typed(
+        inputs: vec![core::DynInput::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
             c1.generate_input(notes_c1_a),
         )],
@@ -524,7 +524,7 @@ fn sanity_check_recovery_non_empty_backup() {
 
     // Spend the notes, which should remove them from the tracker
     let tx_b = Transaction {
-        inputs: vec![core::Input::from_typed(
+        inputs: vec![core::DynInput::from_typed(
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
             c1.generate_input(notes_c1_a0),
         )],

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -375,7 +375,7 @@ fn sanity_check_recovery_fresh_backup() {
     for _ in 0..3 {
         tracker.handle_consensus_item(
             confirmations_c1_a[0].0,
-            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+            &ConsensusItem::Module(core::DynModuleConsensusItem::from_typed(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                 confirmations_c1_a[0].1.clone(),
             )),
@@ -398,7 +398,7 @@ fn sanity_check_recovery_fresh_backup() {
     for wrong_peer_i in 1..2 {
         tracker.handle_consensus_item(
             confirmations_c1_a[wrong_peer_i].0,
-            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+            &ConsensusItem::Module(core::DynModuleConsensusItem::from_typed(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                 confirmations_c1_a[0].1.clone(),
             )),
@@ -421,7 +421,7 @@ fn sanity_check_recovery_fresh_backup() {
     for (peer_id, mint_output_confirmation) in &confirmations_c1_a {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+            &ConsensusItem::Module(core::DynModuleConsensusItem::from_typed(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                 mint_output_confirmation.clone(),
             )),
@@ -543,7 +543,7 @@ fn sanity_check_recovery_non_empty_backup() {
     for (peer_id, mint_output_confirmation) in &confirmations_c1_a1 {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+            &ConsensusItem::Module(core::DynModuleConsensusItem::from_typed(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                 mint_output_confirmation.clone(),
             )),
@@ -728,7 +728,7 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
     for (peer_id, mint_output_confirmation) in &confirmations_c2_a {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+            &ConsensusItem::Module(core::DynModuleConsensusItem::from_typed(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                 mint_output_confirmation.clone(),
             )),
@@ -744,7 +744,7 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
     for (peer_id, mint_output_confirmation) in &confirmations_c1_b {
         tracker.handle_consensus_item(
             *peer_id,
-            &ConsensusItem::Module(core::ConsensusItem::from_typed(
+            &ConsensusItem::Module(core::DynModuleConsensusItem::from_typed(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                 mint_output_confirmation.clone(),
             )),

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -704,7 +704,7 @@ mod tests {
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
                 outputs: vec![SerdeOutputOutcome::from(
-                    &(fedimint_api::core::OutputOutcome::from_typed(
+                    &(fedimint_api::core::DynOutputOutcome::from_typed(
                         LEGACY_HARDCODED_INSTANCE_ID_MINT,
                         mint.output_outcome(OutPoint {
                             txid: tx,

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -237,7 +237,7 @@ mod tests {
             Ok(TransactionStatus::Accepted {
                 epoch: 0,
                 outputs: vec![SerdeOutputOutcome::from(
-                    &fedimint_api::core::OutputOutcome::from_typed(
+                    &fedimint_api::core::DynOutputOutcome::from_typed(
                         LEGACY_HARDCODED_INSTANCE_ID_WALLET,
                         WalletOutputOutcome(Txid::from_slice([0; 32].as_slice()).unwrap()),
                     ),

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -312,12 +312,12 @@ impl std::ops::Deref for DynDecoder {
     }
 }
 
-impl<T> From<T> for Decoder
+impl<T> From<T> for DynDecoder
 where
-    T: PluginDecode + Send + Sync + 'static,
+    T: Decoder + Send + Sync + 'static,
 {
     fn from(value: T) -> Self {
-        Decoder(Arc::new(value))
+        DynDecoder(Arc::new(value))
     }
 }
 

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -173,7 +173,7 @@ macro_rules! module_plugin_trait_define{
     };
 }
 
-/// Implements the `Plugin*` traits for all associated types of a `FederationServerPlugin`.
+/// Implements the necessary traits for all associated types of a `FederationServer` module.
 #[macro_export]
 macro_rules! plugin_types_trait_impl {
     ($key:expr, $input:ty, $output:ty, $outcome:ty, $ci:ty, $cache:ty) => {

--- a/fedimint-api/src/core/client.rs
+++ b/fedimint-api/src/core/client.rs
@@ -6,14 +6,14 @@ use async_trait::async_trait;
 
 use super::ModuleKind;
 use crate::core::Decoder;
-use crate::core::PluginDecode;
+use crate::core::DynDecoder;
 use crate::module::TransactionItemAmount;
 use crate::{dyn_newtype_define, ServerModule};
 
 #[async_trait]
 pub trait ClientModule: Debug {
     const KIND: &'static str;
-    type Decoder: PluginDecode;
+    type Decoder: Decoder;
     type Module: ServerModule;
 
     fn module_kind() -> ModuleKind {
@@ -36,7 +36,7 @@ pub trait IClientModule: Debug {
     fn as_any(&self) -> &dyn Any;
 
     /// Return the type-erased decoder of the module
-    fn decoder(&self) -> Decoder;
+    fn decoder(&self) -> DynDecoder;
 }
 
 dyn_newtype_define!(
@@ -52,7 +52,7 @@ where
         self
     }
 
-    fn decoder(&self) -> Decoder {
-        Decoder::from_typed(<T as ClientModule>::decoder(self))
+    fn decoder(&self) -> DynDecoder {
+        DynDecoder::from_typed(<T as ClientModule>::decoder(self))
     }
 }

--- a/fedimint-api/src/core/encode.rs
+++ b/fedimint-api/src/core/encode.rs
@@ -3,7 +3,7 @@ use std::io;
 use fedimint_api::encoding::{Decodable, DecodeError};
 
 use super::ModuleInstanceId;
-use crate::core::Decoder;
+use crate::core::DynDecoder;
 use crate::module::registry::ModuleDecoderRegistry;
 
 pub fn module_decode_key_prefixed_decodable<T, F, R>(
@@ -13,7 +13,7 @@ pub fn module_decode_key_prefixed_decodable<T, F, R>(
 ) -> Result<T, DecodeError>
 where
     R: io::Read,
-    F: FnOnce(&mut R, &Decoder, ModuleInstanceId) -> Result<T, DecodeError>,
+    F: FnOnce(&mut R, &DynDecoder, ModuleInstanceId) -> Result<T, DecodeError>,
 {
     let key = ModuleInstanceId::consensus_decode(&mut d, modules)?;
 

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -111,7 +111,7 @@ pub trait IServerModule: Debug {
     async fn validate_output(
         &self,
         dbtx: &mut DatabaseTransaction,
-        output: &Output,
+        output: &DynOutput,
     ) -> Result<TransactionItemAmount, ModuleError>;
 
     /// Try to create an output (e.g. issue coins, peg-out BTC, …). On success all necessary updates
@@ -127,7 +127,7 @@ pub trait IServerModule: Debug {
     async fn apply_output<'a>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
-        output: &Output,
+        output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError>;
 
@@ -311,7 +311,7 @@ where
     async fn validate_output(
         &self,
         dbtx: &mut DatabaseTransaction,
-        output: &Output,
+        output: &DynOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         <Self as ServerModule>::validate_output(
             self,
@@ -337,7 +337,7 @@ where
     async fn apply_output<'a>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
-        output: &Output,
+        output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
         <Self as ServerModule>::apply_output(

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -150,7 +150,7 @@ pub trait IServerModule: Debug {
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
-    ) -> Option<OutputOutcome>;
+    ) -> Option<DynOutputOutcome>;
 
     /// Queries the database and returns all assets and liabilities of the module.
     ///
@@ -373,10 +373,10 @@ where
         dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
-    ) -> Option<OutputOutcome> {
+    ) -> Option<DynOutputOutcome> {
         <Self as ServerModule>::output_status(self, dbtx, out_point)
             .await
-            .map(|v| OutputOutcome::from_typed(module_instance_id, v))
+            .map(|v| DynOutputOutcome::from_typed(module_instance_id, v))
     }
 
     /// Queries the database and returns all assets and liabilities of the module.

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -47,7 +47,7 @@ where
 #[async_trait]
 pub trait IServerModule: Debug {
     /// Returns the decoder belonging to the server module
-    fn decoder(&self) -> Decoder;
+    fn decoder(&self) -> DynDecoder;
 
     fn as_any(&self) -> &dyn Any;
 
@@ -174,8 +174,8 @@ impl<T> IServerModule for T
 where
     T: ServerModule + 'static + Sync,
 {
-    fn decoder(&self) -> Decoder {
-        Decoder::from_typed(ServerModule::decoder(self))
+    fn decoder(&self) -> DynDecoder {
+        DynDecoder::from_typed(ServerModule::decoder(self))
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -75,7 +75,7 @@ pub trait IServerModule: Debug {
     /// slow part of verification can be modeled as a pure function not involving any system state
     /// we can build a lookup table in a hyper-parallelized manner. This function is meant for
     /// constructing such lookup tables.
-    fn build_verification_cache(&self, inputs: &[Input]) -> DynVerificationCache;
+    fn build_verification_cache(&self, inputs: &[DynInput]) -> DynVerificationCache;
 
     /// Validate a transaction input before submitting it to the unconfirmed transaction pool. This
     /// function has no side effects and may be called at any time. False positives due to outdated
@@ -86,7 +86,7 @@ pub trait IServerModule: Debug {
         interconnect: &'a dyn ModuleInterconect,
         dbtx: &mut DatabaseTransaction<'_>,
         verification_cache: &DynVerificationCache,
-        input: &Input,
+        input: &DynInput,
     ) -> Result<InputMeta, ModuleError>;
 
     /// Try to spend a transaction input. On success all necessary updates will be part of the
@@ -100,7 +100,7 @@ pub trait IServerModule: Debug {
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
         dbtx: &mut DatabaseTransaction<'c>,
-        input: &'b Input,
+        input: &'b DynInput,
         verification_cache: &DynVerificationCache,
     ) -> Result<InputMeta, ModuleError>;
 
@@ -233,7 +233,7 @@ where
     /// slow part of verification can be modeled as a pure function not involving any system state
     /// we can build a lookup table in a hyper-parallelized manner. This function is meant for
     /// constructing such lookup tables.
-    fn build_verification_cache<'a>(&self, inputs: &[Input]) -> DynVerificationCache {
+    fn build_verification_cache<'a>(&self, inputs: &[DynInput]) -> DynVerificationCache {
         <Self as ServerModule>::build_verification_cache(
             self,
             inputs.iter().map(|i| {
@@ -254,7 +254,7 @@ where
         interconnect: &'a dyn ModuleInterconect,
         dbtx: &mut DatabaseTransaction<'_>,
         verification_cache: &DynVerificationCache,
-        input: &Input,
+        input: &DynInput,
     ) -> Result<InputMeta, ModuleError> {
         <Self as ServerModule>::validate_input(
             self,
@@ -284,7 +284,7 @@ where
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
         dbtx: &mut DatabaseTransaction<'c>,
-        input: &'b Input,
+        input: &'b DynInput,
         verification_cache: &DynVerificationCache,
     ) -> Result<InputMeta, ModuleError> {
         <Self as ServerModule>::apply_input(

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -59,7 +59,7 @@ pub trait IServerModule: Debug {
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         module_instance_id: ModuleInstanceId,
-    ) -> Vec<ConsensusItem>;
+    ) -> Vec<DynModuleConsensusItem>;
 
     /// This function is called once before transaction processing starts. All module consensus
     /// items of this round are supplied as `consensus_items`. The batch will be committed to the
@@ -68,7 +68,7 @@ pub trait IServerModule: Debug {
     async fn begin_consensus_epoch<'a>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
-        consensus_items: Vec<(PeerId, ConsensusItem)>,
+        consensus_items: Vec<(PeerId, DynModuleConsensusItem)>,
     );
 
     /// Some modules may have slow to verify inputs that would block transaction processing. If the
@@ -192,11 +192,11 @@ where
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         module_instance_id: ModuleInstanceId,
-    ) -> Vec<ConsensusItem> {
+    ) -> Vec<DynModuleConsensusItem> {
         <Self as ServerModule>::consensus_proposal(self, dbtx)
             .await
             .into_iter()
-            .map(|v| ConsensusItem::from_typed(module_instance_id, v))
+            .map(|v| DynModuleConsensusItem::from_typed(module_instance_id, v))
             .collect()
     }
 
@@ -207,7 +207,7 @@ where
     async fn begin_consensus_epoch<'a>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
-        consensus_items: Vec<(PeerId, ConsensusItem)>,
+        consensus_items: Vec<(PeerId, DynModuleConsensusItem)>,
     ) {
         <Self as ServerModule>::begin_consensus_epoch(
             self,

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -13,8 +13,8 @@ use thiserror::Error;
 use crate::cancellable::Cancellable;
 use crate::config::{ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ServerModuleConfig};
 use crate::core::{
-    Decoder, DynDecoder, Input, ModuleInstanceId, ModuleKind, Output, PluginConsensusItem,
-    PluginOutputOutcome,
+    Decoder, DynDecoder, Input, ModuleInstanceId, ModuleKind, Output, OutputOutcome,
+    PluginConsensusItem,
 };
 use crate::db::{Database, DatabaseTransaction};
 use crate::module::audit::Audit;
@@ -248,7 +248,7 @@ pub trait ServerModule: Debug + Sized {
     type Decoder: Decoder;
     type Input: Input;
     type Output: Output;
-    type OutputOutcome: PluginOutputOutcome;
+    type OutputOutcome: OutputOutcome;
     type ConsensusItem: PluginConsensusItem;
     type VerificationCache: VerificationCache;
 

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use crate::cancellable::Cancellable;
 use crate::config::{ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ServerModuleConfig};
 use crate::core::{
-    Decoder, ModuleInstanceId, ModuleKind, PluginConsensusItem, PluginDecode, PluginInput,
+    Decoder, DynDecoder, ModuleInstanceId, ModuleKind, PluginConsensusItem, PluginInput,
     PluginOutput, PluginOutputOutcome,
 };
 use crate::db::{Database, DatabaseTransaction};
@@ -202,7 +202,7 @@ where
 /// Once the module config is ready, the module can be instantiated via `[Self::init]`.
 #[async_trait]
 pub trait ModuleInit {
-    fn decoder(&self) -> Decoder;
+    fn decoder(&self) -> DynDecoder;
 
     fn module_kind(&self) -> ModuleKind;
 
@@ -245,7 +245,7 @@ pub trait ModuleInit {
 pub trait ServerModule: Debug + Sized {
     const KIND: ModuleKind;
 
-    type Decoder: PluginDecode;
+    type Decoder: Decoder;
     type Input: PluginInput;
     type Output: PluginOutput;
     type OutputOutcome: PluginOutputOutcome;

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -13,8 +13,8 @@ use thiserror::Error;
 use crate::cancellable::Cancellable;
 use crate::config::{ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ServerModuleConfig};
 use crate::core::{
-    Decoder, DynDecoder, ModuleInstanceId, ModuleKind, PluginConsensusItem, PluginInput,
-    PluginOutput, PluginOutputOutcome,
+    Decoder, DynDecoder, Input, ModuleInstanceId, ModuleKind, PluginConsensusItem, PluginOutput,
+    PluginOutputOutcome,
 };
 use crate::db::{Database, DatabaseTransaction};
 use crate::module::audit::Audit;
@@ -246,7 +246,7 @@ pub trait ServerModule: Debug + Sized {
     const KIND: ModuleKind;
 
     type Decoder: Decoder;
-    type Input: PluginInput;
+    type Input: Input;
     type Output: PluginOutput;
     type OutputOutcome: PluginOutputOutcome;
     type ConsensusItem: PluginConsensusItem;

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use crate::cancellable::Cancellable;
 use crate::config::{ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ServerModuleConfig};
 use crate::core::{
-    Decoder, DynDecoder, Input, ModuleInstanceId, ModuleKind, PluginConsensusItem, PluginOutput,
+    Decoder, DynDecoder, Input, ModuleInstanceId, ModuleKind, Output, PluginConsensusItem,
     PluginOutputOutcome,
 };
 use crate::db::{Database, DatabaseTransaction};
@@ -247,7 +247,7 @@ pub trait ServerModule: Debug + Sized {
 
     type Decoder: Decoder;
     type Input: Input;
-    type Output: PluginOutput;
+    type Output: Output;
     type OutputOutcome: PluginOutputOutcome;
     type ConsensusItem: PluginConsensusItem;
     type VerificationCache: VerificationCache;

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -13,8 +13,8 @@ use thiserror::Error;
 use crate::cancellable::Cancellable;
 use crate::config::{ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ServerModuleConfig};
 use crate::core::{
-    Decoder, DynDecoder, Input, ModuleInstanceId, ModuleKind, Output, OutputOutcome,
-    PluginConsensusItem,
+    Decoder, DynDecoder, Input, ModuleConsensusItem, ModuleInstanceId, ModuleKind, Output,
+    OutputOutcome,
 };
 use crate::db::{Database, DatabaseTransaction};
 use crate::module::audit::Audit;
@@ -249,7 +249,7 @@ pub trait ServerModule: Debug + Sized {
     type Input: Input;
     type Output: Output;
     type OutputOutcome: OutputOutcome;
-    type ConsensusItem: PluginConsensusItem;
+    type ConsensusItem: ModuleConsensusItem;
     type VerificationCache: VerificationCache;
 
     fn module_kind() -> ModuleKind {

--- a/fedimint-api/src/module/registry.rs
+++ b/fedimint-api/src/module/registry.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::core::Decoder;
+use crate::core::DynDecoder;
 pub use crate::core::ModuleInstanceId;
 use crate::server::DynServerModule;
 
@@ -66,20 +66,20 @@ impl ServerModuleRegistry {
 
 /// Collection of decoders belonging to modules, typically obtained from a `ModuleRegistry`
 #[derive(Debug, Default, Clone)]
-pub struct ModuleDecoderRegistry(BTreeMap<ModuleInstanceId, Decoder>);
+pub struct ModuleDecoderRegistry(BTreeMap<ModuleInstanceId, DynDecoder>);
 
 impl ModuleDecoderRegistry {
     /// Return the decoder belonging to the module identified by the supplied `module_key`
     ///
     /// # Panics
     /// If the decoder isn't in the registry
-    pub fn get(&self, module_key: ModuleInstanceId) -> &Decoder {
+    pub fn get(&self, module_key: ModuleInstanceId) -> &DynDecoder {
         self.0.get(&module_key).expect("Module not found")
     }
 }
 
-impl FromIterator<(ModuleInstanceId, Decoder)> for ModuleDecoderRegistry {
-    fn from_iter<T: IntoIterator<Item = (ModuleInstanceId, Decoder)>>(iter: T) -> Self {
+impl FromIterator<(ModuleInstanceId, DynDecoder)> for ModuleDecoderRegistry {
+    fn from_iter<T: IntoIterator<Item = (ModuleInstanceId, DynDecoder)>>(iter: T) -> Self {
         ModuleDecoderRegistry(iter.into_iter().collect())
     }
 }

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::sha256::HashEngine;
-use fedimint_api::core::ConsensusItem as ModuleConsensusItem;
+use fedimint_api::core::DynModuleConsensusItem as ModuleConsensusItem;
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable, UnzipConsensus};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::{serde_module_encoding_wrapper, BitcoinHash, PeerId, TransactionId};

--- a/fedimint-core/src/outcome.rs
+++ b/fedimint-core/src/outcome.rs
@@ -14,7 +14,7 @@ pub enum TransactionStatus {
     },
 }
 
-serde_module_encoding_wrapper!(SerdeOutputOutcome, fedimint_api::core::OutputOutcome);
+serde_module_encoding_wrapper!(SerdeOutputOutcome, fedimint_api::core::DynOutputOutcome);
 
 pub mod legacy {
     use fedimint_api::core::{
@@ -41,8 +41,8 @@ pub mod legacy {
         LN(<LightningModule as ServerModule>::OutputOutcome),
     }
 
-    impl From<fedimint_api::core::OutputOutcome> for OutputOutcome {
-        fn from(oo: fedimint_api::core::OutputOutcome) -> Self {
+    impl From<fedimint_api::core::DynOutputOutcome> for OutputOutcome {
+        fn from(oo: fedimint_api::core::DynOutputOutcome) -> Self {
             match oo.module_instance_id() {
                 LEGACY_HARDCODED_INSTANCE_ID_LN => OutputOutcome::LN(
                     oo.as_any()

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -1,6 +1,6 @@
 use bitcoin::hashes::Hash as BitcoinHash;
 use bitcoin::XOnlyPublicKey;
-use fedimint_api::core::{DynInput, Output};
+use fedimint_api::core::{DynInput, DynOutput};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{serde_module_encoding_wrapper, Amount, TransactionId};
 use rand::Rng;
@@ -14,8 +14,8 @@ use thiserror::Error;
 pub struct Transaction {
     /// [`DynInput`]s consumed by the transaction
     pub inputs: Vec<DynInput>,
-    /// [`Output`]s created as a result of the transaction
-    pub outputs: Vec<Output>,
+    /// [`DynOutput`]s created as a result of the transaction
+    pub outputs: Vec<DynOutput>,
     /// Aggregated MuSig2 signature over all the public keys of the inputs
     pub signature: Option<schnorr::Signature>,
 }
@@ -32,7 +32,7 @@ impl Transaction {
     }
 
     /// Generate the transaction hash.
-    pub fn tx_hash_from_parts(inputs: &[DynInput], outputs: &[Output]) -> TransactionId {
+    pub fn tx_hash_from_parts(inputs: &[DynInput], outputs: &[DynOutput]) -> TransactionId {
         let mut engine = TransactionId::engine();
         inputs
             .consensus_encode(&mut engine)
@@ -242,14 +242,16 @@ pub mod legacy {
                 .iter()
                 .map(|output| match output.clone() {
                     Output::Mint(o) => {
-                        core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, o)
+                        core::DynOutput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, o)
                     }
                     Output::Wallet(o) => {
-                        core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, o)
+                        core::DynOutput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, o)
                     }
-                    Output::LN(o) => core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, o),
+                    Output::LN(o) => {
+                        core::DynOutput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, o)
+                    }
                 })
-                .collect::<Vec<fedimint_api::core::Output>>();
+                .collect::<Vec<fedimint_api::core::DynOutput>>();
 
             let mut engine = TransactionId::engine();
             erased_inputs
@@ -318,13 +320,13 @@ pub mod legacy {
                     .into_iter()
                     .map(|output| match output {
                         Output::Mint(output) => {
-                            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, output)
+                            core::DynOutput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, output)
                         }
                         Output::Wallet(output) => {
-                            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, output)
+                            core::DynOutput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, output)
                         }
                         Output::LN(output) => {
-                            core::Output::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, output)
+                            core::DynOutput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, output)
                         }
                     })
                     .collect(),

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -1,6 +1,6 @@
 use bitcoin::hashes::Hash as BitcoinHash;
 use bitcoin::XOnlyPublicKey;
-use fedimint_api::core::{Input, Output};
+use fedimint_api::core::{DynInput, Output};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{serde_module_encoding_wrapper, Amount, TransactionId};
 use rand::Rng;
@@ -12,8 +12,8 @@ use thiserror::Error;
 /// The mint enforces that the total value of the outputs equals the total value of the inputs, to prevent creating funds out of thin air. In some cases, the value of the inputs and outputs can both be 0 e.g. when creating an offer to a Lightning Gateway.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
 pub struct Transaction {
-    /// [`Input`]s consumed by the transaction
-    pub inputs: Vec<Input>,
+    /// [`DynInput`]s consumed by the transaction
+    pub inputs: Vec<DynInput>,
     /// [`Output`]s created as a result of the transaction
     pub outputs: Vec<Output>,
     /// Aggregated MuSig2 signature over all the public keys of the inputs
@@ -32,7 +32,7 @@ impl Transaction {
     }
 
     /// Generate the transaction hash.
-    pub fn tx_hash_from_parts(inputs: &[Input], outputs: &[Output]) -> TransactionId {
+    pub fn tx_hash_from_parts(inputs: &[DynInput], outputs: &[Output]) -> TransactionId {
         let mut engine = TransactionId::engine();
         inputs
             .consensus_encode(&mut engine)
@@ -229,13 +229,15 @@ pub mod legacy {
             let erased_inputs = inputs
                 .iter()
                 .map(|input| match input.clone() {
-                    Input::Mint(i) => core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, i),
-                    Input::Wallet(i) => {
-                        core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, i)
+                    Input::Mint(i) => {
+                        core::DynInput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, i)
                     }
-                    Input::LN(i) => core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, i),
+                    Input::Wallet(i) => {
+                        core::DynInput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, i)
+                    }
+                    Input::LN(i) => core::DynInput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, i),
                 })
-                .collect::<Vec<fedimint_api::core::Input>>();
+                .collect::<Vec<fedimint_api::core::DynInput>>();
             let erased_outputs = outputs
                 .iter()
                 .map(|output| match output.clone() {
@@ -301,13 +303,13 @@ pub mod legacy {
                     .into_iter()
                     .map(|input| match input {
                         Input::Mint(input) => {
-                            core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, input)
+                            core::DynInput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_MINT, input)
                         }
                         Input::Wallet(input) => {
-                            core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, input)
+                            core::DynInput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET, input)
                         }
                         Input::LN(input) => {
-                            core::Input::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, input)
+                            core::DynInput::from_typed(LEGACY_HARDCODED_INSTANCE_ID_LN, input)
                         }
                     })
                     .collect(),

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -249,7 +249,7 @@ impl FedimintConsensus {
         {
             let per_module_cis: HashMap<
                 ModuleInstanceId,
-                Vec<(PeerId, fedimint_api::core::ConsensusItem)>,
+                Vec<(PeerId, fedimint_api::core::DynModuleConsensusItem)>,
             > = module_cis
                 .into_iter()
                 .into_group_map_by(|(_peer, mci)| mci.module_instance_id());

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -22,7 +22,7 @@ use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::ClientConfig;
 use fedimint_api::core;
 use fedimint_api::core::{
-    ConsensusItem as PerModuleConsensusItem, PluginConsensusItem,
+    DynModuleConsensusItem as PerModuleConsensusItem, ModuleConsensusItem,
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_api::db::mem_impl::MemDatabase;
@@ -1115,7 +1115,7 @@ impl FederationTest {
     }
 }
 
-pub fn assert_ci<M: PluginConsensusItem>(ci: &ConsensusItem) -> &M {
+pub fn assert_ci<M: ModuleConsensusItem>(ci: &ConsensusItem) -> &M {
     if let ConsensusItem::Module(mci) = ci {
         assert_module_ci(mci)
     } else {
@@ -1123,7 +1123,7 @@ pub fn assert_ci<M: PluginConsensusItem>(ci: &ConsensusItem) -> &M {
     }
 }
 
-pub fn assert_module_ci<M: PluginConsensusItem>(mci: &PerModuleConsensusItem) -> &M {
+pub fn assert_module_ci<M: ModuleConsensusItem>(mci: &PerModuleConsensusItem) -> &M {
     debug!(
         module_instance_id = mci.module_instance_id(),
         "Checking module consensus item"

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -810,7 +810,7 @@ impl FederationTest {
                     let mut dbtx = svr.database.begin_transaction().await;
                     let transaction = fedimint_server::transaction::Transaction {
                         inputs: vec![],
-                        outputs: vec![core::Output::from_typed(
+                        outputs: vec![core::DynOutput::from_typed(
                             LEGACY_HARDCODED_INSTANCE_ID_MINT,
                             MintOutput(tokens.clone()),
                         )],
@@ -833,7 +833,7 @@ impl FederationTest {
                         .get(LEGACY_HARDCODED_INSTANCE_ID_MINT)
                         .apply_output(
                             &mut dbtx,
-                            &core::Output::from_typed(
+                            &core::DynOutput::from_typed(
                                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                                 MintOutput(tokens.clone()),
                             ),

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -79,7 +79,7 @@ async fn peg_in_and_peg_out_with_fees() -> Result<()> {
                         mci.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_WALLET
                     })
                     .unwrap()
-            
+
             ),
             PegOutSignature(PegOutSignatureItem {
                 txid,
@@ -348,7 +348,7 @@ async fn drop_peers_who_dont_contribute_decryption_shares() -> Result<()> {
             .decrypt_share_no_verify(&SecretKey::random().public_key().encrypt(""));
         fed.subset_peers(&[3])
             .override_proposal(vec![ConsensusItem::Module(
-                fedimint_api::core::ConsensusItem::from_typed(
+                fedimint_api::core::DynModuleConsensusItem::from_typed(
                     LEGACY_HARDCODED_INSTANCE_ID_LN,
                     LightningConsensusItem {
                         contract_id,
@@ -394,7 +394,7 @@ async fn drop_peers_who_contribute_bad_sigs() -> Result<()> {
             .await;
         let out_point = fed.database_add_coins_for_user(&user, sats(2000)).await;
         let bad_proposal = vec![ConsensusItem::Module(
-            fedimint_api::core::ConsensusItem::from_typed(
+            fedimint_api::core::DynModuleConsensusItem::from_typed(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                 MintOutputConfirmation {
                     out_point,

--- a/modules/fedimint-dummy/src/common.rs
+++ b/modules/fedimint-dummy/src/common.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use fedimint_api::core::PluginDecode;
+use fedimint_api::core::Decoder;
 use fedimint_api::encoding::{Decodable, DecodeError};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 
@@ -9,7 +9,7 @@ use crate::{DummyInput, DummyOutput, DummyOutputConfirmation, DummyOutputOutcome
 #[derive(Debug, Default, Clone)]
 pub struct DummyDecoder;
 
-impl PluginDecode for DummyDecoder {
+impl Decoder for DummyDecoder {
     type Input = DummyInput;
     type Output = DummyOutput;
     type OutputOutcome = DummyOutputOutcome;

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -9,7 +9,7 @@ use fedimint_api::config::{
     ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ModuleConfigGenParams, ServerModuleConfig,
     TypedServerModuleConfig,
 };
-use fedimint_api::core::{Decoder, ModuleInstanceId, ModuleKind};
+use fedimint_api::core::{DynDecoder, ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::__reexports::serde_json;
@@ -49,8 +49,8 @@ pub struct DummyConfigGenerator;
 
 #[async_trait]
 impl ModuleInit for DummyConfigGenerator {
-    fn decoder(&self) -> Decoder {
-        Decoder::from_typed(DummyDecoder)
+    fn decoder(&self) -> DynDecoder {
+        DynDecoder::from_typed(DummyDecoder)
     }
 
     fn module_kind(&self) -> ModuleKind {

--- a/modules/fedimint-ln/src/common.rs
+++ b/modules/fedimint-ln/src/common.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use fedimint_api::core::PluginDecode;
+use fedimint_api::core::Decoder;
 use fedimint_api::encoding::Decodable;
 use fedimint_api::encoding::DecodeError;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -10,7 +10,7 @@ use crate::{LightningConsensusItem, LightningInput, LightningOutput, LightningOu
 #[derive(Debug, Default, Clone)]
 pub struct LightningDecoder;
 
-impl PluginDecode for LightningDecoder {
+impl Decoder for LightningDecoder {
     type Input = LightningInput;
     type Output = LightningOutput;
     type OutputOutcome = LightningOutputOutcome;

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -28,7 +28,7 @@ use fedimint_api::config::{
     TypedServerModuleConfig,
 };
 use fedimint_api::core::{
-    Decoder, ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+    DynDecoder, ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
@@ -234,8 +234,8 @@ pub struct LightningModuleConfigGen;
 
 #[async_trait]
 impl ModuleInit for LightningModuleConfigGen {
-    fn decoder(&self) -> Decoder {
-        Decoder::from_typed(LightningDecoder)
+    fn decoder(&self) -> DynDecoder {
+        DynDecoder::from_typed(LightningDecoder)
     }
 
     fn module_kind(&self) -> ModuleKind {

--- a/modules/fedimint-mint/src/common.rs
+++ b/modules/fedimint-mint/src/common.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::io;
 
 use bitcoin_hashes::{sha256, Hash};
-use fedimint_api::core::PluginDecode;
+use fedimint_api::core::Decoder;
 use fedimint_api::encoding::DecodeError;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -64,7 +64,7 @@ impl SignedBackupRequest {
 #[derive(Debug, Default, Clone)]
 pub struct MintDecoder;
 
-impl PluginDecode for MintDecoder {
+impl Decoder for MintDecoder {
     type Input = MintInput;
     type Output = MintOutput;
     type OutputOutcome = MintOutputOutcome;

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -13,7 +13,7 @@ use fedimint_api::config::{
     scalar, ClientModuleConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, ModuleConfigGenParams,
     ServerModuleConfig, TypedServerModuleConfig,
 };
-use fedimint_api::core::{Decoder, ModuleInstanceId, ModuleKind};
+use fedimint_api::core::{DynDecoder, ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::__reexports::serde_json;
@@ -138,8 +138,8 @@ pub struct MintConfigGenerator;
 
 #[async_trait]
 impl ModuleInit for MintConfigGenerator {
-    fn decoder(&self) -> Decoder {
-        Decoder::from_typed(MintDecoder)
+    fn decoder(&self) -> DynDecoder {
+        DynDecoder::from_typed(MintDecoder)
     }
 
     fn module_kind(&self) -> ModuleKind {

--- a/modules/fedimint-wallet/src/common.rs
+++ b/modules/fedimint-wallet/src/common.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use fedimint_api::core::PluginDecode;
+use fedimint_api::core::Decoder;
 use fedimint_api::encoding::{Decodable, DecodeError};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 
@@ -9,7 +9,7 @@ use crate::{WalletConsensusItem, WalletInput, WalletOutput, WalletOutputOutcome}
 #[derive(Debug, Default, Clone)]
 pub struct WalletDecoder;
 
-impl PluginDecode for WalletDecoder {
+impl Decoder for WalletDecoder {
     type Input = WalletInput;
     type Output = WalletOutput;
     type OutputOutcome = WalletOutputOutcome;

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -24,7 +24,7 @@ use fedimint_api::config::{
     ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ModuleConfigGenParams, ServerModuleConfig,
     TypedServerModuleConfig,
 };
-use fedimint_api::core::{Decoder, ModuleInstanceId, ModuleKind};
+use fedimint_api::core::{DynDecoder, ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable, UnzipConsensus};
 use fedimint_api::module::__reexports::serde_json;
@@ -222,8 +222,8 @@ pub struct WalletConfigGenerator;
 
 #[async_trait]
 impl ModuleInit for WalletConfigGenerator {
-    fn decoder(&self) -> Decoder {
-        Decoder::from_typed(WalletDecoder)
+    fn decoder(&self) -> DynDecoder {
+        DynDecoder::from_typed(WalletDecoder)
     }
 
     fn module_kind(&self) -> ModuleKind {


### PR DESCRIPTION
part of #1232

The `ModuleConsensusItem` still contains `Module` as there is the `ConsensusItem` enum as well. But I think one could work around that and just rename that enum either in the definition or when importing it (if `ModuleConsensusItem` should be renamed to `ConsensusItem`. 

