### PR TITLE
feat: Avoid loading all notes in memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,6 +1561,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bitcoin_hashes",
  "fedimint-core",
  "futures",
  "rand",

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -731,19 +731,15 @@ impl FedimintCli {
                 ),
             Command::Info => {
                 let client = cli.build_client(&self.module_gens).await?;
-                let notes = client.notes().await;
-                let details_vec = notes
-                    .iter()
-                    .map(|(amount, notes)| (amount.to_owned(), notes.len()))
-                    .collect();
+                let summary = client.summary().await;
 
                 Ok(CliOutput::Info {
                     federation_id: client.config().as_ref().federation_id.clone(),
                     network: client.wallet_client().config.network,
                     meta: client.config().0.meta,
-                    total_amount: (notes.total_amount()),
-                    total_num_notes: (notes.count_items()),
-                    details: (details_vec),
+                    total_amount: summary.total_amount(),
+                    total_num_notes: summary.count_items(),
+                    details: summary.iter().collect(),
                 })
             }
             Command::PegOut { address, amount } => {

--- a/fedimint-client-legacy/src/lib.rs
+++ b/fedimint-client-legacy/src/lib.rs
@@ -42,7 +42,7 @@ use fedimint_core::module::ModuleCommon;
 use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::task::{self, sleep};
 use fedimint_core::tiered::InvalidAmountTierError;
-use fedimint_core::{Amount, OutPoint, TieredMulti, TransactionId};
+use fedimint_core::{Amount, OutPoint, TieredMulti, TieredSummary, TransactionId};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_ln_client::{LightningModuleTypes, LightningOutputOutcome};
 use fedimint_logging::LOG_WALLET;
@@ -717,6 +717,11 @@ impl<T: AsRef<ClientConfig> + Clone + Send> Client<T> {
         }
     }
 
+    pub async fn summary(&self) -> TieredSummary {
+        self.mint_client().summary().await
+    }
+
+    // FIXME: loading all notes on memory isn't ideal, consider changing the API
     pub async fn notes(&self) -> TieredMulti<SpendableNote> {
         self.mint_client().notes().await
     }

--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -114,15 +114,28 @@ impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
     }
 
     async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixStream<'_> {
