### PR TITLE
refactor: rename variable in isolated database transaction

### DIFF
--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -363,10 +363,10 @@ impl<'isolated, 'parent: 'isolated, T: Send + Encodable>
 {
     pub fn new(
         dbtx: &'isolated mut DatabaseTransaction<'parent>,
-        prefix: T,
+        module_prefix: T,
     ) -> IsolatedDatabaseTransaction<'isolated, 'parent, T> {
         let mut prefix_bytes = vec![MODULE_GLOBAL_PREFIX];
-        prefix
+        module_prefix
             .consensus_encode(&mut prefix_bytes)
             .expect("Error encoding module instance id as prefix");
         IsolatedDatabaseTransaction {


### PR DESCRIPTION
very small nit; thought I submit it anyway.

just came across when reading about `IsolatedDatabaseTransaction`s. Currently, `new` is only called with the `module_instance_id` as param. If that will be the main value for the `new` function, I think it's worth to rename that parameter. If it will be called with other prefixes in the future (not only module instance id), then just close this PR @m1sterc001guy 