### PR TITLE
Replace uses of `hex` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,7 +2598,6 @@ dependencies = [
  "fedimint-rocksdb",
  "fedimint-testing",
  "futures",
- "hex",
  "hkdf",
  "js-sys",
  "jsonrpsee-core",

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -21,7 +21,6 @@ bincode = "1.3.1"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 futures = "0.3.24"
-hex = "0.4.3"
 hkdf = { path = "../../crypto/hkdf" }
 lightning-invoice = "0.21.0"
 lightning = "0.0.113"

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use bitcoin_hashes::hex::FromHex;
 use db::{CoinKey, CoinKeyPrefix, OutputFinalizationKey, OutputFinalizationKeyPrefix};
 use fedimint_api::core::client::ClientModule;
 use fedimint_api::db::DatabaseTransaction;
@@ -643,7 +644,8 @@ fn deserialize_key_pair<'de, D: serde::Deserializer<'de>>(
 ) -> std::result::Result<KeyPair, D::Error> {
     if d.is_human_readable() {
         let hex_bytes: Cow<'_, str> = Deserialize::deserialize(d)?;
-        let bytes = hex::decode(hex_bytes.as_ref()).map_err(|_| D::Error::custom("Invalid hex"))?;
+        let bytes =
+            Vec::from_hex(hex_bytes.as_ref()).map_err(|_| D::Error::custom("Invalid hex"))?;
         KeyPair::from_seckey_slice(secp256k1_zkp::SECP256K1, &bytes)
             .map_err(|_| D::Error::custom("Not a valid private key"))
     } else {

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use bitcoin::{secp256k1, Network};
+use bitcoin_hashes::hex::FromHex;
 use fedimint_api::db::Database;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -25,7 +26,7 @@ pub fn serialize_ecash(c: &TieredMulti<SpendableNote>) -> String {
 }
 
 pub fn from_hex<D: Decodable>(s: &str) -> Result<D, anyhow::Error> {
-    let bytes = hex::decode(s)?;
+    let bytes = Vec::from_hex(s)?;
     Ok(D::consensus_decode(
         &mut std::io::Cursor::new(bytes),
         &ModuleDecoderRegistry::default(),

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -4,6 +4,7 @@ use std::sync::Mutex;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use bitcoin_hashes::hex::ToHex;
 
 use super::{
     DatabaseDeleteOperation, DatabaseInsertOperation, DatabaseOperation, IDatabase,
@@ -38,7 +39,7 @@ impl MemDatabase {
         let data = self.data.lock().unwrap();
         let data_iter = data.iter();
         for (key, value) in data_iter {
-            println!("{}: {}", hex::encode(key), hex::encode(value));
+            println!("{}: {}", key.to_hex(), value.to_hex());
         }
     }
 }

--- a/fedimint-api/src/fmt_utils.rs
+++ b/fedimint-api/src/fmt_utils.rs
@@ -24,9 +24,9 @@ pub struct AbbreviateHexBytes<'a>(pub &'a [u8]);
 impl<'a> fmt::Display for AbbreviateHexBytes<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.0.len() <= 64 || rust_log_full_enabled() {
-            f.write_str(&hex::encode(self.0))?;
+            bitcoin_hashes::hex::format_hex(self.0, f)?;
         } else {
-            f.write_str(&hex::encode(&self.0[..64]))?;
+            bitcoin_hashes::hex::format_hex(&self.0[..64], f)?;
             f.write_fmt(format_args!("-{}", self.0.len()))?;
         }
         Ok(())


### PR DESCRIPTION
part of #1307

more work to remove the `hex` dependency crate. I can't remove the hex dependency in cargo.toml in `fedimint-api` yet as it is needed because the mint module uses it.
used [here](https://github.com/fedimint/fedimint/blob/8d4ef26a814e53ba7012b1b50fb3afec4382c920/modules/fedimint-mint/src/common.rs#L17) and [here](https://github.com/fedimint/fedimint/blob/8d4ef26a814e53ba7012b1b50fb3afec4382c920/modules/fedimint-mint/src/db.rs#L158)

example: 
```rust
#[derive(Debug, Serialize, Deserialize, Encodable, Decodable)]
pub struct BackupRequest {
    pub id: secp256k1::XOnlyPublicKey,
    #[serde(with = "hex::serde")]
    pub payload: Vec<u8>,
    pub timestamp: std::time::SystemTime,
}
```

thoughts on replacing this? writing a deserialize and serialize function for `Vec<u8>` that de/serializes to hex and use it with `#[serde(serialize_with = ...)]` ? It is still wanted I guess? 

