### PR TITLE
Auth api

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -18,6 +18,7 @@ use fedimint_core::api::{
 };
 use fedimint_core::config::{load_from_file, ClientConfig, FederationId};
 use fedimint_core::db::Database;
+use fedimint_core::module::ApiRequestErased;
 use fedimint_core::query::EventuallyConsistent;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{Amount, OutPoint, TieredMulti, TransactionId};
@@ -462,7 +463,7 @@ async fn handle_command(
                 .request_with_strategy(
                     EventuallyConsistent::new(ws_api.peers().len()),
                     method,
-                    vec![arg],
+                    ApiRequestErased::new(arg),
                 )
                 .await
                 .unwrap();

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -2,14 +2,12 @@ pub mod fake;
 
 use bitcoin::Address;
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
-use fedimint_core::api::{
-    erased_multi_param, erased_no_param, erased_single_param, FederationApiExt, FederationResult,
-    IFederationApi,
-};
+use fedimint_core::api::{FederationApiExt, FederationResult, IFederationApi};
 use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
+use fedimint_core::module::ApiRequestErased;
 use fedimint_core::query::{
     CurrentConsensus, EventuallyConsistent, Retry404, UnionResponses, UnionResponsesSingle,
 };
@@ -43,7 +41,7 @@ where
         self.request_with_strategy(
             Retry404::new(self.all_members().one_honest()),
             format!("/module/{LEGACY_HARDCODED_INSTANCE_ID_LN}/account"),
-            erased_single_param(&contract),
+            ApiRequestErased::new(contract),
         )
         .await
     }
@@ -54,7 +52,7 @@ where
         self.request_with_strategy(
             Retry404::new(self.all_members().one_honest()),
             format!("/module/{LEGACY_HARDCODED_INSTANCE_ID_LN}/offer"),
-            erased_single_param(&payment_hash),
+            ApiRequestErased::new(payment_hash),
         )
         .await
     }
@@ -63,7 +61,7 @@ where
         self.request_with_strategy(
             UnionResponses::new(self.all_members().threshold()),
             format!("/module/{LEGACY_HARDCODED_INSTANCE_ID_LN}/list_gateways"),
-            erased_no_param(),
+            ApiRequestErased::default(),
         )
         .await
     }
@@ -72,7 +70,7 @@ where
         self.request_with_strategy(
             CurrentConsensus::new(self.all_members().threshold()),
             format!("/module/{LEGACY_HARDCODED_INSTANCE_ID_LN}/register_gateway"),
-            erased_single_param(gateway),
+            ApiRequestErased::new(gateway),
         )
         .await
     }
@@ -110,7 +108,7 @@ where
         self.request_with_strategy(
             CurrentConsensus::new(self.all_members().threshold()),
             format!("/module/{LEGACY_HARDCODED_INSTANCE_ID_MINT}/backup"),
-            erased_single_param(request),
+            ApiRequestErased::new(request),
         )
         .await
     }
@@ -124,7 +122,7 @@ where
                     self.all_members().threshold(),
                 ),
                 format!("/module/{LEGACY_HARDCODED_INSTANCE_ID_MINT}/recover"),
-                erased_single_param(id),
+                ApiRequestErased::new(id),
             )
             .await?
             .into_iter()
@@ -152,7 +150,7 @@ where
         self.request_with_strategy(
             EventuallyConsistent::new(self.all_members().one_honest()),
             format!("/module/{LEGACY_HARDCODED_INSTANCE_ID_WALLET}/block_height"),
-            erased_no_param(),
+            ApiRequestErased::default(),
         )
         .await
     }
@@ -164,7 +162,7 @@ where
     ) -> FederationResult<Option<PegOutFees>> {
         self.request_eventually_consistent(
             format!("/module/{LEGACY_HARDCODED_INSTANCE_ID_WALLET}/peg_out_fees"),
-            erased_multi_param(&(address, amount.to_sat())),
+            ApiRequestErased::new((address, amount.to_sat())),
         )
         .await
     }

