### PR TITLE
fix: identifiable contract trait typo

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -78,7 +78,7 @@ use crate::mint::{MintClient, MintClientError, SpendableNote};
 use crate::modules::ln::config::LightningClientConfig;
 use crate::modules::ln::contracts::incoming::{IncomingContract, IncomingContractOffer};
 use crate::modules::ln::contracts::{
-    Contract, ContractId, DecryptedPreimage, IdentifyableContract, Preimage,
+    Contract, ContractId, DecryptedPreimage, IdentifiableContract, Preimage,
 };
 use crate::modules::ln::{ContractOutput, LightningGateway, LightningOutput};
 use crate::modules::mint::config::MintClientConfig;

--- a/client/client-lib/src/ln/incoming.rs
+++ b/client/client-lib/src/ln/incoming.rs
@@ -5,7 +5,7 @@ use lightning_invoice::Invoice;
 use serde::Serialize;
 
 use crate::modules::ln::contracts::incoming::IncomingContract;
-use crate::modules::ln::contracts::{ContractId, IdentifyableContract};
+use crate::modules::ln::contracts::{ContractId, IdentifiableContract};
 use crate::modules::ln::LightningInput;
 
 #[derive(Debug, Clone, Encodable, Decodable)]

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -31,7 +31,7 @@ use crate::modules::ln::config::LightningClientConfig;
 use crate::modules::ln::contracts::incoming::IncomingContractOffer;
 use crate::modules::ln::contracts::outgoing::OutgoingContract;
 use crate::modules::ln::contracts::{
-    Contract, ContractId, EncryptedPreimage, FundedContract, IdentifyableContract, Preimage,
+    Contract, ContractId, EncryptedPreimage, FundedContract, IdentifiableContract, Preimage,
 };
 use crate::modules::ln::{
     ContractAccount, ContractOutput, LightningGateway, LightningInput, LightningModuleTypes,
@@ -351,7 +351,7 @@ mod tests {
     use crate::api::fake::FederationApiFaker;
     use crate::ln::LnClient;
     use crate::modules::ln::config::LightningClientConfig;
-    use crate::modules::ln::contracts::{ContractId, IdentifyableContract};
+    use crate::modules::ln::contracts::{ContractId, IdentifiableContract};
     use crate::modules::ln::{Lightning, LightningGateway, LightningGen, LightningOutput};
     use crate::{module_decode_stubs, ClientContext};
 

--- a/client/client-lib/src/ln/outgoing.rs
+++ b/client/client-lib/src/ln/outgoing.rs
@@ -3,7 +3,7 @@ use fedimint_core::Amount;
 use serde::Serialize;
 
 use crate::modules::ln::contracts::outgoing::OutgoingContract;
-use crate::modules::ln::contracts::{IdentifyableContract, Preimage};
+use crate::modules::ln::contracts::{IdentifiableContract, Preimage};
 use crate::modules::ln::LightningInput;
 
 #[derive(Debug, Encodable, Decodable, Serialize)]

--- a/modules/fedimint-ln/src/contracts/incoming.rs
+++ b/modules/fedimint-ln/src/contracts/incoming.rs
@@ -7,7 +7,7 @@ use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::OutPoint;
 use serde::{Deserialize, Serialize};
 
-use crate::contracts::{ContractId, DecryptedPreimage, EncryptedPreimage, IdentifyableContract};
+use crate::contracts::{ContractId, DecryptedPreimage, EncryptedPreimage, IdentifiableContract};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct IncomingContractOffer {
@@ -90,7 +90,7 @@ hash_newtype!(
     doc = "The hash of a LN incoming contract offer"
 );
 
-impl IdentifyableContract for IncomingContract {
+impl IdentifiableContract for IncomingContract {
     fn contract_id(&self) -> ContractId {
         ContractId::from_hash(self.hash)
     }

--- a/modules/fedimint-ln/src/contracts/mod.rs
+++ b/modules/fedimint-ln/src/contracts/mod.rs
@@ -11,7 +11,7 @@ use fedimint_core::OutPoint;
 use serde::{Deserialize, Serialize};
 
 /// Anything representing a contract which thus has an associated [`ContractId`]
-pub trait IdentifyableContract: Encodable {
+pub trait IdentifiableContract: Encodable {
     fn contract_id(&self) -> ContractId;
 }
 
@@ -59,7 +59,7 @@ impl ContractOutcome {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct OutgoingContractOutcome {}
 
-impl IdentifyableContract for Contract {
+impl IdentifiableContract for Contract {
     fn contract_id(&self) -> ContractId {
         match self {
             Contract::Incoming(c) => c.contract_id(),
@@ -68,7 +68,7 @@ impl IdentifyableContract for Contract {
     }
 }
 
-impl IdentifyableContract for FundedContract {
+impl IdentifiableContract for FundedContract {
     fn contract_id(&self) -> ContractId {
         match self {
             FundedContract::Incoming(c) => c.contract.contract_id(),

--- a/modules/fedimint-ln/src/contracts/outgoing.rs
+++ b/modules/fedimint-ln/src/contracts/outgoing.rs
@@ -2,7 +2,7 @@ use bitcoin_hashes::Hash as BitcoinHash;
 use fedimint_core::encoding::{Decodable, Encodable};
 use serde::{Deserialize, Serialize};
 
-use crate::contracts::{ContractId, IdentifyableContract};
+use crate::contracts::{ContractId, IdentifiableContract};
 
 const CANCELLATION_TAG: &str = "outgoing contract cancellation";
 
@@ -32,7 +32,7 @@ pub struct OutgoingContract {
     pub cancelled: bool,
 }
 
-impl IdentifyableContract for OutgoingContract {
+impl IdentifiableContract for OutgoingContract {
     fn contract_id(&self) -> ContractId {
         let mut engine = ContractId::engine();
         Encodable::consensus_encode(&self.hash, &mut engine).expect("Hashing never fails");

--- a/modules/fedimint-ln/src/lib.rs
+++ b/modules/fedimint-ln/src/lib.rs
@@ -60,7 +60,7 @@ use crate::config::{
 use crate::contracts::incoming::{IncomingContractOffer, OfferId};
 use crate::contracts::{
     Contract, ContractId, ContractOutcome, DecryptedPreimage, EncryptedPreimage, FundedContract,
-    IdentifyableContract, Preimage, PreimageDecryptionShare,
+    IdentifiableContract, Preimage, PreimageDecryptionShare,
 };
 use crate::db::{
     AgreedDecryptionShareKey, AgreedDecryptionShareKeyPrefix, ContractKey, ContractKeyPrefix,

--- a/modules/fedimint-ln/tests/ln_contracts.rs
+++ b/modules/fedimint-ln/tests/ln_contracts.rs
@@ -6,7 +6,7 @@ use fedimint_ln::config::LightningClientConfig;
 use fedimint_ln::contracts::incoming::{IncomingContract, IncomingContractOffer};
 use fedimint_ln::contracts::outgoing::OutgoingContract;
 use fedimint_ln::contracts::{
-    Contract, ContractOutcome, DecryptedPreimage, EncryptedPreimage, IdentifyableContract,
+    Contract, ContractOutcome, DecryptedPreimage, EncryptedPreimage, IdentifiableContract,
     OutgoingContractOutcome, Preimage,
 };
 use fedimint_ln::{


### PR DESCRIPTION
- rename all `IdentifyableContract` trait references to`IdentifiableContract`

~**NOTE:** needs to land on top of #1812~ not anymore