### PR TITLE
feat: Add macro for implementing DatabaseKeyPrefixConst

### DIFF
--- a/client/client-lib/src/db.rs
+++ b/client/client-lib/src/db.rs
@@ -1,5 +1,6 @@
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::impl_db_prefix_const;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
@@ -20,8 +21,12 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ClientSecretKey;
 
-impl DatabaseKeyPrefixConst for ClientSecretKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::ClientSecret as u8;
-    type Key = ClientSecretKey;
-    type Value = ClientSecret;
-}
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ClientSecretPrefixKey;
+
+impl_db_prefix_const!(
+    ClientSecretKey,
+    ClientSecretPrefixKey,
+    ClientSecret,
+    DbKeyPrefix::ClientSecret
+);

--- a/client/client-lib/src/db.rs
+++ b/client/client-lib/src/db.rs
@@ -1,4 +1,3 @@
-use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::impl_db_prefix_const;
 use serde::Serialize;

--- a/client/client-lib/src/db.rs
+++ b/client/client-lib/src/db.rs
@@ -21,12 +21,8 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ClientSecretKey;
 
-#[derive(Debug, Encodable, Decodable, Serialize)]
-pub struct ClientSecretPrefixKey;
-
 impl_db_prefix_const!(
-    ClientSecretKey,
-    ClientSecretPrefixKey,
-    ClientSecret,
-    DbKeyPrefix::ClientSecret
+    key = ClientSecretKey,
+    value = ClientSecret,
+    prefix = DbKeyPrefix::ClientSecret
 );

--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -33,10 +33,10 @@ pub struct OutgoingPaymentKey(pub ContractId);
 pub struct OutgoingPaymentKeyPrefix;
 
 impl_db_prefix_const!(
-    OutgoingPaymentKey,
-    OutgoingPaymentKeyPrefix,
-    OutgoingContractData,
-    DbKeyPrefix::OutgoingPayment
+    key = OutgoingPaymentKey,
+    value = OutgoingContractData,
+    prefix = DbKeyPrefix::OutgoingPayment,
+    key_prefix = OutgoingPaymentKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -46,10 +46,10 @@ pub struct OutgoingPaymentClaimKey(pub ContractId);
 pub struct OutgoingPaymentClaimKeyPrefix;
 
 impl_db_prefix_const!(
-    OutgoingPaymentClaimKey,
-    OutgoingPaymentClaimKeyPrefix,
-    (),
-    DbKeyPrefix::OutgoingPaymentClaim
+    key = OutgoingPaymentClaimKey,
+    value = (),
+    prefix = DbKeyPrefix::OutgoingPaymentClaim,
+    key_prefix = OutgoingPaymentClaimKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -59,10 +59,10 @@ pub struct OutgoingContractAccountKey(pub ContractId);
 pub struct OutgoingContractAccountKeyPrefix;
 
 impl_db_prefix_const!(
-    OutgoingContractAccountKey,
-    OutgoingContractAccountKeyPrefix,
-    OutgoingContractAccount,
-    DbKeyPrefix::OutgoingContractAccount
+    key = OutgoingContractAccountKey,
+    value = OutgoingContractAccount,
+    prefix = DbKeyPrefix::OutgoingContractAccount,
+    key_prefix = OutgoingContractAccountKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -72,10 +72,10 @@ pub struct ConfirmedInvoiceKey(pub ContractId);
 pub struct ConfirmedInvoiceKeyPrefix;
 
 impl_db_prefix_const!(
-    ConfirmedInvoiceKey,
-    ConfirmedInvoiceKeyPrefix,
-    ConfirmedInvoice,
-    DbKeyPrefix::ConfirmedInvoice
+    key = ConfirmedInvoiceKey,
+    value = ConfirmedInvoice,
+    prefix = DbKeyPrefix::ConfirmedInvoice,
+    key_prefix = ConfirmedInvoiceKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -85,8 +85,8 @@ pub struct LightningGatewayKey;
 pub struct LightningGatewayKeyPrefix;
 
 impl_db_prefix_const!(
-    LightningGatewayKey,
-    LightningGatewayKeyPrefix,
-    LightningGateway,
-    DbKeyPrefix::LightningGateway
+    key = LightningGatewayKey,
+    value = LightningGateway,
+    prefix = DbKeyPrefix::LightningGateway,
+    key_prefix = LightningGatewayKeyPrefix
 );

--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -1,4 +1,3 @@
-use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::impl_db_prefix_const;
 use fedimint_core::modules::ln::contracts::ContractId;

--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -1,5 +1,6 @@
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::impl_db_prefix_const;
 use fedimint_core::modules::ln::contracts::ContractId;
 use fedimint_core::modules::ln::LightningGateway;
 use serde::Serialize;
@@ -28,89 +29,64 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct OutgoingPaymentKey(pub ContractId);
 
-impl DatabaseKeyPrefixConst for OutgoingPaymentKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPayment as u8;
-    type Key = Self;
-    type Value = OutgoingContractData;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutgoingPaymentKeyPrefix;
 
-impl DatabaseKeyPrefixConst for OutgoingPaymentKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPayment as u8;
-    type Key = OutgoingPaymentKey;
-    type Value = OutgoingContractData;
-}
+impl_db_prefix_const!(
+    OutgoingPaymentKey,
+    OutgoingPaymentKeyPrefix,
+    OutgoingContractData,
+    DbKeyPrefix::OutgoingPayment
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct OutgoingPaymentClaimKey(pub ContractId);
 
-impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPaymentClaim as u8;
-    type Key = Self;
-    type Value = ();
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutgoingPaymentClaimKeyPrefix;
 
-impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingPaymentClaim as u8;
-    type Key = OutgoingPaymentClaimKey;
-    type Value = ();
-}
+impl_db_prefix_const!(
+    OutgoingPaymentClaimKey,
+    OutgoingPaymentClaimKeyPrefix,
+    (),
+    DbKeyPrefix::OutgoingPaymentClaim
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct OutgoingContractAccountKey(pub ContractId);
 
-impl DatabaseKeyPrefixConst for OutgoingContractAccountKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingContractAccount as u8;
-    type Key = Self;
-    type Value = OutgoingContractAccount;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutgoingContractAccountKeyPrefix;
 
-impl DatabaseKeyPrefixConst for OutgoingContractAccountKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutgoingContractAccount as u8;
-    type Key = OutgoingContractAccountKey;
-    type Value = OutgoingContractAccount;
-}
+impl_db_prefix_const!(
+    OutgoingContractAccountKey,
+    OutgoingContractAccountKeyPrefix,
+    OutgoingContractAccount,
+    DbKeyPrefix::OutgoingContractAccount
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ConfirmedInvoiceKey(pub ContractId);
 
-impl DatabaseKeyPrefixConst for ConfirmedInvoiceKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::ConfirmedInvoice as u8;
-    type Key = Self;
-    type Value = ConfirmedInvoice;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct ConfirmedInvoiceKeyPrefix;
 
-impl DatabaseKeyPrefixConst for ConfirmedInvoiceKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::ConfirmedInvoice as u8;
-    type Key = ConfirmedInvoiceKey;
-    type Value = ConfirmedInvoice;
-}
+impl_db_prefix_const!(
+    ConfirmedInvoiceKey,
+    ConfirmedInvoiceKeyPrefix,
+    ConfirmedInvoice,
+    DbKeyPrefix::ConfirmedInvoice
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct LightningGatewayKey;
 
-impl DatabaseKeyPrefixConst for LightningGatewayKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
-    type Key = Self;
-    type Value = LightningGateway;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct LightningGatewayKeyPrefix;
 
-impl DatabaseKeyPrefixConst for LightningGatewayKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
-    type Key = LightningGatewayKey;
-    type Value = LightningGateway;
-}
+impl_db_prefix_const!(
+    LightningGatewayKey,
+    LightningGatewayKeyPrefix,
+    LightningGateway,
+    DbKeyPrefix::LightningGateway
+);

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -33,7 +33,12 @@ pub struct NoteKey {
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct NoteKeyPrefix;
 
-impl_db_prefix_const!(NoteKey, NoteKeyPrefix, SpendableNote, DbKeyPrefix::Note);
+impl_db_prefix_const!(
+    key = NoteKey,
+    value = SpendableNote,
+    prefix = DbKeyPrefix::Note,
+    key_prefix = NoteKeyPrefix
+);
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct PendingNotesKey(pub TransactionId);
@@ -42,10 +47,10 @@ pub struct PendingNotesKey(pub TransactionId);
 pub struct PendingNotesKeyPrefix;
 
 impl_db_prefix_const!(
-    PendingNotesKey,
-    PendingNotesKeyPrefix,
-    TieredMulti<SpendableNote>,
-    DbKeyPrefix::PendingNotes
+    key = PendingNotesKey,
+    value = TieredMulti<SpendableNote>,
+    prefix = DbKeyPrefix::PendingNotes,
+    key_prefix = PendingNotesKeyPrefix
 );
 
 #[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
@@ -55,10 +60,10 @@ pub struct OutputFinalizationKey(pub OutPoint);
 pub struct OutputFinalizationKeyPrefix;
 
 impl_db_prefix_const!(
-    OutputFinalizationKey,
-    OutputFinalizationKeyPrefix,
-    NoteIssuanceRequests,
-    DbKeyPrefix::OutputFinalizationData
+    key = OutputFinalizationKey,
+    value = NoteIssuanceRequests,
+    prefix = DbKeyPrefix::OutputFinalizationData,
+    key_prefix = OutputFinalizationKeyPrefix
 );
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
@@ -68,21 +73,13 @@ pub struct NextECashNoteIndexKey(pub Amount);
 pub struct NextECashNoteIndexKeyPrefix;
 
 impl_db_prefix_const!(
-    NextECashNoteIndexKey,
-    NextECashNoteIndexKeyPrefix,
-    u64,
-    DbKeyPrefix::NextECashNoteIndex
+    key = NextECashNoteIndexKey,
+    value = u64,
+    prefix = DbKeyPrefix::NextECashNoteIndex,
+    key_prefix = NextECashNoteIndexKeyPrefix
 );
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct NotesPerDenominationKey;
 
-#[derive(Debug, Clone, Encodable, Decodable, Serialize)]
-pub struct NotesPerDenominationKeyPrefix;
-
-impl_db_prefix_const!(
-    NotesPerDenominationKey,
-    NotesPerDenominationKeyPrefix,
-    u16,
-    0
-);
+impl_db_prefix_const!(key = NotesPerDenominationKey, value = u16, prefix = 0);

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -1,4 +1,3 @@
-use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::impl_db_prefix_const;
 use fedimint_api::{Amount, OutPoint, TieredMulti, TransactionId};

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -1,5 +1,6 @@
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::impl_db_prefix_const;
 use fedimint_api::{Amount, OutPoint, TieredMulti, TransactionId};
 use fedimint_core::modules::mint::Nonce;
 use serde::{Deserialize, Serialize};
@@ -29,80 +30,59 @@ pub struct NoteKey {
     pub nonce: Nonce,
 }
 
-impl DatabaseKeyPrefixConst for NoteKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::Note as u8;
-    type Key = Self;
-    type Value = SpendableNote;
-}
-
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct NoteKeyPrefix;
 
-impl DatabaseKeyPrefixConst for NoteKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::Note as u8;
-    type Key = NoteKey;
-    type Value = SpendableNote;
-}
+impl_db_prefix_const!(NoteKey, NoteKeyPrefix, SpendableNote, DbKeyPrefix::Note);
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct PendingNotesKey(pub TransactionId);
 
-impl DatabaseKeyPrefixConst for PendingNotesKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::PendingNotes as u8;
-    type Key = Self;
-    type Value = TieredMulti<SpendableNote>;
-}
-
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct PendingNotesKeyPrefix;
 
-impl DatabaseKeyPrefixConst for PendingNotesKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::PendingNotes as u8;
-    type Key = PendingNotesKey;
-    type Value = TieredMulti<SpendableNote>;
-}
+impl_db_prefix_const!(
+    PendingNotesKey,
+    PendingNotesKeyPrefix,
+    TieredMulti<SpendableNote>,
+    DbKeyPrefix::PendingNotes
+);
 
 #[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct OutputFinalizationKey(pub OutPoint);
 
