### PR TITLE
Bash functions to start all our daemons

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -11,6 +11,7 @@ pre_window:
   - alias mint_rpc_client="\$FM_MINT_RPC_CLIENT"
   - alias dbtool="\$FM_DB_TOOL"
   - alias restart="./scripts/restart-tmux.sh"
+  - source scripts/lib.sh
 tmux_detached: false
 windows:
   - main:
@@ -23,23 +24,19 @@ windows:
         - user:
           - # empty user shell
         - bitcoind:
-          - bitcoind -datadir=$FM_BTC_DIR &
-          - echo $! >> $FM_PID_FILE
+          - start_bitcoind &
           - fg
         - cln:
           - sleep 5 # wait for bitcoind and federation
-          - lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --lightning-dir=$FM_CLN_DIR --plugin=$FM_BIN_DIR/gateway-cln-extension &
-          - echo $! >> $FM_PID_FILE
+          - start_lightningd &
           - fg
         - lnd:
           - sleep 5 # wait for bitcoind and federation
-          - lnd --lnddir=$FM_LND_DIR &
-          - echo $! >> $FM_PID_FILE
+          - start_lnd &
           - fg
         - gateway:
           - sleep 7 # wait for gateway-cln-extension to start
-          - $FM_BIN_DIR/gatewayd
-          - echo $! >> $FM_PID_FILE
+          - start_gatewayd &
           - fg
         - federation:
           - sleep 1 # wait for bitcoind

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,6 +102,10 @@ export FM_GATEWAY_CLI="$FM_BIN_DIR/gateway-cli --rpcpassword=theresnosecondbest"
 export FM_DB_TOOL="$FM_BIN_DIR/dbtool"
 export FM_DISTRIBUTEDGEN="$FM_BIN_DIR/distributedgen"
 
