### PR TITLE
Wallet recovery tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arrayvec"
@@ -3044,9 +3044,12 @@ name = "recoverytool"
 version = "0.1.0"
 dependencies = [
  "aead",
+ "anyhow",
  "bitcoin",
  "clap",
  "fedimint-core",
+ "fedimint-ln",
+ "fedimint-mint",
  "fedimint-rocksdb",
  "fedimint-server",
  "fedimint-wallet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,9 +1389,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1414,15 +1414,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1442,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -1463,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote 1.0.23",
@@ -1474,15 +1474,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-timer"
@@ -1496,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3040,6 +3040,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "recoverytool"
+version = "0.1.0"
+dependencies = [
+ "aead",
+ "bitcoin",
+ "clap",
+ "fedimint-core",
+ "fedimint-rocksdb",
+ "fedimint-server",
+ "fedimint-wallet",
+ "fedimintd",
+ "futures",
+ "miniscript",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,9 +3384,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "modules/fedimint-wallet",
     "integrationtests",
     "fedimint-build",
+    "recoverytool"
 ]
 resolver = "2"
 

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -555,9 +555,9 @@ pub struct Signature;
 /// Transaction that was already signed
 #[derive(Encodable)]
 pub struct Transaction {
-    inputs: Vec<DynInput>,
-    outputs: Vec<DynOutput>,
-    signature: Signature,
+    pub inputs: Vec<DynInput>,
+    pub outputs: Vec<DynOutput>,
+    pub signature: Signature,
 }
 
 impl Decodable for Transaction

--- a/modules/fedimint-wallet/src/keys.rs
+++ b/modules/fedimint-wallet/src/keys.rs
@@ -6,6 +6,7 @@ use bitcoin::secp256k1::{Secp256k1, Verification};
 use bitcoin::PublicKey;
 use fedimint_core::encoding::Encodable;
 use miniscript::{MiniscriptKey, ToPublicKey};
+use secp256k1::Signing;
 use serde::{Deserialize, Serialize};
 
 use crate::tweakable::{Contract, Tweakable};
@@ -89,7 +90,11 @@ impl FromStr for CompressedPublicKey {
 }
 
 impl Tweakable for CompressedPublicKey {
-    fn tweak<Ctx: Verification, Ctr: Contract>(&self, tweak: &Ctr, secp: &Secp256k1<Ctx>) -> Self {
+    fn tweak<Ctx: Verification + Signing, Ctr: Contract>(
+        &self,
+        tweak: &Ctr,
+        secp: &Secp256k1<Ctx>,
+    ) -> Self {
         CompressedPublicKey {
             key: self.key.tweak(tweak, secp),
         }

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -1544,22 +1544,12 @@ impl<'a> StatelessWallet<'a> {
             .enumerate()
         {
             let tweaked_secret = {
-                let tweak_pk_bytes = psbt_input
+                let tweak = psbt_input
                     .proprietary
                     .get(&proprietary_tweak_key())
                     .expect("Malformed PSBT: expected tweak");
-                let pub_key = secp256k1::PublicKey::from_secret_key(self.secp, self.secret_key);
 
-                let tweak = {
-                    let mut hasher = HmacEngine::<sha256::Hash>::new(&pub_key.serialize()[..]);
-                    hasher.input(&tweak_pk_bytes[..]);
-                    Hmac::from_engine(hasher).into_inner()
-                };
-
-                self.secret_key
-                    .add_tweak(&Scalar::from_be_bytes(tweak).expect("can't fail"))
-                    .expect("Tweaking priv key failed") // TODO: why could this
-                                                        // happen?
+                self.secret_key.tweak(tweak, self.secp)
             };
 
             let tx_hash = tx_hasher

--- a/modules/fedimint-wallet/src/tweakable.rs
+++ b/modules/fedimint-wallet/src/tweakable.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use bitcoin::hashes::{sha256, Hash as BitcoinHash, Hmac, HmacEngine};
-use secp256k1::{Scalar, Secp256k1, Verification};
+use secp256k1::{Scalar, Secp256k1, Signing, Verification};
 
 /// An object that can be used as a ricardian contract to tweak a key
 pub trait Contract {
@@ -13,17 +13,44 @@ pub trait Contract {
 /// constructions
 pub trait Tweakable {
     /// Tweak the key with a `tweak` contract
-    fn tweak<Ctx: Verification, Ctr: Contract>(&self, tweak: &Ctr, secp: &Secp256k1<Ctx>) -> Self;
+    fn tweak<Ctx: Verification + Signing, Ctr: Contract>(
+        &self,
+        tweak: &Ctr,
+        secp: &Secp256k1<Ctx>,
+    ) -> Self;
 }
 
 impl Tweakable for secp256k1::PublicKey {
-    fn tweak<Ctx: Verification, Ctr: Contract>(&self, tweak: &Ctr, secp: &Secp256k1<Ctx>) -> Self {
+    fn tweak<Ctx: Verification + Signing, Ctr: Contract>(
+        &self,
+        tweak: &Ctr,
+        secp: &Secp256k1<Ctx>,
+    ) -> Self {
         let mut hasher = HmacEngine::<sha256::Hash>::new(&self.serialize()[..]);
         tweak.encode(&mut hasher).expect("hashing is infallible");
         let tweak = Hmac::from_engine(hasher).into_inner();
 
         self.add_exp_tweak(secp, &Scalar::from_be_bytes(tweak).expect("can't fail"))
             .expect("tweak is always 32 bytes, other failure modes are negligible")
+    }
+}
+
+impl Tweakable for secp256k1::SecretKey {
+    fn tweak<Ctx: Verification + Signing, Ctr: Contract>(
+        &self,
+        tweak_in: &Ctr,
+        secp: &Secp256k1<Ctx>,
+    ) -> Self {
+        let pub_key = secp256k1::PublicKey::from_secret_key(secp, self);
+
+        let tweak = {
+            let mut hasher = HmacEngine::<sha256::Hash>::new(&pub_key.serialize()[..]);
+            tweak_in.encode(&mut hasher).expect("hashing is infallible");
+            Hmac::from_engine(hasher).into_inner()
+        };
+
+        self.add_tweak(&Scalar::from_be_bytes(tweak).expect("can't fail"))
+            .expect("Tweaking priv key failed") // TODO: why could this happen?
     }
 }
 

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -11,6 +11,7 @@ name = "recoverytool"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0.69"
 bitcoin = "0.29.2"
 clap = "4.1.4"
 fedimintd = { path = "../fedimintd" }
@@ -19,6 +20,8 @@ fedimint-core = { path = "../fedimint-core" }
 fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 fedimint-server = { path = "../fedimint-server" }
 fedimint-wallet = { path = "../modules/fedimint-wallet" }
+fedimint-ln = { path = "../modules/fedimint-ln" }
+fedimint-mint = { path = "../modules/fedimint-mint" }
 futures = "0.3.26"
 miniscript = { version = "7.0.0", git = "https://github.com/rust-bitcoin/rust-miniscript/", rev = "2f1535e470c75fad85dbad8633986aae36a89a92" }
 secp256k1 = { version = "0.24.3", features = [ "serde", "global-context" ] }

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "recoverytool"
+version = "0.1.0"
+edition = "2021"
+authors = ["The Fedimint Developers"]
+description = "recoverytool allows retrieving on-chain funds from a offline federation"
+license = "MIT"
+
+[[bin]]
+name = "recoverytool"
+path = "src/main.rs"
+
+[dependencies]
+bitcoin = "0.29.2"
+clap = "4.1.4"
+fedimintd = { path = "../fedimintd" }
+aead = { path = "../crypto/aead" }
+fedimint-core = { path = "../fedimint-core" }
+fedimint-rocksdb = { path = "../fedimint-rocksdb" }
+fedimint-server = { path = "../fedimint-server" }
+fedimint-wallet = { path = "../modules/fedimint-wallet" }
+futures = "0.3.26"
+miniscript = { version = "7.0.0", git = "https://github.com/rust-bitcoin/rust-miniscript/", rev = "2f1535e470c75fad85dbad8633986aae36a89a92" }
+secp256k1 = { version = "0.24.3", features = [ "serde", "global-context" ] }
+serde = { version = "1.0.152", features = [ "derive" ] }
+serde_json = "1.0.93"
+tokio = { version = "1.25.0", features = [ "rt-multi-thread", "macros" ] }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"

--- a/recoverytool/README.md
+++ b/recoverytool/README.md
@@ -1,0 +1,118 @@
+# Recovery tool
+
+The `recoverytool` allows extracting wallet descriptors and their corresponding private keys from an offline federation.
+This is useful in cases where a federation has been shut down and users have withdrawn their funds, but due to lost
+e-cash notes or other operational difficulties there are funds left in the federation's on-chain wallet.
+
+**IMPORTANT**:
+* **This is an expert tool, handle with care**
+* **Do not share any output with untrusted parties, it contains secret key material**
+* **Do not use while federation is running or if it is expected to be ever started again**
+
+## Usage
+
+```
+Tool to recover the on-chain wallet of a Fedimint federation
+
+Usage: recoverytool [OPTIONS] <--cfg <CONFIG>|--descriptor <DESCRIPTOR>> <COMMAND>
+
+Commands:
+  direct  Derive the wallet descriptor using a single tweak
+  utxos   Derive all wallet descriptors of confirmed UTXOs in the on-chain wallet. Note that unconfirmed change UTXOs will not appear here
+  epochs  Derive all wallet descriptors of tweaks that were ever used according to the epoch log. In a long-running and busy federation this list will contain many empty descriptors
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --cfg <CONFIG>             Directory containing server config files
+      --password <PASSWORD>      The password that encrypts the configs, will prompt if not passed in [env: FM_PASSWORD=]
+      --descriptor <DESCRIPTOR>  Wallet descriptor, can be used instead of --cfg
+      --key <KEY>                Wallet secret key, can be used instead of config together with --descriptor
+      --network <NETWORK>        Network to operate on, has to be specified if --cfg isn't present [default: bitcoin]
+  -h, --help                     Print help
+```
+
+To recover a wallet this tool requires the guardian's secret key, the federation's wallet descriptor and the tweaks used
+to derive wallet descriptors.
+
+The secret key and wallet descriptor can be supplied in two ways:
+  1. **Config**: By specifying the `--cfg` flag the tool will read the key and descriptor directly from the config files
+  2. **Direct argument**: Otherwise the `--key` and `--descriptor` flags have to be provided. Optionally the `--network`
+flag can be provided to specify the network in this case since it cannot be determined from the config.
+
+The tweaks making up the wallet can be provided in three ways, these correspond to the commands listed in the help
+above:
+  1. **direct**: Provide a single tweak manually (e.g. extracted from user wallet that attempted a peg-in after 
+federation shutdown) 
+  2. **utxos**: Read all confirmed UTXOs from the provided database, this will leave out in-flight UTXOs
+  3. **epochs**: Scan entire epoch history in the provided database for tweaks, this will return the most wallet
+descriptors, most of them empty, but should cover funds and edge cases.
+
+In case of **utxos** and **epochs** the provided database does not need to be the one of the guardian that is trying to
+recover, but of any guardian that stayed in-consensus till the end. This means funds are recoverable even with 1
+database and `t` of `n` configs/secret keys.
+
+## Recovery
+This tool is meant to be used together with a Bitcoin Core wallet and the `jq` tool. While we include a brief overview
+of a possible usage pattern below, please consult the [Bitcoin Core documentation](https://bitcoincore.org/en/doc/24.0.0/)
+for more information about wallet and transaction handling.
+
+The output of `recoverytool` consists of an array of wallet descriptors with optionally some meta-data. The descriptors
+include n-1 public keys and 1 private key (belonging to the guardian running the script):
+
+```
+$ recoverytool --cfg server-1 --password pass1 utxos --db server-1/database/ | jq
+[
+  {
+    "outpoint": "c76d51c9c6dc6b8e462c37b3fa376e7c2055f04f16a8fffc2ab66c5bf0deff55:1",
+    "descriptor": "wsh(sortedmulti(3,0280bf3115766b7e1cb23f2f57caf4de5a9171d3985934f2895cc568b384b52319,cSRM825vXJwf8iXcngedon8nQsPC9VMB18wSiG1Fgw6Y1Kzi16ta,021123625d9b21822e1178fc0d2b3f737d0397584cfac821df3250e49c3127cab5,03865705be62a71a3776cca1169908099ad6d138a0c0ed4aeeaf2c8e64616f4085))#h2zg3uhw",
+    "amount_sat": 20000
+  },
+  {
+    "outpoint": "d19b1545907679882e925ea0c2130969eab26ab2e27431404fef7d30a5fd649c:1",
+    "descriptor": "wsh(sortedmulti(3,025fbaf8b94d101215d608ae6485b5746142933c261dc5616190f3a331eeaf5f3a,cTgHDPq43RFCy5i9jr2XwMQQNEJ1Y2cYHxhyvXj2wLpF8pi2LxUj,02e25f08feee064cb4bbbb3b33c7e0ddf4d06ed261201f40532c4f5d2152072ecf,03b215967b608d4309fec126a42d49950f6049406b439d4f743cb368362a0cfce0))#v6s5xpsa",
+    "amount_sat": 10000
+  }
+]
+```
+
+To import it into bitcoin core use the following `jq` command to transform the tool's output into a valid input format
+for [`bitcoin-cli importdescriptors`](https://bitcoincore.org/en/doc/24.0.0/rpc/wallet/importdescriptors/):
+
+```bash
+$ WALLETS="$(recoverytool --cfg server-1 --password pass1 utxos --db server-1/database/ | jq '. | map({"desc": .descriptor, "timestamp":0})')"
+[
+  {
+    "desc": "wsh(sortedmulti(3,0280bf3115766b7e1cb23f2f57caf4de5a9171d3985934f2895cc568b384b52319,cSRM825vXJwf8iXcngedon8nQsPC9VMB18wSiG1Fgw6Y1Kzi16ta,021123625d9b21822e1178fc0d2b3f737d0397584cfac821df3250e49c3127cab5,03865705be62a71a3776cca1169908099ad6d138a0c0ed4aeeaf2c8e64616f4085))#h2zg3uhw",
+    "timestamp": 0
+  },
+  {
+    "desc": "wsh(sortedmulti(3,025fbaf8b94d101215d608ae6485b5746142933c261dc5616190f3a331eeaf5f3a,cTgHDPq43RFCy5i9jr2XwMQQNEJ1Y2cYHxhyvXj2wLpF8pi2LxUj,02e25f08feee064cb4bbbb3b33c7e0ddf4d06ed261201f40532c4f5d2152072ecf,03b215967b608d4309fec126a42d49950f6049406b439d4f743cb368362a0cfce0))#v6s5xpsa",
+    "timestamp": 0
+  }
+]
+```
+
+And run `importdescriptors` in `bitcoin-cli`:
+
+```
+$ bitcoin-cli importdescriptors "$WALLETS"
+[                                                                                                                                       
+  {                                                                                                                                                                                                                                                                             
+    "success": true,                                                                                                                                                                                                                                                            
+    "warnings": [                                                                                                                                                                                                                                                               
+      "Not all private keys provided. Some wallet functionality may return unexpected errors"                                                                                                                                                                                       ]                                                                                                                                                                                                                                                                             },                                                                                                                                                                                                                                                                            
+  {                                                                                                                                                                                                                                                                             
+    "success": true,                                                                                                                                                                                                                                                            
+    "warnings": [                                                                                                                                                                                                                                                               
+      "Not all private keys provided. Some wallet functionality may return unexpected errors"
+    ]                                                                                                                                   
+  }                                                                                                                                                                                                                                                                             ]
+```
+
+To move these funds create a transaction using [`walletcreatefundedpsbt`](https://bitcoincore.org/en/doc/24.0.0/rpc/wallet/walletcreatefundedpsbt/),
+sign it with `t` of the wallets using [`walletprocesspsbt`](https://bitcoincore.org/en/doc/24.0.0/rpc/wallet/walletprocesspsbt/)
+and extract the final transaction with [`finalizepsbt`](https://bitcoincore.org/en/doc/24.0.0/rpc/rawtransactions/finalizepsbt/).
+The resulting transaction can be broadcasted using [`sendrawtransaction`](https://bitcoincore.org/en/doc/24.0.0/rpc/rawtransactions/sendrawtransaction/).
+
+This workflow has been tested with `n` different wallets in Bitcoin Core and with PSBTs to collaboratively sign
+transactions. You might be able to import all keys into one wallet though and sign transactions right away.

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -1,0 +1,269 @@
+use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
+use std::hash::Hasher;
+use std::path::PathBuf;
+
+use bitcoin::hashes::sha256::Hash;
+use bitcoin::OutPoint;
+use clap::Parser;
+use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
+use fedimint_core::db::Database;
+use fedimint_rocksdb::RocksDb;
+use fedimint_server::config::io::read_server_config;
+use fedimint_wallet::config::WalletConfig;
+use fedimint_wallet::db::{UTXOKey, UTXOPrefixKey};
+use fedimint_wallet::keys::CompressedPublicKey;
+use fedimint_wallet::tweakable::Tweakable;
+use fedimint_wallet::SpendableUTXO;
+use futures::stream::StreamExt;
+use miniscript::{Descriptor, MiniscriptKey, ToPublicKey, TranslatePk, Translator};
+use serde::Serialize;
+use tracing_subscriber::EnvFilter;
+
+/// Tool to recover the on-chain wallet of a Fedimint federation
+#[derive(Debug, Parser)]
+struct RecoveryTool {
+    /// Extract UTXOs from a database without module partitioning
+    #[arg(long = "legacy")]
+    legacy: bool,
+    /// Path to database
+    #[arg(long = "db")]
+    db: PathBuf,
+    /// Directory containing server config files
+    #[arg(long = "cfg")]
+    config: PathBuf,
+    /// The password that encrypts the configs
+    #[arg(long = "password", env = "FM_PASSWORD")]
+    password: String,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("error,mint_client=info,fedimint_cli=info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let opts: RecoveryTool = RecoveryTool::parse();
+
+    let cfg = read_server_config(&opts.password, opts.config).expect("Could not read config file");
+    let wallet_cfg: WalletConfig = cfg
+        .get_module_config_typed(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
+        .expect("Malformed wallet config");
+
+    let db = Database::new(
+        RocksDb::open(opts.db).expect("Error opening DB"),
+        Default::default(),
+    );
+
+    let db = if opts.legacy {
+        db
+    } else {
+        db.new_isolated(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
+    };
+
+    let ctx = secp256k1::Secp256k1::new();
+    let base_descriptor = wallet_cfg.consensus.peg_in_descriptor;
+    let base_key = wallet_cfg.private.peg_in_key;
+
+    let utxos: Vec<ImportableWallet> = db
+        .begin_transaction()
+        .await
+        .find_by_prefix(&UTXOPrefixKey)
+        .await
+        .map(|res| {
+            let (UTXOKey(outpoint), SpendableUTXO { tweak, amount }) = res.expect("DB error");
+            let secret_key = base_key.tweak(&tweak, &ctx);
+            let pub_key =
+                CompressedPublicKey::new(secp256k1::PublicKey::from_secret_key_global(&secret_key));
+            let descriptor = base_descriptor
+                .tweak(&tweak, &ctx)
+                .translate_pk(&mut SecretKeyInjector {
+                    secret: bitcoin::util::key::PrivateKey {
+                        compressed: true,
+                        network: wallet_cfg.consensus.network,
+                        inner: secret_key,
+                    },
+                    public: pub_key,
+                })
+                .expect("can't fail");
+
+            ImportableWallet {
+                outpoint,
+                descriptor,
+                amount_sat: amount,
+            }
+        })
+        .collect()
+        .await;
+
+    serde_json::to_writer(std::io::stdout().lock(), &utxos).expect("Could not encode to stdout")
+}
+
+/// A UTXO with its Bitcoin Core importable descriptor
+#[derive(Debug, Serialize)]
+struct ImportableWallet {
+    outpoint: OutPoint,
+    descriptor: Descriptor<Key>,
+    #[serde(with = "bitcoin::util::amount::serde::as_sat")]
+    amount_sat: bitcoin::Amount,
+}
+
+/// `MiniscriptKey` that is either a WIF-encoded private key or a compressed,
+/// hex-encoded public key
+#[derive(Debug, Clone, Copy, Eq)]
+enum Key {
+    Public(CompressedPublicKey),
+    Private(bitcoin::util::key::PrivateKey),
+}
+
+impl PartialOrd for Key {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.to_compressed_public_key()
+            .partial_cmp(&other.to_compressed_public_key())
+    }
+}
+
+impl Ord for Key {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.to_compressed_public_key()
+            .cmp(&other.to_compressed_public_key())
+    }
+}
+
+impl PartialEq for Key {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_compressed_public_key()
+            .eq(&other.to_compressed_public_key())
+    }
+}
+
+impl std::hash::Hash for Key {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.to_compressed_public_key().hash(state)
+    }
+}
+
+impl Key {
+    fn to_compressed_public_key(self) -> CompressedPublicKey {
+        match self {
+            Key::Public(pk) => pk,
+            Key::Private(sk) => {
+                CompressedPublicKey::new(secp256k1::PublicKey::from_secret_key_global(&sk.inner))
+            }
+        }
+    }
+}
+
+impl Display for Key {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Key::Public(pk) => Display::fmt(pk, f),
+            Key::Private(sk) => Display::fmt(sk, f),
+        }
+    }
+}
+
+impl MiniscriptKey for Key {
+    fn is_uncompressed(&self) -> bool {
+        false
+    }
+
+    type RawPkHash = Key;
+    type Sha256 = bitcoin::hashes::sha256::Hash;
+    type Hash256 = miniscript::hash256::Hash;
+    type Ripemd160 = bitcoin::hashes::ripemd160::Hash;
+    type Hash160 = bitcoin::hashes::hash160::Hash;
+
+    fn to_pubkeyhash(&self) -> Self::RawPkHash {
+        *self
+    }
+}
+
+impl ToPublicKey for Key {
+    fn to_public_key(&self) -> bitcoin::PublicKey {
+        self.to_compressed_public_key().to_public_key()
+    }
+
+    fn hash_to_hash160(
+        hash: &<Self as MiniscriptKey>::RawPkHash,
+    ) -> bitcoin::hashes::hash160::Hash {
+        <CompressedPublicKey as ToPublicKey>::hash_to_hash160(&hash.to_compressed_public_key())
+    }
+
+    fn to_sha256(hash: &<Self as MiniscriptKey>::Sha256) -> Hash {
+        *hash
+    }
+
+    fn to_hash256(hash: &<Self as MiniscriptKey>::Hash256) -> miniscript::hash256::Hash {
+        *hash
+    }
+
+    fn to_ripemd160(hash: &<Self as MiniscriptKey>::Ripemd160) -> bitcoin::hashes::ripemd160::Hash {
+        *hash
+    }
+
+    fn to_hash160(hash: &<Self as MiniscriptKey>::Hash160) -> bitcoin::hashes::hash160::Hash {
+        *hash
+    }
+}
+
+/// Miniscript [`Translator`] that replaces a public key with a private key we
+/// know.
+#[derive(Debug)]
+struct SecretKeyInjector {
+    secret: bitcoin::util::key::PrivateKey,
+    public: CompressedPublicKey,
+}
+
+impl Translator<CompressedPublicKey, Key, ()> for SecretKeyInjector {
+    fn pk(&mut self, pk: &CompressedPublicKey) -> Result<Key, ()> {
+        if &self.public == pk {
+            Ok(Key::Private(self.secret))
+        } else {
+            Ok(Key::Public(*pk))
+        }
+    }
+
+    fn pkh(
+        &mut self,
+        pkh: &<CompressedPublicKey as MiniscriptKey>::RawPkHash,
+    ) -> Result<<Key as MiniscriptKey>::RawPkHash, ()> {
+        if &self.public == pkh {
+            Ok(Key::Private(self.secret))
+        } else {
+            Ok(Key::Public(*pkh))
+        }
+    }
+
+    fn sha256(
+        &mut self,
+        _sha256: &<CompressedPublicKey as MiniscriptKey>::Sha256,
+    ) -> Result<<Key as MiniscriptKey>::Sha256, ()> {
+        unimplemented!()
+    }
+
+    fn hash256(
+        &mut self,
+        _hash256: &<CompressedPublicKey as MiniscriptKey>::Hash256,
+    ) -> Result<<Key as MiniscriptKey>::Hash256, ()> {
+        unimplemented!()
+    }
+
+    fn ripemd160(
+        &mut self,
+        _ripemd160: &<CompressedPublicKey as MiniscriptKey>::Ripemd160,
+    ) -> Result<<Key as MiniscriptKey>::Ripemd160, ()> {
+        unimplemented!()
+    }
+
+    fn hash160(
+        &mut self,
+        _hash160: &<CompressedPublicKey as MiniscriptKey>::Hash160,
+    ) -> Result<<Key as MiniscriptKey>::Hash160, ()> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
Tool to recover on-chain funds from abandoned federations, after a lot of reckless mainnet testing I finally wanted my Bitcoin back :laughing: 

The output consists of an array of UTXOs with their out point, the wallet descriptor including n-1 public keys and 1 private key (belonging to the guardian running the script) and the amount:

```
$ recoverytool --db server-1/database/ --cfg server-1 --password pass1 | jq
[
  {
    "outpoint": "c76d51c9c6dc6b8e462c37b3fa376e7c2055f04f16a8fffc2ab66c5bf0deff55:1",
    "descriptor": "wsh(sortedmulti(3,0280bf3115766b7e1cb23f2f57caf4de5a9171d3985934f2895cc568b384b52319,cSRM825vXJwf8iXcngedon8nQsPC9VMB18wSiG1Fgw6Y1Kzi16ta,021123625d9b21822e1178fc0d2b3f737d0397584cfac821df3250e49c3127cab5,03865705be62a71a3776cca1169908099ad6d138a0c0ed4aeeaf2c8e64616f4085))#h2zg3uhw",
    "amount_sat": 20000
  },
  {
    "outpoint": "d19b1545907679882e925ea0c2130969eab26ab2e27431404fef7d30a5fd649c:1",
    "descriptor": "wsh(sortedmulti(3,025fbaf8b94d101215d608ae6485b5746142933c261dc5616190f3a331eeaf5f3a,cTgHDPq43RFCy5i9jr2XwMQQNEJ1Y2cYHxhyvXj2wLpF8pi2LxUj,02e25f08feee064cb4bbbb3b33c7e0ddf4d06ed261201f40532c4f5d2152072ecf,03b215967b608d4309fec126a42d49950f6049406b439d4f743cb368362a0cfce0))#v6s5xpsa",
    "amount_sat": 10000
  }
]
```

To import it into bitcoin core use the following `jq` command:

```
$ recoverytool --db server-1/database/ --cfg server-1 --password pass1 | jq '. | map({"desc": .descriptor, "timestamp":0})'
[
  {
    "desc": "wsh(sortedmulti(3,0280bf3115766b7e1cb23f2f57caf4de5a9171d3985934f2895cc568b384b52319,cSRM825vXJwf8iXcngedon8nQsPC9VMB18wSiG1Fgw6Y1Kzi16ta,021123625d9b21822e1178fc0d2b3f737d0397584cfac821df3250e49c3127cab5,03865705be62a71a3776cca1169908099ad6d138a0c0ed4aeeaf2c8e64616f4085))#h2zg3uhw",
    "timestamp": 0
  },
  {
    "desc": "wsh(sortedmulti(3,025fbaf8b94d101215d608ae6485b5746142933c261dc5616190f3a331eeaf5f3a,cTgHDPq43RFCy5i9jr2XwMQQNEJ1Y2cYHxhyvXj2wLpF8pi2LxUj,02e25f08feee064cb4bbbb3b33c7e0ddf4d06ed261201f40532c4f5d2152072ecf,03b215967b608d4309fec126a42d49950f6049406b439d4f743cb368362a0cfce0))#v6s5xpsa",
    "timestamp": 0
  }
]
```

And run `importdescriptors` in `bitcoin-cli`:

```
$ bitcoin-cli -rpcwallet=<wallet> importdescriptors "$(recoverytool --db server-1/database/ --cfg server-1 --password pass1 | jq '. | map({"desc": .descriptor, "timestamp":0})')"
[                                                                                                                                       
  {                                                                                                                                                                                                                                                                             
    "success": true,                                                                                                                                                                                                                                                            
    "warnings": [                                                                                                                                                                                                                                                               
      "Not all private keys provided. Some wallet functionality may return unexpected errors"                                                                                                                                                                                       ]                                                                                                                                                                                                                                                                             },                                                                                                                                                                                                                                                                            
  {                                                                                                                                                                                                                                                                             
    "success": true,                                                                                                                                                                                                                                                            
    "warnings": [                                                                                                                                                                                                                                                               
      "Not all private keys provided. Some wallet functionality may return unexpected errors"
    ]                                                                                                                                   
  }                                                                                                                                                                                                                                                                             ]
```

So far I used it with `n` different wallets in Bitcoin Core and with PSBTs to collaboratively sign transactions. You might be able to import all keys into one wallet though and sign transactions right away.