### PR TITLE
Bump axum from 0.5.17 to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,14 +62,13 @@ dependencies = [
 
 [[package]]
 name = "askama_axum"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1463e29c311d12424dce7d3ef3d064200c56da064e339c37c40478269eb7ea68"
+checksum = "780920656d4e3c8fc3999c1059cb036416423376b814fe8690dbd8c04308aba1"
 dependencies = [
  "askama",
- "axum-core 0.1.2",
+ "axum-core",
  "http",
- "http-body",
 ]
 
 [[package]]
@@ -185,41 +184,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.4.8"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f346c92c1e9a71d14fe4aaf7c2a5d9932cc4e5e48d8fb6641524416eb79ddd"
+checksum = "1304eab461cf02bd70b083ed8273388f9724c549b316ba3d1e213ce0e9e7fb7e"
 dependencies = [
  "async-trait",
- "axum-core 0.1.2",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "matchit 0.4.6",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http 0.2.5",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
-dependencies = [
- "async-trait",
- "axum-core 0.2.9",
+ "axum-core",
  "bitflags",
  "bytes",
  "futures-util",
@@ -227,86 +197,29 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa",
- "matchit 0.5.0",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http 0.3.5",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
-dependencies = [
- "async-trait",
- "axum-core 0.3.0",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit 0.7.0",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
- "tower-http 0.3.5",
+ "tower-http",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.1.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcda393bef9c87572779cb8ef916f12d77750b27535dd6819fa86591627a51"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
+checksum = "f487e40dc9daee24d8a1779df88522f159a54a980f99cfbe43db0be0bd3444a8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -321,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6293dae2ec708e679da6736e857cf8532886ef258e92930f38279c12641628b8"
+checksum = "cc7d7c3e69f305217e317a28172aab29f275667f2e1c15b87451e134fe27c7b1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1361,7 +1274,7 @@ dependencies = [
  "askama",
  "askama_axum",
  "async-trait",
- "axum 0.4.8",
+ "axum",
  "axum-macros",
  "bincode",
  "bitcoin",
@@ -1620,7 +1533,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.5.17",
+ "axum",
  "axum-macros",
  "bitcoin",
  "clap",
@@ -2422,7 +2335,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.5.17",
+ "axum",
  "axum-macros",
  "bitcoin",
  "bitcoin_hashes 0.11.0",
@@ -2446,7 +2359,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
- "tower-http 0.3.5",
+ "tower-http",
  "tracing",
  "url",
 ]
@@ -2484,18 +2397,6 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
-name = "matchit"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9376a4f0340565ad675d11fc1419227faf5f60cd7ac9cb2e7185a471f30af833"
-
-[[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "matchit"
@@ -3555,6 +3456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,9 +4048,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -4153,7 +4063,7 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.1",
+ "axum",
  "base64 0.13.1",
  "bytes",
  "futures-core",
@@ -4210,25 +4120,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -62,12 +62,12 @@ url = { version = "2.3.1", features = ["serde"] }
 threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
 
 # setup dependencies
-askama = { version = "0.11.1", features = ["with-axum"] }
+askama = "0.11.1"
+askama_axum = "0.2.1"
+axum = { version = "0.6.2", default-features = false, features = [ "form", "tokio" ] }
+axum-macros = "0.3.1"
 http = "0.2"
 http-body = "0.4"
-askama_axum = "0.1.0"
-axum = { version = "0.4", default-features = false }
-axum-macros = "0.2.3"
 hyper = { version = "0.14", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
 qrcode-generator = "4.1.6"

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -116,7 +116,7 @@ async fn post_guardians(
         .join(CONSENSUS_CONFIG)
         .with_extension(JSON_EXT);
     if std::path::Path::new(&consensus_path).exists() {
-        return Ok(Redirect::to("/run".parse().unwrap()));
+        return Ok(Redirect::to("/run"));
     }
 
     // Make vec of guardians
@@ -206,9 +206,9 @@ async fn post_guardians(
         })
         .await;
     match dkg_receiver.await.expect("failed to read over channel") {
-        UiMessage::DKGSuccess => Ok(Redirect::to("/run".parse().unwrap())),
+        UiMessage::DKGSuccess => Ok(Redirect::to("/run")),
         // TODO: flash a message that it failed
-        UiMessage::DKGFailure => Ok(Redirect::to("/add_guardians".parse().unwrap())),
+        UiMessage::DKGFailure => Ok(Redirect::to("/add_guardians")),
     }
 }
 
@@ -290,7 +290,7 @@ async fn post_federation_params(
         network: form.network,
     });
 
-    Ok(Redirect::to("/add_guardians".parse().unwrap()))
+    Ok(Redirect::to("/add_guardians"))
 }
 
 pub struct UIError(pub StatusCode, pub String);
@@ -322,10 +322,7 @@ async fn qr(Extension(state): Extension<MutableState>) -> impl IntoResponse {
     };
     let png_bytes: Vec<u8> =
         qrcode_generator::to_png_to_vec(connection_string, QrCodeEcc::Low, 1024).unwrap();
-    (
-        axum::response::Headers([(axum::http::header::CONTENT_TYPE, "image/png")]),
-        png_bytes,
-    )
+    ([(axum::http::header::CONTENT_TYPE, "image/png")], png_bytes)
 }
 
 // FIXME: this is so similar to ParamsForm ...

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.59"
-axum = "0.5.16"
-axum-macros = "0.2.3"
+axum = "0.6.2"
+axum-macros = "0.3.1"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 clap = { version = "4.0.29", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 fedimint-server = { path = "../../fedimint-server/" }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/bin/ln_gateway.rs"
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.59"
-axum = "0.5.16"
-axum-macros = "0.2.3"
+axum = "0.6.2"
+axum-macros = "0.3.1"
 bitcoin_hashes = "0.11.0"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 cln-rpc = "0.1.1"


### PR DESCRIPTION
Also bumps dependencies that need to stay in lock step.

If we don't want yet another git dependency we are blocked on https://github.com/djc/askama/pull/758 making it into a release, which [might happen soon though](https://github.com/djc/askama/issues/757#issuecomment-1378025890).

Closes #1009