### PR TITLE
chore: increase linux cross compile timeout

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -165,7 +165,7 @@ jobs:
           - on: linux
             runs-on: ubuntu-22.04
             build-in-pr: true
-            timeout: 15
+            timeout: 20
           - host: macos
             runs-on: macos-12
             build-in-pr: false


### PR DESCRIPTION
15 minutes is not enough from time to time. Example: https://github.com/fedimint/fedimint/actions/runs/4752263039/jobs/8442402557?pr=2251