### PR TITLE
fix: shutdown gateway-cln-extension on lightningd exit

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -86,10 +86,11 @@ function await_cln_block_processing() {
 
 # Function for killing processes stored in FM_PID_FILE
 function kill_fedimint_processes {
+  $FM_LN1 plugin stop "gateway-cln-extension" 2>/dev/null || true;
+
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
   pkill "gatewayd" 2>/dev/null || true;
-  pkill "gateway-cln-extension" 2>/dev/null || true;
   rm -f $FM_PID_FILE
 }
 


### PR DESCRIPTION
 -Works when lightningd requests plugin stop, and when the task group is generally shutting down
 
 > Re: _cdecker, "the shutdown signal is not reliable (if the main daemon crashes or aborts the plugin's don't get the signal), as such we must be robust against sudden disappearances"_

we should observe the reliability of `cln-plugin` shutdown subscription, so we can be resilient to lightningd crashes.