### PR TITLE
Renames in mint module

### DIFF
--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -22,7 +22,7 @@ use fedimint_api::{
 };
 use fedimint_core::{
     epoch::{ConsensusItem, SignedEpochOutcome},
-    modules::mint::{MintInput, MintOutput, MintOutputConfirmation},
+    modules::mint::{MintConsensusItem, MintInput, MintOutput},
 };
 use fedimint_mint::{BackupRequest, SignedBackupRequest};
 use tbs::{combine_valid_shares, verify_blind_share, BlindedMessage, PublicKeyShare};
@@ -680,7 +680,7 @@ impl EcashRecoveryTracker {
         }
     }
 
-    pub fn handle_output_confirmation(&mut self, peer_id: PeerId, sigs: &MintOutputConfirmation) {
+    pub fn handle_output_confirmation(&mut self, peer_id: PeerId, sigs: &MintConsensusItem) {
         let enough_shares = if let Some((output_data, peer_shares)) =
             self.pending_outputs.get_mut(&sigs.out_point)
         {
@@ -833,7 +833,7 @@ impl EcashRecoveryTracker {
                 if module_item.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_MINT {
                     let mint_item = module_item
                         .as_any()
-                        .downcast_ref::<MintOutputConfirmation>()
+                        .downcast_ref::<MintConsensusItem>()
                         .expect("mint key just checked");
 
                     self.handle_output_confirmation(peer_id, mint_item);

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -8,7 +8,7 @@ use fedimint_api::{
 use fedimint_core::{
     epoch::ConsensusItem,
     modules::mint::{
-        BlindNonce, MintConsensusItem, MintInput, MintOutput, OutputConfirmationSignatures,
+        BlindNonce, MintConsensusItem, MintInput, MintOutput, MintOutputSignatureShare,
     },
     transaction::Transaction,
 };
@@ -177,7 +177,7 @@ impl MicroMintFed {
                     *peer_id,
                     MintConsensusItem {
                         out_point,
-                        signatures: OutputConfirmationSignatures(TieredMulti::from_iter(
+                        signatures: MintOutputSignatureShare(TieredMulti::from_iter(
                             output.0.iter_items().map(|(amount, blind_nonce)| {
                                 let blind_message = blind_nonce.0;
 

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -8,7 +8,7 @@ use fedimint_api::{
 use fedimint_core::{
     epoch::ConsensusItem,
     modules::mint::{
-        BlindNonce, MintInput, MintOutput, MintOutputConfirmation, OutputConfirmationSignatures,
+        BlindNonce, MintConsensusItem, MintInput, MintOutput, OutputConfirmationSignatures,
     },
     transaction::Transaction,
 };
@@ -169,13 +169,13 @@ impl MicroMintFed {
         &self,
         out_point: OutPoint,
         output: &MintOutput,
-    ) -> Vec<(PeerId, MintOutputConfirmation)> {
+    ) -> Vec<(PeerId, MintConsensusItem)> {
         self.sec_key_shares
             .iter()
             .map(|(peer_id, sec_keys)| {
                 (
                     *peer_id,
-                    MintOutputConfirmation {
+                    MintConsensusItem {
                         out_point,
                         signatures: OutputConfirmationSignatures(TieredMulti::from_iter(
                             output.0.iter_items().map(|(amount, blind_nonce)| {
@@ -210,7 +210,7 @@ impl MicroMintFed {
     fn combine_output_confirmations(
         &self,
         note_iss_requests: &[(Amount, BlindNonce, NoteIssuanceRequest)],
-        confirmations: &[(PeerId, MintOutputConfirmation)],
+        confirmations: &[(PeerId, MintConsensusItem)],
     ) -> Vec<(Amount, SpendableNote)> {
         let mut confs_by_order: Vec<HashMap<PeerId, BlindedSignatureShare>> = vec![];
 

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -14,7 +14,8 @@ use fedimint_api::tiered::InvalidAmountTierError;
 use fedimint_api::{Amount, OutPoint, ServerModule, Tiered, TieredMulti, TransactionId};
 use fedimint_core::modules::mint::config::MintClientConfig;
 use fedimint_core::modules::mint::{
-    BlindNonce, Mint, MintInput, MintOutput, MintOutputOutcome, Nonce, Note, OutputOutcome,
+    BlindNonce, Mint, MintInput, MintOutput, MintOutputBlindSignatures, MintOutputOutcome, Nonce,
+    Note,
 };
 use fedimint_core::transaction::legacy::{Input, Output, Transaction};
 use secp256k1_zkp::{KeyPair, Secp256k1, Signing};
@@ -517,12 +518,12 @@ impl Extend<(Amount, NoteIssuanceRequest)> for NoteIssuanceRequests {
 }
 
 impl NoteIssuanceRequests {
-    /// Finalize the issuance request using a [`OutputOutcome`] from the mint containing the blind
+    /// Finalize the issuance request using a [`MintOutputBlindSignatures`] from the mint containing the blind
     /// signatures for all coins in this `IssuanceRequest`. It also takes the mint's
     /// [`AggregatePublicKey`] to validate the supplied blind signatures.
     pub fn finalize(
         &self,
-        bsigs: OutputOutcome,
+        bsigs: MintOutputBlindSignatures,
         mint_pub_key: &Tiered<AggregatePublicKey>,
     ) -> std::result::Result<TieredMulti<SpendableNote>, CoinFinalizationError> {
         if !self.coins.structural_eq(&bsigs.0) {

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -234,7 +234,7 @@ impl<'a> DatabaseDump<'a> {
                         self,
                         MintRange::OutputOutcomeKeyPrefix,
                         MintRange::OutputOutcomeKey,
-                        fedimint_mint::OutputOutcome,
+                        fedimint_mint::MintOutputBlindSignatures,
                         mint,
                         "Output Outcomes"
                     );

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -244,7 +244,7 @@ impl<'a> DatabaseDump<'a> {
                         self,
                         MintRange::ProposedPartialSignaturesKeyPrefix,
                         MintRange::ProposedPartialSignatureKey,
-                        fedimint_mint::OutputConfirmationSignatures,
+                        fedimint_mint::MintOutputSignatureShare,
                         mint,
                         "Proposed Signature Shares"
                     );
@@ -254,7 +254,7 @@ impl<'a> DatabaseDump<'a> {
                         self,
                         MintRange::ReceivedPartialSignaturesKeyPrefix,
                         MintRange::ReceivedPartialSignatureKey,
-                        fedimint_mint::OutputConfirmationSignatures,
+                        fedimint_mint::MintOutputSignatureShare,
                         mint,
                         "Received Signature Shares"
                     );

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -14,7 +14,7 @@ use fedimint_api::task::TaskGroup;
 use fedimint_api::{msats, sats, TieredMulti};
 use fedimint_ln::contracts::{Preimage, PreimageDecryptionShare};
 use fedimint_ln::LightningConsensusItem;
-use fedimint_mint::{MintConsensusItem, OutputConfirmationSignatures};
+use fedimint_mint::{MintConsensusItem, MintOutputSignatureShare};
 use fedimint_server::consensus::TransactionSubmissionError::TransactionError;
 use fedimint_server::epoch::ConsensusItem;
 use fedimint_server::transaction::legacy::Output;
@@ -398,7 +398,7 @@ async fn drop_peers_who_contribute_bad_sigs() -> Result<()> {
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
                 MintConsensusItem {
                     out_point,
-                    signatures: OutputConfirmationSignatures(TieredMulti::default()),
+                    signatures: MintOutputSignatureShare(TieredMulti::default()),
                 },
             ),
         )];

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -14,7 +14,7 @@ use fedimint_api::task::TaskGroup;
 use fedimint_api::{msats, sats, TieredMulti};
 use fedimint_ln::contracts::{Preimage, PreimageDecryptionShare};
 use fedimint_ln::LightningConsensusItem;
-use fedimint_mint::{MintOutputConfirmation, OutputConfirmationSignatures};
+use fedimint_mint::{MintConsensusItem, OutputConfirmationSignatures};
 use fedimint_server::consensus::TransactionSubmissionError::TransactionError;
 use fedimint_server::epoch::ConsensusItem;
 use fedimint_server::transaction::legacy::Output;
@@ -396,7 +396,7 @@ async fn drop_peers_who_contribute_bad_sigs() -> Result<()> {
         let bad_proposal = vec![ConsensusItem::Module(
             fedimint_api::core::DynModuleConsensusItem::from_typed(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
-                MintOutputConfirmation {
+                MintConsensusItem {
                     out_point,
                     signatures: OutputConfirmationSignatures(TieredMulti::default()),
                 },

--- a/modules/fedimint-mint/src/common.rs
+++ b/modules/fedimint-mint/src/common.rs
@@ -9,7 +9,7 @@ use fedimint_api::module::registry::ModuleDecoderRegistry;
 use secp256k1_zkp::{KeyPair, Message, Secp256k1, Signing, Verification};
 use serde::{Deserialize, Serialize};
 
-use crate::{MintInput, MintOutput, MintOutputConfirmation, MintOutputOutcome};
+use crate::{MintConsensusItem, MintInput, MintOutput, MintOutputOutcome};
 
 #[derive(Debug, Serialize, Deserialize, Encodable, Decodable)]
 pub struct BackupRequest {
@@ -68,7 +68,7 @@ impl Decoder for MintDecoder {
     type Input = MintInput;
     type Output = MintOutput;
     type OutputOutcome = MintOutputOutcome;
-    type ConsensusItem = MintOutputConfirmation;
+    type ConsensusItem = MintConsensusItem;
 
     fn decode_input(&self, mut d: &mut dyn io::Read) -> Result<MintInput, DecodeError> {
         MintInput::consensus_decode(&mut d, &ModuleDecoderRegistry::default())
@@ -88,7 +88,7 @@ impl Decoder for MintDecoder {
     fn decode_consensus_item(
         &self,
         mut r: &mut dyn io::Read,
-    ) -> Result<MintOutputConfirmation, DecodeError> {
-        MintOutputConfirmation::consensus_decode(&mut r, &ModuleDecoderRegistry::default())
+    ) -> Result<MintConsensusItem, DecodeError> {
+        MintConsensusItem::consensus_decode(&mut r, &ModuleDecoderRegistry::default())
     }
 }

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -6,7 +6,7 @@ use fedimint_api::{Amount, OutPoint, PeerId};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
-use crate::{MintOutputBlindSignatures, Nonce, OutputConfirmationSignatures};
+use crate::{MintOutputBlindSignatures, MintOutputSignatureShare, Nonce};
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -51,7 +51,7 @@ pub struct ProposedPartialSignatureKey {
 impl DatabaseKeyPrefixConst for ProposedPartialSignatureKey {
     const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
     type Key = Self;
-    type Value = OutputConfirmationSignatures;
+    type Value = MintOutputSignatureShare;
 }
 
 #[derive(Debug, Encodable, Decodable)]
@@ -60,7 +60,7 @@ pub struct ProposedPartialSignaturesKeyPrefix;
 impl DatabaseKeyPrefixConst for ProposedPartialSignaturesKeyPrefix {
     const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
     type Key = ProposedPartialSignatureKey;
-    type Value = OutputConfirmationSignatures;
+    type Value = MintOutputSignatureShare;
 }
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -72,7 +72,7 @@ pub struct ReceivedPartialSignatureKey {
 impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKey {
     const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = Self;
-    type Value = OutputConfirmationSignatures;
+    type Value = MintOutputSignatureShare;
 }
 
 #[derive(Debug, Encodable, Decodable)]
@@ -83,7 +83,7 @@ pub struct ReceivedPartialSignatureKeyOutputPrefix {
 impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKeyOutputPrefix {
     const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = ReceivedPartialSignatureKey;
-    type Value = OutputConfirmationSignatures;
+    type Value = MintOutputSignatureShare;
 }
 
 #[derive(Debug, Encodable, Decodable)]
@@ -92,7 +92,7 @@ pub struct ReceivedPartialSignaturesKeyPrefix;
 impl DatabaseKeyPrefixConst for ReceivedPartialSignaturesKeyPrefix {
     const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
     type Key = ReceivedPartialSignatureKey;
-    type Value = OutputConfirmationSignatures;
+    type Value = MintOutputSignatureShare;
 }
 
 /// Transaction id and output index identifying an output outcome

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -6,7 +6,7 @@ use fedimint_api::{Amount, OutPoint, PeerId};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
-use crate::{Nonce, OutputConfirmationSignatures, OutputOutcome};
+use crate::{MintOutputBlindSignatures, Nonce, OutputConfirmationSignatures};
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -102,7 +102,7 @@ pub struct OutputOutcomeKey(pub OutPoint);
 impl DatabaseKeyPrefixConst for OutputOutcomeKey {
     const DB_PREFIX: u8 = DbKeyPrefix::OutputOutcome as u8;
     type Key = Self;
-    type Value = OutputOutcome;
+    type Value = MintOutputBlindSignatures;
 }
 
 #[derive(Debug, Encodable, Decodable)]
@@ -111,7 +111,7 @@ pub struct OutputOutcomeKeyPrefix;
 impl DatabaseKeyPrefixConst for OutputOutcomeKeyPrefix {
     const DB_PREFIX: u8 = DbKeyPrefix::OutputOutcome as u8;
     type Key = OutputOutcomeKey;
-    type Value = OutputOutcome;
+    type Value = MintOutputBlindSignatures;
 }
 
 /// Represents the amounts of issued (signed) and redeemed (verified) coins for auditing


### PR DESCRIPTION
part of #1342

The first commit does renames agreed upon in #1342 .

The second commit renames `OutputConfirmationSignatures` to `MintOutputSignatureShare`. according to the comment above the struct, it will contain (at some point) only the `tbs::BlindedSignatureShare` and the `tbs::BlindedMessage` will be remembered by the mint. If you don't agree I remove the second commit.

```rust
// FIXME: optimize out blinded msg by making the mint remember it
/// Blind signature share from one Federation peer for a single [`MintOutput`]
#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
pub struct MintOutputSignatureShare(
    pub TieredMulti<(tbs::BlindedMessage, tbs::BlindedSignatureShare)>,
);
```

thoughts @dpc @elsirion 

--- 

I rebased this branch on #1389, otherwise some tests failed with `No gateway` or something similar. 