### PR TITLE
feat: Warn users about too small ulimit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -883,6 +883,10 @@
                 fi
 
                 >&2 echo "💡 Run 'just' for a list of available 'just ...' helper recipies"
+
+                if [ "$(ulimit -Sn)" -lt "1024" ]; then
+                    >&2 echo "⚠️  ulimit too small. Run 'ulimit -Sn 1024' to avoid problems running tests"
+                fi
               '';
             };
 

--- a/justfile
+++ b/justfile
@@ -7,10 +7,17 @@ check:
 build:
   cargo build --all --all-targets
 
-test: build
+# check if ulimit is set correctly
+check-ulimit:
+  #!/usr/bin/env bash
+  if [ "$(ulimit -Sn)" -lt "1024" ]; then
+      >&2 echo "⚠️  ulimit too small. Run 'ulimit -Sn 1024' to avoid problems running tests"
+  fi
+
+test: build check-ulimit
   cargo test
 
-test-real:
+test-real: check-ulimit
   ./scripts/rust-tests.sh
 
 lint:


### PR DESCRIPTION
Unfortunately trying to set it automatically doesn't seem to work
for `direnv` users.