### PR TITLE
feat: Combine `fetch` and `wait-invoice` CLI commands

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -1146,10 +1146,7 @@ impl Client<UserClientConfig> {
 
         // Only return error if no contracts were successfully claimed
         if !errors.is_empty() && contract_outpoints.is_empty() {
-            Err(ClientError::FailedToClaimIncomingContracts(
-                errors,
-                contract_outpoints,
-            ))
+            Err(ClientError::FailedToClaimIncomingContracts(errors))
         } else {
             Ok(contract_outpoints)
         }
@@ -1728,7 +1725,7 @@ pub enum ClientError {
     #[error("Failed to fetch notes we expected to be issued {0:?}")]
     UnableToFetchAllNotes(Vec<ClientError>, Vec<OutPoint>),
     #[error("Failed to claim incoming contracts {0:?}")]
-    FailedToClaimIncomingContracts(Vec<(ContractId, ClientError)>, Vec<(ContractId, OutPoint)>),
+    FailedToClaimIncomingContracts(Vec<(ContractId, ClientError)>),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
I've started work on this PR to resolve #1463 following the suggested approach of checking for unexpired `ConfirmedInvoice`s in the DB.

I haven't yet added any tests or removed the `wait-invoice` command (we may want to keep it still?).

There may be a more efficient way to iterate over the contracts to claim.

The `fetch` command now tries to claim contracts for all unexpired `ConfirmedInvoice`s as a first step, but I haven't added anything to check the output of this step or return it to the user.

I'll be grateful for your feedback. Thanks.
