### PR TITLE
Allowing overwritting modules to be instantiated during dkg using Clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes",
  "bitvec",
+ "clap",
  "erased-serde",
  "fedimint-derive",
  "fedimint-logging",

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -44,6 +44,7 @@ miniscript = { version = "7.0.0", git = "https://github.com/rust-bitcoin/rust-mi
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
 macro_rules_attribute = "0.1.3"
 bitvec = "1.0.1"
+clap = { version = "4.1.6"}
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 jsonrpsee-ws-client = "0.16.2"


### PR DESCRIPTION
Fixes issue: #1956 
using `clap::{Command,Arg}` I passed some `--extra-module-instance <kind>` in the command line that gets passed as `extra_modules<ModuleKind>` and eventually gets chained to the `legacy_init_order_iter` with the initial 3 module instances
which are `["mint", "ln", "wallet"]`.
code supports multiple user generated modules, for e.g `--extra-module-instance <kind> --extra-module-instance <kind>`.
I tried to fix the issue with my best understanding of the problem, do correct me if I am missing something.
Thanks.