### PR TITLE
Gatewayd route hints

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -34,7 +34,7 @@ windows:
           - fg
         - ln2:
           - sleep 5 # wait for bitcoind and federation
-          - export GW_CLN_EXTENSION_LISTEN_ADDRESS=127.0.0.1:10001
+          - export GW_CLN_EXTENSION_LISTEN_ADDRESS=0.0.0.0:54321
           - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN2_DIR --addr=127.0.0.1:9001 --plugin=$FM_BIN_DIR/gateway-cln-extension &
           - echo $! >> $FM_PID_FILE
           - fg

--- a/fedimint-testing/src/ln/fixtures.rs
+++ b/fedimint-testing/src/ln/fixtures.rs
@@ -11,10 +11,10 @@ use fedimint_ln::route_hints::RouteHint;
 use futures::stream;
 use lightning::ln::PaymentSecret;
 use lightning_invoice::{Currency, Invoice, InvoiceBuilder, SignedRawInvoice, DEFAULT_EXPIRY_TIME};
-use ln_gateway::gatewayd::lnrpc_client::{GetRouteHintsResponse, HtlcStream, ILnRpcClient};
+use ln_gateway::gatewayd::lnrpc_client::{HtlcStream, ILnRpcClient};
 use ln_gateway::gatewaylnrpc::{
-    CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyResponse, PayInvoiceRequest,
-    PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyResponse, GetRouteHintsResponse,
+    PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
 use ln_gateway::ln::{LightningError, LnRpc};
 use mint_client::modules::ln::contracts::Preimage;

--- a/fedimint-testing/src/ln/fixtures.rs
+++ b/fedimint-testing/src/ln/fixtures.rs
@@ -110,7 +110,7 @@ impl ILnRpcClient for FakeLightningTest {
         })
     }
 
