### PR TITLE
feat: test unreliable (mock) network

### DIFF
--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -645,7 +645,7 @@ mod tests {
     use fedimint_core::PeerId;
     use futures::Future;
 
-    use crate::net::connect::mock::MockNetwork;
+    use crate::net::connect::mock::{MockNetwork, StreamReliability};
     use crate::net::connect::Connector;
     use crate::net::peers::{IPeerConnections, NetworkConfig, ReconnectPeerConnections};
 
@@ -684,7 +684,9 @@ mod tests {
                     bind_addr: bind.parse().unwrap(),
                     peers: peers_ref.clone(),
                 };
-                let connect = net_ref.connector(cfg.identity).into_dyn();
+                let connect = net_ref
+                    .connector(cfg.identity, StreamReliability::MILDLY_UNRELIABLE)
+                    .into_dyn();
                 ReconnectPeerConnections::<u64>::new(cfg, connect, &mut task_group).await
             };
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -43,7 +43,7 @@ use fedimint_server::consensus::{
     ConsensusProposal, FedimintConsensus, HbbftConsensusOutcome, TransactionSubmissionError,
 };
 use fedimint_server::db::GLOBAL_DATABASE_VERSION;
-use fedimint_server::net::connect::mock::MockNetwork;
+use fedimint_server::net::connect::mock::{MockNetwork, StreamReliability};
 use fedimint_server::net::connect::{Connector, TlsTcpConnector};
 use fedimint_server::net::peers::PeerConnector;
 use fedimint_server::{consensus, EpochMessage, FedimintServer};
@@ -387,8 +387,11 @@ pub async fn fixtures(num_peers: u16, gateway_node: GatewayNode) -> anyhow::Resu
 
             let net = MockNetwork::new();
             let net_ref = &net;
-            let connect_gen =
-                move |cfg: &ServerConfig| net_ref.connector(cfg.local.identity).into_dyn();
+            let connect_gen = move |cfg: &ServerConfig| {
+                net_ref
+                    .connector(cfg.local.identity, StreamReliability::FullyReliable)
+                    .into_dyn()
+            };
 
             let fed_db = |decoders| Database::new(MemDatabase::new(), decoders);
             let fed = FederationTest::new(


### PR DESCRIPTION
Addresses https://github.com/fedimint/fedimint/issues/163

Creates a `StreamReliability` configuration for `MockConnector` making connections randomly fail on read/write and be delayed (have latency).

Introduces these failures on `test_connect()` test.