### PR TITLE
feat: `just lint` to check `clippy` and `docs`

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,6 +12,8 @@ test: build
 
 lint:
   env NO_STASH=true misc/git-hooks/pre-commit
+  just clippy
+  cargo doc --profile dev --no-deps --document-private-items
 
 clippy:
   cargo clippy --all --all-targets


### PR DESCRIPTION
We don't put them in pre-commit hook because they potentially take a long while to rebuild everything, but when executed manually, I think it's totally fine. The user can always ctrl+c and we do lints from the fastest to slowest.