### PR TITLE
feat: run integration tests under unreliable network conditions

### DIFF
--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -36,7 +36,7 @@ use crate::fedimint_core::encoding::Encodable;
 use crate::fedimint_core::{BitcoinHash, NumPeers};
 use crate::multiplexed::PeerConnectionMultiplexer;
 use crate::net::connect::{parse_host_port, Connector, TlsConfig};
-use crate::net::peers::NetworkConfig;
+use crate::net::peers::{DelayCalculator, NetworkConfig};
 use crate::{ReconnectPeerConnections, TlsTcpConnector};
 
 pub mod distributedgen;
@@ -422,9 +422,16 @@ impl ServerConfig {
     pub async fn distributed_gen(
         params: &ServerConfigParams,
         registry: ServerModuleGenRegistry,
+        delay_calculator: DelayCalculator,
         task_group: &mut TaskGroup,
     ) -> DkgResult<Self> {
-        let server_conn = connect(params.p2p_network.clone(), params.tls.clone(), task_group).await;
+        let server_conn = connect(
+            params.p2p_network.clone(),
+            params.tls.clone(),
+            delay_calculator,
+            task_group,
+        )
+        .await;
         let connections = PeerConnectionMultiplexer::new(server_conn).into_dyn();
         let mut rng = OsRng;
 
@@ -766,13 +773,14 @@ impl ServerConfigParams {
 pub async fn connect<T>(
     network: NetworkConfig,
     certs: TlsConfig,
+    delay_calculator: DelayCalculator,
     task_group: &mut TaskGroup,
 ) -> PeerConnections<T>
 where
     T: std::fmt::Debug + Clone + Serialize + DeserializeOwned + Unpin + Send + Sync + 'static,
 {
     let connector = TlsTcpConnector::new(certs, network.identity).into_dyn();
-    ReconnectPeerConnections::new(network, connector, task_group)
+    ReconnectPeerConnections::new(network, delay_calculator, connector, task_group)
         .await
         .into_dyn()
 }

--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -322,6 +322,7 @@ pub mod mock {
         latency: LatencyInterval,
         failure_rate: FailureRate,
         sleep_future: Option<Pin<Box<tokio::time::Sleep>>>,
+        successes: u64,
     }
 
     impl UnreliabilityGenerator {
@@ -330,6 +331,7 @@ pub mod mock {
                 latency,
                 failure_rate,
                 sleep_future: None,
+                successes: 0,
             }
         }
 
@@ -347,13 +349,18 @@ pub mod mock {
                 std::task::Poll::Pending => return std::task::Poll::Pending,
             }
             if self.failure_rate.random_fail() {
-                tracing::debug!("Returning random error on unreliable stream");
-                return std::task::Poll::Ready(Err(std::io::Error::new(
+                tracing::debug!(
+                    "Returning random error on unreliable stream after {} successes",
+                    self.successes
+                );
+                std::task::Poll::Ready(Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "Randomly failed",
-                )));
+                )))
+            } else {
+                self.successes += 1;
+                std::task::Poll::Ready(Ok(()))
             }
-            std::task::Poll::Ready(Ok(()))
         }
     }
 
