### PR TITLE
chore: debug build with release-profile level of debug symbols

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -50,26 +50,26 @@ jobs:
         continue-on-error: true
 
       - name: Build workspace
-        run: nix build -L .#debug.workspaceBuild
+        run: nix build -L .#ci.workspaceBuild
 
       - name: Clippy workspace
-        run: nix build -L .#debug.workspaceClippy
+        run: nix build -L .#ci.workspaceClippy
 
       - name: Run cargo doc
-        run: nix build -L .#debug.workspaceDoc
+        run: nix build -L .#ci.workspaceDoc
 
       - name: Run cargo audit
-        run: nix build -L .#debug.workspaceAudit
+        run: nix build -L .#ci.workspaceAudit
 
       # `ccov` job will run `cargo test`, so no need to spend time on it here
       # - name: Test workspace
       #   run: nix build -L .#workspaceTest
 
       - name: Test docs
-        run: nix build -L .#debug.workspaceTestDoc
+        run: nix build -L .#ci.workspaceTestDoc
 
       - name: Tests
-        run: nix build -L .#debug.cli-test.all
+        run: nix build -L .#ci.cli-test.all
 
   # Code Coverage will build using a completely different profile (neither debug/release)
   # Which means we can not reuse much from `build` job. Might as well run it as another
@@ -90,7 +90,7 @@ jobs:
         continue-on-error: true
 
       - name: Build and run tests with Code Coverage
-        run: nix build -L .#debug.workspaceCov
+        run: nix build -L .#ci.workspaceCov
 
       - name: Ensure lcov.info exists
         run: test -f result/lcov.info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
 [profile.dev]
 split-debuginfo = "packed"
-debug = 1
 
 # in dev mode optimize crates that are perf-critical (usually just crypto crates)
 [profile.dev.package]
@@ -72,6 +71,12 @@ bls12_381 = { opt-level = 3 }
 subtle = { opt-level = 3 }
 ring = { opt-level = 3 }
 threshold_crypto = { opt-level = 3 }
+
+
+[profile.ci]
+inherits = "dev"
+split-debuginfo = "packed"
+debug = 1
 
 [patch.crates-io]
 secp256k1-zkp = { git = "https://github.com/dpc/rust-secp256k1-zkp/", branch = "sanket-pr" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
 [profile.dev]
 split-debuginfo = "packed"
+debug = 1
 
 # in dev mode optimize crates that are perf-critical (usually just crypto crates)
 [profile.dev.package]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,7 +31,7 @@ cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}}
 
 # Define temporary directories to not overwrite manually created config if run locally
 export FM_TEST_DIR=$FM_TMP_DIR
-export FM_BIN_DIR="$SRC_DIR/target/debug"
+export FM_BIN_DIR="$SRC_DIR/target/${CARGO_PROFILE:-debug}"
 export FM_PID_FILE="$FM_TMP_DIR/.pid"
 export FM_CLN_DIR="$FM_TEST_DIR/cln"
 export FM_LND_DIR="$FM_TEST_DIR/lnd"


### PR DESCRIPTION
Before (`nix build #.debug.workspaceBuild`, uncompressed => compressed):

```
fedimint-workspace-build> /*stdin*\            : 17.83%   (  9.16 GiB =>   1.63 GiB, /nix/store/mfy5k84rxqfh3x7ss3wwnyxf8z1zv752-fedimint-workspace-build-0.0.1/target.tar.zst)
```

After:

```
fedimint-workspace-build> /*stdin*\            : 17.46%   (  6.57 GiB =>   1.15 GiB, /nix/store/j7gh6rsi65g2ld3z3wkqdn8ymfyjl7j4-fedimint-workspace-build-0.0.1/target.tar.zst)
```

According to https://users.rust-lang.org/t/keeping-debug-info-but-smaller/55009/3 `debug=1` is the same level that release build uses, which should be adequate for CI.

BTW. If you're curious, `debug=0` produces:

```
fedimint-workspace-build> /*stdin*\            : 18.85%   (  4.04 GiB =>    779 MiB, /nix/store/4f5niazddwy5gk00bnzspxsph0iwp3ch-fedimint-workspace-build-0.0.1/target.tar.zst)
```