### PR TITLE
refactor: `RealBitcoinTest` locking

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -854,26 +854,24 @@ impl FederationTest {
             .unwrap();
 
         for server in &self.servers {
-            block_on(async {
-                let svr = server.lock().await;
-                let mut dbtx = svr.database.begin_transaction().await;
+            let svr = server.lock().await;
+            let mut dbtx = svr.database.begin_transaction().await;
 
-                {
-                    let mut module_dbtx = dbtx.with_module_prefix(self.wallet_id);
-                    module_dbtx
-                        .insert_new_entry(
-                            &UTXOKey(input.outpoint()),
-                            &SpendableUTXO {
-                                tweak: input.tweak_contract_key().serialize(),
-                                amount: bitcoin::Amount::from_sat(input.tx_output().value),
-                            },
-                        )
-                        .await
-                        .expect("DB Error");
-                }
+            {
+                let mut module_dbtx = dbtx.with_module_prefix(self.wallet_id);
+                module_dbtx
+                    .insert_new_entry(
+                        &UTXOKey(input.outpoint()),
+                        &SpendableUTXO {
+                            tweak: input.tweak_contract_key().serialize(),
+                            amount: bitcoin::Amount::from_sat(input.tx_output().value),
+                        },
+                    )
+                    .await
+                    .expect("DB Error");
+            }
 
-                dbtx.commit_tx().await.expect("DB Error");
-            });
+            dbtx.commit_tx().await.expect("DB Error");
         }
         bitcoin
             .mine_blocks(user.client.wallet_client().config.finality_delay as u64)


### PR DESCRIPTION
Please https://github.com/fedimint/fedimint/pull/1599 first.


Instead of having bunch of ad-hoc `xyz_no_lock`, make them a separate lowest-level (locking-oblivious) `struct`, and let the higher level `struct`s wrap it.