### PR TITLE
refactor: rename Reconnect to ReconnectLightning

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -11,7 +11,7 @@ use ln_gateway::rpc::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
     LightningReconnectPayload, RestorePayload, WithdrawPayload,
 };
-use ln_gateway::Mode;
+use ln_gateway::LightningMode;
 use url::Url;
 
 #[derive(Parser)]
@@ -65,9 +65,9 @@ pub enum Commands {
     /// Restore ecash from last available snapshot or from scratch
     Restore { federation_id: FederationId },
     // Reconnect to the Lightning Node
-    Reconnect {
+    ReconnectLightning {
         #[clap(subcommand)]
-        mode: Mode,
+        lightning_mode: LightningMode,
     },
 }
 
@@ -173,17 +173,17 @@ async fn main() -> anyhow::Result<()> {
 
             print_response(response).await;
         }
-        Commands::Reconnect { mode } => {
-            let payload = match mode {
-                Mode::Cln { cln_extension_addr } => LightningReconnectPayload {
-                    node_type: Some(Mode::Cln { cln_extension_addr }),
+        Commands::ReconnectLightning { lightning_mode } => {
+            let payload = match lightning_mode {
+                LightningMode::Cln { cln_extension_addr } => LightningReconnectPayload {
+                    node_type: Some(LightningMode::Cln { cln_extension_addr }),
                 },
-                Mode::Lnd {
+                LightningMode::Lnd {
                     lnd_rpc_addr,
                     lnd_tls_cert,
                     lnd_macaroon,
                 } => LightningReconnectPayload {
-                    node_type: Some(Mode::Lnd {
+                    node_type: Some(LightningMode::Lnd {
                         lnd_rpc_addr,
                         lnd_tls_cert,
                         lnd_macaroon,

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -16,14 +16,14 @@ use fedimint_core::module::ModuleCommon;
 use fedimint_core::task::TaskGroup;
 use fedimint_logging::TracingSetup;
 use ln_gateway::client::{DynGatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder};
-use ln_gateway::{Gateway, Mode};
+use ln_gateway::{Gateway, LightningMode};
 use tracing::{error, info};
 use url::Url;
 
 #[derive(Parser)]
 pub struct GatewayOpts {
     #[clap(subcommand)]
-    mode: Mode,
+    mode: LightningMode,
 
     /// Path to folder containing gateway config and data files
     #[arg(long = "data-dir", env = "FM_GATEWAY_DATA_DIR")]

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -61,7 +61,7 @@ const INITIAL_SCID: u64 = 1;
 pub type Result<T> = std::result::Result<T, GatewayError>;
 
 #[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]
-pub enum Mode {
+pub enum LightningMode {
     #[clap(name = "lnd")]
     Lnd {
         /// LND RPC address
@@ -115,7 +115,7 @@ pub struct Gateway {
     decoders: ModuleDecoderRegistry,
     module_gens: ClientModuleGenRegistry,
     lnrpc: Arc<RwLock<dyn ILnRpcClient>>,
-    lightning_mode: Option<Mode>,
+    lightning_mode: Option<LightningMode>,
     actors: Mutex<HashMap<String, Arc<RwLock<GatewayActor>>>>,
     client_builder: DynGatewayClientBuilder,
     sender: mpsc::Sender<GatewayRequest>,
@@ -127,7 +127,7 @@ pub struct Gateway {
 impl Gateway {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        lightning_mode: Mode,
+        lightning_mode: LightningMode,
         client_builder: DynGatewayClientBuilder,
         decoders: ModuleDecoderRegistry,
         module_gens: ClientModuleGenRegistry,
@@ -188,11 +188,11 @@ impl Gateway {
     }
 
     async fn create_lightning_client(
-        mode: Mode,
+        mode: LightningMode,
         task_group: TaskGroup,
     ) -> Result<Arc<RwLock<dyn ILnRpcClient>>> {
         let lnrpc: Arc<RwLock<dyn ILnRpcClient>> = match mode {
-            Mode::Cln { cln_extension_addr } => {
+            LightningMode::Cln { cln_extension_addr } => {
                 info!(
                     "Gateway configured to connect to remote LnRpcClient at \n cln extension address: {:?} ",
                     cln_extension_addr
@@ -201,7 +201,7 @@ impl Gateway {
                     NetworkLnRpcClient::new(cln_extension_addr).await?,
                 ))
             }
-            Mode::Lnd {
+            LightningMode::Lnd {
                 lnd_rpc_addr,
                 lnd_tls_cert,
                 lnd_macaroon,

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tokio::sync::{mpsc, oneshot};
 use tracing::error;
 
-use crate::{Gateway, GatewayError, Mode, Result};
+use crate::{Gateway, GatewayError, LightningMode, Result};
 
 #[derive(Debug, Clone)]
 pub struct GatewayRpcSender {
@@ -78,7 +78,7 @@ pub struct RestorePayload {
 pub struct LightningReconnectPayload {
     // Sending `None` for node_type will be interpreted as just reconnecting using the existing
     // settings
-    pub node_type: Option<Mode>,
+    pub node_type: Option<LightningMode>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
`Reconnect` is ambiguous because it could mean reconnect to a federation or reconnect to the lightning node. This PR makes it more explicit by renaming structs to include "Lightning" if they're dealing with lightning