### PR TITLE
feat: free users of `fedimintd`-lib from manually adding std modules

### DIFF
--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -1,14 +1,6 @@
-use fedimint_ln::LightningGen;
-use fedimint_mint::MintGen;
-use fedimint_wallet::WalletGen;
 use fedimintd::distributed_gen::DistributedGen;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    DistributedGen::new()?
-        .attach(WalletGen)
-        .attach(MintGen)
-        .attach(LightningGen)
-        .run()
-        .await
+    DistributedGen::new()?.with_default_modules().run().await
 }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,14 +1,6 @@
-use fedimint_ln::LightningGen;
-use fedimint_mint::MintGen;
-use fedimint_wallet::WalletGen;
 use fedimintd::fedimintd::Fedimintd;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    Fedimintd::new()?
-        .attach(WalletGen)
-        .attach(MintGen)
-        .attach(LightningGen)
-        .run()
-        .await
+    Fedimintd::new()?.with_default_modules().run().await
 }


### PR DESCRIPTION
As a user of `fedimintd`-lib I just want to depend on `fedimintd` and add my own modules.