### PR TITLE
Configgen refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "serde",
  "threshold_crypto",
  "tokio",
+ "tokio-rustls 0.23.4",
  "tonic_lnd",
  "tracing",
  "url",

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -330,7 +330,7 @@ mod tests {
     use std::sync::Arc;
 
     use bitcoin::hashes::{sha256, Hash};
-    use fedimint_core::config::ConfigGenParams;
+    use fedimint_core::config::ConfigGenModuleParams;
     use fedimint_core::core::{
         DynOutputOutcome, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_LN,
     };
@@ -435,7 +435,7 @@ mod tests {
             FakeFed::<Lightning>::new(
                 4,
                 |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
-                &ConfigGenParams::null(),
+                &ConfigGenModuleParams::null(),
                 &LightningGen,
                 module_id,
             )

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -654,7 +654,7 @@ mod tests {
 
     use bitcoin::hashes::Hash;
     use fedimint_core::api::WsFederationApi;
-    use fedimint_core::config::ConfigGenParams;
+    use fedimint_core::config::ConfigGenModuleParams;
     use fedimint_core::core::{
         DynOutputOutcome, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     };
@@ -741,7 +741,7 @@ mod tests {
             FakeFed::<Mint>::new(
                 4,
                 |cfg, _db| async move { Ok(Mint::new(cfg.to_typed().unwrap())) },
-                &ConfigGenParams::from_typed(MintGenParams {
+                &ConfigGenModuleParams::from_typed(MintGenParams {
                     mint_amounts: vec![
                         Amount::from_sats(1),
                         Amount::from_sats(10),

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -193,7 +193,7 @@ mod tests {
     use bitcoin::hashes::sha256;
     use bitcoin::{Address, Txid};
     use bitcoin_hashes::Hash;
-    use fedimint_core::config::ConfigGenParams;
+    use fedimint_core::config::ConfigGenModuleParams;
     use fedimint_core::core::{
         DynOutputOutcome, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
     };
@@ -289,7 +289,7 @@ mod tests {
                         .await?)
                     }
                 },
-                &ConfigGenParams::from_typed(WalletGenParams {
+                &ConfigGenModuleParams::from_typed(WalletGenParams {
                     network: bitcoin::network::constants::Network::Regtest,
                     finality_delay: 10,
                 })

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -14,7 +14,7 @@ use bech32::{FromBase32, ToBase32};
 use bitcoin::consensus::ReadExt;
 use bitcoin_hashes::sha256;
 use fedimint_core::config::{
-    ApiEndpoint, ClientConfig, CommonModuleGenRegistry, ConfigResponse, FederationId,
+    ClientConfig, CommonModuleGenRegistry, ConfigResponse, FederationId, PeerUrl,
 };
 use fedimint_core::fmt_utils::AbbreviateDebug;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -575,7 +575,7 @@ pub struct WsClientConnectInfo {
 }
 
 impl WsClientConnectInfo {
-    pub fn new(id: &FederationId, api: &BTreeMap<PeerId, ApiEndpoint>) -> Self {
+    pub fn new(id: &FederationId, api: &BTreeMap<PeerId, PeerUrl>) -> Self {
         Self {
             urls: api
                 .iter()

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -94,11 +94,10 @@ impl JsonWithKind {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable)]
-pub struct ApiEndpoint {
-    /// The peer's API websocket network address and port (e.g.
-    /// `ws://10.42.0.10:5000`)
+pub struct PeerUrl {
+    /// The peer's public URL (e.g. `wss://fedimint-server-1:5000`)
     pub url: Url,
-    /// human-readable name
+    /// The peer's name
     pub name: String,
 }
 
@@ -110,7 +109,7 @@ pub struct ClientConfig {
     // Stable and unique id and threshold pubkey of the federation for authenticating configs
     pub federation_id: FederationId,
     /// API endpoints for each federation member
-    pub api_endpoints: BTreeMap<PeerId, ApiEndpoint>,
+    pub api_endpoints: BTreeMap<PeerId, PeerUrl>,
     /// Threshold pubkey for authenticating epoch history
     pub epoch_pk: threshold_crypto::PublicKey,
     /// Configs from other client modules

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -270,7 +270,7 @@ impl<M> Default for ModuleGenRegistry<M> {
 /// Module **generation** (so passed to dkg, not to the module itself) config
 /// parameters
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
-pub struct ConfigGenParams(serde_json::Value);
+pub struct ConfigGenModuleParams(serde_json::Value);
 
 pub type ServerModuleGenRegistry = ModuleGenRegistry<DynServerModuleGen>;
 
@@ -285,7 +285,7 @@ impl ServerModuleGenRegistry {
     }
 }
 
-impl ConfigGenParams {
+impl ConfigGenModuleParams {
     /// Null value, used as a config gen parameters for module gens that don't
     /// need any parameters
     pub fn null() -> Self {
@@ -309,7 +309,7 @@ pub type CommonModuleGenRegistry = ModuleGenRegistry<DynCommonModuleGen>;
 /// Note: in the future, we should make this one a
 /// `ModuleRegistry<ConfigGenParams>`, as each module **instance** will need a
 /// distinct config for dkg.
-pub type ServerModuleGenParamsRegistry = ModuleGenRegistry<ConfigGenParams>;
+pub type ServerModuleGenParamsRegistry = ModuleGenRegistry<ConfigGenModuleParams>;
 
 impl Eq for ServerModuleGenParamsRegistry {}
 
@@ -339,7 +339,7 @@ impl<'de> Deserialize<'de> for ServerModuleGenParamsRegistry {
         let mut params = BTreeMap::new();
 
         for (key, value) in json {
-            params.insert(key, ConfigGenParams(value));
+            params.insert(key, ConfigGenModuleParams(value));
         }
         Ok(ModuleGenRegistry(params))
     }
@@ -409,7 +409,7 @@ impl<M> ModuleGenRegistry<M> {
     }
 }
 
-impl ModuleGenRegistry<ConfigGenParams> {
+impl ModuleGenRegistry<ConfigGenModuleParams> {
     pub fn attach_config_gen_params<T>(&mut self, kind: ModuleKind, gen: T) -> &mut Self
     where
         T: ModuleGenParams,
@@ -418,7 +418,8 @@ impl ModuleGenRegistry<ConfigGenParams> {
             .0
             .insert(
                 kind.clone(),
-                ConfigGenParams::from_typed(gen).expect("Invalid config gen params for {kind}"),
+                ConfigGenModuleParams::from_typed(gen)
+                    .expect("Invalid config gen params for {kind}"),
             )
             .is_some()
         {
@@ -435,7 +436,8 @@ impl ModuleGenRegistry<ConfigGenParams> {
             .0
             .insert(
                 kind.clone(),
-                ConfigGenParams::from_typed(gen).expect("Invalid config gen params for {kind}"),
+                ConfigGenModuleParams::from_typed(gen)
+                    .expect("Invalid config gen params for {kind}"),
             )
             .is_some()
         {

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -10,7 +10,7 @@ use bitcoin::Denomination;
 use bitcoin_hashes::hash_newtype;
 use bitcoin_hashes::sha256::Hash as Sha256;
 pub use bitcoin_hashes::Hash as BitcoinHash;
-use fedimint_core::config::ApiEndpoint;
+use fedimint_core::config::PeerUrl;
 pub use macro_rules_attribute::apply;
 pub use module::ServerModule;
 use serde::{Deserialize, Serialize};
@@ -167,7 +167,7 @@ impl NumPeers for Vec<PeerId> {
     }
 }
 
-impl NumPeers for Vec<ApiEndpoint> {
+impl NumPeers for Vec<PeerUrl> {
     fn total(&self) -> usize {
         self.len()
     }

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use thiserror::Error;
 use tracing::instrument;
 
-use crate::config::{ConfigGenParams, DkgPeerMsg, ServerModuleConfig};
+use crate::config::{ConfigGenModuleParams, DkgPeerMsg, ServerModuleConfig};
 use crate::core::{
     Decoder, DecoderBuilder, Input, ModuleConsensusItem, ModuleInstanceId, ModuleKind, Output,
     OutputOutcome,
@@ -430,13 +430,13 @@ pub trait IServerModuleGen: IDynCommonModuleGen {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig>;
 
     async fn distributed_gen(
         &self,
         peers: &PeerHandle,
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> DkgResult<ServerModuleConfig>;
 
     fn to_config_response(&self, config: serde_json::Value)
@@ -613,13 +613,13 @@ pub trait ServerModuleGen: ExtendsCommonModuleGen + Sized {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig>;
 
     async fn distributed_gen(
         &self,
         peer: &PeerHandle,
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> DkgResult<ServerModuleConfig>;
 
     fn to_config_response(&self, config: serde_json::Value)
@@ -664,7 +664,7 @@ where
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         <Self as ServerModuleGen>::trusted_dealer_gen(self, peers, params)
     }
@@ -672,7 +672,7 @@ where
     async fn distributed_gen(
         &self,
         peers: &PeerHandle,
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> DkgResult<ServerModuleConfig> {
         <Self as ServerModuleGen>::distributed_gen(self, peers, params).await
     }

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -377,7 +377,7 @@ impl ServerConfig {
         let authinfo = NetworkInfo::generate_map(peers.to_vec(), &mut rng)
             .expect("Could not generate HBBFT netinfo");
 
-        let null_config_gen = ConfigGenParams::null();
+        let null_config_gen = ConfigGenModuleParams::null();
 
         // We assume user wants one module instance for every module kind
         let module_configs: BTreeMap<_, _> = registry
@@ -471,7 +471,7 @@ impl ServerConfig {
         // of each module that was compiled in. This is how things were
         // initially, where we consider "module as a code" as "module as an instance at
         // runtime"
-        let null_config_gen = ConfigGenParams::null();
+        let null_config_gen = ConfigGenModuleParams::null();
         for (module_instance_id, (kind, gen)) in registry {
             let dkg = PeerHandle::new(&connections, module_instance_id, *our_id, peers.clone());
             module_cfgs.insert(

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::{bail, format_err, Context};
+use anyhow::{bail, format_err};
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::sha256::HashEngine;
 use fedimint_aead::{encrypted_read, get_encryption_key, get_password_hash};
@@ -40,7 +40,7 @@ use crate::config::io::{parse_peer_params, CODE_VERSION, SALT_FILE, TLS_CERT, TL
 use crate::fedimint_core::encoding::Encodable;
 use crate::fedimint_core::{BitcoinHash, NumPeers};
 use crate::multiplexed::PeerConnectionMultiplexer;
-use crate::net::connect::{parse_host_port, Connector, TlsConfig};
+use crate::net::connect::{Connector, TlsConfig};
 use crate::net::peers::{DelayCalculator, NetworkConfig};
 use crate::{ReconnectPeerConnections, TlsTcpConnector};
 
@@ -671,7 +671,7 @@ impl ConfigGenParams {
             .map(|(peer, _)| *peer)
             .ok_or_else(|| anyhow::Error::msg("Our id not found"))?;
 
-        Ok(ConfigGenParams::gen_params(
+        Ok(ConfigGenParams::new(
             ApiAuth(api_auth),
             bind_p2p,
             bind_api,
@@ -685,7 +685,7 @@ impl ConfigGenParams {
 
     /// Generates the parameters necessary for running server config generation
     #[allow(clippy::too_many_arguments)]
-    pub fn gen_params(
+    pub fn new(
         api_auth: ApiAuth,
         p2p_bind: SocketAddr,
         api_bind: SocketAddr,
@@ -711,59 +711,6 @@ impl ConfigGenParams {
                 },
             },
         }
-    }
-
-    /// config for servers running on different ports on a local network
-    pub fn gen_local(
-        peers: &[PeerId],
-        base_port: u16,
-        federation_name: &str,
-        modules: ServerModuleGenParamsRegistry,
-    ) -> anyhow::Result<HashMap<PeerId, ConfigGenParams>> {
-        let keys: HashMap<PeerId, (rustls::Certificate, rustls::PrivateKey)> = peers
-            .iter()
-            .map(|peer| {
-                let (cert, key) = gen_cert_and_key(&format!("peer-{}", peer.to_usize())).unwrap();
-                (*peer, (cert, key))
-            })
-            .collect::<HashMap<_, _>>();
-
-        let peer_params: BTreeMap<PeerId, PeerServerParams> = peers
-            .iter()
-            .map(|peer| {
-                let peer_port = base_port + u16::from(*peer) * 10;
-                let p2p_url = format!("ws://127.0.0.1:{peer_port}");
-                let api_url = format!("ws://127.0.0.1:{}", peer_port + 1);
-
-                let params: PeerServerParams = PeerServerParams {
-                    cert: keys[peer].0.clone(),
-                    p2p_url: p2p_url.parse().expect("Should parse"),
-                    api_url: api_url.parse().expect("Should parse"),
-                    name: format!("peer-{}", peer.to_usize()),
-                };
-                (*peer, params)
-            })
-            .collect();
-
-        peers
-            .iter()
-            .map(|peer| {
-                let bind_p2p = parse_host_port(peer_params[peer].clone().p2p_url)?;
-                let bind_api = parse_host_port(peer_params[peer].clone().api_url)?;
-
-                let params: ConfigGenParams = Self::gen_params(
-                    ApiAuth("dummy_password".to_string()),
-                    bind_p2p.parse().context("when parsing bind_p2p")?,
-                    bind_api.parse().context("when parsing bind_api")?,
-                    keys[peer].1.clone(),
-                    *peer,
-                    peer_params.clone(),
-                    federation_name.to_string(),
-                    modules.clone(),
-                );
-                Ok((*peer, params))
-            })
-            .collect::<anyhow::Result<HashMap<_, _>>>()
     }
 }
 

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::{env, fs, io};
 
 use async_trait::async_trait;
-use fedimint_core::config::{ClientModuleConfig, ConfigGenParams, ServerModuleConfig};
+use fedimint_core::config::{ClientModuleConfig, ConfigGenModuleParams, ServerModuleConfig};
 use fedimint_core::core::{ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::{Database, DatabaseTransaction, ModuleDatabaseTransaction};
@@ -49,7 +49,7 @@ where
     pub async fn new<ConfGen, F, FF>(
         members: usize,
         constructor: F,
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
         conf_gen: &ConfGen,
         module_instance_id: ModuleInstanceId,
     ) -> anyhow::Result<FakeFed<Module>>

--- a/fedimintd/src/distributed_gen.rs
+++ b/fedimintd/src/distributed_gen.rs
@@ -13,7 +13,7 @@ use fedimint_ln_server::LightningGen;
 use fedimint_logging::TracingSetup;
 use fedimint_mint_server::MintGen;
 use fedimint_server::config::io::{create_cert, write_server_config, CODE_VERSION, SALT_FILE};
-use fedimint_server::config::{ServerConfig, ServerConfigParams};
+use fedimint_server::config::{ConfigGenParams, ServerConfig};
 use fedimint_server::net::peers::DelayCalculator;
 use fedimint_wallet_server::WalletGen;
 use tracing::info;
@@ -197,7 +197,7 @@ impl DistributedGen {
                     network,
                     finality_delay,
                 );
-                let params = ServerConfigParams::parse_from_connect_strings(
+                let params = ConfigGenParams::parse_from_connect_strings(
                     bind_p2p,
                     bind_api,
                     &dir_out_path,

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -20,7 +20,7 @@ use fedimint_core::Amount;
 use fedimint_server::config::io::{
     create_cert, parse_peer_params, write_server_config, CONSENSUS_CONFIG, JSON_EXT,
 };
-use fedimint_server::config::{ServerConfig, ServerConfigConsensus, ServerConfigParams};
+use fedimint_server::config::{ConfigGenParams, ServerConfig, ServerConfigConsensus};
 use fedimint_server::net::peers::DelayCalculator;
 use http::StatusCode;
 use qrcode_generator::QrCodeEcc;
@@ -183,7 +183,7 @@ async fn post_guardians(
             tracing::info!("Running DKG");
 
             state_copy.lock().await.dkg_state = Some(DkgState::Running);
-            let maybe_config = match ServerConfigParams::parse_from_connect_strings(
+            let maybe_config = match ConfigGenParams::parse_from_connect_strings(
                 params.bind_p2p,
                 params.bind_api,
                 &dir_out_path,

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -42,6 +42,7 @@ mint-client = { path = "../client/client-lib" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 tokio = { version = "1.26.0", features = ["full"] }
+tokio-rustls = "0.23.4"
 tracing ="0.1.37"
 url = "2.3.1"
 hbbft = { git = "https://github.com/fedimint/hbbft" }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -38,7 +38,7 @@ use fedimint_mint_client::MintClientGen;
 use fedimint_mint_server::common::db::NonceKeyPrefix;
 use fedimint_mint_server::common::MintOutput;
 use fedimint_mint_server::MintGen;
-use fedimint_server::config::{ServerConfig, ServerConfigParams};
+use fedimint_server::config::{ConfigGenParams, ServerConfig};
 use fedimint_server::consensus::{
     ConsensusProposal, FedimintConsensus, HbbftConsensusOutcome, TransactionSubmissionError,
 };
@@ -214,8 +214,7 @@ pub async fn fixtures(num_peers: u16, gateway_node: GatewayNode) -> anyhow::Resu
         bitcoin::network::constants::Network::Regtest,
         10,
     );
-    let params =
-        ServerConfigParams::gen_local(&peers, base_port, "test", module_gens_params).unwrap();
+    let params = ConfigGenParams::gen_local(&peers, base_port, "test", module_gens_params).unwrap();
 
     let server_module_inits = ServerModuleGenRegistry::from(vec![
         DynServerModuleGen::from(WalletGen),
@@ -531,7 +530,7 @@ pub async fn create_user_client(
 
 async fn distributed_config(
     peers: &[PeerId],
-    params: HashMap<PeerId, ServerConfigParams>,
+    params: HashMap<PeerId, ConfigGenParams>,
     registry: ServerModuleGenRegistry,
     task_group: &mut TaskGroup,
 ) -> Cancellable<(BTreeMap<PeerId, ServerConfig>, ClientConfig)> {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -9,12 +9,14 @@ use std::sync::atomic::{AtomicI64, AtomicU16, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::{secp256k1, Address, KeyPair};
 use cln_rpc::ClnRpc;
 use fedimint_bitcoind::bitcoincore_rpc::{make_bitcoind_rpc, make_electrum_rpc, make_esplora_rpc};
 use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_client::module::gen::{ClientModuleGenRegistry, DynClientModuleGen};
+use fedimint_core::admin_client::PeerServerParams;
 use fedimint_core::api::WsFederationApi;
 use fedimint_core::bitcoin_rpc::read_bitcoin_backend_from_global_env;
 use fedimint_core::cancellable::Cancellable;
@@ -26,7 +28,7 @@ use fedimint_core::core::{
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::Database;
 use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
-use fedimint_core::module::DynServerModuleGen;
+use fedimint_core::module::{ApiAuth, DynServerModuleGen};
 use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::{timeout, RwLock, TaskGroup};
@@ -38,13 +40,13 @@ use fedimint_mint_client::MintClientGen;
 use fedimint_mint_server::common::db::NonceKeyPrefix;
 use fedimint_mint_server::common::MintOutput;
 use fedimint_mint_server::MintGen;
-use fedimint_server::config::{ConfigGenParams, ServerConfig};
+use fedimint_server::config::{gen_cert_and_key, ConfigGenParams, ServerConfig};
 use fedimint_server::consensus::{
     ConsensusProposal, FedimintConsensus, HbbftConsensusOutcome, TransactionSubmissionError,
 };
 use fedimint_server::db::GLOBAL_DATABASE_VERSION;
 use fedimint_server::net::connect::mock::{MockNetwork, StreamReliability};
-use fedimint_server::net::connect::{Connector, TlsTcpConnector};
+use fedimint_server::net::connect::{parse_host_port, Connector, TlsTcpConnector};
 use fedimint_server::net::peers::{DelayCalculator, PeerConnector};
 use fedimint_server::{consensus, EpochMessage, FedimintServer};
 use fedimint_testing::btc::fixtures::FakeBitcoinTest;
@@ -76,6 +78,7 @@ use rand::rngs::OsRng;
 use rand::RngCore;
 use real::{RealBitcoinTest, RealLightningTest};
 use tokio::sync::Mutex;
+use tokio_rustls::rustls;
 use tonic_lnd::connect;
 use tracing::{debug, info};
 use url::Url;
@@ -214,7 +217,7 @@ pub async fn fixtures(num_peers: u16, gateway_node: GatewayNode) -> anyhow::Resu
         bitcoin::network::constants::Network::Regtest,
         10,
     );
-    let params = ConfigGenParams::gen_local(&peers, base_port, "test", module_gens_params).unwrap();
+    let params = gen_local(&peers, base_port, "test", module_gens_params).unwrap();
 
     let server_module_inits = ServerModuleGenRegistry::from(vec![
         DynServerModuleGen::from(WalletGen),
@@ -458,6 +461,59 @@ pub async fn fixtures(num_peers: u16, gateway_node: GatewayNode) -> anyhow::Resu
     }
 
     Ok(fixtures)
+}
+
+/// config for servers running on different ports on our localhost
+pub fn gen_local(
+    peers: &[PeerId],
+    base_port: u16,
+    federation_name: &str,
+    modules: ServerModuleGenParamsRegistry,
+) -> anyhow::Result<HashMap<PeerId, ConfigGenParams>> {
+    let keys: HashMap<PeerId, (rustls::Certificate, rustls::PrivateKey)> = peers
+        .iter()
+        .map(|peer| {
+            let (cert, key) = gen_cert_and_key(&format!("peer-{}", peer.to_usize())).unwrap();
+            (*peer, (cert, key))
+        })
+        .collect::<HashMap<_, _>>();
+
+    let peer_params: BTreeMap<PeerId, PeerServerParams> = peers
+        .iter()
+        .map(|peer| {
+            let peer_port = base_port + u16::from(*peer) * 10;
+            let p2p_url = format!("ws://127.0.0.1:{peer_port}");
+            let api_url = format!("ws://127.0.0.1:{}", peer_port + 1);
+
+            let params: PeerServerParams = PeerServerParams {
+                cert: keys[peer].0.clone(),
+                p2p_url: p2p_url.parse().expect("Should parse"),
+                api_url: api_url.parse().expect("Should parse"),
+                name: format!("peer-{}", peer.to_usize()),
+            };
+            (*peer, params)
+        })
+        .collect();
+
+    peers
+        .iter()
+        .map(|peer| {
+            let bind_p2p = parse_host_port(peer_params[peer].clone().p2p_url)?;
+            let bind_api = parse_host_port(peer_params[peer].clone().api_url)?;
+
+            let params: ConfigGenParams = ConfigGenParams::new(
+                ApiAuth("dummy_password".to_string()),
+                bind_p2p.parse().context("when parsing bind_p2p")?,
+                bind_api.parse().context("when parsing bind_api")?,
+                keys[peer].1.clone(),
+                *peer,
+                peer_params.clone(),
+                federation_name.to_string(),
+                modules.clone(),
+            );
+            Ok((*peer, params))
+        })
+        .collect::<anyhow::Result<HashMap<_, _>>>()
 }
 
 pub async fn create_lightning_adapter(

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -3,8 +3,8 @@ use std::ffi::OsString;
 
 use async_trait::async_trait;
 use fedimint_core::config::{
-    ConfigGenParams, DkgResult, ModuleConfigResponse, ServerModuleConfig, TypedServerModuleConfig,
-    TypedServerModuleConsensusConfig,
+    ConfigGenModuleParams, DkgResult, ModuleConfigResponse, ServerModuleConfig,
+    TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseVersion, MigrationMap, ModuleDatabaseTransaction};
@@ -66,7 +66,7 @@ impl ServerModuleGen for DummyServerGen {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        _params: &ConfigGenParams,
+        _params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let mint_cfg: BTreeMap<_, DummyConfig> = peers
             .iter()
@@ -90,7 +90,7 @@ impl ServerModuleGen for DummyServerGen {
     async fn distributed_gen(
         &self,
         _peers: &PeerHandle,
-        _params: &ConfigGenParams,
+        _params: &ConfigGenModuleParams,
     ) -> DkgResult<ServerModuleConfig> {
         let server = DummyConfig {
             private: DummyConfigPrivate {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -4,8 +4,8 @@ use std::ops::Sub;
 
 use bitcoin_hashes::Hash as BitcoinHash;
 use fedimint_core::config::{
-    ConfigGenParams, DkgResult, ModuleConfigResponse, ServerModuleConfig, TypedServerModuleConfig,
-    TypedServerModuleConsensusConfig,
+    ConfigGenModuleParams, DkgResult, ModuleConfigResponse, ServerModuleConfig,
+    TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::{ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
 use fedimint_core::db::{Database, DatabaseVersion, ModuleDatabaseTransaction};
@@ -78,7 +78,7 @@ impl ServerModuleGen for LightningGen {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        _params: &ConfigGenParams,
+        _params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let sks = threshold_crypto::SecretKeySet::random(peers.degree(), &mut OsRng);
         let pks = sks.public_keys();
@@ -110,7 +110,7 @@ impl ServerModuleGen for LightningGen {
     async fn distributed_gen(
         &self,
         peers: &PeerHandle,
-        _params: &ConfigGenParams,
+        _params: &ConfigGenModuleParams,
     ) -> DkgResult<ServerModuleConfig> {
         let g1 = peers.run_dkg_g1(()).await?;
 

--- a/modules/fedimint-ln-server/tests/ln_contracts.rs
+++ b/modules/fedimint-ln-server/tests/ln_contracts.rs
@@ -1,5 +1,5 @@
 use bitcoin_hashes::{sha256, Hash as BitcoinHash};
-use fedimint_core::config::ConfigGenParams;
+use fedimint_core::config::ConfigGenModuleParams;
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
 use fedimint_core::{Amount, OutPoint};
 use fedimint_ln_common::config::LightningClientConfig;
@@ -23,7 +23,7 @@ async fn test_outgoing() {
     let mut fed = FakeFed::<Lightning>::new(
         4,
         |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
-        &ConfigGenParams::null(),
+        &ConfigGenModuleParams::null(),
         &LightningGen,
         LEGACY_HARDCODED_INSTANCE_ID_LN,
     )
@@ -123,7 +123,7 @@ async fn test_incoming() {
     let mut fed = FakeFed::<Lightning>::new(
         4,
         |cfg, _db| async move { Ok(Lightning::new(cfg.to_typed()?)) },
-        &ConfigGenParams::null(),
+        &ConfigGenModuleParams::null(),
         &LightningGen,
         LEGACY_HARDCODED_INSTANCE_ID_LN,
     )

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -4,7 +4,7 @@ use std::iter::FromIterator;
 use std::ops::Sub;
 
 use fedimint_core::config::{
-    ConfigGenParams, DkgResult, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
+    ConfigGenModuleParams, DkgResult, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
@@ -92,7 +92,7 @@ impl ServerModuleGen for MintGen {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let params = params
             .to_typed::<MintGenParams>()
@@ -149,7 +149,7 @@ impl ServerModuleGen for MintGen {
     async fn distributed_gen(
         &self,
         peers: &PeerHandle,
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> DkgResult<ServerModuleConfig> {
         let params = params
             .to_typed::<MintGenParams>()
@@ -950,7 +950,8 @@ impl Mint {
 #[cfg(test)]
 mod test {
     use fedimint_core::config::{
-        ClientModuleConfig, ConfigGenParams, ServerModuleConfig, TypedServerModuleConsensusConfig,
+        ClientModuleConfig, ConfigGenModuleParams, ServerModuleConfig,
+        TypedServerModuleConsensusConfig,
     };
     use fedimint_core::module::ServerModuleGen;
     use fedimint_core::{Amount, PeerId, TieredMulti};
@@ -969,7 +970,7 @@ mod test {
         let peers = (0..MINTS as u16).map(PeerId::from).collect::<Vec<_>>();
         let mint_cfg = MintGen.trusted_dealer_gen(
             &peers,
-            &ConfigGenParams::from_typed(MintGenParams {
+            &ConfigGenModuleParams::from_typed(MintGenParams {
                 mint_amounts: vec![Amount::from_sats(1)],
             })
             .unwrap(),

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -29,7 +29,7 @@ use fedimint_core::bitcoin_rpc::{
     FM_ELECTRUM_RPC_ENV, FM_ESPLORA_RPC_ENV,
 };
 use fedimint_core::config::{
-    ConfigGenParams, DkgResult, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
+    ConfigGenModuleParams, DkgResult, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
@@ -113,7 +113,7 @@ impl ServerModuleGen for WalletGen {
     fn trusted_dealer_gen(
         &self,
         peers: &[PeerId],
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let params = params
             .to_typed::<WalletGenParams>()
@@ -152,7 +152,7 @@ impl ServerModuleGen for WalletGen {
     async fn distributed_gen(
         &self,
         peers: &PeerHandle,
-        params: &ConfigGenParams,
+        params: &ConfigGenModuleParams,
     ) -> DkgResult<ServerModuleConfig> {
         let params = params
             .to_typed::<WalletGenParams>()


### PR DESCRIPTION
Simplifies and standardizes our config gen parameters.

Redundant `ServerConfigParams` is replaced by the new `ConfigGenParams` struct.

Renames some duplicate names:
- `ConfigGenParams` -> `ConfigGenModuleParams`
- `ApiEndpoint` -> `PeerUrl`

Moves `gen_local` to the test crate so it isn't used accidentally.