### PR TITLE
refactor: remove subscribe htlcs and complete_htlc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,19 +152,20 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote 1.0.23",
@@ -1556,6 +1557,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
 ]
@@ -1598,6 +1600,7 @@ dependencies = [
  "threshold_crypto",
  "tokio",
  "tokio-rustls 0.23.4",
+ "tokio-stream",
  "tonic_lnd",
  "tracing",
  "url",

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -37,4 +37,5 @@ serde_json = "1.0.91"
 tracing ="0.1.37"
 rand = "0.8"
 tokio = { version = "1.26.0", features = ["full"] }
+tokio-stream = "0.1.11"
 url = "2.3.1"

--- a/fedimint-testing/src/ln/fixtures.rs
+++ b/fedimint-testing/src/ln/fixtures.rs
@@ -11,12 +11,13 @@ use futures::stream;
 use lightning::ln::PaymentSecret;
 use lightning_invoice::{Currency, Invoice, InvoiceBuilder, SignedRawInvoice, DEFAULT_EXPIRY_TIME};
 use ln_gateway::gatewaylnrpc::{
-    self, CompleteHtlcsRequest, CompleteHtlcsResponse, GetNodeInfoResponse, GetRouteHintsResponse,
-    PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    self, GetNodeInfoResponse, GetRouteHintsResponse, PayInvoiceRequest, PayInvoiceResponse,
+    RouteHtlcRequest,
 };
-use ln_gateway::lnrpc_client::{HtlcStream, ILnRpcClient};
+use ln_gateway::lnrpc_client::{ILnRpcClient, RouteHtlcStream};
 use ln_gateway::GatewayError;
 use rand::rngs::OsRng;
+use tokio_stream::wrappers::ReceiverStream;
 
 use super::LightningTest;
 
@@ -26,7 +27,6 @@ pub struct FakeLightningTest {
     pub gateway_node_pub_key: secp256k1::PublicKey,
     gateway_node_sec_key: secp256k1::SecretKey,
     amount_sent: Arc<Mutex<u64>>,
-    is_connected: bool,
 }
 
 impl FakeLightningTest {
@@ -40,7 +40,6 @@ impl FakeLightningTest {
             gateway_node_sec_key: SecretKey::from_keypair(&kp),
             gateway_node_pub_key: PublicKey::from_keypair(&kp),
             amount_sent,
-            is_connected: true,
         }
     }
 }
