### PR TITLE
Logging improvements starter pack

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: use-log-targets
+  languages:
+    - rust
+  message: Log statements should have static target defined to aid filtering
+  patterns:
+    # semgrep struggles with finding boundries of rust macro invocation when elipsis (`...`) is used
+    # so matching this one with raw regexes instead
+    - pattern-regex: (error|warn)!\([^;]*?\);
+    - pattern-not-regex: '(error|warn)!\(\s*target: [^;]*?\);'
+
+  severity: WARNING

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -30,6 +30,7 @@ use url::Url;
 use crate::fedimint_api::encoding::Encodable;
 use crate::fedimint_api::BitcoinHash;
 use crate::fedimint_api::NumPeers;
+use crate::logging::{LOG_NET_PEER, LOG_NET_PEER_DKG};
 use crate::net::connect::TlsConfig;
 use crate::net::connect::{parse_host_port, Connector};
 use crate::net::peers::NetworkConfig;
@@ -488,7 +489,7 @@ impl ServerConfig {
                         done_peers.insert(peer_id);
                     },
                     Ok((peer_id, msg)) => {
-                        error!(%peer_id, ?msg, "Received incorrect message after dkg was supposed to be finished. Probably dkg multiplexing bug.");
+                        error!(target: LOG_NET_PEER_DKG, %peer_id, ?msg, "Received incorrect message after dkg was supposed to be finished. Probably dkg multiplexing bug.");
                     },
                     Err(Cancelled) => {/* ignore shutdown for time being, we'll timeout soon anyway */},
                 }
@@ -496,7 +497,7 @@ impl ServerConfig {
         })
         .await
         {
-            error!("Timeout waiting for dkg completion confirmation from other peers");
+            error!(target: LOG_NET_PEER_DKG, "Timeout waiting for dkg completion confirmation from other peers");
         };
 
         let server = ServerConfig::from(
@@ -509,7 +510,10 @@ impl ServerConfig {
             module_cfgs,
         );
 
-        info!("Distributed key generation has completed successfully!");
+        info!(
+            target: LOG_NET_PEER,
+            "Distributed key generation has completed successfully!"
+        );
 
         Ok(Ok(server))
     }

--- a/fedimint-server/src/logging.rs
+++ b/fedimint-server/src/logging.rs
@@ -1,0 +1,6 @@
+pub const LOG_CONSENSUS: &str = "consensus";
+pub const LOG_NET: &str = "net";
+pub const LOG_NET_PEER: &str = "net::peer";
+pub const LOG_NET_PEER_DKG: &str = "net::peer::dkg";
+pub const LOG_NET_API: &str = "net::api";
+pub const LOG_DB: &str = "db";

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -11,8 +11,9 @@ use fedimint_api::cancellable::Cancellable;
 use fedimint_api::net::peers::{IMuxPeerConnections, PeerConnections};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::{sync::Mutex, time::sleep};
-use tracing::{debug, error};
+use tracing::{debug, warn};
 
+use crate::logging::LOG_NET_PEER;
 use crate::PeerId;
 
 /// TODO: Use proper ModuleId after modularization is complete
