### PR TITLE
refactor: Make `FedimintServer` `Send` and `Sync`

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -102,6 +102,20 @@ pub struct FedimintServer {
     pub decoders: ModuleDecoderRegistry,
 }
 
+// TODO: delete this after we convert the codebase to actually
+// use (and thus enforce) `Send` and `Sync` on `FedimintServer`
+const _: () = {
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
+    #[allow(path_statements)]
+    #[allow(clippy::no_effect)]
+    fn assert_all() {
+        assert_send::<FedimintServer>;
+        assert_sync::<FedimintServer>();
+    }
+};
+
 impl FedimintServer {
     /// Start all the components of the mint and plug them together
     pub async fn run(

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -86,8 +86,8 @@ where
 #[async_trait]
 impl<MuxKey, Msg> IMuxPeerConnections<MuxKey, Msg> for PeerConnectionMultiplexer<MuxKey, Msg>
 where
-    Msg: Serialize + DeserializeOwned + Unpin + Send + Debug,
-    MuxKey: Serialize + DeserializeOwned + Unpin + Send + Debug + Eq + Hash + Clone,
+    Msg: Serialize + DeserializeOwned + Sync + Send + Debug,
+    MuxKey: Serialize + DeserializeOwned + Sync + Send + Debug + Eq + Hash + Clone,
 {
     async fn send(&self, peers: &[PeerId], key: MuxKey, msg: Msg) -> Cancellable<()> {
         debug!("Sending to {peers:?}/{key:?}, {msg:?}");
@@ -127,7 +127,7 @@ where
             }
 
             // try lock is used to avoid a deadlock (see below)
-            if let Ok(mut connections) = self.inner.connections.try_lock() {
+            if let Ok(connections) = self.inner.connections.try_lock() {
                 // `out_of_order` lock guard is dropped *after* we obtained `connections`,
                 // guaranteeing that new elements could have been added to `out_of_order`
                 // since we've last checked.


### PR DESCRIPTION
I'm working on something else, and this is blocking me.

Dealing with `Unpin` and `!Send` things in async seems like something we should avoid anyway.