### PR TITLE
fix(cli): re-add default value for invoice description

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -339,6 +339,7 @@ enum Command {
     LnInvoice {
         #[clap(value_parser = parse_fedimint_amount)]
         amount: Amount,
+        #[clap(default_value = "")]
         description: String,
         expiry_time: Option<u64>,
     },


### PR DESCRIPTION
This change was originally made in #1996, but I think was accidentally removed in #2004.