### PR TITLE
refactor: clean up ConfigGenParams, add ConfigGenParamsRegistry

### DIFF
--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -435,7 +435,7 @@ mod tests {
             FakeFed::<Lightning>::new(
                 4,
                 |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
-                &ConfigGenParams::new(),
+                &ConfigGenParams::null(),
                 &LightningGen,
                 module_id,
             )

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -743,13 +743,14 @@ mod tests {
             FakeFed::<Mint>::new(
                 4,
                 |cfg, _db| async move { Ok(Mint::new(cfg.to_typed().unwrap())) },
-                &ConfigGenParams::new().attach(MintGenParams {
+                &ConfigGenParams::from_typed(MintGenParams {
                     mint_amounts: vec![
                         Amount::from_sats(1),
                         Amount::from_sats(10),
                         Amount::from_sats(20),
                     ],
-                }),
+                })
+                .expect("Invalid mint config"),
                 &MintGen,
                 module_id,
             )

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -291,10 +291,11 @@ mod tests {
                         .await?)
                     }
                 },
-                &ConfigGenParams::new().attach(WalletGenParams {
+                &ConfigGenParams::from_typed(WalletGenParams {
                     network: bitcoin::network::constants::Network::Regtest,
                     finality_delay: 10,
-                }),
+                })
+                .expect("Invalid wallet gen config"),
                 &WalletGen,
                 module_id,
             )

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -246,6 +246,12 @@ pub struct ConfigGenParams(serde_json::Value);
 pub type ServerModuleGenRegistry = ModuleGenRegistry<DynServerModuleGen>;
 
 impl ConfigGenParams {
+    /// Null value, used as a config gen parameters for module gens that don't
+    /// need any parameters
+    pub fn null() -> Self {
+        Self(jsonrpsee_core::JsonValue::Null)
+    }
+
     pub fn to_typed<P: ModuleGenParams>(&self) -> anyhow::Result<P> {
         serde_json::from_value(self.0.clone())
             .map_err(|e| anyhow::Error::new(e).context("Invalid module params"))

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -229,37 +229,6 @@ impl ClientConfig {
     }
 }
 
-/// Parameters for generating all module configs
-///
-/// The same `ModuleKind` may have multiple instances with different settings
-#[derive(Debug, Clone, Default)]
-pub struct ConfigGenParams(BTreeMap<String, serde_json::Value>);
-
-impl ConfigGenParams {
-    pub fn new() -> ConfigGenParams {
-        ConfigGenParams::default()
-    }
-
-    /// Add params for a module
-    pub fn attach<P: ModuleGenParams>(mut self, module_params: P) -> Self {
-        self.0.insert(
-            P::MODULE_NAME.to_string(),
-            serde_json::to_value(&module_params).expect("Encoding to value doesn't fail"),
-        );
-        self
-    }
-
-    /// Retrieve a typed config generation parameters for a module
-    pub fn get<P: ModuleGenParams>(&self) -> anyhow::Result<P> {
-        let value = self
-            .0
-            .get(P::MODULE_NAME)
-            .ok_or_else(|| anyhow::anyhow!("No params found for module {}", P::MODULE_NAME))?;
-        serde_json::from_value(value.clone())
-            .map_err(|e| anyhow::Error::new(e).context("Invalid module params"))
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct ModuleGenRegistry<M>(BTreeMap<ModuleKind, M>);
 
@@ -269,9 +238,32 @@ impl<M> Default for ModuleGenRegistry<M> {
     }
 }
 
+/// Module **generation** (so passed to dkg, not to the module itself) config
+/// parameters
+#[derive(Debug, Clone, Default)]
+pub struct ConfigGenParams(serde_json::Value);
+
 pub type ServerModuleGenRegistry = ModuleGenRegistry<DynServerModuleGen>;
 
+impl ConfigGenParams {
+    pub fn to_typed<P: ModuleGenParams>(&self) -> anyhow::Result<P> {
+        serde_json::from_value(self.0.clone())
+            .map_err(|e| anyhow::Error::new(e).context("Invalid module params"))
+    }
+
+    pub fn from_typed<P: ModuleGenParams>(p: P) -> anyhow::Result<Self> {
+        Ok(Self(serde_json::to_value(p)?))
+    }
+}
+
 pub type CommonModuleGenRegistry = ModuleGenRegistry<DynCommonModuleGen>;
+
+/// Configs for each module's DKG
+///
+/// Note: in the future, we should make this one a
+/// `ModuleRegistry<ConfigGenParams>`, as each module **instance** will need a
+/// distinct config for dkg.
+pub type ConfigGenParamsRegistry = ModuleGenRegistry<ConfigGenParams>;
 
 impl<M> From<Vec<M>> for ModuleGenRegistry<M>
 where
@@ -334,6 +326,25 @@ impl<M> ModuleGenRegistry<M> {
             next_id: 0,
             rest: self.0.clone(),
         }
+    }
+}
+
+impl ModuleGenRegistry<ConfigGenParams> {
+    pub fn attach_config_gen_params<T>(mut self, kind: ModuleKind, gen: T) -> Self
+    where
+        T: ModuleGenParams,
+    {
+        if self
+            .0
+            .insert(
+                kind.clone(),
+                ConfigGenParams::from_typed(gen).expect("Invalid config gen params for {kind}"),
+            )
+            .is_some()
+        {
+            panic!("Can't insert module of same kind twice: {kind}");
+        }
+        self
     }
 }
 
