### PR TITLE
Greedy note select

### DIFF
--- a/fedimint-api/src/tiered.rs
+++ b/fedimint-api/src/tiered.rs
@@ -86,6 +86,21 @@ impl Tiered<SecretKeyShare> {
     }
 }
 
+impl Tiered<()> {
+    /// Generates denominations as powers of 2 until a `max`
+    pub fn gen_denominations(max: Amount) -> Tiered<()> {
+        let mut amounts = vec![];
+
+        let mut denomination = Amount::from_msats(1);
+        while denomination < max {
+            amounts.push((denomination, ()));
+            denomination = denomination * 2;
+        }
+
+        amounts.into_iter().collect()
+    }
+}
+
 impl<T> FromIterator<(Amount, T)> for Tiered<T> {
     fn from_iter<I: IntoIterator<Item = (Amount, T)>>(iter: I) -> Self {
         Tiered(iter.into_iter().collect())

--- a/fedimint-api/src/tiered_multi.rs
+++ b/fedimint-api/src/tiered_multi.rs
@@ -370,11 +370,11 @@ mod test {
     }
 
     #[test]
-    fn select_notes_returns_exact_amount() {
+    fn select_notes_returns_exact_amount_with_minimum_notes() {
         let starting = notes(vec![
-            (Amount::from_sats(1), 5),
-            (Amount::from_sats(5), 5),
-            (Amount::from_sats(20), 5),
+            (Amount::from_sats(1), 10),
+            (Amount::from_sats(5), 10),
+            (Amount::from_sats(20), 10),
         ]);
 
         assert_eq!(
@@ -384,11 +384,20 @@ mod test {
                 (Amount::from_sats(5), 1)
             ]))
         );
+
+        assert_eq!(
+            starting.select_notes(Amount::from_sats(20)),
+            Some(notes(vec![(Amount::from_sats(20), 1),]))
+        );
     }
 
     #[test]
-    fn select_notes_uses_smaller_denominations() {
-        let starting = notes(vec![(Amount::from_sats(5), 5), (Amount::from_sats(20), 5)]);
+    fn select_notes_returns_next_smallest_amount_if_exact_change_cannot_be_made() {
+        let starting = notes(vec![
+            (Amount::from_sats(1), 1),
+            (Amount::from_sats(5), 5),
+            (Amount::from_sats(20), 5),
+        ]);
 
         assert_eq!(
             starting.select_notes(Amount::from_sats(7)),
@@ -401,6 +410,22 @@ mod test {
         let starting = notes(vec![(Amount::from_sats(10), 1)]);
 
         assert_eq!(starting.select_notes(Amount::from_sats(100)), None);
+    }
+
+    #[test]
+    fn select_notes_avg_test() {
+        let max_amount = Amount::from_sats(1000000);
+        let tiers = Tiered::gen_denominations(max_amount);
+        let tiered =
+            TieredMulti::represent_amount::<(), ()>(max_amount, &Default::default(), &tiers, 3);
+
+        let mut total_notes = 0;
+        for multiplier in 1..100 {
+            let notes = notes(tiered.as_map().clone().into_iter().collect());
+            let select = notes.select_notes(Amount::from_sats(multiplier * 1000));
+            total_notes += select.unwrap().into_iter_items().count();
+        }
+        assert_eq!(total_notes / 100, 10);
     }
 
     fn notes(notes: Vec<(Amount, usize)>) -> TieredMulti<usize> {

--- a/fedimint-server/src/config.rs
+++ b/fedimint-server/src/config.rs
@@ -14,7 +14,7 @@ use fedimint_api::config::{
 use fedimint_api::core::{ModuleInstanceId, ModuleKind, MODULE_INSTANCE_ID_GLOBAL};
 use fedimint_api::net::peers::{IPeerConnections, MuxPeerConnections, PeerConnections};
 use fedimint_api::task::{timeout, Elapsed, TaskGroup};
-use fedimint_api::{Amount, PeerId};
+use fedimint_api::{Amount, PeerId, Tiered};
 pub use fedimint_core::config::*;
 use fedimint_core::modules::mint::MintGenParams;
 use fedimint_wallet::WalletGenParams;
@@ -574,19 +574,6 @@ pub struct PeerServerParams {
 }
 
 impl ServerConfigParams {
-    /// Generates denominations as powers of 2 until a `max`
-    pub fn gen_denominations(max: Amount) -> Vec<Amount> {
-        let mut amounts = vec![];
-
-        let mut denomination = Amount::from_msats(1);
-        while denomination < max {
-            amounts.push(denomination);
-            denomination = denomination * 2;
-        }
-
-        amounts
-    }
-
     pub fn peers(&self) -> BTreeMap<PeerId, PeerEndpoint> {
         self.fed_network
             .peers
@@ -661,7 +648,10 @@ impl ServerConfigParams {
                     finality_delay,
                 })
                 .attach(MintGenParams {
-                    mint_amounts: ServerConfigParams::gen_denominations(max_denomination),
+                    mint_amounts: Tiered::gen_denominations(max_denomination)
+                        .tiers()
+                        .cloned()
+                        .collect(),
                 }),
         }
     }


### PR DESCRIPTION
Transferring ecash offline takes a long time ~15-30 sec because of the all the data that needs to be transferred.

Part of the problem is our note selection algorithm isn't greedy, resulting in many notes to be transferred.

This reduces the avg number of selected notes from ~70 to ~10, tested using 100 different amounts from 1k to 100k sats.

BTW if we didn't use millisats (only sat denominations) that drops from 10 to 6.

Minor improvements in our latency tests as well:
AVG REISSUE TIME: 1.037 seconds
AVG LN SEND TIME: 3.452 seconds
AVG LN RECEIVE TIME: 3.685 seconds

Previously:
AVG REISSUE TIME: 1.420 seconds
AVG LN SEND TIME: 3.552 seconds
AVG LN RECEIVE TIME: 3.942 seconds