### PR TITLE
refactor: split `impl_db_record` into two macros

### DIFF
--- a/client/client-lib/src/db.rs
+++ b/client/client-lib/src/db.rs
@@ -1,5 +1,5 @@
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::impl_db_prefix_const;
+use fedimint_core::impl_db_record;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
@@ -20,7 +20,7 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ClientSecretKey;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ClientSecretKey,
     value = ClientSecret,
     db_prefix = DbKeyPrefix::ClientSecret

--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -1,5 +1,5 @@
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::impl_db_prefix_const;
+use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::Serialize;
 use strum_macros::EnumIter;
 
@@ -31,10 +31,13 @@ pub struct OutgoingPaymentKey(pub ContractId);
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutgoingPaymentKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = OutgoingPaymentKey,
     value = OutgoingContractData,
     db_prefix = DbKeyPrefix::OutgoingPayment,
+);
+impl_db_lookup!(
+    key = OutgoingPaymentKey,
     query_prefix = OutgoingPaymentKeyPrefix
 );
 
@@ -44,10 +47,13 @@ pub struct OutgoingPaymentClaimKey(pub ContractId);
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutgoingPaymentClaimKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = OutgoingPaymentClaimKey,
     value = (),
     db_prefix = DbKeyPrefix::OutgoingPaymentClaim,
+);
+impl_db_lookup!(
+    key = OutgoingPaymentClaimKey,
     query_prefix = OutgoingPaymentClaimKeyPrefix
 );
 
@@ -57,10 +63,13 @@ pub struct OutgoingContractAccountKey(pub ContractId);
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutgoingContractAccountKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = OutgoingContractAccountKey,
     value = OutgoingContractAccount,
     db_prefix = DbKeyPrefix::OutgoingContractAccount,
+);
+impl_db_lookup!(
+    key = OutgoingContractAccountKey,
     query_prefix = OutgoingContractAccountKeyPrefix
 );
 
@@ -70,10 +79,13 @@ pub struct ConfirmedInvoiceKey(pub ContractId);
 #[derive(Debug, Encodable, Decodable)]
 pub struct ConfirmedInvoiceKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ConfirmedInvoiceKey,
     value = ConfirmedInvoice,
     db_prefix = DbKeyPrefix::ConfirmedInvoice,
+);
+impl_db_lookup!(
+    key = ConfirmedInvoiceKey,
     query_prefix = ConfirmedInvoiceKeyPrefix
 );
 
@@ -83,9 +95,12 @@ pub struct LightningGatewayKey;
 #[derive(Debug, Encodable, Decodable)]
 pub struct LightningGatewayKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = LightningGatewayKey,
     value = LightningGateway,
     db_prefix = DbKeyPrefix::LightningGateway,
+);
+impl_db_lookup!(
+    key = LightningGatewayKey,
     query_prefix = LightningGatewayKeyPrefix
 );

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -1,5 +1,5 @@
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::{impl_db_prefix_const, Amount, OutPoint, TieredMulti, TransactionId};
+use fedimint_core::{impl_db_lookup, impl_db_record, Amount, OutPoint, TieredMulti, TransactionId};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
@@ -31,12 +31,12 @@ pub struct NoteKey {
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct NoteKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = NoteKey,
     value = SpendableNote,
     db_prefix = DbKeyPrefix::Note,
-    query_prefix = NoteKeyPrefix
 );
+impl_db_lookup!(key = NoteKey, query_prefix = NoteKeyPrefix);
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct PendingNotesKey(pub TransactionId);
@@ -44,12 +44,12 @@ pub struct PendingNotesKey(pub TransactionId);
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct PendingNotesKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = PendingNotesKey,
     value = TieredMulti<SpendableNote>,
     db_prefix = DbKeyPrefix::PendingNotes,
-    query_prefix = PendingNotesKeyPrefix
 );
+impl_db_lookup!(key = PendingNotesKey, query_prefix = PendingNotesKeyPrefix);
 
 #[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct OutputFinalizationKey(pub OutPoint);
@@ -57,10 +57,13 @@ pub struct OutputFinalizationKey(pub OutPoint);
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct OutputFinalizationKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = OutputFinalizationKey,
     value = NoteIssuanceRequests,
     db_prefix = DbKeyPrefix::OutputFinalizationData,
