### PR TITLE
Emphasize how often the function is run

### DIFF
--- a/gateway/ln-gateway/src/utils.rs
+++ b/gateway/ln-gateway/src/utils.rs
@@ -3,34 +3,41 @@ use std::{future::Future, result::Result, time::Duration};
 use tokio::time::sleep;
 use tracing::info;
 
-/// Retry an operation util the operation succeeds, OR
-/// The maximum number of attempts are made without success
-pub async fn retry<F, R, T>(
+/// Run the given closure up to `max_attempts` times while waiting for
+/// the specified `Duration` between attempts
+///
+/// # Returns
+///
+/// - If the closure is run succesfully, the result is immediately
+///   returned.
+/// - The closure is run at most `max_attempts` times after which the
+///   error of the closure is returned.
+pub async fn retry<F, Fut, T>(
     op_name: String,
     op_fn: F,
     wait: Duration,
-    max_retries: u32,
+    max_attempts: u32,
 ) -> Result<T, anyhow::Error>
 where
-    F: Fn() -> R,
-    R: Future<Output = Result<T, anyhow::Error>>,
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, anyhow::Error>>,
 {
-    let mut att = 0;
+    let mut counter = 1;
     loop {
         match op_fn().await {
             Ok(result) => return Ok(result),
-            Err(e) => {
-                att += 1;
-                if att > max_retries {
-                    return Err(e);
+            Err(err) => {
+                if counter == max_attempts {
+                    return Err(err);
                 }
                 info!(
                     "{} failed with error: {}. Retrying in {} seconds",
                     op_name,
-                    e,
+                    err,
                     wait.as_secs()
                 );
                 sleep(wait).await;
+                counter += 1;
             }
         }
     }


### PR DESCRIPTION
So, *technically* the code was actually not wrong, but I think it did not do what it was intended to do. 

It you said that `max_retries` is 3, it ran the closure 4 times. So, while it technically is correct that the function *retried* to run the closure 3 times, I don't think that this is expected behavior. (?)

So, I changed the naming a bit to say `max_attempts`. If you say `max_attempts=3` it will run the closure at most three times.

If you don't agree, feel free to close. But I think this makes it more clear.

edit: the same behavior appears in the [`autocommit` function](https://github.com/fedimint/fedimint/blob/544d7ea12cfe681529d14f40c237f23662fa5c28/fedimint-api/src/db/mod.rs#L147) where it's also explicitly documented. So maybe it's just me or I was tired, but when I saw the parameter `max_retries`, I *expected* it to control the maximum number of times the closure is run.  