### PR TITLE
chore: put 10 minutes timeout on ci tests

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -8,6 +8,7 @@ use std::ffi::OsString;
 use std::iter::FromIterator;
 use std::os::unix::prelude::OsStrExt;
 use std::sync::Mutex;
+use std::time::Duration;
 
 use anyhow::format_err;
 use fedimint_core::config::{ConfigResponse, ServerModuleGenRegistry};
@@ -24,7 +25,7 @@ use fedimint_core::module::registry::{
 use fedimint_core::module::{ModuleError, TransactionItemAmount};
 use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::server::{DynServerModule, DynVerificationCache};
-use fedimint_core::task::TaskGroup;
+use fedimint_core::task::{sleep, TaskGroup};
 use fedimint_core::{Amount, NumPeers, OutPoint, PeerId, TransactionId};
 use fedimint_logging::{LOG_CONSENSUS, LOG_CORE};
 use futures::future::select_all;
@@ -855,6 +856,11 @@ impl FedimintConsensus {
                 self.accepted_transaction_status(txid, accepted, &mut dbtx).await
             }
             rejected = self.db.wait_key_exists(&rejected_key) => {
+                // HACK: Just because a copy of it was rejected, doesn't mean one was not actually included
+                sleep(Duration::from_millis(1000)).await;
+                if let Some(status) = self.transaction_status(txid).await {
+                    return status;
+                }
                 TransactionStatus::Rejected(rejected)
             }
         }

--- a/scripts/test-ci-all.sh
+++ b/scripts/test-ci-all.sh
@@ -59,7 +59,7 @@ export -f cli_test_always_fail
 # --memfree to make sure tests have enough memory to run
 # --nice to let you browse twitter without lag while the tests are running
 # try to keep the slowest tests first
-parallel --load 150% --delay 5 --memfree 512M --nice 15 ::: \
+parallel --timeout 600 --load 150% --delay 5 --memfree 512M --nice 15 ::: \
   cli_test_rust_tests \
   cli_test_latency \
   cli_test_reconnect \


### PR DESCRIPTION
They normally complete in < 5 minutes, so 10 should be enough.