### PR TITLE
Directly flag to bitcoin.conf

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -220,7 +220,8 @@ jobs:
 
     steps:
     - name: Discord notifications on failure                                                         
-      if: failure()                              
+      # https://stackoverflow.com/a/74562058/134409
+      if: ${{ always() && contains(needs.*.result, 'failure') }}
       # https://github.com/marketplace/actions/actions-status-discord
       uses: sarisia/actions-status-discord@v1
       with:

--- a/fedimint-bin-tests/src/main.rs
+++ b/fedimint-bin-tests/src/main.rs
@@ -42,7 +42,10 @@ impl Bitcoind {
         let conf_path = project_root.join("misc/test/bitcoin.conf");
         let conf_path_string = conf_path.to_str().context("path must be valid UTF-8")?;
         let process = processmgr
-            .spawn_daemon("bitcoind", cmd!("bitcoind", "-datadir={btc_dir}", "-conf={conf_path_string}"))
+            .spawn_daemon(
+                "bitcoind",
+                cmd!("bitcoind", "-datadir={btc_dir}", "-conf={conf_path_string}"),
+            )
             .await?;
 
         let url = env::var("FM_TEST_BITCOIND_RPC")?.parse()?;

--- a/fedimint-bin-tests/src/main.rs
+++ b/fedimint-bin-tests/src/main.rs
@@ -38,8 +38,11 @@ pub struct Bitcoind {
 impl Bitcoind {
     pub async fn new(processmgr: &ProcessManager) -> Result<Self> {
         let btc_dir = env::var("FM_BTC_DIR")?;
+        let project_root: PathBuf = env::var("FM_SRC_DIR")?.parse()?;
+        let conf_path = project_root.join("misc/test/bitcoin.conf");
+        let conf_path_string = conf_path.to_str().context("path must be valid UTF-8")?;
         let process = processmgr
-            .spawn_daemon("bitcoind", cmd!("bitcoind", "-datadir={btc_dir}"))
+            .spawn_daemon("bitcoind", cmd!("bitcoind", "-datadir={btc_dir}", "-conf={conf_path_string}"))
             .await?;
 
         let url = env::var("FM_TEST_BITCOIND_RPC")?.parse()?;

--- a/fedimint-bin-tests/src/main.rs
+++ b/fedimint-bin-tests/src/main.rs
@@ -423,6 +423,8 @@ async fn latency_tests(dev_fed: DevFed) -> Result<()> {
         fed,
         gw_cln,
         gw_lnd,
+        electrs,
+        esplora,
     } = dev_fed;
 
     fed.pegin(10_000_000).await?;
@@ -521,13 +523,17 @@ struct DevFed {
     fed: Federation,
     gw_cln: Gatewayd,
     gw_lnd: Gatewayd,
+    electrs: Electrs,
+    esplora: Esplora,
 }
 
 async fn dev_fed(task_group: &TaskGroup, process_mgr: &ProcessManager) -> Result<DevFed> {
     let bitcoind = Bitcoind::new(process_mgr).await?;
-    let (cln, lnd) = tokio::try_join!(
+    let (cln, lnd, electrs, esplora) = tokio::try_join!(
         Lightningd::new(process_mgr, bitcoind.clone()),
         Lnd::new(process_mgr, bitcoind.clone()),
+        Electrs::new(process_mgr, bitcoind.clone()),
+        Esplora::new(process_mgr, bitcoind.clone()),
     )?;
     info!("lightning and bitcoind started");
     run_dkg(task_group, 4).await?;
@@ -551,6 +557,8 @@ async fn dev_fed(task_group: &TaskGroup, process_mgr: &ProcessManager) -> Result
         fed,
         gw_cln,
         gw_lnd,
+        electrs,
+        esplora,
     })
 }
 
@@ -566,6 +574,63 @@ async fn tmuxinator(process_mgr: &ProcessManager, task_group: &TaskGroup) -> Res
             fs::write(ready_file, "ERROR").await?;
             Err(e)
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct Electrs {
+    _process: ProcessHandle,
+    _bitcoind: Bitcoind,
+}
+
+impl Electrs {
+    pub async fn new(process_mgr: &ProcessManager, bitcoind: Bitcoind) -> Result<Self> {
+        let electrs_dir = env::var("FM_ELECTRS_DIR")?;
+
+        let cmd = cmd!(
+            "electrs",
+            "--conf-dir={electrs_dir}",
+            "--db-dir={electrs_dir}",
+        );
+        let process = process_mgr.spawn_daemon("electrs", cmd).await?;
+        info!("electrs started");
+
+        Ok(Self {
+            _bitcoind: bitcoind,
+            _process: process,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct Esplora {
+    _process: ProcessHandle,
+    _bitcoind: Bitcoind,
+}
+
+impl Esplora {
+    pub async fn new(process_mgr: &ProcessManager, bitcoind: Bitcoind) -> Result<Self> {
+        let daemon_dir = env::var("FM_BTC_DIR")?;
+        let esplora_dir = env::var("FM_ESPLORA_DIR")?;
+
+        // spawn esplora
+        let cmd = cmd!(
+            "esplora",
+            "--daemon-dir={daemon_dir}",
+            "--db-dir={esplora_dir}",
+            "--cookie=bitcoin:bitcoin",
+            "--network=regtest",
+            "--daemon-rpc-addr=127.0.0.1:18443",
+            "--http-addr=127.0.0.1:50002",
+            "--monitoring-addr=127.0.0.1:50003",
+        );
+        let process = process_mgr.spawn_daemon("esplora", cmd).await?;
+        info!("esplora started");
+
+        Ok(Self {
+            _bitcoind: bitcoind,
+            _process: process,
+        })
     }
 }
 

--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -151,7 +151,8 @@ async fn await_fedimint_block_sync() -> anyhow::Result<()> {
 }
 
 async fn run_bitcoind() -> anyhow::Result<()> {
-    let project_root: PathBuf = env::var("FM_SRC_DIR")?.parse()?;
+    //let project_root: PathBuf = env::var("FM_SRC_DIR")?.parse()?; 
+    let project_root = fedimint_testing::get_project_root()?;
     let btc_dir = env::var("FM_BTC_DIR")?;
     let conf_path = project_root.join("misc/test/bitcoin.conf");
     let conf_path_string = conf_path.to_str().context("path must be valid UTF-8")?;

--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -151,8 +151,7 @@ async fn await_fedimint_block_sync() -> anyhow::Result<()> {
 }
 
 async fn run_bitcoind() -> anyhow::Result<()> {
-    //let project_root: PathBuf = env::var("FM_SRC_DIR")?.parse()?; 
-    let project_root = fedimint_testing::get_project_root()?;
+    let project_root: PathBuf = env::var("FM_SRC_DIR")?.parse()?; 
     let btc_dir = env::var("FM_BTC_DIR")?;
     let conf_path = project_root.join("misc/test/bitcoin.conf");
     let conf_path_string = conf_path.to_str().context("path must be valid UTF-8")?;

--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -157,9 +157,9 @@ async fn run_bitcoind() -> anyhow::Result<()> {
     let conf_path_string = conf_path.to_str().context("path must be valid UTF-8")?;
     // Spawn bitcoind
     let mut bitcoind = Command::new("bitcoind")
-    .arg(format!("-datadir={btc_dir}"))
-    .arg(format!("-conf={conf_path_string}"))
-    .spawn()?;
+        .arg(format!("-datadir={btc_dir}"))
+        .arg(format!("-conf={conf_path_string}"))
+        .spawn()?;
     kill_on_exit(&bitcoind).await?;
     info!("bitcoind started");
 

--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -248,12 +248,12 @@ async fn run_esplora() -> anyhow::Result<()> {
     await_bitcoind_ready("esplora").await?;
 
     let daemon_dir = env::var("FM_BTC_DIR")?;
-    let test_dir = env::var("FM_TEST_DIR")?;
+    let esplora_dir = env::var("FM_ESPLORA_DIR")?;
 
     // spawn esplora
     let mut esplora = Command::new("esplora")
         .arg(format!("--daemon-dir={daemon_dir}"))
-        .arg(format!("--db-dir={test_dir}/esplora"))
+        .arg(format!("--db-dir={esplora_dir}"))
         .arg("--cookie=bitcoin:bitcoin")
         .arg("--network=regtest")
         .arg("--daemon-rpc-addr=127.0.0.1:18443")

--- a/justfile
+++ b/justfile
@@ -81,3 +81,7 @@ format:
 # start tmuxinator with a dev federation setup
 tmuxinator:
   ./scripts/tmuxinator.sh
+
+# exit tmuxinator session
+exit-tmuxinator:
+  tmux kill-session -t fedimint-dev

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,12 +40,14 @@ export FM_LND_DIR="$FM_TEST_DIR/lnd"
 export FM_BTC_DIR="$FM_TEST_DIR/bitcoin"
 export FM_CFG_DIR="$FM_TEST_DIR/cfg"
 export FM_ELECTRS_DIR="$FM_TEST_DIR/electrs"
+export FM_ESPLORA_DIR="$FM_TEST_DIR/esplora"
 mkdir -p $FM_LOGS_DIR
 mkdir -p $FM_CLN_DIR
 mkdir -p $FM_LND_DIR
 mkdir -p $FM_BTC_DIR
 mkdir -p $FM_CFG_DIR
 mkdir -p $FM_ELECTRS_DIR
+mkdir -p $FM_ESPLORA_DIR
 touch $FM_PID_FILE
 
 # Copy configs to data directories

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,14 +24,15 @@ export FM_POLL_INTERVAL=1
 echo "Setting up env variables in $FM_TMP_DIR"
 
 # Builds the rust executables and sets environment variables
-SRC_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
-cd $SRC_DIR || exit 1
+FM_SRC_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+cd $FM_SRC_DIR || exit 1
+export FM_SRC_DIR
 # Note: Respect 'CARGO_PROFILE' that crane uses
 cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}}
 
 # Define temporary directories to not overwrite manually created config if run locally
 export FM_TEST_DIR=$FM_TMP_DIR
-export FM_BIN_DIR="$SRC_DIR/target/${CARGO_PROFILE:-debug}"
+export FM_BIN_DIR="$FM_SRC_DIR/target/${CARGO_PROFILE:-debug}"
 export FM_PID_FILE="$FM_TMP_DIR/.pid"
 export FM_LOGS_DIR="$FM_TEST_DIR/logs"
 export FM_CLN_DIR="$FM_TEST_DIR/cln"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,7 +49,6 @@ mkdir -p $FM_ELECTRS_DIR
 touch $FM_PID_FILE
 
 # Copy configs to data directories
-cp misc/test/bitcoin.conf $FM_BTC_DIR
 cp misc/test/lnd.conf $FM_LND_DIR
 cp misc/test/lightningd.conf $FM_CLN_DIR/config
 cp misc/test/electrs.toml $FM_ELECTRS_DIR


### PR DESCRIPTION
Issue solved: #1857 
Instead of copying using `cp misc/test/bitcoin.conf $FM_BTC_DIR`, Directly `CLI Flaged` the `bitcoin.conf` while spawning the bitcoind using `-conf={cwd}/misc/test/bitcoin.conf`. Used `let project_root: PathBuf = env::var("FM_SRC_DIR")?.parse()?;` to find the {cwd}. Here {cwd} stands for the current working directory. Converted the `PathBuf` variable into `string` using  `let conf_path_string = conf_path.to_str().context("path must be valid UTF-8")?;` to be use it further in `-conf=`. Introduced and exported a new variable `FM_SRC_DIR` in `scripts/build.sh`, which stores the Project root for external use as stated in #1987 . Also added the same changes in `fedimint-bin-tests/src/main.rs`