--- a/client/client-lib/src/api/fake.rs
+++ b/client/client-lib/src/api/fake.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use fedimint_core::api::{IFederationApi, JsonRpcResult};
+use fedimint_core::module::ApiRequest;
 use fedimint_core::PeerId;
 use futures::Future;
 use serde;
@@ -72,10 +73,10 @@ where
                         ));
                     }
 
-                    let params = serde_json::from_value(
+                    let request: ApiRequest<Param> = serde_json::from_value(
                         params.first().expect("just checked the len").clone(),
                     )?;
-                    let ret = f(state, params).await?;
+                    let ret = f(state, request.params).await?;
                     let ret = serde_json::to_value(ret)
                         .expect("Serialization of the return value must not fail");
 

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -42,6 +42,7 @@ use tracing::{debug, error, instrument, trace};
 use url::Url;
 
 use crate::epoch::{SerdeEpochHistory, SignedEpochOutcome};
+use crate::module::ApiRequest;
 use crate::outcome::TransactionStatus;
 use crate::query::{
     CurrentConsensus, EventuallyConsistent, QueryStep, QueryStrategy, UnionResponses,
@@ -154,7 +155,9 @@ pub trait IFederationApi: Debug + MaybeSend + MaybeSync {
 /// Notably the caling convention of fedimintd api is a bit weird ATM, so by
 /// using this function you'll make it easier to change it in the future.
 pub fn erased_no_param() -> Vec<JsonValue> {
-    vec![JsonValue::Null]
+    let params_raw = serde_json::to_value(ApiRequest::default())
+        .expect("parameter serialization error - this should not happen");
+    vec![params_raw]
 }
 
 /// Build a `Vec<json::Value>` that [`IFederationApi::request_raw`] expects when
@@ -162,13 +165,12 @@ pub fn erased_no_param() -> Vec<JsonValue> {
 ///
 /// Notably the caling convention of fedimintd api is a bit weird ATM, so by
 /// using this function you'll make it easier to change it in the future.
-pub fn erased_single_param<Params>(param: &Params) -> Vec<JsonValue>
+pub fn erased_single_param<Params>(params: &Params) -> Vec<JsonValue>
 where
     Params: Serialize,
 {
-    let params_raw = serde_json::to_value(param)
+    let params_raw = serde_json::to_value(ApiRequest { auth: None, params })
         .expect("parameter serialization error - this should not happen");
-
     vec![params_raw]
 }
 
@@ -179,11 +181,11 @@ where
 ///
 /// Notably the caling convention of fedimintd api is a bit weird ATM, so by
 /// using this function you'll make it easier to change it in the future.
-pub fn erased_multi_param<Params>(param: &Params) -> Vec<JsonValue>
+pub fn erased_multi_param<Params>(params: &Params) -> Vec<JsonValue>
 where
     Params: Serialize,
 {
-    let params_raw = serde_json::to_value(param)
+    let params_raw = serde_json::to_value(ApiRequest { auth: None, params })
         .expect("parameter serialization error - this should not happen");
 
     vec![params_raw]

--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -15,8 +15,8 @@ use super::*;
 use crate::db::ModuleDatabaseTransaction;
 use crate::maybe_add_send_sync;
 use crate::module::{
-    ApiEndpoint, ApiVersion, ConsensusProposal, InputMeta, ModuleCommon, ModuleConsensusVersion,
-    ModuleError, ServerModule, TransactionItemAmount,
+    ApiAuth, ApiEndpoint, ApiVersion, ConsensusProposal, InputMeta, ModuleCommon,
+    ModuleConsensusVersion, ModuleError, ServerModule, TransactionItemAmount,
 };
 use crate::task::{MaybeSend, MaybeSync};
 
@@ -440,12 +440,19 @@ where
                     move |module: &DynServerModule,
                           dbtx: fedimint_core::db::DatabaseTransaction<'_>,
                           value: serde_json::Value,
-                          module_instance_id: Option<ModuleInstanceId>| {
+                          module_instance_id: Option<ModuleInstanceId>,
+                          api_auth: ApiAuth| {
                         let typed_module = module
                             .as_any()
                             .downcast_ref::<T>()
                             .expect("the dispatcher should always call with the right module");
-                        Box::pin(handler(typed_module, dbtx, value, module_instance_id))
+                        Box::pin(handler(
+                            typed_module,
+                            dbtx,
+                            value,
+                            module_instance_id,
+                            api_auth,
+                        ))
                     },
                 ),
             })

--- a/fedimint-core/src/module/interconnect.rs
+++ b/fedimint-core/src/module/interconnect.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 
 use super::ApiError;
 use crate::core::ModuleInstanceId;
+use crate::module::ApiRequestErased;
 
 /// Provides an interface to call APIs of other modules
 #[async_trait]
@@ -12,6 +13,6 @@ pub trait ModuleInterconect: Sync + Send {
         &self,
         module_id: ModuleInstanceId,
         path: String,
-        data: serde_json::Value,
+        data: ApiRequestErased,
     ) -> Result<serde_json::Value, ApiError>;
 }

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -58,6 +58,10 @@ impl TransactionItemAmount {
     };
 }
 
+/// Authentication uses the hashed user password in PHC format
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiAuth(pub String);
+
 #[derive(Debug)]
 pub struct ApiError {
     pub code: i32,

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use bitcoin_hashes::sha256;
 use bitcoin_hashes::sha256::Hash;
 use futures::Future;
+use jsonrpsee_core::JsonValue;
 use secp256k1_zkp::XOnlyPublicKey;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -58,8 +59,26 @@ impl TransactionItemAmount {
     };
 }
 
+/// All requests from client to server contain these fields
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiRequest<T> {
+    /// Hashed user password if the API requires authentication
+    pub auth: Option<ApiAuth>,
+    /// Parameters required by the API
+    pub params: T,
+}
+
+impl Default for ApiRequest<JsonValue> {
+    fn default() -> Self {
+        Self {
+            auth: None,
+            params: JsonValue::Null,
+        }
+    }
+}
+
 /// Authentication uses the hashed user password in PHC format
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ApiAuth(pub String);
 
 #[derive(Debug)]
@@ -95,7 +114,8 @@ pub trait TypedApiEndpoint {
     async fn handle<'a, 'b>(
         state: &'a Self::State,
         dbtx: &'a mut fedimint_core::db::ModuleDatabaseTransaction<'b, ModuleInstanceId>,
-        params: Self::Param,
+        request: Self::Param,
+        has_auth: bool,
     ) -> Result<Self::Response, ApiError>;
 }
 
@@ -136,6 +156,7 @@ macro_rules! __api_endpoint {
                 $state: &'a Self::State,
                 $dbtx: &'a mut fedimint_core::db::ModuleDatabaseTransaction<'b, ModuleInstanceId>,
                 $param: Self::Param,
+                has_auth: bool,
             ) -> ::std::result::Result<Self::Response, $crate::module::ApiError> {
                 $body
             }
@@ -159,6 +180,7 @@ type HandlerFn<M> = Box<
             fedimint_core::db::DatabaseTransaction<'a>,
             serde_json::Value,
             Option<ModuleInstanceId>,
+            ApiAuth,
         ) -> HandlerFnReturn<'a>
     ),
 >;
