### PR TITLE
cleanup: remove serialize to string and deserialize hack

### DIFF
--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -183,11 +183,7 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
     vec![
         api_endpoint! {
             "/transaction",
-            async |fedimint: &FedimintConsensus, _dbtx, transaction: serde_json::Value| -> TransactionId {
-                // deserializing Transaction from json Value always fails
-                // we need to convert it to string first
-                let string = serde_json::to_string(&transaction).map_err(|e| ApiError::bad_request(e.to_string()))?;
-                let serde_transaction: SerdeTransaction = serde_json::from_str(&string).map_err(|e| ApiError::bad_request(e.to_string()))?;
+            async |fedimint: &FedimintConsensus, _dbtx, serde_transaction: SerdeTransaction| -> TransactionId {
                 let transaction = serde_transaction.try_into_inner(&fedimint.modules.decoder_registry()).map_err(|e| ApiError::bad_request(e.to_string()))?;
 
                 let tx_id = transaction.tx_hash();


### PR DESCRIPTION
this is no longer needed because use `SerdeTransaction` now.
earlier some types from hbbft could not be deserialized directly.