-impl DatabaseKeyPrefixConst for OutputFinalizationKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutputFinalizationData as u8;
-    type Key = Self;
-    type Value = NoteIssuanceRequests;
-}
-
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct OutputFinalizationKeyPrefix;
 
-impl DatabaseKeyPrefixConst for OutputFinalizationKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutputFinalizationData as u8;
-    type Key = OutputFinalizationKey;
-    type Value = NoteIssuanceRequests;
-}
-
-#[derive(Debug, Clone, Encodable, Decodable)]
-pub struct NextECashNoteIndexKeyPrefix;
-
-impl DatabaseKeyPrefixConst for NextECashNoteIndexKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::NextECashNoteIndex as u8;
-    type Key = NextECashNoteIndexKey;
-    type Value = u64;
-}
+impl_db_prefix_const!(
+    OutputFinalizationKey,
+    OutputFinalizationKeyPrefix,
+    NoteIssuanceRequests,
+    DbKeyPrefix::OutputFinalizationData
+);
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct NextECashNoteIndexKey(pub Amount);
 
-impl DatabaseKeyPrefixConst for NextECashNoteIndexKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::NextECashNoteIndex as u8;
-    type Key = Self;
-    type Value = u64;
-}
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct NextECashNoteIndexKeyPrefix;
+
+impl_db_prefix_const!(
+    NextECashNoteIndexKey,
+    NextECashNoteIndexKeyPrefix,
+    u64,
+    DbKeyPrefix::NextECashNoteIndex
+);
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct NotesPerDenominationKey;
 
-impl DatabaseKeyPrefixConst for NotesPerDenominationKey {
-    const DB_PREFIX: u8 = 0;
-    type Key = Self;
-    type Value = u16;
-}
+#[derive(Debug, Clone, Encodable, Decodable, Serialize)]
+pub struct NotesPerDenominationKeyPrefix;
+
+impl_db_prefix_const!(
+    NotesPerDenominationKey,
+    NotesPerDenominationKeyPrefix,
+    u16,
+    0
+);

