### PR TITLE
refactor: remove  return values in public database transaction functions

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -332,7 +332,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
             );
             secret
         };
-        tx.expect_commit_tx().await;
+        tx.commit_tx().await;
         secret.into_root_secret()
     }
 
@@ -369,7 +369,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
     ) -> Result<TransactionId> {
         let mut dbtx = self.context.db.begin_transaction().await;
         let final_tx = tx.build(self, &mut dbtx, rng).await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
         let result = self
             .context
             .api
@@ -404,7 +404,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
             };
             dbtx.insert_entry(&key, &note).await;
         }
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         let mut tx = TransactionBuilder::default();
         let (mut keys, input) = MintClient::ecash_input(notes)?;
@@ -478,7 +478,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
         self.mint_client()
             .receive_notes(amount, &mut dbtx, create_tx)
             .await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
     }
 
     pub async fn new_peg_out_with_fees(
@@ -559,7 +559,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
             .wallet_client()
             .get_new_pegin_address(&mut dbtx, rng)
             .await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
         address
     }
 
@@ -601,7 +601,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
             })
             .await;
         }
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         Ok(final_notes)
     }
@@ -641,7 +641,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
             })
             .await;
         }
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         Ok(notes)
     }
@@ -653,7 +653,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
     pub async fn fetch_notes<'a>(&self, outpoint: OutPoint) -> Result<()> {
         let mut dbtx = self.context.db.begin_transaction().await;
         self.mint_client().fetch_notes(&mut dbtx, outpoint).await?;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
         Ok(())
     }
 
@@ -690,7 +690,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
             notes_to_reissue.extend(notes);
             dbtx.remove_entry(&key).await;
         }
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         debug!(target: LOG_WALLET, notes_to_reissue = ?notes_to_reissue.summary(), total = %notes_to_reissue.total_amount());
         trace!(target: LOG_WALLET, ?notes_to_reissue, "foo");
@@ -809,7 +809,7 @@ impl Client<UserClientConfig> {
         };
         let mut dbtx = self.context.db.begin_transaction().await;
         dbtx.insert_entry(&LightningGatewayKey, &gateway).await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
         Ok(gateway)
     }
 
@@ -836,7 +836,7 @@ impl Client<UserClientConfig> {
             )
             .await?;
 
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         let (contract_id, amount) = match &contract {
             LightningOutput::Contract(c) => {
@@ -889,7 +889,7 @@ impl Client<UserClientConfig> {
         dbtx.remove_entry(&OutgoingPaymentKey(contract_id))
             .await
             .ok_or(ClientError::DeleteUnknownOutgoingContract)?;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         Ok(OutPoint { txid, out_idx: 0 })
     }
@@ -1242,7 +1242,7 @@ impl Client<GatewayClientConfig> {
             &contract,
         )
         .await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
     }
 
     /// Lists all previously saved transactions that have not been driven to
@@ -1267,7 +1267,7 @@ impl Client<GatewayClientConfig> {
             .remove_entry(&OutgoingContractAccountKey(contract_id))
             .await
             .ok_or(ClientError::CancelUnknownOutgoingContract)?;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         self.cancel_outgoing_contract(contract_account).await
     }
@@ -1326,7 +1326,7 @@ impl Client<GatewayClientConfig> {
             .await;
         dbtx.insert_entry(&OutgoingPaymentClaimKey(contract_id), &())
             .await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         tx.input(&mut vec![self.config.redeem_key], input);
         let txid = self.submit_tx_with_change(tx, rng).await?;
@@ -1486,7 +1486,7 @@ impl Client<GatewayClientConfig> {
         let mut dbtx = self.context.db.begin_transaction().await;
         dbtx.remove_entry(&OutgoingPaymentClaimKey(contract_id))
             .await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
         Ok(())
     }
 

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -320,23 +320,19 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
     /// none is present
     async fn get_secret(db: &Database) -> DerivableSecret {
         let mut tx = db.begin_transaction().await;
-        let client_secret = tx.get_value(&ClientSecretKey).await.expect("DB error");
+        let client_secret = tx.get_value(&ClientSecretKey).await;
         let secret = if let Some(client_secret) = client_secret {
             client_secret
         } else {
             let secret: ClientSecret = thread_rng().gen();
-            let no_replacement = tx
-                .insert_entry(&ClientSecretKey, &secret)
-                .await
-                .expect("DB error")
-                .is_none();
+            let no_replacement = tx.insert_entry(&ClientSecretKey, &secret).await.is_none();
             assert!(
                 no_replacement,
                 "We would have overwritten our secret key, aborting!"
             );
             secret
         };
-        tx.commit_tx().await.expect("db failure");
+        tx.expect_commit_tx().await;
         secret.into_root_secret()
     }
 
@@ -373,7 +369,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
     ) -> Result<TransactionId> {
         let mut dbtx = self.context.db.begin_transaction().await;
         let final_tx = tx.build(self, &mut dbtx, rng).await;
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
         let result = self
             .context
             .api
@@ -406,9 +402,9 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
                 amount,
                 nonce: note.note.0,
             };
-            dbtx.insert_entry(&key, &note).await.expect("DB error");
+            dbtx.insert_entry(&key, &note).await;
         }
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         let mut tx = TransactionBuilder::default();
         let (mut keys, input) = MintClient::ecash_input(notes)?;
@@ -482,7 +478,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
         self.mint_client()
             .receive_notes(amount, &mut dbtx, create_tx)
             .await;
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
     }
 
     pub async fn new_peg_out_with_fees(
@@ -563,7 +559,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
             .wallet_client()
             .get_new_pegin_address(&mut dbtx, rng)
             .await;
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
         address
     }
 
@@ -603,10 +599,9 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
                 amount,
                 nonce: note.note.0,
             })
-            .await
-            .expect("DB Error");
+            .await;
         }
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         Ok(final_notes)
     }
@@ -644,10 +639,9 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
                 amount,
                 nonce: note.note.0,
             })
-            .await
-            .expect("DB Error");
+            .await;
         }
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         Ok(notes)
     }
@@ -659,7 +653,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
     pub async fn fetch_notes<'a>(&self, outpoint: OutPoint) -> Result<()> {
         let mut dbtx = self.context.db.begin_transaction().await;
         self.mint_client().fetch_notes(&mut dbtx, outpoint).await?;
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
         Ok(())
     }
 
@@ -671,7 +665,6 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
         let pending: Vec<_> = dbtx
             .find_by_prefix(&PendingNotesKeyPrefix)
             .await
-            .map(|res| res.expect("DB error"))
             .collect()
             .await;
 
@@ -695,9 +688,9 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
         for result in stream.collect::<Vec<_>>().await {
             let (key, notes) = result?;
             notes_to_reissue.extend(notes);
-            dbtx.remove_entry(&key).await.expect("DB Error");
+            dbtx.remove_entry(&key).await;
         }
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         debug!(target: LOG_WALLET, notes_to_reissue = ?notes_to_reissue.summary(), total = %notes_to_reissue.total_amount());
         trace!(target: LOG_WALLET, ?notes_to_reissue, "foo");
@@ -778,7 +771,6 @@ impl Client<UserClientConfig> {
             .await
             .get_value(&LightningGatewayKey)
             .await
-            .expect("DB error")
             .filter(|gw| gw.valid_until > fedimint_core::time::now())
         {
             return Ok(gateway);
@@ -816,10 +808,8 @@ impl Client<UserClientConfig> {
             }
         };
         let mut dbtx = self.context.db.begin_transaction().await;
-        dbtx.insert_entry(&LightningGatewayKey, &gateway)
-            .await
-            .expect("DB error");
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.insert_entry(&LightningGatewayKey, &gateway).await;
+        dbtx.expect_commit_tx().await;
         Ok(gateway)
     }
 
