### PR TITLE
Make API attach_endpoints generic

### DIFF
--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -15,8 +15,8 @@ use super::*;
 use crate::db::ModuleDatabaseTransaction;
 use crate::maybe_add_send_sync;
 use crate::module::{
-    ApiAuth, ApiEndpoint, ApiVersion, ConsensusProposal, InputMeta, ModuleCommon,
-    ModuleConsensusVersion, ModuleError, ServerModule, TransactionItemAmount,
+    ApiEndpoint, ApiEndpointContext, ApiRequestErased, ApiVersion, ConsensusProposal, InputMeta,
+    ModuleCommon, ModuleConsensusVersion, ModuleError, ServerModule, TransactionItemAmount,
 };
 use crate::task::{MaybeSend, MaybeSync};
 
@@ -438,21 +438,13 @@ where
                 path,
                 handler: Box::new(
                     move |module: &DynServerModule,
-                          dbtx: fedimint_core::db::DatabaseTransaction<'_>,
-                          value: serde_json::Value,
-                          module_instance_id: Option<ModuleInstanceId>,
-                          api_auth: ApiAuth| {
+                          context: ApiEndpointContext<'_>,
+                          value: ApiRequestErased| {
                         let typed_module = module
                             .as_any()
                             .downcast_ref::<T>()
                             .expect("the dispatcher should always call with the right module");
-                        Box::pin(handler(
-                            typed_module,
-                            dbtx,
-                            value,
-                            module_instance_id,
-                            api_auth,
-                        ))
+                        Box::pin(handler(typed_module, context, value))
                     },
                 ),
             })

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -1,7 +1,6 @@
 pub mod audit;
 pub mod interconnect;
 pub mod registry;
-
 use std::collections::{BTreeMap, HashSet};
 use std::ffi::OsString;
 use std::fmt::Debug;
@@ -24,7 +23,9 @@ use crate::core::{
     Decoder, DecoderBuilder, Input, ModuleConsensusItem, ModuleInstanceId, ModuleKind, Output,
     OutputOutcome,
 };
-use crate::db::{Database, DatabaseVersion, MigrationMap, ModuleDatabaseTransaction};
+use crate::db::{
+    Database, DatabaseTransaction, DatabaseVersion, MigrationMap, ModuleDatabaseTransaction,
+};
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::audit::Audit;
 use crate::module::interconnect::ModuleInterconect;
@@ -98,6 +99,15 @@ impl ApiRequestErased {
             params: self.params,
         }
     }
+
+    pub fn to_typed<T: serde::de::DeserializeOwned>(
+        self,
+    ) -> Result<ApiRequest<T>, serde_json::Error> {
+        Ok(ApiRequest {
+            auth: self.auth,
+            params: serde_json::from_value::<T>(self.params)?,
+        })
+    }
 }
 
 /// Authentication uses the hashed user password in PHC format
@@ -134,20 +144,44 @@ impl ApiError {
 
 /// State made available to all API endpoints for handling a request
 pub struct ApiEndpointContext<'a> {
-    dbtx: ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+    dbtx: DatabaseTransaction<'a>,
     has_auth: bool,
+    module_id: Option<ModuleInstanceId>,
 }
 
 impl<'a> ApiEndpointContext<'a> {
+    pub fn new(
+        has_auth: bool,
+        dbtx: DatabaseTransaction<'a>,
+        module_id: Option<ModuleInstanceId>,
+    ) -> Self {
+        Self {
+            has_auth,
+            dbtx,
+            module_id,
+        }
+    }
+
     /// Database tx handle, will be committed
-    pub fn dbtx(&mut self) -> &mut ModuleDatabaseTransaction<'a, ModuleInstanceId> {
-        &mut self.dbtx
+    pub fn dbtx(&mut self) -> ModuleDatabaseTransaction<'_, ModuleInstanceId> {
+        match self.module_id {
+            None => self.dbtx.get_isolated(),
+            Some(id) => self.dbtx.with_module_prefix(id),
+        }
     }
 
     /// Whether the request was authenticated as the guardian who controls this
     /// fedimint server
     pub fn has_auth(&self) -> bool {
         self.has_auth
+    }
+
+    /// Attempts to commit the dbtx or returns an ApiError
+    pub async fn commit_tx_result(self) -> Result<(), ApiError> {
+        self.dbtx.commit_tx_result().await.map_err(|_err| ApiError {
+            code: 500,
+            message: "API server error when writing to database".to_string(),
+        })
     }
 }
 