-    async fn route_hints(&self) -> ln_gateway::Result<GetRouteHintsResponse> {
+    async fn routehints(&self) -> ln_gateway::Result<GetRouteHintsResponse> {
         Ok(GetRouteHintsResponse {
             route_hints: vec![RouteHint(vec![])],
         })

--- a/fedimint-testing/src/ln/fixtures.rs
+++ b/fedimint-testing/src/ln/fixtures.rs
@@ -13,7 +13,7 @@ use lightning::ln::PaymentSecret;
 use lightning_invoice::{Currency, Invoice, InvoiceBuilder, SignedRawInvoice, DEFAULT_EXPIRY_TIME};
 use ln_gateway::gatewayd::lnrpc_client::{HtlcStream, ILnRpcClient};
 use ln_gateway::gatewaylnrpc::{
-    CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyResponse, GetRouteHintsResponse,
+    self, CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyResponse, GetRouteHintsResponse,
     PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
 use ln_gateway::ln::{LightningError, LnRpc};
@@ -112,7 +112,7 @@ impl ILnRpcClient for FakeLightningTest {
 
     async fn routehints(&self) -> ln_gateway::Result<GetRouteHintsResponse> {
         Ok(GetRouteHintsResponse {
-            route_hints: vec![RouteHint(vec![])],
+            route_hints: vec![gatewaylnrpc::get_route_hints_response::RouteHint { hops: vec![] }],
         })
     }
 

--- a/gateway/ln-gateway/proto/gatewaylnrpc.proto
+++ b/gateway/ln-gateway/proto/gatewaylnrpc.proto
@@ -8,6 +8,9 @@ service GatewayLightning {
   /* GetPubKey returns the public key of the associated lightning node */
   rpc GetPubKey(GetPubKeyRequest) returns (GetPubKeyResponse) {}
 
+  /* GetRouteHints returns the route hints to the associated lightning node */
+  rpc GetRouteHints(EmptyRequest) returns (GetRouteHintsResponse) {}
+
   /* PayInvoice attempts to pay an invoice using the associated lightning node
    */
   rpc PayInvoice(PayInvoiceRequest) returns (PayInvoiceResponse) {}
@@ -29,6 +32,8 @@ service GatewayLightning {
    */
   rpc CompleteHtlc(CompleteHtlcsRequest) returns (CompleteHtlcsResponse) {}
 }
+
+message EmptyRequest {}
 
 message GetPubKeyRequest {}
 
@@ -127,3 +132,37 @@ message CompleteHtlcsRequest {
 }
 
 message CompleteHtlcsResponse {}
+
+message GetRouteHintsResponse {
+  message RouteHintHop {
+    // The node_id of the non-target end of the route.
+    bytes src_node_id = 1;
+
+    // The short_channel_id of this channel.
+    uint64 short_channel_id = 2;
+
+    // Flat routing fee in millisatoshis.
+    uint32 base_msat = 3;
+
+    // Liquidity-based routing fee in millionths of a routed amount.
+    // In other words, 10000 is 1%.
+    uint32 proportional_millionths = 4;
+
+    // The difference in CLTV values between this node and the next node.
+    uint32 cltv_expiry_delta = 5;
+
+    // The minimum value, in msat, which must be relayed to the next hop.
+    optional uint64 htlc_minimum_msat = 6;
+
+    // The maximum value in msat available for routing with a single HTLC.
+    optional uint64 htlc_maximum_msat = 7;
+  }
+
+  message RouteHint {
+    // Hops that make up a route hint to the associated lightning node
+    repeated RouteHintHop hops = 1;
+  }
+
+  // The route hints to the associated lightning node
+  repeated RouteHint route_hints = 1;
+}

--- a/gateway/ln-gateway/proto/gatewaylnrpc.proto
+++ b/gateway/ln-gateway/proto/gatewaylnrpc.proto
@@ -6,7 +6,7 @@ package gatewaylnrpc;
  * from a lightning node to Fedimint gateways */
 service GatewayLightning {
   /* GetPubKey returns the public key of the associated lightning node */
-  rpc GetPubKey(GetPubKeyRequest) returns (GetPubKeyResponse) {}
+  rpc GetPubKey(EmptyRequest) returns (GetPubKeyResponse) {}
 
   /* GetRouteHints returns the route hints to the associated lightning node */
   rpc GetRouteHints(EmptyRequest) returns (GetRouteHintsResponse) {}
@@ -34,8 +34,6 @@ service GatewayLightning {
 }
 
 message EmptyRequest {}
-
-message GetPubKeyRequest {}
 
 message GetPubKeyResponse {
   // The public key of the associated lightning node

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -21,7 +21,7 @@ use ln_gateway::gatewaylnrpc::gateway_lightning_server::{
 };
 use ln_gateway::gatewaylnrpc::get_route_hints_response::{RouteHint, RouteHintHop};
 use ln_gateway::gatewaylnrpc::{
-    CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyRequest, GetPubKeyResponse,
+    CompleteHtlcsRequest, CompleteHtlcsResponse, EmptyRequest, GetPubKeyResponse,
     GetRouteHintsResponse, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
     SubscribeInterceptHtlcsResponse,
 };
@@ -210,7 +210,7 @@ impl ClnRpcService {
 impl GatewayLightning for ClnRpcService {
     async fn get_pub_key(
         &self,
-        _request: tonic::Request<GetPubKeyRequest>,
+        _request: tonic::Request<EmptyRequest>,
     ) -> Result<tonic::Response<GetPubKeyResponse>, Status> {
         self.pubkey()
             .await

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -62,9 +62,9 @@ impl Gateway {
         let mut num_retries = 0;
         let route_hints = loop {
             let GetRouteHintsResponse { route_hints } = lnrpc
-                .route_hints()
+                .routehints()
                 .await
-                .expect("Could not feth route hints");
+                .expect("Could not fetch route hints");
 
             if !route_hints.is_empty() || num_retries == ROUTE_HINT_RETRIES {
                 break route_hints;
@@ -336,8 +336,7 @@ impl Gateway {
                         inner.handle(|payload| self.handle_get_info(payload)).await;
                     }
                     GatewayRequest::ConnectFederation(inner) => {
-                        let GetRouteHintsResponse { route_hints } =
-                            self.lnrpc.route_hints().await?;
+                        let GetRouteHintsResponse { route_hints } = self.lnrpc.routehints().await?;
                         inner
                             .handle(|payload| {
                                 self.handle_connect_federation(payload, route_hints.clone())

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -21,8 +21,8 @@ use tracing::{error, info, warn};
 
 use super::actor::GatewayActor;
 use crate::client::DynGatewayClientBuilder;
-use crate::gatewayd::lnrpc_client::{DynLnRpcClient, GetRouteHintsResponse};
-use crate::gatewaylnrpc::GetPubKeyResponse;
+use crate::gatewayd::lnrpc_client::DynLnRpcClient;
+use crate::gatewaylnrpc::{GetPubKeyResponse, GetRouteHintsResponse};
 use crate::rpc::rpc_server::run_webserver;
 use crate::rpc::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,

--- a/gateway/ln-gateway/src/gatewayd/gateway.rs
+++ b/gateway/ln-gateway/src/gatewayd/gateway.rs
@@ -22,7 +22,7 @@ use tracing::{error, info, warn};
 use super::actor::GatewayActor;
 use crate::client::DynGatewayClientBuilder;
 use crate::gatewayd::lnrpc_client::DynLnRpcClient;
-use crate::gatewaylnrpc::{GetPubKeyResponse, GetRouteHintsResponse};
+use crate::gatewaylnrpc::GetPubKeyResponse;
 use crate::rpc::rpc_server::run_webserver;
 use crate::rpc::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
@@ -61,10 +61,12 @@ impl Gateway {
         // Source route hints form the LN node
         let mut num_retries = 0;
         let route_hints = loop {
-            let GetRouteHintsResponse { route_hints } = lnrpc
+            let route_hints: Vec<RouteHint> = lnrpc
                 .routehints()
                 .await
-                .expect("Could not fetch route hints");
+                .expect("Could not fetch route hints")
+                .try_into()
+                .expect("Could not parse route hints");
 
             if !route_hints.is_empty() || num_retries == ROUTE_HINT_RETRIES {
                 break route_hints;
@@ -336,7 +338,8 @@ impl Gateway {
                         inner.handle(|payload| self.handle_get_info(payload)).await;
                     }
                     GatewayRequest::ConnectFederation(inner) => {
-                        let GetRouteHintsResponse { route_hints } = self.lnrpc.routehints().await?;
+                        let route_hints: Vec<RouteHint> =
+                            self.lnrpc.routehints().await?.try_into()?;
                         inner
                             .handle(|payload| {
                                 self.handle_connect_federation(payload, route_hints.clone())

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use crate::gatewaylnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gatewaylnrpc::{
-    CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyRequest, GetPubKeyResponse,
+    CompleteHtlcsRequest, CompleteHtlcsResponse, EmptyRequest, GetPubKeyRequest, GetPubKeyResponse,
     GetRouteHintsResponse, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
     SubscribeInterceptHtlcsResponse,
 };
@@ -95,7 +95,12 @@ impl ILnRpcClient for NetworkLnRpcClient {
     }
 
     async fn route_hints(&self) -> Result<GetRouteHintsResponse> {
-        unimplemented!()
+        let req = Request::new(EmptyRequest {});
+
+        let mut client = self.client.clone();
+        let res = client.get_route_hints(req).await?;
+
+        Ok(res.into_inner())
     }
 
     async fn pay(&self, invoice: PayInvoiceRequest) -> Result<PayInvoiceResponse> {

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -27,7 +27,7 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     async fn pubkey(&self) -> Result<GetPubKeyResponse>;
 
     /// Get route hints to the lightning node
-    async fn route_hints(&self) -> Result<GetRouteHintsResponse>;
+    async fn routehints(&self) -> Result<GetRouteHintsResponse>;
 
     /// Attempt to pay an invoice using the lightning node
     async fn pay(&self, invoice: PayInvoiceRequest) -> Result<PayInvoiceResponse>;
@@ -94,7 +94,7 @@ impl ILnRpcClient for NetworkLnRpcClient {
         Ok(res.into_inner())
     }
 
-    async fn route_hints(&self) -> Result<GetRouteHintsResponse> {
+    async fn routehints(&self) -> Result<GetRouteHintsResponse> {
         let req = Request::new(EmptyRequest {});
 
         let mut client = self.client.clone();

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -5,7 +5,6 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use fedimint_core::dyn_newtype_define;
 use futures::stream::BoxStream;
-use mint_client::modules::ln::route_hints::RouteHint;
 use tonic::transport::{Channel, Endpoint};
 use tonic::Request;
 use tracing::error;

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use crate::gatewaylnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gatewaylnrpc::{
-    CompleteHtlcsRequest, CompleteHtlcsResponse, EmptyRequest, GetPubKeyRequest, GetPubKeyResponse,
+    CompleteHtlcsRequest, CompleteHtlcsResponse, EmptyRequest, GetPubKeyResponse,
     GetRouteHintsResponse, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
     SubscribeInterceptHtlcsResponse,
 };
@@ -86,7 +86,7 @@ impl NetworkLnRpcClient {
 #[async_trait]
 impl ILnRpcClient for NetworkLnRpcClient {
     async fn pubkey(&self) -> Result<GetPubKeyResponse> {
-        let req = Request::new(GetPubKeyRequest {});
+        let req = Request::new(EmptyRequest {});
 
         let mut client = self.client.clone();
         let res = client.get_pub_key(req).await?;

--- a/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/gatewayd/lnrpc_client.rs
@@ -14,15 +14,10 @@ use url::Url;
 use crate::gatewaylnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gatewaylnrpc::{
     CompleteHtlcsRequest, CompleteHtlcsResponse, GetPubKeyRequest, GetPubKeyResponse,
-    PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    GetRouteHintsResponse, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
     SubscribeInterceptHtlcsResponse,
 };
 use crate::{LnGatewayError, Result};
-
-// TODO: Issue 1554: Define gatewaylnpc spec for getting route hints
-pub struct GetRouteHintsResponse {
-    pub route_hints: Vec<RouteHint>,
-}
 
 pub type HtlcStream<'a> =
     BoxStream<'a, std::result::Result<SubscribeInterceptHtlcsResponse, tonic::Status>>;

--- a/gateway/ln-gateway/src/gatewayd/mod.rs
+++ b/gateway/ln-gateway/src/gatewayd/mod.rs
@@ -18,3 +18,4 @@
 pub mod actor;
 pub mod gateway;
 pub mod lnrpc_client;
+pub mod types;

--- a/gateway/ln-gateway/src/gatewayd/types.rs
+++ b/gateway/ln-gateway/src/gatewayd/types.rs
@@ -1,0 +1,52 @@
+//! Map `gatewaylnrpc` protobuf types to rust types
+
+use anyhow::anyhow;
+use secp256k1::PublicKey;
+
+impl TryFrom<crate::gatewaylnrpc::get_route_hints_response::RouteHintHop>
+    for mint_client::modules::ln::route_hints::RouteHintHop
+{
+    type Error = anyhow::Error;
+
+    fn try_from(
+        hop: crate::gatewaylnrpc::get_route_hints_response::RouteHintHop,
+    ) -> Result<Self, Self::Error> {
+        let binding = hop.src_node_id.try_into();
+        let slice: &[u8; 33] = match &binding {
+            Ok(slice) => slice,
+            Err(_) => return Err(anyhow!("malformed source node id")),
+        };
+
+        Ok(Self {
+            src_node_id: PublicKey::from_slice(slice).expect("invalid source node id"),
+            short_channel_id: hop.short_channel_id,
+            base_msat: hop.base_msat,
+            proportional_millionths: hop.proportional_millionths,
+            cltv_expiry_delta: hop.cltv_expiry_delta as u16,
+            htlc_minimum_msat: hop.htlc_minimum_msat,
+            htlc_maximum_msat: hop.htlc_maximum_msat,
+        })
+    }
+}
+
+impl TryFrom<crate::gatewaylnrpc::GetRouteHintsResponse>
+    for Vec<mint_client::modules::ln::route_hints::RouteHint>
+{
+    type Error = anyhow::Error;
+
+    fn try_from(res: crate::gatewaylnrpc::GetRouteHintsResponse) -> Result<Self, Self::Error> {
+        let mut route_hints = Vec::<mint_client::modules::ln::route_hints::RouteHint>::new();
+
+        for route_hint in res.route_hints {
+            let mut hops = Vec::new();
+
+            for hop in route_hint.hops {
+                hops.push(hop.try_into()?);
+            }
+
+            route_hints.push(mint_client::modules::ln::route_hints::RouteHint(hops));
+        }
+
+        Ok(route_hints)
+    }
+}

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -1141,7 +1141,7 @@ pub mod route_hints {
         pub src_node_id: PublicKey,
         /// The short_channel_id of this channel
         pub short_channel_id: u64,
-        /// Flat routing fee in satoshis
+        /// Flat routing fee in millisatoshis
         pub base_msat: u32,
         /// Liquidity-based routing fee in millionths of a routed amount.
         /// In other words, 10000 is 1%.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -73,7 +73,7 @@ export FM_GATEWAY_LISTEN_ADDR="127.0.0.1:10000"
 export FM_GATEWAY_API_ADDR="http://127.0.0.1:10000"
 export FM_GATEWAY_PASSWORD="theresnosecondbest"
 
-export FM_GATEWAY_LIGHTNING_ADDR="http://127.0.0.1:10001"
+export FM_GATEWAY_LIGHTNING_ADDR="http://localhost:54321"
 
 mkdir -p $FM_GATEWAY_DATA_DIR
 


### PR DESCRIPTION
Define gRPC spec for sourcing route hints from a [GatewayLightning](https://github.com/fedimint/fedimint/blob/master/gateway/ln-gateway/proto/gatewaylnrpc.proto#L7) service. We then implement this logic for [gateway-cln-rpc](https://github.com/fedimint/fedimint/blob/master/gateway/ln-gateway/src/bin/cln_extension.rs#L193) and mock it in shared [FakeLightning](https://github.com/fedimint/fedimint/blob/master/fedimint-testing/src/ln/fixtures.rs#L113) test fixture.
Along the way, we define a pattern for mapping grpc Rust autogen structs into Fedimint locally defined structs

closes #1554 