### PR TITLE
feat: In test run consensus operations in parallel

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -208,7 +208,7 @@ impl<T> Client<T> {
 }
 
 // TODO: `get_module` is parsing `serde_json::Value` every time, which is not best for performance
-impl<T: AsRef<ClientConfig> + Clone> Client<T> {
+impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
     pub fn db(&self) -> &Database {
         &self.context.db
     }

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -84,13 +84,13 @@ impl TransactionBuilder {
 
     pub fn change_required<C>(&self, client: &Client<C>) -> Amount
     where
-        C: AsRef<ClientConfig> + Clone,
+        C: AsRef<ClientConfig> + Clone + Send,
     {
         self.input_amount(client) - self.output_amount(client) - self.fee_amount(client)
     }
 
     /// Builds and signs the final transaction with correct change
-    pub async fn build<C: AsRef<ClientConfig> + Clone, R: RngCore + CryptoRng>(
+    pub async fn build<C: AsRef<ClientConfig> + Clone + Send, R: RngCore + CryptoRng>(
         self,
         client: &Client<C>,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -137,7 +137,7 @@ impl TransactionBuilder {
         client: &'a Client<C>,
     ) -> impl Iterator<Item = TransactionItemAmount> + 'a
     where
-        C: AsRef<ClientConfig> + Clone,
+        C: AsRef<ClientConfig> + Clone + Send,
     {
         self.tx.inputs.iter().map(|i| match i {
             Input::Mint(input) => client.mint_client().input_amount(input),
@@ -151,7 +151,7 @@ impl TransactionBuilder {
         client: &'a Client<C>,
     ) -> impl Iterator<Item = TransactionItemAmount> + 'a
     where
-        C: AsRef<ClientConfig> + Clone + 'a,
+        C: AsRef<ClientConfig> + Clone + Send + 'a,
     {
         self.tx.outputs.iter().map(|o| match o {
             Output::Mint(output) => client.mint_client().output_amount(output),
@@ -162,7 +162,7 @@ impl TransactionBuilder {
 
     fn input_amount<C>(&self, client: &Client<C>) -> Amount
     where
-        C: AsRef<ClientConfig> + Clone,
+        C: AsRef<ClientConfig> + Send + Clone,
     {
         self.input_amount_iter(client)
             .map(|amount_info| amount_info.amount)
@@ -171,7 +171,7 @@ impl TransactionBuilder {
 
     fn output_amount<C>(&self, client: &Client<C>) -> Amount
     where
-        C: AsRef<ClientConfig> + Clone,
+        C: AsRef<ClientConfig> + Send + Clone,
     {
         self.output_amount_iter(client)
             .map(|amount_info| amount_info.amount)
@@ -180,7 +180,7 @@ impl TransactionBuilder {
 
     fn fee_amount<C>(&self, client: &Client<C>) -> Amount
     where
-        C: AsRef<ClientConfig> + Clone,
+        C: AsRef<ClientConfig> + Send + Clone,
     {
         self.input_amount_iter(client)
             .chain(self.output_amount_iter(client))

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
-use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::{error::Error, marker::PhantomData};
 
 use anyhow::Result;
 use async_trait::async_trait;
+use futures::future::BoxFuture;
 use futures::{stream, Stream, StreamExt};
 use thiserror::Error;
 use tracing::{debug, instrument, trace, warn};
@@ -151,9 +151,7 @@ impl Database {
         max_retries: Option<usize>,
     ) -> Result<T, AutocommitError<E>>
     where
-        for<'a> F: Fn(
-            &'a mut DatabaseTransaction<'dt>,
-        ) -> Pin<Box<dyn Future<Output = Result<T, E>> + 'a>>,
+        for<'a> F: Fn(&'a mut DatabaseTransaction<'dt>) -> BoxFuture<'a, Result<T, E>>,
     {
         let mut retries: usize = 0;
         loop {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -396,8 +396,7 @@ impl FedimintConsensus {
             let span = info_span!("Processing transaction");
             async {
                 trace!(?transaction);
-                let mut tx_cache = self.tx_cache.lock().unwrap();
-                tx_cache.remove(&transaction);
+                self.tx_cache.lock().unwrap().remove(&transaction);
 
                 dbtx.set_tx_savepoint().await;
                 // TODO: use borrowed transaction

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -280,7 +280,8 @@ impl FedimintServer {
         // once we produce an outcome we no longer need to rejoin
         self.rejoin_at_epoch = None;
 
-        for epoch_num in self.next_epoch_to_process()..=last_outcome.epoch {
+        let next_epoch_to_process = self.next_epoch_to_process();
+        for epoch_num in next_epoch_to_process..=last_outcome.epoch {
             let (items, epoch, prev_epoch_hash, rejected_txs, at_know_trusted_checkpoint) =
                 if epoch_num == last_outcome.epoch {
                     (

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -54,7 +54,7 @@ async fn peg_in_and_peg_out_with_fees() -> Result<()> {
         fed.run_consensus_epochs(2).await; // peg-out tx + peg out signing epoch
 
         assert_matches!(
-            unwrap_item(&fed.find_module_item(fed.wallet_id)),
+            unwrap_item(&fed.find_module_item(fed.wallet_id).await),
             PegOutSignature(_)
         );
 
@@ -66,7 +66,7 @@ async fn peg_in_and_peg_out_with_fees() -> Result<()> {
             .unwrap();
 
         assert!(matches!(
-            unwrap_item(&fed.find_module_item(fed.wallet_id)),
+            unwrap_item(&fed.find_module_item(fed.wallet_id).await),
             PegOutSignature(PegOutSignatureItem {
                 txid,
                 ..
@@ -293,14 +293,18 @@ async fn ecash_in_wallet_can_sent_through_a_tx() -> Result<()> {
 
 async fn drop_peer_3_during_epoch(fed: &FederationTest) -> Result<()> {
     // ensure that peers 1,2,3 create an epoch, so they can see peer 3's bad proposal
-    fed.subset_peers(&[1, 2, 3]).run_consensus_epochs(1).await;
-    fed.subset_peers(&[0]).run_consensus_epochs(1).await;
+    fed.subset_peers(&[1, 2, 3])
+        .await
+        .run_consensus_epochs(1)
+        .await;
+    fed.subset_peers(&[0]).await.run_consensus_epochs(1).await;
 
     // let peers run consensus, but delay peer 0 so if peer 3 wasn't dropped peer 0 won't be included
     for maybe_cancelled in join_all(vec![
-        Either::Left(fed.subset_peers(&[1, 2]).run_consensus_epochs_wait(1)),
+        Either::Left(fed.subset_peers(&[1, 2]).await.run_consensus_epochs_wait(1)),
         Either::Right(
             fed.subset_peers(&[0, 3])
+                .await
                 .race_consensus_epoch(vec![Duration::from_millis(500), Duration::from_millis(0)]),
         ),
     ])
@@ -323,10 +327,13 @@ async fn drop_peers_who_dont_contribute_peg_out_psbts() -> Result<()> {
         let peg_out_address = bitcoin.get_new_address().await;
         user.peg_out(1000, &peg_out_address).await;
         // Ensure peer 0 who received the peg out request is in the next epoch
-        fed.subset_peers(&[0, 1, 2]).run_consensus_epochs(1).await;
-        fed.subset_peers(&[3]).run_consensus_epochs(1).await;
+        fed.subset_peers(&[0, 1, 2])
+            .await
+            .run_consensus_epochs(1)
+            .await;
+        fed.subset_peers(&[3]).await.run_consensus_epochs(1).await;
 
-        fed.subset_peers(&[3]).override_proposal(vec![]);
+        fed.subset_peers(&[3]).await.override_proposal(vec![]).await;
         drop_peer_3_during_epoch(&fed).await.unwrap();
 
         fed.broadcast_transactions().await;
@@ -334,7 +341,7 @@ async fn drop_peers_who_dont_contribute_peg_out_psbts() -> Result<()> {
             bitcoin.mine_block_and_get_received(&peg_out_address).await,
             sats(1000)
         );
-        assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
+        assert!(fed.subset_peers(&[0, 1, 2]).await.has_dropped_peer(3).await);
         assert_eq!(fed.max_balance_sheet(), 0);
     })
     .await
@@ -374,6 +381,7 @@ async fn drop_peers_who_dont_contribute_decryption_shares() -> Result<()> {
         let share = SecretKeyShare::default()
             .decrypt_share_no_verify(&SecretKey::random().public_key().encrypt(""));
         fed.subset_peers(&[3])
+            .await
             .override_proposal(vec![ConsensusItem::Module(
                 fedimint_api::core::DynModuleConsensusItem::from_typed(
                     fed.ln_id,
@@ -382,17 +390,21 @@ async fn drop_peers_who_dont_contribute_decryption_shares() -> Result<()> {
                         share: PreimageDecryptionShare(share),
                     },
                 ),
-            )]);
+            )])
+            .await;
         drop_peer_3_during_epoch(&fed).await.unwrap(); // preimage decryption
 
         user.client
             .claim_incoming_contract(contract_id, rng())
             .await
             .unwrap();
-        fed.subset_peers(&[0, 1, 2]).run_consensus_epochs(2).await; // contract to mint notes, sign notes
+        fed.subset_peers(&[0, 1, 2])
+            .await
+            .run_consensus_epochs(2)
+            .await; // contract to mint notes, sign notes
 
         user.assert_total_notes(payment_amount).await;
-        assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
+        assert!(fed.subset_peers(&[0, 1, 2]).await.has_dropped_peer(3).await);
         assert_eq!(fed.max_balance_sheet(), 0);
     })
     .await
@@ -405,11 +417,11 @@ async fn drop_peers_who_dont_contribute_blind_sigs() -> Result<()> {
             .await;
         fed.database_add_notes_for_user(&user, sats(2000)).await;
 
-        fed.subset_peers(&[3]).override_proposal(vec![]);
+        fed.subset_peers(&[3]).await.override_proposal(vec![]).await;
         drop_peer_3_during_epoch(&fed).await.unwrap();
 
         user.assert_total_notes(sats(2000)).await;
-        assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
+        assert!(fed.subset_peers(&[0, 1, 2]).await.has_dropped_peer(3).await);
     })
     .await
 }
@@ -430,11 +442,14 @@ async fn drop_peers_who_contribute_bad_sigs() -> Result<()> {
             ),
         )];
 
-        fed.subset_peers(&[3]).override_proposal(bad_proposal);
+        fed.subset_peers(&[3])
+            .await
+            .override_proposal(bad_proposal)
+            .await;
         drop_peer_3_during_epoch(&fed).await.unwrap();
 
         user.assert_total_notes(sats(2000)).await;
-        assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
+        assert!(fed.subset_peers(&[0, 1, 2]).await.has_dropped_peer(3).await);
     })
     .await
 }
@@ -855,7 +870,7 @@ async fn lightning_gateway_cannot_claim_invalid_preimage() -> Result<()> {
         assert!(response.is_err());
 
         fed.run_empty_epochs(1).await; // if valid would create contract to mint notes
-        assert_eq!(fed.find_module_item(fed.ln_id), None);
+        assert_eq!(fed.find_module_item(fed.ln_id).await, None);
         assert_eq!(fed.max_balance_sheet(), 0);
     })
     .await
@@ -1038,8 +1053,8 @@ async fn rejoin_consensus_single_peer() -> Result<()> {
         fed.run_consensus_epochs(1).await;
 
         // Keep peer 3 out of consensus
-        let online_peers = fed.subset_peers(&[0, 1, 2]);
-        let peer3 = fed.subset_peers(&[3]);
+        let online_peers = fed.subset_peers(&[0, 1, 2]).await;
+        let peer3 = fed.subset_peers(&[3]).await;
         bitcoin.mine_blocks(100).await;
         online_peers.run_consensus_epochs(1).await;
         bitcoin.mine_blocks(100).await;
@@ -1186,20 +1201,22 @@ async fn cannot_replay_transactions() -> Result<()> {
         let response = fed.submit_transaction(tx.clone()).await;
         assert_matches!(response, Ok(()));
         fed.run_empty_epochs(2).await;
-        assert!(fed.find_module_item(fed.mint_id).is_some());
+        assert!(fed.find_module_item(fed.mint_id).await.is_some());
         fed.clear_spent_mint_nonces().await;
 
         // verify resubmitting the tx fails at the API level
         let response = fed.submit_transaction(tx.clone()).await;
         assert_matches!(response, Err(TransactionReplayError(_)));
         fed.run_empty_epochs(2).await;
-        assert!(fed.find_module_item(fed.mint_id).is_none());
+        assert!(fed.find_module_item(fed.mint_id).await.is_none());
 
         // verify resubmitting the tx fails at the P2P level
         fed.subset_peers(&[0])
-            .override_proposal(vec![ConsensusItem::Transaction(tx)]);
+            .await
+            .override_proposal(vec![ConsensusItem::Transaction(tx)])
+            .await;
         fed.run_empty_epochs(2).await;
-        assert!(fed.find_module_item(fed.mint_id).is_none());
+        assert!(fed.find_module_item(fed.mint_id).await.is_none());
     })
     .await
 }


### PR DESCRIPTION
Note: Let's land #1592 first, as these two are going to create a merge conflict.

While `join` provides concurrency, it does not provide parallelism. Operations that are CPU heavy, will block other futures from running, and multiple cores will be under-utilized.

This change uses `spawn` to create multiple tasks for certain heavy and common operations, which should help utilize multiple-cores better.