### PR TITLE
gateway-clin-extension shuts down properly (uses fork of cln_plugin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,8 +531,7 @@ dependencies = [
 [[package]]
 name = "cln-plugin"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49be99e6e5ad55d420884b5b2a68aca890bcd1a1540ed6d2892363623a60f538"
+source = "git+https://github.com/justinmoon/lightning?branch=stdio-exit#170723076dc0f44c5953eb6d69027b675e4d505c"
 dependencies = [
  "anyhow",
  "bytes",

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -29,7 +29,9 @@ bitcoin_hashes = "0.11.0"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
 cln-rpc = "0.1.1"
-cln-plugin = "0.1.1"
+# cln-plugin = "0.1.1"
+# cln-plugin =  { path = "../../../../code/lightning/plugins" }
+cln-plugin =  { git = "https://github.com/justinmoon/lightning", branch = "stdio-exit" }
 futures = "0.3.24"
 lightning-invoice = "0.21.0"
 fedimint-core ={ path = "../../fedimint-core" }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -86,8 +86,6 @@ function await_cln_block_processing() {
 
 # Function for killing processes stored in FM_PID_FILE
 function kill_fedimint_processes {
-  $FM_LN1 plugin stop "gateway-cln-extension" 2>/dev/null || true;
-
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
   pkill "gatewayd" 2>/dev/null || true;

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -86,10 +86,11 @@ function await_cln_block_processing() {
 
 # Function for killing processes stored in FM_PID_FILE
 function kill_fedimint_processes {
+  $FM_LN1 plugin stop "gateway-cln-extension" 2>/dev/null || true;
+
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
   pkill "gatewayd" 2>/dev/null || true;
-  pkill "gateway-cln-extension" 2>/dev/null || true;
   rm -f $FM_PID_FILE
 }
 


### PR DESCRIPTION
Built on https://github.com/fedimint/fedimint/pull/1765 to avoid merge conflicts. Both are useful. https://github.com/fedimint/fedimint/pull/1765 for graceful exits, this for non-graceful exits.

Also, don't call `lightning-cli plugin stop gateway-cln-extension` in `lib.sh`. `cln_plugin` now exits the process whenever stdin disconnects https://github.com/ElementsProject/lightning/pull/6036