@@ -516,6 +523,30 @@ pub mod mock {
                 write_failure_rate: failure_rate,
                 flush_failure_rate: failure_rate,
                 shutdown_failure_rate: failure_rate,
+                read_latency: latency,
+                write_latency: latency,
+                flush_latency: latency,
+                shutdown_latency: latency,
+            }
+        };
+
+        pub const INTEGRATION_TEST: StreamReliability = {
+            // Based on empirical testing: creates errors without causing tests to take
+            // additional time compared to StreamReliability::FullyReliable
+            // If an order of magnitude higher, tests may take unreasonable amounts of time.
+            // If an order of magnitude lower, a test may run without any error actually
+            // happening
+            let failure_rate_base = 1e-3;
+            let latency = LatencyInterval {
+                min_millis: 1,
+                max_millis: 10,
+            };
+            Self::RandomlyUnreliable {
+                // Try to make read_failure_rate = write_failure_rate + flush_failure_rate
+                read_failure_rate: FailureRate(failure_rate_base * 2.0),
+                write_failure_rate: FailureRate(failure_rate_base),
+                flush_failure_rate: FailureRate(failure_rate_base),
+                shutdown_failure_rate: FailureRate(failure_rate_base),
                 read_latency: latency,
                 write_latency: latency,
                 flush_latency: latency,

--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -579,7 +579,7 @@ pub mod mock {
                 let (stream_our, stream_theirs) = tokio::io::duplex(43_689);
                 let mut stream_our = UnreliableDuplexStream::new(stream_our, self.reliability);
                 let stream_theirs = UnreliableDuplexStream::new(stream_theirs, self.reliability);
-                client.send(stream_theirs).await.unwrap();
+                client.send(stream_theirs).await?;
                 let peer = do_handshake(self.id, &mut stream_our).await?;
                 let framed = BidiFramed::<
                     M,

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -81,12 +81,47 @@ struct PeerConnectionStateMachine<M> {
     state: PeerConnectionState<M>,
 }
 
+/// Calculates delays for reconnecting to peers
+/// The default values are in the order of seconds
+#[derive(Debug, Clone, Copy)]
+pub struct DelayCalculator {
+    scaling_factor: f64,
+}
+
+impl DelayCalculator {
+    fn new() -> Self {
+        Self {
+            scaling_factor: 1.0,
+        }
+    }
+
+    /// This instance is tuned for tests and scales delays down to milliseconds.
+    /// This makes it feasible to run tests where errors
+    /// and disconnections are common.
+    pub const TEST_DEFAULT: Self = Self {
+        scaling_factor: 0.1e-3,
+    };
+
+    fn reconnection_delay(&self, disconnect_count: u64) -> Duration {
+        let scaling_factor = disconnect_count as f64 * self.scaling_factor;
+        let delay: f64 = thread_rng().gen_range(1.0 * scaling_factor..4.0 * scaling_factor);
+        Duration::from_secs_f64(delay)
+    }
+}
+
+impl Default for DelayCalculator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 struct CommonPeerConnectionState<M> {
     resend_queue: MessageQueue<M>,
     incoming: Sender<M>,
     outgoing: Receiver<M>,
     peer: PeerId,
     peer_address: Url,
+    delay_calculator: DelayCalculator,
     connect: SharedAnyConnector<PeerMessage<M>>,
     incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,
     last_received: Option<MessageId>,
@@ -117,6 +152,7 @@ where
     #[instrument(skip_all)]
     pub async fn new(
         cfg: NetworkConfig,
+        delay_calculator: DelayCalculator,
         connect: PeerConnector<T>,
         task_group: &mut TaskGroup,
     ) -> Self {
@@ -136,6 +172,7 @@ where
                         PeerConnection::new(
                             peer,
                             peer_address.clone(),
+                            delay_calculator,
                             shared_connector.clone(),
                             connection_receiver,
                             task_group,
@@ -350,7 +387,9 @@ where
         disconnect_count: u64,
     ) -> PeerConnectionState<M> {
         debug!(target: LOG_NET_PEER,
-            peer = ?self.peer, "Received incoming connection");
+            peer = ?self.peer, %disconnect_count,
+            resend_queue_len = self.resend_queue.queue.len(),
+            "Received incoming connection");
         match self.resend_buffer_contents(&mut new_connection).await {
             Ok(()) => PeerConnectionState::Connected(ConnectedPeerConnectionState {
                 connection: new_connection,
@@ -379,13 +418,16 @@ where
         disconnect_count += 1;
 
         let reconnect_at = {
-            let scaling_factor = disconnect_count as f64;
-            let delay: f64 = thread_rng().gen_range(1.0 * scaling_factor..4.0 * scaling_factor);
+            let delay = self.delay_calculator.reconnection_delay(disconnect_count);
+            let delay_secs = delay.as_secs_f64();
             debug!(
                 target: LOG_NET_PEER,
-                delay, "Scheduling reopening of connection"
+                %disconnect_count,
+                peer = ?self.peer,
+                delay_secs,
+                "Scheduling reopening of connection"
             );
-            Instant::now() + Duration::from_secs_f64(delay)
+            Instant::now() + delay
         };
 
         PeerConnectionState::Disconnected(DisconnectedPeerConnectionState {
@@ -448,8 +490,7 @@ where
             .unwrap_or(msg.id);
 
         if msg.id < expected {
-            info!(
-                        target: LOG_NET_PEER,
+            info!(target: LOG_NET_PEER,
                 ?expected, received = ?msg.id, "Received old message");
             return Ok(());
         }
@@ -568,6 +609,7 @@ where
     fn new(
         id: PeerId,
         peer_address: Url,
+        delay_calculator: DelayCalculator,
         connect: SharedAnyConnector<PeerMessage<M>>,
         incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,
         task_group: &mut TaskGroup,
@@ -583,6 +625,7 @@ where
                     outgoing_receiver,
                     id,
                     peer_address,
+                    delay_calculator,
                     connect,
                     incoming_connections,
                     &handle,
@@ -605,12 +648,14 @@ where
         self.incoming.recv().await.ok_or(Cancelled)
     }
 
+    #[allow(clippy::too_many_arguments)] // TODO: consider refactoring
     #[instrument(skip_all, fields(peer))]
     async fn run_io_thread(
         incoming: Sender<M>,
         outgoing: Receiver<M>,
         peer: PeerId,
         peer_address: Url,
+        delay_calculator: DelayCalculator,
         connect: SharedAnyConnector<PeerMessage<M>>,
         incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,
         task_handle: &TaskHandle,
@@ -621,6 +666,7 @@ where
             outgoing,
             peer,
             peer_address,
+            delay_calculator,
             connect,
             incoming_connections,
             last_received: None,
@@ -645,6 +691,7 @@ mod tests {
     use fedimint_core::PeerId;
     use futures::Future;
 
+    use super::DelayCalculator;
     use crate::net::connect::mock::{MockNetwork, StreamReliability};
     use crate::net::connect::Connector;
     use crate::net::peers::{IPeerConnections, NetworkConfig, ReconnectPeerConnections};
@@ -687,7 +734,13 @@ mod tests {
                 let connect = net_ref
                     .connector(cfg.identity, StreamReliability::MILDLY_UNRELIABLE)
                     .into_dyn();
-                ReconnectPeerConnections::<u64>::new(cfg, connect, &mut task_group).await
+                ReconnectPeerConnections::<u64>::new(
+                    cfg,
+                    DelayCalculator::TEST_DEFAULT,
+                    connect,
+                    &mut task_group,
+                )
+                .await
             };
 
             let mut peers_a = build_peers("127.0.0.1:1000", 1, task_group.clone()).await;
@@ -708,5 +761,17 @@ mod tests {
 
         task_group.shutdown().await;
         task_group.join_all(None).await.unwrap();
+    }
+
+    #[test]
+    fn test_delay_calculator() {
+        // Test delays should be on the order of milliseconds, not seconds.
+        let c = DelayCalculator::TEST_DEFAULT;
+        assert!(c.reconnection_delay(1).as_millis() < 1);
+        assert!(c.reconnection_delay(100).as_millis() < 100);
+        // Default/prod delays should be on the order of seconds.
+        let c = DelayCalculator::default();
+        assert!((1..10).contains(&c.reconnection_delay(1).as_secs()));
+        assert!((100..1000).contains(&c.reconnection_delay(100).as_secs()));
     }
 }

--- a/fedimintd/src/distributed_gen.rs
+++ b/fedimintd/src/distributed_gen.rs
@@ -14,6 +14,7 @@ use fedimint_logging::TracingSetup;
 use fedimint_mint_server::MintGen;
 use fedimint_server::config::io::{create_cert, write_server_config, CODE_VERSION, SALT_FILE};
 use fedimint_server::config::{ServerConfig, ServerConfigParams};
+use fedimint_server::net::peers::DelayCalculator;
 use fedimint_wallet_server::WalletGen;
 use tracing::info;
 use url::Url;
@@ -208,6 +209,7 @@ impl DistributedGen {
                 let server = match ServerConfig::distributed_gen(
                     &params,
                     self.module_gens.clone(),
+                    DelayCalculator::default(),
                     &mut task_group,
                 )
                 .await

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -21,6 +21,7 @@ use fedimint_server::config::io::{
     create_cert, parse_peer_params, write_server_config, CONSENSUS_CONFIG, JSON_EXT,
 };
 use fedimint_server::config::{ServerConfig, ServerConfigConsensus, ServerConfigParams};
+use fedimint_server::net::peers::DelayCalculator;
 use http::StatusCode;
 use qrcode_generator::QrCodeEcc;
 use serde::Deserialize;
@@ -191,11 +192,14 @@ async fn post_guardians(
                 &password,
                 module_gens_params,
             ) {
-                Ok(params) => {
-                    ServerConfig::distributed_gen(&params, module_gens.clone(), &mut dkg_task_group)
-                        .await
-                        .map_err(|e| format_err!("Failed {}", e))
-                }
+                Ok(params) => ServerConfig::distributed_gen(
+                    &params,
+                    module_gens.clone(),
+                    DelayCalculator::default(),
+                    &mut dkg_task_group,
+                )
+                .await
+                .map_err(|e| format_err!("Failed {}", e)),
                 Err(err) => Err(err),
             };
 


### PR DESCRIPTION
Also makes the reconnection delay a parameter with low default values on tests to avoid exponential growth in test duration when simulated network failures happen.

Closes https://github.com/fedimint/fedimint/issues/163 by completing the work started on https://github.com/fedimint/fedimint/pull/1982