### PR TITLE
Use block_in_place for synchronous Rocksdb operations

### DIFF
--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -897,7 +897,7 @@ mod tests {
     }
 
     #[allow(clippy::needless_collect)]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_parallel_issuance() {
         const ITERATIONS: usize = 10_000;
 


### PR DESCRIPTION
This PR wraps all Rocksdb I/O operations in fedimint_api::task::block_in_place so that the executor thread is not blocked on I/O. Rocksdb does not do I/O during writes (it always writes to memory or it fails), but insert/remove operations return the previous value, so they have a chance of doing I/O while reading for the previous value.

Issue: https://github.com/fedimint/fedimint/issues/1528