### PR TITLE
Change `btc_client` to `bitcoin-cli` for consistency

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -5,7 +5,7 @@ pre_window:
   - source .tmpenv
   - alias ln1="\$FM_LN1"
   - alias ln2="\$FM_LN2"
-  - alias btc_client="\$FM_BTC_CLIENT"
+  - alias bitcoin-cli="\$FM_BTC_CLIENT"
   - alias fedimint-cli="\$FM_MINT_CLIENT"
   - alias gateway-cli="\$FM_GATEWAY_CLI"
   - alias mint_rpc_client="\$FM_MINT_RPC_CLIENT"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -80,7 +80,7 @@ export FM_DISTRIBUTEDGEN="$FM_BIN_DIR/distributedgen"
 # Alias clients
 alias ln1="\$FM_LN1"
 alias ln2="\$FM_LN2"
-alias btc_client="\$FM_BTC_CLIENT"
+alias bitcoin-cli="\$FM_BTC_CLIENT"
 alias mint_client="\$FM_MINT_CLIENT"
 alias mint_rpc_client="\$FM_MINT_RPC_CLIENT"
 alias gateway-cli="\$FM_GATEWAY_CLI"

--- a/scripts/tmux-user-shell.sh
+++ b/scripts/tmux-user-shell.sh
@@ -11,7 +11,7 @@ await_cln_rpc | show_verbose_output
 await_fedimint_block_sync | show_verbose_output
 
 echo Setting up bitcoind ...
-btc_client createwallet default | show_verbose_output
+bitcoin-cli createwallet default | show_verbose_output
 mine_blocks 101 | show_verbose_output
 
 echo Setting up lightning channel ...
@@ -32,7 +32,7 @@ echo "This shell provides the following aliases:"
 echo ""
 echo "  fedimint-cli   - cli client to interact with the federation"
 echo "  ln1, ln2       - cli clients for the two lightning nodes (1 is gateway)"
-echo "  btc_client     - cli client for bitcoind"
+echo "  bitcoin-cli    - cli client for bitcoind"
 echo "  gateway-cli    - cli client for the gateway"
 echo
 echo "Use '--help' on each command for more information"


### PR DESCRIPTION
I'm aware that this alias "shadows" the real `bitcoin-cli`. But I'd argue it's fine to do that in the tmuxinator? 
alias points to: 
```
bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin
```

If you think that's a problem, then I'd go for the name `btc-cli`. That gets rid of the annyoing to type underscore (:smile:)  and doesn't shadow the real `bitcoin-cli`