### PR TITLE
Message buffering to make sending not blocking

### DIFF
--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -46,7 +46,7 @@ use crate::fedimint_core::NumPeers;
 use crate::multiplexed::PeerConnectionMultiplexer;
 use crate::net::connect::{Connector, TlsConfig};
 use crate::net::peers::{DelayCalculator, NetworkConfig};
-use crate::{ReconnectPeerConnections, TlsTcpConnector};
+use crate::{MaybeEpochMessage, ReconnectPeerConnections, TlsTcpConnector};
 
 pub mod api;
 pub mod distributedgen;
@@ -782,7 +782,15 @@ pub async fn connect<T>(
     task_group: &mut TaskGroup,
 ) -> PeerConnections<T>
 where
-    T: std::fmt::Debug + Clone + Serialize + DeserializeOwned + Unpin + Send + Sync + 'static,
+    T: std::fmt::Debug
+        + Clone
+        + Serialize
+        + DeserializeOwned
+        + MaybeEpochMessage
+        + Unpin
+        + Send
+        + Sync
+        + 'static,
 {
     let connector = TlsTcpConnector::new(certs, network.identity).into_dyn();
     let (connections, _) =

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -51,6 +51,15 @@ impl MaybeEpochMessage for HbbftMessage {
     }
 }
 
+// FIXME: implement alternative anti-DoS measure during DKG
+/// We don't care about epochs during DKG, we don't enforce an upper limit on caching messages since
+/// DKG is assumed to only happen under supervision.
+impl MaybeEpochMessage for fedimint_core::config::DkgPeerMsg {
+    fn message_epoch(&self) -> Option<u64> {
+        None
+    }
+}
+
 // TODO remove HBBFT `Batch` from `ConsensusOutcome`
 #[derive(Debug, Clone)]
 pub struct ConsensusOutcomeConversion(pub HbbftConsensusOutcome);

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -39,6 +39,18 @@ pub type HbbftSerdeConsensusOutcome = hbbft::honey_badger::Batch<Vec<SerdeConsen
 pub type HbbftConsensusOutcome = hbbft::honey_badger::Batch<Vec<ConsensusItem>, PeerId>;
 pub type HbbftMessage = hbbft::honey_badger::Message<PeerId>;
 
+/// A message sent by a consensus protocol that might belong to a specific epoch
+pub trait MaybeEpochMessage {
+    /// Return the epoch the message belongs to, if any
+    fn message_epoch(&self) -> Option<u64>;
+}
+
+impl MaybeEpochMessage for HbbftMessage {
+    fn message_epoch(&self) -> Option<u64> {
+        Some(self.epoch())
+    }
+}
+
 // TODO remove HBBFT `Batch` from `ConsensusOutcome`
 #[derive(Debug, Clone)]
 pub struct ConsensusOutcomeConversion(pub HbbftConsensusOutcome);

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -52,8 +52,8 @@ impl MaybeEpochMessage for HbbftMessage {
 }
 
 // FIXME: implement alternative anti-DoS measure during DKG
