### PR TITLE
fix: remove .tmpenv file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ ln1
 ln2
 it
 .idea
-.tmpenv
 .direnv
 .vscode

--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -2,7 +2,6 @@ name: fedimint-dev
 root: .
 socket_name: fedimint-dev
 pre_window:
-  - source .tmpenv
   - alias ln1="\$FM_LN1"
   - alias ln2="\$FM_LN2"
   - alias bitcoin-cli="\$FM_BTC_CLIENT"

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -18,13 +18,9 @@ export FM_VERBOSE_OUTPUT=0
 source scripts/build.sh
 echo "Running in temporary directory $FM_TEST_DIR"
 
-env | sed -En 's/(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
-
 export FM_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
 
 SHELL=$(which bash) tmuxinator local
 tmux -L fedimint-dev kill-session -t fedimint-dev || true
 pkill bitcoind
 pkill lightningd
-
-rm .tmpenv


### PR DESCRIPTION
Tmuxinator works just fine without this file ***for me***. Seems that environment is passed to the tmuxinator environment by default?
