### PR TITLE
Adds encoded ignore and hashes to remove some duplication

### DIFF
--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -311,12 +311,6 @@ impl ServerModuleConfig {
 pub trait TypedServerModuleConsensusConfig: DeserializeOwned + Serialize + Encodable {
     /// Derive client side config for this module (type-erased)
     fn to_client_config(&self) -> ClientModuleConfig;
-
-    fn hash(&self) -> anyhow::Result<sha256::Hash> {
-        let mut engine = HashEngine::default();
-        self.consensus_encode(&mut engine)?;
-        Ok(sha256::Hash::from_engine(engine))
-    }
 }
 
 /// Module (server side) config

--- a/fedimint-api/src/encoding/mod.rs
+++ b/fedimint-api/src/encoding/mod.rs
@@ -12,6 +12,9 @@ use std::io::{self, Error, Read, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::format_err;
+use bitcoin_hashes::sha256;
+use bitcoin_hashes::sha256::HashEngine;
+use bitcoin_hashes::Hash;
 pub use fedimint_derive::{Decodable, Encodable, UnzipConsensus};
 use thiserror::Error;
 use url::Url;
@@ -66,6 +69,15 @@ pub trait Encodable {
         let mut bytes = vec![];
         self.consensus_encode(&mut bytes)?;
         Ok(bytes)
+    }
+
+    /// Generate a SHA256 hash of the consensus encoding
+    ///
+    /// Can be used to validate all federation members agree on state without revealing the object
+    fn consensus_hash(&self) -> anyhow::Result<sha256::Hash> {
+        let mut engine = HashEngine::default();
+        self.consensus_encode(&mut engine)?;
+        Ok(sha256::Hash::from_engine(engine))
     }
 }
 

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -2,12 +2,11 @@ use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashSet};
 
 use bitcoin_hashes::sha256::Hash as Sha256;
-use bitcoin_hashes::sha256::HashEngine;
 use fedimint_api::core::DynModuleConsensusItem as ModuleConsensusItem;
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable, UnzipConsensus};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::module::SerdeModuleEncoding;
-use fedimint_api::{BitcoinHash, PeerId, TransactionId};
+use fedimint_api::{PeerId, TransactionId};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::{PublicKey, PublicKeySet, Signature, SignatureShare};
@@ -55,14 +54,6 @@ pub struct EpochOutcome {
     pub rejected_txs: BTreeSet<TransactionId>,
 }
 
