### PR TITLE
Add checks, refactor, test the wallet validation

### DIFF
--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -340,10 +340,7 @@ mod tests {
         let output = PegOut {
             recipient: addr.clone(),
             amount,
-            fees: PegOutFees {
-                fee_rate: Feerate { sats_per_kvb: 1000 },
-                total_weight: 0,
-            },
+            fees: PegOutFees::new(1000, 883),
         };
 
         // agree on output

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use assert_matches::assert_matches;
 use bitcoin::{Amount, KeyPair};
 use fedimint_core::task::TaskGroup;
-use fedimint_core::{msats, sats, Feerate, TieredMulti};
+use fedimint_core::{msats, sats, TieredMulti};
 use fedimint_ln_client::contracts::{Preimage, PreimageDecryptionShare};
 use fedimint_ln_client::LightningConsensusItem;
 use fedimint_logging::LOG_TEST;
@@ -168,10 +168,7 @@ async fn wallet_peg_outs_support_rbf() -> Result<()> {
 
         // RBF by increasing sats per kvb by 1000
         let rbf = Rbf {
-            fees: PegOutFees {
-                fee_rate: Feerate { sats_per_kvb: 1000 },
-                total_weight: fees.total_weight,
-            },
+            fees: PegOutFees::new(1000, fees.total_weight),
             txid,
         };
         let out_point = user.client.rbf_tx(rbf.clone()).await.unwrap();

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -152,6 +152,13 @@ pub struct PegOutFees {
 }
 
 impl PegOutFees {
+    pub fn new(sats_per_kvb: u64, total_weight: u64) -> Self {
+        PegOutFees {
+            fee_rate: Feerate { sats_per_kvb },
+            total_weight,
+        }
+    }
+
     pub fn amount(&self) -> Amount {
         self.fee_rate.calculate_fee(self.total_weight)
     }
@@ -303,15 +310,17 @@ pub enum WalletError {
     #[error("The peg-in was already claimed")]
     PegInAlreadyClaimed,
     #[error("Peg-out fee rate {0:?} is set below consensus {1:?}")]
-    PegOutFeeRate(Feerate, Feerate),
+    PegOutFeeBelowConsensus(Feerate, Feerate),
     #[error("Not enough SpendableUTXO")]
     NotEnoughSpendableUTXO,
     #[error("Peg out amount was under the dust limit")]
     PegOutUnderDustLimit,
     #[error("RBF transaction id not found")]
     RbfTransactionIdNotFound,
-    #[error("RBF has tx weight set incorrectly")]
-    RbfTxWeightIncorrect,
+    #[error("Peg-out fee weight {0} doesn't match actual weight {1}")]
+    TxWeightIncorrect(u64, u64),
+    #[error("Peg-out fee rate is below min relay fee")]
+    BelowMinRelayFee,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
As a follow-up to RBF, add checks for if peg-outs `fee < min_relay_fee` or the `fee_tx_weight != actual_tx_weight`.

Refactors all the validation into a separate function in `StatelessWallet` for easier unit testing.