### PR TITLE
chore: clean&unify `--data-dir` argument to fedimintd and fedimint-cli

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -285,7 +285,7 @@ impl fmt::Display for CliError {
 #[command(version)]
 struct Opts {
     /// The working directory of the client containing the config and db
-    #[arg(long = "workdir")]
+    #[arg(long = "data-dir", alias = "workdir", env = "FM_DATA_DIR")]
     workdir: Option<PathBuf>,
 
     #[clap(subcommand)]
@@ -296,7 +296,7 @@ impl Opts {
     fn workdir(&self) -> CliResult<&PathBuf> {
         self.workdir
             .as_ref()
-            .ok_or_cli_msg(CliErrorKind::IOError, "`--workdir=` argument not set.")
+            .ok_or_cli_msg(CliErrorKind::IOError, "`--data-dir=` argument not set.")
     }
 
     fn load_config(&self) -> CliResult<UserClientConfig> {

--- a/docs/dev-running.md
+++ b/docs/dev-running.md
@@ -190,7 +190,7 @@ There also exist some other, more experimental commands that can be explored usi
 ```shell
 $ fedimint-cli help
 
-Usage: fedimint-cli --workdir <WORKDIR> <COMMAND>
+Usage: fedimint-cli --data-dir <WORKDIR> <COMMAND>
 
 Commands:
   version-hash         Print the latest git commit hash this bin. was build with
@@ -221,7 +221,7 @@ Commands:
   help                 Print this message or the help of the given subcommand(s)
 
 Options:
-      --workdir <WORKDIR>  The working directory of the client containing the config and db
+      --data-dir <WORKDIR>  The working directory of the client containing the config and db
   -h, --help               Print help
   -V, --version            Print version
 ```

--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -280,6 +280,7 @@ async fn run_fedimintd(id: usize) -> anyhow::Result<()> {
 
     // spawn fedimintd
     let mut fedimintd = Command::new(format!("{bin_dir}/fedimintd"))
+        .arg("--data-dir")
         .arg(data_dir)
         .envs(env_vars)
         .spawn()?;

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -31,6 +31,7 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 #[derive(Parser)]
 pub struct ServerOpts {
     /// Path to folder containing federation config files
+    #[arg(long = "data-dir", env = "FM_DATA_DIR")]
     pub data_dir: PathBuf,
     /// Password to encrypt sensitive config files
     // TODO: should probably never send password to the server directly, rather send the hash via

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -70,7 +70,7 @@ mkdir -p $FM_GATEWAY_DATA_DIR
 export FM_LIGHTNING_CLI="lightning-cli --network regtest --lightning-dir=$FM_CLN_DIR"
 export FM_LNCLI="lncli -n regtest --lnddir=$FM_LND_DIR --rpcserver=localhost:11009"
 export FM_BTC_CLIENT="bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin"
-export FM_MINT_CLIENT="$FM_BIN_DIR/fedimint-cli --workdir $FM_CFG_DIR"
+export FM_MINT_CLIENT="$FM_BIN_DIR/fedimint-cli --data-dir $FM_CFG_DIR"
 export FM_MINT_RPC_CLIENT="$FM_BIN_DIR/mint-rpc-client"
 export FM_GWCLI_CLN="$FM_BIN_DIR/gateway-cli --rpcpassword=theresnosecondbest"
 export FM_GWCLI_LND="$FM_BIN_DIR/gateway-cli --rpcpassword=theresnosecondbest -a http://127.0.0.1:28175/"

--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -83,7 +83,7 @@ function generate_bitcoind_container_def() {
 function generate_fedimintd_container_def() {
     echo "  server-$1:" >> $6
     echo "    image: $5" >> $6
-    echo "    command: fedimintd /var/fedimint" >> $6
+    echo "    command: fedimintd --data-dir /var/fedimint" >> $6
     echo "    ports:" >> $6
     echo "      - $2:$2" >> $6
     echo "      - $3:$3" >> $6


### PR DESCRIPTION
* Make it possible to pass by env variable
* Make it always explicit, not positional
* Use the same name (keep an alias for easier transation)