### PR TITLE
feat: add `federation_id` filter and details on gateway-cli info

### DIFF
--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -43,7 +43,7 @@ impl GatewayTest {
 
     /// Returns the last registration we sent to a fed
     pub async fn last_registered(&self) -> LightningGateway {
-        let info = self.get_rpc().await.get_info().await;
+        let info = self.get_rpc().await.get_info(None).await;
         let fed = info.expect("Failed to get_info").federations;
         fed.last().expect("No feds registered").registration.clone()
     }

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -16,10 +16,10 @@ axum = "0.6.4"
 axum-macros = "0.3.1"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
-ln-gateway = { path= "../ln-gateway" }
 fedimint-client-legacy = { path = "../../fedimint-client-legacy" }
-fedimint-core ={ path = "../../fedimint-core" }
+fedimint-core = { path = "../../fedimint-core" }
 fedimint-logging = { path = "../../fedimint-logging" }
+ln-gateway = { path= "../ln-gateway" }
 reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }
 rpassword = "7.2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -30,8 +30,9 @@ struct Cli {
 pub enum Commands {
     /// Display CLI version hash
     VersionHash,
-    /// Display high-level information about the Gateway
-    Info,
+    /// Display high-level information about the Gateway, or display in-depth
+    /// Federation information for given [FederationId]
+    Info { federation_id: Option<FederationId> },
     /// Check gateway balance
     Balance {
         #[clap(long)]
@@ -97,8 +98,8 @@ async fn main() -> anyhow::Result<()> {
         Commands::VersionHash => {
             println!("version: {}", env!("CODE_VERSION"));
         }
-        Commands::Info => {
-            let response = client.get_info().await?;
+        Commands::Info { federation_id } => {
+            let response = client.get_info(federation_id).await?;
 
             print_response(response).await;
         }

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -655,11 +655,22 @@ impl GatewayActor {
         Ok(self.client.summary().await.total_amount())
     }
 
-    pub fn get_info(&self) -> Result<FederationInfo> {
-        let cfg = self.client.config();
+    pub async fn get_detailed_info(&self) -> Result<FederationInfo> {
+        let summary_info = self.get_summary_info()?;
+        let balance = self.get_balance().await?;
+
         Ok(FederationInfo {
-            federation_id: cfg.client_config.federation_id,
-            registration: self.registration.lock().expect("poisoned").clone(),
+            federation_id: summary_info.federation_id,
+            registration: summary_info.registration,
+            balance: Some(balance),
         })
+    }
+
+    pub fn get_summary_info(&self) -> Result<FederationInfo> {
+        let cfg = self.client.config();
+        Ok(FederationInfo::new(
+            cfg.client_config.federation_id,
+            self.registration.lock().expect("poisoned").clone(),
+        ))
     }
 }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -122,6 +122,19 @@ pub struct FederationInfo {
     pub federation_id: FederationId,
     /// Information we registered with the fed
     pub registration: LightningGateway,
+    /// The current federation balance
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub balance: Option<Amount>,
+}
+
+impl FederationInfo {
+    pub fn new(federation_id: FederationId, registration: LightningGateway) -> Self {
+        FederationInfo {
+            federation_id,
+            registration,
+            balance: None,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -65,7 +65,9 @@ pub struct ConnectFedPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct InfoPayload;
+pub struct InfoPayload {
+    pub federation_id: Option<FederationId>,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BackupPayload {

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -1,6 +1,7 @@
 use std::result::Result;
 
 use bitcoin::Address;
+use fedimint_core::config::FederationId;
 use fedimint_core::{Amount, TransactionId};
 use reqwest::StatusCode;
 pub use reqwest::{Error, Response};
@@ -37,8 +38,16 @@ impl GatewayRpcClient {
         GatewayRpcClient::new(self.base_url.clone(), password)
     }
 
-    pub async fn get_info(&self) -> GatewayRpcResult<GatewayInfo> {
-        let url = self.base_url.join("/info").expect("invalid base url");
+    pub async fn get_info(
+        &self,
+        federation_id: Option<FederationId>,
+    ) -> GatewayRpcResult<GatewayInfo> {
+        let path = match federation_id {
+            Some(id) => format!("/info?federation_id={id}"),
+            None => "/info".to_string(),
+        };
+
+        let url = self.base_url.join(path.as_str()).expect("invalid base url");
         self.call(url, ()).await
     }
 

--- a/gateway/ln-gateway/tests/authentication_tests.rs
+++ b/gateway/ln-gateway/tests/authentication_tests.rs
@@ -40,8 +40,8 @@ async fn gatewayd_api_authentication() -> anyhow::Result<()> {
     auth_fails(|| client2.connect_federation(payload.clone())).await;
 
     // Test gateway authentication on `get_info` function
-    auth_success(|| client1.get_info()).await;
-    auth_fails(|| client2.get_info()).await;
+    auth_success(|| client1.get_info(None)).await;
+    auth_fails(|| client2.get_info(None)).await;
 
     // Test gateway authentication on `get_balance` function
     let payload = BalancePayload { federation_id };

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -12,7 +12,7 @@ use ln_gateway::rpc::ConnectFedPayload;
 async fn gatewayd_supports_connecting_multiple_federations() {
     let (_, rpc, fed1, fed2, _) = fixtures::fixtures(None).await;
 
-    assert_eq!(rpc.get_info().await.unwrap().federations.len(), 0);
+    assert_eq!(rpc.get_info(None).await.unwrap().federations.len(), 0);
 
     let connection1 = fed1.connection_code();
     let info = rpc
@@ -38,14 +38,14 @@ async fn gatewayd_supports_connecting_multiple_federations() {
 async fn gatewayd_shows_info_about_all_connected_federations() {
     let (_, rpc, fed1, fed2, _) = fixtures::fixtures(None).await;
 
-    assert_eq!(rpc.get_info().await.unwrap().federations.len(), 0);
+    assert_eq!(rpc.get_info(None).await.unwrap().federations.len(), 0);
 
     let id1 = fed1.connection_code().id;
     let id2 = fed2.connection_code().id;
 
     connect_federations(&rpc, &[fed1, fed2]).await.unwrap();
 
-    let info = rpc.get_info().await.unwrap();
+    let info = rpc.get_info(None).await.unwrap();
 
     assert_eq!(info.federations.len(), 2);
     assert!(info

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -59,6 +59,13 @@ async fn gatewayd_shows_info_about_all_connected_federations() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn gatewayd_shows_detailed_info_about_filtered_federation() -> anyhow::Result<()> {
+    // todo: implement test case
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn gatewayd_shows_balance_for_any_connected_federation() -> anyhow::Result<()> {
     // todo: implement test case
 


### PR DESCRIPTION
## Description
The gatewayd info currently returns only high-level information related to the gateway and all federations, as discussed in #1725 it would be useful to have a way to get the information related to a specific federation, therefore filtering the information by a `federation_id`.

That said, this PR aims to add this feature by making it possible to get gatewayd info filtered for a federation, when passing a federation_id.

## How
This PR adds:
- gateway-cli: adds a new `FederationId` optional parameter for the `Info` command.
- rpc-client: updates the `get_info` to expect an optional `FederationId` parameter, and calls the rpc-server with a `QueryParam` as `?federation_id=` when it has been passed, with no query param otherwise.
- rpc-server: updates the `/info` route handler to use the `QueryParam` axum extractor, it handles both when param, empty or none param is passed as guided here: https://github.com/tokio-rs/axum/blob/main/examples/query-params-with-empty-strings/src/main.rs
- ln-gateway: updates the `handle_info` to expect a `FederationId` field on the `InfoPayload` parameter, filters the selected actor, and use a new `get_detailed_info` `GatewayActor method if a federation_id is passed, old behavior otherwise.
- **_wip(integration-test):_** adds a new test for getting detailed info, when passing a federation_id.

fixes #1725  