@@ -846,7 +836,7 @@ impl Client<UserClientConfig> {
             )
             .await?;
 
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         let (contract_id, amount) = match &contract {
             LightningOutput::Contract(c) => {
@@ -886,7 +876,6 @@ impl Client<UserClientConfig> {
             .await
             .get_value(&OutgoingPaymentKey(contract_id))
             .await
-            .expect("DB error")
             .ok_or(ClientError::RefundUnknownOutgoingContract)?;
 
         let mut tx = TransactionBuilder::default();
@@ -899,9 +888,8 @@ impl Client<UserClientConfig> {
         let mut dbtx = self.context.db.begin_transaction().await;
         dbtx.remove_entry(&OutgoingPaymentKey(contract_id))
             .await
-            .expect("DB error")
             .ok_or(ClientError::DeleteUnknownOutgoingContract)?;
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         Ok(OutPoint { txid, out_idx: 0 })
     }
@@ -1253,9 +1241,8 @@ impl Client<GatewayClientConfig> {
             &OutgoingContractAccountKey(contract.contract.contract_id()),
             &contract,
         )
-        .await
-        .expect("DB error");
-        dbtx.commit_tx().await.expect("DB Error");
+        .await;
+        dbtx.expect_commit_tx().await;
     }
 
     /// Lists all previously saved transactions that have not been driven to
@@ -1267,7 +1254,7 @@ impl Client<GatewayClientConfig> {
             .await
             .find_by_prefix(&OutgoingContractAccountKeyPrefix)
             .await
-            .map(|res| res.expect("DB error").1)
+            .map(|(_, contract)| contract)
             .collect()
             .await
     }
@@ -1279,9 +1266,8 @@ impl Client<GatewayClientConfig> {
         let contract_account = dbtx
             .remove_entry(&OutgoingContractAccountKey(contract_id))
             .await
-            .expect("DB error")
             .ok_or(ClientError::CancelUnknownOutgoingContract)?;
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         self.cancel_outgoing_contract(contract_account).await
     }
@@ -1337,12 +1323,10 @@ impl Client<GatewayClientConfig> {
         let input = Input::LN(contract.claim(preimage));
 
         dbtx.remove_entry(&OutgoingContractAccountKey(contract_id))
-            .await
-            .expect("DB Error");
+            .await;
         dbtx.insert_entry(&OutgoingPaymentClaimKey(contract_id), &())
-            .await
-            .expect("DB Error");
-        dbtx.commit_tx().await.expect("DB Error");
+            .await;
+        dbtx.expect_commit_tx().await;
 
         tx.input(&mut vec![self.config.redeem_key], input);
         let txid = self.submit_tx_with_change(tx, rng).await?;
@@ -1435,7 +1419,7 @@ impl Client<GatewayClientConfig> {
             .await
             .find_by_prefix(&OutgoingPaymentClaimKeyPrefix)
             .await
-            .map(|res| res.expect("DB error").0 .0)
+            .map(|(key, _)| key.0)
             .collect()
             .await
     }
@@ -1501,9 +1485,8 @@ impl Client<GatewayClientConfig> {
         // have to worry
         let mut dbtx = self.context.db.begin_transaction().await;
         dbtx.remove_entry(&OutgoingPaymentClaimKey(contract_id))
-            .await
-            .expect("DB error");
-        dbtx.commit_tx().await.expect("DB Error");
+            .await;
+        dbtx.expect_commit_tx().await;
         Ok(())
     }
 

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -265,7 +265,7 @@ impl LnClient {
         let mut dbtx = self.context.db.begin_transaction().await;
         dbtx.insert_entry(&ConfirmedInvoiceKey(invoice.contract_id()), invoice)
             .await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
     }
 
     pub async fn get_confirmed_invoice(&self, contract_id: ContractId) -> Result<ConfirmedInvoice> {
@@ -487,7 +487,7 @@ mod tests {
             .await
             .unwrap();
 
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         let contract = match &output {
             LightningOutput::Contract(c) => &c.contract,

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -93,7 +93,7 @@ impl MintClient {
             dbtx.insert_entry(&NextECashNoteIndexKey(amount), &note_idx.as_u64())
                 .await;
         }
-        dbtx.commit_tx().await?;
+        dbtx.commit_tx_result().await?;
 
         Ok(Ok(()))
     }
@@ -101,7 +101,7 @@ impl MintClient {
     pub async fn wipe_notes(&self) -> Result<()> {
         let mut dbtx = self.start_dbtx().await;
         Self::wipe_notes_static(&mut dbtx).await?;
-        dbtx.commit_tx().await?;
+        dbtx.commit_tx_result().await?;
         Ok(())
     }
 

--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -81,19 +81,17 @@ impl MintClient {
                 amount,
                 nonce: note.note.0,
             };
-            dbtx.insert_entry(&key, &note).await.expect("DB error");
+            dbtx.insert_entry(&key, &note).await;
         }
 
         for (txid, issuance_requests) in snapshot.unconfirmed_notes {
             dbtx.insert_entry(&OutputFinalizationKey(txid), &issuance_requests)
-                .await
-                .expect("DB Error");
+                .await;
         }
 
         for (amount, note_idx) in snapshot.next_note_idx.iter() {
             dbtx.insert_entry(&NextECashNoteIndexKey(amount), &note_idx.as_u64())
-                .await
-                .expect("DB Error");
+                .await;
         }
         dbtx.commit_tx().await?;
 
@@ -112,9 +110,9 @@ impl MintClient {
     /// Useful for cleaning previous data before restoring data recovered from
     /// backup.
     async fn wipe_notes_static(dbtx: &mut DatabaseTransaction<'_>) -> Result<()> {
-        dbtx.remove_by_prefix(&NoteKeyPrefix).await?;
-        dbtx.remove_by_prefix(&OutputFinalizationKeyPrefix).await?;
-        dbtx.remove_by_prefix(&NextECashNoteIndexKeyPrefix).await?;
+        dbtx.remove_by_prefix(&NoteKeyPrefix).await;
+        dbtx.remove_by_prefix(&OutputFinalizationKeyPrefix).await;
+        dbtx.remove_by_prefix(&NextECashNoteIndexKeyPrefix).await;
         Ok(())
     }
 
@@ -196,7 +194,6 @@ impl MintClient {
         let pending_notes: Vec<_> = dbtx
             .find_by_prefix(&OutputFinalizationKeyPrefix)
             .await
-            .map(|res| res.expect("DB error"))
             .collect()
             .await;
 

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -199,13 +199,9 @@ impl MintClient {
                         amount,
                         nonce: note.0,
                     };
-                    let spendable = dbtx
-                        .get_value(&key)
-                        .await
-                        .expect("DB Error")
-                        .expect("Missing note");
+                    let spendable = dbtx.get_value(&key).await.expect("Missing note");
                     input_ecash.push((amount, spendable));
-                    dbtx.remove_entry(&key).await.expect("DB Error");
+                    dbtx.remove_entry(&key).await;
                 }
             }
         }
@@ -228,9 +224,7 @@ impl MintClient {
         // move ecash to pending state, awaiting a transaction
         if !input_ecash.is_empty() {
             let pending = TieredMulti::from_iter(input_ecash.into_iter());
-            dbtx.insert_entry(&PendingNotesKey(txid), &pending)
-                .await
-                .expect("DB Error");
+            dbtx.insert_entry(&PendingNotesKey(txid), &pending).await;
         }
 
         // write ecash outputs to db to await for tx success to be fetched later
@@ -242,23 +236,19 @@ impl MintClient {
                 }),
                 &notes.clone(),
             )
-            .await
-            .expect("DB Error");
+            .await;
         }
     }
 
     pub async fn set_notes_per_denomination(&self, notes: u16) {
         let mut dbtx = self.start_dbtx().await;
-        dbtx.insert_entry(&NotesPerDenominationKey, &notes)
-            .await
-            .expect("DB error");
-        dbtx.commit_tx().await.expect("DB error");
+        dbtx.insert_entry(&NotesPerDenominationKey, &notes).await;
+        dbtx.expect_commit_tx().await;
     }
 
     async fn notes_per_denomination(&self, dbtx: &mut DatabaseTransaction<'_>) -> u16 {
         dbtx.get_value(&NotesPerDenominationKey)
             .await
-            .expect("DB Error")
             .unwrap_or(self.config.max_notes_per_denomination - 1)
     }
 
@@ -325,10 +315,7 @@ impl MintClient {
             .await
             .find_by_prefix(&NoteKeyPrefix)
             .await
-            .map(|res| {
-                let (key, spendable_note) = res.expect("DB error");
-                (key.amount, spendable_note)
-            })
+            .map(|(key, spendable_note)| (key.amount, spendable_note))
             .collect()
             .await
     }
@@ -340,10 +327,7 @@ impl MintClient {
     ) -> TieredMulti<SpendableNote> {
         dbtx.find_by_prefix(&NoteKeyPrefix)
             .await
-            .map(|res| {
-                let (key, spendable_note) = res.expect("DB error");
-                (key.amount, spendable_note)
-            })
+            .map(|(key, spendable_note)| (key.amount, spendable_note))
             .collect()
             .await
     }
@@ -356,7 +340,6 @@ impl MintClient {
         NoteIndex(
             dbtx.get_value(&NextECashNoteIndexKey(amount))
                 .await
-                .expect("DB error")
                 .unwrap_or(0),
         )
     }
@@ -368,8 +351,7 @@ impl MintClient {
     ) -> DerivableSecret {
         let new_idx = self.get_next_note_index(dbtx, amount).await;
         dbtx.insert_entry(&NextECashNoteIndexKey(amount), &new_idx.next().as_u64())
-            .await
-            .expect("DB Error");
+            .await;
         Self::new_note_secret_static(&self.secret, amount, new_idx)
     }
 
@@ -426,8 +408,7 @@ impl MintClient {
             .await;
         let out_point = create_tx(notes).await;
         dbtx.insert_new_entry(&OutputFinalizationKey(out_point), &finalization)
-            .await
-            .expect("DB Error");
+            .await;
     }
 
     pub async fn await_fetch_notes<'a>(
@@ -470,7 +451,6 @@ impl MintClient {
             .await
             .get_value(&OutputFinalizationKey(outpoint))
             .await
-            .expect("DB error")
             .ok_or(MintClientError::FinalizationError(
                 NoteFinalizationError::UnknownIssuance,
             ))?;
@@ -493,11 +473,9 @@ impl MintClient {
                 nonce: note.note.0,
             };
             let value = note;
-            dbtx.insert_new_entry(&key, &value).await.expect("DB Error");
+            dbtx.insert_new_entry(&key, &value).await;
         }
-        dbtx.remove_entry(&OutputFinalizationKey(outpoint))
-            .await
-            .expect("DB Error");
+        dbtx.remove_entry(&OutputFinalizationKey(outpoint)).await;
 
         Ok(())
     }
