### PR TITLE
Fixes some of the flakiness of reconnecting

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -480,8 +480,11 @@ impl FedimintServer {
                 Ok(self.handle_step(step).await?)
             }
             (_, EpochMessage::RejoinRequest(epoch)) => {
-                info!("Requested to run {} epochs", epoch);
-                self.run_empty_epochs = min(NUM_EPOCHS_REJOIN_AHEAD, epoch);
+                self.run_empty_epochs += min(NUM_EPOCHS_REJOIN_AHEAD, epoch);
+                info!(
+                    "Requested to run {} epochs, running {} epochs",
+                    epoch, self.run_empty_epochs
+                );
                 Ok(vec![])
             }
         }


### PR DESCRIPTION
Realized that sometimes the reconnect can stall because the `run_empty_epochs` may be overridden with a smaller number.  This change makes that additive.