### PR TITLE
chore: use `fedimint` instead of `src` for nix flake source dir

### DIFF
--- a/flake.crane.nix
+++ b/flake.crane.nix
@@ -4,7 +4,7 @@ let
   # filter source code at path `src` to include only the list of `modules`
   filterModules = modules: raw-src:
     let
-      src = builtins.path { path = raw-src; name = "src"; };
+      src = builtins.path { path = raw-src; name = "fedimint"; };
       basePath = toString src + "/";
       relPathAllCargoTomlFiles = builtins.filter
         (pathStr: lib.strings.hasSuffix "/Cargo.toml" pathStr)
@@ -51,7 +51,7 @@ let
 
   filterSrcWithRegexes = regexes: raw-src:
     let
-      src = builtins.path { path = raw-src; name = "src"; };
+      src = builtins.path { path = raw-src; name = "fedimint"; };
       basePath = toString src + "/";
     in
     lib.cleanSourceWith {


### PR DESCRIPTION
See https://github.com/fedimint/fedimint/pull/1934/files/e7cc5e99979601b7f5fb826137c1e985e1f5e976#diff-41e9269e557f97c7fa1206494a0d185e6dbfb639b08a7e07cd4868274af58118