### PR TITLE
Default to millisats in CLI when parsing amount

### DIFF
--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -51,8 +51,8 @@ pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_api::Amount, ParseAmoun
         let (amt, denom) = s.split_at(i);
         fedimint_api::Amount::from_str_in(amt, denom.parse()?)
     } else {
-        //default to satoshi
-        fedimint_api::Amount::from_str_in(s, bitcoin::Denomination::Satoshi)
+        //default to millisatoshi
+        fedimint_api::Amount::from_str_in(s, bitcoin::Denomination::MilliSatoshi)
     }
 }
 
@@ -76,4 +76,24 @@ pub fn network_to_currency(network: Network) -> Currency {
         Network::Testnet => Currency::BitcoinTestnet,
         Network::Signet => Currency::Signet,
     }
+}
+
+#[test]
+fn sanity_check_parse_fedimint_amount() {
+    assert_eq!(
+        parse_fedimint_amount("34").unwrap(),
+        fedimint_api::Amount { msats: 34 }
+    );
+    assert_eq!(
+        parse_fedimint_amount("34msat").unwrap(),
+        fedimint_api::Amount { msats: 34 }
+    );
+    assert_eq!(
+        parse_fedimint_amount("34sat").unwrap(),
+        fedimint_api::Amount { msats: 34 * 1000 }
+    );
+    assert_eq!(
+        parse_fedimint_amount("34satoshi").unwrap(),
+        fedimint_api::Amount { msats: 34 * 1000 }
+    );
 }


### PR DESCRIPTION
This PR relates to https://github.com/fedimint/fedimint/issues/1177.

As discussed with @justinmoon in discord (https://discord.com/channels/990354215060795454/1069535765874343976), I've changed the parser so that amounts entered default to millisats while still allowing for other denominations to be specified with a suffix, e.g. `100sat`.