@@ -509,10 +487,7 @@ impl MintClient {
             .await
             .find_by_prefix(&OutputFinalizationKeyPrefix)
             .await
-            .map(|res| {
-                let (OutputFinalizationKey(outpoint), cfd) = res.expect("DB error");
-                (outpoint, cfd)
-            })
+            .map(|(OutputFinalizationKey(outpoint), cfd)| (outpoint, cfd))
             .collect()
             .await
     }
@@ -529,7 +504,7 @@ impl MintClient {
             futures.push(Box::pin(async {
                 let mut dbtx = self.context.db.begin_transaction().await;
                 let res = self.await_fetch_notes(&mut dbtx, outpoint).await;
-                dbtx.commit_tx().await.expect("DB Error");
+                dbtx.expect_commit_tx().await;
                 res
             }))
         }
@@ -801,7 +776,7 @@ mod tests {
                 out_point
             })
             .await;
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         client.fetch_all_notes().await;
     }
@@ -860,7 +835,7 @@ mod tests {
                 secp,
             )
             .await;
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         if let Input::Mint(input) = ecash_input {
             let meta = fed.lock().await.verify_input(&input).await.unwrap();
@@ -902,7 +877,7 @@ mod tests {
                 secp,
             )
             .await;
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         if let Input::Mint(input) = ecash_input {
             let meta = fed.lock().await.verify_input(&input).await.unwrap();
@@ -996,7 +971,6 @@ mod tests {
             .await
             .get_value(&NextECashNoteIndexKey(amount))
             .await
-            .expect("DB error")
             .unwrap_or(0);
         // Ensure we didn't skip any keys
         assert_eq!(last_idx, result_count as u64);

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -243,7 +243,7 @@ impl MintClient {
     pub async fn set_notes_per_denomination(&self, notes: u16) {
         let mut dbtx = self.start_dbtx().await;
         dbtx.insert_entry(&NotesPerDenominationKey, &notes).await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
     }
 
     async fn notes_per_denomination(&self, dbtx: &mut DatabaseTransaction<'_>) -> u16 {
@@ -504,7 +504,7 @@ impl MintClient {
             futures.push(Box::pin(async {
                 let mut dbtx = self.context.db.begin_transaction().await;
                 let res = self.await_fetch_notes(&mut dbtx, outpoint).await;
-                dbtx.expect_commit_tx().await;
+                dbtx.commit_tx().await;
                 res
             }))
         }
@@ -776,7 +776,7 @@ mod tests {
                 out_point
             })
             .await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         client.fetch_all_notes().await;
     }
@@ -835,7 +835,7 @@ mod tests {
                 secp,
             )
             .await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         if let Input::Mint(input) = ecash_input {
             let meta = fed.lock().await.verify_input(&input).await.unwrap();
@@ -877,7 +877,7 @@ mod tests {
                 secp,
             )
             .await;
-        dbtx.expect_commit_tx().await;
+        dbtx.commit_tx().await;
 
         if let Input::Mint(input) = ecash_input {
             let meta = fed.lock().await.verify_input(&input).await.unwrap();
@@ -937,7 +937,7 @@ mod tests {
                             let (_, nonce) = client
                                 .new_ecash_note(secp256k1_zkp::SECP256K1, amount, &mut dbtx)
                                 .await;
-                            dbtx.commit_tx().await.map(|_| nonce).ok()
+                            dbtx.commit_tx_result().await.map(|_| nonce).ok()
                         })
                     }
                 })

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -93,8 +93,7 @@ impl WalletClient {
             },
             &peg_in_keypair.secret_bytes(),
         )
-        .await
-        .expect("DB Error");
+        .await;
 
         address
     }
@@ -116,7 +115,6 @@ impl WalletClient {
                         peg_in_script: out.script_pubkey.clone(),
                     })
                     .await
-                    .expect("DB error")
                     .map(|tweak_secret| (idx, tweak_secret));
                 if result.is_some() {
                     return result;

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -84,12 +84,10 @@ where
                             let is_active_state = dbtx
                                 .get_value(&ActiveStateKey::<GC>(state.clone()))
                                 .await
-                                .expect("DB error")
                                 .is_some();
                             let is_inactive_state = dbtx
                                 .get_value(&InactiveStateKey::<GC>(state.clone()))
                                 .await
-                                .expect("DB error")
                                 .is_some();
 
                             if is_active_state || is_inactive_state {
@@ -100,7 +98,7 @@ where
                                 bail!("State is already terminal, adding it to the executor doesn't make sense.")
                             }
 
-                            dbtx.insert_entry(&ActiveStateKey(state), &ActiveState::new()).await.expect("DB error");
+                            dbtx.insert_entry(&ActiveStateKey(state), &ActiveState::new()).await;
                         }
 
                         Ok(())
@@ -229,12 +227,9 @@ where
                             state.clone(),
                         )
                         .await;
-                        dbtx.remove_entry(&ActiveStateKey(state.clone()))
-                            .await
-                            .expect("DB error");
+                        dbtx.remove_entry(&ActiveStateKey(state.clone())).await;
                         dbtx.insert_entry(&InactiveStateKey(state.clone()), &meta.into_inactive())
-                            .await
-                            .expect("DB error");
+                            .await;
 
                         let context = &self
                             .module_contexts
@@ -249,12 +244,10 @@ where
                                 &InactiveStateKey(new_state),
                                 &ActiveState::new().into_inactive(),
                             )
-                            .await
-                            .expect("DB error");
+                            .await;
                         } else {
                             dbtx.insert_entry(&ActiveStateKey(new_state), &ActiveState::new())
-                                .await
-                                .expect("DB error");
+                                .await;
                         }
 
                         Ok(())
@@ -280,10 +273,7 @@ where
             .await
             .find_by_prefix(&ActiveStateKeyPrefix::<GC>::new())
             .await
-            .map(|res| {
-                let (ActiveStateKey(state), meta) = res.expect("DB error");
-                (state, meta)
-            })
+            .map(|(state, meta)| (state.0, meta))
             .collect::<Vec<_>>()
             .await
     }
@@ -294,10 +284,7 @@ where
             .await
             .find_by_prefix(&InactiveStateKeyPrefix::new())
             .await
-            .map(|res| {
-                let (InactiveStateKey(state), meta) = res.expect("DB error");
-                (state, meta)
-            })
+            .map(|(state, meta)| (state.0, meta))
             .collect::<Vec<_>>()
             .await
     }

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -520,17 +520,23 @@ impl<'isolated, T: Send + Encodable> ModuleDatabaseTransaction<'isolated, T> {
     }
 
     #[instrument(level = "debug", skip_all, fields(?key), ret)]
-    pub async fn get_value<K>(&mut self, key: &K) -> Result<Option<K::Value>>
+    pub async fn get_value<K>(&mut self, key: &K) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,
     {
         let key_bytes = key.to_bytes();
-        let value_bytes = match self.isolated_tx.raw_get_bytes(&key_bytes).await? {
-            Some(value) => value,
-            None => return Ok(None),
-        };
-
-        Ok(Some(decode_value::<K::Value>(&value_bytes, self.decoders)?))
+        let value_bytes = self
+            .isolated_tx
+            .raw_get_bytes(&key_bytes)
+            .await
+            .expect("Unrecoverable error when reading from database");
+        match value_bytes {
+            Some(value_bytes) => Some(
+                decode_value::<K::Value>(&value_bytes, self.decoders)
+                    .expect("Unrecoverable error when decoding the database value"),
+            ),
+            None => None,
+        }
     }
 
     #[instrument(level = "debug", skip_all, fields(key = ?key_prefix))]
@@ -538,10 +544,10 @@ impl<'isolated, T: Send + Encodable> ModuleDatabaseTransaction<'isolated, T> {
         &mut self,
         key_prefix: &KP,
     ) -> impl Stream<
-        Item = Result<(
+        Item = (
             KP::Record,
             <<KP as DatabaseLookup>::Record as DatabaseRecord>::Value,
-        )>,
+        ),
     > + '_
     where
         KP: DatabaseLookup,
@@ -555,14 +561,16 @@ impl<'isolated, T: Send + Encodable> ModuleDatabaseTransaction<'isolated, T> {
             .await
             .expect("Error doing prefix search in database")
             .map(move |(key_bytes, value_bytes)| {
-                let key = KP::Record::from_bytes(&key_bytes, &decoders)?;
-                let value = decode_value(&value_bytes, &decoders)?;
-                Ok((key, value))
+                let key = KP::Record::from_bytes(&key_bytes, &decoders)
+                    .expect("Unrecoverable error reading the DatabaseKey");
+                let value = decode_value(&value_bytes, &decoders)
+                    .expect("Unrecoverable error decoding the DatabaseValue");
+                (key, value)
             })
     }
 
     #[instrument(level = "debug", skip_all, fields(?key, ?value), ret)]