+# Fedimint config variables
+export FM_TEST_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
+export FM_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
+
 # Alias clients
 alias lightning-cli="\$FM_LIGHTNING_CLI"
 alias lncli="\$FM_LNCLI"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -85,7 +85,11 @@ function kill_fedimint_processes {
 function gw_connect_fed() {
   # connect federation with the gateway
   FM_CONNECT_STR="$($FM_MINT_CLIENT connect-info | jq -e -r '.connect_info')"
-  $FM_GATEWAY_CLI connect-fed "$FM_CONNECT_STR"
+  until $FM_GATEWAY_CLI connect-fed "$FM_CONNECT_STR"
+  do
+    echo "gateway-cli connect-fed failed ... retrying"
+    sleep 1
+  done
 }
 
 function get_finality_delay() {

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -82,13 +82,6 @@ function kill_fedimint_processes {
   rm -f $FM_PID_FILE
 }
 
-function start_gatewayd() {
-  $FM_BIN_DIR/gatewayd &
-  echo $! >> $FM_PID_FILE
-  echo "started gatewayd"
-  gw_connect_fed
-}
-
 function gw_connect_fed() {
   # connect federation with the gateway
   FM_CONNECT_STR="$($FM_MINT_CLIENT connect-info | jq -e -r '.connect_info')"
@@ -151,4 +144,55 @@ function await_gateway_registered() {
     until [ "$($FM_MINT_CLIENT list-gateways | jq -e ".num_gateways")" = "1" ]; do
         sleep $POLL_INTERVAL
     done
+}
+
+### Start Daemons ###
+
+function start_bitcoind() {
+  bitcoind -datadir=$FM_BTC_DIR &
+  echo $! >> $FM_PID_FILE
+  until [ "$($FM_BTC_CLIENT getblockchaininfo | jq -e -r '.chain')" == "regtest" ]; do
+    sleep $POLL_INTERVAL
+  done
+  # create a default RPC wallet
+  $FM_BTC_CLIENT createwallet ""
+  # mine some blocks
+  mine_blocks 101 | show_verbose_output
+}
+
+function start_lightningd() {
+  await_bitcoin_rpc
+  # if we're running developer build, enable some flags to make it lightningd run faster
+  if [[ "$(lightningd --bitcoin-cli "$(which false)" --dev-no-plugin-checksum 2>&1 )" =~ .*"--dev-no-plugin-checksum: unrecognized option".* ]]; then
+    LIGHTNING_FLAGS=""
+  else
+    LIGHTNING_FLAGS="--dev-fast-gossip --dev-bitcoind-poll=1"
+  fi
+  lightningd $LIGHTNING_FLAGS --lightning-dir=$FM_CLN_DIR --plugin=$FM_BIN_DIR/gateway-cln-extension &
+  echo $! >> $FM_PID_FILE
+}
+
+function start_lnd() {
+  await_bitcoin_rpc
+  lnd --lnddir=$FM_LND_DIR &
+  echo $! >> $FM_PID_FILE
+}
+
+function start_gatewayd() {
+  await_fedimint_block_sync
+  $FM_BIN_DIR/gatewayd &
+  echo $! >> $FM_PID_FILE
+  gw_connect_fed
+}
+
+function start_electrs() {
+  await_bitcoin_rpc
+  electrs --conf-dir "$FM_ELECTRS_DIR" --db-dir "$FM_ELECTRS_DIR" --daemon-dir "$FM_BTC_DIR" &
+  echo $! >> $FM_PID_FILE
+}
+
+function start_esplora() {
+  await_bitcoin_rpc
+  esplora --cookie "bitcoin:bitcoin" --network "regtest" --daemon-dir "$FM_BTC_DIR" --http-addr "127.0.0.1:50002" --daemon-rpc-addr "127.0.0.1:18443" --monitoring-addr "127.0.0.1:50003" --db-dir "$FM_TEST_DIR/esplora" &
+  echo $! >> $FM_PID_FILE
 }

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -8,42 +8,12 @@ FM_FED_SIZE=${1:-4}
 
 source ./scripts/build.sh $FM_FED_SIZE
 
-# Starts Bitcoin and 2 LN nodes, opening a channel between the LN nodes
-POLL_INTERVAL=1
-
-# Start bitcoind and wait for it to become ready
-bitcoind -datadir=$FM_BTC_DIR &
-echo $! >> $FM_PID_FILE
-
-until [ "$($FM_BTC_CLIENT getblockchaininfo | jq -e -r '.chain')" == "regtest" ]; do
-  sleep $POLL_INTERVAL
-done
-$FM_BTC_CLIENT createwallet ""
-
-# Start electrs
-electrs --conf-dir "$FM_ELECTRS_DIR" --db-dir "$FM_ELECTRS_DIR" --daemon-dir "$FM_BTC_DIR" &
-echo $! >> $FM_PID_FILE
-
-# Start esplora
-esplora --cookie "bitcoin:bitcoin" --network "regtest" --daemon-dir "$FM_BTC_DIR" --http-addr "127.0.0.1:50002" --daemon-rpc-addr "127.0.0.1:18443" --monitoring-addr "127.0.0.1:50003" --db-dir "$FM_TEST_DIR/esplora" &
-echo $! >> $FM_PID_FILE
-
-if [[ "$(lightningd --bitcoin-cli "$(which false)" --dev-no-plugin-checksum 2>&1 )" =~ .*"--dev-no-plugin-checksum: unrecognized option".* ]]; then
-  LIGHTNING_FLAGS=""
-else
-  LIGHTNING_FLAGS="--dev-fast-gossip --dev-bitcoind-poll=1"
-fi
-
-# Start Core Lightning
-lightningd $LIGHTNING_FLAGS --lightning-dir=$FM_CLN_DIR --plugin=$FM_BIN_DIR/gateway-cln-extension &
-echo $! >> $FM_PID_FILE
-
-# Start LND
-lnd --lnddir=$FM_LND_DIR &
-echo $! >> $FM_PID_FILE
-
-# Initialize wallet and get ourselves some money
-mine_blocks 101
+# start daemons
+start_bitcoind
+start_electrs
+start_esplora
+start_lightningd
+start_lnd
 
 # Open channel
 open_channel

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -15,10 +15,6 @@ POLL_INTERVAL=1
 bitcoind -datadir=$FM_BTC_DIR &
 echo $! >> $FM_PID_FILE
 
-# Required by tests to manipulate bitcoind
-export FM_TEST_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
-export FM_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
-
 until [ "$($FM_BTC_CLIENT getblockchaininfo | jq -e -r '.chain')" == "regtest" ]; do
   sleep $POLL_INTERVAL
 done

--- a/scripts/tmux-user-shell.sh
+++ b/scripts/tmux-user-shell.sh
@@ -5,24 +5,17 @@ source ./scripts/lib.sh
 POLL_INTERVAL=0.5
 export POLL_INTERVAL
 
-# wait for bitcoind
-await_bitcoin_rpc | show_verbose_output
-echo Setting up bitcoind ...
-bitcoin-cli createwallet default | show_verbose_output
-mine_blocks 101 | show_verbose_output
-
-# wait for core lightning & fedimint to sync
+# wait for bitcoin RPC, lightningd & fedimint block sync
+await_bitcoin_rpc
 await_lightning_node_block_processing | show_verbose_output
 await_fedimint_block_sync | show_verbose_output
+await_gateway_registered | show_verbose_output
 
 echo Setting up lightning channel ...
 open_channel | show_verbose_output
 
 echo Funding user e-cash wallet ...
 scripts/pegin.sh 10000.0 | show_verbose_output
-
-echo Connecting federation to gateway
-gw_connect_fed
 
 echo Funding gateway e-cash wallet ...
 scripts/pegin.sh 20000.0 1 | show_verbose_output

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -20,8 +20,6 @@ echo "Running in temporary directory $FM_TEST_DIR"
 
 env | sed -En 's/^(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
 
-export FM_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
-
 SHELL=$(which bash) tmuxinator local
 tmux -L fedimint-dev kill-session -t fedimint-dev || true
 pkill bitcoind


### PR DESCRIPTION
I was noticing some inconsistencies between how daemons are spawned and disposed (https://github.com/fedimint/fedimint/pull/1865) in tests vs tmuxinator and thought I'd make it more consistent, readable, and easier to reason about.

* If a daemon depends on another, I try to wait for it in the start function.
* `start_bitcoind` creates RPC wallet and mines 101 blocks.
* `start_gatewayd` connects to federation.
* Also, updated `gw_connect_fed` to retry if it fails. That should help address [this failure](https://discord.com/channels/990354215060795454/990354215878688860/1083640931556806737).