### PR TITLE
refactor: simplify lightning connection logic

### DIFF
--- a/fedimint-testing/src/ln/fixtures.rs
+++ b/fedimint-testing/src/ln/fixtures.rs
@@ -159,14 +159,4 @@ impl ILnRpcClient for FakeLightningTest {
 
         Ok(CompleteHtlcsResponse {})
     }
-
-    async fn connect(&mut self) -> ln_gateway::Result<()> {
-        self.is_connected = true;
-        Ok(())
-    }
-
-    async fn disconnect(&mut self) -> ln_gateway::Result<()> {
-        self.is_connected = false;
-        Ok(())
-    }
 }

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -123,16 +123,12 @@ impl GatewayActor {
         stream: &mut HTLCStream,
         receiver: &mut Receiver<Arc<AtomicBool>>,
         gw_rpc_copy: GatewayRpcSender,
-        lnrpc: Arc<RwLock<dyn ILnRpcClient>>,
     ) -> Option<SubscribeInterceptHtlcsResponse> {
         tokio::select! {
             msg = stream.next() => match msg {
                 Some(Ok(msg)) => Some(msg),
                 Some(Err(e)) => {
                     warn!("Error sent over HTLC subscription: {}. Sending reconnect RPC", e);
-                    // Disconnect the lightning node connection in case the RPC fails
-                    lnrpc.write().await.disconnect().await.expect("Error disconnecting the lightning node connection");
-
                     // Sending a `LightningReconnectPayload` with `node_type` as None will use the existing
                     // credentials to reconnect to the same node.
                     let reconnect_req = LightningReconnectPayload { node_type: None };
@@ -182,7 +178,6 @@ impl GatewayActor {
                         &mut stream,
                         &mut receiver,
                         gw_rpc_copy.clone(),
-                        lnrpc_copy.clone(),
                     )
                     .await
                     {

--- a/gateway/ln-gateway/tests/fixtures/mod.rs
+++ b/gateway/ln-gateway/tests/fixtures/mod.rs
@@ -48,7 +48,7 @@ pub async fn fixtures(api_addr: Url) -> Result<Fixtures> {
     // Create task group for controlled shutdown of the gateway
     let task_group = TaskGroup::new();
 
-    let gateway = Gateway::new(
+    let gateway = Gateway::new_with_lightning_connection(
         lnrpc,
         client_builder,
         decoders,

--- a/integrationtests/tests/fixtures/utils.rs
+++ b/integrationtests/tests/fixtures/utils.rs
@@ -84,12 +84,4 @@ impl ILnRpcClient for LnRpcAdapter {
     ) -> ln_gateway::Result<CompleteHtlcsResponse> {
         self.client.read().await.complete_htlc(complete).await
     }
-
-    async fn connect(&mut self) -> ln_gateway::Result<()> {
-        self.client.write().await.connect().await
-    }
-
-    async fn disconnect(&mut self) -> ln_gateway::Result<()> {
-        self.client.write().await.disconnect().await
-    }
 }


### PR DESCRIPTION
PR to simplify `gatewayd`'s lightning reconnection logic. `connect` and `disconnect` no longer exist and the `connect` logic is moved into the constructor of CLN or LND client. Fixes: https://github.com/fedimint/fedimint/issues/2069

I attempted to use `ArcSwap` but ran into difficulties since `ArcSwap` is not cloneable and each actor currently needs access to the lightning connection. 