### PR TITLE
Shutdown gateway-cln-plugin when lightningd stops running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,8 +531,7 @@ dependencies = [
 [[package]]
 name = "cln-plugin"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49be99e6e5ad55d420884b5b2a68aca890bcd1a1540ed6d2892363623a60f538"
+source = "git+https://github.com/fedimint/lightning?rev=2db131d5#2db131d531922771c3d2e7d2a34e685786bcea2b"
 dependencies = [
  "anyhow",
  "bytes",

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -29,7 +29,7 @@ bitcoin_hashes = "0.11.0"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
 cln-rpc = "0.1.1"
-cln-plugin = "0.1.1"
+cln-plugin = { git = "https://github.com/fedimint/lightning", rev = "2db131d5" }
 futures = "0.3.24"
 lightning-invoice = "0.21.0"
 fedimint-core ={ path = "../../fedimint-core" }

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -49,7 +49,7 @@ pub struct ClnExtensionOpts {
 async fn main() -> Result<(), anyhow::Error> {
     let tg = TaskGroup::new();
 
-    let (service, listen) = ClnRpcService::new(tg.clone())
+    let (service, listen, plugin) = ClnRpcService::new()
         .await
         .expect("Failed to create cln rpc service");
 
@@ -61,10 +61,10 @@ async fn main() -> Result<(), anyhow::Error> {
     Server::builder()
         .add_service(GatewayLightningServer::new(service))
         .serve_with_shutdown(listen, async {
-            // Wait for a shutdown signal received from the controlling task group
-            // The plugin will be shutdown when this callback returns
-            let shutdown_rx = tg.make_handle().make_shutdown_rx().await;
-            let _ = shutdown_rx.await;
+            // Wait for plugin to signal it's shutting down
+            // Shut down everything else via TaskGroup regardless of error
+            let _ = plugin.join().await;
+            tg.shutdown().await;
         })
         .await
         .map_err(|e| ClnExtensionError::Error(anyhow!("Failed to start server, {:?}", e)))?;
@@ -116,12 +116,12 @@ pub struct ClnRpcClient {}
 pub struct ClnRpcService {
     socket: PathBuf,
     interceptor: Arc<ClnHtlcInterceptor>,
-    task_group: TaskGroup,
 }
 
 impl ClnRpcService {
-    pub async fn new(task_group: TaskGroup) -> Result<(Self, SocketAddr), ClnExtensionError> {
-        let interceptor = Arc::new(ClnHtlcInterceptor::new(task_group.clone()));
+    pub async fn new(
+    ) -> Result<(Self, SocketAddr, Plugin<Arc<ClnHtlcInterceptor>>), ClnExtensionError> {
+        let interceptor = Arc::new(ClnHtlcInterceptor::new());
 
         if let Some(plugin) = Builder::new(stdin(), stdout())
             .option(options::ConfigOption::new(
@@ -153,12 +153,8 @@ impl ClnRpcService {
             .subscribe(
                 "shutdown",
                 |plugin: Plugin<Arc<ClnHtlcInterceptor>>, _: serde_json::Value| async move {
-                    info!("Received shutdown event ... gracefully shutting down the plugin");
-                    let handle = tokio::spawn(async move {
-                        plugin.state().shutdown().await;
-                        Ok(())
-                    });
-                    handle.await?
+                    info!("Received \"shutdown\" notification from lightningd ... requesting cln_plugin shutdown");
+                    plugin.shutdown()
                 },
             )
             .dynamic() // Allow reloading the plugin
@@ -189,10 +185,10 @@ impl ClnRpcService {
             Ok((
                 Self {
                     socket,
-                    task_group,
                     interceptor,
                 },
                 listen,
+                plugin,
             ))
         } else {
             Err(ClnExtensionError::Error(anyhow!(
@@ -511,23 +507,17 @@ type HtlcOutcomeSender = oneshot::Sender<serde_json::Value>;
 /// Functional structure to filter intercepted HTLCs into subscription streams.
 /// Used as a CLN plugin
 #[derive(Clone)]
-struct ClnHtlcInterceptor {
+pub struct ClnHtlcInterceptor {
     subscriptions: Arc<Mutex<HashMap<u64, HtlcSubscriptionSender>>>,
     pub outcomes: Arc<Mutex<HashMap<sha256::Hash, HtlcOutcomeSender>>>,
-    task_group: TaskGroup,
 }
 
 impl ClnHtlcInterceptor {
-    fn new(task_group: TaskGroup) -> Self {
+    fn new() -> Self {
         Self {
             subscriptions: Arc::new(Mutex::new(HashMap::new())),
             outcomes: Arc::new(Mutex::new(HashMap::new())),
-            task_group,
         }
-    }
-
-    async fn shutdown(&self) {
-        self.task_group.shutdown().await;
     }
 
     async fn intercept_htlc(&self, payload: HtlcAccepted) -> serde_json::Value {

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -86,8 +86,6 @@ function await_cln_block_processing() {
 
 # Function for killing processes stored in FM_PID_FILE
 function kill_fedimint_processes {
-  $FM_LN1 plugin stop "gateway-cln-extension" 2>/dev/null || true;
-
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
   pkill "gatewayd" 2>/dev/null || true;


### PR DESCRIPTION
Replaces https://github.com/fedimint/fedimint/pull/1772 and https://github.com/fedimint/fedimint/pull/1770.

Closes https://github.com/fedimint/fedimint/issues/1766.

Switched to our [own fork of core-lightning](https://github.com/fedimint/lightning/tree/fedimint) to get [this change](https://github.com/ElementsProject/lightning/pull/6041).