### PR TITLE
fix: continue when we fail to buy preimage (don't return)

### DIFF
--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -175,7 +175,7 @@ impl GatewayActor {
                                     })),
                                 })
                                 .await;
-                            return;
+                            continue;
                         }
                     };
 


### PR DESCRIPTION
Spotted by @Maan2003 https://github.com/fedimint/fedimint/pull/1197/commits/cf44e05ca711eaa886c5fc008b42672313f66cac

Just wanted to get this in now since the polling PR is still in progress