### PR TITLE
chore: use default type paramater in ModuleDatabaseTransaction

### DIFF
--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -58,15 +58,12 @@ pub trait IServerModule: Debug {
     fn versions(&self) -> (ModuleConsensusVersion, &[ApiVersion]);
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-    );
+    async fn await_consensus_proposal(&self, dbtx: &mut ModuleDatabaseTransaction<'_>);
 
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         module_instance_id: ModuleInstanceId,
     ) -> ConsensusProposal<DynModuleConsensusItem>;
 
@@ -77,7 +74,7 @@ pub trait IServerModule: Debug {
     /// results are available when processing transactions.
     async fn begin_consensus_epoch<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
         consensus_items: Vec<(PeerId, DynModuleConsensusItem)>,
     );
 
@@ -96,7 +93,7 @@ pub trait IServerModule: Debug {
     async fn validate_input<'a>(
         &self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         verification_cache: &DynVerificationCache,
         input: &DynInput,
     ) -> Result<InputMeta, ModuleError>;
@@ -112,7 +109,7 @@ pub trait IServerModule: Debug {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'c>,
         input: &'b DynInput,
         verification_cache: &DynVerificationCache,
     ) -> Result<InputMeta, ModuleError>;
@@ -124,7 +121,7 @@ pub trait IServerModule: Debug {
     /// them and merely generate a warning.
     async fn validate_output(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         output: &DynOutput,
     ) -> Result<TransactionItemAmount, ModuleError>;
 
@@ -142,7 +139,7 @@ pub trait IServerModule: Debug {
     /// once all transactions have been processed.
     async fn apply_output<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
         output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError>;
@@ -156,7 +153,7 @@ pub trait IServerModule: Debug {
     async fn end_consensus_epoch<'a>(
         &self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
     ) -> Vec<PeerId>;
 
     /// Retrieve the current status of the output. Depending on the module this
@@ -165,7 +162,7 @@ pub trait IServerModule: Debug {
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome>;
@@ -175,11 +172,7 @@ pub trait IServerModule: Debug {
     ///
     /// Summing over all modules, if liabilities > assets then an error has
     /// occurred in the database and consensus should halt.
-    async fn audit(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        audit: &mut Audit,
-    );
+    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit);
 
     /// Returns a list of custom API endpoints defined by the module. These are
     /// made available both to users as well as to other modules. They thus
@@ -211,17 +204,14 @@ where
     }
 
     /// Blocks until a new `consensus_proposal` is available.
-    async fn await_consensus_proposal(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-    ) {
+    async fn await_consensus_proposal(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) {
         <Self as ServerModule>::await_consensus_proposal(self, dbtx).await
     }
 
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         module_instance_id: ModuleInstanceId,
     ) -> ConsensusProposal<DynModuleConsensusItem> {
         <Self as ServerModule>::consensus_proposal(self, dbtx)
@@ -236,7 +226,7 @@ where
     /// results are available when processing transactions.
     async fn begin_consensus_epoch<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
         consensus_items: Vec<(PeerId, DynModuleConsensusItem)>,
     ) {
         <Self as ServerModule>::begin_consensus_epoch(
@@ -285,7 +275,7 @@ where
     async fn validate_input<'a>(
         &self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         verification_cache: &DynVerificationCache,
         input: &DynInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -317,7 +307,7 @@ where
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'c>,
         input: &'b DynInput,
         verification_cache: &DynVerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -345,7 +335,7 @@ where
     /// them and merely generate a warning.
     async fn validate_output(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         output: &DynOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         <Self as ServerModule>::validate_output(
@@ -373,7 +363,7 @@ where
     /// once all transactions have been processed.
     async fn apply_output<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
         output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -398,7 +388,7 @@ where
     async fn end_consensus_epoch<'a>(
         &self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
     ) -> Vec<PeerId> {
         <Self as ServerModule>::end_consensus_epoch(self, consensus_peers, dbtx).await
     }
@@ -409,7 +399,7 @@ where
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome> {
@@ -423,11 +413,7 @@ where
     ///
     /// Summing over all modules, if liabilities > assets then an error has
     /// occurred in the database and consensus should halt.
-    async fn audit(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        audit: &mut Audit,
-    ) {
+    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
         <Self as ServerModule>::audit(self, dbtx, audit).await
     }
 

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -905,7 +905,7 @@ impl<'parent> DatabaseTransaction<'parent> {
     pub fn with_module_prefix(
         &mut self,
         module_instance_id: ModuleInstanceId,
-    ) -> ModuleDatabaseTransaction<'_, ModuleInstanceId> {
+    ) -> ModuleDatabaseTransaction<'_> {
         ModuleDatabaseTransaction::new(
             self.tx.as_mut(),
             Some(module_instance_id),
@@ -914,7 +914,7 @@ impl<'parent> DatabaseTransaction<'parent> {
         )
     }
 
-    pub fn get_isolated(&mut self) -> ModuleDatabaseTransaction<'_, ModuleInstanceId> {
+    pub fn get_isolated(&mut self) -> ModuleDatabaseTransaction<'_> {
         ModuleDatabaseTransaction::new(
             self.tx.as_mut(),
             None,

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -2,7 +2,6 @@ use std::fmt::{Display, Formatter};
 
 use futures::StreamExt;
 
-use crate::core::ModuleInstanceId;
 use crate::db::{DatabaseKey, DatabaseLookup, DatabaseRecord, ModuleDatabaseTransaction};
 
 #[derive(Default)]
@@ -25,7 +24,7 @@ impl Audit {
 
     pub async fn add_items<KP, F>(
         &mut self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         key_prefix: &KP,
         to_milli_sat: F,
     ) where

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -617,7 +617,7 @@ impl FedimintConsensus {
 
     pub async fn get_config_with_sig(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> ConfigResponse {
         let mut client = self.client_cfg.clone();
         let maybe_sig = dbtx.get_value(&ClientConfigSignatureKey).await;

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -97,7 +97,7 @@ where
 
         async fn member_validate<M: ServerModule>(
             member: &M,
-            dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+            dbtx: &mut ModuleDatabaseTransaction<'_>,
             fake_ic: &FakeInterconnect,
             input: &<M::Common as ModuleCommon>::Input,
         ) -> Result<TestInputMeta, ModuleError> {

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -6,7 +6,6 @@ use fedimint_core::config::{
     ConfigGenParams, DkgResult, ModuleConfigResponse, ServerModuleConfig, TypedServerModuleConfig,
     TypedServerModuleConsensusConfig,
 };
-use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseVersion, MigrationMap, ModuleDatabaseTransaction};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::__reexports::serde_json;
@@ -120,7 +119,7 @@ impl ServerModuleGen for DummyServerGen {
 
     async fn dump_database(
         &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_>,
         _prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         Box::new(BTreeMap::new().into_iter())
@@ -146,23 +145,20 @@ impl ServerModule for Dummy {
         )
     }
 
-    async fn await_consensus_proposal(
-        &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-    ) {
+    async fn await_consensus_proposal(&self, _dbtx: &mut ModuleDatabaseTransaction<'_>) {
         std::future::pending().await
     }
 
     async fn consensus_proposal(
         &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> ConsensusProposal<DummyConsensusItem> {
         ConsensusProposal::empty()
     }
 
     async fn begin_consensus_epoch<'a, 'b>(
         &'a self,
-        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b>,
         _consensus_items: Vec<(PeerId, DummyConsensusItem)>,
     ) {
     }
@@ -177,7 +173,7 @@ impl ServerModule for Dummy {
     async fn validate_input<'a, 'b>(
         &self,
         _interconnect: &dyn ModuleInterconect,
-        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b>,
         _verification_cache: &Self::VerificationCache,
         _input: &'a DummyInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -187,7 +183,7 @@ impl ServerModule for Dummy {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         _interconnect: &'a dyn ModuleInterconect,
-        _dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'c>,
         _input: &'b DummyInput,
         _cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -196,7 +192,7 @@ impl ServerModule for Dummy {
 
     async fn validate_output(
         &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_>,
         _output: &DummyOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         unimplemented!()
@@ -204,7 +200,7 @@ impl ServerModule for Dummy {
 
     async fn apply_output<'a, 'b>(
         &'a self,
-        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b>,
         _output: &'a DummyOutput,
         _out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -214,25 +210,20 @@ impl ServerModule for Dummy {
     async fn end_consensus_epoch<'a, 'b>(
         &'a self,
         _consensus_peers: &HashSet<PeerId>,
-        _dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'b>,
     ) -> Vec<PeerId> {
         vec![]
     }
 
     async fn output_status(
         &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_>,
         _out_point: OutPoint,
     ) -> Option<DummyOutputOutcome> {
         None
     }
 
-    async fn audit(
-        &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        _audit: &mut Audit,
-    ) {
-    }
+    async fn audit(&self, _dbtx: &mut ModuleDatabaseTransaction<'_>, _audit: &mut Audit) {}
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![api_endpoint! {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -7,7 +7,7 @@ use fedimint_core::config::{
     ConfigGenParams, DkgResult, ModuleConfigResponse, ServerModuleConfig, TypedServerModuleConfig,
     TypedServerModuleConsensusConfig,
 };
-use fedimint_core::core::{ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
+use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::db::{Database, DatabaseVersion, ModuleDatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::audit::Audit;
@@ -149,7 +149,7 @@ impl ServerModuleGen for LightningGen {
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut lightning: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =
@@ -264,10 +264,7 @@ impl ServerModule for Lightning {
         )
     }
 
-    async fn await_consensus_proposal(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-    ) {
+    async fn await_consensus_proposal(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) {
         if !self.consensus_proposal(dbtx).await.forces_new_epoch() {
             std::future::pending().await
         }
@@ -275,7 +272,7 @@ impl ServerModule for Lightning {
 
     async fn consensus_proposal(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> ConsensusProposal<LightningConsensusItem> {
         ConsensusProposal::new_auto_trigger(
             dbtx.find_by_prefix(&ProposeDecryptionShareKeyPrefix)
@@ -293,7 +290,7 @@ impl ServerModule for Lightning {
 
     async fn begin_consensus_epoch<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
         consensus_items: Vec<(PeerId, LightningConsensusItem)>,
     ) {
         for (peer, decryption_share) in consensus_items.into_iter() {
@@ -318,7 +315,7 @@ impl ServerModule for Lightning {
     async fn validate_input<'a, 'b>(
         &self,
         interconnect: &dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
         _verification_cache: &Self::VerificationCache,
         input: &'a LightningInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -390,7 +387,7 @@ impl ServerModule for Lightning {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'c>,
         input: &'b LightningInput,
         cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -411,7 +408,7 @@ impl ServerModule for Lightning {
 
     async fn validate_output(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         output: &LightningOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         match output {
@@ -483,7 +480,7 @@ impl ServerModule for Lightning {
 
     async fn apply_output<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
         output: &'a LightningOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -576,7 +573,7 @@ impl ServerModule for Lightning {
     async fn end_consensus_epoch<'a, 'b>(
         &'a self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
     ) -> Vec<PeerId> {
         // Decrypt preimages
         let preimage_decryption_shares = dbtx
@@ -733,17 +730,13 @@ impl ServerModule for Lightning {
 
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<LightningOutputOutcome> {
         dbtx.get_value(&ContractUpdateKey(out_point)).await
     }
 
-    async fn audit(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        audit: &mut Audit,
-    ) {
+    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
         audit
             .add_items(dbtx, &ContractKeyPrefix, |_, v| -(v.amount.msats as i64))
             .await;
@@ -808,7 +801,7 @@ impl Lightning {
 
     pub async fn get_offer(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         payment_hash: bitcoin_hashes::sha256::Hash,
     ) -> Option<IncomingContractOffer> {
         dbtx.get_value(&OfferKey(payment_hash)).await
@@ -816,7 +809,7 @@ impl Lightning {
 
     pub async fn get_offers(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> Vec<IncomingContractOffer> {
         dbtx.find_by_prefix(&OfferKeyPrefix)
             .await
@@ -827,7 +820,7 @@ impl Lightning {
 
     pub async fn get_contract_account(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         contract_id: ContractId,
     ) -> Option<ContractAccount> {
         dbtx.get_value(&ContractKey(contract_id)).await
@@ -835,7 +828,7 @@ impl Lightning {
 
     pub async fn list_gateways(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> Vec<LightningGateway> {
         let stream = dbtx.find_by_prefix(&LightningGatewayKeyPrefix).await;
         stream
@@ -853,7 +846,7 @@ impl Lightning {
 
     pub async fn register_gateway(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         gateway: LightningGateway,
     ) {
         dbtx.insert_entry(&LightningGatewayKey(gateway.node_pub_key), &gateway)

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -7,7 +7,6 @@ use fedimint_core::config::{
     ConfigGenParams, DkgResult, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
-use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseVersion, ModuleDatabaseTransaction};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::__reexports::serde_json;
@@ -211,7 +210,7 @@ impl ServerModuleGen for MintGen {
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut mint: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> = BTreeMap::new();
@@ -293,10 +292,7 @@ impl ServerModule for Mint {
     type Gen = MintGen;
     type VerificationCache = VerifiedNotes;
 
-    async fn await_consensus_proposal(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-    ) {
+    async fn await_consensus_proposal(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) {
         if !self.consensus_proposal(dbtx).await.forces_new_epoch() {
             std::future::pending().await
         }
@@ -311,7 +307,7 @@ impl ServerModule for Mint {
 
     async fn consensus_proposal(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> ConsensusProposal<MintConsensusItem> {
         ConsensusProposal::new_auto_trigger(
             dbtx.find_by_prefix(&ProposedPartialSignaturesKeyPrefix)
@@ -327,7 +323,7 @@ impl ServerModule for Mint {
 
     async fn begin_consensus_epoch<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
         consensus_items: Vec<(PeerId, MintConsensusItem)>,
     ) {
         for (peer, consensus_item) in consensus_items {
@@ -370,7 +366,7 @@ impl ServerModule for Mint {
     async fn validate_input<'a, 'b>(
         &self,
         _interconnect: &dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
         verification_cache: &Self::VerificationCache,
         input: &'a MintInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -405,7 +401,7 @@ impl ServerModule for Mint {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'c>,
         input: &'b MintInput,
         cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -425,7 +421,7 @@ impl ServerModule for Mint {
 
     async fn validate_output(
         &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        _dbtx: &mut ModuleDatabaseTransaction<'_>,
         output: &MintOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         if output.longest_tier_len() > self.cfg.consensus.max_notes_per_denomination.into() {
@@ -455,7 +451,7 @@ impl ServerModule for Mint {
 
     async fn apply_output<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
         output: &'a MintOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -481,7 +477,7 @@ impl ServerModule for Mint {
     async fn end_consensus_epoch<'a, 'b>(
         &'a self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
     ) -> Vec<PeerId> {
         struct IssuanceData {
             out_point: OutPoint,
@@ -599,7 +595,7 @@ impl ServerModule for Mint {
 
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<MintOutputOutcome> {
         let we_proposed = dbtx
@@ -626,11 +622,7 @@ impl ServerModule for Mint {
         }
     }
 
-    async fn audit(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        audit: &mut Audit,
-    ) {
+    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
         audit
             .add_items(dbtx, &MintAuditItemKeyPrefix, |k, v| match k {
                 MintAuditItemKey::Issuance(_) => -(v.msats as i64),
@@ -665,7 +657,7 @@ impl ServerModule for Mint {
 impl Mint {
     async fn handle_backup_request(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         request: SignedBackupRequest,
     ) -> Result<(), ApiError> {
         let request = request
@@ -695,7 +687,7 @@ impl Mint {
 
     async fn handle_recover_request(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         id: secp256k1_zkp::XOnlyPublicKey,
     ) -> Option<ECashUserBackupSnapshot> {
         dbtx.get_value(&EcashBackupKey(id)).await
@@ -918,7 +910,7 @@ impl Mint {
 
     async fn process_partial_signature<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
         peer: PeerId,
         output_id: OutPoint,
         partial_sig: MintOutputSignatureShare,

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -32,7 +32,6 @@ use fedimint_core::config::{
     ConfigGenParams, DkgResult, ModuleConfigResponse, ModuleGenParams, ServerModuleConfig,
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
-use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
     Database, DatabaseTransaction, DatabaseVersion, ModuleDatabaseTransaction,
 };
@@ -196,7 +195,7 @@ impl ServerModuleGen for WalletGen {
     }
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut wallet: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> = BTreeMap::new();
@@ -284,10 +283,7 @@ impl ServerModule for Wallet {
         )
     }
 
-    async fn await_consensus_proposal(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-    ) {
+    async fn await_consensus_proposal(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) {
         while !self.consensus_proposal(dbtx).await.forces_new_epoch() {
             // FIXME: remove after modularization finishes
             #[cfg(not(target_family = "wasm"))]
@@ -297,7 +293,7 @@ impl ServerModule for Wallet {
 
     async fn consensus_proposal<'a>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> ConsensusProposal<WalletConsensusItem> {
         // TODO: implement retry logic in case bitcoind is temporarily unreachable
         let our_target_height = self.target_height().await;
@@ -354,7 +350,7 @@ impl ServerModule for Wallet {
 
     async fn begin_consensus_epoch<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
         consensus_items: Vec<(PeerId, WalletConsensusItem)>,
     ) {
         trace!(?consensus_items, "Received consensus proposals");
@@ -389,7 +385,7 @@ impl ServerModule for Wallet {
     async fn validate_input<'a, 'b>(
         &self,
         _interconnect: &dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
         _verification_cache: &Self::VerificationCache,
         input: &'a WalletInput,
     ) -> Result<InputMeta, ModuleError> {
@@ -418,7 +414,7 @@ impl ServerModule for Wallet {
     async fn apply_input<'a, 'b, 'c>(
         &'a self,
         interconnect: &'a dyn ModuleInterconect,
-        dbtx: &mut ModuleDatabaseTransaction<'c, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'c>,
         input: &'b WalletInput,
         cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError> {
@@ -441,7 +437,7 @@ impl ServerModule for Wallet {
 
     async fn validate_output(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         output: &WalletOutput,
     ) -> Result<TransactionItemAmount, ModuleError> {
         let fee_rate = self.current_round_consensus(dbtx).await.unwrap().fee_rate;
@@ -462,7 +458,7 @@ impl ServerModule for Wallet {
 
     async fn apply_output<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
         output: &'a WalletOutput,
         out_point: fedimint_core::OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -525,7 +521,7 @@ impl ServerModule for Wallet {
     async fn end_consensus_epoch<'a, 'b>(
         &'a self,
         consensus_peers: &HashSet<PeerId>,
-        dbtx: &mut ModuleDatabaseTransaction<'b, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
     ) -> Vec<PeerId> {
         // Sign and finalize any unsigned transactions that have signatures
         let unsigned_txs = dbtx
@@ -580,17 +576,13 @@ impl ServerModule for Wallet {
 
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<WalletOutputOutcome> {
         dbtx.get_value(&PegOutBitcoinTransaction(out_point)).await
     }
 
-    async fn audit(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-        audit: &mut Audit,
-    ) {
+    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
         audit
             .add_items(dbtx, &UTXOPrefixKey, |_, v| v.amount.to_sat() as i64 * 1000)
             .await;
@@ -733,7 +725,7 @@ impl Wallet {
 
     async fn save_peg_out_signatures<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
         signatures: Vec<(PeerId, PegOutSignatureItem)>,
     ) {
         let mut cache: BTreeMap<Txid, UnsignedTransaction> = dbtx
@@ -911,7 +903,7 @@ impl Wallet {
 
     pub async fn current_round_consensus(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> Option<RoundConsensus> {
         dbtx.get_value(&RoundConsensusKey).await
     }
@@ -925,10 +917,7 @@ impl Wallet {
         our_network_height.saturating_sub(self.cfg.consensus.finality_delay)
     }
 
-    pub async fn consensus_height(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
-    ) -> Option<u32> {
+    pub async fn consensus_height(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) -> Option<u32> {
         self.current_round_consensus(dbtx)
             .await
             .map(|rc| rc.block_height)
@@ -936,7 +925,7 @@ impl Wallet {
 
     async fn sync_up_to_consensus_height<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
         new_height: u32,
     ) {
         let old_height = self
@@ -1024,7 +1013,7 @@ impl Wallet {
     /// in a block that we got consensus on.
     async fn recognize_change_utxo<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
         pending_tx: &PendingTransaction,
     ) {
         self.remove_rbf_transactions(dbtx, pending_tx).await;
@@ -1055,7 +1044,7 @@ impl Wallet {
     /// Removes the `PendingTransaction` and any transactions tied to it via RBF
     async fn remove_rbf_transactions<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'a>,
         pending_tx: &PendingTransaction,
     ) {
         let mut all_transactions: BTreeMap<Txid, PendingTransaction> = dbtx
@@ -1093,7 +1082,7 @@ impl Wallet {
 
     async fn block_is_known(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         block_hash: BlockHash,
     ) -> bool {
         dbtx.get_value(&BlockHashKey(block_hash)).await.is_some()
@@ -1101,7 +1090,7 @@ impl Wallet {
 
     async fn create_peg_out_tx(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
         output: &WalletOutput,
     ) -> Result<UnsignedTransaction, WalletError> {
         let change_tweak = self
@@ -1141,7 +1130,7 @@ impl Wallet {
 
     async fn available_utxos(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> Vec<(UTXOKey, SpendableUTXO)> {
         dbtx.find_by_prefix(&UTXOPrefixKey)
             .await
@@ -1151,7 +1140,7 @@ impl Wallet {
 
     pub async fn get_wallet_value(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_, ModuleInstanceId>,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
     ) -> bitcoin::Amount {
         let sat_sum = self
             .available_utxos(dbtx)


### PR DESCRIPTION
it was already `ModuleDatabaseTransaction<..., T = ModuleInstanceId>`, but not used in the rest of code base.