### PR TITLE
Change how the `IFederationApi` works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,8 @@ dependencies = [
  "serde_json",
  "threshold_crypto",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -3218,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -4,19 +4,30 @@ use std::error::Error;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::process::exit;
+use std::sync::Arc;
 
 use bitcoin::{secp256k1, Address, Transaction};
 use clap::{Parser, Subcommand};
 use fedimint_api::config::ClientConfig;
+use fedimint_api::core::{
+    LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+    LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+};
 use fedimint_api::db::Database;
+use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::task::TaskGroup;
-use fedimint_api::{Amount, NumPeers, OutPoint, TieredMulti, TransactionId};
+use fedimint_api::{Amount, OutPoint, TieredMulti, TransactionId};
 use fedimint_core::config::load_from_file;
+use fedimint_core::modules::ln::common::LightningDecoder;
 use fedimint_core::modules::ln::contracts::ContractId;
+use fedimint_core::modules::wallet::common::WalletDecoder;
 use fedimint_core::modules::wallet::txoproof::TxOutProof;
-use mint_client::api::{WsFederationApi, WsFederationConnect};
+use fedimint_mint::common::MintDecoder;
+use mint_client::api::{
+    GlobalFederationApi, IFederationApi, IFederationApiFed, WsFederationApi, WsFederationConnect,
+};
 use mint_client::mint::SpendableNote;
-use mint_client::query::{CurrentConsensus, EventuallyConsistent};
+use mint_client::query::EventuallyConsistent;
 use mint_client::utils::{
     from_hex, parse_bitcoin_amount, parse_ecash, parse_fedimint_amount, parse_node_pub_key,
     serialize_ecash,
@@ -362,18 +373,12 @@ async fn main() {
         if let Command::JoinFederation { connect } = cli.command {
             let connect_obj: WsFederationConnect = serde_json::from_str(&connect)
                 .or_terminate(CliErrorKind::InvalidValue, "invalid connect info");
-            let api = WsFederationApi::new(connect_obj.members);
-            let cfg: ClientConfig = api
-                .request(
-                    "/config",
-                    (),
-                    CurrentConsensus::new(api.peers().one_honest()),
-                )
-                .await
-                .or_terminate(
-                    CliErrorKind::NetworkError,
-                    "couldn't download config from peer",
-                );
+            let api = Arc::new(WsFederationApi::new(connect_obj.members))
+                as Arc<dyn IFederationApi + Send + Sync + 'static>;
+            let cfg: ClientConfig = api.get_client_config().await.or_terminate(
+                CliErrorKind::NetworkError,
+                "couldn't download config from peer",
+            );
             let cfg_path = cli.workdir.join("client.json");
             std::fs::create_dir_all(&cli.workdir)
                 .or_terminate(CliErrorKind::IOError, "failed to create config directory");
@@ -397,7 +402,13 @@ async fn main() {
 
         let rng = rand::rngs::OsRng;
 
-        let client = Client::new(cfg.clone(), db, Default::default()).await;
+        let decoders = ModuleDecoderRegistry::from_iter([
+            (LEGACY_HARDCODED_INSTANCE_ID_LN, LightningDecoder.into()),
+            (LEGACY_HARDCODED_INSTANCE_ID_MINT, MintDecoder.into()),
+            (LEGACY_HARDCODED_INSTANCE_ID_WALLET, WalletDecoder.into()),
+        ]);
+
+        let client = Client::new(cfg.clone(), decoders, db, Default::default()).await;
 
         let cli_result = handle_command(cli, client, rng).await;
 
@@ -422,12 +433,12 @@ async fn handle_command(
     match cli.command {
         Command::Api { method, arg } => {
             let arg: Value = serde_json::from_str(&arg).unwrap();
-            let ws_api = WsFederationApi::from_config(client.config().as_ref());
+            let ws_api: Arc<_> = WsFederationApi::from_config(client.config().as_ref()).into();
             let response: Value = ws_api
-                .request(
-                    &method,
-                    arg,
+                .request_fed_with_strategy(
                     EventuallyConsistent::new(ws_api.peers().len()),
+                    method,
+                    vec![arg],
                 )
                 .await
                 .unwrap();

--- a/client/client-lib/src/api/fake.rs
+++ b/client/client-lib/src/api/fake.rs
@@ -1,0 +1,126 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fmt;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fedimint_api::PeerId;
+use futures::Future;
+use serde;
+use serde::Serialize;
+use serde_json::Value;
+use tracing::info;
+use tracing::warn;
+
+use crate::api::IFederationApi;
+use crate::api::JsonRpcResult;
+
+#[allow(clippy::type_complexity)]
+type Handler<State> = Pin<
+    Box<
+        dyn Fn(
+                Arc<State>,
+                Vec<Value>,
+            )
+                -> Pin<Box<dyn Future<Output = jsonrpsee_core::RpcResult<serde_json::Value>> + Send>>
+            + Send
+            + Sync,
+    >,
+>;
+
+/// A fake [`super::IFederationApi`] builder
+///
+/// This struct allows easily stubbing responses to given API calls,
+/// by listing a list of handlers for methods that are expected to be.
+pub struct FederationApiFaker<State> {
+    state: Arc<State>,
+    members: BTreeSet<PeerId>,
+    handlers: BTreeMap<String, Handler<State>>,
+}
+
+impl<State> fmt::Debug for FederationApiFaker<State> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("FederationApiFaker")
+    }
+}
+
+impl<State> FederationApiFaker<State>
+where
+    State: fmt::Debug,
+{
+    pub fn new(state: Arc<State>, members: BTreeSet<PeerId>) -> Self {
+        Self {
+            state,
+            members,
+            handlers: BTreeMap::default(),
+        }
+    }
+
+    /// Add a handler `f` to a `method ` call
+    pub fn with<F, Fut, Param, Ret>(mut self, method: impl Into<String>, f: F) -> Self
+    where
+        State: Send + Sync + 'static,
+        F: Fn(Arc<State>, Param) -> Fut + Send + Sync + 'static + Copy,
+        Fut: Future<Output = jsonrpsee_core::RpcResult<Ret>> + std::marker::Send + 'static,
+        Param: serde::de::DeserializeOwned + Send + Sync,
+        Ret: Serialize,
+    {
+        self.handlers.insert(
+            method.into(),
+            Box::pin(move |state, params| {
+                Box::pin(async move {
+                    if params.len() != 1 {
+                        return Err(jsonrpsee_core::Error::Custom(
+                            "wrong number of arguments".into(),
+                        ));
+                    }
+
+                    let params = serde_json::from_value(
+                        params.first().expect("just checked the len").clone(),
+                    )?;
+                    let ret = f(state, params).await?;
+                    let ret = serde_json::to_value(ret)
+                        .expect("Serialization of the return value must not fail");
+
+                    Ok(ret)
+                })
+            }),
+        );
+        self
+    }
+}
+
+#[cfg_attr(target_family = "wasm", async_trait(? Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+impl<State> IFederationApi for FederationApiFaker<State>
+where
+    State: fmt::Debug + Send + Sync,
+{
+    fn all_members(&self) -> &BTreeSet<PeerId> {
+        &self.members
+    }
+
+    async fn request_raw(
+        &self,
+        _peer_id: PeerId,
+        method: &str,
+        params: &[Value],
+    ) -> JsonRpcResult<Value> {
+        if let Some(handler) = self.handlers.get(method) {
+            info!(
+                method,
+                params = serde_json::to_string(&params).expect("serialization not to fail"),
+                "Faker is handling an API call"
+            );
+            handler(self.state.clone(), params.to_owned()).await
+        } else {
+            warn!(
+                method,
+                params = serde_json::to_string(&params).expect("serialization not to fail"),
+                "Faker has no handler for the API call"
+            );
+            Err(jsonrpsee_core::Error::MethodNotFound(method.into()))
+        }
+    }
+}

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -30,7 +30,7 @@ use tokio::sync::mpsc;
 use tracing::{error, info};
 
 use super::{db::NextECashNoteIndexKeyPrefix, *};
-use crate::api;
+use crate::api::{self, GlobalFederationApi, MintFederationApi};
 
 impl MintClient {
     /// Prepare an encrypted backup and send it to federation for storing
@@ -219,7 +219,7 @@ impl MintClient {
     async fn fetch_epochs(
         &self,
         epoch_range: RangeInclusive<u64>,
-        sender: mpsc::Sender<api::Result<SignedEpochOutcome>>,
+        sender: mpsc::Sender<api::FedResult<SignedEpochOutcome>>,
         task_handle: &TaskHandle,
     ) {
         for epoch in epoch_range {
@@ -232,7 +232,7 @@ impl MintClient {
             match self
                 .context
                 .api
-                .fetch_epoch_history(epoch, self.epoch_pk)
+                .fetch_epoch_history(epoch, self.epoch_pk, &self.context.decoders)
                 .await
             {
                 Ok(epoch_history) => {

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -60,6 +60,7 @@ pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Er
 
 #[derive(Debug)]
 pub struct ClientContext {
+    pub decoders: ModuleDecoderRegistry,
     pub db: Database,
     pub api: DynFederationApi,
     pub secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,

--- a/fedimint-api/src/macros.rs
+++ b/fedimint-api/src/macros.rs
@@ -265,7 +265,7 @@ macro_rules! dyn_newtype_impl_dyn_clone_passhthrough_with_instance_id {
 macro_rules! serde_module_encoding_wrapper {
     ($wrapper_name:ident, $wrapped:ty) => {
         #[derive(Clone, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-        pub struct $wrapper_name(Vec<u8>);
+        pub struct $wrapper_name(#[serde(with = "hex::serde")] Vec<u8>);
 
         impl ::std::fmt::Debug for $wrapper_name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -18,7 +18,7 @@ pub mod btc;
 
 #[derive(Debug)]
 pub struct FakeFed<Module> {
-    members: Vec<(PeerId, Module, Database)>,
+    pub members: Vec<(PeerId, Module, Database)>,
     client_cfg: ClientModuleConfig,
     block_height: Arc<std::sync::atomic::AtomicU64>,
 }

--- a/gateway/tests/Cargo.toml
+++ b/gateway/tests/Cargo.toml
@@ -27,4 +27,6 @@ rand = "0.8"
 serde_json = "1.0.89"
 threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
 tokio = { version = "1.23.1", features = ["full"] }
+tracing ="0.1.37"
+tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 url = { version = "2.3.1", features = ["serde"] }

--- a/gateway/tests/tests/fixtures/fed.rs
+++ b/gateway/tests/tests/fixtures/fed.rs
@@ -1,113 +1,39 @@
-use async_trait::async_trait;
-use bitcoin::{secp256k1, Address};
-use fedimint_api::TransactionId;
-use fedimint_core::{
-    epoch::SignedEpochOutcome,
-    modules::{
-        ln::{
-            contracts::{incoming::IncomingContractOffer, ContractId},
-            ContractAccount, LightningGateway,
-        },
-        mint::db::ECashUserBackupSnapshot,
-        wallet::PegOutFees,
-    },
-    outcome::TransactionStatus,
-    transaction::legacy::Transaction as LegacyTransaction,
-};
-use mint_client::api::{ApiError, IFederationApi};
+use std::{collections::BTreeSet, sync::Arc};
+
+use fedimint_api::{core::ModuleInstanceId, PeerId};
+use fedimint_ln::LightningGateway;
+use mint_client::api::fake::FederationApiFaker;
 use tokio::sync::Mutex;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MockApi {
-    gateway: Mutex<Option<LightningGateway>>,
+    gateway: Option<LightningGateway>,
 }
 
 impl MockApi {
-    pub fn new() -> Self {
-        Self {
-            gateway: Mutex::new(None),
-        }
-    }
-}
-
-#[async_trait]
-impl IFederationApi for MockApi {
-    async fn fetch_tx_outcome(&self, _tx: TransactionId) -> Result<TransactionStatus, ApiError> {
-        unimplemented!()
-    }
-
-    async fn submit_transaction(&self, _tx: LegacyTransaction) -> Result<TransactionId, ApiError> {
-        unimplemented!()
-    }
-
-    async fn fetch_contract(&self, _contract: ContractId) -> Result<ContractAccount, ApiError> {
-        unimplemented!()
-    }
-
-    async fn fetch_consensus_block_height(&self) -> Result<u64, ApiError> {
-        unimplemented!()
-    }
-
-    async fn fetch_offer(
-        &self,
-        _payment_hash: bitcoin::hashes::sha256::Hash,
-    ) -> Result<IncomingContractOffer, ApiError> {
-        unimplemented!();
-    }
-
-    async fn fetch_peg_out_fees(
-        &self,
-        _address: &Address,
-        _amount: &bitcoin::Amount,
-    ) -> Result<Option<PegOutFees>, ApiError> {
-        unimplemented!();
-    }
-
-    async fn fetch_gateways(&self) -> Result<Vec<LightningGateway>, ApiError> {
-        Ok(self
-            .gateway
-            .lock()
-            .await
-            .clone()
-            .into_iter()
-            .collect::<Vec<LightningGateway>>())
-    }
-
-    async fn register_gateway(&self, gateway: LightningGateway) -> Result<(), ApiError> {
-        *self.gateway.lock().await = Some(gateway);
-        Ok(())
-    }
-
-    async fn fetch_epoch_history(
-        &self,
-        _epoch: u64,
-        _pk: threshold_crypto::PublicKey,
-    ) -> Result<SignedEpochOutcome, ApiError> {
-        unimplemented!()
-    }
-
-    async fn fetch_last_epoch(&self) -> Result<u64, ApiError> {
-        unimplemented!()
-    }
-
-    async fn offer_exists(
-        &self,
-        _payment_hash: bitcoin::hashes::sha256::Hash,
-    ) -> Result<bool, ApiError> {
-        unimplemented!()
-    }
-
-    async fn upload_ecash_backup(
-        &self,
-        _request: &fedimint_mint::SignedBackupRequest,
-    ) -> Result<(), ApiError> {
-        unimplemented!()
-    }
-
-    async fn download_ecash_backup(
-        &self,
-        _id: &secp256k1::XOnlyPublicKey,
-    ) -> Result<Vec<ECashUserBackupSnapshot>, ApiError> {
-        unimplemented!()
+    pub async fn make_test_fed(
+        module_id: ModuleInstanceId,
+        members: BTreeSet<PeerId>,
+    ) -> FederationApiFaker<tokio::sync::Mutex<MockApi>> {
+        FederationApiFaker::new(Arc::new(Mutex::new(MockApi::default())), members)
+            .with(
+                format!("/module/{}/register_gateway", module_id),
+                |mint: Arc<Mutex<MockApi>>, gateway: LightningGateway| async move {
+                    mint.lock().await.gateway = Some(gateway);
+                    Ok(())
+                },
+            )
+            .with(
+                format!("/module/{}/list_gateways", module_id),
+                |mint: Arc<Mutex<MockApi>>, _: ()| async move {
+                    Ok(mint
+                        .lock()
+                        .await
+                        .gateway
+                        .clone()
+                        .into_iter()
+                        .collect::<Vec<LightningGateway>>())
+                },
+            )
     }
 }

--- a/gateway/tests/tests/fixtures/mod.rs
+++ b/gateway/tests/tests/fixtures/mod.rs
@@ -9,6 +9,7 @@ use ln_gateway::{
     rpc::GatewayRequest,
     LnGateway,
 };
+use mint_client::module_decode_stubs;
 use tokio::sync::mpsc;
 
 pub mod client;
@@ -29,8 +30,18 @@ pub async fn fixtures(gw_cfg: GatewayConfig) -> Result<Fixtures> {
     let client_builder: DynGatewayClientBuilder =
         client::TestGatewayClientBuilder::new(MemDbFactory.into()).into();
     let (tx, rx) = mpsc::channel::<GatewayRequest>(100);
+    let decoders = module_decode_stubs();
 
-    let gateway = LnGateway::new(gw_cfg, ln_rpc, client_builder, tx, rx, task_group.clone()).await;
+    let gateway = LnGateway::new(
+        gw_cfg,
+        decoders,
+        ln_rpc,
+        client_builder,
+        tx,
+        rx,
+        task_group.clone(),
+    )
+    .await;
     let bitcoin = Box::new(FakeBitcoinTest::new());
 
     Ok(Fixtures {

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -17,10 +17,17 @@ use ln_gateway::{
     utils::retry,
 };
 use mint_client::api::WsFederationConnect;
+use tracing_subscriber::EnvFilter;
 use url::Url;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_authentication() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("info,fedimint::consensus=warn")),
+        )
+        .init();
     let gw_password = "password".to_string();
     let gw_port = portpicker::pick_unused_port().expect("Failed to pick port");
     let gw_bind_address = SocketAddr::from(([127, 0, 0, 1], gw_port));

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -510,6 +510,7 @@ async fn lightning_gateway_pays_outgoing_invoice() -> Result<()> {
         let invoice = lightning.invoice(sats(1000), None).await;
 
         fed.mine_and_mint(&user, &*bitcoin, sats(2000)).await;
+
         let (contract_id, outpoint) = user
             .client
             .fund_outgoing_ln_contract(invoice, rng())


### PR DESCRIPTION
List of follow-ups (before lands):

* [x] that `T: Deref<...>` is stupid there, isn't it?
* [x] fix wasm, probably painful

List of follow-ups (after lands):
* [ ] name errors (and results) `MemberError` and `FederationError`
* [ ] I made passing everything by value to dying in a dyn+async+lifetimes hell. Revisit after landing.
* [ ] move module Api traits to corresponding modules
* [ ] rename `IFederationApiFed` to `FederationApiExt`

Close  #1169