### PR TITLE
chore: rename `aeae` to `fedimint-aead`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,16 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aead"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "hex",
- "rand",
- "ring",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +888,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-aead"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hex",
+ "rand",
+ "ring",
+]
+
+[[package]]
 name = "fedimint-bitcoind"
 version = "0.1.0"
 dependencies = [
@@ -1015,12 +1015,12 @@ dependencies = [
 name = "fedimint-dbtool"
 version = "0.1.0"
 dependencies = [
- "aead",
  "anyhow",
  "bitcoin_hashes",
  "bytes",
  "clap",
  "erased-serde",
+ "fedimint-aead",
  "fedimint-core",
  "fedimint-ln-server",
  "fedimint-logging",
@@ -1346,13 +1346,13 @@ dependencies = [
 name = "fedimint-server"
 version = "0.1.0"
 dependencies = [
- "aead",
  "anyhow",
  "async-trait",
  "bincode",
  "bitcoin",
  "bitcoin_hashes",
  "bytes",
+ "fedimint-aead",
  "fedimint-build",
  "fedimint-core",
  "fedimint-logging",
@@ -1554,7 +1554,6 @@ dependencies = [
 name = "fedimintd"
 version = "0.1.0"
 dependencies = [
- "aead",
  "anyhow",
  "askama",
  "askama_axum",
@@ -1566,6 +1565,7 @@ dependencies = [
  "bytes",
  "clap",
  "console-subscriber",
+ "fedimint-aead",
  "fedimint-build",
  "fedimint-core",
  "fedimint-ln-server",
@@ -2757,13 +2757,13 @@ dependencies = [
 name = "mint-client"
 version = "0.1.0"
 dependencies = [
- "aead",
  "anyhow",
  "async-trait",
  "base64 0.20.0",
  "bincode",
  "bitcoin",
  "bitcoin_hashes",
+ "fedimint-aead",
  "fedimint-client",
  "fedimint-core",
  "fedimint-derive-secret",
@@ -3432,10 +3432,10 @@ dependencies = [
 name = "recoverytool"
 version = "0.1.0"
 dependencies = [
- "aead",
  "anyhow",
  "bitcoin",
  "clap",
+ "fedimint-aead",
  "fedimint-core",
  "fedimint-ln-server",
  "fedimint-logging",

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 
 
 [dependencies]
-aead = { path = "../../crypto/aead" }
+fedimint-aead = { path = "../../crypto/aead" }
 anyhow = "1.0.66"
 async-trait = "0.1.64"
 base64 = "0.20.0"

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "aead"
+name = "fedimint-aead"
 version = "0.1.0"
 authors = ["The Fedimint Developers"]
 edition = "2021"

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -11,7 +11,7 @@ name = "dbtool"
 
 [dependencies]
 anyhow = "1.0.68"
-aead = { path = "../crypto/aead" }
+fedimint-aead = { path = "../crypto/aead" }
 bitcoin_hashes = "0.11.0"
 bytes = "1.4.0"
 clap = { version = "4.1.6", features  = [ "derive" ] }

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -13,7 +13,7 @@ name = "fedimint_server"
 path = "src/lib.rs"
 
 [dependencies]
-aead = { path = "../crypto/aead" }
+fedimint-aead = { path = "../crypto/aead" }
 anyhow = "1.0.66"
 async-trait = "0.1.64"
 bincode = "1.3.1"

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -23,7 +23,7 @@ name = "distributedgen"
 path  = "src/bin/distributedgen.rs"
 
 [dependencies]
-aead = { path = "../crypto/aead" }
+fedimint-aead = { path = "../crypto/aead" }
 ring = "0.16.20"
 anyhow = "1.0.66"
 async-trait = "0.1.64"

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.69"
 bitcoin = "0.29.2"
 clap = "4.1.6"
 fedimintd = { path = "../fedimintd" }
-aead = { path = "../crypto/aead" }
+fedimint-aead = { path = "../crypto/aead" }
 fedimint-core = { path = "../fedimint-core" }
 fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 fedimint-server = { path = "../fedimint-server" }


### PR DESCRIPTION
We'll need to eventually publish it on crates.io, and so we need it prefixed with `fedimint-`.