### PR TITLE
chore: fix failure conditions for discord notification

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -220,7 +220,8 @@ jobs:
 
     steps:
     - name: Discord notifications on failure                                                         
-      if: failure()                              
+      # https://stackoverflow.com/a/74562058/134409
+      if: ${{ always() && contains(needs.*.result, 'failure') }}
       # https://github.com/marketplace/actions/actions-status-discord
       uses: sarisia/actions-status-discord@v1
       with:


### PR DESCRIPTION
Seems like `if: failure()` is true only if any previous step in the same job failed. :shrug: