### PR TITLE
Refactor api endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "thiserror",
  "threshold_crypto",
  "tokio",
+ "tokio-rustls 0.23.4",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -792,12 +792,11 @@ async fn handle_command(
             let salt = fs::read_to_string(salt_path)
                 .map_err(|_| format_err!("Unable to open salt file"))?;
             let auth = ApiAuth(get_password_hash(&password, &salt)?);
-            // TODO: store PeerId -> Url in client
             let url = client
                 .config()
                 .as_ref()
-                .nodes
-                .get(u16::from(our_id) as usize)
+                .api_endpoints
+                .get(&our_id)
                 .expect("Endpoint exists")
                 .url
                 .clone();

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -40,6 +40,7 @@ fedimint-derive = { path = "../fedimint-derive" }
 fedimint-logging = { path = "../fedimint-logging" }
 hbbft = { git = "https://github.com/fedimint/hbbft" }
 rand = "0.8.5"
+tokio-rustls = "0.23.4"
 miniscript = { version = "7.0.0", git = "https://github.com/rust-bitcoin/rust-miniscript/", rev = "2f1535e470c75fad85dbad8633986aae36a89a92", features = [ "compiler", "serde" ] }
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
 macro_rules_attribute = "0.1.3"

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -566,9 +566,12 @@ pub struct WsClientConnectInfo {
 }
 
 impl WsClientConnectInfo {
-    pub fn new(id: &FederationId, endpoints: &[ApiEndpoint]) -> Self {
+    pub fn new(id: &FederationId, api: &BTreeMap<PeerId, ApiEndpoint>) -> Self {
         Self {
-            urls: endpoints.iter().map(|node| node.url.clone()).collect(),
+            urls: api
+                .iter()
+                .map(|(_, endpoint)| endpoint.url.clone())
+                .collect(),
             id: id.clone(),
         }
     }
@@ -578,9 +581,9 @@ impl WsClientConnectInfo {
     ///
     /// Minimizes the serialized size of the connect info
     pub fn from_honest_peers(config: &ClientConfig) -> Self {
-        let all = config.nodes.clone();
+        let all = config.api_endpoints.clone();
         let num_honest = all.one_honest();
-        let honest: Vec<_> = all.into_iter().take(num_honest).collect();
+        let honest: BTreeMap<_, _> = all.into_iter().take(num_honest).collect();
 
         WsClientConnectInfo::new(&config.federation_id, &honest)
     }
@@ -665,7 +668,7 @@ impl<'de> Deserialize<'de> for WsClientConnectInfo {
 
 impl From<&ClientConfig> for WsClientConnectInfo {
     fn from(config: &ClientConfig) -> Self {
-        WsClientConnectInfo::new(&config.federation_id, &config.nodes)
+        WsClientConnectInfo::new(&config.federation_id, &config.api_endpoints)
     }
 }
 

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -109,7 +109,7 @@ pub struct ClientConfig {
     // Stable and unique id and threshold pubkey of the federation for authenticating configs
     pub federation_id: FederationId,
     /// API endpoints for each federation member
-    pub nodes: Vec<ApiEndpoint>,
+    pub api_endpoints: BTreeMap<PeerId, ApiEndpoint>,
     /// Threshold pubkey for authenticating epoch history
     pub epoch_pk: threshold_crypto::PublicKey,
     /// Configs from other client modules

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -5,6 +5,7 @@
 mod btc;
 mod secp256k1;
 mod tbs;
+mod tls;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Formatter};

--- a/fedimint-core/src/encoding/tls.rs
+++ b/fedimint-core/src/encoding/tls.rs
@@ -1,0 +1,12 @@
+use std::io::{Error, Write};
+
+use bitcoin_hashes::hex::ToHex;
+use tokio_rustls::rustls;
+
+use crate::encoding::Encodable;
+
+impl Encodable for rustls::Certificate {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        self.0.to_hex().consensus_encode(writer)
+    }
+}

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -204,7 +204,7 @@ macro_rules! __api_endpoint {
 
             async fn handle<'a, 'b>(
                 $state: &'a Self::State,
-                $context: &'a mut fedimint_core::module::ApiEndpointContext<'b>,
+                $context: &'a mut $crate::module::ApiEndpointContext<'b>,
                 $param: Self::Param,
                 _has_auth: bool,
             ) -> ::std::result::Result<Self::Response, $crate::module::ApiError> {

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -135,7 +135,6 @@ impl ApiError {
 /// State made available to all API endpoints for handling a request
 pub struct ApiEndpointContext<'a> {
     dbtx: ModuleDatabaseTransaction<'a, ModuleInstanceId>,
-
     has_auth: bool,
 }
 

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -100,7 +100,7 @@ pub struct ServerConfigConsensus {
     #[serde(with = "serde_binary_human_readable")]
     pub epoch_pk_set: hbbft::crypto::PublicKeySet,
     /// Network addresses and names for all peer APIs
-    pub api: BTreeMap<PeerId, ApiEndpoint>,
+    pub api_endpoints: BTreeMap<PeerId, ApiEndpoint>,
     /// All configuration that needs to be the same for modules
     #[encodable_ignore]
     pub modules: BTreeMap<ModuleInstanceId, JsonWithKind>,
@@ -202,7 +202,7 @@ impl ServerConfigConsensus {
         let client = ClientConfig {
             federation_id: FederationId(self.auth_pk_set.public_key()),
             epoch_pk: self.epoch_pk_set.public_key(),
-            nodes: self.api.values().cloned().collect(),
+            api_endpoints: self.api_endpoints.clone(),
             modules: modules.into_iter().map(|(k, v)| (k, v.client)).collect(),
             meta: self.meta.clone(),
         };
@@ -256,7 +256,7 @@ impl ServerConfig {
             auth_pk_set: auth_keys.public_key_set,
             hbbft_pk_set: hbbft_keys.public_key_set,
             epoch_pk_set: epoch_keys.public_key_set,
-            api: params.api_nodes(),
+            api_endpoints: params.api_nodes(),
             modules: Default::default(),
             meta: params.meta,
         };
@@ -566,7 +566,7 @@ impl ServerConfig {
                 .collect(),
             peer_names: self
                 .consensus
-                .api
+                .api_endpoints
                 .iter()
                 .map(|(peer, cfg)| (*peer, cfg.name.to_string()))
                 .collect(),

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -101,6 +101,9 @@ pub struct ServerConfigConsensus {
     pub epoch_pk_set: hbbft::crypto::PublicKeySet,
     /// Network addresses and names for all peer APIs
     pub api_endpoints: BTreeMap<PeerId, ApiEndpoint>,
+    /// Certs for TLS communication, required for peer authentication
+    #[serde(with = "serde_tls_cert")]
+    pub tls_certs: BTreeMap<PeerId, rustls::Certificate>,
     /// All configuration that needs to be the same for modules
     #[encodable_ignore]
     pub modules: BTreeMap<ModuleInstanceId, JsonWithKind>,
@@ -110,30 +113,18 @@ pub struct ServerConfigConsensus {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfigLocal {
-    /// Network addresses and certs for all p2p connections
-    pub p2p: BTreeMap<PeerId, PeerEndpoint>,
+    /// Network addresses and names for all p2p connections
+    pub p2p_endpoints: BTreeMap<PeerId, ApiEndpoint>,
     /// Our peer id (generally should not change)
     pub identity: PeerId,
     /// Our bind address for communicating with peers
     pub fed_bind: SocketAddr,
     /// Our bind address for our API endpoints
     pub api_bind: SocketAddr,
-    /// Our publicly known TLS cert
-    #[serde(with = "serde_tls_cert")]
-    pub tls_cert: rustls::Certificate,
     /// How many API connections we will accept
     pub max_connections: u32,
     /// Non-consensus, non-private configuration from modules
     pub modules: BTreeMap<ModuleInstanceId, JsonWithKind>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PeerEndpoint {
-    /// Certs for TLS communication, required for peer authentication
-    #[serde(with = "serde_tls_cert")]
-    pub tls_cert: rustls::Certificate,
-    /// The TLS network address and port, used for HBBFT consensus
-    pub hbbft: Url,
 }
 
 #[derive(Debug, Clone)]
@@ -151,7 +142,7 @@ pub struct ServerConfigParams {
     /// How we authenticate our communication with peers during DKG
     pub tls: TlsConfig,
     /// Endpoints for P2P communication
-    pub fed_network: NetworkConfig,
+    pub p2p_network: NetworkConfig,
     /// Endpoints for client API communication
     pub api_network: NetworkConfig,
     /// Guardian-defined key-value pairs that will be passed to the client.
@@ -243,11 +234,10 @@ impl ServerConfig {
             modules: Default::default(),
         };
         let local = ServerConfigLocal {
-            p2p: params.peers(),
+            p2p_endpoints: params.peers(),
             identity,
-            fed_bind: params.fed_network.bind_addr,
+            fed_bind: params.p2p_network.bind_addr,
             api_bind: params.api_network.bind_addr,
-            tls_cert: params.tls.our_certificate.clone(),
             max_connections: DEFAULT_MAX_CLIENT_CONNECTIONS,
             modules: Default::default(),
         };
@@ -257,6 +247,7 @@ impl ServerConfig {
             hbbft_pk_set: hbbft_keys.public_key_set,
             epoch_pk_set: epoch_keys.public_key_set,
             api_endpoints: params.api_nodes(),
+            tls_certs: params.tls.peer_certs.clone(),
             modules: Default::default(),
             meta: params.meta,
         };
@@ -333,7 +324,7 @@ impl ServerConfig {
         identity: &PeerId,
         module_config_gens: &ServerModuleGenRegistry,
     ) -> anyhow::Result<()> {
-        let peers = self.local.p2p.clone();
+        let peers = self.local.p2p_endpoints.clone();
         let consensus = self.consensus.clone();
         let private = self.private.clone();
         let id = identity.to_usize();
@@ -429,7 +420,7 @@ impl ServerConfig {
         registry: ServerModuleGenRegistry,
         task_group: &mut TaskGroup,
     ) -> DkgResult<Self> {
-        let server_conn = connect(params.fed_network.clone(), params.tls.clone(), task_group).await;
+        let server_conn = connect(params.p2p_network.clone(), params.tls.clone(), task_group).await;
         let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
         let mut rng = OsRng;
 
@@ -547,28 +538,22 @@ impl ServerConfig {
             bind_addr: self.local.fed_bind,
             peers: self
                 .local
-                .p2p
+                .p2p_endpoints
                 .iter()
-                .map(|(&id, peer)| (id, peer.hbbft.clone()))
+                .map(|(&id, endpoint)| (id, endpoint.url.clone()))
                 .collect(),
         }
     }
 
     pub fn tls_config(&self) -> TlsConfig {
         TlsConfig {
-            our_certificate: self.local.tls_cert.clone(),
             our_private_key: self.private.tls_key.clone(),
-            peer_certs: self
-                .local
-                .p2p
-                .iter()
-                .map(|(peer, cfg)| (*peer, cfg.tls_cert.clone()))
-                .collect(),
+            peer_certs: self.consensus.tls_certs.clone(),
             peer_names: self
-                .consensus
-                .api_endpoints
+                .local
+                .p2p_endpoints
                 .iter()
-                .map(|(peer, cfg)| (*peer, cfg.name.to_string()))
+                .map(|(id, endpoint)| (*id, endpoint.name.to_string()))
                 .collect(),
         }
     }
@@ -587,16 +572,16 @@ pub struct PeerServerParams {
 }
 
 impl ServerConfigParams {
-    pub fn peers(&self) -> BTreeMap<PeerId, PeerEndpoint> {
-        self.fed_network
+    pub fn peers(&self) -> BTreeMap<PeerId, ApiEndpoint> {
+        self.p2p_network
             .peers
             .iter()
-            .map(|(peer, hbbft)| {
+            .map(|(id, url)| {
                 (
-                    *peer,
-                    PeerEndpoint {
-                        tls_cert: self.tls.peer_certs[peer].clone(),
-                        hbbft: hbbft.clone(),
+                    *id,
+                    ApiEndpoint {
+                        url: url.clone(),
+                        name: self.tls.peer_names.get(id).expect("exists").clone(),
                     },
                 )
             })
@@ -604,7 +589,7 @@ impl ServerConfigParams {
     }
 
     pub fn api_nodes(&self) -> BTreeMap<PeerId, ApiEndpoint> {
-        self.fed_network
+        self.p2p_network
             .peers
             .keys()
             .map(|peer| {
@@ -671,18 +656,17 @@ impl ServerConfigParams {
         federation_name: String,
         modules: ConfigGenParams,
     ) -> ServerConfigParams {
-        let peer_certs: HashMap<PeerId, rustls::Certificate> = peers
+        let peer_certs: BTreeMap<PeerId, rustls::Certificate> = peers
             .iter()
             .map(|(peer, params)| (*peer, params.cert.clone()))
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
-        let peer_names: HashMap<PeerId, String> = peers
+        let peer_names: BTreeMap<PeerId, String> = peers
             .iter()
             .map(|(peer, params)| (*peer, params.name.to_string()))
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         let tls = TlsConfig {
-            our_certificate: peers[&our_id].cert.clone(),
             our_private_key: key,
             peer_certs,
             peer_names,
@@ -693,7 +677,7 @@ impl ServerConfigParams {
             peer_ids: peers.keys().cloned().collect(),
             api_auth,
             tls,
-            fed_network: Self::gen_network(&bind_p2p, &our_id, peers, |params| params.p2p_url),
+            p2p_network: Self::gen_network(&bind_p2p, &our_id, peers, |params| params.p2p_url),
             api_network: Self::gen_network(&bind_api, &our_id, peers, |params| params.api_url),
             meta: BTreeMap::from([(META_FEDERATION_NAME_KEY.to_owned(), federation_name)]),
             modules,
@@ -781,7 +765,7 @@ pub async fn connect<T>(
 where
     T: std::fmt::Debug + Clone + Serialize + DeserializeOwned + Unpin + Send + Sync + 'static,
 {
-    let connector = TlsTcpConnector::new(certs).into_dyn();
+    let connector = TlsTcpConnector::new(certs, network.identity).into_dyn();
     ReconnectPeerConnections::new(network, connector, task_group)
         .await
         .into_dyn()
@@ -811,27 +795,45 @@ pub fn gen_cert_and_key(
 
 mod serde_tls_cert {
     use std::borrow::Cow;
+    use std::collections::BTreeMap;
 
     use bitcoin_hashes::hex::{FromHex, ToHex};
+    use fedimint_core::PeerId;
     use serde::de::Error;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde::ser::SerializeMap;
+    use serde::{Deserialize, Deserializer, Serializer};
     use tokio_rustls::rustls;
 
-    pub fn serialize<S>(cert: &rustls::Certificate, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(
+        certs: &BTreeMap<PeerId, rustls::Certificate>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let hex_str = cert.0.to_hex();
-        Serialize::serialize(&hex_str, serializer)
+        let mut serializer = serializer.serialize_map(Some(certs.len()))?;
+        for (key, value) in certs.iter() {
+            serializer.serialize_key(key)?;
+            let hex_str = value.0.to_hex();
+            serializer.serialize_value(&hex_str)?;
+        }
+        serializer.end()
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<rustls::Certificate, D::Error>
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<BTreeMap<PeerId, rustls::Certificate>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let hex_str: Cow<str> = Deserialize::deserialize(deserializer)?;
-        let bytes = Vec::from_hex(&hex_str).map_err(D::Error::custom)?;
-        Ok(rustls::Certificate(bytes))
+        let map: BTreeMap<PeerId, Cow<str>> = Deserialize::deserialize(deserializer)?;
+        let mut certs = BTreeMap::new();
+
+        for (key, value) in map {
+            let cert = rustls::Certificate(Vec::from_hex(&value).map_err(D::Error::custom)?);
+            certs.insert(key, cert);
+        }
+        Ok(certs)
     }
 }
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -590,7 +590,7 @@ impl FedimintConsensus {
             .await
             .get_value(&ConsensusUpgradeKey)
             .await
-            .filter(|peers| peers.len() >= self.cfg.consensus.api.threshold())
+            .filter(|peers| peers.len() >= self.cfg.consensus.api_endpoints.threshold())
             .is_some()
     }
 

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -204,7 +204,7 @@ impl FedimintServer {
 
         let api_endpoints = cfg
             .consensus
-            .api
+            .api_endpoints
             .clone()
             .into_iter()
             .map(|(id, node)| (id, node.url));

--- a/gateway/ln-gateway/tests/fixtures/client.rs
+++ b/gateway/ln-gateway/tests/fixtures/client.rs
@@ -81,7 +81,7 @@ impl IGatewayClientBuilder for TestGatewayClientBuilder {
         let client_config = ClientConfig {
             federation_id: FederationId(auth_pk),
             epoch_pk: threshold_crypto::SecretKey::random().public_key(),
-            nodes: [].into(),
+            api_endpoints: [].into(),
             modules: [].into(),
             meta: Default::default(),
         };

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -294,8 +294,9 @@ pub async fn fixtures(num_peers: u16, gateway_node: GatewayNode) -> anyhow::Resu
             let lightning = RealLightningTest::new(rpc_cln, rpc_lnd, gateway_node.clone()).await;
 
             // federation
-            let connect_gen =
-                |cfg: &ServerConfig| TlsTcpConnector::new(cfg.tls_config()).into_dyn();
+            let connect_gen = |cfg: &ServerConfig| {
+                TlsTcpConnector::new(cfg.tls_config(), cfg.local.identity).into_dyn()
+            };
             let fed_db = |decoders| Database::new(rocks(dir.clone()), decoders);
             let fed = FederationTest::new(
                 server_config,
@@ -495,8 +496,8 @@ pub async fn create_user_client(
             .0
             .api_endpoints
             .iter()
-            .filter(|(id, _)| peers.contains(&id))
-            .map(|(id, endpoint)| (id.clone(), endpoint.url.clone()))
+            .filter(|(id, _)| peers.contains(id))
+            .map(|(id, endpoint)| (*id, endpoint.url.clone()))
             .collect(),
     )
     .into();

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -493,11 +493,10 @@ pub async fn create_user_client(
     let api = WsFederationApi::new(
         config
             .0
-            .nodes
+            .api_endpoints
             .iter()
-            .enumerate()
-            .filter(|(id, _)| peers.contains(&PeerId::from(*id as u16)))
-            .map(|(id, node)| (PeerId::from(id as u16), node.url.clone()))
+            .filter(|(id, _)| peers.contains(&id))
+            .map(|(id, endpoint)| (id.clone(), endpoint.url.clone()))
             .collect(),
     )
     .into();

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -32,7 +32,7 @@ FED_ID="$(get_federation_id)"
 [[ "$($FM_MINT_CLIENT decode-connect-info "$CONNECT_STRING" | jq -e -r '.id')" = "${FED_ID}" ]]
 # Number required for one honest is ceil(($FM_FED_SIZE-1)/3+1)
 ONE_HONEST=2
-ONE_HONEST_URLS=$(cat $FM_CFG_DIR/client.json | jq --argjson one_honest $ONE_HONEST -e -r '.nodes[:$one_honest] | map(.url) | join(",")')
+ONE_HONEST_URLS=$(cat $FM_CFG_DIR/client.json | jq --argjson one_honest $ONE_HONEST -e -r '.api_endpoints | to_entries[:$one_honest] | map(.value.url) | join(",")')
 [[ "$($FM_MINT_CLIENT decode-connect-info "$CONNECT_STRING" | jq -e -r '.urls | join(",")')" = "$ONE_HONEST_URLS" ]]
 [[ "$($FM_MINT_CLIENT encode-connect-info --urls $ONE_HONEST_URLS --id $FED_ID | jq -e -r '.connect_info')" = "$CONNECT_STRING" ]]
 


### PR DESCRIPTION
Refactors our use of `ApiEndpoint` to be more consistent and also moves the TLS certs into `ServerConfigConsensus` so that we can verify them during our new config setup process documented in #1628