### PR TITLE
feat: `tokio-console` support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "--cfg", "tokio_unstable"]
 
 # mold is currently broken on MacOS
 # [target.aarch64-apple-darwin]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "console-api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1298,7 @@ dependencies = [
  "bitcoin",
  "bytes",
  "clap",
+ "console-subscriber",
  "fedimint-api",
  "fedimint-build",
  "fedimint-core",
@@ -1691,6 +1728,19 @@ dependencies = [
  "thiserror",
  "threshold_crypto",
  "tiny-keccak",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -3829,6 +3879,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys",
 ]
 

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = "1.0.91"
 sha3 = "0.10.5"
 tbs = { path = "../crypto/tbs" }
 thiserror = "1.0.37"
-tokio = { version = "1.24.2", features = ["full"] }
+tokio = { version = "1.24.2", features = ["full", "tracing"] }
 tokio-rustls = "0.23.4"
 tokio-util = { version = "0.7.4", features = [ "codec" ] }
 tracing ="0.1.37"
@@ -70,6 +70,7 @@ http-body = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
 qrcode-generator = "4.1.7"
+console-subscriber = "0.1.8"
 
 [build-dependencies]
 fedimint-build = { path = "../fedimint-build" }

--- a/flake.nix
+++ b/flake.nix
@@ -890,6 +890,7 @@
                 tmux
                 tmuxinator
                 docker-compose
+                pkgs.tokio-console
 
                 # Nix
                 pkgs.nixpkgs-fmt


### PR DESCRIPTION
The whole feature is said to be "unstable", but it might turned out very useful, and it's enabled only optionally, so should be OK.

Run `fedimintd` with an extra `--tokio-console-bind=127.0.0.1:1111` to enable. Connect with `tokio-console http://127.0.0.1:1111` (don't forget about `http://` part or it will not work, but not give you a plain error either).

Preview:

![image](https://user-images.githubusercontent.com/9209/217609347-7f785f77-ed78-412f-9e72-ccbaff0df41d.png)


Re: #865