### PR TITLE
Tmuxinator pane titles

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -21,8 +21,14 @@ windows:
             - source scripts/tmux-user-shell.sh
   - federation:
       panes:
-        - federation:
-          - tail -n +0 -F $FM_LOGS_DIR/fedimint-*.log
+        - fedimint0:
+          - tail -n +0 -F $FM_LOGS_DIR/fedimintd-0.log
+        - fedimint1:
+          - tail -n +0 -F $FM_LOGS_DIR/fedimintd-1.log
+        - fedimint2:
+          - tail -n +0 -F $FM_LOGS_DIR/fedimintd-2.log
+        - fedimint3:
+          - tail -n +0 -F $FM_LOGS_DIR/fedimintd-3.log
   - lightning:
       layout: tiled
       panes:

--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -13,34 +13,44 @@ pre_window:
   - alias dbtool="\$FM_DB_TOOL"
   # - alias restart="./scripts/restart-tmux.sh"
   - source scripts/lib.sh
+  - tmux_pane_title_setup
 tmux_detached: false
 windows:
-  - main:
+  - shell:
       panes:
-        - user:
-            - source scripts/tmux-user-shell.sh
+        - shell:
+          - tmux_pane_title shell 0 shell
+          - source scripts/tmux-user-shell.sh
   - federation:
       panes:
-        - fedimint0:
+        - fedimintd-0:
+          - tmux_pane_title federation 0 fedimintd-0
           - tail -n +0 -F $FM_LOGS_DIR/fedimintd-0.log
-        - fedimint1:
+        - fedimintd-1:
+          - tmux_pane_title federation 1 fedimintd-1
           - tail -n +0 -F $FM_LOGS_DIR/fedimintd-1.log
-        - fedimint2:
+        - fedimintd-2:
+          - tmux_pane_title federation 2 fedimintd-2
           - tail -n +0 -F $FM_LOGS_DIR/fedimintd-2.log
-        - fedimint3:
+        - fedimintd-3:
+          - tmux_pane_title federation 3 fedimintd-3
           - tail -n +0 -F $FM_LOGS_DIR/fedimintd-3.log
   - lightning:
-      layout: tiled
       panes:
         - cln:
+          - tmux_pane_title lightning 0 cln
           - tail -n +0 -F $FM_LOGS_DIR/lightningd.log
         - lnd:
+          - tmux_pane_title lightning 1 lnd
           - tail -n +0 -F $FM_LOGS_DIR/lnd.log
         - cln-gw:
+          - tmux_pane_title lightning 2 cln-gw
           - tail -n +0 -F $FM_LOGS_DIR/gatewayd-cln.log
         - lnd-gw:
+          - tmux_pane_title lightning 3 lnd-gw
           - tail -n +0 -F $FM_LOGS_DIR/gatewayd-lnd.log
   - bitcoin:
       panes:
         - bitcoind:
+          - tmux_pane_title bitcoin 0 bitcoind
           - tail -n +0 -F $FM_LOGS_DIR/bitcoind.log

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -2,6 +2,21 @@
 
 export LEGACY_HARDCODED_INSTANCE_ID_WALLET="2"
 
+# globally enable tmux pane titles
+# FIXME: can we just set this in the current pay with -p flag?
+function tmux_pane_title_setup() {
+  tmux set-option -g allow-rename off
+  tmux set -g pane-border-status top
+  tmux set -g pane-border-format "  #{pane_title}  "
+}
+
+function tmux_pane_title() {
+  WINDOW=$1
+  PANE_NUMBER=$2
+  TITLE=$3
+  tmux select-pane -T $TITLE -t $WINDOW.$PANE_NUMBER
+}
+
 function mine_blocks() {
     PEG_IN_ADDR="$($FM_BTC_CLIENT getnewaddress)"
     $FM_BTC_CLIENT generatetoaddress $1 $PEG_IN_ADDR


### PR DESCRIPTION
I don't think this is mergeable as-is because it sets global tmux options which will probably interfere with the local setups of people who use tmux for non-tmuxinator dev work. I need to figure out how to do `tmux set` / `tmux set-option` for just the current pane or window. There is a `-p` option that's supposed to do this, but couldn't get that to work. Tmux wizard plz halp.

But I think this is a very nice little improvement. Much easier to understand what a given pane is doing.

Based on [this](https://github.com/tmuxinator/tmuxinator/issues/873)

![image](https://user-images.githubusercontent.com/4335621/229969883-5b35c25f-1a07-4013-a82a-e70be4fc6c24.png)
