### PR TITLE
Add ln-gateway container build

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -169,6 +169,11 @@ jobs:
           nix build -L .#container.fedimint-cli
           echo "mint_client_cli_container_tag=$(docker load < result | awk '{ print $3 }')" >> $GITHUB_ENV
 
+      - name: Build ln-gateway container
+        run: |
+          nix build -L .#container.ln-gateway
+          echo "ln_gateway_container_tag=$(docker load < result | awk '{ print $3 }')" >> $GITHUB_ENV
+
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/kody-setup-rebase'
         uses: docker/login-action@v2

--- a/flake.nix
+++ b/flake.nix
@@ -780,6 +780,28 @@
                 };
               };
 
+              ln-gateway =
+                let
+                  entrypointScript =
+                    pkgs.writeShellScriptBin "entrypoint" ''
+                      exec bash "${./misc/ln-gateway-container-entrypoint.sh}" "$@"
+                    '';
+                in
+                pkgs.dockerTools.buildLayeredImage {
+                  name = "ln-gateway";
+                  contents = [ ln-gateway gateway-cli pkgs.bash pkgs.coreutils ];
+                  config = {
+                    Cmd = [ ]; # entrypoint will handle empty vs non-empty cmd
+                    Entrypoint = [
+                      "${entrypointScript}/bin/entrypoint"
+                    ];
+                    ExposedPorts = {
+                      "${builtins.toString 8175}/tcp" = { };
+                    };
+                  };
+                  enableFakechroot = true;
+                };
+
               ln-gateway-clightning =
                 let
                   # Will be placed in `/config-example.cfg` by `fakeRootCommands` below

--- a/misc/ln-gateway-container-entrypoint.sh
+++ b/misc/ln-gateway-container-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ "$1" == "gateway-cli" ]; then
+ exec "$@"
+fi
+
+exec ln_gateway "$@"


### PR DESCRIPTION
I intend to use it eventually with `podman` to deploy ln-gateway as simple bash wrapper:

```bash
#!/usr/bin/env bash

exec podman run $MOUNT_OPTS_ETC -q -i docker.io/fedimint/ln-gateway "$@"
```

This behaves very much like we were running `ln_gateway` process itself: stdio, stdout, stderr, etc. Though I'm hitting https://github.com/containers/podman/issues/14707 which makes ctrl+c not work.

Re: #1436 