### PR TITLE
fix: discord notifications report failures as success

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -226,3 +226,5 @@ jobs:
       uses: sarisia/actions-status-discord@v1
       with:
         webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        # current job is a success, but that's not what we're interested in
+        status: failure


### PR DESCRIPTION
It needs to be reminded that it's a failure. [Relevant info on failure management ;)](https://www.youtube.com/watch?v=cQpq56FmIN4).