--- a/client/client-lib/src/wallet/db.rs
+++ b/client/client-lib/src/wallet/db.rs
@@ -1,6 +1,7 @@
 use bitcoin::Script;
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::impl_db_prefix_const;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
@@ -21,17 +22,7 @@ pub struct PegInKey {
     pub peg_in_script: Script,
 }
 
-impl DatabaseKeyPrefixConst for PegInKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::PegIn as u8;
-    type Key = Self;
-    type Value = [u8; 32]; // TODO: introduce newtype
-}
-
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct PegInPrefixKey;
 
-impl DatabaseKeyPrefixConst for PegInPrefixKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::PegIn as u8;
-    type Key = PegInKey;
-    type Value = [u8; 32];
-}
+impl_db_prefix_const!(PegInKey, PegInPrefixKey, [u8; 32], DbKeyPrefix::PegIn);

--- a/client/client-lib/src/wallet/db.rs
+++ b/client/client-lib/src/wallet/db.rs
@@ -25,4 +25,9 @@ pub struct PegInKey {
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct PegInPrefixKey;
 
-impl_db_prefix_const!(PegInKey, PegInPrefixKey, [u8; 32], DbKeyPrefix::PegIn);
+impl_db_prefix_const!(
+    key = PegInKey,
+    value = [u8; 32],
+    prefix = DbKeyPrefix::PegIn,
+    key_prefix = PegInPrefixKey
+);

--- a/client/client-lib/src/wallet/db.rs
+++ b/client/client-lib/src/wallet/db.rs
@@ -1,5 +1,4 @@
 use bitcoin::Script;
-use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::impl_db_prefix_const;
 use serde::Serialize;

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -698,14 +698,14 @@ where
 #[macro_export]
 macro_rules! impl_db_prefix_const {
     (key = $key:ty, value = $val:ty, prefix = $prefix:expr $(, key_prefix = $prefix_ty:ty)* $(,)?) => {
-        impl DatabaseKeyPrefixConst for $key {
+        impl fedimint_api::db::DatabaseKeyPrefixConst for $key {
             const DB_PREFIX: u8 = $prefix as u8;
             type Key = Self;
             type Value = $val;
         }
 
         $(
-            impl DatabaseKeyPrefixConst for $prefix_ty {
+            impl $crate::db::DatabaseKeyPrefixConst for $prefix_ty {
                 const DB_PREFIX: u8 = $prefix as u8;
                 type Key = $key;
                 type Value = $val;
@@ -793,7 +793,6 @@ mod tests {
     use futures::StreamExt;
 
     use super::Database;
-    use crate::db::DatabaseKeyPrefixConst;
     use crate::encoding::{Decodable, Encodable};
 
     #[repr(u8)]

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -680,6 +680,23 @@ where
     }
 }
 
+#[macro_export]
+macro_rules! impl_db_prefix_const {
+    ($key:ty, $key_prefix:ty, $val:ty, $prefix:expr) => {
+        impl DatabaseKeyPrefixConst for $key_prefix {
+            const DB_PREFIX: u8 = $prefix as u8;
+            type Key = $key;
+            type Value = $val;
+        }
+
+        impl DatabaseKeyPrefixConst for $key {
+            const DB_PREFIX: u8 = $prefix as u8;
+            type Key = Self;
+            type Value = $val;
+        }
+    };
+}
+
 #[derive(Debug, Error)]
 pub enum DecodingError {
     #[error("Key had a wrong prefix, expected {expected} but got {found}")]
@@ -773,56 +790,36 @@ mod tests {
     #[derive(Debug, Encodable, Decodable)]
     struct TestKey(u64);
 
-    impl DatabaseKeyPrefixConst for TestKey {
-        const DB_PREFIX: u8 = TestDbKeyPrefix::Test as u8;
-        type Key = Self;
-        type Value = TestVal;
-    }
-
     #[derive(Debug, Encodable, Decodable)]
     struct DbPrefixTestPrefix;
 
-    impl DatabaseKeyPrefixConst for DbPrefixTestPrefix {
-        const DB_PREFIX: u8 = TestDbKeyPrefix::Test as u8;
-        type Key = TestKey;
-        type Value = TestVal;
-    }
+    impl_db_prefix_const!(TestKey, DbPrefixTestPrefix, TestVal, TestDbKeyPrefix::Test);
 
     #[derive(Debug, Encodable, Decodable)]
     struct AltTestKey(u64);
 
-    impl DatabaseKeyPrefixConst for AltTestKey {
-        const DB_PREFIX: u8 = TestDbKeyPrefix::AltTest as u8;
-        type Key = Self;
-        type Value = TestVal;
-    }
-
     #[derive(Debug, Encodable, Decodable)]
     struct AltDbPrefixTestPrefix;
 
-    impl DatabaseKeyPrefixConst for AltDbPrefixTestPrefix {
-        const DB_PREFIX: u8 = TestDbKeyPrefix::AltTest as u8;
-        type Key = AltTestKey;
-        type Value = TestVal;
-    }
+    impl_db_prefix_const!(
+        AltTestKey,
+        AltDbPrefixTestPrefix,
+        TestVal,
+        TestDbKeyPrefix::AltTest
+    );
 
     #[derive(Debug, Encodable, Decodable)]
     struct PercentTestKey(u64);
 
-    impl DatabaseKeyPrefixConst for PercentTestKey {
-        const DB_PREFIX: u8 = TestDbKeyPrefix::PercentTestKey as u8;
-        type Key = Self;
-        type Value = TestVal;
-    }
-
     #[derive(Debug, Encodable, Decodable)]
     struct PercentPrefixTestPrefix;
 
-    impl DatabaseKeyPrefixConst for PercentPrefixTestPrefix {
-        const DB_PREFIX: u8 = TestDbKeyPrefix::PercentTestKey as u8;
-        type Key = PercentTestKey;
-        type Value = TestVal;
-    }
+    impl_db_prefix_const!(
+        PercentTestKey,
+        PercentPrefixTestPrefix,
+        TestVal,
+        TestDbKeyPrefix::PercentTestKey
+    );
 
     #[derive(Debug, Encodable, Decodable, Eq, PartialEq)]
     struct TestVal(u64);

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use fedimint_api::db::{DatabaseKeyPrefixConst, MODULE_GLOBAL_PREFIX};
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::impl_db_prefix_const;
 use fedimint_api::{PeerId, TransactionId};
 use fedimint_core::epoch::{SerdeSignature, SignedEpochOutcome};
 use serde::Serialize;
@@ -30,98 +31,72 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct AcceptedTransactionKey(pub TransactionId);
 
-impl DatabaseKeyPrefixConst for AcceptedTransactionKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::AcceptedTransaction as u8;
-    type Key = Self;
-    type Value = AcceptedTransaction;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct AcceptedTransactionKeyPrefix;
 
-impl DatabaseKeyPrefixConst for AcceptedTransactionKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::AcceptedTransaction as u8;
-    type Key = AcceptedTransactionKey;
-    type Value = AcceptedTransaction;
-}
+impl_db_prefix_const!(
+    AcceptedTransactionKey,
+    AcceptedTransactionKeyPrefix,
+    AcceptedTransaction,
+    DbKeyPrefix::AcceptedTransaction
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct RejectedTransactionKey(pub TransactionId);
 
-impl DatabaseKeyPrefixConst for RejectedTransactionKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::RejectedTransaction as u8;
-    type Key = Self;
-    type Value = String;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct RejectedTransactionKeyPrefix;
 
-impl DatabaseKeyPrefixConst for RejectedTransactionKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::RejectedTransaction as u8;
-    type Key = RejectedTransactionKey;
-    type Value = String;
-}
+impl_db_prefix_const!(
+    RejectedTransactionKey,
+    RejectedTransactionKeyPrefix,
+    String,
+    DbKeyPrefix::RejectedTransaction
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct DropPeerKey(pub PeerId);
 
-impl DatabaseKeyPrefixConst for DropPeerKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::DropPeer as u8;
-    type Key = Self;
-    type Value = ();
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct DropPeerKeyPrefix;
 
-impl DatabaseKeyPrefixConst for DropPeerKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::DropPeer as u8;
-    type Key = DropPeerKey;
-    type Value = ();
-}
+impl_db_prefix_const!(DropPeerKey, DropPeerKeyPrefix, (), DbKeyPrefix::DropPeer);
 
 #[derive(Debug, Copy, Clone, Encodable, Decodable, Serialize)]
 pub struct EpochHistoryKey(pub u64);
 
-impl DatabaseKeyPrefixConst for EpochHistoryKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::EpochHistory as u8;
-    type Key = Self;
-    type Value = SignedEpochOutcome;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct EpochHistoryKeyPrefix;
 
-impl DatabaseKeyPrefixConst for EpochHistoryKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::EpochHistory as u8;
-    type Key = EpochHistoryKey;
-    type Value = SignedEpochOutcome;
-}
+impl_db_prefix_const!(
+    EpochHistoryKey,
+    EpochHistoryKeyPrefix,
+    SignedEpochOutcome,
+    DbKeyPrefix::EpochHistory
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct LastEpochKey;
 
-impl DatabaseKeyPrefixConst for LastEpochKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::LastEpoch as u8;
-    type Key = Self;
-    type Value = EpochHistoryKey;
-}
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct LastEpochKeyPrefix;
+
+impl_db_prefix_const!(
+    LastEpochKey,
+    LastEpochKeyPrefix,
+    EpochHistoryKey,
+    DbKeyPrefix::LastEpoch
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ClientConfigSignatureKey;
 
-impl DatabaseKeyPrefixConst for ClientConfigSignatureKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::ClientConfigSignature as u8;
-    type Key = Self;
-    type Value = SerdeSignature;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct ClientConfigSignatureKeyPrefix;
 
-impl DatabaseKeyPrefixConst for ClientConfigSignatureKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::ClientConfigSignature as u8;
-    type Key = ClientConfigSignatureKey;
-    type Value = SerdeSignature;
-}
+impl_db_prefix_const!(
+    ClientConfigSignatureKey,
+    ClientConfigSignatureKeyPrefix,
+    SerdeSignature,
+    DbKeyPrefix::ClientConfigSignature
+);

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -35,10 +35,10 @@ pub struct AcceptedTransactionKey(pub TransactionId);
 pub struct AcceptedTransactionKeyPrefix;
 
 impl_db_prefix_const!(
-    AcceptedTransactionKey,
-    AcceptedTransactionKeyPrefix,
-    AcceptedTransaction,
-    DbKeyPrefix::AcceptedTransaction
+    key = AcceptedTransactionKey,
+    value = AcceptedTransaction,
+    prefix = DbKeyPrefix::AcceptedTransaction,
+    key_prefix = AcceptedTransactionKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -48,10 +48,10 @@ pub struct RejectedTransactionKey(pub TransactionId);
 pub struct RejectedTransactionKeyPrefix;
 
 impl_db_prefix_const!(
-    RejectedTransactionKey,
-    RejectedTransactionKeyPrefix,
-    String,
-    DbKeyPrefix::RejectedTransaction
+    key = RejectedTransactionKey,
+    value = String,
+    prefix = DbKeyPrefix::RejectedTransaction,
+    key_prefix = RejectedTransactionKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -60,7 +60,12 @@ pub struct DropPeerKey(pub PeerId);
 #[derive(Debug, Encodable, Decodable)]
 pub struct DropPeerKeyPrefix;
 
-impl_db_prefix_const!(DropPeerKey, DropPeerKeyPrefix, (), DbKeyPrefix::DropPeer);
+impl_db_prefix_const!(
+    key = DropPeerKey,
+    value = (),
+    prefix = DbKeyPrefix::DropPeer,
+    key_prefix = DropPeerKeyPrefix
+);
 
 #[derive(Debug, Copy, Clone, Encodable, Decodable, Serialize)]
 pub struct EpochHistoryKey(pub u64);
@@ -69,23 +74,19 @@ pub struct EpochHistoryKey(pub u64);
 pub struct EpochHistoryKeyPrefix;
 
 impl_db_prefix_const!(
-    EpochHistoryKey,
-    EpochHistoryKeyPrefix,
-    SignedEpochOutcome,
-    DbKeyPrefix::EpochHistory
+    key = EpochHistoryKey,
+    value = SignedEpochOutcome,
+    prefix = DbKeyPrefix::EpochHistory,
+    key_prefix = EpochHistoryKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct LastEpochKey;
 
-#[derive(Debug, Encodable, Decodable, Serialize)]
-pub struct LastEpochKeyPrefix;
-
 impl_db_prefix_const!(
-    LastEpochKey,
-    LastEpochKeyPrefix,
-    EpochHistoryKey,
-    DbKeyPrefix::LastEpoch
+    key = LastEpochKey,
+    value = EpochHistoryKey,
+    prefix = DbKeyPrefix::LastEpoch
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -95,8 +96,8 @@ pub struct ClientConfigSignatureKey;
 pub struct ClientConfigSignatureKeyPrefix;
 
 impl_db_prefix_const!(
-    ClientConfigSignatureKey,
-    ClientConfigSignatureKeyPrefix,
-    SerdeSignature,
-    DbKeyPrefix::ClientConfigSignature
+    key = ClientConfigSignatureKey,
+    value = SerdeSignature,
+    prefix = DbKeyPrefix::ClientConfigSignature,
+    key_prefix = ClientConfigSignatureKeyPrefix
 );

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use fedimint_api::db::{DatabaseKeyPrefixConst, MODULE_GLOBAL_PREFIX};
+use fedimint_api::db::MODULE_GLOBAL_PREFIX;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::impl_db_prefix_const;
 use fedimint_api::{PeerId, TransactionId};

--- a/modules/fedimint-dummy/src/db.rs
+++ b/modules/fedimint-dummy/src/db.rs
@@ -22,4 +22,9 @@ pub struct ExampleKey(pub u64);
 #[derive(Debug, Encodable, Decodable)]
 pub struct ExampleKeyPrefix;
 
-impl_db_prefix_const!(ExampleKey, ExampleKeyPrefix, (), DbKeyPrefix::Example);
+impl_db_prefix_const!(
+    key = ExampleKey,
+    value = (),
+    prefix = DbKeyPrefix::Example,
+    key_prefix = ExampleKeyPrefix
+);

--- a/modules/fedimint-dummy/src/db.rs
+++ b/modules/fedimint-dummy/src/db.rs
@@ -1,12 +1,12 @@
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::impl_db_prefix_const;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
-    // TODO: Make sure this does not collide with other modules
     Example = 0x80,
 }
 
@@ -19,17 +19,7 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Debug, Clone, Encodable, Decodable, Eq, PartialEq, Hash, Serialize)]
 pub struct ExampleKey(pub u64);
 
-impl DatabaseKeyPrefixConst for ExampleKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::Example as u8;
-    type Key = Self;
-    type Value = ();
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct ExampleKeyPrefix;
 
-impl DatabaseKeyPrefixConst for ExampleKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::Example as u8;
-    type Key = ExampleKey;
-    type Value = ();
-}
+impl_db_prefix_const!(ExampleKey, ExampleKeyPrefix, (), DbKeyPrefix::Example);

--- a/modules/fedimint-dummy/src/db.rs
+++ b/modules/fedimint-dummy/src/db.rs
@@ -1,4 +1,3 @@
-use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::impl_db_prefix_const;
 use serde::Serialize;

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -1,5 +1,6 @@
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::impl_db_prefix_const;
 use fedimint_api::{OutPoint, PeerId};
 use secp256k1::PublicKey;
 use serde::Serialize;
@@ -28,111 +29,81 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Debug, Clone, Copy, Encodable, Decodable, Serialize)]
 pub struct ContractKey(pub ContractId);
 
-impl DatabaseKeyPrefixConst for ContractKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::Contract as u8;
-    type Key = Self;
-    type Value = ContractAccount;
-}
-
 #[derive(Debug, Clone, Copy, Encodable, Decodable)]
 pub struct ContractKeyPrefix;
 
-impl DatabaseKeyPrefixConst for ContractKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::Contract as u8;
-    type Key = ContractKey;
-    type Value = ContractAccount;
-}
+impl_db_prefix_const!(
+    ContractKey,
+    ContractKeyPrefix,
+    ContractAccount,
+    DbKeyPrefix::Contract
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ContractUpdateKey(pub OutPoint);
 
-impl DatabaseKeyPrefixConst for ContractUpdateKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::ContractUpdate as u8;
-    type Key = Self;
-    type Value = LightningOutputOutcome;
-}
-
 #[derive(Debug, Clone, Copy, Encodable, Decodable)]
 pub struct ContractUpdateKeyPrefix;
 
-impl DatabaseKeyPrefixConst for ContractUpdateKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::ContractUpdate as u8;
-    type Key = ContractUpdateKey;
-    type Value = LightningOutputOutcome;
-}
+impl_db_prefix_const!(
+    ContractUpdateKey,
+    ContractUpdateKeyPrefix,
+    LightningOutputOutcome,
+    DbKeyPrefix::ContractUpdate
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct OfferKey(pub bitcoin_hashes::sha256::Hash);
 
-impl DatabaseKeyPrefixConst for OfferKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::Offer as u8;
-    type Key = Self;
-    type Value = IncomingContractOffer;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct OfferKeyPrefix;
 
-impl DatabaseKeyPrefixConst for OfferKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::Offer as u8;
-    type Key = OfferKey;
-    type Value = IncomingContractOffer;
-}
+impl_db_prefix_const!(
+    OfferKey,
+    OfferKeyPrefix,
+    IncomingContractOffer,
+    DbKeyPrefix::Offer
+);
 
 // TODO: remove redundancy
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ProposeDecryptionShareKey(pub ContractId);
 
-impl DatabaseKeyPrefixConst for ProposeDecryptionShareKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::ProposeDecryptionShare as u8;
-    type Key = Self;
-    type Value = PreimageDecryptionShare;
-}
-
 /// Our preimage decryption shares that still need to be broadcasted
 #[derive(Debug, Encodable)]
 pub struct ProposeDecryptionShareKeyPrefix;
 
