### PR TITLE
refactor: limit test reconnection delays

### DIFF
--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -240,7 +240,7 @@ impl ConfigGenApi {
         let config = ServerConfig::distributed_gen(
             &params,
             module_gens,
-            DelayCalculator::default(),
+            DelayCalculator::PROD_DEFAULT,
             &mut task_group,
         )
         .await;

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -113,7 +113,7 @@ impl ConsensusServer {
             db,
             module_inits,
             connector,
-            DelayCalculator::default(),
+            DelayCalculator::PROD_DEFAULT,
             task_group,
         )
         .await

--- a/fedimintd/src/distributed_gen.rs
+++ b/fedimintd/src/distributed_gen.rs
@@ -209,7 +209,7 @@ impl DistributedGen {
                 let server = match ServerConfig::distributed_gen(
                     &params,
                     self.module_gens.clone().legacy_init_modules(),
-                    DelayCalculator::default(),
+                    DelayCalculator::PROD_DEFAULT,
                     &mut task_group,
                 )
                 .await

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -181,7 +181,7 @@ async fn post_guardians(
                 Ok(params) => ServerConfig::distributed_gen(
                     &params,
                     module_gens.clone().legacy_init_modules(),
-                    DelayCalculator::default(),
+                    DelayCalculator::PROD_DEFAULT,
                     &mut dkg_task_group,
                 )
                 .await

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -50,7 +50,7 @@ use fedimint_server::consensus::{
 };
 use fedimint_server::net::connect::mock::{MockNetwork, StreamReliability};
 use fedimint_server::net::connect::{parse_host_port, Connector, TlsTcpConnector};
-use fedimint_server::net::peers::PeerConnector;
+use fedimint_server::net::peers::{DelayCalculator, PeerConnector};
 use fedimint_server::{consensus, FedimintServer};
 use fedimint_testing::btc::bitcoind::FakeWalletGen;
 use fedimint_testing::btc::fixtures::FakeBitcoinTest;
@@ -559,7 +559,7 @@ async fn distributed_config(
             let cfg = ServerConfig::distributed_gen(
                 &our_params,
                 registry.legacy_init_modules(),
-                Default::default(),
+                DelayCalculator::TEST_DEFAULT,
                 &mut task_group,
             );
             (*peer, cfg.await.expect("generation failed"))
@@ -1264,7 +1264,7 @@ impl FederationTest {
                 db.clone(),
                 module_inits.clone(),
                 connect_gen(cfg),
-                Default::default(),
+                DelayCalculator::TEST_DEFAULT,
                 &mut task_group,
             )
             .await


### PR DESCRIPTION
Introduce again limits on test reconnection delay but without introducing the flood solved by https://github.com/fedimint/fedimint/pull/2261

Further context is on https://github.com/fedimint/fedimint/issues/2263

(still WIP)