### PR TITLE
feat: add esplora block source support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "esplora-client"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bbba572d03ca4d628b653f01e60ba6947c67df65ee8910c79daaf252897924"
+dependencies = [
+ "bitcoin",
+ "log",
+ "reqwest",
+ "serde",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +907,7 @@ dependencies = [
  "bitcoin_hashes",
  "bitcoincore-rpc",
  "electrum-client",
+ "esplora-client",
  "fedimint-core",
  "rand",
  "serde",
@@ -1371,6 +1384,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1886,6 +1914,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -2495,6 +2536,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,10 +2626,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -3111,10 +3209,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3124,7 +3224,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3892,6 +3994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,6 +4012,18 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -12,16 +12,17 @@ name = "fedimint_bitcoind"
 path = "src/lib.rs"
 
 [features]
-bitcoincore-rpc = [ "dep:bitcoincore-rpc", "dep:electrum-client" ]
+bitcoincore-rpc = ["dep:bitcoincore-rpc", "dep:electrum-client"]
 default = []
 
 [dependencies]
 anyhow = "1.0.66"
+async-trait = "*"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
-bitcoincore-rpc = { version = "0.16.0" , optional = true }
+bitcoincore-rpc = { version = "0.16.0", optional = true }
 electrum-client = { version = "0.12.0", optional = true }
-async-trait = "*"
+esplora-client = { version = "0.3.0", default-features = false, features = ["async", "async-https"] }
 fedimint-core  = { path = "../fedimint-core" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -26,4 +26,4 @@ fedimint-core  = { path = "../fedimint-core" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 tracing = "0.1.37"
-url = "2.3.1"                   
+url = "2.3.1"

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -56,6 +56,9 @@ pub fn make_bitcoin_rpc_backend(
             .context("bitcoind rpc backend initialization failed"),
         BitcoindRpcBackend::Electrum(url) => make_electrum_rpc(url, task_handle)
             .context("electrum rpc backend initialization failed"),
+        BitcoindRpcBackend::Esplora(_) => {
+            todo!("esplora rpc backend is currently not implemented yet")
+        }
     }
 }
 

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 
 use ::bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
@@ -56,9 +57,7 @@ pub fn make_bitcoin_rpc_backend(
             .context("bitcoind rpc backend initialization failed"),
         BitcoindRpcBackend::Electrum(url) => make_electrum_rpc(url, task_handle)
             .context("electrum rpc backend initialization failed"),
-        BitcoindRpcBackend::Esplora(_) => {
-            todo!("esplora rpc backend is currently not implemented yet")
-        }
+        BitcoindRpcBackend::Esplora(url) => make_esplora_rpc(url, task_handle),
     }
 }
 
@@ -76,6 +75,13 @@ pub fn make_bitcoind_rpc(url: &Url, task_handle: TaskHandle) -> Result<DynBitcoi
 
 pub fn make_electrum_rpc(url: &Url, _task_handle: TaskHandle) -> Result<DynBitcoindRpc> {
     Ok(ElectrumClient::new(url)?.into())
+}
+
+pub fn make_esplora_rpc(url: &Url, task_handle: TaskHandle) -> Result<DynBitcoindRpc> {
+    let esplora_client = EsploraClient::new(url)?;
+    let retry_client = RetryClient::new(esplora_client, task_handle);
+
+    Ok(retry_client.into())
 }
 
 /// Wrapper around [`bitcoincore_rpc::Client`] logging failures
@@ -294,5 +300,98 @@ impl IBitcoindRpc for ElectrumClient {
                     (history_item.height as u64) == height && history_item.tx_hash == txid
                 }))
         })
