### PR TITLE
refactor: split CommonModuleGen from ServerModuleGen

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -13,9 +13,9 @@ use clap::{Parser, Subcommand};
 use fedimint_core::api::{
     FederationApiExt, GlobalFederationApi, IFederationApi, WsClientConnectInfo, WsFederationApi,
 };
-use fedimint_core::config::{load_from_file, ClientConfig, FederationId, ModuleGenRegistry};
+use fedimint_core::config::{load_from_file, ClientConfig, FederationId, ServerModuleGenRegistry};
 use fedimint_core::db::Database;
-use fedimint_core::module::DynModuleGen;
+use fedimint_core::module::DynServerModuleGen;
 use fedimint_core::query::EventuallyConsistent;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{Amount, OutPoint, TieredMulti, TransactionId};
@@ -384,10 +384,10 @@ async fn main() {
             );
         };
     } else {
-        let module_gens = ModuleGenRegistry::from(vec![
-            DynModuleGen::from(WalletGen),
-            DynModuleGen::from(MintGen),
-            DynModuleGen::from(LightningGen),
+        let module_gens = ServerModuleGenRegistry::from(vec![
+            DynServerModuleGen::from(WalletGen),
+            DynServerModuleGen::from(MintGen),
+            DynServerModuleGen::from(LightningGen),
         ]);
 
         let cli = Cli::parse();

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -25,7 +25,7 @@ use fedimint_core::api::{
     DynFederationApi, FederationError, GlobalFederationApi, MemberError, OutputOutcomeError,
     WsFederationApi,
 };
-use fedimint_core::config::{ClientConfig, FederationId, ModuleGenRegistry};
+use fedimint_core::config::{ClientConfig, FederationId, ServerModuleGenRegistry};
 use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
@@ -157,7 +157,7 @@ impl<C> Client<C> {
         &self.context.decoders
     }
 
-    pub fn module_gens(&self) -> &ModuleGenRegistry {
+    pub fn module_gens(&self) -> &ServerModuleGenRegistry {
         &self.context.module_gens
     }
 }
@@ -281,7 +281,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
     pub async fn new(
         config: T,
         decoders: ModuleDecoderRegistry,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
         db: Database,
         secp: Secp256k1<All>,
     ) -> Self {
@@ -292,7 +292,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
     pub async fn new_with_api(
         config: T,
         decoders: ModuleDecoderRegistry,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
         db: Database,
         api: DynFederationApi,
         secp: Secp256k1<All>,

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use bitcoin::{secp256k1, Network};
 use bitcoin_hashes::hex::FromHex;
 use fedimint_core::api::DynFederationApi;
-use fedimint_core::config::ModuleGenRegistry;
+use fedimint_core::config::ServerModuleGenRegistry;
 use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -63,7 +63,7 @@ pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Er
 #[derive(Debug)]
 pub struct ClientContext {
     pub decoders: ModuleDecoderRegistry,
-    pub module_gens: ModuleGenRegistry,
+    pub module_gens: ServerModuleGenRegistry,
     pub db: Database,
     pub api: DynFederationApi,
     pub secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -14,7 +14,7 @@ use bech32::{FromBase32, ToBase32};
 use bitcoin::consensus::ReadExt;
 use bitcoin_hashes::sha256;
 use fedimint_core::config::{
-    ApiEndpoint, ClientConfig, ConfigResponse, FederationId, ModuleGenRegistry,
+    ApiEndpoint, ClientConfig, ConfigResponse, FederationId, ServerModuleGenRegistry,
 };
 use fedimint_core::core::DynOutputOutcome;
 use fedimint_core::fmt_utils::AbbreviateDebug;
@@ -395,7 +395,7 @@ pub trait GlobalFederationApi {
     async fn download_client_config(
         &self,
         id: &FederationId,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
     ) -> FederationResult<ClientConfig>;
 
     /// Fetches the server consensus hash if enough peers agree on it
@@ -543,7 +543,7 @@ where
     async fn download_client_config(
         &self,
         id: &FederationId,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
     ) -> FederationResult<ClientConfig> {
         let id = id.clone();
         let qs = VerifiableResponse::new(

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -2,10 +2,10 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use erased_serde::Serialize;
-use fedimint_core::config::ModuleGenRegistry;
+use fedimint_core::config::ServerModuleGenRegistry;
 use fedimint_core::db::{DatabaseTransaction, SingleUseDatabaseTransaction};
 use fedimint_core::encoding::Encodable;
-use fedimint_core::module::DynModuleGen;
+use fedimint_core::module::DynServerModuleGen;
 use fedimint_core::module::__reexports::serde_json;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{push_db_key_items, push_db_pair_items, push_db_pair_items_no_serde};
@@ -43,7 +43,7 @@ pub struct DatabaseDump<'a> {
     modules: Vec<String>,
     prefixes: Vec<String>,
     cfg: Option<ServerConfig>,
-    module_inits: ModuleGenRegistry,
+    module_inits: ServerModuleGenRegistry,
 }
 
 impl<'a> DatabaseDump<'a> {
@@ -75,10 +75,10 @@ impl<'a> DatabaseDump<'a> {
             };
         }
 
-        let module_inits = ModuleGenRegistry::from(vec![
-            DynModuleGen::from(WalletGen),
-            DynModuleGen::from(MintGen),
-            DynModuleGen::from(LightningGen),
+        let module_inits = ServerModuleGenRegistry::from(vec![
+            DynServerModuleGen::from(WalletGen),
+            DynServerModuleGen::from(MintGen),
+            DynServerModuleGen::from(LightningGen),
         ]);
 
         let cfg = read_server_config(&password, cfg_dir).unwrap();

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -7,7 +7,7 @@ use aead::{encrypted_read, encrypted_write, get_key, LessSafeKey};
 use anyhow::{ensure, format_err};
 use bitcoin_hashes::hex::{FromHex, ToHex};
 use fedimint_core::api::WsClientConnectInfo;
-use fedimint_core::config::ModuleGenRegistry;
+use fedimint_core::config::ServerModuleGenRegistry;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio_rustls::rustls;
@@ -126,7 +126,7 @@ pub fn write_server_config(
     server: &ServerConfig,
     path: PathBuf,
     password: &str,
-    module_config_gens: &ModuleGenRegistry,
+    module_config_gens: &ServerModuleGenRegistry,
 ) -> anyhow::Result<()> {
     let key = get_key(password, path.join(SALT_FILE))?;
 

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -12,7 +12,7 @@ use fedimint_core::cancellable::Cancelled;
 pub use fedimint_core::config::*;
 use fedimint_core::config::{
     ApiEndpoint, ClientConfig, ConfigGenParams, ConfigResponse, DkgPeerMsg, FederationId,
-    JsonWithKind, ModuleConfigResponse, ModuleGenRegistry, ServerModuleConfig,
+    JsonWithKind, ModuleConfigResponse, ServerModuleConfig, ServerModuleGenRegistry,
     TypedServerModuleConfig,
 };
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, MODULE_INSTANCE_ID_GLOBAL};
@@ -170,7 +170,7 @@ impl ServerConfigConsensus {
     /// TODO use the derive macro to automatically pick up new fields here
     fn try_to_config_response(
         &self,
-        module_config_gens: &ModuleGenRegistry,
+        module_config_gens: &ServerModuleGenRegistry,
     ) -> anyhow::Result<ConfigResponse> {
         let modules: BTreeMap<ModuleInstanceId, ModuleConfigResponse> = self
             .modules
@@ -210,7 +210,10 @@ impl ServerConfigConsensus {
         })
     }
 
-    pub fn to_config_response(&self, module_config_gens: &ModuleGenRegistry) -> ConfigResponse {
+    pub fn to_config_response(
+        &self,
+        module_config_gens: &ServerModuleGenRegistry,
+    ) -> ConfigResponse {
         self.try_to_config_response(module_config_gens)
             .expect("configuration mismatch")
     }
@@ -324,7 +327,7 @@ impl ServerConfig {
     pub fn validate_config(
         &self,
         identity: &PeerId,
-        module_config_gens: &ModuleGenRegistry,
+        module_config_gens: &ServerModuleGenRegistry,
     ) -> anyhow::Result<()> {
         let peers = self.local.p2p.clone();
         let consensus = self.consensus.clone();
@@ -363,7 +366,7 @@ impl ServerConfig {
 
     pub fn trusted_dealer_gen(
         params: &HashMap<PeerId, ServerConfigParams>,
-        registry: ModuleGenRegistry,
+        registry: ServerModuleGenRegistry,
     ) -> BTreeMap<PeerId, Self> {
         let mut rng = OsRng;
         let peer0 = &params[&PeerId::from(0)];
@@ -419,7 +422,7 @@ impl ServerConfig {
     /// Runs the distributed key gen algorithm
     pub async fn distributed_gen(
         params: &ServerConfigParams,
-        registry: ModuleGenRegistry,
+        registry: ServerModuleGenRegistry,
         task_group: &mut TaskGroup,
     ) -> DkgResult<Self> {
         let server_conn = connect(params.fed_network.clone(), params.tls.clone(), task_group).await;

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -9,7 +9,7 @@ use std::iter::FromIterator;
 use std::os::unix::prelude::OsStrExt;
 use std::sync::Mutex;
 
-use fedimint_core::config::{ConfigResponse, ModuleGenRegistry};
+use fedimint_core::config::{ConfigResponse, ServerModuleGenRegistry};
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{apply_migrations, Database, DatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -87,7 +87,7 @@ pub struct FedimintConsensus {
     /// `Self::get_config_with_sig`
     client_cfg: ConfigResponse,
 
-    pub module_inits: ModuleGenRegistry,
+    pub module_inits: ServerModuleGenRegistry,
 
     pub modules: ServerModuleRegistry,
     /// KV Database into which all state is persisted to recover from in case of
@@ -134,7 +134,7 @@ impl FedimintConsensus {
     pub async fn new(
         cfg: ServerConfig,
         db: Database,
-        module_inits: ModuleGenRegistry,
+        module_inits: ServerModuleGenRegistry,
         task_group: &mut TaskGroup,
     ) -> anyhow::Result<(Self, Receiver<Transaction>)> {
         let mut modules = BTreeMap::new();
@@ -199,7 +199,7 @@ impl FedimintConsensus {
     pub fn new_with_modules(
         cfg: ServerConfig,
         db: Database,
-        module_inits: ModuleGenRegistry,
+        module_inits: ServerModuleGenRegistry,
         modules: ModuleRegistry<DynServerModule>,
     ) -> (Self, Receiver<Transaction>) {
         let (tx_sender, tx_receiver) = mpsc::channel(TRANSACTION_BUFFER_SIZE);

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -12,7 +12,8 @@ use fedimint_core::db::{Database, DatabaseTransaction};
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{
-    ApiError, InputMeta, ModuleCommon, ModuleError, ServerModuleGen, TransactionItemAmount,
+    ApiError, CommonModuleGen, InputMeta, ModuleCommon, ModuleError, ServerModuleGen,
+    TransactionItemAmount,
 };
 use fedimint_core::{OutPoint, PeerId, ServerModule};
 
@@ -60,7 +61,10 @@ where
         for (peer, cfg) in server_cfg {
             let db = Database::new(
                 MemDatabase::new(),
-                ModuleDecoderRegistry::from_iter([(module_instance_id, conf_gen.decoder())]),
+                ModuleDecoderRegistry::from_iter([(
+                    module_instance_id,
+                    <ConfGen as ServerModuleGen>::Common::decoder(),
+                )]),
             );
             let member = constructor(cfg, db.clone()).await?;
             members.push((peer, member, db, module_instance_id));

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -12,7 +12,7 @@ use fedimint_core::db::{Database, DatabaseTransaction};
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{
-    ApiError, InputMeta, ModuleCommon, ModuleError, ModuleGen, TransactionItemAmount,
+    ApiError, InputMeta, ModuleCommon, ModuleError, ServerModuleGen, TransactionItemAmount,
 };
 use fedimint_core::{OutPoint, PeerId, ServerModule};
 
@@ -45,7 +45,7 @@ where
         module_instance_id: ModuleInstanceId,
     ) -> anyhow::Result<FakeFed<Module>>
     where
-        ConfGen: ModuleGen,
+        ConfGen: ServerModuleGen,
         F: Fn(ServerModuleConfig, Database) -> FF,
         FF: Future<Output = anyhow::Result<Module>>,
     {

--- a/fedimintd/src/distributed_gen.rs
+++ b/fedimintd/src/distributed_gen.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 
 use aead::{encrypted_read, encrypted_write, get_key};
 use clap::{Parser, Subcommand};
-use fedimint_core::config::{DkgError, ModuleGenRegistry};
-use fedimint_core::module::ModuleGen;
+use fedimint_core::config::{DkgError, ServerModuleGenRegistry};
+use fedimint_core::module::ServerModuleGen;
 use fedimint_core::task::{self, TaskGroup};
 use fedimint_core::Amount;
 use fedimint_ln::LightningGen;
@@ -133,7 +133,7 @@ enum Command {
 ///
 /// See [`super::fedimintd::Fedimintd`] for more info.
 pub struct DistributedGen {
-    module_gens: ModuleGenRegistry,
+    module_gens: ServerModuleGenRegistry,
     opts: Cli,
 }
 
@@ -145,14 +145,14 @@ impl DistributedGen {
         TracingSetup::default().init()?;
 
         Ok(Self {
-            module_gens: ModuleGenRegistry::new(),
+            module_gens: ServerModuleGenRegistry::new(),
             opts,
         })
     }
 
     pub fn with_module<T>(mut self, gen: T) -> Self
     where
-        T: ModuleGen + 'static + task::MaybeSend + task::MaybeSync,
+        T: ServerModuleGen + 'static + task::MaybeSend + task::MaybeSync,
     {
         self.module_gens.attach(gen);
         self

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -3,9 +3,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::Parser;
-use fedimint_core::config::ModuleGenRegistry;
+use fedimint_core::config::ServerModuleGenRegistry;
 use fedimint_core::db::Database;
-use fedimint_core::module::ModuleGen;
+use fedimint_core::module::ServerModuleGen;
 use fedimint_core::task::{sleep, TaskGroup};
 use fedimint_ln::LightningGen;
 use fedimint_logging::TracingSetup;
@@ -72,7 +72,7 @@ pub struct ServerOpts {
 /// }
 /// ```
 pub struct Fedimintd {
-    module_gens: ModuleGenRegistry,
+    module_gens: ServerModuleGenRegistry,
     opts: ServerOpts,
 }
 
@@ -95,14 +95,14 @@ impl Fedimintd {
             .init()?;
 
         Ok(Self {
-            module_gens: ModuleGenRegistry::new(),
+            module_gens: ServerModuleGenRegistry::new(),
             opts,
         })
     }
 
     pub fn with_module<T>(mut self, gen: T) -> Self
     where
-        T: ModuleGen + 'static + Send + Sync,
+        T: ServerModuleGen + 'static + Send + Sync,
     {
         self.module_gens.attach(gen);
         self
@@ -172,7 +172,7 @@ impl Fedimintd {
 async fn run(
     opts: ServerOpts,
     mut task_group: TaskGroup,
-    module_gens: ModuleGenRegistry,
+    module_gens: ServerModuleGenRegistry,
 ) -> anyhow::Result<()> {
     let (ui_sender, mut ui_receiver) = tokio::sync::mpsc::channel(1);
 

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -13,7 +13,7 @@ use axum_macros::debug_handler;
 use bitcoin::Network;
 use fedimint_core::api::WsClientConnectInfo;
 use fedimint_core::bitcoin_rpc::BitcoindRpcBackend;
-use fedimint_core::config::{ClientConfig, ModuleGenRegistry};
+use fedimint_core::config::{ClientConfig, ServerModuleGenRegistry};
 use fedimint_core::task::TaskGroup;
 use fedimint_core::util::SanitizedUrl;
 use fedimint_core::Amount;
@@ -374,7 +374,7 @@ struct State {
     password: String,
     task_group: TaskGroup,
     dkg_task_group: Option<TaskGroup>,
-    module_gens: ModuleGenRegistry,
+    module_gens: ServerModuleGenRegistry,
     dkg_state: Option<DkgState>,
 }
 type MutableState = Arc<Mutex<State>>;
@@ -399,7 +399,7 @@ pub async fn run_ui(
     bind_addr: SocketAddr,
     password: String,
     task_group: TaskGroup,
-    module_gens: ModuleGenRegistry,
+    module_gens: ServerModuleGenRegistry,
 ) {
     let state = Arc::new(Mutex::new(State {
         params: None,

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -2,13 +2,13 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use clap::Parser;
-use fedimint_core::config::ModuleGenRegistry;
+use fedimint_core::config::ServerModuleGenRegistry;
 use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::module::DynModuleGen;
+use fedimint_core::module::DynServerModuleGen;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::ServerModule;
 use fedimint_logging::TracingSetup;
@@ -103,10 +103,10 @@ async fn main() -> Result<(), anyhow::Error> {
     ]);
 
     // Create module generator registry
-    let module_gens = ModuleGenRegistry::from(vec![
-        DynModuleGen::from(WalletGen),
-        DynModuleGen::from(MintGen),
-        DynModuleGen::from(LightningGen),
+    let module_gens = ServerModuleGenRegistry::from(vec![
+        DynServerModuleGen::from(WalletGen),
+        DynServerModuleGen::from(MintGen),
+        DynServerModuleGen::from(LightningGen),
     ]);
 
     // Create gateway instance

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use fedimint_core::api::{
     DynFederationApi, GlobalFederationApi, WsClientConnectInfo, WsFederationApi,
 };
-use fedimint_core::config::{load_from_file, FederationId, ModuleGenRegistry};
+use fedimint_core::config::{load_from_file, FederationId, ServerModuleGenRegistry};
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::Database;
 use fedimint_core::dyn_newtype_define;
@@ -74,7 +74,7 @@ pub trait IGatewayClientBuilder: Debug {
         &self,
         config: GatewayClientConfig,
         decoders: ModuleDecoderRegistry,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
     ) -> Result<Client<GatewayClientConfig>>;
 
     /// Create a new gateway federation client config from connect info
@@ -83,7 +83,7 @@ pub trait IGatewayClientBuilder: Debug {
         connect: WsClientConnectInfo,
         mint_channel_id: u64,
         node_pubkey: PublicKey,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
     ) -> Result<GatewayClientConfig>;
 
     /// Save and persist the configuration of the gateway federation client
@@ -122,7 +122,7 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
         &self,
         config: GatewayClientConfig,
         decoders: ModuleDecoderRegistry,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
     ) -> Result<Client<GatewayClientConfig>> {
         let federation_id = config.client_config.federation_id.clone();
 
@@ -141,7 +141,7 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
         connect: WsClientConnectInfo,
         mint_channel_id: u64,
         node_pubkey: PublicKey,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
     ) -> Result<GatewayClientConfig> {
         let api: DynFederationApi = WsFederationApi::from_urls(&connect).into();
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -22,7 +22,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use bitcoin::Address;
 use fedimint_core::api::WsClientConnectInfo;
-use fedimint_core::config::{FederationId, ModuleGenRegistry};
+use fedimint_core::config::{FederationId, ServerModuleGenRegistry};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{Amount, TransactionId};
@@ -68,7 +68,7 @@ impl IntoResponse for GatewayError {
 }
 pub struct Gateway {
     decoders: ModuleDecoderRegistry,
-    module_gens: ModuleGenRegistry,
+    module_gens: ServerModuleGenRegistry,
     lnrpc: DynLnRpcClient,
     actors: Mutex<HashMap<String, Arc<GatewayActor>>>,
     client_builder: DynGatewayClientBuilder,
@@ -84,7 +84,7 @@ impl Gateway {
         lnrpc: DynLnRpcClient,
         client_builder: DynGatewayClientBuilder,
         decoders: ModuleDecoderRegistry,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
         task_group: TaskGroup,
     ) -> Self {
         // Create message channels for the webserver
@@ -134,7 +134,7 @@ impl Gateway {
     async fn load_federation_actors(
         &self,
         decoders: ModuleDecoderRegistry,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
         route_hints: Vec<RouteHint>,
     ) {
         if let Ok(configs) = self.client_builder.load_configs() {

--- a/gateway/tests/tests/fixtures/client.rs
+++ b/gateway/tests/tests/fixtures/client.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use bitcoin::{secp256k1, KeyPair};
 use fedimint_core::api::{DynFederationApi, WsClientConnectInfo};
-use fedimint_core::config::{ClientConfig, FederationId, ModuleGenRegistry};
+use fedimint_core::config::{ClientConfig, FederationId, ServerModuleGenRegistry};
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::PeerId;
@@ -38,7 +38,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
         &self,
         config: GatewayClientConfig,
         decoders: ModuleDecoderRegistry,
-        _module_gens: ModuleGenRegistry,
+        _module_gens: ServerModuleGenRegistry,
     ) -> Result<Client<GatewayClientConfig>, GatewayError> {
         let federation_id = config.client_config.federation_id.clone();
         // Ignore `config`s, hardcode one peer.
@@ -70,7 +70,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
         _connect: WsClientConnectInfo,
         mint_channel_id: u64,
         node_pubkey: PublicKey,
-        _module_gens: ModuleGenRegistry,
+        _module_gens: ServerModuleGenRegistry,
     ) -> Result<GatewayClientConfig, GatewayError> {
         // TODO: use the connect info urls to get the federation name?
         // Simulate clients in the same federation by seeding the generated

--- a/gateway/tests/tests/fixtures/mod.rs
+++ b/gateway/tests/tests/fixtures/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use fedimint_core::config::ModuleGenRegistry;
-use fedimint_core::module::DynModuleGen;
+use fedimint_core::config::ServerModuleGenRegistry;
+use fedimint_core::module::DynServerModuleGen;
 use fedimint_core::task::TaskGroup;
 use fedimint_ln::LightningGen;
 use fedimint_mint::MintGen;
@@ -32,10 +32,10 @@ pub async fn fixtures(api_addr: Url) -> Result<Fixtures> {
         client::TestGatewayClientBuilder::new(MemDbFactory.into(), api_addr).into();
 
     let decoders = module_decode_stubs();
-    let module_gens = ModuleGenRegistry::from(vec![
-        DynModuleGen::from(WalletGen),
-        DynModuleGen::from(MintGen),
-        DynModuleGen::from(LightningGen),
+    let module_gens = ServerModuleGenRegistry::from(vec![
+        DynServerModuleGen::from(WalletGen),
+        DynServerModuleGen::from(MintGen),
+        DynServerModuleGen::from(LightningGen),
     ]);
 
     // Create task group for controlled shutdown of the gateway

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -16,7 +16,7 @@ use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_core::api::WsFederationApi;
 use fedimint_core::bitcoin_rpc::read_bitcoin_backend_from_global_env;
 use fedimint_core::cancellable::Cancellable;
-use fedimint_core::config::{ClientConfig, ModuleGenRegistry};
+use fedimint_core::config::{ClientConfig, ServerModuleGenRegistry};
 use fedimint_core::core::{
     DynModuleConsensusItem, ModuleConsensusItem, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_LN,
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
@@ -24,7 +24,7 @@ use fedimint_core::core::{
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::Database;
 use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
-use fedimint_core::module::DynModuleGen;
+use fedimint_core::module::DynServerModuleGen;
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::{timeout, TaskGroup};
 use fedimint_core::{core, sats, Amount, OutPoint, PeerId, TieredMulti};
@@ -150,10 +150,10 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
     );
     let params = ServerConfigParams::gen_local(&peers, base_port, "test", modules).unwrap();
 
-    let module_inits = ModuleGenRegistry::from(vec![
-        DynModuleGen::from(WalletGen),
-        DynModuleGen::from(MintGen),
-        DynModuleGen::from(LightningGen),
+    let module_inits = ServerModuleGenRegistry::from(vec![
+        DynServerModuleGen::from(WalletGen),
+        DynServerModuleGen::from(MintGen),
+        DynServerModuleGen::from(LightningGen),
     ]);
 
     let decoders = module_decode_stubs();
@@ -373,7 +373,7 @@ pub fn peers(peers: &[u16]) -> Vec<PeerId> {
 pub async fn create_user_client(
     config: UserClientConfig,
     decoders: ModuleDecoderRegistry,
-    module_gens: ModuleGenRegistry,
+    module_gens: ServerModuleGenRegistry,
     peers: Vec<PeerId>,
     db: Database,
 ) -> UserClient {
@@ -395,7 +395,7 @@ pub async fn create_user_client(
 async fn distributed_config(
     peers: &[PeerId],
     params: HashMap<PeerId, ServerConfigParams>,
-    registry: ModuleGenRegistry,
+    registry: ServerModuleGenRegistry,
     task_group: &mut TaskGroup,
 ) -> Cancellable<(BTreeMap<PeerId, ServerConfig>, ClientConfig)> {
     let configs: Vec<(PeerId, ServerConfig)> = join_all(peers.iter().map(|peer| {
@@ -448,7 +448,7 @@ impl GatewayTest {
         adapter: LnRpcAdapter,
         client_config: ClientConfig,
         decoders: ModuleDecoderRegistry,
-        module_gens: ModuleGenRegistry,
+        module_gens: ServerModuleGenRegistry,
         node_pub_key: secp256k1::PublicKey,
         bind_port: u16,
     ) -> Self {
@@ -1154,7 +1154,7 @@ impl FederationTest {
         database_gen: &impl Fn(ModuleDecoderRegistry) -> Database,
         bitcoin_gen: &impl Fn() -> DynBitcoindRpc,
         connect_gen: &impl Fn(&ServerConfig) -> PeerConnector<EpochMessage>,
-        module_inits: ModuleGenRegistry,
+        module_inits: ServerModuleGenRegistry,
         override_modules: impl Fn(
             ServerConfig,
             Database,

--- a/modules/fedimint-dummy/src/lib.rs
+++ b/modules/fedimint-dummy/src/lib.rs
@@ -16,7 +16,7 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiVersion, ConsensusProposal, CoreConsensusVersion, InputMeta,
-    ModuleCommon, ModuleConsensusVersion, ModuleError, ModuleGen, PeerHandle,
+    ModuleCommon, ModuleConsensusVersion, ModuleError, PeerHandle, ServerModuleGen,
     TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
@@ -51,7 +51,7 @@ pub struct DummyVerificationCache;
 pub struct DummyConfigGenerator;
 
 #[async_trait]
-impl ModuleGen for DummyConfigGenerator {
+impl ServerModuleGen for DummyConfigGenerator {
     const KIND: ModuleKind = KIND;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(1);
 

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -33,8 +33,8 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiError, ApiVersion, ConsensusProposal, CoreConsensusVersion,
-    InputMeta, IntoModuleError, ModuleCommon, ModuleConsensusVersion, ModuleError, ModuleGen,
-    PeerHandle, TransactionItemAmount,
+    InputMeta, IntoModuleError, ModuleCommon, ModuleConsensusVersion, ModuleError, PeerHandle,
+    ServerModuleGen, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::TaskGroup;
@@ -262,7 +262,7 @@ pub struct LightningVerificationCache;
 pub struct LightningGen;
 
 #[apply(async_trait_maybe_send!)]
-impl ModuleGen for LightningGen {
+impl ServerModuleGen for LightningGen {
     const KIND: ModuleKind = KIND;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 

--- a/modules/fedimint-mint/src/lib.rs
+++ b/modules/fedimint-mint/src/lib.rs
@@ -19,8 +19,8 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiError, ApiVersion, ConsensusProposal, CoreConsensusVersion,
-    InputMeta, IntoModuleError, ModuleCommon, ModuleConsensusVersion, ModuleError, ModuleGen,
-    PeerHandle, TransactionItemAmount,
+    InputMeta, IntoModuleError, ModuleCommon, ModuleConsensusVersion, ModuleError, PeerHandle,
+    ServerModuleGen, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::{MaybeSend, TaskGroup};
@@ -148,7 +148,7 @@ pub struct VerifiedNotes {
 pub struct MintGen;
 
 #[apply(async_trait_maybe_send!)]
-impl ModuleGen for MintGen {
+impl ServerModuleGen for MintGen {
     const KIND: ModuleKind = KIND;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
@@ -1234,7 +1234,7 @@ mod test {
     use fedimint_core::config::{
         ClientModuleConfig, ConfigGenParams, ServerModuleConfig, TypedServerModuleConsensusConfig,
     };
-    use fedimint_core::module::ModuleGen;
+    use fedimint_core::module::ServerModuleGen;
     use fedimint_core::{Amount, PeerId, TieredMulti};
     use tbs::{blind_message, unblind_signature, verify, AggregatePublicKey, BlindingKey, Message};
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -35,8 +35,8 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiVersion, ConsensusProposal, CoreConsensusVersion, InputMeta,
-    IntoModuleError, ModuleCommon, ModuleConsensusVersion, ModuleError, ModuleGen, PeerHandle,
-    TransactionItemAmount,
+    IntoModuleError, ModuleCommon, ModuleConsensusVersion, ModuleError, PeerHandle,
+    ServerModuleGen, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
 #[cfg(not(target_family = "wasm"))]
@@ -232,7 +232,7 @@ impl std::fmt::Display for WalletOutputOutcome {
 pub struct WalletGen;
 
 #[apply(async_trait_maybe_send!)]
-impl ModuleGen for WalletGen {
+impl ServerModuleGen for WalletGen {
     const KIND: ModuleKind = KIND;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 

--- a/modules/fedimint-wallet/src/lib.rs
+++ b/modules/fedimint-wallet/src/lib.rs
@@ -34,9 +34,9 @@ use fedimint_core::module::__reexports::serde_json;
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::{
-    api_endpoint, ApiEndpoint, ApiVersion, ConsensusProposal, CoreConsensusVersion, InputMeta,
-    IntoModuleError, ModuleCommon, ModuleConsensusVersion, ModuleError, PeerHandle,
-    ServerModuleGen, TransactionItemAmount,
+    api_endpoint, ApiEndpoint, ApiVersion, CommonModuleGen, ConsensusProposal,
+    CoreConsensusVersion, InputMeta, IntoModuleError, ModuleCommon, ModuleConsensusVersion,
+    ModuleError, PeerHandle, ServerModuleGen, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
 #[cfg(not(target_family = "wasm"))]
@@ -229,16 +229,27 @@ impl std::fmt::Display for WalletOutputOutcome {
 }
 
 #[derive(Debug)]
+pub struct WalletCommonGen;
+
+impl CommonModuleGen for WalletCommonGen {
+    const KIND: ModuleKind = KIND;
+    fn decoder() -> Decoder {
+        <Wallet as ServerModule>::decoder()
+    }
+
+    fn hash_client_module(config: serde_json::Value) -> anyhow::Result<sha256::Hash> {
+        serde_json::from_value::<WalletClientConfig>(config)?.consensus_hash()
+    }
+}
+
+#[derive(Debug)]
 pub struct WalletGen;
 
 #[apply(async_trait_maybe_send!)]
 impl ServerModuleGen for WalletGen {
-    const KIND: ModuleKind = KIND;
-    const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
+    type Common = WalletCommonGen;
 
-    fn decoder(&self) -> Decoder {
-        <Wallet as ServerModule>::decoder()
-    }
+    const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
         &[ModuleConsensusVersion(0)]
@@ -350,11 +361,6 @@ impl ServerModuleGen for WalletGen {
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
         config.to_typed::<WalletConfig>()?.validate_config(identity)
     }
-
-    fn hash_client_module(&self, config: serde_json::Value) -> anyhow::Result<sha256::Hash> {
-        serde_json::from_value::<WalletClientConfig>(config)?.consensus_hash()
-    }
-
     async fn dump_database(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,


### PR DESCRIPTION
On top of #1773

I'd like to actually split server & client sides of modules into sub-crates to stop `ModuleGen`'s server-side functionality on the client. To do so, we need to split `ModulGen`.