### PR TITLE
fix: depend on fedimint forks of `hbbft` and `threshold_crypto`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "hbbft"
 version = "0.1.1"
-source = "git+https://github.com/jkitman/hbbft?branch=upgrade-threshold-crypto-libs#3951544ab6834f56d300d065f43e673a6009ecad"
+source = "git+https://github.com/fedimint/hbbft#ff7069e7a276e35ded01a0f376986cbe00433031"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "threshold_crypto"
 version = "0.4.0"
-source = "git+https://github.com/jkitman/threshold_crypto?branch=upgrade-threshold-crypto-libs#82146b3eecd6602231c7741f508f9d910e887072"
+source = "git+https://github.com/fedimint/threshold_crypto#f5b283e74268f566eae7439a2b82bef14cdd0b2a"
 dependencies = [
  "bls12_381",
  "byteorder",

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -48,7 +48,7 @@ jsonrpsee-types = "0.16.0"
 jsonrpsee-core = { version = "0.16.2", features = [ "client" ] }
 serde_json = "1.0.91"
 url = { version = "2.3.1", features = ["serde"] }
-threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 jsonrpsee-ws-client = "0.16.2"

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -30,7 +30,7 @@ tbs = { path = "../crypto/tbs" }
 tokio = { version = "1.25.0", features = ["sync"] }
 thiserror = "1.0.37"
 tracing ="0.1.37"
-threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 url = { version = "2.3.1", features = ["serde"] }
 bitcoin = { version = "0.29.2", features = [ "rand", "serde" ] }
 bitcoin_hashes = { version = "0.11", features = ["serde"] }
@@ -38,7 +38,7 @@ erased-serde = "0.3"
 lightning-invoice = "0.21.0"
 fedimint-derive = { path = "../fedimint-derive" }
 fedimint-logging = { path = "../fedimint-logging" }
-hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
+hbbft = { git = "https://github.com/fedimint/hbbft" }
 rand = "0.8.5"
 miniscript = { version = "7.0.0", git = "https://github.com/rust-bitcoin/rust-miniscript/", rev = "2f1535e470c75fad85dbad8633986aae36a89a92", features = [ "compiler", "serde" ] }
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -20,7 +20,7 @@ bincode = "1.3.1"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 bytes = "1.4.0"
-hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
+hbbft = { git = "https://github.com/fedimint/hbbft" }
 futures = "0.3.24"
 impl-tools = "0.8.0"
 itertools = "0.10.5"
@@ -39,7 +39,7 @@ tbs = { path = "../crypto/tbs" }
 thiserror = "1.0.37"
 tracing ="0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
-threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-stream = "0.1.11"

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = "0.1.64"
 bincode = "1.3.1"
 bitcoin = "0.29.2"
 bytes = "1.4.0"
-hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
+hbbft = { git = "https://github.com/fedimint/hbbft" }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
 futures = "0.3.24"
 itertools = "0.10.5"
@@ -57,7 +57,7 @@ tokio-rustls = "0.23.4"
 tokio-util = { version = "0.7.4", features = [ "codec" ] }
 tracing ="0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
-threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 
 # setup dependencies
 askama = "0.11.1"

--- a/gateway/tests/Cargo.toml
+++ b/gateway/tests/Cargo.toml
@@ -25,7 +25,7 @@ mint-client = { path = "../../client/client-lib" }
 portpicker = "0.1.1"
 rand = "0.8"
 serde_json = "1.0.91"
-threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 tokio = { version = "1.25.0", features = ["full"] }
 tracing ="0.1.37"
 url = { version = "2.3.1", features = ["serde"] }

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -40,5 +40,5 @@ serde = { version = "1.0.149", features = [ "derive" ] }
 tokio = { version = "1.25.0", features = ["full"] }
 tracing ="0.1.37"
 url = "2.3.1"
-hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
-threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
+hbbft = { git = "https://github.com/fedimint/hbbft" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }

--- a/modules/fedimint-ln/Cargo.toml
+++ b/modules/fedimint-ln/Cargo.toml
@@ -33,11 +33,11 @@ serde_json = "1.0.91"
 strum = "0.24"
 strum_macros = "0.24"
 thiserror = "1.0.37"
-threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 tracing = "0.1.37"
 rand = "0.8"
 url = { version = "2.3.1", features = ["serde"] }
-hbbft = { git = "https://github.com/jkitman/hbbft", branch = "upgrade-threshold-crypto-libs" }
+hbbft = { git = "https://github.com/fedimint/hbbft" }
 fedimint-server = { path = "../../fedimint-server", optional = true  }
 
 [dev-dependencies]

--- a/modules/fedimint-mint/Cargo.toml
+++ b/modules/fedimint-mint/Cargo.toml
@@ -34,7 +34,7 @@ strum = "0.24"
 strum_macros = "0.24"
 tbs = { path = "../../crypto/tbs" }
 thiserror = "1.0.37"
-threshold_crypto = { git = "https://github.com/jkitman/threshold_crypto", branch = "upgrade-threshold-crypto-libs" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 tracing ="0.1.37"
 impl-tools = "0.8.0"
 fedimint-server = { path = "../../fedimint-server", optional = true  }


### PR DESCRIPTION
After fedimint/threshold_crypto#6 and fedimint/hbbft#7 got merged we can now migrate to our own fork of these. This should also fix some breakage on master.