### PR TITLE
Unify CLN plugin types between old and new plugin

### DIFF
--- a/gateway/ln-gateway/src/cln.rs
+++ b/gateway/ln-gateway/src/cln.rs
@@ -30,10 +30,12 @@ where
 }
 
 // TODO: upstream these structs to cln-plugin
+// See: https://github.com/ElementsProject/lightning/blob/master/doc/PLUGINS.md#htlc_accepted
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Htlc {
+    pub short_channel_id: String,
     #[serde(deserialize_with = "as_fedimint_amount")]
-    pub amount: Amount,
+    pub amount_msat: Amount,
     pub cltv_expiry: u32,
     pub cltv_expiry_relative: u32,
     pub payment_hash: bitcoin_hashes::sha256::Hash,
@@ -42,11 +44,9 @@ pub struct Htlc {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Onion {
     pub payload: String,
-    #[serde(rename = "type")]
-    pub type_: String,
     pub short_channel_id: String,
     #[serde(deserialize_with = "as_fedimint_amount")]
-    pub forward_amount: Amount,
+    pub forward_msat: Amount,
     pub outgoing_cltv_value: u32,
     pub shared_secret: bitcoin_hashes::sha256::Hash,
     pub next_onion: String,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -226,7 +226,7 @@ impl LnGateway {
     async fn handle_receive_payment(&self, payload: ReceivePaymentPayload) -> Result<Preimage> {
         let ReceivePaymentPayload { htlc_accepted } = payload;
 
-        let invoice_amount = htlc_accepted.htlc.amount;
+        let invoice_amount = htlc_accepted.htlc.amount_msat;
         let payment_hash = htlc_accepted.htlc.payment_hash;
         debug!("Incoming htlc for payment hash {}", payment_hash);
 


### PR DESCRIPTION
6723518fa2b018686ddb5570f9e97fd23fedb38a changed the type definition of `Htlc` and `Onion` to be compliant with the current spec, but only for the new CLN plugin. The old one remained out of spec, which this commit fixes.

As a second step we should either upstream these types (together with tests, so that the CLN team notices when they break their API) or put them in a common crate so we don't have to maintain this redundancy.