### PR TITLE
fix: rename generate_unsigned_invoice -> generate_unconfirmed_invoice

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -941,13 +941,13 @@ impl Client<UserClientConfig> {
         expiry_time: Option<u64>,
     ) -> Result<ConfirmedInvoice> {
         let (txid, invoice, payment_keypair) = self
-            .generate_unsigned_invoice_and_submit(amount, description, &mut rng, expiry_time)
+            .generate_unconfirmed_invoice_and_submit(amount, description, &mut rng, expiry_time)
             .await?;
 
         self.await_invoice_confirmation(txid, invoice, payment_keypair)
             .await
     }
-    pub async fn generate_unsigned_invoice_and_submit<R: RngCore + CryptoRng>(
+    pub async fn generate_unconfirmed_invoice_and_submit<R: RngCore + CryptoRng>(
         &self,
         amount: Amount,
         description: String,
@@ -956,7 +956,13 @@ impl Client<UserClientConfig> {
     ) -> Result<(TransactionId, Invoice, KeyPair)> {
         let payment_keypair = KeyPair::new(&self.context.secp, &mut rng);
         let (invoice, ln_output) = self
-            .generate_unsigned_invoice(amount, description, payment_keypair, &mut rng, expiry_time)
+            .generate_unconfirmed_invoice(
+                amount,
+                description,
+                payment_keypair,
+                &mut rng,
+                expiry_time,
+            )
             .await?;
 
         // There is no input here because this is just an announcement
@@ -967,7 +973,7 @@ impl Client<UserClientConfig> {
         Ok((txid, invoice, payment_keypair))
     }
 
-    pub async fn generate_unsigned_invoice<R: RngCore + CryptoRng>(
+    pub async fn generate_unconfirmed_invoice<R: RngCore + CryptoRng>(
         &self,
         amount: Amount,
         description: String,

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -361,7 +361,7 @@ async fn drop_peers_who_dont_contribute_decryption_shares() -> Result<()> {
 
         let (txid, invoice, payment_keypair) = user
             .client
-            .generate_unsigned_invoice_and_submit(payment_amount, "".into(), &mut rng(), None)
+            .generate_unconfirmed_invoice_and_submit(payment_amount, "".into(), &mut rng(), None)
             .await
             .unwrap();
         fed.run_consensus_epochs(1).await;
@@ -470,7 +470,7 @@ async fn lightning_gateway_pays_internal_invoice() -> Result<()> {
         let confirmed_invoice = {
             let (txid, invoice, payment_keypair) = receiving_user
                 .client
-                .generate_unsigned_invoice_and_submit(sats(1000), "".into(), &mut rng(), None)
+                .generate_unconfirmed_invoice_and_submit(sats(1000), "".into(), &mut rng(), None)
                 .await
                 .unwrap();
             fed.run_consensus_epochs(1).await;
@@ -631,7 +631,7 @@ async fn lightning_gateway_claims_refund_for_internal_invoice() -> Result<()> {
 
         let (txid, invoice, payment_keypair) = receiving_client
             .client
-            .generate_unsigned_invoice_and_submit(sats(1000), "".into(), &mut rng(), None)
+            .generate_unconfirmed_invoice_and_submit(sats(1000), "".into(), &mut rng(), None)
             .await
             .unwrap();
         fed.run_consensus_epochs(1).await;
@@ -727,7 +727,7 @@ async fn receive_lightning_payment_valid_preimage() -> Result<()> {
         // consensus
         let (txid, invoice, payment_keypair) = user
             .client
-            .generate_unsigned_invoice_and_submit(preimage_price, "".into(), &mut rng(), None)
+            .generate_unconfirmed_invoice_and_submit(preimage_price, "".into(), &mut rng(), None)
             .await
             .unwrap();
         fed.run_consensus_epochs(1).await;


### PR DESCRIPTION
This invoice is signed (all BOLT11 invoices are) but it isn't confirmed in the federation, yet