@@ -153,7 +154,7 @@ where
                         .or_default()
                         .push_back((peer, new_msg.msg));
                 } else {
-                    error!("Peer {peer} has already {peer_msgs_pending_count} pending out of order messages. Droping new message.");
+                    warn!(target: LOG_NET_PEER, "Peer {peer} has already {peer_msgs_pending_count} pending out of order messages. Droping new message.");
                 }
             } else {
                 drop(out_of_order);

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -25,6 +25,7 @@ use tracing::{debug, error};
 
 use crate::config::ServerConfig;
 use crate::consensus::FedimintConsensus;
+use crate::logging::LOG_NET_API;
 use crate::transaction::SerdeTransaction;
 
 /// A state of fedimint server passed to each rpc handler callback
@@ -113,7 +114,10 @@ fn attach_endpoints(
                     .catch_unwind()
                     .await
                     .map_err(|_| {
-                        error!(path, "API handler panicked, DO NOT IGNORE, FIX IT!!!");
+                        error!(
+                            target: LOG_NET_API,
+                            path, "API handler panicked, DO NOT IGNORE, FIX IT!!!"
+                        );
                         jsonrpsee::core::Error::Call(CallError::Custom(ErrorObject::owned(
                             500,
                             "API handler panicked",
@@ -163,7 +167,10 @@ fn attach_endpoints_erased(
                 .catch_unwind()
                 .await
                 .map_err(|_| {
-                    error!(path, "API handler panicked, DO NOT IGNORE, FIX IT!!!");
+                    error!(
+                        target: LOG_NET_API,
+                        path, "API handler panicked, DO NOT IGNORE, FIX IT!!!"
+                    );
                     jsonrpsee::core::Error::Call(CallError::Custom(ErrorObject::owned(
                         500,
                         "API handler panicked",

--- a/fedimint-server/src/net/framed.rs
+++ b/fedimint-server/src/net/framed.rs
@@ -13,6 +13,8 @@ use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{error, trace};
 
+use crate::logging::LOG_NET_PEER;
+
 /// Owned [`FramedTransport`] trait object
 pub type AnyFramedTransport<M> = Box<dyn FramedTransport<M> + Send + Unpin + 'static>;
 
@@ -185,7 +187,10 @@ where
 
         // Then we serialize the message into the buffer
         bincode::serialize_into(dst.writer(), &item).map_err(|e| {
-            error!("Serializing message failed: {:?}", item);
+            error!(
+                target: LOG_NET_PEER,
+                "Serializing message failed: {:?}", item
+            );
             e
         })?;
 

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -23,9 +23,10 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::Instant;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, info, instrument, trace, warn};
 use url::Url;
 
+use crate::logging::LOG_NET_PEER;
 use crate::net::connect::{AnyConnector, SharedAnyConnector};
 use crate::net::framed::AnyFramedTransport;
 use crate::net::queue::{MessageId, MessageQueue, UniqueMessage};
@@ -170,7 +171,7 @@ where
             let (peer, connection) = match new_connection.expect("Listener closed") {
                 Ok(connection) => connection,
                 Err(e) => {
-                    error!(mint = ?cfg.identity, err = %e, "Error while opening incoming connection");
+                    warn!(target: LOG_NET_PEER, mint = ?cfg.identity, err = %e, "Error while opening incoming connection");
                     continue;
                 }
             };
@@ -184,6 +185,7 @@ where
 
             if err {
                 warn!(
+                    target: LOG_NET_PEER,
                     ?peer,
                     "Could not send incoming connection to peer io task (possibly banned)"
                 );
@@ -243,7 +245,7 @@ where
 
     async fn ban_peer(&mut self, peer: PeerId) {
         self.connections.remove(&peer);
-        warn!("Peer {} banned.", peer);
+        warn!(target: LOG_NET_PEER, "Peer {} banned.", peer);
     }
 }
 
@@ -313,7 +315,7 @@ where
             new_connection_res = self.incoming_connections.recv() => {
                 match new_connection_res {
                     Some(new_connection) => {
-                        warn!("Replacing existing connection");
+                        info!(target: LOG_NET_PEER, "Replacing existing connection");
                         self.connect(new_connection, 0).await
                     },
                     None => {
@@ -435,7 +437,7 @@ where
         }
 
         if msg.id > expected {
-            warn!(?expected, received = ?msg.id, "Received message from the future");
+            warn!(target: LOG_NET_PEER, ?expected, received = ?msg.id, "Received message from the future");
             return Err(anyhow::anyhow!("Received message from the future"));
         }
 

--- a/flake.nix
+++ b/flake.nix
@@ -880,6 +880,7 @@
                 cargo-llvm-cov
                 cargo-udeps
                 pkgs.parallel
+                pkgs.semgrep
 
                 # This is required to prevent a mangled bash shell in nix develop
                 # see: https://discourse.nixos.org/t/interactive-bash-with-nix-develop-flake/15486
@@ -959,6 +960,7 @@
                 pkgs.shellcheck
                 pkgs.git
                 pkgs.parallel
+                pkgs.semgrep
               ];
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -879,6 +879,7 @@
                 fenixToolchainRustfmt
                 cargo-llvm-cov
                 cargo-udeps
+                pkgs.parallel
 
                 # This is required to prevent a mangled bash shell in nix develop
                 # see: https://discourse.nixos.org/t/interactive-bash-with-nix-develop-flake/15486
@@ -957,7 +958,7 @@
                 pkgs.nixpkgs-fmt
                 pkgs.shellcheck
                 pkgs.git
-                pkgs-unstable.convco
+                pkgs.parallel
               ];
             };
 
@@ -981,4 +982,6 @@
     extra-substituters = [ "https://fedimint.cachix.org" ];
     extra-trusted-public-keys = [ "fedimint.cachix.org-1:FpJJjy1iPVlvyv4OMiN5y9+/arFLPcnZhZVVCHCDYTs=" ];
   };
+
+
 }

--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -58,6 +58,11 @@ function check_dbg() {
 }
 export -f check_dbg
 
+function check_semgrep() {
+  semgrep -q --error --config .semgrep.yaml fedimint-server/
+}
+export -f check_semgrep
+
 
 function check_shellcheck() {
   for path in $(echo "$git_ls_files" | grep -E '.*\.sh$')  ; do
@@ -91,4 +96,4 @@ function check_eof() {
 export -f check_eof
 
 
-parallel ::: check_nix check_cargo_fmt check_dbg check_shellcheck check_eof 
+parallel ::: check_nix check_cargo_fmt check_dbg check_semgrep check_shellcheck check_eof 

--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -21,46 +21,74 @@ if [ $is_unclean -ne 0 ]; then
   trap revert_git_stash EXIT
 fi
 
+
+export git_ls_files
 git_ls_files="$(git ls-files)"
 
-errors=""
 
-# shellcheck disable=SC2046
-nixpkgs-fmt --check $(echo "$git_ls_files" | grep -E '.*\.nix$')
+function check_nix() {
+  # shellcheck disable=SC2046
+  nixpkgs-fmt --check $(echo "$git_ls_files" | grep -E '.*\.nix$')
+}
+export -f check_nix
 
 
-# Note: avoid `cargo fmt --all` so we don't need extra stuff in `ci` shell
-# so that CI is faster
-# shellcheck disable=SC2046
-cargo fmt --all --check
+function check_cargo_fmt() {
+  # Note: avoid `cargo fmt --all` so we don't need extra stuff in `ci` shell
+  # so that CI is faster
+  # shellcheck disable=SC2046
+  cargo fmt --all --check
+}
+export -f check_cargo_fmt
 
-for path in $(echo "$git_ls_files" | grep  '.*\.rs'); do
-  if grep 'dbg!(' "$path"  > /dev/null; then
-    >&2 echo "$path contains dbg! macro"
-    errors="true"
+
+function check_dbg() {
+  errors=""
+  for path in $(echo "$git_ls_files" | grep  '.*\.rs'); do
+    if grep 'dbg!(' "$path"  > /dev/null; then
+      >&2 echo "$path contains dbg! macro"
+      errors="true"
+    fi
+  done
+
+  if [ -n "$errors" ]; then
+    >&2 echo "Fix the problems above or use --no-verify" 1>&2
+    return 1
   fi
-done
+}
+export -f check_dbg
 
 
-for path in $(echo "$git_ls_files" | grep -E '.*\.sh$')  ; do
-  shellcheck --severity=warning "$path"
-done
+function check_shellcheck() {
+  for path in $(echo "$git_ls_files" | grep -E '.*\.sh$')  ; do
+    shellcheck --severity=warning "$path"
+  done
+}
+export -f check_shellcheck
 
-for path in $(echo "$git_ls_files" | grep -v -E '.*\.(ods|jpg)'); do
-  # extra branches for clarity
-  if [ ! -s "$path" ]; then
-     # echo "$path is empty"
-     true
-  elif [ -z "$(tail -c 1 < "$path")" ]; then
-     # echo "$path ends with a newline or with a null byte"
-     true
-  else
-    >&2 echo "$path doesn't end with a newline" 1>&2
-    errors="true"
+
+function check_eof() {
+  errors=""
+  for path in $(echo "$git_ls_files" | grep -v -E '.*\.(ods|jpg)'); do
+    # extra branches for clarity
+    if [ ! -s "$path" ]; then
+       # echo "$path is empty"
+       true
+    elif [ -z "$(tail -c 1 < "$path")" ]; then
+       # echo "$path ends with a newline or with a null byte"
+       true
+    else
+      >&2 echo "$path doesn't end with a newline" 1>&2
+      errors="true"
+    fi
+  done
+
+  if [ -n "$errors" ]; then
+    >&2 echo "Fix the problems above or use --no-verify" 1>&2
+    return 1
   fi
-done
+}
+export -f check_eof
 
-if [ -n "$errors" ]; then
-  >&2 echo "Fix the problems above or use --no-verify" 1>&2
-  exit 1
-fi
+
+parallel ::: check_nix check_cargo_fmt check_dbg check_shellcheck check_eof 


### PR DESCRIPTION
This is to start the ball rolling on #1469 .

New constants are defined, committing us to certain logging categories, which we will treat as a semi-public API. This way users can set their logging levels, and they will not change out of the blue, just because we shuffled some code around.

Then, as a showcase,  I change the `error!` and `warn!` use to utilize this. This does add a bit of noise, but I think it's reasonable. We could introduce things like `error_net_peer!(...)`, `warn_consensus!(...)` wrappers etc. if we decide that we don't like the noise.

Lastly, we introduce `semgrep` rules and add them to git pre-commit hook, to enforce correct usage.


I limited the scope of changes to one package and two logging levels, to keep the change small and get some feedback first, before attempting to go all in.

While at it, I changed some logging levels that I've found wrong. Let me know if you disagree.