### PR TITLE
ci: update to use dtolnay instead of actions-rs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,9 +20,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           override: true
 
       - name: Installs cargo-udeps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,8 @@ jobs:
           sudo apt-get -y install mold
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           profile: minimal
           override: true
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,15 +48,9 @@ jobs:
         if: github.ref == 'refs/heads/master' || matrix.build-in-pr
 
       - name: Build
-        run: cargo build
         if: github.ref == 'refs/heads/master' || matrix.build-in-pr
-        with:
-          args: ${{ matrix.extra-build-args }}
-          use-cross: ${{ matrix.use-cross }}
+        run: cargo build
 
       - name: Clippy
-        run: cargo clippy
         if: github.ref == 'refs/heads/master' || matrix.build-in-pr
-        with:
-          args: ${{ matrix.extra-build-args }} -- --deny warnings
-          use-cross: ${{ matrix.use-cross }}
+        run: cargo clippy -- --deny warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,10 +37,9 @@ jobs:
         # is not supported and workarounds are very gnarly
         if: github.ref == 'refs/heads/master' || matrix.build-in-pr
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         if: github.ref == 'refs/heads/master' || matrix.build-in-pr
         with:
-          toolchain: stable
           target: ${{ matrix.target }}
           default: true
           profile: minimal
@@ -49,17 +48,15 @@ jobs:
         if: github.ref == 'refs/heads/master' || matrix.build-in-pr
 
       - name: Build
+        run: cargo build
         if: github.ref == 'refs/heads/master' || matrix.build-in-pr
-        uses: actions-rs/cargo@v1
         with:
-          command: build
           args: ${{ matrix.extra-build-args }}
           use-cross: ${{ matrix.use-cross }}
 
       - name: Clippy
+        run: cargo clippy
         if: github.ref == 'refs/heads/master' || matrix.build-in-pr
-        uses: actions-rs/cargo@v1
         with:
-          command: clippy
           args: ${{ matrix.extra-build-args }} -- --deny warnings
           use-cross: ${{ matrix.use-cross }}


### PR DESCRIPTION
## Description

As described in https://github.com/rust-bitcoin/rust-bitcoin/pull/1509 and https://github.com/actions-rs/toolchain/issues/216 the actions-rs is unmaintained.

A different [Github Action](https://github.com/dtolnay/rust-toolchain ) maintained by dtolnay rust developer can be used instead.

This PR updates to use the `stable` and `nightly` toolchain instead of the action-rs one, and also need to run a `cargo build` and `cargo clippy` command as the dtolnay's rust-toolchain action does not have a cargo build/clippy one.

Fixes #1172 