### PR TITLE
chore: put aliases in its own file to be easily sourced

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -3,16 +3,8 @@ root: .
 socket_name: fedimint-dev
 pre_window:
   - source .tmpenv
-  - alias lightning-cli="\$FM_LIGHTNING_CLI"
-  - alias lncli="\$FM_LNCLI"
-  - alias bitcoin-cli="\$FM_BTC_CLIENT"
-  - alias fedimint-cli="\$FM_MINT_CLIENT"
-  - alias gateway-cln="\$FM_GWCLI_CLN"
-  - alias gateway-lnd="\$FM_GWCLI_LND"
-  - alias mint_rpc_client="\$FM_MINT_RPC_CLIENT"
-  - alias dbtool="\$FM_DB_TOOL"
-  # - alias restart="./scripts/restart-tmux.sh"
   - source scripts/lib.sh
+  - source scripts/aliases.sh
 tmux_detached: false
 windows:
   - main:

--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+alias lightning-cli="\$FM_LIGHTNING_CLI"
+alias lncli="\$FM_LNCLI"
+alias bitcoin-cli="\$FM_BTC_CLIENT"
+alias fedimint-cli="\$FM_MINT_CLIENT"
+alias gateway-cln="\$FM_GWCLI_CLN"
+alias gateway-lnd="\$FM_GWCLI_LND"
+alias mint_rpc_client="\$FM_MINT_RPC_CLIENT"
+alias dbtool="\$FM_DB_TOOL"
+# alias restart="./scripts/restart-tmux.sh"


### PR DESCRIPTION
When opening a new tmux pane in tmuxinator, you can easily source the aliases file with `. .aliases.sh` or `source .aliases.sh`

The core issue is that the commands in `pre_window` of tmuxinator are only executed when tmux is started, but not when I manually open a new pane or window.
```yaml
pre_window:
  - source .tmpenv
  - source scripts/lib.sh
  - source .aliases.sh
```

I thought that's annoying since I open and close panes in the tmuxinator, too, and these new manually opened panes don't have any aliases set. This way you can just source them. 

I'm not sure if we can automate the sourcing as well? perhaps somehow via nix @dpc? 

thoughts in general?
I also just copy & pasted the aliases. The restart script was (and still is) commented out for a reason?

