### PR TITLE
refactor: remove redundancy in impl_db_lookup

### DIFF
--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -414,7 +414,6 @@ where
     GC: GlobalContext,
 {
     type Record = ActiveStateKey<GC>;
-    type Key = ActiveStateKey<GC>;
 }
 impl ActiveState {
     fn new() -> ActiveState {
@@ -493,7 +492,6 @@ where
     GC: GlobalContext,
 {
     type Record = InactiveStateKey<GC>;
-    type Key = InactiveStateKey<GC>;
 }
 
 #[cfg(test)]

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use futures::StreamExt;
 
 use crate::core::ModuleInstanceId;
-use crate::db::{DatabaseLookup, DatabaseRecord, ModuleDatabaseTransaction};
+use crate::db::{DatabaseKey, DatabaseLookup, DatabaseRecord, ModuleDatabaseTransaction};
 
 #[derive(Default)]
 pub struct Audit {
@@ -30,7 +30,8 @@ impl Audit {
         to_milli_sat: F,
     ) where
         KP: DatabaseLookup + 'static,
-        F: Fn(KP::Key, <<KP as DatabaseLookup>::Record as DatabaseRecord>::Value) -> i64,
+        KP::Record: DatabaseKey,
+        F: Fn(KP::Record, <<KP as DatabaseLookup>::Record as DatabaseRecord>::Value) -> i64,
     {
         let mut new_items = dbtx
             .find_by_prefix(key_prefix)


### PR DESCRIPTION
Redundancy in `DatabaseLookup` leftover from refactors.

Fixes: https://github.com/fedimint/fedimint/issues/1827