### PR TITLE
fix: handle peer names with special chars

### DIFF
--- a/fedimint-bin-tests/src/federation.rs
+++ b/fedimint-bin-tests/src/federation.rs
@@ -185,7 +185,7 @@ pub async fn run_dkg(root_task_group: &TaskGroup, servers: usize) -> anyhow::Res
     async fn create_tls(id: usize, sender: Sender<String>) -> anyhow::Result<()> {
         // set env vars
         let bin_dir = env::var("FM_BIN_DIR")?;
-        let server_name = format!("Server-{id}");
+        let server_name = format!("Server {id}!");
         let env_vars = fedimint_env(id)?;
         let p2p_url = env_vars.get("FM_P2P_URL").context("FM_P2P_URL not found")?;
         let api_url = env_vars.get("FM_API_URL").context("FM_API_URL not found")?;

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -91,11 +91,6 @@ impl ConfigGenApi {
         &self,
         request: ConfigGenConnectionsRequest,
     ) -> ApiResult<()> {
-        // TODO: should probably just replace bad chars with '_' in `TlsTcpConnector`
-        if rustls::ServerName::try_from(request.our_name.as_str()).is_err() {
-            return Self::bad_request("Name must be a valid domain string");
-        }
-
         let connection = {
             let mut state = self.state.lock().expect("lock poisoned");
 

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -89,7 +89,6 @@ fn gen_tls(
     let (cert, pk) = gen_cert_and_key(&name)?;
     encrypted_write(pk.0, key, dir_out_path.join(TLS_PK))?;
 
-    rustls::ServerName::try_from(name.as_str())?;
     // TODO Base64 encode name, hash fingerprint cert_string
     let cert_url = format!("{}@{}@{}@{}", p2p_url, api_url, name, cert.0.to_hex());
     fs::write(dir_out_path.join(TLS_CERT), &cert_url)?;

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -734,14 +734,15 @@ pub fn gen_cert_and_key(
 ) -> Result<(rustls::Certificate, rustls::PrivateKey), anyhow::Error> {
     let keypair = rcgen::KeyPair::generate(&rcgen::PKCS_ECDSA_P256_SHA256)?;
     let keypair_ser = keypair.serialize_der();
-    let mut params = rcgen::CertificateParams::new(vec![name.to_owned()]);
+    let sanitized_name = name.replace(|c: char| !c.is_ascii_alphanumeric(), "_");
+    let mut params = rcgen::CertificateParams::new(vec![sanitized_name.to_owned()]);
 
     params.key_pair = Some(keypair);
     params.alg = &rcgen::PKCS_ECDSA_P256_SHA256;
     params.is_ca = rcgen::IsCa::NoCa;
     params
         .distinguished_name
-        .push(rcgen::DnType::CommonName, name);
+        .push(rcgen::DnType::CommonName, sanitized_name);
 
     let cert = rcgen::Certificate::from_params(params)?;
 

--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -170,8 +170,10 @@ where
             )
             .expect("Failed to create TLS config");
 
-        let fake_domain = rustls::ServerName::try_from(self.peer_names[&peer].as_str())
-            .expect("Always a valid DNS name");
+        let sanitized_name =
+            self.peer_names[&peer].replace(|c: char| !c.is_ascii_alphanumeric(), "_");
+        let fake_domain =
+            rustls::ServerName::try_from(sanitized_name.as_str()).expect("Always a valid DNS name");
 
         let connector = TlsConnector::from(Arc::new(cfg));
         let tls_conn = connector

--- a/fedimint-testing/src/bin/fixtures.rs
+++ b/fedimint-testing/src/bin/fixtures.rs
@@ -365,7 +365,7 @@ fn fedimint_env(id: usize) -> anyhow::Result<HashMap<String, String>> {
 async fn create_tls(id: usize, sender: Sender<String>) -> anyhow::Result<()> {
     // set env vars
     let bin_dir = env::var("FM_BIN_DIR")?;
-    let server_name = format!("Server-{id}");
+    let server_name = format!("Server {id}!");
     let env_vars = fedimint_env(id)?;
     let p2p_url = env_vars
         .get("FM_P2P_URL")

--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -15,7 +15,7 @@ function generate_certs() {
         fed_port=$(echo "$BASE_PORT + $ID * 10" | bc -l)
         api_port=$(echo "$BASE_PORT + $ID * 10 + 1" | bc -l)
         export FM_PASSWORD="pass$ID"
-        docker run -v $1/server-$ID:/var/fedimint -e FM_PASSWORD=pass$ID $2 distributedgen create-cert --p2p-url ws://server-$ID:$fed_port --api-url ws://server-$ID:$api_port --out-dir /var/fedimint --name "Server-$ID"
+        docker run -v $1/server-$ID:/var/fedimint -e FM_PASSWORD=pass$ID $2 distributedgen create-cert --p2p-url ws://server-$ID:$fed_port --api-url ws://server-$ID:$api_port --out-dir /var/fedimint --name "Server $ID!"
         CERTS="$CERTS,$(cat $1/server-$ID/tls-cert)"
     done
     export CERTS=${CERTS:1}


### PR DESCRIPTION
Fixes  #2074

@SumantxD took a shot at fixing it, using your string replacement code