### PR TITLE
chore(ci): run tests in parallel more efficiently

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -69,7 +69,7 @@ jobs:
         run: nix build -L .#debug.workspaceTestDoc
 
       - name: Tests
-        run: nix develop --ignore-environment .#lint --command ./scripts/test-ci-all.sh
+        run: nix build -L .#debug.cli-test.all
 
   # Code Coverage will build using a completely different profile (neither debug/release)
   # Which means we can not reuse much from `build` job. Might as well run it as another

--- a/flake.crane.nix
+++ b/flake.crane.nix
@@ -97,6 +97,12 @@ rec {
       pkgs.llvmPackages.bintools
       rocksdb
       protobuf
+
+      moreutils-ts
+      parallel
+    ] ++ lib.optionals (!stdenv.isDarwin) [
+      util-linux
+      iproute2
     ] ++ lib.optionals stdenv.isDarwin [
       libiconv
       darwin.apple_sdk.frameworks.Security
@@ -291,6 +297,13 @@ rec {
     version = "0.0.1";
     cargoArtifacts = workspaceBuild;
     buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/rust-tests.sh";
+  });
+
+  cliTestsAll = craneLib.mkCargoDerivation (commonCliTestArgs // {
+    pname = "${commonCliTestArgs.pname}-all";
+    version = "0.0.1";
+    cargoArtifacts = workspaceBuild;
+    buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/test-ci-all.sh";
   });
 
   cliTestAlwaysFail = craneLib.mkCargoDerivation (commonCliTestArgs // {

--- a/flake.crane.nix
+++ b/flake.crane.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, advisory-db, clightning-dev, pkgs-kitman }:
+{ pkgs, lib, advisory-db, clightning-dev, pkgs-kitman, moreutils-ts }:
 craneLib:
 let
   # filter source code at path `src` to include only the list of `modules`
@@ -108,7 +108,7 @@ rec {
 
     nativeBuildInputs = with pkgs; [
       pkg-config
-      ts
+      moreutils-ts
 
       # tests
       (hiPrio pkgs.bashInteractive)

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
 
         # `moreutils/bin/parallel` and `parallel/bin/parallel` conflict, so just use
         # the binary we need from `moreutils`
-        ts = pkgs.writeShellScriptBin "ts" "exec ${pkgs.moreutils}/bin/ts \"$@\"";
+        moreutils-ts = pkgs.writeShellScriptBin "ts" "exec ${pkgs.moreutils}/bin/ts \"$@\"";
 
         isArch64Darwin = stdenv.isAarch64 || stdenv.isDarwin;
 
@@ -212,7 +212,7 @@
 
         craneBuild = import ./flake.crane.nix
           {
-            inherit pkgs pkgs-kitman clightning-dev advisory-db lib;
+            inherit pkgs pkgs-kitman clightning-dev advisory-db lib moreutils-ts;
           };
 
         craneBuildNative = craneBuild craneLibNative;
@@ -310,7 +310,7 @@
                   tmuxinator
                   docker-compose
                   pkgs.tokio-console
-                  ts
+                  moreutils-ts
 
                   # Nix
                   pkgs.nixpkgs-fmt
@@ -409,7 +409,7 @@
                 git
                 parallel
                 semgrep
-                ts
+                moreutils-ts
                 nix
               ];
             };

--- a/flake.nix
+++ b/flake.nix
@@ -462,6 +462,7 @@
           ;
 
           cli-test = {
+            all = craneBuildNative.cliTestsAll;
             reconnect = craneBuildNative.cliTestReconnect;
             latency = craneBuildNative.cliTestLatency;
             cli = craneBuildNative.cliTestCli;

--- a/scripts/test-ci-all.sh
+++ b/scripts/test-ci-all.sh
@@ -13,35 +13,34 @@ fi
 
 
 # Avoid re-building workspace in parallel in all test derivations
->&2 echo "### Making sure workspace is built..."
-nix build -L .#debug.workspaceBuild 2>&1 | ts -s
-
+# Note: Respect 'CARGO_PROFILE' that crane uses
+cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}}
 
 function cli_test_reconnect() {
   set -eo pipefail # pipefail must be set manually again
   echo "### Starting reconnect test..."
-  nix build -L .#debug.cli-test.reconnect 2>&1 | ts -s
+  unshare -rn bash -c "ip link set lo up && exec unshare --user ./scripts/reconnect-test.sh" 2>&1 | ts -s
 }
 export -f cli_test_reconnect
 
 function cli_test_latency() {
   set -eo pipefail # pipefail must be set manually again
   echo "### Starting latency test..."
-  nix build -L .#debug.cli-test.latency 2>&1 | ts -s
+  unshare -rn bash -c "ip link set lo up && exec unshare --user ./scripts/latency-test.sh" 2>&1 | ts -s
 }
 export -f cli_test_latency
 
 function cli_test_cli() {
   set -eo pipefail # pipefail must be set manually again
   echo "### Starting cli test..."
-  nix build -L .#debug.cli-test.cli 2>&1 | ts -s
+  unshare -rn bash -c "ip link set lo up && exec unshare --user ./scripts/cli-test.sh" 2>&1 | ts -s
 }
 export -f cli_test_cli
 
 function cli_test_rust_tests() {
   set -eo pipefail # pipefail must be set manually again
   echo "### Starting integration test..."
-  nix build -L .#debug.cli-test.rust-tests 2>&1 | ts -s
+  unshare -rn bash -c "ip link set lo up && exec unshare --user ./scripts/rust-tests.sh" 2>&1 | ts -s
 }
 export -f cli_test_rust_tests
 
@@ -49,7 +48,7 @@ function cli_test_always_fail() {
   set -eo pipefail # pipefail must be set manually again
   echo "### Starting always_fail test..."
   # this must fail, so we know nix build is actually running tests
-  ! nix build -L .#debug.cli-test.always-fail 2>&1 | ts -s
+  ! unshare -rn bash -c "ip link set lo up && exec unshare --user ./scripts/always-fail.sh" 2>&1 | ts -s
 }
 export -f cli_test_always_fail
 


### PR DESCRIPTION
Instead of running in parallel bunch of `nix build -L ...`, where
each `nix build` invocation will have to load the previously built
`./target` (gigabytes) individually, run one `nix build` that runs
`parallel` of each test.

The major difficulty here is sandboxing each tests (network namespace).
Running in `nix build` was giving us sandboxing for free. Now
I have to resort to weird `unshare ... unshare` invocation that seems
to work, but is not best. It also won't work on Mac, but we mostly
care about CI here anyway.