### PR TITLE
fix: Remove outdated entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
 /target
 /result
-cfg
-ln1
-ln2
-it
 .idea
 .tmpenv
 .direnv


### PR DESCRIPTION
I think the integration tests used to store stuff there. But that's all in a tmp directory now.