### PR TITLE
Improve gateway instantiation

### DIFF
--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::process::exit;
 
 use clap::{Parser, Subcommand};
 use fedimint_client::module::gen::{ClientModuleGenRegistry, DynClientModuleGen};
@@ -164,7 +165,11 @@ async fn main() -> Result<(), anyhow::Error> {
         module_gens,
         task_group.make_subgroup().await,
     )
-    .await;
+    .await
+    .unwrap_or_else(|e| {
+        eprintln!("Failed to start gateway: {e:?}");
+        exit(1)
+    });
 
     if let Err(e) = gateway.run(listen, password).await {
         task_group.shutdown_join_all(None).await?;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -167,18 +167,6 @@ impl Gateway {
         Ok(())
     }
 
-    async fn select_actor(&self, federation_id: FederationId) -> Result<Arc<GatewayActor>> {
-        self.actors
-            .lock()
-            .await
-            .get(&federation_id.to_string())
-            .cloned()
-            .ok_or(GatewayError::Other(anyhow::anyhow!(
-                "No federation with id {}",
-                federation_id.to_string()
-            )))
-    }
-
     pub async fn load_actor(
         &self,
         client: Arc<GatewayClient>,
@@ -199,6 +187,18 @@ impl Gateway {
             actor.clone(),
         );
         Ok(actor)
+    }
+
+    async fn select_actor(&self, federation_id: FederationId) -> Result<Arc<GatewayActor>> {
+        self.actors
+            .lock()
+            .await
+            .get(&federation_id.to_string())
+            .cloned()
+            .ok_or(GatewayError::Other(anyhow::anyhow!(
+                "No federation with id {}",
+                federation_id.to_string()
+            )))
     }
 
     async fn handle_connect_federation(

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -108,12 +108,12 @@ impl Gateway {
             module_gens: module_gens.clone(),
         };
 
-        gw.load_federation_actors(decoders, module_gens).await?;
+        gw.load_actors(decoders, module_gens).await?;
 
         Ok(gw)
     }
 
-    async fn load_federation_actors(
+    async fn load_actors(
         &self,
         decoders: ModuleDecoderRegistry,
         module_gens: ClientModuleGenRegistry,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -151,10 +151,7 @@ impl Gateway {
                     .await
                     .expect("Could not build federation client");
 
-                if let Err(e) = self
-                    .connect_federation(Arc::new(client), route_hints.clone())
-                    .await
-                {
+                if let Err(e) = self.load_actor(Arc::new(client), route_hints.clone()).await {
                     error!("Failed to connect federation: {}", e);
                 }
 
@@ -182,7 +179,7 @@ impl Gateway {
             )))
     }
 
-    pub async fn connect_federation(
+    pub async fn load_actor(
         &self,
         client: Arc<GatewayClient>,
         route_hints: Vec<RouteHint>,
@@ -238,7 +235,7 @@ impl Gateway {
                 .expect("Failed to build gateway client"),
         );
 
-        if let Err(e) = self.connect_federation(client.clone(), route_hints).await {
+        if let Err(e) = self.load_actor(client.clone(), route_hints).await {
             error!("Failed to connect federation: {}", e);
         }
 

--- a/gateway/ln-gateway/tests/fixtures/mod.rs
+++ b/gateway/ln-gateway/tests/fixtures/mod.rs
@@ -54,10 +54,10 @@ pub async fn fixtures(api_addr: Url) -> Result<Fixtures> {
         module_gens,
         task_group.clone(),
     )
-    .await;
+    .await
+    .unwrap();
 
     let rpc = RpcClient::new(api_addr);
-
     let bitcoin = Box::new(FakeBitcoinTest::new());
     let lightning = Box::new(FakeLightningTest::new());
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -620,7 +620,7 @@ impl GatewayTest {
         );
 
         let actor = gateway
-            .connect_federation(client.clone(), vec![])
+            .load_actor(client.clone(), vec![])
             .await
             .expect("Could not connect federation");
         // Note: We don't run the gateway in test scenarios

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -609,7 +609,8 @@ impl GatewayTest {
             module_gens.clone(),
             TaskGroup::new(),
         )
-        .await;
+        .await
+        .unwrap();
 
         let client = Arc::new(
             client_builder


### PR DESCRIPTION
- Don't panic
- Don't retry fetching route hints if empty vec is returned. I don't think this solves anything, and it confuses control flow because the constructor can just block forever if you have a node with no channels. IMO that's just weird behavior, but maybe I'm missing something.