### PR TITLE
Moves tx submission into a channel

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -7,7 +7,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ffi::OsString;
 use std::iter::FromIterator;
 use std::os::unix::prelude::OsStrExt;
-use std::sync::Arc;
 
 use fedimint_api::config::ModuleGenRegistry;
 use fedimint_api::core::ModuleInstanceId;
@@ -25,7 +24,8 @@ use futures::future::select_all;
 use hbbft::honey_badger::Batch;
 use itertools::Itertools;
 use thiserror::Error;
-use tokio::sync::Notify;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
 
 use crate::config::ServerConfig;
@@ -39,6 +39,9 @@ use crate::transaction::{Transaction, TransactionError};
 pub type HbbftSerdeConsensusOutcome = hbbft::honey_badger::Batch<Vec<SerdeConsensusItem>, PeerId>;
 pub type HbbftConsensusOutcome = hbbft::honey_badger::Batch<Vec<ConsensusItem>, PeerId>;
 pub type HbbftMessage = hbbft::honey_badger::Message<PeerId>;
+
+/// How many txs can be stored in memory before blocking the API
+const TRANSACTION_BUFFER_SIZE: usize = 1000;
 
 // TODO remove HBBFT `Batch` from `ConsensusOutcome`
 #[derive(Debug, Clone)]
@@ -78,8 +81,8 @@ pub struct FedimintConsensus {
     /// KV Database into which all state is persisted to recover from in case of a crash
     pub db: Database,
 
-    /// Notifies tasks when there is a new transaction
-    pub transaction_notify: Arc<Notify>,
+    /// For sending new transactions to consensus
+    pub tx_sender: Sender<Transaction>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
@@ -109,12 +112,13 @@ impl FedimintConsensus {
             .collect()
     }
 
+    /// Returns a new consensus with a receiver for handling submitted transactions
     pub async fn new(
         cfg: ServerConfig,
         db: Database,
         module_inits: ModuleGenRegistry,
         task_group: &mut TaskGroup,
-    ) -> anyhow::Result<Self> {
+    ) -> anyhow::Result<(Self, Receiver<Transaction>)> {
         let mut modules = BTreeMap::new();
 
         let env = Self::get_env_vars_map();
@@ -138,13 +142,18 @@ impl FedimintConsensus {
             modules.insert(*module_id, module);
         }
 
-        Ok(Self {
-            modules: ModuleRegistry::from(modules),
-            cfg,
-            module_inits,
-            db,
-            transaction_notify: Arc::new(Notify::new()),
-        })
+        let (tx_sender, tx_receiver) = mpsc::channel(TRANSACTION_BUFFER_SIZE);
+
+        Ok((
+            Self {
+                modules: ModuleRegistry::from(modules),
+                cfg,
+                module_inits,
+                db,
+                tx_sender,
+            },
+            tx_receiver,
+        ))
     }
 
     /// Like [`Self::new`], but when you want to initialize modules separately.
@@ -153,14 +162,19 @@ impl FedimintConsensus {
         db: Database,
         module_inits: ModuleGenRegistry,
         modules: ModuleRegistry<DynServerModule>,
-    ) -> Self {
-        Self {
-            modules,
-            cfg,
-            module_inits,
-            db,
-            transaction_notify: Arc::new(Notify::new()),
-        }
+    ) -> (Self, Receiver<Transaction>) {
+        let (tx_sender, tx_receiver) = mpsc::channel(TRANSACTION_BUFFER_SIZE);
+
+        (
+            Self {
+                modules,
+                cfg,
+                module_inits,
+                db,
+                tx_sender,
+            },
+            tx_receiver,
+        )
     }
 }
 
@@ -239,8 +253,19 @@ impl FedimintConsensus {
 
         funding_verifier.verify_funding()?;
 
+        self.tx_sender
+            .send(transaction)
+            .await
+            .map_err(|_e| TransactionSubmissionError::TxChannelError)?;
+        Ok(())
+    }
+
+    /// For saving a tx, should be done prior to making a consensus proposal
+    pub async fn save_transaction_to_db(&self, transaction: Transaction) {
+        let mut dbtx = self.db.begin_transaction().await;
+
         let new = dbtx
-            .insert_entry(&ProposedTransactionKey(tx_hash), &transaction)
+            .insert_entry(&ProposedTransactionKey(transaction.tx_hash()), &transaction)
             .await
             .expect("DB error");
         dbtx.commit_tx().await.expect("DB Error");
@@ -248,9 +273,6 @@ impl FedimintConsensus {
         if new.is_some() {
             warn!("Added consensus item was already in consensus queue");
         }
-
-        self.transaction_notify.notify_one();
-        Ok(())
     }
 
     /// Calculate the result of the `consensus_outcome` and save it/them.
@@ -750,4 +772,6 @@ pub enum TransactionSubmissionError {
     ModuleError(TransactionId, ModuleError),
     #[error("Transaction conflict error")]
     TransactionConflictError,
+    #[error("Transaction channel was closed")]
+    TxChannelError,
 }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -200,9 +200,10 @@ async fn run(opts: ServerOpts, mut task_group: TaskGroup) -> anyhow::Result<()> 
         decoders.clone(),
     );
 
-    let consensus = FedimintConsensus::new(cfg.clone(), db, module_inits, &mut task_group).await?;
+    let (consensus, tx_receiver) =
+        FedimintConsensus::new(cfg.clone(), db, module_inits, &mut task_group).await?;
 
-    FedimintServer::run(cfg, consensus, decoders, &mut task_group).await?;
+    FedimintServer::run(cfg, consensus, tx_receiver, decoders, &mut task_group).await?;
 
     Ok(())
 }

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use anyhow::Result;
 use assert_matches::assert_matches;
 use bitcoin::{Amount, KeyPair};
-use fedimint_api::cancellable::Cancellable;
 use fedimint_api::core::{
     LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
@@ -285,7 +284,7 @@ async fn ecash_in_wallet_can_sent_through_a_tx() -> Result<()> {
     .await
 }
 
-async fn drop_peer_3_during_epoch(fed: &FederationTest) -> Cancellable<()> {
+async fn drop_peer_3_during_epoch(fed: &FederationTest) -> Result<()> {
     // ensure that peers 1,2,3 create an epoch, so they can see peer 3's bad proposal
     fed.subset_peers(&[1, 2, 3]).run_consensus_epochs(1).await;
     fed.subset_peers(&[0]).run_consensus_epochs(1).await;


### PR DESCRIPTION
First step to solving #1353.

This uses a channel to move txs from the api to the consensus thread which at the very least prevents the issue we had with multiple threads writing to the same DB key.

Next step would be to get the consensus proposals to use a cache rather than the DB for building proposals.