### PR TITLE
fix: disable codecov in-code annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
-comment: false # https://docs.codecov.com/docs/pull-request-comments#disable-comment
+github_checks:
+    annotations: false
 codecov:
   require_ci_to_pass: true
   coverage:


### PR DESCRIPTION
https://docs.codecov.com/docs/github-checks#disabling-github-checks-patch-annotations-via-yaml