### PR TITLE
fix: silence gnu parallel

### DIFF
--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -2,6 +2,14 @@
 
 set -eo pipefail
 
+# https://stackoverflow.com/a/72183258/134409
+# this hangs in CI (no tty?)
+# yes 'will cite' | parallel --citation 2>/dev/null 1>/dev/null || true
+if [ -n "${HOME:-}" ] && [ -d "$HOME" ]; then
+  mkdir -p "$HOME/.parallel"
+  touch "$HOME/.parallel/will-cite"
+fi
+
 # Revert `git stash` on exit
 function revert_git_stash {
   >&2 echo "Unstashing uncommited changes..."


### PR DESCRIPTION
GNU Parallel displays this annoying prompt to give them money.

Make it go away for everyone automatically.