### PR TITLE
CLN extension allows node to receive payment

### DIFF
--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -36,6 +36,7 @@ pub struct ClnExtensionOpts {
 }
 
 // Note: Once this binary is stable, we should be able to remove current 'ln_gateway'
+// Use CLN_PLUGIN_LOG=<log-level> to enable debug logging from within cln-plugin
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let (service, listen) = ClnRpcService::new()

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -29,8 +29,8 @@ use tokio::sync::mpsc;
 use tracing::error;
 
 /// Fedimint gateway packaged as a CLN plugin
+// Use CLN_PLUGIN_LOG=<log-level> to enable debug logging from within cln-plugin
 #[tokio::main]
-#[deprecated(note = "Prefer to use `gateway-cln-extension` binary instead")]
 async fn main() -> Result<(), Error> {
     let mut args = std::env::args();
 


### PR DESCRIPTION
Applies fix introduced by #1496 to allow gateway node to receive payment not meant for federations

Bonus commit to make a note on how to enable debug logging