### PR TITLE
Consensus upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes",
  "clap",
+ "fedimint-aead",
  "fedimint-build",
  "fedimint-client",
  "fedimint-core",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -18,6 +18,7 @@ bitcoin_hashes = "0.11.0"
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions" ], default-features = false }
 lightning-invoice = { version = "0.21.0", features = [ "serde" ] }
 mint-client = { path = "../client-lib" }
+fedimint-aead = { path = "../../crypto/aead" }
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-core ={ path = "../../fedimint-core" }
 fedimint-rocksdb = { path = "../../fedimint-rocksdb" }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -133,6 +133,10 @@ enum CliOutput {
     Backup,
 
     SignalUpgrade,
+
+    EpochCount {
+        count: u64,
+    },
 }
 
 impl fmt::Display for CliOutput {
@@ -370,6 +374,9 @@ enum Command {
         #[arg(env = "FM_PASSWORD")]
         password: String,
     },
+
+    /// Gets the current epoch count
+    EpochCount,
 }
 
 trait ErrorHandler<T, E> {
@@ -797,6 +804,10 @@ async fn handle_command(
             let auth_api = WsAuthenticatedApi::new(url, our_id, auth);
             auth_api.signal_upgrade().await?;
             Ok(CliOutput::SignalUpgrade)
+        }
+        Command::EpochCount => {
+            let count = client.context().api.fetch_epoch_count().await?;
+            Ok(CliOutput::EpochCount { count })
         }
     }
 }

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -1,3 +1,4 @@
+use std::num::ParseIntError;
 use std::str::FromStr;
 
 use bitcoin::{secp256k1, Network};
@@ -7,7 +8,7 @@ use fedimint_core::api::DynFederationApi;
 use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::{ParseAmountError, TieredMulti};
+use fedimint_core::{ParseAmountError, PeerId, TieredMulti};
 use lightning_invoice::Currency;
 
 use crate::mint::SpendableNote;
@@ -58,6 +59,10 @@ pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_core::Amount, ParseAmou
 
 pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Error> {
     secp256k1::PublicKey::from_str(s)
+}
+
+pub fn parse_peer_id(s: &str) -> Result<PeerId, ParseIntError> {
+    Ok(PeerId::from(s.parse::<u16>()?))
 }
 
 #[derive(Debug)]

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -228,9 +228,9 @@ impl<'a> DatabaseDump<'a> {
                     );
                 }
                 ConsensusRange::DbKeyPrefix::ConsensusUpgrade => {
-                    let shutdown = dbtx.get_value(&ConsensusRange::ConsensusUpgradeKey).await;
-                    if let Some(shutdown) = shutdown {
-                        consensus.insert("ShutdownSignal".to_string(), Box::new(shutdown));
+                    let upgrade = dbtx.get_value(&ConsensusRange::ConsensusUpgradeKey).await;
+                    if let Some(upgrade) = upgrade {
+                        consensus.insert("ConsensusUpgrade".to_string(), Box::new(upgrade));
                     }
                 }
                 // Module is a global prefix for all module data

--- a/fedimint-server/src/consensus/debug.rs
+++ b/fedimint-server/src/consensus/debug.rs
@@ -39,6 +39,6 @@ fn item_message(item: &ConsensusItem) -> String {
             }
             tx_debug
         }
