### PR TITLE
fix: unify cross and native package builds

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -118,9 +118,9 @@ jobs:
     strategy:
       matrix:
         build:
-          - aarch64-android
-          - x86_64-android
-          - wasm32
+          - aarch64-linux-android
+          - x86_64-linux-android
+          - wasm32-unknown-unknown
 
     runs-on: ubuntu-22.04
     timeout-minutes: 30

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -112,7 +112,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: result/lcov.info
 
-  wasm32:
+  cross:
     name: "Cross-compile: ${{ matrix.build }}"
 
     strategy:


### PR DESCRIPTION
This fixes `nix build .#client-pkgs`

I had renamed the cross compilation target from made up "shot-names" to just full triple the compiler actually uses. It was just getting in away and confusing.