### PR TITLE
Remove leftover debugging statement and outdated FIXME from shell function 

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -14,7 +14,6 @@ function open_channel() {
     LN_ADDR="$($FM_LIGHTNING_CLI newaddr | jq -e -r '.bech32')"
     $FM_BTC_CLIENT sendtoaddress $LN_ADDR 1
     mine_blocks 10
-    # FIXME: do I need these exports
     LND_PUBKEY="$($FM_LNCLI getinfo | jq -e -r '.identity_pubkey')"
     $FM_LIGHTNING_CLI connect $LND_PUBKEY@127.0.0.1:9734
     until $FM_LIGHTNING_CLI -k fundchannel id=$LND_PUBKEY amount=0.1btc push_msat=5000000000; do sleep $POLL_INTERVAL; done

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -14,7 +14,6 @@ function open_channel() {
     LN_ADDR="$($FM_LIGHTNING_CLI newaddr | jq -e -r '.bech32')"
     $FM_BTC_CLIENT sendtoaddress $LN_ADDR 1
     mine_blocks 10
-    $FM_LNCLI getinfo
     # FIXME: do I need these exports
     LND_PUBKEY="$($FM_LNCLI getinfo | jq -e -r '.identity_pubkey')"
     $FM_LIGHTNING_CLI connect $LND_PUBKEY@127.0.0.1:9734


### PR DESCRIPTION
`$FM_LNCLI getinfo` was leftover debugging code from #1852. 

The FIXME was because some variables internal to this function were `export`ed and didn't need to be. Removed the exports but forgot to remove the FIXME.