### PR TITLE
fix: remove sleep in gatewayd web server event loop

### DIFF
--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -136,6 +136,7 @@ pub enum GatewayRequest {
     Backup(GatewayRequestInner<BackupPayload>),
     Restore(GatewayRequestInner<RestorePayload>),
     LightningReconnect(GatewayRequestInner<LightningReconnectPayload>),
+    Shutdown,
 }
 
 #[derive(Debug)]

--- a/gateway/ln-gateway/tests/fixtures/mod.rs
+++ b/gateway/ln-gateway/tests/fixtures/mod.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use fedimint_client::module::gen::{ClientModuleGenRegistry, DynClientModuleGen};
@@ -108,5 +109,8 @@ where
         testfn(bitcoin, lightning, Some(gateway), rpc).await;
     }
 
-    task_group.shutdown_join_all(None).await
+    // wrap up gatewayd tasks within one second or be killed
+    task_group
+        .shutdown_join_all(Some(Duration::from_secs(1)))
+        .await
 }


### PR DESCRIPTION
For `gatewayd`'s web server event loop, we currently have two loops with a `sleep` in between. This is not necessary, it is simplier to just block on the channel that is waiting for messages. This PR adds a new message that is sent during shutdown.

Fixes: https://github.com/fedimint/fedimint/issues/1603