### PR TITLE
Support shutting-down at an epoch

### DIFF
--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -790,8 +790,6 @@ impl EcashRecoveryTracker {
     ) {
         debug!(target: LOG_ECASH_RECOVERY, ?item, "handling consensus item");
         match item {
-            ConsensusItem::ClientConfigSignatureShare(_) => {}
-            ConsensusItem::EpochOutcomeSignatureShare(_) => {}
             ConsensusItem::Transaction(tx) => {
                 let txid = tx.tx_hash();
 
@@ -850,6 +848,7 @@ impl EcashRecoveryTracker {
                     self.handle_output_confirmation(peer_id, mint_item);
                 }
             }
+            _ => {}
         }
     }
 

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -12,13 +12,25 @@ use threshold_crypto::{PublicKey, PublicKeySet, Signature, SignatureShare};
 
 use crate::transaction::Transaction;
 
+/// All the items that may be produced during a consensus epoch
 #[derive(Debug, Clone, Eq, PartialEq, Hash, UnzipConsensus, Encodable, Decodable)]
 pub enum ConsensusItem {
+    /// Fed shutdown occurs once a threshold want to upgrade
+    ConsensusUpgrade(ConsensusUpgrade),
+    /// Threshold sign the configs for verification via the API
     ClientConfigSignatureShare(SerdeSignatureShare),
+    /// Threshold sign the epoch history for verification via the API
     EpochOutcomeSignatureShare(SerdeSignatureShare),
+    /// Fedimint tx that contains module inputs and outputs that are net
+    /// equal
     Transaction(Transaction),
+    /// Any data that modules require consensus on
     Module(ModuleConsensusItem),
 }
+
+/// May eventually contains consensus info about the upgrade
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
+pub struct ConsensusUpgrade;
 
 pub type SerdeConsensusItem = SerdeModuleEncoding<ConsensusItem>;
 

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -220,6 +220,12 @@ impl<'a> DatabaseDump<'a> {
                         "Client Config Signature"
                     );
                 }
+                ConsensusRange::DbKeyPrefix::ConsensusUpgrade => {
+                    let shutdown = dbtx.get_value(&ConsensusRange::ConsensusUpgradeKey).await;
+                    if let Some(shutdown) = shutdown {
+                        consensus.insert("ShutdownSignal".to_string(), Box::new(shutdown));
+                    }
+                }
                 // Module is a global prefix for all module data
                 ConsensusRange::DbKeyPrefix::Module => {}
             }

--- a/fedimint-server/src/consensus/debug.rs
+++ b/fedimint-server/src/consensus/debug.rs
@@ -39,5 +39,6 @@ fn item_message(item: &ConsensusItem) -> String {
             }
             tx_debug
         }
+        ConsensusItem::ConsensusUpgrade(reason) => format!("Shutdown signal for {reason:?}"),
     }
 }

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fmt::Debug;
 
 use fedimint_core::db::{DatabaseVersion, MigrationMap, MODULE_GLOBAL_PREFIX};
@@ -20,6 +21,7 @@ pub enum DbKeyPrefix {
     EpochHistory = 0x05,
     LastEpoch = 0x06,
     ClientConfigSignature = 0x07,
+    ConsensusUpgrade = 0x08,
     Module = MODULE_GLOBAL_PREFIX,
 }
 
@@ -110,6 +112,15 @@ impl_db_record!(
 impl_db_lookup!(
     key = ClientConfigSignatureKey,
     query_prefix = ClientConfigSignatureKeyPrefix
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ConsensusUpgradeKey;
+
+impl_db_record!(
+    key = ConsensusUpgradeKey,
+    value = BTreeSet<PeerId>,
+    db_prefix = DbKeyPrefix::ConsensusUpgrade,
 );
 
 pub fn get_global_database_migrations<'a>() -> MigrationMap<'a> {

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -39,6 +39,8 @@ pub struct ServerOpts {
     pub tokio_console_bind: Option<SocketAddr>,
     #[arg(long, default_value = "false")]
     pub with_telemetry: bool,
+    #[arg(long = "upgrade-epoch")]
+    pub upgrade_epoch: Option<u64>,
 }
 
 /// `fedimintd` builder
@@ -228,6 +230,10 @@ async fn run(
 
     let (consensus, tx_receiver) =
         FedimintConsensus::new(cfg.clone(), db, module_gens, &mut task_group).await?;
+
+    if let Some(epoch) = opts.upgrade_epoch {
+        consensus.remove_upgrade_items(epoch).await?;
+    }
 
     FedimintServer::run(cfg, consensus, tx_receiver, decoders, &mut task_group).await?;
 


### PR DESCRIPTION
This is the preliminary code for supporting shutdown at an epoch #948

What remains is the client code + tests to enable guardians to actually trigger the shutdown.  Since that requires developing an authenticated API it'll be done in a follow-up PR. See #1841