### PR TITLE
Create interface for module generation trait

### DIFF
--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -56,7 +56,7 @@ pub const LEGACY_HARDCODED_INSTANCE_ID_WALLET: ModuleInstanceId = 2;
 ///
 /// This is a short string that identifies type of a module.
 /// Authors of 3rd party modules are free to come up with a string,
-/// long enough to avoid conflicts with similiar modules.
+/// long enough to avoid conflicts with similar modules.
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ModuleKind(Cow<'static, str>);
 

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -267,7 +267,7 @@ pub trait ModuleGen: Debug + Sized {
 
     type Decoder: Decoder;
 
-    fn module_kind(&self) -> ModuleKind {
+    fn module_kind() -> ModuleKind {
         Self::KIND
     }
 
@@ -318,7 +318,7 @@ where
     }
 
     fn module_kind(&self) -> ModuleKind {
-        <Self as ModuleGen>::module_kind(self)
+        <Self as ModuleGen>::module_kind()
     }
 
     async fn init(

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -1,11 +1,10 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use docopt::Docopt;
 use erased_serde::Serialize;
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::encoding::Encodable;
-use fedimint_api::module::ModuleGen;
+use fedimint_api::module::DynModuleGen;
 use fedimint_ln::{db as LightningRange, LightningConfigGenerator};
 use fedimint_mint::{db as MintRange, MintConfigGenerator};
 use fedimint_rocksdb::RocksDbReadOnly;
@@ -676,9 +675,9 @@ async fn main() {
     };
 
     let _module_inits = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
-        Arc::new(MintConfigGenerator),
-        Arc::new(LightningConfigGenerator),
+        DynModuleGen::from(WalletConfigGenerator),
+        DynModuleGen::from(MintConfigGenerator),
+        DynModuleGen::from(LightningConfigGenerator),
     ]);
 
     let decoders = Default::default(); // TODO: read config and use it to create decoders

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::net::SocketAddr;
 use std::os::unix::prelude::OsStrExt;
-use std::sync::Arc;
 
 use anyhow::{bail, format_err};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
@@ -16,7 +15,7 @@ use fedimint_api::core::{
 };
 use fedimint_api::db::Database;
 use fedimint_api::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
-use fedimint_api::module::ModuleGen;
+use fedimint_api::module::DynModuleGen;
 use fedimint_api::net::peers::{IPeerConnections, MuxPeerConnections, PeerConnections};
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
@@ -181,9 +180,6 @@ impl ServerConfigConsensus {
             .expect("configuration mismatch")
     }
 }
-
-// TODO: turn into newtype
-pub type DynModuleGen = Arc<dyn ModuleGen + Send + Sync>;
 
 #[derive(Clone)]
 pub struct ModuleInitRegistry(BTreeMap<ModuleKind, DynModuleGen>);

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -59,7 +59,7 @@ where
         for (peer, cfg) in server_cfg {
             let db = Database::new(
                 MemDatabase::new(),
-                ModuleDecoderRegistry::from_iter([(module_instance_id, conf_gen.decoder())]),
+                ModuleDecoderRegistry::from_iter([(module_instance_id, conf_gen.decoder().into())]),
             );
             let member = constructor(cfg, db.clone()).await?;
             members.push((peer, member, db));

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -2,10 +2,9 @@ use std::fs;
 use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use clap::{Parser, Subcommand};
-use fedimint_api::module::ModuleGen;
+use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
 use fedimint_ln::LightningConfigGenerator;
@@ -133,9 +132,9 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let module_config_gens = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
-        Arc::new(MintConfigGenerator),
-        Arc::new(LightningConfigGenerator),
+        DynModuleGen::from(WalletConfigGenerator),
+        DynModuleGen::from(MintConfigGenerator),
+        DynModuleGen::from(LightningConfigGenerator),
     ]);
 
     let mut task_group = TaskGroup::new();

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,10 +1,9 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use clap::Parser;
 use fedimint_api::db::Database;
-use fedimint_api::module::ModuleGen;
+use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_ln::LightningConfigGenerator;
 use fedimint_mint::MintConfigGenerator;
@@ -121,9 +120,9 @@ async fn main() -> anyhow::Result<()> {
     task_group.install_kill_handler();
 
     let module_inits = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
-        Arc::new(MintConfigGenerator),
-        Arc::new(LightningConfigGenerator),
+        DynModuleGen::from(WalletConfigGenerator),
+        DynModuleGen::from(MintConfigGenerator),
+        DynModuleGen::from(LightningConfigGenerator),
     ]);
 
     let decoders = module_inits.decoders(cfg.iter_module_instances())?;

--- a/fedimintd/src/distributedgen.rs
+++ b/fedimintd/src/distributedgen.rs
@@ -2,10 +2,9 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use anyhow::ensure;
-use fedimint_api::module::ModuleGen;
+use fedimint_api::module::DynModuleGen;
 use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
