### PR TITLE
fix: adjust instrument name to correct method name

### DIFF
--- a/gateway/ln-gateway/src/cln.rs
+++ b/gateway/ln-gateway/src/cln.rs
@@ -107,7 +107,7 @@ impl LnRpc for ClnRpc {
         }
     }
 
-    #[instrument(name = "LnRpc::route_hints", skip(self))]
+    #[instrument(name = "LnRpc::pay", skip(self))]
     async fn pay(
         &self,
         invoice: Invoice,


### PR DESCRIPTION
I think that was just a copy/paste whatever mistake [introduced here](https://github.com/fedimint/fedimint/pull/1577/files#diff-4dc1d69fdaa69b89bc846149cfaf8ff5b802853d13c5049362d5c934258cab50L86) ? 