### PR TITLE
Connect Lightning to Gatewayd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,6 +2339,7 @@ dependencies = [
  "axum-macros",
  "bitcoin",
  "bitcoin_hashes 0.11.0",
+ "clap",
  "cln-plugin",
  "cln-rpc",
  "fedimint-api",

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -7,8 +7,8 @@ use fedimint_server::modules::wallet::txoproof::TxOutProof;
 use ln_gateway::{
     config::GatewayConfig,
     rpc::{
-        rpc_client::RpcClient, BalancePayload, ConnectFedPayload, DepositAddressPayload,
-        DepositPayload, WithdrawPayload,
+        rpc_client::RpcClient, BalancePayload, ConnectFedPayload, ConnectLnPayload,
+        DepositAddressPayload, DepositPayload, WithdrawPayload,
     },
 };
 use mint_client::utils::from_hex;
@@ -68,6 +68,12 @@ pub enum Commands {
     ConnectFed {
         /// ConnectInfo code to connect to the federation
         connect: String,
+    },
+    /// Register gateway lightning rpc service
+    /// NOTE: This will replace any existing connection to a lightning service
+    ConnectLn {
+        /// URL to a gateway lightning rpc service
+        url: Url,
     },
 }
 
@@ -181,6 +187,14 @@ async fn main() {
                 )
                 .await
                 .expect("Failed to connect federation");
+
+            print_response(response).await;
+        }
+        Commands::ConnectLn { url } => {
+            let response = client
+                .connect_lightning(source_password(cli.rpcpassword), ConnectLnPayload { url })
+                .await
+                .expect("Failed to connect gateway lightning");
 
             print_response(response).await;
         }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -13,6 +13,10 @@ name = "ln_gateway"
 path = "src/lib.rs"
 
 [[bin]]
+name = "gatewayd"
+path = "src/bin/gatewayd.rs"
+
+[[bin]]
 name = "ln_gateway"
 path = "src/bin/ln_gateway.rs"
 
@@ -23,6 +27,7 @@ axum = "0.6.2"
 axum-macros = "0.3.1"
 bitcoin_hashes = "0.11.0"
 bitcoin = { version = "0.29.2", features = ["serde"] }
