### PR TITLE
Gateway connect* API renames

### DIFF
--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -100,7 +100,7 @@ impl RpcClient {
         password: String,
         payload: LightningReconnectPayload,
     ) -> Result<Response, Error> {
-        let url = self.base_url.join("/reconnect").expect("invalid base url");
+        let url = self.base_url.join("/connect-ln").expect("invalid base url");
         self.call(url, password, payload).await
     }
 

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -70,7 +70,10 @@ impl RpcClient {
         password: String,
         payload: ConnectFedPayload,
     ) -> Result<Response, Error> {
-        let url = self.base_url.join("/connect").expect("invalid base url");
+        let url = self
+            .base_url
+            .join("/connect-fed")
+            .expect("invalid base url");
         self.call(url, password, payload).await
     }
 

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -31,7 +31,7 @@ pub async fn run_webserver(
         .route("/address", post(address))
         .route("/deposit", post(deposit))
         .route("/withdraw", post(withdraw))
-        .route("/connect", post(connect))
+        .route("/connect-fed", post(connect_fed))
         .route("/backup", post(backup))
         .route("/restore", post(restore))
         .route("/reconnect", post(reconnect))
@@ -117,7 +117,7 @@ async fn pay_invoice(
 
 /// Connect a new federation
 #[instrument(skip_all, err)]
-async fn connect(
+async fn connect_fed(
     Extension(rpc): Extension<GatewayRpcSender>,
     Json(payload): Json<ConnectFedPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -34,7 +34,7 @@ pub async fn run_webserver(
         .route("/connect-fed", post(connect_fed))
         .route("/backup", post(backup))
         .route("/restore", post(restore))
-        .route("/reconnect", post(reconnect))
+        .route("/connect-ln", post(connect_ln))
         .layer(RequireAuthorizationLayer::bearer(&authkey));
 
     let app = Router::new()
@@ -147,7 +147,7 @@ async fn restore(
 
 // Reconnect to the lightning node
 #[instrument(skip_all, err)]
-async fn reconnect(
+async fn connect_ln(
     Extension(rpc): Extension<GatewayRpcSender>,
     Json(payload): Json<LightningReconnectPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {


### PR DESCRIPTION
#2019 added `/reconnect` API to the gateway. However, `/connect` and `/reconnect` are very confusing and poorly named APIs which don't say much about the underlying functionality. This PR proposes a rename of the following form:

   - `/connect` > `/connect-fed`
   - `/reconnect` > `/connect-ln`
