### PR TITLE
feat: add CLI command `encode-connect-info`

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -285,6 +285,14 @@ enum Command {
     /// Decode connection info into its JSON representation
     DecodeConnectInfo { connect_info: WsClientConnectInfo },
 
+    /// Encode connection info from its constituent parts
+    EncodeConnectInfo {
+        #[clap(long = "urls", required = true, value_delimiter = ',')]
+        urls: Vec<Url>,
+        #[clap(long = "id")]
+        id: FederationId,
+    },
+
     /// Config enabling client to establish websocket connection to federation
     ConnectInfo,
 
@@ -633,6 +641,9 @@ async fn handle_command(
         Command::DecodeConnectInfo { connect_info } => Ok(CliOutput::DecodeConnectInfo {
             urls: connect_info.urls,
             id: connect_info.id,
+        }),
+        Command::EncodeConnectInfo { urls, id } => Ok(CliOutput::ConnectInfo {
+            connect_info: WsClientConnectInfo { urls, id },
         }),
         Command::JoinFederation { .. } => {
             unreachable!()

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -33,9 +33,9 @@ FED_ID="$(get_federation_id)"
 [[ "$($FM_MINT_CLIENT decode-connect-info "$CONNECT_STRING" | jq -e -r '.id')" = "${FED_ID}" ]]
 # Number required for one honest is ceil(($FM_FED_SIZE-1)/3+1)
 ONE_HONEST=2
-for ((ID = 0; ID < $ONE_HONEST; ID++)); do
-[[ "$($FM_MINT_CLIENT decode-connect-info "$CONNECT_STRING" | jq --argjson id $ID -e -r '.urls[$id]')" = "$(cat $FM_CFG_DIR/client.json | jq --argjson id $ID -e -r '.nodes[$id] | .url')" ]]
-done
+ONE_HONEST_URLS=$(cat $FM_CFG_DIR/client.json | jq --argjson one_honest $ONE_HONEST -e -r '.nodes[:$one_honest] | map(.url) | join(",")')
+[[ "$($FM_MINT_CLIENT decode-connect-info "$CONNECT_STRING" | jq -e -r '.urls | join(",")')" = "$ONE_HONEST_URLS" ]]
+[[ "$($FM_MINT_CLIENT encode-connect-info --urls $ONE_HONEST_URLS --id $FED_ID | jq -e -r '.connect_info')" = "$CONNECT_STRING" ]]
 
 # reissue
 NOTES=$($FM_MINT_CLIENT spend '42000msat' | jq -e -r '.note')


### PR DESCRIPTION
This is for the encoding part of #1730.

I've used named arguments in accordance with #1562.

I understood from yesterday's dev call that it might be better to pass in a JSON directly instead of individual `--id` and `--urls` arguments, so I could do that instead if required.