### PR TITLE
fix: Print lightning gateway version at startup

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -81,6 +81,8 @@ impl LnGateway {
         receiver: mpsc::Receiver<GatewayRequest>,
         task_group: TaskGroup,
     ) -> Self {
+        info!(version = env!("GIT_HASH"), "Starting lightning gateway");
+
         let mut num_retries = 0;
         let route_hints = loop {
             let route_hints = ln_rpc


### PR DESCRIPTION
fixes #1607 