### PR TITLE
Don't hang the UI during dkg

### DIFF
--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -114,7 +114,7 @@ async fn main() -> anyhow::Result<()> {
         let local_cfg_path = opts.data_dir.join(LOCAL_CONFIG).with_extension(JSON_EXT);
         if !std::path::Path::new(&local_cfg_path).exists() {
             loop {
-                if let UiMessage::DKGSuccess = ui_receiver
+                if let UiMessage::DkgSuccess = ui_receiver
                     .recv()
                     .await
                     .expect("failed to receive setup message")

--- a/fedimintd/templates/run.html
+++ b/fedimintd/templates/run.html
@@ -2,14 +2,19 @@
 
 {% block title %} Fedimint {% endblock %}
 {% block head %}
-{% if !has_connection_string %}
- <meta http-equiv="refresh" content="5" />
-{% endif %}
+  {% match state %}
+    {% when RunTemplateState::DkgInProgress %}
+      <meta http-equiv="refresh" content="5" />
+    {% when RunTemplateState::DkgNotStarted %}
+      <meta http-equiv="refresh" content="1; url = /" />
+    {% when _ %}
+  {% endmatch %}
 {% endblock %}
 
 {% block content %}
 <div class="container text-center mt-5 p-3">
-{% if has_connection_string %}
+{% match state %}
+  {% when RunTemplateState::DkgDone with (connection_string) %}
     <img src="/qr" alt="federation qr code" width="200" height="200" />
     <div class="input-group mb-3 mt-3">
         <input id="connection-string" type="text" class="form-control" value="{{ connection_string }}"
@@ -18,9 +23,16 @@
             <button class="btn btn-outline-primary" type="button" id="copy-button">Copy</button>
         </div>
     </div>
-{% else %}
-    <div>Starting ...</div>
-{% endif %}
+  {% when RunTemplateState::DkgInProgress%}
+    <div>Distributed key generation in progress...</div>
+  {% when RunTemplateState::DkgFailed with (e) %}
+    <div>Distributed key generation failed with: {{ e }}</div>
+    <a class="btn btn-primary" href="/" role="button">Try again</a>
+  {% when RunTemplateState::LocalIoError with (e) %}
+    <div>Local IO Error: {{ e }}</div>
+  {% when RunTemplateState::DkgNotStarted %}
+    <div>Not Running (redirecting)</div>
+{% endmatch %}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Follow up to #1421

I tested the success case and getting back to `/` after restart, but I'm unable to trigger error handling I've added. Seems like nothing from what is being entered to the UI is actually compared, trying to make the settings wrong results in dkg not being able to connect or panics, and never actually a failure, so :shrug: for now.

At least you'll get

![image](https://user-images.githubusercontent.com/9209/213644841-667a3ddb-5aa1-49ca-a7d6-65830fc7fea2.png)

when dkg is running, which switches automatically to connection string when dkg completes, which is better then previous behavior where call would hang until dkg is complete.