-impl DatabaseKeyPrefixConst for ProposeDecryptionShareKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::ProposeDecryptionShare as u8;
-    type Key = ProposeDecryptionShareKey;
-    type Value = PreimageDecryptionShare;
-}
+impl_db_prefix_const!(
+    ProposeDecryptionShareKey,
+    ProposeDecryptionShareKeyPrefix,
+    PreimageDecryptionShare,
+    DbKeyPrefix::ProposeDecryptionShare
+);
 
 /// Preimage decryption shares we received
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct AgreedDecryptionShareKey(pub ContractId, pub PeerId);
 
-impl DatabaseKeyPrefixConst for AgreedDecryptionShareKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::AgreedDecryptionShare as u8;
-    type Key = Self;
-    type Value = PreimageDecryptionShare;
-}
-
 /// Preimage decryption shares we received
 #[derive(Debug, Encodable)]
 pub struct AgreedDecryptionShareKeyPrefix;
 
-impl DatabaseKeyPrefixConst for AgreedDecryptionShareKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::AgreedDecryptionShare as u8;
-    type Key = AgreedDecryptionShareKey;
-    type Value = PreimageDecryptionShare;
-}
+impl_db_prefix_const!(
+    AgreedDecryptionShareKey,
+    AgreedDecryptionShareKeyPrefix,
+    PreimageDecryptionShare,
+    DbKeyPrefix::AgreedDecryptionShare
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct LightningGatewayKey(pub PublicKey);
 
-impl DatabaseKeyPrefixConst for LightningGatewayKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
-    type Key = Self;
-    type Value = LightningGateway;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct LightningGatewayKeyPrefix;
 
-impl DatabaseKeyPrefixConst for LightningGatewayKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::LightningGateway as u8;
-    type Key = LightningGatewayKey;
-    type Value = LightningGateway;
-}
+impl_db_prefix_const!(
+    LightningGatewayKey,
+    LightningGatewayKeyPrefix,
+    LightningGateway,
+    DbKeyPrefix::LightningGateway
+);

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -33,10 +33,10 @@ pub struct ContractKey(pub ContractId);
 pub struct ContractKeyPrefix;
 
 impl_db_prefix_const!(
-    ContractKey,
-    ContractKeyPrefix,
-    ContractAccount,
-    DbKeyPrefix::Contract
+    key = ContractKey,
+    value = ContractAccount,
+    prefix = DbKeyPrefix::Contract,
+    key_prefix = ContractKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -46,10 +46,10 @@ pub struct ContractUpdateKey(pub OutPoint);
 pub struct ContractUpdateKeyPrefix;
 
 impl_db_prefix_const!(
-    ContractUpdateKey,
-    ContractUpdateKeyPrefix,
-    LightningOutputOutcome,
-    DbKeyPrefix::ContractUpdate
+    key = ContractUpdateKey,
+    value = LightningOutputOutcome,
+    prefix = DbKeyPrefix::ContractUpdate,
+    key_prefix = ContractUpdateKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -59,10 +59,10 @@ pub struct OfferKey(pub bitcoin_hashes::sha256::Hash);
 pub struct OfferKeyPrefix;
 
 impl_db_prefix_const!(
-    OfferKey,
-    OfferKeyPrefix,
-    IncomingContractOffer,
-    DbKeyPrefix::Offer
+    key = OfferKey,
+    value = IncomingContractOffer,
+    prefix = DbKeyPrefix::Offer,
+    key_prefix = OfferKeyPrefix
 );
 
 // TODO: remove redundancy
@@ -74,10 +74,10 @@ pub struct ProposeDecryptionShareKey(pub ContractId);
 pub struct ProposeDecryptionShareKeyPrefix;
 
 impl_db_prefix_const!(
-    ProposeDecryptionShareKey,
-    ProposeDecryptionShareKeyPrefix,
-    PreimageDecryptionShare,
-    DbKeyPrefix::ProposeDecryptionShare
+    key = ProposeDecryptionShareKey,
+    value = PreimageDecryptionShare,
+    prefix = DbKeyPrefix::ProposeDecryptionShare,
+    key_prefix = ProposeDecryptionShareKeyPrefix
 );
 
 /// Preimage decryption shares we received
@@ -89,10 +89,10 @@ pub struct AgreedDecryptionShareKey(pub ContractId, pub PeerId);
 pub struct AgreedDecryptionShareKeyPrefix;
 
 impl_db_prefix_const!(
-    AgreedDecryptionShareKey,
-    AgreedDecryptionShareKeyPrefix,
-    PreimageDecryptionShare,
-    DbKeyPrefix::AgreedDecryptionShare
+    key = AgreedDecryptionShareKey,
+    value = PreimageDecryptionShare,
+    prefix = DbKeyPrefix::AgreedDecryptionShare,
+    key_prefix = AgreedDecryptionShareKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -102,8 +102,8 @@ pub struct LightningGatewayKey(pub PublicKey);
 pub struct LightningGatewayKeyPrefix;
 
 impl_db_prefix_const!(
-    LightningGatewayKey,
-    LightningGatewayKeyPrefix,
-    LightningGateway,
-    DbKeyPrefix::LightningGateway
+    key = LightningGatewayKey,
+    value = LightningGateway,
+    prefix = DbKeyPrefix::LightningGateway,
+    key_prefix = LightningGatewayKeyPrefix
 );

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -1,4 +1,3 @@
-use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::impl_db_prefix_const;
 use fedimint_api::{OutPoint, PeerId};

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -2,6 +2,7 @@ use std::time::SystemTime;
 
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::impl_db_prefix_const;
 use fedimint_api::{Amount, OutPoint, PeerId};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
@@ -28,40 +29,25 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Debug, Clone, Encodable, Decodable, Eq, PartialEq, Hash, Serialize)]
 pub struct NonceKey(pub Nonce);
 
-impl DatabaseKeyPrefixConst for NonceKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::NoteNonce as u8;
-    type Key = Self;
-    type Value = ();
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct NonceKeyPrefix;
 
-impl DatabaseKeyPrefixConst for NonceKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::NoteNonce as u8;
-    type Key = NonceKey;
-    type Value = ();
-}
+impl_db_prefix_const!(NonceKey, NonceKeyPrefix, (), DbKeyPrefix::NoteNonce);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ProposedPartialSignatureKey {
     pub out_point: OutPoint, // tx + output idx
 }
 
