### PR TITLE
fix: conventional commit checking when using `git commit -m`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -882,6 +882,8 @@
                 pkgs.parallel
                 pkgs.semgrep
 
+                (pkgs.writeShellScriptBin "git-recommit" "exec git commit --edit -F <(cat \"$(git rev-parse --git-path COMMIT_EDITMSG)\" | grep -v -E '^#.*') \"$@\"")
+
                 # This is required to prevent a mangled bash shell in nix develop
                 # see: https://discourse.nixos.org/t/interactive-bash-with-nix-develop-flake/15486
                 (hiPrio pkgs.bashInteractive)

--- a/misc/git-hooks/commit-msg
+++ b/misc/git-hooks/commit-msg
@@ -10,44 +10,21 @@ function rm_tmp_file {
 
 trap rm_tmp_file EXIT
 
-while : ; do
-  # Sanitize file first, by removing leading lines that are empty or start with a hash,
-  # as `convco` currently does not do it automatically (but git will)
-  echo -n "" > "$tmp_file"
-  body_detected=""
-  while read -r line ; do
-    # skip any initial comments (possibly from previous run)
-    if [ -z "${body_detected:-}" ] && { [[ "$line" =~ ^#.*$ ]] || [ "$line" == "" ]; }; then
-      continue
-    fi
-    body_detected="true"
-
-    echo "$line" >> "$tmp_file"
-  done < "$1"
-
-  # We have a sanitized version in "$tmp_file" now, move it the original
-  cp "$tmp_file" "$1"
-
-
-  # Run convco, start preparing a buffer we will display to the user,
-  # if lint fails.
-  echo -n "# " > "$tmp_file"
-  if convco check < "$1" 2>> "$tmp_file" ; then
-     break
+# Sanitize file first, by removing leading lines that are empty or start with a hash,
+# as `convco` currently does not do it automatically (but git will)
+# TODO: next release of convco should be able to do it automatically
+echo -n "" > "$tmp_file"
+while read -r line ; do
+  # skip any initial comments (possibly from previous run)
+  if [ -z "${body_detected:-}" ] && { [[ "$line" =~ ^#.*$ ]] || [ "$line" == "" ]; }; then
+    continue
   fi
+  body_detected="true"
 
-  # lint failed, prepare the content to show
-  {
-    echo "# Refer to https://www.conventionalcommits.org/en/v1.0.0/#summary"
-    echo "# Quit without changes to abort"
-    cat "$1"
-  } >> "$tmp_file"
+  echo "$line" >> "$tmp_file"
+done < "$1"
 
-  # "$tmp_file" has a commit message prefixed with comments explaining what's wrong.
-  cp "$tmp_file" "$1"
-  "${VISUAL:-${EDITOR:-vi}}" "$1"
-  if cmp -s "$tmp_file" "$1"; then
-    >&2 echo "Not changes. Exiting..."
-    exit 1
-  fi
-done
+if ! convco check < "$tmp_file" ; then
+   >&2 echo "Use git recommit <args> to fix your commit"
+  exit 1
+fi


### PR DESCRIPTION
The approach I used before (starting editor to edit commit message) does not play well with how git commit hooks work (IMO, poorly designed).

Instead of opening an editor, print an error message and introduce a helper to try again without figuring out how to recover the old message.