### PR TITLE
Client connect string

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -625,7 +625,7 @@ async fn handle_command(
             )
         }
         Command::ConnectInfo => {
-            let info = WsClientConnectInfo::from(client.config().as_ref());
+            let info = WsClientConnectInfo::from_honest_peers(client.config().as_ref());
             Ok(CliOutput::ConnectInfo {
                 connect_info: (info),
             })

--- a/fedimint-api/src/lib.rs
+++ b/fedimint-api/src/lib.rs
@@ -9,6 +9,7 @@ use bitcoin::Denomination;
 use bitcoin_hashes::hash_newtype;
 use bitcoin_hashes::sha256::Hash as Sha256;
 pub use bitcoin_hashes::Hash as BitcoinHash;
+use fedimint_api::config::ApiEndpoint;
 pub use module::ServerModule;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -150,6 +151,12 @@ impl NumPeers for &[PeerId] {
 }
 
 impl NumPeers for Vec<PeerId> {
+    fn total(&self) -> usize {
+        self.len()
+    }
+}
+
+impl NumPeers for Vec<ApiEndpoint> {
     fn total(&self) -> usize {
         self.len()
     }

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -5,7 +5,7 @@ use anyhow::format_err;
 use bitcoin::Network;
 use fedimint_api::config::{ConfigGenParams, ModuleGenRegistry};
 use fedimint_api::{Amount, Tiered};
-use fedimint_core::api::WsFederationConnect;
+use fedimint_core::api::WsClientConnectInfo;
 use fedimint_mint::MintGenParams;
 use fedimint_server::config::ServerConfig;
 use fedimint_wallet::WalletGenParams;
@@ -110,7 +110,7 @@ pub fn write_nonprivate_configs(
     plaintext_json_write(&server.local, path.join(LOCAL_CONFIG))?;
     plaintext_json_write(&server.consensus, path.join(CONSENSUS_CONFIG))?;
     plaintext_json_write(
-        &WsFederationConnect::from(&client_config),
+        &WsClientConnectInfo::from(&client_config),
         path.join(CLIENT_CONNECT_FILE),
     )?;
     plaintext_json_write(&client_config, path.join(CLIENT_CONFIG))

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -110,7 +110,7 @@ pub fn write_nonprivate_configs(
     plaintext_json_write(&server.local, path.join(LOCAL_CONFIG))?;
     plaintext_json_write(&server.consensus, path.join(CONSENSUS_CONFIG))?;
     plaintext_json_write(
-        &WsClientConnectInfo::from(&client_config),
+        &WsClientConnectInfo::from_honest_peers(&client_config),
         path.join(CLIENT_CONNECT_FILE),
     )?;
     plaintext_json_write(&client_config, path.join(CLIENT_CONFIG))

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -75,7 +75,7 @@ async fn run_page(axum::extract::State(state): axum::extract::State<MutableState
                 match std::fs::File::open(path) {
                     Ok(file) => match serde_json::from_reader(file) {
                         Ok(cfg) => {
-                            let connect_info = WsClientConnectInfo::from(&cfg);
+                            let connect_info = WsClientConnectInfo::from_honest_peers(&cfg);
 
                             RunTemplateState::DkgDone(
                                 serde_json::to_string(&connect_info).expect("should deserialize"),
@@ -329,7 +329,7 @@ async fn qr(axum::extract::State(state): axum::extract::State<MutableState>) -> 
         Ok(file) => {
             let cfg: ClientConfig =
                 serde_json::from_reader(file).expect("Could not parse cfg file.");
-            let connect_info = WsClientConnectInfo::from(&cfg);
+            let connect_info = WsClientConnectInfo::from_honest_peers(&cfg);
             serde_json::to_string(&connect_info).expect("should deserialize")
         }
         Err(_) => "".into(),

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -16,7 +16,7 @@ use fedimint_api::bitcoin_rpc::BitcoindRpcBackend;
 use fedimint_api::config::{ClientConfig, ModuleGenRegistry};
 use fedimint_api::task::TaskGroup;
 use fedimint_api::Amount;
-use fedimint_core::api::WsFederationConnect;
+use fedimint_core::api::WsClientConnectInfo;
 use fedimint_core::util::SanitizedUrl;
 use http::StatusCode;
 use qrcode_generator::QrCodeEcc;
@@ -75,7 +75,7 @@ async fn run_page(axum::extract::State(state): axum::extract::State<MutableState
                 match std::fs::File::open(path) {
                     Ok(file) => match serde_json::from_reader(file) {
                         Ok(cfg) => {
-                            let connect_info = WsFederationConnect::from(&cfg);
+                            let connect_info = WsClientConnectInfo::from(&cfg);
 
                             RunTemplateState::DkgDone(
                                 serde_json::to_string(&connect_info).expect("should deserialize"),
@@ -329,7 +329,7 @@ async fn qr(axum::extract::State(state): axum::extract::State<MutableState>) -> 
         Ok(file) => {
             let cfg: ClientConfig =
                 serde_json::from_reader(file).expect("Could not parse cfg file.");
-            let connect_info = WsFederationConnect::from(&cfg);
+            let connect_info = WsClientConnectInfo::from(&cfg);
             serde_json::to_string(&connect_info).expect("should deserialize")
         }
         Err(_) => "".into(),

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -14,8 +14,8 @@ use fedimint_api::{
 };
 use fedimint_server::api::DynFederationApi;
 use fedimint_server::api::GlobalFederationApi;
+use fedimint_server::api::WsClientConnectInfo;
 use fedimint_server::api::WsFederationApi;
-use fedimint_server::api::WsFederationConnect;
 use fedimint_server::config::load_from_file;
 use mint_client::{module_decode_stubs, Client, GatewayClientConfig};
 use secp256k1::{KeyPair, PublicKey};
@@ -85,7 +85,7 @@ pub trait IGatewayClientBuilder: Debug {
     /// Create a new gateway federation client config from connect info
     async fn create_config(
         &self,
-        connect: WsFederationConnect,
+        connect: WsClientConnectInfo,
         mint_channel_id: u64,
         node_pubkey: PublicKey,
         module_gens: ModuleGenRegistry,
@@ -143,12 +143,12 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
 
     async fn create_config(
         &self,
-        connect: WsFederationConnect,
+        connect: WsClientConnectInfo,
         mint_channel_id: u64,
         node_pubkey: PublicKey,
         module_gens: ModuleGenRegistry,
     ) -> Result<GatewayClientConfig> {
-        let api: DynFederationApi = WsFederationApi::new(connect.members).into();
+        let api: DynFederationApi = WsFederationApi::from_urls(&connect).into();
 
         let client_config = api
             .download_client_config(&connect.id, module_gens)

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -16,7 +16,7 @@ use fedimint_api::{
     task::TaskGroup,
     Amount, TransactionId,
 };
-use fedimint_server::api::WsFederationConnect;
+use fedimint_server::api::WsClientConnectInfo;
 use mint_client::{
     ln::PayInvoicePayload,
     modules::ln::{contracts::Preimage, route_hints::RouteHint},
@@ -175,7 +175,7 @@ impl Gateway {
         payload: ConnectFedPayload,
         route_hints: Vec<RouteHint>,
     ) -> Result<()> {
-        let connect: WsFederationConnect = serde_json::from_str(&payload.connect).map_err(|e| {
+        let connect: WsClientConnectInfo = serde_json::from_str(&payload.connect).map_err(|e| {
             LnGatewayError::Other(anyhow::anyhow!("Invalid federation member string {}", e))
         })?;
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -27,7 +27,7 @@ use bitcoin::Address;
 use fedimint_api::config::ModuleGenRegistry;
 use fedimint_api::{config::FederationId, module::registry::ModuleDecoderRegistry};
 use fedimint_api::{task::TaskGroup, Amount, TransactionId};
-use fedimint_server::api::WsFederationConnect;
+use fedimint_server::api::WsClientConnectInfo;
 use mint_client::modules::ln::contracts::Preimage;
 use mint_client::modules::ln::route_hints::RouteHint;
 use mint_client::{ln::PayInvoicePayload, mint::MintClientError, ClientError, GatewayClient};
@@ -195,7 +195,7 @@ impl LnGateway {
         payload: ConnectFedPayload,
         route_hints: Vec<RouteHint>,
     ) -> Result<()> {
-        let connect: WsFederationConnect = serde_json::from_str(&payload.connect).map_err(|e| {
+        let connect: WsClientConnectInfo = serde_json::from_str(&payload.connect).map_err(|e| {
             LnGatewayError::Other(anyhow::anyhow!("Invalid federation member string {}", e))
         })?;
 

--- a/gateway/tests/tests/fixtures/client.rs
+++ b/gateway/tests/tests/fixtures/client.rs
@@ -10,7 +10,7 @@ use fedimint_api::{
     module::registry::ModuleDecoderRegistry,
     PeerId,
 };
-use fedimint_core::api::{DynFederationApi, WsFederationConnect};
+use fedimint_core::api::{DynFederationApi, WsClientConnectInfo};
 use ln_gateway::{
     client::{DynDbFactory, IGatewayClientBuilder},
     LnGatewayError,
@@ -71,7 +71,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
 
     async fn create_config(
         &self,
-        _connect: WsFederationConnect,
+        _connect: WsClientConnectInfo,
         mint_channel_id: u64,
         node_pubkey: PublicKey,
         _module_gens: ModuleGenRegistry,

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use fedimint_api::config::FederationId;
-use fedimint_core::api::WsFederationConnect;
+use fedimint_core::api::WsClientConnectInfo;
 use fixtures::{fixtures, Fixtures};
 use ln_gateway::rpc::rpc_client::{Error, Response};
 use ln_gateway::{
@@ -79,8 +79,8 @@ async fn test_gateway_authentication() -> Result<()> {
     // *  `connect_federation` with correct password succeeds
     // *  `connect_federation` with incorrect password fails
     let payload = ConnectFedPayload {
-        connect: serde_json::to_string(&WsFederationConnect {
-            members: vec![],
+        connect: serde_json::to_string(&WsClientConnectInfo {
+            urls: vec![],
             id: FederationId::dummy(),
         })?,
     };


### PR DESCRIPTION
Refactors the client connection string to use `one_honest` number of peers.  Now that we verify against the `federation_id` we can use a smaller number of urls or even non-federation urls to download from, and the urls don't need to be trusted.

JSON still seems like the best format since it's easy to construct and read, I tried other formats and they don't compress the information much.  Bytes for 10 guardians goes down from `649` to `242` with this change.

Example config:
```
{
  "urls": [
    "ws://127.0.0.1:18174/",
    "ws://127.0.0.1:18184/",
  ],
  "id": "ab011cbb464a4b71d90bc1f08a9034e43365a3620a72b76fd06e07d90221c5510d8a7489e78d4375114aae30ff3250b4"
}
```

Fixes #614
Will also close #1205 as most of the stable fed id work is done, will open new issue for updating P2P federation connections.