### PR TITLE
fix: config listen address on gateway-cln-extention

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -33,7 +33,7 @@ windows:
           - fg
         - ln2:
           - sleep 5 # wait for bitcoind and federation
-          - export GW_CLN_EXTENSION_BIND_ADDRESS=127.0.0.1:10001
+          # - export GW_CLN_EXTENSION_LISTEN_ADDRESS=127.0.0.1:10001
           - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN2_DIR --addr=127.0.0.1:9001 --plugin=$FM_BIN_DIR/gateway-cln-extension &
           - echo $! >> $FM_PID_FILE
           - fg


### PR DESCRIPTION
Misconfigured the listen address on new `gateway-cln-extension` introduced by #1295. The node already has an `addr` config, so we need a new name for the bind address config we define on the extension
```
lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN2_DIR --addr=127.0.0.1:9001 --plugin=$FM_BIN_DIR/gateway-cln-extension
2023-01-19T16:43:13.617Z INFO    lightningd: Creating configuration directory /tmp/nix-shell.WruqEt/fm-SxxT/ln2/regtest
error starting plugin '<path>/fedimint/target/debug/gateway-cln-extension': option name '--addr' is already taken
thread 'main' panicked at 'Failed to create cln rpc service: Error(Failed to start cln plugin)', gateway/ln-gateway/src/bin/cln_extension.rs:43:10

```
This PR renames the configuration option, and [improves error messaging to user when we fall back to `listen`](https://github.com/fedimint/fedimint/pull/1295#discussion_r1080652038) configured via cln plugin options