### PR TITLE
Update docs to include description of module prefixes

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -9,83 +9,90 @@ Fedimint uses a simple key-value store as its database. In theory any such KV st
 We currently use RocksDB on both the client and the server.
 
 ## Server DB Layout
-The Database is split into different key spaces based on prefixing that can be understood as different tables (each "table's" content can be retrieved using prefix search). There are three general prefix ranges:
+The database is logically partitioned based on the module instance id of the module. Each module's keyspace is split up based on prefixing. Each prefix within a module identifies a logical entity.
+Entity prefixes between modules can overlap because they are logically partitioned by the module instance id. The key value pairs that belong to consensus do not belong to any specific module, so they are
+not prepended with a module prefix. Below is the format for prefixes within a module:
 
-* `0x00-0x0A`: consensus
-* `0x10-0x1A`: mint
-* `0x20-0x2A`: client (different db, but to be sure)
-* `0x30-0x3A`: wallet
-* `0x40-0x4A`: lightning
+<GLOBAL PREFIX BYTE><2 BYTE MODULE ID><ENTITY PREFIX>
+
+Example for the Mint Module: 0xFF 0x00 0x00 0x10
+In the above example, the module instance id = 0 and the entity it identifies is a NoteNonce. 0xFF is the global prefix byte that identifies this as module data.
+
+Example for consensus data: 0x01
+In the above example, because the consensus data does not apply to any specific module, the global prefix byte and module instance id prefixes are missing.
+
+The client is not currently modularized, so nothing is prepended to the below prefixes.
+
 
 ### Consensus
 
-| Name                | Prefix | Key                              | Value                         |
-|---------------------|--------|----------------------------------|-------------------------------|
-| ProposedTransaction | `0x01` | Transaction ID (sha256, 32bytes) | Transaction                   |
-| AcceptedTransaction | `0x02` | Transaction ID (sha256, 32bytes) | AcceptedTransaction           |
-| DropPeer            | `0x03` | Peer ID (u16)                    | None                          |
-| RejectedTransaction | `0x04` | Transaction ID (sha256, 32bytes) | Reason for rejection (string) |
-| EpochHistory        | `0x05` | Epoch ID (u16)                   | Epoch history record          |
-| LastEpoch           | `0x06` | none                             | Epoph ID (u16)                |
+| Name                | Entity Prefix | Key                              | Value                         |
+|---------------------|---------------|----------------------------------|-------------------------------|
+| ProposedTransaction |     `0x01`    | Transaction ID (sha256, 32bytes) | Transaction                   |
+| AcceptedTransaction |     `0x02`    | Transaction ID (sha256, 32bytes) | AcceptedTransaction           |
+| DropPeer            |     `0x03`    | Peer ID (u16)                    | None                          |
+| RejectedTransaction |     `0x04`    | Transaction ID (sha256, 32bytes) | Reason for rejection (string) |
+| EpochHistory        |     `0x05`    | Epoch ID (u16)                   | Epoch history record          |
+| LastEpoch           |     `0x06`    | none                             | Epoph ID (u16)                |
 
 ### Mint
 
-| Name               | Prefix | Key                                                 | Value                 |
-|--------------------|--------|-----------------------------------------------------|-----------------------|
-| NoteNonce          | `0x10` | note nonce (unknown bytes, bincode magic currently) | none                  |
-| ProposedPartialSig | `0x11` | mint outpoint (40 bytes)                            | blind signature share |
-| ReceivedPartialSig | `0x12` | mint outpoint (40 bytes), peer (2 bytes)            | blind signature share |
-| OutputOutcome      | `0x13` | mint outpoint (40 bytes)                            | blind signature       |
-| MintAuditItem      | `0x14` | AuditItem                                           | Amount                |
-| EcashBackup        | `0x15` | backup id (public key)                              | ts + encrypted data   |
+| Name               | Entity Prefix | Key                                                 | Value                 |
+|--------------------|---------------|-----------------------------------------------------|-----------------------|
+| NoteNonce          |     `0x10`    | note nonce (unknown bytes, bincode magic currently) | none                  |
+| ProposedPartialSig |     `0x11`    | mint outpoint (40 bytes)                            | blind signature share |
+| ReceivedPartialSig |     `0x12`    | mint outpoint (40 bytes), peer (2 bytes)            | blind signature share |
+| OutputOutcome      |     `0x13`    | mint outpoint (40 bytes)                            | blind signature       |
+| MintAuditItem      |     `0x14`    | AuditItem                                           | Amount                |
+| EcashBackup        |     `0x15`    | backup id (public key)                              | ts + encrypted data   |
 
 ### Wallet
 