+);
+impl_db_lookup!(
+    key = OutputFinalizationKey,
     query_prefix = OutputFinalizationKeyPrefix
 );
 
@@ -70,14 +73,17 @@ pub struct NextECashNoteIndexKey(pub Amount);
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct NextECashNoteIndexKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = NextECashNoteIndexKey,
     value = u64,
     db_prefix = DbKeyPrefix::NextECashNoteIndex,
+);
+impl_db_lookup!(
+    key = NextECashNoteIndexKey,
     query_prefix = NextECashNoteIndexKeyPrefix
 );
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct NotesPerDenominationKey;
 
-impl_db_prefix_const!(key = NotesPerDenominationKey, value = u16, db_prefix = 0);
+impl_db_record!(key = NotesPerDenominationKey, value = u16, db_prefix = 0);

--- a/client/client-lib/src/wallet/db.rs
+++ b/client/client-lib/src/wallet/db.rs
@@ -1,6 +1,6 @@
 use bitcoin::Script;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::impl_db_prefix_const;
+use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::Serialize;
 use strum_macros::EnumIter;
 
@@ -24,9 +24,9 @@ pub struct PegInKey {
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct PegInPrefixKey;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = PegInKey,
     value = [u8; 32],
     db_prefix = DbKeyPrefix::PegIn,
-    query_prefix = PegInPrefixKey
 );
+impl_db_lookup!(key = PegInKey, query_prefix = PegInPrefixKey);

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -860,7 +860,7 @@ where
 ///     MyKey = 0x50,
 /// }
 ///
-/// impl_db_prefix_const!(key = MyKey, value = MyValue, db_prefix = DbKeyPrefix::MyKey);
+/// impl_db_record!(key = MyKey, value = MyValue, db_prefix = DbKeyPrefix::MyKey);
 /// ```
 ///
 /// Use the required parameters and specify one `query_prefix`
@@ -884,22 +884,24 @@ where
 /// #[derive(Debug, Encodable, Decodable)]
 /// struct MyKeyPrefix;
 ///
-/// impl_db_prefix_const!(
-///     key = MyKey,
-///     value = MyValue,
-///     db_prefix = DbKeyPrefix::MyKey,
-///     query_prefix = MyKeyPrefix
-/// );
+/// impl_db_record!(key = MyKey, value = MyValue, db_prefix = DbKeyPrefix::MyKey,);
+///
+/// impl_db_lookup!(key = MyKey, query_prefix = MyKeyPrefix);
 /// ```
 #[macro_export]
