### PR TITLE
Fix logging a lot of raw byte debug strings in certain places

### DIFF
--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -7,7 +7,10 @@ use async_trait::async_trait;
 use thiserror::Error;
 use tracing::{trace, warn};
 
-use crate::encoding::{Decodable, Encodable};
+use crate::{
+    encoding::{Decodable, Encodable},
+    fmt_utils::AbbreviateHexBytes,
+};
 
 pub mod mem_impl;
 
@@ -222,9 +225,9 @@ impl<'a> DatabaseTransaction<'a> {
         };
 
         trace!(
-            "get_value: Decoding {} from bytes {:?}",
+            "get_value: Decoding {} from bytes {}",
             std::any::type_name::<K::Value>(),
-            value_bytes
+            AbbreviateHexBytes(&value_bytes)
         );
         Ok(Some(K::Value::from_bytes(&value_bytes, self.decoders)?))
     }
@@ -245,9 +248,9 @@ impl<'a> DatabaseTransaction<'a> {
                 res.and_then(|(key_bytes, value_bytes)| {
                     let key = KP::Key::from_bytes(&key_bytes, &decoders)?;
                     trace!(
-                        "find by prefix: Decoding {} from bytes {:?}",
+                        "find by prefix: Decoding {} from bytes {}",
                         std::any::type_name::<KP::Value>(),
-                        value_bytes
+                        AbbreviateHexBytes(&value_bytes)
                     );
                     let value = KP::Value::from_bytes(&value_bytes, &decoders)?;
                     Ok((key, value))
@@ -266,9 +269,9 @@ impl<'a> DatabaseTransaction<'a> {
         {
             Some(old_val_bytes) => {
                 trace!(
-                    "insert_bytes: Decoding {} from bytes {:?}",
+                    "insert_entry: Decoding {} from bytes {}",
                     std::any::type_name::<K::Value>(),
-                    old_val_bytes
+                    AbbreviateHexBytes(&old_val_bytes)
                 );
                 Ok(Some(K::Value::from_bytes(&old_val_bytes, self.decoders)?))
             }

--- a/fedimint-api/src/fmt_utils.rs
+++ b/fedimint-api/src/fmt_utils.rs
@@ -1,0 +1,16 @@
+use std::fmt;
+
+/// Use for displaying bytes in the logs
+pub struct AbbreviateHexBytes<'a>(pub &'a [u8]);
+
+impl<'a> fmt::Display for AbbreviateHexBytes<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0.len() <= 64 {
+            f.write_str(&hex::encode(self.0))?;
+        } else {
+            f.write_str(&hex::encode(&self.0[..64]))?;
+            f.write_fmt(format_args!("-{}", self.0.len()))?;
+        }
+        Ok(())
+    }
+}

--- a/fedimint-api/src/lib.rs
+++ b/fedimint-api/src/lib.rs
@@ -25,6 +25,7 @@ pub mod config;
 pub mod core;
 pub mod db;
 pub mod encoding;
+pub mod fmt_utils;
 pub mod macros;
 pub mod module;
 pub mod net;


### PR DESCRIPTION
Without some kind of abbreviation reading through log outputs is going to be painful, and usually first bytes are the most significant ones.