### PR TITLE
Receive HTLC to default fed

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -96,8 +96,6 @@ async fn main() {
                     announce_address,
                     // TODO: Generate a strong random password
                     password: source_password(cli.rpcpassword),
-                    // TODO: Remove this field with hardcoded value once we have fixed Issue 664:
-                    default_federation: FederationId::dummy(),
                 },
             )
             .expect("Failed to write gateway configs to file");

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -1,6 +1,5 @@
 use std::net::SocketAddr;
 
-use fedimint_api::config::FederationId;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -12,7 +11,4 @@ pub struct GatewayConfig {
     pub announce_address: Url,
     /// webserver authentication password
     pub password: String,
-    // FIXME: Issue 664: We should avoid having a special reference to a federation
-    // all requests, including `ReceivePaymentPayload`, should contain the federation id
-    pub default_federation: FederationId,
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -220,9 +220,11 @@ impl LnGateway {
 
         // FIXME: Issue 664: We should avoid having a special reference to a federation
         // all requests, including `ReceivePaymentPayload`, should contain the federation id
-        // TODO: Parse federation id from routing hint in htlc_accepted message
-        self.select_actor(self.config.default_federation.clone())
-            .await?
+        //
+        // We use a random federation as the default (works because we only have one federation registered)
+        //
+        // TODO: Use subscribe intercept htlc streams to avoid actor selection with every intercepted htlc!
+        self.actors.lock().await.values().collect::<Vec<_>>()[0]
             .buy_preimage_internal(&payment_hash, &invoice_amount)
             .await
     }

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -37,7 +37,6 @@ async fn test_gateway_authentication() -> Result<()> {
 
     let cfg = GatewayConfig {
         password: gw_password.clone(),
-        default_federation: federation_id.clone(),
         bind_address: gw_bind_address,
         announce_address: gw_announce_address.clone(),
     };

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -497,7 +497,6 @@ impl GatewayTest {
             bind_address: bind_addr,
             announce_address: announce_addr,
             password: "abc".into(),
-            default_federation: gw_client_cfg.client_config.federation_id.clone(),
         };
 
         let gateway = LnGateway::new(

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -93,8 +93,8 @@ function kill_fedimint_processes {
 }
 
 function start_gateway() {
-  $FM_GATEWAY_CLI generate-config '127.0.0.1:8175' 'http://127.0.0.1:8175' $FM_CFG_DIR # generate gateway config
-  $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR &
+  $FM_GATEWAY_CLI generate-config '127.0.0.1:8175' 'http://127.0.0.1:8175' $FM_CFG_DIR/gateway # generate gateway config
+  $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR/gateway &
   sleep 5 # wait for plugin to start
   gw_connect_fed
 }


### PR DESCRIPTION
Since we don't fully support multiple federations, we need to *guess* the intended destination actor for every incoming payment received via intercepted htlc. This pr removes any reference of `default_federation` in gateway configs, and instead, picks a listed actor in the gateway, then attempts to settle payment into the federation represented by this actor.

#1337 proposes a long term fix for this issue, by actively streaming intercepted htlcs into a subscribing actor, therefore avoiding the need to select actors for every intercepted htlc

See #664 for details on supporting multiple federations