### PR TITLE
fix: Improve tmuxinator environment variable filtering

### DIFF
--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -18,7 +18,7 @@ export FM_VERBOSE_OUTPUT=0
 source scripts/build.sh
 echo "Running in temporary directory $FM_TEST_DIR"
 
-env | sed -En 's/(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
+env | sed -En 's/^(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
 
 export FM_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
 


### PR DESCRIPTION
I had an environment variable with `FM_` in the middle of the value, which caused an "invalid variable" error. Instead, we look for `FM_` only at the beginning of an environment variable.

See log https://gist.github.com/justinmoon/2480ba4fa8ce486e60d610f6e3a04fe0 for full error