### PR TITLE
fix: don't fail when external websites are down

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -5,6 +5,7 @@ name: Markdown Link Check
 jobs:
   markdown-link-check:
     runs-on: ubuntu-22.04
+    continue-on-error: true # can fail for external reasons, so don't be a blocker
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
One of the websites we link to had a temporary problem, and I don't want this to block our PRs.