### PR TITLE
chore: expose ro fields of Client

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -166,6 +166,14 @@ impl<C> Client<C> {
     pub fn module_gens(&self) -> &ClientModuleGenRegistry {
         &self.context.module_gens
     }
+
+    pub fn context(&self) -> &Arc<ClientContext> {
+        &self.context
+    }
+
+    pub fn root_secret(&self) -> &DerivableSecret {
+        &self.root_secret
+    }
 }
 
 #[derive(Encodable, Decodable)]


### PR DESCRIPTION
I'm trying to extend the `Client<T>` out of tree, to make it usable for 3rd party client builders, and these fields are important to be able to access.