### PR TITLE
Second iteration on the config gen API

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -16,9 +16,10 @@ use fedimint_aead::get_password_hash;
 use fedimint_client::module::gen::{
     ClientModuleGen, ClientModuleGenRegistry, ClientModuleGenRegistryExt,
 };
+use fedimint_core::admin_client::WsAdminClient;
 use fedimint_core::api::{
-    FederationApiExt, FederationError, GlobalFederationApi, IFederationApi, WsAuthenticatedApi,
-    WsClientConnectInfo, WsFederationApi,
+    FederationApiExt, FederationError, GlobalFederationApi, IFederationApi, WsClientConnectInfo,
+    WsFederationApi,
 };
 use fedimint_core::config::{load_from_file, ClientConfig, FederationId};
 use fedimint_core::db::{Database, DatabaseValue};
@@ -939,7 +940,7 @@ impl FedimintCli {
                     .expect("Endpoint exists")
                     .url
                     .clone();
-                let auth_api = WsAuthenticatedApi::new(url, our_id, auth);
+                let auth_api = WsAdminClient::new(url, our_id, auth);
                 auth_api.signal_upgrade().await?;
                 Ok(CliOutput::SignalUpgrade)
             }

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -1,0 +1,80 @@
+use std::fmt::Debug;
+
+use fedimint_core::task::MaybeSend;
+use serde::{Deserialize, Serialize};
+use tokio_rustls::rustls;
+use url::Url;
+
+use crate::api::{DynFederationApi, FederationApiExt, FederationResult, WsFederationApi};
+use crate::module::{ApiAuth, ApiRequestErased};
+use crate::PeerId;
+
+/// For a guardian to communicate with their server
+// TODO: Maybe should have it's own CLI client so it doesn't need to be in core
+pub struct WsAdminClient {
+    inner: DynFederationApi,
+    auth: ApiAuth,
+}
+
+impl WsAdminClient {
+    pub fn new(url: Url, our_id: PeerId, auth: ApiAuth) -> Self {
+        Self {
+            inner: WsFederationApi::new(vec![(our_id, url)]).into(),
+            auth,
+        }
+    }
+
+    pub async fn set_password(&self, auth: ApiAuth) -> FederationResult<()> {
+        self.request("/set_password", ApiRequestErased::new(auth))
+            .await
+    }
+
+    pub async fn signal_upgrade(&self) -> FederationResult<()> {
+        self.request("/upgrade", ApiRequestErased::default()).await
+    }
+
+    async fn request<Ret>(&self, method: &str, params: ApiRequestErased) -> FederationResult<Ret>
+    where
+        Ret: serde::de::DeserializeOwned + Eq + Debug + Clone + MaybeSend,
+    {
+        self.inner
+            .request_current_consensus(method.to_owned(), params.with_auth(&self.auth))
+            .await
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PeerServerParams {
+    #[serde(with = "serde_tls_cert")]
+    pub cert: rustls::Certificate,
+    pub p2p_url: Url,
+    pub api_url: Url,
+    pub name: String,
+}
+
+mod serde_tls_cert {
+    use std::borrow::Cow;
+
+    use bitcoin_hashes::hex::{FromHex, ToHex};
+    use serde::de::Error;
+    use serde::{Deserialize, Deserializer, Serializer};
+    use tokio_rustls::rustls;
+
+    pub fn serialize<S>(certs: &rustls::Certificate, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex_str = certs.0.to_hex();
+        serializer.serialize_str(&hex_str)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<rustls::Certificate, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value: Cow<str> = Deserialize::deserialize(deserializer)?;
+        Ok(rustls::Certificate(
+            Vec::from_hex(&value).map_err(D::Error::custom)?,
+        ))
+    }
+}

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -24,16 +24,81 @@ impl WsAdminClient {
         }
     }
 
+    /// Sets the password used to decrypt the configs and authenticate
+    ///
+    /// Must be called first before any other calls to the API
     pub async fn set_password(&self, auth: ApiAuth) -> FederationResult<()> {
-        self.request("/set_password", ApiRequestErased::new(auth))
+        self.request_auth("/set_password", ApiRequestErased::new(auth))
             .await
     }
 
-    pub async fn signal_upgrade(&self) -> FederationResult<()> {
-        self.request("/upgrade", ApiRequestErased::default()).await
+    /// During config gen, sets the server connection containing our endpoints
+    ///
+    /// Optionally sends our server info to the config gen leader using
+    /// `add_config_gen_peer`
+    pub async fn set_config_gen_connections(
+        &self,
+        info: ConfigGenConnectionsRequest,
+    ) -> FederationResult<()> {
+        self.request_auth("/set_config_gen_connections", ApiRequestErased::new(info))
+            .await
     }
 
-    async fn request<Ret>(&self, method: &str, params: ApiRequestErased) -> FederationResult<Ret>
+    /// During config gen, used for an API-to-API call that adds a peer's server
+    /// connection info to the leader.
+    ///
+    /// Note this call will fail until the leader has their API running and has
+    /// `set_server_connections` so clients should retry.
+    ///
+    /// This call is not authenticated because it's guardian-to-guardian
+    pub async fn add_config_gen_peer(&self, peer: PeerServerParams) -> FederationResult<()> {
+        self.inner
+            .request_current_consensus(
+                "/add_config_gen_peer".to_owned(),
+                ApiRequestErased::new(peer),
+            )
+            .await
+    }
+
+    /// During config gen, gets all the server connections we've received from
+    /// peers using `add_config_gen_peer`
+    ///
+    /// Could be called on the leader, so it's not authenticated
+    pub async fn get_config_gen_peers(&self) -> FederationResult<Vec<PeerServerParams>> {
+        self.inner
+            .request_current_consensus(
+                "/get_config_gen_peers".to_owned(),
+                ApiRequestErased::default(),
+            )
+            .await
+    }
+
+    /// During config gen, waits to receive server connections from a number of
+    /// `peers`
+    pub async fn await_config_gen_peers(
+        &self,
+        peers: usize,
+    ) -> FederationResult<Vec<PeerServerParams>> {
+        self.inner
+            .request_current_consensus(
+                "/await_config_gen_peers".to_owned(),
+                ApiRequestErased::new(peers),
+            )
+            .await
+    }
+
+    /// Sends a signal to consensus that we are ready to shutdown the federation
+    /// and upgrade
+    pub async fn signal_upgrade(&self) -> FederationResult<()> {
+        self.request_auth("/upgrade", ApiRequestErased::default())
+            .await
+    }
+
+    async fn request_auth<Ret>(
+        &self,
+        method: &str,
+        params: ApiRequestErased,
+    ) -> FederationResult<Ret>
     where
         Ret: serde::de::DeserializeOwned + Eq + Debug + Clone + MaybeSend,
     {
@@ -43,7 +108,17 @@ impl WsAdminClient {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// Sent by admin user to the API
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigGenConnectionsRequest {
+    /// Our guardian name
+    pub our_name: String,
+    /// Url of "leader" guardian to send our connection info to
+    /// Will be `None` if we are the leader
+    pub leader_api_url: Option<Url>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct PeerServerParams {
     #[serde(with = "serde_tls_cert")]
     pub cert: rustls::Certificate,

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -42,7 +42,7 @@ use url::Url;
 
 use crate::core::OutputOutcome;
 use crate::epoch::{SerdeEpochHistory, SignedEpochOutcome};
-use crate::module::{ApiAuth, ApiRequestErased};
+use crate::module::ApiRequestErased;
 use crate::outcome::TransactionStatus;
 use crate::query::{
     CurrentConsensus, EventuallyConsistent, QueryStep, QueryStrategy, UnionResponses,
@@ -784,39 +784,6 @@ impl<C> WsFederationApi<C> {
                 })
                 .collect(),
         }
-    }
-}
-
-/// For a guardian to communicate with their server
-pub struct WsAuthenticatedApi {
-    inner: DynFederationApi,
-    auth: ApiAuth,
-}
-
-impl WsAuthenticatedApi {
-    pub fn new(url: Url, our_id: PeerId, auth: ApiAuth) -> Self {
-        Self {
-            inner: WsFederationApi::new(vec![(our_id, url)]).into(),
-            auth,
-        }
-    }
-
-    pub async fn set_password(&self, auth: ApiAuth) -> FederationResult<()> {
-        self.request("/set_password", ApiRequestErased::new(auth))
-            .await
-    }
-
-    pub async fn signal_upgrade(&self) -> FederationResult<()> {
-        self.request("/upgrade", ApiRequestErased::default()).await
-    }
-
-    async fn request<Ret>(&self, method: &str, params: ApiRequestErased) -> FederationResult<Ret>
-    where
-        Ret: serde::de::DeserializeOwned + Eq + Debug + Clone + MaybeSend,
-    {
-        self.inner
-            .request_current_consensus(method.to_owned(), params.with_auth(&self.auth))
-            .await
     }
 }
 

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -22,6 +22,7 @@ pub use crate::core::server;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 
+pub mod admin_client;
 pub mod api;
 pub mod bitcoin_rpc;
 pub mod cancellable;

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -122,7 +122,8 @@ mod tests {
     use std::path::PathBuf;
     use std::{env, fs};
 
-    use fedimint_core::api::{FederationResult, WsAuthenticatedApi};
+    use fedimint_core::admin_client::WsAdminClient;
+    use fedimint_core::api::FederationResult;
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::Database;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -134,7 +135,7 @@ mod tests {
 
     /// Helper in config API tests for simulating a guardian's client and server
     struct TestConfigApi {
-        client: WsAuthenticatedApi,
+        client: WsAdminClient,
         server: ServerHandle,
         auth: ApiAuth,
     }
@@ -153,7 +154,7 @@ mod tests {
         let server = run_server(data_dir.clone(), socket, db).await;
         // our id doesn't really exist at this point
         let auth = ApiAuth(format!("password-{port}"));
-        let client = WsAuthenticatedApi::new(url, PeerId::from(0), auth.clone());
+        let client = WsAdminClient::new(url, PeerId::from(0), auth.clone());
         TestConfigApi {
             client,
             server,

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -1,63 +1,226 @@
+use std::collections::BTreeMap;
+use std::iter::once;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use fedimint_core::admin_client::{ConfigGenConnectionsRequest, PeerServerParams, WsAdminClient};
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::Database;
 use fedimint_core::module::{
     api_endpoint, ApiAuth, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased,
 };
+use fedimint_core::PeerId;
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use jsonrpsee::RpcModule;
+use tokio::sync::Notify;
+use tokio_rustls::rustls;
+use url::Url;
 
+use crate::config::gen_cert_and_key;
 use crate::net::api::{attach_endpoints, HasApiContext, RpcHandlerCtx};
 
-/// Serves the config API endpoints
-pub struct ConfigApi {
+pub type ApiResult<T> = std::result::Result<T, ApiError>;
+
+/// Serves the config gen API endpoints
+pub struct ConfigGenApi {
     /// Directory the configs will be created in
     _data_dir: PathBuf,
     /// In-memory state machine
     state: Mutex<ConfigApiState>,
     /// DB not really used
     db: Database,
-    /// Bind address for the API
-    _bind_api: SocketAddr,
+    /// Our connection info configured locally
+    our_connections: ConfigGenConnections,
+    /// Notify if we receive connections from peer
+    notify_peer_connection: Notify,
 }
 
-impl ConfigApi {
-    pub fn new(data_dir: PathBuf, bind_api: SocketAddr, db: Database) -> Self {
+impl ConfigGenApi {
+    pub fn new(data_dir: PathBuf, our_connections: ConfigGenConnections, db: Database) -> Self {
         Self {
             _data_dir: data_dir,
             state: Mutex::new(ConfigApiState::SetPassword),
             db,
-            _bind_api: bind_api,
+            our_connections,
+            notify_peer_connection: Default::default(),
         }
     }
 
     // Sets the auth and decryption key derived from the password
-    pub fn set_password(&self, auth: ApiAuth) -> Result<(), ApiError> {
+    pub fn set_password(&self, auth: ApiAuth) -> ApiResult<()> {
         let mut state = self.state.lock().expect("lock poisoned");
 
-        if *state != ConfigApiState::SetPassword {
-            Err(ApiError::bad_request("Password already set".to_string()))
-        } else {
-            *state = ConfigApiState::SetPeerConnectionInfo(auth);
-            Ok(())
+        match &*state {
+            ConfigApiState::SetPassword => *state = ConfigApiState::SetConnections(auth),
+            _ => return Err(ApiError::bad_request("Password already set".to_string())),
         }
+
+        Ok(())
+    }
+
+    /// Sets our connection info, possibly sending it to a leader
+    pub async fn set_config_gen_connections(
+        &self,
+        request: ConfigGenConnectionsRequest,
+    ) -> ApiResult<()> {
+        let connection = {
+            let mut state = self.state.lock().expect("lock poisoned");
+
+            let connection = match (*state).clone() {
+                ConfigApiState::SetConnections(auth) => {
+                    ConfigGenConnectionsState::new(request, self.our_connections.clone(), auth)?
+                }
+                ConfigApiState::SetConfigGenParams(old) => old.with_request(request),
+                _ => return Err(ApiError::bad_request("Config already set".to_string())),
+            };
+            *state = ConfigApiState::SetConfigGenParams(connection.clone());
+
+            connection
+        };
+
+        if let Some(url) = connection.request.leader_api_url.clone() {
+            // Note PeerIds don't really exist at this point, but id doesn't matter because
+            // it's not used in the WS client for anything, perhaps it should be removed
+            let client = WsAdminClient::new(url, PeerId::from(0), connection.auth.clone());
+            client
+                .add_config_gen_peer(connection.as_peer_info())
+                .await
+                .map_err(|_| ApiError::not_found("Unable to connect to the leader".to_string()))?;
+        }
+
+        self.notify_peer_connection.notify_one();
+        Ok(())
+    }
+
+    /// Called from `set_config_gen_connections` to add a peer's connection info
+    /// to the leader
+    pub fn add_config_gen_peer(&self, peer: PeerServerParams) -> ApiResult<()> {
+        let mut state = self.state.lock().expect("lock poisoned");
+
+        let mut connection = match &*state {
+            ConfigApiState::SetConfigGenParams(connection) => connection.clone(),
+            _ => return Self::bad_request("Not ready to receive peer server params"),
+        };
+        connection.peers.insert(peer.cert.clone(), peer);
+        *state = ConfigApiState::SetConfigGenParams(connection);
+
+        self.notify_peer_connection.notify_one();
+        Ok(())
+    }
+
+    /// Returns the peers that have called `add_config_gen_peer` on the leader
+    pub fn get_config_gen_peers(&self) -> ApiResult<Vec<PeerServerParams>> {
+        let state = self.state.lock().expect("lock poisoned");
+
+        let connection = match &*state {
+            ConfigApiState::SetConfigGenParams(connection) => connection.clone(),
+            _ => return Self::bad_request("Not ready to return peer server params"),
+        };
+
+        Ok(connection.get_peer_info())
+    }
+
+    /// Waits for at least `num_peers` connections to be added
+    pub async fn await_config_gen_peers(&self, peers: usize) -> ApiResult<Vec<PeerServerParams>> {
+        let mut peer_info = self.get_config_gen_peers()?;
+        while peer_info.len() < peers {
+            self.notify_peer_connection.notified().await;
+            peer_info = self.get_config_gen_peers()?;
+        }
+
+        Ok(peer_info)
+    }
+
+    fn bad_request<T>(msg: &str) -> ApiResult<T> {
+        Err(ApiError::bad_request(msg.to_string()))
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+/// All the connections info we configure locally without talking to peers
+#[derive(Debug, Clone)]
+pub struct ConfigGenConnections {
+    /// Bind address for our P2P connection
+    pub p2p_bind: SocketAddr,
+    /// Bind address for our API connection
+    pub api_bind: SocketAddr,
+    /// Url for our P2P connection
+    pub p2p_url: Url,
+    /// Url for our API connection
+    pub api_url: Url,
+}
+
+/// State held by the API after receiving a `ConfigGenConnectionsRequest`
+#[derive(Debug, Clone)]
+pub struct ConfigGenConnectionsState {
+    /// Our connection info configured locally
+    our_connections: ConfigGenConnections,
+    /// Our auth string
+    auth: ApiAuth,
+    /// Our TLS private key
+    _tls_private: rustls::PrivateKey,
+    /// Our TLS public cert
+    tls_cert: rustls::Certificate,
+    /// Info sent by the admin user
+    request: ConfigGenConnectionsRequest,
+    /// Connection info received from other guardians, unique by certificate
+    /// (because it's non-user configurable)
+    peers: BTreeMap<rustls::Certificate, PeerServerParams>,
+}
+
+impl ConfigGenConnectionsState {
+    fn new(
+        request: ConfigGenConnectionsRequest,
+        our_connections: ConfigGenConnections,
+        auth: ApiAuth,
+    ) -> ApiResult<Self> {
+        let (tls_cert, tls_private) = gen_cert_and_key(&request.our_name)
+            .map_err(|_| ApiError::server_error("Unable to generate TLS keys".to_string()))?;
+        Ok(Self {
+            our_connections,
+            auth,
+            _tls_private: tls_private,
+            tls_cert,
+            request,
+            peers: Default::default(),
+        })
+    }
+
+    fn with_request(mut self, request: ConfigGenConnectionsRequest) -> Self {
+        self.request = request;
+        self
+    }
+
+    fn as_peer_info(&self) -> PeerServerParams {
+        PeerServerParams {
+            cert: self.tls_cert.clone(),
+            p2p_url: self.our_connections.p2p_url.clone(),
+            api_url: self.our_connections.api_url.clone(),
+            name: self.request.our_name.clone(),
+        }
+    }
+
+    fn get_peer_info(&self) -> Vec<PeerServerParams> {
+        self.peers
+            .values()
+            .cloned()
+            .chain(once(self.as_peer_info()))
+            .collect()
+    }
+}
+
+/// The current state of config generation, required in a top-to-bottom order
+#[derive(Debug, Clone)]
 /// State machine for config generation, required in a top-to-bottom order
 pub enum ConfigApiState {
     /// Guardian must first enter a password for auth/decryption
     SetPassword,
-    /// Guardian must add connection info for at least 1 peer
-    SetPeerConnectionInfo(ApiAuth),
-    /// A guardian (possibly us) must set the config gen parameters
-    SetConfigParams,
+    /// Guardians must send connection info to a "leader"
+    SetConnections(ApiAuth),
+    /// A "leader" guardian (possibly us) must set the config gen parameters
+    SetConfigGenParams(ConfigGenConnectionsState),
     /// Guardian must verify the correct config gen params
     VerifyConfigParams,
     /// Running DKG may take a minute
@@ -69,18 +232,24 @@ pub enum ConfigApiState {
 }
 
 #[async_trait]
-impl HasApiContext<ConfigApi> for ConfigApi {
+impl HasApiContext<ConfigGenApi> for ConfigGenApi {
     async fn context(
         &self,
         request: &ApiRequestErased,
         id: Option<ModuleInstanceId>,
-    ) -> (&ConfigApi, ApiEndpointContext<'_>) {
+    ) -> (&ConfigGenApi, ApiEndpointContext<'_>) {
         let dbtx = self.db.begin_transaction().await;
         let state = self.state.lock().expect("locks");
+        let auth = request.auth.as_ref();
         let has_auth = match &*state {
-            ConfigApiState::SetPeerConnectionInfo(info) => Some(info.clone()) == request.auth,
             // The first client to connect gets the set the password
-            _ => true,
+            ConfigApiState::SetPassword => true,
+            ConfigApiState::SetConnections(api_auth) => Some(api_auth) == auth,
+            ConfigApiState::SetConfigGenParams(connections) => Some(&connections.auth) == auth,
+            ConfigApiState::VerifyConfigParams => false,
+            ConfigApiState::RunningDkg => false,
+            ConfigApiState::VerifyConsensusConfig => false,
+            ConfigApiState::RunningConsensus => false,
         };
 
         (self, ApiEndpointContext::new(has_auth, dbtx, id))
@@ -89,9 +258,13 @@ impl HasApiContext<ConfigApi> for ConfigApi {
 
 /// Starts the configuration server
 // TODO: combine with net::run_server and replace DKG CLI with the API
-pub async fn run_server(data_dir: PathBuf, bind_api: SocketAddr, db: Database) -> ServerHandle {
+pub async fn run_server(
+    data_dir: PathBuf,
+    our_connections: ConfigGenConnections,
+    db: Database,
+) -> ServerHandle {
     let state = RpcHandlerCtx {
-        rpc_context: Arc::new(ConfigApi::new(data_dir, bind_api, db)),
+        rpc_context: Arc::new(ConfigGenApi::new(data_dir, our_connections.clone(), db)),
     };
     let mut rpc_module = RpcModule::new(state);
 
@@ -100,7 +273,7 @@ pub async fn run_server(data_dir: PathBuf, bind_api: SocketAddr, db: Database) -
     ServerBuilder::new()
         .max_connections(10)
         .ping_interval(Duration::from_secs(10))
-        .build(&bind_api.to_string())
+        .build(&our_connections.api_bind.to_string())
         .await
         .expect("Could not start API server")
         .start(rpc_module)
@@ -108,17 +281,55 @@ pub async fn run_server(data_dir: PathBuf, bind_api: SocketAddr, db: Database) -
 }
 
 /// Returns the endpoints that are necessary prior to the config being generated
-fn config_endpoints() -> Vec<ApiEndpoint<ConfigApi>> {
-    vec![api_endpoint! {
-        "/set_password",
-        async |config: &ConfigApi, _context, auth: ApiAuth| -> () {
-            config.set_password(auth)
-        }
-    }]
+fn config_endpoints() -> Vec<ApiEndpoint<ConfigGenApi>> {
+    vec![
+        api_endpoint! {
+            "/set_password",
+            async |config: &ConfigGenApi, context, auth: ApiAuth| -> () {
+                check_auth(context)?;
+                config.set_password(auth)
+            }
+        },
+        api_endpoint! {
+            "/set_config_gen_connections",
+            async |config: &ConfigGenApi, context, server: ConfigGenConnectionsRequest| -> () {
+                check_auth(context)?;
+                config.set_config_gen_connections(server).await
+            }
+        },
+        api_endpoint! {
+            "/add_config_gen_peer",
+            async |config: &ConfigGenApi, _context, peer: PeerServerParams| -> () {
+                // No auth required since this is an API-to-API call and the peer connections will be manually accepted or not in the UI
+                config.add_config_gen_peer(peer)
+            }
+        },
+        api_endpoint! {
+            "/get_config_gen_peers",
+            async |config: &ConfigGenApi, _context, _v: ()| -> Vec<PeerServerParams> {
+                config.get_config_gen_peers()
+            }
+        },
+        api_endpoint! {
+            "/await_config_gen_peers",
+            async |config: &ConfigGenApi, _context, peers: usize| -> Vec<PeerServerParams> {
+                config.await_config_gen_peers(peers).await
+            }
+        },
+    ]
+}
+
+fn check_auth(context: &mut ApiEndpointContext) -> ApiResult<()> {
+    if !context.has_auth() {
+        Err(ApiError::unauthorized())
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+
     use std::path::PathBuf;
     use std::{env, fs};
 
@@ -129,36 +340,67 @@ mod tests {
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::module::ApiAuth;
     use fedimint_core::PeerId;
+    use itertools::Itertools;
     use jsonrpsee::server::ServerHandle;
+    use url::Url;
 
-    use crate::config::api::run_server;
+    use crate::config::api::{run_server, ConfigGenConnections, ConfigGenConnectionsRequest};
 
     /// Helper in config API tests for simulating a guardian's client and server
     struct TestConfigApi {
         client: WsAdminClient,
         server: ServerHandle,
         auth: ApiAuth,
+        name: String,
+        our_connections: ConfigGenConnections,
     }
 
     impl TestConfigApi {
+        /// Creates a new test API taking up a port, with P2P endpoint on the
+        /// next port
+        async fn new(port: u16, name_suffix: u16, data_dir: PathBuf) -> TestConfigApi {
+            let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
+
+            let name = format!("peer{name_suffix}").to_string();
+            let api_bind = format!("127.0.0.1:{port}").parse().expect("parses");
+            let api_url: Url = format!("ws://127.0.0.1:{port}").parse().expect("parses");
+            let p2p_bind = format!("127.0.0.1:{}", port + 1).parse().expect("parses");
+            let p2p_url = format!("ws://127.0.0.1:{}", port + 1)
+                .parse()
+                .expect("parses");
+            let our_connections = ConfigGenConnections {
+                p2p_bind,
+                api_bind,
+                p2p_url,
+                api_url: api_url.clone(),
+            };
+            let server = run_server(data_dir.clone(), our_connections.clone(), db).await;
+            // our id doesn't really exist at this point
+            let auth = ApiAuth(format!("password-{port}"));
+            let client = WsAdminClient::new(api_url.clone(), PeerId::from(0), auth.clone());
+
+            TestConfigApi {
+                client,
+                server,
+                auth,
+                name,
+                our_connections,
+            }
+        }
+
+        /// Helper function using the auth we generated
         async fn set_password(&self) -> FederationResult<()> {
             self.client.set_password(self.auth.clone()).await
         }
-    }
 
-    async fn server_client(port: u16, data_dir: PathBuf) -> TestConfigApi {
-        let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
-
-        let socket = format!("127.0.0.1:{port}").parse().expect("parses");
-        let url = format!("ws://127.0.0.1:{port}").parse().expect("parses");
-        let server = run_server(data_dir.clone(), socket, db).await;
-        // our id doesn't really exist at this point
-        let auth = ApiAuth(format!("password-{port}"));
-        let client = WsAdminClient::new(url, PeerId::from(0), auth.clone());
-        TestConfigApi {
-            client,
-            server,
-            auth,
+        /// Helper function using generated urls
+        async fn set_connections(&self, leader: &Option<Url>) -> FederationResult<()> {
+            self.client
+                .set_config_gen_connections(ConfigGenConnectionsRequest {
+                    our_name: self.name.clone(),
+                    leader_api_url: leader.clone(),
+                })
+                .await
         }
     }
 
@@ -180,13 +422,35 @@ mod tests {
         fs::create_dir(data_dir.clone()).expect("Unable to create test dir");
 
         // TODO: Choose port in common way with `fedimint_env`
-        let api1 = server_client(18103, data_dir.clone()).await;
+        let base_port = 18103;
+        let mut leader = TestConfigApi::new(base_port, 0, data_dir.clone()).await;
 
-        api1.set_password().await.unwrap();
         // Cannot set the password twice
-        assert!(api1.set_password().await.is_err());
+        leader.set_password().await.unwrap();
+        assert!(leader.set_password().await.is_err());
 
-        api1.server.stop().expect("stops");
+        // We can call this twice to change the leader name
+        leader.set_connections(&None).await.unwrap();
+        leader.name = "leader".to_string();
+        leader.set_connections(&None).await.unwrap();
+
+        // Setup followers and send connection info
+        for i in 1..=3 {
+            let port = base_port + (i * 2);
+            let mut follower = TestConfigApi::new(port, i, data_dir.clone()).await;
+            follower.set_password().await.unwrap();
+            let leader_url = Some(leader.our_connections.api_url.clone());
+            follower.set_connections(&leader_url).await.unwrap();
+            follower.name = format!("{}!", follower.name);
+            follower.set_connections(&leader_url).await.unwrap();
+        }
+
+        // Confirm we can get peer servers if we are the leader
+        let peers = leader.client.await_config_gen_peers(4).await.unwrap();
+        let names: Vec<_> = peers.into_iter().map(|peer| peer.name).sorted().collect();
+        assert_eq!(names, vec!["leader", "peer1!", "peer2!", "peer3!"]);
+
+        leader.server.stop().expect("stops");
         fs::remove_dir(data_dir).expect("Unable to remove dir");
     }
 }

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -8,6 +8,7 @@ use bitcoin_hashes::hex::{FromHex, ToHex};
 use fedimint_aead::{
     encrypted_read, encrypted_write, get_encryption_key, random_salt, LessSafeKey,
 };
+use fedimint_core::admin_client::PeerServerParams;
 use fedimint_core::api::WsClientConnectInfo;
 use fedimint_core::config::ServerModuleGenRegistry;
 use serde::de::DeserializeOwned;
@@ -15,7 +16,7 @@ use serde::Serialize;
 use tokio_rustls::rustls;
 use url::Url;
 
-use crate::config::{gen_cert_and_key, PeerServerParams, ServerConfig};
+use crate::config::{gen_cert_and_key, ServerConfig};
 
 /// Version of the server code (should be the same among peers)
 pub const CODE_VERSION: &str = env!("CODE_VERSION");

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -8,6 +8,7 @@ use anyhow::{bail, format_err, Context};
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::sha256::HashEngine;
 use fedimint_aead::{encrypted_read, get_encryption_key, get_password_hash};
+use fedimint_core::admin_client::PeerServerParams;
 use fedimint_core::cancellable::Cancelled;
 pub use fedimint_core::config::*;
 use fedimint_core::config::{
@@ -102,7 +103,7 @@ pub struct ServerConfigConsensus {
     /// Network addresses and names for all peer APIs
     pub api_endpoints: BTreeMap<PeerId, ApiEndpoint>,
     /// Certs for TLS communication, required for peer authentication
-    #[serde(with = "serde_tls_cert")]
+    #[serde(with = "serde_tls_cert_map")]
     pub tls_certs: BTreeMap<PeerId, rustls::Certificate>,
     /// All configuration that needs to be the same for modules
     #[encodable_ignore]
@@ -570,14 +571,6 @@ impl ServerConfig {
     }
 }
 
-#[derive(Clone)]
-pub struct PeerServerParams {
-    pub cert: rustls::Certificate,
-    pub p2p_url: Url,
-    pub api_url: Url,
-    pub name: String,
-}
-
 impl ServerConfigParams {
     pub fn peers(&self) -> BTreeMap<PeerId, ApiEndpoint> {
         self.p2p_network
@@ -800,7 +793,7 @@ pub fn gen_cert_and_key(
     ))
 }
 
-mod serde_tls_cert {
+mod serde_tls_cert_map {
     use std::borrow::Cow;
     use std::collections::BTreeMap;
 


### PR DESCRIPTION
Second iteration on the config gen API.

Adds the ability of peers to send their server connections to a leader and then the leader to return the list of peers that have connected.

Related to https://github.com/fedimint/fedimint/issues/1893 https://github.com/fedimint/fedimint/issues/1628