-impl DatabaseKeyPrefixConst for ProposedPartialSignatureKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
-    type Key = Self;
-    type Value = MintOutputSignatureShare;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct ProposedPartialSignaturesKeyPrefix;
 
-impl DatabaseKeyPrefixConst for ProposedPartialSignaturesKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::ProposedPartialSig as u8;
-    type Key = ProposedPartialSignatureKey;
-    type Value = MintOutputSignatureShare;
-}
+impl_db_prefix_const!(
+    ProposedPartialSignatureKey,
+    ProposedPartialSignaturesKeyPrefix,
+    MintOutputSignatureShare,
+    DbKeyPrefix::ProposedPartialSig
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ReceivedPartialSignatureKey {
@@ -69,11 +55,15 @@ pub struct ReceivedPartialSignatureKey {
     pub peer_id: PeerId,
 }
 
-impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
-    type Key = Self;
-    type Value = MintOutputSignatureShare;
-}
+#[derive(Debug, Encodable, Decodable)]
+pub struct ReceivedPartialSignaturesKeyPrefix;
+
+impl_db_prefix_const!(
+    ReceivedPartialSignatureKey,
+    ReceivedPartialSignaturesKeyPrefix,
+    MintOutputSignatureShare,
+    DbKeyPrefix::ReceivedPartialSig
+);
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct ReceivedPartialSignatureKeyOutputPrefix {
@@ -86,33 +76,19 @@ impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKeyOutputPrefix {
     type Value = MintOutputSignatureShare;
 }
 
-#[derive(Debug, Encodable, Decodable)]
-pub struct ReceivedPartialSignaturesKeyPrefix;
-
-impl DatabaseKeyPrefixConst for ReceivedPartialSignaturesKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
-    type Key = ReceivedPartialSignatureKey;
-    type Value = MintOutputSignatureShare;
-}
-
 /// Transaction id and output index identifying an output outcome
 #[derive(Debug, Clone, Copy, Encodable, Decodable, Serialize)]
 pub struct OutputOutcomeKey(pub OutPoint);
 
-impl DatabaseKeyPrefixConst for OutputOutcomeKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutputOutcome as u8;
-    type Key = Self;
-    type Value = MintOutputBlindSignatures;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutputOutcomeKeyPrefix;
 
-impl DatabaseKeyPrefixConst for OutputOutcomeKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::OutputOutcome as u8;
-    type Key = OutputOutcomeKey;
-    type Value = MintOutputBlindSignatures;
-}
+impl_db_prefix_const!(
+    OutputOutcomeKey,
+    OutputOutcomeKeyPrefix,
+    MintOutputBlindSignatures,
+    DbKeyPrefix::OutputOutcome
+);
 
 /// Represents the amounts of issued (signed) and redeemed (verified) notes for auditing
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
@@ -123,33 +99,29 @@ pub enum MintAuditItemKey {
     RedemptionTotal,
 }
 
