### PR TITLE
chore: limit amount of parallel tests in test-ci-all.sh

### DIFF
--- a/scripts/test-ci-all.sh
+++ b/scripts/test-ci-all.sh
@@ -121,7 +121,8 @@ if parallel \
   --timeout 600 \
   --load 150% \
   --delay 5 \
-  --memfree 512M \
+  --jobs '+0' \
+  --memfree 1G \
   --nice 15 ::: \
   cli_test_always_success \
   cli_test_rust_tests_bitcoind \


### PR DESCRIPTION
MacOS Github runner is running out of memory in our CI. I'm looking for a simple way to prevent that.

https://www.gnu.org/software/parallel/parallel.html#options

`--jobs +0` will run at most as many tests as cpus available, which makes sense as the tests are already decently parallelized.

For buildjet, it will be still more then amount of high level tests we have. For `macos-12` it will be 3.

Also, increase the amount of free memory required before starting a new test job. Just in case.