### PR TITLE
chore: make Code Coverage build run tests in parallel 

### DIFF
--- a/flake.crane.nix
+++ b/flake.crane.nix
@@ -268,7 +268,7 @@ rec {
     pnameSuffix = "-lcov";
     version = "0.0.1";
     cargoArtifacts = workspaceDepsCov;
-    buildPhaseCargoCommand = "mkdir -p $out ; env RUST_LOG=timing=debug,info cargo llvm-cov --locked --workspace --profile $CARGO_PROFILE --lcov --all-targets --tests --output-path $out/lcov.info";
+    buildPhaseCargoCommand = "mkdir -p $out ; env RUST_LOG=info,timing=debug cargo llvm-cov --locked --workspace --profile $CARGO_PROFILE --lcov --all-targets --tests --output-path $out/lcov.info";
     installPhaseCommand = "true";
     nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
     doCheck = false;

--- a/flake.crane.nix
+++ b/flake.crane.nix
@@ -268,7 +268,7 @@ rec {
     pnameSuffix = "-lcov";
     version = "0.0.1";
     cargoArtifacts = workspaceDepsCov;
-    buildPhaseCargoCommand = "mkdir -p $out ; env RUST_LOG=info,timing=debug cargo llvm-cov --locked --workspace --profile $CARGO_PROFILE --lcov --all-targets --tests --output-path $out/lcov.info";
+    buildPhaseCargoCommand = "mkdir -p $out ; env RUST_LOG=info,timing=debug cargo llvm-cov --locked --workspace --profile $CARGO_PROFILE --lcov --all-targets --tests --output-path $out/lcov.info --  --test-threads=$(($(nproc) * 2))";
     installPhaseCommand = "true";
     nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ cargo-llvm-cov ];
     doCheck = false;


### PR DESCRIPTION
According to:

https://github.com/taiki-e/cargo-llvm-cov#known-limitations

it's only defaulting to 1 thread, because of rustc issue:

https://github.com/rust-lang/rust/issues/91092

but it seems the issue is that relatively infrequently some tests
will fail to be reported... which if fine with me if it makes
the CI faster. And they are talking about thousands of tests,
while we probably have <100.


From:

![image](https://user-images.githubusercontent.com/9209/232180375-cdd2f58f-7ea6-44b2-aab4-ff9a99fa1c54.png)

to:

![image](https://user-images.githubusercontent.com/9209/232180388-d70bffc9-dddf-44ae-ac31-e8400d12f595.png)

while it still says:

![image](https://user-images.githubusercontent.com/9209/232180415-b4deefe4-45e0-4bf8-b5b9-db532b8c04e5.png)

so LGTM

