### PR TITLE
chore: use `fedimint://` for P2P URL placeholder

### DIFF
--- a/fedimintd/templates/params.html
+++ b/fedimintd/templates/params.html
@@ -55,7 +55,7 @@ content %}
         class="form-control"
         id="p2p_url"
         name="p2p_url"
-        placeholder="wss://p2p.your-website.com"
+        placeholder="fedimint://p2p.your-website.com"
         value="{{p2p_url}}"
       />
     </div>


### PR DESCRIPTION
This resolves #1744.