### PR TITLE
Verifies the client config in the API

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -127,8 +127,8 @@ impl FedimintServer {
 
         loop {
             info!("Waiting for peers to agree on a consensus config hash");
-            match server.api.download_client_config().await {
-                Ok(response) if response.consensus_hash == consensus.consensus_hash => break,
+            match server.api.consensus_config_hash().await {
+                Ok(consensus_hash) if consensus_hash == consensus.consensus_hash => break,
                 Ok(_) => bail!("Our consensus config doesn't match peers!"),
                 Err(e) => {
                     warn!(target: LOG_CONSENSUS, "ERROR {:?}", e)

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -197,6 +197,7 @@ impl Gateway {
                 channel_id,
                 node_pub_key,
                 self.config.announce_address.clone(),
+                self.module_gens.clone(),
             )
             .await
             .expect("Failed to create gateway client config");

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -214,6 +214,7 @@ impl LnGateway {
                 channel_id,
                 node_pub_key,
                 self.config.announce_address.clone(),
+                self.module_gens.clone(),
             )
             .await
             .expect("Failed to create gateway client config");

--- a/gateway/tests/tests/fixtures/client.rs
+++ b/gateway/tests/tests/fixtures/client.rs
@@ -71,6 +71,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
         mint_channel_id: u64,
         node_pubkey: PublicKey,
         announce_address: Url,
+        _module_gens: ModuleGenRegistry,
     ) -> Result<GatewayClientConfig, LnGatewayError> {
         // TODO: use the connect info urls to get the federation name?
         // Simulate clients in the same federation by seeding the generated `client_config`

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -79,7 +79,10 @@ async fn test_gateway_authentication() -> Result<()> {
     // *  `connect_federation` with correct password succeeds
     // *  `connect_federation` with incorrect password fails
     let payload = ConnectFedPayload {
-        connect: serde_json::to_string(&WsFederationConnect { members: vec![] })?,
+        connect: serde_json::to_string(&WsFederationConnect {
+            members: vec![],
+            id: FederationId::dummy(),
+        })?,
     };
     test_auth(&gw_password, move |pw| {
         client_ref.connect_federation(pw, payload.clone())

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -1175,7 +1175,9 @@ async fn verifies_client_configs() -> Result<()> {
         let res = user.client.verify_config(&id).await;
         assert_matches!(
             res,
-            Err(ClientError::ConfigVerify(ConfigVerifyError::Unsigned))
+            Err(ClientError::ConfigVerify(
+                ConfigVerifyError::InvalidSignature
+            ))
         );
 
         fed.run_consensus_epochs(1).await;


### PR DESCRIPTION
Creates a generic `VerifySigned` query strategy that can be used to validate the client configs are signed.

Next step towards verifiable client config downloads from any number of URLs using the `WsFederationConnect` JSON.