### PR TITLE
feat: allow gatewayd to reconnect to CLN or LND

### DIFF
--- a/fedimint-testing/src/ln/fixtures.rs
+++ b/fedimint-testing/src/ln/fixtures.rs
@@ -14,6 +14,7 @@ use ln_gateway::gatewaylnrpc::{
     PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
 use ln_gateway::lnrpc_client::{HtlcStream, ILnRpcClient};
+use ln_gateway::GatewayError;
 use mint_client::modules::ln::contracts::Preimage;
 use rand::rngs::OsRng;
 
@@ -25,6 +26,7 @@ pub struct FakeLightningTest {
     pub gateway_node_pub_key: secp256k1::PublicKey,
     gateway_node_sec_key: secp256k1::SecretKey,
     amount_sent: Arc<Mutex<u64>>,
+    is_connected: bool,
 }
 
 impl FakeLightningTest {
@@ -38,6 +40,7 @@ impl FakeLightningTest {
             gateway_node_sec_key: SecretKey::from_keypair(&kp),
             gateway_node_pub_key: PublicKey::from_keypair(&kp),
             amount_sent,
+            is_connected: true,
         }
     }
 }
@@ -50,10 +53,20 @@ impl Default for FakeLightningTest {
 
 #[async_trait]
 impl LightningTest for FakeLightningTest {
-    async fn invoice(&self, amount: Amount, expiry_time: Option<u64>) -> Invoice {
+    async fn invoice(
+        &self,
+        amount: Amount,
+        expiry_time: Option<u64>,
+    ) -> ln_gateway::Result<Invoice> {
+        if !self.is_connected {
+            return Err(GatewayError::Other(anyhow::anyhow!(
+                "Error not connected to Lightning"
+            )));
+        }
+
         let ctx = bitcoin::secp256k1::Secp256k1::new();
 
-        InvoiceBuilder::new(Currency::Regtest)
+        Ok(InvoiceBuilder::new(Currency::Regtest)
             .description("".to_string())
             .payment_hash(sha256::Hash::hash(&self.preimage.0))
             .current_timestamp()
@@ -64,7 +77,7 @@ impl LightningTest for FakeLightningTest {
                 expiry_time.unwrap_or(DEFAULT_EXPIRY_TIME),
             ))
             .build_signed(|m| ctx.sign_ecdsa_recoverable(m, &self.gateway_node_sec_key))
-            .unwrap()
+            .unwrap())
     }
 
     async fn amount_sent(&self) -> Amount {
@@ -79,6 +92,12 @@ impl LightningTest for FakeLightningTest {
 #[async_trait]
 impl ILnRpcClient for FakeLightningTest {
     async fn info(&self) -> ln_gateway::Result<GetNodeInfoResponse> {
+        if !self.is_connected {
+            return Err(GatewayError::Other(anyhow::anyhow!(
+                "Error not connected to Lightning"
+            )));
+        }
+
         Ok(GetNodeInfoResponse {
             pub_key: self.gateway_node_pub_key.serialize().to_vec(),
             alias: "FakeLightningNode".to_string(),
@@ -86,12 +105,24 @@ impl ILnRpcClient for FakeLightningTest {
     }
 
     async fn routehints(&self) -> ln_gateway::Result<GetRouteHintsResponse> {
+        if !self.is_connected {
+            return Err(GatewayError::Other(anyhow::anyhow!(
+                "Error not connected to Lightning"
+            )));
+        }
+
         Ok(GetRouteHintsResponse {
             route_hints: vec![gatewaylnrpc::get_route_hints_response::RouteHint { hops: vec![] }],
         })
     }
 
     async fn pay(&self, invoice: PayInvoiceRequest) -> ln_gateway::Result<PayInvoiceResponse> {
+        if !self.is_connected {
+            return Err(GatewayError::Other(anyhow::anyhow!(
+                "Error not connected to Lightning"
+            )));
+        }
+
         let signed = invoice.invoice.parse::<SignedRawInvoice>().unwrap();
         *self.amount_sent.lock().unwrap() += Invoice::from_signed(signed)
             .unwrap()
@@ -107,6 +138,12 @@ impl ILnRpcClient for FakeLightningTest {
         &self,
         _subscription: SubscribeInterceptHtlcsRequest,
     ) -> ln_gateway::Result<HtlcStream<'a>> {
+        if !self.is_connected {
+            return Err(GatewayError::Other(anyhow::anyhow!(
+                "Error not connected to Lightning"
+            )));
+        }
+
         Ok(Box::pin(stream::iter(vec![])))
     }
 
@@ -114,6 +151,22 @@ impl ILnRpcClient for FakeLightningTest {
         &self,
         _complete: CompleteHtlcsRequest,
     ) -> ln_gateway::Result<CompleteHtlcsResponse> {
+        if !self.is_connected {
+            return Err(GatewayError::Other(anyhow::anyhow!(
+                "Error not connected to Lightning"
+            )));
+        }
+
         Ok(CompleteHtlcsResponse {})
+    }
+
+    async fn connect(&mut self) -> ln_gateway::Result<()> {
+        self.is_connected = true;
+        Ok(())
+    }
+
+    async fn disconnect(&mut self) -> ln_gateway::Result<()> {
+        self.is_connected = false;
+        Ok(())
     }
 }

--- a/fedimint-testing/src/ln/mod.rs
+++ b/fedimint-testing/src/ln/mod.rs
@@ -7,7 +7,11 @@ pub mod fixtures;
 #[async_trait]
 pub trait LightningTest {
     /// Creates invoice from a non-gateway LN node
-    async fn invoice(&self, amount: Amount, expiry_time: Option<u64>) -> Invoice;
+    async fn invoice(
+        &self,
+        amount: Amount,
+        expiry_time: Option<u64>,
+    ) -> ln_gateway::Result<Invoice>;
 
     /// Returns the amount that the gateway LN node has sent
     async fn amount_sent(&self) -> Amount;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -23,24 +23,30 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use bitcoin::Address;
 use bitcoin_hashes::hex::ToHex;
+use clap::Subcommand;
 use fedimint_client::module::gen::ClientModuleGenRegistry;
 use fedimint_core::api::{FederationError, WsClientConnectInfo};
 use fedimint_core::config::FederationId;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::task::TaskGroup;
+use fedimint_core::task::{RwLock, TaskGroup};
 use fedimint_core::{Amount, TransactionId};
+use gatewaylnrpc::GetNodeInfoResponse;
+use lnrpc_client::ILnRpcClient;
 use mint_client::ln::PayInvoicePayload;
 use mint_client::modules::ln::route_hints::RouteHint;
 use mint_client::{ClientError, GatewayClient};
+use rpc::{FederationInfo, LightningReconnectPayload};
 use secp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{error, info, warn};
+use url::Url;
 
 use crate::actor::GatewayActor;
 use crate::client::DynGatewayClientBuilder;
-use crate::gatewaylnrpc::GetNodeInfoResponse;
-use crate::lnrpc_client::DynLnRpcClient;
+use crate::lnd::GatewayLndClient;
+use crate::lnrpc_client::NetworkLnRpcClient;
 use crate::rpc::rpc_server::run_webserver;
 use crate::rpc::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
@@ -53,6 +59,29 @@ const ROUTE_HINT_RETRY_SLEEP: Duration = Duration::from_secs(2);
 const INITIAL_SCID: u64 = 1;
 
 pub type Result<T> = std::result::Result<T, GatewayError>;
+
+#[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]
+pub enum Mode {
+    #[clap(name = "lnd")]
+    Lnd {
+        /// LND RPC address
+        #[arg(long = "lnd-rpc-host", env = "FM_LND_RPC_ADDR")]
+        lnd_rpc_addr: String,
+
+        /// LND TLS cert file path
+        #[arg(long = "lnd-tls-cert", env = "FM_LND_TLS_CERT")]
+        lnd_tls_cert: String,
+
+        /// LND macaroon file path
+        #[arg(long = "lnd-macaroon", env = "FM_LND_MACAROON")]
+        lnd_macaroon: String,
+    },
+    #[clap(name = "cln")]
+    Cln {
+        #[arg(long = "cln-extension-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
+        cln_extension_addr: Url,
+    },
+}
 
 #[derive(Debug, Error)]
 pub enum GatewayError {
@@ -68,6 +97,13 @@ pub enum GatewayError {
     FailedToFetchRouteHints,
 }
 
+impl GatewayError {
+    pub fn other(msg: String) -> Self {
+        error!(msg);
+        GatewayError::Other(anyhow!(msg))
+    }
+}
+
 impl IntoResponse for GatewayError {
     fn into_response(self) -> Response {
         let mut err = Cow::<'static, str>::Owned(format!("{self:?}")).into_response();
@@ -78,8 +114,8 @@ impl IntoResponse for GatewayError {
 pub struct Gateway {
     decoders: ModuleDecoderRegistry,
     module_gens: ClientModuleGenRegistry,
-    lnrpc: DynLnRpcClient,
-    actors: Mutex<HashMap<String, Arc<GatewayActor>>>,
+    lnrpc: Arc<RwLock<dyn ILnRpcClient>>,
+    actors: Mutex<HashMap<String, Arc<RwLock<GatewayActor>>>>,
     client_builder: DynGatewayClientBuilder,
     sender: mpsc::Sender<GatewayRequest>,
     receiver: mpsc::Receiver<GatewayRequest>,
@@ -90,7 +126,7 @@ pub struct Gateway {
 impl Gateway {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        lnrpc: DynLnRpcClient,
+        lnrpc: Arc<RwLock<dyn ILnRpcClient>>,
         client_builder: DynGatewayClientBuilder,
         decoders: ModuleDecoderRegistry,
         module_gens: ClientModuleGenRegistry,
@@ -126,6 +162,8 @@ impl Gateway {
         let route_hints = loop {
             let route_hints: Vec<RouteHint> = self
                 .lnrpc
+                .read()
+                .await
                 .routehints()
                 .await
                 .expect("Could not fetch route hints")
@@ -174,16 +212,17 @@ impl Gateway {
         &self,
         client: Arc<GatewayClient>,
         route_hints: Vec<RouteHint>,
-    ) -> Result<Arc<GatewayActor>> {
-        let actor = Arc::new(
+    ) -> Result<Arc<RwLock<GatewayActor>>> {
+        let actor = Arc::new(RwLock::new(
             GatewayActor::new(
                 client.clone(),
                 self.lnrpc.clone(),
                 route_hints,
                 self.task_group.clone(),
+                GatewayRpcSender::new(self.sender.clone()),
             )
             .await?,
-        );
+        ));
 
         self.actors.lock().await.insert(
             client.config().client_config.federation_id.to_string(),
@@ -192,7 +231,7 @@ impl Gateway {
         Ok(actor)
     }
 
-    async fn select_actor(&self, federation_id: FederationId) -> Result<Arc<GatewayActor>> {
+    async fn select_actor(&self, federation_id: FederationId) -> Result<Arc<RwLock<GatewayActor>>> {
         self.actors
             .lock()
             .await
@@ -213,7 +252,7 @@ impl Gateway {
             GatewayError::Other(anyhow::anyhow!("Invalid federation member string {}", e))
         })?;
 
-        let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.info().await?;
+        let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.read().await.info().await?;
         let node_pub_key = PublicKey::from_slice(&pub_key)
             .map_err(|e| GatewayError::Other(anyhow!("Invalid node pubkey {}", e)))?;
 
@@ -253,15 +292,13 @@ impl Gateway {
     }
 
     async fn handle_get_info(&self, _payload: InfoPayload) -> Result<GatewayInfo> {
-        let federations = self
-            .actors
-            .lock()
-            .await
-            .iter()
-            .map(|(_, actor)| actor.get_info().expect("Failed to get actor info"))
-            .collect();
+        let actors = self.actors.lock().await;
+        let mut federations: Vec<FederationInfo> = Vec::new();
+        for actor in actors.values() {
+            federations.push(actor.read().await.get_info()?);
+        }
 
-        let ln_info = self.lnrpc.info().await?;
+        let ln_info = self.lnrpc.read().await.info().await?;
 
         Ok(GatewayInfo {
             federations,
@@ -277,7 +314,8 @@ impl Gateway {
             contract_id,
         } = payload;
 
-        let actor = self.select_actor(federation_id).await?;
+        let actor_lock = self.select_actor(federation_id).await?;
+        let actor = actor_lock.read().await;
         let outpoint = actor.pay_invoice(contract_id).await?;
         actor
             .await_outgoing_contract_claimed(contract_id, outpoint)
@@ -288,6 +326,8 @@ impl Gateway {
     async fn handle_balance_msg(&self, payload: BalancePayload) -> Result<Amount> {
         self.select_actor(payload.federation_id)
             .await?
+            .read()
+            .await
             .get_balance()
             .await
     }
@@ -295,6 +335,8 @@ impl Gateway {
     async fn handle_address_msg(&self, payload: DepositAddressPayload) -> Result<Address> {
         self.select_actor(payload.federation_id)
             .await?
+            .read()
+            .await
             .get_deposit_address()
             .await
     }
@@ -308,6 +350,8 @@ impl Gateway {
 
         self.select_actor(federation_id)
             .await?
+            .read()
+            .await
             .deposit(txout_proof, transaction)
             .await
     }
@@ -321,6 +365,8 @@ impl Gateway {
 
         self.select_actor(federation_id)
             .await?
+            .read()
+            .await
             .withdraw(amount, address)
             .await
     }
@@ -329,14 +375,79 @@ impl Gateway {
         &self,
         BackupPayload { federation_id }: BackupPayload,
     ) -> Result<()> {
-        self.select_actor(federation_id).await?.backup().await
+        self.select_actor(federation_id)
+            .await?
+            .read()
+            .await
+            .backup()
+            .await
     }
 
     async fn handle_restore_msg(
         &self,
         RestorePayload { federation_id }: RestorePayload,
     ) -> Result<()> {
-        self.select_actor(federation_id).await?.restore().await
+        self.select_actor(federation_id)
+            .await?
+            .read()
+            .await
+            .restore()
+            .await
+    }
+
+    async fn handle_lightning_reconnect(
+        &mut self,
+        payload: LightningReconnectPayload,
+    ) -> Result<()> {
+        let LightningReconnectPayload { node_type } = payload;
+
+        let actors = self.actors.lock().await;
+
+        // Stop all threads that are listening for HTLCs
+        tracing::info!("Stopping all HTLC subscription threads.");
+        for actor in actors.values() {
+            actor.write().await.stop_subscribing_htlcs().await?;
+        }
+
+        // Disconnect the lightning connection, then reconnect it
+        self.lnrpc.write().await.disconnect().await?;
+
+        let new_lnrpc: Arc<RwLock<dyn ILnRpcClient>> = match node_type {
+            Some(Mode::Cln { cln_extension_addr }) => Arc::new(RwLock::new(
+                NetworkLnRpcClient::new(cln_extension_addr).await?,
+            )),
+            Some(Mode::Lnd {
+                lnd_rpc_addr,
+                lnd_tls_cert,
+                lnd_macaroon,
+            }) => Arc::new(RwLock::new(
+                GatewayLndClient::new(
+                    lnd_rpc_addr,
+                    lnd_tls_cert,
+                    lnd_macaroon,
+                    self.task_group.make_subgroup().await,
+                )
+                .await?,
+            )),
+            None => {
+                let new_client = self.lnrpc.clone();
+                // Reconnect the existing client without re-creating it
+                new_client.write().await.connect().await?;
+                new_client
+            }
+        };
+
+        self.lnrpc = new_lnrpc.clone();
+
+        // Restart the subscription of HTLCs for each actor
+        tracing::info!("Restarting HTLC subscription threads.");
+        for actor in actors.values() {
+            let mut actor = actor.write().await;
+            actor.lnrpc = new_lnrpc.clone();
+            actor.subscribe_htlcs().await?;
+        }
+
+        Ok(())
     }
 
     pub async fn run(mut self, listen: SocketAddr, password: String) -> Result<()> {
@@ -370,50 +481,75 @@ impl Gateway {
                 tracing::trace!("Gateway received message {:?}", msg);
                 match msg {
                     GatewayRequest::Info(inner) => {
-                        inner.handle(|payload| self.handle_get_info(payload)).await;
+                        inner
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_get_info(payload)
+                            })
+                            .await;
                     }
                     GatewayRequest::ConnectFederation(inner) => {
                         let route_hints: Vec<RouteHint> =
-                            self.lnrpc.routehints().await?.try_into()?;
+                            self.lnrpc.read().await.routehints().await?.try_into()?;
                         inner
-                            .handle(|payload| {
-                                self.handle_connect_federation(payload, route_hints.clone())
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_connect_federation(payload, route_hints.clone())
                             })
                             .await;
                     }
                     GatewayRequest::PayInvoice(inner) => {
                         inner
-                            .handle(|payload| self.handle_pay_invoice_msg(payload))
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_pay_invoice_msg(payload)
+                            })
                             .await;
                     }
                     GatewayRequest::Balance(inner) => {
                         inner
-                            .handle(|payload| self.handle_balance_msg(payload))
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_balance_msg(payload)
+                            })
                             .await;
                     }
                     GatewayRequest::DepositAddress(inner) => {
                         inner
-                            .handle(|payload| self.handle_address_msg(payload))
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_address_msg(payload)
+                            })
                             .await;
                     }
                     GatewayRequest::Deposit(inner) => {
                         inner
-                            .handle(|payload| self.handle_deposit_msg(payload))
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_deposit_msg(payload)
+                            })
                             .await;
                     }
                     GatewayRequest::Withdraw(inner) => {
                         inner
-                            .handle(|payload| self.handle_withdraw_msg(payload))
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_withdraw_msg(payload)
+                            })
                             .await;
                     }
                     GatewayRequest::Backup(inner) => {
                         inner
-                            .handle(|payload| self.handle_backup_msg(payload))
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_backup_msg(payload)
+                            })
                             .await;
                     }
                     GatewayRequest::Restore(inner) => {
                         inner
-                            .handle(|payload| self.handle_restore_msg(payload))
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_restore_msg(payload)
+                            })
+                            .await;
+                    }
+                    GatewayRequest::LightningReconnect(inner) => {
+                        inner
+                            .handle(&mut self, |gateway, payload| {
+                                gateway.handle_lightning_reconnect(payload)
+                            })
                             .await;
                     }
                 }

--- a/gateway/ln-gateway/src/lnd.rs
+++ b/gateway/ln-gateway/src/lnd.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bitcoin_hashes::{sha256, Hash};
-use fedimint_core::task::TaskGroup;
+use fedimint_core::task::{sleep, TaskGroup};
 use secp256k1::PublicKey;
 use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
@@ -35,11 +36,14 @@ type OutcomeMap = Arc<Mutex<HashMap<sha256::Hash, (LndSenderRef, Option<CircuitK
 
 pub struct GatewayLndClient {
     /// LND client
-    client: LndClient,
+    client: Option<LndClient>,
     /// Passes state between subscribe_htlcs() and complete_htlc()
     outcomes: OutcomeMap,
     /// Used to spawn a task handling HTLC subscriptions
     task_group: TaskGroup,
+    address: String,
+    tls_cert: String,
+    macaroon: String,
 }
 
 // Reference to a sender that forwards ForwardHtlcInterceptResponse messages to
@@ -53,16 +57,16 @@ impl GatewayLndClient {
         macaroon: String,
         task_group: TaskGroup,
     ) -> crate::Result<Self> {
-        let client = connect(address, tls_cert, macaroon).await.map_err(|e| {
-            error!("Failed to connect to lnrpc server: {:?}", e);
-            GatewayError::Other(anyhow!("Failed to connect to lnrpc server"))
-        })?;
-
-        Ok(Self {
-            client,
+        let mut gw_rpc = GatewayLndClient {
+            client: None,
             outcomes: Arc::new(Mutex::new(HashMap::new())),
             task_group,
-        })
+            address,
+            tls_cert,
+            macaroon,
+        };
+        gw_rpc.connect().await?;
+        Ok(gw_rpc)
     }
 }
 
@@ -75,32 +79,36 @@ impl fmt::Debug for GatewayLndClient {
 #[async_trait]
 impl ILnRpcClient for GatewayLndClient {
     async fn info(&self) -> crate::Result<GetNodeInfoResponse> {
-        let mut client = self.client.clone();
+        if let Some(mut client) = self.client.clone() {
+            let info = client
+                .lightning()
+                .get_info(GetInfoRequest {})
+                .await
+                .map_err(|e| {
+                    GatewayError::LnRpcError(tonic::Status::new(
+                        tonic::Code::Internal,
+                        format!("LND error: {e:?}"),
+                    ))
+                })?
+                .into_inner();
 
-        let info = client
-            .lightning()
-            .get_info(GetInfoRequest {})
-            .await
-            .map_err(|e| {
+            let pub_key: PublicKey = info.identity_pubkey.parse().map_err(|e| {
                 GatewayError::LnRpcError(tonic::Status::new(
                     tonic::Code::Internal,
                     format!("LND error: {e:?}"),
                 ))
-            })?
-            .into_inner();
+            })?;
+            info!("LND pubkey {:?} Alias: {}", pub_key, info.alias);
 
-        let pub_key: PublicKey = info.identity_pubkey.parse().map_err(|e| {
-            GatewayError::LnRpcError(tonic::Status::new(
-                tonic::Code::Internal,
-                format!("LND error: {e:?}"),
-            ))
-        })?;
-        info!("fetched pubkey {:?}", pub_key);
+            return Ok(GetNodeInfoResponse {
+                pub_key: pub_key.serialize().to_vec(),
+                alias: info.alias,
+            });
+        }
 
-        Ok(GetNodeInfoResponse {
-            pub_key: pub_key.serialize().to_vec(),
-            alias: info.alias,
-        })
+        Err(GatewayError::other(
+            "Error: not connected to LND".to_string(),
+        ))
     }
 
     async fn routehints(&self) -> crate::Result<GetRouteHintsResponse> {
@@ -111,35 +119,45 @@ impl ILnRpcClient for GatewayLndClient {
     }
 
     async fn pay(&self, invoice: PayInvoiceRequest) -> crate::Result<PayInvoiceResponse> {
-        let mut client = self.client.clone();
+        if let Some(mut client) = self.client.clone() {
+            let send_response = client
+                .lightning()
+                .send_payment_sync(SendRequest {
+                    payment_request: invoice.invoice.to_string(),
+                    ..Default::default()
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!(format!("LND error: {e:?}")))?
+                .into_inner();
+            info!("send response {:?}", send_response);
 
-        let send_response = client
-            .lightning()
-            .send_payment_sync(SendRequest {
-                payment_request: invoice.invoice.to_string(),
-                ..Default::default()
-            })
-            .await
-            .map_err(|e| anyhow::anyhow!(format!("LND error: {e:?}")))?
-            .into_inner();
-        info!("send response {:?}", send_response);
+            if send_response.payment_preimage.is_empty() {
+                return Err(GatewayError::LnRpcError(tonic::Status::new(
+                    tonic::Code::Internal,
+                    "LND did not return a preimage",
+                )));
+            };
 
-        if send_response.payment_preimage.is_empty() {
-            return Err(GatewayError::LnRpcError(tonic::Status::new(
-                tonic::Code::Internal,
-                "LND did not return a preimage",
-            )));
-        };
+            return Ok(PayInvoiceResponse {
+                preimage: send_response.payment_preimage,
+            });
+        }
 
-        Ok(PayInvoiceResponse {
-            preimage: send_response.payment_preimage,
-        })
+        Err(GatewayError::other(
+            "Error: not connected to LND".to_string(),
+        ))
     }
 
     async fn subscribe_htlcs<'a>(
         &self,
         subscription: SubscribeInterceptHtlcsRequest,
     ) -> crate::Result<HtlcStream<'a>> {
+        if self.client.is_none() {
+            return Err(GatewayError::other(
+                "Error: not connected to LND".to_string(),
+            ));
+        }
+
         const CHANNEL_SIZE: usize = 100;
 
         // Channel to send responses to LND after processing intercepted HTLC
@@ -150,7 +168,7 @@ impl ILnRpcClient for GatewayLndClient {
             mpsc::channel::<Result<SubscribeInterceptHtlcsResponse, tonic::Status>>(CHANNEL_SIZE);
 
         let scid = subscription.short_channel_id;
-        let mut client = self.client.clone();
+        let mut client = self.client.clone().unwrap();
 
         let mut tg = self.task_group.clone();
         let outcomes = self.outcomes.clone();
@@ -267,6 +285,12 @@ impl ILnRpcClient for GatewayLndClient {
         &self,
         request: CompleteHtlcsRequest,
     ) -> crate::Result<CompleteHtlcsResponse> {
+        if self.client.is_none() {
+            return Err(GatewayError::other(
+                "Error: not connected to LND".to_string(),
+            ));
+        }
+
         let CompleteHtlcsRequest {
             action,
             intercepted_htlc_id,
@@ -314,6 +338,33 @@ impl ILnRpcClient for GatewayLndClient {
                 "No interceptor reference found for this processed htlc with id: {intercepted_htlc_id:?}",
             );
         }
+    }
+
+    async fn connect(&mut self) -> crate::Result<()> {
+        let client = loop {
+            match connect(
+                self.address.clone(),
+                self.tls_cert.clone(),
+                self.macaroon.clone(),
+            )
+            .await
+            {
+                Ok(client) => break client,
+                Err(_) => {
+                    tracing::warn!("Couldn't connect to LND, retrying in 5 seconds...");
+                    sleep(Duration::from_secs(5)).await;
+                }
+            }
+        };
+
+        self.client = Some(client);
+        Ok(())
+    }
+
+    async fn disconnect(&mut self) -> crate::Result<()> {
+        tracing::warn!("Disconnected from LND");
+        self.client = None;
+        Ok(())
     }
 }
 

--- a/gateway/ln-gateway/src/lnd.rs
+++ b/gateway/ln-gateway/src/lnd.rs
@@ -362,7 +362,6 @@ impl ILnRpcClient for GatewayLndClient {
     }
 
     async fn disconnect(&mut self) -> crate::Result<()> {
-        tracing::warn!("Disconnected from LND");
         self.client = None;
         Ok(())
     }

--- a/gateway/ln-gateway/src/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/lnrpc_client.rs
@@ -162,7 +162,6 @@ impl ILnRpcClient for NetworkLnRpcClient {
     }
 
     async fn disconnect(&mut self) -> Result<()> {
-        tracing::warn!("Disconnected from CLN extension");
         self.client = None;
         Ok(())
     }

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -6,7 +6,7 @@ use url::Url;
 
 use super::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
-    RestorePayload, WithdrawPayload,
+    LightningReconnectPayload, RestorePayload, WithdrawPayload,
 };
 
 pub struct RpcClient {
@@ -89,6 +89,15 @@ impl RpcClient {
         payload: RestorePayload,
     ) -> Result<Response, Error> {
         let url = self.base_url.join("/restore").expect("invalid base url");
+        self.call(url, password, payload).await
+    }
+
+    pub async fn reconnect(
+        &self,
+        password: String,
+        payload: LightningReconnectPayload,
+    ) -> Result<Response, Error> {
+        let url = self.base_url.join("/reconnect").expect("invalid base url");
         self.call(url, password, payload).await
     }
 

--- a/gateway/ln-gateway/tests/fixtures/mod.rs
+++ b/gateway/ln-gateway/tests/fixtures/mod.rs
@@ -1,8 +1,9 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use anyhow::Result;
 use fedimint_client::module::gen::{ClientModuleGenRegistry, DynClientModuleGen};
-use fedimint_core::task::TaskGroup;
+use fedimint_core::task::{RwLock, TaskGroup};
 use fedimint_ln_client::LightningClientGen;
 use fedimint_mint_client::MintClientGen;
 use fedimint_testing::btc::fixtures::FakeBitcoinTest;
@@ -11,7 +12,7 @@ use fedimint_testing::ln::fixtures::FakeLightningTest;
 use fedimint_testing::ln::LightningTest;
 use futures::Future;
 use ln_gateway::client::{DynGatewayClientBuilder, MemDbFactory};
-use ln_gateway::lnrpc_client::DynLnRpcClient;
+use ln_gateway::lnrpc_client::ILnRpcClient;
 use ln_gateway::rpc::rpc_client::RpcClient;
 use ln_gateway::Gateway;
 use mint_client::module_decode_stubs;
@@ -31,7 +32,7 @@ pub struct Fixtures {
 
 pub async fn fixtures(api_addr: Url) -> Result<Fixtures> {
     // Create a lightning rpc client
-    let lnrpc: DynLnRpcClient = FakeLightningTest::new().into();
+    let lnrpc: Arc<RwLock<dyn ILnRpcClient>> = Arc::new(RwLock::new(FakeLightningTest::new()));
 
     // Create federation client builder
     let client_builder: DynGatewayClientBuilder =

--- a/integrationtests/tests/fixtures/real.rs
+++ b/integrationtests/tests/fixtures/real.rs
@@ -40,7 +40,11 @@ pub struct RealLightningTest {
 
 #[async_trait]
 impl LightningTest for RealLightningTest {
-    async fn invoice(&self, amount: Amount, expiry_time: Option<u64>) -> Invoice {
+    async fn invoice(
+        &self,
+        amount: Amount,
+        expiry_time: Option<u64>,
+    ) -> ln_gateway::Result<Invoice> {
         match self.gateway_node {
             // If we're using CLN as the gateway, use LND to fetch an invoice
             GatewayNode::Cln => {
@@ -64,7 +68,7 @@ impl LightningTest for RealLightningTest {
                     .unwrap()
                     .into_inner();
 
-                Invoice::from_str(&invoice_resp.payment_request).unwrap()
+                Ok(Invoice::from_str(&invoice_resp.payment_request).unwrap())
             }
             // If we're using LND as the gateway, use CLN to fetch an invoice
             GatewayNode::Lnd => {
@@ -95,7 +99,7 @@ impl LightningTest for RealLightningTest {
                     panic!("cln-rpc response did not match expected InvoiceResponse")
                 };
 
-                Invoice::from_str(&invoice_resp.bolt11).unwrap()
+                Ok(Invoice::from_str(&invoice_resp.bolt11).unwrap())
             }
         }
     }

--- a/integrationtests/tests/fixtures/utils.rs
+++ b/integrationtests/tests/fixtures/utils.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use fedimint_core::task::RwLock;
 use ln_gateway::gatewaylnrpc::{
     CompleteHtlcsRequest, CompleteHtlcsResponse, GetNodeInfoResponse, GetRouteHintsResponse,
     PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
-use ln_gateway::lnrpc_client::{DynLnRpcClient, HtlcStream, ILnRpcClient};
+use ln_gateway::lnrpc_client::{HtlcStream, ILnRpcClient};
 use ln_gateway::GatewayError;
 use tokio::sync::Mutex;
 
@@ -16,14 +17,14 @@ use tokio::sync::Mutex;
 #[derive(Debug, Clone)]
 pub struct LnRpcAdapter {
     /// The actual `ILnRpcClient` that we add behavior to.
-    client: DynLnRpcClient,
+    client: Arc<RwLock<dyn ILnRpcClient>>,
     /// A pair of <PayInvoiceRequest> and <Count> where client.pay() will fail
     /// <Count> times for each <String> (bolt11 invoice)
     fail_invoices: Arc<Mutex<HashMap<String, u8>>>,
 }
 
 impl LnRpcAdapter {
-    pub fn new(client: DynLnRpcClient) -> Self {
+    pub fn new(client: Arc<RwLock<dyn ILnRpcClient>>) -> Self {
         let fail_invoices = Arc::new(Mutex::new(HashMap::new()));
 
         LnRpcAdapter {
@@ -46,11 +47,11 @@ impl LnRpcAdapter {
 #[async_trait]
 impl ILnRpcClient for LnRpcAdapter {
     async fn info(&self) -> ln_gateway::Result<GetNodeInfoResponse> {
-        self.client.info().await
+        self.client.read().await.info().await
     }
 
     async fn routehints(&self) -> ln_gateway::Result<GetRouteHintsResponse> {
-        self.client.routehints().await
+        self.client.read().await.routehints().await
     }
 
     async fn pay(&self, invoice: PayInvoiceRequest) -> ln_gateway::Result<PayInvoiceResponse> {
@@ -67,20 +68,28 @@ impl ILnRpcClient for LnRpcAdapter {
             }
         }
         self.fail_invoices.lock().await.remove(&invoice.invoice);
-        self.client.pay(invoice).await
+        self.client.read().await.pay(invoice).await
     }
 
     async fn subscribe_htlcs<'a>(
         &self,
         subscription: SubscribeInterceptHtlcsRequest,
     ) -> ln_gateway::Result<HtlcStream<'a>> {
-        self.client.subscribe_htlcs(subscription).await
+        self.client.read().await.subscribe_htlcs(subscription).await
     }
 
     async fn complete_htlc(
         &self,
         complete: CompleteHtlcsRequest,
     ) -> ln_gateway::Result<CompleteHtlcsResponse> {
-        self.client.complete_htlc(complete).await
+        self.client.read().await.complete_htlc(complete).await
+    }
+
+    async fn connect(&mut self) -> ln_gateway::Result<()> {
+        self.client.write().await.connect().await
+    }
+
+    async fn disconnect(&mut self) -> ln_gateway::Result<()> {
+        self.client.write().await.disconnect().await
     }
 }


### PR DESCRIPTION
PR adds the ability for `gatewayd` to reconnect to CLN or LND if they go down. This API could also be used to switch which lightning implementation is used without needing to restart `gatewayd`.

Manual testing using tmuxinator is working. Integration test for sending an outgoing payment after a disconnection has been added.