### PR TITLE
feat: introduce our own WASM-compatible version of `BoxStream`

### DIFF
--- a/fedimint-core/src/util.rs
+++ b/fedimint-core/src/util.rs
@@ -10,6 +10,9 @@ use crate::maybe_add_send;
 /// Future that is `Send` unless targeting WASM
 pub type BoxFuture<'a, T> = Pin<Box<maybe_add_send!(dyn Future<Output = T> + 'a)>>;
 
+/// Stream that is `Send` unless targeting WASM
+pub type BoxStream<'a, T> = Pin<Box<maybe_add_send!(dyn futures::Stream<Item = T> + 'a)>>;
+
 // TODO: make fully RFC1738 conformant
 /// Wrapper for `Url` that only prints the scheme, domain, port and path portion
 /// of a `Url` in its `Display` implementation. This is useful to hide private


### PR DESCRIPTION
Making this a separate PR mostly to let make people aware of our versions of `BoxFuture` and `BoxStream`.