### PR TITLE
feat: enforce conventional commit format using `convco`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,6 +139,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1675183161,
+        "narHash": "sha256-Zq8sNgAxDckpn7tJo7V1afRSk2eoVbu3OjI1QklGLNg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e1e1b192c1a5aab2960bf0a0bd53a2e8124fa18e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "advisory-db": "advisory-db",
@@ -146,7 +162,8 @@
         "fenix": "fenix",
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "rust-analyzer-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     crane.url = "github:ipetkov/crane?rev=98894bb39b03bfb379c5e10523cd61160e1ac782"; # https://github.com/ipetkov/crane/releases/tag/v0.11.0
     crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
@@ -18,12 +19,17 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, flake-compat, fenix, crane, advisory-db }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils, flake-compat, fenix, crane, advisory-db }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
         };
+
+        pkgs-unstable = import nixpkgs-unstable {
+          inherit system;
+        };
+
         lib = pkgs.lib;
         stdenv = pkgs.stdenv;
 
@@ -885,6 +891,7 @@
                 pkgs.nixpkgs-fmt
                 pkgs.shellcheck
                 pkgs.rnix-lsp
+                pkgs-unstable.convco
                 pkgs.nodePackages.bash-language-server
               ] ++ cliTestsDeps;
               RUST_SRC_PATH = "${fenixChannel.rust-src}/lib/rustlib/src/rust/library";
@@ -950,6 +957,7 @@
                 pkgs.nixpkgs-fmt
                 pkgs.shellcheck
                 pkgs.git
+                pkgs-unstable.convco
               ];
             };
 

--- a/misc/git-hooks/commit-msg
+++ b/misc/git-hooks/commit-msg
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -eu
+
+export tmp_file="$1.tmp"
+
+function rm_tmp_file {
+  rm -f "$tmp_file"
+}
+
+trap rm_tmp_file EXIT
+
+while : ; do
+  # Sanitize file first, by removing leading lines that are empty or start with a hash,
+  # as `convco` currently does not do it automatically (but git will)
+  echo -n "" > "$tmp_file"
+  body_detected=""
+  while read -r line ; do
+    # skip any initial comments (possibly from previous run)
+    if [ -z "${body_detected:-}" ] && { [[ "$line" =~ ^#.*$ ]] || [ "$line" == "" ]; }; then
+      continue
+    fi
+    body_detected="true"
+
+    echo "$line" >> "$tmp_file"
+  done < "$1"
+
+  # We have a sanitized version in "$tmp_file" now, move it the original
+  cp "$tmp_file" "$1"
+
+
+  # Run convco, start preparing a buffer we will display to the user,
+  # if lint fails.
+  echo -n "# " > "$tmp_file"
+  if convco check < "$1" 2>> "$tmp_file" ; then
+     break
+  fi
+
+  # lint failed, prepare the content to show
+  {
+    echo "# Refer to https://www.conventionalcommits.org/en/v1.0.0/#summary"
+    echo "# Quit without changes to abort"
+    cat "$1"
+  } >> "$tmp_file"
+
+  # "$tmp_file" has a commit message prefixed with comments explaining what's wrong.
+  cp "$tmp_file" "$1"
+  "${VISUAL:-${EDITOR:-vi}}" "$1"
+  if cmp -s "$tmp_file" "$1"; then
+    >&2 echo "Not changes. Exiting..."
+    exit 1
+  fi
+done


### PR DESCRIPTION
Currently only via git commit check hook, but will add a proper CI test after we try it out, and decide that we want to keep it.

* https://www.conventionalcommits.org
* https://github.com/convco/convco/

Needed to pull in `nixpkgs-unstable` to get a version of the linter that supports stdin. It doesn't seem to increase the amount of things being downloaded much, so should be OK, and we can remove it in the future.