### PR TITLE
Rename module generation structs for `ModuleGen` consistency

### DIFF
--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -342,7 +342,7 @@ mod tests {
     use fedimint_core::modules::ln::config::LightningClientConfig;
     use fedimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
     use fedimint_core::modules::ln::contracts::{ContractId, IdentifyableContract};
-    use fedimint_core::modules::ln::{ContractAccount, Lightning, LightningConfigGenerator};
+    use fedimint_core::modules::ln::{ContractAccount, Lightning, LightningGen};
     use fedimint_core::modules::ln::{LightningGateway, LightningOutput};
     use fedimint_core::modules::mint::db::ECashUserBackupSnapshot;
     use fedimint_core::modules::wallet::PegOutFees;
@@ -478,7 +478,7 @@ mod tests {
                 4,
                 |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
                 &ConfigGenParams::new(),
-                &LightningConfigGenerator,
+                &LightningGen,
                 LEGACY_HARDCODED_INSTANCE_ID_LN,
             )
             .await

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -669,9 +669,7 @@ mod tests {
     use fedimint_core::modules::ln::{ContractAccount, LightningGateway};
     use fedimint_core::modules::mint::config::MintClientConfig;
     use fedimint_core::modules::mint::db::ECashUserBackupSnapshot;
-    use fedimint_core::modules::mint::{
-        Mint, MintConfigGenParams, MintConfigGenerator, MintOutput,
-    };
+    use fedimint_core::modules::mint::{Mint, MintGen, MintGenParams, MintOutput};
     use fedimint_core::modules::wallet::PegOutFees;
     use fedimint_core::outcome::{SerdeOutputOutcome, TransactionStatus};
     use fedimint_core::transaction::legacy::Input;
@@ -801,14 +799,14 @@ mod tests {
             FakeFed::<Mint>::new(
                 4,
                 |cfg, _db| async move { Ok(Mint::new(cfg.to_typed().unwrap())) },
-                &ConfigGenParams::new().attach(MintConfigGenParams {
+                &ConfigGenParams::new().attach(MintGenParams {
                     mint_amounts: vec![
                         Amount::from_sats(1),
                         Amount::from_sats(10),
                         Amount::from_sats(20),
                     ],
                 }),
-                &MintConfigGenerator,
+                &MintGen,
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
             )
             .await

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -206,8 +206,7 @@ mod tests {
     use fedimint_core::modules::mint::db::ECashUserBackupSnapshot;
     use fedimint_core::modules::wallet::config::WalletClientConfig;
     use fedimint_core::modules::wallet::{
-        PegOut, PegOutFees, Wallet, WalletConfigGenParams, WalletConfigGenerator, WalletOutput,
-        WalletOutputOutcome,
+        PegOut, PegOutFees, Wallet, WalletGen, WalletGenParams, WalletOutput, WalletOutputOutcome,
     };
     use fedimint_core::outcome::{SerdeOutputOutcome, TransactionStatus};
     use fedimint_testing::btc::bitcoind::{FakeBitcoindRpc, FakeBitcoindRpcController};
@@ -346,11 +345,11 @@ mod tests {
                         .await?)
                     }
                 },
-                &ConfigGenParams::new().attach(WalletConfigGenParams {
+                &ConfigGenParams::new().attach(WalletGenParams {
                     network: bitcoin::network::constants::Network::Regtest,
                     finality_delay: 10,
                 }),
-                &WalletConfigGenerator,
+                &WalletGen,
                 LEGACY_HARDCODED_INSTANCE_ID_WALLET,
             )
             .await

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -5,12 +5,12 @@ use erased_serde::Serialize;
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::encoding::Encodable;
 use fedimint_api::module::DynModuleGen;
-use fedimint_ln::{db as LightningRange, LightningConfigGenerator};
-use fedimint_mint::{db as MintRange, MintConfigGenerator};
+use fedimint_ln::{db as LightningRange, LightningGen};
+use fedimint_mint::{db as MintRange, MintGen};
 use fedimint_rocksdb::RocksDbReadOnly;
 use fedimint_server::config::ModuleInitRegistry;
 use fedimint_server::db as ConsensusRange;
-use fedimint_wallet::{db as WalletRange, WalletConfigGenerator};
+use fedimint_wallet::{db as WalletRange, WalletGen};
 use mint_client::db as ClientRange;
 use mint_client::ln::db as ClientLightningRange;
 use mint_client::mint::db as ClientMintRange;
@@ -675,9 +675,9 @@ async fn main() {
     };
 
     let _module_inits = ModuleInitRegistry::from(vec![
-        DynModuleGen::from(WalletConfigGenerator),
-        DynModuleGen::from(MintConfigGenerator),
-        DynModuleGen::from(LightningConfigGenerator),
+        DynModuleGen::from(WalletGen),
+        DynModuleGen::from(MintGen),
+        DynModuleGen::from(LightningGen),
     ]);
 
     let decoders = Default::default(); // TODO: read config and use it to create decoders

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -20,8 +20,8 @@ use fedimint_api::net::peers::{IPeerConnections, MuxPeerConnections, PeerConnect
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
 pub use fedimint_core::config::*;
-use fedimint_core::modules::mint::MintConfigGenParams;
-use fedimint_wallet::WalletConfigGenParams;
+use fedimint_core::modules::mint::MintGenParams;
+use fedimint_wallet::WalletGenParams;
 use hbbft::crypto::serde_impl::SerdeSecret;
 use hbbft::NetworkInfo;
 use rand::{CryptoRng, RngCore};
@@ -742,12 +742,12 @@ impl ServerConfigParams {
             api_network: Self::gen_network(&bind_api, &our_id, peers, |params| params.api_url),
             federation_name,
             modules: ConfigGenParams::new()
-                .attach(WalletConfigGenParams {
+                .attach(WalletGenParams {
                     network,
                     // TODO this is not very elegant, but I'm planning to get rid of it in a next commit anyway
                     finality_delay,
                 })
-                .attach(MintConfigGenParams {
+                .attach(MintGenParams {
                     mint_amounts: ServerConfigParams::gen_denominations(max_denomination),
                 }),
         }

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -7,10 +7,10 @@ use clap::{Parser, Subcommand};
 use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
-use fedimint_ln::LightningConfigGenerator;
-use fedimint_mint::MintConfigGenerator;
+use fedimint_ln::LightningGen;
+use fedimint_mint::MintGen;
 use fedimint_server::config::ModuleInitRegistry;
-use fedimint_wallet::WalletConfigGenerator;
+use fedimint_wallet::WalletGen;
 use fedimintd::distributedgen::{create_cert, run_dkg};
 use fedimintd::encrypt::*;
 use fedimintd::*;
@@ -132,9 +132,9 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let module_config_gens = ModuleInitRegistry::from(vec![
-        DynModuleGen::from(WalletConfigGenerator),
-        DynModuleGen::from(MintConfigGenerator),
-        DynModuleGen::from(LightningConfigGenerator),
+        DynModuleGen::from(WalletGen),
+        DynModuleGen::from(MintGen),
+        DynModuleGen::from(LightningGen),
     ]);
 
     let mut task_group = TaskGroup::new();

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -5,12 +5,12 @@ use clap::Parser;
 use fedimint_api::db::Database;
 use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
-use fedimint_ln::LightningConfigGenerator;
-use fedimint_mint::MintConfigGenerator;
+use fedimint_ln::LightningGen;
+use fedimint_mint::MintGen;
 use fedimint_server::config::ModuleInitRegistry;
 use fedimint_server::consensus::FedimintConsensus;
 use fedimint_server::FedimintServer;
-use fedimint_wallet::WalletConfigGenerator;
+use fedimint_wallet::WalletGen;
 use fedimintd::encrypt::*;
 use fedimintd::ui::run_ui;
 use fedimintd::ui::UiMessage;
@@ -120,9 +120,9 @@ async fn main() -> anyhow::Result<()> {
     task_group.install_kill_handler();
 
     let module_inits = ModuleInitRegistry::from(vec![
-        DynModuleGen::from(WalletConfigGenerator),
-        DynModuleGen::from(MintConfigGenerator),
-        DynModuleGen::from(LightningConfigGenerator),
+        DynModuleGen::from(WalletGen),
+        DynModuleGen::from(MintGen),
+        DynModuleGen::from(LightningGen),
     ]);
 
     let decoders = module_inits.decoders(cfg.iter_module_instances())?;

--- a/fedimintd/src/distributedgen.rs
+++ b/fedimintd/src/distributedgen.rs
@@ -8,11 +8,11 @@ use fedimint_api::module::DynModuleGen;
 use fedimint_api::net::peers::IMuxPeerConnections;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::{Amount, PeerId};
-use fedimint_ln::LightningConfigGenerator;
-use fedimint_mint::MintConfigGenerator;
+use fedimint_ln::LightningGen;
+use fedimint_mint::MintGen;
 use fedimint_server::config::{PeerServerParams, ServerConfig, ServerConfigParams};
 use fedimint_server::multiplexed::PeerConnectionMultiplexer;
-use fedimint_wallet::WalletConfigGenerator;
+use fedimint_wallet::WalletGen;
 use itertools::Itertools;
 use rand::rngs::OsRng;
 use ring::aead::LessSafeKey;
@@ -84,9 +84,9 @@ pub async fn run_dkg(
     let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
 
     let module_config_gens = ModuleInitRegistry::from(vec![
-        DynModuleGen::from(WalletConfigGenerator),
-        DynModuleGen::from(MintConfigGenerator),
-        DynModuleGen::from(LightningConfigGenerator),
+        DynModuleGen::from(WalletGen),
+        DynModuleGen::from(MintGen),
+        DynModuleGen::from(LightningGen),
     ]);
 
     let result = ServerConfig::distributed_gen(

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -16,10 +16,10 @@ use fedimint_api::config::ClientConfig;
 use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
-use fedimint_ln::LightningConfigGenerator;
-use fedimint_mint::MintConfigGenerator;
+use fedimint_ln::LightningGen;
+use fedimint_mint::MintGen;
 use fedimint_server::config::ModuleInitRegistry;
-use fedimint_wallet::WalletConfigGenerator;
+use fedimint_wallet::WalletGen;
 use http::StatusCode;
 use mint_client::api::WsFederationConnect;
 use qrcode_generator::QrCodeEcc;
@@ -135,9 +135,9 @@ async fn post_guardians(
     let max_denomination = Amount::from_msats(100000000000);
     let (dkg_sender, dkg_receiver) = tokio::sync::oneshot::channel::<UiMessage>();
     let module_config_gens = ModuleInitRegistry::from(vec![
-        DynModuleGen::from(WalletConfigGenerator),
-        DynModuleGen::from(MintConfigGenerator),
-        DynModuleGen::from(LightningConfigGenerator),
+        DynModuleGen::from(WalletGen),
+        DynModuleGen::from(MintGen),
+        DynModuleGen::from(LightningGen),
     ]);
     let dir_out_path = state.data_dir.clone();
     let fedimintd_sender = state.sender.clone();

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -38,8 +38,8 @@ use fedimint_api::PeerId;
 use fedimint_api::TieredMulti;
 use fedimint_api::{sats, Amount};
 use fedimint_bitcoind::DynBitcoindRpc;
-use fedimint_ln::{LightningConfigGenerator, LightningGateway};
-use fedimint_mint::{MintConfigGenerator, MintOutput};
+use fedimint_ln::{LightningGateway, LightningGen};
+use fedimint_mint::{MintGen, MintOutput};
 use fedimint_server::config::{connect, ServerConfig};
 use fedimint_server::config::{ModuleInitRegistry, ServerConfigParams};
 use fedimint_server::consensus::{ConsensusProposal, HbbftConsensusOutcome};
@@ -54,7 +54,7 @@ use fedimint_wallet::config::WalletConfig;
 use fedimint_wallet::db::UTXOKey;
 use fedimint_wallet::Wallet;
 use fedimint_wallet::WalletConsensusItem;
-use fedimint_wallet::{SpendableUTXO, WalletConfigGenerator};
+use fedimint_wallet::{SpendableUTXO, WalletGen};
 use futures::executor::block_on;
 use futures::future::{join_all, select_all};
 use hbbft::honey_badger::Batch;
@@ -161,9 +161,9 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
     let max_evil = hbbft::util::max_faulty(peers.len());
 
     let module_inits = ModuleInitRegistry::from(vec![
-        DynModuleGen::from(WalletConfigGenerator),
-        DynModuleGen::from(MintConfigGenerator),
-        DynModuleGen::from(LightningConfigGenerator),
+        DynModuleGen::from(WalletGen),
+        DynModuleGen::from(MintGen),
+        DynModuleGen::from(LightningGen),
     ]);
 
     match env::var("FM_TEST_DISABLE_MOCKS") {

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -230,10 +230,10 @@ impl std::fmt::Display for LightningConsensusItem {
 pub struct LightningVerificationCache;
 
 #[derive(Debug)]
-pub struct LightningConfigGenerator;
+pub struct LightningGen;
 
 #[async_trait]
-impl ModuleGen for LightningConfigGenerator {
+impl ModuleGen for LightningGen {
     const KIND: ModuleKind = KIND;
     type Decoder = LightningDecoder;
 

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -11,7 +11,7 @@ use fedimint_ln::contracts::{
     AccountContractOutcome, Contract, ContractOutcome, DecryptedPreimage, EncryptedPreimage,
     IdentifyableContract, OutgoingContractOutcome, Preimage,
 };
-use fedimint_ln::LightningConfigGenerator;
+use fedimint_ln::LightningGen;
 use fedimint_ln::{
     ContractOutput, Lightning, LightningError, LightningInput, LightningOutput,
     LightningOutputOutcome,
@@ -27,7 +27,7 @@ async fn test_account() {
         4,
         |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
         &ConfigGenParams::new(),
-        &LightningConfigGenerator,
+        &LightningGen,
         LEGACY_HARDCODED_INSTANCE_ID_LN,
     )
     .await
@@ -78,7 +78,7 @@ async fn test_outgoing() {
         4,
         |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
         &ConfigGenParams::new(),
-        &LightningConfigGenerator,
+        &LightningGen,
         LEGACY_HARDCODED_INSTANCE_ID_LN,
     )
     .await
@@ -178,7 +178,7 @@ async fn test_incoming() {
         4,
         |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
         &ConfigGenParams::new(),
-        &LightningConfigGenerator,
+        &LightningGen,
         LEGACY_HARDCODED_INSTANCE_ID_LN,
     )
     .await

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -136,10 +136,10 @@ pub struct VerifiedNotes {
 }
 
 #[derive(Debug)]
-pub struct MintConfigGenerator;
+pub struct MintGen;
 
 #[async_trait]
-impl ModuleGen for MintConfigGenerator {
+impl ModuleGen for MintGen {
     const KIND: ModuleKind = KIND;
 
     type Decoder = MintDecoder;
@@ -163,9 +163,7 @@ impl ModuleGen for MintConfigGenerator {
         peers: &[PeerId],
         params: &ConfigGenParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
-        let params = params
-            .get::<MintConfigGenParams>()
-            .expect("Invalid mint params");
+        let params = params.get::<MintGenParams>().expect("Invalid mint params");
 
         let tbs_keys = params
             .mint_amounts
@@ -225,9 +223,7 @@ impl ModuleGen for MintConfigGenerator {
         params: &ConfigGenParams,
         _task_group: &mut TaskGroup,
     ) -> anyhow::Result<Cancellable<ServerModuleConfig>> {
-        let params = params
-            .get::<MintConfigGenParams>()
-            .expect("Invalid mint params");
+        let params = params.get::<MintGenParams>().expect("Invalid mint params");
 
         let mut dkg = DkgRunner::multi(
             params.mint_amounts.to_vec(),
@@ -300,11 +296,11 @@ impl ModuleGen for MintConfigGenerator {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MintConfigGenParams {
+pub struct MintGenParams {
     pub mint_amounts: Vec<Amount>,
 }
 
-impl ModuleConfigGenParams for MintConfigGenParams {
+impl ModuleConfigGenParams for MintGenParams {
     const MODULE_NAME: &'static str = "mint";
 }
 
@@ -1139,8 +1135,8 @@ mod test {
 
     use crate::config::{FeeConsensus, MintClientConfig};
     use crate::{
-        BlindNonce, CombineError, Mint, MintConfig, MintConfigConsensus, MintConfigGenParams,
-        MintConfigGenerator, MintConfigPrivate, PeerErrorType,
+        BlindNonce, CombineError, Mint, MintConfig, MintConfigConsensus, MintConfigPrivate,
+        MintGen, MintGenParams, PeerErrorType,
     };
 
     const THRESHOLD: usize = 1;
@@ -1148,9 +1144,9 @@ mod test {
 
     fn build_configs() -> (Vec<ServerModuleConfig>, ClientModuleConfig) {
         let peers = (0..MINTS as u16).map(PeerId::from).collect::<Vec<_>>();
-        let mint_cfg = MintConfigGenerator.trusted_dealer_gen(
+        let mint_cfg = MintGen.trusted_dealer_gen(
             &peers,
-            &ConfigGenParams::new().attach(MintConfigGenParams {
+            &ConfigGenParams::new().attach(MintGenParams {
                 mint_amounts: vec![Amount::from_sats(1)],
             }),
         );

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -220,10 +220,10 @@ impl std::fmt::Display for WalletOutputOutcome {
 }
 
 #[derive(Debug)]
-pub struct WalletConfigGenerator;
+pub struct WalletGen;
 
 #[async_trait]
-impl ModuleGen for WalletConfigGenerator {
+impl ModuleGen for WalletGen {
     const KIND: ModuleKind = KIND;
     type Decoder = WalletDecoder;
 
@@ -249,7 +249,7 @@ impl ModuleGen for WalletConfigGenerator {
         params: &ConfigGenParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let params = params
-            .get::<WalletConfigGenParams>()
+            .get::<WalletGenParams>()
             .expect("Invalid wallet params");
 
         let secp = secp256k1::Secp256k1::new();
@@ -292,7 +292,7 @@ impl ModuleGen for WalletConfigGenerator {
         _task_group: &mut TaskGroup,
     ) -> anyhow::Result<Cancellable<ServerModuleConfig>> {
         let params = params
-            .get::<WalletConfigGenParams>()
+            .get::<WalletGenParams>()
             .expect("Invalid wallet params");
 
         let secp = secp256k1::Secp256k1::new();
@@ -357,12 +357,12 @@ impl ModuleGen for WalletConfigGenerator {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WalletConfigGenParams {
+pub struct WalletGenParams {
     pub network: bitcoin::network::constants::Network,
     pub finality_delay: u32,
 }
 
-impl ModuleConfigGenParams for WalletConfigGenParams {
+impl ModuleConfigGenParams for WalletGenParams {
     const MODULE_NAME: &'static str = "wallet";
 }
 


### PR DESCRIPTION
folluw up for #1314  @dpc , also ACK @elsirion ?

Renaming the `MintConfigGeneration` to `MintGen` for consistency with `ModuleGen`.
Same for `MintConfigGenerationParams` -> `MintGenParams`.

same applies to the other modules.