+        let data = self
+            .tx_data
+            .range::<Vec<u8>, _>((key_prefix.to_vec())..)
+            .take_while(|(key, _)| key.starts_with(key_prefix))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Vec<_>>();
+        Box::pin(stream::iter(data))
+    }
+
+    async fn raw_find_by_prefix_sorted_descending(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>> {
         let mut data = self
             .tx_data
             .range::<Vec<u8>, _>((key_prefix.to_vec())..)
             .take_while(|(key, _)| key.starts_with(key_prefix))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect::<Vec<_>>();
-        data.reverse();
+        data.sort_by(|a, b| a.cmp(b).reverse());
 
-        Box::pin(stream::iter(data))
+        Ok(Box::pin(stream::iter(data)))
     }
 
     async fn commit_tx(self) -> Result<()> {

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -320,7 +320,7 @@ impl Database {
 /// write-write conflicts are prevented).
 ///
 /// Specifically, Fedimint expects the database implementation to prevent the
-/// following anamolies:
+/// following anomalies:
 ///
 /// Non-Readable Write: TX1 writes (K1, V1) at time t but cannot read (K1, V1)
 /// at time (t + i)
@@ -351,7 +351,15 @@ pub trait IDatabaseTransaction<'a>: 'a + MaybeSend {
 
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
+    /// Returns an stream of key-value pairs with keys that start with
+    /// `key_prefix`. No particular ordering is guaranteed.
     async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixStream<'_>;
+
+    /// Same as [`Self::raw_find_by_prefix`] but the order is descending by key.
+    async fn raw_find_by_prefix_sorted_descending(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>>;
 
     /// Default implementation is a combination of [`Self::raw_find_by_prefix`]
     /// + loop over [`Self::raw_remove_entry`]
@@ -401,6 +409,11 @@ pub trait ISingleUseDatabaseTransaction<'a>: 'a + MaybeSend {
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
     async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> Result<PrefixStream<'_>>;
+
+    async fn raw_find_by_prefix_sorted_descending(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>>;
 
     async fn raw_remove_by_prefix(&mut self, key_prefix: &[u8]) -> Result<()>;
 
@@ -461,6 +474,17 @@ impl<'a, Tx: IDatabaseTransaction<'a> + MaybeSend> ISingleUseDatabaseTransaction
             .context("Cannot retrieve from already consumed transaction")?
             .raw_find_by_prefix(key_prefix)
             .await)
+    }
+
+    async fn raw_find_by_prefix_sorted_descending(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>> {
+        self.0
+            .as_mut()
+            .context("Cannot retrieve from already consumed transaction")?
+            .raw_find_by_prefix_sorted_descending(key_prefix)
+            .await
     }
 
     async fn raw_remove_by_prefix(&mut self, key_prefix: &[u8]) -> Result<()> {
@@ -571,6 +595,19 @@ impl<'a> ISingleUseDatabaseTransaction<'a> for CommittableIsolatedDatabaseTransa
     async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> Result<PrefixStream<'_>> {
         let prefix_with_module = IsolatedDatabaseTransaction::prefix_with_module(&self.prefix);
         IsolatedDatabaseTransaction::<u16>::raw_find_by_prefix(
+            prefix_with_module,
+            self.dbtx.as_mut(),
+            key_prefix,
+        )
+        .await
+    }
+
+    async fn raw_find_by_prefix_sorted_descending(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>> {
+        let prefix_with_module = IsolatedDatabaseTransaction::prefix_with_module(&self.prefix);
+        IsolatedDatabaseTransaction::<u16>::raw_find_by_prefix_sorted_descending(
             prefix_with_module,
             self.dbtx.as_mut(),
             key_prefix,
@@ -819,6 +856,23 @@ impl<'isolated, 'parent: 'isolated, T: MaybeSend + Encodable>
             (stripped_key.to_vec(), value)
         })))
     }
+
+    async fn raw_find_by_prefix_sorted_descending(
+        mut prefix_with_module: Vec<u8>,
+        dbtx: &'isolated mut dyn ISingleUseDatabaseTransaction<'parent>,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'isolated>> {
+        let original_prefix_len = prefix_with_module.len();
+        prefix_with_module.extend_from_slice(key_prefix);
+        let raw_prefix = dbtx
+            .raw_find_by_prefix_sorted_descending(prefix_with_module.as_slice())
+            .await?;
+
+        Ok(Box::pin(raw_prefix.map(move |(key, value)| {
+            let stripped_key = &key[original_prefix_len..];
+            (stripped_key.to_vec(), value)
+        })))
+    }
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -852,6 +906,18 @@ impl<'isolated, 'parent, T: MaybeSend + Encodable + 'isolated>
 
     async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> Result<PrefixStream<'_>> {
         IsolatedDatabaseTransaction::<T>::raw_find_by_prefix(
+            self.prefix.clone(),
+            self.inner_tx,
+            key_prefix,
+        )
+        .await
+    }
+
+    async fn raw_find_by_prefix_sorted_descending(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>> {
+        IsolatedDatabaseTransaction::<T>::raw_find_by_prefix_sorted_descending(
             self.prefix.clone(),
             self.inner_tx,
             key_prefix,
@@ -1018,8 +1084,42 @@ impl<'parent> DatabaseTransaction<'parent> {
             .expect("Error doing prefix search in database")
             .map(move |(key_bytes, value_bytes)| {
                 let key = KP::Record::from_bytes(&key_bytes, &decoders)
+                    .with_context(|| anyhow::anyhow!("key: {}", AbbreviateHexBytes(&key_bytes)))
                     .expect("Unrecoverable error reading DatabaseKey");
                 let value = decode_value(&value_bytes, &decoders)
+                    .with_context(|| anyhow::anyhow!("key: {}", AbbreviateHexBytes(&key_bytes)))
+                    .expect("Unrecoverable decoding DatabaseValue");
+                (key, value)
+            })
+    }
+
+    #[instrument(level = "debug", skip_all, fields(key = ?key_prefix))]
+    pub async fn find_by_prefix_sorted_descending<KP>(
+        &mut self,
+        key_prefix: &KP,
+    ) -> impl Stream<
+        Item = (
+            KP::Record,
+            <<KP as DatabaseLookup>::Record as DatabaseRecord>::Value,
+        ),
+    > + '_
+    where
+        KP: DatabaseLookup,
+        KP::Record: DatabaseKey,
+    {
+        debug!("find by prefix sorted descending");
+        let decoders = self.decoders.clone();
+        let prefix_bytes = key_prefix.to_bytes();
+        self.tx
+            .raw_find_by_prefix_sorted_descending(&prefix_bytes)
+            .await
+            .expect("Error doing prefix search in database")
+            .map(move |(key_bytes, value_bytes)| {
+                let key = KP::Record::from_bytes(&key_bytes, &decoders)
+                    .with_context(|| anyhow::anyhow!("key: {}", AbbreviateHexBytes(&key_bytes)))
+                    .expect("Unrecoverable error reading DatabaseKey");
+                let value = decode_value(&value_bytes, &decoders)
+                    .with_context(|| anyhow::anyhow!("key: {}", AbbreviateHexBytes(&key_bytes)))
                     .expect("Unrecoverable decoding DatabaseValue");
                 (key, value)
             })
@@ -1463,7 +1563,7 @@ mod test_utils {
         PercentTestKey = 0x25,
     }
 
-    #[derive(Debug, Encodable, Decodable)]
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
     pub(super) struct TestKey(pub u64);
 
     #[derive(Debug, Encodable, Decodable)]
@@ -1490,7 +1590,7 @@ mod test_utils {
     );
     impl_db_lookup!(key = TestKeyV0, query_prefix = DbPrefixTestPrefixV0);
 
-    #[derive(Debug, Encodable, Decodable)]
+    #[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Encodable, Decodable)]
     struct AltTestKey(u64);
 
     #[derive(Debug, Encodable, Decodable)]
@@ -1516,7 +1616,7 @@ mod test_utils {
     );
 
     impl_db_lookup!(key = PercentTestKey, query_prefix = PercentPrefixTestPrefix);
-    #[derive(Debug, Encodable, Decodable, Eq, PartialEq)]
+    #[derive(Debug, Encodable, Decodable, Eq, PartialEq, PartialOrd, Ord)]
     pub(super) struct TestVal(pub u64);
 
     const TEST_MODULE_PREFIX: u16 = 1;
@@ -1591,47 +1691,45 @@ mod test_utils {
 
         // Verify finding by prefix returns the correct set of key pairs
         let mut dbtx = db.begin_transaction().await;
-        let expected_keys = 2;
 
-        let returned_keys = dbtx
+        let mut returned_keys = dbtx
             .find_by_prefix(&DbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, (key, value)| async move {
-                match key {
-                    TestKey(55) => {
-                        assert!(value.eq(&TestVal(9999)));
-                    }
-                    TestKey(54) => {
-                        assert!(value.eq(&TestVal(8888)));
-                    }
-                    _ => {}
-                };
-                returned_keys + 1
-            })
+            .collect::<Vec<_>>()
             .await;
+        returned_keys.sort();
+        let expected = vec![(TestKey(54), TestVal(8888)), (TestKey(55), TestVal(9999))];
+        assert_eq!(returned_keys, expected);
 
-        assert_eq!(returned_keys, expected_keys);
+        let reversed = dbtx
+            .find_by_prefix_sorted_descending(&DbPrefixTestPrefix)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        let mut reversed_expected = expected;
+        reversed_expected.reverse();
+        assert_eq!(reversed, reversed_expected);
 
-        let expected_keys = 2;
-
-        let returned_keys = dbtx
+        let mut returned_keys = dbtx
             .find_by_prefix(&AltDbPrefixTestPrefix)
             .await
-            .fold(0, |returned_keys, (key, value)| async move {
-                match key {
-                    AltTestKey(55) => {
-                        assert!(value.eq(&TestVal(7777)));
-                    }
-                    AltTestKey(54) => {
-                        assert!(value.eq(&TestVal(6666)));
-                    }
-                    _ => {}
-                };
-                returned_keys + 1
-            })
+            .collect::<Vec<_>>()
             .await;
+        returned_keys.sort();
+        let expected = vec![
+            (AltTestKey(54), TestVal(6666)),
+            (AltTestKey(55), TestVal(7777)),
+        ];
+        assert_eq!(returned_keys, expected);
 
-        assert_eq!(returned_keys, expected_keys);
+        let reversed = dbtx
+            .find_by_prefix_sorted_descending(&AltDbPrefixTestPrefix)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        let mut reversed_expected = expected;
+        reversed_expected.reverse();
+        assert_eq!(reversed, reversed_expected);
     }
 
     pub async fn verify_commit(db: Database) {
@@ -2112,6 +2210,13 @@ mod test_utils {
                 &mut self,
                 _key_prefix: &[u8],
             ) -> crate::db::PrefixStream<'_> {
+                unimplemented!()
+            }
+
+            async fn raw_find_by_prefix_sorted_descending(
+                &mut self,
+                _key_prefix: &[u8],
+            ) -> anyhow::Result<crate::db::PrefixStream<'_>> {
                 unimplemented!()
             }
 

--- a/fedimint-core/src/db/notifications.rs
+++ b/fedimint-core/src/db/notifications.rs
@@ -143,6 +143,15 @@ impl<'a> ISingleUseDatabaseTransaction<'a> for NotifyingTransaction<'a> {
         self.dbtx.raw_find_by_prefix(key_prefix).await
     }
 
+    async fn raw_find_by_prefix_sorted_descending(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>> {
+        self.dbtx
+            .raw_find_by_prefix_sorted_descending(key_prefix)
+            .await
+    }
+
     async fn raw_remove_by_prefix(&mut self, key_prefix: &[u8]) -> Result<()> {
         self.dbtx.raw_remove_by_prefix(key_prefix).await
     }

--- a/fedimint-core/src/tiered.rs
+++ b/fedimint-core/src/tiered.rs
@@ -37,6 +37,10 @@ impl<T> Tiered<T> {
         self.0.get(amount).ok_or(InvalidAmountTierError(*amount))
     }
 
+    pub fn count_tiers(&self) -> usize {
+        self.0.len()
+    }
+
     pub fn tiers(&self) -> impl DoubleEndedIterator<Item = &Amount> {
         self.0.keys()
     }

--- a/fedimint-core/src/tiered_multi.rs
+++ b/fedimint-core/src/tiered_multi.rs
@@ -32,7 +32,7 @@ impl<T> TieredMulti<T> {
             .iter()
             .map(|(tier, notes)| tier.msats * (notes.len() as u64))
             .sum();
-        Amount { msats: milli_sat }
+        Amount::from_msats(milli_sat)
     }
 
     /// Returns the number of items in all vectors
@@ -51,8 +51,10 @@ impl<T> TieredMulti<T> {
     }
 
     /// Returns the summary of number of items in each tier
-    pub fn summary(&self) -> Tiered<usize> {
-        Tiered::from_iter(self.iter().map(|(amount, values)| (*amount, values.len())))
+    pub fn summary(&self) -> TieredSummary {
+        TieredSummary(Tiered::from_iter(
+            self.iter().map(|(amount, values)| (*amount, values.len())),
+        ))
     }
 
     /// Verifies whether all vectors in all tiers are empty
@@ -88,7 +90,6 @@ impl<T> TieredMulti<T> {
             .values()
             .zip(other.0.values())
             .all(|(c1, c2)| c1.len() == c2.len());
-
         tier_eq && per_tier_eq
     }
 
@@ -146,86 +147,6 @@ impl<T> TieredMulti<T> {
     // sure there are no empty `Vec`s after removal)
     pub fn get_mut(&mut self, amt: Amount) -> Option<&mut Vec<T>> {
         self.0.get_mut(&amt)
-    }
-}
-
-impl<C> TieredMulti<C>
-where
-    C: Clone,
-{
-    /// Select notes with total amount of *at least* `amount`. If more than
-    /// requested amount of notes are returned it was because exact change
-    /// couldn't be made, and the next smallest amount will be returned.
-    ///
-    /// The caller can request change from the federation.
-    // TODO: move somewhere else?
-    pub fn select_notes(&self, mut amount: Amount) -> Option<TieredMulti<C>> {
-        if amount > self.total_amount() {
-            return None;
-        }
-
-        let mut selected = vec![];
-        let mut remaining = self.total_amount();
-
-        for (note_amount, note) in self.iter_items().rev() {
-            remaining -= note_amount;
-
-            if note_amount <= amount {
-                amount -= note_amount;
-                selected.push((note_amount, (*note).clone()))
-            } else if remaining < amount {
-                // we can't make exact change, so just use this note
-                selected.push((note_amount, (*note).clone()));
-                break;
-            }
-        }
-
-        Some(selected.into_iter().collect::<TieredMulti<C>>())
-    }
-}
-
-impl TieredMulti<()> {
-    /// Determines the denominations to use when representing an amount
-    ///
-    /// Algorithm tries to leave the user with a target number of
-    /// `denomination_sets` starting at the lowest denomination.  `self`
-    /// gives the denominations that the user already has.
-    pub fn represent_amount<K, V>(
-        amount: Amount,
-        current_denominations: &TieredMulti<V>,
-        tiers: &Tiered<K>,
-        denomination_sets: u16,
-    ) -> Tiered<usize> {
-        let mut remaining_amount = amount;
-        let mut denominations: Tiered<usize> = Default::default();
-
-        // try to hit the target `denomination_sets`
-        for tier in tiers.tiers() {
-            let notes = current_denominations
-                .get(*tier)
-                .map(|v| v.len())
-                .unwrap_or(0);
-            let missing_notes = (denomination_sets as u64).saturating_sub(notes as u64);
-            let possible_notes = remaining_amount / *tier;
-
-            let add_notes = min(possible_notes, missing_notes);
-            *denominations.get_mut_or_default(*tier) = add_notes as usize;
-            remaining_amount -= *tier * add_notes;
-        }
-
-        // if there is a remaining amount, add denominations with a greedy algorithm
-        for tier in tiers.tiers().rev() {
-            let res = remaining_amount / *tier;
-            remaining_amount %= *tier;
-            *denominations.get_mut_or_default(*tier) += res as usize;
-        }
-
-        let represented: u64 = denominations
-            .iter()
-            .map(|(k, v)| k.msats * (*v as u64))
-            .sum();
-        assert_eq!(represented, amount.msats);
-        denominations
     }
 }
 
@@ -344,11 +265,108 @@ where
     }
 }
 
+#[derive(Debug, PartialEq, Default)]
+pub struct TieredSummary(Tiered<usize>);
+
+impl TieredSummary {
+    /// Determines the denominations to use when representing an amount
+    ///
+    /// Algorithm tries to leave the user with a target number of
+    /// `denomination_sets` starting at the lowest denomination.  `self`
+    /// gives the denominations that the user already has.
+    pub fn represent_amount<K>(
+        amount: Amount,
+        current_denominations: &TieredSummary,
+        tiers: &Tiered<K>,
+        denomination_sets: u16,
+    ) -> TieredSummary {
+        let mut remaining_amount = amount;
+        let mut denominations = TieredSummary::default();
+
+        // try to hit the target `denomination_sets`
+        for tier in tiers.tiers() {
+            let notes = current_denominations
+                .0
+                .get(*tier)
+                .copied()
+                .unwrap_or_default();
+            let missing_notes = (denomination_sets as u64).saturating_sub(notes as u64);
+            let possible_notes = remaining_amount / *tier;
+
+            let add_notes = min(possible_notes, missing_notes);
+            denominations.inc(*tier, add_notes as usize);
+            remaining_amount -= *tier * add_notes;
+        }
+
+        // if there is a remaining amount, add denominations with a greedy algorithm
+        for tier in tiers.tiers().rev() {
+            let res = remaining_amount / *tier;
+            remaining_amount %= *tier;
+            denominations.inc(*tier, res as usize);
+        }
+
+        let represented: u64 = denominations
+            .0
+            .iter()
+            .map(|(k, v)| k.msats * (*v as u64))
+            .sum();
+        assert_eq!(represented, amount.msats);
+        denominations
+    }
+
+    pub fn inc(&mut self, tier: Amount, n: usize) {
+        *self.0.get_mut_or_default(tier) += n;
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (Amount, usize)> + '_ {
+        self.0.iter().map(|(k, v)| (k, *v))
+    }
+
+    pub fn total_amount(&self) -> Amount {
+        self.0.iter().map(|(k, v)| k * (*v as u64)).sum::<Amount>()
+    }
+
+    pub fn count_items(&self) -> usize {
+        self.0.iter().map(|(_, v)| *v).sum()
+    }
+
+    pub fn count_tiers(&self) -> usize {
+        self.0.count_tiers()
+    }
+}
+
+impl FromIterator<(Amount, usize)> for TieredSummary {
+    fn from_iter<I: IntoIterator<Item = (Amount, usize)>>(iter: I) -> Self {
+        TieredSummary(iter.into_iter().collect())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use fedimint_core::Amount;
 
-    use crate::{Tiered, TieredMulti};
+    use super::*;
+
+    #[test]
+    fn summary_works() {
+        let notes = notes(vec![
+            (Amount::from_sats(1), 1),
+            (Amount::from_sats(2), 3),
+            (Amount::from_sats(3), 2),
+        ]);
+        let summary = notes.summary();
+        assert_eq!(
+            summary.iter().collect::<Vec<_>>(),
+            vec![
+                (Amount::from_sats(1), 1),
+                (Amount::from_sats(2), 3),
+                (Amount::from_sats(3), 2),
+            ]
+        );
+        assert_eq!(summary.total_amount(), notes.total_amount());
+        assert_eq!(summary.count_items(), notes.count_items());
+        assert_eq!(summary.count_tiers(), notes.count_tiers());
+    }
 
     #[test]
     fn represent_amount_targets_denomination_sets() {
@@ -356,12 +374,13 @@ mod test {
             (Amount::from_sats(1), 1),
             (Amount::from_sats(2), 3),
             (Amount::from_sats(3), 2),
-        ]);
+        ])
+        .summary();
         let tiers = tiers(vec![1, 2, 3, 4]);
 
         // target 3 tiers will fill out the 1 and 3 denominations
         assert_eq!(
-            TieredMulti::represent_amount(Amount::from_sats(6), &starting, &tiers, 3),
+            TieredSummary::represent_amount(Amount::from_sats(6), &starting, &tiers, 3),
             denominations(vec![
                 (Amount::from_sats(1), 3),
                 (Amount::from_sats(2), 0),
@@ -372,7 +391,7 @@ mod test {
 
         // target 2 tiers will fill out the 1 and 4 denominations
         assert_eq!(
-            TieredMulti::represent_amount(Amount::from_sats(6), &starting, &tiers, 2),
+            TieredSummary::represent_amount(Amount::from_sats(6), &starting, &tiers, 2),
             denominations(vec![
                 (Amount::from_sats(1), 2),
                 (Amount::from_sats(2), 0),
@@ -382,69 +401,10 @@ mod test {
         );
     }
 
-    #[test]
-    fn select_notes_returns_exact_amount_with_minimum_notes() {
-        let starting = notes(vec![
-            (Amount::from_sats(1), 10),
-            (Amount::from_sats(5), 10),
-            (Amount::from_sats(20), 10),
-        ]);
-
-        assert_eq!(
-            starting.select_notes(Amount::from_sats(7)),
-            Some(notes(vec![
-                (Amount::from_sats(1), 2),
-                (Amount::from_sats(5), 1)
-            ]))
-        );
-
-        assert_eq!(
-            starting.select_notes(Amount::from_sats(20)),
-            Some(notes(vec![(Amount::from_sats(20), 1),]))
-        );
-    }
-
-    #[test]
-    fn select_notes_returns_next_smallest_amount_if_exact_change_cannot_be_made() {
-        let starting = notes(vec![
-            (Amount::from_sats(1), 1),
-            (Amount::from_sats(5), 5),
-            (Amount::from_sats(20), 5),
-        ]);
-
-        assert_eq!(
-            starting.select_notes(Amount::from_sats(7)),
-            Some(notes(vec![(Amount::from_sats(5), 2)]))
-        );
-    }
-
-    #[test]
-    fn select_notes_returns_none_if_amount_is_too_large() {
-        let starting = notes(vec![(Amount::from_sats(10), 1)]);
-
-        assert_eq!(starting.select_notes(Amount::from_sats(100)), None);
-    }
-
-    #[test]
-    fn select_notes_avg_test() {
-        let max_amount = Amount::from_sats(1000000);
-        let tiers = Tiered::gen_denominations(max_amount);
-        let tiered =
-            TieredMulti::represent_amount::<(), ()>(max_amount, &Default::default(), &tiers, 3);
-
-        let mut total_notes = 0;
-        for multiplier in 1..100 {
-            let notes = notes(tiered.as_map().clone().into_iter().collect());
-            let select = notes.select_notes(Amount::from_sats(multiplier * 1000));
-            total_notes += select.unwrap().into_iter_items().count();
-        }
-        assert_eq!(total_notes / 100, 10);
-    }
-
     fn notes(notes: Vec<(Amount, usize)>) -> TieredMulti<usize> {
         notes
             .into_iter()
-            .flat_map(|(amount, number)| vec![(amount, 0_usize); number])
+            .flat_map(|(amount, number)| vec![(amount, 0usize); number])
             .collect()
     }
 
@@ -455,7 +415,7 @@ mod test {
             .collect()
     }
 
-    fn denominations(denominations: Vec<(Amount, usize)>) -> Tiered<usize> {
-        denominations.into_iter().collect()
+    fn denominations(denominations: Vec<(Amount, usize)>) -> TieredSummary {
+        TieredSummary::from_iter(denominations)
     }
 }

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -51,6 +51,30 @@ impl From<RocksDb> for rocksdb::OptimisticTransactionDB {
     }
 }
 
+// When finding by prefix iterating in Reverse order, we need to start from
+// "prefix+1" instead of "prefix", using lexicographic ordering. See the tests
+// below.
+// Will return None if there is no next prefix (i.e prefix is already the last
+// possible/max one)
+fn next_prefix(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut next_prefix = prefix.to_vec();
+    let mut is_last_prefix = true;
+    for i in (0..next_prefix.len()).rev() {
+        next_prefix[i] = next_prefix[i].wrapping_add(1);
+        if next_prefix[i] > 0 {
+            is_last_prefix = false;
+            break;
+        }
+    }
+    if is_last_prefix {
+        // The given prefix is already the last/max prefix, so there is no next prefix,
+        // return None to represent that
+        None
+    } else {
+        Some(next_prefix)
+    }
+}
+
 #[async_trait]
 impl IDatabase for RocksDb {
     async fn begin_transaction<'a>(&'a self) -> Box<dyn ISingleUseDatabaseTransaction<'a>> {
@@ -97,7 +121,6 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
                 rocksdb::IteratorMode::From(&prefix, rocksdb::Direction::Forward),
                 options,
             );
-
             let rocksdb_iter = iter
                 .map_while(move |res| {
                     let (key_bytes, value_bytes) = res.expect("Error reading from RocksDb");
@@ -106,9 +129,35 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
                         .then_some((key_bytes, value_bytes))
                 })
                 .map(|(key_bytes, value_bytes)| (key_bytes.to_vec(), value_bytes.to_vec()));
-
             Box::pin(stream::iter(rocksdb_iter))
         })
+    }
+
+    async fn raw_find_by_prefix_sorted_descending(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>> {
+        let prefix = key_prefix.to_vec();
+        let next_prefix = next_prefix(&prefix);
+        let iterator_mode = if let Some(next_prefix) = &next_prefix {
+            rocksdb::IteratorMode::From(next_prefix, rocksdb::Direction::Reverse)
+        } else {
+            rocksdb::IteratorMode::End
+        };
+        Ok(fedimint_core::task::block_in_place(|| {
+            let mut options = rocksdb::ReadOptions::default();
+            options.set_iterate_range(rocksdb::PrefixRange(prefix.clone()));
+            let iter = self.0.snapshot().iterator_opt(iterator_mode, options);
+            let rocksdb_iter = iter
+                .map_while(move |res| {
+                    let (key_bytes, value_bytes) = res.expect("Error reading from RocksDb");
+                    key_bytes
+                        .starts_with(&prefix)
+                        .then_some((key_bytes, value_bytes))
+                })
+                .map(|(key_bytes, value_bytes)| (key_bytes.to_vec(), value_bytes.to_vec()));
+            Box::pin(stream::iter(rocksdb_iter))
+        }))
     }
 
     async fn commit_tx(self) -> Result<()> {
@@ -151,7 +200,6 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
     async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> PrefixStream<'_> {
         fedimint_core::task::block_in_place(|| {
             let prefix = key_prefix.to_vec();
-
             let rocksdb_iter = self
                 .0
                 .prefix_iterator(prefix.clone())
@@ -162,9 +210,35 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
                         .then_some((key_bytes, value_bytes))
                 })
                 .map(|(key_bytes, value_bytes)| (key_bytes.to_vec(), value_bytes.to_vec()));
-
             Box::pin(stream::iter(rocksdb_iter))
         })
+    }
+
+    async fn raw_find_by_prefix_sorted_descending(
+        &mut self,
+        key_prefix: &[u8],
+    ) -> Result<PrefixStream<'_>> {
+        let prefix = key_prefix.to_vec();
+        let next_prefix = next_prefix(&prefix);
+        let iterator_mode = if let Some(next_prefix) = &next_prefix {
+            rocksdb::IteratorMode::From(next_prefix, rocksdb::Direction::Reverse)
+        } else {
+            rocksdb::IteratorMode::End
+        };
+        Ok(fedimint_core::task::block_in_place(|| {
+            let mut options = rocksdb::ReadOptions::default();
+            options.set_iterate_range(rocksdb::PrefixRange(prefix.clone()));
+            let iter = self.0.snapshot().iterator_opt(iterator_mode, options);
+            let rocksdb_iter = iter
+                .map_while(move |res| {
+                    let (key_bytes, value_bytes) = res.expect("Error reading from RocksDb");
+                    key_bytes
+                        .starts_with(&prefix)
+                        .then_some((key_bytes, value_bytes))
+                })
+                .map(|(key_bytes, value_bytes)| (key_bytes.to_vec(), value_bytes.to_vec()));
+            Box::pin(stream::iter(rocksdb_iter))
+        }))
     }
 
     async fn commit_tx(self) -> Result<()> {
@@ -182,10 +256,13 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
 
 #[cfg(test)]
 mod fedimint_rocksdb_tests {
-    use fedimint_core::db::Database;
+    use fedimint_core::db::{notifications, Database};
+    use fedimint_core::encoding::{Decodable, Encodable};
     use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::{impl_db_lookup, impl_db_record};
+    use futures::StreamExt;
 
-    use crate::RocksDb;
+    use super::*;
 
     fn open_temp_db(temp_path: &str) -> Database {
         let path = tempfile::Builder::new()
@@ -315,5 +392,151 @@ mod fedimint_rocksdb_tests {
         // try to isolate the database again
         let module_instance_id = 2;
         db.new_isolated(module_instance_id);
+    }
+
+    #[test]
+    fn test_next_prefix() {
+        // Note: although we are testing the general case of a vector with N elements,
+        // the prefixes currently use N = 1
+        assert_eq!(next_prefix(&[1, 2, 3]).unwrap(), vec![1, 2, 4]);
+        assert_eq!(next_prefix(&[1, 2, 254]).unwrap(), vec![1, 2, 255]);
+        assert_eq!(next_prefix(&[1, 2, 255]).unwrap(), vec![1, 3, 0]);
+        assert_eq!(next_prefix(&[1, 255, 255]).unwrap(), vec![2, 0, 0]);
+        // this is a "max" prefix
+        assert!(next_prefix(&[255, 255, 255]).is_none());
+        // these are the common case
+        assert_eq!(next_prefix(&[0]).unwrap(), vec![1]);
+        assert_eq!(next_prefix(&[254]).unwrap(), vec![255]);
+        assert!(next_prefix(&[255]).is_none()); // this is a "max" prefix
+    }
+
+    #[repr(u8)]
+    #[derive(Clone)]
+    pub enum TestDbKeyPrefix {
+        Test = 254,
+        MaxTest = 255,
+    }
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+    pub(super) struct TestKey(pub Vec<u8>);
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+    pub(super) struct TestVal(pub Vec<u8>);
+
+    #[derive(Debug, Encodable, Decodable)]
+    struct DbPrefixTestPrefix;
+
+    impl_db_record!(
+        key = TestKey,
+        value = TestVal,
+        db_prefix = TestDbKeyPrefix::Test,
+        notify_on_modify = true,
+    );
+    impl_db_lookup!(key = TestKey, query_prefix = DbPrefixTestPrefix);
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+    pub(super) struct TestKey2(pub Vec<u8>);
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+    pub(super) struct TestVal2(pub Vec<u8>);
+
+    #[derive(Debug, Encodable, Decodable)]
+    struct DbPrefixTestPrefixMax;
+
+    impl_db_record!(
+        key = TestKey2,
+        value = TestVal2,
+        db_prefix = TestDbKeyPrefix::MaxTest, // max/last prefix
+        notify_on_modify = true,
+    );
+    impl_db_lookup!(key = TestKey2, query_prefix = DbPrefixTestPrefixMax);
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_retrieve_descending_order() {
+        let path = tempfile::Builder::new()
+            .prefix("fcb-rocksdb-test-descending-order")
+            .tempdir()
+            .unwrap();
+        {
+            let db = Database::new(
+                RocksDb::open(&path).unwrap(),
+                ModuleDecoderRegistry::default(),
+            );
+            let mut dbtx = db.begin_transaction().await;
+            dbtx.insert_entry(&TestKey(vec![0]), &TestVal(vec![3]))
+                .await;
+            dbtx.insert_entry(&TestKey(vec![254]), &TestVal(vec![1]))
+                .await;
+            dbtx.insert_entry(&TestKey(vec![255]), &TestVal(vec![2]))
+                .await;
+            dbtx.insert_entry(&TestKey2(vec![0]), &TestVal2(vec![3]))
+                .await;
+            dbtx.insert_entry(&TestKey2(vec![254]), &TestVal2(vec![1]))
+                .await;
+            dbtx.insert_entry(&TestKey2(vec![255]), &TestVal2(vec![2]))
+                .await;
+            let query = dbtx
+                .find_by_prefix_sorted_descending(&DbPrefixTestPrefix)
+                .await
+                .collect::<Vec<_>>()
+                .await;
+            assert_eq!(
+                query,
+                vec![
+                    (TestKey(vec![255]), TestVal(vec![2])),
+                    (TestKey(vec![254]), TestVal(vec![1])),
+                    (TestKey(vec![0]), TestVal(vec![3]))
+                ]
+            );
+            let query = dbtx
+                .find_by_prefix_sorted_descending(&DbPrefixTestPrefixMax)
+                .await
+                .collect::<Vec<_>>()
+                .await;
+            assert_eq!(
+                query,
+                vec![
+                    (TestKey2(vec![255]), TestVal2(vec![2])),
+                    (TestKey2(vec![254]), TestVal2(vec![1])),
+                    (TestKey2(vec![0]), TestVal2(vec![3]))
+                ]
+            );
+            dbtx.commit_tx().await;
+        }
+        // Test readonly implementation
+        let db_readonly = RocksDbReadOnly::open_read_only(path).unwrap();
+        let single_use = SingleUseDatabaseTransaction::new(db_readonly);
+        let notifications = notifications::Notifications::new();
+        let mut dbtx = fedimint_core::db::DatabaseTransaction::new(
+            Box::new(single_use),
+            ModuleDecoderRegistry::default(),
+            &notifications,
+        );
+        let query = dbtx
+            .find_by_prefix_sorted_descending(&DbPrefixTestPrefix)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(
+            query,
+            vec![
+                (TestKey(vec![255]), TestVal(vec![2])),
+                (TestKey(vec![254]), TestVal(vec![1])),
+                (TestKey(vec![0]), TestVal(vec![3]))
+            ]
+        );
+        let query = dbtx
+            .find_by_prefix_sorted_descending(&DbPrefixTestPrefixMax)
+            .await
+            .collect::<Vec<_>>()
+            .await;
+        assert_eq!(
+            query,
+            vec![
+                (TestKey2(vec![255]), TestVal2(vec![2])),
+                (TestKey2(vec![254]), TestVal2(vec![1])),
+                (TestKey2(vec![0]), TestVal2(vec![3]))
+            ]
+        );
     }
 }

--- a/fedimint-sqlite/Cargo.toml
+++ b/fedimint-sqlite/Cargo.toml
@@ -15,6 +15,7 @@ sqlx = { version = "0.7.0-alpha.2", default-features = false, features = ["runti
 fedimint-core ={ path = "../fedimint-core" }
 rand = "0.8"
 tracing = "0.1.37"
+bitcoin_hashes = "0.11.0"
 
 [dev-dependencies]
 tempfile = "3.4.0"

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -630,7 +630,7 @@ impl GatewayActor {
     pub async fn get_balance(&self) -> Result<Amount> {
         self.fetch_all_notes().await;
 
-        Ok(self.client.notes().await.total_amount())
+        Ok(self.client.summary().await.total_amount())
     }
 
     pub fn get_info(&self) -> Result<FederationInfo> {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -770,7 +770,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> UserTest<T> {
 
     /// Returns sum total of all notes
     pub async fn total_notes(&self) -> Amount {
-        self.client.notes().await.total_amount()
+        self.client.summary().await.total_amount()
     }
 
     pub async fn assert_total_notes(&self, amount: Amount) {
@@ -781,10 +781,10 @@ impl<T: AsRef<ClientConfig> + Clone + Send> UserTest<T> {
     /// Asserts the amounts are equal to the denominations held by the user
     pub fn assert_note_amounts(&self, amounts: Vec<Amount>) {
         block_on(self.client.fetch_all_notes()).unwrap();
-        let notes = block_on(self.client.notes());
-        let user_amounts = notes
+        let summary = block_on(self.client.summary());
+        let user_amounts = summary
             .iter()
-            .flat_map(|(a, c)| repeat(*a).take(c.len()))
+            .flat_map(|(a, len)| repeat(a).take(len))
             .sorted()
             .collect::<Vec<Amount>>();
 


### PR DESCRIPTION
Stream data from DB in descending denomination order then only uses the required notes. Also calculates and uses a summary of the notes when some metrics like `total amount` are required.

Although this started as solution to https://github.com/fedimint/fedimint/issues/82 and may improve the speed of `select_notes`, the focus is mostly on reducing memory usage.