### PR TITLE
fix: don't kill pkill gatewayd in lib.sh

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -90,12 +90,12 @@ function kill_fedimint_processes {
 
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
-  pkill "gatewayd" 2>/dev/null || true;
   rm -f $FM_PID_FILE
 }
 
 function start_gatewayd() {
   $FM_BIN_DIR/gatewayd &
+  echo $! >> $FM_PID_FILE
   echo "started gatewayd"
   gw_connect_fed
 }


### PR DESCRIPTION
Instead, save process ID and kill it later like everything else