### PR TITLE
feat: `nightly` Rust dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -392,6 +392,10 @@
                 nativeBuildInputs = shellCommonNative.nativeBuildInputs ++ [ toolchain.fenixToolchain ];
               });
 
+              nightly = pkgs.mkShell (shellCommonNative
+                // {
+                nativeBuildInputs = shellCommonNative.nativeBuildInputs ++ [ toolchain.fenixToolchainNightly pkgs.cargo-fuzz ];
+              });
 
               # Shell with extra stuff to support cross-compilation with `cargo build --target <target>`
               #

--- a/flake.toolchain.nix
+++ b/flake.toolchain.nix
@@ -130,6 +130,15 @@ let
     "llvm-tools-preview"
   ]);
 
+  fenixToolchainNightly = (fenixChannelNightly.withComponents [
+    "rustc"
+    "cargo"
+    "clippy"
+    "rust-analysis"
+    "rust-src"
+    "llvm-tools-preview"
+  ]);
+
   fenixToolchainRustfmt = (fenixChannelNightly.withComponents [
     "rustfmt"
   ]);
@@ -174,4 +183,4 @@ let
     crossTargets
   ;
 in
-{ inherit crossTargets androidCrossEnvVars wasm32CrossEnvVars fenixToolchain fenixChannel fenixToolchainRustfmt fenixToolchainCargoFmt fenixToolchainCrossAll fenixToolchainCrossWasm fenixToolchainCross craneLibNative craneLibNativeDocExport craneLibCross; }
+{ inherit crossTargets androidCrossEnvVars wasm32CrossEnvVars fenixToolchain fenixToolchainNightly fenixChannel fenixToolchainRustfmt fenixToolchainCargoFmt fenixToolchainCrossAll fenixToolchainCrossWasm fenixToolchainCross craneLibNative craneLibNativeDocExport craneLibCross; }


### PR DESCRIPTION
For nightly-only tools, like `cargo-fuzz`.

Use with `nix develop .#nightly`.

Requested by @Maaxxs 