### PR TITLE
feat(cli): add default value for invoice description

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -311,6 +311,7 @@ enum Command {
     LnInvoice {
         #[clap(value_parser = parse_fedimint_amount)]
         amount: Amount,
+        #[clap(default_value = "")]
         description: String,
         expiry_time: Option<u64>,
     },


### PR DESCRIPTION
This PR is to resolve #1863.

The default value of `""` is the same as that used by `lncli`. Please let me know if a different value should be used (or any other comments). Thanks.