### PR TITLE
Inject module_instance_id as prefix into database operations

### DIFF
--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -362,7 +362,7 @@ mod tests {
             .await
             .members
             .iter()
-            .map(|(peer_id, _, _)| *peer_id)
+            .map(|(peer_id, _, _, _)| *peer_id)
             .collect();
         FederationApiFaker::new(fed, members)
             // TODO: is the output here is supposed to be a mint or wallet?
@@ -390,9 +390,15 @@ mod tests {
                     Ok(mint
                         .lock()
                         .await
-                        .fetch_from_all(|m, db| async {
-                            m.get_contract_account(&mut db.begin_transaction().await, contract)
-                                .await
+                        .fetch_from_all(|m, db, module_instance_id| async {
+                            m.get_contract_account(
+                                &mut db
+                                    .begin_transaction()
+                                    .await
+                                    .with_module_prefix(*module_instance_id),
+                                contract,
+                            )
+                            .await
                         })
                         .await
                         .unwrap())

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -680,7 +680,7 @@ mod tests {
             .await
             .members
             .iter()
-            .map(|(peer_id, _, _)| *peer_id)
+            .map(|(peer_id, _, _, _)| *peer_id)
             .collect();
         FederationApiFaker::new(fed, members).with(
             "/fetch_transaction",

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -237,7 +237,7 @@ mod tests {
             .await
             .members
             .iter()
-            .map(|(peer_id, _, _)| *peer_id)
+            .map(|(peer_id, _, _, _)| *peer_id)
             .collect();
         FederationApiFaker::new(fed, members).with(
             "/fetch_transaction",
@@ -369,9 +369,14 @@ mod tests {
         let wallet_value = fed
             .lock()
             .await
-            .fetch_from_all(|wallet, db| async {
+            .fetch_from_all(|wallet, db, module_instance_id| async {
                 wallet
-                    .get_wallet_value(&mut db.begin_transaction().await)
+                    .get_wallet_value(
+                        &mut db
+                            .begin_transaction()
+                            .await
+                            .with_module_prefix(*module_instance_id),
+                    )
                     .await
             })
             .await;
@@ -385,9 +390,14 @@ mod tests {
         let wallet_value = fed
             .lock()
             .await
-            .fetch_from_all(|wallet, db| async {
+            .fetch_from_all(|wallet, db, module_instance_id| async {
                 wallet
-                    .get_wallet_value(&mut db.begin_transaction().await)
+                    .get_wallet_value(
+                        &mut db
+                            .begin_transaction()
+                            .await
+                            .with_module_prefix(*module_instance_id),
+                    )
                     .await
             })
             .await;

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -193,14 +193,11 @@ where
         dbtx: &mut DatabaseTransaction<'_>,
         module_instance_id: ModuleInstanceId,
     ) -> Vec<DynModuleConsensusItem> {
-        <Self as ServerModule>::consensus_proposal(
-            self,
-            &mut dbtx.with_module_prefix(module_instance_id),
-        )
-        .await
-        .into_iter()
-        .map(|v| DynModuleConsensusItem::from_typed(module_instance_id, v))
-        .collect()
+        <Self as ServerModule>::consensus_proposal(self, dbtx)
+            .await
+            .into_iter()
+            .map(|v| DynModuleConsensusItem::from_typed(module_instance_id, v))
+            .collect()
     }
 
     /// This function is called once before transaction processing starts. All module consensus
@@ -377,13 +374,9 @@ where
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome> {
-        <Self as ServerModule>::output_status(
-            self,
-            &mut dbtx.with_module_prefix(module_instance_id),
-            out_point,
-        )
-        .await
-        .map(|v| DynOutputOutcome::from_typed(module_instance_id, v))
+        <Self as ServerModule>::output_status(self, dbtx, out_point)
+            .await
+            .map(|v| DynOutputOutcome::from_typed(module_instance_id, v))
     }
 
     /// Queries the database and returns all assets and liabilities of the module.

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -230,4 +230,9 @@ mod tests {
     async fn test_dbtx_remove_by_prefix() {
         fedimint_api::db::verify_remove_by_prefix(database()).await;
     }
+
+    #[test_log::test(tokio::test)]
+    async fn test_module_dbtx() {
+        fedimint_api::db::verify_module_prefix(database()).await;
+    }
 }

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 use tracing::{trace, warn};
 
 use crate::{
+    core::ModuleInstanceId,
     encoding::{Decodable, Encodable},
     fmt_utils::AbbreviateHexBytes,
 };
@@ -17,6 +18,8 @@ pub mod mem_impl;
 pub use tests::*;
 
 use crate::module::registry::ModuleDecoderRegistry;
+
+pub const MODULE_GLOBAL_PREFIX: u8 = 0xff;
 
 pub trait DatabaseKeyPrefixConst {
     const DB_PREFIX: u8;
@@ -69,7 +72,10 @@ impl Database {
     }
 
     pub async fn begin_transaction(&self) -> DatabaseTransaction {
-        DatabaseTransaction::new(self.0.db.begin_transaction().await, &self.0.module_decoders)
+        DatabaseTransaction::new(
+            self.0.db.begin_transaction().await,
+            self.0.module_decoders.clone(),
+        )
     }
 }
 
@@ -152,10 +158,86 @@ impl Drop for CommitTracker {
     }
 }
 
+struct IsolatedDatabaseTransaction<'isolated, 'parent: 'isolated> {
+    tx: &'isolated mut DatabaseTransaction<'parent>,
+    prefix: Vec<u8>,
+}
+
+impl<'isolated, 'parent: 'isolated> IsolatedDatabaseTransaction<'isolated, 'parent> {
+    pub fn new(
+        dbtx: &'isolated mut DatabaseTransaction<'parent>,
+        module_instance_id: ModuleInstanceId,
+    ) -> IsolatedDatabaseTransaction<'isolated, 'parent> {
+        let mut prefix_bytes = vec![MODULE_GLOBAL_PREFIX];
+        module_instance_id
+            .consensus_encode(&mut prefix_bytes)
+            .expect("Error encoding module instance id as prefix");
+        IsolatedDatabaseTransaction {
+            tx: dbtx,
+            prefix: prefix_bytes,
+        }
+    }
+}
+
+#[async_trait]
+impl<'isolated, 'parent> IDatabaseTransaction<'isolated>
+    for IsolatedDatabaseTransaction<'isolated, 'parent>
+{
+    async fn raw_insert_bytes(&mut self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
+        let mut key_with_prefix = self.prefix.clone();
+        key_with_prefix.append(&mut key.to_vec());
+        self.tx
+            .raw_insert_bytes(key_with_prefix.as_slice(), value)
+            .await
+    }
+
+    async fn raw_get_bytes(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        let mut key_with_prefix = self.prefix.clone();
+        key_with_prefix.append(&mut key.to_vec());
+        self.tx.raw_get_bytes(key_with_prefix.as_slice()).await
+    }
+
+    async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        let mut key_with_prefix = self.prefix.clone();
+        key_with_prefix.append(&mut key.to_vec());
+        self.tx.raw_remove_entry(key_with_prefix.as_slice()).await
+    }
+
+    async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixIter<'_> {
+        let mut prefix_with_module = self.prefix.clone();
+        prefix_with_module.append(&mut key_prefix.to_vec());
+        let raw_prefix = self
+            .tx
+            .raw_find_by_prefix(prefix_with_module.as_slice())
+            .await;
+        Box::new(raw_prefix.map(|pair| match pair {
+            Ok(kv) => {
+                let key = kv.0;
+                let stripped_key = &key[(self.prefix.len())..];
+                Ok((stripped_key.to_vec(), kv.1))
+            }
+            _ => pair,
+        }))
+    }
+
+    async fn commit_tx(self: Box<Self>) -> Result<()> {
+        tracing::warn!("DatabaseTransaction inside modules cannot be committed");
+        Ok(())
+    }
+
+    async fn rollback_tx_to_savepoint(&mut self) {
+        self.tx.rollback_tx_to_savepoint().await
+    }
+
+    async fn set_tx_savepoint(&mut self) {
+        self.tx.set_tx_savepoint().await
+    }
+}
+
 #[doc = " A handle to a type-erased database implementation"]
 pub struct DatabaseTransaction<'a> {
     tx: Box<dyn IDatabaseTransaction<'a> + Send + 'a>,
-    decoders: &'a ModuleDecoderRegistry,
+    decoders: ModuleDecoderRegistry,
     commit_tracker: CommitTracker,
 }
 
@@ -173,17 +255,37 @@ impl<'a> std::ops::DerefMut for DatabaseTransaction<'a> {
     }
 }
 
-impl<'a> DatabaseTransaction<'a> {
+impl<'parent> DatabaseTransaction<'parent> {
     pub fn new(
-        dbtx: Box<dyn IDatabaseTransaction<'a> + Send + 'a>,
-        decoders: &'a ModuleDecoderRegistry,
-    ) -> DatabaseTransaction<'a> {
+        dbtx: Box<dyn IDatabaseTransaction<'parent> + Send + 'parent>,
+        decoders: ModuleDecoderRegistry,
+    ) -> DatabaseTransaction<'parent> {
         DatabaseTransaction {
             tx: dbtx,
             decoders,
             commit_tracker: CommitTracker {
                 is_committed: false,
                 has_writes: false,
+            },
+        }
+    }
+
+    pub fn with_module_prefix<'isolated>(
+        &'isolated mut self,
+        module_instance_id: ModuleInstanceId,
+    ) -> DatabaseTransaction<'isolated>
+    where
+        'parent: 'isolated,
+    {
+        let decoders = self.decoders.clone();
+        let isolated = Box::new(IsolatedDatabaseTransaction::new(self, module_instance_id));
+        DatabaseTransaction {
+            tx: isolated,
+            decoders,
+            // DatabaseTransaction passed to modules cannot be committed, so the commit tracker is set to committed to surpress the warning
+            commit_tracker: CommitTracker {
+                is_committed: true,
+                has_writes: true,
             },
         }
     }
@@ -208,7 +310,7 @@ impl<'a> DatabaseTransaction<'a> {
             std::any::type_name::<K::Value>(),
             AbbreviateHexBytes(&value_bytes)
         );
-        Ok(Some(K::Value::from_bytes(&value_bytes, self.decoders)?))
+        Ok(Some(K::Value::from_bytes(&value_bytes, &self.decoders)?))
     }
 
     pub async fn find_by_prefix<KP>(
@@ -252,7 +354,7 @@ impl<'a> DatabaseTransaction<'a> {
                     std::any::type_name::<K::Value>(),
                     AbbreviateHexBytes(&old_val_bytes)
                 );
-                Ok(Some(K::Value::from_bytes(&old_val_bytes, self.decoders)?))
+                Ok(Some(K::Value::from_bytes(&old_val_bytes, &self.decoders)?))
             }
             None => Ok(None),
         }
@@ -293,7 +395,7 @@ impl<'a> DatabaseTransaction<'a> {
             None => return Ok(None),
         };
 
-        Ok(Some(K::Value::from_bytes(&value_bytes, self.decoders)?))
+        Ok(Some(K::Value::from_bytes(&value_bytes, &self.decoders)?))
     }
 
     pub async fn remove_by_prefix<KP>(&mut self, key_prefix: &KP) -> Result<()>
@@ -455,6 +557,9 @@ mod tests {
 
     #[derive(Debug, Encodable, Decodable, Eq, PartialEq)]
     struct TestVal(u64);
+
+    const TEST_MODULE_PREFIX: u16 = 1;
+    const ALT_MODULE_PREFIX: u16 = 2;
 
     pub async fn verify_insert_elements(db: Database) {
         let mut dbtx = db.begin_transaction().await;
@@ -878,5 +983,88 @@ mod tests {
         }
 
         assert_eq!(returned_keys, expected_keys);
+    }
+
+    pub async fn verify_module_prefix(db: Database) {
+        let mut test_dbtx = db.begin_transaction().await;
+        {
+            let mut test_module_dbtx = test_dbtx.with_module_prefix(TEST_MODULE_PREFIX);
+
+            assert!(test_module_dbtx
+                .insert_entry(&TestKey(100), &TestVal(101))
+                .await
+                .is_ok());
+
+            assert!(test_module_dbtx
+                .insert_entry(&TestKey(101), &TestVal(102))
+                .await
+                .is_ok());
+        }
+
+        test_dbtx.commit_tx().await.expect("DB Error");
+
+        let mut alt_dbtx = db.begin_transaction().await;
+        {
+            let mut alt_module_dbtx = alt_dbtx.with_module_prefix(ALT_MODULE_PREFIX);
+
+            assert!(alt_module_dbtx
+                .insert_entry(&TestKey(100), &TestVal(103))
+                .await
+                .is_ok());
+
+            assert!(alt_module_dbtx
+                .insert_entry(&TestKey(101), &TestVal(104))
+                .await
+                .is_ok());
+        }
+
+        alt_dbtx.commit_tx().await.expect("DB Error");
+
+        // verfiy test_module_dbtx can only see key/value pairs from its own module
+        let mut test_dbtx = db.begin_transaction().await;
+        let mut test_module_dbtx = test_dbtx.with_module_prefix(TEST_MODULE_PREFIX);
+        assert_eq!(
+            test_module_dbtx.get_value(&TestKey(100)).await.unwrap(),
+            Some(TestVal(101))
+        );
+
+        assert_eq!(
+            test_module_dbtx.get_value(&TestKey(101)).await.unwrap(),
+            Some(TestVal(102))
+        );
+
+        let mut returned_keys = 0;
+        let expected_keys = 2;
+        for res in test_module_dbtx.find_by_prefix(&DbPrefixTestPrefix).await {
+            match res.as_ref().unwrap().0 {
+                TestKey(100) => {
+                    assert!(res.unwrap().1.eq(&TestVal(101)));
+                    returned_keys += 1;
+                }
+                TestKey(101) => {
+                    assert!(res.unwrap().1.eq(&TestVal(102)));
+                    returned_keys += 1;
+                }
+                _ => {
+                    returned_keys += 1;
+                }
+            }
+        }
+
+        assert_eq!(returned_keys, expected_keys);
+
+        let removed = test_module_dbtx.remove_entry(&TestKey(100)).await;
+        assert!(removed.is_ok());
+        assert_eq!(removed.unwrap(), Some(TestVal(101)));
+        assert_eq!(
+            test_module_dbtx.get_value(&TestKey(100)).await.unwrap(),
+            None
+        );
+
+        // test_dbtx on its own wont find the key because it does not use a module prefix
+        let mut test_dbtx = db.begin_transaction().await;
+        assert_eq!(test_dbtx.get_value(&TestKey(101)).await.unwrap(), None);
+
+        test_dbtx.commit_tx().await.expect("DB Error");
     }
 }

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -4,6 +4,7 @@ use docopt::Docopt;
 use erased_serde::Serialize;
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::encoding::Encodable;
+use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::module::DynModuleGen;
 use fedimint_ln::{db as LightningRange, LightningGen};
 use fedimint_mint::{db as MintRange, MintGen};
@@ -195,6 +196,8 @@ impl<'a> DatabaseDump<'a> {
                         consensus.insert("LastEpoch".to_string(), Box::new(last_epoch));
                     }
                 }
+                // Module is a global prefix for all module data
+                ConsensusRange::DbKeyPrefix::Module => {}
             }
         }
 
