### PR TITLE
fix: codecov.yml invalid

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,8 @@ github_checks:
 
 codecov:
   require_ci_to_pass: true
+  notify:
+    wait_for_ci: no
 
 coverage:
   precision: 2
@@ -14,5 +16,3 @@ coverage:
       default:
         target: auto
         threshold: 1%
-  notify:
-    wait_for_ci: no

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -89,6 +89,9 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 
+      - name: Validate codecov.yaml configuration
+        run: nix run nixpkgs#curl -- --fail-with-body -X POST --data-binary @.codecov.yml https://codecov.io/validate
+
       - name: Build and run tests with Code Coverage
         run: nix build -L .#ci.workspaceCov
 


### PR DESCRIPTION
While at it, rename it to be hidden. (Docs say it's OK)

Turns out one can validate it with:

```
curl -X POST --data-binary @.codecov.yml https://codecov.io/validate
```