### PR TITLE
Rename `ln_gateway` binary to `ln-gateway` for consistency

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -28,7 +28,7 @@ windows:
         - ln1:
           - sleep 5 # wait for bitcoind and federation
           - gateway-cli generate-config 127.0.0.1:8175 'http://127.0.0.1:8175' $FM_CFG_DIR #generate gateway config
-          - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 --plugin=$FM_BIN_DIR/ln_gateway --fedimint-cfg=$FM_CFG_DIR &
+          - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 --plugin=$FM_BIN_DIR/ln-gateway --fedimint-cfg=$FM_CFG_DIR &
           - echo $! >> $FM_PID_FILE
           - fg
         - ln2:

--- a/flake.nix
+++ b/flake.nix
@@ -817,7 +817,7 @@
                     rpc-file-mode=0660
                     log-timestamps=false
 
-                    plugin=${ln-gateway}/bin/ln_gateway
+                    plugin=${ln-gateway}/bin/ln-gateway
                     fedimint-cfg=/var/fedimint/fedimint-gw
 
                     announce-addr=104.244.73.68:9735
@@ -833,7 +833,7 @@
                   contents = [ ln-gateway clightning-dev pkgs.bash pkgs.coreutils gateway-cli ];
                   config = {
                     Cmd = [
-                      "${ln-gateway}/bin/ln_gateway"
+                      "${ln-gateway}/bin/ln-gateway"
                     ];
                     ExposedPorts = {
                       "${builtins.toString 9735}/tcp" = { };

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -13,7 +13,7 @@ name = "ln_gateway"
 path = "src/lib.rs"
 
 [[bin]]
-name = "ln_gateway"
+name = "ln-gateway"
 path = "src/bin/ln_gateway.rs"
 
 [[bin]]

--- a/scripts/gw-reload.sh
+++ b/scripts/gw-reload.sh
@@ -3,9 +3,9 @@
 
 set -euo pipefail
 
-cargo build --bin ln_gateway
+cargo build --bin ln-gateway
 
-$FM_LN1 plugin stop ln_gateway &> /dev/null || true
-$FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR &> /dev/null
+$FM_LN1 plugin stop ln-gateway &> /dev/null || true
+$FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln-gateway fedimint-cfg=$FM_CFG_DIR &> /dev/null
 
 echo "Gateway plugin reloaded"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -88,13 +88,13 @@ function await_cln_block_processing() {
 function kill_fedimint_processes {
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
-  pkill "ln_gateway" 2>/dev/null || true;
+  pkill "ln-gateway" 2>/dev/null || true;
   rm -f $FM_PID_FILE
 }
 
 function start_gateway() {
   $FM_GATEWAY_CLI generate-config '127.0.0.1:8175' 'http://127.0.0.1:8175' $FM_CFG_DIR/gateway # generate gateway config
-  $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR/gateway &
+  $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln-gateway fedimint-cfg=$FM_CFG_DIR/gateway &
   sleep 5 # wait for plugin to start
   gw_connect_fed
 }
@@ -149,7 +149,7 @@ function get_federation_id() {
 
 function show_verbose_output()
 {
-    if [[ $FM_VERBOSE_OUTPUT -ne 1 ]] 
+    if [[ $FM_VERBOSE_OUTPUT -ne 1 ]]
     then
         cat > /dev/null 2>&1
     else


### PR DESCRIPTION
yeah, I know, ln-gatway will be replaced eventually. But since I already made the changes, I created the pr anyway.

If you don't like it, just close this pr.

This just renames the binary. Makes it consistent to other plugins such as `plugin-chanbackup` or `plugin-bookkeeper` (-> `plugin-ln-gateway` and to our own binaries such as `fedimint-cli`.

saw this in the ln logs with tmuxinator.

```log
2023-01-21T03:25:58.892Z INFO    plugin-chanbackup: Creating Emergency Recovery
2023-01-21T03:25:58.892Z INFO    plugin-bookkeeper: Creating database
2023-01-21T03:25:58.904Z UNUSUAL plugin-ln_gateway: Could not parse config: missing field `client_config` at line 248 column 1
2023-01-21T03:25:59.644Z UNUSUAL lightningd: Bitcoin backend now synced.
2023-01-21T03:26:01.568Z INFO    02ec562a7338228c2dad2fd6839053a525cdd573047410a077f52ff5b4bca8bfdd-chan#1: State changed from CHANNELD_AWAITING_LOCKIN to CHANNELD_NORMAL
2023-01-21T03:26:01.568Z INFO    plugin-chanbackup: Updating the SCB
2023-01-21T03:26:05.075Z INFO    plugin-ln_gateway: connect;
2023-01-21T03:26:05.085Z INFO    plugin-ln_gateway: LnRpc::pubkey;
2023-01-21T03:26:05.086Z INFO    plugin-ln_gateway: request; peer=0
2023-01-21T03:26:05.086Z INFO    plugin-ln_gateway: request; peer=1
2023-01-21T03:26:05.086Z INFO    plugin-ln_gateway: request; peer=2
2023-01-21T03:26:05.086Z INFO    plugin-ln_gateway: request; peer=3
```


