### PR TITLE
Cross-compile fedimint-sqlite in CI

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -130,6 +130,8 @@ jobs:
 
       - name: Build mint-client for ${{ matrix.build }}
         run: nix build -L .#cross.${{ matrix.build }}.mint-client
+      - name: Build fedimint-sqlite for ${{ matrix.build }}
+        run: nix build -L .#cross.${{ matrix.build }}.fedimint-sqlite
 
   containers:
     name: "Containers"

--- a/flake.nix
+++ b/flake.nix
@@ -590,6 +590,14 @@
           ];
         };
 
+        fedimint-sqlite = { target }: pkgCross {
+          name = "fedimint-sqlite";
+          inherit target;
+          dirs = [
+            "fedimint-sqlite"
+          ];
+        };
+
         fedimint-tests = pkg {
           name = "fedimint-tests";
           dirs = [
@@ -712,6 +720,7 @@
           cross = builtins.mapAttrs
             (attr: target: {
               mint-client = mint-client { inherit target; };
+              fedimint-sqlite = fedimint-sqlite { inherit target; };
             })
             crossTargets;
 


### PR DESCRIPTION
Inspired by https://github.com/fedimint/fedimint/pull/1270, our CI should probably check that `mint-client` **and** `fedimint-sqlite` can compile on ios / android targets since most mobile apps will use these 2 libraries in tandem.

Not sure how much this will slow down CI, though ...