### PR TITLE
test: lightning module database migration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "fedimint-bitcoind",
  "fedimint-core",
  "fedimint-ln-client",
+ "fedimint-rocksdb",
  "fedimint-server",
  "fedimint-wallet-client",
  "futures",
@@ -1413,6 +1414,7 @@ dependencies = [
  "secp256k1-zkp",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -22,10 +22,12 @@ fedimint-bitcoind = { path = "../fedimint-bitcoind" }
 fedimint-ln-client = { path = "../modules/fedimint-ln-client" }
 fedimint-server = { path = "../fedimint-server" }
 fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
+fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 ln-gateway = { path = "../gateway/ln-gateway" }
 futures = "0.3"
 lightning = "0.0.113"
 lightning-invoice = "0.21.0"
+tempfile = "3.3.0"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
 serde = "1.0.149"
 serde_json = "1.0.91"

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -878,3 +878,268 @@ async fn block_height(interconnect: &dyn ModuleInterconect) -> u32 {
 
     serde_json::from_value(body).expect("Malformed block height response from wallet module!")
 }
+
+#[cfg(test)]
+mod fedimint_migration_tests {
+    use std::str::FromStr;
+    use std::time::SystemTime;
+
+    use bitcoin_hashes::Hash;
+    use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
+    use fedimint_core::db::{apply_migrations, DatabaseTransaction};
+    use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::module::DynServerModuleGen;
+    use fedimint_core::{OutPoint, ServerModule, TransactionId};
+    use fedimint_ln_common::contracts::incoming::{
+        FundedIncomingContract, IncomingContract, IncomingContractOffer, OfferId,
+    };
+    use fedimint_ln_common::contracts::{
+        outgoing, ContractId, DecryptedPreimage, EncryptedPreimage, FundedContract, Preimage,
+        PreimageDecryptionShare,
+    };
+    use fedimint_ln_common::db::{
+        AgreedDecryptionShareKey, AgreedDecryptionShareKeyPrefix, ContractKey, ContractKeyPrefix,
+        ContractUpdateKey, ContractUpdateKeyPrefix, DbKeyPrefix, LightningGatewayKey,
+        LightningGatewayKeyPrefix, OfferKey, OfferKeyPrefix, ProposeDecryptionShareKey,
+        ProposeDecryptionShareKeyPrefix,
+    };
+    use fedimint_testing::{prepare_snapshot, validate_migrations};
+    use futures::StreamExt;
+    use lightning_invoice::Invoice;
+    use rand::distributions::Standard;
+    use rand::prelude::Distribution;
+    use rand::rngs::OsRng;
+    use strum::IntoEnumIterator;
+    use threshold_crypto::G1Projective;
+    use url::Url;
+
+    use crate::{
+        ContractAccount, Lightning, LightningGateway, LightningGen, LightningOutputOutcome,
+    };
+
+    const STRING_64: &str = "0123456789012345678901234567890101234567890123456789012345678901";
+    const BYTE_8: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+    const BYTE_32: [u8; 32] = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        0, 1,
+    ];
+
+    /// Create a database with version 0 data. The database produced is not
+    /// intended to be real data or semantically correct. It is only
+    /// intended to provide coverage when reading the database
+    /// in future code versions. This function should not be updated when
+    /// database keys/values change - instead a new function should be added
+    /// that creates a new database backup that can be tested.
+    async fn create_db_with_v0_data(mut dbtx: DatabaseTransaction<'_>) {
+        let contract_id = ContractId::from_str(STRING_64).unwrap();
+        let amount = fedimint_core::Amount { msats: 1000 };
+        let threshold_key = threshold_crypto::PublicKey::from(G1Projective::identity());
+        let (_, pk) = secp256k1::generate_keypair(&mut OsRng);
+        let incoming_contract = IncomingContract {
+            hash: secp256k1::hashes::sha256::Hash::hash(&BYTE_8),
+            encrypted_preimage: EncryptedPreimage::new(Preimage(BYTE_32), &threshold_key),
+            decrypted_preimage: DecryptedPreimage::Some(Preimage(BYTE_32)),
+            gateway_key: pk.x_only_public_key().0,
+        };
+        let out_point = OutPoint {
+            txid: TransactionId::all_zeros(),
+            out_idx: 0,
+        };
+        let incoming_contract = FundedContract::Incoming(FundedIncomingContract {
+            contract: incoming_contract,
+            out_point,
+        });
+        dbtx.insert_new_entry(
+            &ContractKey(contract_id),
+            &ContractAccount {
+                amount,
+                contract: incoming_contract,
+            },
+        )
+        .await;
+        let invoice = str::parse::<Invoice>("lnbc10u1pjq37rgsp5cry9r0qqdzp0tl0m27jedvxtrazq0v8xh5rfvzuhm7yxydg50m9qpp5r0cjzjzt7pjwae8trp6dtteh6hstdakzv68atpqx0zshaexghpwsdqqcqpjrzjqfzekav6v27ra0lf3geqmg3hj3xvfu652cuyhk8aa7naqdqvwh6x7zagh5qqy3qqqyqqqqqpqqqqqqgq9q9qyysgq6vf5z83a2q2ua9nwanmc7pql26pwt8smt2xzwp7kjd0mgplmy925s5yz6nlfxt99p2dlffw82gw8kte7lv87pcf4nahslg2vyhhkzwqqxuqmgp");
+        let outgoing_contract = FundedContract::Outgoing(outgoing::OutgoingContract {
+            hash: secp256k1::hashes::sha256::Hash::hash(&[0, 2, 3, 4, 5, 6, 7, 8]),
+            gateway_key: pk.x_only_public_key().0,
+            timelock: 1000000,
+            user_key: pk.x_only_public_key().0,
+            invoice: invoice.unwrap(),
+            cancelled: false,
+        });
+        dbtx.insert_new_entry(
+            &ContractKey(contract_id),
+            &ContractAccount {
+                amount,
+                contract: outgoing_contract,
+            },
+        )
+        .await;
+
+        let incoming_offer = IncomingContractOffer {
+            amount: fedimint_core::Amount { msats: 1000 },
+            hash: secp256k1::hashes::sha256::Hash::hash(&BYTE_8),
+            encrypted_preimage: EncryptedPreimage::new(Preimage(BYTE_32), &threshold_key),
+            expiry_time: None,
+        };
+        dbtx.insert_new_entry(&OfferKey(incoming_offer.hash), &incoming_offer)
+            .await;
+
+        let contract_update_key = ContractUpdateKey(OutPoint {
+            txid: TransactionId::from_slice(&BYTE_32).unwrap(),
+            out_idx: 0,
+        });
+        let lightning_output_outcome = LightningOutputOutcome::Offer {
+            id: OfferId::from_str(STRING_64).unwrap(),
+        };
+        dbtx.insert_new_entry(&contract_update_key, &lightning_output_outcome)
+            .await;
+
+        let preimage_decryption_share = PreimageDecryptionShare(Standard.sample(&mut OsRng));
+        dbtx.insert_new_entry(
+            &ProposeDecryptionShareKey(contract_id),
+            &preimage_decryption_share,
+        )
+        .await;
+
+        dbtx.insert_new_entry(
+            &AgreedDecryptionShareKey(contract_id, 0.into()),
+            &preimage_decryption_share,
+        )
+        .await;
+
+        let gateway = LightningGateway {
+            mint_channel_id: 100,
+            mint_pub_key: pk.x_only_public_key().0,
+            node_pub_key: pk,
+            api: Url::parse("http://example.com")
+                .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),
+            route_hints: vec![],
+            valid_until: SystemTime::now(),
+        };
+        dbtx.insert_new_entry(&LightningGatewayKey(pk), &gateway)
+            .await;
+
+        dbtx.commit_tx().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_migration_snapshots() {
+        prepare_snapshot(
+            "lightning-v0",
+            |dbtx| {
+                Box::pin(async move {
+                    create_db_with_v0_data(dbtx).await;
+                })
+            },
+            ModuleDecoderRegistry::from_iter([(
+                LEGACY_HARDCODED_INSTANCE_ID_LN,
+                <Lightning as ServerModule>::decoder(),
+            )]),
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_migrations() {
+        validate_migrations(
+            |db| async move {
+                let module = DynServerModuleGen::from(LightningGen);
+                apply_migrations(
+                    &db,
+                    module.module_kind().to_string(),
+                    module.database_version(),
+                    module.get_database_migrations(),
+                )
+                .await
+                .expect("Error applying migrations to temp database");
+
+                // Verify that all of the data from the lightning namespace can be read. If a
+                // database migration failed or was not properly supplied,
+                // the struct will fail to be read.
+                let mut dbtx = db.begin_transaction().await;
+
+                for prefix in DbKeyPrefix::iter() {
+                    match prefix {
+                        DbKeyPrefix::Contract => {
+                            let contracts = dbtx
+                                .find_by_prefix(&ContractKeyPrefix)
+                                .await
+                                .collect::<Vec<_>>()
+                                .await;
+                            let num_contracts = contracts.len();
+                            assert!(
+                                num_contracts > 0,
+                                "validate_migrations was not able to read any contracts"
+                            );
+                        }
+                        DbKeyPrefix::AgreedDecryptionShare => {
+                            let agreed_decryption_shares = dbtx
+                                .find_by_prefix(&AgreedDecryptionShareKeyPrefix)
+                                .await
+                                .collect::<Vec<_>>()
+                                .await;
+                            let num_shares = agreed_decryption_shares.len();
+                            assert!(
+                            num_shares > 0,
+                            "validate_migrations was not able to read any AgreedDecryptionShares"
+                        );
+                        }
+                        DbKeyPrefix::ContractUpdate => {
+                            let contract_updates = dbtx
+                                .find_by_prefix(&ContractUpdateKeyPrefix)
+                                .await
+                                .collect::<Vec<_>>()
+                                .await;
+                            let num_updates = contract_updates.len();
+                            assert!(
+                                num_updates > 0,
+                                "validate_migrations was not able to read any ContractUpdates"
+                            );
+                        }
+                        DbKeyPrefix::LightningGateway => {
+                            let gateways = dbtx
+                                .find_by_prefix(&LightningGatewayKeyPrefix)
+                                .await
+                                .collect::<Vec<_>>()
+                                .await;
+                            let num_gateways = gateways.len();
+                            assert!(
+                                num_gateways > 0,
+                                "validate_migrations was not able to read any LightningGateways"
+                            );
+                        }
+                        DbKeyPrefix::Offer => {
+                            let offers = dbtx
+                                .find_by_prefix(&OfferKeyPrefix)
+                                .await
+                                .collect::<Vec<_>>()
+                                .await;
+                            let num_offers = offers.len();
+                            assert!(
+                                num_offers > 0,
+                                "validate_migrations was not able to read any Offers"
+                            );
+                        }
+                        DbKeyPrefix::ProposeDecryptionShare => {
+                            let proposed_decryption_shares = dbtx
+                                .find_by_prefix(&ProposeDecryptionShareKeyPrefix)
+                                .await
+                                .collect::<Vec<_>>()
+                                .await;
+                            let num_shares = proposed_decryption_shares.len();
+                            assert!(
+                            num_shares > 0,
+                            "validate_migrations was not able to read any ProposeDecryptionShares"
+                        );
+                        }
+                    }
+                }
+            },
+            ModuleDecoderRegistry::from_iter([(
+                LEGACY_HARDCODED_INSTANCE_ID_LN,
+                <Lightning as ServerModule>::decoder(),
+            )]),
+        )
+        .await;
+    }
+}


### PR DESCRIPTION
Right now, we do not currently have a mechanism for catching if someone updated a database key or value, but forgot to update the corresponding database migration. This PR aims to add test coveage to catch this scenario, starting with the lightning module.

There are two components to testing database migrations:

1. Creating a backup. This can be done by setting `export FM_TEST_DB_BACKUP_DIR` to a directory then running `cargo test prepare_migration_snapshots`. This will create database backups in the directory specified by the environment variable. This directory can then be saved/zipped for step 2 that can be run at a later date.

2. Run the database migration tests against a backup. The database migration tests are only run if the FM_TEST_DB_BACKUP_DIR has been set (otherwise they just pass). The database migration tests will then apply the database migrations to every database and then read every key/value from every database. If a database migration has failed, or the key/value type has been changed but no migration has been specified, these tests should fail.

The idea is that steps 1 and 2 will be run at different times. Step 1 should be run when doing releases (or ideally, anytime a database key/value changes). Step 2 should ideally be run as part of CI or a daily cadence so that mistakes are caught early.

Next: Update CI to automatically run step 2 from a pre-saved backup.