### PR TITLE
feat: share dependency builds between different packages

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -132,12 +132,9 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 
-      - name: Build mint-client for ${{ matrix.build }}
-        run: nix build -L .#cross.${{ matrix.build }}.mint-client
+      - name: Build client packages for ${{ matrix.build }}
+        run: nix build -L .#cross.${{ matrix.build }}.client-pkgs
 
-      - name: Build fedimint-sqlite for ${{ matrix.build }}
-        if: matrix.build != 'wasm32'
-        run: nix build -L .#cross.${{ matrix.build }}.fedimint-sqlite
 
   containers:
     name: "Containers"


### PR DESCRIPTION
By compiling multiple packages together we can re-use their
dependency builds.

Unfortunately this can't be done just "one for all" as some
targets can compile only a subset of packages (wasm), etc.
so we need to be mindful about grouping them.