@@ -165,7 +199,6 @@ pub trait TypedApiEndpoint {
         state: &'a Self::State,
         context: &'a mut ApiEndpointContext<'b>,
         request: Self::Param,
-        has_auth: bool,
     ) -> Result<Self::Response, ApiError>;
 }
 
@@ -206,7 +239,6 @@ macro_rules! __api_endpoint {
                 $state: &'a Self::State,
                 $context: &'a mut $crate::module::ApiEndpointContext<'b>,
                 $param: Self::Param,
-                _has_auth: bool,
             ) -> ::std::result::Result<Self::Response, $crate::module::ApiError> {
                 $body
             }
@@ -225,13 +257,7 @@ type HandlerFnReturn<'a> =
     Pin<Box<maybe_add_send!(dyn Future<Output = Result<serde_json::Value, ApiError>> + 'a)>>;
 type HandlerFn<M> = Box<
     maybe_add_send_sync!(
-        dyn for<'a> Fn(
-            &'a M,
-            fedimint_core::db::DatabaseTransaction<'a>,
-            serde_json::Value,
-            Option<ModuleInstanceId>,
-            ApiAuth,
-        ) -> HandlerFnReturn<'a>
+        dyn for<'a> Fn(&'a M, ApiEndpointContext<'a>, ApiRequestErased) -> HandlerFnReturn<'a>
     ),
 >;
 
@@ -265,9 +291,8 @@ impl ApiEndpoint<()> {
         )]
         async fn handle_request<'a, 'b, E>(
             state: &'a E::State,
-            dbtx: fedimint_core::db::ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+            context: &'a mut ApiEndpointContext<'b>,
             request: ApiRequest<E::Param>,
-            api_auth: ApiAuth,
         ) -> Result<E::Response, ApiError>
         where
             E: TypedApiEndpoint,
