### PR TITLE
Adds tests for electrum

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -282,6 +282,7 @@
           cliTestsDeps = with pkgs; [
             bc
             bitcoind
+            electrs
             clightning-dev
             jq
             netcat

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -30,7 +30,7 @@ use tracing::{debug, info, instrument};
 use crate::fixtures::{peers, test, unwrap_item, FederationTest};
 
 #[tokio::test(flavor = "multi_thread")]
-async fn peg_in_and_peg_out_with_fees() -> Result<()> {
+async fn wallet_peg_in_and_peg_out_with_fees() -> Result<()> {
     test(2, |fed, user, bitcoin, _, _| async move {
         // TODO: this should not be needed, but I get errors on `peg_in` below sometimes
         let bitcoin = bitcoin.lock_exclusive().await;
@@ -86,7 +86,7 @@ async fn peg_in_and_peg_out_with_fees() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn peg_outs_are_rejected_if_fees_are_too_low() -> Result<()> {
+async fn wallet_peg_outs_are_rejected_if_fees_are_too_low() -> Result<()> {
     test(2, |fed, user, bitcoin, _, _| async move {
         let peg_out_amount = Amount::from_sat(1000);
         let peg_out_address = bitcoin.get_new_address().await;
@@ -108,7 +108,7 @@ async fn peg_outs_are_rejected_if_fees_are_too_low() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 #[instrument(name = "peg_outs_are_only_allowed_once_per_epoch")]
-async fn peg_outs_are_only_allowed_once_per_epoch() -> Result<()> {
+async fn wallet_peg_outs_are_only_allowed_once_per_epoch() -> Result<()> {
     test(2, |fed, user, bitcoin, _, _| async move {
         let address1 = bitcoin.get_new_address().await;
         let address2 = bitcoin.get_new_address().await;
@@ -142,7 +142,7 @@ async fn peg_outs_are_only_allowed_once_per_epoch() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn peg_ins_that_are_unconfirmed_are_rejected() -> Result<()> {
+async fn wallet_peg_ins_that_are_unconfirmed_are_rejected() -> Result<()> {
     test(2, |_fed, user, bitcoin, _, _| async move {
         let peg_in_address = user.client.get_new_pegin_address(rng()).await;
         let (proof, tx) = bitcoin
@@ -159,7 +159,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn peg_outs_must_wait_for_available_utxos() -> Result<()> {
+async fn wallet_peg_outs_must_wait_for_available_utxos() -> Result<()> {
     test(2, |fed, user, bitcoin, _, _| async move {
         // at least one epoch needed to estabilish fees
         bitcoin.prepare_funding_wallet().await;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,10 +37,12 @@ export FM_LN1_DIR="$FM_TEST_DIR/ln1"
 export FM_LN2_DIR="$FM_TEST_DIR/ln2"
 export FM_BTC_DIR="$FM_TEST_DIR/bitcoin"
 export FM_CFG_DIR="$FM_TEST_DIR/cfg"
+export FM_ELECTRS_DIR="$FM_TEST_DIR/electrs"
 mkdir -p $FM_LN1_DIR
 mkdir -p $FM_LN2_DIR
 mkdir -p $FM_BTC_DIR
 mkdir -p $FM_CFG_DIR
+mkdir -p $FM_ELECTRS_DIR
 
 # Generate federation configs
 CERTS=""

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -15,3 +15,8 @@ fi
 
 export FM_TEST_DISABLE_MOCKS=1
 env RUST_BACKTRACE=1 cargo test -p fedimint-tests -- --test-threads=$(($(nproc) * 2)) "$@"
+
+# Switch to electrum and run wallet tests
+unset FM_BITCOIND_RPC
+export FM_ELECTRUM_RPC="tcp://127.0.0.1:50001"
+env RUST_BACKTRACE=1 cargo test -p fedimint-tests wallet -- --test-threads=$(($(nproc) * 2)) "$@"

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -12,15 +12,26 @@ source ./scripts/build.sh $FM_FED_SIZE
 POLL_INTERVAL=1
 
 # Start bitcoind and wait for it to become ready
-bitcoind -regtest -fallbackfee=0.0004 -txindex -server -rpcuser=bitcoin -rpcpassword=bitcoin -datadir=$FM_BTC_DIR &
+bitcoind -regtest -fallbackfee=0.00001 -txindex -server -rpcuser=bitcoin -rpcpassword=bitcoin -datadir=$FM_BTC_DIR &
 echo $! >> $FM_PID_FILE
 
+# Required by tests to manipulate bitcoind
+export FM_TEST_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
 export FM_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
 
 until [ "$($FM_BTC_CLIENT getblockchaininfo | jq -e -r '.chain')" == "regtest" ]; do
   sleep $POLL_INTERVAL
 done
 $FM_BTC_CLIENT createwallet ""
+
+# Start electrs
+ELECTRS_CFG="$FM_ELECTRS_DIR"/electrs.toml
+echo 'auth = "bitcoin:bitcoin"' > $ELECTRS_CFG
+echo 'daemon_rpc_addr = "127.0.0.1:18443"' >> $ELECTRS_CFG
+echo 'daemon_p2p_addr = "127.0.0.1:18444"' >> $ELECTRS_CFG
+echo 'electrum_rpc_addr = "127.0.0.1:50001"' >> $ELECTRS_CFG
+electrs --network "regtest" --conf "$ELECTRS_CFG" --db-dir "$FM_ELECTRS_DIR" &
+echo $! >> $FM_PID_FILE
 
 if [[ "$(lightningd --bitcoin-cli "$(which false)" --dev-no-plugin-checksum 2>&1 )" =~ .*"--dev-no-plugin-checksum: unrecognized option".* ]]; then
   LIGHTNING_FLAGS=""


### PR DESCRIPTION
Runs wallet tests using `electrs` fixing a bug where the fee rate could be below the min relay fee.

Note that we should do the same for `esplora` eventually, although it's not in Nix packages.

Also we should handle errors more intelligently in general I think rather than just retrying all the time.