### PR TITLE
fix: incorrect `ts` used

### DIFF
--- a/flake.crane.nix
+++ b/flake.crane.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, advisory-db, clightning-dev, pkgs-kitman }:
+{ pkgs, lib, advisory-db, clightning-dev, pkgs-kitman, moreutils-ts }:
 craneLib:
 let
   # filter source code at path `src` to include only the list of `modules`
@@ -108,7 +108,7 @@ rec {
 
     nativeBuildInputs = with pkgs; [
       pkg-config
-      ts
+      moreutils-ts
 
       # tests
       (hiPrio pkgs.bashInteractive)

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
 
         # `moreutils/bin/parallel` and `parallel/bin/parallel` conflict, so just use
         # the binary we need from `moreutils`
-        ts = pkgs.writeShellScriptBin "ts" "exec ${pkgs.moreutils}/bin/ts \"$@\"";
+        moreutils-ts = pkgs.writeShellScriptBin "ts" "exec ${pkgs.moreutils}/bin/ts \"$@\"";
 
         isArch64Darwin = stdenv.isAarch64 || stdenv.isDarwin;
 
@@ -212,7 +212,7 @@
 
         craneBuild = import ./flake.crane.nix
           {
-            inherit pkgs pkgs-kitman clightning-dev advisory-db lib;
+            inherit pkgs pkgs-kitman clightning-dev advisory-db lib moreutils-ts;
           };
 
         craneBuildNative = craneBuild craneLibNative;
@@ -310,7 +310,7 @@
                   tmuxinator
                   docker-compose
                   pkgs.tokio-console
-                  ts
+                  moreutils-ts
 
                   # Nix
                   pkgs.nixpkgs-fmt
@@ -409,7 +409,7 @@
                 git
                 parallel
                 semgrep
-                ts
+                moreutils-ts
                 nix
               ];
             };


### PR DESCRIPTION
After refactoring crane build into separate file, some parts of the code picked `ts` from `with pkgs`, and not the wrapper that we want to use.