### PR TITLE
fix: apply database migrations for the consensus keys and values

### DIFF
--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -14,7 +14,7 @@ use strum_macros::EnumIter;
 use thiserror::Error;
 use tracing::{debug, info, instrument, trace, warn};
 
-use crate::core::{ModuleInstanceId, ModuleKind};
+use crate::core::ModuleInstanceId;
 use crate::encoding::{Decodable, Encodable};
 use crate::fmt_utils::AbbreviateHexBytes;
 
@@ -926,7 +926,7 @@ pub type MigrationMap<'a> = BTreeMap<
 /// will be able to read and write from the database successfully.
 pub async fn apply_migrations<'a>(
     db: &'a Database,
-    kind: ModuleKind,
+    kind: String,
     target_db_version: DatabaseVersion,
     migrations: MigrationMap<'a>,
 ) -> Result<(), anyhow::Error> {
@@ -1667,7 +1667,7 @@ mod tests {
 
         apply_migrations(
             &db,
-            ModuleKind::from_static_str("TestModule"),
+            "TestModule".to_string(),
             DatabaseVersion(1),
             migrations,
         )

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -36,9 +36,9 @@ use crate::config::ServerConfig;
 use crate::consensus::interconnect::FedimintInterconnect;
 use crate::consensus::TransactionSubmissionError::TransactionReplayError;
 use crate::db::{
-    get_consensus_database_migrations, AcceptedTransactionKey, ClientConfigSignatureKey,
-    DropPeerKey, DropPeerKeyPrefix, EpochHistoryKey, LastEpochKey, RejectedTransactionKey,
-    CONSENSUS_DATABASE_VERSION,
+    get_global_database_migrations, AcceptedTransactionKey, ClientConfigSignatureKey, DropPeerKey,
+    DropPeerKeyPrefix, EpochHistoryKey, LastEpochKey, RejectedTransactionKey,
+    GLOBAL_DATABASE_VERSION,
 };
 use crate::logging::LOG_CONSENSUS;
 use crate::transaction::{Transaction, TransactionError};
@@ -143,9 +143,9 @@ impl FedimintConsensus {
 
         apply_migrations(
             &db,
-            "Consensus".to_string(),
-            CONSENSUS_DATABASE_VERSION,
-            get_consensus_database_migrations(),
+            "Global".to_string(),
+            GLOBAL_DATABASE_VERSION,
+            get_global_database_migrations(),
         )
         .await?;
 

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -9,7 +9,7 @@ use strum_macros::EnumIter;
 
 use crate::consensus::AcceptedTransaction;
 
-pub const CONSENSUS_DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
+pub const GLOBAL_DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -103,6 +103,6 @@ impl_db_prefix_const!(
     query_prefix = ClientConfigSignatureKeyPrefix
 );
 
-pub fn get_consensus_database_migrations<'a>() -> MigrationMap<'a> {
+pub fn get_global_database_migrations<'a>() -> MigrationMap<'a> {
     MigrationMap::new()
 }

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use fedimint_core::db::MODULE_GLOBAL_PREFIX;
+use fedimint_core::db::{DatabaseVersion, MigrationMap, MODULE_GLOBAL_PREFIX};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::{SerdeSignature, SignedEpochOutcome};
 use fedimint_core::{impl_db_prefix_const, PeerId, TransactionId};
@@ -8,6 +8,8 @@ use serde::Serialize;
 use strum_macros::EnumIter;
 
 use crate::consensus::AcceptedTransaction;
+
+pub const CONSENSUS_DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -100,3 +102,7 @@ impl_db_prefix_const!(
     db_prefix = DbKeyPrefix::ClientConfigSignature,
     query_prefix = ClientConfigSignatureKeyPrefix
 );
+
+pub fn get_consensus_database_migrations<'a>() -> MigrationMap<'a> {
+    MigrationMap::new()
+}

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -35,6 +35,7 @@ use fedimint_server::config::{connect, ServerConfig, ServerConfigParams};
 use fedimint_server::consensus::{
     ConsensusProposal, FedimintConsensus, HbbftConsensusOutcome, TransactionSubmissionError,
 };
+use fedimint_server::db::CONSENSUS_DATABASE_VERSION;
 use fedimint_server::logging::TracingSetup;
 use fedimint_server::multiplexed::PeerConnectionMultiplexer;
 use fedimint_server::net::connect::mock::MockNetwork;
@@ -1206,6 +1207,15 @@ impl FederationTest {
             let mut modules = BTreeMap::new();
             let env_vars = FedimintConsensus::get_env_vars_map();
 
+            fedimint_core::db::apply_migrations(
+                &db,
+                "Consensus".to_string(),
+                CONSENSUS_DATABASE_VERSION,
+                fedimint_server::db::get_consensus_database_migrations(),
+            )
+            .await
+            .expect("Error while applying consensus database migrations");
+
             for (kind, gen) in module_inits.legacy_init_order_iter() {
                 let id = cfg.get_module_id_by_kind(kind.clone()).unwrap();
                 if let Some(module) = override_modules.remove(kind.as_str()) {
@@ -1217,12 +1227,12 @@ impl FederationTest {
                     let isolated_db = db.new_isolated(id);
                     fedimint_core::db::apply_migrations(
                         &isolated_db,
-                        gen.module_kind(),
+                        kind.to_string(),
                         gen.database_version(),
                         gen.get_database_migrations(),
                     )
                     .await
-                    .unwrap();
+                    .expect("Error while apply database migrations for module");
 
                     let module = gen
                         .init(


### PR DESCRIPTION
Through some refactors this code was accidentally dropped from https://github.com/fedimint/fedimint/pull/1567

We need to apply database migrations to the consensus keys/values as well to ensure that these stay up to date with the code, in addition to the modules.