+clap = { version = "4.0.29", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
 cln-rpc = "0.1.1"
 cln-plugin = "0.1.1"
 futures = "0.3.24"

--- a/gateway/ln-gateway/src/actor_fork.rs
+++ b/gateway/ln-gateway/src/actor_fork.rs
@@ -1,0 +1,245 @@
+use std::{sync::Arc, time::Duration};
+
+use bitcoin::{Address, Transaction};
+use bitcoin_hashes::sha256;
+use fedimint_api::{Amount, OutPoint, TransactionId};
+use fedimint_server::modules::{
+    ln::contracts::{ContractId, Preimage},
+    wallet::txoproof::TxOutProof,
+};
+use mint_client::{GatewayClient, PaymentParameters};
+use rand::{CryptoRng, RngCore};
+use tracing::{debug, info, instrument, warn};
+
+use crate::{ln::LnRpc, rpc::FederationInfo, utils::retry, LnGatewayError, Result};
+
+pub struct GatewayActor {
+    client: Arc<GatewayClient>,
+}
+
+impl GatewayActor {
+    pub async fn new(client: Arc<GatewayClient>) -> Result<Self> {
+        // Retry gateway registration
+        match retry(
+            String::from("Register With Federation"),
+            #[allow(clippy::unit_arg)]
+            || async {
+                Ok(client
+                    .register_with_federation(client.config().into())
+                    .await?)
+            },
+            Duration::from_secs(1),
+            5,
+        )
+        .await
+        {
+            Ok(_) => info!("Connected with federation"),
+            Err(e) => warn!("Failed to connect with federation: {}", e),
+        }
+
+        Ok(Self { client })
+    }
+
+    async fn fetch_all_coins(&self) {
+        for fetch_result in self.client.fetch_all_coins().await {
+            if let Err(e) = fetch_result {
+                debug!(error = %e, "Fetching coins failed")
+            };
+        }
+    }
+
+    pub async fn buy_preimage_offer(
+        &self,
+        payment_hash: &sha256::Hash,
+        amount: &Amount,
+        rng: impl RngCore + CryptoRng,
+    ) -> Result<(OutPoint, ContractId)> {
+        let (outpoint, contract_id) = self
+            .client
+            .buy_preimage_offer(payment_hash, amount, rng)
+            .await?;
+        Ok((outpoint, contract_id))
+    }
+
+    // TODO: Move this API to messaging
+    pub async fn await_preimage_decryption(&self, outpoint: OutPoint) -> Result<Preimage> {
+        let preimage = self.client.await_preimage_decryption(outpoint).await?;
+        Ok(preimage)
+    }
+
+    #[instrument(skip_all, fields(%contract_id))]
+    pub async fn pay_invoice(
+        &self,
+        ln_rpc: Arc<dyn LnRpc>,
+        contract_id: ContractId,
+    ) -> Result<OutPoint> {
+        debug!("Fetching contract");
+        let rng = rand::rngs::OsRng;
+        let contract_account = self.client.fetch_outgoing_contract(contract_id).await?;
+
+        let payment_params = self
+            .client
+            .validate_outgoing_account(&contract_account)
+            .await?;
+
+        debug!(
+            account = ?contract_account,
+            "Fetched and validated contract account"
+        );
+
+        self.client
+            .save_outgoing_payment(contract_account.clone())
+            .await;
+
+        let is_internal_payment = payment_params.maybe_internal
+            && self
+                .client
+                .ln_client()
+                .offer_exists(payment_params.payment_hash)
+                .await
+                .unwrap_or(false);
+
+        let preimage_res = if is_internal_payment {
+            self.buy_preimage_internal(&payment_params.payment_hash, &payment_params.invoice_amount)
+                .await
+        } else {
+            self.buy_preimage_external(ln_rpc, contract_account.contract.invoice, &payment_params)
+                .await
+        };
+
+        match preimage_res {
+            Ok(preimage) => {
+                let outpoint = self
+                    .client
+                    .claim_outgoing_contract(contract_id, preimage, rng)
+                    .await?;
+
+                Ok(outpoint)
+            }
+            Err(e) => {
+                warn!("Invoice payment failed: {}. Aborting", e);
+                // FIXME: combine both errors?
+                self.client.abort_outgoing_payment(contract_id).await?;
+                Err(e)
+            }
+        }
+    }
+
+    pub async fn buy_preimage_internal(
+        &self,
+        payment_hash: &sha256::Hash,
+        invoice_amount: &Amount,
+    ) -> Result<Preimage> {
+        self.fetch_all_coins().await;
+
+        let mut rng = rand::rngs::OsRng;
+        let (out_point, contract_id) = self
+            .client
+            .buy_preimage_offer(payment_hash, invoice_amount, &mut rng)
+            .await?;
+
+        debug!("Awaiting decryption of preimage of hash {}", payment_hash);
+        match self.client.await_preimage_decryption(out_point).await {
+            Ok(preimage) => {
+                debug!("Decrypted preimage {:?}", preimage);
+                Ok(preimage)
+            }
+            Err(e) => {
+                warn!("Failed to decrypt preimage. Now requesting a refund: {}", e);
+                self.client
+                    .refund_incoming_contract(contract_id, rng)
+                    .await?;
+                Err(LnGatewayError::ClientError(e))
+            }
+        }
+    }
+
+    pub async fn buy_preimage_external(
+        &self,
+        ln_rpc: Arc<dyn LnRpc>,
+        invoice: lightning_invoice::Invoice,
+        payment_params: &PaymentParameters,
+    ) -> Result<Preimage> {
+        match ln_rpc
+            .pay(
+                invoice,
+                payment_params.max_delay,
+                payment_params.max_fee_percent(),
+            )
+            .await
+        {
+            Ok(preimage) => {
+                debug!(?preimage, "Successfully paid LN invoice");
+                Ok(preimage)
+            }
+            Err(e) => {
+                warn!("LN payment failed, aborting");
+                Err(LnGatewayError::CouldNotRoute(e))
+            }
+        }
+    }
+
+    pub async fn await_outgoing_contract_claimed(
+        &self,
+        contract_id: ContractId,
+        outpoint: OutPoint,
+    ) -> Result<()> {
+        Ok(self
+            .client
+            .await_outgoing_contract_claimed(contract_id, outpoint)
+            .await?)
+    }
+
+    pub async fn get_deposit_address(&self) -> Result<Address> {
+        let rng = rand::rngs::OsRng;
+        Ok(self.client.get_new_pegin_address(rng).await)
+    }
+
+    pub async fn deposit(
+        &self,
+        txout_proof: TxOutProof,
+        transaction: Transaction,
+    ) -> Result<TransactionId> {
+        let rng = rand::rngs::OsRng;
+
+        self.client
+            .peg_in(txout_proof, transaction, rng)
+            .await
+            .map_err(LnGatewayError::ClientError)
+    }
+
+    pub async fn withdraw(
+        &self,
+        amount: bitcoin::Amount,
+        address: Address,
+    ) -> Result<TransactionId> {
+        self.fetch_all_coins().await;
+
+        let rng = rand::rngs::OsRng;
+
+        let peg_out = self
+            .client
+            .new_peg_out_with_fees(amount, address)
+            .await
+            .expect("Failed to create pegout with fees");
+        self.client
+            .peg_out(peg_out, rng)
+            .await
+            .map_err(LnGatewayError::ClientError)
+            .map(|out_point| out_point.txid)
+    }
+
+    pub async fn get_balance(&self) -> Result<Amount> {
+        self.fetch_all_coins().await;
+
+        Ok(self.client.coins().await.total_amount())
+    }
+
+    pub fn get_info(&self) -> Result<FederationInfo> {
+        let cfg = self.client.config();
+        Ok(FederationInfo {
+            federation_id: cfg.client_config.federation_id.clone(),
+            mint_pubkey: cfg.redeem_key.x_only_public_key().0,
+        })
+    }
+}

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -1,0 +1,97 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use fedimint_api::{
+    core::{
+        LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+        LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+    },
+    module::registry::ModuleDecoderRegistry,
+    task::TaskGroup,
+};
+use fedimint_server::{
+    config::load_from_file,
+    modules::{
+        ln::common::LightningDecoder, mint::common::MintDecoder, wallet::common::WalletDecoder,
+    },
+};
+use ln_gateway::{
+    client::{DynGatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder},
+    config::GatewayConfig,
+    gateway::Gateway,
+    rpc::lnrpc_client::{DynLnRpcClientFactory, NetworkLnRpcClientFactory},
+};
+use tracing::{error, info};
+
+#[derive(Parser)]
+pub struct GatewayOpts {
+    /// Path to folder containing gateway config and data files
+    #[arg(long = "cfg-dir", env = "GW_CONFIG_DIR")]
+    pub cfg_dir: PathBuf,
+}
+
+/// Fedimint Gateway Binary
+///
+/// This binary runs a webserver with an API that can be used by Fedimint clients to request routing of payments
+/// through the Lightning Network. It uses a Gateway Lightning RPC client to communicate with a Lightning node.
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let mut args = std::env::args();
+
+    if let Some(ref arg) = args.nth(1) {
+        if arg.as_str() == "version-hash" {
+            println!("{}", env!("GIT_HASH"));
+            return Ok(());
+        }
+    }
+
+    // Read configurations
+    let GatewayOpts { cfg_dir } = GatewayOpts::parse();
+    let gw_cfg_path = cfg_dir.join("gateway.config");
+    let config: GatewayConfig = match load_from_file(&gw_cfg_path) {
+        Ok(cfg) => {
+            info!("Loaded gateway config from {}", gw_cfg_path.display());
+            cfg
+        }
+        Err(e) => {
+            error!("Failed to load gateway config: {}", e);
+            return Err(e);
+        }
+    };
+
+    // Create federation client builder
+    let client_builder: DynGatewayClientBuilder =
+        StandardGatewayClientBuilder::new(cfg_dir.clone(), RocksDbFactory.into()).into();
+
+    // Create task group for controlled shutdown of the gateway
+    let task_group = TaskGroup::new();
+
+    // Create a lightning rpc client factory
+    let lnrpc_factory: DynLnRpcClientFactory = NetworkLnRpcClientFactory::default().into();
+
+    // Create module decoder registry
+    let decoders = ModuleDecoderRegistry::from_iter([
+        (LEGACY_HARDCODED_INSTANCE_ID_LN, LightningDecoder.into()),
+        (LEGACY_HARDCODED_INSTANCE_ID_MINT, MintDecoder.into()),
+        (LEGACY_HARDCODED_INSTANCE_ID_WALLET, WalletDecoder.into()),
+    ]);
+
+    // Create gateway instance
+    let gateway = Gateway::new(
+        config,
+        decoders,
+        lnrpc_factory,
+        client_builder,
+        task_group.clone(),
+    )
+    .await;
+
+    if let Err(e) = gateway.run().await {
+        task_group.shutdown_join_all().await?;
+
+        error!("Gateway stopped with error: {}", e);
+        return Err(e.into());
+    }
+
+    Ok(())
+}

