### PR TITLE
add generated dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+*target/
 /result
 .idea
 .tmpenv


### PR DESCRIPTION
There are a couple dirs now generated when running tests that we can ignore.

Talking with @m1sterc001guy `db/` will exist after https://github.com/fedimint/fedimint/pull/1935