### PR TITLE
Isolate each Database when initializing the module

### DIFF
--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -274,7 +274,7 @@ mod tests {
                     async move {
                         Ok(Wallet::new_with_bitcoind(
                             cfg.to_typed().unwrap(),
-                            db,
+                            db.new_isolated(module_id),
                             btc_rpc_clone.clone().into(),
                             &mut task_group,
                         )

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -170,10 +170,15 @@ impl Iterator for MemDbIter {
 #[cfg(test)]
 mod tests {
     use super::MemDatabase;
-    use crate::{db::Database, module::registry::ModuleDecoderRegistry};
+    use crate::{core::ModuleInstanceId, db::Database, module::registry::ModuleDecoderRegistry};
 
     fn database() -> Database {
         Database::new(MemDatabase::new(), ModuleDecoderRegistry::default())
+    }
+
+    fn module_database(module_instance_id: ModuleInstanceId) -> Database {
+        let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
+        db.new_isolated(module_instance_id)
     }
 
     #[test_log::test(tokio::test)]
@@ -234,5 +239,10 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn test_module_dbtx() {
         fedimint_api::db::verify_module_prefix(database()).await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_module_db() {
+        fedimint_api::db::verify_module_db(database(), module_database(1)).await;
     }
 }

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -285,4 +285,15 @@ mod fedimint_rocksdb_tests {
         )
         .await;
     }
+
+    #[test_log::test()]
+    #[should_panic(expected = "Cannot isolate and already isolated database.")]
+    fn test_cannot_isolate_already_isolated_db() {
+        let module_instance_id = 1;
+        let db = open_temp_db("rocksdb-test-already-isolated").new_isolated(module_instance_id);
+
+        // try to isolate the database again
+        let module_instance_id = 2;
+        db.new_isolated(module_instance_id);
+    }
 }

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -265,4 +265,24 @@ mod fedimint_rocksdb_tests {
         fedimint_api::db::verify_module_prefix(open_temp_db("fcb-rocksdb-test-module-prefix"))
             .await;
     }
+
+    #[test_log::test(tokio::test)]
+    async fn test_module_db() {
+        let module_instance_id = 1;
+        let path = tempfile::Builder::new()
+            .prefix("fcb-rocksdb-test-module-db-prefix")
+            .tempdir()
+            .unwrap();
+
+        let module_db = Database::new(
+            RocksDb::open(path).unwrap(),
+            ModuleDecoderRegistry::default(),
+        );
+
+        fedimint_api::db::verify_module_db(
+            open_temp_db("fcb-rocksdb-test-module-db"),
+            module_db.new_isolated(module_instance_id),
+        )
+        .await;
+    }
 }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -130,7 +130,7 @@ impl FedimintConsensus {
             let module = init
                 .init(
                     cfg.get_module_config(*module_id)?,
-                    db.clone(),
+                    db.new_isolated(*module_id),
                     &env,
                     task_group,
                 )

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -1112,7 +1112,7 @@ impl FederationTest {
                     let module = gen
                         .init(
                             cfg.get_module_config(id).unwrap(),
-                            db.clone(),
+                            db.new_isolated(id),
                             &env_vars,
                             &mut task_group,
                         )

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -29,7 +29,7 @@ use fedimint_api::config::{
     ConfigGenParams, DkgPeerMsg, ModuleGenParams, ServerModuleConfig, TypedServerModuleConfig,
 };
 use fedimint_api::config::{ModuleConfigResponse, TypedServerModuleConsensusConfig};
-use fedimint_api::core::{ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
+use fedimint_api::core::{ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable, UnzipConsensus};
 use fedimint_api::module::__reexports::serde_json;
@@ -1541,13 +1541,7 @@ pub fn is_address_valid_for_network(address: &Address, network: Network) -> bool
 #[instrument(level = "debug", skip_all)]
 pub async fn run_broadcast_pending_tx(db: Database, rpc: DynBitcoindRpc, tg_handle: &TaskHandle) {
     while !tg_handle.is_shutting_down() {
-        broadcast_pending_tx(
-            db.begin_transaction()
-                .await
-                .with_module_prefix(LEGACY_HARDCODED_INSTANCE_ID_WALLET),
-            &rpc,
-        )
-        .await;
+        broadcast_pending_tx(db.begin_transaction().await, &rpc).await;
         // FIXME: remove after modularization finishes
         #[cfg(not(target_family = "wasm"))]
         fedimint_api::task::sleep(Duration::from_secs(10)).await;


### PR DESCRIPTION
As a follow up to https://github.com/fedimint/fedimint/pull/1331, this PR allows for entire Databases to be isolated instead of just individual DatabaseTransactions. We want the ability to isolate Databases and DatabaseTransactions because there are some db transactions that need to atomically span multiple modules, but we also sometimes give each module a handle to the database, such as during module_initialization (this db handle is only used in the wallet module currently). 

Isolated databases have the same API as normal databases accept that begin_transaction now returns a DatabaseTransaction that is isolated, so all operations will have a prefix prepended to each key to keep the data separate.