### PR TITLE
Refactor ApiEndpointContext out for use in api_endpoint!

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -73,8 +73,8 @@ pub enum EpochMessage {
 type EpochStep = Step<Vec<SerdeConsensusItem>, PeerId>;
 
 enum EpochTriggerEvent {
-    /// A user has sent us a new transaction
-    NewTransaction,
+    /// A new event has been sent to us from the API
+    ApiEvent,
     /// A peer has sent us a consensus message
     NewMessage(PeerMessage),
     /// One of our modules triggered an event (e.g. new bitcoin block)
@@ -496,7 +496,7 @@ impl FedimintServer {
         }
 
         tokio::select! {
-            _peek = Pin::new(&mut self.api_receiver).peek() => Ok(EpochTriggerEvent::NewTransaction),
+            _peek = Pin::new(&mut self.api_receiver).peek() => Ok(EpochTriggerEvent::ApiEvent),
             () = self.consensus.await_consensus_proposal() => Ok(EpochTriggerEvent::ModuleProposalEvent),
             msg = self.connections.receive() => Ok(EpochTriggerEvent::NewMessage(msg?))
         }

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -211,7 +211,7 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
     vec![
         api_endpoint! {
             "/transaction",
-            async |fedimint: &FedimintConsensus, _dbtx, serde_transaction: SerdeTransaction| -> TransactionId {
+            async |fedimint: &FedimintConsensus, _context, serde_transaction: SerdeTransaction| -> TransactionId {
                 let transaction = serde_transaction.try_into_inner(&fedimint.modules.decoder_registry()).map_err(|e| ApiError::bad_request(e.to_string()))?;
 
                 let tx_id = transaction.tx_hash();
@@ -225,7 +225,7 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
         },
         api_endpoint! {
             "/fetch_transaction",
-            async |fedimint: &FedimintConsensus, _dbtx, tx_hash: TransactionId| -> Option<TransactionStatus> {
+            async |fedimint: &FedimintConsensus, _context, tx_hash: TransactionId| -> Option<TransactionStatus> {
                 debug!(transaction = %tx_hash, "Recieved request");
 
                 let tx_status = fedimint.transaction_status(tx_hash)
@@ -237,7 +237,7 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
         },
         api_endpoint! {
             "/wait_transaction",
-            async |fedimint: &FedimintConsensus, _dbtx, tx_hash: TransactionId| -> TransactionStatus {
+            async |fedimint: &FedimintConsensus, _context, tx_hash: TransactionId| -> TransactionStatus {
                 debug!(transaction = %tx_hash, "Recieved request");
 
                 let tx_status = fedimint.wait_transaction_status(tx_hash)
@@ -249,27 +249,27 @@ fn server_endpoints() -> Vec<ApiEndpoint<FedimintConsensus>> {
         },
         api_endpoint! {
             "/fetch_epoch_history",
-            async |fedimint: &FedimintConsensus, _dbtx, epoch: u64| -> SerdeEpochHistory {
+            async |fedimint: &FedimintConsensus, _context, epoch: u64| -> SerdeEpochHistory {
                 let epoch = fedimint.epoch_history(epoch).await.ok_or_else(|| ApiError::not_found(String::from("epoch not found")))?;
                 Ok((&epoch).into())
             }
         },
         api_endpoint! {
             "/fetch_epoch_count",
-            async |fedimint: &FedimintConsensus, _dbtx, _v: ()| -> u64 {
+            async |fedimint: &FedimintConsensus, _context, _v: ()| -> u64 {
                 Ok(fedimint.get_epoch_count().await)
             }
         },
         api_endpoint! {
             "/config",
-            async |fedimint: &FedimintConsensus, dbtx, _v: ()| -> ConfigResponse {
-                Ok(fedimint.get_config_with_sig(dbtx).await)
+            async |fedimint: &FedimintConsensus, context, _v: ()| -> ConfigResponse {
+                Ok(fedimint.get_config_with_sig(context.dbtx()).await)
             }
         },
         api_endpoint! {
             "/upgrade",
-            async |fedimint: &FedimintConsensus, _dbtx, _v: (), has_auth| -> () {
-                if has_auth {
+            async |fedimint: &FedimintConsensus, context, _v: ()| -> () {
+                if context.has_auth() {
                     fedimint.signal_upgrade().await.map_err(|_| ApiError::server_error("Unable to send signal to server".to_string()))?;
                     Ok(())
                 } else {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -753,18 +753,18 @@ impl ServerModule for Lightning {
         vec![
             api_endpoint! {
                 "/account",
-                async |module: &Lightning, dbtx, contract_id: ContractId| -> ContractAccount {
+                async |module: &Lightning, context, contract_id: ContractId| -> ContractAccount {
                     module
-                        .get_contract_account(dbtx, contract_id)
+                        .get_contract_account(context.dbtx(), contract_id)
                         .await
                         .ok_or_else(|| ApiError::not_found(String::from("Contract not found")))
                 }
             },
             api_endpoint! {
                 "/offer",
-                async |module: &Lightning, dbtx, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
+                async |module: &Lightning, context, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
                     let offer = module
-                        .get_offer(dbtx, payment_hash)
+                        .get_offer(context.dbtx(), payment_hash)
                         .await
                         .ok_or_else(|| ApiError::not_found(String::from("Offer not found")))?;
 
@@ -774,14 +774,14 @@ impl ServerModule for Lightning {
             },
             api_endpoint! {
                 "/list_gateways",
-                async |module: &Lightning, dbtx, _v: ()| -> Vec<LightningGateway> {
-                    Ok(module.list_gateways(dbtx).await)
+                async |module: &Lightning, context, _v: ()| -> Vec<LightningGateway> {
+                    Ok(module.list_gateways(context.dbtx()).await)
                 }
             },
             api_endpoint! {
                 "/register_gateway",
-                async |module: &Lightning, dbtx, gateway: LightningGateway| -> () {
-                    module.register_gateway(dbtx, gateway).await;
+                async |module: &Lightning, context, gateway: LightningGateway| -> () {
+                    module.register_gateway(context.dbtx(), gateway).await;
                     Ok(())
                 }
             },

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -643,17 +643,17 @@ impl ServerModule for Mint {
         vec![
             api_endpoint! {
                 "/backup",
-                async |module: &Mint, dbtx, request: SignedBackupRequest| -> () {
+                async |module: &Mint, context, request: SignedBackupRequest| -> () {
                     module
-                        .handle_backup_request(dbtx, request).await?;
+                        .handle_backup_request(context.dbtx(), request).await?;
                     Ok(())
                 }
             },
             api_endpoint! {
                 "/recover",
-                async |module: &Mint, dbtx, id: secp256k1_zkp::XOnlyPublicKey| -> Option<ECashUserBackupSnapshot> {
+                async |module: &Mint, context, id: secp256k1_zkp::XOnlyPublicKey| -> Option<ECashUserBackupSnapshot> {
                     Ok(module
-                        .handle_recover_request(dbtx, id).await)
+                        .handle_recover_request(context.dbtx(), id).await)
                 }
             },
         ]

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -638,20 +638,20 @@ impl ServerModule for Wallet {
         vec![
             api_endpoint! {
                 "/block_height",
-                async |module: &Wallet, dbtx, _params: ()| -> u32 {
-                    Ok(module.consensus_height(dbtx).await.unwrap_or(0))
+                async |module: &Wallet, context, _params: ()| -> u32 {
+                    Ok(module.consensus_height(context.dbtx()).await.unwrap_or(0))
                 }
             },
             api_endpoint! {
                 "/peg_out_fees",
-                async |module: &Wallet, dbtx, params: (Address, u64)| -> Option<PegOutFees> {
+                async |module: &Wallet, context, params: (Address, u64)| -> Option<PegOutFees> {
                     let (address, sats) = params;
-                    let consensus = module.current_round_consensus(dbtx).await.unwrap();
+                    let consensus = module.current_round_consensus(context.dbtx()).await.unwrap();
                     let tx = module.offline_wallet().create_tx(
                         bitcoin::Amount::from_sat(sats),
                         address.script_pubkey(),
                         vec![],
-                        module.available_utxos(dbtx).await,
+                        module.available_utxos(context.dbtx()).await,
                         consensus.fee_rate,
                         &consensus.randomness_beacon,
                         None


### PR DESCRIPTION
Refactors `ApiEndpointContext` out so we can pass state to all API endpoints.