### PR TITLE
Make fixture initializer wait for gateway being registered

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -168,7 +168,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
 
     let decoders = module_decode_stubs();
 
-    match env::var("FM_TEST_DISABLE_MOCKS") {
+    let fixtures = match env::var("FM_TEST_DISABLE_MOCKS") {
         Ok(s) if s == "1" => {
             info!("Testing with REAL Bitcoin and Lightning services");
             let mut config_task_group = task_group.make_subgroup().await;
@@ -248,14 +248,14 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
             )
             .await;
 
-            Ok(Fixtures {
+            Fixtures {
                 fed,
                 user,
                 bitcoin: Box::new(bitcoin),
                 gateway,
                 lightning: Box::new(lightning),
                 task_group,
-            })
+            }
         }
         _ => {
             info!("Testing with FAKE Bitcoin and Lightning services");
@@ -327,16 +327,24 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
             )
             .await;
 
-            Ok(Fixtures {
+            Fixtures {
                 fed,
                 user,
                 bitcoin: Box::new(bitcoin),
                 gateway,
                 lightning: Box::new(lightning),
                 task_group,
-            })
+            }
         }
+    };
+
+    // Wait till the gateway has registered itself
+    while fixtures.user.client.fetch_active_gateway().await.is_err() {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        info!("Waiting for gateway to register");
     }
+
+    Ok(fixtures)
 }
 
 pub fn peers(peers: &[u16]) -> Vec<PeerId> {

--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -26,6 +26,8 @@ do
 done
 time2=$(date +%s.%N)
 
+await_gateway_registered
+
 ## outgoing lightning
 for i in $( seq 1 $ITERATIONS )
 do

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -156,3 +156,9 @@ function show_verbose_output()
         cat
     fi
 }
+
+function await_gateway_registered() {
+    until [ "$($FM_MINT_CLIENT list-gateways | jq -e ".num_gateways")" -gt "0" ]; do
+        sleep $POLL_INTERVAL
+    done
+}


### PR DESCRIPTION
This is my best guess at why `lightning_gateway_claims_refund_for_internal_invoice` fails sometimes. https://github.com/fedimint/fedimint/issues/222#issuecomment-1385766750