### PR TITLE
chore: fix test-ci-all ignoring failures

### DIFF
--- a/scripts/test-ci-all.sh
+++ b/scripts/test-ci-all.sh
@@ -18,31 +18,35 @@ nix build -L .#debug.workspaceBuild 2>&1 | ts -s
 
 
 function cli_test_reconnect() {
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting reconnect test..."
   nix build -L .#debug.cli-test.reconnect 2>&1 | ts -s
 }
 export -f cli_test_reconnect
 
 function cli_test_latency() {
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting latency test..."
   nix build -L .#debug.cli-test.latency 2>&1 | ts -s
 }
 export -f cli_test_latency
 
 function cli_test_cli() {
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting cli test..."
   nix build -L .#debug.cli-test.cli 2>&1 | ts -s
 }
 export -f cli_test_cli
 
 function cli_test_rust_tests() {
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting integration test..."
   nix build -L .#debug.cli-test.rust-tests 2>&1 | ts -s
 }
 export -f cli_test_rust_tests
 
 function cli_test_always_fail() {
-  set -o pipefail
+  set -eo pipefail # pipefail must be set manually again
   echo "### Starting always_fail test..."
   # this must fail, so we know nix build is actually running tests
   ! nix build -L .#debug.cli-test.always-fail 2>&1 | ts -s


### PR DESCRIPTION
set -o pipefail gets reset when parallel invokes a bash function.