### PR TITLE
Use new gateway code in cli + rust tests

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -28,14 +28,12 @@ windows:
           - fg
         - ln1:
           - sleep 5 # wait for bitcoind and federation
-          - gateway-cli generate-config 127.0.0.1:8175 'http://127.0.0.1:8175' $FM_CFG_DIR #generate gateway config
-          - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 --plugin=$FM_BIN_DIR/ln_gateway --fedimint-cfg=$FM_CFG_DIR &
+          - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 --plugin=$FM_BIN_DIR/gateway-cln-extension &
           - echo $! >> $FM_PID_FILE
           - fg
         - ln2:
           - sleep 5 # wait for bitcoind and federation
-          - export GW_CLN_EXTENSION_LISTEN_ADDRESS=0.0.0.0:54321
-          - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN2_DIR --addr=127.0.0.1:9001 --plugin=$FM_BIN_DIR/gateway-cln-extension &
+          - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN2_DIR --addr=127.0.0.1:9001
           - echo $! >> $FM_PID_FILE
           - fg
         - gateway:

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -77,13 +77,13 @@ where
     ))
 }
 
-// TODO: Keep in sync with cln-plugin:
+// TODO: upstream these structs to cln-plugin
 // See: https://github.com/ElementsProject/lightning/blob/master/doc/PLUGINS.md#htlc_accepted
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Htlc {
-    pub short_channel_id: u64,
     #[serde(deserialize_with = "as_fedimint_amount")]
     pub amount_msat: Amount,
+    // TODO: use these to validate we can actually redeem the HTLC in time
     pub cltv_expiry: u32,
     pub cltv_expiry_relative: u32,
     pub payment_hash: bitcoin_hashes::sha256::Hash,
@@ -92,7 +92,7 @@ pub struct Htlc {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Onion {
     #[serde(default)]
-    pub short_channel_id: Option<u64>,
+    pub short_channel_id: Option<String>,
     #[serde(deserialize_with = "as_fedimint_amount")]
     pub forward_msat: Amount,
 }

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -38,7 +38,7 @@ use tracing::{debug, error, trace, warn};
 #[derive(Parser)]
 pub struct ClnExtensionOpts {
     /// Gateway CLN extension service listen address
-    #[arg(long = "listen", env = "GW_CLN_EXTENSION_LISTEN_ADDRESS")]
+    #[arg(long = "listen", env = "FM_CLN_EXTENSION_LISTEN_ADDRESS")]
     pub listen: SocketAddr,
 }
 
@@ -153,7 +153,7 @@ impl ClnRpcService {
                     Some(options::Value::String(listen)) => {
                         if listen == "default-dont-use" {
                             panic!(
-                                "Gateway cln extension is missing a listen address configuration. You can set it via GW_CLN_EXTENSION_LISTEN_ADDRESS env variable, or by adding a --listen config option to the cln plugin"
+                                "Gateway cln extension is missing a listen address configuration. You can set it via FM_CLN_EXTENSION_LISTEN_ADDRESS env variable, or by adding a --listen config option to the cln plugin"
                             )
                         } else {
                             SocketAddr::from_str(&listen).expect("invalid listen address")

--- a/gateway/ln-gateway/src/gatewayd/actor.rs
+++ b/gateway/ln-gateway/src/gatewayd/actor.rs
@@ -92,6 +92,7 @@ impl GatewayActor {
             .to_owned()
             .subscribe_htlcs(SubscribeInterceptHtlcsRequest { short_channel_id })
             .await?;
+        info!("Subscribed to HTLCs with {:?}", short_channel_id);
 
         let actor = self.to_owned();
         let lnrpc_copy = self.lnrpc.to_owned();

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -24,6 +24,7 @@ use url::Url;
 
 use crate::fixtures::LightningTest;
 
+#[derive(Clone)]
 pub struct RealLightningTest {
     rpc_gateway: Arc<Mutex<ClnRpc>>,
     rpc_other: Arc<Mutex<ClnRpc>>,

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -515,7 +515,7 @@ async fn lightning_gateway_pays_internal_invoice() -> Result<()> {
         let claim_outpoint = {
             let buy_preimage = gateway
                 .actor
-                .pay_invoice_buy_preimage(gateway.adapter.clone(), contract_id)
+                .pay_invoice_buy_preimage(contract_id)
                 .await
                 .unwrap();
 
@@ -599,11 +599,7 @@ async fn lightning_gateway_pays_outgoing_invoice() -> Result<()> {
             .await
             .unwrap();
 
-        let claim_outpoint = gateway
-            .actor
-            .pay_invoice(gateway.adapter.clone(), contract_id)
-            .await
-            .unwrap();
+        let claim_outpoint = gateway.actor.pay_invoice(contract_id).await.unwrap();
         fed.run_consensus_epochs(2).await; // contract to mint notes, sign notes
 
         gateway
@@ -678,7 +674,7 @@ async fn lightning_gateway_claims_refund_for_internal_invoice() -> Result<()> {
         let response = {
             let buy_preimage = gateway
                 .actor
-                .pay_invoice_buy_preimage(gateway.adapter.clone(), contract_id)
+                .pay_invoice_buy_preimage(contract_id)
                 .await
                 .unwrap();
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -70,11 +70,12 @@ mv $FM_CFG_DIR/server-0/client* $FM_CFG_DIR/
 
 # Generate gateway config
 export FM_GATEWAY_DATA_DIR=$FM_CFG_DIR/gateway
-export FM_GATEWAY_LISTEN_ADDR="127.0.0.1:10000"
-export FM_GATEWAY_API_ADDR="http://127.0.0.1:10000"
+export FM_GATEWAY_LISTEN_ADDR="127.0.0.1:8175"
+export FM_GATEWAY_API_ADDR="http://127.0.0.1:8175"
 export FM_GATEWAY_PASSWORD="theresnosecondbest"
 
-export FM_GATEWAY_LIGHTNING_ADDR="http://localhost:54321"
+export FM_CLN_EXTENSION_LISTEN_ADDRESS="0.0.0.0:8177"
+export FM_GATEWAY_LIGHTNING_ADDR="http://localhost:8177"
 
 mkdir -p $FM_GATEWAY_DATA_DIR
 

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -19,7 +19,7 @@ cmp --silent $FM_CFG_DIR/server-0/config-plaintext.json $FM_CFG_DIR/server-0/con
 ./scripts/pegin.sh # peg in user
 
 export PEG_IN_AMOUNT=99999
-start_gateway
+start_gatewayd
 ./scripts/pegin.sh $PEG_IN_AMOUNT 1 # peg in gateway
 
 #### BEGIN TESTS ####

--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -10,7 +10,7 @@ export PEG_IN_AMOUNT=10000000
 source ./scripts/setup-tests.sh $FM_FED_SIZE
 ./scripts/start-fed.sh
 ./scripts/pegin.sh
-start_gateway
+start_gatewayd
 
 #### BEGIN TESTS ####
 echo "Running with fed size $FM_FED_SIZE"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -88,14 +88,13 @@ function await_cln_block_processing() {
 function kill_fedimint_processes {
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
-  pkill "ln_gateway" 2>/dev/null || true;
+  pkill "gatewayd" 2>/dev/null || true;
   rm -f $FM_PID_FILE
 }
 
-function start_gateway() {
-  $FM_GATEWAY_CLI generate-config '127.0.0.1:8175' 'http://127.0.0.1:8175' $FM_CFG_DIR/gateway # generate gateway config
-  $FM_LN1 -k plugin subcommand=start plugin=$FM_BIN_DIR/ln_gateway fedimint-cfg=$FM_CFG_DIR/gateway &
-  sleep 5 # wait for plugin to start
+function start_gatewayd() {
+  $FM_BIN_DIR/gatewayd &
+  echo "started gatewayd"
   gw_connect_fed
 }
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -89,6 +89,7 @@ function kill_fedimint_processes {
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
   pkill "gatewayd" 2>/dev/null || true;
+  pkill "gateway-cln-extension" 2>/dev/null || true;
   rm -f $FM_PID_FILE
 }
 

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -13,6 +13,5 @@ else
   source ./scripts/setup-tests.sh ""
 fi
 
-
 export FM_TEST_DISABLE_MOCKS=1
 env RUST_BACKTRACE=1 cargo test -p fedimint-tests -- --test-threads=$(($(nproc) * 2)) "$@"

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # Start lightning nodes
-lightningd $LIGHTNING_FLAGS --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 &
+lightningd $LIGHTNING_FLAGS --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN1_DIR --addr=127.0.0.1:9000 --plugin=$FM_BIN_DIR/gateway-cln-extension &
 echo $! >> $FM_PID_FILE
 lightningd $LIGHTNING_FLAGS --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$FM_LN2_DIR --addr=127.0.0.1:9001 &
 echo $! >> $FM_PID_FILE


### PR DESCRIPTION
In place of the existing `ln_gateway`, we integrated `gatewayd` + `gateway_cln_extension` to the existing CLI and rust tests. This implies the new gateway architecture has parity of test coverage as we had on the old gateway, and we can proceed to remove the old gateway at will.

Next comes #1718 