### PR TITLE
Fix integration tests with real fixures

### DIFF
--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -15,6 +15,8 @@ POLL_INTERVAL=1
 bitcoind -regtest -fallbackfee=0.0004 -txindex -server -rpcuser=bitcoin -rpcpassword=bitcoin -datadir=$FM_BTC_DIR &
 echo $! >> $FM_PID_FILE
 
+export FM_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
+
 until [ "$($FM_BTC_CLIENT getblockchaininfo | jq -e -r '.chain')" == "regtest" ]; do
   sleep $POLL_INTERVAL
 done


### PR DESCRIPTION
Running integration tests with real fixtures currently has two problems:

1. Environment variables are not passed to the wallet module, causing the RPCs to bitcoind to fail.
2. The task group running DKG is not shut down causing a port conflict when running the federation.

This PR fixes both by setting the regtest bitcoin connection address, passing the environment variables to the wallet module, and shutting down DKG so the federation can re-use the port.