### PR TITLE
 Consensus and Api versioning - APIs

### DIFF
--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -75,7 +75,7 @@ impl JsonWithKind {
     /// TODO: In the future, we should have a typed and erased versions of
     /// module construction traits, and then we can try with and
     /// without the workaround to have both cases working.
-    /// See https://github.com/fedimint/fedimint/issues/1303
+    /// See <https://github.com/fedimint/fedimint/issues/1303>
     pub fn with_fixed_empty_value(self) -> Self {
         if let serde_json::Value::Object(ref o) = self.value {
             if o.is_empty() {

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -15,7 +15,8 @@ use fedimint_api::{
 
 use super::*;
 use crate::module::{
-    ApiEndpoint, ConsensusProposal, InputMeta, ModuleError, ServerModule, TransactionItemAmount,
+    ApiEndpoint, ApiVersion, ConsensusProposal, InputMeta, ModuleConsensusVersion, ModuleError,
+    ServerModule, TransactionItemAmount,
 };
 
 pub trait IVerificationCache: Debug {
@@ -48,10 +49,12 @@ where
 /// Server side Fedimint module needs to implement this trait.
 #[async_trait]
 pub trait IServerModule: Debug {
+    fn as_any(&self) -> &dyn Any;
+
     /// Returns the decoder belonging to the server module
     fn decoder(&self) -> DynDecoder;
 
-    fn as_any(&self) -> &dyn Any;
+    fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]);
 
     /// Blocks until a new `consensus_proposal` is available.
     async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>);
@@ -182,6 +185,10 @@ where
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]) {
+        <Self as ServerModule>::versions(self)
     }
 
     /// Blocks until a new `consensus_proposal` is available.

--- a/gateway/ln-gateway/src/cln.rs
+++ b/gateway/ln-gateway/src/cln.rs
@@ -251,7 +251,7 @@ fn scid_to_u64(scid: ShortChannelId) -> u64 {
     scid_num
 }
 
-/// BOLT 4: https://github.com/lightning/bolts/blob/master/04-onion-routing.md#failure-messages
+/// BOLT 4: <https://github.com/lightning/bolts/blob/master/04-onion-routing.md#failure-messages>
 /// 16399 error code reports unknown payment details.
 ///
 /// TODO: We should probably use a more specific error code based on htlc processing fail reason

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -17,8 +17,8 @@ use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
-    api_endpoint, ApiEndpoint, ConsensusProposal, InputMeta, ModuleError, ModuleGen,
-    TransactionItemAmount,
+    api_endpoint, ApiEndpoint, ApiVersion, ConsensusProposal, CoreConsensusVersion, InputMeta,
+    ModuleConsensusVersion, ModuleError, ModuleGen, TransactionItemAmount,
 };
 use fedimint_api::net::peers::MuxPeerConnections;
 use fedimint_api::server::DynServerModule;
@@ -58,6 +58,10 @@ impl ModuleGen for DummyConfigGenerator {
 
     fn decoder(&self) -> DummyDecoder {
         DummyDecoder
+    }
+
+    fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
+        &[ModuleConsensusVersion(0)]
     }
 
     async fn init(
@@ -203,6 +207,13 @@ impl ServerModule for Dummy {
 
     fn decoder(&self) -> Self::Decoder {
         DummyDecoder
+    }
+
+    fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]) {
+        (
+            ModuleConsensusVersion(0),
+            &[ApiVersion { major: 0, minor: 0 }],
+        )
     }
 
     async fn await_consensus_proposal(&self, _dbtx: &mut DatabaseTransaction<'_>) {

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -33,8 +33,9 @@ use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
-    api_endpoint, ApiEndpoint, ApiError, ConsensusProposal, InputMeta, IntoModuleError,
-    ModuleError, ModuleGen, TransactionItemAmount,
+    api_endpoint, ApiEndpoint, ApiError, ApiVersion, ConsensusProposal, CoreConsensusVersion,
+    InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError, ModuleGen,
+    TransactionItemAmount,
 };
 use fedimint_api::net::peers::MuxPeerConnections;
 use fedimint_api::server::DynServerModule;
@@ -252,6 +253,10 @@ impl ModuleGen for LightningGen {
         LightningDecoder
     }
 
+    fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
+        &[ModuleConsensusVersion(0)]
+    }
+
     async fn init(
         &self,
         cfg: ServerModuleConfig,
@@ -440,6 +445,13 @@ impl ServerModule for Lightning {
 
     fn decoder(&self) -> Self::Decoder {
         LightningDecoder
+    }
+
+    fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]) {
+        (
+            ModuleConsensusVersion(0),
+            &[ApiVersion { major: 0, minor: 0 }],
+        )
     }
 
     async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -21,8 +21,9 @@ use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
-    api_endpoint, ApiEndpoint, ApiError, ConsensusProposal, InputMeta, IntoModuleError,
-    ModuleError, ModuleGen, TransactionItemAmount,
+    api_endpoint, ApiEndpoint, ApiError, ApiVersion, ConsensusProposal, CoreConsensusVersion,
+    InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError, ModuleGen,
+    TransactionItemAmount,
 };
 use fedimint_api::net::peers::MuxPeerConnections;
 use fedimint_api::server::DynServerModule;
@@ -149,6 +150,10 @@ impl ModuleGen for MintGen {
 
     fn decoder(&self) -> MintDecoder {
         MintDecoder
+    }
+
+    fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
+        &[ModuleConsensusVersion(0)]
     }
 
     async fn init(
@@ -446,6 +451,13 @@ impl ServerModule for Mint {
         if !self.consensus_proposal(dbtx).await.forces_new_epoch() {
             std::future::pending().await
         }
+    }
+
+    fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]) {
+        (
+            ModuleConsensusVersion(0),
+            &[ApiVersion { major: 0, minor: 0 }],
+        )
     }
 
     async fn consensus_proposal(

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -37,7 +37,8 @@ use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
-    api_endpoint, ConsensusProposal, InputMeta, IntoModuleError, ModuleGen, TransactionItemAmount,
+    api_endpoint, ApiVersion, ConsensusProposal, CoreConsensusVersion, InputMeta, IntoModuleError,
+    ModuleConsensusVersion, ModuleGen, TransactionItemAmount,
 };
 use fedimint_api::module::{ApiEndpoint, ModuleError};
 use fedimint_api::net::peers::MuxPeerConnections;
@@ -239,6 +240,10 @@ impl ModuleGen for WalletGen {
 
     fn decoder(&self) -> WalletDecoder {
         WalletDecoder {}
+    }
+
+    fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
+        &[ModuleConsensusVersion(0)]
     }
 
     async fn init(
@@ -489,6 +494,13 @@ impl ServerModule for Wallet {
 
     fn decoder(&self) -> Self::Decoder {
         WalletDecoder
+    }
+
+    fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]) {
+        (
+            ModuleConsensusVersion(0),
+            &[ApiVersion { major: 0, minor: 0 }],
+        )
     }
 
     async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {


### PR DESCRIPTION
Currently rebased on top of #1575 to avoid merge conflict. See only the last commit.

Implement the basic types and module-related primitves to support
versioning.

These are currently not used for anything, and here only for
moving forward with the discussion from https://github.com/fedimint/fedimint/issues/1548.