### PR TITLE
feat: Spawn electrs and esplora in fedimint-bin-tests

### DIFF
--- a/fedimint-bin-tests/src/main.rs
+++ b/fedimint-bin-tests/src/main.rs
@@ -423,6 +423,7 @@ async fn latency_tests(dev_fed: DevFed) -> Result<()> {
         fed,
         gw_cln,
         gw_lnd,
+        electrs,
     } = dev_fed;
 
     fed.pegin(10_000_000).await?;

--- a/fedimint-bin-tests/src/main.rs
+++ b/fedimint-bin-tests/src/main.rs
@@ -611,13 +611,13 @@ pub struct Esplora {
 impl Esplora {
     pub async fn new(process_mgr: &ProcessManager, bitcoind: Bitcoind) -> Result<Self> {
         let daemon_dir = env::var("FM_BTC_DIR")?;
-        let test_dir = env::var("FM_TEST_DIR")?;
+        let esplora_dir = env::var("FM_ESPLORA_DIR")?;
 
         // spawn esplora
         let cmd = cmd!(
             "esplora",
             "--daemon-dir={daemon_dir}",
-            "--db-dir={test_dir}/esplora",
+            "--db-dir={esplora_dir}",
             "--cookie=bitcoin:bitcoin",
             "--network=regtest",
             "--daemon-rpc-addr=127.0.0.1:18443",

--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -245,12 +245,12 @@ async fn run_esplora() -> anyhow::Result<()> {
     await_bitcoind_ready("esplora").await?;
 
     let daemon_dir = env::var("FM_BTC_DIR")?;
-    let test_dir = env::var("FM_TEST_DIR")?;
+    let esplora_dir = env::var("FM_ESPLORA_DIR")?;
 
     // spawn esplora
     let mut esplora = Command::new("esplora")
         .arg(format!("--daemon-dir={daemon_dir}"))
-        .arg(format!("--db-dir={test_dir}/esplora"))
+        .arg(format!("--db-dir={esplora_dir}"))
         .arg("--cookie=bitcoin:bitcoin")
         .arg("--network=regtest")
         .arg("--daemon-rpc-addr=127.0.0.1:18443")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,6 +39,7 @@ export FM_LND_DIR="$FM_TEST_DIR/lnd"
 export FM_BTC_DIR="$FM_TEST_DIR/bitcoin"
 export FM_CFG_DIR="$FM_TEST_DIR/cfg"
 export FM_ELECTRS_DIR="$FM_TEST_DIR/electrs"
+export FM_ESPLORA_DIR="$FM_TEST_DIR/esplora"
 mkdir -p $FM_LOGS_DIR
 mkdir -p $FM_CLN_DIR
 mkdir -p $FM_LND_DIR

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,6 +46,7 @@ mkdir -p $FM_LND_DIR
 mkdir -p $FM_BTC_DIR
 mkdir -p $FM_CFG_DIR
 mkdir -p $FM_ELECTRS_DIR
+mkdir -p $FM_ESPLORA_DIR
 touch $FM_PID_FILE
 
 # Copy configs to data directories


### PR DESCRIPTION
This is done to partially address #2101 issue 5, and will help migrate the remaining portions of Fedimint's testing infra to Rust away from Bash scripts. 