### PR TITLE
Gatewayd

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -38,6 +38,11 @@ windows:
           - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN2_DIR --addr=127.0.0.1:9001 --plugin=$FM_BIN_DIR/gateway-cln-extension &
           - echo $! >> $FM_PID_FILE
           - fg
+        - gateway:
+          - sleep 7 # wait for gateway-cln-extension to start
+          - $FM_BIN_DIR/gatewayd
+          - echo $! >> $FM_PID_FILE
+          - fg
         - federation:
           - sleep 1 # wait for bitcoind
           - ./scripts/start-fed.sh

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -13,6 +13,10 @@ name = "ln_gateway"
 path = "src/lib.rs"
 
 [[bin]]
+name = "gatewayd"
+path = "src/bin/gatewayd.rs"
+
+[[bin]]
 name = "ln_gateway"
 path = "src/bin/ln_gateway.rs"
 

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -10,17 +10,17 @@ use fedimint_api::{
     module::{registry::ModuleDecoderRegistry, DynModuleGen},
     task::TaskGroup,
 };
-use fedimint_server::modules::{
-    ln::{common::LightningDecoder, LightningGen},
-    mint::{common::MintDecoder, MintGen},
-    wallet::{common::WalletDecoder, WalletGen},
-};
 use ln_gateway::{
     client::{DynGatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder},
     gatewayd::{
         gateway::Gateway,
         lnrpc_client::{DynLnRpcClient, NetworkLnRpcClient},
     },
+};
+use mint_client::modules::{
+    ln::{common::LightningDecoder, LightningGen},
+    mint::{common::MintDecoder, MintGen},
+    wallet::{common::WalletDecoder, WalletGen},
 };
 use tracing::{error, info};
 use url::Url;

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -1,0 +1,122 @@
+use std::{net::SocketAddr, path::PathBuf};
+
+use clap::Parser;
+use fedimint_api::{
+    config::ModuleGenRegistry,
+    core::{
+        LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+        LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+    },
+    module::{registry::ModuleDecoderRegistry, DynModuleGen},
+    task::TaskGroup,
+};
+use fedimint_server::modules::{
+    ln::{common::LightningDecoder, LightningGen},
+    mint::{common::MintDecoder, MintGen},
+    wallet::{common::WalletDecoder, WalletGen},
+};
+use ln_gateway::{
+    client::{DynGatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder},
+    gatewayd::{
+        gateway::Gateway,
+        lnrpc_client::{DynLnRpcClient, NetworkLnRpcClient},
+    },
+};
+use tracing::{error, info};
+use url::Url;
+
+#[derive(Parser)]
+pub struct GatewayOpts {
+    /// Path to folder containing gateway config and data files
+    #[arg(long = "data-dir", env = "FM_GATEWAY_DATA_DIR")]
+    pub data_dir: PathBuf,
+
+    /// Gateway webserver listen address
+    #[arg(long = "listen", env = "FM_GATEWAY_LISTEN_ADDR")]
+    pub listen: SocketAddr,
+
+    /// Public URL from which the webserver API is reachable
+    #[arg(long = "api-addr", env = "FM_GATEWAY_API_ADDR")]
+    pub api_addr: Url,
+
+    /// Gateway webserver authentication password
+    #[arg(long = "password", env = "FM_GATEWAY_PASSWORD")]
+    pub password: String,
+
+    /// Public URL to a Gateway Lightning rpc service
+    #[arg(long = "lnrpc-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
+    pub lnrpc_addr: Url,
+}
+
+// Fedimint Gateway Binary
+///
+/// This binary runs a webserver with an API that can be used by Fedimint clients to request routing of payments through the Lightning Network.
+/// It uses a `GatewayLightningClient`, an rpc client to communicate with a remote Lightning node accessible through a `GatewayLightningServer`.
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let mut args = std::env::args();
+
+    if let Some(ref arg) = args.nth(1) {
+        if arg.as_str() == "version-hash" {
+            println!("{}", env!("GIT_HASH"));
+            return Ok(());
+        }
+    }
+
+    // Read configurations
+    let GatewayOpts {
+        data_dir,
+        listen,
+        api_addr,
+        lnrpc_addr,
+        password,
+    } = GatewayOpts::parse();
+
+    info!(
+        "Starting gateway with these configs \n data directory: {:?},\n listen: {},\n api address: {},\n lnrpc address: {} ",
+        data_dir, listen, api_addr, lnrpc_addr
+    );
+
+    // Create federation client builder
+    let client_builder: DynGatewayClientBuilder =
+        StandardGatewayClientBuilder::new(data_dir.clone(), RocksDbFactory.into(), api_addr).into();
+
+    // Create task group for controlled shutdown of the gateway
+    let task_group = TaskGroup::new();
+
+    // Create a lightning rpc client
+    let lnrpc: DynLnRpcClient = NetworkLnRpcClient::new(lnrpc_addr).await?.into();
+
+    // Create module decoder registry
+    let decoders = ModuleDecoderRegistry::from_iter([
+        (LEGACY_HARDCODED_INSTANCE_ID_LN, LightningDecoder.into()),
+        (LEGACY_HARDCODED_INSTANCE_ID_MINT, MintDecoder.into()),
+        (LEGACY_HARDCODED_INSTANCE_ID_WALLET, WalletDecoder.into()),
+    ]);
+
+    // Create module generator registry
+    let module_gens = ModuleGenRegistry::from(vec![
+        DynModuleGen::from(WalletGen),
+        DynModuleGen::from(MintGen),
+        DynModuleGen::from(LightningGen),
+    ]);
+
+    // Create gateway instance
+    let gateway = Gateway::new(
+        lnrpc,
+        client_builder,
+        decoders,
+        module_gens,
+        task_group.clone(),
+    )
+    .await;
+
+    if let Err(e) = gateway.run(listen, password).await {
+        task_group.shutdown_join_all(None).await?;
+
+        error!("Gateway stopped with error: {}", e);
+        return Err(e.into());
+    }
+
+    Ok(())
+}

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -48,8 +48,12 @@ async fn main() -> Result<(), Error> {
     let gw_cfg: GatewayConfig = load_from_file(&gw_cfg_path).expect("Failed to parse config");
 
     // Create federation client builder
-    let client_builder: DynGatewayClientBuilder =
-        StandardGatewayClientBuilder::new(work_dir.clone(), RocksDbFactory.into()).into();
+    let client_builder: DynGatewayClientBuilder = StandardGatewayClientBuilder::new(
+        work_dir.clone(),
+        RocksDbFactory.into(),
+        gw_cfg.announce_address.clone(),
+    )
+    .into();
     let decoders = ModuleDecoderRegistry::from_iter([
         (LEGACY_HARDCODED_INSTANCE_ID_LN, LightningDecoder.into()),
         (LEGACY_HARDCODED_INSTANCE_ID_MINT, MintDecoder.into()),

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -88,7 +88,6 @@ pub trait IGatewayClientBuilder: Debug {
         connect: WsFederationConnect,
         mint_channel_id: u64,
         node_pubkey: PublicKey,
-        announce_address: Url,
         module_gens: ModuleGenRegistry,
     ) -> Result<GatewayClientConfig>;
 
@@ -109,13 +108,15 @@ dyn_newtype_define! {
 pub struct StandardGatewayClientBuilder {
     work_dir: PathBuf,
     db_factory: DynDbFactory,
+    gateway_api: Url,
 }
 
 impl StandardGatewayClientBuilder {
-    pub fn new(work_dir: PathBuf, db_factory: DynDbFactory) -> Self {
+    pub fn new(work_dir: PathBuf, db_factory: DynDbFactory, gateway_api: Url) -> Self {
         Self {
             work_dir,
             db_factory,
+            gateway_api,
         }
     }
 }
@@ -145,7 +146,6 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
         connect: WsFederationConnect,
         mint_channel_id: u64,
         node_pubkey: PublicKey,
-        announce_address: Url,
         module_gens: ModuleGenRegistry,
     ) -> Result<GatewayClientConfig> {
         let api: DynFederationApi = WsFederationApi::new(connect.members).into();
@@ -165,7 +165,7 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
             redeem_key: kp_fed,
             timelock_delta: 10,
             node_pub_key: node_pubkey,
-            api: announce_address,
+            api: self.gateway_api.clone(),
         })
     }
 

--- a/gateway/ln-gateway/src/gatewayd/actor.rs
+++ b/gateway/ln-gateway/src/gatewayd/actor.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use bitcoin::{Address, Transaction};
-use bitcoin_hashes::sha256;
+use bitcoin_hashes::{sha256, Hash};
 use fedimint_api::{task::TaskGroup, Amount, OutPoint, TransactionId};
 use mint_client::modules::{
     ln::{
@@ -12,11 +12,15 @@ use mint_client::modules::{
 };
 use mint_client::{GatewayClient, PaymentParameters};
 use rand::{CryptoRng, RngCore};
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 use crate::{
     gatewayd::lnrpc_client::DynLnRpcClient,
-    gatewaylnrpc::{PayInvoiceRequest, PayInvoiceResponse},
+    gatewaylnrpc::{
+        complete_htlcs_request::{Action, Cancel, Settle},
+        CompleteHtlcsRequest, PayInvoiceRequest, PayInvoiceResponse,
+        SubscribeInterceptHtlcsRequest, SubscribeInterceptHtlcsResponse,
+    },
     rpc::FederationInfo,
     utils::retry,
     LnGatewayError, Result,
@@ -25,12 +29,20 @@ use crate::{
 /// How long a gateway announcement stays valid
 const GW_ANNOUNCEMENT_TTL: Duration = Duration::from_secs(600);
 
+#[derive(Clone)]
 pub struct GatewayActor {
     client: Arc<GatewayClient>,
+    lnrpc: DynLnRpcClient,
+    task_group: TaskGroup,
 }
 
 impl GatewayActor {
-    pub async fn new(client: Arc<GatewayClient>, route_hints: Vec<RouteHint>) -> Result<Self> {
+    pub async fn new(
+        client: Arc<GatewayClient>,
+        lnrpc: DynLnRpcClient,
+        route_hints: Vec<RouteHint>,
+        task_group: TaskGroup,
+    ) -> Result<Self> {
         let register_client = client.clone();
         tokio::spawn(async move {
             loop {
@@ -63,7 +75,114 @@ impl GatewayActor {
             }
         });
 
-        Ok(Self { client })
+        let actor = Self {
+            client,
+            lnrpc,
+            task_group,
+        };
+
+        actor.subscribe_htlcs().await?;
+
+        Ok(actor)
+    }
+
+    async fn subscribe_htlcs(&self) -> Result<()> {
+        let actor = self.to_owned();
+        let lnrpc_copy = self.lnrpc.to_owned();
+        let short_channel_id = self.client.config().mint_channel_id;
+        let mut tg = self.task_group.clone();
+
+        let mut stream = lnrpc_copy
+            .subscribe_htlcs(SubscribeInterceptHtlcsRequest { short_channel_id })
+            .await?;
+
+        tg.spawn(
+            "Subscribe to intercepted HTLCs in stream",
+            move |subscription| async move {
+                while let Some(SubscribeInterceptHtlcsResponse {
+                    payment_hash,
+                    outgoing_amount_msat,
+                    intercepted_htlc_id,
+                    ..
+                }) = match stream.message().await {
+                    Ok(Some(msg)) => Some(msg),
+                    Ok(None) => {
+                        warn!("HTLC stream closed by service");
+                        None
+                    }
+                    Err(e) => {
+                        error!("HTLC stream closed with error: {:?}", e);
+                        None
+                    }
+                } {
+                    if subscription.is_shutting_down() {
+                        info!("Shutting down HTLC subscription");
+                        break;
+                    }
+
+                    // TODO: Assert short channel id matches the one we subscribed to, or cancel processing of intercepted HTLC
+                    // TODO: Assert the offered fee derived from invoice amount and outgoing amount is acceptable or cancel processing of intercepted HTLC
+                    // TODO: Assert the HTLC expiry or cancel processing of intercepted HTLC
+
+                    let hash = match sha256::Hash::from_slice(&payment_hash) {
+                        Ok(hash) => hash,
+                        Err(e) => {
+                            let fail = "Failed to parse payment hash";
+
+                            error!("{}: {:?}", fail, e);
+                            let _ = lnrpc_copy
+                                .complete_htlc(CompleteHtlcsRequest {
+                                    intercepted_htlc_id,
+                                    action: Some(Action::Cancel(Cancel {
+                                        reason: fail.to_string(),
+                                    })),
+                                })
+                                .await;
+                            continue;
+                        }
+                    };
+
+                    let amount_msat = Amount::from_msats(outgoing_amount_msat);
+
+                    match actor.buy_preimage_internal(&hash, &amount_msat).await {
+                        Ok(preimage) => {
+                            info!("Successfully processed intercepted HTLC");
+                            if let Err(e) = lnrpc_copy
+                                .complete_htlc(CompleteHtlcsRequest {
+                                    intercepted_htlc_id,
+                                    action: Some(Action::Settle(Settle {
+                                        preimage: preimage.0.to_vec(),
+                                    })),
+                                })
+                                .await
+                            {
+                                error!("Failed to complete HTLC: {:?}", e);
+                                // Note: To prevent loss of funds for the gateway,
+                                // we should either retry completing the htlc or reclaim funds from the federation
+                            };
+                        }
+                        Err(e) => {
+                            error!("Failed to process intercepted HTLC: {:?}", e);
+                            // Note: this specific complete htlc requires no futher action.
+                            // If we fail to send the complete htlc message, or get an error result,
+                            // lightning node will still cancel HTCL after expiry period lapses.
+                            // Result can be safely ignored.
+                            let _ = lnrpc_copy
+                                .complete_htlc(CompleteHtlcsRequest {
+                                    intercepted_htlc_id,
+                                    action: Some(Action::Cancel(Cancel {
+                                        reason: e.to_string(),
+                                    })),
+                                })
+                                .await;
+                        }
+                    };
+                }
+            },
+        )
+        .await;
+
+        Ok(())
     }
 
     async fn fetch_all_notes(&self) {

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -17,8 +17,10 @@ use fedimint_api::{
     Amount, TransactionId,
 };
 use fedimint_server::api::WsFederationConnect;
-use mint_client::modules::ln::{
-    contracts::Preimage, route_hints::RouteHint, GatewayClient, PayInvoicePayload,
+use mint_client::{
+    ln::PayInvoicePayload,
+    modules::ln::{contracts::Preimage, route_hints::RouteHint},
+    GatewayClient,
 };
 use secp256k1::PublicKey;
 use tokio::sync::{mpsc, Mutex};

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -152,12 +152,14 @@ impl Gateway {
         route_hints: Vec<RouteHint>,
     ) -> Result<Arc<GatewayActor>> {
         let actor = Arc::new(
-            GatewayActor::new(client.clone(), route_hints)
-                .await
-                .expect("Failed to create actor"),
+            GatewayActor::new(
+                client.clone(),
+                self.lnrpc.clone(),
+                route_hints,
+                self.task_group.clone(),
+            )
+            .await?,
         );
-
-        // TODO: Subscribe for HTLC intercept on behalf of this federation
 
         self.actors.lock().await.insert(
             client.config().client_config.federation_id.to_string(),

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -246,7 +246,7 @@ impl Gateway {
         } = payload;
 
         let actor = self.select_actor(federation_id).await?;
-        let outpoint = actor.pay_invoice(self.lnrpc.clone(), contract_id).await?;
+        let outpoint = actor.pay_invoice(contract_id).await?;
         actor
             .await_outgoing_contract_claimed(contract_id, outpoint)
             .await?;

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -192,13 +192,7 @@ impl Gateway {
 
         let gw_client_cfg = self
             .client_builder
-            .create_config(
-                connect,
-                channel_id,
-                node_pub_key,
-                self.config.announce_address.clone(),
-                self.module_gens.clone(),
-            )
+            .create_config(connect, channel_id, node_pub_key, self.module_gens.clone())
             .await
             .expect("Failed to create gateway client config");
 

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -6,8 +6,7 @@ use fedimint_api::dyn_newtype_define;
 use fedimint_server::modules::ln::route_hints::RouteHint;
 use tonic::{
     transport::{Channel, Endpoint},
-    Request,
-    Streaming,
+    Request, Streaming,
 };
 use tracing::error;
 use url::Url;
@@ -113,12 +112,22 @@ impl ILnRpcClient for NetworkLnRpcClient {
 
     async fn subscribe_htlcs(
         &self,
-        _subscription: SubscribeInterceptHtlcsRequest,
+        subscription: SubscribeInterceptHtlcsRequest,
     ) -> Result<HtlcStream> {
-        unimplemented!()
+        let req = Request::new(subscription);
+
+        let mut client = self.client.clone();
+        let res = client.subscribe_intercept_htlcs(req).await?;
+
+        Ok(res.into_inner())
     }
 
-    async fn complete_htlc(&self, _outcome: CompleteHtlcsRequest) -> Result<CompleteHtlcsResponse> {
-        unimplemented!()
+    async fn complete_htlc(&self, outcome: CompleteHtlcsRequest) -> Result<CompleteHtlcsResponse> {
+        let req = Request::new(outcome);
+
+        let mut client = self.client.clone();
+        let res = client.complete_htlc(req).await?;
+
+        Ok(res.into_inner())
     }
 }

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -6,6 +6,7 @@ use fedimint_api::dyn_newtype_define;
 use fedimint_server::modules::ln::route_hints::RouteHint;
 use tonic::{
     transport::{Channel, Endpoint},
+    Request,
     Streaming,
 };
 use tracing::error;
@@ -14,8 +15,8 @@ use url::Url;
 use crate::{
     gatewaylnrpc::{
         gateway_lightning_client::GatewayLightningClient, CompleteHtlcsRequest,
-        CompleteHtlcsResponse, GetPubKeyResponse, PayInvoiceRequest, PayInvoiceResponse,
-        SubscribeInterceptHtlcsRequest, SubscribeInterceptHtlcsResponse,
+        CompleteHtlcsResponse, GetPubKeyRequest, GetPubKeyResponse, PayInvoiceRequest,
+        PayInvoiceResponse, SubscribeInterceptHtlcsRequest, SubscribeInterceptHtlcsResponse,
     },
     LnGatewayError, Result,
 };
@@ -89,7 +90,12 @@ impl NetworkLnRpcClient {
 #[async_trait]
 impl ILnRpcClient for NetworkLnRpcClient {
     async fn pubkey(&self) -> Result<GetPubKeyResponse> {
-        unimplemented!()
+        let req = Request::new(GetPubKeyRequest {});
+
+        let mut client = self.client.clone();
+        let res = client.get_pub_key(req).await?;
+
+        Ok(res.into_inner())
     }
 
     async fn route_hints(&self) -> Result<GetRouteHintsResponse> {

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -1,0 +1,54 @@
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use fedimint_api::dyn_newtype_define;
+use fedimint_server::modules::ln::route_hints::RouteHint;
+use tonic::Streaming;
+
+use crate::{
+    gatewaylnrpc::{
+        CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyResponse, PayInvoiceRequest,
+        PayInvoiceResponse, SubscribeInterceptHtlcsRequest, SubscribeInterceptHtlcsResponse,
+    },
+    Result,
+};
+
+// TODO: Issue 1554: Define gatewaylnpc spec for getting route hints
+pub struct GetRouteHintsResponse {
+    pub route_hints: Vec<RouteHint>,
+}
+
+pub type HtlcStream = Streaming<SubscribeInterceptHtlcsResponse>;
+
+#[async_trait]
+pub trait ILnRpcClient: Debug + Send + Sync {
+    /// Get the public key of the lightning node
+    async fn pubkey(&self) -> Result<GetPubKeyResponse>;
+
+    /// Get route hints to the lightning node
+    async fn route_hints(&self) -> Result<GetRouteHintsResponse>;
+
+    /// Attempt to pay an invoice using the lightning node
+    async fn pay(&self, invoice: PayInvoiceRequest) -> Result<PayInvoiceResponse>;
+
+    /// Subscribe to intercept htlcs that belong to a specific mint identified by `short_channel_id`
+    async fn subscribe_htlcs(
+        &self,
+        subscription: SubscribeInterceptHtlcsRequest,
+    ) -> Result<HtlcStream>;
+
+    /// Request completion of an intercepted htlc after processing and determining an outcome
+    async fn complete_htlc(&self, outcome: CompleteHtlcsRequest) -> Result<CompleteHtlcsResponse>;
+}
+
+dyn_newtype_define!(
+    /// Arc reference to a gateway lightning rpc client
+    #[derive(Clone)]
+    pub DynLnRpcClient(Arc<ILnRpcClient>)
+);
+
+impl DynLnRpcClient {
+    pub fn new(client: Arc<dyn ILnRpcClient + Send + Sync>) -> Self {
+        DynLnRpcClient(client)
+    }
+}

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, sync::Arc};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fedimint_api::dyn_newtype_define;
-use fedimint_server::modules::ln::route_hints::RouteHint;
+use mint_client::modules::ln::route_hints::RouteHint;
 use tonic::{
     transport::{Channel, Endpoint},
     Request, Streaming,

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -102,8 +102,13 @@ impl ILnRpcClient for NetworkLnRpcClient {
         unimplemented!()
     }
 
-    async fn pay(&self, _invoice: PayInvoiceRequest) -> Result<PayInvoiceResponse> {
-        unimplemented!()
+    async fn pay(&self, invoice: PayInvoiceRequest) -> Result<PayInvoiceResponse> {
+        let req = Request::new(invoice);
+
+        let mut client = self.client.clone();
+        let res = client.pay_invoice(req).await?;
+
+        Ok(res.into_inner())
     }
 
     async fn subscribe_htlcs(

--- a/gateway/ln-gateway/src/gatewayd/mod.rs
+++ b/gateway/ln-gateway/src/gatewayd/mod.rs
@@ -1,13 +1,13 @@
-// ### Why make a fork of `LnGateway` : copy code of `../src/lib.rs` to `./gateway.rs` ?
-// - Note: `LnGateway` is renamed to `Gateway` in this new file
-// - so we can change the constructor signature of `LnGateway`
-// - so we can change how the gateway gets HTLC intercepts. `Gateway` in `src/gateway.rs` does not implement `handle_receive_payment`. Instead, actors directly subscribe to htlc intercepts on an entirely new pattern. More on this below
+//! ### Why make a fork of `LnGateway` : copy code of `../src/lib.rs` to `./gateway.rs` ?
+//! - Note: `LnGateway` is renamed to `Gateway` in this new file
+//! - so we can change the constructor signature of `LnGateway`
+//! - so we can change how the gateway gets HTLC intercepts. `Gateway` in `src/gateway.rs` does not implement `handle_receive_payment`. Instead, actors directly subscribe to htlc intercepts on an entirely new pattern. More on this below
 
-// ### Why make a fork of `GatewayActor` : copy code of `../src/actor.rs` to `./actor.rs` ?
-// - So we can change constructor signature of `GatewayActor`. Have the new actor take a reference to lnrpc, which is
-// - So we can enable direct subscription to intercepted HTLCs using the owned lnrpc
-// - API signature of the `GatewayActor` changes because it owns a reference to lnrpc, rather than expec these to be passed in at api calls.
-// - Note: Changes incoming. You can preview them at #1337
+//! ### Why make a fork of `GatewayActor` : copy code of `../src/actor.rs` to `./actor.rs` ?
+//! - So we can change constructor signature of `GatewayActor`. Have the new actor take a reference to lnrpc, which is
+//! - So we can enable direct subscription to intercepted HTLCs using the owned lnrpc
+//! - API signature of the `GatewayActor` changes because it owns a reference to lnrpc, rather than expec these to be passed in at api calls.
+//! - Note: Changes incoming. You can preview them at #1337
 
 pub mod actor;
 pub mod gateway;

--- a/gateway/ln-gateway/src/gatewayd/mod.rs
+++ b/gateway/ln-gateway/src/gatewayd/mod.rs
@@ -11,3 +11,4 @@
 
 pub mod actor;
 pub mod gateway;
+pub mod lnrpc_client;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -453,6 +453,8 @@ impl Drop for LnGateway {
 pub enum LnGatewayError {
     #[error("Federation client operation error: {0:?}")]
     ClientError(#[from] ClientError),
+    #[error("Lightning rpc operation error: {0:?}")]
+    LnRpcError(#[from] tonic::Status),
     #[error("Our LN node could not route the payment: {0:?}")]
     CouldNotRoute(LightningError),
     #[error("Mint client error: {0:?}")]

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -211,13 +211,7 @@ impl LnGateway {
 
         let gw_client_cfg = self
             .client_builder
-            .create_config(
-                connect,
-                channel_id,
-                node_pub_key,
-                self.config.announce_address.clone(),
-                self.module_gens.clone(),
-            )
+            .create_config(connect, channel_id, node_pub_key, self.module_gens.clone())
             .await
             .expect("Failed to create gateway client config");
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -180,6 +180,8 @@ impl LnGateway {
                 .expect("Failed to create actor"),
         );
 
+        // TODO: Subscribe for HTLC intercept on behalf of this federation
+
         self.actors.lock().await.insert(
             client.config().client_config.federation_id.to_string(),
             actor.clone(),

--- a/gateway/tests/tests/fixtures/client.rs
+++ b/gateway/tests/tests/fixtures/client.rs
@@ -24,11 +24,15 @@ use super::fed::MockApi;
 #[derive(Debug, Clone)]
 pub struct TestGatewayClientBuilder {
     db_factory: DynDbFactory,
+    gateway_api: Url,
 }
 
 impl TestGatewayClientBuilder {
-    pub fn new(db_factory: DynDbFactory) -> Self {
-        Self { db_factory }
+    pub fn new(db_factory: DynDbFactory, gateway_api: Url) -> Self {
+        Self {
+            db_factory,
+            gateway_api,
+        }
     }
 }
 
@@ -70,7 +74,6 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
         _connect: WsFederationConnect,
         mint_channel_id: u64,
         node_pubkey: PublicKey,
-        announce_address: Url,
         _module_gens: ModuleGenRegistry,
     ) -> Result<GatewayClientConfig, LnGatewayError> {
         // TODO: use the connect info urls to get the federation name?
@@ -95,7 +98,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
             redeem_key: kp_fed,
             timelock_delta: 10,
             node_pub_key: node_pubkey,
-            api: announce_address,
+            api: self.gateway_api.clone(),
         })
     }
 

--- a/gateway/tests/tests/fixtures/mod.rs
+++ b/gateway/tests/tests/fixtures/mod.rs
@@ -33,7 +33,8 @@ pub async fn fixtures(gw_cfg: GatewayConfig) -> Result<Fixtures> {
     let ln_rpc = Arc::new(ln::MockLnRpc::new());
 
     let client_builder: DynGatewayClientBuilder =
-        client::TestGatewayClientBuilder::new(MemDbFactory.into()).into();
+        client::TestGatewayClientBuilder::new(MemDbFactory.into(), gw_cfg.announce_address.clone())
+            .into();
     let (tx, rx) = mpsc::channel::<GatewayRequest>(100);
     let decoders = module_decode_stubs();
     let module_gens = ModuleGenRegistry::from(vec![

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -542,8 +542,12 @@ impl GatewayTest {
         };
 
         // Create federation client builder for the gateway
-        let client_builder: DynGatewayClientBuilder =
-            StandardGatewayClientBuilder::new(PathBuf::new(), MemDbFactory.into()).into();
+        let client_builder: DynGatewayClientBuilder = StandardGatewayClientBuilder::new(
+            PathBuf::new(),
+            MemDbFactory.into(),
+            announce_addr.clone(),
+        )
+        .into();
 
         let (sender, receiver) = tokio::sync::mpsc::channel::<GatewayRequest>(100);
         let adapter = Arc::new(ln_client_adapter);

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -67,6 +67,16 @@ wait
 # Move the client config to root dir
 mv $FM_CFG_DIR/server-0/client* $FM_CFG_DIR/
 
+# Generate gateway config
+export FM_GATEWAY_DATA_DIR=$FM_CFG_DIR/gateway
+export FM_GATEWAY_LISTEN_ADDR="127.0.0.1:10000"
+export FM_GATEWAY_API_ADDR="http://127.0.0.1:10000"
+export FM_GATEWAY_PASSWORD="theresnosecondbest"
+
+export FM_GATEWAY_LIGHTNING_ADDR="http://127.0.0.1:10001"
+
+mkdir -p $FM_GATEWAY_DATA_DIR
+
 # Define clients
 export FM_LN1="lightning-cli --network regtest --lightning-dir=$FM_LN1_DIR"
 export FM_LN2="lightning-cli --network regtest --lightning-dir=$FM_LN2_DIR"

--- a/scripts/restart-tmux.sh
+++ b/scripts/restart-tmux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
  
-tmux send-keys -t fedimint-dev:1.4 "pkill -9 fedimintd" C-m
-tmux send-keys -t fedimint-dev:1.4 "cargo build --bin fedimintd" C-m
-tmux send-keys -t fedimint-dev:1.4 "./scripts/start-fed.sh" C-m
+tmux send-keys -t fedimint-dev:1.5 "pkill -9 fedimintd" C-m
+tmux send-keys -t fedimint-dev:1.5 "cargo build --bin fedimintd" C-m
+tmux send-keys -t fedimint-dev:1.5 "./scripts/start-fed.sh" C-m
 
 ./scripts/gw-reload.sh


### PR DESCRIPTION
Gateway daemon that uses a [GatewayLightning](https://github.com/fedimint/fedimint/blob/master/gateway/ln-gateway/proto/gatewaylnrpc.proto#L7:L19) rpc client for lightning functions

- The production `gatewayd` instance uses a network gateway lightning rpc client which calls into a remote node to
  - get node pubkey for constructing invoices
  - pay invoice on behalf of user
  - subscribe to htlcs directed at a federation
  - process and respond to htlcs intercepted
- RPC calls are agnostic of the lightning node implementation

- #1295 is an example of gateway lightning extension this client can call into

![image](https://user-images.githubusercontent.com/11217077/212963288-a2841085-62e7-47d8-8a34-537fe24d1959.png)
