### PR TITLE
fix: needless rebuilds when running tests in release mode

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,7 +26,8 @@ echo "Setting up env variables in $FM_TMP_DIR"
 # Builds the rust executables and sets environment variables
 SRC_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 cd $SRC_DIR || exit 1
-cargo build
+# Note: Respect 'CARGO_PROFILE' that crane uses
+cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}}
 
 # Define temporary directories to not overwrite manually created config if run locally
 export FM_TEST_DIR=$FM_TMP_DIR

--- a/scripts/gw-reload.sh
+++ b/scripts/gw-reload.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-cargo build --bin ln_gateway
+cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --bin ln_gateway
 
 $FM_LN1 plugin stop ln_gateway &> /dev/null || true
 $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR &> /dev/null


### PR DESCRIPTION
Make `cargo build` used in tests respect 'CARGO_PROFILE'.

`crane` that we use in CI, uses 'CARGO_PROFILE' env variable to select between debug and release mode. We have a special transformation that prefixes all nix outputs names with `.debug` while overriding `CARGO_PROFILE` to `dev` to get a debug build versions.

Since we run the tests in the CI, and these tests are attempting `cargo build` if they don't respect this variable it leads to debug build being built for no good reason. This can be observed
 by running `nix build -L .#cli-test.reconnect` (instead of
`nix build -L .#cli-test.debug.reconnect` that we actually use in CI). The workspace will built in release mode, but the test build will rebuild everything in debug mode.