### PR TITLE
fix: rust_log_full_enabled check env var only once

### DIFF
--- a/fedimint-api/src/fmt_utils.rs
+++ b/fedimint-api/src/fmt_utils.rs
@@ -1,18 +1,14 @@
-use std::cell::Cell;
 use std::fmt;
 use std::thread_local;
 
-thread_local!(static RUST_LOG_FULL: Cell<bool> = Cell::new(false));
-
 pub fn rust_log_full_enabled() -> bool {
     // this will be called only once per-thread for best performance
-    RUST_LOG_FULL.with(|v| {
-        let enabled = std::env::var_os("RUST_LOG_FULL")
+    thread_local!(static RUST_LOG_FULL: bool = {
+        std::env::var_os("RUST_LOG_FULL")
             .map(|val| !val.is_empty())
-            .unwrap_or(false);
-        v.set(enabled);
-        enabled
-    })
+            .unwrap_or(false)
+    });
+    RUST_LOG_FULL.with(|x| *x)
 }
 
 /// Use for displaying bytes in the logs


### PR DESCRIPTION
LocalKey::with executes the closure everytime :shrug: 

thread_local is lazy by default. So we can do non const initialization.