### PR TITLE
Bump lightning-invoice from 0.20.0 to 0.21.0 and lightning from 0.0.1…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,18 +2336,18 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.112"
+version = "0.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb857f23c88083ac09bc31fe4eadccf4b2779fb3c973862691258bff38b0e2"
+checksum = "087add70f81d2fdc6d4409bc0cef69e11ad366ef1d0068550159bd22b3ac8664"
 dependencies = [
  "bitcoin",
 ]
 
 [[package]]
 name = "lightning-invoice"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc6ec960257cddce1b85d5ce258821a6138dcd0ae9fd9661b2c3061df588289"
+checksum = "e9680857590c3529cf8c7d32b04501f215f2bf1e029fdfa22f4112f66c1741e4"
 dependencies = [
  "bech32",
  "bitcoin_hashes 0.11.0",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 clap = { version = "4.0.29", features = ["derive", "std", "help", "usage", "error-context", "suggestions" ], default-features = false }
-lightning-invoice = { version = "0.20.0", features = [ "serde" ] }
+lightning-invoice = { version = "0.21.0", features = [ "serde" ] }
 mint-client = { path = "../client-lib" }
 fedimint-api = { path = "../../fedimint-api" }
 fedimint-core = { path = "../../fedimint-core" }

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -23,8 +23,8 @@ bitcoin_hashes = "0.11.0"
 futures = "0.3.24"
 hex = "0.4.3"
 hkdf = { path = "../../crypto/hkdf" }
-lightning-invoice = "0.20.0"
-lightning = "0.0.112"
+lightning-invoice = "0.21.0"
+lightning = "0.0.113"
 miniscript = { version = "7.0.0", git = "https://github.com/rust-bitcoin/rust-miniscript/", rev = "2f1535e470c75fad85dbad8633986aae36a89a92" }
 fedimint-core = { path = "../../fedimint-core" }
 fedimint-derive-secret = { path = "../../crypto/derive-secret" }

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -19,7 +19,7 @@ bitcoin = { version = "0.29.2", features = [ "rand", "serde" ] }
 bitcoin_hashes = { version = "0.11", features = ["serde"] }
 futures = "0.3.24"
 hex = { version = "0.4.3", features = [ "serde" ] }
-lightning-invoice = "0.20.0"
+lightning-invoice = "0.21.0"
 fedimint-derive = { path = "../fedimint-derive" }
 hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
 rand = "0.8.5"

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -27,7 +27,7 @@ cln-rpc = "0.1.1"
 cln-plugin = "0.1.1"
 futures = "0.3.24"
 hex = "0.4.3"
-lightning-invoice = "0.20.0"
+lightning-invoice = "0.21.0"
 fedimint-server = { path = "../../fedimint-server/" }
 fedimint-api = { path = "../../fedimint-api" }
 fedimint-rocksdb = { path = "../../fedimint-rocksdb" }

--- a/gateway/tests/Cargo.toml
+++ b/gateway/tests/Cargo.toml
@@ -19,7 +19,7 @@ fedimint-core = { path = "../../fedimint-core" }
 fedimint-ln = { path = "../../modules/fedimint-ln" }
 fedimint-testing = { path = "../../fedimint-testing" }
 fedimint-mint = { path = "../../modules/fedimint-mint" }
-lightning-invoice = "0.20.0"
+lightning-invoice = "0.21.0"
 ln-gateway = { path = "../ln-gateway" }
 mint-client = { path = "../../client/client-lib" }
 portpicker = "0.1.1"

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -19,9 +19,9 @@ bitcoincore-rpc = "0.16.0"
 cln-rpc = "0.1.1"
 futures = "0.3.24"
 itertools = "0.10.5"
-lightning-invoice = "0.20.0"
+lightning-invoice = "0.21.0"
 ln-gateway = { path = "../gateway/ln-gateway" }
-lightning = "0.0.112"
+lightning = "0.0.113"
 fedimint-server = { path = "../fedimint-server" }
 fedimint-bitcoind = { path = "../fedimint-bitcoind" }
 fedimint-api = { path = "../fedimint-api" }

--- a/modules/fedimint-ln/Cargo.toml
+++ b/modules/fedimint-ln/Cargo.toml
@@ -19,8 +19,8 @@ bincode = "1"
 bitcoin_hashes = "0.11.0"
 futures = "0.3.24"
 itertools = "0.10.5"
-lightning = "0.0.112"
-lightning-invoice = { version = "0.20.0", features = [ "serde" ] }
+lightning = "0.0.113"
+lightning-invoice = { version = "0.21.0", features = [ "serde" ] }
 fedimint-api = { path = "../../fedimint-api" }
 secp256k1 = { version="0.24.2", default-features=false }
 serde = {version = "1.0.149", features = [ "derive" ] }


### PR DESCRIPTION
…12 to 0.0.113

Bumps [lightning-invoice](https://github.com/lightningdevkit/rust-lightning) from 0.20.0 to 0.21.0.
- [Release notes](https://github.com/lightningdevkit/rust-lightning/releases)
- [Changelog](https://github.com/lightningdevkit/rust-lightning/blob/main/CHANGELOG.md)
- [Commits](https://github.com/lightningdevkit/rust-lightning/commits)

---
updated-dependencies:
- dependency-name: lightning-invoice dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>

closes #1139