-macro_rules! impl_db_prefix_const {
-    (key = $key:ty, value = $val:ty, db_prefix = $db_prefix:expr $(, query_prefix = $query_prefix:ty)* $(,)?) => {
+macro_rules! impl_db_record {
+    (key = $key:ty, value = $val:ty, db_prefix = $db_prefix:expr $(,)?) => {
         impl $crate::db::DatabaseRecord for $key {
             const DB_PREFIX: u8 = $db_prefix as u8;
             type Key = Self;
             type Value = $val;
         }
+    };
+}
 
+#[macro_export]
+macro_rules! impl_db_lookup{
+    (key = $key:ty $(, query_prefix = $query_prefix:ty)* $(,)?) => {
         $(
             impl $crate::db::DatabaseLookup for $query_prefix {
                 type Record = $key;
@@ -915,7 +917,7 @@ pub struct DatabaseVersionKey;
 #[derive(Debug, Encodable, Decodable, Serialize, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct DatabaseVersion(pub u64);
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = DatabaseVersionKey,
     value = DatabaseVersion,
     db_prefix = DbKeyPrefix::DatabaseVersion
@@ -1106,12 +1108,12 @@ mod tests {
     #[derive(Debug, Encodable, Decodable)]
     struct DbPrefixTestPrefix;
 
-    impl_db_prefix_const!(
+    impl_db_record!(
         key = TestKey,
         value = TestVal,
-        db_prefix = TestDbKeyPrefix::Test,
-        query_prefix = DbPrefixTestPrefix
+        db_prefix = TestDbKeyPrefix::Test
     );
+    impl_db_lookup!(key = TestKey, query_prefix = DbPrefixTestPrefix);
 
     #[derive(Debug, Encodable, Decodable)]
     struct TestKeyV0(u64, u64);
@@ -1119,12 +1121,12 @@ mod tests {
     #[derive(Debug, Encodable, Decodable)]
     struct DbPrefixTestPrefixV0;
 
-    impl_db_prefix_const!(
+    impl_db_record!(
         key = TestKeyV0,
         value = TestVal,
         db_prefix = TestDbKeyPrefix::Test,
-        query_prefix = DbPrefixTestPrefixV0
     );
+    impl_db_lookup!(key = TestKeyV0, query_prefix = DbPrefixTestPrefixV0);
 
     #[derive(Debug, Encodable, Decodable)]
     struct AltTestKey(u64);
@@ -1132,12 +1134,12 @@ mod tests {
     #[derive(Debug, Encodable, Decodable)]
     struct AltDbPrefixTestPrefix;
 
-    impl_db_prefix_const!(
+    impl_db_record!(
         key = AltTestKey,
         value = TestVal,
         db_prefix = TestDbKeyPrefix::AltTest,
-        query_prefix = AltDbPrefixTestPrefix
     );
+    impl_db_lookup!(key = AltTestKey, query_prefix = AltDbPrefixTestPrefix);
 
     #[derive(Debug, Encodable, Decodable)]
     struct PercentTestKey(u64);
@@ -1145,13 +1147,13 @@ mod tests {
     #[derive(Debug, Encodable, Decodable)]
     struct PercentPrefixTestPrefix;
 
-    impl_db_prefix_const!(
+    impl_db_record!(
         key = PercentTestKey,
         value = TestVal,
         db_prefix = TestDbKeyPrefix::PercentTestKey,
-        query_prefix = PercentPrefixTestPrefix
     );
 
+    impl_db_lookup!(key = PercentTestKey, query_prefix = PercentPrefixTestPrefix);
     #[derive(Debug, Encodable, Decodable, Eq, PartialEq)]
     struct TestVal(u64);
 

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use fedimint_core::db::{DatabaseVersion, MigrationMap, MODULE_GLOBAL_PREFIX};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::{SerdeSignature, SignedEpochOutcome};
-use fedimint_core::{impl_db_prefix_const, PeerId, TransactionId};
+use fedimint_core::{impl_db_lookup, impl_db_record, PeerId, TransactionId};
 use serde::Serialize;
 use strum_macros::EnumIter;
 
@@ -35,10 +35,13 @@ pub struct AcceptedTransactionKey(pub TransactionId);
 #[derive(Debug, Encodable, Decodable)]
 pub struct AcceptedTransactionKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = AcceptedTransactionKey,
     value = AcceptedTransaction,
     db_prefix = DbKeyPrefix::AcceptedTransaction,
+);
+impl_db_lookup!(
+    key = AcceptedTransactionKey,
     query_prefix = AcceptedTransactionKeyPrefix
 );
 
@@ -48,10 +51,13 @@ pub struct RejectedTransactionKey(pub TransactionId);
 #[derive(Debug, Encodable, Decodable)]
 pub struct RejectedTransactionKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = RejectedTransactionKey,
     value = String,
     db_prefix = DbKeyPrefix::RejectedTransaction,
+);
+impl_db_lookup!(
+    key = RejectedTransactionKey,
     query_prefix = RejectedTransactionKeyPrefix
 );
 
@@ -61,12 +67,12 @@ pub struct DropPeerKey(pub PeerId);
 #[derive(Debug, Encodable, Decodable)]
 pub struct DropPeerKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = DropPeerKey,
     value = (),
     db_prefix = DbKeyPrefix::DropPeer,
-    query_prefix = DropPeerKeyPrefix
 );
+impl_db_lookup!(key = DropPeerKey, query_prefix = DropPeerKeyPrefix);
 
 #[derive(Debug, Copy, Clone, Encodable, Decodable, Serialize)]
 pub struct EpochHistoryKey(pub u64);
@@ -74,17 +80,17 @@ pub struct EpochHistoryKey(pub u64);
 #[derive(Debug, Encodable, Decodable)]
 pub struct EpochHistoryKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = EpochHistoryKey,
     value = SignedEpochOutcome,
     db_prefix = DbKeyPrefix::EpochHistory,
-    query_prefix = EpochHistoryKeyPrefix
 );
+impl_db_lookup!(key = EpochHistoryKey, query_prefix = EpochHistoryKeyPrefix);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct LastEpochKey;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = LastEpochKey,
     value = EpochHistoryKey,
     db_prefix = DbKeyPrefix::LastEpoch
@@ -96,10 +102,13 @@ pub struct ClientConfigSignatureKey;
 #[derive(Debug, Encodable, Decodable)]
 pub struct ClientConfigSignatureKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ClientConfigSignatureKey,
     value = SerdeSignature,
     db_prefix = DbKeyPrefix::ClientConfigSignature,
+);
+impl_db_lookup!(
+    key = ClientConfigSignatureKey,
     query_prefix = ClientConfigSignatureKeyPrefix
 );
 

--- a/modules/fedimint-dummy/src/db.rs
+++ b/modules/fedimint-dummy/src/db.rs
@@ -1,6 +1,6 @@
 use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::impl_db_prefix_const;
+use fedimint_core::{impl_db_lookup, impl_db_record};
 use futures::StreamExt;
 use serde::Serialize;
 use strum_macros::EnumIter;
@@ -44,22 +44,22 @@ pub struct ExampleKeyV0(pub u64);
 #[derive(Debug, Encodable, Decodable)]
 pub struct ExampleKeyPrefixV0;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ExampleKeyV0,
     value = (),
     db_prefix = DbKeyPrefix::Example,
-    query_prefix = ExampleKeyPrefixV0
 );
 
+impl_db_lookup!(key = ExampleKeyV0, query_prefix = ExampleKeyPrefixV0);
 #[derive(Debug, Clone, Encodable, Decodable, Eq, PartialEq, Hash, Serialize)]
 pub struct ExampleKey(pub u64, pub String);
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct ExampleKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ExampleKey,
     value = (),
     db_prefix = DbKeyPrefix::Example,
-    query_prefix = ExampleKeyPrefix
 );
+impl_db_lookup!(key = ExampleKey, query_prefix = ExampleKeyPrefix);

--- a/modules/fedimint-ln/src/db.rs
+++ b/modules/fedimint-ln/src/db.rs
@@ -1,5 +1,5 @@
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::{impl_db_prefix_const, OutPoint, PeerId};
+use fedimint_core::{impl_db_lookup, impl_db_record, OutPoint, PeerId};
 use secp256k1::PublicKey;
 use serde::Serialize;
 use strum_macros::EnumIter;
@@ -31,12 +31,12 @@ pub struct ContractKey(pub ContractId);
 #[derive(Debug, Clone, Copy, Encodable, Decodable)]
 pub struct ContractKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ContractKey,
     value = ContractAccount,
     db_prefix = DbKeyPrefix::Contract,
-    query_prefix = ContractKeyPrefix
 );
+impl_db_lookup!(key = ContractKey, query_prefix = ContractKeyPrefix);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ContractUpdateKey(pub OutPoint);
@@ -44,10 +44,13 @@ pub struct ContractUpdateKey(pub OutPoint);
 #[derive(Debug, Clone, Copy, Encodable, Decodable)]
 pub struct ContractUpdateKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ContractUpdateKey,
     value = LightningOutputOutcome,
     db_prefix = DbKeyPrefix::ContractUpdate,
+);
+impl_db_lookup!(
+    key = ContractUpdateKey,
     query_prefix = ContractUpdateKeyPrefix
 );
 
@@ -57,12 +60,12 @@ pub struct OfferKey(pub bitcoin_hashes::sha256::Hash);
 #[derive(Debug, Encodable, Decodable)]
 pub struct OfferKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = OfferKey,
     value = IncomingContractOffer,
     db_prefix = DbKeyPrefix::Offer,
-    query_prefix = OfferKeyPrefix
 );
+impl_db_lookup!(key = OfferKey, query_prefix = OfferKeyPrefix);
 
 // TODO: remove redundancy
 #[derive(Debug, Encodable, Decodable, Serialize)]
@@ -72,10 +75,13 @@ pub struct ProposeDecryptionShareKey(pub ContractId);
 #[derive(Debug, Encodable)]
 pub struct ProposeDecryptionShareKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ProposeDecryptionShareKey,
     value = PreimageDecryptionShare,
     db_prefix = DbKeyPrefix::ProposeDecryptionShare,
+);
+impl_db_lookup!(
+    key = ProposeDecryptionShareKey,
     query_prefix = ProposeDecryptionShareKeyPrefix
 );
 
@@ -87,10 +93,13 @@ pub struct AgreedDecryptionShareKey(pub ContractId, pub PeerId);
 #[derive(Debug, Encodable)]
 pub struct AgreedDecryptionShareKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = AgreedDecryptionShareKey,
     value = PreimageDecryptionShare,
     db_prefix = DbKeyPrefix::AgreedDecryptionShare,
+);
+impl_db_lookup!(
+    key = AgreedDecryptionShareKey,
     query_prefix = AgreedDecryptionShareKeyPrefix
 );
 
@@ -100,9 +109,12 @@ pub struct LightningGatewayKey(pub PublicKey);
 #[derive(Debug, Encodable, Decodable)]
 pub struct LightningGatewayKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = LightningGatewayKey,
     value = LightningGateway,
     db_prefix = DbKeyPrefix::LightningGateway,
+);
+impl_db_lookup!(
+    key = LightningGatewayKey,
     query_prefix = LightningGatewayKeyPrefix
 );

--- a/modules/fedimint-mint/src/db.rs
+++ b/modules/fedimint-mint/src/db.rs
@@ -1,7 +1,7 @@
 use std::time::SystemTime;
 
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::{impl_db_prefix_const, Amount, OutPoint, PeerId};
+use fedimint_core::{impl_db_lookup, impl_db_record, Amount, OutPoint, PeerId};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
@@ -30,12 +30,12 @@ pub struct NonceKey(pub Nonce);
 #[derive(Debug, Encodable, Decodable)]
 pub struct NonceKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = NonceKey,
     value = (),
     db_prefix = DbKeyPrefix::NoteNonce,
-    query_prefix = NonceKeyPrefix
 );
