### PR TITLE
WIP: One Click Digital Ocean Fedimint Deployment

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,21 +1,7 @@
-alerts:
-- rule: DEPLOYMENT_FAILED
-- rule: DOMAIN_FAILED
-name: fedimintd
-region: nyc
-services:
-- envs:
-  - key: FM_PASSWORD
-    scope: RUN_AND_BUILD_TIME
-    value: pass0
-  http_port: 8176
-  image:
-    registry: fedimint
-    registry_type: DOCKER_HUB
-    repository: fedimintd
-    tag: master
-  instance_count: 1
-  instance_size_slug: basic-xs
-  name: fedimint-fedimintd
-  routes:
-  - path: /
+spec:
+  name: fedimint
+  services:
+    - name: fedimintd
+      git:
+        branch: digital_ocean_deploy
+        repo_clone_url: https://github.com/m1sterc001guy/fedimint.git

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,7 +1,22 @@
 spec:
- name: sample-html
- static_sites:
- - git:
-     branch: main
-     repo_clone_url: https://github.com/digitalocean/sample-html.git
-   name: sample-html
+  alerts:
+  - rule: DEPLOYMENT_FAILED
+  - rule: DOMAIN_FAILED
+  name: fedimintd
+  region: nyc
+  services:
+  - envs:
+    - key: FM_PASSWORD
+      scope: RUN_AND_BUILD_TIME
+      value: pass0
+    http_port: 8176
+    image:
+      registry: fedimint
+      registry_type: DOCKER_HUB
+      repository: fedimintd
+      tag: master
+    instance_count: 1
+    instance_size_slug: basic-xs
+    name: fedimint-fedimintd
+    routes:
+    - path: /

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,26 +1,21 @@
-spec:
-  alerts:
-  - rule: DEPLOYMENT_FAILED
-  - rule: DOMAIN_FAILED
-  name: fedimintd
-  region: nyc
-  services:
-  - name: web
-    git:
-      branch: master
-      repo_clone_url: https://github.com/fedimint/fedimint.git
-  - envs:
-    - key: FM_PASSWORD
-      scope: RUN_AND_BUILD_TIME
-      value: pass0
-    http_port: 8176
-    image:
-      registry: fedimint
-      registry_type: DOCKER_HUB
-      repository: fedimintd
-      tag: master
-    instance_count: 1
-    instance_size_slug: basic-xs
-    name: fedimint-fedimintd
-    routes:
-    - path: /
+alerts:
+- rule: DEPLOYMENT_FAILED
+- rule: DOMAIN_FAILED
+name: fedimintd
+region: nyc
+services:
+- envs:
+  - key: FM_PASSWORD
+    scope: RUN_AND_BUILD_TIME
+    value: pass0
+  http_port: 8176
+  image:
+    registry: fedimint
+    registry_type: DOCKER_HUB
+    repository: fedimintd
+    tag: master
+  instance_count: 1
+  instance_size_slug: basic-xs
+  name: fedimint-fedimintd
+  routes:
+  - path: /

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,8 +1,7 @@
 spec:
-  name: fedimint
-  services:
-    - name: fedimintd
-      git:
-        branch: digital_ocean_deploy
-        repo_clone_url: https://github.com/m1sterc001guy/fedimint.git
-      dockerfile_path: misc/DigitalOcean/Dockerfile
+ name: sample-html
+ static_sites:
+ - git:
+     branch: main
+     repo_clone_url: https://github.com/digitalocean/sample-html.git
+   name: sample-html

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,16 +1,22 @@
 spec:
+  alerts:
+  - rule: DEPLOYMENT_FAILED
+  - rule: DOMAIN_FAILED
   name: fedimintd
+  region: nyc
   services:
