### PR TITLE
Add our own hex::serde implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,6 @@ dependencies = [
  "getrandom",
  "gloo-timers",
  "hbbft",
- "hex",
  "lightning-invoice",
  "miniscript",
  "rand",
@@ -987,7 +986,6 @@ dependencies = [
  "fedimint-rocksdb",
  "fedimint-server",
  "fedimint-wallet",
- "hex",
  "mint-client",
  "secp256k1",
  "serde",
@@ -1090,7 +1088,6 @@ dependencies = [
  "counter",
  "fedimint-api",
  "futures",
- "hex",
  "impl-tools",
  "itertools",
  "rand",
@@ -1774,9 +1771,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "hex_fmt"

--- a/fedimint-api/Cargo.toml
+++ b/fedimint-api/Cargo.toml
@@ -18,7 +18,6 @@ bincode = "1.3.1"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde" ] }
 bitcoin_hashes = { version = "0.11", features = ["serde"] }
 futures = "0.3.24"
-hex = { version = "0.4.3", features = [ "serde" ] }
 lightning-invoice = "0.21.0"
 fedimint-derive = { path = "../fedimint-derive" }
 hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }

--- a/fedimint-api/src/hex/mod.rs
+++ b/fedimint-api/src/hex/mod.rs
@@ -1,0 +1,1 @@
+pub mod serde;

--- a/fedimint-api/src/hex/serde.rs
+++ b/fedimint-api/src/hex/serde.rs
@@ -1,0 +1,53 @@
+use std::borrow::Cow;
+
+use bitcoin_hashes::hex::{FromHex, ToHex};
+use serde::de::Error;
+use serde::{Deserialize, Serializer};
+
+/// Serialize a `&[u8]` to a hex String
+pub fn serialize<S>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let hex: String = data.to_hex();
+    serializer.serialize_str(&hex)
+}
+
+/// Deserialize a hex String to a `Vec<u8>`
+pub fn deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+    let hex_bytes: Cow<'de, str> = Deserialize::deserialize(d)?;
+    Vec::from_hex(hex_bytes.as_ref()).map_err(|_| D::Error::custom("invalid hex"))
+}
+
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Data {
+        #[serde(with = "fedimint_api::hex::serde")]
+        inner: Vec<u8>,
+    }
+
+    #[test]
+    fn hex_serialize() {
+        let data = Data {
+            inner: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        };
+        let json = serde_json::to_string(&data).unwrap();
+
+        assert_eq!(json, r#"{"inner":"000102030405060708090a0b0c0d0e0f10"}"#);
+    }
+
+    #[test]
+    fn hex_deserialize() {
+        let json = r#"{"inner":"000102030405060708090a0b0c0d0e0f10"}"#;
+        let data: Data = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            data,
+            Data {
+                inner: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+            }
+        );
+    }
+}

--- a/fedimint-api/src/lib.rs
+++ b/fedimint-api/src/lib.rs
@@ -26,6 +26,7 @@ pub mod core;
 pub mod db;
 pub mod encoding;
 pub mod fmt_utils;
+pub mod hex;
 pub mod macros;
 pub mod module;
 pub mod net;

--- a/fedimint-dbdump/Cargo.toml
+++ b/fedimint-dbdump/Cargo.toml
@@ -15,7 +15,6 @@ fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 fedimint-mint = { path = "../modules/fedimint-mint" }
 fedimint-ln = { path = "../modules/fedimint-ln" }
 fedimint-wallet = { path = "../modules/fedimint-wallet" }
-hex = { version = "0.4.3", features = [ "serde"] }
 mint-client = { path = "../client/client-lib" }
 erased-serde = "0.3"
 docopt = "1.1.1"

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -40,7 +40,7 @@ macro_rules! push_db_pair_items {
 }
 
 #[derive(Debug, serde::Serialize)]
-struct SerdeWrapper(#[serde(with = "hex::serde")] Vec<u8>);
+struct SerdeWrapper(#[serde(with = "fedimint_api::hex::serde")] Vec<u8>);
 
 impl SerdeWrapper {
     fn from_encodable<T: Encodable>(e: T) -> SerdeWrapper {

--- a/modules/fedimint-mint/Cargo.toml
+++ b/modules/fedimint-mint/Cargo.toml
@@ -18,7 +18,6 @@ bincode = "1.3.1"
 bitcoin_hashes = "0.11.0"
 counter = "0.5.7"
 futures = "0.3"
-hex = "0.4.2"
 itertools = "0.10.5"
 fedimint-api = { path = "../../fedimint-api" }
 rand = "0.8"

--- a/modules/fedimint-mint/src/common.rs
+++ b/modules/fedimint-mint/src/common.rs
@@ -14,7 +14,7 @@ use crate::{MintConsensusItem, MintInput, MintOutput, MintOutputOutcome};
 #[derive(Debug, Serialize, Deserialize, Encodable, Decodable)]
 pub struct BackupRequest {
     pub id: secp256k1::XOnlyPublicKey,
-    #[serde(with = "hex::serde")]
+    #[serde(with = "fedimint_api::hex::serde")]
     pub payload: Vec<u8>,
     pub timestamp: std::time::SystemTime,
 }

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -155,7 +155,7 @@ impl DatabaseKeyPrefixConst for EcashBackupKeyPrefix {
 #[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct ECashUserBackupSnapshot {
     pub timestamp: SystemTime,
-    #[serde(with = "hex::serde")]
+    #[serde(with = "fedimint_api::hex::serde")]
     pub data: Vec<u8>,
 }
 


### PR DESCRIPTION
part of #1307 

the serialize and deserialize functions are specific to `Vec<u8>` but I think that works so far. 

thoughts? is it ok like this or should be more generic? 
@dpc @elsirion 