-/// We don't care about epochs during DKG, we don't enforce an upper limit on caching messages since
-/// DKG is assumed to only happen under supervision.
+/// We don't care about epochs during DKG, we don't enforce an upper limit on
+/// caching messages since DKG is assumed to only happen under supervision.
 impl MaybeEpochMessage for fedimint_core::config::DkgPeerMsg {
     fn message_epoch(&self) -> Option<u64> {
         None

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -29,8 +29,8 @@ use tracing::{error, info};
 
 use crate::config::api::{ConfigGenApi, ConfigGenSettings};
 use crate::config::io::PLAINTEXT_PASSWORD;
-use crate::consensus::server::ConsensusServer;
-use crate::consensus::HbbftConsensusOutcome;
+use crate::consensus::server::{ConsensusServer, EpochMessage};
+use crate::consensus::{HbbftConsensusOutcome, MaybeEpochMessage};
 use crate::net::api::RpcHandlerCtx;
 use crate::net::connect::TlsTcpConnector;
 use crate::net::peers::ReconnectPeerConnections;
@@ -64,6 +64,15 @@ pub trait HasApiContext<State> {
         request: &ApiRequestErased,
         id: Option<ModuleInstanceId>,
     ) -> (&State, ApiEndpointContext<'_>);
+}
+
+impl MaybeEpochMessage for EpochMessage {
+    fn message_epoch(&self) -> Option<u64> {
+        match self {
+            EpochMessage::Continue(msg) => msg.message_epoch(),
+            EpochMessage::RejoinRequest(_) => None,
+        }
+    }
 }
 
 /// Main server for running Fedimint consensus and APIs

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -14,7 +14,7 @@ use tokio::sync::Mutex;
 use tokio::time::sleep;
 use tracing::{debug, warn};
 
-use crate::PeerId;
+use crate::{MaybeEpochMessage, PeerId};
 
 /// TODO: Use proper ModuleId after modularization is complete
 pub type ModuleId = String;
@@ -31,6 +31,15 @@ pub const MAX_PEER_OUT_OF_ORDER_MESSAGES: u64 = 10000;
 pub struct ModuleMultiplexed<MuxKey, Msg> {
     pub key: MuxKey,
     pub msg: Msg,
+}
+
+impl<MuxKey, Msg> MaybeEpochMessage for ModuleMultiplexed<MuxKey, Msg>
+where
+    Msg: MaybeEpochMessage,
+{
+    fn message_epoch(&self) -> Option<u64> {
+        self.msg.message_epoch()
+    }
 }
 
 struct ModuleMultiplexerOutOfOrder<MuxKey, Msg> {

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -34,8 +34,13 @@ use url::Url;
 use crate::net::connect::{AnyConnector, SharedAnyConnector};
 use crate::net::framed::AnyFramedTransport;
 use crate::net::queue::{MessageId, MessageQueue, UniqueMessage};
+use crate::MaybeEpochMessage;
 
+/// How many unsent messages will be buffered before a connection is re-established
 const MAX_UNSENT_MESSAGES: usize = 4096;
+
+/// Messages for how many epochs the resend buffer will hold before the session is reset
+const MAX_BUFFERED_EPOCHS: u64 = 100;
 
 /// Owned [`Connector`](crate::net::connect::Connector) trait object used by
 /// [`ReconnectPeerConnections`]
@@ -213,7 +218,14 @@ enum PeerConnectionState<M> {
 
 impl<T: 'static> ReconnectPeerConnections<T>
 where
-    T: std::fmt::Debug + Clone + Serialize + DeserializeOwned + Unpin + Send + Sync,
+    T: std::fmt::Debug
+        + Clone
+        + Serialize
+        + DeserializeOwned
+        + MaybeEpochMessage
+        + Unpin
+        + Send
+        + Sync,
 {
     /// Creates a new `ReconnectPeerConnections` connection manager from a
     /// network config and a [`Connector`](crate::net::connect::Connector).
@@ -334,7 +346,15 @@ impl PeerSlice for Target<PeerId> {
 #[async_trait]
 impl<T> IPeerConnections<T> for ReconnectPeerConnections<T>
 where
-    T: std::fmt::Debug + Serialize + DeserializeOwned + Clone + Unpin + Send + Sync + 'static,
+    T: std::fmt::Debug
+        + Serialize
+        + DeserializeOwned
+        + Clone
+        + MaybeEpochMessage
+        + Unpin
+        + Send
+        + Sync
+        + 'static,
 {
     #[must_use]
     async fn send(&mut self, peers: &[PeerId], msg: T) -> Cancellable<()> {
@@ -373,7 +393,7 @@ where
 
 impl<M> PeerConnectionStateMachine<M>
 where
-    M: Debug + Clone,
+    M: Debug + Clone + MaybeEpochMessage,
 {
     async fn run(mut self, task_handle: &TaskHandle) {
         let peer = self.common.peer;
@@ -419,7 +439,7 @@ where
 
 impl<M> CommonPeerConnectionState<M>
 where
-    M: Debug + Clone,
+    M: Debug + Clone + MaybeEpochMessage,
 {
     async fn state_transition_connected(
         &mut self,
@@ -622,9 +642,16 @@ where
     ) -> Option<PeerConnectionState<M>> {
         Some(tokio::select! {
             maybe_msg = self.outgoing.recv() => {
+                let buffer_ready = self.message_buffer.buffered_epochs() < MAX_BUFFERED_EPOCHS;
                 match maybe_msg {
-                    Some(msg) => {
+                    Some(msg)if buffer_ready  => {
                         self.message_buffer.queue_message(msg);
+                        PeerConnectionState::Disconnected(disconnected)
+                    }
+                    Some(_) => {
+                        // FIXME: only begin buffering again once we have a new connection
+                        // Drop buffer if it gets too big, now the peer will have to rejoin consensus
+                        self.message_buffer = Default::default();
                         PeerConnectionState::Disconnected(disconnected)
                     }
                     None => {
@@ -688,7 +715,7 @@ where
 
 impl<M> PeerConnection<M>
 where
-    M: Debug + Clone + Send + Sync + 'static,
+    M: Debug + Clone + MaybeEpochMessage + Send + Sync + 'static,
 {
     fn new(
         id: PeerId,
@@ -779,11 +806,13 @@ mod tests {
     use fedimint_core::task::TaskGroup;
     use fedimint_core::PeerId;
     use futures::Future;
+    use serde::{Deserialize, Serialize};
 
     use super::DelayCalculator;
     use crate::net::connect::mock::{MockNetwork, StreamReliability};
     use crate::net::connect::Connector;
     use crate::net::peers::{IPeerConnections, NetworkConfig, ReconnectPeerConnections};
+    use crate::MaybeEpochMessage;
 
     async fn timeout<F, T>(f: F) -> Option<T>
     where
@@ -794,6 +823,15 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_connect() {
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        struct TestMessage(u64);
+
+        impl MaybeEpochMessage for TestMessage {
+            fn message_epoch(&self) -> Option<u64> {
+                None
+            }
+        }
+
         let task_group = TaskGroup::new();
 
         {
@@ -823,7 +861,7 @@ mod tests {
                 let connect = net_ref
                     .connector(cfg.identity, StreamReliability::MILDLY_UNRELIABLE)
                     .into_dyn();
-                ReconnectPeerConnections::<u64>::new(
+                ReconnectPeerConnections::<TestMessage>::new(
                     cfg,
                     DelayCalculator::TEST_DEFAULT,
                     connect,
@@ -837,15 +875,21 @@ mod tests {
             let (mut peers_b, peer_status_client_b) =
                 build_peers("127.0.0.1:2000", 2, task_group.clone()).await;
 
-            peers_a.send(&[PeerId::from(2)], 42).await.unwrap();
+            peers_a
+                .send(&[PeerId::from(2)], TestMessage(42))
+                .await
+                .unwrap();
             let recv = timeout(peers_b.receive()).await.unwrap().unwrap();
             assert_eq!(recv.0, PeerId::from(1));
-            assert_eq!(recv.1, 42);
+            assert_eq!(recv.1 .0, 42);
             let status = peer_status_client_a.get_all_status().await;
             assert_eq!(status.len(), 2);
             assert!(status.values().all(|s| s.is_ok()));
 
-            peers_a.send(&[PeerId::from(3)], 21).await.unwrap();
+            peers_a
+                .send(&[PeerId::from(3)], TestMessage(21))
+                .await
+                .unwrap();
             let status = peer_status_client_b.get_all_status().await;
             assert_eq!(status.len(), 2);
             assert!(status.values().all(|s| s.is_ok()));
@@ -854,7 +898,7 @@ mod tests {
                 build_peers("127.0.0.1:3000", 3, task_group.clone()).await;
             let recv = timeout(peers_c.receive()).await.unwrap().unwrap();
             assert_eq!(recv.0, PeerId::from(1));
-            assert_eq!(recv.1, 21);
+            assert_eq!(recv.1 .0, 21);
             let status = peer_status_client_c.get_all_status().await;
             assert_eq!(status.len(), 2);
             assert!(status.values().all(|s| s.is_ok()));

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -36,10 +36,12 @@ use crate::net::framed::AnyFramedTransport;
 use crate::net::queue::{MessageId, MessageQueue, UniqueMessage};
 use crate::MaybeEpochMessage;
 
-/// How many unsent messages will be buffered before a connection is re-established
+/// How many unsent messages will be buffered before a connection is
+/// re-established
 const MAX_UNSENT_MESSAGES: usize = 4096;
 
-/// Messages for how many epochs the resend buffer will hold before the session is reset
+/// Messages for how many epochs the resend buffer will hold before the session
+/// is reset
 const MAX_BUFFERED_EPOCHS: u64 = 100;
 
 /// Owned [`Connector`](crate::net::connect::Connector) trait object used by
@@ -176,11 +178,11 @@ impl DelayCalculator {
 
 /// IO task state that is required no matter if there is a connection
 struct CommonPeerConnectionState<M> {
-    /// Buffer containing both to-be-sent messages and messages that were already sent but not
-    /// acknowledged yet.
+    /// Buffer containing both to-be-sent messages and messages that were
+    /// already sent but not acknowledged yet.
     message_buffer: MessageQueue<M>,
-    /// Some if the connection was just re-established and we are still sending old messages from
-    /// the buffer None otherwise.
+    /// Some if the connection was just re-established and we are still sending
+    /// old messages from the buffer None otherwise.
     resend_catch_up_goal: Option<MessageId>,
     /// Send side of the incoming message channel from io task to main task
     incoming: Sender<M>,
@@ -191,13 +193,14 @@ struct CommonPeerConnectionState<M> {
     /// The peer's address we try to connect to
     peer_address: Url,
     delay_calculator: DelayCalculator,
-    /// Network connector to establish new connections with. The connector determines what kind of
-    /// underlying transport is used (plain TCP, TLS, Tor)
+    /// Network connector to establish new connections with. The connector
+    /// determines what kind of underlying transport is used (plain TCP,
+    /// TLS, Tor)
     connect: SharedAnyConnector<PeerMessage<M>>,
     /// Receiver that incoming connections from this io tasks' peer are sent to
     incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,
-    /// Message id of the last received message that will be acknowledged in the next message we
-    /// send
+    /// Message id of the last received message that will be acknowledged in the
+    /// next message we send
     last_received: Option<MessageId>,
     status_query_receiver: PeerStatusChannelReceiver,
 }
@@ -207,8 +210,8 @@ struct DisconnectedPeerConnectionState {
     reconnect_at: Instant,
     /// Number used to calculate time till next reconnect attempt
     failed_reconnect_counter: u64,
-    /// If a connection was dropped because of a full `message_buffer` we do not need to buffer any
-    /// messages till there is a new TCP connection.
+    /// If a connection was dropped because of a full `message_buffer` we do not
+    /// need to buffer any messages till there is a new TCP connection.
     session_active: bool,
 }
 

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -734,7 +734,7 @@ where
         status_query_receiver: PeerStatusChannelReceiver,
         task_group: &mut TaskGroup,
     ) -> PeerConnection<M> {
-        let (outgoing_sender, outgoing_receiver) = tokio::sync::mpsc::channel::<M>(1024);
+        let (outgoing_sender, outgoing_receiver) = tokio::sync::mpsc::channel::<M>(1);
         let (incoming_sender, incoming_receiver) = tokio::sync::mpsc::channel::<M>(1024);
 
         futures::executor::block_on(task_group.spawn(

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -35,6 +35,8 @@ use crate::net::connect::{AnyConnector, SharedAnyConnector};
 use crate::net::framed::AnyFramedTransport;
 use crate::net::queue::{MessageId, MessageQueue, UniqueMessage};
 
+const MAX_UNSENT_MESSAGES: usize = 4096;
+
 /// Owned [`Connector`](crate::net::connect::Connector) trait object used by
 /// [`ReconnectPeerConnections`]
 pub type PeerConnector<M> = AnyConnector<PeerMessage<M>>;
@@ -445,10 +447,17 @@ where
 
         Some(tokio::select! {
             maybe_msg = self.outgoing.recv() => {
+                // If we aren't resending right after a reconnect we want to enforce a maximum
+                // buffer size and otherwise disconnect and try again with a new connection
+                let is_buffer_ready = self.resend_catch_up_goal.is_some() ||
+                    self.message_buffer.unsent_len() < MAX_UNSENT_MESSAGES;
                 match maybe_msg {
-                    Some(msg) => {
+                    Some(msg) if is_buffer_ready => {
                         self.message_buffer.queue_message(msg);
                         PeerConnectionState::Connected(connected)
+                    },
+                    Some(_) => {
+                        self.disconnect_err(anyhow::anyhow!("Buffer too full, disconnecting"), 0)
                     },
                     None => {
                         debug!(target: LOG_NET_PEER, "Exiting peer connection IO task - parent disconnected");
@@ -460,6 +469,13 @@ where
                 match buffer_send_res {
                     Ok(msg_id) => {
                         self.message_buffer.mark_sent(msg_id);
+
+                        // If we are resending messages we don't enforce the maximum send buffer
+                        // size. Once we are caught up we want to start again. Here we set the catch
+                        // up goal to None, which means we are done resending.
+                        if self.resend_catch_up_goal.map(|goal| goal <= msg_id).unwrap_or(false) {
+                            self.resend_catch_up_goal = None;
+                        }
                         PeerConnectionState::Connected(connected)
                     },
                     Err(e) => {

--- a/fedimint-server/src/net/queue.rs
+++ b/fedimint-server/src/net/queue.rs
@@ -133,6 +133,11 @@ where
             Some((oldest, newest))
         }
     }
+
+    /// Return the number of unsent messages
+    pub fn unsent_len(&self) -> usize {
+        self.unsent_messages as usize
+    }
 }
 
 #[cfg(test)]

--- a/fedimint-server/src/net/queue.rs
+++ b/fedimint-server/src/net/queue.rs
@@ -3,10 +3,31 @@ use std::collections::VecDeque;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
 
+/// Message queue to manage unsent and unacknowledged messages
+///
+/// # Lifetime of a message
+/// 1. A message is inserted into the queue using `queue_message`. It receives an auto-incrementing
+///    message id.
+/// 2. Unsent messages are retrieved using `next_send_message`.
+/// 3. If sending a message succeeds `mark_sent` is called after which the next call to
+///    `next_send_message` will return the next message to be sent. The message remains in the
+///    buffer though till an ACK is received.
+///
+///    The separation of step 2+3 is necessary to make the future that attempts to send the message
+///    cancellation safe. Marking the message as sent has to happen right after the future writing
+///    it to the destination returns, without an await point in between.
+/// 4. Once an acknowledgement is received for a message, `ack` is called with its message id. All
+///    messages with a lower or equal id will be removed from the buffer.
+/// 5. If a reconnect happens all messages that have not been acknowledged have to be resent. In
+///    that case `resend_all` has to be called.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct MessageQueue<M> {
+    /// Messages that were scheduled to be sent (sent and unsent) and not acknowledged yet
     pub(super) queue: VecDeque<UniqueMessage<M>>,
-    pub(super) next_id: MessageId,
+    /// Id for the next message to be inserted into the queue
+    next_id: MessageId,
+    /// How many of the messages at the tip of the queue weren't sent out yet
+    unsent_messages: u64,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
@@ -29,6 +50,7 @@ impl<M> Default for MessageQueue<M> {
         MessageQueue {
             queue: Default::default(),
             next_id: MessageId(1),
+            unsent_messages: 0,
         }
     }
 }
@@ -37,18 +59,18 @@ impl<M> MessageQueue<M>
 where
     M: Clone,
 {
-    pub fn push(&mut self, msg: M) -> UniqueMessage<M> {
-        let id_msg = UniqueMessage {
+    /// Queue message for being sent over the wire
+    pub fn queue_message(&mut self, msg: M) {
+        self.queue.push_back(UniqueMessage {
             id: self.next_id,
             msg,
-        };
-
-        self.queue.push_back(id_msg.clone());
+        });
+        trace!(id = ?self.next_id, "Queueing outgoing message");
         self.next_id = self.next_id.increment();
-
-        id_msg
+        self.unsent_messages += 1;
     }
 
+    /// Remove all messages older than `msg_id` from the buffer since they were received by our peer
     pub fn ack(&mut self, msg_id: MessageId) {
         debug!("Received ACK for {:?}", msg_id);
         while self
@@ -60,49 +82,111 @@ where
             let msg = self.queue.pop_front().expect("Checked in while head");
             trace!("Removing message {:?} from resend buffer", msg.id);
         }
+
+        // If we got an ACK from the future we remove all of them from the queue even if we haven't
+        // sent them yet (can happen on reconnect). In that case we need to adjust the unsent
+        // messages field so we never try to send messages not in the buffer anymore
+        let queued_messages = self.queue.len() as u64;
+        if self.unsent_messages > queued_messages {
+            self.unsent_messages = queued_messages;
+        }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &UniqueMessage<M>> {
-        self.queue.iter()
+    /// Fetch the next message to be sent from the queue
+    pub fn next_send_message(&self) -> Option<&UniqueMessage<M>> {
+        if self.unsent_messages > 0 {
+            let idx = self.queue.len() - (self.unsent_messages as usize);
+            // If we always properly update unsent_messages this can never fail
+            let maybe_message = self
+                .queue
+                .get(idx)
+                .expect("We tried to send a message no longer in the buffer");
+
+            Some(maybe_message)
+        } else {
+            None
+        }
+    }
+
+    /// Marks the message `msg_id` as sent over the wire. This does not aknowledge the receipt by
+    /// our peer and thus keeps the message in the buffer in case it needs to be re-sent.
+    pub fn mark_sent(&mut self, msg_id: MessageId) {
+        assert_ne!(self.unsent_messages, 0, "There are no messages to be sent!");
+        assert_eq!(
+            msg_id.0,
+            self.next_id.0 - self.unsent_messages,
+            "The sent message is not the expected one!"
+        );
+        self.unsent_messages -= 1;
+    }
+
+    /// Mark all messages as unsent to attempt re-sending and return the oldest and newest messages
+    /// to be sent.
+    pub fn resend_all(&mut self) -> Option<(MessageId, MessageId)> {
+        self.unsent_messages = self.queue.len() as u64;
+
+        if self.queue.is_empty() {
+            None
+        } else {
+            let oldest = self.queue.front().expect("Queue not empty").id;
+            let newest = self.queue.back().expect("Queue not empty").id;
+            Some((oldest, newest))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::net::queue::{MessageId, MessageQueue};
+    use crate::net::queue::{MessageId, MessageQueue, UniqueMessage};
 
     #[test]
     fn test_queue() {
         let mut queue = MessageQueue::default();
 
+        // Test queuing unsent
         for i in 0u64..10 {
-            let umsg = queue.push(42 * i);
-            assert_eq!(umsg.msg, 42 * i);
-            assert_eq!(umsg.id.0, i + 1);
+            queue.queue_message(42 * i);
+            assert_eq!(queue.next_id, MessageId(i + 2));
+            assert_eq!(queue.unsent_messages, i + 1);
+            assert_eq!(
+                queue.next_send_message().unwrap(),
+                &UniqueMessage {
+                    id: MessageId(1),
+                    msg: 0
+                }
+            );
         }
 
-        fn assert_contains(queue: &MessageQueue<u64>, iter: impl Iterator<Item = u64>) {
-            let mut queue_iter = queue.iter();
-
-            for i in iter {
-                let umsg = queue_iter.next().unwrap();
-                assert_eq!(umsg.msg, 42 * i);
-                assert_eq!(umsg.id.0, i + 1);
+        // Test sending
+        queue.mark_sent(MessageId(1));
+        assert_eq!(
+            queue.next_send_message().unwrap(),
+            &UniqueMessage {
+                id: MessageId(2),
+                msg: 42
             }
+        );
+        queue.mark_sent(MessageId(2));
+        assert_eq!(
+            queue.next_send_message().unwrap(),
+            &UniqueMessage {
+                id: MessageId(3),
+                msg: 84
+            }
+        );
 
-            assert_eq!(queue_iter.next(), None);
-        }
-
-        assert_eq!(queue.iter().count(), 10);
-        assert_contains(&queue, 0..10);
-
+        // Test ACK
         queue.ack(MessageId(1));
-        assert_contains(&queue, 1..10);
+        assert_eq!(queue.queue.len(), 9);
 
-        queue.ack(MessageId(4));
-        assert_contains(&queue, 4..10);
-
-        queue.ack(MessageId(2)); // TODO: should that throw an error?
-        assert_contains(&queue, 4..10);
+        // Test resend
+        queue.resend_all();
+        assert_eq!(
+            queue.next_send_message().unwrap(),
+            &UniqueMessage {
+                id: MessageId(2),
+                msg: 42
+            }
+        );
     }
 }

--- a/fedimint-server/src/net/queue.rs
+++ b/fedimint-server/src/net/queue.rs
@@ -75,8 +75,8 @@ where
         self.unsent_messages += 1;
     }
 
-    /// Remove all messages older than `msg_id` from the buffer since they were
-    /// received by our peer
+    /// Remove all messages older than (meaning less or equal than) `msg_id`
+    /// from the buffer since they were received by our peer
     pub fn ack(&mut self, msg_id: MessageId) {
         debug!("Received ACK for {:?}", msg_id);
         while self
@@ -165,6 +165,9 @@ impl<M: MaybeEpochMessage> MessageQueue<M> {
         match (maybe_oldest, maybe_newest) {
             (Some(oldest_epoch), Some(newest_epoch)) => {
                 assert!(oldest_epoch <= newest_epoch);
+                // number of epochs includes both, the oldest and the newest,
+                // hence we must add one after the subtraction.
+                // e.g.: 10 - 8 + 1 = 3  (includes epochs 8, 9, 10)
                 newest_epoch - oldest_epoch + 1
             }
             _ => 0,


### PR DESCRIPTION
This PR picks up the work of @elsirion  in #1149

Original PR description: 

> Previously the network stack could block when trying to send too many messages to a TCP connection that could not send them out quickly enough. In theory that could lead to deadlocks, in practice it was hidden by the channels sending messages between main and io threads being large.
> 
> This PR makes sending messages non-blocking by buffering them inside the io thread. To avoid DoS two two limits are introduced:
> 
> 1. Maximum number of unsent messages: if a connection can't send messages quickly enough and messages pile up it gets closed and re-established, hopefully this helps.
> 
> 2. Maximum queued epochs: while there is no connection we still queue messages in the hope it gets re-established quickly. If there are messages from too many epochs in the buffer we drop it and won't buffer anything till there is a new connection.
> 
> 
> TODO: 
> * [x]  Implement message buffer
> * [x]  Drop connections with overfull send buffers
> * [x]  Drop sessions with overfull resend buffers
> * [x]  Keep them dropped till reconnect
> * [ ]  Tests

It's rebased and I added a another case for the message queuing test. (I was also wondering if it is worth to split up that one test into multiple smaller tests, though, they would all test the message queuing functionality. thoughts?)

It's not done quite yet. I want to take another look at what we can test here as this was the last open ToDo but wanted to put it here as WIP anyway.

