### PR TITLE
refactor: expose ModuleDatabaseTransaction for modules

### DIFF
--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -223,8 +223,12 @@ where
                     let transition_fn = transition_fn.clone();
                     let transition_outcome = transition_outcome.clone();
                     Box::pin(async move {
-                        let new_state =
-                            transition_fn(dbtx, transition_outcome, state.clone()).await;
+                        let new_state = transition_fn(
+                            &mut dbtx.with_module_prefix(state.module_instance_id()),
+                            transition_outcome,
+                            state.clone(),
+                        )
+                        .await;
                         dbtx.remove_entry(&ActiveStateKey(state.clone()))
                             .await
                             .expect("DB error");

--- a/fedimint-client/src/sm/state.rs
+++ b/fedimint-client/src/sm/state.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::DatabaseTransaction;
+use fedimint_core::db::IsolatedDatabaseTransaction;
 use fedimint_core::dyn_newtype_define_with_instance_id;
 use fedimint_core::encoding::{Decodable, DynEncodable, Encodable};
 use futures::future::BoxFuture;
@@ -83,7 +83,11 @@ where
 type TriggerFuture = Pin<Box<dyn Future<Output = serde_json::Value> + Send + 'static>>;
 // TODO: remove Arc, maybe make it a fn pointer?
 type StateTransitionFunction<S> = Arc<
-    dyn for<'a> Fn(&'a mut DatabaseTransaction<'_>, serde_json::Value, S) -> BoxFuture<'a, S>
+    dyn for<'a> Fn(
+            &'a mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+            serde_json::Value,
+            S,
+        ) -> BoxFuture<'a, S>
         + Send
         + Sync,
 >;
@@ -129,7 +133,11 @@ impl<S> StateTransition<S> {
         S: Send + Sync + Clone + 'static,
         V: serde::Serialize + serde::de::DeserializeOwned + Send,
         Trigger: Future<Output = V> + Send + 'static,
-        TransitionFn: for<'a> Fn(&'a mut DatabaseTransaction<'_>, V, S) -> BoxFuture<'a, S>
+        TransitionFn: for<'a> Fn(
+                &'a mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+                V,
+                S,
+            ) -> BoxFuture<'a, S>
             + Send
             + Sync
             + Copy
@@ -174,11 +182,13 @@ where
         .map(|st| StateTransition {
             trigger: st.trigger,
             transition: Arc::new(
-                move |dbtx: &mut DatabaseTransaction, val, state: DynState<GC>| {
+                move |dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+                      val,
+                      state: DynState<GC>| {
                     let transition = st.transition.clone();
                     Box::pin(async move {
                         let new_state = transition(
-                            &mut dbtx.with_module_prefix(state.module_instance_id()),
+                            dbtx,
                             val,
                             state
                                 .as_any()

--- a/fedimint-client/src/sm/state.rs
+++ b/fedimint-client/src/sm/state.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::IsolatedDatabaseTransaction;
+use fedimint_core::db::ModuleDatabaseTransaction;
 use fedimint_core::dyn_newtype_define_with_instance_id;
 use fedimint_core::encoding::{Decodable, DynEncodable, Encodable};
 use futures::future::BoxFuture;
@@ -84,7 +84,7 @@ type TriggerFuture = Pin<Box<dyn Future<Output = serde_json::Value> + Send + 'st
 // TODO: remove Arc, maybe make it a fn pointer?
 type StateTransitionFunction<S> = Arc<
     dyn for<'a> Fn(
-            &'a mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+            &'a mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
             serde_json::Value,
             S,
         ) -> BoxFuture<'a, S>
@@ -134,7 +134,7 @@ impl<S> StateTransition<S> {
         V: serde::Serialize + serde::de::DeserializeOwned + Send,
         Trigger: Future<Output = V> + Send + 'static,
         TransitionFn: for<'a> Fn(
-                &'a mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+                &'a mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
                 V,
                 S,
             ) -> BoxFuture<'a, S>
@@ -182,7 +182,7 @@ where
         .map(|st| StateTransition {
             trigger: st.trigger,
             transition: Arc::new(
-                move |dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+                move |dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
                       val,
                       state: DynState<GC>| {
                     let transition = st.transition.clone();

--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -7,12 +7,12 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::{apply, async_trait_maybe_send, OutPoint, PeerId};
 
 use super::*;
+use crate::db::IsolatedDatabaseTransaction;
 use crate::maybe_add_send_sync;
 use crate::module::{
     ApiEndpoint, ApiVersion, ConsensusProposal, InputMeta, ModuleCommon, ModuleConsensusVersion,
@@ -58,12 +58,15 @@ pub trait IServerModule: Debug {
     fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]);
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>);
+    async fn await_consensus_proposal(
+        &self,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+    );
 
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         module_instance_id: ModuleInstanceId,
     ) -> ConsensusProposal<DynModuleConsensusItem>;
 
@@ -74,7 +77,7 @@ pub trait IServerModule: Debug {
     /// results are available when processing transactions.
     async fn begin_consensus_epoch<'a>(
         &self,
-        dbtx: &mut DatabaseTransaction<'a>,
+        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
         consensus_items: Vec<(PeerId, DynModuleConsensusItem)>,
     );
 
@@ -93,7 +96,7 @@ pub trait IServerModule: Debug {
     async fn validate_input<'a>(
         &self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         verification_cache: &DynVerificationCache,
         input: &DynInput,
     ) -> Result<InputMeta, ModuleError>;
@@ -109,7 +112,7 @@ pub trait IServerModule: Debug {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut DatabaseTransaction<'c>,
+        dbtx: &mut IsolatedDatabaseTransaction<'c, '_, ModuleInstanceId>,
         input: &'b DynInput,
         verification_cache: &DynVerificationCache,
     ) -> Result<InputMeta, ModuleError>;
@@ -121,7 +124,7 @@ pub trait IServerModule: Debug {
     /// them and merely generate a warning.
     async fn validate_output(
         &self,
-        dbtx: &mut DatabaseTransaction,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         output: &DynOutput,
     ) -> Result<TransactionItemAmount, ModuleError>;
 
@@ -139,7 +142,7 @@ pub trait IServerModule: Debug {
     /// once all transactions have been processed.
     async fn apply_output<'a>(
         &self,
-        dbtx: &mut DatabaseTransaction<'a>,
+        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
         output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError>;
@@ -153,7 +156,7 @@ pub trait IServerModule: Debug {
     async fn end_consensus_epoch<'a>(
         &self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut DatabaseTransaction<'a>,
+        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
     ) -> Vec<PeerId>;
 
     /// Retrieve the current status of the output. Depending on the module this
@@ -162,7 +165,7 @@ pub trait IServerModule: Debug {
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome>;
@@ -172,7 +175,11 @@ pub trait IServerModule: Debug {
     ///
     /// Summing over all modules, if liabilities > assets then an error has
     /// occurred in the database and consensus should halt.
-    async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit);
+    async fn audit(
+        &self,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        audit: &mut Audit,
+    );
 
     /// Returns a list of custom API endpoints defined by the module. These are
     /// made available both to users as well as to other modules. They thus
@@ -204,14 +211,17 @@ where
     }
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(&self, dbtx: &mut DatabaseTransaction<'_>) {
+    async fn await_consensus_proposal(
+        &self,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+    ) {
         <Self as ServerModule>::await_consensus_proposal(self, dbtx).await
     }
 
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         module_instance_id: ModuleInstanceId,
     ) -> ConsensusProposal<DynModuleConsensusItem> {
         <Self as ServerModule>::consensus_proposal(self, dbtx)
@@ -226,7 +236,7 @@ where
     /// results are available when processing transactions.
     async fn begin_consensus_epoch<'a>(
         &self,
-        dbtx: &mut DatabaseTransaction<'a>,
+        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
         consensus_items: Vec<(PeerId, DynModuleConsensusItem)>,
     ) {
         <Self as ServerModule>::begin_consensus_epoch(
@@ -275,7 +285,7 @@ where
     async fn validate_input<'a>(
         &self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         verification_cache: &DynVerificationCache,
         input: &DynInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -307,7 +317,7 @@ where
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut DatabaseTransaction<'c>,
+        dbtx: &mut IsolatedDatabaseTransaction<'c, '_, ModuleInstanceId>,
         input: &'b DynInput,
         verification_cache: &DynVerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -335,7 +345,7 @@ where
     /// them and merely generate a warning.
     async fn validate_output(
         &self,
-        dbtx: &mut DatabaseTransaction,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         output: &DynOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         <Self as ServerModule>::validate_output(
@@ -363,7 +373,7 @@ where
     /// once all transactions have been processed.
     async fn apply_output<'a>(
         &self,
-        dbtx: &mut DatabaseTransaction<'a>,
+        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
         output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -388,7 +398,7 @@ where
     async fn end_consensus_epoch<'a>(
         &self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut DatabaseTransaction<'a>,
+        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
     ) -> Vec<PeerId> {
         <Self as ServerModule>::end_consensus_epoch(self, consensus_peers, dbtx).await
     }
@@ -399,7 +409,7 @@ where
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome> {
@@ -413,7 +423,11 @@ where
     ///
     /// Summing over all modules, if liabilities > assets then an error has
     /// occurred in the database and consensus should halt.
-    async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit) {
+    async fn audit(
+        &self,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        audit: &mut Audit,
+    ) {
         <Self as ServerModule>::audit(self, dbtx, audit).await
     }
 

--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -12,7 +12,7 @@ use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::{apply, async_trait_maybe_send, OutPoint, PeerId};
 
 use super::*;
-use crate::db::IsolatedDatabaseTransaction;
+use crate::db::ModuleDatabaseTransaction;
 use crate::maybe_add_send_sync;
 use crate::module::{
     ApiEndpoint, ApiVersion, ConsensusProposal, InputMeta, ModuleCommon, ModuleConsensusVersion,
@@ -60,13 +60,13 @@ pub trait IServerModule: Debug {
     /// Blocks until a new `consensus_proposal` is available.
     async fn await_consensus_proposal(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
     );
 
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         module_instance_id: ModuleInstanceId,
     ) -> ConsensusProposal<DynModuleConsensusItem>;
 
@@ -77,7 +77,7 @@ pub trait IServerModule: Debug {
     /// results are available when processing transactions.
     async fn begin_consensus_epoch<'a>(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
         consensus_items: Vec<(PeerId, DynModuleConsensusItem)>,
     );
 
@@ -96,7 +96,7 @@ pub trait IServerModule: Debug {
     async fn validate_input<'a>(
         &self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         verification_cache: &DynVerificationCache,
         input: &DynInput,
     ) -> Result<InputMeta, ModuleError>;
@@ -112,7 +112,7 @@ pub trait IServerModule: Debug {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut IsolatedDatabaseTransaction<'c, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
         input: &'b DynInput,
         verification_cache: &DynVerificationCache,
     ) -> Result<InputMeta, ModuleError>;
@@ -124,7 +124,7 @@ pub trait IServerModule: Debug {
     /// them and merely generate a warning.
     async fn validate_output(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         output: &DynOutput,
     ) -> Result<TransactionItemAmount, ModuleError>;
 
@@ -142,7 +142,7 @@ pub trait IServerModule: Debug {
     /// once all transactions have been processed.
     async fn apply_output<'a>(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
         output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError>;
@@ -156,7 +156,7 @@ pub trait IServerModule: Debug {
     async fn end_consensus_epoch<'a>(
         &self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
     ) -> Vec<PeerId>;
 
     /// Retrieve the current status of the output. Depending on the module this
@@ -165,7 +165,7 @@ pub trait IServerModule: Debug {
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome>;
@@ -177,7 +177,7 @@ pub trait IServerModule: Debug {
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         audit: &mut Audit,
     );
 
@@ -213,7 +213,7 @@ where
     /// Blocks until a new `consensus_proposal` is available.
     async fn await_consensus_proposal(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
     ) {
         <Self as ServerModule>::await_consensus_proposal(self, dbtx).await
     }
@@ -221,7 +221,7 @@ where
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         module_instance_id: ModuleInstanceId,
     ) -> ConsensusProposal<DynModuleConsensusItem> {
         <Self as ServerModule>::consensus_proposal(self, dbtx)
@@ -236,7 +236,7 @@ where
     /// results are available when processing transactions.
     async fn begin_consensus_epoch<'a>(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
         consensus_items: Vec<(PeerId, DynModuleConsensusItem)>,
     ) {
         <Self as ServerModule>::begin_consensus_epoch(
@@ -285,7 +285,7 @@ where
     async fn validate_input<'a>(
         &self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         verification_cache: &DynVerificationCache,
         input: &DynInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -317,7 +317,7 @@ where
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut IsolatedDatabaseTransaction<'c, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
         input: &'b DynInput,
         verification_cache: &DynVerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -345,7 +345,7 @@ where
     /// them and merely generate a warning.
     async fn validate_output(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         output: &DynOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         <Self as ServerModule>::validate_output(
@@ -373,7 +373,7 @@ where
     /// once all transactions have been processed.
     async fn apply_output<'a>(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
         output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -398,7 +398,7 @@ where
     async fn end_consensus_epoch<'a>(
         &self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut IsolatedDatabaseTransaction<'a, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
     ) -> Vec<PeerId> {
         <Self as ServerModule>::end_consensus_epoch(self, consensus_peers, dbtx).await
     }
@@ -409,7 +409,7 @@ where
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome> {
@@ -425,7 +425,7 @@ where
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         audit: &mut Audit,
     ) {
         <Self as ServerModule>::audit(self, dbtx, audit).await

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use futures::StreamExt;
 
 use crate::core::ModuleInstanceId;
-use crate::db::{DatabaseLookup, DatabaseRecord, IsolatedDatabaseTransaction};
+use crate::db::{DatabaseLookup, DatabaseRecord, ModuleDatabaseTransaction};
 
 #[derive(Default)]
 pub struct Audit {
@@ -25,7 +25,7 @@ impl Audit {
 
     pub async fn add_items<KP, F>(
         &mut self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         key_prefix: &KP,
         to_milli_sat: F,
     ) where

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -2,7 +2,8 @@ use std::fmt::{Display, Formatter};
 
 use futures::StreamExt;
 
-use crate::db::{DatabaseLookup, DatabaseRecord, DatabaseTransaction};
+use crate::core::ModuleInstanceId;
+use crate::db::{DatabaseLookup, DatabaseRecord, IsolatedDatabaseTransaction};
 
 #[derive(Default)]
 pub struct Audit {
@@ -24,7 +25,7 @@ impl Audit {
 
     pub async fn add_items<KP, F>(
         &mut self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         key_prefix: &KP,
         to_milli_sat: F,
     ) where

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -22,7 +22,7 @@ use crate::core::{
     Decoder, DecoderBuilder, Input, ModuleConsensusItem, ModuleInstanceId, ModuleKind, Output,
     OutputOutcome,
 };
-use crate::db::{Database, DatabaseTransaction, DatabaseVersion, MigrationMap};
+use crate::db::{Database, DatabaseVersion, IsolatedDatabaseTransaction, MigrationMap};
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::audit::Audit;
 use crate::module::interconnect::ModuleInterconect;
@@ -89,7 +89,7 @@ pub trait TypedApiEndpoint {
 
     async fn handle<'a, 'b>(
         state: &'a Self::State,
-        dbtx: &'a mut fedimint_core::db::DatabaseTransaction<'b>,
+        dbtx: &'a mut fedimint_core::db::IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
         params: Self::Param,
     ) -> Result<Self::Response, ApiError>;
 }
@@ -102,7 +102,7 @@ pub mod __reexports {
 /// # Example
 ///
 /// ```rust
-/// # use fedimint_core::module::{api_endpoint, ApiEndpoint};
+/// # use fedimint_core::module::{api_endpoint, ApiEndpoint, registry::ModuleInstanceId};
 /// struct State;
 ///
 /// let _: ApiEndpoint<State> = api_endpoint! {
@@ -129,7 +129,11 @@ macro_rules! __api_endpoint {
 
             async fn handle<'a, 'b>(
                 $state: &'a Self::State,
-                $dbtx: &'a mut fedimint_core::db::DatabaseTransaction<'b>,
+                $dbtx: &'a mut fedimint_core::db::IsolatedDatabaseTransaction<
+                    'b,
+                    '_,
+                    ModuleInstanceId,
+                >,
                 $param: Self::Param,
             ) -> ::std::result::Result<Self::Response, $crate::module::ApiError> {
                 $body
@@ -188,7 +192,7 @@ impl ApiEndpoint<()> {
         )]
         async fn handle_request<'a, 'b, E>(
             state: &'a E::State,
-            dbtx: &mut fedimint_core::db::DatabaseTransaction<'b>,
+            dbtx: &mut fedimint_core::db::IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
             param: E::Param,
         ) -> Result<E::Response, ApiError>
         where
@@ -216,7 +220,7 @@ impl ApiEndpoint<()> {
                             let mut module_dbtx = dbtx.with_module_prefix(module_instance_id);
                             handle_request::<E>(m, &mut module_dbtx, params).await?
                         }
-                        None => handle_request::<E>(m, &mut dbtx, params).await?,
+                        None => handle_request::<E>(m, &mut dbtx.get_isolated(), params).await?,
                     };
 
                     dbtx.commit_tx()
@@ -394,7 +398,7 @@ pub trait IServerModuleGen: Debug {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_>;
 }
@@ -560,7 +564,7 @@ pub trait ServerModuleGen: Debug + Sized {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_>;
 }
@@ -651,7 +655,7 @@ where
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         <Self as ServerModuleGen>::dump_database(self, dbtx, prefix_names).await
@@ -767,12 +771,15 @@ pub trait ServerModule: Debug + Sized {
     fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]);
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal<'a>(&'a self, dbtx: &mut DatabaseTransaction<'_>);
+    async fn await_consensus_proposal<'a>(
+        &'a self,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+    );
 
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal<'a>(
         &'a self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
     ) -> ConsensusProposal<<Self::Common as ModuleCommon>::ConsensusItem>;
 
     /// This function is called once before transaction processing starts. All
@@ -782,7 +789,7 @@ pub trait ServerModule: Debug + Sized {
     /// results are available when processing transactions.
     async fn begin_consensus_epoch<'a, 'b>(
         &'a self,
-        dbtx: &mut DatabaseTransaction<'b>,
+        dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
         consensus_items: Vec<(PeerId, <Self::Common as ModuleCommon>::ConsensusItem)>,
     );
 
@@ -804,7 +811,7 @@ pub trait ServerModule: Debug + Sized {
     async fn validate_input<'a, 'b>(
         &self,
         interconnect: &dyn ModuleInterconect,
-        dbtx: &mut DatabaseTransaction<'b>,
+        dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
         verification_cache: &Self::VerificationCache,
         input: &'a <Self::Common as ModuleCommon>::Input,
     ) -> Result<InputMeta, ModuleError>;
@@ -820,7 +827,7 @@ pub trait ServerModule: Debug + Sized {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut DatabaseTransaction<'c>,
+        dbtx: &mut IsolatedDatabaseTransaction<'c, '_, ModuleInstanceId>,
         input: &'b <Self::Common as ModuleCommon>::Input,
         verification_cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError>;
@@ -832,7 +839,7 @@ pub trait ServerModule: Debug + Sized {
     /// them and merely generate a warning.
     async fn validate_output(
         &self,
-        dbtx: &mut DatabaseTransaction,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         output: &<Self::Common as ModuleCommon>::Output,
     ) -> Result<TransactionItemAmount, ModuleError>;
 
@@ -850,7 +857,7 @@ pub trait ServerModule: Debug + Sized {
     /// once all transactions have been processed.
     async fn apply_output<'a, 'b>(
         &'a self,
-        dbtx: &mut DatabaseTransaction<'b>,
+        dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
         output: &'a <Self::Common as ModuleCommon>::Output,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError>;
@@ -864,7 +871,7 @@ pub trait ServerModule: Debug + Sized {
     async fn end_consensus_epoch<'a, 'b>(
         &'a self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut DatabaseTransaction<'b>,
+        dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
     ) -> Vec<PeerId>;
 
     /// Retrieve the current status of the output. Depending on the module this
@@ -873,7 +880,7 @@ pub trait ServerModule: Debug + Sized {
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         out_point: OutPoint,
     ) -> Option<<Self::Common as ModuleCommon>::OutputOutcome>;
 
@@ -882,7 +889,11 @@ pub trait ServerModule: Debug + Sized {
     ///
     /// Summing over all modules, if liabilities > assets then an error has
     /// occurred in the database and consensus should halt.
-    async fn audit(&self, dbtx: &mut DatabaseTransaction<'_>, audit: &mut Audit);
+    async fn audit(
+        &self,
+        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        audit: &mut Audit,
+    );
 
     /// Returns a list of custom API endpoints defined by the module. These are
     /// made available both to users as well as to other modules. They thus

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 use fedimint_core::config::{ConfigResponse, ServerModuleGenRegistry};
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    apply_migrations, Database, DatabaseTransaction, IsolatedDatabaseTransaction,
+    apply_migrations, Database, DatabaseTransaction, ModuleDatabaseTransaction,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::*;
@@ -553,7 +553,7 @@ impl FedimintConsensus {
 
     pub async fn get_config_with_sig(
         &self,
-        dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
     ) -> ConfigResponse {
         let mut client = self.client_cfg.clone();
         let maybe_sig = dbtx.get_value(&ClientConfigSignatureKey).await;

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use fedimint_core::config::{ClientModuleConfig, ConfigGenParams, ServerModuleConfig};
 use fedimint_core::core::{ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
 use fedimint_core::db::mem_impl::MemDatabase;
-use fedimint_core::db::{Database, DatabaseTransaction};
+use fedimint_core::db::{Database, IsolatedDatabaseTransaction};
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{
@@ -89,7 +89,7 @@ where
 
         async fn member_validate<M: ServerModule>(
             member: &M,
-            dbtx: &mut DatabaseTransaction<'_>,
+            dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
             fake_ic: &FakeInterconnect,
             input: &<M::Common as ModuleCommon>::Input,
         ) -> Result<TestInputMeta, ModuleError> {

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use fedimint_core::config::{ClientModuleConfig, ConfigGenParams, ServerModuleConfig};
 use fedimint_core::core::{ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
 use fedimint_core::db::mem_impl::MemDatabase;
-use fedimint_core::db::{Database, IsolatedDatabaseTransaction};
+use fedimint_core::db::{Database, ModuleDatabaseTransaction};
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{
@@ -89,7 +89,7 @@ where
 
         async fn member_validate<M: ServerModule>(
             member: &M,
-            dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+            dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
             fake_ic: &FakeInterconnect,
             input: &<M::Common as ModuleCommon>::Input,
         ) -> Result<TestInputMeta, ModuleError> {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -909,10 +909,10 @@ impl FederationTest {
     pub async fn broadcast_transactions(&self) {
         for server in &self.servers {
             let svr = server.lock().await;
-            let mut dbtx = block_on(svr.database.begin_transaction());
-            let module_dbtx = dbtx.with_module_prefix(self.wallet_id);
+            let db = svr.database.new_isolated(self.wallet_id);
+            let dbtx = block_on(db.begin_transaction());
             block_on(fedimint_wallet::broadcast_pending_tx(
-                module_dbtx,
+                dbtx,
                 &svr.bitcoin_rpc,
             ));
         }

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -9,7 +9,7 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
-use fedimint_core::db::{Database, DatabaseTransaction, DatabaseVersion, MigrationMap};
+use fedimint_core::db::{Database, DatabaseVersion, IsolatedDatabaseTransaction, MigrationMap};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::__reexports::serde_json;
 use fedimint_core::module::audit::Audit;
@@ -153,7 +153,7 @@ impl ServerModuleGen for DummyServerGen {
 
     async fn dump_database(
         &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
+        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         _prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         Box::new(BTreeMap::new().into_iter())
@@ -227,20 +227,23 @@ impl ServerModule for Dummy {
         )
     }
 
-    async fn await_consensus_proposal(&self, _dbtx: &mut DatabaseTransaction<'_>) {
+    async fn await_consensus_proposal(
+        &self,
+        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+    ) {
         std::future::pending().await
     }
 
     async fn consensus_proposal(
         &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
+        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
     ) -> ConsensusProposal<DummyConsensusItem> {
         ConsensusProposal::empty()
     }
 
     async fn begin_consensus_epoch<'a, 'b>(
         &'a self,
-        _dbtx: &mut DatabaseTransaction<'b>,
+        _dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
         _consensus_items: Vec<(PeerId, DummyConsensusItem)>,
     ) {
     }
@@ -255,7 +258,7 @@ impl ServerModule for Dummy {
     async fn validate_input<'a, 'b>(
         &self,
         _interconnect: &dyn ModuleInterconect,
-        _dbtx: &mut DatabaseTransaction<'b>,
+        _dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
         _verification_cache: &Self::VerificationCache,
         _input: &'a DummyInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -265,7 +268,7 @@ impl ServerModule for Dummy {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         _interconnect: &'a dyn ModuleInterconect,
-        _dbtx: &mut DatabaseTransaction<'c>,
+        _dbtx: &mut IsolatedDatabaseTransaction<'c, '_, ModuleInstanceId>,
         _input: &'b DummyInput,
         _cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -274,7 +277,7 @@ impl ServerModule for Dummy {
 
     async fn validate_output(
         &self,
-        _dbtx: &mut DatabaseTransaction,
+        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         _output: &DummyOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         unimplemented!()
@@ -282,7 +285,7 @@ impl ServerModule for Dummy {
 
     async fn apply_output<'a, 'b>(
         &'a self,
-        _dbtx: &mut DatabaseTransaction<'b>,
+        _dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
         _output: &'a DummyOutput,
         _out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -292,20 +295,25 @@ impl ServerModule for Dummy {
     async fn end_consensus_epoch<'a, 'b>(
         &'a self,
         _consensus_peers: &HashSet<PeerId>,
-        _dbtx: &mut DatabaseTransaction<'b>,
+        _dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
     ) -> Vec<PeerId> {
         vec![]
     }
 
     async fn output_status(
         &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
+        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
         _out_point: OutPoint,
     ) -> Option<DummyOutputOutcome> {
         None
     }
 
-    async fn audit(&self, _dbtx: &mut DatabaseTransaction<'_>, _audit: &mut Audit) {}
+    async fn audit(
+        &self,
+        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        _audit: &mut Audit,
+    ) {
+    }
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![api_endpoint! {

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -9,7 +9,7 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
-use fedimint_core::db::{Database, DatabaseVersion, IsolatedDatabaseTransaction, MigrationMap};
+use fedimint_core::db::{Database, DatabaseVersion, MigrationMap, ModuleDatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::__reexports::serde_json;
 use fedimint_core::module::audit::Audit;
@@ -153,7 +153,7 @@ impl ServerModuleGen for DummyServerGen {
 
     async fn dump_database(
         &self,
-        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         _prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         Box::new(BTreeMap::new().into_iter())
@@ -229,21 +229,21 @@ impl ServerModule for Dummy {
 
     async fn await_consensus_proposal(
         &self,
-        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
     ) {
         std::future::pending().await
     }
 
     async fn consensus_proposal(
         &self,
-        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
     ) -> ConsensusProposal<DummyConsensusItem> {
         ConsensusProposal::empty()
     }
 
     async fn begin_consensus_epoch<'a, 'b>(
         &'a self,
-        _dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
         _consensus_items: Vec<(PeerId, DummyConsensusItem)>,
     ) {
     }
@@ -258,7 +258,7 @@ impl ServerModule for Dummy {
     async fn validate_input<'a, 'b>(
         &self,
         _interconnect: &dyn ModuleInterconect,
-        _dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
         _verification_cache: &Self::VerificationCache,
         _input: &'a DummyInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -268,7 +268,7 @@ impl ServerModule for Dummy {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         _interconnect: &'a dyn ModuleInterconect,
-        _dbtx: &mut IsolatedDatabaseTransaction<'c, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
         _input: &'b DummyInput,
         _cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -277,7 +277,7 @@ impl ServerModule for Dummy {
 
     async fn validate_output(
         &self,
-        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         _output: &DummyOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         unimplemented!()
@@ -285,7 +285,7 @@ impl ServerModule for Dummy {
 
     async fn apply_output<'a, 'b>(
         &'a self,
-        _dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
         _output: &'a DummyOutput,
         _out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -295,14 +295,14 @@ impl ServerModule for Dummy {
     async fn end_consensus_epoch<'a, 'b>(
         &'a self,
         _consensus_peers: &HashSet<PeerId>,
-        _dbtx: &mut IsolatedDatabaseTransaction<'b, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
     ) -> Vec<PeerId> {
         vec![]
     }
 
     async fn output_status(
         &self,
-        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         _out_point: OutPoint,
     ) -> Option<DummyOutputOutcome> {
         None
@@ -310,7 +310,7 @@ impl ServerModule for Dummy {
 
     async fn audit(
         &self,
-        _dbtx: &mut IsolatedDatabaseTransaction<'_, '_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         _audit: &mut Audit,
     ) {
     }

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -6,7 +6,8 @@ use fedimint_core::config::{
     ConfigGenParams, DkgResult, ModuleConfigResponse, ServerModuleConfig, TypedServerModuleConfig,
     TypedServerModuleConsensusConfig,
 };
-use fedimint_core::db::{Database, DatabaseTransaction, DatabaseVersion, MigrationMap};
+use fedimint_core::core::ModuleInstanceId;
+use fedimint_core::db::{Database, DatabaseVersion, MigrationMap, ModuleDatabaseTransaction};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::__reexports::serde_json;
 use fedimint_core::module::audit::Audit;
@@ -116,7 +117,7 @@ impl ServerModuleGen for DummyServerGen {
 
     async fn dump_database(
         &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         _prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         Box::new(BTreeMap::new().into_iter())
@@ -142,20 +143,23 @@ impl ServerModule for Dummy {
         )
     }
 
-    async fn await_consensus_proposal(&self, _dbtx: &mut DatabaseTransaction<'_>) {
+    async fn await_consensus_proposal(
+        &self,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+    ) {
         std::future::pending().await
     }
 
     async fn consensus_proposal(
         &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
     ) -> ConsensusProposal<DummyConsensusItem> {
         ConsensusProposal::empty()
     }
 
     async fn begin_consensus_epoch<'a, 'b>(
         &'a self,
-        _dbtx: &mut DatabaseTransaction<'b>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
         _consensus_items: Vec<(PeerId, DummyConsensusItem)>,
     ) {
     }
@@ -170,7 +174,7 @@ impl ServerModule for Dummy {
     async fn validate_input<'a, 'b>(
         &self,
         _interconnect: &dyn ModuleInterconect,
-        _dbtx: &mut DatabaseTransaction<'b>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
         _verification_cache: &Self::VerificationCache,
         _input: &'a DummyInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -180,7 +184,7 @@ impl ServerModule for Dummy {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         _interconnect: &'a dyn ModuleInterconect,
-        _dbtx: &mut DatabaseTransaction<'c>,
+        _dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
         _input: &'b DummyInput,
         _cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -189,7 +193,7 @@ impl ServerModule for Dummy {
 
     async fn validate_output(
         &self,
-        _dbtx: &mut DatabaseTransaction,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         _output: &DummyOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         unimplemented!()
@@ -197,7 +201,7 @@ impl ServerModule for Dummy {
 
     async fn apply_output<'a, 'b>(
         &'a self,
-        _dbtx: &mut DatabaseTransaction<'b>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
         _output: &'a DummyOutput,
         _out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -207,20 +211,25 @@ impl ServerModule for Dummy {
     async fn end_consensus_epoch<'a, 'b>(
         &'a self,
         _consensus_peers: &HashSet<PeerId>,
-        _dbtx: &mut DatabaseTransaction<'b>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
     ) -> Vec<PeerId> {
         vec![]
     }
 
     async fn output_status(
         &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
         _out_point: OutPoint,
     ) -> Option<DummyOutputOutcome> {
         None
     }
 
-    async fn audit(&self, _dbtx: &mut DatabaseTransaction<'_>, _audit: &mut Audit) {}
+    async fn audit(
+        &self,
+        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        _audit: &mut Audit,
+    ) {
+    }
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![api_endpoint! {


### PR DESCRIPTION
Today we wrap `IsolatedDatabaseTransaction` inside `DatabaseTransaction` and only expose `DatabaseTransaction` to the modules. This has some downsides, such as the fact that `commit_tx` is exposed as a possible function for the modules to call. This should not be allowed though, since modules should not be allowed to commit to the database because the fedimint server is responsible for managing the lifetime of a database transaction. Today if this happens, `commit_tx` will panic.

This PR is a refactor to expose `ModuleDatabaseTransaction` to the modules and add the public facing database transaction API to `ModuleDatabaseTransaction`, but removed the functions that modules should not be allowed to call. This allows us to keep the wrapper functionality that we have introduced in previous PRs, but also address the issue of not exposing the full database transaction API.

Fixes: https://github.com/fedimint/fedimint/issues/1729