### PR TITLE
chore: remove duplicate code from dummy-module

### DIFF
--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -1,45 +1,22 @@
-use std::collections::{BTreeMap, HashSet};
-use std::ffi::OsString;
 use std::fmt;
 
 use async_trait::async_trait;
 use bitcoin_hashes::sha256;
-use fedimint_core::config::{
-    ConfigGenParams, DkgResult, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
-    TypedServerModuleConfig, TypedServerModuleConsensusConfig,
-};
+use fedimint_core::config::ModuleGenParams;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
-use fedimint_core::db::{Database, DatabaseVersion, MigrationMap, ModuleDatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::__reexports::serde_json;
-use fedimint_core::module::audit::Audit;
-use fedimint_core::module::interconnect::ModuleInterconect;
-use fedimint_core::module::{
-    api_endpoint, ApiEndpoint, ApiVersion, CommonModuleGen, ConsensusProposal,
-    CoreConsensusVersion, ExtendsCommonModuleGen, InputMeta, ModuleCommon, ModuleConsensusVersion,
-    ModuleError, PeerHandle, ServerModuleGen, TransactionItemAmount,
-};
-use fedimint_core::server::DynServerModule;
-use fedimint_core::task::TaskGroup;
-use fedimint_core::{plugin_types_trait_impl, OutPoint, PeerId, ServerModule};
-use futures::FutureExt;
+use fedimint_core::module::{CommonModuleGen, ModuleCommon};
+use fedimint_core::plugin_types_trait_impl;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::config::{DummyClientConfig, DummyConfig, DummyConfigConsensus, DummyConfigPrivate};
-use crate::db::migrate_dummy_db_version_0;
+use crate::config::DummyClientConfig;
 use crate::serde_json::Value;
-
 pub mod config;
 pub mod db;
 
 const KIND: ModuleKind = ModuleKind::from_static_str("dummy");
-
-/// Dummy module
-#[derive(Debug)]
-pub struct Dummy {
-    pub cfg: DummyConfig,
-}
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct DummyConsensusItem;
@@ -55,110 +32,11 @@ impl CommonModuleGen for DummyCommonGen {
     const KIND: ModuleKind = KIND;
 
     fn decoder() -> Decoder {
-        <Dummy as ServerModule>::decoder()
+        DummyModuleTypes::decoder_builder().build()
     }
 
     fn hash_client_module(config: Value) -> anyhow::Result<sha256::Hash> {
         serde_json::from_value::<DummyClientConfig>(config)?.consensus_hash()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct DummyServerGen;
-
-impl ExtendsCommonModuleGen for DummyServerGen {
-    type Common = DummyCommonGen;
-}
-
-#[async_trait]
-impl ServerModuleGen for DummyServerGen {
-    const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(1);
-
-    fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
-        &[ModuleConsensusVersion(0)]
-    }
-
-    async fn init(
-        &self,
-        cfg: ServerModuleConfig,
-        _db: Database,
-        _env: &BTreeMap<OsString, OsString>,
-        _task_group: &mut TaskGroup,
-    ) -> anyhow::Result<DynServerModule> {
-        Ok(Dummy::new(cfg.to_typed()?).into())
-    }
-
-    fn get_database_migrations(&self) -> MigrationMap {
-        let mut migrations = MigrationMap::new();
-
-        migrations.insert(DatabaseVersion(0), move |dbtx| {
-            migrate_dummy_db_version_0(dbtx).boxed()
-        });
-
-        migrations
-    }
-
-    fn trusted_dealer_gen(
-        &self,
-        peers: &[PeerId],
-        _params: &ConfigGenParams,
-    ) -> BTreeMap<PeerId, ServerModuleConfig> {
-        let mint_cfg: BTreeMap<_, DummyConfig> = peers
-            .iter()
-            .map(|&peer| {
-                let config = DummyConfig {
-                    private: DummyConfigPrivate {
-                        something_private: 3,
-                    },
-                    consensus: DummyConfigConsensus { something: 1 },
-                };
-                (peer, config)
-            })
-            .collect();
-
-        mint_cfg
-            .into_iter()
-            .map(|(k, v)| (k, v.to_erased()))
-            .collect()
-    }
-
-    async fn distributed_gen(
-        &self,
-        _peers: &PeerHandle,
-        _params: &ConfigGenParams,
-    ) -> DkgResult<ServerModuleConfig> {
-        let server = DummyConfig {
-            private: DummyConfigPrivate {
-                something_private: 3,
-            },
-            consensus: DummyConfigConsensus { something: 2 },
-        };
-
-        Ok(server.to_erased())
-    }
-
-    fn to_config_response(
-        &self,
-        config: serde_json::Value,
-    ) -> anyhow::Result<ModuleConfigResponse> {
-        let config = serde_json::from_value::<DummyConfigConsensus>(config)?;
-
-        Ok(ModuleConfigResponse {
-            client: config.to_client_config(),
-            consensus_hash: config.consensus_hash()?,
-        })
-    }
-
-    fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
-        config.to_typed::<DummyConfig>()?.validate_config(identity)
-    }
-
-    async fn dump_database(
-        &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        _prefix_names: Vec<String>,
-    ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
-        Box::new(BTreeMap::new().into_iter())
     }
 }
 
@@ -214,124 +92,6 @@ impl ModuleCommon for DummyModuleTypes {
     type Output = DummyOutput;
     type OutputOutcome = DummyOutputOutcome;
     type ConsensusItem = DummyConsensusItem;
-}
-
-#[async_trait]
-impl ServerModule for Dummy {
-    type Common = DummyModuleTypes;
-    type Gen = DummyServerGen;
-    type VerificationCache = DummyVerificationCache;
-
-    fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]) {
-        (
-            ModuleConsensusVersion(0),
-            &[ApiVersion { major: 0, minor: 0 }],
-        )
-    }
-
-    async fn await_consensus_proposal(
-        &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-    ) {
-        std::future::pending().await
-    }
-
-    async fn consensus_proposal(
-        &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-    ) -> ConsensusProposal<DummyConsensusItem> {
-        ConsensusProposal::empty()
-    }
-
-    async fn begin_consensus_epoch<'a, 'b>(
-        &'a self,
-        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
-        _consensus_items: Vec<(PeerId, DummyConsensusItem)>,
-    ) {
-    }
-
-    fn build_verification_cache<'a>(
-        &'a self,
-        _inputs: impl Iterator<Item = &'a DummyInput> + Send,
-    ) -> Self::VerificationCache {
-        DummyVerificationCache
-    }
-
-    async fn validate_input<'a, 'b>(
-        &self,
-        _interconnect: &dyn ModuleInterconect,
-        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
-        _verification_cache: &Self::VerificationCache,
-        _input: &'a DummyInput,
-    ) -> Result<InputMeta, ModuleError> {
-        unimplemented!()
-    }
-
-    async fn apply_input<'a, 'b, 'c>(
-        &'a self,
-        _interconnect: &'a dyn ModuleInterconect,
-        _dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
-        _input: &'b DummyInput,
-        _cache: &Self::VerificationCache,
-    ) -> Result<InputMeta, ModuleError> {
-        unimplemented!()
-    }
-
-    async fn validate_output(
-        &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        _output: &DummyOutput,
-    ) -> Result<TransactionItemAmount, ModuleError> {
-        unimplemented!()
-    }
-
-    async fn apply_output<'a, 'b>(
-        &'a self,
-        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
-        _output: &'a DummyOutput,
-        _out_point: OutPoint,
-    ) -> Result<TransactionItemAmount, ModuleError> {
-        unimplemented!()
-    }
-
-    async fn end_consensus_epoch<'a, 'b>(
-        &'a self,
-        _consensus_peers: &HashSet<PeerId>,
-        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
-    ) -> Vec<PeerId> {
-        vec![]
-    }
-
-    async fn output_status(
-        &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        _out_point: OutPoint,
-    ) -> Option<DummyOutputOutcome> {
-        None
-    }
-
-    async fn audit(
-        &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        _audit: &mut Audit,
-    ) {
-    }
-
-    fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
-        vec![api_endpoint! {
-            "/dummy",
-            async |_module: &Dummy, _dbtx, _request: ()| -> () {
-                Ok(())
-            }
-        }]
-    }
-}
-
-impl Dummy {
-    /// Create new module instance
-    pub fn new(cfg: DummyConfig) -> Dummy {
-        Dummy { cfg }
-    }
 }
 
 plugin_types_trait_impl!(

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -7,7 +7,7 @@ use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::__reexports::serde_json;
 use fedimint_core::module::{CommonModuleGen, ModuleCommon};
-use fedimint_core::plugin_types_trait_impl;
+use fedimint_core::plugin_types_trait_impl_common;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -20,9 +20,6 @@ const KIND: ModuleKind = ModuleKind::from_static_str("dummy");
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct DummyConsensusItem;
-
-#[derive(Debug, Clone)]
-pub struct DummyVerificationCache;
 
 #[derive(Debug)]
 pub struct DummyCommonGen;
@@ -94,12 +91,11 @@ impl ModuleCommon for DummyModuleTypes {
     type ConsensusItem = DummyConsensusItem;
 }
 
-plugin_types_trait_impl!(
+plugin_types_trait_impl_common!(
     DummyInput,
     DummyOutput,
     DummyOutputOutcome,
-    DummyConsensusItem,
-    DummyVerificationCache
+    DummyConsensusItem
 );
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Error)]

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -24,7 +24,7 @@ use fedimint_dummy_common::config::{DummyConfig, DummyConfigConsensus, DummyConf
 use fedimint_dummy_common::db::migrate_dummy_db_version_0;
 use fedimint_dummy_common::{
     DummyCommonGen, DummyConsensusItem, DummyInput, DummyModuleTypes, DummyOutput,
-    DummyOutputOutcome,
+    DummyOutputOutcome, DummyVerificationCache,
 };
 use futures::FutureExt;
 
@@ -250,8 +250,3 @@ impl Dummy {
         Dummy { cfg }
     }
 }
-
-#[derive(Debug, Clone)]
-pub struct DummyVerificationCache;
-
-impl fedimint_core::server::VerificationCache for DummyVerificationCache {}

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -24,7 +24,7 @@ use fedimint_dummy_common::config::{DummyConfig, DummyConfigConsensus, DummyConf
 use fedimint_dummy_common::db::migrate_dummy_db_version_0;
 use fedimint_dummy_common::{
     DummyCommonGen, DummyConsensusItem, DummyInput, DummyModuleTypes, DummyOutput,
-    DummyOutputOutcome, DummyVerificationCache,
+    DummyOutputOutcome,
 };
 use futures::FutureExt;
 
@@ -243,6 +243,11 @@ impl ServerModule for Dummy {
         }]
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct DummyVerificationCache;
+
+impl fedimint_core::server::VerificationCache for DummyVerificationCache {}
 
 impl Dummy {
     /// Create new module instance


### PR DESCRIPTION
Cleans up duplicated code in the dummy-modules:
* Remove ServerModuleGen and ServerModule from dummy-common
* Remove DummyVerificationCache from dummy-server and use the DummyVerificationCache from the dummy-common module instead
