### PR TITLE
Replay prevention2

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -854,8 +854,6 @@ pub enum TransactionSubmissionError {
     TransactionError(#[from] TransactionError),
     #[error("Module input or output error in tx {0}: {1}")]
     ModuleError(TransactionId, ModuleError),
-    #[error("Transaction conflict error")]
-    TransactionConflictError,
     #[error("Transaction channel was closed")]
     TxChannelError,
 }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -32,6 +32,7 @@ use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument
 
 use crate::config::ServerConfig;
 use crate::consensus::interconnect::FedimintInterconnect;
+use crate::consensus::TransactionSubmissionError::TransactionReplayError;
 use crate::db::{
     AcceptedTransactionKey, ClientConfigSignatureKey, DropPeerKey, DropPeerKeyPrefix,
     EpochHistoryKey, LastEpochKey, RejectedTransactionKey,
@@ -221,7 +222,7 @@ impl FedimintConsensus {
             .await
             .is_some()
         {
-            return Ok(());
+            return Err(TransactionReplayError(transaction.tx_hash()));
         }
 
         let tx_hash = transaction.tx_hash();
@@ -684,6 +685,15 @@ impl FedimintConsensus {
 
         let tx_hash = transaction.tx_hash();
 
+        if dbtx
+            .get_value(&AcceptedTransactionKey(tx_hash))
+            .await
+            .expect("DB Error")
+            .is_some()
+        {
+            return Err(TransactionReplayError(tx_hash));
+        }
+
         let mut pub_keys = Vec::new();
         for input in transaction.inputs.iter() {
             let meta = self
@@ -856,4 +866,6 @@ pub enum TransactionSubmissionError {
     ModuleError(TransactionId, ModuleError),
     #[error("Transaction channel was closed")]
     TxChannelError,
+    #[error("Transaction was already successfully processed: {0}")]
+    TransactionReplayError(TransactionId),
 }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -22,9 +22,10 @@ use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::{ClientConfig, ModuleGenRegistry};
 use fedimint_api::core;
 use fedimint_api::core::{
-    DynModuleConsensusItem as PerModuleConsensusItem, ModuleConsensusItem,
+    ModuleConsensusItem,
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
+use fedimint_api::core::{DynModuleConsensusItem, ModuleInstanceId};
 use fedimint_api::db::mem_impl::MemDatabase;
 use fedimint_api::db::Database;
 use fedimint_api::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
@@ -47,6 +48,7 @@ use fedimint_server::multiplexed::PeerConnectionMultiplexer;
 use fedimint_server::net::connect::mock::MockNetwork;
 use fedimint_server::net::connect::{Connector, TlsTcpConnector};
 use fedimint_server::net::peers::PeerConnector;
+use fedimint_server::transaction::legacy::Transaction;
 use fedimint_server::{consensus, EpochMessage, FedimintServer};
 use fedimint_testing::btc::{fixtures::FakeBitcoinTest, BitcoinTest};
 use fedimint_wallet::config::WalletConfig;
@@ -68,6 +70,7 @@ use ln_gateway::{
     LnGateway,
 };
 use mint_client::module_decode_stubs;
+use mint_client::transaction::TransactionBuilder;
 use mint_client::{
     api::WsFederationApi, mint::SpendableNote, Client, GatewayClient, GatewayClientConfig,
     UserClient, UserClientConfig,
@@ -75,7 +78,7 @@ use mint_client::{
 use rand::rngs::OsRng;
 use rand::RngCore;
 use real::{RealBitcoinTest, RealLightningTest};
-use tracing::{debug, info};
+use tracing::{info};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 use url::Url;
@@ -607,6 +610,22 @@ impl<T: AsRef<ClientConfig> + Clone> UserTest<T> {
         UserTest { client, config }
     }
 
+    /// Creates a transaction for testing submissions to the federation
+    pub async fn tx_with_change(&self, builder: TransactionBuilder, change: Amount) -> Transaction {
+        let mint = self.client.mint_client();
+        let mut dbtx = mint.start_dbtx().await;
+
+        builder
+            .build_with_change(
+                self.client.mint_client(),
+                &mut dbtx,
+                rng(),
+                vec![change],
+                &secp(),
+            )
+            .await
+    }
+
     /// Helper for readability
     pub async fn set_notes_per_denomination(&self, notes: u16) {
         self.client
@@ -670,19 +689,18 @@ struct ServerTest {
 
 /// Represents a collection of fedimint peer servers
 impl FederationTest {
-    /// Returns the outcome of the last consensus epoch
-    pub fn last_consensus(&self) -> HbbftConsensusOutcome {
-        self.last_consensus.borrow().clone()
-    }
-
-    /// Returns the items that were in the last consensus
-    /// Filters out redundant consensus rounds where the block height doesn't change
-    pub fn last_consensus_items(&self) -> Vec<ConsensusItem> {
-        self.last_consensus()
+    /// Returns the first item with the given module id from the last consensus outcome
+    pub fn find_module_item(&self, id: ModuleInstanceId) -> Option<DynModuleConsensusItem> {
+        self.last_consensus
+            .borrow()
+            .clone()
             .contributions
             .values()
             .flat_map(|items| items.clone())
-            .collect()
+            .find_map(|ci| match ci {
+                ConsensusItem::Module(mci) if mci.module_instance_id() == id => Some(mci),
+                _ => None,
+            })
     }
 
     /// Sends a custom proposal, ignoring whatever is in FedimintConsensus
@@ -1002,19 +1020,14 @@ impl FederationTest {
         for item in proposal.items {
             match item {
                 // ignore items that get automatically generated
-                ConsensusItem::Module(mci) => {
-                    if mci.module_instance_id() != LEGACY_HARDCODED_INSTANCE_ID_WALLET {
-                        return false;
+                ConsensusItem::Module(mci) => match mci.as_any().downcast_ref() {
+                    Some(WalletConsensusItem::RoundConsensus(rci))
+                        if rci.block_height == height =>
+                    {
+                        continue
                     }
-
-                    let wci = assert_module_ci(&mci);
-                    if let WalletConsensusItem::RoundConsensus(rci) = wci {
-                        if rci.block_height == height {
-                            continue;
-                        }
-                    }
-                    return false;
-                }
+                    _ => return false,
+                },
                 ConsensusItem::EpochOutcomeSignatureShare(_) => continue,
                 _ => return false,
             }
@@ -1210,18 +1223,11 @@ impl FederationTest {
     }
 }
 
-pub fn assert_ci<M: ModuleConsensusItem>(ci: &ConsensusItem) -> &M {
-    if let ConsensusItem::Module(mci) = ci {
-        assert_module_ci(mci)
-    } else {
-        panic!("Not a module consensus item");
-    }
-}
-
-pub fn assert_module_ci<M: ModuleConsensusItem>(mci: &PerModuleConsensusItem) -> &M {
-    debug!(
-        module_instance_id = mci.module_instance_id(),
-        "Checking module consensus item"
-    );
-    mci.as_any().downcast_ref().unwrap()
+/// Unwraps a dyn consensus item into a specific one for making assertions
+pub fn unwrap_item<M: ModuleConsensusItem>(mci: &Option<DynModuleConsensusItem>) -> &M {
+    mci.as_ref()
+        .expect("Module item exists")
+        .as_any()
+        .downcast_ref()
+        .unwrap()
 }

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -28,7 +28,7 @@ use mint_client::{ClientError, ConfigVerifyError};
 use threshold_crypto::{SecretKey, SecretKeyShare};
 use tracing::{debug, info, instrument};
 
-use crate::fixtures::{assert_ci, peers, test, FederationTest};
+use crate::fixtures::{peers, test, unwrap_item, FederationTest};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_in_and_peg_out_with_fees() -> Result<()> {
@@ -56,15 +56,7 @@ async fn peg_in_and_peg_out_with_fees() -> Result<()> {
         fed.run_consensus_epochs(2).await; // peg-out tx + peg out signing epoch
 
         assert_matches!(
-            assert_ci(
-                fed.last_consensus_items()
-                    .iter()
-                    .find(|ci| {
-                        let ConsensusItem::Module(mci) = ci else { return false };
-                        mci.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_WALLET
-                    })
-                    .unwrap()
-            ),
+            unwrap_item(&fed.find_module_item(LEGACY_HARDCODED_INSTANCE_ID_WALLET)),
             PegOutSignature(_)
         );
 
@@ -74,17 +66,9 @@ async fn peg_in_and_peg_out_with_fees() -> Result<()> {
             .await_peg_out_outcome(out_point)
             .await
             .unwrap();
-        assert!(matches!(
-            assert_ci(
-                fed.last_consensus_items()
-                    .iter()
-                    .find(|ci| {
-                        let ConsensusItem::Module(mci) = ci else { return false };
-                        mci.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_WALLET
-                    })
-                    .unwrap()
 
-            ),
+        assert!(matches!(
+            unwrap_item(&fed.find_module_item(LEGACY_HARDCODED_INSTANCE_ID_WALLET)),
             PegOutSignature(PegOutSignatureItem {
                 txid,
                 ..
@@ -874,17 +858,7 @@ async fn lightning_gateway_cannot_claim_invalid_preimage() -> Result<()> {
         bitcoin.mine_blocks(100).await; // create non-empty epoch
         fed.run_consensus_epochs(1).await; // if valid would create contract to mint notes
 
-        let ln_items = fed
-            .last_consensus_items()
-            .iter()
-            .filter(|item| match item {
-                ConsensusItem::Module(mci) => {
-                    mci.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_LN
-                }
-                _ => false,
-            })
-            .count();
-        assert_eq!(ln_items, 0);
+        assert_eq!(fed.find_module_item(LEGACY_HARDCODED_INSTANCE_ID_LN), None);
         assert_eq!(fed.max_balance_sheet(), 0);
     })
     .await
@@ -1006,18 +980,7 @@ async fn unbalanced_transactions_get_rejected() -> Result<()> {
     test(2, |fed, user, _, _, _| async move {
         // cannot make change for this invoice (results in unbalanced tx)
         let builder = TransactionBuilder::default();
-        let mint = user.client.mint_client();
-
-        let mut dbtx = mint.start_dbtx().await;
-        let tx = builder
-            .build_with_change(
-                user.client.mint_client(),
-                &mut dbtx,
-                rng(),
-                vec![sats(1000)],
-                &secp(),
-            )
-            .await;
+        let tx = user.tx_with_change(builder, sats(1000)).await;
         let response = fed.submit_transaction(tx.into_type_erased()).await;
 
         assert_matches!(


### PR DESCRIPTION
Prevents the replay of transactions with an error at the API and P2P levels with integration tests.  Small refactor of some test code as a separate commit.

Should close #1402
Last bit of work to close #1353
Also should close #1347