### PR TITLE
Don't create zero amount change ouputs

### DIFF
--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -207,7 +207,10 @@ impl MintClient {
 
         let mut change_outputs: Vec<(usize, NoteIssuanceRequests)> = vec![];
         let notes_per_denomination = self.notes_per_denomination(&mut dbtx).await;
-        for amount in change {
+        for amount in change.clone() {
+            if amount.msats == 0 {
+                continue;
+            }
             let (issuances, nonces) = self
                 .create_ecash(amount, notes_per_denomination, &mut dbtx)
                 .await;

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -439,7 +439,7 @@ async fn lightning_gateway_pays_internal_invoice() -> Result<()> {
             .fund_outgoing_ln_contract(invoice, rng())
             .await
             .unwrap();
-        fed.run_consensus_epochs(2).await; // send coins to LN contract
+        fed.run_consensus_epochs(1).await; // send coins to LN contract
 
         let contract_account = user
             .client
@@ -576,7 +576,7 @@ async fn lightning_gateway_claims_refund_for_internal_invoice() -> Result<()> {
             .fund_outgoing_ln_contract(invoice, rng())
             .await
             .unwrap();
-        fed.run_consensus_epochs(2).await; // send coins to LN contract
+        fed.run_consensus_epochs(1).await; // send coins to LN contract
 
         let contract_account = user
             .client


### PR DESCRIPTION
Closes #1319

When creating lightning offers, we request zero change, which adds a zero amount output.