-| Name                  | Prefix | Key                                       | Value                                     |
-|-----------------------|--------|-------------------------------------------|-------------------------------------------|
-| BlockHash             | `0x30` | block hash (32 bytes)                     | none                                      |
-| Utxo                  | `0x31` | OutPoint (32 bytes txid + 4 bytes output) | data necessary for spending               |
-| RoundConsensus        | `0x32` | none                                      | block height, fee rate, randomness beacon |
-| UnsignedTransaction   | `0x34` | bitcoin tx id (32 bytes)                  | PSBT                                      |
-| PendingTransaction    | `0x35` | bitcoin tx id (32 bytes)                  | consensus encoded tx, change tweak        |
-| PegOutTxSigCi         | `0x36` | bitcoin tx id (32 bytes)                  | list of signatures (1 per input)          |
-| PegOutBitcoinOutPoint | `0x37` | Fedimint out point                        | Outpoint                                  |
+| Name                  | Entity Prefix | Key                                       | Value                                     |
+|-----------------------|---------------|-------------------------------------------|-------------------------------------------|
+| BlockHash             |     `0x30`    | block hash (32 bytes)                     | none                                      |
+| Utxo                  |     `0x31`    | OutPoint (32 bytes txid + 4 bytes output) | data necessary for spending               |
+| RoundConsensus        |     `0x32`    | none                                      | block height, fee rate, randomness beacon |
+| UnsignedTransaction   |     `0x34`    | bitcoin tx id (32 bytes)                  | PSBT                                      |
+| PendingTransaction    |     `0x35`    | bitcoin tx id (32 bytes)                  | consensus encoded tx, change tweak        |
+| PegOutTxSigCi         |     `0x36`    | bitcoin tx id (32 bytes)                  | list of signatures (1 per input)          |
+| PegOutBitcoinOutPoint |     `0x37`    | Fedimint out point                        | Outpoint                                  |
 
 ### Lightning
 
-| Name                             | Prefix | Key                                 | Value                        |
-|----------------------------------|--------|-------------------------------------|------------------------------|
-| Contract                         | `0x40` | ContractId                          | `ContractAccount`            |
-| Offer                            | `0x41` | payment hash (sha256)               | `IncomingContractOffer`      |
-| ProposedDecryptionShare          | `0x42` | contract id (sha256)                | `DecryptionShare`            |
-| AgreedDecryptionShare            | `0x43` | contract id (sha256), peer id (u16) | `DecryptionShare`            |
-| ContractUpdate                   | `0x44` | out point (sha256, out idx)         | `fedimint_ln::OutputOutcome` |
-| LightningGateway                 | `0x45` | Node Pubkey (PublicKey)             | `LightningGateway`           |
+| Name                     | Entity Prefix | Key                                 | Value                        |
+|--------------------------|---------------|-------------------------------------|------------------------------|
+| Contract                 |     `0x40`    | ContractId                          | `ContractAccount`            |
+| Offer                    |     `0x41`    | payment hash (sha256)               | `IncomingContractOffer`      |
+| ProposedDecryptionShare  |     `0x42`    | contract id (sha256)                | `DecryptionShare`            |
+| AgreedDecryptionShare    |     `0x43`    | contract id (sha256), peer id (u16) | `DecryptionShare`            |
+| ContractUpdate           |     `0x44`    | out point (sha256, out idx)         | `fedimint_ln::OutputOutcome` |
+| LightningGateway         |     `0x45`    | Node Pubkey (PublicKey)             | `LightningGateway`           |
 
 ## Client DB Layout
-| Name                    | Prefix | Key                                | Value                        |
-|-------------------------|--------|------------------------------------|------------------------------|
-| ClientSecret            | `0x29` | none                               | `ClientSecret`               |
+| Name                    | Entity Prefix | Key                                | Value                        |
+|-------------------------|---------------|------------------------------------|------------------------------|
+| ClientSecret            |     `0x29`    | none                               | `ClientSecret`               |
 
 ### LightningClient
