### PR TITLE
chore: skip eof check on all files under `./db`

### DIFF
--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -121,11 +121,7 @@ function check_eof() {
   set -eo pipefail
 
   errors=""
-  for path in $(echo "$git_ls_files" | grep -v -E '.*\.(ods|jpg|png|log)'); do
-    # Skip checking files named IDENTITY since DB contains files without newline at the end
-    if [[ "$path" == *"IDENTITY"* ]]; then
-      continue
-    fi
+  for path in $(echo "$git_ls_files" | grep -v -E '.*\.(ods|jpg|png|log)' | grep -v -E '^db/'); do
 
     # extra branches for clarity
     if [ ! -s "$path" ]; then


### PR DESCRIPTION
Previous checks produces warnings.