### PR TITLE
chore: rename `aead` *lib* to `fedimint_aead`

### DIFF
--- a/client/client-lib/src/mint/backup.rs
+++ b/client/client-lib/src/mint/backup.rs
@@ -158,8 +158,10 @@ impl MintClient {
 
     /// Static version of [`Self::get_derived_backup_encryption_key`] for
     /// testing without creating whole `MintClient`
-    fn get_derived_backup_encryption_key_static(secret: &DerivableSecret) -> aead::LessSafeKey {
-        aead::LessSafeKey::new(
+    fn get_derived_backup_encryption_key_static(
+        secret: &DerivableSecret,
+    ) -> fedimint_aead::LessSafeKey {
+        fedimint_aead::LessSafeKey::new(
             secret
                 .child_key(MINT_E_CASH_BACKUP_SNAPSHOT_TYPE_CHILD_ID)
                 .to_chacha20_poly1305_key(),
@@ -176,7 +178,7 @@ impl MintClient {
             .to_secp_key(&Secp256k1::<secp256k1::SignOnly>::gen_new())
     }
 
-    fn get_derived_backup_encryption_key(&self) -> aead::LessSafeKey {
+    fn get_derived_backup_encryption_key(&self) -> fedimint_aead::LessSafeKey {
         Self::get_derived_backup_encryption_key_static(&self.secret)
     }
 
@@ -369,10 +371,10 @@ impl PlaintextEcashBackup {
     }
 
     /// Encrypt with a key and turn into [`EcashBackup`]
-    pub fn encrypt_to(&self, key: &aead::LessSafeKey) -> Result<EcashBackup> {
+    pub fn encrypt_to(&self, key: &fedimint_aead::LessSafeKey) -> Result<EcashBackup> {
         let encoded = self.encode()?;
 
-        let encrypted = aead::encrypt(encoded, key)?;
+        let encrypted = fedimint_aead::encrypt(encoded, key)?;
         Ok(EcashBackup(encrypted))
     }
 }
@@ -381,8 +383,11 @@ impl PlaintextEcashBackup {
 pub struct EcashBackup(Vec<u8>);
 
 impl EcashBackup {
-    pub fn decrypt_with(mut self, key: &aead::LessSafeKey) -> Result<PlaintextEcashBackup> {
-        let decrypted = aead::decrypt(&mut self.0, key)?;
+    pub fn decrypt_with(
+        mut self,
+        key: &fedimint_aead::LessSafeKey,
+    ) -> Result<PlaintextEcashBackup> {
+        let decrypted = fedimint_aead::decrypt(&mut self.0, key)?;
         PlaintextEcashBackup::decode(decrypted)
     }
 

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -7,7 +7,7 @@ description = "aead utilities on top of ring "
 license = "MIT"
 
 [lib]
-name = "aead"
+name = "fedimint_aead"
 path = "src/lib.rs"
 
 [dependencies]

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -3,9 +3,11 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use aead::{encrypted_read, encrypted_write, get_encryption_key, random_salt, LessSafeKey};
 use anyhow::{ensure, format_err};
 use bitcoin_hashes::hex::{FromHex, ToHex};
+use fedimint_aead::{
+    encrypted_read, encrypted_write, get_encryption_key, random_salt, LessSafeKey,
+};
 use fedimint_core::api::WsClientConnectInfo;
 use fedimint_core::config::ServerModuleGenRegistry;
 use serde::de::DeserializeOwned;

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -4,10 +4,10 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
 
-use aead::{encrypted_read, get_encryption_key, get_password_hash};
 use anyhow::{bail, format_err, Context};
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::sha256::HashEngine;
+use fedimint_aead::{encrypted_read, get_encryption_key, get_password_hash};
 use fedimint_core::cancellable::Cancelled;
 pub use fedimint_core::config::*;
 use fedimint_core::config::{

--- a/fedimintd/src/distributed_gen.rs
+++ b/fedimintd/src/distributed_gen.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use aead::{encrypted_read, encrypted_write, get_encryption_key};
 use clap::{Parser, Subcommand};
+use fedimint_aead::{encrypted_read, encrypted_write, get_encryption_key};
 use fedimint_core::config::{DkgError, ServerModuleGenRegistry};
 use fedimint_core::module::ServerModuleGen;
 use fedimint_core::task::{self, TaskGroup};


### PR DESCRIPTION
We previously rename the *crate*, but forgot about renaming the library inside it.