### PR TITLE
Allocate 8176 as a default port number for Fedimint Admin UI

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -5,5 +5,6 @@ Default ports:
 * fedimintd p2p: 8173
 * fedimint API: 8174
 * ln-gateway API: 8175
+* fedimint Admin: 8176
 
 To be expanded.

--- a/flake.nix
+++ b/flake.nix
@@ -775,7 +775,7 @@
                   ExposedPorts = {
                     "${builtins.toString 8173}/tcp" = { };
                     "${builtins.toString 8174}/tcp" = { };
-                    "${builtins.toString 8175}/tcp" = { };
+                    "${builtins.toString 8176}/tcp" = { };
                   };
                 };
               };

--- a/misc/fedimintd-container-entrypoint.sh
+++ b/misc/fedimintd-container-entrypoint.sh
@@ -22,7 +22,7 @@ fi
 
 mkdir -p "$FM_DATA_DIR"
 
-export FM_LISTEN_UI=0.0.0.0:8175
+export FM_LISTEN_UI=0.0.0.0:8176
 
 1>&2 echo 'Starting fedimintd'
 fedimintd "$FM_DATA_DIR/"


### PR DESCRIPTION
In the docker file entrypoint I default to 8175, which now conflicts with ln-gateway, making it a bit odd to set them both up on a system (which sometimes might be needed).