-impl EpochOutcome {
-    pub fn hash(&self) -> Sha256 {
-        let mut engine = HashEngine::default();
-        self.consensus_encode(&mut engine).unwrap();
-        Sha256::from_engine(engine)
-    }
-}
-
 impl SignedEpochOutcome {
     pub fn new(
         epoch: u64,
@@ -82,7 +73,7 @@ impl SignedEpochOutcome {
         };
 
         SignedEpochOutcome {
-            hash: outcome.hash(),
+            hash: outcome.consensus_hash().expect("Hashes"),
             outcome,
             signature: None,
         }
@@ -147,14 +138,15 @@ impl SignedEpochOutcome {
         if self.outcome.epoch > 0 {
             match prev_epoch {
                 None => return Err(EpochVerifyError::MissingPreviousEpoch),
-                Some(prev_epoch) if Some(prev_epoch.outcome.hash()) != self.outcome.last_hash => {
-                    return Err(EpochVerifyError::InvalidPreviousEpochHash)
+                Some(prev_epoch) => {
+                    if prev_epoch.outcome.consensus_hash().ok() != self.outcome.last_hash {
+                        return Err(EpochVerifyError::InvalidPreviousEpochHash);
+                    }
                 }
-                _ => {}
             }
         }
 
-        if self.hash == self.outcome.hash() {
+        if Some(self.hash) == self.outcome.consensus_hash().ok() {
             Ok(())
         } else {
             Err(EpochVerifyError::InvalidEpochHash)
@@ -213,6 +205,7 @@ mod tests {
     use std::collections::{BTreeSet, HashSet};
 
     use bitcoin::hashes::Hash;
+    use fedimint_api::encoding::Encodable;
     use fedimint_api::PeerId;
     use rand::rngs::OsRng;
     use threshold_crypto::{SecretKey, SecretKeySet};
@@ -226,7 +219,7 @@ mod tests {
         sk: &SecretKey,
     ) -> SignedEpochOutcome {
         let missing_sig = history(epoch, prev_epoch, None);
-        let signature = sk.sign(missing_sig.outcome.hash());
+        let signature = sk.sign(missing_sig.outcome.consensus_hash().expect("Hashes"));
         history(epoch, prev_epoch, Some(EpochOutcomeSignature(signature)))
     }
 
@@ -245,7 +238,7 @@ mod tests {
         };
 
         SignedEpochOutcome {
-            hash: outcome.hash(),
+            hash: outcome.consensus_hash().expect("Hashes"),
             outcome,
             signature,
         }

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -83,7 +83,7 @@ pub struct ServerConfigPrivate {
     pub modules: BTreeMap<ModuleInstanceId, JsonWithKind>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encodable)]
 pub struct ServerConfigConsensus {
     /// The version of the binary code running
     pub code_version: String,
@@ -101,6 +101,7 @@ pub struct ServerConfigConsensus {
     /// Network addresses and names for all peer APIs
     pub api: BTreeMap<PeerId, ApiEndpoint>,
     /// All configuration that needs to be the same for modules
+    #[encodable_ignore]
     pub modules: BTreeMap<ModuleInstanceId, JsonWithKind>,
 }
 
@@ -175,12 +176,7 @@ impl ServerConfigConsensus {
             .collect::<anyhow::Result<_>>()?;
 
         let mut engine = HashEngine::default();
-        self.code_version.consensus_encode(&mut engine)?;
-        self.federation_name.consensus_encode(&mut engine)?;
-        self.auth_pk_set.consensus_encode(&mut engine)?;
-        self.auth_pk_set.consensus_encode(&mut engine)?;
-        self.epoch_pk_set.consensus_encode(&mut engine)?;
-        self.api.consensus_encode(&mut engine)?;
+        self.consensus_encode(&mut engine)?;
         for (k, v) in modules.iter() {
             k.consensus_encode(&mut engine)?;
             v.consensus_hash.consensus_encode(&mut engine)?;

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -32,6 +32,7 @@ use crate::consensus::{
     ConsensusProposal, FedimintConsensus, HbbftConsensusOutcome, HbbftSerdeConsensusOutcome,
 };
 use crate::db::LastEpochKey;
+use crate::fedimint_api::encoding::Encodable;
 use crate::fedimint_api::net::peers::IPeerConnections;
 use crate::net::connect::{Connector, TlsTcpConnector};
 use crate::net::peers::PeerSlice;
@@ -257,7 +258,7 @@ impl FedimintServer {
                         last_outcome.epoch,
                         self.last_processed_epoch
                             .as_ref()
-                            .map(|epoch| epoch.outcome.hash()),
+                            .and_then(|epoch| epoch.outcome.consensus_hash().ok()),
                         None,
                         true,
                     )

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -126,7 +126,7 @@ impl ModuleGen for DummyConfigGenerator {
 
         Ok(ModuleConfigResponse {
             client: config.to_client_config(),
-            consensus_hash: config.hash()?,
+            consensus_hash: config.consensus_hash()?,
         })
     }
 

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -324,7 +324,7 @@ impl ModuleGen for LightningGen {
 
         Ok(ModuleConfigResponse {
             client: config.to_client_config(),
-            consensus_hash: config.hash()?,
+            consensus_hash: config.consensus_hash()?,
         })
     }
 

--- a/modules/fedimint-mint/src/common.rs
+++ b/modules/fedimint-mint/src/common.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::io;
 
-use bitcoin_hashes::{sha256, Hash};
+use bitcoin_hashes::sha256;
 use fedimint_api::core::Decoder;
 use fedimint_api::encoding::DecodeError;
 use fedimint_api::encoding::{Decodable, Encodable};
@@ -21,12 +21,8 @@ pub struct BackupRequest {
 
 impl BackupRequest {
     fn hash(&self) -> sha256::Hash {
-        let mut sha = sha256::HashEngine::default();
-
-        self.consensus_encode(&mut sha)
-            .expect("Encoding to hash engine can't fail");
-
-        sha256::Hash::from_engine(sha)
+        self.consensus_hash()
+            .expect("Encoding to hash engine can't fail")
     }
 
     pub fn sign(self, keypair: &KeyPair) -> anyhow::Result<SignedBackupRequest> {

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -282,7 +282,7 @@ impl ModuleGen for MintGen {
 
         Ok(ModuleConfigResponse {
             client: config.to_client_config(),
-            consensus_hash: config.hash()?,
+            consensus_hash: config.consensus_hash()?,
         })
     }
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -347,7 +347,7 @@ impl ModuleGen for WalletGen {
 
         Ok(ModuleConfigResponse {
             client: config.to_client_config(),
-            consensus_hash: config.hash()?,
+            consensus_hash: config.consensus_hash()?,
         })
     }
 


### PR DESCRIPTION
Clean-up that adds an `encodable_ignore` and `consensus_hash` to `Encodable`.

This simplifies some of our code and allows `ServerConsensusConfig` to automatically pick up new fields in `Encodable`