-    pub async fn insert_entry<K>(&mut self, key: &K, value: &K::Value) -> Result<Option<K::Value>>
+    pub async fn insert_entry<K>(&mut self, key: &K, value: &K::Value) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,
     {
@@ -570,19 +578,19 @@ impl<'isolated, T: Send + Encodable> ModuleDatabaseTransaction<'isolated, T> {
         match self
             .isolated_tx
             .raw_insert_bytes(&key.to_bytes(), value.to_bytes())
-            .await?
+            .await
+            .expect("Unrecoverable error while inserting into the database")
         {
-            Some(old_val_bytes) => Ok(Some(decode_value(&old_val_bytes, self.decoders)?)),
-            None => Ok(None),
+            Some(old_val_bytes) => Some(
+                decode_value(&old_val_bytes, self.decoders)
+                    .expect("Unrecoverable error while decoding the database value"),
+            ),
+            None => None,
         }
     }
 
     #[instrument(level = "debug", skip_all, fields(?key, ?value), ret)]
-    pub async fn insert_new_entry<K>(
-        &mut self,
-        key: &K,
-        value: &K::Value,
-    ) -> Result<Option<K::Value>>
+    pub async fn insert_new_entry<K>(&mut self, key: &K, value: &K::Value) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,
     {
@@ -590,7 +598,8 @@ impl<'isolated, T: Send + Encodable> ModuleDatabaseTransaction<'isolated, T> {
         match self
             .isolated_tx
             .raw_insert_bytes(&key.to_bytes(), value.to_bytes())
-            .await?
+            .await
+            .expect("Unrecoverable error occurred while inserting new entry into database")
         {
             Some(_) => {
                 warn!(
@@ -598,29 +607,35 @@ impl<'isolated, T: Send + Encodable> ModuleDatabaseTransaction<'isolated, T> {
                     "Database overwriting element when expecting insertion of new entry. Key: {:?}",
                     key
                 );
-                Ok(None)
+                None
             }
-            None => Ok(None),
+            None => None,
         }
     }
 
     #[instrument(level = "debug", skip_all, fields(?key, ret), ret)]
-    pub async fn remove_entry<K>(&mut self, key: &K) -> Result<Option<K::Value>>
+    pub async fn remove_entry<K>(&mut self, key: &K) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,
     {
         self.commit_tracker.has_writes = true;
         let key_bytes = key.to_bytes();
-        let value_bytes = match self.isolated_tx.raw_remove_entry(&key_bytes).await? {
-            Some(value) => value,
-            None => return Ok(None),
-        };
-
-        Ok(Some(K::Value::from_bytes(&value_bytes, self.decoders)?))
+        match self
+            .isolated_tx
+            .raw_remove_entry(&key_bytes)
+            .await
+            .expect("Unrecoverable error occurred while removing an entry from the database")
+        {
+            Some(value) => Some(
+                K::Value::from_bytes(&value, self.decoders)
+                    .expect("Unrecoverable error when decoding the database value"),
+            ),
+            None => None,
+        }
     }
 
     #[instrument(level = "debug", skip_all, fields(key = ?key_prefix), ret)]
-    pub async fn remove_by_prefix<KP>(&mut self, key_prefix: &KP) -> Result<()>
+    pub async fn remove_by_prefix<KP>(&mut self, key_prefix: &KP)
     where
         KP: DatabaseLookup,
     {
@@ -628,6 +643,7 @@ impl<'isolated, T: Send + Encodable> ModuleDatabaseTransaction<'isolated, T> {
         self.isolated_tx
             .raw_remove_by_prefix(&key_prefix.to_bytes())
             .await
+            .expect("Unrecoverable error occurred while removing by prefix");
     }
 }
 
@@ -811,21 +827,32 @@ impl<'parent> DatabaseTransaction<'parent> {
         return self.tx.commit_tx().await;
     }
 
+    pub async fn expect_commit_tx(mut self) {
+        self.commit_tracker.is_committed = true;
+        self.tx
+            .commit_tx()
+            .await
+            .expect("Unrecoverable error occurred while committing to the database.");
+    }
+
     #[instrument(level = "debug", skip_all, fields(?key), ret)]
-    pub async fn get_value<K>(&mut self, key: &K) -> Result<Option<K::Value>>
+    pub async fn get_value<K>(&mut self, key: &K) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,
     {
         let key_bytes = key.to_bytes();
-        let value_bytes = match self.tx.raw_get_bytes(&key_bytes).await? {
-            Some(value) => value,
-            None => return Ok(None),
-        };
-
-        Ok(Some(decode_value::<K::Value>(
-            &value_bytes,
-            &self.decoders,
-        )?))
+        let value_bytes = self
+            .tx
+            .raw_get_bytes(&key_bytes)
+            .await
+            .expect("Unrecoverable error when reading from database");
+        match value_bytes {
+            Some(value_bytes) => Some(
+                decode_value::<K::Value>(&value_bytes, &self.decoders)
+                    .expect("Unrecoverable error when decoding the database value"),
+            ),
+            None => None,
+        }
     }
 
     #[instrument(level = "debug", skip_all, fields(key = ?key_prefix))]
@@ -833,10 +860,10 @@ impl<'parent> DatabaseTransaction<'parent> {
         &mut self,
         key_prefix: &KP,
     ) -> impl Stream<
-        Item = Result<(
+        Item = (
             KP::Record,
             <<KP as DatabaseLookup>::Record as DatabaseRecord>::Value,
-        )>,
+        ),
     > + '_
     where
         KP: DatabaseLookup,
@@ -850,14 +877,16 @@ impl<'parent> DatabaseTransaction<'parent> {
             .await
             .expect("Error doing prefix search in database")
             .map(move |(key_bytes, value_bytes)| {
-                let key = KP::Record::from_bytes(&key_bytes, &decoders)?;
-                let value = decode_value(&value_bytes, &decoders)?;
-                Ok((key, value))
+                let key = KP::Record::from_bytes(&key_bytes, &decoders)
+                    .expect("Unrecoverable error reading DatabaseKey");
+                let value = decode_value(&value_bytes, &decoders)
+                    .expect("Unrecoverable decoding DatabaseValue");
+                (key, value)
             })
     }
 
     #[instrument(level = "debug", skip_all, fields(?key, ?value), ret)]
-    pub async fn insert_entry<K>(&mut self, key: &K, value: &K::Value) -> Result<Option<K::Value>>
+    pub async fn insert_entry<K>(&mut self, key: &K, value: &K::Value) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,
     {
@@ -865,19 +894,19 @@ impl<'parent> DatabaseTransaction<'parent> {
         match self
             .tx
             .raw_insert_bytes(&key.to_bytes(), value.to_bytes())
-            .await?
+            .await
+            .expect("Unrecoverable error while inserting into the database")
         {
-            Some(old_val_bytes) => Ok(Some(decode_value(&old_val_bytes, &self.decoders)?)),
-            None => Ok(None),
+            Some(old_val_bytes) => Some(
+                decode_value(&old_val_bytes, &self.decoders)
+                    .expect("Unrecoverable error while decoding the database value"),
+            ),
+            None => None,
         }
     }
 
     #[instrument(level = "debug", skip_all, fields(?key, ?value), ret)]
-    pub async fn insert_new_entry<K>(
-        &mut self,
-        key: &K,
-        value: &K::Value,
-    ) -> Result<Option<K::Value>>
+    pub async fn insert_new_entry<K>(&mut self, key: &K, value: &K::Value) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,
     {
@@ -885,7 +914,8 @@ impl<'parent> DatabaseTransaction<'parent> {
         match self
             .tx
             .raw_insert_bytes(&key.to_bytes(), value.to_bytes())
-            .await?
+            .await
+            .expect("Unrecoverable error while inserting new entry into the database")
         {
             Some(_) => {
                 warn!(
@@ -893,34 +923,43 @@ impl<'parent> DatabaseTransaction<'parent> {
                     "Database overwriting element when expecting insertion of new entry. Key: {:?}",
                     key
                 );
-                Ok(None)
+                None
             }
-            None => Ok(None),
+            None => None,
         }
     }
 
     #[instrument(level = "debug", skip_all, fields(?key, ret), ret)]
-    pub async fn remove_entry<K>(&mut self, key: &K) -> Result<Option<K::Value>>
+    pub async fn remove_entry<K>(&mut self, key: &K) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,
     {
         self.commit_tracker.has_writes = true;
         let key_bytes = key.to_bytes();
-        let value_bytes = match self.tx.raw_remove_entry(&key_bytes).await? {
-            Some(value) => value,
-            None => return Ok(None),
-        };
-
-        Ok(Some(K::Value::from_bytes(&value_bytes, &self.decoders)?))
+        match self
+            .tx
+            .raw_remove_entry(&key_bytes)
+            .await
+            .expect("Unrecoverable error occurred while removing an entry from the database")
+        {
+            Some(value) => Some(
+                K::Value::from_bytes(&value, &self.decoders)
+                    .expect("Unrecoverable error occurred while decoding the database value"),
+            ),
+            None => None,
+        }
     }
 
     #[instrument(level = "debug", skip_all, fields(key = ?key_prefix), ret)]
-    pub async fn remove_by_prefix<KP>(&mut self, key_prefix: &KP) -> Result<()>
+    pub async fn remove_by_prefix<KP>(&mut self, key_prefix: &KP)
     where
         KP: DatabaseLookup,
     {
         self.commit_tracker.has_writes = true;
-        self.tx.raw_remove_by_prefix(&key_prefix.to_bytes()).await
+        self.tx
+            .raw_remove_by_prefix(&key_prefix.to_bytes())
+            .await
+            .expect("Unrecoverable error occurred while removing by prefix");
     }
 
     #[instrument(level = "debug", skip_all, ret)]
@@ -1135,10 +1174,6 @@ macro_rules! push_db_pair_items {
         let db_items = $dbtx
             .find_by_prefix(&$prefix_type)
             .await
-            .map(|res| {
-                let (key, val) = res.expect("DB Error");
-                (key, val)
-            })
             .collect::<Vec<($key_type, $value_type)>>()
             .await;
 
@@ -1152,10 +1187,7 @@ macro_rules! push_db_pair_items_no_serde {
         let db_items = $dbtx
             .find_by_prefix(&$prefix_type)
             .await
-            .map(|res| {
-                let (key, val) = res.expect("DB Error");
-                (key, SerdeWrapper::from_encodable(val))
-            })
+            .map(|(key, val)| (key, SerdeWrapper::from_encodable(val)))
             .collect::<Vec<_>>()
             .await;
 
@@ -1169,10 +1201,7 @@ macro_rules! push_db_key_items {
         let db_items = $dbtx
             .find_by_prefix(&$prefix_type)
             .await
-            .map(|res| {
-                let (key, _) = res.expect("DB Error");
-                key
-            })
+            .map(|(key, _)| key)
             .collect::<Vec<$key_type>>()
             .await;
 
@@ -1205,7 +1234,7 @@ pub async fn apply_migrations<'a>(
     migrations: MigrationMap<'a>,
 ) -> Result<(), anyhow::Error> {
     let mut dbtx = db.begin_transaction().await;
-    let disk_version = dbtx.get_value(&DatabaseVersionKey).await?;
+    let disk_version = dbtx.get_value(&DatabaseVersionKey).await;
     let db_version = if let Some(disk_version) = disk_version {
         let mut current_db_version = disk_version;
 
@@ -1224,13 +1253,13 @@ pub async fn apply_migrations<'a>(
 
             current_db_version.increment();
             dbtx.insert_entry(&DatabaseVersionKey, &current_db_version)
-                .await?;
+                .await;
         }
 
         current_db_version
     } else {
         dbtx.insert_entry(&DatabaseVersionKey, &target_db_version)
-            .await?;
+            .await;
         target_db_version
     };
 
@@ -1320,103 +1349,70 @@ mod tests {
 
     pub async fn verify_insert_elements(db: Database) {
         let mut dbtx = db.begin_transaction().await;
-        assert!(dbtx
-            .insert_entry(&TestKey(1), &TestVal(2))
-            .await
-            .unwrap()
-            .is_none());
+        assert!(dbtx.insert_entry(&TestKey(1), &TestVal(2)).await.is_none());
 
-        assert!(dbtx
-            .insert_entry(&TestKey(2), &TestVal(3))
-            .await
-            .unwrap()
-            .is_none());
+        assert!(dbtx.insert_entry(&TestKey(2), &TestVal(3)).await.is_none());
 
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
     }
 
     pub async fn verify_remove_nonexisting(db: Database) {
         let mut dbtx = db.begin_transaction().await;
-        assert_eq!(dbtx.get_value(&TestKey(1)).await.unwrap(), None);
+        assert_eq!(dbtx.get_value(&TestKey(1)).await, None);
         let removed = dbtx.remove_entry(&TestKey(1)).await;
-        assert!(removed.is_ok());
+        assert!(removed.is_none());
 
         // Commit to surpress the warning message
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
     }
 
     pub async fn verify_remove_existing(db: Database) {
         let mut dbtx = db.begin_transaction().await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(1), &TestVal(2))
-            .await
-            .unwrap()
-            .is_none());
+        assert!(dbtx.insert_entry(&TestKey(1), &TestVal(2)).await.is_none());
 
-        assert_eq!(dbtx.get_value(&TestKey(1)).await.unwrap(), Some(TestVal(2)));
+        assert_eq!(dbtx.get_value(&TestKey(1)).await, Some(TestVal(2)));
 
         let removed = dbtx.remove_entry(&TestKey(1)).await;
-        assert!(removed.is_ok());
-        assert_eq!(removed.unwrap(), Some(TestVal(2)));
-        assert_eq!(dbtx.get_value(&TestKey(1)).await.unwrap(), None);
+        assert_eq!(removed, Some(TestVal(2)));
+        assert_eq!(dbtx.get_value(&TestKey(1)).await, None);
 
         // Commit to surpress the warning message
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
     }
 
     pub async fn verify_read_own_writes(db: Database) {
         let mut dbtx = db.begin_transaction().await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(1), &TestVal(2))
-            .await
-            .unwrap()
-            .is_none());
+        assert!(dbtx.insert_entry(&TestKey(1), &TestVal(2)).await.is_none());
 
-        assert_eq!(dbtx.get_value(&TestKey(1)).await.unwrap(), Some(TestVal(2)));
+        assert_eq!(dbtx.get_value(&TestKey(1)).await, Some(TestVal(2)));
 
         // Commit to surpress the warning message
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
     }
 
     pub async fn verify_prevent_dirty_reads(db: Database) {
         let mut dbtx = db.begin_transaction().await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(1), &TestVal(2))
-            .await
-            .unwrap()
-            .is_none());
+        assert!(dbtx.insert_entry(&TestKey(1), &TestVal(2)).await.is_none());
 
         // dbtx2 should not be able to see uncommitted changes
         let mut dbtx2 = db.begin_transaction().await;
-        assert_eq!(dbtx2.get_value(&TestKey(1)).await.unwrap(), None);
+        assert_eq!(dbtx2.get_value(&TestKey(1)).await, None);
 
         // Commit to surpress the warning message
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
     }
 
     pub async fn verify_find_by_prefix(db: Database) {
         let mut dbtx = db.begin_transaction().await;
-        assert!(dbtx
-            .insert_entry(&TestKey(55), &TestVal(9999))
-            .await
-            .is_ok());
-        assert!(dbtx
-            .insert_entry(&TestKey(54), &TestVal(8888))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&TestKey(55), &TestVal(9999)).await;
+        dbtx.insert_entry(&TestKey(54), &TestVal(8888)).await;
 
-        assert!(dbtx
-            .insert_entry(&AltTestKey(55), &TestVal(7777))
-            .await
-            .is_ok());
-        assert!(dbtx
-            .insert_entry(&AltTestKey(54), &TestVal(6666))
-            .await
-            .is_ok());
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.insert_entry(&AltTestKey(55), &TestVal(7777)).await;
+        dbtx.insert_entry(&AltTestKey(54), &TestVal(6666)).await;
+        dbtx.expect_commit_tx().await;
 
         // Verify finding by prefix returns the correct set of key pairs
         let mut dbtx = db.begin_transaction().await;
@@ -1425,8 +1421,7 @@ mod tests {
         let returned_keys = dbtx
             .find_by_prefix(&DbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, kv| async move {
-                let (key, value) = kv.unwrap();
+            .fold(0, |returned_keys, (key, value)| async move {
                 match key {
                     TestKey(55) => {
                         assert!(value.eq(&TestVal(9999)));
@@ -1447,8 +1442,7 @@ mod tests {
         let returned_keys = dbtx
             .find_by_prefix(&AltDbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, kv| async move {
-                let (key, value) = kv.unwrap();
+            .fold(0, |returned_keys, (key, value)| async move {
                 match key {
                     AltTestKey(55) => {
                         assert!(value.eq(&TestVal(7777)));
@@ -1468,45 +1462,36 @@ mod tests {
     pub async fn verify_commit(db: Database) {
         let mut dbtx = db.begin_transaction().await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(1), &TestVal(2))
-            .await
-            .unwrap()
-            .is_none());
-        dbtx.commit_tx().await.expect("DB Error");
+        assert!(dbtx.insert_entry(&TestKey(1), &TestVal(2)).await.is_none());
+        dbtx.expect_commit_tx().await;
 
         // Verify dbtx2 can see committed transactions
         let mut dbtx2 = db.begin_transaction().await;
-        assert_eq!(
-            dbtx2.get_value(&TestKey(1)).await.unwrap(),
-            Some(TestVal(2))
-        );
+        assert_eq!(dbtx2.get_value(&TestKey(1)).await, Some(TestVal(2)));
     }
 
     pub async fn verify_rollback_to_savepoint(db: Database) {
         let mut dbtx_rollback = db.begin_transaction().await;
 
-        assert!(dbtx_rollback
+        dbtx_rollback
             .insert_entry(&TestKey(20), &TestVal(2000))
-            .await
-            .is_ok());
+            .await;
 
         dbtx_rollback
             .set_tx_savepoint()
             .await
             .expect("Error setting transaction savepoint");
 
-        assert!(dbtx_rollback
+        dbtx_rollback
             .insert_entry(&TestKey(21), &TestVal(2001))
-            .await
-            .is_ok());
+            .await;
 
         assert_eq!(
-            dbtx_rollback.get_value(&TestKey(20)).await.unwrap(),
+            dbtx_rollback.get_value(&TestKey(20)).await,
             Some(TestVal(2000))
         );
         assert_eq!(
-            dbtx_rollback.get_value(&TestKey(21)).await.unwrap(),
+            dbtx_rollback.get_value(&TestKey(21)).await,
             Some(TestVal(2001))
         );
 
@@ -1516,41 +1501,37 @@ mod tests {
             .expect("Error setting transaction savepoint");
 
         assert_eq!(
-            dbtx_rollback.get_value(&TestKey(20)).await.unwrap(),
+            dbtx_rollback.get_value(&TestKey(20)).await,
             Some(TestVal(2000))
         );
 
-        assert_eq!(dbtx_rollback.get_value(&TestKey(21)).await.unwrap(), None);
+        assert_eq!(dbtx_rollback.get_value(&TestKey(21)).await, None);
 
         // Commit to surpress the warning message
-        dbtx_rollback.commit_tx().await.expect("DB Error");
+        dbtx_rollback.expect_commit_tx().await;
     }
 
     pub async fn verify_prevent_nonrepeatable_reads(db: Database) {
         let mut dbtx = db.begin_transaction().await;
-        assert_eq!(dbtx.get_value(&TestKey(100)).await.unwrap(), None);
+        assert_eq!(dbtx.get_value(&TestKey(100)).await, None);
 
         let mut dbtx2 = db.begin_transaction().await;
 
-        assert!(dbtx2
-            .insert_entry(&TestKey(100), &TestVal(101))
-            .await
-            .is_ok());
+        dbtx2.insert_entry(&TestKey(100), &TestVal(101)).await;
 
-        assert_eq!(dbtx.get_value(&TestKey(100)).await.unwrap(), None);
+        assert_eq!(dbtx.get_value(&TestKey(100)).await, None);
 
-        dbtx2.commit_tx().await.expect("DB Error");
+        dbtx2.expect_commit_tx().await;
 
         // dbtx should still read None because it is operating over a snapshot
         // of the data when the transaction started
-        assert_eq!(dbtx.get_value(&TestKey(100)).await.unwrap(), None);
+        assert_eq!(dbtx.get_value(&TestKey(100)).await, None);
 
         let expected_keys = 0;
         let returned_keys = dbtx
             .find_by_prefix(&DbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, kv| async move {
-                let (key, value) = kv.unwrap();
+            .fold(0, |returned_keys, (key, value)| async move {
                 if let TestKey(100) = key {
                     assert!(value.eq(&TestVal(101)));
                 }
@@ -1564,25 +1545,18 @@ mod tests {
     pub async fn verify_phantom_entry(db: Database) {
         let mut dbtx = db.begin_transaction().await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(100), &TestVal(101))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&TestKey(100), &TestVal(101)).await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(101), &TestVal(102))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&TestKey(101), &TestVal(102)).await;
 
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         let mut dbtx = db.begin_transaction().await;
         let expected_keys = 2;
         let returned_keys = dbtx
             .find_by_prefix(&DbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, kv| async move {
-                let (key, value) = kv.unwrap();
+            .fold(0, |returned_keys, (key, value)| async move {
                 match key {
                     TestKey(100) => {
                         assert!(value.eq(&TestVal(101)));
@@ -1600,18 +1574,14 @@ mod tests {
 
         let mut dbtx2 = db.begin_transaction().await;
 
-        assert!(dbtx2
-            .insert_entry(&TestKey(102), &TestVal(103))
-            .await
-            .is_ok());
+        dbtx2.insert_entry(&TestKey(102), &TestVal(103)).await;
 
-        dbtx2.commit_tx().await.expect("DB Error");
+        dbtx2.expect_commit_tx().await;
 
         let returned_keys = dbtx
             .find_by_prefix(&DbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, kv| async move {
-                let (key, value) = kv.unwrap();
+            .fold(0, |returned_keys, (key, value)| async move {
                 match key {
                     TestKey(100) => {
                         assert!(value.eq(&TestVal(101)));
@@ -1630,76 +1600,47 @@ mod tests {
 
     pub async fn expect_write_conflict(db: Database) {
         let mut dbtx = db.begin_transaction().await;
-        assert!(dbtx
-            .insert_entry(&TestKey(100), &TestVal(101))
-            .await
-            .is_ok());
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.insert_entry(&TestKey(100), &TestVal(101)).await;
+        dbtx.expect_commit_tx().await;
 
         let mut dbtx2 = db.begin_transaction().await;
         let mut dbtx3 = db.begin_transaction().await;
 
-        assert!(dbtx2
-            .insert_entry(&TestKey(100), &TestVal(102))
-            .await
-            .is_ok());
+        dbtx2.insert_entry(&TestKey(100), &TestVal(102)).await;
 
         // Depending on if the database implementation supports optimistic or
         // pessimistic transactions, this test should generate an error here
         // (pessimistic) or at commit time (optimistic)
-        let res = dbtx3
-            .insert_entry(&TestKey(100), &TestVal(103))
-            .await
-            .is_ok();
+        dbtx3.insert_entry(&TestKey(100), &TestVal(103)).await;
 
-        dbtx2.commit_tx().await.expect("DB Error");
-
-        // We do not need to commit the second transaction if the insert failed.
-        if res {
-            dbtx3.commit_tx().await.expect_err("Expecting an error to be returned because this transaction is in a write-write conflict with dbtx");
-        }
+        dbtx2.expect_commit_tx().await;
+        dbtx3.commit_tx().await.expect_err("Expecting an error to be returned because this transaction is in a write-write conflict with dbtx");
     }
 
     pub async fn verify_string_prefix(db: Database) {
         let mut dbtx = db.begin_transaction().await;
-        assert!(dbtx
-            .insert_entry(&PercentTestKey(100), &TestVal(101))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&PercentTestKey(100), &TestVal(101)).await;
 
         assert_eq!(
-            dbtx.get_value(&PercentTestKey(100)).await.unwrap(),
+            dbtx.get_value(&PercentTestKey(100)).await,
             Some(TestVal(101))
         );
 
-        assert!(dbtx
-            .insert_entry(&PercentTestKey(101), &TestVal(100))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&PercentTestKey(101), &TestVal(100)).await;
 
-        assert!(dbtx
-            .insert_entry(&PercentTestKey(101), &TestVal(100))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&PercentTestKey(101), &TestVal(100)).await;
 
-        assert!(dbtx
-            .insert_entry(&PercentTestKey(101), &TestVal(100))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&PercentTestKey(101), &TestVal(100)).await;
 
         // If the wildcard character ('%') is not handled properly, this will make
         // find_by_prefix return 5 results instead of 4
-        assert!(dbtx
-            .insert_entry(&TestKey(101), &TestVal(100))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&TestKey(101), &TestVal(100)).await;
 
         let expected_keys = 4;
         let returned_keys = dbtx
             .find_by_prefix(&PercentPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, kv| async move {
-                let (key, value) = kv.unwrap();
+            .fold(0, |returned_keys, (key, value)| async move {
                 if let PercentTestKey(101) = key {
                     assert!(value.eq(&TestVal(100)));
                 }
@@ -1713,32 +1654,22 @@ mod tests {
     pub async fn verify_remove_by_prefix(db: Database) {
         let mut dbtx = db.begin_transaction().await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(100), &TestVal(101))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&TestKey(100), &TestVal(101)).await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(101), &TestVal(102))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&TestKey(101), &TestVal(102)).await;
 
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         let mut remove_dbtx = db.begin_transaction().await;
-        remove_dbtx
-            .remove_by_prefix(&DbPrefixTestPrefix)
-            .await
-            .expect("DB Error");
-        remove_dbtx.commit_tx().await.expect("DB Error");
+        remove_dbtx.remove_by_prefix(&DbPrefixTestPrefix).await;
+        remove_dbtx.expect_commit_tx().await;
 
         let mut dbtx = db.begin_transaction().await;
         let expected_keys = 0;
         let returned_keys = dbtx
             .find_by_prefix(&DbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, kv| async move {
-                let (key, value) = kv.unwrap();
+            .fold(0, |returned_keys, (key, value)| async move {
                 match key {
                     TestKey(100) => {
                         assert!(value.eq(&TestVal(101)));
@@ -1758,57 +1689,38 @@ mod tests {
     pub async fn verify_module_db(db: Database, module_db: Database) {
         let mut dbtx = db.begin_transaction().await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(100), &TestVal(101))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&TestKey(100), &TestVal(101)).await;
 
-        assert!(dbtx
-            .insert_entry(&TestKey(101), &TestVal(102))
-            .await
-            .is_ok());
+        dbtx.insert_entry(&TestKey(101), &TestVal(102)).await;
 
-        dbtx.commit_tx().await.expect("DB Error");
+        dbtx.expect_commit_tx().await;
 
         // verify module_dbtx can only read key/value pairs from its own module
         let mut module_dbtx = module_db.begin_transaction().await;
-        assert_eq!(module_dbtx.get_value(&TestKey(100)).await.unwrap(), None);
+        assert_eq!(module_dbtx.get_value(&TestKey(100)).await, None);
 
-        assert_eq!(module_dbtx.get_value(&TestKey(101)).await.unwrap(), None);
+        assert_eq!(module_dbtx.get_value(&TestKey(101)).await, None);
 
         // verify module_dbtx can read key/value pairs that it wrote
         let mut dbtx = db.begin_transaction().await;
-        assert_eq!(
-            dbtx.get_value(&TestKey(100)).await.unwrap(),
-            Some(TestVal(101))
-        );
+        assert_eq!(dbtx.get_value(&TestKey(100)).await, Some(TestVal(101)));
 
-        assert_eq!(
-            dbtx.get_value(&TestKey(101)).await.unwrap(),
-            Some(TestVal(102))
-        );
+        assert_eq!(dbtx.get_value(&TestKey(101)).await, Some(TestVal(102)));
 
         let mut module_dbtx = module_db.begin_transaction().await;
 
-        assert!(module_dbtx
-            .insert_entry(&TestKey(100), &TestVal(103))
-            .await
-            .is_ok());
+        module_dbtx.insert_entry(&TestKey(100), &TestVal(103)).await;
 
-        assert!(module_dbtx
-            .insert_entry(&TestKey(101), &TestVal(104))
-            .await
-            .is_ok());
+        module_dbtx.insert_entry(&TestKey(101), &TestVal(104)).await;
 
-        module_dbtx.commit_tx().await.expect("DB Error");
+        module_dbtx.expect_commit_tx().await;
 
         let expected_keys = 2;
         let mut dbtx = db.begin_transaction().await;
         let returned_keys = dbtx
             .find_by_prefix(&DbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, kv| async move {
-                let (key, value) = kv.unwrap();
+            .fold(0, |returned_keys, (key, value)| async move {
                 match key {
                     TestKey(100) => {
                         assert!(value.eq(&TestVal(101)));
@@ -1825,13 +1737,12 @@ mod tests {
         assert_eq!(returned_keys, expected_keys);
 
         let removed = dbtx.remove_entry(&TestKey(100)).await;
-        assert!(removed.is_ok());
-        assert_eq!(removed.unwrap(), Some(TestVal(101)));
-        assert_eq!(dbtx.get_value(&TestKey(100)).await.unwrap(), None);
+        assert_eq!(removed, Some(TestVal(101)));
+        assert_eq!(dbtx.get_value(&TestKey(100)).await, None);
 
         let mut module_dbtx = module_db.begin_transaction().await;
         assert_eq!(
-            module_dbtx.get_value(&TestKey(100)).await.unwrap(),
+            module_dbtx.get_value(&TestKey(100)).await,
             Some(TestVal(103))
         );
     }
@@ -1841,46 +1752,42 @@ mod tests {
         {
             let mut test_module_dbtx = test_dbtx.with_module_prefix(TEST_MODULE_PREFIX);
 
-            assert!(test_module_dbtx
+            test_module_dbtx
                 .insert_entry(&TestKey(100), &TestVal(101))
-                .await
-                .is_ok());
+                .await;
 
-            assert!(test_module_dbtx
+            test_module_dbtx
                 .insert_entry(&TestKey(101), &TestVal(102))
-                .await
-                .is_ok());
+                .await;
         }
 
-        test_dbtx.commit_tx().await.expect("DB Error");
+        test_dbtx.expect_commit_tx().await;
 
         let mut alt_dbtx = db.begin_transaction().await;
         {
             let mut alt_module_dbtx = alt_dbtx.with_module_prefix(ALT_MODULE_PREFIX);
 
-            assert!(alt_module_dbtx
+            alt_module_dbtx
                 .insert_entry(&TestKey(100), &TestVal(103))
-                .await
-                .is_ok());
+                .await;
 
-            assert!(alt_module_dbtx
+            alt_module_dbtx
                 .insert_entry(&TestKey(101), &TestVal(104))
-                .await
-                .is_ok());
+                .await;
         }
 
-        alt_dbtx.commit_tx().await.expect("DB Error");
+        alt_dbtx.expect_commit_tx().await;
 
         // verfiy test_module_dbtx can only see key/value pairs from its own module
         let mut test_dbtx = db.begin_transaction().await;
         let mut test_module_dbtx = test_dbtx.with_module_prefix(TEST_MODULE_PREFIX);
         assert_eq!(
-            test_module_dbtx.get_value(&TestKey(100)).await.unwrap(),
+            test_module_dbtx.get_value(&TestKey(100)).await,
             Some(TestVal(101))
         );
 
         assert_eq!(
-            test_module_dbtx.get_value(&TestKey(101)).await.unwrap(),
+            test_module_dbtx.get_value(&TestKey(101)).await,
             Some(TestVal(102))
         );
 
@@ -1888,8 +1795,7 @@ mod tests {
         let returned_keys = test_module_dbtx
             .find_by_prefix(&DbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, kv| async move {
-                let (key, value) = kv.unwrap();
+            .fold(0, |returned_keys, (key, value)| async move {
                 match key {
                     TestKey(100) => {
                         assert!(value.eq(&TestVal(101)));
@@ -1906,19 +1812,15 @@ mod tests {
         assert_eq!(returned_keys, expected_keys);
 
         let removed = test_module_dbtx.remove_entry(&TestKey(100)).await;
-        assert!(removed.is_ok());
-        assert_eq!(removed.unwrap(), Some(TestVal(101)));
-        assert_eq!(
-            test_module_dbtx.get_value(&TestKey(100)).await.unwrap(),
-            None
-        );
+        assert_eq!(removed, Some(TestVal(101)));
+        assert_eq!(test_module_dbtx.get_value(&TestKey(100)).await, None);
 
         // test_dbtx on its own wont find the key because it does not use a module
         // prefix
         let mut test_dbtx = db.begin_transaction().await;
-        assert_eq!(test_dbtx.get_value(&TestKey(101)).await.unwrap(), None);
+        assert_eq!(test_dbtx.get_value(&TestKey(101)).await, None);
 
-        test_dbtx.commit_tx().await.expect("DB Error");
+        test_dbtx.expect_commit_tx().await;
     }
 
     #[cfg(test)]
@@ -1930,14 +1832,12 @@ mod tests {
         let mut dbtx = db.begin_transaction().await;
         for i in 0..expected_test_keys_size {
             dbtx.insert_new_entry(&TestKeyV0(i as u64, (i + 1) as u64), &TestVal(i as u64))
-                .await
-                .expect("DB Error");
+                .await;
         }
 
         dbtx.insert_new_entry(&DatabaseVersionKey, &DatabaseVersion(0))
-            .await
-            .expect("DB Error");
-        dbtx.commit_tx().await.expect("DB Error");
+            .await;
+        dbtx.expect_commit_tx().await;
 
         let mut migrations = MigrationMap::new();
 
@@ -1965,8 +1865,7 @@ mod tests {
             .await;
         let test_keys_size = test_keys.len();
         assert_eq!(test_keys_size, expected_test_keys_size);
-        for test_key in test_keys {
-            let (key, val) = test_key.unwrap();
+        for (key, val) in test_keys {
             assert_eq!(key.0, val.0 + 1);
         }
     }
@@ -1980,11 +1879,10 @@ mod tests {
             .await
             .collect::<Vec<_>>()
             .await;
-        dbtx.remove_by_prefix(&DbPrefixTestPrefixV0).await?;
-        for pair in example_keys_v0 {
-            let (key, val) = pair?;
+        dbtx.remove_by_prefix(&DbPrefixTestPrefixV0).await;
+        for (key, val) in example_keys_v0 {
             let key_v2 = TestKey(key.1);
-            dbtx.insert_new_entry(&key_v2, &val).await?;
+            dbtx.insert_new_entry(&key_v2, &val).await;
         }
         Ok(())
     }

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -36,8 +36,7 @@ impl Audit {
         let mut new_items = dbtx
             .find_by_prefix(key_prefix)
             .await
-            .map(|res| {
-                let (key, value) = res.expect("DB error");
+            .map(|(key, value)| {
                 let name = format!("{key:?}");
                 let milli_sat = to_milli_sat(key, value);
                 AuditItem { name, milli_sat }

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -219,12 +219,12 @@ impl ApiEndpoint<()> {
                         None => handle_request::<E>(m, &mut dbtx.get_isolated(), params).await?,
                     };
 
-                    dbtx.commit_tx()
-                        .await
-                        .map_err(|_err| fedimint_core::module::ApiError {
+                    dbtx.commit_tx_result().await.map_err(|_err| {
+                        fedimint_core::module::ApiError {
                             code: 500,
                             message: "Internal Server Error".to_string(),
-                        })?;
+                        }
+                    })?;
                     Ok(serde_json::to_value(ret).expect("encoding error"))
                 })
             }),

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -199,7 +199,7 @@ impl<'a> DatabaseDump<'a> {
                     );
                 }
                 ConsensusRange::DbKeyPrefix::LastEpoch => {
-                    let last_epoch = dbtx.get_value(&ConsensusRange::LastEpochKey).await.unwrap();
+                    let last_epoch = dbtx.get_value(&ConsensusRange::LastEpochKey).await;
                     if let Some(last_epoch) = last_epoch {
                         consensus.insert("LastEpoch".to_string(), Box::new(last_epoch));
                     }
@@ -344,8 +344,7 @@ impl<'a> DatabaseDump<'a> {
                 ClientMintRange::DbKeyPrefix::NotesPerDenomination => {
                     let notes = dbtx
                         .get_value(&ClientMintRange::NotesPerDenominationKey)
-                        .await
-                        .unwrap();
+                        .await;
                     if let Some(notes) = notes {
                         mint_client.insert("NotesPerDenomination".to_string(), Box::new(notes));
                     }
@@ -400,8 +399,7 @@ impl<'a> DatabaseDump<'a> {
                     let secret = self
                         .read_only
                         .get_value(&ClientRange::ClientSecretKey)
-                        .await
-                        .unwrap();
+                        .await;
                     if let Some(secret) = secret {
                         client.insert("Client Secret".to_string(), Box::new(secret));
                     }

--- a/fedimint-dbtool/src/main.rs
+++ b/fedimint-dbtool/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
             for (key, value) in prefix_iter {
                 print_kv(&key, &value);
             }
-            dbtx.commit_tx().await.expect("DB Error");
+            dbtx.commit_tx().await.expect("Error committing to RocksDb");
         }
         DbCommand::Write { key, value } => {
             let rocksdb: Box<dyn IDatabase> =
@@ -93,15 +93,17 @@ async fn main() -> Result<()> {
             let mut dbtx = rocksdb.begin_transaction().await;
             dbtx.raw_insert_bytes(&key, value.into())
                 .await
-                .expect("DB error");
-            dbtx.commit_tx().await.expect("DB Error");
+                .expect("Error inserting entry into RocksDb");
+            dbtx.commit_tx().await.expect("Error committing to RocksDb");
         }
         DbCommand::Delete { key } => {
             let rocksdb: Box<dyn IDatabase> =
                 Box::new(fedimint_rocksdb::RocksDb::open(&options.database).unwrap());
             let mut dbtx = rocksdb.begin_transaction().await;
-            dbtx.raw_remove_entry(&key).await.expect("DB error");
-            dbtx.commit_tx().await.expect("DB Error");
+            dbtx.raw_remove_entry(&key)
+                .await
+                .expect("Error removing entry from RocksDb");
+            dbtx.commit_tx().await.expect("Error committing to RocksDb");
         }
         DbCommand::Dump {
             cfg_dir,

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -100,7 +100,7 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
 
             let rocksdb_iter = iter
                 .map_while(move |res| {
-                    let (key_bytes, value_bytes) = res.expect("DB error");
+                    let (key_bytes, value_bytes) = res.expect("Error reading from RocksDb");
                     key_bytes
                         .starts_with(&prefix)
                         .then_some((key_bytes, value_bytes))
@@ -156,7 +156,7 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
                 .0
                 .prefix_iterator(prefix.clone())
                 .map_while(move |res| {
-                    let (key_bytes, value_bytes) = res.expect("DB error");
+                    let (key_bytes, value_bytes) = res.expect("Error reading from RocksDb");
                     key_bytes
                         .starts_with(&prefix)
                         .then_some((key_bytes, value_bytes))

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -252,8 +252,8 @@ impl FedimintServer {
         let db = self.consensus.db.clone();
         let mut tx = db.begin_transaction().await;
 
-        if let Some(key) = tx.get_value(&LastEpochKey).await.expect("DB error") {
-            self.last_processed_epoch = tx.get_value(&key).await.expect("DB error");
+        if let Some(key) = tx.get_value(&LastEpochKey).await {
+            self.last_processed_epoch = tx.get_value(&key).await;
         }
 
         let epoch = self.next_epoch_to_process();

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -116,7 +116,7 @@ where
                 )
                 .await,
             );
-            dbtx.expect_commit_tx().await;
+            dbtx.commit_tx().await;
         }
 
         assert_all_equal_result(results.into_iter())
@@ -197,7 +197,7 @@ where
                 member.end_consensus_epoch(&peers, &mut module_dbtx).await;
             }
 
-            dbtx.expect_commit_tx().await;
+            dbtx.commit_tx().await;
         }
     }
 
@@ -258,7 +258,7 @@ where
                     .await;
             }
 
-            dbtx.expect_commit_tx().await;
+            dbtx.commit_tx().await;
         }
     }
 

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -116,7 +116,7 @@ where
                 )
                 .await,
             );
-            dbtx.commit_tx().await.expect("DB tx failed");
+            dbtx.expect_commit_tx().await;
         }
 
         assert_all_equal_result(results.into_iter())
@@ -197,7 +197,7 @@ where
                 member.end_consensus_epoch(&peers, &mut module_dbtx).await;
             }
 
-            dbtx.commit_tx().await.expect("DB Error");
+            dbtx.expect_commit_tx().await;
         }
     }
 
@@ -244,8 +244,7 @@ where
                 let mut module_dbtx = dbtx.with_module_prefix(*module_instance_id);
                 module_dbtx
                     .insert_entry(&fedimint_wallet_client::db::UTXOKey(out_point), &utxo)
-                    .await
-                    .unwrap();
+                    .await;
 
                 module_dbtx
                     .insert_entry(
@@ -256,11 +255,10 @@ where
                             randomness_beacon: tweak,
                         },
                     )
-                    .await
-                    .unwrap();
+                    .await;
             }
 
-            dbtx.commit_tx().await.expect("DB Error");
+            dbtx.expect_commit_tx().await;
         }
     }
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -800,11 +800,10 @@ impl FederationTest {
                             amount: bitcoin::Amount::from_sat(input.tx_output().value),
                         },
                     )
-                    .await
-                    .expect("DB Error");
+                    .await;
             }
 
-            dbtx.commit_tx().await.expect("DB Error");
+            dbtx.expect_commit_tx().await;
         }
         bitcoin
             .mine_blocks(user.client.wallet_client().config.finality_delay as u64)
@@ -822,13 +821,10 @@ impl FederationTest {
                 {
                     let mut module_dbtx = dbtx.with_module_prefix(self.mint_id);
 
-                    module_dbtx
-                        .remove_by_prefix(&NonceKeyPrefix)
-                        .await
-                        .expect("DB Error");
+                    module_dbtx.remove_by_prefix(&NonceKeyPrefix).await;
                 }
 
-                dbtx.commit_tx().await.expect("DB Error");
+                dbtx.expect_commit_tx().await;
             });
         }
     }
@@ -885,8 +881,7 @@ impl FederationTest {
                             transaction,
                         },
                     )
-                    .await
-                    .expect("DB Error");
+                    .await;
 
                     svr.fedimint
                         .consensus
@@ -899,7 +894,7 @@ impl FederationTest {
                         )
                         .await
                         .unwrap();
-                    dbtx.commit_tx().await.expect("DB Error");
+                    dbtx.expect_commit_tx().await;
                 }
                 out_point
             })

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -803,7 +803,7 @@ impl FederationTest {
                     .await;
             }
 
-            dbtx.expect_commit_tx().await;
+            dbtx.commit_tx().await;
         }
         bitcoin
             .mine_blocks(user.client.wallet_client().config.finality_delay as u64)
@@ -824,7 +824,7 @@ impl FederationTest {
                     module_dbtx.remove_by_prefix(&NonceKeyPrefix).await;
                 }
 
-                dbtx.expect_commit_tx().await;
+                dbtx.commit_tx().await;
             });
         }
     }
@@ -894,7 +894,7 @@ impl FederationTest {
                         )
                         .await
                         .unwrap();
-                    dbtx.expect_commit_tx().await;
+                    dbtx.commit_tx().await;
                 }
                 out_point
             })

--- a/modules/fedimint-dummy-common/src/db.rs
+++ b/modules/fedimint-dummy-common/src/db.rs
@@ -17,11 +17,10 @@ pub async fn migrate_dummy_db_version_0<'a, 'b>(
         .await
         .collect::<Vec<_>>()
         .await;
-    dbtx.remove_by_prefix(&ExampleKeyPrefixV0).await?;
-    for pair in example_keys_v0 {
-        let (key, val) = pair?;
+    dbtx.remove_by_prefix(&ExampleKeyPrefixV0).await;
+    for (key, val) in example_keys_v0 {
         let key_v2 = ExampleKey(key.0, "Example String".to_string());
-        dbtx.insert_new_entry(&key_v2, &val).await?;
+        dbtx.insert_new_entry(&key_v2, &val).await;
     }
     Ok(())
 }


### PR DESCRIPTION
Currently in our database code we propagate all errors via `Result`s all the way up to the application code. This was done partly because there was a discussion on where database errors should be handled https://github.com/fedimint/fedimint/discussions/1370

In practice, we were just calling `expect` on database errors, which makes the code much more verbose and difficult to read. This PRs refactors the error handling so that the public database transaction functions do not return `Result`, except for `commit_tx`. Right now database error handling is done after attempting to commit to the database. Database implementations that fail prematurely (e.g sqlite) can swallow their failures and fail during `commit_tx` as well, so that the failure semantics are similar across database implementations.

Fixes: https://github.com/fedimint/fedimint/issues/1829