### PR TITLE
Remove `hex` dependency from crypto crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fedimint-api",
- "hex",
  "hkdf",
  "ring",
  "secp256k1-zkp",
@@ -3952,11 +3951,11 @@ name = "tbs"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "bitcoin_hashes 0.11.0",
  "bls12_381",
  "clap",
  "ff",
  "group",
- "hex",
  "rand",
  "rand_chacha",
  "serde",

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.66"
 fedimint-api = { path = "../../fedimint-api" }
-hex = "0.4.3"
 hkdf = { path = "../../crypto/hkdf" }
 ring = "0.16.20"
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }

--- a/crypto/derive-secret/src/lib.rs
+++ b/crypto/derive-secret/src/lib.rs
@@ -4,7 +4,7 @@ use std::fmt::Formatter;
 
 use fedimint_api::encoding::{Decodable, Encodable};
 use hkdf::hashes::Sha512;
-use hkdf::Hkdf;
+use hkdf::{bitcoin_hashes, Hkdf};
 use ring::aead;
 use secp256k1_zkp::{KeyPair, Secp256k1, Signing};
 use tbs::Scalar;
@@ -91,15 +91,12 @@ fn tagged_derive(tag: &[u8; 8], derivation: ChildId) -> [u8; 16] {
 
 impl std::fmt::Debug for DerivableSecret {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DerivableSecret")?;
-        write!(
+        write!(f, "DerivableSecret#")?;
+        bitcoin_hashes::hex::format_hex(
+            &self
+                .kdf
+                .derive::<8>(b"just a debug fingerprint derivation salt"),
             f,
-            "#{}",
-            // Note: bothers me that `hex` can't avoid allocating here :shrug:
-            hex::encode(
-                self.kdf
-                    .derive::<8>(b"just a debug fingerprint derivation salt")
-            )
         )
     }
 }

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -20,9 +20,9 @@ path = "src/lib.rs"
 bls12_381 = { version = "0.7.1", features = [ "zeroize", "groups" ] }
 ff = "0.12.1"
 group = "0.12.1"
-hex = "0.4.2"
 rand = "0.8"
 rand_chacha = "0.3.1"
+bitcoin_hashes = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10.5"
 

--- a/crypto/tbs/examples/keygen.rs
+++ b/crypto/tbs/examples/keygen.rs
@@ -1,3 +1,4 @@
+use bitcoin_hashes::hex::ToHex;
 use clap::Parser;
 use serde::Serialize;
 use tbs::dealer_keygen;
@@ -21,5 +22,5 @@ fn main() {
 
 fn to_hex<T: Serialize>(obj: &T) -> String {
     let bytes = bincode::serialize(obj).unwrap();
-    hex::encode(bytes)
+    bytes.to_hex()
 }

--- a/crypto/tbs/src/serde_impl/scalar.rs
+++ b/crypto/tbs/src/serde_impl/scalar.rs
@@ -1,3 +1,4 @@
+use bitcoin_hashes::hex::{FromHex, ToHex};
 use bls12_381::Scalar;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serializer};
@@ -5,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serializer};
 pub fn serialize<S: Serializer>(x: &Scalar, s: S) -> Result<S::Ok, S::Error> {
     let bytes = x.to_bytes();
     if s.is_human_readable() {
-        s.serialize_str(&hex::encode(bytes))
+        s.serialize_str(&bytes.to_hex())
     } else {
         s.serialize_bytes(&bytes)
     }
@@ -13,7 +14,8 @@ pub fn serialize<S: Serializer>(x: &Scalar, s: S) -> Result<S::Ok, S::Error> {
 
 pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<Scalar, D::Error> {
     let bytes: Vec<u8> = if d.is_human_readable() {
-        hex::decode::<String>(Deserialize::deserialize(d)?).map_err(serde::de::Error::custom)?
+        let deser: String = Deserialize::deserialize(d)?;
+        Vec::<u8>::from_hex(&deser).map_err(serde::de::Error::custom)?
     } else {
         Deserialize::deserialize(d)?
     };


### PR DESCRIPTION
part of #1307 

I couldn't put this part into one line. Not exactly sure why.
```rust
// current state
let deser: String = Deserialize::deserialize(d)?;
Vec::<u8>::from_hex(&deser).map_err(serde::de::Error::custom)?

// does compile but tests fail:
Vec::<u8>::from_hex(Deserialize::deserialize(d)?).map_err(serde::de::Error::custom)?
```

example test failure message: 
```
---- set_lightning_invoice_expiry stdout ----
thread 'set_lightning_invoice_expiry' panicked at 'configuration mismatch: invalid type: string "a7d06980c1c68997f040d35e2abc52d1a30eb1dd760c607ca53d7089fffcc55ff737b7e7c641b1c5c226d20023290a0d0c6cc12c95da3c5f9c19480ae2f079cf483d71f55c0fbb386659df645482840468927fed439226d51ab7a8fd2d882445", expected a borrowed string', fedimint-server/src/config.rs:180:14
```