-        ConsensusItem::ConsensusUpgrade(reason) => format!("Shutdown signal for {reason:?}"),
+        ConsensusItem::ConsensusUpgrade(_) => "Consensus Upgrade".to_string(),
     }
 }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -599,12 +599,10 @@ impl FedimintConsensus {
     /// Called to remove the upgrade items after the upgrade is complete
     pub async fn remove_upgrade_items(&self, epoch: u64) -> anyhow::Result<()> {
         let last_epoch = self.get_epoch_count().await;
+        let mut tx = self.db.begin_transaction().await;
         if last_epoch == epoch {
-            self.db
-                .begin_transaction()
-                .await
-                .remove_entry(&ConsensusUpgradeKey)
-                .await;
+            tx.remove_entry(&ConsensusUpgradeKey).await;
+            tx.commit_tx().await;
             Ok(())
         } else {
             Err(format_err!(

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -34,6 +34,7 @@ use hbbft::honey_badger::Batch;
 use itertools::Itertools;
 use thiserror::Error;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
 
@@ -81,6 +82,13 @@ pub struct ConsensusProposal {
     pub force_new_epoch: bool,
 }
 
+/// Events that can be sent from the API to consensus thread
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub enum ApiEvent {
+    Transaction(Transaction),
+    UpgradeSignal,
+}
+
 // TODO: we should make other fields private and get rid of this
 #[non_exhaustive]
 pub struct FedimintConsensus {
@@ -98,12 +106,12 @@ pub struct FedimintConsensus {
     /// a crash
     pub db: Database,
 
-    /// For sending new transactions to consensus
-    pub tx_sender: Sender<Transaction>,
+    /// For sending API events to consensus
+    pub api_sender: Sender<ApiEvent>,
 
-    /// Cache of transactions to include in a proposal
+    /// Cache of `ApiEvent` to include in a proposal
     // TODO should be able to eventually remove this Mutex
-    pub tx_cache: Mutex<HashSet<Transaction>>,
+    pub api_event_cache: Mutex<HashSet<ApiEvent>>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
@@ -140,7 +148,7 @@ impl FedimintConsensus {
         db: Database,
         module_inits: ServerModuleGenRegistry,
         task_group: &mut TaskGroup,
-    ) -> anyhow::Result<(Self, Receiver<Transaction>)> {
+    ) -> anyhow::Result<(Self, Receiver<ApiEvent>)> {
         let mut modules = BTreeMap::new();
 
         let env = Self::get_env_vars_map();
@@ -182,7 +190,7 @@ impl FedimintConsensus {
             modules.insert(*module_id, module);
         }
 
-        let (tx_sender, tx_receiver) = mpsc::channel(TRANSACTION_BUFFER_SIZE);
+        let (api_sender, api_receiver) = mpsc::channel(TRANSACTION_BUFFER_SIZE);
         let client_cfg = cfg.consensus.to_config_response(&module_inits);
 
         Ok((
@@ -192,10 +200,10 @@ impl FedimintConsensus {
                 client_cfg,
                 module_inits,
                 db,
-                tx_sender,
-                tx_cache: Default::default(),
+                api_sender,
+                api_event_cache: Default::default(),
             },
-            tx_receiver,
+            api_receiver,
         ))
     }
 
@@ -205,8 +213,8 @@ impl FedimintConsensus {
         db: Database,
         module_inits: ServerModuleGenRegistry,
         modules: ModuleRegistry<DynServerModule>,
-    ) -> (Self, Receiver<Transaction>) {
-        let (tx_sender, tx_receiver) = mpsc::channel(TRANSACTION_BUFFER_SIZE);
+    ) -> (Self, Receiver<ApiEvent>) {
+        let (api_sender, api_receiver) = mpsc::channel(TRANSACTION_BUFFER_SIZE);
         let client_cfg = cfg.consensus.to_config_response(&module_inits);
 
         (
@@ -216,10 +224,10 @@ impl FedimintConsensus {
                 client_cfg,
                 module_inits,
                 db,
-                tx_sender,
-                tx_cache: Default::default(),
+                api_sender,
+                api_event_cache: Default::default(),
             },
-            tx_receiver,
+            api_receiver,
         )
     }
 }
@@ -295,8 +303,8 @@ impl FedimintConsensus {
 
         funding_verifier.verify_funding()?;
 
-        self.tx_sender
-            .send(transaction)
+        self.api_sender
+            .send(ApiEvent::Transaction(transaction))
             .await
             .map_err(|_e| TransactionSubmissionError::TxChannelError)?;
         Ok(())
@@ -426,7 +434,8 @@ impl FedimintConsensus {
             let span = info_span!("Processing transaction");
             async {
                 trace!(?transaction);
-                self.tx_cache.lock().unwrap().remove(&transaction);
+                let event = ApiEvent::Transaction(transaction.clone());
+                self.api_event_cache.lock().unwrap().remove(&event);
 
                 dbtx.set_tx_savepoint()
                     .await
@@ -562,6 +571,12 @@ impl FedimintConsensus {
             let mut peers = maybe_exists.unwrap_or_default();
             peers.extend(upgrade_signals.iter().map(|(peer, _)| peer));
             dbtx.insert_entry(&ConsensusUpgradeKey, &peers).await;
+
+            // Remove our upgrade signal event if we signaled
+            if peers.contains(&self.cfg.local.identity) {
+                let mut cache = self.api_event_cache.lock().expect("locks");
+                cache.remove(&ApiEvent::UpgradeSignal);
+            }
         }
     }
 
@@ -574,6 +589,11 @@ impl FedimintConsensus {
             .await
             .filter(|peers| peers.len() >= self.cfg.consensus.api.threshold())
             .is_some()
+    }
+
+    /// Sends an upgrade signal to the fedimint server thread
+    pub async fn signal_upgrade(&self) -> Result<(), SendError<ApiEvent>> {
+        self.api_sender.send(ApiEvent::UpgradeSignal).await
     }
 
     /// Called to remove the upgrade items after the upgrade is complete
@@ -705,12 +725,15 @@ impl FedimintConsensus {
             .await;
 
         let mut items: Vec<ConsensusItem> = self
-            .tx_cache
+            .api_event_cache
             .lock()
             .unwrap()
             .iter()
             .cloned()
-            .map(ConsensusItem::Transaction)
+            .map(|event| match event {
+                ApiEvent::Transaction(tx) => ConsensusItem::Transaction(tx),
+                ApiEvent::UpgradeSignal => ConsensusItem::ConsensusUpgrade(ConsensusUpgrade),
+            })
             .collect();
         let mut force_new_epoch = false;
 

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -266,5 +266,16 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
                 Ok(fedimint.get_config_with_sig(dbtx).await)
             }
         },
+        api_endpoint! {
+            "/upgrade",
+            async |fedimint: &FedimintConsensus, _dbtx, _v: (), has_auth| -> () {
+                if has_auth {
+                    fedimint.signal_upgrade().await.map_err(|_| ApiError::server_error("Unable to send signal to server".to_string()))?;
+                    Ok(())
+                } else {
+                    Err(ApiError::unauthorized())
+                }
+            }
+        },
     ]
 }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -233,14 +233,14 @@ async fn run(
         decoders.clone(),
     );
 
-    let (consensus, tx_receiver) =
+    let (consensus, api_receiver) =
         FedimintConsensus::new(cfg.clone(), db, module_gens, &mut task_group).await?;
 
     if let Some(epoch) = opts.upgrade_epoch {
         consensus.remove_upgrade_items(epoch).await?;
     }
 
-    FedimintServer::run(cfg, consensus, tx_receiver, decoders, &mut task_group).await?;
+    FedimintServer::run(cfg, consensus, api_receiver, decoders, &mut task_group).await?;
 
     Ok(())
 }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -38,7 +38,7 @@ pub struct ServerOpts {
     #[arg(long = "listen-ui", env = "FM_LISTEN_UI")]
     pub listen_ui: Option<SocketAddr>,
     /// After an upgrade the epoch must be passed in
-    #[arg(long = "upgrade-epoch")]
+    #[arg(env = "FM_UPGRADE_EPOCH")]
     pub upgrade_epoch: Option<u64>,
     /// Enable tokio console logging
     #[arg(long = "tokio-console-bind", env = "FM_TOKIO_CONSOLE_BIND")]

--- a/flake.crane.nix
+++ b/flake.crane.nix
@@ -278,6 +278,13 @@ rec {
     buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/reconnect-test.sh";
   });
 
+  cliTestUpgrade = craneLib.mkCargoDerivation (commonCliTestArgs // {
+    pname = "${commonCliTestArgs.pname}-upgrade";
+    version = "0.0.1";
+    cargoArtifacts = workspaceBuild;
+    buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/upgrade-test.sh";
+  });
+
   cliTestLatency = craneLib.mkCargoDerivation (commonCliTestArgs // {
     pname = "${commonCliTestArgs.pname}-latency";
     version = "0.0.1";

--- a/flake.nix
+++ b/flake.nix
@@ -465,6 +465,7 @@
           cli-test = {
             all = craneBuildNative.cliTestsAll;
             reconnect = craneBuildNative.cliTestReconnect;
+            upgrade = craneBuildNative.cliTestUpgrade;
             latency = craneBuildNative.cliTestLatency;
             cli = craneBuildNative.cliTestCli;
             rust-tests = craneBuildNative.cliRustTests;

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -1006,7 +1006,7 @@ impl FederationTest {
             let fedimint_server = &mut server.fedimint;
 
             // Pending transactions will trigger an epoch
-            if let Some(Some(_)) = Pin::new(&mut fedimint_server.tx_receiver)
+            if let Some(Some(_)) = Pin::new(&mut fedimint_server.api_receiver)
                 .peek()
                 .now_or_never()
             {

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -89,3 +89,5 @@ PAYMENT_HASH="$(echo $ADD_INVOICE| jq -e -r '.r_hash')"
 $FM_LIGHTNING_CLI pay "$INVOICE"
 INVOICE_STATUS="$($FM_LNCLI lookupinvoice $PAYMENT_HASH | jq -e -r '.state')"
 [[ "$INVOICE_STATUS" = "SETTLED" ]]
+
+echo "fm success: cli-test"

--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -70,8 +70,10 @@ if [[ $(echo "$LN_SEND < 5" | bc -l) != 1 ]] ; then
   echo "SEND TOO SLOW: $LN_SEND"
   exit 1
 fi
-  
+
 if [[ $(echo "$LN_RECEIVE < 5" | bc -l) != 1 ]] ; then
   echo "RECEIVE TOO SLOW: $LN_RECEIVE"
   exit 1
 fi
+
+echo "fm success: latency-test"

--- a/scripts/reconnect-test.sh
+++ b/scripts/reconnect-test.sh
@@ -50,4 +50,4 @@ kill_server $server4
 
 start_federation
 await_all_peers
-echo "Successfully restarted consensus!"
+echo "fm success: reconnect-test"

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -25,3 +25,5 @@ env RUST_BACKTRACE=1 cargo test -p fedimint-tests wallet -- --test-threads=$(($(
 unset FM_ELECTRUM_RPC
 export FM_ESPLORA_RPC="http://127.0.0.1:50002"
 env RUST_BACKTRACE=1 cargo test -p fedimint-tests wallet -- --test-threads=$(($(nproc) * 2)) "$@"
+
+echo "fm success: rust-tests"

--- a/scripts/test-ci-all.sh
+++ b/scripts/test-ci-all.sh
@@ -23,6 +23,13 @@ function cli_test_reconnect() {
 }
 export -f cli_test_reconnect
 
+function cli_test_upgrade() {
+  set -eo pipefail # pipefail must be set manually again
+  echo "### Starting upgrade test..."
+  unshare -rn bash -c "ip link set lo up && exec unshare --user ./scripts/upgrade-test.sh" 2>&1 | ts -s
+}
+export -f cli_test_upgrade
+
 function cli_test_latency() {
   set -eo pipefail # pipefail must be set manually again
   echo "### Starting latency test..."
@@ -62,5 +69,6 @@ parallel --timeout 600 --load 150% --delay 5 --memfree 512M --nice 15 ::: \
   cli_test_rust_tests \
   cli_test_latency \
   cli_test_reconnect \
+  cli_test_upgrade \
   cli_test_cli \
   cli_test_always_fail

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Runs a test to see what happens if we upgrade consensus
+
+set -euxo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source ./scripts/setup-tests.sh
+
+server4=$(tail -4 $FM_PID_FILE | head -1)
+server3=$(tail -3 $FM_PID_FILE | head -1)
+server2=$(tail -2 $FM_PID_FILE | head -1)
+server1=$(tail -1 $FM_PID_FILE | head -1)
+
+
+function wait_server_shutdown() {
+  echo "Waiting for $1 to shutdown..."
+  tail --pid=$1 -f /dev/null
+  echo "Server $1 has shutdown."
+}
+
+await_fedimint_block_sync
+
+# test a consensus upgrade
+FM_PASSWORD="pass0" $FM_MINT_CLIENT signal-upgrade $FM_CFG_DIR/server-0/private.salt 0
+FM_PASSWORD="pass1" $FM_MINT_CLIENT signal-upgrade $FM_CFG_DIR/server-1/private.salt 1
+
+mine_blocks 1
+await_fedimint_block_sync
+
+EPOCH=$($FM_MINT_CLIENT epoch-count | jq -e -r '.count')
+FM_UPGRADE_EPOCH=$(echo "$EPOCH + 1" | bc -l)
+export FM_UPGRADE_EPOCH
+FM_PASSWORD="pass2" $FM_MINT_CLIENT signal-upgrade $FM_CFG_DIR/server-2/private.salt 2
+
+wait_server_shutdown "$server1"
+wait_server_shutdown "$server2"
+wait_server_shutdown "$server3"
+wait_server_shutdown "$server4"
+
+start_federation
+
+mine_blocks 1
+await_fedimint_block_sync
+await_all_peers
+echo "fm success: upgrade-test"


### PR DESCRIPTION
PR for adding consensus upgrades to the API, fixing #948.
- Adds the consensus upgrade signaling code via an authorized API.
- Introduces `ApiEvent` so we can send non-transaction events from the API to consensus thread
- Adds a new integration test for signaling the upgrade
- Eventually the upgrade signaling/start-up should move into an admin UI.

Will follow-up with a refactor suggested by @Maan2003 to introduce `ApiEndpointContext`