### PR TITLE
fix: Move "coverage" key to top-level in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,18 @@
 github_checks:
-    annotations: false
+  annotations: false
+
+
 codecov:
   require_ci_to_pass: true
-  coverage:
-    precision: 2
-    round: down
-    range: "60...100"
-    status:
-      project:
-        default:
-          target: auto
-          threshold: 1%
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
   notify:
     wait_for_ci: no


### PR DESCRIPTION
While trying to figure out why the annoying "annotations" keep showing up in our diffs (https://discord.com/channels/990354215060795454/1075857804692295720/1092933724003377203) I found a [PR to another project](https://github.com/SFML/SFML/pull/2261/files) which disabled annotations. It does this:

```
github_checks:
  annotations: false
```

We had an extra 2 spaces before `annotations` so removed those. I also noticed they had `coverage` at the top-level whereas we had it nested under `codecov`. So I updated ours to be the same. This is also what [example from the docs does](https://docs.codecov.com/docs/codecovyml-reference#coverage). 

If this doesn't get rid of the annotations, I don't know what will ...

One other difference is that this other project has `.github/.codecov.yml` and we have just `codecov.yml` in the root. But the [docs clearly say to put `codecov.yml` in the project root](https://docs.codecov.com/docs/codecov-yaml#repository-yaml) so not changing that.