-impl DatabaseKeyPrefixConst for MintAuditItemKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::MintAuditItem as u8;
-    type Key = Self;
-    type Value = Amount;
-}
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct MintAuditItemKeyPrefix;
 
-impl DatabaseKeyPrefixConst for MintAuditItemKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::MintAuditItem as u8;
-    type Key = MintAuditItemKey;
-    type Value = Amount;
-}
-
-#[derive(Debug, Encodable, Decodable)]
-pub struct EcashBackupKeyPrefix;
+impl_db_prefix_const!(
+    MintAuditItemKey,
+    MintAuditItemKeyPrefix,
+    Amount,
+    DbKeyPrefix::MintAuditItem
+);
 
 /// Key used to store user's ecash backups
 #[derive(Debug, Clone, Copy, Encodable, Decodable, Serialize)]
 pub struct EcashBackupKey(pub secp256k1_zkp::XOnlyPublicKey);
 
-impl DatabaseKeyPrefixConst for EcashBackupKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::EcashBackup as u8;
-    type Key = EcashBackupKey;
-    type Value = ECashUserBackupSnapshot;
-}
+#[derive(Debug, Encodable, Decodable)]
+pub struct EcashBackupKeyPrefix;
+
+impl_db_prefix_const!(
+    EcashBackupKey,
+    EcashBackupKeyPrefix,
+    ECashUserBackupSnapshot,
+    DbKeyPrefix::EcashBackup
+);
 
 /// User's backup, received at certain time, containing encrypted payload
 #[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