@@ -85,9 +84,9 @@ pub async fn run_dkg(
     let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
 
     let module_config_gens = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
-        Arc::new(MintConfigGenerator),
-        Arc::new(LightningConfigGenerator),
+        DynModuleGen::from(WalletConfigGenerator),
+        DynModuleGen::from(MintConfigGenerator),
+        DynModuleGen::from(LightningConfigGenerator),
     ]);
 
     let result = ServerConfig::distributed_gen(

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -13,7 +13,7 @@ use axum::{
 use axum_macros::debug_handler;
 use bitcoin::Network;
 use fedimint_api::config::ClientConfig;
-use fedimint_api::module::ModuleGen;
+use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
 use fedimint_ln::LightningConfigGenerator;
@@ -135,9 +135,9 @@ async fn post_guardians(
     let max_denomination = Amount::from_msats(100000000000);
     let (dkg_sender, dkg_receiver) = tokio::sync::oneshot::channel::<UiMessage>();
     let module_config_gens = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
-        Arc::new(MintConfigGenerator),
-        Arc::new(LightningConfigGenerator),
+        DynModuleGen::from(WalletConfigGenerator),
+        DynModuleGen::from(MintConfigGenerator),
+        DynModuleGen::from(LightningConfigGenerator),
     ]);
     let dir_out_path = state.data_dir.clone();
     let fedimintd_sender = state.sender.clone();

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -29,7 +29,7 @@ use fedimint_api::core::{
 use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::Database;
 use fedimint_api::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
-use fedimint_api::module::ModuleGen;
+use fedimint_api::module::DynModuleGen;
 use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::server::DynServerModule;
 use fedimint_api::task::{timeout, TaskGroup};
@@ -161,9 +161,9 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
     let max_evil = hbbft::util::max_faulty(peers.len());
 
     let module_inits = ModuleInitRegistry::from(vec![
-        Arc::new(WalletConfigGenerator) as Arc<dyn ModuleGen + Send + Sync>,
-        Arc::new(MintConfigGenerator),
-        Arc::new(LightningConfigGenerator),
+        DynModuleGen::from(WalletConfigGenerator),
+        DynModuleGen::from(MintConfigGenerator),
+        DynModuleGen::from(LightningConfigGenerator),
     ]);
 
     match env::var("FM_TEST_DISABLE_MOCKS") {

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -51,19 +51,12 @@ pub struct DummyConfigGenerator;
 
 #[async_trait]
 impl ModuleGen for DummyConfigGenerator {
-    const KIND: ModuleKind = ModuleKind::from_static_str("dummy");
+    const KIND: ModuleKind = KIND;
     type Decoder = DummyDecoder;
 
     fn decoder(&self) -> DummyDecoder {
         DummyDecoder
     }
-
-    // TODO: is this method always required to be implemented? Or maybe have default impl that
-    // returns ModuleKind::from_static(KIND) and define `KIND = "dummy"`?
-    // fn module_kind(&self) -> ModuleKind {
-    //     const KIND: &str = "dummy";
-    //     ModuleKind::from_static_str(KIND)
-    // }
 
     async fn init(
         &self,

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -10,7 +10,7 @@ use fedimint_api::config::{
     ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ModuleConfigGenParams, ServerModuleConfig,
     TypedServerModuleConfig,
 };
-use fedimint_api::core::{DynDecoder, ModuleInstanceId, ModuleKind};
+use fedimint_api::core::{ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::__reexports::serde_json;
@@ -46,18 +46,24 @@ pub struct DummyOutputConfirmation;
 #[derive(Debug, Clone)]
 pub struct DummyVerificationCache;
 
+#[derive(Debug)]
 pub struct DummyConfigGenerator;
 
 #[async_trait]
 impl ModuleGen for DummyConfigGenerator {
-    fn decoder(&self) -> DynDecoder {
-        DynDecoder::from_typed(DummyDecoder)
+    const KIND: ModuleKind = ModuleKind::from_static_str("dummy");
+    type Decoder = DummyDecoder;
+
+    fn decoder(&self) -> DummyDecoder {
+        DummyDecoder
     }
 
-    fn module_kind(&self) -> ModuleKind {
-        const KIND: &str = "dummy";
-        ModuleKind::from_static_str(KIND)
-    }
+    // TODO: is this method always required to be implemented? Or maybe have default impl that
+    // returns ModuleKind::from_static(KIND) and define `KIND = "dummy"`?
+    // fn module_kind(&self) -> ModuleKind {
+    //     const KIND: &str = "dummy";
+    //     ModuleKind::from_static_str(KIND)
+    // }
 
     async fn init(
         &self,

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -28,9 +28,7 @@ use fedimint_api::config::{
     ClientModuleConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, ServerModuleConfig,
     TypedServerModuleConfig,
 };
-use fedimint_api::core::{
-    DynDecoder, ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
-};
+use fedimint_api::core::{ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
@@ -231,12 +229,16 @@ impl std::fmt::Display for LightningConsensusItem {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub struct LightningVerificationCache;
 
+#[derive(Debug)]
 pub struct LightningConfigGenerator;
 
 #[async_trait]
 impl ModuleGen for LightningConfigGenerator {
-    fn decoder(&self) -> DynDecoder {
-        DynDecoder::from_typed(LightningDecoder)
+    const KIND: ModuleKind = ModuleKind::from_static_str("LightningConfigGenerator");
+    type Decoder = LightningDecoder;
+
+    fn decoder(&self) -> LightningDecoder {
+        LightningDecoder
     }
 
     fn module_kind(&self) -> ModuleKind {

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -234,15 +234,11 @@ pub struct LightningConfigGenerator;
 
 #[async_trait]
 impl ModuleGen for LightningConfigGenerator {
-    const KIND: ModuleKind = ModuleKind::from_static_str("LightningConfigGenerator");
+    const KIND: ModuleKind = KIND;
     type Decoder = LightningDecoder;
 
     fn decoder(&self) -> LightningDecoder {
         LightningDecoder
-    }
-
-    fn module_kind(&self) -> ModuleKind {
-        KIND
     }
 
     async fn init(

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -140,15 +140,12 @@ pub struct MintConfigGenerator;
 
 #[async_trait]
 impl ModuleGen for MintConfigGenerator {
-    const KIND: ModuleKind = ModuleKind::from_static_str("MintConfigGenerator");
+    const KIND: ModuleKind = KIND;
+
     type Decoder = MintDecoder;
 
     fn decoder(&self) -> MintDecoder {
         MintDecoder
-    }
-
-    fn module_kind(&self) -> ModuleKind {
-        Self::KIND
     }
 
     async fn init(

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -14,7 +14,7 @@ use fedimint_api::config::{
     scalar, ClientModuleConfig, ConfigGenParams, DkgPeerMsg, DkgRunner, ModuleConfigGenParams,
     ServerModuleConfig, TypedServerModuleConfig,
 };
-use fedimint_api::core::{DynDecoder, ModuleInstanceId, ModuleKind};
+use fedimint_api::core::{ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::__reexports::serde_json;
@@ -135,16 +135,20 @@ pub struct VerifiedNotes {
     valid_notes: HashMap<Note, Amount>,
 }
 
+#[derive(Debug)]
 pub struct MintConfigGenerator;
 
 #[async_trait]
 impl ModuleGen for MintConfigGenerator {
-    fn decoder(&self) -> DynDecoder {
-        DynDecoder::from_typed(MintDecoder)
+    const KIND: ModuleKind = ModuleKind::from_static_str("MintConfigGenerator");
+    type Decoder = MintDecoder;
+
+    fn decoder(&self) -> MintDecoder {
+        MintDecoder
     }
 
     fn module_kind(&self) -> ModuleKind {
-        KIND
+        Self::KIND
     }
 
     async fn init(

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -26,7 +26,7 @@ use fedimint_api::config::{
     ClientModuleConfig, ConfigGenParams, DkgPeerMsg, ModuleConfigGenParams, ServerModuleConfig,
     TypedServerModuleConfig,
 };
-use fedimint_api::core::{DynDecoder, ModuleInstanceId, ModuleKind};
+use fedimint_api::core::{ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable, UnzipConsensus};
 use fedimint_api::module::__reexports::serde_json;
@@ -219,12 +219,16 @@ impl std::fmt::Display for WalletOutputOutcome {
     }
 }
 
+#[derive(Debug)]
 pub struct WalletConfigGenerator;
 
 #[async_trait]
 impl ModuleGen for WalletConfigGenerator {
-    fn decoder(&self) -> DynDecoder {
-        DynDecoder::from_typed(WalletDecoder)
+    const KIND: ModuleKind = ModuleKind::from_static_str("WalletConfigGenerator");
+    type Decoder = WalletDecoder;
+
+    fn decoder(&self) -> WalletDecoder {
+        WalletDecoder {}
     }
 
     fn module_kind(&self) -> ModuleKind {

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -224,15 +224,11 @@ pub struct WalletConfigGenerator;
 
 #[async_trait]
 impl ModuleGen for WalletConfigGenerator {
-    const KIND: ModuleKind = ModuleKind::from_static_str("WalletConfigGenerator");
+    const KIND: ModuleKind = KIND;
     type Decoder = WalletDecoder;
 
     fn decoder(&self) -> WalletDecoder {
         WalletDecoder {}
-    }
-
-    fn module_kind(&self) -> ModuleKind {
-        KIND
     }
 
     async fn init(


### PR DESCRIPTION
part of #1303

- creates an `IModuleGen` for `ModuleGen` and the blanket impl
- `ModuleGen` is now the typed trait with associated types

- [x] is the method `module_kind()` always supposed to be implemented? or default impl? see TODO comment  (edit: yes, default impl)
