### PR TITLE
fix: remove flood of Replacing existing connection in test output

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -50,7 +50,7 @@ use fedimint_server::consensus::{
 };
 use fedimint_server::net::connect::mock::{MockNetwork, StreamReliability};
 use fedimint_server::net::connect::{parse_host_port, Connector, TlsTcpConnector};
-use fedimint_server::net::peers::{DelayCalculator, PeerConnector};
+use fedimint_server::net::peers::PeerConnector;
 use fedimint_server::{consensus, FedimintServer};
 use fedimint_testing::btc::bitcoind::FakeWalletGen;
 use fedimint_testing::btc::fixtures::FakeBitcoinTest;
@@ -559,7 +559,7 @@ async fn distributed_config(
             let cfg = ServerConfig::distributed_gen(
                 &our_params,
                 registry.legacy_init_modules(),
-                DelayCalculator::TEST_DEFAULT,
+                Default::default(),
                 &mut task_group,
             );
             (*peer, cfg.await.expect("generation failed"))
@@ -1264,7 +1264,7 @@ impl FederationTest {
                 db.clone(),
                 module_inits.clone(),
                 connect_gen(cfg),
-                DelayCalculator::TEST_DEFAULT,
+                Default::default(),
                 &mut task_group,
             )
             .await


### PR DESCRIPTION
Fixes #2107

This was annoying me when debugging as well.  Confirmed the culprit, don't take much of a performance hit for adding normal reconnect delays.

```
time ./scripts/rust-tests.sh > out-delayed.txt 2>&1 

real	5m26.697s
user	24m35.680s
sys	2m34.754s

grep -c "Replacing existing connection" out-delayed.txt
2

...

time ./scripts/rust-tests.sh > out-normal.txt 2>&1 

real	5m6.703s
user	26m43.863s
sys	2m46.803s

grep -c "Replacing existing connection" out-normal.txt
72491
```