### PR TITLE
DO NOT MERGE: Simulate DB failure during tx processsing

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -229,7 +229,7 @@ impl FedimintConsensus {
         &self,
         consensus_outcome: HbbftConsensusOutcome,
         reference_rejected_txs: &Option<BTreeSet<TransactionId>>,
-    ) -> SignedEpochOutcome {
+    ) -> Option<SignedEpochOutcome> {
         let epoch = consensus_outcome.epoch;
         let epoch_peers: HashSet<PeerId> =
             consensus_outcome.contributions.keys().copied().collect();
@@ -263,6 +263,11 @@ impl FedimintConsensus {
             }
 
             dbtx.commit_tx().await.expect("DB Error");
+        }
+
+        warn!("{:?}, epoch {}", self.cfg.local.identity, epoch);
+        if self.cfg.local.identity == PeerId::from(0) && epoch == 1 {
+            return None;
         }
 
         // Process transactions
@@ -365,7 +370,7 @@ impl FedimintConsensus {
             )
         }
 
-        epoch_history
+        Some(epoch_history)
     }
 
     pub async fn get_last_epoch(&self) -> Option<u64> {

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -281,7 +281,9 @@ impl FedimintServer {
                             &rejected_txs,
                         )
                         .await;
-                    self.last_processed_epoch = Some(epoch);
+                    if epoch != None {
+                        self.last_processed_epoch = epoch;
+                    }
                 }
             }
         }

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -1018,6 +1018,17 @@ async fn rejoin_consensus_threshold_peers() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn simulate_failure() -> Result<()> {
+    test(4, |fed, user_send, bitcoin, _, _| async move {
+        fed.mine_and_mint(&user_send, &*bitcoin, sats(5000)).await;
+        user_send.client.reissue(user_send.client.coins().await, rng()).await.unwrap();
+        fed.subset_peers(&[0, 1, 2]).run_consensus_epochs(1).await;
+        fed.subset_peers(&[3]).run_consensus_epochs(1).await;
+        fed.subset_peers(&[0, 1, 2]).run_consensus_epochs(1).await;
+    }).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn ecash_can_be_recovered() -> Result<()> {
     test(2, |fed, user_send, bitcoin, _, _| async move {
         let user_receive = user_send.new_user_with_peers(peers(&[0, 1, 2])).await;


### PR DESCRIPTION
Simulates the failure in #1318.

One of the peers only partially updates the DB, leading to them failing to submit blind sig shares and getting banned by peers.