-  - name: fedimintd
-    image: fedimint/fedimintd:f8717727bebabfcca4ebf4963d07f98e1d580742
-    cmd: ["fedimintd", "/var/fedimint", "pass0", "--listen-ui", "0.0.0.0:8176"]
-    envs:
-    - key: FEDIMINT_HOME
-      value: /var/fedimint
-    ports:
-    - port: 8176
-      targetPort: 8176
-    volumes:
-    - name: fedimint-volume
-      size: 10Gi
-      path: /var/fedimint
+  - envs:
+    - key: FM_PASSWORD
+      scope: RUN_AND_BUILD_TIME
+      value: pass0
+    http_port: 8176
+    image:
+      registry: fedimint
+      registry_type: DOCKER_HUB
+      repository: fedimintd
+      tag: master
+    instance_count: 1
+    instance_size_slug: basic-xs
+    name: fedimint-fedimintd
+    routes:
+    - path: /

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -5,3 +5,4 @@ spec:
       git:
         branch: digital_ocean_deploy
         repo_clone_url: https://github.com/m1sterc001guy/fedimint.git
+      dockerfile_path: misc/DigitalOcean/Dockerfile

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,16 @@
+spec:
+  name: fedimintd
+  services:
+  - name: fedimintd
+    image: fedimint/fedimintd:f8717727bebabfcca4ebf4963d07f98e1d580742
+    cmd: ["fedimintd", "/var/fedimint", "pass0", "--listen-ui", "0.0.0.0:8176"]
+    envs:
+    - key: FEDIMINT_HOME
+      value: /var/fedimint
+    ports:
+    - port: 8176
+      targetPort: 8176
+    volumes:
+    - name: fedimint-volume
+      size: 10Gi
+      path: /var/fedimint

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -5,6 +5,10 @@ spec:
   name: fedimintd
   region: nyc
   services:
+  - name: web
+    git:
+      branch: master
+      repo_clone_url: https://github.com/fedimint/fedimint.git
   - envs:
     - key: FM_PASSWORD
       scope: RUN_AND_BUILD_TIME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM fedimint/fedimintd:f8717727bebabfcca4ebf4963d07f98e1d580742
+WORKDIR /var/fedimint
+COPY . .
+RUN fedimintd /var/fedimint pass0 --listen-ui 0.0.0.0:8176
+EXPOSE 8176
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/fedimint/fedimint/tree/master)
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/m1sterc001guy/fedimint/tree/digital_ocean_deploy)
 
 <h1 align="center">
   <a href="https://fedimint.org">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/fedimint/fedimint/tree/master)
+
 <h1 align="center">
   <a href="https://fedimint.org">
     Fedimint

--- a/misc/DigitalOcean/Dockerfile
+++ b/misc/DigitalOcean/Dockerfile
@@ -1,0 +1,6 @@
+FROM fedimint/fedimintd:f8717727bebabfcca4ebf4963d07f98e1d580742
+WORKDIR /var/fedimint
+COPY . .
+RUN fedimintd /var/fedimint pass0 --listen-ui 0.0.0.0:8176
+EXPOSE 8176
+

--- a/misc/DigitalOcean/Dockerfile
+++ b/misc/DigitalOcean/Dockerfile
@@ -1,6 +1,0 @@
-FROM fedimint/fedimintd:f8717727bebabfcca4ebf4963d07f98e1d580742
-WORKDIR /var/fedimint
-COPY . .
-RUN fedimintd /var/fedimint pass0 --listen-ui 0.0.0.0:8176
-EXPOSE 8176
-


### PR DESCRIPTION
This is a PR that adds a button to the README that will deploy a docker container on Digital Ocean with one click. This might be useful for people wanting to play around with Fedimint but don't want to build it from source using the developer environment. 

![image](https://user-images.githubusercontent.com/1859166/227313503-2afb1ac6-6bf7-43ff-b750-4f3c3cd60e5d.png)


This is a work in-progress so there are a number of things that can be improved:

 - Use master (or some "tagged" commit) instead of the hard coded hash.
 - Figure out how to get rid of the Dockerfile at the root of the directory (in my limited testing Digital Ocean wants the Dockerfile at the root)
 - Expose all of the necessary ports (currently only exposing the port for the setup UI)
 - Auto-fill parameters to sensible defaults (bitcoin connection to public electrum, signet/testnet, autofill listen addresses, etc)
 - Deploy a "[shellinabox](https://github.com/shellinabox/shellinabox)" container that has `fedimint-cli` already installed so the user can immediately begun playing with ecash.