### PR TITLE
fix: Remove unnecessary sleep and await_fedimint_block_sync calls

### DIFF
--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -47,8 +47,6 @@ $FM_MINT_CLIENT fetch
 # peg out
 PEG_OUT_ADDR="$($FM_BTC_CLIENT getnewaddress)"
 $FM_MINT_CLIENT peg-out $PEG_OUT_ADDR 500
-sleep 5 # FIXME wait for tx to be included
-await_fedimint_block_sync
 until [ "$($FM_BTC_CLIENT getreceivedbyaddress $PEG_OUT_ADDR 0)" == "0.00000500" ]; do
   sleep $POLL_INTERVAL
 done


### PR DESCRIPTION
In the process of trying to get `gateway-cli-extension` to reliably stop after running `cli-test.sh`, I noticed that we had an unnecessary sleep in `cli-test.sh`. We can just poll `getreceivedbyaddress` which is the next line in the script.