### PR TITLE
fix: shut down CLN plugin when lightningd stops running

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -86,8 +86,6 @@ function await_cln_block_processing() {
 
 # Function for killing processes stored in FM_PID_FILE
 function kill_fedimint_processes {
-  $FM_LN1 plugin stop "gateway-cln-extension" 2>/dev/null || true;
-
   # shellcheck disable=SC2046
   kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') 2>/dev/null #sed reverses the order here
   pkill "gatewayd" 2>/dev/null || true;


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/1766.

Alternative to https://github.com/fedimint/fedimint/pull/1775 which doesn't fork `cln_plugin` dependency. Sometimes it hits logging-related panics on shutdown, but I don't think this is a problem https://github.com/fedimint/fedimint/pull/1775#issuecomment-1445201224.

Whenever `cln_plugin` stops, the `plugin.join()` future will resolve. Do our `TaskGroup`-related cleanup at this point.