### PR TITLE
Make outcome fetching API module-compatible

### DIFF
--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -28,7 +28,6 @@ use crate::modules::mint::config::MintClientConfig;
 use crate::modules::mint::{
     BlindNonce, MintInput, MintOutput, MintOutputBlindSignatures, MintOutputOutcome, Nonce, Note,
 };
-use crate::outcome::legacy::OutputOutcome;
 use crate::transaction::legacy::{Input, Output, Transaction};
 use crate::utils::ClientContext;
 use crate::{ChildId, DerivableSecret, FuturesUnordered};
@@ -458,10 +457,9 @@ impl MintClient {
         let bsig = self
             .context
             .api
-            .fetch_output_outcome::<OutputOutcome>(outpoint, &self.context.decoders)
+            .fetch_output_outcome::<MintOutputOutcome>(outpoint, &self.context.decoders)
             .await?
             .ok_or(MintClientError::OutputNotReadyYet(outpoint))?
-            .try_into_variant::<MintOutputOutcome>()?
             .as_ref()
             .cloned()
             .ok_or(MintClientError::OutputNotReadyYet(outpoint))?;

--- a/client/client-lib/src/outcome.rs
+++ b/client/client-lib/src/outcome.rs
@@ -1,7 +1,7 @@
 pub mod legacy {
-    use fedimint_core::api::{DynTryIntoOutcome, OutputOutcomeError};
+    use fedimint_core::api::OutputOutcomeError;
     use fedimint_core::core::{
-        DynOutputOutcome, LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+        LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
         LEGACY_HARDCODED_INSTANCE_ID_WALLET,
     };
     use fedimint_core::encoding::{Decodable, Encodable};
@@ -52,15 +52,9 @@ pub mod legacy {
         fn try_into_outcome(common_outcome: OutputOutcome) -> Result<Self, CoreError>;
     }
 
-    impl DynTryIntoOutcome for OutputOutcome {
-        fn try_into_outcome(outcome: DynOutputOutcome) -> Result<Self, CoreError> {
-            Ok(OutputOutcome::from(outcome))
-        }
-    }
-
     impl OutputOutcome {
         pub fn try_into_variant<T: TryIntoOutcome>(self) -> Result<T, OutputOutcomeError> {
-            T::try_into_outcome(self).map_err(OutputOutcomeError::from)
+            T::try_into_outcome(self).map_err(|e| OutputOutcomeError::Core(anyhow::Error::from(e)))
         }
     }
 

--- a/client/client-lib/src/outcome.rs
+++ b/client/client-lib/src/outcome.rs
@@ -9,7 +9,7 @@ pub mod legacy {
     use fedimint_core::CoreError;
     use fedimint_ln_client::contracts::incoming::OfferId;
     use fedimint_ln_client::contracts::{
-        ContractOutcome, DecryptedPreimage, OutgoingContractOutcome, Preimage,
+        ContractOutcome, DecryptedPreimage, OutgoingContractOutcome,
     };
     use fedimint_ln_client::{LightningModuleTypes, LightningOutputOutcome};
     use fedimint_mint_client::{MintModuleTypes, MintOutputOutcome};
@@ -94,18 +94,14 @@ pub mod legacy {
         }
     }
 
-    impl TryIntoOutcome for Preimage {
+    impl TryIntoOutcome for DecryptedPreimage {
         fn try_into_outcome(common_outcome: OutputOutcome) -> Result<Self, CoreError> {
             if let OutputOutcome::LN(fedimint_ln_client::LightningOutputOutcome::Contract {
                 outcome: ContractOutcome::Incoming(decrypted_preimage),
                 ..
             }) = common_outcome
             {
-                match decrypted_preimage {
-                    DecryptedPreimage::Some(preimage) => Ok(preimage),
-                    DecryptedPreimage::Pending => Err(CoreError::PendingPreimage),
-                    _ => Err(CoreError::MismatchingVariant("ln::incoming", "other")),
-                }
+                Ok(decrypted_preimage)
             } else {
                 Err(CoreError::MismatchingVariant("ln::incoming", "other"))
             }

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -16,7 +16,6 @@ use crate::modules::wallet::config::WalletClientConfig;
 use crate::modules::wallet::tweakable::Tweakable;
 use crate::modules::wallet::txoproof::{PegInProof, PegInProofError, TxOutProof};
 use crate::modules::wallet::{WalletInput, WalletModuleTypes, WalletOutput, WalletOutputOutcome};
-use crate::outcome::legacy::OutputOutcome;
 use crate::utils::ClientContext;
 use crate::MemberError;
 
@@ -160,12 +159,11 @@ impl WalletClient {
     ) -> Result<bitcoin::Txid> {
         // TODO: define timeout centrally
         let timeout = std::time::Duration::from_secs(15);
-        let outcome: WalletOutputOutcome = self
+        let outcome = self
             .context
             .api
-            .await_output_outcome::<OutputOutcome>(out_point, timeout, &self.context.decoders)
-            .await?
-            .try_into_variant()?;
+            .await_output_outcome::<WalletOutputOutcome>(out_point, timeout, &self.context.decoders)
+            .await?;
         Ok(outcome.0)
     }
 }

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -379,14 +379,4 @@ impl Feerate {
 pub enum CoreError {
     #[error("Mismatching outcome variant: expected {0}, got {1}")]
     MismatchingVariant(&'static str, &'static str),
-    #[error("Pending preimage decryption")]
-    PendingPreimage,
-}
-
-impl CoreError {
-    /// Returns `true` if queried outpoint isn't ready yet but may become ready
-    /// later
-    pub fn is_retryable(&self) -> bool {
-        matches!(self, CoreError::PendingPreimage)
-    }
 }


### PR DESCRIPTION
Fetching output outcomes still assumed that there are only the three hard coded modules. This PR allows fetching output outcomes from arbitrary outcomes.

I could probably do more, especially around error cleanup (is that `CoreError` error really needed?) but this was the part that was directly blocking. Maybe @mxz42 can take a look at if we can get rid of `CoreError`.