### PR TITLE
IDatabaseTransaction taking self by move during commit

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -421,7 +421,9 @@ impl FedimintConsensus {
                 trace!(?transaction);
                 self.tx_cache.lock().unwrap().remove(&transaction);
 
-                dbtx.set_tx_savepoint().await;
+                dbtx.set_tx_savepoint()
+                    .await
+                    .expect("Error setting transaction savepoint");
                 // TODO: use borrowed transaction
                 match self
                     .process_transaction(dbtx, transaction.clone(), &caches)
@@ -437,7 +439,9 @@ impl FedimintConsensus {
                     }
                     Err(error) => {
                         rejected_txs.insert(txid);
-                        dbtx.rollback_tx_to_savepoint().await;
+                        dbtx.rollback_tx_to_savepoint()
+                            .await
+                            .expect("Error rolling back to transaction savepoint");
                         warn!(target: LOG_CONSENSUS, %error, "Transaction failed");
                         dbtx.insert_entry(&RejectedTransactionKey(txid), &format!("{error:?}"))
                             .await


### PR DESCRIPTION
This PR attempts to fix https://github.com/fedimint/fedimint/issues/1635

Right now additional allocations need to be taken because `commit_tx` takes `self` by move and not by `&mut` like the other functions in the trait. This PR introduces a new trait that contains an `Option` of the database transaction and consumes it during commit, and panics if the transaction is `None`. Additional wrapper was also introduced to accomodate the new trait.

This will directly conflict with https://github.com/fedimint/fedimint/pull/1197