@@ -275,9 +300,7 @@ impl ApiEndpoint<()> {
             E::Response: Debug,
         {
             tracing::trace!(target: "fedimint_server::request", ?request, "received request");
-            let has_auth = request.auth == Some(api_auth);
-            let mut context = ApiEndpointContext { dbtx, has_auth };
-            let result = E::handle(state, &mut context, request.params, has_auth).await;
+            let result = E::handle(state, context, request.params).await;
             if let Err(error) = &result {
                 tracing::trace!(target: "fedimint_server::request", ?error, "error");
             }
@@ -286,27 +309,16 @@ impl ApiEndpoint<()> {
 
         ApiEndpoint {
             path: E::PATH,
-            handler: Box::new(|m, mut dbtx, param, module_instance_id, api_auth| {
+            handler: Box::new(|m, mut context, request| {
                 Box::pin(async move {
-                    let params = serde_json::from_value(param)
+                    let request = request
+                        .to_typed()
                         .map_err(|e| ApiError::bad_request(e.to_string()))?;
 
-                    let ret = match module_instance_id {
-                        Some(module_instance_id) => {
-                            let module_dbtx = dbtx.with_module_prefix(module_instance_id);
-                            handle_request::<E>(m, module_dbtx, params, api_auth).await?
-                        }
-                        None => {
-                            handle_request::<E>(m, dbtx.get_isolated(), params, api_auth).await?
-                        }
-                    };
+                    let ret = handle_request::<E>(m, &mut context, request).await?;
 
-                    dbtx.commit_tx_result().await.map_err(|_err| {
-                        fedimint_core::module::ApiError {
-                            code: 500,
-                            message: "Internal Server Error".to_string(),
-                        }
-                    })?;
+                    context.commit_tx_result().await?;
+
                     Ok(serde_json::to_value(ret).expect("encoding error"))
                 })
             }),

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -3,7 +3,7 @@ use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::{ApiError, ApiRequestErased};
 use serde_json::Value;
-
+use crate::net::api::HasApiContext;
 use crate::consensus::FedimintConsensus;
 
 pub struct FedimintInterconnect<'a> {
@@ -28,10 +28,8 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
 
                 return (endpoint.handler)(
                     module,
-                    self.fedimint.db.begin_transaction().await,
-                    data.to_json(),
-                    Some(module_id),
-                    self.fedimint.cfg.private.api_auth.clone(),
+                    self.fedimint.context(&data, Some(id)).await,
+                    data,
                 )
                 .await;
             }

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -3,8 +3,9 @@ use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::module::interconnect::ModuleInterconect;
 use fedimint_core::module::{ApiError, ApiRequestErased};
 use serde_json::Value;
-use crate::net::api::HasApiContext;
+
 use crate::consensus::FedimintConsensus;
+use crate::net::api::HasApiContext;
 
 pub struct FedimintInterconnect<'a> {
     pub fedimint: &'a FedimintConsensus,
@@ -25,13 +26,9 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
                     .into_iter()
                     .find(|endpoint| endpoint.path == path)
                     .ok_or_else(|| ApiError::not_found(String::from("Method not found")))?;
+                let (state, context) = self.fedimint.context(&data, Some(id)).await;
 
-                return (endpoint.handler)(
-                    module,
-                    self.fedimint.context(&data, Some(id)).await,
-                    data,
-                )
-                .await;
+                return (endpoint.handler)(state, context, data).await;
             }
         }
         panic!("Module not registered: {id}");

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -20,9 +20,7 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::registry::{
     ModuleDecoderRegistry, ModuleRegistry, ServerModuleRegistry,
 };
-use fedimint_core::module::{
-    ModuleError, TransactionItemAmount,
-};
+use fedimint_core::module::{ModuleError, TransactionItemAmount};
 use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::server::{DynServerModule, DynVerificationCache};
 use fedimint_core::task::TaskGroup;

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -2,7 +2,6 @@
 
 pub mod debug;
 mod interconnect;
-
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ffi::OsString;
 use std::iter::FromIterator;
@@ -21,7 +20,9 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::registry::{
     ModuleDecoderRegistry, ModuleRegistry, ServerModuleRegistry,
 };
-use fedimint_core::module::{ModuleError, TransactionItemAmount};
+use fedimint_core::module::{
+    ModuleError, TransactionItemAmount,
+};
 use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::server::{DynServerModule, DynVerificationCache};
 use fedimint_core::task::TaskGroup;

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -1,15 +1,17 @@
 //! Implements the client API through which users interact with the federation
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Duration;
-use async_trait::async_trait;
 
 use anyhow::Context;
+use async_trait::async_trait;
 use fedimint_core::config::ConfigResponse;
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::epoch::SerdeEpochHistory;
-use fedimint_core::module::{api_endpoint, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased};
+use fedimint_core::module::{
+    api_endpoint, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased,
+};
 use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::TaskHandle;
@@ -28,37 +30,58 @@ use crate::transaction::SerdeTransaction;
 
 /// A state that has context for the API, passed to each rpc handler callback
 #[derive(Clone)]
-pub struct RpcHandlerCtx {
-    fedimint: Arc<FedimintConsensus>,
+pub struct RpcHandlerCtx<M> {
+    rpc_context: Arc<M>,
 }
 
-impl std::fmt::Debug for RpcHandlerCtx {
+impl<M: Debug> Debug for RpcHandlerCtx<M> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str("State { ... }")
     }
 }
 
 /// Has the context necessary for serving API endpoints
+///
+/// Returns the specific `State` the endpoint requires and the
+/// `ApiEndpointContext` which all endpoints can access.
 #[async_trait]
-pub trait HasApiContext {
+pub trait HasApiContext<State> {
     async fn context(
         &self,
         request: &ApiRequestErased,
         id: Option<ModuleInstanceId>,
-    ) -> ApiEndpointContext<'_>;
+    ) -> (&State, ApiEndpointContext<'_>);
 }
 
 #[async_trait]
-impl HasApiContext for FedimintConsensus {
+impl HasApiContext<FedimintConsensus> for FedimintConsensus {
     async fn context(
         &self,
         request: &ApiRequestErased,
         id: Option<ModuleInstanceId>,
-    ) -> ApiEndpointContext<'_> {
-        ApiEndpointContext::new(
-            request.auth == Some(self.cfg.private.api_auth.clone()),
-            self.db.begin_transaction().await,
-            id,
+    ) -> (&FedimintConsensus, ApiEndpointContext<'_>) {
+        (
+            self,
+            ApiEndpointContext::new(
+                request.auth == Some(self.cfg.private.api_auth.clone()),
+                self.db.begin_transaction().await,
+                id,
+            ),
+        )
+    }
+}
+
+#[async_trait]
+impl HasApiContext<DynServerModule> for FedimintConsensus {
+    async fn context(
+        &self,
+        request: &ApiRequestErased,
+        id: Option<ModuleInstanceId>,
+    ) -> (&DynServerModule, ApiEndpointContext<'_>) {
+        let (_, context): (&FedimintConsensus, _) = self.context(request, id).await;
+        (
+            self.modules.get_expect(id.expect("required module id")),
+            context,
         )
     }
 }
@@ -69,14 +92,14 @@ pub async fn run_server(
     task_handle: TaskHandle,
 ) {
     let state = RpcHandlerCtx {
-        fedimint: fedimint.clone(),
+        rpc_context: fedimint.clone(),
     };
     let mut rpc_module = RpcModule::new(state);
 
     attach_endpoints(&mut rpc_module, server_endpoints(), None);
 
     for (id, module) in fedimint.modules.iter_modules() {
-        attach_endpoints_erased(&mut rpc_module, id, module);
+        attach_endpoints(&mut rpc_module, module.api_endpoints(), Some(id));
     }
 
     debug!(addr = cfg.local.api_bind.to_string(), "Starting WSServer");
@@ -108,12 +131,15 @@ pub async fn run_server(
 
 const API_ENDPOINT_TIMEOUT: Duration = Duration::from_secs(60);
 
-// TODO: remove once modularized
-fn attach_endpoints(
-    rpc_module: &mut RpcModule<RpcHandlerCtx>,
-    endpoints: Vec<ApiEndpoint<FedimintConsensus>>,
+/// Attaches `endpoints` to the `RpcModule`
+pub fn attach_endpoints<State, T>(
+    rpc_module: &mut RpcModule<RpcHandlerCtx<T>>,
+    endpoints: Vec<ApiEndpoint<State>>,
     module_instance_id: Option<ModuleInstanceId>,
-) {
+) where
+    T: HasApiContext<State> + Sync + Send + 'static,
+    State: Sync + Send + 'static,
+{
     for endpoint in endpoints {
         let path = if let Some(module_instance_id) = module_instance_id {
             // This memory leak is fine because it only happens on server startup
@@ -128,9 +154,9 @@ fn attach_endpoints(
         let handler: &'static _ = Box::leak(endpoint.handler);
 
         rpc_module
-            .register_async_method(path, move |params, state| async move {
+            .register_async_method(path, move |params, rpc_state| async move {
                 let params = params.one::<serde_json::Value>()?;
-                let fedimint = &state.fedimint;
+                let rpc_context = &rpc_state.rpc_context;
 
                 // Using AssertUnwindSafe here is far from ideal. In theory this means we could
                 // end up with an inconsistent state in theory. In practice most API functions
@@ -139,72 +165,9 @@ fn attach_endpoints(
                 AssertUnwindSafe(tokio::time::timeout(API_ENDPOINT_TIMEOUT, async {
                     let request = serde_json::from_value(params)
                         .map_err(|e| ApiError::bad_request(e.to_string()))?;
-                    let context = fedimint.context(&request, module_instance_id).await;
+                    let (state, context) = rpc_context.context(&request, module_instance_id).await;
 
-                    let res = (handler)(fedimint, context, request).await;
-
-                    res
-                }))
-                .catch_unwind()
-                .await
-                .map_err(|_| {
-                    error!(
-                        target: LOG_NET_API,
-                        path, "API handler panicked, DO NOT IGNORE, FIX IT!!!"
-                    );
-                    jsonrpsee::core::Error::Call(CallError::Custom(ErrorObject::owned(
-                        500,
-                        "API handler panicked",
-                        None::<()>,
-                    )))
-                })?
-                .map_err(|tokio::time::error::Elapsed { .. }| {
-                    jsonrpsee::core::Error::RequestTimeout
-                })?
-                .map_err(|e| {
-                    jsonrpsee::core::Error::Call(CallError::Custom(ErrorObject::owned(
-                        e.code, e.message, None::<()>,
-                    )))
-                })
-            })
-            .expect("Failed to register async method");
-    }
-}
-
-fn attach_endpoints_erased(
-    rpc_module: &mut RpcModule<RpcHandlerCtx>,
-    module_instance: ModuleInstanceId,
-    server_module: &DynServerModule,
-) {
-    let endpoints = server_module.api_endpoints();
-
-    for endpoint in endpoints {
-        // This memory leak is fine because it only happens on server startup
-        // and path has to live till the end of program anyways.
-        let path: &'static _ =
-            Box::leak(format!("/module/{}{}", module_instance, endpoint.path).into_boxed_str());
-        let handler: &'static _ = Box::leak(endpoint.handler);
-
-        rpc_module
-            .register_async_method(path, move |params, state| async move {
-                // Hack to avoid Sync/Send issues
-                let params = params.one::<serde_json::Value>()?;
-                let fedimint = &state.fedimint;
-                // Using AssertUnwindSafe here is far from ideal. In theory this means we could
-                // end up with an inconsistent state in theory. In practice most API functions
-                // are only reading and the few that do write anything are atomic. Lastly, this
-                // is only the last line of defense
-                AssertUnwindSafe(tokio::time::timeout(API_ENDPOINT_TIMEOUT, async {
-                    let request = serde_json::from_value(params)
-                        .map_err(|e| ApiError::bad_request(e.to_string()))?;
-                    let context = fedimint.context(&request, Some(module_instance)).await;
-
-                    let res = (handler)(
-                        fedimint.modules.get_expect(module_instance),
-                        context,
-                        request,
-                    )
-                    .await;
+                    let res = (handler)(state, context, request).await;
 
                     res
                 }))

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -755,7 +755,7 @@ impl ServerModule for Lightning {
                 "/account",
                 async |module: &Lightning, context, contract_id: ContractId| -> ContractAccount {
                     module
-                        .get_contract_account(context.dbtx(), contract_id)
+                        .get_contract_account(&mut context.dbtx(), contract_id)
                         .await
                         .ok_or_else(|| ApiError::not_found(String::from("Contract not found")))
                 }
@@ -764,7 +764,7 @@ impl ServerModule for Lightning {
                 "/offer",
                 async |module: &Lightning, context, payment_hash: bitcoin_hashes::sha256::Hash| -> IncomingContractOffer {
                     let offer = module
-                        .get_offer(context.dbtx(), payment_hash)
+                        .get_offer(&mut context.dbtx(), payment_hash)
                         .await
                         .ok_or_else(|| ApiError::not_found(String::from("Offer not found")))?;
 
@@ -775,13 +775,13 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 "/list_gateways",
                 async |module: &Lightning, context, _v: ()| -> Vec<LightningGateway> {
-                    Ok(module.list_gateways(context.dbtx()).await)
+                    Ok(module.list_gateways(&mut context.dbtx()).await)
                 }
             },
             api_endpoint! {
                 "/register_gateway",
                 async |module: &Lightning, context, gateway: LightningGateway| -> () {
-                    module.register_gateway(context.dbtx(), gateway).await;
+                    module.register_gateway(&mut context.dbtx(), gateway).await;
                     Ok(())
                 }
             },

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -645,7 +645,7 @@ impl ServerModule for Mint {
                 "/backup",
                 async |module: &Mint, context, request: SignedBackupRequest| -> () {
                     module
-                        .handle_backup_request(context.dbtx(), request).await?;
+                        .handle_backup_request(&mut context.dbtx(), request).await?;
                     Ok(())
                 }
             },
@@ -653,7 +653,7 @@ impl ServerModule for Mint {
                 "/recover",
                 async |module: &Mint, context, id: secp256k1_zkp::XOnlyPublicKey| -> Option<ECashUserBackupSnapshot> {
                     Ok(module
-                        .handle_recover_request(context.dbtx(), id).await)
+                        .handle_recover_request(&mut context.dbtx(), id).await)
                 }
             },
         ]

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -639,19 +639,19 @@ impl ServerModule for Wallet {
             api_endpoint! {
                 "/block_height",
                 async |module: &Wallet, context, _params: ()| -> u32 {
-                    Ok(module.consensus_height(context.dbtx()).await.unwrap_or(0))
+                    Ok(module.consensus_height(&mut context.dbtx()).await.unwrap_or(0))
                 }
             },
             api_endpoint! {
                 "/peg_out_fees",
                 async |module: &Wallet, context, params: (Address, u64)| -> Option<PegOutFees> {
                     let (address, sats) = params;
-                    let consensus = module.current_round_consensus(context.dbtx()).await.unwrap();
+                    let consensus = module.current_round_consensus(&mut context.dbtx()).await.unwrap();
                     let tx = module.offline_wallet().create_tx(
                         bitcoin::Amount::from_sat(sats),
                         address.script_pubkey(),
                         vec![],
-                        module.available_utxos(context.dbtx()).await,
+                        module.available_utxos(&mut context.dbtx()).await,
                         consensus.fee_rate,
                         &consensus.randomness_beacon,
                         None


### PR DESCRIPTION
I needed to make `attach_endpoints` generic in order to serve an API for config generation, prior to being able to create `FedimintConsensus`.

I had to put the DB tx and module id into `ApiEndpointContext` and return it from a generic `HasApiContext` which I can implement for config generation.

Cleans up some duplicate code and the long list of parameters passed into the handlers.