@@ -680,12 +683,12 @@ async fn main() {
         DynModuleGen::from(LightningGen),
     ]);
 
-    let decoders = Default::default(); // TODO: read config and use it to create decoders
+    let decoders: ModuleDecoderRegistry = Default::default(); // TODO: read config and use it to create decoders
 
     let serialized: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
     let mut dbdump = DatabaseDump {
         serialized,
-        read_only: DatabaseTransaction::new(Box::new(read_only), &decoders),
+        read_only: DatabaseTransaction::new(Box::new(read_only), decoders),
         ranges,
         prefixes,
         include_all_prefixes: csv_prefix == "All",

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -259,4 +259,10 @@ mod fedimint_rocksdb_tests {
         ))
         .await;
     }
+
+    #[test_log::test(tokio::test)]
+    async fn test_module_dbtx() {
+        fedimint_api::db::verify_module_prefix(open_temp_db("fcb-rocksdb-test-module-prefix"))
+            .await;
+    }
 }

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -30,6 +30,7 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
                     module,
                     self.fedimint.database_transaction().await,
                     data,
+                    Some(module_id),
                 )
                 .await;
             }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -514,7 +514,7 @@ impl FedimintConsensus {
         for (instance_id, module) in self.modules.iter_modules() {
             items.extend(
                 module
-                    .consensus_proposal(&mut dbtx, instance_id)
+                    .consensus_proposal(&mut dbtx.with_module_prefix(instance_id), instance_id)
                     .await
                     .into_iter()
                     .map(ConsensusItem::Module),
@@ -603,7 +603,11 @@ impl FedimintConsensus {
                 let outcome = self
                     .modules
                     .get_expect(output.module_instance_id())
-                    .output_status(&mut dbtx, outpoint, output.module_instance_id())
+                    .output_status(
+                        &mut dbtx.with_module_prefix(output.module_instance_id()),
+                        outpoint,
+                        output.module_instance_id(),
+                    )
                     .await
                     .expect("the transaction was processed, so should be known");
                 outputs.push((&outcome).into())

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use fedimint_api::db::DatabaseKeyPrefixConst;
+use fedimint_api::db::{DatabaseKeyPrefixConst, MODULE_GLOBAL_PREFIX};
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::{PeerId, TransactionId};
 use fedimint_core::epoch::SignedEpochOutcome;
@@ -19,6 +19,7 @@ pub enum DbKeyPrefix {
     RejectedTransaction = 0x04,
     EpochHistory = 0x05,
     LastEpoch = 0x06,
+    Module = MODULE_GLOBAL_PREFIX,
 }
 
 impl std::fmt::Display for DbKeyPrefix {

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -109,7 +109,7 @@ fn attach_endpoints(
                 // end up with an inconsistent state in theory. In practice most API functions
                 // are only reading and the few that do write anything are atomic. Lastly, this
                 // is only the last line of defense
-                AssertUnwindSafe((handler)(fedimint, dbtx, params))
+                AssertUnwindSafe((handler)(fedimint, dbtx, params, module_instance_id))
                     .catch_unwind()
                     .await
                     .map_err(|_| {
@@ -158,6 +158,7 @@ fn attach_endpoints_erased(
                     fedimint.modules.get_expect(module_instance),
                     dbtx,
                     params,
+                    Some(module_instance),
                 ))
                 .catch_unwind()
                 .await

--- a/fedimint-sqlite/src/lib.rs
+++ b/fedimint-sqlite/src/lib.rs
@@ -236,7 +236,12 @@ mod fedimint_sqlite_tests {
 
     #[test_log::test(tokio::test)]
     async fn test_dbtx_remove_by_prefix() {
-        fedimint_api::db::verify_remove_by_prefix(open_temp_db("verify-remove_by_prefix").await)
+        fedimint_api::db::verify_remove_by_prefix(open_temp_db("verify-remove-by-prefix").await)
             .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_module_dbtx() {
+        fedimint_api::db::verify_module_prefix(open_temp_db("verify-module-prefix").await).await;
     }
 }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -873,13 +873,12 @@ impl FederationTest {
                         .modules
                         .get_expect(LEGACY_HARDCODED_INSTANCE_ID_MINT)
                         .apply_output(
-                            &mut dbtx,
+                            &mut dbtx.with_module_prefix(LEGACY_HARDCODED_INSTANCE_ID_MINT),
                             &core::DynOutput::from_typed(
                                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                                 MintOutput(tokens.clone()),
                             ),
                             out_point,
-                            LEGACY_HARDCODED_INSTANCE_ID_MINT,
                         )
                         .await
                         .unwrap();

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -858,7 +858,7 @@ impl ServerModule for Lightning {
                 "/account",
                 async |module: &Lightning, dbtx, contract_id: ContractId| -> ContractAccount {
                     module
-                        .get_contract_account(&mut dbtx, contract_id)
+                        .get_contract_account(dbtx, contract_id)
                         .await
                         .ok_or_else(|| ApiError::not_found(String::from("Contract not found")))
                 }
@@ -866,14 +866,14 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 "/offers",
                 async |module: &Lightning, dbtx, _params: ()| -> Vec<IncomingContractOffer> {
-                    Ok(module.get_offers(&mut dbtx).await)
+                    Ok(module.get_offers(dbtx).await)
                 }
             },
             api_endpoint! {
                 "/offer",
                 async |module: &Lightning, dbtx, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
                     let offer = module
-                        .get_offer(&mut dbtx, payment_hash)
+                        .get_offer(dbtx, payment_hash)
                         .await
                         .ok_or_else(|| ApiError::not_found(String::from("Offer not found")))?;
 
@@ -884,14 +884,13 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 "/list_gateways",
                 async |module: &Lightning, dbtx, _v: ()| -> Vec<LightningGateway> {
-                    Ok(module.list_gateways(&mut dbtx).await)
+                    Ok(module.list_gateways(dbtx).await)
                 }
             },
             api_endpoint! {
                 "/register_gateway",
                 async |module: &Lightning, dbtx, gateway: LightningGateway| -> () {
-                    module.register_gateway(&mut dbtx, gateway).await;
-                    dbtx.commit_tx().await.expect("DB Error");
+                    module.register_gateway(dbtx, gateway).await;
                     Ok(())
                 }
             },

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -211,7 +211,15 @@ async fn test_incoming() {
     fed.consensus_round(&[], &[(offer_out_point, offer_output)])
         .await;
     let offers = fed
-        .fetch_from_all(|m, db| async { m.get_offers(&mut db.begin_transaction().await).await })
+        .fetch_from_all(|m, db, module_instance_id| async {
+            m.get_offers(
+                &mut db
+                    .begin_transaction()
+                    .await
+                    .with_module_prefix(*module_instance_id),
+            )
+            .await
+        })
         .await;
     assert_eq!(offers, vec![offer.clone()]);
 

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -718,8 +718,7 @@ impl ServerModule for Mint {
                 "/backup",
                 async |module: &Mint, dbtx, request: SignedBackupRequest| -> () {
                     module
-                        .handle_backup_request(&mut dbtx, request).await?;
-                    dbtx.commit_tx().await.map_err(|e| ApiError::new(1000, format!("Transaction error: {}", e)))?;
+                        .handle_backup_request(dbtx, request).await?;
                     Ok(())
                 }
             },
@@ -727,7 +726,7 @@ impl ServerModule for Mint {
                 "/recover",
                 async |module: &Mint, dbtx, id: secp256k1_zkp::XOnlyPublicKey| -> Option<ECashUserBackupSnapshot> {
                     Ok(module
-                        .handle_recover_request(&mut dbtx, id).await)
+                        .handle_recover_request(dbtx, id).await)
                 }
             },
         ]


### PR DESCRIPTION
This PR introduces a wrapper struct to wrap the DatabaseTransaction into an IsolatedDatabaseTransaction. IsolatedDatabaseTransaction will now always prepend a 2 byte "module_prefix", which is the ModuleInstanceId, when inserting and reading from the database. The purpose of this is to logically partition the database so modules can use keys that have conflicting prefixes. This also allows us to use the same key for different modules (ex: ModuleDatabaseVersion).

When passing a DatabaseTransaction to a module, it is first wrapped using with_module_prefix, which wraps the existing DatabaseTransaction inside an IsolatedDatabaseTransaction. This means they cannot overwrite keys from other modules. The fedimint server is now responsible for committing the wrapped DatabaseTransactions, because the individual modules cannot commit because they do not own the transaction. This approach also allows the fedimint server to create a DatabaseTransaction that spans over multiple modules and is also atomic.

[Original issue](https://github.com/fedimint/fedimint/issues/1265)