### PR TITLE
Add script to show tests per package

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ check-ulimit:
 test: build check-ulimit
   cargo test
 
+# show number of tests per package
+test-count:
+  ./scripts/test-cov.sh
+
 test-real: check-ulimit
   ./scripts/rust-tests.sh
 

--- a/scripts/test-cov.sh
+++ b/scripts/test-cov.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+#
+# Shows a table with the number of tests for each package
+#
+
+set -eu
+
+# create array of all possible package targets
+mapfile -t packages < <(cargo test -p 2>&1 | rg '^\s+(.+)$' -r '$1')
+
+# we set pipefail here as `cargo test -p` above returns a failure exit code
+set -o pipefail
+
+# create nice table header
+printf "%-30s: %s\n" "packages" "tests"
+printf "%0.s-" {1..30}
+printf ":"
+printf "%0.s-" {1..15}
+printf "\n"
+
+for package in "${packages[@]}"; do
+  # --all-targets does not run doc tests
+  test_counts=$(cargo test -p "$package" --all-targets 2>/dev/null | rg 'running (\d+) tests?'  -r '$1')
+
+  # add all numbers in `$test_counts`
+  total=$(echo -n "$test_counts" | xargs | tr ' ' '+' | bc -l)
+
+  printf "%-30s: %-3s\n" "$package" "$total"
+done


### PR DESCRIPTION
I was wondering how tests are distributed between all packages. 

I think @justinmoon  you talked about that somewhere, too, though I can't find it anymore.

Might be useful to include this script here? 

Output looks like:
```sh
$ just test-count
./scripts/test-cov.sh
packages                      : tests
------------------------------:---------------
aead                          : 0
fedimint-derive-secret        : 0
fedimint-core                 : 47
fedimint-derive               : 0
tbs                           : 4
hkdf                          : 9
ln-gateway                    : 0
fedimint-rocksdb              : 15
fedimint-server               : 10
fedimint-build                : 0
mint-client                   : 13
fedimint-ln                   : 3
fedimint-testing              : 0
fedimint-bitcoind             : 0
fedimint-wallet               : 1
fedimint-mint                 : 2
gateway-cli                   : 0
gateway-tests                 : 1
fedimintd                     : 0
fedimint-client               : 0
fedimint-dbtool               : 0
fedimint-sqlite               : 15
fedimint-cli                  : 0
fedimint-dummy                : 0
fedimint-tests                : 31
recoverytool                  : 0
```