### PR TITLE
DO NOT MERGE: trigger false CI pass

### DIFF
--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Runs a test to determine the latency of certain user actions
 
+exit 1 # this should cause CI to fail
+
 set -eu
 FM_FED_SIZE=${1:-4}
 ITERATIONS=${2:-10}

--- a/scripts/test-ci-all.sh
+++ b/scripts/test-ci-all.sh
@@ -18,31 +18,35 @@ nix build -L .#debug.workspaceBuild 2>&1 | ts -s
 
 
 function cli_test_reconnect() {
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting reconnect test..."
   nix build -L .#debug.cli-test.reconnect 2>&1 | ts -s
 }
 export -f cli_test_reconnect
 
 function cli_test_latency() {
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting latency test..."
   nix build -L .#debug.cli-test.latency 2>&1 | ts -s
 }
 export -f cli_test_latency
 
 function cli_test_cli() {
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting cli test..."
   nix build -L .#debug.cli-test.cli 2>&1 | ts -s
 }
 export -f cli_test_cli
 
 function cli_test_rust_tests() {
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting integration test..."
   nix build -L .#debug.cli-test.rust-tests 2>&1 | ts -s
 }
 export -f cli_test_rust_tests
 
 function cli_test_always_fail() {
-  set -o pipefail
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting always_fail test..."
   # this must fail, so we know nix build is actually running tests
   ! nix build -L .#debug.cli-test.always-fail 2>&1 | ts -s


### PR DESCRIPTION
Over the weekend this CI run passed but the latency tests clearly had an error and should have caused it to fail https://github.com/fedimint/fedimint/actions/runs/4393951590/jobs/7694690151#step:10:1729

This PR adds `exit 1` to `latency-test.sh` and CI still passes, but it shouldn't ...