### PR TITLE
First step at adding a client module hash verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bitcoin_hashes",
  "fedimint-api",
  "futures",
  "impl-tools",

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -431,6 +431,7 @@ mod tests {
                 LEGACY_HARDCODED_INSTANCE_ID_LN,
                 LightningDecoder.into(),
             )]),
+            module_gens: Default::default(),
             db: Database::new(MemDatabase::new(), module_decode_stubs()),
             api: api.into(),
             secp: secp256k1_zkp::Secp256k1::new(),

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -732,6 +732,7 @@ mod tests {
 
         let client_context = ClientContext {
             decoders: ModuleDecoderRegistry::from_iter([(module_id, MintDecoder.into())]),
+            module_gens: Default::default(),
             db: Database::new(MemDatabase::new(), module_decode_stubs()),
             api: api.into(),
             secp: secp256k1_zkp::Secp256k1::new(),
@@ -887,6 +888,7 @@ mod tests {
             },
             context: Arc::new(ClientContext {
                 decoders: ModuleDecoderRegistry::from_iter([(module_id, MintDecoder.into())]),
+                module_gens: Default::default(),
                 db: Database::new(db, module_decode_stubs()),
                 api: WsFederationApi::new(vec![]).into(),
                 secp: Default::default(),

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use bitcoin::{secp256k1, Network};
 use bitcoin_hashes::hex::FromHex;
+use fedimint_api::config::ModuleGenRegistry;
 use fedimint_api::db::Database;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -62,6 +63,7 @@ pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Er
 #[derive(Debug)]
 pub struct ClientContext {
     pub decoders: ModuleDecoderRegistry,
+    pub module_gens: ModuleGenRegistry,
     pub db: Database,
     pub api: DynFederationApi,
     pub secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -297,6 +297,7 @@ mod tests {
 
         let client = ClientContext {
             decoders: ModuleDecoderRegistry::from_iter([(module_id, WalletDecoder.into())]),
+            module_gens: Default::default(),
             db: Database::new(MemDatabase::new(), module_decode_stubs()),
             api: api.into(),
             secp: secp256k1_zkp::Secp256k1::new(),

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -9,6 +9,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bitcoin_hashes::sha256;
+use bitcoin_hashes::sha256::Hash;
 use futures::future::BoxFuture;
 use secp256k1_zkp::XOnlyPublicKey;
 use serde::{Deserialize, Serialize};
@@ -296,6 +298,8 @@ pub trait IModuleGen: Debug {
     fn to_config_response(&self, config: serde_json::Value)
         -> anyhow::Result<ModuleConfigResponse>;
 
+    fn hash_client_module(&self, config: serde_json::Value) -> anyhow::Result<sha256::Hash>;
+
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()>;
 }
 
@@ -347,6 +351,8 @@ pub trait ModuleGen: Debug + Sized {
         -> anyhow::Result<ModuleConfigResponse>;
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()>;
+
+    fn hash_client_module(&self, config: serde_json::Value) -> anyhow::Result<sha256::Hash>;
 }
 
 #[async_trait]
@@ -406,6 +412,10 @@ where
         config: serde_json::Value,
     ) -> anyhow::Result<ModuleConfigResponse> {
         <Self as ModuleGen>::to_config_response(self, config)
+    }
+
+    fn hash_client_module(&self, config: serde_json::Value) -> anyhow::Result<Hash> {
+        <Self as ModuleGen>::hash_client_module(self, config)
     }
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {

--- a/fedimint-dbdump/src/main.rs
+++ b/fedimint-dbdump/src/main.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use docopt::Docopt;
 use erased_serde::Serialize;
+use fedimint_api::config::ModuleGenRegistry;
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::encoding::Encodable;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
@@ -9,7 +10,6 @@ use fedimint_api::module::DynModuleGen;
 use fedimint_ln::{db as LightningRange, LightningGen};
 use fedimint_mint::{db as MintRange, MintGen};
 use fedimint_rocksdb::RocksDbReadOnly;
-use fedimint_server::config::ModuleGenRegistry;
 use fedimint_server::db as ConsensusRange;
 use fedimint_wallet::{db as WalletRange, WalletGen};
 use mint_client::db as ClientRange;

--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -4,12 +4,12 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
+use fedimint_api::config::ModuleGenRegistry;
 use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
 use fedimint_ln::LightningGen;
 use fedimint_mint::MintGen;
-use fedimint_server::config::ModuleGenRegistry;
 use fedimint_wallet::WalletGen;
 use fedimintd::distributedgen::{create_cert, run_dkg};
 use fedimintd::encrypt::*;

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -2,12 +2,12 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use clap::Parser;
+use fedimint_api::config::ModuleGenRegistry;
 use fedimint_api::db::Database;
 use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_ln::LightningGen;
 use fedimint_mint::MintGen;
-use fedimint_server::config::ModuleGenRegistry;
 use fedimint_server::consensus::FedimintConsensus;
 use fedimint_server::FedimintServer;
 use fedimint_wallet::WalletGen;

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -2,7 +2,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::format_err;
-use fedimint_server::config::{ModuleGenRegistry, ServerConfig};
+use fedimint_api::config::ModuleGenRegistry;
+use fedimint_server::config::ServerConfig;
 use ring::aead::LessSafeKey;
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -13,11 +13,10 @@ use axum::{
 use axum_macros::debug_handler;
 use bitcoin::Network;
 use fedimint_api::bitcoin_rpc::BitcoindRpcBackend;
-use fedimint_api::config::ClientConfig;
+use fedimint_api::config::{ClientConfig, ModuleGenRegistry};
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
 use fedimint_core::util::SanitizedUrl;
-use fedimint_server::config::ModuleGenRegistry;
 use http::StatusCode;
 use mint_client::api::WsFederationConnect;
 use qrcode_generator::QrCodeEcc;

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -1,4 +1,6 @@
 use cln_plugin::Error;
+use fedimint_api::config::ModuleGenRegistry;
+use fedimint_api::module::DynModuleGen;
 use fedimint_api::{
     core::{
         LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
@@ -7,6 +9,9 @@ use fedimint_api::{
     module::registry::ModuleDecoderRegistry,
     task::TaskGroup,
 };
+use fedimint_server::modules::ln::LightningGen;
+use fedimint_server::modules::mint::MintGen;
+use fedimint_server::modules::wallet::WalletGen;
 use fedimint_server::{
     config::load_from_file,
     modules::{
@@ -52,12 +57,18 @@ async fn main() -> Result<(), Error> {
         (LEGACY_HARDCODED_INSTANCE_ID_MINT, MintDecoder.into()),
         (LEGACY_HARDCODED_INSTANCE_ID_WALLET, WalletDecoder.into()),
     ]);
+    let module_gens = ModuleGenRegistry::from(vec![
+        DynModuleGen::from(WalletGen),
+        DynModuleGen::from(MintGen),
+        DynModuleGen::from(LightningGen),
+    ]);
 
     // Create gateway instance
     let task_group = TaskGroup::new();
     let gateway = LnGateway::new(
         gw_cfg,
         decoders,
+        module_gens,
         ln_rpc,
         client_builder,
         tx,

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use fedimint_api::config::{ConfigResponse, FederationId};
+use fedimint_api::config::{ConfigResponse, FederationId, ModuleGenRegistry};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::{
     db::{mem_impl::MemDatabase, Database},
@@ -78,6 +78,7 @@ pub trait IGatewayClientBuilder: Debug {
         &self,
         config: GatewayClientConfig,
         decoders: ModuleDecoderRegistry,
+        module_gens: ModuleGenRegistry,
     ) -> Result<Client<GatewayClientConfig>>;
 
     /// Create a new gateway federation client config from connect info
@@ -123,6 +124,7 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
         &self,
         config: GatewayClientConfig,
         decoders: ModuleDecoderRegistry,
+        module_gens: ModuleGenRegistry,
     ) -> Result<Client<GatewayClientConfig>> {
         let federation_id = config.client_config.federation_id.clone();
 
@@ -133,7 +135,7 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
         )?;
         let ctx = secp256k1::Secp256k1::new();
 
-        Ok(Client::new(config, decoders, db, ctx).await)
+        Ok(Client::new(config, decoders, module_gens, db, ctx).await)
     }
 
     async fn create_config(

--- a/gateway/tests/tests/fixtures/client.rs
+++ b/gateway/tests/tests/fixtures/client.rs
@@ -1,7 +1,9 @@
+use std::default::Default;
 use std::{collections::BTreeSet, path::PathBuf};
 
 use async_trait::async_trait;
 use bitcoin::{secp256k1, KeyPair};
+use fedimint_api::config::ModuleGenRegistry;
 use fedimint_api::{
     config::{ClientConfig, FederationId},
     core::LEGACY_HARDCODED_INSTANCE_ID_LN,
@@ -38,6 +40,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
         &self,
         config: GatewayClientConfig,
         decoders: ModuleDecoderRegistry,
+        _module_gens: ModuleGenRegistry,
     ) -> Result<Client<GatewayClientConfig>, LnGatewayError> {
         let federation_id = config.client_config.federation_id.clone();
         // Ignore `config`s, hardcode one peer.
@@ -53,7 +56,15 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
             module_decode_stubs(),
         )?;
 
-        Ok(GatewayClient::new_with_api(config, decoders, db, api, Default::default()).await)
+        Ok(GatewayClient::new_with_api(
+            config,
+            decoders,
+            Default::default(),
+            db,
+            api,
+            Default::default(),
+        )
+        .await)
     }
 
     async fn create_config(

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -906,7 +906,7 @@ async fn runs_consensus_if_new_block() -> Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[should_panic]
 async fn audit_negative_balance_sheet_panics() {
-    test(2, |fed, user, _bitcoin, _, _| async move {
+    test(2, |fed, user, _, _, _| async move {
         fed.mint_coins_for_user(&user, sats(2000)).await;
         fed.run_consensus_epochs(1).await;
     })
@@ -1064,6 +1064,14 @@ async fn ecash_can_be_recovered() -> Result<()> {
         assert_eq!(user_send.total_coins().await, sats(1500));
 
         task_group.join_all().await.unwrap();
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn verifies_client_configs() -> Result<()> {
+    test(2, |_, user, _, _, _| async move {
+        user.client.verify_config().await.expect("verifies");
     })
     .await
 }

--- a/modules/fedimint-dummy/Cargo.toml
+++ b/modules/fedimint-dummy/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1"
+bitcoin_hashes = "0.11.0"
 futures = "0.3"
 fedimint-api = { path = "../../fedimint-api" }
 rand = "0.8"

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -3,6 +3,7 @@ use std::ffi::OsString;
 use std::fmt;
 
 use async_trait::async_trait;
+use bitcoin_hashes::sha256;
 use common::DummyDecoder;
 use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::{
@@ -25,7 +26,8 @@ use fedimint_api::{plugin_types_trait_impl, OutPoint, PeerId, ServerModule};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::config::{DummyConfig, DummyConfigConsensus, DummyConfigPrivate};
+use crate::config::{DummyClientConfig, DummyConfig, DummyConfigConsensus, DummyConfigPrivate};
+use crate::serde_json::Value;
 
 pub mod common;
 pub mod config;
@@ -132,6 +134,10 @@ impl ModuleGen for DummyConfigGenerator {
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
         config.to_typed::<DummyConfig>()?.validate_config(identity)
+    }
+
+    fn hash_client_module(&self, config: Value) -> anyhow::Result<sha256::Hash> {
+        serde_json::from_value::<DummyClientConfig>(config)?.consensus_hash()
     }
 }
 

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -49,7 +49,9 @@ use tracing::{debug, error, info_span, instrument, trace, warn};
 use url::Url;
 
 use crate::common::LightningDecoder;
-use crate::config::{LightningConfig, LightningConfigConsensus, LightningConfigPrivate};
+use crate::config::{
+    LightningClientConfig, LightningConfig, LightningConfigConsensus, LightningConfigPrivate,
+};
 use crate::contracts::{
     incoming::{IncomingContractOffer, OfferId},
     Contract, ContractId, ContractOutcome, DecryptedPreimage, EncryptedPreimage, FundedContract,
@@ -332,6 +334,13 @@ impl ModuleGen for LightningGen {
         config
             .to_typed::<LightningConfig>()?
             .validate_config(identity)
+    }
+
+    fn hash_client_module(
+        &self,
+        config: serde_json::Value,
+    ) -> anyhow::Result<bitcoin_hashes::sha256::Hash> {
+        serde_json::from_value::<LightningClientConfig>(config)?.consensus_hash()
     }
 }
 

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -47,7 +47,7 @@ use threshold_crypto::group::Curve;
 use tracing::{debug, error, info, warn};
 
 use crate::common::MintDecoder;
-use crate::config::{MintConfig, MintConfigConsensus, MintConfigPrivate};
+use crate::config::{MintClientConfig, MintConfig, MintConfigConsensus, MintConfigPrivate};
 use crate::db::{
     MintAuditItemKey, MintAuditItemKeyPrefix, NonceKey, OutputOutcomeKey,
     ProposedPartialSignatureKey, ProposedPartialSignaturesKeyPrefix, ReceivedPartialSignatureKey,
@@ -288,6 +288,13 @@ impl ModuleGen for MintGen {
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
         config.to_typed::<MintConfig>()?.validate_config(identity)
+    }
+
+    fn hash_client_module(
+        &self,
+        config: serde_json::Value,
+    ) -> anyhow::Result<bitcoin_hashes::sha256::Hash> {
+        serde_json::from_value::<MintClientConfig>(config)?.consensus_hash()
     }
 }
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -56,7 +56,7 @@ use thiserror::Error;
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::common::WalletDecoder;
-use crate::config::WalletConfig;
+use crate::config::{WalletClientConfig, WalletConfig};
 use crate::db::{
     BlockHashKey, PegOutBitcoinTransaction, PegOutTxSignatureCI, PegOutTxSignatureCIPrefix,
     PendingTransactionKey, PendingTransactionPrefixKey, RoundConsensusKey, UTXOKey, UTXOPrefixKey,
@@ -353,6 +353,10 @@ impl ModuleGen for WalletGen {
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
         config.to_typed::<WalletConfig>()?.validate_config(identity)
+    }
+
+    fn hash_client_module(&self, config: serde_json::Value) -> anyhow::Result<sha256::Hash> {
+        serde_json::from_value::<WalletClientConfig>(config)?.consensus_hash()
     }
 }
 


### PR DESCRIPTION
Adds `ModuleGenRegistry` to the client side so that we can manipulate client config modules such as producing hashes for verification.

Having the federation sign the client config hash will be done as a separate PR.

Related to #1205