### PR TITLE
build: change opt-level to 3 in cargo dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,21 +48,21 @@ split-debuginfo = "packed"
 
 # in dev mode optimize crates that are perf-critical (usually just crypto crates)
 [profile.dev.package]
-secp256k1 = { opt-level = 2 }
-secp256k1-zkp = { opt-level = 2 }
-secp256k1-sys = { opt-level = 2 }
-secp256k1-zkp-sys = { opt-level = 2 }
-bitcoin_hashes = { opt-level = 2 }
-ff = { opt-level = 2 }
-group = { opt-level = 2 }
-pairing = { opt-level = 2 }
-rand_core = { opt-level = 2 }
-byteorder = { opt-level = 2 }
-zeroize = { opt-level = 2 }
-bls12_381 = { opt-level = 2 }
-subtle = { opt-level = 2 }
-ring = { opt-level = 2 }
-threshold_crypto = { opt-level = 2 }
+secp256k1 = { opt-level = 3 }
+secp256k1-zkp = { opt-level = 3 }
+secp256k1-sys = { opt-level = 3 }
+secp256k1-zkp-sys = { opt-level = 3 }
+bitcoin_hashes = { opt-level = 3 }
+ff = { opt-level = 3 }
+group = { opt-level = 3 }
+pairing = { opt-level = 3 }
+rand_core = { opt-level = 3 }
+byteorder = { opt-level = 3 }
+zeroize = { opt-level = 3 }
+bls12_381 = { opt-level = 3 }
+subtle = { opt-level = 3 }
+ring = { opt-level = 3 }
+threshold_crypto = { opt-level = 3 }
 
 [patch.crates-io]
 secp256k1-zkp = { git = "https://github.com/dpc/rust-secp256k1-zkp/", branch = "sanket-pr" }


### PR DESCRIPTION
~~Don't merge.~~
edit: Let's merge it. Build time seems to not increase. 



Just testing the difference between `opt-level=2` and `opt-level=3`.

local build times of very rudimentary tests run with 
```sh
cargo clean
time cargo build
```


```
opt-level 3
run 1
________________________________________________________
Executed in   82.28 secs    fish           external
   usr time  830.57 secs    2.69 millis  830.57 secs
   sys time   72.70 secs    0.00 millis   72.70 secs

run 2
________________________________________________________
Executed in   82.31 secs    fish           external
   usr time  825.85 secs    2.43 millis  825.85 secs
   sys time   72.66 secs    0.00 millis   72.66 secs


run 3
________________________________________________________
Executed in   86.30 secs    fish           external
   usr time  811.13 secs    2.65 millis  811.13 secs
   sys time   72.11 secs    0.00 millis   72.11 secs



opt-level 2
run 1
________________________________________________________
Executed in   79.55 secs    fish           external
   usr time  813.15 secs    2.52 millis  813.15 secs
   sys time   73.54 secs    0.00 millis   73.54 secs


run 2
________________________________________________________
Executed in   83.10 secs    fish           external
   usr time  814.13 secs    2.75 millis  814.12 secs
   sys time   74.11 secs    0.00 millis   74.11 secs

run 3
________________________________________________________
Executed in   82.58 secs    fish           external
   usr time  826.63 secs    1.89 millis  826.63 secs
   sys time   73.80 secs    0.66 millis   73.80 secs
```