### PR TITLE
Gatewayd integration test suite proposal

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -147,9 +147,10 @@ impl Display for FederationId {
 
 /// Display as a hex encoding
 impl FederationId {
-    /// Non-unique dummy id for testing
+    /// Random dummy id for testing
     pub fn dummy() -> Self {
-        Self(threshold_crypto::PublicKey::from(G1Projective::identity()))
+        let rand_pk = threshold_crypto::SecretKey::random().public_key();
+        Self(rand_pk)
     }
 
     fn try_from_bytes(bytes: [u8; 48]) -> Option<Self> {

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -24,6 +24,10 @@ path = "src/bin/cln_extension.rs"
 name = "gateway-authentication-tests"
 path = "tests/authentication_tests.rs"
 
+[[test]]
+name = "gatewayd-integration-tests"
+path = "tests/integration_tests.rs"
+
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.64"

--- a/gateway/ln-gateway/tests/authentication_tests.rs
+++ b/gateway/ln-gateway/tests/authentication_tests.rs
@@ -15,11 +15,9 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use anyhow::Result;
 use fedimint_core::api::WsClientConnectInfo;
 use fedimint_core::config::FederationId;
 use fedimint_logging::TracingSetup;
-use fixtures::{fixtures, Fixtures};
 use ln_gateway::rpc::rpc_client::{Error, Response, RpcClient};
 use ln_gateway::rpc::{
     BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload, WithdrawPayload,
@@ -27,109 +25,116 @@ use ln_gateway::rpc::{
 use ln_gateway::utils::retry;
 use url::Url;
 
+use crate::fixtures::test;
+
 #[tokio::test(flavor = "multi_thread")]
-async fn test_gateway_authentication() -> Result<()> {
+async fn gatewayd_api_authentication() -> anyhow::Result<()> {
     TracingSetup::default().init()?;
-    let gw_password = "password".to_string();
+
     let gw_port = portpicker::pick_unused_port().expect("Failed to pick port");
     let gw_listen = SocketAddr::from(([127, 0, 0, 1], gw_port));
     let gw_api_addr = Url::parse(&format!("http://{gw_listen}")).expect("Invalid gateway address");
-    let federation_id = FederationId::dummy();
+    let gw_password = "password".to_string();
 
-    let Fixtures {
-        bitcoin,
-        gateway,
-        mut task_group,
-    } = fixtures(gw_api_addr.clone()).await?;
+    test(
+        gw_api_addr.clone(),
+        Some(gw_listen),
+        Some(gw_password.clone()),
+        |bitcoin, _, _| async move {
+            // Create an RPC client reference
+            let client_ref = &RpcClient::new(gw_api_addr);
 
-    // Run gateway in an isolate thread, so we dont block the test thread
-    let password = gw_password.clone();
-    task_group
-        .spawn("Run Gateway", move |_| async move {
-            if gateway.run(gw_listen, password).await.is_err() {}
-        })
-        .await;
+            // Create a test federation ID
+            let federation_id = FederationId::dummy();
 
-    // Create an RPC client reference
-    let client_ref = &RpcClient::new(gw_api_addr);
+            // Test gateway authentication on `connect_federation` function
+            // * `connect_federation` with correct password succeeds
+            // * `connect_federation` with incorrect password fails
+            let payload = ConnectFedPayload {
+                connect: serde_json::to_string(&WsClientConnectInfo {
+                    urls: vec![],
+                    id: federation_id.clone(),
+                })
+                .unwrap(),
+            };
+            test_auth(&gw_password, move |pw| {
+                client_ref.connect_federation(pw, payload.clone())
+            })
+            .await
+            .unwrap();
 
-    // Test gateway authentication on `connect_federation` function
-    // * `connect_federation` with correct password succeeds
-    // * `connect_federation` with incorrect password fails
-    let payload = ConnectFedPayload {
-        connect: WsClientConnectInfo {
-            urls: vec![],
-            id: FederationId::dummy(),
-        }
-        .to_string(),
-    };
-    test_auth(&gw_password, move |pw| {
-        client_ref.connect_federation(pw, payload.clone())
-    })
+            // Test gateway authentication on `get_info` function
+            // * `get_info` with correct password succeeds
+            // * `get_info` with incorrect password fails
+            test_auth(&gw_password, |pw| client_ref.get_info(pw))
+                .await
+                .unwrap();
+
+            // Test gateway authentication on `get_balance` function
+            // * `get_balance` with correct password succeeds
+            // * `get_balance` with incorrect password fails
+            let payload = BalancePayload {
+                federation_id: federation_id.clone(),
+            };
+            test_auth(&gw_password, move |pw| {
+                client_ref.get_balance(pw, payload.clone())
+            })
+            .await
+            .unwrap();
+
+            // Test gateway authentication on `get_deposit_address` function
+            // * `get_deposit_address` with correct password succeeds
+            // * `get_deposit_address` with incorrect password fails
+            let payload = DepositAddressPayload {
+                federation_id: federation_id.clone(),
+            };
+            test_auth(&gw_password, move |pw| {
+                client_ref.get_deposit_address(pw, payload.clone())
+            })
+            .await
+            .unwrap();
+
+            // Test gateway authentication on `deposit` function
+            // * `deposit` with correct password succeeds
+            // * `deposit` with incorrect password fails
+            let (proof, tx) = bitcoin
+                .send_and_mine_block(
+                    &bitcoin.get_new_address().await,
+                    bitcoin::Amount::from_btc(1.0).unwrap(),
+                )
+                .await;
+            let payload = DepositPayload {
+                federation_id: federation_id.clone(),
+                txout_proof: proof,
+                transaction: tx,
+            };
+            test_auth(&gw_password, move |pw| {
+                client_ref.deposit(pw, payload.clone())
+            })
+            .await
+            .unwrap();
+
+            // Test gateway authentication on `withdraw` function
+            // * `withdraw` with correct password succeeds
+            // * `withdraw` with incorrect password fails
+            let payload = WithdrawPayload {
+                federation_id,
+                amount: bitcoin::Amount::from_sat(100),
+                address: bitcoin.get_new_address().await,
+            };
+            test_auth(&gw_password, |pw| client_ref.withdraw(pw, payload.clone()))
+                .await
+                .unwrap();
+        },
+    )
     .await?;
 
-    // Test gateway authentication on `get_info` function
-    // * `get_info` with correct password succeeds
-    // * `get_info` with incorrect password fails
-    test_auth(&gw_password, |pw| client_ref.get_info(pw)).await?;
-
-    // Test gateway authentication on `get_balance` function
-    // * `get_balance` with correct password succeeds
-    // * `get_balance` with incorrect password fails
-    let payload = BalancePayload {
-        federation_id: federation_id.clone(),
-    };
-    test_auth(&gw_password, move |pw| {
-        client_ref.get_balance(pw, payload.clone())
-    })
-    .await?;
-
-    // Test gateway authentication on `get_deposit_address` function
-    // * `get_deposit_address` with correct password succeeds
-    // * `get_deposit_address` with incorrect password fails
-    let payload = DepositAddressPayload {
-        federation_id: federation_id.clone(),
-    };
-    test_auth(&gw_password, move |pw| {
-        client_ref.get_deposit_address(pw, payload.clone())
-    })
-    .await?;
-
-    // Test gateway authentication on `deposit` function
-    // * `deposit` with correct password succeeds
-    // * `deposit` with incorrect password fails
-    let (proof, tx) = bitcoin
-        .send_and_mine_block(
-            &bitcoin.get_new_address().await,
-            bitcoin::Amount::from_btc(1.0).unwrap(),
-        )
-        .await;
-    let payload = DepositPayload {
-        federation_id: federation_id.clone(),
-        txout_proof: proof,
-        transaction: tx,
-    };
-    test_auth(&gw_password, move |pw| {
-        client_ref.deposit(pw, payload.clone())
-    })
-    .await?;
-
-    // Test gateway authentication on `withdraw` function
-    // * `withdraw` with correct password succeeds
-    // * `withdraw` with incorrect password fails
-    let payload = WithdrawPayload {
-        federation_id,
-        amount: bitcoin::Amount::from_sat(100),
-        address: bitcoin.get_new_address().await,
-    };
-    test_auth(&gw_password, |pw| client_ref.withdraw(pw, payload.clone())).await?;
-
-    task_group.shutdown_join_all(None).await
+    Ok(())
 }
 
 /// Test that a given endpoint/functionality of func fails with the wrong
 /// password but works with the correct one
-async fn test_auth<Fut>(gw_password: &str, func: impl Fn(String) -> Fut) -> Result<()>
+async fn test_auth<Fut>(gw_password: &str, func: impl Fn(String) -> Fut) -> anyhow::Result<()>
 where
     Fut: Future<Output = Result<Response, Error>>,
 {

--- a/gateway/ln-gateway/tests/authentication_tests.rs
+++ b/gateway/ln-gateway/tests/authentication_tests.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use fedimint_core::api::WsClientConnectInfo;
 use fedimint_core::config::FederationId;
 use fedimint_logging::TracingSetup;
-use ln_gateway::rpc::rpc_client::{Error, Response, RpcClient};
+use ln_gateway::rpc::rpc_client::{Error, Response};
 use ln_gateway::rpc::{
     BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload, WithdrawPayload,
 };
@@ -40,9 +40,9 @@ async fn gatewayd_api_authentication() -> anyhow::Result<()> {
         gw_api_addr.clone(),
         Some(gw_listen),
         Some(gw_password.clone()),
-        |bitcoin, _, _| async move {
+        |bitcoin, _, _, rpc| async move {
             // Create an RPC client reference
-            let client_ref = &RpcClient::new(gw_api_addr);
+            let client_ref = &rpc;
 
             // Create a test federation ID
             let federation_id = FederationId::dummy();

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -1,0 +1,90 @@
+//! Gateway integration test suite
+//!
+//! This crate contains integration tests for the gateway business logic.
+//!
+//! The tests run instances of gatewayd with the following mocks:
+//!
+//! * `ILnRpcClient` - fake implementation of `ILnRpcClient` that simulates
+//!   gateway lightning dependency.
+//!
+//! * `IFederationApi` - fake implementation of `IFederationApi` that simulates
+//!   gateway federation client dependency.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_supports_multiple_federations() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_shows_info_about_all_connected_federations() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_shows_balance_for_any_connected_federation() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_allows_deposit_to_any_connected_federation() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_allows_withdrawal_from_any_connected_federation() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_supports_backup_of_any_connected_federation() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_supports_restore_of_any_connected_federation() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+// Internal payments within a federation should not involve the gateway. See
+// Issue #613: Federation facilitates internal payments w/o involving gateway
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_pays_internal_invoice_within_a_connected_federation() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_pays_outgoing_invoice_to_generic_ln() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_pays_outgoing_invoice_between_federations_connected() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_intercepts_htlc_and_settles_to_connected_federation() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -1,7 +1,7 @@
 //! Integration test suite
 //!
-//! This crate contains integration tests that work be creating
-//! per-test federation, ln-gatewa and driving bitcoind and lightning
+//! This crate contains integration tests that work by creating
+//! per-test federation, ln-gateway and driving bitcoind and lightning
 //! nodes to exercise certain behaviors on it.
 //!
 //! We run them in two modes:


### PR DESCRIPTION
Proposes an integration test suite for [gatewayd](https://github.com/fedimint/fedimint/blob/master/gateway/ln-gateway/src/bin/gatewayd.rs).

To start with, tests are only run with mocks of dependencies like `ILnRpcClient` and `IFederationApi`.

In it's full extent, this proposal would involve sharing the following from **fedimint-testing** crate:
- [x] fixtures for setting up [fake bitcoin tests](https://github.com/fedimint/fedimint/blob/master/fedimint-testing/src/btc/fixtures.rs#L30)
- [ ] fixtures for setting up real bitcoin tests
- [x] fixtures for setting up [fake lightning tests](https://github.com/fedimint/fedimint/blob/master/fedimint-testing/src/ln/fixtures.rs#L33)
- [ ] fixtures for setting up real lightning tests
- [ ] fixtures for setting up fake fedimintd with modules
- [ ] fixtures for setting up real fedimintd with modules

Gateway would then own it's own integration tests where it uses real or fake fixtures in validating it's functionality in serving one or more federations

towards #742 