### PR TITLE
chore: use rust-analyzer shipped with NixOS 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -303,7 +303,7 @@
                 commonEnvs // {
                   buildInputs = commonArgs.buildInputs;
                   nativeBuildInputs = with pkgs; commonArgs.nativeBuildInputs ++ [
-                    fenix.packages.${system}.rust-analyzer
+                    pkgs.rust-analyzer
                     toolchain.fenixToolchainRustfmt
                     cargo-llvm-cov
                     cargo-udeps


### PR DESCRIPTION
This spares people some downloading and building when setting up.