+impl_db_lookup!(key = NonceKey, query_prefix = NonceKeyPrefix);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ProposedPartialSignatureKey {
@@ -45,10 +45,13 @@ pub struct ProposedPartialSignatureKey {
 #[derive(Debug, Encodable, Decodable)]
 pub struct ProposedPartialSignaturesKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ProposedPartialSignatureKey,
     value = MintOutputSignatureShare,
     db_prefix = DbKeyPrefix::ProposedPartialSig,
+);
+impl_db_lookup!(
+    key = ProposedPartialSignatureKey,
     query_prefix = ProposedPartialSignaturesKeyPrefix
 );
 
@@ -66,10 +69,13 @@ pub struct ReceivedPartialSignatureKeyOutputPrefix {
     pub request_id: OutPoint, // tx + output idx
 }
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = ReceivedPartialSignatureKey,
     value = MintOutputSignatureShare,
     db_prefix = DbKeyPrefix::ReceivedPartialSig,
+);
+impl_db_lookup!(
+    key = ReceivedPartialSignatureKey,
     query_prefix = ReceivedPartialSignaturesKeyPrefix,
     query_prefix = ReceivedPartialSignatureKeyOutputPrefix
 );
@@ -81,10 +87,13 @@ pub struct OutputOutcomeKey(pub OutPoint);
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutputOutcomeKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = OutputOutcomeKey,
     value = MintOutputBlindSignatures,
     db_prefix = DbKeyPrefix::OutputOutcome,
