### PR TITLE
fix: LND crashes if incoming_circuit_key in None

### DIFF
--- a/gateway/ln-gateway/src/lnd.rs
+++ b/gateway/ln-gateway/src/lnd.rs
@@ -203,7 +203,7 @@ impl ILnRpcClient for GatewayLndClient {
             while let Some(htlc) = match htlc_stream.message().await {
                 Ok(htlc) => htlc,
                 Err(e) => {
-                    error!("Error received over HTLC subscriprion: {:?}", e);
+                    error!("Error received over HTLC subscription: {:?}", e);
                     a_tx.send(Err(tonic::Status::new(
                         tonic::Code::Internal,
                         e.to_string(),
@@ -306,7 +306,9 @@ impl ILnRpcClient for GatewayLndClient {
                     failure_message: vec![],
                     failure_code: FailureCode::TemporaryChannelFailure.into(),
                 },
-                Some(Action::Cancel(Cancel { reason: _ })) => cancel_intercepted_htlc(None),
+                Some(Action::Cancel(Cancel { reason: _ })) => {
+                    cancel_intercepted_htlc(incoming_circuit_key)
+                }
                 None => {
                     error!("No action specified for intercepted htlc id: {:?}", hash);
                     return Err(GatewayError::LnRpcError(tonic::Status::internal(


### PR DESCRIPTION
LND in tmuxinator will currently crash with the following commands:

`fedimint-cli switch-gateway <pub key of lnd>`
`fedimint-cli ln-invoice 1000 description`
`lightning-cli pay <bolt 11 invoice>`

It is crashing because it is failing to buy the preimage (because the LND gateway has no ecash) then it tries to settle the HTLC with a `None` for `incoming_circuit_key`. Looking at the [LND source code](https://github.com/lightningnetwork/lnd/blob/f9f08079d0a0ffefabb99e210708a4733825ebef/lnrpc/routerrpc/forward_interceptor.go#L103), this is not allowed.

This is a simple PR to pass the `incoming_circuit_key` so that LND doesn't crash.