### PR TITLE
Enable debug tracing on gateway binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,6 +2299,7 @@ dependencies = [
  "tonic-build",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -44,6 +44,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
 thiserror = "1.0.37"
 tracing = { version = "0.1.37", default-features = false, features= ["log", "attributes", "std"] }
+tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 tokio = { version = "1.24", features = ["full"] }
 tokio-stream = "0.1.11"
 tonic = { version = "0.8", features = ["transport", "tls"] }

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -27,6 +27,7 @@ use tokio::{
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Server, Status};
 use tracing::{debug, error};
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 pub struct ClnExtensionOpts {
@@ -38,6 +39,12 @@ pub struct ClnExtensionOpts {
 // Note: Once this binary is stable, we should be able to remove current 'ln_gateway'
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
     let (service, listen) = ClnRpcService::new()
         .await
         .expect("Failed to create cln rpc service");

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -27,6 +27,7 @@ use ln_gateway::{
 };
 use tokio::sync::mpsc;
 use tracing::error;
+use tracing_subscriber::EnvFilter;
 
 /// Fedimint gateway packaged as a CLN plugin
 #[tokio::main]
@@ -40,6 +41,12 @@ async fn main() -> Result<(), Error> {
             return Ok(());
         }
     }
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
 
     // Create message channels
     let (tx, rx) = mpsc::channel::<GatewayRequest>(100);


### PR DESCRIPTION
add tracing subscriber on `gateway-cl-extension` and `ln_gateway` binaries.

resolution for #1493 for the gateway