### PR TITLE
feat: Run `rust-tests.sh` in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "secp256k1-zkp",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -1202,6 +1203,7 @@ dependencies = [
  "futures",
  "hbbft",
  "itertools",
+ "lazy_static",
  "lightning",
  "lightning-invoice",
  "ln-gateway",

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -609,7 +609,7 @@ async fn handle_command(
             description,
             expiry_time,
         } => client
-            .generate_invoice(amount, description, &mut rng, expiry_time)
+            .generate_confirmed_invoice(amount, description, &mut rng, expiry_time)
             .await
             .transform(
                 |confirmed_invoice| CliOutput::LnInvoice {

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -129,7 +129,7 @@ impl LnClient {
     }
 
     pub async fn get_contract_account(&self, id: ContractId) -> Result<ContractAccount> {
-        timeout(Duration::from_secs(10), self.context.api.fetch_contract(id))
+        timeout(Duration::from_secs(30), self.context.api.fetch_contract(id))
             .await
             .map_err(|_e| LnClientError::Timeout)?
             .map_err(LnClientError::ApiError)

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -24,3 +24,4 @@ secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_has
 serde = "1.0.149"
 serde_json = "1.0.91"
 rand = "0.8"
+tokio = { version = "1.24.2", features = ["full"] }

--- a/fedimint-testing/src/btc/fixtures.rs
+++ b/fedimint-testing/src/btc/fixtures.rs
@@ -75,8 +75,15 @@ impl FakeBitcoinTest {
     }
 }
 
+#[async_trait]
 impl BitcoinTest for FakeBitcoinTest {
-    fn mine_blocks(&self, block_num: u64) {
+    async fn lock_exclusive(&self) -> Box<dyn BitcoinTest> {
+        // With  FakeBitcoinTest, every test spawns their own instance,
+        // so not need to lock anything
+        Box::new(self.clone())
+    }
+
+    async fn mine_blocks(&self, block_num: u64) {
         let mut blocks = self.blocks.lock().unwrap();
         let mut pending = self.pending.lock().unwrap();
 
@@ -85,7 +92,7 @@ impl BitcoinTest for FakeBitcoinTest {
         }
     }
 
-    fn send_and_mine_block(
+    async fn send_and_mine_block(
         &self,
         address: &Address,
         amount: bitcoin::Amount,
@@ -113,15 +120,15 @@ impl BitcoinTest for FakeBitcoinTest {
         )
     }
 
-    fn get_new_address(&self) -> Address {
+    async fn get_new_address(&self) -> Address {
         let ctx = bitcoin::secp256k1::Secp256k1::new();
         let (_, public_key) = ctx.generate_keypair(&mut OsRng);
 
         Address::p2wpkh(&bitcoin::PublicKey::new(public_key), Network::Regtest).unwrap()
     }
 
-    fn mine_block_and_get_received(&self, address: &Address) -> Amount {
-        self.mine_blocks(1);
+    async fn mine_block_and_get_received(&self, address: &Address) -> Amount {
+        self.mine_blocks(1).await;
         let sats = self
             .blocks
             .lock()

--- a/fedimint-testing/src/btc/mod.rs
+++ b/fedimint-testing/src/btc/mod.rs
@@ -1,25 +1,31 @@
 pub mod bitcoind;
 pub mod fixtures;
 
+use async_trait::async_trait;
 use bitcoin::{Address, Transaction};
 use fedimint_api::Amount;
 use fedimint_wallet::txoproof::TxOutProof;
 
+#[async_trait]
 pub trait BitcoinTest {
+    /// Make the underlying instance act as if it was exclusively available
+    /// for the existance of the returned guard.
+    async fn lock_exclusive(&self) -> Box<dyn BitcoinTest>;
+
     /// Mines a given number of blocks
-    fn mine_blocks(&self, block_num: u64);
+    async fn mine_blocks(&self, block_num: u64);
 
     /// Send some bitcoin to an address then mine a block to confirm it.
     /// Returns the proof that the transaction occurred.
-    fn send_and_mine_block(
+    async fn send_and_mine_block(
         &self,
         address: &Address,
         amount: bitcoin::Amount,
     ) -> (TxOutProof, Transaction);
 
     /// Returns a new address.
-    fn get_new_address(&self) -> Address;
+    async fn get_new_address(&self) -> Address;
 
     /// Mine a block to include any pending transactions then get the amount received to an address
-    fn mine_block_and_get_received(&self, address: &Address) -> Amount;
+    async fn mine_block_and_get_received(&self, address: &Address) -> Amount;
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -273,8 +273,14 @@ impl LnGateway {
         // We use a random federation as the default (works because we only have one federation registered)
         //
         // TODO: Use subscribe intercept htlc streams to avoid actor selection with every intercepted htlc!
-        self.actors.lock().await.values().collect::<Vec<_>>()[0]
-            .buy_preimage_internal(&payment_hash, &invoice_amount)
+        let lock = &self.actors.lock().await;
+        let gateway_actor = lock.values().collect::<Vec<_>>()[0];
+        gateway_actor
+            .pay_invoice_buy_preimage_finalize(actor::BuyPreimage::Internal(
+                gateway_actor
+                    .buy_preimage_internal(&payment_hash, &invoice_amount)
+                    .await?,
+            ))
             .await
     }
 

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -1,3 +1,21 @@
+//! Integration test suite
+//!
+//! This crate contains integration tests that work be creating
+//! per-test federation, ln-gatewa and driving bitcoind and lightning
+//! nodes to exercise certain behaviors on it.
+//!
+//! We run them in two modes:
+//!
+//! * With mocks - fake implementations of Lightning and Bitcoin node
+//!   that only simulate the real behavior. These are instantiated
+//!   per test.
+//! * Without mocks - against real bitcoind and lightningd.
+//!
+//! When running against real bitcoind, the other tests might create
+//! new blocks and transactions, so the tests can't expect to have
+//! exclusive control over it. When it is really necessary, `lock_exclusive`
+//! can be used to achieve it, but that makes the given test run serially
+//! is thus udesireable.
 mod fixtures;
 
 use std::future::Future;

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -98,10 +98,12 @@ async fn test_gateway_authentication() -> Result<()> {
     // Test gateway authentication on `deposit` function
     // *  `deposit` with correct password succeeds
     // *  `deposit` with incorrect password fails
-    let (proof, tx) = bitcoin.send_and_mine_block(
-        &bitcoin.get_new_address(),
-        bitcoin::Amount::from_btc(1.0).unwrap(),
-    );
+    let (proof, tx) = bitcoin
+        .send_and_mine_block(
+            &bitcoin.get_new_address().await,
+            bitcoin::Amount::from_btc(1.0).unwrap(),
+        )
+        .await;
     let payload = DepositPayload {
         federation_id: federation_id.clone(),
         txout_proof: proof,
@@ -118,7 +120,7 @@ async fn test_gateway_authentication() -> Result<()> {
     let payload = WithdrawPayload {
         federation_id,
         amount: bitcoin::Amount::from_sat(100),
-        address: bitcoin.get_new_address(),
+        address: bitcoin.get_new_address().await,
     };
     test_auth(&gw_password, |pw| client_ref.withdraw(pw, payload.clone())).await?;
 

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -19,6 +19,7 @@ bitcoincore-rpc = "0.16.0"
 cln-rpc = "0.1.1"
 futures = "0.3.24"
 itertools = "0.10.5"
+lazy_static = "1.4.0"
 lightning-invoice = "0.21.0"
 ln-gateway = { path = "../gateway/ln-gateway" }
 lightning = "0.0.113"

--- a/integrationtests/tests/fixtures/fake.rs
+++ b/integrationtests/tests/fixtures/fake.rs
@@ -61,6 +61,10 @@ impl LightningTest for FakeLightningTest {
     async fn amount_sent(&self) -> Amount {
         Amount::from_msats(*self.amount_sent.lock().unwrap())
     }
+
+    fn is_shared(&self) -> bool {
+        false
+    }
 }
 
 #[async_trait]

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -164,9 +164,18 @@ impl BitcoinTest for RealBitcoinTest {
     }
 
     async fn mine_blocks(&self, block_num: u64) {
-        self.client
+        if let Some(block_hash) = self
+            .client
             .generate_to_address(block_num, &self.get_new_address().await)
-            .expect(Self::ERROR);
+            .expect(Self::ERROR)
+            .last()
+        {
+            // if this is not true, we will have to add some delay mechanism here, because tests expect it
+            let _ = self
+                .client
+                .get_block(block_hash)
+                .expect("there should be no delay between block being generated and available");
+        };
     }
 
     async fn send_and_mine_block(

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -3,6 +3,7 @@ use std::ops::Sub;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bitcoin::{secp256k1, Address, Transaction};
@@ -16,7 +17,9 @@ use fedimint_api::Amount;
 use fedimint_testing::btc::BitcoinTest;
 use fedimint_wallet::txoproof::TxOutProof;
 use futures::lock::Mutex;
+use lazy_static::lazy_static;
 use lightning_invoice::Invoice;
+use tokio::time::sleep;
 use url::Url;
 
 use crate::fixtures::LightningTest;
@@ -63,6 +66,10 @@ impl LightningTest for RealLightningTest {
     async fn amount_sent(&self) -> Amount {
         self.initial_balance
             .sub(Self::channel_balance(self.rpc_gateway.clone()).await)
+    }
+
+    fn is_shared(&self) -> bool {
+        true
     }
 }
 
@@ -121,7 +128,7 @@ impl RealLightningTest {
 }
 
 pub struct RealBitcoinTest {
-    client: Client,
+    client: Arc<Client>,
 }
 
 impl RealBitcoinTest {
@@ -130,20 +137,39 @@ impl RealBitcoinTest {
     pub fn new(url: &Url) -> Self {
         let (host, auth) =
             fedimint_bitcoind::bitcoincore_rpc::from_url_to_url_auth(url).expect("corrent url");
-        let client = Client::new(&host, auth).expect(Self::ERROR);
+        let client = Arc::new(Client::new(&host, auth).expect(Self::ERROR));
 
         Self { client }
     }
 }
 
+pub struct RealBitcoinTestLocked {
+    inner: RealBitcoinTest,
+    _guard: tokio::sync::MutexGuard<'static, ()>,
+}
+
+lazy_static! {
+    static ref REAL_BITCOIN_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::new(());
+}
+
+#[async_trait]
 impl BitcoinTest for RealBitcoinTest {
-    fn mine_blocks(&self, block_num: u64) {
+    async fn lock_exclusive(&self) -> Box<dyn BitcoinTest> {
+        Box::new(RealBitcoinTestLocked {
+            inner: RealBitcoinTest {
+                client: self.client.clone(),
+            },
+            _guard: REAL_BITCOIN_LOCK.lock().await,
+        })
+    }
+
+    async fn mine_blocks(&self, block_num: u64) {
         self.client
-            .generate_to_address(block_num, &self.get_new_address())
+            .generate_to_address(block_num, &self.get_new_address().await)
             .expect(Self::ERROR);
     }
 
-    fn send_and_mine_block(
+    async fn send_and_mine_block(
         &self,
         address: &Address,
         amount: bitcoin::Amount,
@@ -152,18 +178,26 @@ impl BitcoinTest for RealBitcoinTest {
             .client
             .send_to_address(address, amount, None, None, None, None, None, None)
             .expect(Self::ERROR);
-        self.mine_blocks(1);
+        self.mine_blocks(1).await;
 
         let tx = self
             .client
             .get_raw_transaction(&id, None)
             .expect(Self::ERROR);
         let proof = TxOutProof::consensus_decode(
-            &mut Cursor::new(
-                self.client
-                    .get_tx_out_proof(&[id], None)
-                    .expect(Self::ERROR),
-            ),
+            &mut Cursor::new(loop {
+                match self.client.get_tx_out_proof(&[id], None) {
+                    Ok(o) => break o,
+                    Err(e) => {
+                        if e.to_string().contains("not yet in block") {
+                            // mostly to yield, as we no other yield points
+                            sleep(Duration::from_millis(1)).await;
+                            continue;
+                        }
+                        panic!("Could not get txoutproof: {e}");
+                    }
+                }
+            }),
             &ModuleDecoderRegistry::default(),
         )
         .expect(Self::ERROR);
@@ -171,15 +205,41 @@ impl BitcoinTest for RealBitcoinTest {
         (proof, tx)
     }
 
-    fn get_new_address(&self) -> Address {
+    async fn get_new_address(&self) -> Address {
         self.client.get_new_address(None, None).expect(Self::ERROR)
     }
 
-    fn mine_block_and_get_received(&self, address: &Address) -> Amount {
-        self.mine_blocks(1);
+    async fn mine_block_and_get_received(&self, address: &Address) -> Amount {
+        self.mine_blocks(1).await;
         self.client
             .get_received_by_address(address, None)
             .expect(Self::ERROR)
             .into()
+    }
+}
+#[async_trait]
+impl BitcoinTest for RealBitcoinTestLocked {
+    async fn lock_exclusive(&self) -> Box<dyn BitcoinTest> {
+        panic!("Double-locking would lead to a hang");
+    }
+
+    async fn mine_blocks(&self, block_num: u64) {
+        self.inner.mine_blocks(block_num).await
+    }
+
+    async fn send_and_mine_block(
+        &self,
+        address: &Address,
+        amount: bitcoin::Amount,
+    ) -> (TxOutProof, Transaction) {
+        self.inner.send_and_mine_block(address, amount).await
+    }
+
+    async fn get_new_address(&self) -> Address {
+        self.inner.get_new_address().await
+    }
+
+    async fn mine_block_and_get_received(&self, address: &Address) -> Amount {
+        self.inner.mine_block_and_get_received(address).await
     }
 }

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -4,7 +4,7 @@
 set -euxo pipefail
 export RUST_LOG=info
 
-source ./scripts/setup-tests.sh
+source ./scripts/setup-tests.sh ""
 
 export FM_TEST_DISABLE_MOCKS=1
-cargo test -p fedimint-tests -- --test-threads=1
+cargo test -p fedimint-tests "$@"

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -2,7 +2,7 @@
 # Runs the all the Rust integration tests
 
 set -euxo pipefail
-export RUST_LOG=info
+export RUST_LOG="${RUST_LOG:-info}"
 
 source ./scripts/setup-tests.sh ""
 


### PR DESCRIPTION
This change is trying to take care of a biggest pain point of our current state of testing suite - the long time it takes us to execute the integration tests with real LN and `bitcoind`.


Before:

![image](https://user-images.githubusercontent.com/9209/216913525-f1cbe135-7cbb-4587-8511-812830924dcf.png)

After:

![image](https://user-images.githubusercontent.com/9209/216913438-5e9050d2-1897-4c9c-b2b9-d502a5e4a8a2.png)


After quite a bit of investigation I realized that it should be possible to retain the shared infrastructure (which is great for keeping the performance high and resource usage low) yet run tests in parallel with relatively minor changes.

The biggest assumption that is being broken is strict control over block height. As multiple tests are sharing `bitcoind`, the block height can increase at any time, which will lead to random epochs being introduced.

The common pattern this breaks is:

```
join_all([
  operation,
  await_consensus_epoch(exact_amount_of_epochs_required)
])
```

where `operation` triggers new epochs, and blocks until they are processed, somewhere inside itself, while `await_consensus_epoch` is triggering the epoch processing.

This worked before because `await_consensus_epoch` blocks waiting for events triggering epochs. Since now new block heights can happen randomly, this leads to flakiness.

I refactor affected code by breaking `operation`s into smaller pieces to allow calling `await_consensus_epoch` exactly when required.

In few places this didn't seem easily doable, so I have added an ability to force lock over whole "real" `bitcoind` client to prevent random events. This serializes the execution of given tests, but better few exceptions than all tests.

Couple of minor facilities are added where necessary.