### PR TITLE
Remove confirmed BTC transactions from db

### DIFF
--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -1191,6 +1191,10 @@ impl Wallet {
                 )
                 .await
                 .expect("DB Error");
+
+                dbtx.remove_entry(&PendingTransactionKey(pending_tx.tx.txid()))
+                    .await
+                    .expect("DB error");
             }
         }
     }


### PR DESCRIPTION
Once we have recognized one of our transactions on-chain and have saved change to the DB we can stop trying to submit the transaction to our bitcoin node and forget about it.

Fixes #1534 