### PR TITLE
Rename `ModuleInitRegistry` to `ModuleGenRegistry` for consistency

### DIFF
--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -8,7 +8,7 @@ use fedimint_api::module::DynModuleGen;
 use fedimint_ln::{db as LightningRange, LightningGen};
 use fedimint_mint::{db as MintRange, MintGen};
 use fedimint_rocksdb::RocksDbReadOnly;
-use fedimint_server::config::ModuleInitRegistry;
+use fedimint_server::config::ModuleGenRegistry;
 use fedimint_server::db as ConsensusRange;
 use fedimint_wallet::{db as WalletRange, WalletGen};
 use mint_client::db as ClientRange;
@@ -674,7 +674,7 @@ async fn main() {
         }
     };
 
-    let _module_inits = ModuleInitRegistry::from(vec![
+    let _module_inits = ModuleGenRegistry::from(vec![
         DynModuleGen::from(WalletGen),
         DynModuleGen::from(MintGen),
         DynModuleGen::from(LightningGen),

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -159,7 +159,7 @@ impl ServerConfigConsensus {
     /// TODO use the derive macro to automatically pick up new fields here
     fn try_to_config_response(
         &self,
-        module_config_gens: &ModuleInitRegistry,
+        module_config_gens: &ModuleGenRegistry,
     ) -> anyhow::Result<ConfigResponse> {
         let modules: BTreeMap<ModuleInstanceId, ModuleConfigResponse> = self
             .modules
@@ -198,16 +198,16 @@ impl ServerConfigConsensus {
         })
     }
 
-    pub fn to_config_response(&self, module_config_gens: &ModuleInitRegistry) -> ConfigResponse {
+    pub fn to_config_response(&self, module_config_gens: &ModuleGenRegistry) -> ConfigResponse {
         self.try_to_config_response(module_config_gens)
             .expect("configuration mismatch")
     }
 }
 
 #[derive(Clone)]
-pub struct ModuleInitRegistry(BTreeMap<ModuleKind, DynModuleGen>);
+pub struct ModuleGenRegistry(BTreeMap<ModuleKind, DynModuleGen>);
 
-impl From<Vec<DynModuleGen>> for ModuleInitRegistry {
+impl From<Vec<DynModuleGen>> for ModuleGenRegistry {
     fn from(value: Vec<DynModuleGen>) -> Self {
         Self(BTreeMap::from_iter(
             value.into_iter().map(|i| (i.module_kind(), i)),
@@ -215,7 +215,7 @@ impl From<Vec<DynModuleGen>> for ModuleInitRegistry {
     }
 }
 
-impl ModuleInitRegistry {
+impl ModuleGenRegistry {
     pub fn get(&self, k: &ModuleKind) -> Option<&DynModuleGen> {
         self.0.get(k)
     }
@@ -269,7 +269,7 @@ impl ModuleInitRegistry {
     ) -> anyhow::Result<ModuleRegistry<fedimint_api::server::DynServerModule>> {
         let mut modules = BTreeMap::new();
 
-        let env = ModuleInitRegistry::get_env_vars_map();
+        let env = ModuleGenRegistry::get_env_vars_map();
 
         for (module_id, module_cfg) in &cfg.consensus.modules {
             let kind = module_cfg.kind();
@@ -450,7 +450,7 @@ impl ServerConfig {
     pub fn validate_config(
         &self,
         identity: &PeerId,
-        module_config_gens: &ModuleInitRegistry,
+        module_config_gens: &ModuleGenRegistry,
     ) -> anyhow::Result<()> {
         let peers = self.local.p2p.clone();
         let consensus = self.consensus.clone();
@@ -492,7 +492,7 @@ impl ServerConfig {
         code_version: &str,
         peers: &[PeerId],
         params: &HashMap<PeerId, ServerConfigParams>,
-        module_config_gens: ModuleInitRegistry,
+        module_config_gens: ModuleGenRegistry,
         mut rng: impl RngCore + CryptoRng,
     ) -> BTreeMap<PeerId, Self> {
         let netinfo = NetworkInfo::generate_map(peers.to_vec(), &mut rng)
@@ -552,7 +552,7 @@ impl ServerConfig {
         our_id: &PeerId,
         peers: &[PeerId],
         params: &ServerConfigParams,
-        module_config_gens: ModuleInitRegistry,
+        module_config_gens: ModuleGenRegistry,
         mut rng: impl RngCore + CryptoRng,
         task_group: &mut TaskGroup,
     ) -> anyhow::Result<Cancellable<Self>> {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use tokio::sync::Notify;
 use tracing::{debug, error, info_span, instrument, trace, warn, Instrument};
 
-use crate::config::{ModuleInitRegistry, ServerConfig};
+use crate::config::{ModuleGenRegistry, ServerConfig};
 use crate::consensus::interconnect::FedimintInterconnect;
 use crate::db::{
     AcceptedTransactionKey, DropPeerKey, DropPeerKeyPrefix, EpochHistoryKey, LastEpochKey,
@@ -69,7 +69,7 @@ pub struct FedimintConsensus {
     /// Configuration describing the federation and containing our secrets
     pub cfg: ServerConfig,
 
-    pub module_inits: ModuleInitRegistry,
+    pub module_inits: ModuleGenRegistry,
 
     pub modules: ServerModuleRegistry,
     /// KV Database into which all state is persisted to recover from in case of a crash
@@ -100,7 +100,7 @@ impl FedimintConsensus {
     pub async fn new(
         cfg: ServerConfig,
         db: Database,
-        module_inits: ModuleInitRegistry,
+        module_inits: ModuleGenRegistry,
         task_group: &mut TaskGroup,
     ) -> anyhow::Result<Self> {
         Ok(Self {
@@ -116,7 +116,7 @@ impl FedimintConsensus {
     pub fn new_with_modules(
         cfg: ServerConfig,
         db: Database,
-        module_inits: ModuleInitRegistry,
+        module_inits: ModuleGenRegistry,
         modules: ModuleRegistry<DynServerModule>,
     ) -> Self {
         Self {

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -9,7 +9,7 @@ use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
 use fedimint_ln::LightningGen;
 use fedimint_mint::MintGen;
-use fedimint_server::config::ModuleInitRegistry;
+use fedimint_server::config::ModuleGenRegistry;
 use fedimint_wallet::WalletGen;
 use fedimintd::distributedgen::{create_cert, run_dkg};
 use fedimintd::encrypt::*;
@@ -131,7 +131,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let module_config_gens = ModuleInitRegistry::from(vec![
+    let module_config_gens = ModuleGenRegistry::from(vec![
         DynModuleGen::from(WalletGen),
         DynModuleGen::from(MintGen),
         DynModuleGen::from(LightningGen),

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -7,7 +7,7 @@ use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_ln::LightningGen;
 use fedimint_mint::MintGen;
-use fedimint_server::config::ModuleInitRegistry;
+use fedimint_server::config::ModuleGenRegistry;
 use fedimint_server::consensus::FedimintConsensus;
 use fedimint_server::FedimintServer;
 use fedimint_wallet::WalletGen;
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
     let mut task_group = TaskGroup::new();
     let (ui_sender, mut ui_receiver) = tokio::sync::mpsc::channel(1);
 
-    let module_inits = ModuleInitRegistry::from(vec![
+    let module_inits = ModuleGenRegistry::from(vec![
         DynModuleGen::from(WalletGen),
         DynModuleGen::from(MintGen),
         DynModuleGen::from(LightningGen),

--- a/fedimintd/src/distributedgen.rs
+++ b/fedimintd/src/distributedgen.rs
@@ -84,7 +84,7 @@ pub async fn run_dkg(
 
     let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
 
-    let module_config_gens = ModuleInitRegistry::from(vec![
+    let module_config_gens = ModuleGenRegistry::from(vec![
         DynModuleGen::from(WalletGen),
         DynModuleGen::from(MintGen),
         DynModuleGen::from(LightningGen),

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::format_err;
-use fedimint_server::config::{ModuleInitRegistry, ServerConfig};
+use fedimint_server::config::{ModuleGenRegistry, ServerConfig};
 use ring::aead::LessSafeKey;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -72,7 +72,7 @@ pub fn encrypted_json_read<T: Serialize + DeserializeOwned>(
 pub fn write_nonprivate_configs(
     server: &ServerConfig,
     path: PathBuf,
-    module_config_gens: &ModuleInitRegistry,
+    module_config_gens: &ModuleGenRegistry,
 ) -> anyhow::Result<()> {
     plaintext_json_write(&server.local, path.join(LOCAL_CONFIG))?;
     plaintext_json_write(&server.consensus, path.join(CONSENSUS_CONFIG))?;

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -17,7 +17,7 @@ use fedimint_api::config::ClientConfig;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
 use fedimint_core::util::SanitizedUrl;
-use fedimint_server::config::ModuleInitRegistry;
+use fedimint_server::config::ModuleGenRegistry;
 use http::StatusCode;
 use mint_client::api::WsFederationConnect;
 use qrcode_generator::QrCodeEcc;
@@ -347,7 +347,7 @@ struct State {
     password: String,
     task_group: TaskGroup,
     dkg_task_group: Option<TaskGroup>,
-    module_gens: ModuleInitRegistry,
+    module_gens: ModuleGenRegistry,
 }
 type MutableState = Arc<Mutex<State>>;
 
@@ -363,7 +363,7 @@ pub async fn run_ui(
     bind_addr: SocketAddr,
     password: String,
     task_group: TaskGroup,
-    module_gens: ModuleInitRegistry,
+    module_gens: ModuleGenRegistry,
 ) {
     let state = Arc::new(Mutex::new(State {
         params: None,

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -41,7 +41,7 @@ use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_ln::{LightningGateway, LightningGen};
 use fedimint_mint::{MintGen, MintOutput};
 use fedimint_server::config::{connect, ServerConfig};
-use fedimint_server::config::{ModuleInitRegistry, ServerConfigParams};
+use fedimint_server::config::{ModuleGenRegistry, ServerConfigParams};
 use fedimint_server::consensus::{ConsensusProposal, HbbftConsensusOutcome};
 use fedimint_server::consensus::{FedimintConsensus, TransactionSubmissionError};
 use fedimint_server::multiplexed::PeerConnectionMultiplexer;
@@ -173,7 +173,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
     let params = ServerConfigParams::gen_local(&peers, sats(100000), base_port, "test");
     let max_evil = hbbft::util::max_faulty(peers.len());
 
-    let module_inits = ModuleInitRegistry::from(vec![
+    let module_inits = ModuleGenRegistry::from(vec![
         DynModuleGen::from(WalletGen),
         DynModuleGen::from(MintGen),
         DynModuleGen::from(LightningGen),
@@ -394,7 +394,7 @@ async fn distributed_config(
     code_version: &str,
     peers: &[PeerId],
     params: HashMap<PeerId, ServerConfigParams>,
-    module_config_gens: ModuleInitRegistry,
+    module_config_gens: ModuleGenRegistry,
     _max_evil: usize,
     task_group: &mut TaskGroup,
 ) -> Cancellable<(BTreeMap<PeerId, ServerConfig>, ClientConfig)> {
@@ -1054,7 +1054,7 @@ impl FederationTest {
         database_gen: &impl Fn(ModuleDecoderRegistry) -> Database,
         bitcoin_gen: &impl Fn() -> DynBitcoindRpc,
         connect_gen: &impl Fn(&ServerConfig) -> PeerConnector<EpochMessage>,
-        module_inits: ModuleInitRegistry,
+        module_inits: ModuleGenRegistry,
         override_modules: impl Fn(
             ServerConfig,
             Database,
@@ -1072,7 +1072,7 @@ impl FederationTest {
             let mut override_modules = override_modules(cfg.clone(), db.clone()).await;
 
             let mut modules = BTreeMap::new();
-            let env_vars = ModuleInitRegistry::get_env_vars_map();
+            let env_vars = ModuleGenRegistry::get_env_vars_map();
 
             for (kind, gen) in module_inits.legacy_init_order_iter() {
                 let id = cfg.get_module_id_by_kind(kind.clone()).unwrap();


### PR DESCRIPTION
@dpc 

Rename `ModuleInitRegistry` to `ModuleGenRegistry` for consistency with the other `ModuleGen*` types.