### PR TITLE
fix: Rename FM_TEST_DISABLE_MOCKS to FM_TEST_WITH_REAL_FIXTURES

### DIFF
--- a/integrationtests/README.md
+++ b/integrationtests/README.md
@@ -31,7 +31,7 @@ Tests run by default with fake Lightning and Bitcoin services for fast concurren
 
 To run the tests in parallel against fake versions of Lightning and Bitcoin:
 ```shell
-export FM_TEST_DISABLE_MOCKS=0
+export FM_TEST_USE_REAL_DAEMONS=0
 cargo test -p fedimint-tests
 ```
 
@@ -63,7 +63,7 @@ source ./scripts/setup-tests.sh
 You can now run the integration tests against real instances of Bitcoin and Lightning nodes, using one thread to avoid concurrency issues:
 
 ```shell
-export FM_TEST_DISABLE_MOCKS=1
+export FM_TEST_USE_REAL_DAEMONS=1
 cargo test -p fedimint-tests -- --test-threads=1
 ```
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -158,7 +158,7 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
 
     let decoders = module_decode_stubs();
 
-    let fixtures = match env::var("FM_TEST_DISABLE_MOCKS") {
+    let fixtures = match env::var("FM_TEST_USE_REAL_DAEMONS") {
         Ok(s) if s == "1" => {
             info!("Testing with REAL Bitcoin and Lightning services");
             let mut config_task_group = task_group.make_subgroup().await;

--- a/scripts/final-checks.sh
+++ b/scripts/final-checks.sh
@@ -8,7 +8,7 @@ set -e
 cargo clippy --fix --lib --bins --tests --examples --workspace --allow-dirty
 nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes .#lint --command ./misc/git-hooks/pre-commit
 
-export FM_TEST_DISABLE_MOCKS=0
+export FM_TEST_USE_REAL_DAEMONS=0
 cargo test
 
 if [ "$1" == "nix" ]; then

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -13,5 +13,5 @@ else
   source ./scripts/setup-tests.sh ""
 fi
 
-export FM_TEST_DISABLE_MOCKS=1
+export FM_TEST_USE_REAL_DAEMONS=1
 env RUST_BACKTRACE=1 cargo test -p fedimint-tests -- --test-threads=$(($(nproc) * 2)) "$@"


### PR DESCRIPTION
The double-negative in `FM_TEST_DISABLE_MOCKS` variable always confuses me.

Not sure if `FM_TEST_WITH_REAL_FIXTURES` is the best name, but it confuses me less.

What do you think?