+);
+impl_db_lookup!(
+    key = OutputOutcomeKey,
     query_prefix = OutputOutcomeKeyPrefix
 );
 
@@ -101,10 +110,13 @@ pub enum MintAuditItemKey {
 #[derive(Debug, Encodable, Decodable)]
 pub struct MintAuditItemKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = MintAuditItemKey,
     value = Amount,
     db_prefix = DbKeyPrefix::MintAuditItem,
+);
+impl_db_lookup!(
+    key = MintAuditItemKey,
     query_prefix = MintAuditItemKeyPrefix
 );
 
@@ -115,12 +127,12 @@ pub struct EcashBackupKey(pub secp256k1_zkp::XOnlyPublicKey);
 #[derive(Debug, Encodable, Decodable)]
 pub struct EcashBackupKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = EcashBackupKey,
     value = ECashUserBackupSnapshot,
     db_prefix = DbKeyPrefix::EcashBackup,
-    query_prefix = EcashBackupKeyPrefix
 );
+impl_db_lookup!(key = EcashBackupKey, query_prefix = EcashBackupKeyPrefix);
 
 /// User's backup, received at certain time, containing encrypted payload
 #[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]

--- a/modules/fedimint-wallet/src/db.rs
+++ b/modules/fedimint-wallet/src/db.rs
@@ -1,6 +1,6 @@
 use bitcoin::{BlockHash, Txid};
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::impl_db_prefix_const;
+use fedimint_core::{impl_db_lookup, impl_db_record};
 use secp256k1::ecdsa::Signature;
 use serde::Serialize;
 use strum_macros::EnumIter;
