### PR TITLE
fix: skip connecting to federation if already connected

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -320,6 +320,11 @@ impl Gateway {
             GatewayError::Other(anyhow::anyhow!("Invalid federation member string {}", e))
         })?;
 
+        if self.select_actor(connect.id.clone()).await.is_ok() {
+            info!("Federation {} already connected", connect.id);
+            return Ok(());
+        }
+
         let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.read().await.info().await?;
         let node_pub_key = PublicKey::from_slice(&pub_key)
             .map_err(|e| GatewayError::Other(anyhow!("Invalid node pubkey {}", e)))?;


### PR DESCRIPTION
Replaces #2083 
Fixes #1866 