-| Name                    | Prefix | Key                                | Value                        |
-|-------------------------|--------|------------------------------------|------------------------------|
-| OutoingPayment          | `0x23` | contract id (sha256 payment hash)  | `OutgoingContractData`       |
-| OutgoingPaymentClaim    | `0x24` | contract id (sha256)               | `Transaction`                |
-| OutgoingContractAccount | `0x25` | contract id (sha256)               | `OutgoingContractAccount`    |
-| ConfirmedInvoice        | `0x26` | contract id (sha256 payment hash)  | `ConfirmedInvoice`           |
-| LightingGateway         | `0x28` | none                               | `LightningGateway`           |
-| LastECashNoteIndex      | `0x2a` | none                               | `u64`                        |
+| Name                    | Entity Prefix | Key                         | Value                        |
+|-------------------------|---------------|------------------------------------|------------------------------|
+| OutoingPayment          |     `0x23`    | contract id (sha256 payment hash)  | `OutgoingContractData`       |
+| OutgoingPaymentClaim    |     `0x24`    | contract id (sha256)               | `Transaction`                |
+| OutgoingContractAccount |     `0x25`    | contract id (sha256)               | `OutgoingContractAccount`    |
+| ConfirmedInvoice        |     `0x26`    | contract id (sha256 payment hash)  | `ConfirmedInvoice`           |
+| LightingGateway         |     `0x28`    | none                               | `LightningGateway`           |
+| LastECashNoteIndex      |     `0x2a`    | none                               | `u64`                        |
 
 ### MintClient
-| Name                   | Prefix | Key                                | Value                        |
-|------------------------|--------|------------------------------------|------------------------------|
-| Note                   | `0x20` | amount (8 bytes), nonce (32 bytes) | `SpendableNote`              |
-| OutputFinalizationData | `0x21` | issuance_id (32 bytes)             | `NoteIssuanceRequests`       |
-| PendingNotes           | `0x27` | mint tx id (sha256 payment hash)   | `TieredMulti<SpendableNote>` |
-| NotesPerDenomination   | `0x2b` | determines how many notes to issue | `u16`                        |
+| Name                   | Entity Prefix | Key                                | Value                        |
+|------------------------|---------------|------------------------------------|------------------------------|
+| Note                   |     `0x20`    | amount (8 bytes), nonce (32 bytes) | `SpendableNote`              |
+| OutputFinalizationData |     `0x21`    | issuance_id (32 bytes)             | `NoteIssuanceRequests`       |
+| PendingNotes           |     `0x27`    | mint tx id (sha256 payment hash)   | `TieredMulti<SpendableNote>` |
+| NotesPerDenomination   |     `0x2b`    | determines how many notes to issue | `u16`                        |
 
 ### WalletClient
-| Name                    | Prefix | Key        | Value                        |
-|-------------------------|--------|------------|------------------------------|
-| PegIn                   | `0x22` | `Script`   | `[u8; 32]`                   |
+| Name                    | Entity Prefix | Key        | Value                        |
+|-------------------------|---------------|------------|------------------------------|
+| PegIn                   |     `0x22`    | `Script`   | `[u8; 32]`                   |

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -62,9 +62,9 @@ pub trait IServerModule: Debug {
     ) -> Vec<DynModuleConsensusItem>;
 
     /// This function is called once before transaction processing starts. All module consensus
-    /// items of this round are supplied as `consensus_items`. The batch will be committed to the
-    /// database after all other modules ran `begin_consensus_epoch`, so the results are available
-    /// when processing transactions.
+    /// items of this round are supplied as `consensus_items`. The database transaction will be
+    /// committed to the database after all other modules ran `begin_consensus_epoch`,
+    /// so the results are available when processing transactions.
     async fn begin_consensus_epoch<'a>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
@@ -90,12 +90,12 @@ pub trait IServerModule: Debug {
     ) -> Result<InputMeta, ModuleError>;
 
     /// Try to spend a transaction input. On success all necessary updates will be part of the
-    /// database `batch`. On failure (e.g. double spend) the batch is reset and the operation will
-    /// take no effect.
+    /// database transaction. On failure (e.g. double spend) the database transaction is rolled back and
+    /// the operation will take no effect.
     ///
     /// This function may only be called after `begin_consensus_epoch` and before
-    /// `end_consensus_epoch`. Data is only written to the database once all transaction have been
-    /// processed.
+    /// `end_consensus_epoch`. Data is only written to the database once all transactions have been
+    /// processed
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
@@ -115,8 +115,8 @@ pub trait IServerModule: Debug {
     ) -> Result<TransactionItemAmount, ModuleError>;
 
     /// Try to create an output (e.g. issue notes, peg-out BTC, …). On success all necessary updates
