### PR TITLE
fix: ln client doesn't retry on preimage pending decryption

### DIFF
--- a/modules/fedimint-ln/src/contracts/mod.rs
+++ b/modules/fedimint-ln/src/contracts/mod.rs
@@ -51,6 +51,15 @@ pub enum ContractOutcome {
     Outgoing(OutgoingContractOutcome),
 }
 
+impl ContractOutcome {
+    pub fn is_permanent(&self) -> bool {
+        match self {
+            ContractOutcome::Account(_) => true,
+            ContractOutcome::Incoming(o) => o.is_permanent(),
+            ContractOutcome::Outgoing(_) => true,
+        }
+    }
+}
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct AccountContractOutcome {}
 
@@ -146,6 +155,15 @@ pub enum DecryptedPreimage {
     Invalid,
 }
 
+impl DecryptedPreimage {
+    pub fn is_permanent(&self) -> bool {
+        match self {
+            DecryptedPreimage::Pending => false,
+            DecryptedPreimage::Some(_) => true,
+            DecryptedPreimage::Invalid => true,
+        }
+    }
+}
 /// Threshold-encrypted [`Preimage`]
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct EncryptedPreimage(pub threshold_crypto::Ciphertext);

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -202,6 +202,15 @@ pub enum LightningOutputOutcome {
     },
 }
 
+impl LightningOutputOutcome {
+    pub fn is_permanent(&self) -> bool {
+        match self {
+            LightningOutputOutcome::Contract { id: _, outcome } => outcome.is_permanent(),
+            LightningOutputOutcome::Offer { .. } => true,
+        }
+    }
+}
+
 impl std::fmt::Display for LightningOutputOutcome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
This is a source of test flakiness.

Fix #1795