### PR TITLE
passing the full path to each invocation for Bitcoind

### DIFF
--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -140,6 +140,7 @@ async fn run_bitcoind() -> anyhow::Result<()> {
     // spawn bitcoind
     let mut bitcoind = Command::new("bitcoind")
         .arg(format!("-datadir={btc_dir}"))
+        .arg("-conf=path/to/bitcoind.conf")
         .spawn()?;
     kill_on_exit(&bitcoind).await?;
     info!("bitcoind started");

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,7 +45,7 @@ mkdir -p $FM_CFG_DIR
 mkdir -p $FM_ELECTRS_DIR
 
 # Copy configs to data directories
-cp misc/test/bitcoin.conf $FM_BTC_DIR
+
 cp misc/test/lnd.conf $FM_LND_DIR
 cp misc/test/lightningd.conf $FM_CLN_DIR/config
 cp misc/test/electrs.toml $FM_ELECTRS_DIR


### PR DESCRIPTION
Issue Fixed : #1857 
Removed `cp misc/test/bitcoin.conf $FM_BTC_DIR` instead added `.arg("-conf=path/to/bitcoind.conf")` to the `// spawn bitcoind`
code. I've tried to fix the issue with my best understanding of the problem, do let me know, If I'm missing out on something.