### PR TITLE
refactor: remove unnecessary method to start db transaction

### DIFF
--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -28,7 +28,7 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
 
                 return (endpoint.handler)(
                     module,
-                    self.fedimint.database_transaction().await,
+                    self.fedimint.db.begin_transaction().await,
                     data,
                     Some(module_id),
                 )

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -103,7 +103,8 @@ fn attach_endpoints(
             .register_async_method(path, move |params, state| async move {
                 let params = params.one::<serde_json::Value>()?;
                 let fedimint = &state.fedimint;
-                let dbtx = fedimint.database_transaction().await;
+
+                let dbtx = fedimint.db.begin_transaction().await;
                 // Using AssertUnwindSafe here is far from ideal. In theory this means we could
                 // end up with an inconsistent state in theory. In practice most API functions
                 // are only reading and the few that do write anything are atomic. Lastly, this
@@ -151,7 +152,7 @@ fn attach_endpoints_erased(
                 // Hack to avoid Sync/Send issues
                 let params = params.one::<serde_json::Value>()?;
                 let fedimint = &state.fedimint;
-                let dbtx = fedimint.database_transaction().await;
+                let dbtx = fedimint.db.begin_transaction().await;
                 // Using AssertUnwindSafe here is far from ideal. In theory this means we could
                 // end up with an inconsistent state in theory. In practice most API functions
                 // are only reading and the few that do write anything are atomic. Lastly, this


### PR DESCRIPTION
Is there a reason we have that wrapper? 

- most of the time we use `db.begin_transaction()` already, only in some cases that wrapper was used
- and I like `begin_transaction()` more as the name is more expressive than `database_transaction`

