### PR TITLE
fix: rename database traits

### DIFF
--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use futures::StreamExt;
 
-use crate::db::{DatabaseKeyPrefix, DatabaseKeyPrefixConst, DatabaseTransaction};
+use crate::db::{DatabaseLookup, DatabaseRecord, DatabaseTransaction};
 
 #[derive(Default)]
 pub struct Audit {
@@ -28,8 +28,8 @@ impl Audit {
         key_prefix: &KP,
         to_milli_sat: F,
     ) where
-        KP: DatabaseKeyPrefix + DatabaseKeyPrefixConst + 'static,
-        F: Fn(KP::Key, KP::Value) -> i64,
+        KP: DatabaseLookup + 'static,
+        F: Fn(KP::Key, <<KP as DatabaseLookup>::Record as DatabaseRecord>::Value) -> i64,
     {
         let mut new_items = dbtx
             .find_by_prefix(key_prefix)


### PR DESCRIPTION
Some offline discussion with @dpc and @mxz42 has shown that there is some confusion on the purpose of some database traits. Currently there are many traits named similar things, so their purpose isn't immediately clear. This PR renames the database traits with the intention of making it more clear on their purpose.

- `DatabaseKeyPrefixConst` -> `DatabaseRecord` and `DatabaseLookup`. `DatabaseRecord` is for individual db records and `DatabaseLookup` is for multi-record lookups.
- `SerializableDatabaseValue` was collapsed into `DatabaseValue`
- `DatabaseRecord` and `DatabaseLookup` derive from `DatabaseKeyPrefix` since both of those need the ability to prepend a prefix. This is the same functionality as before but the syntax is a bit cleaner.