### PR TITLE
Caches the submitted txs instead of using DB

### DIFF
--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -157,16 +157,6 @@ impl<'a> DatabaseDump<'a> {
         });
         for table in filtered_prefixes {
             match table {
-                ConsensusRange::DbKeyPrefix::ProposedTransaction => {
-                    push_db_pair_items_no_serde!(
-                        dbtx,
-                        ConsensusRange::ProposedTransactionKeyPrefix,
-                        ConsensusRange::ProposedTransactionKey,
-                        fedimint_core::transaction::Transaction,
-                        consensus,
-                        "Pending Transactions"
-                    );
-                }
                 ConsensusRange::DbKeyPrefix::AcceptedTransaction => {
                     push_db_pair_items_no_serde!(
                         dbtx,

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -8,12 +8,10 @@ use serde::Serialize;
 use strum_macros::EnumIter;
 
 use crate::consensus::AcceptedTransaction;
-use crate::transaction::Transaction;
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
-    ProposedTransaction = 0x01,
     AcceptedTransaction = 0x02,
     DropPeer = 0x03,
     RejectedTransaction = 0x04,
@@ -27,24 +25,6 @@ impl std::fmt::Display for DbKeyPrefix {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{self:?}")
     }
-}
-
-#[derive(Debug, Encodable, Decodable, Serialize)]
-pub struct ProposedTransactionKey(pub TransactionId);
-
-impl DatabaseKeyPrefixConst for ProposedTransactionKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::ProposedTransaction as u8;
-    type Key = Self;
-    type Value = Transaction;
-}
-
-#[derive(Debug, Encodable, Decodable)]
-pub struct ProposedTransactionKeyPrefix;
-
-impl DatabaseKeyPrefixConst for ProposedTransactionKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::ProposedTransaction as u8;
-    type Key = ProposedTransactionKey;
-    type Value = Transaction;
 }
 
 #[derive(Debug, Encodable, Decodable, Serialize)]


### PR DESCRIPTION
Avoids putting pending txs into the DB.

We have to use a `Mutex` around the cache, or alternatively we could put the cache into `FedimintServer` which seems worse.