### PR TITLE
fix: ignore unreliable result of `submit_transaction`

### DIFF
--- a/fedimint-testing/src/btc/bitcoind.rs
+++ b/fedimint-testing/src/btc/bitcoind.rs
@@ -64,14 +64,12 @@ impl IBitcoindRpc for FakeBitcoindRpc {
         Ok(self.state.lock().unwrap().fee_rate)
     }
 
-    async fn submit_transaction(&self, transaction: Transaction) -> Result<()> {
+    async fn submit_transaction(&self, transaction: Transaction) {
         self.state
             .lock()
             .unwrap()
             .transactions
             .push_back(transaction);
-
-        Ok(())
     }
 }
 

--- a/fedimint-testing/src/btc/fixtures.rs
+++ b/fedimint-testing/src/btc/fixtures.rs
@@ -215,7 +215,7 @@ impl IBitcoindRpc for FakeBitcoinTest {
         Ok(None)
     }
 
-    async fn submit_transaction(&self, transaction: Transaction) -> BitcoinRpcResult<()> {
+    async fn submit_transaction(&self, transaction: Transaction) {
         let mut pending = self.pending.lock().unwrap();
         pending.push(transaction);
 
@@ -232,8 +232,6 @@ impl IBitcoindRpc for FakeBitcoinTest {
         }
 
         *pending = filtered.into_values().collect();
-
-        Ok(())
     }
 }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1226,7 +1226,7 @@ pub async fn broadcast_pending_tx(mut dbtx: DatabaseTransaction<'_>, rpc: &DynBi
                 "Broadcasting peg-out",
             );
             trace!(transaction = ?tx);
-            let _ = rpc.submit_transaction(tx).await;
+            rpc.submit_transaction(tx).await;
         }
     }
 }


### PR DESCRIPTION
See comment in the code.


This fixes hangs when backends keep returning error due to transactions being submitted already being included in the blockchain: https://github.com/fedimint/fedimint/actions/runs/4503632304/jobs/7927075007?pr=2004

