### PR TITLE
fix: bandaid for flaky cli_test_upgrade hanging sometimes

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -247,9 +247,17 @@ function start_federation() {
   START_SERVER=${1:-0}
   END_SERVER=${2:-$FM_FED_SIZE}
   $FM_BIN_DIR/fixtures federation $START_SERVER $END_SERVER &
+  # BUG: Give daemons some time to write to `FM_PID_FILE`
+  # before moving on and letting other scripts rely on it.
+  # See https://github.com/fedimint/fedimint/issues/2236
+  sleep 2
 }
 
 function start_all_daemons() {
   $FM_BIN_DIR/fixtures all-daemons &
+  # BUG: Give daemons some time to write to `FM_PID_FILE`
+  # before touching it from here.
+  # See https://github.com/fedimint/fedimint/issues/2236
+  sleep 2
   echo $! >> $FM_PID_FILE
 }

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -2,7 +2,7 @@
 # Runs a test to see what happens if we upgrade consensus
 
 set -euxo pipefail
-export RUST_LOG="${RUST_LOG:-info}"
+export RUST_LOG="${RUST_LOG:-info,timing=trace}"
 
 source ./scripts/setup-tests.sh
 
@@ -13,15 +13,17 @@ server1=$(tail -1 $FM_PID_FILE | head -1)
 
 
 function wait_server_shutdown() {
-  echo "Waiting for $1 to shutdown..."
+  >&2 echo "Waiting for $1 to shutdown..."
   tail --pid=$1 -f /dev/null
   echo "Server $1 has shutdown."
 }
 
 await_fedimint_block_sync
 
+>&2 echo "### Signal upgrade peer0"
 # test a consensus upgrade
 FM_PASSWORD="pass0" $FM_MINT_CLIENT signal-upgrade --salt-path $FM_DATA_DIR/server-0/private.salt --our-id 0
+>&2 echo "### Signal upgrade peer1"
 FM_PASSWORD="pass1" $FM_MINT_CLIENT signal-upgrade --salt-path $FM_DATA_DIR/server-1/private.salt --our-id 1
 
 mine_blocks 1
@@ -30,16 +32,18 @@ await_fedimint_block_sync
 EPOCH=$($FM_MINT_CLIENT epoch-count | jq -e -r '.count')
 FM_UPGRADE_EPOCH=$(echo "$EPOCH + 1" | bc -l)
 export FM_UPGRADE_EPOCH
+>&2 echo "### Signal upgrade peer2"
 FM_PASSWORD="pass2" $FM_MINT_CLIENT signal-upgrade --salt-path $FM_DATA_DIR/server-2/private.salt --our-id 2
 
+>&2 echo "### Wait for server shutdowns"
 wait_server_shutdown "$server1"
 wait_server_shutdown "$server2"
 wait_server_shutdown "$server3"
 wait_server_shutdown "$server4"
 
+>&2 echo "### Restart federation"
 start_federation
 
 mine_blocks 1
 await_fedimint_block_sync
 await_all_peers
-echo "fm success: upgrade-test"


### PR DESCRIPTION
See https://github.com/fedimint/fedimint/issues/2236

My guess is that the reason the test is failing is that 

https://github.com/fedimint/fedimint/blob/fc7b43c650c4685936d0b19faca070e898372f8b/scripts/upgrade-test.sh#L9

sometimes is able to record pids from `FM_PID_FILE` before
it was updated.