### PR TITLE
gateway-clin-extension shuts down properly (doesn't need fork of cln_plugin)

### DIFF
--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -69,9 +69,12 @@ async fn main() -> Result<(), anyhow::Error> {
             // The plugin will be shutdown when this callback returns
             tokio::select! {
                 // task group requested shutdown (e.g. via "shutdown" core-lightning notification)
-                _ = shutdown_rx.await => {}
+                _ = shutdown_rx.await => {
+                    std::fs::write("/Users/justin/fedi/fedimint/1.txt", "done").unwrap();
+                }
                 // plugin encountered error and is exiting, so we kill the task group
                 _ = plugin.join() => {
+                    std::fs::write("/Users/justin/fedi/fedimint/2.txt", "done").unwrap();
                     // shuts down task group
                     // FIXME: should we shutdown_join)_all?
                     tg.shutdown().await;

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -71,14 +71,12 @@ async fn main() -> Result<(), anyhow::Error> {
                 // task group requested shutdown
                 _ = shutdown_rx.await => {
                     info!("(1) Shutting down ...");
-                    std::process::exit(0);
                 }
                 // plugin encountered error and is exiting, so we kill the task group
                 _ = plugin.join() => {
                     // shuts down task group
                     info!("(2) Shutting down ...");
                     tg.shutdown().await;
-                    std::process::exit(0);
                 }
             };
         })

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -69,12 +69,9 @@ async fn main() -> Result<(), anyhow::Error> {
             // The plugin will be shutdown when this callback returns
             tokio::select! {
                 // task group requested shutdown (e.g. via "shutdown" core-lightning notification)
-                _ = shutdown_rx.await => {
-                    info!("(1) Shutting down ...");
-                }
+                _ = shutdown_rx.await => {}
                 // plugin encountered error and is exiting, so we kill the task group
                 _ = plugin.join() => {
-                    info!("(2) Shutting down ...");
                     // shuts down task group
                     // FIXME: should we shutdown_join)_all?
                     tg.shutdown().await;

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -68,14 +68,15 @@ async fn main() -> Result<(), anyhow::Error> {
             // Wait for a shutdown signal received from the controlling task group
             // The plugin will be shutdown when this callback returns
             tokio::select! {
-                // task group requested shutdown
+                // task group requested shutdown (e.g. via "shutdown" core-lightning notification)
                 _ = shutdown_rx.await => {
                     info!("(1) Shutting down ...");
                 }
                 // plugin encountered error and is exiting, so we kill the task group
                 _ = plugin.join() => {
-                    // shuts down task group
                     info!("(2) Shutting down ...");
+                    // shuts down task group
+                    // FIXME: should we shutdown_join)_all?
                     tg.shutdown().await;
                 }
             };

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -86,8 +86,6 @@ function await_cln_block_processing() {
 
 # Function for killing processes stored in FM_PID_FILE
 function kill_fedimint_processes {
-  $FM_LN1 plugin stop "gateway-cln-extension" 2>/dev/null || true;
-
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
   pkill "gatewayd" 2>/dev/null || true;


### PR DESCRIPTION
Alternative to #1770 that doesn't require change to `cln_plugin`

Calls `plugin.join()` to wait for the plugin to say it encountered an error and is shutting down. Once this happens, it tell the task group to shutdown, then returns from `Server::serve_with_shutdown()` which will stop the gRPC server and exit from the `main` function of the plugin.