+    }
+}
+
+pub struct EsploraClient(esplora_client::AsyncClient);
+
+impl EsploraClient {
+    fn new(url: &Url) -> anyhow::Result<Self> {
+        let builder = esplora_client::Builder::new(url.as_str());
+        let client = builder.build_async()?;
+        Ok(Self(client))
+    }
+}
+
+impl fmt::Debug for EsploraClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("EsploraClient")
+    }
+}
+
+#[async_trait]
+impl IBitcoindRpc for EsploraClient {
+    fn backend_type(&self) -> BitcoinRpcBackendType {
+        BitcoinRpcBackendType::Esplora
+    }
+
+    async fn get_network(&self) -> Result<Network> {
+        let genesis_height: u32 = 0;
+        let genesis_hash = self.0.get_block_hash(genesis_height).await?;
+
+        // TODO: How could we extract the BlockHash to a constant, and use something
+        // like the `bitcoin::blockdata::constants::genesis_block` from rust-bitcoin ?
+        let network = match genesis_hash.to_hex().as_str() {
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f" => Network::Bitcoin,
+            "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943" => Network::Testnet,
+            "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6" => Network::Signet,
+            hash => {
+                warn!("Unknown genesis hash {hash} - assuming regtest");
+                Network::Regtest
+            }
+        };
+
+        Ok(network)
+    }
+
+    async fn get_block_height(&self) -> Result<u64> {
+        match self.0.get_height().await {
+            Ok(height) => Ok(height as u64),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
+        self.0
+            .get_block_hash(height as u32)
+            .await
+            .map_err(anyhow::Error::from)
+            .map_err(Into::into)
+    }
+
+    async fn get_block(&self, hash: &BlockHash) -> Result<Block> {
+        self.0
+            .get_block_by_hash(hash)
+            .await
+            .map(|block| {
+                block.ok_or_else(|| {
+                    anyhow::Error::msg(format!(
+                        "The fetched block for given height {hash} has not been not found"
+                    ))
+                })
+            })?
+            .map_err(anyhow::Error::from)
+            .map_err(Into::into)
+    }
+
+    async fn get_fee_rate(&self, confirmation_target: u16) -> Result<Option<Feerate>> {
+        let fee_estimates: HashMap<String, f64> = self.0.get_fee_estimates().await?;
+
+        let fee_rate_vb =
+            esplora_client::convert_fee_rate(confirmation_target.into(), fee_estimates)?;
+
+        let fee_rate_kvb = fee_rate_vb * 1_000f32;
+
+        Ok(Some(Feerate {
+            sats_per_kvb: (fee_rate_kvb).ceil() as u64,
+        }))
+    }
+
+    async fn submit_transaction(&self, transaction: Transaction) -> Result<()> {
+        self.0
+            .broadcast(&transaction)
+            .await
+            .map_err(anyhow::Error::from)
+            .map_err(Into::into)
     }
 }

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -17,7 +17,7 @@ pub mod bitcoincore_rpc;
 
 /// Trait that allows interacting with the Bitcoin blockchain
 ///
-/// Functions may panic if if the bitcoind node is not reachable.
+/// Functions may panic if the bitcoind node is not reachable.
 #[async_trait]
 pub trait IBitcoindRpc: Debug + Send + Sync {
     /// `true` if it's real-bitcoin (not electrum) backend and thus supports
@@ -68,7 +68,7 @@ pub trait IBitcoindRpc: Debug + Send + Sync {
         _transaction: &Transaction,
         _height: u64,
     ) -> Result<bool> {
-        bail!("is_transaction_confirmed_in call not supported in standard (non-electrum) backends")
+        bail!("was_transaction_confirmed_in call not supported in standard (non-electrum/esplora) backends")
     }
 }
 

--- a/fedimint-core/src/bitcoin_rpc.rs
+++ b/fedimint-core/src/bitcoin_rpc.rs
@@ -55,40 +55,20 @@ pub fn select_bitcoin_backend_from_envs(
     esplora_rpc: Option<&OsStr>,
 ) -> anyhow::Result<BitcoindRpcBackend> {
     Ok(if let Some(val) = bitcoind_rpc {
-        BitcoindRpcBackend::Bitcoind(fm_bitcoind_rpc_env_value_to_url(Some(val))?)
+        BitcoindRpcBackend::Bitcoind(fm_backend_rpc_env_value_to_url(val)?)
     } else if let Some(val) = electrum_rpc {
-        BitcoindRpcBackend::Electrum(fm_electrum_rpc_env_value_to_url(val)?)
+        BitcoindRpcBackend::Electrum(fm_backend_rpc_env_value_to_url(val)?)
     } else if let Some(val) = esplora_rpc {
-        BitcoindRpcBackend::Esplora(fm_esplora_rpc_env_value_to_url(val)?)
+        BitcoindRpcBackend::Esplora(fm_backend_rpc_env_value_to_url(val)?)
     } else {
-        BitcoindRpcBackend::Bitcoind(fm_bitcoind_rpc_env_value_to_url(None)?)
+        BitcoindRpcBackend::Bitcoind(Url::parse(FM_BITCOIND_RPC_DEFAULT_FALLBACK)?)
     })
 }
 
 /// Get the value of bitcoin rpc url to use, from the value of env variable
 ///
 /// Useful in places where variable value is already available.
-fn fm_bitcoind_rpc_env_value_to_url(value: Option<&OsStr>) -> anyhow::Result<Url> {
-    Ok(if let Some(url_str) = value {
-        Url::parse(
-            url_str
-                .to_str()
-                .ok_or_else(|| anyhow::format_err!("Url not ascii text"))?,
-        )?
-    } else {
-        Url::parse(FM_BITCOIND_RPC_DEFAULT_FALLBACK)?
-    })
-}
-
-pub fn fm_electrum_rpc_env_value_to_url(value: &OsStr) -> anyhow::Result<Url> {
-    Ok(Url::parse(value.to_str().ok_or_else(|| {
-        anyhow::format_err!("Url not ascii text")
-    })?)?)
-}
-
-// TODO: Should we use a single fn instead of 3, such as:
-// `fm_backend_rpc_env_value_to_url` ? As they are pratically the same
-pub fn fm_esplora_rpc_env_value_to_url(value: &OsStr) -> anyhow::Result<Url> {
+fn fm_backend_rpc_env_value_to_url(value: &OsStr) -> anyhow::Result<Url> {
     Ok(Url::parse(value.to_str().ok_or_else(|| {
         anyhow::format_err!("Url not ascii text")
     })?)?)

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -233,6 +233,10 @@ async fn params_page(
                 let url_str = format!("{}", SanitizedUrl::new_borrowed(&url));
                 ("electrum", url_str)
             }
+            Ok(BitcoindRpcBackend::Esplora(url)) => {
+                let url_str = format!("{}", SanitizedUrl::new_borrowed(&url));
+                ("esplora", url_str)
+            }
             Err(e) => ("error", e.to_string()),
         };
     UrlConnection {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -203,7 +203,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
                     fedimint_core::bitcoin_rpc::BitcoindRpcBackend::Electrum(_) => {
                         panic!("Electrum backend not supported for tests")
                     }
-                    fedimint_api::bitcoin_rpc::BitcoindRpcBackend::Esplora(_) => {
+                    fedimint_core::bitcoin_rpc::BitcoindRpcBackend::Esplora(_) => {
                         panic!("Esplora backend not supported for tests")
                     }
                 };

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -203,6 +203,9 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
                     fedimint_core::bitcoin_rpc::BitcoindRpcBackend::Electrum(_) => {
                         panic!("Electrum backend not supported for tests")
                     }
+                    fedimint_api::bitcoin_rpc::BitcoindRpcBackend::Esplora(_) => {
+                        panic!("Esplora backend not supported for tests")
+                    }
                 };
             let bitcoin_rpc = fedimint_bitcoind::bitcoincore_rpc::make_bitcoind_rpc(
                 &bitcoin_rpc_url,

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -1236,7 +1236,7 @@ impl Wallet {
                 .await;
 
             match self.btc_rpc.backend_type() {
-                BitcoinRpcBackendType::Bitcoind => {
+                BitcoinRpcBackendType::Bitcoind | BitcoinRpcBackendType::Esplora => {
                     if !pending_transactions.is_empty() {
                         let block = self
                             .btc_rpc
@@ -1257,14 +1257,11 @@ impl Wallet {
                             .btc_rpc
                             .was_transaction_confirmed_in(&transaction.1.tx, height as u64)
                             .await
-                            .expect("bitcoin rpc backend failed")
+                            .expect("bitcoin electrum rpc backend failed")
                         {
                             self.recognize_change_utxo(dbtx, transaction.1).await;
                         }
                     }
-                }
-                BitcoinRpcBackendType::Esplora => {
-                    todo!("Esplora backend currently does not have an implementation for IBitcoindRpc trait")
                 }
             }
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -23,7 +23,7 @@ use db::DbKeyPrefix;
 use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_core::bitcoin_rpc::{
     select_bitcoin_backend_from_envs, BitcoinRpcBackendType, FM_BITCOIND_RPC_ENV,
-    FM_ELECTRUM_RPC_ENV,
+    FM_ELECTRUM_RPC_ENV, FM_ESPLORA_RPC_ENV,
 };
 use fedimint_core::cancellable::{Cancellable, Cancelled};
 use fedimint_core::config::{
@@ -927,6 +927,8 @@ impl Wallet {
                 .map(OsString::as_os_str),
             env.get(OsStr::new(FM_ELECTRUM_RPC_ENV))
                 .map(OsString::as_os_str),
+            env.get(OsStr::new(FM_ESPLORA_RPC_ENV))
+                .map(OsString::as_os_str),
         )?;
 
         let btc_rpc = fedimint_bitcoind::bitcoincore_rpc::make_bitcoin_rpc_backend(
@@ -1260,6 +1262,9 @@ impl Wallet {
                             self.recognize_change_utxo(dbtx, transaction.1).await;
                         }
                     }
+                }
+                BitcoinRpcBackendType::Esplora => {
+                    todo!("Esplora backend currently does not have an implementation for IBitcoindRpc trait")
                 }
             }
 


### PR DESCRIPTION
## Description

The bitcoin backend currently supported are both bitcoind and electrum (without integration tests at the moment), as mentioned in #1187 having multiple, easy to use, bitcoin rpc backend support is useful for dogfooding federations and easy setup/deploy.

That said, this PR aims to implement and support [Esplora](https://github.com/Blockstream/esplora) support, although as it's for Electrum it currently does not have any integration test (I'm working on that 😁).

## How
This adds a new implementation for the [`IBitcoindRpc`](https://github.com/fedimint/fedimint/blob/13a0e24e902f63fae682c4e4af6e02069621086a/fedimint-bitcoind/src/lib.rs#L27-L58) trait for Esplora client. However, it could be implemented by using `reqwest` and calling each endpoint available on the Esplora API, this PR uses the [rust-esplora-client](https://github.com/bitcoindevkit/rust-esplora-client) as it's abstract all that logic and makes it easy to use, which is maintained by BDK team.

fixes #1187