### PR TITLE
fix: remove dead RNG generator code

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -34,7 +34,6 @@ use crate::fedimint_api::net::peers::IPeerConnections;
 use crate::net::connect::{Connector, TlsTcpConnector};
 use crate::net::peers::PeerSlice;
 use crate::net::peers::{PeerConnector, ReconnectPeerConnections};
-use crate::rng::RngGenerator;
 
 /// The actual implementation of the federated mint
 pub mod consensus;
@@ -50,9 +49,6 @@ pub mod config;
 
 /// Implementation of multiplexed peer connections
 pub mod multiplexed;
-
-/// Some abstractions to handle randomness
-mod rng;
 
 type PeerMessage = (PeerId, EpochMessage);
 
@@ -449,15 +445,6 @@ impl FedimintServer {
             )
             .await
             .expect("Failed to send rejoin requests");
-    }
-}
-
-pub struct OsRngGen;
-impl RngGenerator for OsRngGen {
-    type Rng = OsRng;
-
-    fn get_rng(&self) -> Self::Rng {
-        OsRng
     }
 }
 

--- a/fedimint-server/src/rng.rs
+++ b/fedimint-server/src/rng.rs
@@ -1,9 +1,0 @@
-use rand::{CryptoRng, RngCore};
-
-/// Cheaply generates a new random number generator. Since these need to be generated often to avoid
-/// locking them when used by different threads the construction should be rather cheap.
-pub trait RngGenerator: Sync + Send {
-    type Rng: RngCore + CryptoRng;
-
-    fn get_rng(&self) -> Self::Rng;
-}


### PR DESCRIPTION
RNG generators were introduced to allow usage of RNGs in rayon parallel iterators when processing transactions. Since then tx processing has been de-parallelized, making RNG gens obsolete.

Fixes #79 (thx @dpc for the archeological work recovering this issue)