--- a/gateway/ln-gateway/src/gateway.rs
+++ b/gateway/ln-gateway/src/gateway.rs
@@ -16,7 +16,7 @@ use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, warn};
 
 use crate::{
-    actor::GatewayActor,
+    actor_fork::GatewayActor,
     client::DynGatewayClientBuilder,
     config::GatewayConfig,
     ln::LnRpc,

--- a/gateway/ln-gateway/src/gateway.rs
+++ b/gateway/ln-gateway/src/gateway.rs
@@ -130,13 +130,10 @@ impl Gateway {
         &self,
         client: Arc<GatewayClient>,
     ) -> Result<Arc<GatewayActor>> {
-        let actor = Arc::new(
-            GatewayActor::new(client.clone())
-                .await
-                .expect("Failed to create actor"),
-        );
+        let lnrpc = self.get_lnrpc_client().await?;
 
-        // TODO: Subscribe for HTLC intercept on behalf of this federation
+        let actor =
+            Arc::new(GatewayActor::new(client.clone(), lnrpc, self.task_group.clone()).await?);
 
         self.actors.lock().await.insert(
             client.config().client_config.federation_id.to_string(),

--- a/gateway/ln-gateway/src/gateway.rs
+++ b/gateway/ln-gateway/src/gateway.rs
@@ -226,9 +226,8 @@ impl Gateway {
             contract_id,
         } = payload;
 
-        let lnrpc = self.get_lnrpc_client().await?;
         let actor = self.select_actor(federation_id).await?;
-        let outpoint = actor.pay_invoice(lnrpc, contract_id).await?;
+        let outpoint = actor.pay_invoice(contract_id).await?;
         actor
             .await_outgoing_contract_claimed(contract_id, outpoint)
             .await?;

--- a/gateway/ln-gateway/src/gateway.rs
+++ b/gateway/ln-gateway/src/gateway.rs
@@ -229,8 +229,9 @@ impl Gateway {
             contract_id,
         } = payload;
 
+        let lnrpc = self.get_lnrpc_client().await?;
         let actor = self.select_actor(federation_id).await?;
-        let outpoint = actor.pay_invoice(self.ln_rpc.clone(), contract_id).await?;
+        let outpoint = actor.pay_invoice(lnrpc, contract_id).await?;
         actor
             .await_outgoing_contract_claimed(contract_id, outpoint)
             .await?;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -42,9 +42,9 @@ use crate::{
     config::GatewayConfig,
     ln::{LightningError, LnRpc},
     rpc::{
-        rpc_server::run_webserver, BalancePayload, ConnectFedPayload, DepositAddressPayload,
-        DepositPayload, GatewayInfo, GatewayRequest, GatewayRpcSender, InfoPayload,
-        ReceivePaymentPayload, WithdrawPayload,
+        rpc_server::run_webserver, BalancePayload, ConnectFedPayload, ConnectLnPayload,
+        DepositAddressPayload, DepositPayload, GatewayInfo, GatewayRequest, GatewayRpcSender,
+        InfoPayload, ReceivePaymentPayload, WithdrawPayload,
     },
 };
 
@@ -285,6 +285,12 @@ impl LnGateway {
             .await
     }
 
+    async fn unimplemented_handle_connect_lnrpc(&self, _payload: ConnectLnPayload) -> Result<()> {
+        Err(LnGatewayError::Other(anyhow::anyhow!(
+            "Not implemented: connect_lnrpc"
+        )))
+    }
+
     pub async fn run(mut self) -> Result<()> {
         let mut tg = self.task_group.clone();
 
@@ -321,6 +327,11 @@ impl LnGateway {
                 match msg {
                     GatewayRequest::Info(inner) => {
                         inner.handle(|payload| self.handle_get_info(payload)).await;
+                    }
+                    GatewayRequest::ConnectLightning(inner) => {
+                        inner
+                            .handle(|payload| self.unimplemented_handle_connect_lnrpc(payload))
+                            .await;
                     }
                     GatewayRequest::ConnectFederation(inner) => {
                         inner

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod actor;
+pub mod actor_fork;
 pub mod client;
 pub mod cln;
 pub mod config;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -376,6 +376,8 @@ impl Drop for LnGateway {
 pub enum LnGatewayError {
     #[error("Federation client operation error: {0:?}")]
     ClientError(#[from] ClientError),
+    #[error("Lightning rpc operation error: {0:?}")]
+    LnrpcError(#[from] tonic::Status),
     #[error("Our LN node could not route the payment: {0:?}")]
     CouldNotRoute(LightningError),
     #[error("Mint client error: {0:?}")]

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -139,6 +139,8 @@ impl LnGateway {
                 .expect("Failed to create actor"),
         );
 
+        // TODO: Subscribe for HTLC intercept on behalf of this federation
+
         self.actors.lock().await.insert(
             client.config().client_config.federation_id.to_string(),
             actor.clone(),

--- a/gateway/ln-gateway/src/rpc/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/lnrpc_client.rs
@@ -1,15 +1,18 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, net::SocketAddr, sync::Arc};
 
+use anyhow::anyhow;
 use async_trait::async_trait;
 use fedimint_api::dyn_newtype_define;
-use tonic::Streaming;
+use tonic::{transport::Channel, Streaming};
+use tracing::error;
 
 use crate::{
     gatewaylnrpc::{
-        CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyResponse, PayInvoiceRequest,
-        PayInvoiceResponse, SubscribeInterceptHtlcsResponse,
+        gateway_lightning_client::GatewayLightningClient, CompleteHtlcsRequest,
+        CompleteHtlcsResponse, GetPubKeyResponse, PayInvoiceRequest, PayInvoiceResponse,
+        SubscribeInterceptHtlcsResponse,
     },
-    Result,
+    LnGatewayError, Result,
 };
 
 /// Convenience wrapper around `GatewayLightningClient` protocol spec
@@ -46,5 +49,55 @@ dyn_newtype_define!(
 impl DynLnRpcClient {
     pub fn new(client: Arc<dyn ILnRpcClient + Send + Sync>) -> Self {
         DynLnRpcClient(client)
+    }
+}
+
+/// An `ILnRpcClient` that wraps around `GatewayLightningClient` for convenience,
+/// and makes real RPC requests over the wire to a remote lightning node.
+/// The lightnign node is exposed via a corresponding `GatewayLightningServer`.
+#[derive(Debug)]
+pub struct NetworkLnRpcClient {
+    client: GatewayLightningClient<Channel>,
+}
+
+impl NetworkLnRpcClient {
+    async fn new(address: SocketAddr) -> Result<Self> {
+        // TODO: Use secure connections to `GatewayLightningServer`
+        let url = format!("http://{}", address);
+
+        let client = GatewayLightningClient::connect(url).await.map_err(|e| {
+            error!("Failed to connect to lnrpc server: {:?}", e);
+            LnGatewayError::Other(anyhow!("Failed to connect to lnrpc server"))
+        })?;
+
+        Ok(Self { client })
+    }
+}
+
+#[async_trait]
+impl ILnRpcClient for NetworkLnRpcClient {
+    async fn get_pubkey(&self) -> Result<GetPubKeyResponse> {
+        unimplemented!()
+    }
+
+    async fn pay_invoice(
+        &self,
+        _invoices: Vec<PayInvoiceRequest>,
+    ) -> Result<Streaming<PayInvoiceResponse>> {
+        unimplemented!()
+    }
+
+    async fn subscribe_intercept_htlcs(
+        &self,
+        _short_channel_id: u64,
+    ) -> Result<Streaming<SubscribeInterceptHtlcsResponse>> {
+        unimplemented!()
+    }
+
+    async fn complete_htlcs(
+        &self,
+        _requests: Vec<CompleteHtlcsRequest>,
+    ) -> Result<Streaming<CompleteHtlcsResponse>> {
+        unimplemented!()
     }
 }

--- a/gateway/ln-gateway/src/rpc/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/lnrpc_client.rs
@@ -101,3 +101,26 @@ impl ILnRpcClient for NetworkLnRpcClient {
         unimplemented!()
     }
 }
+
+/// A generic factory trait for creating `DynLnRpcClient` instances.
+#[async_trait]
+pub trait ILnRpcClientFactory: Debug {
+    async fn create(&self, address: SocketAddr) -> Result<DynLnRpcClient>;
+}
+
+dyn_newtype_define!(
+    /// Arc reference to a gateway lightning rpc client factory
+    #[derive(Clone)]
+    pub DynLnRpcClientFactory(Arc<ILnRpcClientFactory>)
+);
+
+#[derive(Debug, Default)]
+pub struct NetworkLnRpcClientFactory;
+
+/// An `ILnRpcClientFactory` that creates `NetworkLnRpcClient` instances.
+#[async_trait]
+impl ILnRpcClientFactory for NetworkLnRpcClientFactory {
+    async fn create(&self, address: SocketAddr) -> Result<DynLnRpcClient> {
+        Ok(NetworkLnRpcClient::new(address).await?.into())
+    }
+}

--- a/gateway/ln-gateway/src/rpc/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/lnrpc_client.rs
@@ -1,0 +1,50 @@
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use fedimint_api::dyn_newtype_define;
+use tonic::Streaming;
+
+use crate::{
+    gatewaylnrpc::{
+        CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyResponse, PayInvoiceRequest,
+        PayInvoiceResponse, SubscribeInterceptHtlcsResponse,
+    },
+    Result,
+};
+
+/// Convenience wrapper around `GatewayLightningClient` protocol spec
+/// This provides ease in constructing rpc requests
+#[async_trait]
+pub trait ILnRpcClient: Debug + Send + Sync {
+    /// Get the public key of the lightning node
+    async fn get_pubkey(&self) -> Result<GetPubKeyResponse>;
+
+    /// Attempt to pay an invoice using the lightning node
+    async fn pay_invoice(
+        &self,
+        invoices: Vec<PayInvoiceRequest>,
+    ) -> Result<Streaming<PayInvoiceResponse>>;
+
+    /// Subscribe to intercept htlcs that belong to a specific mint identified by `short_channel_id`
+    async fn subscribe_intercept_htlcs(
+        &self,
+        short_channel_id: u64,
+    ) -> Result<Streaming<SubscribeInterceptHtlcsResponse>>;
+
+    async fn complete_htlcs(
+        &self,
+        requests: Vec<CompleteHtlcsRequest>,
+    ) -> Result<Streaming<CompleteHtlcsResponse>>;
+}
+
+dyn_newtype_define!(
+    /// Arc reference to a gateway lightning rpc client
+    #[derive(Clone)]
+    pub DynLnRpcClient(Arc<ILnRpcClient>)
+);
+
+impl DynLnRpcClient {
+    pub fn new(client: Arc<dyn ILnRpcClient + Send + Sync>) -> Self {
+        DynLnRpcClient(client)
+    }
+}

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -1,3 +1,4 @@
+pub mod lnrpc_client;
 pub mod rpc_client;
 pub mod rpc_server;
 
@@ -208,4 +209,9 @@ pub fn serde_hex_serialize<T: bitcoin::consensus::Encodable, S: Serializer>(
     } else {
         s.serialize_bytes(&bytes)
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HtlcInterceptPayload {
+    pub invoice_amount: Amount,
 }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -14,6 +14,7 @@ use mint_client::ln::PayInvoicePayload;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tokio::sync::{mpsc, oneshot};
 use tracing::error;
+use url::Url;
 
 use crate::{cln::HtlcAccepted, LnGatewayError, Result};
 
@@ -52,6 +53,12 @@ impl GatewayRpcSender {
             })
             .map_err(|e| e.into())
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ConnectLnPayload {
+    /// URL to a gateway lightning extension service
+    pub url: Url,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -113,6 +120,7 @@ pub struct GatewayInfo {
 #[derive(Debug)]
 pub enum GatewayRequest {
     Info(GatewayRequestInner<InfoPayload>),
+    ConnectLightning(GatewayRequestInner<ConnectLnPayload>),
     ConnectFederation(GatewayRequestInner<ConnectFedPayload>),
     ReceivePayment(GatewayRequestInner<ReceivePaymentPayload>),
     PayInvoice(GatewayRequestInner<PayInvoicePayload>),
@@ -149,6 +157,7 @@ macro_rules! impl_gateway_request_trait {
 }
 
 impl_gateway_request_trait!(InfoPayload, GatewayInfo, GatewayRequest::Info);
+impl_gateway_request_trait!(ConnectLnPayload, (), GatewayRequest::ConnectLightning);
 impl_gateway_request_trait!(ConnectFedPayload, (), GatewayRequest::ConnectFederation);
 impl_gateway_request_trait!(
     ReceivePaymentPayload,

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -70,7 +70,7 @@ impl RpcClient {
         password: String,
         payload: ConnectFedPayload,
     ) -> Result<Response, Error> {
-        let url = self.base_url.join("/connect").expect("invalid base url");
+        let url = self.base_url.join("/connectfed").expect("invalid base url");
         self.call(url, password, payload).await
     }
 

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -5,7 +5,8 @@ use serde::Serialize;
 use url::Url;
 
 use super::{
-    BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload, WithdrawPayload,
+    BalancePayload, ConnectFedPayload, ConnectLnPayload, DepositAddressPayload, DepositPayload,
+    WithdrawPayload,
 };
 
 pub struct RpcClient {
@@ -70,6 +71,15 @@ impl RpcClient {
         payload: ConnectFedPayload,
     ) -> Result<Response, Error> {
         let url = self.base_url.join("/connect").expect("invalid base url");
+        self.call(url, password, payload).await
+    }
+
+    pub async fn connect_lightning(
+        &self,
+        password: String,
+        payload: ConnectLnPayload,
+    ) -> Result<Response, Error> {
+        let url = self.base_url.join("/connectln").expect("invalid base url");
         self.call(url, password, payload).await
     }
 

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -28,7 +28,7 @@ pub async fn run_webserver(
         .route("/address", post(address))
         .route("/deposit", post(deposit))
         .route("/withdraw", post(withdraw))
-        .route("/connect", post(connect))
+        .route("/connectfed", post(connectfed))
         .route("/connectln", post(connectln))
         .layer(RequireAuthorizationLayer::bearer(&authkey));
 
@@ -112,7 +112,7 @@ async fn pay_invoice(
 
 /// Connect a new federation
 #[instrument(skip_all, err)]
-async fn connect(
+async fn connectfed(
     Extension(rpc): Extension<GatewayRpcSender>,
     Json(payload): Json<ConnectFedPayload>,
 ) -> Result<impl IntoResponse, LnGatewayError> {


### PR DESCRIPTION
Add API and tooling for linking a live [`gateway-<lnrpc>-extension`](https://github.com/fedimint/fedimint/pull/1295) instance to a [gatewayd](https://github.com/fedimint/fedimint/pull/1337) service.

- gateway-cli tool for linking `gateway-<lnrpc>-extension` to `gatewayd`
```sh
$ gateway-cli connect-ln <URL>
```
- gateway admin ui to provides the same functionality