@@ -157,10 +129,4 @@ pub struct ECashUserBackupSnapshot {
     pub timestamp: SystemTime,
     #[serde(with = "fedimint_api::hex::serde")]
     pub data: Vec<u8>,
-}
-
-impl DatabaseKeyPrefixConst for EcashBackupKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::EcashBackup as u8;
-    type Key = Self;
-    type Value = ECashUserBackupSnapshot;
 }

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -32,7 +32,12 @@ pub struct NonceKey(pub Nonce);
 #[derive(Debug, Encodable, Decodable)]
 pub struct NonceKeyPrefix;
 
-impl_db_prefix_const!(NonceKey, NonceKeyPrefix, (), DbKeyPrefix::NoteNonce);
+impl_db_prefix_const!(
+    key = NonceKey,
+    value = (),
+    prefix = DbKeyPrefix::NoteNonce,
+    key_prefix = NonceKeyPrefix
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ProposedPartialSignatureKey {
@@ -43,10 +48,10 @@ pub struct ProposedPartialSignatureKey {
 pub struct ProposedPartialSignaturesKeyPrefix;
 
 impl_db_prefix_const!(
-    ProposedPartialSignatureKey,
-    ProposedPartialSignaturesKeyPrefix,
-    MintOutputSignatureShare,
-    DbKeyPrefix::ProposedPartialSig
+    key = ProposedPartialSignatureKey,
+    value = MintOutputSignatureShare,
+    prefix = DbKeyPrefix::ProposedPartialSig,
+    key_prefix = ProposedPartialSignaturesKeyPrefix
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -58,23 +63,18 @@ pub struct ReceivedPartialSignatureKey {
 #[derive(Debug, Encodable, Decodable)]
 pub struct ReceivedPartialSignaturesKeyPrefix;
 
-impl_db_prefix_const!(
-    ReceivedPartialSignatureKey,
-    ReceivedPartialSignaturesKeyPrefix,
-    MintOutputSignatureShare,
-    DbKeyPrefix::ReceivedPartialSig
-);
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct ReceivedPartialSignatureKeyOutputPrefix {
     pub request_id: OutPoint, // tx + output idx
 }
 
-impl DatabaseKeyPrefixConst for ReceivedPartialSignatureKeyOutputPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::ReceivedPartialSig as u8;
-    type Key = ReceivedPartialSignatureKey;
-    type Value = MintOutputSignatureShare;
-}
+impl_db_prefix_const!(
+    key = ReceivedPartialSignatureKey,
+    value = MintOutputSignatureShare,
+    prefix = DbKeyPrefix::ReceivedPartialSig,
+    key_prefix = ReceivedPartialSignaturesKeyPrefix,
+    key_prefix = ReceivedPartialSignatureKeyOutputPrefix
+);
 
 /// Transaction id and output index identifying an output outcome
 #[derive(Debug, Clone, Copy, Encodable, Decodable, Serialize)]
@@ -84,10 +84,10 @@ pub struct OutputOutcomeKey(pub OutPoint);
 pub struct OutputOutcomeKeyPrefix;
 
 impl_db_prefix_const!(
-    OutputOutcomeKey,
-    OutputOutcomeKeyPrefix,
-    MintOutputBlindSignatures,
-    DbKeyPrefix::OutputOutcome
+    key = OutputOutcomeKey,
+    value = MintOutputBlindSignatures,
+    prefix = DbKeyPrefix::OutputOutcome,
+    key_prefix = OutputOutcomeKeyPrefix
 );
 
 /// Represents the amounts of issued (signed) and redeemed (verified) notes for auditing
@@ -103,10 +103,10 @@ pub enum MintAuditItemKey {
 pub struct MintAuditItemKeyPrefix;
 
 impl_db_prefix_const!(
-    MintAuditItemKey,
-    MintAuditItemKeyPrefix,
-    Amount,
-    DbKeyPrefix::MintAuditItem
+    key = MintAuditItemKey,
+    value = Amount,
+    prefix = DbKeyPrefix::MintAuditItem,
+    key_prefix = MintAuditItemKeyPrefix
 );
 
 /// Key used to store user's ecash backups
@@ -117,10 +117,10 @@ pub struct EcashBackupKey(pub secp256k1_zkp::XOnlyPublicKey);
 pub struct EcashBackupKeyPrefix;
 
 impl_db_prefix_const!(
-    EcashBackupKey,
-    EcashBackupKeyPrefix,
-    ECashUserBackupSnapshot,
-    DbKeyPrefix::EcashBackup
+    key = EcashBackupKey,
+    value = ECashUserBackupSnapshot,
+    prefix = DbKeyPrefix::EcashBackup,
+    key_prefix = EcashBackupKeyPrefix
 );
 
 /// User's backup, received at certain time, containing encrypted payload

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -1,6 +1,5 @@
 use std::time::SystemTime;
 
-use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::impl_db_prefix_const;
 use fedimint_api::{Amount, OutPoint, PeerId};

--- a/modules/fedimint-wallet/src/db.rs
+++ b/modules/fedimint-wallet/src/db.rs
@@ -1,6 +1,7 @@
 use bitcoin::{BlockHash, Txid};
 use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::impl_db_prefix_const;
 use secp256k1::ecdsa::Signature;
 use serde::Serialize;
 use strum_macros::EnumIter;
@@ -30,116 +31,80 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct BlockHashKey(pub BlockHash);
 
-impl DatabaseKeyPrefixConst for BlockHashKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::BlockHash as u8;
-    type Key = Self;
-    type Value = ();
-}
-
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct BlockHashKeyPrefix;
 
-impl DatabaseKeyPrefixConst for BlockHashKeyPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::BlockHash as u8;
-    type Key = BlockHashKey;
-    type Value = ();
-}
+impl_db_prefix_const!(BlockHashKey, BlockHashKeyPrefix, (), DbKeyPrefix::BlockHash);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct UTXOKey(pub bitcoin::OutPoint);
 
-impl DatabaseKeyPrefixConst for UTXOKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::Utxo as u8;
-    type Key = Self;
-    type Value = SpendableUTXO;
-}
-
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct UTXOPrefixKey;
 
-impl DatabaseKeyPrefixConst for UTXOPrefixKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::Utxo as u8;
-    type Key = UTXOKey;
-    type Value = SpendableUTXO;
-}
+impl_db_prefix_const!(UTXOKey, UTXOPrefixKey, SpendableUTXO, DbKeyPrefix::Utxo);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct RoundConsensusKey;
 
-impl DatabaseKeyPrefixConst for RoundConsensusKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::RoundConsensus as u8;
-    type Key = Self;
-    type Value = RoundConsensus;
-}
+#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+pub struct RoundConsensusPrefixKey;
+
+impl_db_prefix_const!(
+    RoundConsensusKey,
+    RoundConsensusPrefixKey,
+    RoundConsensus,
+    DbKeyPrefix::RoundConsensus
+);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct UnsignedTransactionKey(pub Txid);
 
-impl DatabaseKeyPrefixConst for UnsignedTransactionKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::UnsignedTransaction as u8;
-    type Key = Self;
-    type Value = UnsignedTransaction;
-}
-
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct UnsignedTransactionPrefixKey;
 
-impl DatabaseKeyPrefixConst for UnsignedTransactionPrefixKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::UnsignedTransaction as u8;
-    type Key = UnsignedTransactionKey;
-    type Value = UnsignedTransaction;
-}
+impl_db_prefix_const!(
+    UnsignedTransactionKey,
+    UnsignedTransactionPrefixKey,
+    UnsignedTransaction,
+    DbKeyPrefix::UnsignedTransaction
+);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct PendingTransactionKey(pub Txid);
 
