### PR TITLE
refactor: use subcommand to group gatewayd parameters together

### DIFF
--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -277,7 +277,9 @@ async fn run_gatewayd() -> anyhow::Result<()> {
 
     // TODO: await_fedimint_block_sync()
 
-    let mut gatewayd = Command::new(format!("{bin_dir}/gatewayd")).spawn()?;
+    let mut gatewayd = Command::new(format!("{bin_dir}/gatewayd"))
+        .arg("CLN")
+        .spawn()?;
     kill_on_exit(&gatewayd).await?;
     info!("gatewayd started");
 

--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -278,7 +278,7 @@ async fn run_gatewayd() -> anyhow::Result<()> {
     // TODO: await_fedimint_block_sync()
 
     let mut gatewayd = Command::new(format!("{bin_dir}/gatewayd"))
-        .arg("CLN")
+        .arg("cln")
         .spawn()?;
     kill_on_exit(&gatewayd).await?;
     info!("gatewayd started");

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -45,7 +45,7 @@ pub struct GatewayOpts {
 
 #[derive(Debug, Clone, Subcommand)]
 enum Mode {
-    #[clap(name = "LND")]
+    #[clap(name = "lnd")]
     Lnd {
         /// LND RPC address
         #[arg(long = "lnd-rpc-host", env = "FM_LND_RPC_ADDR")]
@@ -59,10 +59,10 @@ enum Mode {
         #[arg(long = "lnd-macaroon", env = "FM_LND_MACAROON")]
         lnd_macaroon: String,
     },
-    #[clap(name = "CLN")]
+    #[clap(name = "cln")]
     Cln {
-        #[arg(long = "lnrpc-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
-        lnrpc_addr: Url,
+        #[arg(long = "cln-extension-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
+        cln_extension_addr: Url,
     },
 }
 
@@ -106,12 +106,12 @@ async fn main() -> Result<(), anyhow::Error> {
     let task_group = TaskGroup::new();
 
     let lnrpc: DynLnRpcClient = match mode {
-        Mode::Cln { lnrpc_addr } => {
+        Mode::Cln { cln_extension_addr } => {
             info!(
-                "Gateway configured to connect to remote LnRpcClient at \n lnrpc address: {:?} ",
-                lnrpc_addr
+                "Gateway configured to connect to remote LnRpcClient at \n cln extension address: {:?} ",
+                cln_extension_addr
             );
-            NetworkLnRpcClient::new(lnrpc_addr).await?.into()
+            NetworkLnRpcClient::new(cln_extension_addr).await?.into()
         }
         Mode::Lnd {
             lnd_rpc_addr,

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -1,8 +1,7 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::process::exit;
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use fedimint_client::module::gen::{ClientModuleGenRegistry, DynClientModuleGen};
 use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
@@ -24,6 +23,9 @@ use url::Url;
 
 #[derive(Parser)]
 pub struct GatewayOpts {
+    #[clap(subcommand)]
+    mode: Mode,
+
     /// Path to folder containing gateway config and data files
     #[arg(long = "data-dir", env = "FM_GATEWAY_DATA_DIR")]
     pub data_dir: PathBuf,
@@ -39,23 +41,29 @@ pub struct GatewayOpts {
     /// Gateway webserver authentication password
     #[arg(long = "password", env = "FM_GATEWAY_PASSWORD")]
     pub password: String,
+}
 
-    /// Public URL to a Gateway Lightning rpc service
-    #[arg(long = "lnrpc-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
-    pub lnrpc_addr: Option<Url>,
+#[derive(Debug, Clone, Subcommand)]
+enum Mode {
+    #[clap(name = "LND")]
+    Lnd {
+        /// LND RPC address
+        #[arg(long = "lnd-rpc-host", env = "FM_LND_RPC_ADDR")]
+        lnd_rpc_addr: String,
 
-    // TODO: Issue #1955: Group clap args for configuring gatewayd with LND
-    /// LND RPC address
-    #[arg(long = "lnd-rpc-host", env = "FM_LND_RPC_ADDR")]
-    pub lnd_rpc_addr: Option<String>,
+        /// LND TLS cert file path
+        #[arg(long = "lnd-tls-cert", env = "FM_LND_TLS_CERT")]
+        lnd_tls_cert: String,
 
-    /// LND TLS cert file path
-    #[arg(long = "lnd-tls-cert", env = "FM_LND_TLS_CERT")]
-    pub lnd_tls_cert: Option<String>,
-
-    /// LND macaroon file path
-    #[arg(long = "lnd-macaroon", env = "FM_LND_MACAROON")]
-    pub lnd_macaroon: Option<String>,
+        /// LND macaroon file path
+        #[arg(long = "lnd-macaroon", env = "FM_LND_MACAROON")]
+        lnd_macaroon: String,
+    },
+    #[clap(name = "CLN")]
+    Cln {
+        #[arg(long = "lnrpc-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
+        lnrpc_addr: Url,
+    },
 }
 
 // Fedimint Gateway Binary
@@ -78,14 +86,11 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Read configurations
     let GatewayOpts {
+        mode,
         data_dir,
         listen,
         api_addr,
         password,
-        lnrpc_addr,
-        lnd_rpc_addr,
-        lnd_tls_cert,
-        lnd_macaroon,
     } = GatewayOpts::parse();
 
     info!(
@@ -100,30 +105,32 @@ async fn main() -> Result<(), anyhow::Error> {
     // Create task group for controlled shutdown of the gateway
     let task_group = TaskGroup::new();
 
-    let lnrpc: DynLnRpcClient = if let Some(lnrpc_addr) = lnrpc_addr {
-        info!(
-            "Gateway configured to connect to remote LnRpcClient at \n lnrpc address: {:?} ",
-            lnrpc_addr
-        );
-        NetworkLnRpcClient::new(lnrpc_addr).await?.into()
-    } else if let (Some(lnd_rpc_addr), Some(lnd_tls_cert), Some(lnd_macaroon)) =
-        (lnd_rpc_addr, lnd_tls_cert, lnd_macaroon)
-    {
-        info!(
-            "Gateway configured to connect to LND LnRpcClient at \n address: {:?},\n tls cert path: {:?},\n macaroon path: {} ",
-            lnd_rpc_addr, lnd_tls_cert, lnd_macaroon
-        );
-        GatewayLndClient::new(
+    let lnrpc: DynLnRpcClient = match mode {
+        Mode::Cln { lnrpc_addr } => {
+            info!(
+                "Gateway configured to connect to remote LnRpcClient at \n lnrpc address: {:?} ",
+                lnrpc_addr
+            );
+            NetworkLnRpcClient::new(lnrpc_addr).await?.into()
+        }
+        Mode::Lnd {
             lnd_rpc_addr,
             lnd_tls_cert,
             lnd_macaroon,
-            task_group.make_subgroup().await,
-        )
-        .await?
-        .into()
-    } else {
-        error!("No lightning node provided. For CLN set FM_GATEWAY_LIGHTNING_ADDR for CLN. For LND set FM_LND_RPC_ADDR, FM_LND_TLS_CERT, and FM_LND_MACAROON");
-        exit(1);
+        } => {
+            info!(
+                "Gateway configured to connect to LND LnRpcClient at \n address: {:?},\n tls cert path: {:?},\n macaroon path: {} ",
+                lnd_rpc_addr, lnd_tls_cert, lnd_macaroon
+            );
+            GatewayLndClient::new(
+                lnd_rpc_addr,
+                lnd_tls_cert,
+                lnd_macaroon,
+                task_group.make_subgroup().await,
+            )
+            .await?
+            .into()
+        }
     };
 
     // Create module decoder registry


### PR DESCRIPTION
Refactor that simplifies the command line arguments, makes it harder to invoke `gatewayd` incorrectly.

Fixes: https://github.com/fedimint/fedimint/issues/1955