### PR TITLE
refactor: ServerModule::distributed_gen interface

### DIFF
--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -16,6 +16,7 @@ use fedimint_core::config::{
     TypedServerModuleConfig,
 };
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, MODULE_INSTANCE_ID_GLOBAL};
+use fedimint_core::module::PeerHandle;
 use fedimint_core::net::peers::{IMuxPeerConnections, IPeerConnections, PeerConnections};
 use fedimint_core::task::{timeout, Elapsed, TaskGroup};
 use fedimint_core::PeerId;
@@ -461,16 +462,10 @@ impl ServerConfig {
         for (module_instance_id, (_kind, gen)) in registry.legacy_init_order_iter().enumerate() {
             let module_instance_id = u16::try_from(module_instance_id)
                 .expect("64k module instances should be enough for everyone");
+            let dkg = PeerHandle::new(&connections, module_instance_id, *our_id, peers.clone());
             module_cfgs.insert(
                 module_instance_id,
-                gen.distributed_gen(
-                    &connections,
-                    our_id,
-                    module_instance_id,
-                    peers,
-                    &params.modules,
-                )
-                .await?,
+                gen.distributed_gen(&dkg, &params.modules).await?,
             );
         }
 

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use async_trait::async_trait;
 use bitcoin_hashes::sha256;
 use fedimint_core::config::{
-    ConfigGenParams, DkgPeerMsg, DkgResult, ModuleConfigResponse, ModuleGenParams,
-    ServerModuleConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
+    ConfigGenParams, DkgResult, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
+    TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{Database, DatabaseTransaction, DatabaseVersion, MigrationMap};
@@ -16,9 +16,9 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiVersion, ConsensusProposal, CoreConsensusVersion, InputMeta,
-    ModuleCommon, ModuleConsensusVersion, ModuleError, ModuleGen, TransactionItemAmount,
+    ModuleCommon, ModuleConsensusVersion, ModuleError, ModuleGen, PeerHandle,
+    TransactionItemAmount,
 };
-use fedimint_core::net::peers::MuxPeerConnections;
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{plugin_types_trait_impl, OutPoint, PeerId, ServerModule};
@@ -109,10 +109,7 @@ impl ModuleGen for DummyConfigGenerator {
 
     async fn distributed_gen(
         &self,
-        _connections: &MuxPeerConnections<ModuleInstanceId, DkgPeerMsg>,
-        _our_id: &PeerId,
-        _instance_id: ModuleInstanceId,
-        _peers: &[PeerId],
+        _peers: &PeerHandle,
         _params: &ConfigGenParams,
     ) -> DkgResult<ServerModuleConfig> {
         let server = DummyConfig {


### PR DESCRIPTION
We're passing a lot of arguments there, most of which should not be accessible to the module itself. The module should have no access to its instance id, or raw dkg connection.

I think we'll need to define more operations, and possibly refactor it all even more, but this should be a good starting step in the right direction.