-impl DatabaseKeyPrefixConst for PendingTransactionKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::PendingTransaction as u8;
-    type Key = Self;
-    type Value = PendingTransaction;
-}
-
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct PendingTransactionPrefixKey;
 
-impl DatabaseKeyPrefixConst for PendingTransactionPrefixKey {
-    const DB_PREFIX: u8 = DbKeyPrefix::PendingTransaction as u8;
-    type Key = PendingTransactionKey;
-    type Value = PendingTransaction;
-}
+impl_db_prefix_const!(
+    PendingTransactionKey,
+    PendingTransactionPrefixKey,
+    PendingTransaction,
+    DbKeyPrefix::PendingTransaction
+);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct PegOutTxSignatureCI(pub Txid);
 
-impl DatabaseKeyPrefixConst for PegOutTxSignatureCI {
-    const DB_PREFIX: u8 = DbKeyPrefix::PegOutTxSigCi as u8;
-    type Key = Self;
-    type Value = Vec<Signature>; // TODO: define newtype
-}
-
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct PegOutTxSignatureCIPrefix;
 
-impl DatabaseKeyPrefixConst for PegOutTxSignatureCIPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::PegOutTxSigCi as u8;
-    type Key = PegOutTxSignatureCI;
-    type Value = Vec<Signature>;
-}
+impl_db_prefix_const!(
+    PegOutTxSignatureCI,
+    PegOutTxSignatureCIPrefix,
+    Vec<Signature>,
+    DbKeyPrefix::PegOutTxSigCi
+);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct PegOutBitcoinTransaction(pub fedimint_api::OutPoint);
 
-impl DatabaseKeyPrefixConst for PegOutBitcoinTransaction {
-    const DB_PREFIX: u8 = DbKeyPrefix::PegOutBitcoinOutPoint as u8;
-    type Key = Self;
-    type Value = WalletOutputOutcome;
-}
-
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct PegOutBitcoinTransactionPrefix;
 
-impl DatabaseKeyPrefixConst for PegOutBitcoinTransactionPrefix {
-    const DB_PREFIX: u8 = DbKeyPrefix::PegOutBitcoinOutPoint as u8;
-    type Key = PegOutBitcoinTransaction;
-    type Value = WalletOutputOutcome;
-}
+impl_db_prefix_const!(
+    PegOutBitcoinTransaction,
+    PegOutBitcoinTransactionPrefix,
+    WalletOutputOutcome,
+    DbKeyPrefix::PegOutBitcoinOutPoint
+);

--- a/modules/fedimint-wallet/src/db.rs
+++ b/modules/fedimint-wallet/src/db.rs
@@ -1,5 +1,4 @@
 use bitcoin::{BlockHash, Txid};
-use fedimint_api::db::DatabaseKeyPrefixConst;
 use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::impl_db_prefix_const;
 use secp256k1::ecdsa::Signature;

--- a/modules/fedimint-wallet/src/db.rs
+++ b/modules/fedimint-wallet/src/db.rs
@@ -34,7 +34,12 @@ pub struct BlockHashKey(pub BlockHash);
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct BlockHashKeyPrefix;
 
-impl_db_prefix_const!(BlockHashKey, BlockHashKeyPrefix, (), DbKeyPrefix::BlockHash);
+impl_db_prefix_const!(
+    key = BlockHashKey,
+    value = (),
+    prefix = DbKeyPrefix::BlockHash,
+    key_prefix = BlockHashKeyPrefix
+);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct UTXOKey(pub bitcoin::OutPoint);
@@ -42,19 +47,20 @@ pub struct UTXOKey(pub bitcoin::OutPoint);
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct UTXOPrefixKey;
 
-impl_db_prefix_const!(UTXOKey, UTXOPrefixKey, SpendableUTXO, DbKeyPrefix::Utxo);
+impl_db_prefix_const!(
+    key = UTXOKey,
+    value = SpendableUTXO,
+    prefix = DbKeyPrefix::Utxo,
+    key_prefix = UTXOPrefixKey
+);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct RoundConsensusKey;
 
-#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
-pub struct RoundConsensusPrefixKey;
-
 impl_db_prefix_const!(
-    RoundConsensusKey,
-    RoundConsensusPrefixKey,
-    RoundConsensus,
-    DbKeyPrefix::RoundConsensus
+    key = RoundConsensusKey,
+    value = RoundConsensus,
+    prefix = DbKeyPrefix::RoundConsensus,
 );
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
@@ -64,10 +70,10 @@ pub struct UnsignedTransactionKey(pub Txid);
 pub struct UnsignedTransactionPrefixKey;
 
 impl_db_prefix_const!(
-    UnsignedTransactionKey,
-    UnsignedTransactionPrefixKey,
-    UnsignedTransaction,
-    DbKeyPrefix::UnsignedTransaction
+    key = UnsignedTransactionKey,
+    value = UnsignedTransaction,
+    prefix = DbKeyPrefix::UnsignedTransaction,
+    key_prefix = UnsignedTransactionPrefixKey
 );
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
@@ -77,10 +83,10 @@ pub struct PendingTransactionKey(pub Txid);
 pub struct PendingTransactionPrefixKey;
 
 impl_db_prefix_const!(
-    PendingTransactionKey,
-    PendingTransactionPrefixKey,
-    PendingTransaction,
-    DbKeyPrefix::PendingTransaction
+    key = PendingTransactionKey,
+    value = PendingTransaction,
+    prefix = DbKeyPrefix::PendingTransaction,
+    key_prefix = PendingTransactionPrefixKey
 );
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
@@ -90,10 +96,10 @@ pub struct PegOutTxSignatureCI(pub Txid);
 pub struct PegOutTxSignatureCIPrefix;
 
 impl_db_prefix_const!(
-    PegOutTxSignatureCI,
-    PegOutTxSignatureCIPrefix,
-    Vec<Signature>,
-    DbKeyPrefix::PegOutTxSigCi
+    key = PegOutTxSignatureCI,
+    value = Vec<Signature>,
+    prefix = DbKeyPrefix::PegOutTxSigCi,
+    key_prefix = PegOutTxSignatureCIPrefix
 );
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
@@ -103,8 +109,8 @@ pub struct PegOutBitcoinTransaction(pub fedimint_api::OutPoint);
 pub struct PegOutBitcoinTransactionPrefix;
 
 impl_db_prefix_const!(
-    PegOutBitcoinTransaction,
-    PegOutBitcoinTransactionPrefix,
-    WalletOutputOutcome,
-    DbKeyPrefix::PegOutBitcoinOutPoint
+    key = PegOutBitcoinTransaction,
+    value = WalletOutputOutcome,
+    prefix = DbKeyPrefix::PegOutBitcoinOutPoint,
+    key_prefix = PegOutBitcoinTransactionPrefix
 );


### PR DESCRIPTION
Database code currently contains a lot of boilerplate code for reading/writing keys, key prefixes, and their associated values. Once every DB struct is versioned, the amount of boilerplate code will become a lot.

This PR attempts to make a code a bit more readable and just add a macro for generating the common key/value and key prefix/value implementations needed for reading/writing to the database.