### PR TITLE
client-ng: add operation log

### DIFF
--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -67,7 +67,7 @@ pub async fn handle_ng_command<D: IDatabase>(
                 .with_input(mint_input.into_dyn(LEGACY_HARDCODED_INSTANCE_ID_MINT));
 
             let txid = client
-                .finalize_and_submit_transaction(notes_hash, tx)
+                .finalize_and_submit_transaction(notes_hash, "test", |_| (), tx)
                 .await
                 .unwrap();
 

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -1,14 +1,17 @@
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::impl_db_record;
+use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::Serialize;
 use strum_macros::EnumIter;
 
-use crate::ClientSecret;
+use crate::sm::OperationId;
+use crate::{ClientSecret, OperationLogEntry};
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
     ClientSecret = 0x29,
+    OperationLog = 0x2c,
+    ChronologicalOperationLog = 0x2d,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -24,4 +27,35 @@ impl_db_record!(
     key = ClientSecretKey,
     value = ClientSecret,
     db_prefix = DbKeyPrefix::ClientSecret
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct OperationLogKey {
+    pub operation_id: OperationId,
+}
+
+impl_db_record!(
+    key = OperationLogKey,
+    value = OperationLogEntry,
+    db_prefix = DbKeyPrefix::OperationLog
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ChronologicalOperationLogKey {
+    pub creation_time: std::time::SystemTime,
+    pub operation_id: OperationId,
+}
+
+#[derive(Debug, Encodable)]
+pub struct ChronologicalOperationLogKeyPrefix;
+
+impl_db_record!(
+    key = ChronologicalOperationLogKey,
+    value = (),
+    db_prefix = DbKeyPrefix::ChronologicalOperationLog
+);
+
+impl_db_lookup!(
+    key = ChronologicalOperationLogKey,
+    query_prefix = ChronologicalOperationLogKeyPrefix
 );

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -510,6 +510,25 @@ where
 }
 
 #[derive(Debug)]
+pub(crate) struct ActiveOperationStateKeyPrefix<GC> {
+    pub operation_id: OperationId,
+    pub _pd: PhantomData<GC>,
+}
+
+impl<GC> Encodable for ActiveOperationStateKeyPrefix<GC> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        self.operation_id.consensus_encode(writer)
+    }
+}
+
+impl<GC> ::fedimint_core::db::DatabaseLookup for ActiveOperationStateKeyPrefix<GC>
+where
+    GC: GlobalContext,
+{
+    type Record = ActiveStateKey<GC>;
+}
+
+#[derive(Debug)]
 pub(crate) struct ActiveModuleOperationStateKeyPrefix<GC> {
     pub operation_id: OperationId,
     pub module_instance: ModuleInstanceId,
@@ -631,6 +650,25 @@ where
             state,
         })
     }
+}
+
+#[derive(Debug)]
+pub(crate) struct InactiveOperationStateKeyPrefix<GC> {
+    pub operation_id: OperationId,
+    pub _pd: PhantomData<GC>,
+}
+
+impl<GC> Encodable for InactiveOperationStateKeyPrefix<GC> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        self.operation_id.consensus_encode(writer)
+    }
+}
+
+impl<GC> ::fedimint_core::db::DatabaseLookup for InactiveOperationStateKeyPrefix<GC>
+where
+    GC: GlobalContext,
+{
+    type Record = InactiveStateKey<GC>;
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Builds on  #2251

This PR adds a log of all operation IDs that also allows the creator to add meta data. This meta data can be used by module clients to indicate the high level intent behind the operation helping with interpreting the associated state machines.