### PR TITLE
Redirect stdout and stderr in one stream to the logfile

### DIFF
--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -22,7 +22,7 @@ echo "Running in temporary directory $FM_TEST_DIR"
 export FM_READY_FILE=$FM_TMP_DIR/ready
 mkfifo $FM_READY_FILE
 
-$FM_BIN_DIR/fedimint-bin-tests tmuxinator 2>$FM_LOGS_DIR/fedimint-dev.log >$FM_LOGS_DIR/fedimint-dev.log &
+$FM_BIN_DIR/fedimint-bin-tests tmuxinator &>$FM_LOGS_DIR/fedimint-dev.log &
 echo $! >> $FM_PID_FILE
 
 env | sed -En 's/^(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv


### PR DESCRIPTION
Otherwise this may result in weird behaviour where one stream overwrites parts of the other stream.

At least I think so. I get this behaviour when doing the following:

src/main.rs
```rust
fn main() {
    println!("Hello, world!");
    println!("Hello, world!");
    println!("Hello, world!");
    println!("Hello, world!");
    println!("Hello, world!");
    println!("Hello, world!");

    eprintln!("this is stderr");
    eprintln!("this is stderr");
    eprintln!("this is stderr");
    eprintln!("this is stderr");
    eprintln!("this is stderr");
}
```

normal output 
```sh
$ cargo r
    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
     Running `target/debug/redirection`
Hello, world!
Hello, world!
Hello, world!
Hello, world!
Hello, world!
Hello, world!
this is stderr
this is stderr
this is stderr
this is stderr
this is stderr
```

separate streams. Note that parts of the cargo message are lost.
```sh
$ cargo r 2>test.log >test.log
$ cat test.log
Hello, world!
Hello, world!
Hello, world!
Hello, world!
Hello, world!
Hello, world!
ebug/redirection`
this is stderr
this is stderr
this is stderr
this is stderr
this is stderr
```

What we expect:
```
$ cargo r &> test2.log
$ cat test2.log
    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
     Running `target/debug/redirection`
Hello, world!
Hello, world!
Hello, world!
Hello, world!
Hello, world!
Hello, world!
this is stderr
this is stderr
this is stderr
this is stderr
this is stderr
```
