### PR TITLE
Make gateway-cln-extension exit smoothly

### DIFF
--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -13,7 +13,6 @@ use clap::Parser;
 use cln_plugin::{options, Builder, Plugin};
 use cln_rpc::model;
 use cln_rpc::primitives::ShortChannelId;
-use fedimint_core::task::TaskGroup;
 use fedimint_core::Amount;
 use ln_gateway::gatewaylnrpc::complete_htlcs_request::{Action, Cancel, Settle};
 use ln_gateway::gatewaylnrpc::gateway_lightning_server::{
@@ -47,8 +46,6 @@ pub struct ClnExtensionOpts {
 // within cln-plugin
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let tg = TaskGroup::new();
-
     let (service, listen, plugin) = ClnRpcService::new()
         .await
         .expect("Failed to create cln rpc service");
@@ -64,7 +61,6 @@ async fn main() -> Result<(), anyhow::Error> {
             // Wait for plugin to signal it's shutting down
             // Shut down everything else via TaskGroup regardless of error
             let _ = plugin.join().await;
-            tg.shutdown().await;
         })
         .await
         .map_err(|e| ClnExtensionError::Error(anyhow!("Failed to start server, {:?}", e)))?;

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -61,6 +61,9 @@ async fn main() -> Result<(), anyhow::Error> {
             // Wait for plugin to signal it's shutting down
             // Shut down everything else via TaskGroup regardless of error
             let _ = plugin.join().await;
+            // lightningd needs to see exit code 0 to notice the plugin has
+            // terminated -- even if we return from main().
+            std::process::exit(0);
         })
         .await
         .map_err(|e| ClnExtensionError::Error(anyhow!("Failed to start server, {:?}", e)))?;


### PR DESCRIPTION
Before this PR, when you call `lightning-cli plugin stop gateway-cln-extension` you'd hit a 30 second timeout before the extension exited, and `pkill -9 lightningd` would usually leave the extension running.

After this PR, both exist smoothly and instantly.