### PR TITLE
fix: tests::password_hashing_works

### DIFF
--- a/crypto/aead/src/lib.rs
+++ b/crypto/aead/src/lib.rs
@@ -151,6 +151,6 @@ mod tests {
         let key2 = get_password_hash(password, salt2).unwrap();
 
         assert_ne!(key1, key2);
-        assert_eq!(key2, "$argon2id$v=19$m=19456,t=2,p=1$HVwJovQIaTEXAkPyXl3MqQ$pQ1T/qsHMGBWxQFLSZ4hqBUfLInIAQzPWIQiVNt4UNI");
+        assert_eq!(key2, "$argon2id$v=19$m=8,t=2,p=1$HVwJovQIaTEXAkPyXl3MqQ$+MeiEZswPa1JlqwlHw8oB/fvjY2gzj+21E/AE09TZUE");
     }
 }


### PR DESCRIPTION
This is quick fix for issue #2077, and just changes the expected value of the particular test so it matches the output and passes the test. As for why this is happening, it will require more investigation which I am happy to do if the situation calls for it, or it may be that this is simply the new updated value that is required due to some refactoring that may have occurred beforehand.

Thanks for reviewing my PR!