### PR TITLE
fix: peg-in LND gateway

### DIFF
--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -9,6 +9,9 @@ source ./scripts/lib.sh
 
 PEG_IN_AMOUNT=${PEG_IN_AMOUNT:-$1}
 USE_GATEWAY=${2:-0}
+GATEWAY_TYPE=${3:-"CLN"}
+
+if [ "$GATEWAY_TYPE" == "CLN" ]; then GATEWAY_CLI=$FM_GWCLI_CLN; else GATEWAY_CLI=$FM_GWCLI_LND; fi
 
 FINALITY_DELAY=$(get_finality_delay)
 echo "Pegging in $PEG_IN_AMOUNT with confirmation in $FINALITY_DELAY blocks"
@@ -16,7 +19,7 @@ echo "Pegging in $PEG_IN_AMOUNT with confirmation in $FINALITY_DELAY blocks"
 FED_ID="$(get_federation_id)"
 
 # get a peg-in address from either the gateway or the client
-if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($FM_GWCLI_CLN address "$FED_ID" | jq -e -r '.address')"; else ADDR="$($FM_MINT_CLIENT peg-in-address | jq -e -r '.address')"; fi
+if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($GATEWAY_CLI address "$FED_ID" | jq -e -r '.address')"; else ADDR="$($FM_MINT_CLIENT peg-in-address | jq -e -r '.address')"; fi
 # send bitcoin to that address and save the txid
 TX_ID=$(send_bitcoin $ADDR $PEG_IN_AMOUNT)
 # wait for confirmation and wait for the fed to sync
@@ -28,7 +31,7 @@ TRANSACTION=$(get_raw_transaction $TX_ID)
 
 # With these proofs we can instruct the client to start the peg-in process. Our client will add the tweak used to derive
 # the peg-in address to the request so that the federation can claim the funds later.
-if [ "$USE_GATEWAY" == 1 ]; then $FM_GWCLI_CLN deposit "$FED_ID" "$TXOUT_PROOF" "$TRANSACTION" && echo "Pegged in to federation with id: $FED_ID"; else $FM_MINT_CLIENT peg-in "$TXOUT_PROOF" "$TRANSACTION"; fi
+if [ "$USE_GATEWAY" == 1 ]; then $GATEWAY_CLI deposit "$FED_ID" "$TXOUT_PROOF" "$TRANSACTION" && echo "Pegged in to federation with id: $FED_ID"; else $FM_MINT_CLIENT peg-in "$TXOUT_PROOF" "$TRANSACTION"; fi
 
 # Since the process is asynchronous have to come back to fetch the result later. We choose to do this right away and
 # just block till we get our notes.

--- a/scripts/tmux-user-shell.sh
+++ b/scripts/tmux-user-shell.sh
@@ -17,8 +17,10 @@ scripts/pegin.sh 10000.0 | show_verbose_output
 
 use_cln_gw
 
-echo Funding gateway e-cash wallet ...
+echo Funding CLN gateway e-cash wallet ...
 scripts/pegin.sh 20000.0 1 | show_verbose_output
+echo Funding LND gateway e-cash wallet ...
+scripts/pegin.sh 20000.0 1 "LND" | show_verbose_output
 
 echo Done!
 echo


### PR DESCRIPTION
Tmuxinator doesn't current peg-in any ecash for LND, so it can't receive payments when tmuxinator starts. This change just pegs-in some ecash for LND so that it can receive payments over the Lightning Network.