### PR TITLE
Switch to Argon2 for passwords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
+name = "argon2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c2fcf79ad1932ac6269a738109997a83c227c09b75842ae564dc8ede6a861c"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +384,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -763,6 +789,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -892,6 +919,7 @@ name = "fedimint-aead"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "hex",
  "rand",
  "ring",
@@ -3132,6 +3160,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.65"
+argon2 = { version = "0.5.0", features = ["password-hash", "alloc"] }
 ring = "0.16.20"
 hex = "0.4.3"
 rand = "0.8"

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
 
-use aead::{encrypted_read, get_key};
+use aead::{encrypted_read, get_encryption_key_with_path};
 use anyhow::{bail, format_err, Context};
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::sha256::HashEngine;
@@ -630,7 +630,7 @@ impl ServerConfigParams {
             peers.insert(PeerId::from(idx as u16), parse_peer_params(cert)?);
         }
 
-        let key = get_key(password, dir_out_path.join(SALT_FILE))?;
+        let key = get_encryption_key_with_path(password, dir_out_path.join(SALT_FILE))?;
         let tls_pk = encrypted_read(&key, dir_out_path.join(TLS_PK))?;
         let cert_string = fs::read_to_string(dir_out_path.join(TLS_CERT))?;
 

--- a/fedimintd/src/distributed_gen.rs
+++ b/fedimintd/src/distributed_gen.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use aead::{encrypted_read, encrypted_write, get_key};
+use aead::{encrypted_read, encrypted_write, get_encryption_key_with_path};
 use clap::{Parser, Subcommand};
 use fedimint_core::config::{DkgError, ServerModuleGenRegistry};
 use fedimint_core::module::ServerModuleGen;
@@ -221,7 +221,7 @@ impl DistributedGen {
             } => {
                 let salt_file =
                     salt_file.unwrap_or_else(|| salt_file_path_from_file_path(&in_file));
-                let key = get_key(&password, salt_file)?;
+                let key = get_encryption_key_with_path(&password, salt_file)?;
                 let decrypted_bytes = encrypted_read(&key, in_file)?;
 
                 let mut out_file_handle =
@@ -242,7 +242,7 @@ impl DistributedGen {
 
                 let salt_file =
                     salt_file.unwrap_or_else(|| salt_file_path_from_file_path(&out_file));
-                let key = get_key(&password, salt_file)?;
+                let key = get_encryption_key_with_path(&password, salt_file)?;
                 encrypted_write(plaintext_bytes, &key, out_file)
             }
         }


### PR DESCRIPTION
Switches our password stretching algorithm from PBKDF2 to Argon2, which is much stronger against brute-force attacks because it's memory-hard and so more difficult to parallelize.

We can use this algorithm for both our password-based encryption and auth #1841

Pretty good explanation here 
https://medium.com/analytics-vidhya/password-hashing-pbkdf2-scrypt-bcrypt-and-argon2-e25aaf41598e