@@ -418,7 +429,14 @@ impl<M> Iterator for LegacyInitOrderIter<M> {
 }
 
 pub trait ModuleGenParams: serde::Serialize + serde::de::DeserializeOwned {
-    const MODULE_NAME: &'static str;
+    fn from_json<P: ModuleGenParams>(value: serde_json::Value) -> anyhow::Result<Self> {
+        serde_json::from_value(value)
+            .map_err(|e| anyhow::Error::new(e).context("Invalid module gen params"))
+    }
+
+    fn to_json(p: Self) -> anyhow::Result<serde_json::Value> {
+        Ok(serde_json::to_value(p)?)
+    }
 }
 
 /// Response from the API for this particular module

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -263,7 +263,7 @@ pub type CommonModuleGenRegistry = ModuleGenRegistry<DynCommonModuleGen>;
 /// Note: in the future, we should make this one a
 /// `ModuleRegistry<ConfigGenParams>`, as each module **instance** will need a
 /// distinct config for dkg.
-pub type ConfigGenParamsRegistry = ModuleGenRegistry<ConfigGenParams>;
+pub type ServerModuleGenParamsRegistry = ModuleGenRegistry<ConfigGenParams>;
 
 impl<M> From<Vec<M>> for ModuleGenRegistry<M>
 where
