### PR TITLE
fix(cli): do not pay a paid invoice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,7 @@ dependencies = [
  "fedimint-wallet-server",
  "futures",
  "hex",
+ "lightning-invoice",
  "serde",
  "serde_json",
  "strum",

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -781,7 +781,7 @@ impl FedimintCli {
             Command::LnPay { bolt11 } => {
                 let client = cli.build_client(&self.module_gens).await?;
                 let (contract_id, outpoint) = client
-                    .fund_outgoing_ln_contract(bolt11, &mut rng)
+                    .fund_outgoing_ln_contract(bolt11.clone(), &mut rng)
                     .await
                     .map_err_cli_msg(
                         CliErrorKind::GeneralFederationError,
@@ -791,8 +791,9 @@ impl FedimintCli {
                     .await_outgoing_contract_acceptance(outpoint)
                     .await
                     .map_err_cli_msg(CliErrorKind::Timeout, "contract wasn't accepted in time")?;
+                client.save_outgoing_contract_pending(bolt11.clone()).await;
                 client
-                    .await_outgoing_contract_execution(contract_id, &mut rng)
+                    .await_outgoing_contract_execution(bolt11, contract_id, &mut rng)
                     .await
                     .map(|_| CliOutput::LnPay {
                         contract_id: (contract_id),

--- a/fedimint-client-legacy/src/ln/db.rs
+++ b/fedimint-client-legacy/src/ln/db.rs
@@ -1,5 +1,7 @@
+use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
+use lightning_invoice::Invoice;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
@@ -17,6 +19,7 @@ pub enum DbKeyPrefix {
     OutgoingContractAccount = 0x25,
     ConfirmedInvoice = 0x26,
     LightningGateway = 0x28,
+    OutgoingContractPending = 0x2c,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -103,4 +106,20 @@ impl_db_record!(
 impl_db_lookup!(
     key = LightningGatewayKey,
     query_prefix = LightningGatewayKeyPrefix
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct OutgoingContractPendingKey(pub Sha256Hash);
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct OutgoingContractPendingKeyPrefix;
+
+impl_db_record!(
+    key = OutgoingContractPendingKey,
+    value = Invoice,
+    db_prefix = DbKeyPrefix::OutgoingContractPending,
+);
+impl_db_lookup!(
+    key = OutgoingContractPendingKey,
+    query_prefix = OutgoingContractPendingKeyPrefix
 );

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3.24"
 erased-serde = "0.3"
 hex = { version = "0.4.3", features = [ "serde"] }
 fedimint-client-legacy = { path = "../fedimint-client-legacy" }
+lightning-invoice = "0.21.0"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.91"
 strum = "0.24"

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -312,6 +312,16 @@ impl<'a> DatabaseDump<'a> {
                         "Outgoing Payment Claims"
                     );
                 }
+                ClientLightningRange::DbKeyPrefix::OutgoingContractPending => {
+                    push_db_pair_items!(
+                        dbtx,
+                        ClientLightningRange::OutgoingContractPendingKeyPrefix,
+                        ClientLightningRange::OutgoingContractPendingKey,
+                        lightning_invoice::Invoice,
+                        ln_client,
+                        "Outgoing Contracts with Pending Payments"
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
The aim of this PR is to fix #608.

@justinmoon As you suggested in https://github.com/fedimint/fedimint/issues/608#issuecomment-1464758957, I've attempted to store the payment hash of paid invoices and refuse attempts to pay an invoice that has already been paid. I'm not sure if this is in the right place.

I may also need to allow for the case where something goes wrong further downstream when paying an invoice, such as in `await_outgoing_contract_acceptance` or `await_outgoing_contract_execution`, so that those parts can still be retried.

If you could take a look and let me know your thoughts, that would be great thanks.