### PR TITLE
Make the gateway fast

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -143,6 +143,7 @@ impl From<GatewayClientConfig> for LightningGateway {
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct Client<C> {
     config: C,
     context: Arc<ClientContext>,


### PR DESCRIPTION
#1530 reports a critical limitation in the gateways, where requests like `/pay_invoice` are handled serially, and so the gateway is not ready to serve multiple users at once!

## Experiment.

Make gateway `/info` super slow, and try to issue multiple requests from `gateway-cli info` tool.

- I used a `10s` sleep in gateway handler for info requests
```fedimint_api::task::sleep_until(Instant::now() + Duration::from_millis(10000)).await;```
- Issued 3 requests to source gateway info. Numbers are representative. _Please account for some few seconds of human switching shell tabs to press ENTER on `gw info (gateway-cli info)` command_

## Observations:
- Before gateway request handler changes included in this PR, all the requests would be handled serially!
![image](https://user-images.githubusercontent.com/11217077/215159157-bf8c00b5-4ffc-43d6-ad09-bf44eb5653b3.png)
  - Client requests are queued up, with longer and longer wait times for each subsequent request
  - Would be a terrible experience for clients that are calling into the gateway for services like `/pay_invoice`
  
- After gateway request handler changes proposed  in this PR, the requests are now parallel
![image](https://user-images.githubusercontent.com/11217077/215160229-99c0034e-4c11-44cc-96e0-d2008f84688c.png)
  - Client requests are handled in parallel using threads spawned by the gateway
  - Requests take as long as the logic of processing needs to operate. Simulated by the `10s` sleep
  
## Blocker
- To apply these changes as an improvement to the gateway, we need some client logic changes to allow for thread safety.
- https://github.com/fedimint/fedimint/blob/master/client/client-lib/src/lib.rs#L145-L150
```
#[derive(Copy, Clone)]
pub struct Client<C> {
    config: C,
    context: Arc<ClientContext>,
    #[allow(unused)]
    root_secret: DerivableSecret,
}
++++
```