### PR TITLE
Gatewayd Compat Setup

### DIFF
--- a/gateway/ln-gateway/src/gatewayd/actor.rs
+++ b/gateway/ln-gateway/src/gatewayd/actor.rs
@@ -1,0 +1,303 @@
+use std::{sync::Arc, time::Duration};
+
+use bitcoin::{Address, Transaction};
+use bitcoin_hashes::sha256;
+use fedimint_api::{task::TaskGroup, Amount, OutPoint, TransactionId};
+use fedimint_server::modules::{
+    ln::{
+        contracts::{ContractId, Preimage},
+        route_hints::RouteHint,
+    },
+    wallet::txoproof::TxOutProof,
+};
+use mint_client::{GatewayClient, PaymentParameters};
+use rand::{CryptoRng, RngCore};
+use tracing::{debug, info, instrument, warn};
+
+use crate::{ln::LnRpc, rpc::FederationInfo, utils::retry, LnGatewayError, Result};
+
+/// How long a gateway announcement stays valid
+const GW_ANNOUNCEMENT_TTL: Duration = Duration::from_secs(600);
+
+pub struct GatewayActor {
+    client: Arc<GatewayClient>,
+}
+
+impl GatewayActor {
+    pub async fn new(client: Arc<GatewayClient>, route_hints: Vec<RouteHint>) -> Result<Self> {
+        let register_client = client.clone();
+        tokio::spawn(async move {
+            loop {
+                // Retry gateway registration
+                match retry(
+                    String::from("Register With Federation"),
+                    #[allow(clippy::unit_arg)]
+                    || async {
+                        let gateway_registration = register_client
+                            .config()
+                            .to_gateway_registration_info(route_hints.clone(), GW_ANNOUNCEMENT_TTL);
+                        Ok(register_client
+                            .register_with_federation(gateway_registration.clone())
+                            .await?)
+                    },
+                    Duration::from_secs(1),
+                    5,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        info!("Connected with federation");
+                        tokio::time::sleep(GW_ANNOUNCEMENT_TTL / 2).await;
+                    }
+                    Err(e) => {
+                        warn!("Failed to connect with federation: {}", e);
+                        tokio::time::sleep(GW_ANNOUNCEMENT_TTL / 4).await;
+                    }
+                }
+            }
+        });
+
+        Ok(Self { client })
+    }
+
+    async fn fetch_all_notes(&self) {
+        for fetch_result in self.client.fetch_all_notes().await {
+            if let Err(e) = fetch_result {
+                debug!(error = %e, "Fetching notes failed")
+            };
+        }
+    }
+
+    pub async fn buy_preimage_offer(
+        &self,
+        payment_hash: &sha256::Hash,
+        amount: &Amount,
+        rng: impl RngCore + CryptoRng,
+    ) -> Result<(OutPoint, ContractId)> {
+        let (outpoint, contract_id) = self
+            .client
+            .buy_preimage_offer(payment_hash, amount, rng)
+            .await?;
+        Ok((outpoint, contract_id))
+    }
+
+    // TODO: Move this API to messaging
+    pub async fn await_preimage_decryption(&self, outpoint: OutPoint) -> Result<Preimage> {
+        let preimage = self.client.await_preimage_decryption(outpoint).await?;
+        Ok(preimage)
+    }
+
+    #[instrument(skip_all, fields(%contract_id))]
+    pub async fn pay_invoice(
+        &self,
+        ln_rpc: Arc<dyn LnRpc>,
+        contract_id: ContractId,
+    ) -> Result<OutPoint> {
+        debug!("Fetching contract");
+        let rng = rand::rngs::OsRng;
+        let contract_account = self.client.fetch_outgoing_contract(contract_id).await?;
+
+        let payment_params = match self
+            .client
+            .validate_outgoing_account(&contract_account)
+            .await
+        {
+            Ok(payment_params) => payment_params,
+            Err(e) => {
+                self.client
+                    .cancel_outgoing_contract(contract_account)
+                    .await?;
+                return Err(e.into());
+            }
+        };
+
+        debug!(
+            account = ?contract_account,
+            "Fetched and validated contract account"
+        );
+
+        self.client
+            .save_outgoing_payment(contract_account.clone())
+            .await;
+
+        let is_internal_payment = payment_params.maybe_internal
+            && self
+                .client
+                .ln_client()
+                .offer_exists(payment_params.payment_hash)
+                .await
+                .unwrap_or(false);
+
+        let preimage_res = if is_internal_payment {
+            self.buy_preimage_internal(&payment_params.payment_hash, &payment_params.invoice_amount)
+                .await
+        } else {
+            self.buy_preimage_external(ln_rpc, contract_account.contract.invoice, &payment_params)
+                .await
+        };
+
+        match preimage_res {
+            Ok(preimage) => {
+                let outpoint = self
+                    .client
+                    .claim_outgoing_contract(contract_id, preimage, rng)
+                    .await?;
+
+                Ok(outpoint)
+            }
+            Err(e) => {
+                warn!("Invoice payment failed: {}. Aborting", e);
+                // FIXME: combine both errors?
+                self.client.abort_outgoing_payment(contract_id).await?;
+                Err(e)
+            }
+        }
+    }
+
+    pub async fn buy_preimage_internal(
+        &self,
+        payment_hash: &sha256::Hash,
+        invoice_amount: &Amount,
+    ) -> Result<Preimage> {
+        self.fetch_all_notes().await;
+
+        let mut rng = rand::rngs::OsRng;
+        let (out_point, contract_id) = self
+            .client
+            .buy_preimage_offer(payment_hash, invoice_amount, &mut rng)
+            .await?;
+
+        debug!("Awaiting decryption of preimage of hash {}", payment_hash);
+        match self.client.await_preimage_decryption(out_point).await {
+            Ok(preimage) => {
+                debug!("Decrypted preimage {:?}", preimage);
+                Ok(preimage)
+            }
+            Err(e) => {
+                warn!("Failed to decrypt preimage. Now requesting a refund: {}", e);
+                self.client
+                    .refund_incoming_contract(contract_id, rng)
+                    .await?;
+                Err(LnGatewayError::ClientError(e))
+            }
+        }
+    }
+
+    pub async fn buy_preimage_external(
+        &self,
+        ln_rpc: Arc<dyn LnRpc>,
+        invoice: lightning_invoice::Invoice,
+        payment_params: &PaymentParameters,
+    ) -> Result<Preimage> {
+        match ln_rpc
+            .pay(
+                invoice,
+                payment_params.max_delay,
+                payment_params.max_fee_percent(),
+            )
+            .await
+        {
+            Ok(preimage) => {
+                debug!(?preimage, "Successfully paid LN invoice");
+                Ok(preimage)
+            }
+            Err(e) => {
+                warn!("LN payment failed, aborting");
+                Err(LnGatewayError::CouldNotRoute(e))
+            }
+        }
+    }
+
+    pub async fn await_outgoing_contract_claimed(
+        &self,
+        contract_id: ContractId,
+        outpoint: OutPoint,
+    ) -> Result<()> {
+        Ok(self
+            .client
+            .await_outgoing_contract_claimed(contract_id, outpoint)
+            .await?)
+    }
+
+    pub async fn get_deposit_address(&self) -> Result<Address> {
+        let rng = rand::rngs::OsRng;
+        Ok(self.client.get_new_pegin_address(rng).await)
+    }
+
+    pub async fn deposit(
+        &self,
+        txout_proof: TxOutProof,
+        transaction: Transaction,
+    ) -> Result<TransactionId> {
+        let rng = rand::rngs::OsRng;
+
+        self.client
+            .peg_in(txout_proof, transaction, rng)
+            .await
+            .map_err(LnGatewayError::ClientError)
+    }
+
+    pub async fn withdraw(
+        &self,
+        amount: bitcoin::Amount,
+        address: Address,
+    ) -> Result<TransactionId> {
+        self.fetch_all_notes().await;
+
+        let rng = rand::rngs::OsRng;
+
+        let peg_out = self
+            .client
+            .new_peg_out_with_fees(amount, address)
+            .await
+            .expect("Failed to create pegout with fees");
+        self.client
+            .peg_out(peg_out, rng)
+            .await
+            .map_err(LnGatewayError::ClientError)
+            .map(|out_point| out_point.txid)
+    }
+
+    pub async fn backup(&self) -> Result<()> {
+        self.client
+            .mint_client()
+            .back_up_ecash_to_federation()
+            .await
+            .map_err(LnGatewayError::Other)?;
+
+        Ok(())
+    }
+
+    pub async fn restore(&self) -> Result<()> {
+        // TODO: get the task group from `self`
+        let mut task_group = TaskGroup::new();
+
+        self.client
+            .mint_client()
+            .restore_ecash_from_federation(10, &mut task_group)
+            .await
+            .map_err(LnGatewayError::Other)?
+            .map_err(|e| LnGatewayError::Other(e.into()))?;
+
+        task_group
+            .join_all(None)
+            .await
+            .map_err(LnGatewayError::Other)?;
+
+        Ok(())
+    }
+
+    pub async fn get_balance(&self) -> Result<Amount> {
+        self.fetch_all_notes().await;
+
+        Ok(self.client.notes().await.total_amount())
+    }
+
+    pub fn get_info(&self) -> Result<FederationInfo> {
+        let cfg = self.client.config();
+        Ok(FederationInfo {
+            federation_id: cfg.client_config.federation_id.clone(),
+            mint_pubkey: cfg.redeem_key.x_only_public_key().0,
+        })
+    }
+}

