### PR TITLE
Refactor the config io to simplify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,6 @@ dependencies = [
  "hex",
  "rand",
  "ring",
- "rpassword",
 ]
 
 [[package]]

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.65"
-rpassword = "7.2.0"
 ring = "0.16.20"
 hex = "0.4.3"
 rand = "0.8"

--- a/crypto/aead/src/lib.rs
+++ b/crypto/aead/src/lib.rs
@@ -87,12 +87,7 @@ pub fn encrypted_read(key: &LessSafeKey, file: PathBuf) -> Result<Vec<u8>> {
 /// stretching along with a 128-bit salt that is randomly generated to
 /// discourage rainbow attacks.  HMAC-SHA256 is used for the authentication
 /// code.  All crypto is from the widely-used `ring` crate we also use for TLS.
-pub fn get_key(password: Option<String>, salt_path: PathBuf) -> Result<LessSafeKey> {
-    let password = match password {
-        None => rpassword::prompt_password("Enter a password to encrypt configs: ").unwrap(),
-        Some(password) => password,
-    };
-
+pub fn get_key(password: &str, salt_path: PathBuf) -> Result<LessSafeKey> {
     let salt_str = fs::read_to_string(salt_path)?;
     let salt = hex::decode(salt_str)?;
     let mut key = [0u8; ring::digest::SHA256_OUTPUT_LEN];

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -12,7 +12,7 @@ use fedimint_core::{push_db_key_items, push_db_pair_items, push_db_pair_items_no
 use fedimint_ln::LightningGen;
 use fedimint_mint::MintGen;
 use fedimint_rocksdb::RocksDbReadOnly;
-use fedimint_server::config::io::{read_server_configs, SALT_FILE};
+use fedimint_server::config::io::read_server_config;
 use fedimint_server::config::ServerConfig;
 use fedimint_server::db as ConsensusRange;
 use fedimint_wallet::WalletGen;
@@ -50,7 +50,7 @@ impl<'a> DatabaseDump<'a> {
     pub fn new(
         cfg_dir: PathBuf,
         data_dir: String,
-        password: Option<String>,
+        password: String,
         modules: Vec<String>,
         prefixes: Vec<String>,
     ) -> DatabaseDump<'a> {
@@ -80,9 +80,7 @@ impl<'a> DatabaseDump<'a> {
             DynModuleGen::from(LightningGen),
         ]);
 
-        let salt_path = cfg_dir.join(SALT_FILE);
-        let key = aead::get_key(password, salt_path).unwrap();
-        let cfg = read_server_configs(&key, cfg_dir).unwrap();
+        let cfg = read_server_config(&password, cfg_dir).unwrap();
         let decoders = module_inits.decoders(cfg.iter_module_instances()).unwrap();
         let dbtx = DatabaseTransaction::new(Box::new(read_only), decoders);
 

--- a/fedimint-dbtool/src/main.rs
+++ b/fedimint-dbtool/src/main.rs
@@ -49,7 +49,7 @@ enum DbCommand {
     Dump {
         cfg_dir: PathBuf,
         #[arg(env = "FM_PASSWORD")]
-        password: Option<String>,
+        password: String,
         #[arg(required = false)]
         modules: Option<String>,
         #[arg(required = false)]


### PR DESCRIPTION
Small refactor to remove the prompt password which we never use and probably shouldn't have deep in the lib code.

Also simplifies some of the shared config io code into `read_server_config` and `write_server_config`