### PR TITLE
Makes fetch notes parallel and eliminates unnecessary retry

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -517,20 +517,20 @@ async fn handle_command(
         ),
         Command::Fetch => {
             let mut result = Vec::<OutPoint>::new();
-            let mut has_error = false;
+            let mut last_error = None;
             for fetch_result in client.fetch_all_notes().await {
                 match fetch_result {
                     Ok(v) => result.push(v),
-                    Err(_) => {
-                        has_error = true;
+                    Err(e) => {
+                        last_error = Some(e);
                     }
                 }
             }
-            if has_error {
+            if let Some(error) = last_error {
                 Err(CliError::from(
                     CliErrorKind::GeneralFederationError,
                     "failed to fetch notes",
-                    None,
+                    Some(Box::new(error)),
                 ))
             } else {
                 Ok(CliOutput::Fetch { issuance: (result) })

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -104,7 +104,7 @@ impl fmt::Display for FederationError {
 }
 
 impl FederationError {
-    fn is_retryable(&self) -> bool {
+    pub fn is_retryable(&self) -> bool {
         self.0.iter().any(|(_, e)| e.is_retryable())
     }
 }
@@ -401,12 +401,8 @@ where
 
     /// Fetch the outcome of an entire transaction
     async fn fetch_tx_outcome(&self, tx: &TransactionId) -> FederationResult<TransactionStatus> {
-        self.request_with_strategy(
-            Retry404::new(self.all_members().one_honest()),
-            "/fetch_transaction".to_owned(),
-            erased_single_param(&tx),
-        )
-        .await
+        self.request_current_consensus("/fetch_transaction".to_owned(), erased_single_param(&tx))
+            .await
     }
 
     async fn fetch_epoch_history(


### PR DESCRIPTION
Since we should retry 404s automatically based on our strategy, we can eliminate the infinite loop here.

In the future once polling is replaced by notifications this becomes further irrelevant.

Fixes #1479