@@ -330,7 +330,24 @@ impl<M> ModuleGenRegistry<M> {
 }
 
 impl ModuleGenRegistry<ConfigGenParams> {
-    pub fn attach_config_gen_params<T>(mut self, kind: ModuleKind, gen: T) -> Self
+    pub fn attach_config_gen_params<T>(&mut self, kind: ModuleKind, gen: T) -> &mut Self
+    where
+        T: ModuleGenParams,
+    {
+        if self
+            .0
+            .insert(
+                kind.clone(),
+                ConfigGenParams::from_typed(gen).expect("Invalid config gen params for {kind}"),
+            )
+            .is_some()
+        {
+            panic!("Can't insert module of same kind twice: {kind}");
+        }
+        self
+    }
+
+    pub fn with_config_gen_params<T>(mut self, kind: ModuleKind, gen: T) -> Self
     where
         T: ModuleGenParams,
     {

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -578,6 +578,10 @@ pub trait ServerModuleGen: ExtendsCommonModuleGen + Sized {
     /// checking purposes.
     fn versions(&self, core: CoreConsensusVersion) -> &[ModuleConsensusVersion];
 
+    fn kind() -> ModuleKind {
+        <Self as ExtendsCommonModuleGen>::Common::KIND
+    }
+
     /// Initialize the [`DynServerModule`] instance from its config
     async fn init(
         &self,

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -150,7 +150,7 @@ pub struct ServerConfigParams {
     pub meta: BTreeMap<String, String>,
     /// Params for the modules we wish to configure, can contain custom
     /// parameters
-    pub modules: ConfigGenParamsRegistry,
+    pub modules: ServerModuleGenParamsRegistry,
 }
 
 impl ServerConfigConsensus {
@@ -624,7 +624,7 @@ impl ServerConfigParams {
         federation_name: String,
         certs: Vec<String>,
         password: &str,
-        module_params: ConfigGenParamsRegistry,
+        module_params: ServerModuleGenParamsRegistry,
     ) -> anyhow::Result<Self> {
         let mut peers = BTreeMap::<PeerId, PeerServerParams>::new();
         for (idx, cert) in certs.into_iter().sorted().enumerate() {
@@ -666,7 +666,7 @@ impl ServerConfigParams {
         our_id: PeerId,
         peers: &BTreeMap<PeerId, PeerServerParams>,
         federation_name: String,
-        modules: ConfigGenParamsRegistry,
+        modules: ServerModuleGenParamsRegistry,
     ) -> ServerConfigParams {
         let peer_certs: BTreeMap<PeerId, rustls::Certificate> = peers
             .iter()
@@ -720,7 +720,7 @@ impl ServerConfigParams {
         peers: &[PeerId],
         base_port: u16,
         federation_name: &str,
-        modules: ConfigGenParamsRegistry,
+        modules: ServerModuleGenParamsRegistry,
     ) -> anyhow::Result<HashMap<PeerId, ServerConfigParams>> {
         let keys: HashMap<PeerId, (rustls::Certificate, rustls::PrivateKey)> = peers
             .iter()

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::Parser;
-use fedimint_core::config::ServerModuleGenRegistry;
+use fedimint_core::config::{
+    ModuleGenParams, ServerModuleGenParamsRegistry, ServerModuleGenRegistry,
+};
+use fedimint_core::core::ModuleKind;
 use fedimint_core::db::Database;
 use fedimint_core::module::ServerModuleGen;
 use fedimint_core::task::{sleep, TaskGroup};
@@ -80,6 +83,7 @@ pub struct ServerOpts {
 /// ```
 pub struct Fedimintd {
     module_gens: ServerModuleGenRegistry,
+    module_gens_params: ServerModuleGenParamsRegistry,
     opts: ServerOpts,
 }
 
@@ -103,6 +107,7 @@ impl Fedimintd {
 
         Ok(Self {
             module_gens: ServerModuleGenRegistry::new(),
+            module_gens_params: ServerModuleGenParamsRegistry::new(),
             opts,
         })
     }
@@ -112,6 +117,15 @@ impl Fedimintd {
         T: ServerModuleGen + 'static + Send + Sync,
     {
         self.module_gens.attach(gen);
+        self
+    }
+
+    pub fn with_extra_module_gens_params<P>(mut self, kind: ModuleKind, params: P) -> Self
+    where
+        P: ModuleGenParams,
+    {
+        self.module_gens_params
+            .attach_config_gen_params(kind, params);
         self
     }
 
@@ -132,7 +146,14 @@ impl Fedimintd {
         let task_group = root_task_group.clone();
         root_task_group
             .spawn_local("main", move |_task_handle| async move {
-                match run(self.opts, task_group.clone(), self.module_gens).await {
+                match run(
+                    self.opts,
+                    task_group.clone(),
+                    self.module_gens,
+                    self.module_gens_params,
+                )
+                .await
+                {
                     Ok(()) => {}
                     Err(e) => {
                         error!(?e, "Main task returned error, shutting down");
@@ -180,6 +201,7 @@ async fn run(
     opts: ServerOpts,
     mut task_group: TaskGroup,
     module_gens: ServerModuleGenRegistry,
+    module_gens_params: ServerModuleGenParamsRegistry,
 ) -> anyhow::Result<()> {
     let (ui_sender, mut ui_receiver) = tokio::sync::mpsc::channel(1);
 
@@ -201,6 +223,7 @@ async fn run(
                     password,
                     ui_task_group,
                     module_gens,
+                    module_gens_params,
                 )
                 .await;
             })

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -1,5 +1,5 @@
 use bitcoin::Network;
-use fedimint_core::config::ConfigGenParamsRegistry;
+use fedimint_core::config::ServerModuleGenParamsRegistry;
 use fedimint_core::module::ServerModuleGen;
 use fedimint_core::{Amount, Tiered};
 use fedimint_mint_server::{MintGen, MintGenParams};
@@ -13,12 +13,13 @@ pub mod distributed_gen;
 pub mod fedimintd;
 
 /// Generates the configuration for the modules configured in the server binary
-pub fn configure_modules(
+pub fn attach_default_module_gen_params(
+    module_gen_params: &mut ServerModuleGenParamsRegistry,
     max_denomination: Amount,
     network: Network,
     finality_delay: u32,
-) -> ConfigGenParamsRegistry {
-    ConfigGenParamsRegistry::new()
+) {
+    module_gen_params
         .attach_config_gen_params(
             WalletGen::kind(),
             WalletGenParams {
@@ -36,5 +37,5 @@ pub fn configure_modules(
                     .cloned()
                     .collect(),
             },
-        )
+        );
 }

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -1,8 +1,9 @@
 use bitcoin::Network;
-use fedimint_core::config::ConfigGenParams;
+use fedimint_core::config::ConfigGenParamsRegistry;
+use fedimint_core::module::ServerModuleGen;
 use fedimint_core::{Amount, Tiered};
-use fedimint_mint_server::MintGenParams;
-use fedimint_wallet_server::WalletGenParams;
+use fedimint_mint_server::{MintGen, MintGenParams};
+use fedimint_wallet_server::{WalletGen, WalletGenParams};
 
 mod ui;
 
@@ -16,18 +17,24 @@ pub fn configure_modules(
     max_denomination: Amount,
     network: Network,
     finality_delay: u32,
-) -> ConfigGenParams {
-    ConfigGenParams::new()
-        .attach(WalletGenParams {
-            network,
-            // TODO this is not very elegant, but I'm planning to get rid of it in a next commit
-            // anyway
-            finality_delay,
-        })
-        .attach(MintGenParams {
-            mint_amounts: Tiered::gen_denominations(max_denomination)
-                .tiers()
-                .cloned()
-                .collect(),
-        })
+) -> ConfigGenParamsRegistry {
+    ConfigGenParamsRegistry::new()
+        .attach_config_gen_params(
+            WalletGen::kind(),
+            WalletGenParams {
+                network,
+                // TODO this is not very elegant, but I'm planning to get rid of it in a next commit
+                // anyway
+                finality_delay,
+            },
+        )
+        .attach_config_gen_params(
+            MintGen::kind(),
+            MintGenParams {
+                mint_amounts: Tiered::gen_denominations(max_denomination)
+                    .tiers()
+                    .cloned()
+                    .collect(),
+            },
+        )
 }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -18,7 +18,7 @@ use fedimint_client::module::gen::{ClientModuleGenRegistry, DynClientModuleGen};
 use fedimint_core::api::WsFederationApi;
 use fedimint_core::bitcoin_rpc::read_bitcoin_backend_from_global_env;
 use fedimint_core::cancellable::Cancellable;
-use fedimint_core::config::{ClientConfig, ServerModuleGenRegistry};
+use fedimint_core::config::{ClientConfig, ServerModuleGenParamsRegistry, ServerModuleGenRegistry};
 use fedimint_core::core::{
     DynModuleConsensusItem, ModuleConsensusItem, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_LN,
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
@@ -207,12 +207,15 @@ pub async fn fixtures(num_peers: u16, gateway_node: GatewayNode) -> anyhow::Resu
     }
 
     let peers = (0..num_peers).map(PeerId::from).collect::<Vec<_>>();
-    let modules = fedimintd::configure_modules(
+    let mut module_gens_params = ServerModuleGenParamsRegistry::default();
+    fedimintd::attach_default_module_gen_params(
+        &mut module_gens_params,
         sats(100000),
         bitcoin::network::constants::Network::Regtest,
         10,
     );
-    let params = ServerConfigParams::gen_local(&peers, base_port, "test", modules).unwrap();
+    let params =
+        ServerConfigParams::gen_local(&peers, base_port, "test", module_gens_params).unwrap();
 
     let server_module_inits = ServerModuleGenRegistry::from(vec![
         DynServerModuleGen::from(WalletGen),

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -42,9 +42,7 @@ pub struct DummyConfigGenParams {
     pub important_param: u64,
 }
 
-impl ModuleGenParams for DummyConfigGenParams {
-    const MODULE_NAME: &'static str = "dummy";
-}
+impl ModuleGenParams for DummyConfigGenParams {}
 
 #[derive(
     Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable, Default,

--- a/modules/fedimint-ln-server/tests/ln_contracts.rs
+++ b/modules/fedimint-ln-server/tests/ln_contracts.rs
@@ -23,7 +23,7 @@ async fn test_outgoing() {
     let mut fed = FakeFed::<Lightning>::new(
         4,
         |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
-        &ConfigGenParams::new(),
+        &ConfigGenParams::null(),
         &LightningGen,
         LEGACY_HARDCODED_INSTANCE_ID_LN,
     )
@@ -123,7 +123,7 @@ async fn test_incoming() {
     let mut fed = FakeFed::<Lightning>::new(
         4,
         |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
-        &ConfigGenParams::new(),
+        &ConfigGenParams::null(),
         &LightningGen,
         LEGACY_HARDCODED_INSTANCE_ID_LN,
     )

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -62,9 +62,7 @@ pub struct MintGenParams {
     pub mint_amounts: Vec<Amount>,
 }
 
-impl ModuleGenParams for MintGenParams {
-    const MODULE_NAME: &'static str = "mint";
-}
+impl ModuleGenParams for MintGenParams {}
 
 #[derive(Debug, Clone)]
 pub struct MintGen;
@@ -96,7 +94,9 @@ impl ServerModuleGen for MintGen {
         peers: &[PeerId],
         params: &ConfigGenParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
-        let params = params.get::<MintGenParams>().expect("Invalid mint params");
+        let params = params
+            .to_typed::<MintGenParams>()
+            .expect("Invalid mint params");
 
         let tbs_keys = params
             .mint_amounts
@@ -151,7 +151,9 @@ impl ServerModuleGen for MintGen {
         peers: &PeerHandle,
         params: &ConfigGenParams,
     ) -> DkgResult<ServerModuleConfig> {
-        let params = params.get::<MintGenParams>().expect("Invalid mint params");
+        let params = params
+            .to_typed::<MintGenParams>()
+            .expect("Invalid mint gen params");
 
         let g2 = peers.run_dkg_multi_g2(params.mint_amounts.to_vec()).await?;
 
@@ -967,9 +969,10 @@ mod test {
         let peers = (0..MINTS as u16).map(PeerId::from).collect::<Vec<_>>();
         let mint_cfg = MintGen.trusted_dealer_gen(
             &peers,
-            &ConfigGenParams::new().attach(MintGenParams {
+            &ConfigGenParams::from_typed(MintGenParams {
                 mint_amounts: vec![Amount::from_sats(1)],
-            }),
+            })
+            .unwrap(),
         );
         let client_cfg = mint_cfg[&PeerId::from(0)]
             .to_typed::<MintConfig>()

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -81,9 +81,7 @@ pub struct WalletGenParams {
     pub finality_delay: u32,
 }
 
-impl ModuleGenParams for WalletGenParams {
-    const MODULE_NAME: &'static str = "wallet";
-}
+impl ModuleGenParams for WalletGenParams {}
 
 #[derive(Debug, Clone)]
 pub struct WalletGen;
@@ -118,8 +116,8 @@ impl ServerModuleGen for WalletGen {
         params: &ConfigGenParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let params = params
-            .get::<WalletGenParams>()
-            .expect("Invalid wallet params");
+            .to_typed::<WalletGenParams>()
+            .expect("Invalid wallet gen params");
 
         let secp = secp256k1::Secp256k1::new();
 
@@ -157,7 +155,7 @@ impl ServerModuleGen for WalletGen {
         params: &ConfigGenParams,
     ) -> DkgResult<ServerModuleConfig> {
         let params = params
-            .get::<WalletGenParams>()
+            .to_typed::<WalletGenParams>()
             .expect("Invalid wallet params");
 
         let secp = secp256k1::Secp256k1::new();


### PR DESCRIPTION
Introduce `Fedimintd::with_extra_module_gens_params` that allows
passing config gen params to use for any additional modules
registered with `Fedimintd::with_module`.

This is very provisional, only to unblock 3rd party module
out-of-tree testing for time being.