### PR TITLE
gateway: skip connecting to federation if already connected

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -252,6 +252,8 @@ impl Gateway {
             GatewayError::Other(anyhow::anyhow!("Invalid federation member string {}", e))
         })?;
 
+        let _ = self.select_actor(connect.id.clone()).await?;
+
         let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.read().await.info().await?;
         let node_pub_key = PublicKey::from_slice(&pub_key)
             .map_err(|e| GatewayError::Other(anyhow!("Invalid node pubkey {}", e)))?;


### PR DESCRIPTION
Just skips connecting to it if the node is already connected
Related: https://github.com/fedimint/fedimint/issues/1866 (needs further looking into)