@@ -194,15 +216,17 @@ impl ApiEndpoint<()> {
         async fn handle_request<'a, 'b, E>(
             state: &'a E::State,
             dbtx: &mut fedimint_core::db::ModuleDatabaseTransaction<'b, ModuleInstanceId>,
-            param: E::Param,
+            request: ApiRequest<E::Param>,
+            api_auth: ApiAuth,
         ) -> Result<E::Response, ApiError>
         where
             E: TypedApiEndpoint,
             E::Param: Debug,
             E::Response: Debug,
         {
-            tracing::trace!(target: "fedimint_server::request", ?param, "recieved request");
-            let result = E::handle(state, dbtx, param).await;
+            tracing::trace!(target: "fedimint_server::request", ?request, "recieved request");
+            let has_auth = request.auth == Some(api_auth);
+            let result = E::handle(state, dbtx, request.params, has_auth).await;
             if let Err(error) = &result {
                 tracing::trace!(target: "fedimint_server::request", ?error, "error");
             }
@@ -211,7 +235,7 @@ impl ApiEndpoint<()> {
 
         ApiEndpoint {
             path: E::PATH,
-            handler: Box::new(|m, mut dbtx, param, module_instance_id| {
+            handler: Box::new(|m, mut dbtx, param, module_instance_id, api_auth| {
                 Box::pin(async move {
                     let params = serde_json::from_value(param)
                         .map_err(|e| ApiError::bad_request(e.to_string()))?;
@@ -219,9 +243,12 @@ impl ApiEndpoint<()> {
                     let ret = match module_instance_id {
                         Some(module_instance_id) => {
                             let mut module_dbtx = dbtx.with_module_prefix(module_instance_id);
-                            handle_request::<E>(m, &mut module_dbtx, params).await?
+                            handle_request::<E>(m, &mut module_dbtx, params, api_auth).await?
                         }
-                        None => handle_request::<E>(m, &mut dbtx.get_isolated(), params).await?,
+                        None => {
+                            handle_request::<E>(m, &mut dbtx.get_isolated(), params, api_auth)
+                                .await?
+                        }
                     };
 
                     dbtx.commit_tx_result().await.map_err(|_err| {

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::module::interconnect::ModuleInterconect;
-use fedimint_core::module::ApiError;
+use fedimint_core::module::{ApiError, ApiRequestErased};
 use serde_json::Value;
 
 use crate::consensus::FedimintConsensus;
@@ -16,7 +16,7 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
         &self,
         id: ModuleInstanceId,
         path: String,
-        data: Value,
+        data: ApiRequestErased,
     ) -> Result<Value, ApiError> {
         for (module_id, module) in self.fedimint.modules.iter_modules() {
             if module_id == id {
@@ -29,7 +29,7 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
                 return (endpoint.handler)(
                     module,
                     self.fedimint.db.begin_transaction().await,
-                    data,
+                    data.to_json(),
                     Some(module_id),
                     self.fedimint.cfg.private.api_auth.clone(),
                 )

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -31,6 +31,7 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
                     self.fedimint.db.begin_transaction().await,
                     data,
                     Some(module_id),
+                    self.fedimint.cfg.private.api_auth.clone(),
                 )
                 .await;
             }

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -113,7 +113,13 @@ fn attach_endpoints(
                 // is only the last line of defense
                 AssertUnwindSafe(tokio::time::timeout(
                     API_ENDPOINT_TIMEOUT,
-                    (handler)(fedimint, dbtx, params, module_instance_id),
+                    (handler)(
+                        fedimint,
+                        dbtx,
+                        params,
+                        module_instance_id,
+                        fedimint.cfg.private.api_auth.clone(),
+                    ),
                 ))
                 .catch_unwind()
                 .await
@@ -172,6 +178,7 @@ fn attach_endpoints_erased(
                         dbtx,
                         params,
                         Some(module_instance),
+                        fedimint.cfg.private.api_auth.clone(),
                     ),
                 ))
                 .catch_unwind()

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -14,8 +14,8 @@ use fedimint_core::db::{Database, DatabaseTransaction, ModuleDatabaseTransaction
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{
-    ApiError, CommonModuleGen, ExtendsCommonModuleGen, InputMeta, ModuleCommon, ModuleError,
-    ServerModuleGen, TransactionItemAmount,
+    ApiError, ApiRequestErased, CommonModuleGen, ExtendsCommonModuleGen, InputMeta, ModuleCommon,
+    ModuleError, ServerModuleGen, TransactionItemAmount,
 };
 use fedimint_core::{OutPoint, PeerId, ServerModule};
 use fedimint_rocksdb::RocksDb;
@@ -458,8 +458,8 @@ impl ModuleInterconect for FakeInterconnect {
         &self,
         module_id: ModuleInstanceId,
         path: String,
-        data: serde_json::Value,
+        data: ApiRequestErased,
     ) -> Result<serde_json::Value, ApiError> {
-        (self.0)(module_id, path, data)
+        (self.0)(module_id, path, data.to_json())
     }
 }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -30,17 +30,22 @@ pub struct ServerOpts {
     /// Path to folder containing federation config files
     pub data_dir: PathBuf,
     /// Password to encrypt sensitive config files
+    // TODO: should probably never send password to the server directly, rather send the hash via
+    // the API
     #[arg(env = "FM_PASSWORD")]
     pub password: String,
     /// Port to run admin UI on
     #[arg(long = "listen-ui", env = "FM_LISTEN_UI")]
     pub listen_ui: Option<SocketAddr>,
-    #[arg(long = "tokio-console-bind", env = "FM_TOKIO_CONSOLE_BIND")]
-    pub tokio_console_bind: Option<SocketAddr>,
-    #[arg(long, default_value = "false")]
-    pub with_telemetry: bool,
+    /// After an upgrade the epoch must be passed in
     #[arg(long = "upgrade-epoch")]
     pub upgrade_epoch: Option<u64>,
+    /// Enable tokio console logging
+    #[arg(long = "tokio-console-bind", env = "FM_TOKIO_CONSOLE_BIND")]
+    pub tokio_console_bind: Option<SocketAddr>,
+    /// Enable telemetry logging
+    #[arg(long, default_value = "false")]
+    pub with_telemetry: bool,
 }
 
 /// `fedimintd` builder

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -3,7 +3,6 @@ use std::ffi::OsString;
 use std::ops::Sub;
 
 use bitcoin_hashes::Hash as BitcoinHash;
-use fedimint_core::api::erased_no_param;
 use fedimint_core::config::{
     ConfigGenParams, DkgResult, ModuleConfigResponse, ServerModuleConfig, TypedServerModuleConfig,
     TypedServerModuleConsensusConfig,
@@ -14,9 +13,9 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::{
-    api_endpoint, ApiEndpoint, ApiError, ApiVersion, ConsensusProposal, CoreConsensusVersion,
-    ExtendsCommonModuleGen, InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError,
-    PeerHandle, ServerModuleGen, TransactionItemAmount,
+    api_endpoint, ApiEndpoint, ApiError, ApiRequestErased, ApiVersion, ConsensusProposal,
+    CoreConsensusVersion, ExtendsCommonModuleGen, InputMeta, IntoModuleError,
+    ModuleConsensusVersion, ModuleError, PeerHandle, ServerModuleGen, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::TaskGroup;
@@ -874,7 +873,7 @@ async fn block_height(interconnect: &dyn ModuleInterconect) -> u32 {
         .call(
             LEGACY_HARDCODED_INSTANCE_ID_WALLET,
             "/block_height".to_owned(),
-            erased_no_param().pop().expect("always exists"),
+            ApiRequestErased::default(),
         )
         .await
         .expect("Wallet module not present or malfunctioning!");

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -3,6 +3,7 @@ use std::ffi::OsString;
 use std::ops::Sub;
 
 use bitcoin_hashes::Hash as BitcoinHash;
+use fedimint_core::api::erased_no_param;
 use fedimint_core::config::{
     ConfigGenParams, DkgResult, ModuleConfigResponse, ServerModuleConfig, TypedServerModuleConfig,
     TypedServerModuleConsensusConfig,
@@ -873,7 +874,7 @@ async fn block_height(interconnect: &dyn ModuleInterconect) -> u32 {
         .call(
             LEGACY_HARDCODED_INSTANCE_ID_WALLET,
             "/block_height".to_owned(),
-            Default::default(),
+            erased_no_param().pop().expect("always exists"),
         )
         .await
         .expect("Wallet module not present or malfunctioning!");


### PR DESCRIPTION
This adds optional auth to the APIs available through the `has_auth` parameter in the `api_endpoint!` handler.

The auth is a hashed password stored in the encrypted `ServerConfig` (better performance + security over DB).

Follow up PR will be to add an authenticated API for #948 along with tests.

Fixes #1841