@@ -58,12 +57,6 @@ impl LightningTest for FakeLightningTest {
         amount: Amount,
         expiry_time: Option<u64>,
     ) -> ln_gateway::Result<Invoice> {
-        if !self.is_connected {
-            return Err(GatewayError::Other(anyhow::anyhow!(
-                "Error not connected to Lightning"
-            )));
-        }
-
         let ctx = bitcoin::secp256k1::Secp256k1::new();
 
         Ok(InvoiceBuilder::new(Currency::Regtest)
@@ -92,12 +85,6 @@ impl LightningTest for FakeLightningTest {
 #[async_trait]
 impl ILnRpcClient for FakeLightningTest {
     async fn info(&self) -> ln_gateway::Result<GetNodeInfoResponse> {
-        if !self.is_connected {
-            return Err(GatewayError::Other(anyhow::anyhow!(
-                "Error not connected to Lightning"
-            )));
-        }
-
         Ok(GetNodeInfoResponse {
             pub_key: self.gateway_node_pub_key.serialize().to_vec(),
             alias: "FakeLightningNode".to_string(),
@@ -105,24 +92,12 @@ impl ILnRpcClient for FakeLightningTest {
     }
 
     async fn routehints(&self) -> ln_gateway::Result<GetRouteHintsResponse> {
-        if !self.is_connected {
-            return Err(GatewayError::Other(anyhow::anyhow!(
-                "Error not connected to Lightning"
-            )));
-        }
-
         Ok(GetRouteHintsResponse {
             route_hints: vec![gatewaylnrpc::get_route_hints_response::RouteHint { hops: vec![] }],
         })
     }
 
     async fn pay(&self, invoice: PayInvoiceRequest) -> ln_gateway::Result<PayInvoiceResponse> {
-        if !self.is_connected {
-            return Err(GatewayError::Other(anyhow::anyhow!(
-                "Error not connected to Lightning"
-            )));
-        }
-
         let signed = invoice.invoice.parse::<SignedRawInvoice>().unwrap();
         *self.amount_sent.lock().unwrap() += Invoice::from_signed(signed)
             .unwrap()
@@ -134,29 +109,10 @@ impl ILnRpcClient for FakeLightningTest {
         })
     }
 
-    async fn subscribe_htlcs<'a>(
+    async fn route_htlc<'a>(
         &self,
-        _subscription: SubscribeInterceptHtlcsRequest,
-    ) -> ln_gateway::Result<HtlcStream<'a>> {
-        if !self.is_connected {
-            return Err(GatewayError::Other(anyhow::anyhow!(
-                "Error not connected to Lightning"
-            )));
-        }
-
+        _events: ReceiverStream<RouteHtlcRequest>,
+    ) -> Result<RouteHtlcStream<'a>, GatewayError> {
         Ok(Box::pin(stream::iter(vec![])))
-    }
-
-    async fn complete_htlc(
-        &self,
-        _complete: CompleteHtlcsRequest,
-    ) -> ln_gateway::Result<CompleteHtlcsResponse> {
-        if !self.is_connected {
-            return Err(GatewayError::Other(anyhow::anyhow!(
-                "Error not connected to Lightning"
-            )));
-        }
-
-        Ok(CompleteHtlcsResponse {})
     }
 }

--- a/gateway/ln-gateway/proto/gatewaylnrpc.proto
+++ b/gateway/ln-gateway/proto/gatewaylnrpc.proto
@@ -15,22 +15,16 @@ service GatewayLightning {
    */
   rpc PayInvoice(PayInvoiceRequest) returns (PayInvoiceResponse) {}
 
-  /* SubscribeInterceptHtlcs opens a stream for a client to receive specific
-   * HTLCs that have a specific short channel id. For every HTLC intercepted and
-   * processed, the client should use `CompleteHtlcs` RPC to stream back a
-   * Success or Failure response.
+  /* RouteHtlcs opens a stream for a client to receive specific
+   * HTLCs that have a specific short channel id and receives a stream as input. 
+   * For every HTLC intercepted and processed, the client can send a CompleteHtlcsRequest
+   * over the input stream to complete the HTLC.
    *
    * Recommendation:
    * GatewayLightning implementations should respond with a channel stream
    * over which intercepted HTLCs are continually sent to the client.
    */
-  rpc SubscribeInterceptHtlcs(SubscribeInterceptHtlcsRequest)
-      returns (stream SubscribeInterceptHtlcsResponse) {}
-
-  /* CompleteHtlc allows a client to send a Success or Failure response
-   * for a HTLC that was intercepted and processed.
-   */
-  rpc CompleteHtlc(CompleteHtlcsRequest) returns (CompleteHtlcsResponse) {}
+  rpc RouteHtlcs(stream RouteHtlcRequest) returns (stream RouteHtlcResponse) {}
 }
 
 message EmptyRequest {}
@@ -54,6 +48,22 @@ message PayInvoiceRequest {
 message PayInvoiceResponse {
   // The preimage of the invoice
   bytes preimage = 1;
+}
+
+// Request to begin intercepting HTLCs or to complete
+// a specific HTLC.
+message RouteHtlcRequest {
+  oneof action {
+    SubscribeInterceptHtlcsRequest subscribe_request = 1;
+    CompleteHtlcsRequest complete_request = 2;
+  }
+}
+
+message RouteHtlcResponse {
+  oneof action {
+    SubscribeInterceptHtlcsResponse subscribe_response = 1;
+    CompleteHtlcsResponse complete_response = 2;
+  }
 }
 
 // Request to subscribe to HTLCs with a specific short channel id
@@ -96,6 +106,17 @@ message SubscribeInterceptHtlcsResponse {
   // A unique identifier for every intercepted HTLC
   // Used to identify an intercepted HTLC through processing and settlement
   bytes intercepted_htlc_id = 11;
+
+  // Optional CircuitKey that LND needs to complete the HTLC
+  CircuitKey key = 12;
+}
+
+message CircuitKey {
+  // The id of the channel that the is part of this circuit.
+  uint64 chan_id = 1;
+
+  // The index of the incoming htlc in the incoming channel.
+  uint64 htlc_id = 2;
 }
 
 message CompleteHtlcsRequest {
@@ -130,6 +151,8 @@ message CompleteHtlcsRequest {
   // A unique identifier for every intercepted HTLC
   // Used to identify an intercepted HTLC through processing and settlement
   bytes intercepted_htlc_id = 3;
+
+  CircuitKey key = 4;
 }
 
 message CompleteHtlcsResponse {}

--- a/gateway/ln-gateway/proto/gatewaylnrpc.proto
+++ b/gateway/ln-gateway/proto/gatewaylnrpc.proto
@@ -103,20 +103,11 @@ message SubscribeInterceptHtlcsResponse {
   // Use this value to confirm relevance of the intercepted HTLC
   uint64 short_channel_id = 10;
 
-  // A unique identifier for every intercepted HTLC
-  // Used to identify an intercepted HTLC through processing and settlement
-  bytes intercepted_htlc_id = 11;
+  // The id of the incoming channel
+  uint64 incoming_chan_id = 12;
 
-  // Optional CircuitKey that LND needs to complete the HTLC
-  CircuitKey key = 12;
-}
-
-message CircuitKey {
-  // The id of the channel that the is part of this circuit.
-  uint64 chan_id = 1;
-
-  // The index of the incoming htlc in the incoming channel.
-  uint64 htlc_id = 2;
+  // The index of the incoming htlc in the incoming channel
+  uint64 htlc_id = 13;
 }
 
 message CompleteHtlcsRequest {
@@ -148,11 +139,11 @@ message CompleteHtlcsRequest {
     Cancel cancel = 2;
   }
 
-  // A unique identifier for every intercepted HTLC
-  // Used to identify an intercepted HTLC through processing and settlement
-  bytes intercepted_htlc_id = 3;
+  // The id of the incoming channel
+  uint64 incoming_chan_id = 4;
 
-  CircuitKey key = 4;
+  // The index of the incoming htlc in the incoming channel
+  uint64 htlc_id = 5;
 }
 
 message CompleteHtlcsResponse {}

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -13,16 +13,18 @@ use clap::Parser;
 use cln_plugin::{options, Builder, Plugin};
 use cln_rpc::model;
 use cln_rpc::primitives::ShortChannelId;
+use fedimint_core::task::TaskGroup;
 use fedimint_core::Amount;
+use futures::stream::StreamExt;
 use ln_gateway::gatewaylnrpc::complete_htlcs_request::{Action, Cancel, Settle};
 use ln_gateway::gatewaylnrpc::gateway_lightning_server::{
     GatewayLightning, GatewayLightningServer,
 };
 use ln_gateway::gatewaylnrpc::get_route_hints_response::{RouteHint, RouteHintHop};
 use ln_gateway::gatewaylnrpc::{
-    CompleteHtlcsRequest, CompleteHtlcsResponse, EmptyRequest, GetNodeInfoResponse,
-    GetRouteHintsResponse, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
-    SubscribeInterceptHtlcsResponse,
+    route_htlc_request, route_htlc_response, CompleteHtlcsRequest, CompleteHtlcsResponse,
+    EmptyRequest, GetNodeInfoResponse, GetRouteHintsResponse, PayInvoiceRequest,
+    PayInvoiceResponse, RouteHtlcRequest, RouteHtlcResponse, SubscribeInterceptHtlcsResponse,
 };
 use secp256k1::PublicKey;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -121,6 +123,7 @@ pub struct ClnRpcClient {}
 pub struct ClnRpcService {
     socket: PathBuf,
     interceptor: Arc<ClnHtlcInterceptor>,
+    task_group: TaskGroup,
 }
 
 impl ClnRpcService {
@@ -191,6 +194,7 @@ impl ClnRpcService {
                 Self {
                     socket,
                     interceptor,
+                    task_group: TaskGroup::new()
                 },
                 listen,
                 plugin,
@@ -229,6 +233,86 @@ impl ClnRpcService {
                 _ => Err(ClnExtensionError::RpcWrongResponse),
             })
             .map_err(ClnExtensionError::RpcError)?
+    }
+
+    async fn complete_htlc(
+        complete_request: CompleteHtlcsRequest,
+        interceptors: Arc<ClnHtlcInterceptor>,
+        sender: mpsc::Sender<Result<RouteHtlcResponse, Status>>,
+    ) -> Result<(), Status> {
+        let CompleteHtlcsRequest {
+            action,
+            intercepted_htlc_id,
+            key: _key,
+        } = complete_request;
+        let hash = match sha256::Hash::from_slice(&intercepted_htlc_id) {
+            Ok(hash) => hash,
+            Err(e) => {
+                error!("Invalid intercepted_htlc_id: {:?}", e);
+                return Err(Status::invalid_argument(e.to_string()));
+            }
+        };
+
+        info!("Completing htlc with reference, {:?}", hash);
+
+        if let Some(outcome) = interceptors.outcomes.lock().await.remove(&hash) {
+            // Translate action request into a cln rpc response for
+            // `htlc_accepted` event
+            let htlca_res = match action {
+                Some(Action::Settle(Settle { preimage })) => {
+                    let assert_pk: Result<[u8; 32], TryFromSliceError> =
+                        preimage.as_slice().try_into();
+                    if let Ok(pk) = assert_pk {
+                        serde_json::json!({ "result": "resolve", "payment_key": pk.to_hex() })
+                    } else {
+                        htlc_processing_failure()
+                    }
+                }
+                Some(Action::Cancel(Cancel { reason: _ })) => {
+                    // TODO: Translate the reason into a BOLT 4 failure message
+                    // See: https://github.com/lightning/bolts/blob/master/04-onion-routing.md#failure-messages
+                    htlc_processing_failure()
+                }
+                None => {
+                    error!("No action specified for intercepted htlc id: {:?}", hash);
+                    return Err(Status::internal(
+                        "No action specified on this intercepted htlc",
+                    ));
+                }
+            };
+
+            // Send translated response to the HTLC interceptor for submission
+            // to the cln rpc
+            match outcome.send(htlca_res) {
+                Ok(_) => {
+                    info!("Successfully sent HTLC response back to thread that will complete it.");
+                    sender
+                        .send(Ok(RouteHtlcResponse {
+                            action: Some(route_htlc_response::Action::CompleteResponse(
+                                CompleteHtlcsResponse {},
+                            )),
+                        }))
+                        .await
+                        .expect("Failed to send CompleteHtlcsResponse");
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to send htlc_accepted response to interceptor: {:?}",
+                        e
+                    );
+                    return Err(Status::internal(
+                        "Failed to send htlc_accepted response to interceptor",
+                    ));
+                }
+            };
+        } else {
+            error!(
+                "No interceptor reference found for this processed htlc with id: {:?}",
+                intercepted_htlc_id
+            );
+            return Err(Status::internal("No interceptor reference found for htlc"));
+        }
+        Ok(())
     }
 }
 
@@ -393,89 +477,48 @@ impl GatewayLightning for ClnRpcService {
         Ok(tonic::Response::new(outcome))
     }
 
-    type SubscribeInterceptHtlcsStream =
-        ReceiverStream<Result<SubscribeInterceptHtlcsResponse, Status>>;
+    type RouteHtlcsStream = ReceiverStream<Result<RouteHtlcResponse, Status>>;
 
-    async fn subscribe_intercept_htlcs(
+    async fn route_htlcs(
         &self,
-        request: tonic::Request<SubscribeInterceptHtlcsRequest>,
-    ) -> Result<tonic::Response<Self::SubscribeInterceptHtlcsStream>, Status> {
-        let SubscribeInterceptHtlcsRequest { short_channel_id } = request.into_inner();
-        let receiver = self.interceptor.add_htlc_subscriber(short_channel_id).await;
+        request: tonic::Request<tonic::Streaming<RouteHtlcRequest>>,
+    ) -> Result<tonic::Response<Self::RouteHtlcsStream>, Status> {
+        let mut stream = request.into_inner();
 
-        Ok(tonic::Response::new(ReceiverStream::new(receiver)))
-    }
+        // First create new channel that we will use to send responses back to gatewayd
+        let (sender, receiver) = mpsc::channel::<Result<RouteHtlcResponse, Status>>(100);
 
-    async fn complete_htlc(
-        &self,
-        request: tonic::Request<CompleteHtlcsRequest>,
-    ) -> Result<tonic::Response<CompleteHtlcsResponse>, Status> {
-        let CompleteHtlcsRequest {
-            action,
-            intercepted_htlc_id,
-        } = request.into_inner();
-
-        let hash = match sha256::Hash::from_slice(&intercepted_htlc_id) {
-            Ok(hash) => hash,
-            Err(e) => {
-                error!("Invalid intercepted_htlc_id: {:?}", e);
-                return Err(Status::invalid_argument(e.to_string()));
-            }
-        };
-
-        info!("Completing htlc with reference, {:?}", hash);
-
-        if let Some(outcome) = self.interceptor.outcomes.lock().await.remove(&hash) {
-            // Translate action request into a cln rpc response for `htlc_accepted` event
-            let htlca_res = match action {
-                Some(Action::Settle(Settle { preimage })) => {
-                    let assert_pk: Result<[u8; 32], TryFromSliceError> =
-                        preimage.as_slice().try_into();
-                    if let Ok(pk) = assert_pk {
-                        serde_json::json!({ "result": "resolve", "payment_key": pk.to_hex() })
-                    } else {
-                        htlc_processing_failure()
+        // Spawn new thread that listens for events from the input stream
+        let interceptors = self.interceptor.clone();
+        tokio::spawn(async move {
+            while let Some(res) = stream.next().await {
+                if let Ok(route_request) = res {
+                    match route_request.action {
+                        Some(route_htlc_request::Action::SubscribeRequest(subscribe_request)) => {
+                            interceptors
+                                .subscriptions
+                                .lock()
+                                .await
+                                .insert(subscribe_request.short_channel_id, sender.clone());
+                        }
+                        Some(route_htlc_request::Action::CompleteRequest(complete_request)) => {
+                            Self::complete_htlc(
+                                complete_request,
+                                interceptors.clone(),
+                                sender.clone(),
+                            )
+                            .await
+                            .expect("CLN Extension failed to complete HTLC");
+                        }
+                        None => {
+                            error!("No action was sent as part of RouteHtlcRequest");
+                        }
                     }
                 }
-                Some(Action::Cancel(Cancel { reason: _ })) => {
-                    // TODO: Translate the reason into a BOLT 4 failure message
-                    // See: https://github.com/lightning/bolts/blob/master/04-onion-routing.md#failure-messages
-                    htlc_processing_failure()
-                }
-                None => {
-                    error!("No action specified for intercepted htlc id: {:?}", hash);
-                    return Err(Status::internal(
-                        "No action specified on this intercepted htlc",
-                    ));
-                }
-            };
+            }
+        });
 
-            // Send translated response to the HTLC interceptor for submission to the cln
-            // rpc
-            match outcome.send(htlca_res) {
-                Ok(_) => {
-                    return Ok(tonic::Response::new(CompleteHtlcsResponse {}));
-                }
-                Err(e) => {
-                    error!(
-                        "Failed to send htlc_accepted response to interceptor: {:?}",
-                        e
-                    );
-                    return Err(Status::internal(
-                        "Failed to send htlc_accepted outcome to interceptor",
-                    ));
-                }
-            };
-        } else {
-            error!(
-                "No interceptor reference found for this processed htlc with id: {:?}",
-                intercepted_htlc_id
-            );
-            // TODO: Use error codes to signal the gateway to take reactionary actions
-            return Err(Status::internal(
-                "No interceptor reference found for this processed htlc. Potential loss of funds",
-            ));
-        }
+        Ok(tonic::Response::new(ReceiverStream::new(receiver)))
     }
 }
 
@@ -509,7 +552,7 @@ fn htlc_processing_failure() -> serde_json::Value {
     })
 }
 
-type HtlcSubscriptionSender = mpsc::Sender<Result<SubscribeInterceptHtlcsResponse, Status>>;
+type HtlcSubscriptionSender = mpsc::Sender<Result<RouteHtlcResponse, Status>>;
 type HtlcOutcomeSender = oneshot::Sender<serde_json::Value>;
 
 /// Functional structure to filter intercepted HTLCs into subscription streams.
@@ -563,13 +606,18 @@ impl ClnHtlcInterceptor {
             );
 
             match subscription
-                .send(Ok(SubscribeInterceptHtlcsResponse {
-                    payment_hash: payment_hash.clone(),
-                    incoming_amount_msat: payload.htlc.amount_msat.msats,
-                    outgoing_amount_msat: payload.onion.forward_msat.msats,
-                    incoming_expiry: htlc_expiry,
-                    short_channel_id,
-                    intercepted_htlc_id: intercepted_htlc_id.into_inner().to_vec(),
+                .send(Ok(RouteHtlcResponse {
+                    action: Some(route_htlc_response::Action::SubscribeResponse(
+                        SubscribeInterceptHtlcsResponse {
+                            payment_hash: payment_hash.clone(),
+                            incoming_amount_msat: payload.htlc.amount_msat.msats,
+                            outgoing_amount_msat: payload.onion.forward_msat.msats,
+                            incoming_expiry: htlc_expiry,
+                            short_channel_id,
+                            intercepted_htlc_id: intercepted_htlc_id.into_inner().to_vec(),
+                            key: None,
+                        },
+                    )),
                 }))
                 .await
             {
@@ -605,19 +653,6 @@ impl ClnHtlcInterceptor {
         // We have no subscription for this HTLC.
         // Ignore it by requesting the node to continue
         serde_json::json!({ "result": "continue" })
-    }
-
-    async fn add_htlc_subscriber(
-        &self,
-        short_channel_id: u64,
-    ) -> mpsc::Receiver<Result<SubscribeInterceptHtlcsResponse, Status>> {
-        let (sender, receiver) =
-            mpsc::channel::<Result<SubscribeInterceptHtlcsResponse, Status>>(100);
-        self.subscriptions
-            .lock()
-            .await
-            .insert(short_channel_id, sender);
-        receiver
     }
 
     // TODO: Add a method to remove a HTLC subscriber

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -504,7 +504,7 @@ impl Gateway {
         // Restart the subscription of HTLCs for each actor
         tracing::info!("Restarting HTLC subscription threads.");
         for actor in actors.values() {
-            actor.write().await.subscribe_htlcs().await?;
+            actor.write().await.route_htlcs().await?;
         }
 
         Ok(())

--- a/gateway/ln-gateway/src/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/lnrpc_client.rs
@@ -14,12 +14,9 @@ use url::Url;
 use crate::gatewaylnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gatewaylnrpc::{
     EmptyRequest, GetNodeInfoResponse, GetRouteHintsResponse, PayInvoiceRequest,
-    PayInvoiceResponse, RouteHtlcRequest, RouteHtlcResponse, SubscribeInterceptHtlcsResponse,
+    PayInvoiceResponse, RouteHtlcRequest, RouteHtlcResponse,
 };
 use crate::{GatewayError, Result};
-
-pub type HtlcStream<'a> =
-    BoxStream<'a, std::result::Result<SubscribeInterceptHtlcsResponse, tonic::Status>>;
 
 pub type RouteHtlcStream<'a> = BoxStream<'a, std::result::Result<RouteHtlcResponse, tonic::Status>>;
 

--- a/gateway/ln-gateway/src/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/lnrpc_client.rs
@@ -34,8 +34,8 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     /// Attempt to pay an invoice using the lightning node
     async fn pay(&self, invoice: PayInvoiceRequest) -> Result<PayInvoiceResponse>;
 
-    async fn route_htlc<'a>(
-        &self,
+    async fn route_htlcs<'a>(
+        &mut self,
         events: ReceiverStream<RouteHtlcRequest>,
     ) -> Result<RouteHtlcStream<'a>>;
 }
@@ -100,8 +100,8 @@ impl ILnRpcClient for NetworkLnRpcClient {
         return Ok(res.into_inner());
     }
 
-    async fn route_htlc<'a>(
-        &self,
+    async fn route_htlcs<'a>(
+        &mut self,
         events: ReceiverStream<RouteHtlcRequest>,
     ) -> Result<RouteHtlcStream<'a>> {
         let mut client = self.client.clone();

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -43,6 +43,7 @@ rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 tokio = { version = "1.26.0", features = ["full"] }
 tokio-rustls = "0.23.4"
+tokio-stream = "0.1.11"
 tracing ="0.1.37"
 url = "2.3.1"
 hbbft = { git = "https://github.com/fedimint/hbbft" }

--- a/integrationtests/tests/fixtures/utils.rs
+++ b/integrationtests/tests/fixtures/utils.rs
@@ -72,10 +72,10 @@ impl ILnRpcClient for LnRpcAdapter {
         self.client.read().await.pay(invoice).await
     }
 
-    async fn route_htlc<'a>(
-        &self,
+    async fn route_htlcs<'a>(
+        &mut self,
         events: ReceiverStream<RouteHtlcRequest>,
     ) -> Result<RouteHtlcStream<'a>, GatewayError> {
-        self.client.read().await.route_htlc(events).await
+        self.client.write().await.route_htlcs(events).await
     }
 }


### PR DESCRIPTION
Currently in the gateway, there are two RPCs needed for completing an HTLC: `subscribe_htlcs` and `complete_htlc`. Subscribe returns a stream which the actors use to determine if they need to take an action with the federation. If the gateway is able to get the preimage, it then calls `complete_htlc` to complete the payment. 

However, it is not necessary to have two separate RPCs and this makes the code a bit more complicated. This refactor changes it so there is only one RPC called `route_htlcs`. This RPC takes a stream as input and returns a stream. This way, the actors can send messages using the input stream rather than needing to call a separate RPC.

This allows us to clean up the code a bit. In the LND implementation, we are able to remove the `outcomes` map.

Fixes: https://github.com/fedimint/fedimint/issues/1936