### PR TITLE
chore: update advisory-db on every run

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -59,6 +59,9 @@ jobs:
         run: nix build -L .#ci.workspaceDoc
 
       - name: Run cargo audit
+        # sometimes we can't fix these immediately, yet
+        # we don't want to stop the world because of it
+        continue-on-error: true
         run: nix build -L .#ci.workspaceAudit
 
       # `ccov` job will run `cargo test`, so no need to spend time on it here

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -58,12 +58,6 @@ jobs:
       - name: Run cargo doc
         run: nix build -L .#ci.workspaceDoc
 
-      - name: Run cargo audit
-        # sometimes we can't fix these immediately, yet
-        # we don't want to stop the world because of it
-        continue-on-error: true
-        run: nix build -L .#ci.workspaceAudit
-
       # `ccov` job will run `cargo test`, so no need to spend time on it here
       # - name: Test workspace
       #   run: nix build -L .#workspaceTest
@@ -73,6 +67,28 @@ jobs:
 
       - name: Tests
         run: nix build -L .#ci.cli-test.all
+
+  audit:
+    name: "Audit"
+    runs-on: buildjet-2vcpu-ubuntu-2004
+    timeout-minutes: 10
+    # sometimes we can't fix these immediately, yet
+    # we don't want to stop the world because of it
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-22.05
+      - uses: cachix/cachix-action@v12
+        with:
+          name: fedimint
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Run cargo audit
+        run: |
+          nix flake lock --update-input advisory-db
+          nix build -L .#ci.workspaceAudit
 
   # Code Coverage will build using a completely different profile (neither debug/release)
   # Which means we can not reuse much from `build` job. Might as well run it as another
@@ -222,6 +238,8 @@ jobs:
     name: "Notifications"
     timeout-minutes: 1
     runs-on: ubuntu-22.04
+    # note: we don't depend on `audit` because it will
+    # be often broken, and we can't fix it immediately
     needs: [ build, cross, ccov, containers, pkgs ]
 
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1676298841,
-        "narHash": "sha256-DWSt8eWvur4rd3VYpX0CreLNMUFyLLhQhQ32xa5O5WI=",
+        "lastModified": 1681141676,
+        "narHash": "sha256-U/lhe5kPY6JcitdPiPxt6O7n6rxH+zw/Ghl1w8C9dB8=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "c536da77d72cf0bd85bf73c8949e41b16077bee1",
+        "rev": "c358dc290a6f3ccb7f889b53f4f26c0b5d18d2ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Turns out we can update `advisory-db` before every run and it doesn't cause a whole project rebuild, so we can always run with an up to date state.

However - it is failing and probably will often start failing out of the blue with no immediate fix, so I'm making it a non-required job.

It will show like that:

![image](https://user-images.githubusercontent.com/9209/231020472-565458bf-3edf-4e58-82c7-0e99a1db9117.png)

which does not prevent merging a PR, and should not report alerts on Discord `#alert` channel. But it will show every PR status as a red-x (just like codecov often does).