### PR TITLE
Rustfmt: Split imports at module level

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -8,9 +8,9 @@ use fedimint_api::core::{
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_api::NumPeers;
-use fedimint_core::api::FederationApiExt;
 use fedimint_core::api::{
-    erased_multi_param, erased_no_param, erased_single_param, FederationResult, IFederationApi,
+    erased_multi_param, erased_no_param, erased_single_param, FederationApiExt, FederationResult,
+    IFederationApi,
 };
 use fedimint_core::query::{EventuallyConsistent, Retry404, UnionResponsesSingle};
 use fedimint_mint::db::ECashUserBackupSnapshot;

--- a/client/client-lib/src/api/fake.rs
+++ b/client/client-lib/src/api/fake.rs
@@ -1,19 +1,16 @@
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use fedimint_api::PeerId;
-use fedimint_core::api::IFederationApi;
-use fedimint_core::api::JsonRpcResult;
+use fedimint_core::api::{IFederationApi, JsonRpcResult};
 use futures::Future;
 use serde;
 use serde::Serialize;
 use serde_json::Value;
-use tracing::info;
-use tracing::warn;
+use tracing::{info, warn};
 
 #[allow(clippy::type_complexity)]
 type Handler<State> = Pin<

--- a/client/client-lib/src/ln/outgoing.rs
+++ b/client/client-lib/src/ln/outgoing.rs
@@ -2,7 +2,8 @@ use fedimint_api::encoding::{Decodable, Encodable};
 use fedimint_api::Amount;
 use serde::Serialize;
 
-use crate::modules::ln::contracts::{outgoing::OutgoingContract, IdentifyableContract, Preimage};
+use crate::modules::ln::contracts::outgoing::OutgoingContract;
+use crate::modules::ln::contracts::{IdentifyableContract, Preimage};
 use crate::modules::ln::LightningInput;
 
 #[derive(Debug, Encodable, Decodable, Serialize)]

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -7,26 +7,23 @@
 //! them with federation. A successfully recovered snapshot can be used
 //! to avoid having to scan the whole history.
 
-use std::{
-    cmp::{max, Reverse},
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    ops::Range,
-};
+use std::cmp::{max, Reverse};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::ops::Range;
 
 use anyhow::Result;
-use fedimint_api::{
-    cancellable::{Cancellable, Cancelled},
-    core::LEGACY_HARDCODED_INSTANCE_ID_MINT,
-    task::TaskGroup,
-    NumPeers, PeerId,
-};
+use fedimint_api::cancellable::{Cancellable, Cancelled};
+use fedimint_api::core::LEGACY_HARDCODED_INSTANCE_ID_MINT;
+use fedimint_api::task::TaskGroup;
+use fedimint_api::{NumPeers, PeerId};
 use fedimint_core::api::{FederationError, GlobalFederationApi};
 use fedimint_core::epoch::{ConsensusItem, SignedEpochOutcome};
 use fedimint_mint::{BackupRequest, SignedBackupRequest};
 use tbs::{combine_valid_shares, verify_blind_share, BlindedMessage, PublicKeyShare};
 use tracing::{error, info};
 
-use super::{db::NextECashNoteIndexKeyPrefix, *};
+use super::db::NextECashNoteIndexKeyPrefix;
+use super::*;
 use crate::api::MintFederationApi;
 use crate::modules::mint::{MintConsensusItem, MintInput, MintOutput};
 

--- a/client/client-lib/src/mint/backup/tests.rs
+++ b/client/client-lib/src/mint/backup/tests.rs
@@ -1,25 +1,22 @@
 use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
-use fedimint_api::{
-    core::{self, DynOutput, LEGACY_HARDCODED_INSTANCE_ID_MINT},
-    msats, Amount, OutPoint, PeerId, Tiered, TieredMulti,
-};
-use fedimint_core::{epoch::ConsensusItem, transaction::Transaction};
+use fedimint_api::core::{self, DynOutput, LEGACY_HARDCODED_INSTANCE_ID_MINT};
+use fedimint_api::{msats, Amount, OutPoint, PeerId, Tiered, TieredMulti};
+use fedimint_core::epoch::ConsensusItem;
+use fedimint_core::transaction::Transaction;
 use fedimint_derive_secret::DerivableSecret;
 use tbs::{AggregatePublicKey, BlindedSignatureShare, PublicKeyShare, SecretKeyShare};
 
 use super::{EcashRecoveryTracker, PlaintextEcashBackup};
+use crate::mint::db::OutputFinalizationKey;
+use crate::mint::{
+    MintClient, NoteIndex, NoteIssuanceRequest, NoteIssuanceRequests, SpendableNote,
+};
 use crate::modules::mint::{
     BlindNonce, MintConsensusItem, MintInput, MintOutput, MintOutputSignatureShare,
 };
-use crate::{
-    mint::{
-        db::OutputFinalizationKey, MintClient, NoteIndex, NoteIssuanceRequest,
-        NoteIssuanceRequests, SpendableNote,
-    },
-    Client,
-};
+use crate::Client;
 
 /// Simplest in-memory mint client for the purpose of writting tests
 /// (at least e-cash recovery ones).

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -1,6 +1,5 @@
 use fedimint_api::encoding::{Decodable, Encodable};
-use fedimint_api::impl_db_prefix_const;
-use fedimint_api::{Amount, OutPoint, TieredMulti, TransactionId};
+use fedimint_api::{impl_db_prefix_const, Amount, OutPoint, TieredMulti, TransactionId};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -17,11 +17,9 @@ use crate::{module_decode_stubs, Client, DecryptedPreimage, MintClient, MintOutp
 /// Old transaction definition used by old client.
 pub mod legacy {
     use bitcoin_hashes::Hash;
-    use fedimint_api::core::DynInput;
-    use fedimint_api::core::DynOutput;
     use fedimint_api::core::{
-        Decoder, LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
-        LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+        Decoder, DynInput, DynOutput, LEGACY_HARDCODED_INSTANCE_ID_LN,
+        LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
     };
     use fedimint_api::encoding::{Decodable, Encodable};
     use fedimint_api::{ServerModule, TransactionId};

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -1,14 +1,12 @@
 use std::sync::Arc;
 
-use bitcoin::Address;
-use bitcoin::KeyPair;
+use bitcoin::{Address, KeyPair};
 use db::PegInKey;
 use fedimint_api::core::client::ClientModule;
 use fedimint_api::db::DatabaseTransaction;
 use fedimint_api::module::TransactionItemAmount;
 use fedimint_api::{Amount, ServerModule};
-use fedimint_core::api::GlobalFederationApi;
-use fedimint_core::api::OutputOutcomeError;
+use fedimint_core::api::{GlobalFederationApi, OutputOutcomeError};
 use rand::{CryptoRng, RngCore};
 use thiserror::Error;
 use tracing::debug;
@@ -17,9 +15,7 @@ use crate::modules::wallet::common::WalletDecoder;
 use crate::modules::wallet::config::WalletClientConfig;
 use crate::modules::wallet::tweakable::Tweakable;
 use crate::modules::wallet::txoproof::{PegInProof, PegInProofError, TxOutProof};
-use crate::modules::wallet::WalletInput;
-use crate::modules::wallet::WalletOutput;
-use crate::modules::wallet::{Wallet, WalletOutputOutcome};
+use crate::modules::wallet::{Wallet, WalletInput, WalletOutput, WalletOutputOutcome};
 use crate::outcome::legacy::OutputOutcome;
 use crate::utils::ClientContext;
 use crate::MemberError;

--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -5,10 +5,8 @@
 
 use std::hash::Hasher;
 
-pub use bls12_381::G1Affine as MessagePoint;
-pub use bls12_381::G2Affine as PubKeyPoint;
-pub use bls12_381::Scalar;
 use bls12_381::{pairing, G1Affine, G1Projective, G2Affine, G2Projective};
+pub use bls12_381::{G1Affine as MessagePoint, G2Affine as PubKeyPoint, Scalar};
 use ff::Field;
 use group::Curve;
 use rand::rngs::OsRng;

--- a/fedimint-api/src/config.rs
+++ b/fedimint-api/src/config.rs
@@ -6,22 +6,18 @@ use std::str::FromStr;
 
 use anyhow::{bail, format_err};
 use bitcoin::secp256k1;
-use bitcoin_hashes::hex;
 use bitcoin_hashes::hex::{FromHex, ToHex};
-use bitcoin_hashes::sha256;
-use bitcoin_hashes::sha256::Hash as Sha256;
-use bitcoin_hashes::sha256::HashEngine;
+use bitcoin_hashes::sha256::{Hash as Sha256, HashEngine};
+use bitcoin_hashes::{hex, sha256};
 use fedimint_api::core::{
     ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_LN,
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_api::encoding::Encodable;
-use fedimint_api::BitcoinHash;
-use fedimint_api::ModuleDecoderRegistry;
+use fedimint_api::{BitcoinHash, ModuleDecoderRegistry};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use tbs::serde_impl;
-use tbs::Scalar;
+use tbs::{serde_impl, Scalar};
 use threshold_crypto::group::{Curve, Group, GroupEncoding};
 use threshold_crypto::{G1Projective, G2Projective, Signature};
 use url::Url;

--- a/fedimint-api/src/core.rs
+++ b/fedimint-api/src/core.rs
@@ -13,10 +13,8 @@ use std::io::Read;
 use std::sync::Arc;
 
 pub use bitcoin::KeyPair;
-use fedimint_api::{
-    dyn_newtype_define,
-    encoding::{Decodable, DecodeError, DynEncodable, Encodable},
-};
+use fedimint_api::dyn_newtype_define;
+use fedimint_api::encoding::{Decodable, DecodeError, DynEncodable, Encodable};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/fedimint-api/src/core/client.rs
+++ b/fedimint-api/src/core/client.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use super::ModuleKind;
-use crate::core::Decoder;
-use crate::core::DynDecoder;
+use crate::core::{Decoder, DynDecoder};
 use crate::module::TransactionItemAmount;
 use crate::{dyn_newtype_define, ServerModule};
 

--- a/fedimint-api/src/core/server.rs
+++ b/fedimint-api/src/core/server.rs
@@ -4,14 +4,14 @@
 //!
 //! This (Rust) module defines common interoperability types
 //! and functionality that are only used on the server side.
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
+use std::sync::Arc;
 
 use async_trait::async_trait;
-use fedimint_api::{
-    db::DatabaseTransaction,
-    module::{audit::Audit, interconnect::ModuleInterconect},
-    OutPoint, PeerId,
-};
+use fedimint_api::db::DatabaseTransaction;
+use fedimint_api::module::audit::Audit;
+use fedimint_api::module::interconnect::ModuleInterconect;
+use fedimint_api::{OutPoint, PeerId};
 
 use super::*;
 use crate::module::{

--- a/fedimint-api/src/db/mem_impl.rs
+++ b/fedimint-api/src/db/mem_impl.rs
@@ -159,7 +159,9 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
 #[cfg(test)]
 mod tests {
     use super::MemDatabase;
-    use crate::{core::ModuleInstanceId, db::Database, module::registry::ModuleDecoderRegistry};
+    use crate::core::ModuleInstanceId;
+    use crate::db::Database;
+    use crate::module::registry::ModuleDecoderRegistry;
 
     fn database() -> Database {
         Database::new(MemDatabase::new(), ModuleDecoderRegistry::default())

--- a/fedimint-api/src/db/mod.rs
+++ b/fedimint-api/src/db/mod.rs
@@ -1,7 +1,8 @@
+use std::error::Error;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::{error::Error, marker::PhantomData};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -10,11 +11,9 @@ use futures::{stream, Stream, StreamExt};
 use thiserror::Error;
 use tracing::{debug, instrument, trace, warn};
 
-use crate::{
-    core::ModuleInstanceId,
-    encoding::{Decodable, Encodable},
-    fmt_utils::AbbreviateHexBytes,
-};
+use crate::core::ModuleInstanceId;
+use crate::encoding::{Decodable, Encodable};
+use crate::fmt_utils::AbbreviateHexBytes;
 
 pub mod mem_impl;
 

--- a/fedimint-api/src/encoding/mod.rs
+++ b/fedimint-api/src/encoding/mod.rs
@@ -12,9 +12,8 @@ use std::io::{self, Error, Read, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::format_err;
-use bitcoin_hashes::sha256;
 use bitcoin_hashes::sha256::HashEngine;
-use bitcoin_hashes::Hash;
+use bitcoin_hashes::{sha256, Hash};
 pub use fedimint_derive::{Decodable, Encodable, UnzipConsensus};
 use thiserror::Error;
 use url::Url;

--- a/fedimint-api/src/fmt_utils.rs
+++ b/fedimint-api/src/fmt_utils.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::{cmp, ops, thread_local};
+use std::{cmp, fmt, ops, thread_local};
 
 use serde_json::Value;
 

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -7,9 +7,9 @@ use anyhow::bail;
 pub use anyhow::Result;
 use async_trait::async_trait;
 use bitcoin::{Block, BlockHash, Network, Transaction};
-use fedimint_api::{
-    bitcoin_rpc::BitcoinRpcBackendType, dyn_newtype_define, task::TaskHandle, Feerate,
-};
+use fedimint_api::bitcoin_rpc::BitcoinRpcBackendType;
+use fedimint_api::task::TaskHandle;
+use fedimint_api::{dyn_newtype_define, Feerate};
 use tracing::info;
 
 #[cfg(feature = "bitcoincore-rpc")]

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -13,8 +13,7 @@ use fedimint_api::config::{
 use fedimint_api::core::DynOutputOutcome;
 use fedimint_api::fmt_utils::AbbreviateDebug;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
-use fedimint_api::task::sleep;
-use fedimint_api::task::{RwLock, RwLockWriteGuard};
+use fedimint_api::task::{sleep, RwLock, RwLockWriteGuard};
 use fedimint_api::{dyn_newtype_define, NumPeers, OutPoint, PeerId, TransactionId};
 use futures::stream::FuturesUnordered;
 use futures::{Future, StreamExt};
@@ -804,16 +803,12 @@ impl<C: JsonRpcClient> WsFederationApi<C> {}
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashSet,
-        fmt,
-        str::FromStr,
-        sync::{
-            atomic::{AtomicBool, AtomicUsize, Ordering},
-            Mutex,
-        },
-        time::Duration,
-    };
+    use std::collections::HashSet;
+    use std::fmt;
+    use std::str::FromStr;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Mutex;
+    use std::time::Duration;
 
     use anyhow::anyhow;
     use jsonrpsee_core::client::BatchResponse;

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeSet;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use bitcoin_hashes::sha256::Hash as Sha256;
 use fedimint_api::core::DynModuleConsensusItem as ModuleConsensusItem;
@@ -211,8 +210,10 @@ mod tests {
     use rand::rngs::OsRng;
     use threshold_crypto::{SecretKey, SecretKeySet};
 
-    use crate::epoch::{ConsensusItem, SerdeSignatureShare, Sha256};
-    use crate::epoch::{EpochOutcome, EpochVerifyError, SerdeSignature, SignedEpochOutcome};
+    use crate::epoch::{
+        ConsensusItem, EpochOutcome, EpochVerifyError, SerdeSignature, SerdeSignatureShare, Sha256,
+        SignedEpochOutcome,
+    };
 
     fn signed_history(
         epoch: u16,

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -1,18 +1,20 @@
-use std::{collections::BTreeMap, path::PathBuf};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use erased_serde::Serialize;
-use fedimint_api::{
-    config::ModuleGenRegistry,
-    db::DatabaseTransaction,
-    encoding::Encodable,
-    module::{DynModuleGen, __reexports::serde_json, registry::ModuleDecoderRegistry},
-    push_db_key_items, push_db_pair_items, push_db_pair_items_no_serde,
-};
+use fedimint_api::config::ModuleGenRegistry;
+use fedimint_api::db::DatabaseTransaction;
+use fedimint_api::encoding::Encodable;
+use fedimint_api::module::DynModuleGen;
+use fedimint_api::module::__reexports::serde_json;
+use fedimint_api::module::registry::ModuleDecoderRegistry;
+use fedimint_api::{push_db_key_items, push_db_pair_items, push_db_pair_items_no_serde};
 use fedimint_ln::LightningGen;
 use fedimint_mint::MintGen;
 use fedimint_rocksdb::RocksDbReadOnly;
 use fedimint_server::config::io::{read_server_configs, SALT_FILE};
-use fedimint_server::{config::ServerConfig, db as ConsensusRange};
+use fedimint_server::config::ServerConfig;
+use fedimint_server::db as ConsensusRange;
 use fedimint_wallet::WalletGen;
 use futures::StreamExt;
 use mint_client::db as ClientRange;

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -177,7 +177,8 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
 
 #[cfg(test)]
 mod fedimint_rocksdb_tests {
-    use fedimint_api::{db::Database, module::registry::ModuleDecoderRegistry};
+    use fedimint_api::db::Database;
+    use fedimint_api::module::registry::ModuleDecoderRegistry;
 
     use crate::RocksDb;
 

--- a/fedimint-server/src/config/distributedgen.rs
+++ b/fedimint-server/src/config/distributedgen.rs
@@ -4,13 +4,11 @@ use std::hash::Hash;
 use std::io::Write;
 
 use anyhow::{ensure, format_err};
-use bitcoin_hashes::sha256::Hash as Sha256;
-use bitcoin_hashes::sha256::HashEngine;
+use bitcoin_hashes::sha256::{Hash as Sha256, HashEngine};
 use fedimint_api::config::{DkgGroup, DkgMessage, DkgPeerMsg, ISupportedDkgMessage};
 use fedimint_api::core::ModuleInstanceId;
 use fedimint_api::net::peers::MuxPeerConnections;
-use fedimint_api::BitcoinHash;
-use fedimint_api::PeerId;
+use fedimint_api::{BitcoinHash, PeerId};
 use hbbft::crypto::poly::Commitment;
 use hbbft::crypto::{G1Projective, G2Projective, PublicKeySet, SecretKeyShare};
 use rand::{CryptoRng, RngCore};

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -27,11 +27,9 @@ use url::Url;
 
 use crate::config::distributedgen::{DkgRunner, ThresholdKeys};
 use crate::fedimint_api::encoding::Encodable;
-use crate::fedimint_api::BitcoinHash;
-use crate::fedimint_api::NumPeers;
+use crate::fedimint_api::{BitcoinHash, NumPeers};
 use crate::logging::{LOG_NET_PEER, LOG_NET_PEER_DKG};
-use crate::net::connect::TlsConfig;
-use crate::net::connect::{parse_host_port, Connector};
+use crate::net::connect::{parse_host_port, Connector, TlsConfig};
 use crate::net::peers::NetworkConfig;
 use crate::{ReconnectPeerConnections, TlsTcpConnector};
 

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -2,8 +2,7 @@ use std::fmt::Debug;
 
 use fedimint_api::db::MODULE_GLOBAL_PREFIX;
 use fedimint_api::encoding::{Decodable, Encodable};
-use fedimint_api::impl_db_prefix_const;
-use fedimint_api::{PeerId, TransactionId};
+use fedimint_api::{impl_db_prefix_const, PeerId, TransactionId};
 use fedimint_core::epoch::{SerdeSignature, SignedEpochOutcome};
 use serde::Serialize;
 use strum_macros::EnumIter;

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -14,16 +14,14 @@ use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::net::peers::PeerConnections;
 use fedimint_api::task::{sleep, TaskGroup, TaskHandle};
 use fedimint_api::{NumPeers, PeerId};
-use fedimint_core::api::WsFederationApi;
-use fedimint_core::api::{DynFederationApi, GlobalFederationApi};
+use fedimint_core::api::{DynFederationApi, GlobalFederationApi, WsFederationApi};
 use fedimint_core::epoch::{
     ConsensusItem, EpochVerifyError, SerdeConsensusItem, SignedEpochOutcome,
 };
 use fedimint_core::transaction::Transaction;
 pub use fedimint_core::*;
 use futures::stream::Peekable;
-use futures::FutureExt;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use hbbft::honey_badger::{Batch, HoneyBadger, Message, Step};
 use hbbft::{Epoched, NetworkInfo, Target};
 use itertools::Itertools;
@@ -42,8 +40,7 @@ use crate::fedimint_api::encoding::Encodable;
 use crate::fedimint_api::net::peers::IPeerConnections;
 use crate::logging::LOG_CONSENSUS;
 use crate::net::connect::{Connector, TlsTcpConnector};
-use crate::net::peers::PeerSlice;
-use crate::net::peers::{PeerConnector, ReconnectPeerConnections};
+use crate::net::peers::{PeerConnector, PeerSlice, ReconnectPeerConnections};
 
 /// The actual implementation of the federated mint
 pub mod consensus;

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -1,16 +1,16 @@
+use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::{
-    collections::{HashMap, VecDeque},
-    sync::Arc,
-    time::Duration,
-};
+use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use fedimint_api::cancellable::Cancellable;
 use fedimint_api::net::peers::{IMuxPeerConnections, PeerConnections};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use tokio::{sync::Mutex, time::sleep};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tokio::time::sleep;
 use tracing::{debug, warn};
 
 use crate::logging::LOG_NET_PEER;

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -7,20 +7,17 @@ use std::time::Duration;
 use anyhow::Context;
 use fedimint_api::config::ConfigResponse;
 use fedimint_api::core::ModuleInstanceId;
+use fedimint_api::module::{api_endpoint, ApiEndpoint, ApiError};
 use fedimint_api::server::DynServerModule;
-use fedimint_api::{
-    module::{api_endpoint, ApiEndpoint, ApiError},
-    task::TaskHandle,
-    TransactionId,
-};
+use fedimint_api::task::TaskHandle;
+use fedimint_api::TransactionId;
 use fedimint_core::epoch::SerdeEpochHistory;
 use fedimint_core::outcome::TransactionStatus;
 use futures::FutureExt;
-use jsonrpsee::{
-    server::ServerBuilder,
-    types::{error::CallError, ErrorObject},
-    RpcModule,
-};
+use jsonrpsee::server::ServerBuilder;
+use jsonrpsee::types::error::CallError;
+use jsonrpsee::types::ErrorObject;
+use jsonrpsee::RpcModule;
 use tracing::{debug, error};
 
 use crate::config::ServerConfig;

--- a/fedimint-sqlite/src/lib.rs
+++ b/fedimint-sqlite/src/lib.rs
@@ -155,10 +155,11 @@ impl<'a> IDatabaseTransaction<'a> for SqliteDbTransaction<'a> {
 mod fedimint_sqlite_tests {
     use std::fs;
 
-    use fedimint_api::{
-        core::ModuleInstanceId, db::Database, module::registry::ModuleDecoderRegistry,
-    };
-    use rand::{rngs::OsRng, RngCore};
+    use fedimint_api::core::ModuleInstanceId;
+    use fedimint_api::db::Database;
+    use fedimint_api::module::registry::ModuleDecoderRegistry;
+    use rand::rngs::OsRng;
+    use rand::RngCore;
 
     use crate::SqliteDb;
 

--- a/fedimint-testing/src/btc/fixtures.rs
+++ b/fedimint-testing/src/btc/fixtures.rs
@@ -1,12 +1,12 @@
-use std::{
-    iter::repeat,
-    sync::{Arc, Mutex},
-};
+use std::iter::repeat;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use bitcoin::hash_types::Txid;
+use bitcoin::hashes::Hash;
+use bitcoin::util::merkleblock::PartialMerkleTree;
 use bitcoin::{
-    hash_types::Txid, hashes::Hash, util::merkleblock::PartialMerkleTree, Address, Block,
-    BlockHash, BlockHeader, Network, PackedLockTime, Transaction, TxOut,
+    Address, Block, BlockHash, BlockHeader, Network, PackedLockTime, Transaction, TxOut,
 };
 use fedimint_api::{Amount, Feerate};
 use fedimint_bitcoind::{IBitcoindRpc, Result as BitcoinRpcResult};

--- a/fedimint-testing/src/ln/fixtures.rs
+++ b/fedimint-testing/src/ln/fixtures.rs
@@ -1,7 +1,5 @@
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::Error;
 use async_trait::async_trait;
@@ -13,14 +11,12 @@ use fedimint_ln::route_hints::RouteHint;
 use futures::stream;
 use lightning::ln::PaymentSecret;
 use lightning_invoice::{Currency, Invoice, InvoiceBuilder, SignedRawInvoice, DEFAULT_EXPIRY_TIME};
-use ln_gateway::{
-    gatewayd::lnrpc_client::{GetRouteHintsResponse, HtlcStream, ILnRpcClient},
-    gatewaylnrpc::{
-        CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyResponse, PayInvoiceRequest,
-        PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
-    },
-    ln::{LightningError, LnRpc},
+use ln_gateway::gatewayd::lnrpc_client::{GetRouteHintsResponse, HtlcStream, ILnRpcClient};
+use ln_gateway::gatewaylnrpc::{
+    CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyResponse, PayInvoiceRequest,
+    PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
+use ln_gateway::ln::{LightningError, LnRpc};
 use mint_client::modules::ln::contracts::Preimage;
 use rand::rngs::OsRng;
 

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -11,15 +11,13 @@ use fedimint_server::config::io::{
 };
 use fedimint_server::consensus::FedimintConsensus;
 use fedimint_server::FedimintServer;
-use fedimintd::ui::run_ui;
-use fedimintd::ui::UiMessage;
+use fedimintd::ui::{run_ui, UiMessage};
 use fedimintd::*;
 use futures::FutureExt;
 use tokio::select;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::Layer;
+use tracing_subscriber::{EnvFilter, Layer};
 
 /// Time we will wait before forcefully shutting down tasks
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -7,10 +7,8 @@ use anyhow::{format_err, Error};
 use askama::Template;
 use axum::extract::Form;
 use axum::response::{IntoResponse, Redirect, Response};
-use axum::{
-    routing::{get, post},
-    Router,
-};
+use axum::routing::{get, post};
+use axum::Router;
 use axum_macros::debug_handler;
 use bitcoin::Network;
 use fedimint_api::bitcoin_rpc::BitcoindRpcBackend;

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -1,14 +1,14 @@
-use std::{net::SocketAddr, path::PathBuf};
+use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use bitcoin::{Address, Amount, Transaction};
 use clap::{Parser, Subcommand};
 use fedimint_api::config::FederationId;
-use ln_gateway::{
-    config::GatewayConfig,
-    rpc::{
-        rpc_client::RpcClient, BackupPayload, BalancePayload, ConnectFedPayload,
-        DepositAddressPayload, DepositPayload, RestorePayload, WithdrawPayload,
-    },
+use ln_gateway::config::GatewayConfig;
+use ln_gateway::rpc::rpc_client::RpcClient;
+use ln_gateway::rpc::{
+    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
+    RestorePayload, WithdrawPayload,
 };
 use mint_client::modules::wallet::txoproof::TxOutProof;
 use mint_client::utils::from_hex;

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -1,18 +1,21 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
+use std::time::Duration;
 
 use bitcoin::{Address, Transaction};
 use bitcoin_hashes::sha256;
-use fedimint_api::{task::TaskGroup, Amount, OutPoint, TransactionId};
+use fedimint_api::task::TaskGroup;
+use fedimint_api::{Amount, OutPoint, TransactionId};
+use mint_client::modules::ln::contracts::{ContractId, Preimage};
 use mint_client::modules::ln::route_hints::RouteHint;
-use mint_client::modules::{
-    ln::contracts::{ContractId, Preimage},
-    wallet::txoproof::TxOutProof,
-};
+use mint_client::modules::wallet::txoproof::TxOutProof;
 use mint_client::{GatewayClient, PaymentParameters};
 use rand::{CryptoRng, RngCore};
 use tracing::{debug, info, instrument, warn};
 
-use crate::{ln::LnRpc, rpc::FederationInfo, utils::retry, LnGatewayError, Result};
+use crate::ln::LnRpc;
+use crate::rpc::FederationInfo;
+use crate::utils::retry;
+use crate::{LnGatewayError, Result};
 
 /// How long a gateway announcement stays valid
 const GW_ANNOUNCEMENT_TTL: Duration = Duration::from_secs(600);

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -1,29 +1,35 @@
-use std::{
-    array::TryFromSliceError, collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr,
-    sync::Arc, time::Duration,
-};
+use std::array::TryFromSliceError;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::anyhow;
-use bitcoin_hashes::{hex::ToHex, sha256, Hash};
+use bitcoin_hashes::hex::ToHex;
+use bitcoin_hashes::{sha256, Hash};
 use clap::Parser;
 use cln_plugin::{options, Builder, Plugin};
 use cln_rpc::{model, ClnRpc};
-use fedimint_api::{task::TaskGroup, Amount};
+use fedimint_api::task::TaskGroup;
+use fedimint_api::Amount;
+use ln_gateway::gatewaylnrpc::complete_htlcs_request::{Action, Cancel, Settle};
+use ln_gateway::gatewaylnrpc::gateway_lightning_server::{
+    GatewayLightning, GatewayLightningServer,
+};
 use ln_gateway::gatewaylnrpc::{
-    complete_htlcs_request::{Action, Cancel, Settle},
-    gateway_lightning_server::{GatewayLightning, GatewayLightningServer},
     CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyRequest, GetPubKeyResponse,
     PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
     SubscribeInterceptHtlcsResponse,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
-use tokio::{
-    io::{stdin, stdout},
-    sync::{mpsc, oneshot, Mutex},
-};
+use tokio::io::{stdin, stdout};
+use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
-use tonic::{transport::Server, Status};
+use tonic::transport::Server;
+use tonic::Status;
 use tracing::{debug, error};
 
 #[derive(Parser)]

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -1,27 +1,24 @@
-use std::{net::SocketAddr, path::PathBuf};
+use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use clap::Parser;
-use fedimint_api::{
-    config::ModuleGenRegistry,
-    core::{
-        LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
-        LEGACY_HARDCODED_INSTANCE_ID_WALLET,
-    },
-    module::{registry::ModuleDecoderRegistry, DynModuleGen},
-    task::TaskGroup,
+use fedimint_api::config::ModuleGenRegistry;
+use fedimint_api::core::{
+    LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+    LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
-use ln_gateway::{
-    client::{DynGatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder},
-    gatewayd::{
-        gateway::Gateway,
-        lnrpc_client::{DynLnRpcClient, NetworkLnRpcClient},
-    },
-};
-use mint_client::modules::{
-    ln::{common::LightningDecoder, LightningGen},
-    mint::{common::MintDecoder, MintGen},
-    wallet::{common::WalletDecoder, WalletGen},
-};
+use fedimint_api::module::registry::ModuleDecoderRegistry;
+use fedimint_api::module::DynModuleGen;
+use fedimint_api::task::TaskGroup;
+use ln_gateway::client::{DynGatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder};
+use ln_gateway::gatewayd::gateway::Gateway;
+use ln_gateway::gatewayd::lnrpc_client::{DynLnRpcClient, NetworkLnRpcClient};
+use mint_client::modules::ln::common::LightningDecoder;
+use mint_client::modules::ln::LightningGen;
+use mint_client::modules::mint::common::MintDecoder;
+use mint_client::modules::mint::MintGen;
+use mint_client::modules::wallet::common::WalletDecoder;
+use mint_client::modules::wallet::WalletGen;
 use tracing::{error, info};
 use url::Url;
 

--- a/gateway/ln-gateway/src/bin/ln_gateway.rs
+++ b/gateway/ln-gateway/src/bin/ln_gateway.rs
@@ -1,28 +1,24 @@
 use cln_plugin::Error;
 use fedimint_api::config::ModuleGenRegistry;
+use fedimint_api::core::{
+    LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+    LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+};
+use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::module::DynModuleGen;
-use fedimint_api::{
-    core::{
-        LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
-        LEGACY_HARDCODED_INSTANCE_ID_WALLET,
-    },
-    module::registry::ModuleDecoderRegistry,
-    task::TaskGroup,
-};
+use fedimint_api::task::TaskGroup;
 use fedimint_server::config::load_from_file;
-use ln_gateway::{
-    client::{DynGatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder},
-    cln::{build_cln_rpc, ClnRpcRef},
-    config::GatewayConfig,
-    rpc::{GatewayRequest, GatewayRpcSender},
-    LnGateway,
-};
+use ln_gateway::client::{DynGatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder};
+use ln_gateway::cln::{build_cln_rpc, ClnRpcRef};
+use ln_gateway::config::GatewayConfig;
+use ln_gateway::rpc::{GatewayRequest, GatewayRpcSender};
+use ln_gateway::LnGateway;
+use mint_client::modules::ln::common::LightningDecoder;
 use mint_client::modules::ln::LightningGen;
+use mint_client::modules::mint::common::MintDecoder;
 use mint_client::modules::mint::MintGen;
+use mint_client::modules::wallet::common::WalletDecoder;
 use mint_client::modules::wallet::WalletGen;
-use mint_client::modules::{
-    ln::common::LightningDecoder, mint::common::MintDecoder, wallet::common::WalletDecoder,
-};
 use tokio::sync::mpsc;
 use tracing::error;
 

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -1,21 +1,17 @@
-use std::{
-    fmt::Debug,
-    fs::File,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::fmt::Debug;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use fedimint_api::config::{FederationId, ModuleGenRegistry};
+use fedimint_api::db::mem_impl::MemDatabase;
+use fedimint_api::db::Database;
+use fedimint_api::dyn_newtype_define;
 use fedimint_api::module::registry::ModuleDecoderRegistry;
-use fedimint_api::{
-    db::{mem_impl::MemDatabase, Database},
-    dyn_newtype_define,
+use fedimint_server::api::{
+    DynFederationApi, GlobalFederationApi, WsClientConnectInfo, WsFederationApi,
 };
-use fedimint_server::api::DynFederationApi;
-use fedimint_server::api::GlobalFederationApi;
-use fedimint_server::api::WsClientConnectInfo;
-use fedimint_server::api::WsFederationApi;
 use fedimint_server::config::load_from_file;
 use mint_client::{module_decode_stubs, Client, GatewayClientConfig};
 use secp256k1::{KeyPair, PublicKey};

--- a/gateway/ln-gateway/src/cln.rs
+++ b/gateway/ln-gateway/src/cln.rs
@@ -16,11 +16,9 @@ use serde::{Deserialize, Deserializer, Serialize};
 use tokio::io::{stdin, stdout};
 use tracing::{debug, error, instrument, trace, warn};
 
+use crate::ln::{LightningError, LnRpc};
+use crate::rpc::GatewayRpcSender;
 use crate::ReceivePaymentPayload;
-use crate::{
-    ln::{LightningError, LnRpc},
-    rpc::GatewayRpcSender,
-};
 
 /// The core-lightning `htlc_accepted` event's `amount` field has a "msat"
 /// suffix

--- a/gateway/ln-gateway/src/gatewayd/actor.rs
+++ b/gateway/ln-gateway/src/gatewayd/actor.rs
@@ -1,31 +1,27 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
+use std::time::Duration;
 
 use bitcoin::{Address, Transaction};
 use bitcoin_hashes::{sha256, Hash};
-use fedimint_api::{task::TaskGroup, Amount, OutPoint, TransactionId};
+use fedimint_api::task::TaskGroup;
+use fedimint_api::{Amount, OutPoint, TransactionId};
 use futures::stream::StreamExt;
-use mint_client::modules::{
-    ln::{
-        contracts::{ContractId, Preimage},
-        route_hints::RouteHint,
-    },
-    wallet::txoproof::TxOutProof,
-};
+use mint_client::modules::ln::contracts::{ContractId, Preimage};
+use mint_client::modules::ln::route_hints::RouteHint;
+use mint_client::modules::wallet::txoproof::TxOutProof;
 use mint_client::{GatewayClient, PaymentParameters};
 use rand::{CryptoRng, RngCore};
 use tracing::{debug, error, info, instrument, warn};
 
-use crate::{
-    gatewayd::lnrpc_client::DynLnRpcClient,
-    gatewaylnrpc::{
-        complete_htlcs_request::{Action, Cancel, Settle},
-        CompleteHtlcsRequest, PayInvoiceRequest, PayInvoiceResponse,
-        SubscribeInterceptHtlcsRequest, SubscribeInterceptHtlcsResponse,
-    },
-    rpc::FederationInfo,
-    utils::retry,
-    LnGatewayError, Result,
+use crate::gatewayd::lnrpc_client::DynLnRpcClient;
+use crate::gatewaylnrpc::complete_htlcs_request::{Action, Cancel, Settle};
+use crate::gatewaylnrpc::{
+    CompleteHtlcsRequest, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    SubscribeInterceptHtlcsResponse,
 };
+use crate::rpc::FederationInfo;
+use crate::utils::retry;
+use crate::{LnGatewayError, Result};
 
 /// How long a gateway announcement stays valid
 const GW_ANNOUNCEMENT_TTL: Duration = Duration::from_secs(600);

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -1,43 +1,35 @@
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::{Duration, Instant},
-};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use bitcoin::Address;
-use fedimint_api::{
-    config::{FederationId, ModuleGenRegistry},
-    module::registry::ModuleDecoderRegistry,
-    task::TaskGroup,
-    Amount, TransactionId,
-};
+use fedimint_api::config::{FederationId, ModuleGenRegistry};
+use fedimint_api::module::registry::ModuleDecoderRegistry;
+use fedimint_api::task::TaskGroup;
+use fedimint_api::{Amount, TransactionId};
 use fedimint_server::api::WsClientConnectInfo;
-use mint_client::{
-    ln::PayInvoicePayload,
-    modules::ln::{contracts::Preimage, route_hints::RouteHint},
-    GatewayClient,
-};
+use mint_client::ln::PayInvoicePayload;
+use mint_client::modules::ln::contracts::Preimage;
+use mint_client::modules::ln::route_hints::RouteHint;
+use mint_client::GatewayClient;
 use secp256k1::PublicKey;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{error, info, warn};
 
 use super::actor::GatewayActor;
-use crate::{
-    client::DynGatewayClientBuilder,
-    gatewayd::lnrpc_client::{DynLnRpcClient, GetRouteHintsResponse},
-    gatewaylnrpc::GetPubKeyResponse,
-    rpc::{
-        rpc_server::run_webserver, BackupPayload, BalancePayload, ConnectFedPayload,
-        DepositAddressPayload, DepositPayload, GatewayInfo, GatewayRequest, GatewayRpcSender,
-        InfoPayload, ReceivePaymentPayload, RestorePayload, WithdrawPayload,
-    },
-    LnGatewayError, Result,
+use crate::client::DynGatewayClientBuilder;
+use crate::gatewayd::lnrpc_client::{DynLnRpcClient, GetRouteHintsResponse};
+use crate::gatewaylnrpc::GetPubKeyResponse;
+use crate::rpc::rpc_server::run_webserver;
+use crate::rpc::{
+    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
+    GatewayInfo, GatewayRequest, GatewayRpcSender, InfoPayload, ReceivePaymentPayload,
+    RestorePayload, WithdrawPayload,
 };
+use crate::{LnGatewayError, Result};
 
 const ROUTE_HINT_RETRIES: usize = 10;
 const ROUTE_HINT_RETRY_SLEEP: Duration = Duration::from_secs(2);

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -1,25 +1,23 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fedimint_api::dyn_newtype_define;
 use futures::stream::BoxStream;
 use mint_client::modules::ln::route_hints::RouteHint;
-use tonic::{
-    transport::{Channel, Endpoint},
-    Request,
-};
+use tonic::transport::{Channel, Endpoint};
+use tonic::Request;
 use tracing::error;
 use url::Url;
 
-use crate::{
-    gatewaylnrpc::{
-        gateway_lightning_client::GatewayLightningClient, CompleteHtlcsRequest,
-        CompleteHtlcsResponse, GetPubKeyRequest, GetPubKeyResponse, PayInvoiceRequest,
-        PayInvoiceResponse, SubscribeInterceptHtlcsRequest, SubscribeInterceptHtlcsResponse,
-    },
-    LnGatewayError, Result,
+use crate::gatewaylnrpc::gateway_lightning_client::GatewayLightningClient;
+use crate::gatewaylnrpc::{
+    CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyRequest, GetPubKeyResponse,
+    PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    SubscribeInterceptHtlcsResponse,
 };
+use crate::{LnGatewayError, Result};
 
 // TODO: Issue 1554: Define gatewaylnpc spec for getting route hints
 pub struct GetRouteHintsResponse {

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -11,12 +11,14 @@ use fedimint_api::config::FederationId;
 use fedimint_api::{Amount, TransactionId};
 use futures::Future;
 use mint_client::ln::PayInvoicePayload;
-use mint_client::{modules::ln::contracts::Preimage, modules::wallet::txoproof::TxOutProof};
+use mint_client::modules::ln::contracts::Preimage;
+use mint_client::modules::wallet::txoproof::TxOutProof;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tokio::sync::{mpsc, oneshot};
 use tracing::error;
 
-use crate::{cln::HtlcAccepted, LnGatewayError, Result};
+use crate::cln::HtlcAccepted;
+use crate::{LnGatewayError, Result};
 
 #[derive(Debug, Clone)]
 pub struct GatewayRpcSender {

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -1,10 +1,13 @@
 use std::net::SocketAddr;
 
-use axum::{response::IntoResponse, routing::post, Extension, Json, Router};
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Extension, Json, Router};
 use axum_macros::debug_handler;
 use mint_client::ln::PayInvoicePayload;
 use serde_json::json;
-use tower_http::{auth::RequireAuthorizationLayer, cors::CorsLayer};
+use tower_http::auth::RequireAuthorizationLayer;
+use tower_http::cors::CorsLayer;
 use tracing::instrument;
 
 use super::{

--- a/gateway/ln-gateway/src/utils.rs
+++ b/gateway/ln-gateway/src/utils.rs
@@ -1,4 +1,6 @@
-use std::{future::Future, result::Result, time::Duration};
+use std::future::Future;
+use std::result::Result;
+use std::time::Duration;
 
 use tokio::time::sleep;
 use tracing::info;

--- a/gateway/tests/tests/fixtures/client.rs
+++ b/gateway/tests/tests/fixtures/client.rs
@@ -1,20 +1,16 @@
+use std::collections::BTreeSet;
 use std::default::Default;
-use std::{collections::BTreeSet, path::PathBuf};
+use std::path::PathBuf;
 
 use async_trait::async_trait;
 use bitcoin::{secp256k1, KeyPair};
-use fedimint_api::config::ModuleGenRegistry;
-use fedimint_api::{
-    config::{ClientConfig, FederationId},
-    core::LEGACY_HARDCODED_INSTANCE_ID_LN,
-    module::registry::ModuleDecoderRegistry,
-    PeerId,
-};
+use fedimint_api::config::{ClientConfig, FederationId, ModuleGenRegistry};
+use fedimint_api::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
+use fedimint_api::module::registry::ModuleDecoderRegistry;
+use fedimint_api::PeerId;
 use fedimint_core::api::{DynFederationApi, WsClientConnectInfo};
-use ln_gateway::{
-    client::{DynDbFactory, IGatewayClientBuilder},
-    LnGatewayError,
-};
+use ln_gateway::client::{DynDbFactory, IGatewayClientBuilder};
+use ln_gateway::LnGatewayError;
 use mint_client::{module_decode_stubs, Client, GatewayClient, GatewayClientConfig};
 use secp256k1::{PublicKey, Secp256k1};
 use url::Url;

--- a/gateway/tests/tests/fixtures/fed.rs
+++ b/gateway/tests/tests/fixtures/fed.rs
@@ -1,6 +1,8 @@
-use std::{collections::BTreeSet, sync::Arc};
+use std::collections::BTreeSet;
+use std::sync::Arc;
 
-use fedimint_api::{core::ModuleInstanceId, PeerId};
+use fedimint_api::core::ModuleInstanceId;
+use fedimint_api::PeerId;
 use fedimint_ln::LightningGateway;
 use mint_client::api::fake::FederationApiFaker;
 use tokio::sync::Mutex;

--- a/gateway/tests/tests/fixtures/mod.rs
+++ b/gateway/tests/tests/fixtures/mod.rs
@@ -4,15 +4,14 @@ use fedimint_api::module::DynModuleGen;
 use fedimint_api::task::TaskGroup;
 use fedimint_ln::LightningGen;
 use fedimint_mint::MintGen;
-use fedimint_testing::{
-    btc::{fixtures::FakeBitcoinTest, BitcoinTest},
-    ln::fixtures::FakeLightningTest,
-};
-use ln_gateway::{
-    client::{DynGatewayClientBuilder, MemDbFactory},
-    gatewayd::{gateway::Gateway, lnrpc_client::DynLnRpcClient},
-};
-use mint_client::{module_decode_stubs, modules::wallet::WalletGen};
+use fedimint_testing::btc::fixtures::FakeBitcoinTest;
+use fedimint_testing::btc::BitcoinTest;
+use fedimint_testing::ln::fixtures::FakeLightningTest;
+use ln_gateway::client::{DynGatewayClientBuilder, MemDbFactory};
+use ln_gateway::gatewayd::gateway::Gateway;
+use ln_gateway::gatewayd::lnrpc_client::DynLnRpcClient;
+use mint_client::module_decode_stubs;
+use mint_client::modules::wallet::WalletGen;
 use url::Url;
 
 pub mod client;

--- a/gateway/tests/tests/tests.rs
+++ b/gateway/tests/tests/tests.rs
@@ -25,14 +25,11 @@ use anyhow::Result;
 use fedimint_api::config::FederationId;
 use fedimint_core::api::WsClientConnectInfo;
 use fixtures::{fixtures, Fixtures};
-use ln_gateway::rpc::rpc_client::{Error, Response};
-use ln_gateway::{
-    rpc::{
-        rpc_client::RpcClient, BalancePayload, ConnectFedPayload, DepositAddressPayload,
-        DepositPayload, WithdrawPayload,
-    },
-    utils::retry,
+use ln_gateway::rpc::rpc_client::{Error, Response, RpcClient};
+use ln_gateway::rpc::{
+    BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload, WithdrawPayload,
 };
+use ln_gateway::utils::retry;
 use tracing_subscriber::EnvFilter;
 use url::Url;
 

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -10,8 +10,9 @@ use fedimint_api::{msats, sats, TieredMulti};
 use fedimint_ln::contracts::{Preimage, PreimageDecryptionShare};
 use fedimint_ln::LightningConsensusItem;
 use fedimint_mint::{MintConsensusItem, MintOutputSignatureShare};
-use fedimint_server::consensus::TransactionSubmissionError::TransactionError;
-use fedimint_server::consensus::TransactionSubmissionError::TransactionReplayError;
+use fedimint_server::consensus::TransactionSubmissionError::{
+    TransactionError, TransactionReplayError,
+};
 use fedimint_server::epoch::ConsensusItem;
 use fedimint_server::transaction::TransactionError::UnbalancedTransaction;
 use fedimint_wallet::PegOutSignatureItem;

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -7,9 +7,9 @@ use bitcoin_hashes::sha256;
 use common::DummyDecoder;
 use fedimint_api::cancellable::Cancellable;
 use fedimint_api::config::{
-    ConfigGenParams, DkgPeerMsg, ModuleGenParams, ServerModuleConfig, TypedServerModuleConfig,
+    ConfigGenParams, DkgPeerMsg, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
+    TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
-use fedimint_api::config::{ModuleConfigResponse, TypedServerModuleConsensusConfig};
 use fedimint_api::core::{ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};

--- a/modules/fedimint-ln/src/common.rs
+++ b/modules/fedimint-ln/src/common.rs
@@ -1,8 +1,7 @@
 use std::io;
 
 use fedimint_api::core::Decoder;
-use fedimint_api::encoding::Decodable;
-use fedimint_api::encoding::DecodeError;
+use fedimint_api::encoding::{Decodable, DecodeError};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 
 use crate::{LightningConsensusItem, LightningInput, LightningOutput, LightningOutputOutcome};

--- a/modules/fedimint-ln/src/contracts/incoming.rs
+++ b/modules/fedimint-ln/src/contracts/incoming.rs
@@ -1,8 +1,7 @@
 use std::io::Error;
 
-use bitcoin_hashes::hash_newtype;
 use bitcoin_hashes::sha256::Hash as Sha256;
-use bitcoin_hashes::Hash as BitcoinHash;
+use bitcoin_hashes::{hash_newtype, Hash as BitcoinHash};
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::OutPoint;

--- a/modules/fedimint-ln/src/contracts/mod.rs
+++ b/modules/fedimint-ln/src/contracts/mod.rs
@@ -4,9 +4,8 @@ pub mod outgoing;
 
 use std::io::Error;
 
-use bitcoin_hashes::hash_newtype;
 use bitcoin_hashes::sha256::Hash as Sha256;
-use bitcoin_hashes::Hash as BitcoinHash;
+use bitcoin_hashes::{hash_newtype, Hash as BitcoinHash};
 use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use fedimint_api::OutPoint;

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -1,11 +1,11 @@
 use fedimint_api::encoding::{Decodable, Encodable};
-use fedimint_api::impl_db_prefix_const;
-use fedimint_api::{OutPoint, PeerId};
+use fedimint_api::{impl_db_prefix_const, OutPoint, PeerId};
 use secp256k1::PublicKey;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
-use crate::contracts::{incoming::IncomingContractOffer, ContractId, PreimageDecryptionShare};
+use crate::contracts::incoming::IncomingContractOffer;
+use crate::contracts::{ContractId, PreimageDecryptionShare};
 use crate::{ContractAccount, LightningGateway, LightningOutputOutcome};
 
 #[repr(u8)]

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -24,9 +24,9 @@ use config::FeeConsensus;
 use db::{DbKeyPrefix, LightningGatewayKey, LightningGatewayKeyPrefix};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
-    ConfigGenParams, DkgPeerMsg, ServerModuleConfig, TypedServerModuleConfig,
+    ConfigGenParams, DkgPeerMsg, ModuleConfigResponse, ServerModuleConfig, TypedServerModuleConfig,
+    TypedServerModuleConsensusConfig,
 };
-use fedimint_api::config::{ModuleConfigResponse, TypedServerModuleConsensusConfig};
 use fedimint_api::core::{ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};
@@ -41,8 +41,9 @@ use fedimint_api::net::peers::MuxPeerConnections;
 use fedimint_api::server::DynServerModule;
 use fedimint_api::task::TaskGroup;
 use fedimint_api::time::SystemTime;
-use fedimint_api::{plugin_types_trait_impl, push_db_pair_items, Amount, NumPeers, PeerId};
-use fedimint_api::{OutPoint, ServerModule};
+use fedimint_api::{
+    plugin_types_trait_impl, push_db_pair_items, Amount, NumPeers, OutPoint, PeerId, ServerModule,
+};
 #[cfg(feature = "server")]
 use fedimint_server::config::distributedgen::DkgRunner;
 use futures::StreamExt;
@@ -58,8 +59,8 @@ use crate::common::LightningDecoder;
 use crate::config::{
     LightningClientConfig, LightningConfig, LightningConfigConsensus, LightningConfigPrivate,
 };
+use crate::contracts::incoming::{IncomingContractOffer, OfferId};
 use crate::contracts::{
-    incoming::{IncomingContractOffer, OfferId},
     Contract, ContractId, ContractOutcome, DecryptedPreimage, EncryptedPreimage, FundedContract,
     IdentifyableContract, Preimage, PreimageDecryptionShare,
 };

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -1,5 +1,4 @@
-use bitcoin_hashes::sha256;
-use bitcoin_hashes::Hash as BitcoinHash;
+use bitcoin_hashes::{sha256, Hash as BitcoinHash};
 use fedimint_api::config::ConfigGenParams;
 use fedimint_api::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
 use fedimint_api::{Amount, OutPoint};
@@ -11,9 +10,8 @@ use fedimint_ln::contracts::{
     AccountContractOutcome, Contract, ContractOutcome, DecryptedPreimage, EncryptedPreimage,
     IdentifyableContract, OutgoingContractOutcome, Preimage,
 };
-use fedimint_ln::LightningGen;
 use fedimint_ln::{
-    ContractOutput, Lightning, LightningError, LightningInput, LightningOutput,
+    ContractOutput, Lightning, LightningError, LightningGen, LightningInput, LightningOutput,
     LightningOutputOutcome,
 };
 use fedimint_testing::FakeFed;

--- a/modules/fedimint-mint/src/common.rs
+++ b/modules/fedimint-mint/src/common.rs
@@ -3,8 +3,7 @@ use std::io;
 
 use bitcoin_hashes::sha256;
 use fedimint_api::core::Decoder;
-use fedimint_api::encoding::DecodeError;
-use fedimint_api::encoding::{Decodable, Encodable};
+use fedimint_api::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_api::module::registry::ModuleDecoderRegistry;
 use secp256k1_zkp::{KeyPair, Message, Secp256k1, Signing, Verification};
 use serde::{Deserialize, Serialize};

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -1,8 +1,7 @@
 use std::time::SystemTime;
 
 use fedimint_api::encoding::{Decodable, Encodable};
-use fedimint_api::impl_db_prefix_const;
-use fedimint_api::{Amount, OutPoint, PeerId};
+use fedimint_api::{impl_db_prefix_const, Amount, OutPoint, PeerId};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -10,9 +10,9 @@ use config::FeeConsensus;
 use db::{ECashUserBackupSnapshot, EcashBackupKey, NonceKeyPrefix};
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
-    ConfigGenParams, DkgPeerMsg, ModuleGenParams, ServerModuleConfig, TypedServerModuleConfig,
+    ConfigGenParams, DkgPeerMsg, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
+    TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
-use fedimint_api::config::{ModuleConfigResponse, TypedServerModuleConsensusConfig};
 use fedimint_api::core::{ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable};

--- a/modules/fedimint-wallet/src/config.rs
+++ b/modules/fedimint-wallet/src/config.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
-use anyhow::bail;
-use anyhow::format_err;
+use anyhow::{bail, format_err};
 use bitcoin::Network;
-use fedimint_api::config::ClientModuleConfig;
-use fedimint_api::config::TypedServerModuleConfig;
-use fedimint_api::config::{TypedClientModuleConfig, TypedServerModuleConsensusConfig};
+use fedimint_api::config::{
+    ClientModuleConfig, TypedClientModuleConfig, TypedServerModuleConfig,
+    TypedServerModuleConsensusConfig,
+};
 use fedimint_api::core::ModuleKind;
 use fedimint_api::encoding::Encodable;
 use fedimint_api::module::__reexports::serde_json;

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -15,10 +15,9 @@ use bitcoin::util::psbt::raw::ProprietaryKey;
 use bitcoin::util::psbt::{Input, PartiallySignedTransaction};
 use bitcoin::util::sighash::SighashCache;
 use bitcoin::{
-    Address, Amount, BlockHash, EcdsaSig, EcdsaSighashType, Network, Script, Transaction, TxIn,
-    TxOut, Txid,
+    Address, Amount, BlockHash, EcdsaSig, EcdsaSighashType, Network, PackedLockTime, Script,
+    Sequence, Transaction, TxIn, TxOut, Txid,
 };
-use bitcoin::{PackedLockTime, Sequence};
 use config::WalletConfigConsensus;
 use db::DbKeyPrefix;
 use fedimint_api::bitcoin_rpc::{
@@ -27,9 +26,9 @@ use fedimint_api::bitcoin_rpc::{
 };
 use fedimint_api::cancellable::{Cancellable, Cancelled};
 use fedimint_api::config::{
-    ConfigGenParams, DkgPeerMsg, ModuleGenParams, ServerModuleConfig, TypedServerModuleConfig,
+    ConfigGenParams, DkgPeerMsg, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
+    TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
-use fedimint_api::config::{ModuleConfigResponse, TypedServerModuleConsensusConfig};
 use fedimint_api::core::{ModuleInstanceId, ModuleKind};
 use fedimint_api::db::{Database, DatabaseTransaction};
 use fedimint_api::encoding::{Decodable, Encodable, UnzipConsensus};
@@ -37,10 +36,9 @@ use fedimint_api::module::__reexports::serde_json;
 use fedimint_api::module::audit::Audit;
 use fedimint_api::module::interconnect::ModuleInterconect;
 use fedimint_api::module::{
-    api_endpoint, ApiVersion, ConsensusProposal, CoreConsensusVersion, InputMeta, IntoModuleError,
-    ModuleConsensusVersion, ModuleGen, TransactionItemAmount,
+    api_endpoint, ApiEndpoint, ApiVersion, ConsensusProposal, CoreConsensusVersion, InputMeta,
+    IntoModuleError, ModuleConsensusVersion, ModuleError, ModuleGen, TransactionItemAmount,
 };
-use fedimint_api::module::{ApiEndpoint, ModuleError};
 use fedimint_api::net::peers::MuxPeerConnections;
 use fedimint_api::server::DynServerModule;
 #[cfg(not(target_family = "wasm"))]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 group_imports = "StdExternalCrate"
 wrap_comments = true
 format_code_in_doc_comments = true
+imports_granularity = "Module"


### PR DESCRIPTION
style. this PR adds the option to rustfmt to split imports at the module level. 

```toml
imports_granularity = "Module"
```


supersedes #1369  and fixes #258 

