### PR TITLE
chore: re-export `fedimint_core` from `fedimint_server`

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(where_clauses_object_safety)] // https://github.com/dtolnay/async-trait/issues/228
-extern crate fedimint_core;
+/// Re-export for dependencies so they don't have to import  separately
+pub extern crate fedimint_core;
 
 use std::cmp::min;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};


### PR DESCRIPTION
This is to save module developers having to import fedimint deps multiple times.