### PR TITLE
feat: add restart command for tmuxinator

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -10,6 +10,7 @@ pre_window:
   - alias gateway-cli="\$FM_GATEWAY_CLI"
   - alias mint_rpc_client="\$FM_MINT_RPC_CLIENT"
   - alias dbtool="\$FM_DB_TOOL"
+  - alias restart="./scripts/restart-tmux.sh"
 tmux_detached: false
 windows:
   - main:

--- a/scripts/restart-tmux.sh
+++ b/scripts/restart-tmux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+ 
+tmux send-keys -t fedimint-dev:1.4 "pkill -9 fedimintd" C-m
+tmux send-keys -t fedimint-dev:1.4 "cargo build --bin fedimintd" C-m
+tmux send-keys -t fedimint-dev:1.4 "./scripts/start-fed.sh" C-m
+
+./scripts/gw-reload.sh


### PR DESCRIPTION
A first draft to address #1553. Adds a tmuxinator alias `restart` that runs the new script "restart-tmux", which sends the commands referenced in this [message](https://discord.com/channels/990354215060795454/1060246795004944466/1064727278568878160) and runs gw-reload.sh. Not sure if this is the best approach so I definitely welcome suggested alternatives.