--- a/gateway/ln-gateway/src/gatewayd/mod.rs
+++ b/gateway/ln-gateway/src/gatewayd/mod.rs
@@ -1,0 +1,13 @@
+// ### Why make a fork of `LnGateway` : copy code of `../src/lib.rs` to `./gateway.rs` ?
+// - Note: `LnGateway` is renamed to `Gateway` in this new file
+// - so we can change the constructor signature of `LnGateway`
+// - so we can change how the gateway gets HTLC intercepts. `Gateway` in `src/gateway.rs` does not implement `handle_receive_payment`. Instead, actors directly subscribe to htlc intercepts on an entirely new pattern. More on this below
+
+// ### Why make a fork of `GatewayActor` : copy code of `../src/actor.rs` to `./actor.rs` ?
+// - So we can change constructor signature of `GatewayActor`. Have the new actor take a reference to lnrpc, which is
+// - So we can enable direct subscription to intercepted HTLCs using the owned lnrpc
+// - API signature of the `GatewayActor` changes because it owns a reference to lnrpc, rather than expec these to be passed in at api calls.
+// - Note: Changes incoming. You can preview them at #1337
+
+pub mod actor;
+pub mod gateway;


### PR DESCRIPTION
Cherry pick back-compatibility changes that will allow us to introduce the proposed `gatewayd` (#1337 ) while still supporting the current `ln_gateway`.

### Why make a fork of `LnGateway` : copy code of `src/lib.rs` to `src/gatewayd/gateway.rs` ?
- Note: `LnGateway` is renamed to `Gateway` in this new file
- so we can change the constructor signature of `LnGateway`
- so we can change how the gateway gets HTLC intercepts. `Gateway` in `src/gateway.rs` does not implement `handle_receive_payment`. Instead, actors directly subscribe to htlc intercepts on an entirely new pattern. More on this below


### Why make a fork of `GatewayActor` : copy code of `src/actor.rs` to `src/gatewayd/actor.rs` ?
- So we can change constructor signature of `GatewayActor`. Have the new actor take a reference to lnrpc, which is 
- So we can enable direct subscription to intercepted HTLCs using the owned lnrpc
- API signature of the `GatewayActor` changes because it owns a reference to lnrpc, rather than expec these to be passed in at api calls.
- Note: Changes incoming. You can preview them at #1337 