@@ -33,12 +33,12 @@ pub struct BlockHashKey(pub BlockHash);
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct BlockHashKeyPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = BlockHashKey,
     value = (),
     db_prefix = DbKeyPrefix::BlockHash,
-    query_prefix = BlockHashKeyPrefix
 );
+impl_db_lookup!(key = BlockHashKey, query_prefix = BlockHashKeyPrefix);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct UTXOKey(pub bitcoin::OutPoint);
@@ -46,17 +46,17 @@ pub struct UTXOKey(pub bitcoin::OutPoint);
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct UTXOPrefixKey;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = UTXOKey,
     value = SpendableUTXO,
     db_prefix = DbKeyPrefix::Utxo,
-    query_prefix = UTXOPrefixKey
 );
+impl_db_lookup!(key = UTXOKey, query_prefix = UTXOPrefixKey);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct RoundConsensusKey;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = RoundConsensusKey,
     value = RoundConsensus,
     db_prefix = DbKeyPrefix::RoundConsensus,
@@ -68,10 +68,13 @@ pub struct UnsignedTransactionKey(pub Txid);
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct UnsignedTransactionPrefixKey;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = UnsignedTransactionKey,
     value = UnsignedTransaction,
     db_prefix = DbKeyPrefix::UnsignedTransaction,
+);
+impl_db_lookup!(
+    key = UnsignedTransactionKey,
     query_prefix = UnsignedTransactionPrefixKey
 );
 
@@ -81,10 +84,13 @@ pub struct PendingTransactionKey(pub Txid);
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct PendingTransactionPrefixKey;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = PendingTransactionKey,
     value = PendingTransaction,
     db_prefix = DbKeyPrefix::PendingTransaction,
+);
+impl_db_lookup!(
+    key = PendingTransactionKey,
     query_prefix = PendingTransactionPrefixKey
 );
 
@@ -94,10 +100,13 @@ pub struct PegOutTxSignatureCI(pub Txid);
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct PegOutTxSignatureCIPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = PegOutTxSignatureCI,
     value = Vec<Signature>,
     db_prefix = DbKeyPrefix::PegOutTxSigCi,
+);
+impl_db_lookup!(
+    key = PegOutTxSignatureCI,
     query_prefix = PegOutTxSignatureCIPrefix
 );
 
@@ -107,9 +116,12 @@ pub struct PegOutBitcoinTransaction(pub fedimint_core::OutPoint);
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct PegOutBitcoinTransactionPrefix;
 
-impl_db_prefix_const!(
+impl_db_record!(
     key = PegOutBitcoinTransaction,
     value = WalletOutputOutcome,
     db_prefix = DbKeyPrefix::PegOutBitcoinOutPoint,
+);
+impl_db_lookup!(
+    key = PegOutBitcoinTransaction,
     query_prefix = PegOutBitcoinTransactionPrefix
 );


### PR DESCRIPTION
Why? Because the types these macro `impl`s traits for can come from different crates making it impossible to use it.

Currently this does not happen, but I'm experimenting with 3rd party module building and spliting module into server/client/common sub-parts and this becomes a blocker.

Also, it seems it's easier to use and understand when each macro is smaller (functionaly).