-    /// to the database will be part of the `batch`. On failure (e.g. double spend) the batch is
-    /// reset and the operation will take no effect.
+    /// to the database will be part of the database transaction. On failure (e.g. double spend) the
+    /// database transaction is rolled back and the operation will take no effect.
     ///
     /// The supplied `out_point` identifies the operation (e.g. a peg-out or note issuance) and can
     /// be used to retrieve its outcome later using `output_status`.
@@ -201,9 +201,9 @@ where
     }
 
     /// This function is called once before transaction processing starts. All module consensus
-    /// items of this round are supplied as `consensus_items`. The batch will be committed to the
-    /// database after all other modules ran `begin_consensus_epoch`, so the results are available
-    /// when processing transactions.
+    /// items of this round are supplied as `consensus_items`. The database transaction will be
+    /// committed to the database after all other modules ran `begin_consensus_epoch`,
+    /// so the results are available when processing transactions.
     async fn begin_consensus_epoch<'a>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
@@ -274,12 +274,12 @@ where
     }
 
     /// Try to spend a transaction input. On success all necessary updates will be part of the
-    /// database `batch`. On failure (e.g. double spend) the batch is reset and the operation will
-    /// take no effect.
+    /// database transaction. On failure (e.g. double spend) the database transaction is rolled back and
+    /// the operation will take no effect.
     ///
     /// This function may only be called after `begin_consensus_epoch` and before
-    /// `end_consensus_epoch`. Data is only written to the database once all transaction have been
-    /// processed.
+    /// `end_consensus_epoch`. Data is only written to the database once all transactions have been
+    /// processed
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
@@ -325,8 +325,8 @@ where
     }
 
     /// Try to create an output (e.g. issue notes, peg-out BTC, …). On success all necessary updates
-    /// to the database will be part of the `batch`. On failure (e.g. double spend) the batch is
-    /// reset and the operation will take no effect.
+    /// to the database will be part of the database transaction. On failure (e.g. double spend) the
+    /// database transaction is rolled back and the operation will take no effect.
     ///
     /// The supplied `out_point` identifies the operation (e.g. a peg-out or note issuance) and can
     /// be used to retrieve its outcome later using `output_status`.

--- a/fedimint-api/src/module/mod.rs
+++ b/fedimint-api/src/module/mod.rs
@@ -451,9 +451,9 @@ pub trait ServerModule: Debug + Sized {
     ) -> Vec<Self::ConsensusItem>;
 
     /// This function is called once before transaction processing starts. All module consensus
-    /// items of this round are supplied as `consensus_items`. The batch will be committed to the
-    /// database after all other modules ran `begin_consensus_epoch`, so the results are available
-    /// when processing transactions.
+    /// items of this round are supplied as `consensus_items`. The database transaction will be
+    /// committed to the database after all other modules ran `begin_consensus_epoch`,
+    /// so the results are available when processing transactions.
     async fn begin_consensus_epoch<'a, 'b>(
         &'a self,
         dbtx: &mut DatabaseTransaction<'b>,
@@ -482,11 +482,11 @@ pub trait ServerModule: Debug + Sized {
     ) -> Result<InputMeta, ModuleError>;
 
     /// Try to spend a transaction input. On success all necessary updates will be part of the
-    /// database `batch`. On failure (e.g. double spend) the batch is reset and the operation will
-    /// take no effect.
+    /// database transaction. On failure (e.g. double spend) the database transaction is rolled back and
+    /// the operation will take no effect.
     ///
     /// This function may only be called after `begin_consensus_epoch` and before
-    /// `end_consensus_epoch`. Data is only written to the database once all transaction have been
+    /// `end_consensus_epoch`. Data is only written to the database once all transactions have been
     /// processed.
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
@@ -507,8 +507,8 @@ pub trait ServerModule: Debug + Sized {
     ) -> Result<TransactionItemAmount, ModuleError>;
 
     /// Try to create an output (e.g. issue notes, peg-out BTC, …). On success all necessary updates
-    /// to the database will be part of the `batch`. On failure (e.g. double spend) the batch is
-    /// reset and the operation will take no effect.
+    /// to the database will be part of the database transaction. On failure (e.g. double spend) the
+    /// database transaction is rolled back and the operation will take no effect.
     ///
     /// The supplied `out_point` identifies the operation (e.g. a peg-out or note issuance) and can
     /// be used to retrieve its outcome later using `output_status`.


### PR DESCRIPTION
Updating the documentation in two spots:

- docs/database.md to include a description and examples of the prefixes that are prepended for each module.
- Remove references to `batch` in the module definition documentation.

Addresses https://github.com/fedimint/fedimint/issues/1538