### PR TITLE
feat: improved CODEOWNERS flow

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,9 +5,37 @@
 # * last matching line wins (so order from most general to most specific)
 # * multiple elements on the same line means "OR"
 
-# default: unless more specific rule is found, these will be the reviewers assigned; should be a broad group
-* @fedimint/Reviewers
+# default: unless more specific rule is found, these will be the reviewers assigned
+# this will be a chore for people here, but guarantees that *someone* gets to look
+# at every PR (they can unassign and unsubscribe themselves after taking an initial look)
+* @fedimint/firehose
 
-# TODO: replace with @fedimint/infra or smth
-*.nix     @dpc
-*.github/ @dpc
+
+*.nix     @fedimint/infra
+*.sh      @fedimint/infra
+.github/  @fedimint/infra
+misc/     @fedimint/infra
+scripts/  @fedimint/infra
+
+
+gateway/ @fedimint/lightning
+
+
+fedimint-rocksdb/    @fedimint/database
+fedimint-dbtool/     @fedimint/database
+fedimint-sqlite/     @fedimint/database
+fedimint-core/src/db @fedimint/database
+db/                  @fedimint/database
+**/db.rs             @fedimint/database
+**/db/               @fedimint/database
+
+fedimint-server/src/consensus @fedimint/consensus
+fedimint-server/src/config    @fedimint/consensus
+./fedimint-core/src/config.rs @fedimint/consensus
+
+
+gateway/ui/         @fedimint/lightning @fedimint/ui
+fedimintd/src/ui.rs @fedimint/ui
+
+
+crypto/             @fedimint/crypto


### PR DESCRIPTION
So as things are these groups are only to make sure relevant people get a notification and review request assigned automatically, to help everyone see what is relevant for them. **Importantly**, we still require 2 reviews of __anyone__ with reviewer (write) role. Being in a given team is more of a chore  while being reviewer at all is a privilege (power to approve).

Please don't be shy to ask to be added and removed from any group, fill PRs to modify the CODEOWNERS , and if anything is not ideal etc we can tweak and iterate.