### PR TITLE
feat: Avoid loading all notes in memory

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -699,6 +699,7 @@ impl FedimintCli {
                 ),
             Command::Info => {
                 let client = cli.build_client(&self.module_gens).await?;
+                // FIXME: replace by methods that don't load everything in memory
                 let notes = client.notes().await;
                 let details_vec = notes
                     .iter()

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -745,6 +745,10 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
         }
     }
 
+    pub async fn total_amount(&self) -> Amount {
+        self.mint_client().total_amount().await
+    }
+
     pub async fn notes(&self) -> TieredMulti<SpendableNote> {
         self.mint_client().notes().await
     }

--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -114,15 +114,28 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
     }
 
     async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixStream<'_> {
+        let data = self
+            .tx_data
+            .range::<Vec<u8>, _>((key_prefix.to_vec())..)
+            .take_while(|(key, _)| key.starts_with(key_prefix))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Vec<_>>();
+        Box::pin(stream::iter(data))
+    }
+
+    async fn raw_find_by_prefix_sorted_reverse(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>> {
         let mut data = self
             .tx_data
             .range::<Vec<u8>, _>((key_prefix.to_vec())..)
             .take_while(|(key, _)| key.starts_with(key_prefix))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect::<Vec<_>>();
-        data.reverse();
+        data.sort_by(|a, b| a.cmp(b).reverse());
 
-        Box::pin(stream::iter(data))
+        Ok(Box::pin(stream::iter(data)))
     }
 
     async fn commit_tx(self) -> Result<()> {

--- a/fedimint-core/src/db/notifications.rs
+++ b/fedimint-core/src/db/notifications.rs
@@ -143,6 +143,15 @@ impl<'a> ISingleUseDatabaseTransaction<'a> for NotifyingTransaction<'a> {
         self.dbtx.raw_find_by_prefix(key_prefix).await
     }
 
+    async fn raw_find_by_prefix_sorted_reverse(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>> {
+        self.dbtx
+            .raw_find_by_prefix_sorted_reverse(key_prefix)
+            .await
+    }
+
     async fn raw_remove_by_prefix(&mut self, key_prefix: &[u8]) -> Result<()> {
         self.dbtx.raw_remove_by_prefix(key_prefix).await
     }

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -129,7 +129,7 @@ macro_rules! impl_encode_decode_num {
     ($num_type:ty) => {
         impl Encodable for $num_type {
             fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
-                let bytes = self.to_le_bytes();
+                let bytes = self.to_be_bytes();
                 writer.write_all(&bytes[..])?;
                 Ok(bytes.len())
             }
@@ -142,7 +142,7 @@ macro_rules! impl_encode_decode_num {
             ) -> Result<Self, crate::encoding::DecodeError> {
                 let mut bytes = [0u8; (<$num_type>::BITS / 8) as usize];
                 d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
-                Ok(<$num_type>::from_le_bytes(bytes))
+                Ok(<$num_type>::from_be_bytes(bytes))
             }
         }
     };

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -571,7 +571,7 @@ impl GatewayActor {
     pub async fn get_balance(&self) -> Result<Amount> {
         self.fetch_all_notes().await;
 
-        Ok(self.client.notes().await.total_amount())
+        Ok(self.client.total_amount().await)
     }
 
     pub fn get_info(&self) -> Result<FederationInfo> {


### PR DESCRIPTION
Will fix https://github.com/fedimint/fedimint/issues/82 by streaming up data from DB in descending denomination order then only using the required notes.

Why draft:
Only after implementing almost everything I realized the key encoding using little endian won't lead to a sane ordering.

There are not many comments on Internet, but the usual recommendation seems to always use big endian for keys on LevelDB/RocksDB to preserve ordering.

As changing the endianess may be impactful, I'm opening this PR earlier as a draft to discuss the possibilities. There are some options:
1. Change the consensus encoding to use big endian for primitives
2. Change only `NoteKey` to use big endian
3. Figure out what are the denominations then make multiple queries using each denomination to load the notes in a random `Nonce` order
4. Change database
5. Forget about it: if you are rich enough to have a big wallet you are rich enough to have a powerful computer/smartphone

There is a variation of 1) and 2) where you could implement some custom rocksdb comparator, but it would still require changing the encoding because it's just inconsistent to write data in little endian using the usual ordering of fields. To work you would need to start with the last field, then going backwards

Note the code right know is implementing 1)