### PR TITLE
feat: expose fedimintd building & dev shell as a nix library

### DIFF
--- a/fedimintd/src/bin/distributedgen.rs
+++ b/fedimintd/src/bin/distributedgen.rs
@@ -1,14 +1,6 @@
-use fedimint_ln::LightningGen;
-use fedimint_mint::MintGen;
-use fedimint_wallet::WalletGen;
 use fedimintd::distributed_gen::DistributedGen;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    DistributedGen::new()?
-        .attach(WalletGen)
-        .attach(MintGen)
-        .attach(LightningGen)
-        .run()
-        .await
+    DistributedGen::new()?.with_default_modules().run().await
 }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,14 +1,6 @@
-use fedimint_ln::LightningGen;
-use fedimint_mint::MintGen;
-use fedimint_wallet::WalletGen;
 use fedimintd::fedimintd::Fedimintd;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    Fedimintd::new()?
-        .attach(WalletGen)
-        .attach(MintGen)
-        .attach(LightningGen)
-        .run()
-        .await
+    Fedimintd::new()?.with_default_modules().run().await
 }


### PR DESCRIPTION
On top of #1739 #1720 

I'm trying to make building a `fedimintd` with custom modules as simple as possible.

The corresponding downstream `flake.nix`:

```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
    flake-utils.url = "github:numtide/flake-utils";
    flake-compat = {
      url = "github:edolstra/flake-compat";
      flake = false;
    };
    fedimint = {
      url = "github:fedimint/fedimint?rev=...";
    };
    crane.url = "github:ipetkov/crane?ref=v0.11.3";
    crane.inputs.nixpkgs.follows = "nixpkgs";
  };

  outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils, flake-compat, fedimint, crane }:
    flake-utils.lib.eachDefaultSystem (system:
      let
        pkgs = import nixpkgs {
          inherit system;
        };
        fmLib = fedimint.lib.${system};
        fenix = fedimint.inputs.fenix;
        commonArgsBase = fmLib.commonArgsBase;

        fenixChannel = fenix.packages.${system}.stable;

        fenixToolchain = (fenixChannel.withComponents [
          "rustc"
          "cargo"
          "clippy"
          "rust-analysis"
          "rust-src"
          "llvm-tools-preview"
        ]);

        craneLib = crane.lib.${system}.overrideToolchain fenixToolchain;

        fedimintd-fork = craneLib.buildPackage (commonArgsBase // {
          pname = "fedimintd-fork";
          src = ./.;
          cargoExtraArgs = "--package fedimintd-fork";
          doCheck = false;
        });
      in
      {
        packages =
          {
            inherit fedimintd-fork;
          };
        devShells = fmLib.devShells;
      });

}
```

but again - probably just a good start and improvement will be needed.