### PR TITLE
WIP: Bundle mintgate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,6 +2684,7 @@ dependencies = [
  "prost 0.11.6",
  "rand",
  "reqwest",
+ "rust-embed",
  "secp256k1",
  "serde",
  "serde_json",
@@ -3769,6 +3770,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b68543d5527e158213414a92832d2aab11a84d2571a5eb021ebe22c43aab066"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4e0f0ced47ded9a68374ac145edd65a6c1fa13a96447b873660b2a568a0fd7"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.23",
+ "rust-embed-utils",
+ "syn 1.0.107",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512b0ab6853f7e14e3c8754acb43d6f748bb9ced66aa5915a6553ac8213f7731"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,6 +3886,15 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -5029,6 +5073,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -48,6 +48,7 @@ mint-client = { path = "../../client/client-lib" }
 prost = "0.11"
 rand = "0.8"
 reqwest = { version = "0.11.14", features = [ "json" ], default-features = false }
+rust-embed = "6.6.0"
 secp256k1 = "0.24.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"


### PR DESCRIPTION
Uses [rust-embed](https://crates.io/crates/rust-embed) crate to bundle `gateway/ui` into `gatewayd` binary. This assumes the i is already built as a bundle-ready assets in `gateway/ui/build`

**Further consideraions**
- How would we trigger automated build of `gateway/ui` as a prerequisite of `gatewayd` build
- Would it be useful to build one binary that bundles the UI and one that doesn't?