### PR TITLE
Add RBF support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2761,6 +2762,7 @@ dependencies = [
  "fedimint-rocksdb",
  "fedimint-testing",
  "fedimint-wallet-client",
+ "fedimint-wallet-common",
  "fedimint-wallet-server",
  "futures",
  "hkdf",

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -31,6 +31,7 @@ fedimint-ln-client = { path = "../../modules/fedimint-ln-client" }
 fedimint-logging = { path = "../../fedimint-logging" }
 fedimint-mint-client = { path = "../../modules/fedimint-mint-client" }
 fedimint-wallet-client = { path = "../../modules/fedimint-wallet-client", default-features = false }
+fedimint-wallet-common = { path = "../../modules/fedimint-wallet-common", default-features = false }
 itertools = "0.10.5"
 rand = "0.8"
 ring = "0.16.20"

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -47,7 +47,7 @@ impl ClientModule for WalletClient {
 
     fn output_amount(&self, output: &WalletOutput) -> TransactionItemAmount {
         TransactionItemAmount {
-            amount: (output.amount + output.fees.amount()).into(),
+            amount: output.amount().into(),
             fee: self.config.fee_consensus.peg_out_abs,
         }
     }
@@ -323,9 +323,8 @@ mod tests {
             context: Arc::new(client_context),
         };
 
-        // Set fees low forever
         btc_rpc
-            .set_fee_rate(Some(Feerate { sats_per_kvb: 0 }))
+            .set_fee_rate(Some(Feerate { sats_per_kvb: 1000 }))
             .await;
 
         // generate fake UTXO
@@ -342,7 +341,7 @@ mod tests {
             recipient: addr.clone(),
             amount,
             fees: PegOutFees {
-                fee_rate: Feerate { sats_per_kvb: 0 },
+                fee_rate: Feerate { sats_per_kvb: 1000 },
                 total_weight: 0,
             },
         };
@@ -351,7 +350,7 @@ mod tests {
         btc_rpc.set_block_height(100).await;
         fed.lock()
             .await
-            .consensus_round(&[], &[(out_point, WalletOutput(output))])
+            .consensus_round(&[], &[(out_point, WalletOutput::PegOut(output))])
             .await;
 
         // begin pegout

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -29,5 +29,6 @@ lightning-invoice = "0.21.0"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
 serde = "1.0.149"
 serde_json = "1.0.91"
+tracing ="0.1.37"
 rand = "0.8"
 tokio = { version = "1.25.0", features = ["full"] }

--- a/fedimint-testing/src/btc/mod.rs
+++ b/fedimint-testing/src/btc/mod.rs
@@ -2,7 +2,7 @@ pub mod bitcoind;
 pub mod fixtures;
 
 use async_trait::async_trait;
-use bitcoin::{Address, Transaction};
+use bitcoin::{Address, Transaction, Txid};
 use fedimint_core::Amount;
 use fedimint_wallet_client::txoproof::TxOutProof;
 
@@ -38,4 +38,6 @@ pub trait BitcoinTest {
     /// Mine a block to include any pending transactions then get the amount
     /// received to an address
     async fn mine_block_and_get_received(&self, address: &Address) -> Amount;
+
+    async fn get_mempool_tx_fee(&self, txid: &Txid) -> Amount;
 }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -49,7 +49,7 @@ use fedimint_testing::ln::fixtures::FakeLightningTest;
 use fedimint_testing::ln::LightningTest;
 use fedimint_wallet_server::common::config::WalletConfig;
 use fedimint_wallet_server::common::db::UTXOKey;
-use fedimint_wallet_server::common::SpendableUTXO;
+use fedimint_wallet_server::common::{PegOutFees, SpendableUTXO};
 use fedimint_wallet_server::{Wallet, WalletGen};
 use futures::executor::block_on;
 use futures::future::{join_all, select_all};
@@ -581,14 +581,14 @@ impl<T: AsRef<ClientConfig> + Clone + Send> UserTest<T> {
     }
 
     /// Helper to simplify the peg_out method calls
-    pub async fn peg_out(&self, amount: u64, address: &Address) -> (Amount, OutPoint) {
+    pub async fn peg_out(&self, amount: u64, address: &Address) -> (PegOutFees, OutPoint) {
         let peg_out = self
             .client
             .new_peg_out_with_fees(bitcoin::Amount::from_sat(amount), address.clone())
             .await
             .unwrap();
         let out_point = self.client.peg_out(peg_out.clone(), rng()).await.unwrap();
-        (peg_out.fees.amount().into(), out_point)
+        (peg_out.fees, out_point)
     }
 
     /// Returns sum total of all notes

--- a/modules/fedimint-wallet-common/src/db.rs
+++ b/modules/fedimint-wallet-common/src/db.rs
@@ -40,7 +40,7 @@ impl_db_record!(
 );
 impl_db_lookup!(key = BlockHashKey, query_prefix = BlockHashKeyPrefix);
 
-#[derive(Clone, Debug, Encodable, Decodable, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize)]
 pub struct UTXOKey(pub bitcoin::OutPoint);
 
 #[derive(Clone, Debug, Encodable, Decodable)]


### PR DESCRIPTION
- Allows clients to submit RBF transactions to bump the fees of a stuck transaction
- Note there is a risk the fed could bank a small profit if in a rare case the non-RBF tx confirms first

**Follow-up fee fix**
- Need to add checks to avoid fees set below `minRelayFee` that could cause `submit_transaction` to fail
- Switch to sat/vb for clarity
- Confirm that the actual tx weight matches the `PegOutFees` paid for (could not if it pulls in an additional UTXO)

Fixes #1480
Fixes #233