### PR TITLE
feat: just check-wasm

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,8 +41,11 @@ lint:
 # run all checks recommended before opening a PR
 final-check: lint
   cargo test --doc
-  nix develop .#crossWasm -c cargo check --target wasm32-unknown-unknown --package mint-client
+  just check-wasm
   just test
+
+check-wasm:
+  nix develop .#crossWasm -c cargo check --target wasm32-unknown-unknown --package mint-client
 
 # check files you've touched for spelling errors
 spell:


### PR DESCRIPTION
Useful when you want to quickly check if wasm still compiles (because it often doesn't).