### PR TITLE
Add backup&restore to ln-gateway (and gateway-cli)

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -7,8 +7,8 @@ use fedimint_server::modules::wallet::txoproof::TxOutProof;
 use ln_gateway::{
     config::GatewayConfig,
     rpc::{
-        rpc_client::RpcClient, BalancePayload, ConnectFedPayload, DepositAddressPayload,
-        DepositPayload, WithdrawPayload,
+        rpc_client::RpcClient, BackupPayload, BalancePayload, ConnectFedPayload,
+        DepositAddressPayload, DepositPayload, RestorePayload, WithdrawPayload,
     },
 };
 use mint_client::utils::from_hex;
@@ -69,6 +69,10 @@ pub enum Commands {
         /// ConnectInfo code to connect to the federation
         connect: String,
     },
+    /// Make a backup of snapshot of all ecash
+    Backup { federation_id: FederationId },
+    /// Restore ecash from last available snapshot or from scratch
+    Restore { federation_id: FederationId },
 }
 
 #[tokio::main]
@@ -179,6 +183,28 @@ async fn main() {
                 )
                 .await
                 .expect("Failed to connect federation");
+
+            print_response(response).await;
+        }
+        Commands::Backup { federation_id } => {
+            let response = client
+                .backup(
+                    source_password(cli.rpcpassword),
+                    BackupPayload { federation_id },
+                )
+                .await
+                .expect("Failed to withdraw");
+
+            print_response(response).await;
+        }
+        Commands::Restore { federation_id } => {
+            let response = client
+                .restore(
+                    source_password(cli.rpcpassword),
+                    RestorePayload { federation_id },
+                )
+                .await
+                .expect("Failed to withdraw");
 
             print_response(response).await;
         }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -68,6 +68,16 @@ pub struct ReceivePaymentPayload {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InfoPayload;
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupPayload {
+    pub federation_id: FederationId,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RestorePayload {
+    pub federation_id: FederationId,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BalancePayload {
     pub federation_id: FederationId,
@@ -119,6 +129,8 @@ pub enum GatewayRequest {
     DepositAddress(GatewayRequestInner<DepositAddressPayload>),
     Deposit(GatewayRequestInner<DepositPayload>),
     Withdraw(GatewayRequestInner<WithdrawPayload>),
+    Backup(GatewayRequestInner<BackupPayload>),
+    Restore(GatewayRequestInner<RestorePayload>),
 }
 
 #[derive(Debug)]
@@ -163,6 +175,8 @@ impl_gateway_request_trait!(
 );
 impl_gateway_request_trait!(DepositPayload, TransactionId, GatewayRequest::Deposit);
 impl_gateway_request_trait!(WithdrawPayload, TransactionId, GatewayRequest::Withdraw);
+impl_gateway_request_trait!(BackupPayload, (), GatewayRequest::Backup);
+impl_gateway_request_trait!(RestorePayload, (), GatewayRequest::Restore);
 
 impl<T> GatewayRequestInner<T>
 where

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -5,7 +5,8 @@ use serde::Serialize;
 use url::Url;
 
 use super::{
-    BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload, WithdrawPayload,
+    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
+    RestorePayload, WithdrawPayload,
 };
 
 pub struct RpcClient {
@@ -70,6 +71,24 @@ impl RpcClient {
         payload: ConnectFedPayload,
     ) -> Result<Response, Error> {
         let url = self.base_url.join("/connect").expect("invalid base url");
+        self.call(url, password, payload).await
+    }
+
+    pub async fn backup(
+        &self,
+        password: String,
+        payload: BackupPayload,
+    ) -> Result<Response, Error> {
+        let url = self.base_url.join("/backup").expect("invalid base url");
+        self.call(url, password, payload).await
+    }
+
+    pub async fn restore(
+        &self,
+        password: String,
+        payload: RestorePayload,
+    ) -> Result<Response, Error> {
+        let url = self.base_url.join("/restore").expect("invalid base url");
         self.call(url, password, payload).await
     }
 

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -8,8 +8,8 @@ use tower_http::{auth::RequireAuthorizationLayer, cors::CorsLayer};
 use tracing::instrument;
 
 use super::{
-    BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload, GatewayRpcSender,
-    InfoPayload, WithdrawPayload,
+    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
+    GatewayRpcSender, InfoPayload, RestorePayload, WithdrawPayload,
 };
 use crate::LnGatewayError;
 
@@ -29,6 +29,8 @@ pub async fn run_webserver(
         .route("/deposit", post(deposit))
         .route("/withdraw", post(withdraw))
         .route("/connect", post(connect))
+        .route("/backup", post(backup))
+        .route("/restore", post(restore))
         .layer(RequireAuthorizationLayer::bearer(&authkey));
 
     let app = Router::new()
@@ -114,6 +116,26 @@ async fn pay_invoice(
 async fn connect(
     Extension(rpc): Extension<GatewayRpcSender>,
     Json(payload): Json<ConnectFedPayload>,
+) -> Result<impl IntoResponse, LnGatewayError> {
+    rpc.send(payload).await?;
+    Ok(())
+}
+
+/// Backup a gateway actor state
+#[instrument(skip_all, err)]
+async fn backup(
+    Extension(rpc): Extension<GatewayRpcSender>,
+    Json(payload): Json<BackupPayload>,
+) -> Result<impl IntoResponse, LnGatewayError> {
+    rpc.send(payload).await?;
+    Ok(())
+}
+
+// Restore a gateway actor state
+#[instrument(skip_all, err)]
+async fn restore(
+    Extension(rpc): Extension<GatewayRpcSender>,
+    Json(payload): Json<RestorePayload>,
 ) -> Result<impl IntoResponse, LnGatewayError> {
     rpc.send(payload).await?;
     Ok(())


### PR DESCRIPTION
It didn't take me long before I corrupted first mainnet ln-gateway I've set up by doing a `gateway-cli deposit` one block too early. Since our client code does db modifications first, and asks federation to make a tx second, the gateway is now stuck looping and waiting for an outcome of a transaction that didn't ever happen. :S

After I realized what happened I first made a loudest facepalm in the world. Then I started thinking if I could easily recover from this corruption, and it occurred to me that a e-cash restore that is already implemented in the client would probably fix it. So here it is - just enough code to be able to make gateway do `restore` (and `backup`, as I'm already doing it).

Considering the state of the `client` consensus state handling, we probably really, really need this to work.