### PR TITLE
client-ng: Mint extension trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,6 +1485,7 @@ name = "fedimint-mint-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aquamarine",
  "async-stream",
  "async-trait",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "fedimint-mint-client",
  "fedimint-rocksdb",
  "fedimint-wallet-client",
+ "futures",
  "lightning-invoice",
  "rand",
  "serde",
@@ -1484,6 +1485,7 @@ name = "fedimint-mint-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bincode",
  "bitcoin_hashes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,6 +2901,7 @@ dependencies = [
  "fedimint-mint-client",
  "fedimint-rocksdb",
  "fedimint-testing",
+ "fedimint-wallet-client",
  "futures",
  "lightning-invoice",
  "portpicker",

--- a/fedimint-bin-tests/src/main.rs
+++ b/fedimint-bin-tests/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::env;
 use std::future::Future;
 use std::path::PathBuf;
@@ -924,6 +924,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     // ## reissue e-cash
 
     const CLIENT_NG_REISSE_AMOUNT: u64 = 420;
+    const CLIENT_NG_SPEND_AMOUNT: u64 = 42;
 
     let initial_clientng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
         .as_u64()
@@ -947,6 +948,33 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .as_u64()
         .unwrap();
     assert_eq!(initial_clientng_balance, CLIENT_NG_REISSE_AMOUNT);
+
+    // # Spend from client ng
+    let reissue_notes_denominations = cmd!(fed, "ng", "spend", CLIENT_NG_SPEND_AMOUNT)
+        .out_json()
+        .await?
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(|s| s.to_owned())
+        .collect::<BTreeSet<_>>();
+
+    let expected_denominations = vec!["2", "8", "32"]
+        .into_iter()
+        .map(|s| s.to_owned())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(reissue_notes_denominations, expected_denominations);
+
+    let clientng_post_spend_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(
+        clientng_post_spend_balance,
+        CLIENT_NG_REISSE_AMOUNT - CLIENT_NG_SPEND_AMOUNT
+    );
+
+    // TODO: test cancel/timeout
 
     Ok(())
 }

--- a/fedimint-bin-tests/src/main.rs
+++ b/fedimint-bin-tests/src/main.rs
@@ -920,6 +920,34 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .state();
     anyhow::ensure!(invoice_status == tonic_lnd::lnrpc::invoice::InvoiceState::Settled);
 
+    // # Clinet-NG tests
+    // ## reissue e-cash
+
+    const CLIENT_NG_REISSE_AMOUNT: u64 = 420;
+
+    let initial_clientng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(initial_clientng_balance, 0);
+
+    let reissue_notes = cmd!(fed, "spend", CLIENT_NG_REISSE_AMOUNT)
+        .out_json()
+        .await?["note"]
+        .as_str()
+        .map(|s| s.to_owned())
+        .unwrap();
+    let client_ng_reissue_amt = cmd!(fed, "ng", "reissue", reissue_notes)
+        .out_json()
+        .await?
+        .as_u64()
+        .unwrap();
+    assert_eq!(client_ng_reissue_amt, CLIENT_NG_REISSE_AMOUNT);
+
+    let initial_clientng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(initial_clientng_balance, CLIENT_NG_REISSE_AMOUNT);
+
     Ok(())
 }
 

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -21,6 +21,7 @@ base64 = "0.20.0"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
+futures = "0.3.28"
 lightning-invoice = { version = "0.21.0", features = [ "serde" ] }
 fedimint-client-legacy = { path = "../fedimint-client-legacy" }
 fedimint-aead = { path = "../crypto/aead" }

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -325,9 +325,11 @@ impl Opts {
     ) -> ModuleDecoderRegistry {
         ModuleDecoderRegistry::new(cfg.clone().0.modules.into_iter().filter_map(
             |(id, module_cfg)| {
-                module_gens.get(module_cfg.kind()).map(|module_gen| {
+                let kind = module_cfg.kind().clone();
+                module_gens.get(&kind).map(|module_gen| {
                     (
                         id,
+                        kind,
                         IClientModuleGen::decoder(AsRef::<dyn IClientModuleGen + 'static>::as_ref(
                             module_gen,
                         )),

--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use clap::Subcommand;
 use fedimint_client::ClientBuilder;
 use fedimint_core::config::ClientConfig;
@@ -20,6 +22,9 @@ pub enum ClientNg {
     Reissue {
         #[clap(value_parser = parse_ecash)]
         notes: TieredMulti<SpendableNote>,
+    },
+    Spend {
+        amount: Amount,
     },
 }
 
@@ -72,6 +77,12 @@ pub async fn handle_ng_command<D: IDatabase>(
             }
 
             Ok(serde_json::to_value(amount).unwrap())
+        }
+        ClientNg::Spend { amount } => {
+            let (operation, notes) = client.spend_notes(amount, Duration::from_secs(30)).await?;
+            info!("Spend e-cash operation: {operation:?}");
+
+            Ok(serde_json::to_value(notes).unwrap())
         }
     }
 }

--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -57,7 +57,7 @@ pub async fn handle_ng_command<D: IDatabase>(
                 .get_module_client::<MintClientModule>(LEGACY_HARDCODED_INSTANCE_ID_MINT)
                 .unwrap();
 
-            let notes_hash = notes.consensus_hash().unwrap().into_inner();
+            let notes_hash = notes.consensus_hash().into_inner();
             let mint_input = mint_client
                 .create_input_from_notes(notes_hash, notes)
                 .await

--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -67,7 +67,7 @@ pub async fn handle_ng_command<D: IDatabase>(
                 .with_input(mint_input.into_dyn(LEGACY_HARDCODED_INSTANCE_ID_MINT));
 
             let txid = client
-                .finalize_and_submit_transaction(notes_hash, tx)
+                .finalize_and_submit_transaction(notes_hash, "test", |_| (), tx)
                 .await
                 .unwrap();
 

--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -1,17 +1,17 @@
-use bitcoin_hashes::Hash;
 use clap::Subcommand;
-use fedimint_client::transaction::TransactionBuilder;
 use fedimint_client::ClientBuilder;
 use fedimint_core::config::ClientConfig;
-use fedimint_core::core::{IntoDynInstance, LEGACY_HARDCODED_INSTANCE_ID_MINT};
+use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_MINT;
 use fedimint_core::db::IDatabase;
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::Decodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::TaskGroup;
-use fedimint_core::{OutPoint, TieredMulti};
+use fedimint_core::{Amount, TieredMulti, TieredSummary};
 use fedimint_ln_client::LightningClientGen;
-use fedimint_mint_client::{MintClientGen, MintClientModule, SpendableNote};
+use fedimint_mint_client::{MintClientExt, MintClientGen, MintClientModule, SpendableNote};
 use fedimint_wallet_client::WalletClientGen;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
 use tracing::info;
 
 #[derive(Debug, Clone, Subcommand)]
@@ -43,46 +43,43 @@ pub async fn handle_ng_command<D: IDatabase>(
             let mint_client = client
                 .get_module_client::<MintClientModule>(LEGACY_HARDCODED_INSTANCE_ID_MINT)
                 .unwrap();
-            let info = mint_client
+            let summary = mint_client
                 .get_wallet_summary(
                     &mut client.db().begin_transaction().await.with_module_prefix(1),
                 )
                 .await;
-            Ok(serde_json::to_value(info).unwrap())
+            Ok(serde_json::to_value(InfoResponse {
+                total_msat: summary.total_amount(),
+                denominations_msat: summary,
+            })
+            .unwrap())
         }
         ClientNg::Reissue { notes } => {
-            let amt = notes.total_amount();
+            let amount = notes.total_amount();
 
-            let mint_client = client
-                .get_module_client::<MintClientModule>(LEGACY_HARDCODED_INSTANCE_ID_MINT)
-                .unwrap();
-
-            let notes_hash = notes.consensus_hash().into_inner();
-            let mint_input = mint_client
-                .create_input_from_notes(notes_hash, notes)
+            let operation_id = client.reissue_external_notes(notes).await?;
+            let mut updates = client
+                .subscribe_reissue_external_notes_updates(operation_id)
                 .await
                 .unwrap();
 
-            let tx = TransactionBuilder::new()
-                .with_input(mint_input.into_dyn(LEGACY_HARDCODED_INSTANCE_ID_MINT));
+            while let Some(update) = updates.next().await {
+                if let fedimint_mint_client::ReissueExternalNotesState::Failed(e) = update {
+                    return Err(anyhow::Error::msg(format!("Reissue failed: {e}")));
+                }
 
-            let txid = client
-                .finalize_and_submit_transaction(notes_hash, "test", |_| (), tx)
-                .await
-                .unwrap();
+                info!("Update: {:?}", update);
+            }
 
-            info!("Transaction submitted: {}", txid);
-            client.await_tx_accepted(notes_hash, txid).await;
-            info!("Transaction accepted");
-            mint_client
-                .await_output_finalized(notes_hash, OutPoint { txid, out_idx: 0 })
-                .await
-                .unwrap();
-            info!("Output finalized");
-
-            Ok(serde_json::to_value(amt).unwrap())
+            Ok(serde_json::to_value(amount).unwrap())
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InfoResponse {
+    total_msat: Amount,
+    denominations_msat: TieredSummary,
 }
 
 pub fn parse_ecash(s: &str) -> anyhow::Result<TieredMulti<SpendableNote>> {

--- a/fedimint-client-legacy/src/lib.rs
+++ b/fedimint-client-legacy/src/lib.rs
@@ -38,17 +38,19 @@ use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::SignedEpochOutcome;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::module::ModuleCommon;
+use fedimint_core::module::{CommonModuleGen, ModuleCommon};
 use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::task::{self, sleep};
 use fedimint_core::tiered::InvalidAmountTierError;
 use fedimint_core::{Amount, OutPoint, TieredMulti, TieredSummary, TransactionId};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
-use fedimint_ln_client::{LightningClientModule, LightningModuleTypes, LightningOutputOutcome};
+use fedimint_ln_client::{
+    LightningClientModule, LightningCommonGen, LightningModuleTypes, LightningOutputOutcome,
+};
 use fedimint_logging::LOG_WALLET;
-use fedimint_mint_client::{MintClientModule, MintModuleTypes};
+use fedimint_mint_client::{MintClientModule, MintCommonGen, MintModuleTypes};
 use fedimint_wallet_client::WalletModuleTypes;
-use fedimint_wallet_common::Rbf;
+use fedimint_wallet_common::{Rbf, WalletCommonGen};
 use futures::stream::{self, FuturesUnordered};
 use futures::StreamExt;
 use itertools::{Either, Itertools};
@@ -1542,14 +1544,17 @@ pub fn module_decode_stubs() -> ModuleDecoderRegistry {
     ModuleDecoderRegistry::from_iter([
         (
             LEGACY_HARDCODED_INSTANCE_ID_LN,
+            LightningCommonGen::KIND,
             LightningModuleTypes::decoder(),
         ),
         (
             LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+            WalletCommonGen::KIND,
             WalletModuleTypes::decoder(),
         ),
         (
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
+            MintCommonGen::KIND,
             MintModuleTypes::decoder(),
         ),
     ])

--- a/fedimint-client-legacy/src/ln/mod.rs
+++ b/fedimint-client-legacy/src/ln/mod.rs
@@ -337,8 +337,10 @@ mod tests {
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::Database;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::module::CommonModuleGen;
     use fedimint_core::outcome::{SerdeOutputOutcome, TransactionStatus};
     use fedimint_core::{Amount, OutPoint, ServerModule, TransactionId};
+    use fedimint_ln_client::LightningCommonGen;
     use fedimint_ln_server::{Lightning, LightningGen};
     use fedimint_testing::FakeFed;
     use lightning_invoice::Invoice;
@@ -469,6 +471,7 @@ mod tests {
         let client_context = ClientContext {
             decoders: ModuleDecoderRegistry::from_iter([(
                 LEGACY_HARDCODED_INSTANCE_ID_LN,
+                LightningCommonGen::KIND,
                 <Lightning as ServerModule>::decoder(),
             )]),
             module_gens: Default::default(),

--- a/fedimint-client-legacy/src/mint/mod.rs
+++ b/fedimint-client-legacy/src/mint/mod.rs
@@ -690,8 +690,10 @@ mod tests {
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::Database;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::module::CommonModuleGen;
     use fedimint_core::outcome::{SerdeOutputOutcome, TransactionStatus};
     use fedimint_core::{Amount, OutPoint, ServerModule, Tiered, TransactionId};
+    use fedimint_mint_client::MintCommonGen;
     use fedimint_mint_server::{Mint, MintGen, MintGenParams};
     use fedimint_testing::FakeFed;
     use futures::executor::block_on;
@@ -793,6 +795,7 @@ mod tests {
         let client_context = ClientContext {
             decoders: ModuleDecoderRegistry::from_iter([(
                 module_id,
+                MintCommonGen::KIND,
                 <Mint as ServerModule>::decoder(),
             )]),
             module_gens: Default::default(),
@@ -989,6 +992,7 @@ mod tests {
             context: Arc::new(ClientContext {
                 decoders: ModuleDecoderRegistry::from_iter([(
                     module_id,
+                    MintCommonGen::KIND,
                     <Mint as ServerModule>::decoder(),
                 )]),
                 module_gens: Default::default(),

--- a/fedimint-client-legacy/src/wallet/mod.rs
+++ b/fedimint-client-legacy/src/wallet/mod.rs
@@ -205,11 +205,13 @@ mod tests {
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::Database;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::module::CommonModuleGen;
     use fedimint_core::outcome::{SerdeOutputOutcome, TransactionStatus};
     use fedimint_core::task::TaskGroup;
     use fedimint_core::{Feerate, OutPoint, ServerModule, TransactionId};
     use fedimint_testing::btc::bitcoind::{FakeBitcoindRpc, FakeBitcoindRpcController};
     use fedimint_testing::FakeFed;
+    use fedimint_wallet_common::WalletCommonGen;
     use fedimint_wallet_server::{Wallet, WalletGen, WalletGenParams};
     use tokio::sync::Mutex;
 
@@ -312,6 +314,7 @@ mod tests {
         let client = ClientContext {
             decoders: ModuleDecoderRegistry::from_iter([(
                 module_id,
+                WalletCommonGen::KIND,
                 <Wallet as ServerModule>::decoder(),
             )]),
             module_gens: Default::default(),

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -1,14 +1,17 @@
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::impl_db_record;
+use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::Serialize;
 use strum_macros::EnumIter;
 
-use crate::ClientSecret;
+use crate::sm::OperationId;
+use crate::{ClientSecret, OperationLogEntry};
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
     ClientSecret = 0x29,
+    OperationLog = 0x2c,
+    ChronologicalOperationLog = 0x2d,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -24,4 +27,35 @@ impl_db_record!(
     key = ClientSecretKey,
     value = ClientSecret,
     db_prefix = DbKeyPrefix::ClientSecret
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct OperationLogKey {
+    pub operation_id: OperationId,
+}
+
+impl_db_record!(
+    key = OperationLogKey,
+    value = OperationLogEntry,
+    db_prefix = DbKeyPrefix::OperationLog
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ChronologicalOperationLogKey {
+    pub creation_time: std::time::SystemTime,
+    pub operation_id: OperationId,
+}
+
+#[derive(Debug, Encodable)]
+pub struct ChronologicalOperationLogKeyPrefix;
+
+impl_db_record!(
+    key = ChronologicalOperationLogKey,
+    value = (),
+    db_prefix = DbKeyPrefix::ChronologicalOperationLog
+);
+
+impl_db_lookup!(
+    key = ChronologicalOperationLogKey,
+    query_prefix = ChronologicalOperationLogKeyPrefix
 );

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -241,7 +241,7 @@ impl Debug for ClientInner {
 #[derive(Clone, Debug)]
 struct ModuleGlobalClientContext {
     client: Arc<ClientInner>,
-    module_instance: ModuleInstanceId,
+    module_instance_id: ModuleInstanceId,
     operation: OperationId,
 }
 
@@ -257,9 +257,9 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         input: InstancelessDynClientInput,
     ) -> TransactionId {
         let instance_input = ClientInput {
-            input: DynInput::from_parts(self.module_instance, input.input),
+            input: DynInput::from_parts(self.module_instance_id, input.input),
             keys: input.keys,
-            state_machines: states_add_instance(self.module_instance, input.state_machines),
+            state_machines: states_add_instance(self.module_instance_id, input.state_machines),
         };
 
         self.client
@@ -278,8 +278,8 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         output: InstancelessDynClientOutput,
     ) -> anyhow::Result<TransactionId> {
         let instance_output = ClientOutput {
-            output: DynOutput::from_parts(self.module_instance, output.output),
-            state_machines: states_add_instance(self.module_instance, output.state_machines),
+            output: DynOutput::from_parts(self.module_instance_id, output.output),
+            state_machines: states_add_instance(self.module_instance_id, output.state_machines),
         };
 
         self.client
@@ -519,7 +519,7 @@ impl ClientInner {
         Arc::new(move |module_instance, operation| {
             ModuleGlobalClientContext {
                 client: client_inner.clone(),
-                module_instance,
+                module_instance_id: module_instance,
                 operation,
             }
             .into()

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -141,7 +141,7 @@ impl AsRef<maybe_add_send_sync!(dyn IClientModule + 'static)> for DynClientModul
 }
 
 pub type StateGenerator<S> =
-    Box<maybe_add_send_sync!(dyn Fn(TransactionId, u64) -> Vec<S> + 'static)>;
+    Arc<maybe_add_send_sync!(dyn Fn(TransactionId, u64) -> Vec<S> + 'static)>;
 
 /// A client module that can be used as funding source and to generate arbitrary
 /// change outputs for unbalanced transactions.

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -510,6 +510,25 @@ where
 }
 
 #[derive(Debug)]
+pub(crate) struct ActiveOperationStateKeyPrefix<GC> {
+    pub operation_id: OperationId,
+    pub _pd: PhantomData<GC>,
+}
+
+impl<GC> Encodable for ActiveOperationStateKeyPrefix<GC> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        self.operation_id.consensus_encode(writer)
+    }
+}
+
+impl<GC> ::fedimint_core::db::DatabaseLookup for ActiveOperationStateKeyPrefix<GC>
+where
+    GC: GlobalContext,
+{
+    type Record = ActiveStateKey<GC>;
+}
+
+#[derive(Debug)]
 pub(crate) struct ActiveModuleOperationStateKeyPrefix<GC> {
     pub operation_id: OperationId,
     pub module_instance: ModuleInstanceId,
@@ -631,6 +650,25 @@ where
             state,
         })
     }
+}
+
+#[derive(Debug)]
+pub(crate) struct InactiveOperationStateKeyPrefix<GC> {
+    pub operation_id: OperationId,
+    pub _pd: PhantomData<GC>,
+}
+
+impl<GC> Encodable for InactiveOperationStateKeyPrefix<GC> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        self.operation_id.consensus_encode(writer)
+    }
+}
+
+impl<GC> ::fedimint_core::db::DatabaseLookup for InactiveOperationStateKeyPrefix<GC>
+where
+    GC: GlobalContext,
+{
+    type Record = InactiveStateKey<GC>;
 }
 
 #[derive(Debug)]

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -740,7 +740,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId};
+    use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind};
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::Database;
     use fedimint_core::encoding::{Decodable, Encodable};
@@ -858,7 +858,8 @@ mod tests {
         decoder_builder.with_decodable_type::<MockStateMachine>();
         let decoder = decoder_builder.build();
 
-        let decoders = ModuleDecoderRegistry::new(vec![(42, decoder)]);
+        let decoders =
+            ModuleDecoderRegistry::new(vec![(42, ModuleKind::from_static_str("test"), decoder)]);
         let db = Database::new(MemDatabase::new(), decoders);
 
         let mut executor_builder = Executor::<()>::builder();

--- a/fedimint-client/src/transaction/builder.rs
+++ b/fedimint-client/src/transaction/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use fedimint_core::core::{DynInput, DynOutput, IntoDynInstance, KeyPair, ModuleInstanceId};
 use fedimint_core::transaction::Transaction;
 use fedimint_core::Amount;
@@ -9,6 +11,7 @@ use crate::module::StateGenerator;
 use crate::sm::DynState;
 use crate::DynGlobalClientContext;
 
+#[derive(Clone)]
 pub struct ClientInput<I = DynInput, S = DynState<DynGlobalClientContext>> {
     pub input: I,
     pub keys: Vec<KeyPair>,
@@ -31,6 +34,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct ClientOutput<O = DynOutput, S = DynState<DynGlobalClientContext>> {
     pub output: O,
     pub state_machines: StateGenerator<S>,
@@ -51,7 +55,7 @@ where
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct TransactionBuilder {
     pub(crate) inputs: Vec<ClientInput>,
     pub(crate) outputs: Vec<ClientOutput>,
@@ -134,7 +138,7 @@ fn state_gen_to_dyn<S>(
 where
     S: IntoDynInstance<DynType = DynState<DynGlobalClientContext>> + 'static,
 {
-    Box::new(move |txid, index| {
+    Arc::new(move |txid, index| {
         let states = state_gen(txid, index);
         states
             .into_iter()

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -217,7 +217,7 @@ mod tests {
 
     use async_trait::async_trait;
     use fedimint_core::api::{IFederationApi, JsonRpcResult};
-    use fedimint_core::core::IntoDynInstance;
+    use fedimint_core::core::{IntoDynInstance, ModuleKind};
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::Database;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -389,6 +389,7 @@ mod tests {
             MemDatabase::new(),
             ModuleDecoderRegistry::new([(
                 TRANSACTION_SUBMISSION_MODULE_INSTANCE,
+                ModuleKind::from_static_str("test_transaction_submission"),
                 tx_submission_sm_decoder(),
             )]),
         );

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -565,7 +565,7 @@ impl ClientModuleConfig {
     ) -> anyhow::Result<Self> {
         Ok(Self {
             kind,
-            consensus_hash: value.consensus_hash()?,
+            consensus_hash: value.consensus_hash(),
             config: serde_json::to_value(value)?,
         })
     }

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -471,9 +471,9 @@ where
                 anyhow::bail!("Detected configuration for unsupported module kind: {kind}")
             };
 
-            modules.insert(id, init.as_ref().decoder());
+            modules.insert(id, (kind.clone(), init.as_ref().decoder()));
         }
-        Ok(ModuleDecoderRegistry::from_iter(modules))
+        Ok(ModuleDecoderRegistry::from(modules))
     }
 }
 

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -84,10 +84,11 @@ pub trait Encodable {
     ///
     /// Can be used to validate all federation members agree on state without
     /// revealing the object
-    fn consensus_hash(&self) -> anyhow::Result<sha256::Hash> {
+    fn consensus_hash(&self) -> sha256::Hash {
         let mut engine = HashEngine::default();
-        self.consensus_encode(&mut engine)?;
-        Ok(sha256::Hash::from_engine(engine))
+        self.consensus_encode(&mut engine)
+            .expect("writing to HashEngine cannot fail");
+        sha256::Hash::from_engine(engine)
     }
 }
 

--- a/fedimint-core/src/epoch.rs
+++ b/fedimint-core/src/epoch.rs
@@ -85,7 +85,7 @@ impl SignedEpochOutcome {
         };
 
         SignedEpochOutcome {
-            hash: outcome.consensus_hash().expect("Hashes"),
+            hash: outcome.consensus_hash(),
             outcome,
             signature: None,
         }
@@ -151,14 +151,14 @@ impl SignedEpochOutcome {
             match prev_epoch {
                 None => return Err(EpochVerifyError::MissingPreviousEpoch),
                 Some(prev_epoch) => {
-                    if prev_epoch.outcome.consensus_hash().ok() != self.outcome.last_hash {
+                    if Some(prev_epoch.outcome.consensus_hash()) != self.outcome.last_hash {
                         return Err(EpochVerifyError::InvalidPreviousEpochHash);
                     }
                 }
             }
         }
 
-        if Some(self.hash) == self.outcome.consensus_hash().ok() {
+        if self.hash == self.outcome.consensus_hash() {
             Ok(())
         } else {
             Err(EpochVerifyError::InvalidEpochHash)
@@ -233,7 +233,7 @@ mod tests {
         sk: &SecretKey,
     ) -> SignedEpochOutcome {
         let missing_sig = history(epoch, prev_epoch, None);
-        let signature = sk.sign(missing_sig.outcome.consensus_hash().expect("Hashes"));
+        let signature = sk.sign(missing_sig.outcome.consensus_hash());
         history(epoch, prev_epoch, Some(SerdeSignature(signature)))
     }
 
@@ -252,7 +252,7 @@ mod tests {
         };
 
         SignedEpochOutcome {
-            hash: outcome.consensus_hash().expect("Hashes"),
+            hash: outcome.consensus_hash(),
             outcome,
             signature,
         }

--- a/fedimint-core/src/module/registry.rs
+++ b/fedimint-core/src/module/registry.rs
@@ -2,13 +2,13 @@ use std::collections::BTreeMap;
 
 use anyhow::anyhow;
 
-use crate::core::Decoder;
 pub use crate::core::ModuleInstanceId;
+use crate::core::{Decoder, ModuleKind};
 use crate::server::DynServerModule;
 
 /// Module Registry hold module-specific data `M` by the `ModuleInstanceId`
 #[derive(Debug, Clone)]
-pub struct ModuleRegistry<M>(BTreeMap<ModuleInstanceId, M>);
+pub struct ModuleRegistry<M>(BTreeMap<ModuleInstanceId, (ModuleKind, M)>);
 
 impl<M> Default for ModuleRegistry<M> {
     fn default() -> Self {
@@ -16,32 +16,36 @@ impl<M> Default for ModuleRegistry<M> {
     }
 }
 
-impl<M> From<BTreeMap<ModuleInstanceId, M>> for ModuleRegistry<M> {
-    fn from(value: BTreeMap<ModuleInstanceId, M>) -> Self {
+impl<M> From<BTreeMap<ModuleInstanceId, (ModuleKind, M)>> for ModuleRegistry<M> {
+    fn from(value: BTreeMap<ModuleInstanceId, (ModuleKind, M)>) -> Self {
         Self(value)
     }
 }
 
-impl<M> FromIterator<(ModuleInstanceId, M)> for ModuleRegistry<M> {
-    fn from_iter<T: IntoIterator<Item = (ModuleInstanceId, M)>>(iter: T) -> Self {
+impl<M> FromIterator<(ModuleInstanceId, ModuleKind, M)> for ModuleRegistry<M> {
+    fn from_iter<T: IntoIterator<Item = (ModuleInstanceId, ModuleKind, M)>>(iter: T) -> Self {
         Self::new(iter)
     }
 }
 
 impl<M> ModuleRegistry<M> {
     /// Create [`Self`] from an iterator of pairs
-    pub fn new(iter: impl IntoIterator<Item = (ModuleInstanceId, M)>) -> Self {
-        Self(iter.into_iter().collect())
+    pub fn new(iter: impl IntoIterator<Item = (ModuleInstanceId, ModuleKind, M)>) -> Self {
+        Self(
+            iter.into_iter()
+                .map(|(id, kind, module)| (id, (kind, module)))
+                .collect(),
+        )
     }
 
     /// Return an iterator over all module data
-    pub fn iter_modules(&self) -> impl Iterator<Item = (ModuleInstanceId, &M)> {
-        self.0.iter().map(|(id, m)| (*id, m))
+    pub fn iter_modules(&self) -> impl Iterator<Item = (ModuleInstanceId, &ModuleKind, &M)> {
+        self.0.iter().map(|(id, (kind, m))| (*id, kind, m))
     }
 
     /// Get module data by instance id
     pub fn get(&self, id: ModuleInstanceId) -> Option<&M> {
-        self.0.get(&id)
+        self.0.get(&id).map(|m| &m.1)
     }
 }
 
@@ -52,7 +56,8 @@ impl<M: std::fmt::Debug> ModuleRegistry<M> {
     /// # Panics
     /// If the module isn't in the registry
     pub fn get_expect(&self, id: ModuleInstanceId) -> &M {
-        self.0
+        &self
+            .0
             .get(&id)
             .ok_or_else(|| {
                 anyhow!(
@@ -62,13 +67,14 @@ impl<M: std::fmt::Debug> ModuleRegistry<M> {
                 )
             })
             .expect("Only existing instance should be fetched")
+            .1
     }
 
     /// Add a module to the registry
-    pub fn register_module(&mut self, id: ModuleInstanceId, module: M) {
+    pub fn register_module(&mut self, id: ModuleInstanceId, kind: ModuleKind, module: M) {
         // FIXME: return result
         assert!(
-            self.0.insert(id, module).is_none(),
+            self.0.insert(id, (kind, module)).is_none(),
             "Module was already registered!"
         )
     }
@@ -81,7 +87,11 @@ impl ServerModuleRegistry {
     /// Generate a `ModuleDecoderRegistry` from this `ModuleRegistry`
     pub fn decoder_registry(&self) -> ModuleDecoderRegistry {
         // TODO: cache decoders
-        ModuleDecoderRegistry::from_iter(self.0.iter().map(|(&id, module)| (id, module.decoder())))
+        ModuleDecoderRegistry::from_iter(
+            self.0
+                .iter()
+                .map(|(&id, (kind, module))| (id, kind.clone(), module.decoder())),
+        )
     }
 }
 

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -86,7 +86,7 @@ impl ServerConfig {
             core: Self::supported_api_versions(),
             modules: modules
                 .iter_modules()
-                .map(|(id, module)| (id, module.supported_api_versions()))
+                .map(|(id, _, module)| (id, module.supported_api_versions()))
                 .collect(),
         }
     }

--- a/fedimint-server/src/consensus/interconnect.rs
+++ b/fedimint-server/src/consensus/interconnect.rs
@@ -19,7 +19,7 @@ impl<'a> ModuleInterconect for FedimintInterconnect<'a> {
         path: String,
         data: ApiRequestErased,
     ) -> Result<Value, ApiError> {
-        for (module_id, module) in self.fedimint.modules.iter_modules() {
+        for (module_id, _, module) in self.fedimint.modules.iter_modules() {
             if module_id == id {
                 let endpoint = module
                     .api_endpoints()

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -310,7 +310,7 @@ impl FedimintConsensus {
             .save_epoch_history(outcome.clone(), dbtx, &mut drop_peers, rejected_txs)
             .await;
 
-        for (module_key, module) in self.modules.iter_modules() {
+        for (module_key, _, module) in self.modules.iter_modules() {
             let module_drop_peers = module
                 .end_consensus_epoch(consensus_peers, &mut dbtx.with_module_prefix(module_key))
                 .await;
@@ -463,7 +463,7 @@ impl FedimintConsensus {
         let proposal_futures = self
             .modules
             .iter_modules()
-            .map(|(module_instance_id, module)| {
+            .map(|(module_instance_id, _kind, module)| {
                 Box::pin(async move {
                     let mut dbtx = self.db.begin_transaction().await;
                     let mut module_dbtx = dbtx.with_module_prefix(module_instance_id);
@@ -500,7 +500,7 @@ impl FedimintConsensus {
             .collect();
         let mut force_new_epoch = false;
 
-        for (instance_id, module) in self.modules.iter_modules() {
+        for (instance_id, _, module) in self.modules.iter_modules() {
             let consensus_proposal = module
                 .consensus_proposal(&mut dbtx.with_module_prefix(instance_id), instance_id)
                 .await;
@@ -627,7 +627,7 @@ impl FedimintConsensus {
     pub async fn audit(&self) -> Audit {
         let mut dbtx = self.db.begin_transaction().await;
         let mut audit = Audit::default();
-        for (module_instance_id, module) in self.modules.iter_modules() {
+        for (module_instance_id, _, module) in self.modules.iter_modules() {
             module
                 .audit(&mut dbtx.with_module_prefix(module_instance_id), &mut audit)
                 .await

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -148,9 +148,9 @@ impl ConsensusServer {
         .await?;
 
         for (module_id, module_cfg) in &cfg.consensus.modules {
-            let kind = module_cfg.kind();
+            let kind = module_cfg.kind().clone();
 
-            let Some(init) = module_inits.get(kind) else {
+            let Some(init) = module_inits.get(&kind) else {
                 bail!("Detected configuration for unsupported module kind: {kind}")
             };
             info!(target: LOG_CORE,
@@ -173,7 +173,7 @@ impl ConsensusServer {
                     task_group,
                 )
                 .await?;
-            modules.insert(*module_id, module);
+            modules.insert(*module_id, (kind, module));
         }
 
         // Check the configs are valid

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -345,7 +345,7 @@ impl ConsensusServer {
                         last_outcome.epoch,
                         self.last_processed_epoch
                             .as_ref()
-                            .and_then(|epoch| epoch.outcome.consensus_hash().ok()),
+                            .map(|epoch| epoch.outcome.consensus_hash()),
                         None,
                         true,
                     )

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -161,9 +161,10 @@ mod fedimint_migration_tests {
         SignedEpochOutcome,
     };
     use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::module::CommonModuleGen;
     use fedimint_core::transaction::Transaction;
     use fedimint_core::{PeerId, ServerModule, TransactionId};
-    use fedimint_dummy_common::{DummyInput, DummyOutput};
+    use fedimint_dummy_common::{DummyCommonGen, DummyInput, DummyOutput};
     use fedimint_dummy_server::Dummy;
     use fedimint_testing::{prepare_snapshot, validate_migrations, BYTE_32, BYTE_8};
     use futures::StreamExt;
@@ -274,7 +275,11 @@ mod fedimint_migration_tests {
                     create_db_with_v0_data(dbtx).await;
                 })
             },
-            ModuleDecoderRegistry::from_iter([(0, <Dummy as ServerModule>::decoder())]),
+            ModuleDecoderRegistry::from_iter([(
+                0,
+                DummyCommonGen::KIND,
+                <Dummy as ServerModule>::decoder(),
+            )]),
         )
         .await;
     }
@@ -385,6 +390,7 @@ mod fedimint_migration_tests {
             },
             ModuleDecoderRegistry::from_iter([(
                 0,
+                DummyCommonGen::KIND,
                 <Dummy as ServerModule>::decoder(),
             )]),
         )

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -149,7 +149,7 @@ impl FedimintServer {
     pub async fn run_consensus_api(&self, api: &ConsensusApi) -> FedimintApiHandler {
         let mut rpc_module = RpcHandlerCtx::new_module(api.clone());
         Self::attach_endpoints(&mut rpc_module, net::api::server_endpoints(), None);
-        for (id, module) in api.modules.iter_modules() {
+        for (id, _, module) in api.modules.iter_modules() {
             Self::attach_endpoints(&mut rpc_module, module.api_endpoints(), Some(id));
         }
 

--- a/fedimint-testing/src/lib.rs
+++ b/fedimint-testing/src/lib.rs
@@ -71,6 +71,7 @@ where
                 MemDatabase::new(),
                 ModuleDecoderRegistry::from_iter([(
                     module_instance_id,
+                    ConfGen::kind(),
                     <ConfGen as ExtendsCommonModuleGen>::Common::decoder(),
                 )]),
             );

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -42,6 +42,9 @@ fedimint-client = { path = "../../fedimint-client" }
 fedimint-core = { path = "../../fedimint-core" }
 fedimint-logging = { path = "../../fedimint-logging" }
 fedimint-rocksdb = { path = "../../fedimint-rocksdb" }
+fedimint-ln-client = { path = "../../modules/fedimint-ln-client" }
+fedimint-mint-client = { path = "../../modules/fedimint-mint-client" }
+fedimint-wallet-client = { path = "../../modules/fedimint-wallet-client" }
 futures = "0.3.24"
 lightning-invoice = "0.21.0"
 fedimint-client-legacy = { path = "../../fedimint-client-legacy" }

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -7,15 +7,19 @@ use clap::Parser;
 use fedimint_client::module::gen::{ClientModuleGenRegistry, DynClientModuleGen};
 use fedimint_client_legacy::modules::ln::{LightningClientGen, LightningModuleTypes};
 use fedimint_client_legacy::modules::mint::{MintClientGen, MintModuleTypes};
-use fedimint_client_legacy::modules::wallet::{WalletClientGen, WalletModuleTypes};
+use fedimint_client_legacy::modules::wallet::{
+    WalletClientGen, WalletCommonGen, WalletModuleTypes,
+};
 use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::module::ModuleCommon;
+use fedimint_core::module::{CommonModuleGen, ModuleCommon};
 use fedimint_core::task::TaskGroup;
+use fedimint_ln_client::LightningCommonGen;
 use fedimint_logging::TracingSetup;
+use fedimint_mint_client::MintCommonGen;
 use ln_gateway::client::{DynGatewayClientBuilder, RocksDbFactory, StandardGatewayClientBuilder};
 use ln_gateway::{Gateway, LightningMode};
 use tracing::{error, info};
@@ -88,14 +92,17 @@ async fn main() -> Result<(), anyhow::Error> {
     let decoders = ModuleDecoderRegistry::from_iter([
         (
             LEGACY_HARDCODED_INSTANCE_ID_LN,
+            LightningCommonGen::KIND,
             LightningModuleTypes::decoder(),
         ),
         (
             LEGACY_HARDCODED_INSTANCE_ID_MINT,
+            MintCommonGen::KIND,
             MintModuleTypes::decoder(),
         ),
         (
             LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+            WalletCommonGen::KIND,
             WalletModuleTypes::decoder(),
         ),
     ]);

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -33,7 +33,7 @@ impl CommonModuleGen for DummyCommonGen {
     }
 
     fn hash_client_module(config: Value) -> anyhow::Result<sha256::Hash> {
-        serde_json::from_value::<DummyClientConfig>(config)?.consensus_hash()
+        Ok(serde_json::from_value::<DummyClientConfig>(config)?.consensus_hash())
     }
 }
 

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -109,7 +109,7 @@ impl ServerModuleGen for DummyServerGen {
 
         Ok(ModuleConfigResponse {
             client: config.to_client_config(),
-            consensus_hash: config.consensus_hash()?,
+            consensus_hash: config.consensus_hash(),
         })
     }
 

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -193,7 +193,7 @@ impl CommonModuleGen for LightningCommonGen {
     fn hash_client_module(
         config: serde_json::Value,
     ) -> anyhow::Result<bitcoin_hashes::sha256::Hash> {
-        serde_json::from_value::<LightningClientConfig>(config)?.consensus_hash()
+        Ok(serde_json::from_value::<LightningClientConfig>(config)?.consensus_hash())
     }
 }
 

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -913,7 +913,7 @@ mod fedimint_migration_tests {
     use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
     use fedimint_core::db::{apply_migrations, DatabaseTransaction};
     use fedimint_core::module::registry::ModuleDecoderRegistry;
-    use fedimint_core::module::DynServerModuleGen;
+    use fedimint_core::module::{CommonModuleGen, DynServerModuleGen};
     use fedimint_core::{OutPoint, ServerModule, TransactionId};
     use fedimint_ln_common::contracts::incoming::{
         FundedIncomingContract, IncomingContract, IncomingContractOffer, OfferId,
@@ -928,6 +928,7 @@ mod fedimint_migration_tests {
         LightningGatewayKeyPrefix, OfferKey, OfferKeyPrefix, ProposeDecryptionShareKey,
         ProposeDecryptionShareKeyPrefix,
     };
+    use fedimint_ln_common::LightningCommonGen;
     use fedimint_testing::{prepare_snapshot, validate_migrations, BYTE_32, BYTE_8, STRING_64};
     use futures::StreamExt;
     use lightning_invoice::Invoice;
@@ -1051,6 +1052,7 @@ mod fedimint_migration_tests {
             },
             ModuleDecoderRegistry::from_iter([(
                 LEGACY_HARDCODED_INSTANCE_ID_LN,
+                LightningCommonGen::KIND,
                 <Lightning as ServerModule>::decoder(),
             )]),
         )
@@ -1156,6 +1158,7 @@ mod fedimint_migration_tests {
             },
             ModuleDecoderRegistry::from_iter([(
                 LEGACY_HARDCODED_INSTANCE_ID_LN,
+                LightningCommonGen::KIND,
                 <Lightning as ServerModule>::decoder(),
             )]),
         )

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -138,7 +138,7 @@ impl ServerModuleGen for LightningGen {
 
         Ok(ModuleConfigResponse {
             client: config.to_client_config(),
-            consensus_hash: config.consensus_hash()?,
+            consensus_hash: config.consensus_hash(),
         })
     }
 

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 anyhow = "1.0.66"
 async-stream = "0.3.5"
 async-trait = "0.1"
+aquamarine = "0.3.1"
 bincode = "1.3.1"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
@@ -33,6 +34,7 @@ strum_macros = "0.24"
 tbs = { path = "../../crypto/tbs" }
 thiserror = "1.0.39"
 threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
+tokio = { version = "1.27.0", features = [ "sync" ] }
 tracing ="0.1.37"
 
 [dev-dependencies]

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.66"
+async-stream = "0.3.5"
 async-trait = "0.1"
 bincode = "1.3.1"
 bitcoin_hashes = "0.11.0"

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, StateTransition};
 use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
@@ -144,7 +146,7 @@ impl MintInputStateCreated {
             keys: spend_keys,
             // The input of the refund tx is managed by this state machine, so no new state machines
             // need to be created
-            state_machines: Box::new(|_, _| vec![]),
+            state_machines: Arc::new(|_, _| vec![]),
         };
 
         let refund_txid = global_context.claim_input(dbtx, refund_input).await;

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1,10 +1,15 @@
 mod db;
+/// State machines for mint inputs
 mod input;
+/// State machines for out-of-band transmitted e-cash notes
+mod oob;
+/// State machines for mint outputs
 mod output;
 
 use std::cmp::Ordering;
 use std::fmt::Formatter;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{anyhow, bail};
 use async_stream::stream;
@@ -18,7 +23,7 @@ use fedimint_client::sm::{Context, DynState, ModuleNotifier, OperationId, State,
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
 use fedimint_client::{sm_enum_variant_translation, Client, DynGlobalClientContext};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId};
-use fedimint_core::db::{Database, ModuleDatabaseTransaction};
+use fedimint_core::db::{AutocommitError, Database, ModuleDatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     CommonModuleGen, ExtendsCommonModuleGen, ModuleCommon, TransactionItemAmount,
@@ -26,6 +31,7 @@ use fedimint_core::module::{
 use fedimint_core::util::{BoxStream, NextOrPending};
 use fedimint_core::{
     apply, async_trait_maybe_send, Amount, OutPoint, Tiered, TieredMulti, TieredSummary,
+    TransactionId,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 pub use fedimint_mint_common as common;
@@ -42,6 +48,7 @@ use crate::db::{NextECashNoteIndexKey, NoteKey, NoteKeyPrefix};
 use crate::input::{
     MintInputCommon, MintInputStateCreated, MintInputStateMachine, MintInputStates,
 };
+use crate::oob::{MintOOBStateMachine, MintOOBStates, MintOOBStatesCreated};
 use crate::output::{
     MintOutputCommon, MintOutputStateMachine, MintOutputStates, MintOutputStatesCreated,
     MultiNoteIssuanceRequest, NoteIssuanceRequest,
@@ -65,6 +72,36 @@ pub trait MintClientExt {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<BoxStream<ReissueExternalNotesState>>;
+
+    /// Fetches and removes notes of *at least* amount `min_amount` from the
+    /// wallet to be sent to the recipient out of band. These spends can be
+    /// canceled by calling [`MintClientExt::try_cancel_spend_notes`] as long as
+    /// the recipient hasn't reissued the e-cash notes themselves yet.
+    ///
+    /// The client will also automatically attempt to cancel the operation after
+    /// `try_cancel_after` time has passed. This is a safety mechanism to avoid
+    /// users forgetting about failed out-of-band transactions. The timeout
+    /// should be chosen such that the recipient (who is potentially offline at
+    /// the time of receiving the e-cash notes) had a reasonable timeframe to
+    /// come online and reissue the notes themselves.
+    async fn spend_notes(
+        &self,
+        min_amount: Amount,
+        try_cancel_after: Duration,
+    ) -> anyhow::Result<(OperationId, TieredMulti<SpendableNote>)>;
+
+    /// Try to cancel a spend operation started with
+    /// [`MintClientExt::spend_notes`]. If the e-cash notes have already been
+    /// spent this operation will fail which can be observed using
+    /// [`MintClientExt::subscribe_spend_notes_updates`].
+    async fn try_cancel_spend_notes(&self, operation_id: OperationId);
+
+    /// Subscribe to updates on the progress of a raw e-cash spend operation
+    /// started with [`MintClientExt::spend_notes`].
+    async fn subscribe_spend_notes_updates(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<BoxStream<SpendOOBState>>;
 }
 
 /// The high-level state of a reissue operation started with
@@ -81,6 +118,30 @@ pub enum ReissueExternalNotesState {
     Done,
     /// Some error happened and the operation failed.
     Failed(String),
+}
+
+/// The high-level state of a raw e-cash spend operation started with
+/// [`MintClientExt::spend_notes`].
+pub enum SpendOOBState {
+    /// The e-cash has been selected and given to the caller
+    Created,
+    /// The user requested a cancellation of the operation, we are waiting for
+    /// the outcome of the cancel transaction.
+    UserCanceledProcessing,
+    /// The user-requested cancellation was successful, we got all our money
+    /// back.
+    UserCanceledSuccess,
+    /// The user-requested cancellation failed, the e-cash notes have been spent
+    /// by someone else already.
+    UserCanceledFailure,
+    /// We tried to cancel the operation automatically after the timeout but
+    /// failed, indicating the recipient reissued the e-cash to themselves,
+    /// making the out-of-band spend **successful**.
+    Success,
+    /// We tried to cancel the operation automatically after the timeout and
+    /// succeeded, indicating the recipient did not reissue the e-cash to
+    /// themselves, meaning the out-of-band spend **failed**.
+    Refunded,
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -122,17 +183,9 @@ impl MintClientExt for Client {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<BoxStream<ReissueExternalNotesState>> {
-        let operation = self
-            .get_operation(operation_id)
-            .await
-            .ok_or(anyhow!("Operation not found"))?;
-
-        if operation.operation_type() != MintCommonGen::KIND.as_str() {
-            bail!("Operation is not a mint operation");
-        }
-
-        let out_point = match operation.meta() {
+        let out_point = match mint_operation(self, operation_id).await? {
             MintMeta::Reissuance { out_point } => out_point,
+            _ => bail!("Operation is not a reissuance"),
         };
 
         let (_, mint_client) = mint_client(self);
@@ -165,6 +218,102 @@ impl MintClientExt for Client {
             }
         }))
     }
+
+    async fn spend_notes(
+        &self,
+        min_amount: Amount,
+        try_cancel_after: Duration,
+    ) -> anyhow::Result<(OperationId, TieredMulti<SpendableNote>)> {
+        let (mint_client_instance, mint_client) = mint_client(self);
+
+        self.db()
+            .autocommit(
+                |dbtx| {
+                    Box::pin(async move {
+                        let (operation_id, states, notes) = mint_client
+                            .spend_notes_oob(
+                                &mut dbtx.with_module_prefix(mint_client_instance),
+                                min_amount,
+                                try_cancel_after,
+                            )
+                            .await?;
+
+                        let dyn_states = states
+                            .into_iter()
+                            .map(|s| s.into_dyn(mint_client_instance))
+                            .collect();
+
+                        self.add_state_machines(dbtx, dyn_states).await?;
+                        self.add_operation_log_entry(
+                            dbtx,
+                            operation_id,
+                            MintCommonGen::KIND.as_str(),
+                            MintMeta::SpendOOB,
+                        )
+                        .await;
+
+                        Ok((operation_id, notes))
+                    })
+                },
+                Some(100),
+            )
+            .await
+            .map_err(|e| match e {
+                AutocommitError::ClosureError { error, .. } => error,
+                AutocommitError::CommitFailed { last_error, .. } => {
+                    anyhow!("Commit to DB failed: {last_error}")
+                }
+            })
+    }
+
+    async fn try_cancel_spend_notes(&self, operation_id: OperationId) {
+        let (_, mint_client) = mint_client(self);
+
+        // TODO: make robust by writing to the DB, this can fail
+        let _ = mint_client.cancel_oob_payment_bc.send(operation_id);
+    }
+
+    async fn subscribe_spend_notes_updates(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<BoxStream<SpendOOBState>> {
+        if !matches!(
+            mint_operation(self, operation_id).await?,
+            MintMeta::SpendOOB
+        ) {
+            bail!("Operation is not a out-of-band spend");
+        };
+
+        let tx_subscription = self.transaction_updates(operation_id).await;
+        let refund_future = mint_client(self).1.await_spend_oob_refund(operation_id);
+
+        // TODO: check if operation exists and is a spend operation
+        Ok(Box::pin(stream! {
+            yield SpendOOBState::Created;
+
+            let refund = refund_future.await;
+            if refund.user_triggered {
+                yield SpendOOBState::UserCanceledProcessing;
+                match tx_subscription.await_tx_accepted(refund.transaction_id).await {
+                    Ok(()) => {
+                        yield SpendOOBState::UserCanceledSuccess;
+                    },
+                    Err(()) => {
+                        yield SpendOOBState::UserCanceledFailure;
+                    }
+                }
+            } else {
+                match tx_subscription.await_tx_accepted(refund.transaction_id).await {
+                    Ok(()) => {
+                        yield SpendOOBState::Refunded;
+                    },
+                    Err(()) => {
+                        yield SpendOOBState::Success;
+                    }
+                }
+            }
+        }))
+    }
 }
 
 fn mint_client(client: &Client) -> (ModuleInstanceId, &MintClientModule) {
@@ -179,9 +328,23 @@ fn mint_client(client: &Client) -> (ModuleInstanceId, &MintClientModule) {
     (mint_client_instance, mint_client)
 }
 
+async fn mint_operation(client: &Client, operation_id: OperationId) -> anyhow::Result<MintMeta> {
+    let operation = client
+        .get_operation(operation_id)
+        .await
+        .ok_or(anyhow!("Operation not found"))?;
+
+    if operation.operation_type() != MintCommonGen::KIND.as_str() {
+        bail!("Operation is not a mint operation");
+    }
+
+    Ok(operation.meta())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 enum MintMeta {
     Reissuance { out_point: OutPoint },
+    SpendOOB,
 }
 
 #[derive(Debug, Clone)]
@@ -203,11 +366,13 @@ impl ClientModuleGen for MintClientGen {
         module_root_secret: DerivableSecret,
         notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
     ) -> anyhow::Result<Self::Module> {
+        let (cancel_oob_payment_bc, _) = tokio::sync::broadcast::channel(16);
         Ok(MintClientModule {
             cfg,
             secret: module_root_secret,
             secp: Secp256k1::new(),
             notifier,
+            cancel_oob_payment_bc,
         })
     }
 
@@ -231,6 +396,7 @@ pub struct MintClientModule {
     secret: DerivableSecret,
     secp: Secp256k1<All>,
     notifier: ModuleNotifier<DynGlobalClientContext, MintClientStateMachines>,
+    cancel_oob_payment_bc: tokio::sync::broadcast::Sender<OperationId>,
 }
 
 // TODO: wrap in Arc
@@ -238,6 +404,13 @@ pub struct MintClientModule {
 pub struct MintClientContext {
     pub mint_decoder: Decoder,
     pub mint_keys: Tiered<AggregatePublicKey>,
+    pub cancel_oob_payment_bc: tokio::sync::broadcast::Sender<OperationId>,
+}
+
+impl MintClientContext {
+    fn subscribe_cancel_oob_payment(&self) -> tokio::sync::broadcast::Receiver<OperationId> {
+        self.cancel_oob_payment_bc.subscribe()
+    }
 }
 
 impl Context for MintClientContext {}
@@ -251,6 +424,7 @@ impl ClientModule for MintClientModule {
         MintClientContext {
             mint_decoder: self.decoder(),
             mint_keys: self.cfg.tbs_pks.clone(),
+            cancel_oob_payment_bc: self.cancel_oob_payment_bc.clone(),
         }
     }
 
@@ -464,6 +638,64 @@ impl MintClientModule {
         })
     }
 
+    async fn spend_notes_oob(
+        &self,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        min_amount: Amount,
+        try_cancel_after: Duration,
+    ) -> anyhow::Result<(
+        OperationId,
+        Vec<MintClientStateMachines>,
+        TieredMulti<SpendableNote>,
+    )> {
+        let spendable_selected_notes = Self::select_notes(dbtx, min_amount).await?;
+
+        let operation_id = spendable_selected_notes.consensus_hash().into_inner();
+
+        for (amount, note) in spendable_selected_notes.iter_items() {
+            dbtx.remove_entry(&NoteKey {
+                amount,
+                nonce: note.note.0,
+            })
+            .await;
+        }
+
+        let state_machines = vec![MintClientStateMachines::OOB(MintOOBStateMachine {
+            operation_id,
+            state: MintOOBStates::Created(MintOOBStatesCreated {
+                notes: spendable_selected_notes.clone(),
+                timeout: fedimint_core::time::now() + try_cancel_after,
+            }),
+        })];
+
+        Ok((operation_id, state_machines, spendable_selected_notes))
+    }
+
+    pub async fn await_spend_oob_refund(&self, operation_id: OperationId) -> SpendOOBRefund {
+        Box::pin(
+            self.notifier
+                .subscribe(operation_id)
+                .await
+                .filter_map(|state| async move {
+                    let MintClientStateMachines::OOB(state) = state else { return None };
+
+                    match state.state {
+                        MintOOBStates::TimeoutRefund(refund) => Some(SpendOOBRefund {
+                            user_triggered: false,
+                            transaction_id: refund.refund_txid,
+                        }),
+                        MintOOBStates::UserRefund(refund) => Some(SpendOOBRefund {
+                            user_triggered: true,
+                            transaction_id: refund.refund_txid,
+                        }),
+                        MintOOBStates::Created(_) => None,
+                    }
+                }),
+        )
+        .next_or_pending()
+        .await
+    }
+
     /// Select notes with total amount of *at least* `amount`. If more than
     /// requested amount of notes are returned it was because exact change
     /// couldn't be made, and the next smallest amount will be returned.
@@ -530,6 +762,11 @@ impl MintClientModule {
         let secret = self.new_note_secret(amount, dbtx).await;
         NoteIssuanceRequest::new(&self.secp, secret)
     }
+}
+
+pub struct SpendOOBRefund {
+    pub user_triggered: bool,
+    pub transaction_id: TransactionId,
 }
 
 // We are using a greedy algorithm to select notes. We start with the largest
@@ -620,6 +857,7 @@ impl std::fmt::Display for InsufficientBalanceError {
 pub enum MintClientStateMachines {
     Output(MintOutputStateMachine),
     Input(MintInputStateMachine),
+    OOB(MintOOBStateMachine),
 }
 
 impl IntoDynInstance for MintClientStateMachines {
@@ -652,6 +890,12 @@ impl State for MintClientStateMachines {
                     MintClientStateMachines::Input
                 )
             }
+            MintClientStateMachines::OOB(oob_state) => {
+                sm_enum_variant_translation!(
+                    oob_state.transitions(context, global_context),
+                    MintClientStateMachines::OOB
+                )
+            }
         }
     }
 
@@ -659,6 +903,7 @@ impl State for MintClientStateMachines {
         match self {
             MintClientStateMachines::Output(issuance_state) => issuance_state.operation_id(),
             MintClientStateMachines::Input(redemption_state) => redemption_state.operation_id(),
+            MintClientStateMachines::OOB(oob_state) => oob_state.operation_id(),
         }
     }
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -4,6 +4,7 @@ mod output;
 
 use std::cmp::Ordering;
 use std::fmt::Formatter;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use fedimint_client::module::gen::ClientModuleGen;
@@ -201,7 +202,7 @@ impl MintClientModule {
         let (note_issuance, sig_req): (MultiNoteIssuanceRequest, MintOutput) =
             amount_requests.into_iter().unzip();
 
-        let state_generator = Box::new(move |txid, out_idx| {
+        let state_generator = Arc::new(move |txid, out_idx| {
             vec![MintClientStateMachines::Output(MintOutputStateMachine {
                 common: MintOutputCommon {
                     operation_id,
@@ -296,7 +297,7 @@ impl MintClientModule {
             .map(|(amt, spendable_note)| (spendable_note.spend_key, (amt, spendable_note.note)))
             .unzip();
 
-        let sm_gen = Box::new(move |txid, input_idx| {
+        let sm_gen = Arc::new(move |txid, input_idx| {
             vec![MintClientStateMachines::Input(MintInputStateMachine {
                 common: MintInputCommon {
                     operation_id,

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -137,7 +137,10 @@ impl MintClientExt for Client {
 
         let (_, mint_client) = mint_client(self);
 
-        let tx_accepted_future = self.await_tx_accepted(operation_id, out_point.txid);
+        let tx_accepted_future = self
+            .transaction_updates(operation_id)
+            .await
+            .await_tx_accepted(out_point.txid);
         let output_finalized_future = mint_client.await_output_finalized(operation_id, out_point);
 
         Ok(Box::pin(stream! {

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -1,0 +1,211 @@
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, StateTransition};
+use fedimint_client::transaction::ClientInput;
+use fedimint_client::DynGlobalClientContext;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::{TieredMulti, TransactionId};
+use fedimint_mint_common::MintInput;
+
+use crate::input::{
+    MintInputCommon, MintInputStateCreated, MintInputStateMachine, MintInputStates,
+};
+use crate::{MintClientContext, SpendableNote};
+
+#[aquamarine::aquamarine]
+/// State machine managing e-cash that has been taken out of the wallet for
+/// out-of-band transmission.
+///
+/// ```mermaid
+/// graph LR
+///     Created -- User triggered refund --> RefundU["User Refund"]
+///     Created -- Timeout triggered refund --> RefundT["Timeout Refund"]
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+pub enum MintOOBStates {
+    /// The e-cash has been taken out of the wallet and we are waiting for the
+    /// recipient to reissue it or the user to trigger a refund.
+    Created(MintOOBStatesCreated),
+    /// The user has triggered a refund.
+    UserRefund(MintOOBStatesUserRefund),
+    /// The timeout of this out-of-band transaction was hit and we attempted to
+    /// refund. This refund *failing* is the expected behavior since the
+    /// recipient is supposed to have already reissued it.
+    TimeoutRefund(MintOOBStatesTimeoutRefund),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+pub struct MintOOBStateMachine {
+    pub(crate) operation_id: OperationId,
+    pub(crate) state: MintOOBStates,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+pub struct MintOOBStatesCreated {
+    pub(crate) notes: TieredMulti<SpendableNote>,
+    pub(crate) timeout: SystemTime,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+pub struct MintOOBStatesUserRefund {
+    pub(crate) refund_txid: TransactionId,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+pub struct MintOOBStatesTimeoutRefund {
+    pub(crate) refund_txid: TransactionId,
+}
+
+impl State for MintOOBStateMachine {
+    type ModuleContext = MintClientContext;
+    type GlobalContext = DynGlobalClientContext;
+
+    fn transitions(
+        &self,
+        context: &Self::ModuleContext,
+        global_context: &Self::GlobalContext,
+    ) -> Vec<StateTransition<Self>> {
+        match &self.state {
+            MintOOBStates::Created(created) => {
+                created.transitions(self.operation_id, context, global_context)
+            }
+            MintOOBStates::UserRefund(_) => {
+                vec![]
+            }
+            MintOOBStates::TimeoutRefund(_) => {
+                vec![]
+            }
+        }
+    }
+
+    fn operation_id(&self) -> OperationId {
+        self.operation_id
+    }
+}
+
+impl MintOOBStatesCreated {
+    fn transitions(
+        &self,
+        operation_id: OperationId,
+        context: &MintClientContext,
+        global_context: &DynGlobalClientContext,
+    ) -> Vec<StateTransition<MintOOBStateMachine>> {
+        // TODO: pass refund contexts into state transitions
+        let user_cancel_gc = global_context.clone();
+        let timeout_cancel_gc = global_context.clone();
+        vec![
+            StateTransition::new(
+                await_user_cancels(operation_id, context.subscribe_cancel_oob_payment()),
+                move |dbtx, (), state| {
+                    Box::pin(transition_user_cancel(state, dbtx, user_cancel_gc.clone()))
+                },
+            ),
+            StateTransition::new(
+                await_timeout_cancel(self.timeout),
+                move |dbtx, (), state| {
+                    Box::pin(transition_timeout_cancel(
+                        state,
+                        dbtx,
+                        timeout_cancel_gc.clone(),
+                    ))
+                },
+            ),
+        ]
+    }
+}
+
+async fn await_user_cancels(
+    operation_id: OperationId,
+    mut oob_cancel_receiver: tokio::sync::broadcast::Receiver<OperationId>,
+) {
+    while let Ok(op) = oob_cancel_receiver.recv().await {
+        if operation_id == op {
+            return;
+        }
+    }
+    std::future::pending().await
+}
+
+async fn transition_user_cancel(
+    prev_state: MintOOBStateMachine,
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    global_context: DynGlobalClientContext,
+) -> MintOOBStateMachine {
+    let spendable_notes = match prev_state.state {
+        MintOOBStates::Created(created) => created.notes,
+        _ => panic!("Invalid previous state: {prev_state:?}"),
+    };
+
+    let refund_txid = try_cancel_oob_spend(
+        dbtx,
+        prev_state.operation_id,
+        spendable_notes,
+        global_context,
+    )
+    .await;
+    MintOOBStateMachine {
+        operation_id: prev_state.operation_id,
+        state: MintOOBStates::UserRefund(MintOOBStatesUserRefund { refund_txid }),
+    }
+}
+
+async fn await_timeout_cancel(deadline: SystemTime) {
+    if let Ok(time_until_deadline) = deadline.duration_since(fedimint_core::time::now()) {
+        tokio::time::sleep(time_until_deadline).await;
+    }
+}
+
+async fn transition_timeout_cancel(
+    prev_state: MintOOBStateMachine,
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    global_context: DynGlobalClientContext,
+) -> MintOOBStateMachine {
+    let spendable_notes = match prev_state.state {
+        MintOOBStates::Created(created) => created.notes,
+        _ => panic!("Invalid previous state: {prev_state:?}"),
+    };
+
+    let refund_txid = try_cancel_oob_spend(
+        dbtx,
+        prev_state.operation_id,
+        spendable_notes,
+        global_context,
+    )
+    .await;
+    MintOOBStateMachine {
+        operation_id: prev_state.operation_id,
+        state: MintOOBStates::TimeoutRefund(MintOOBStatesTimeoutRefund { refund_txid }),
+    }
+}
+
+async fn try_cancel_oob_spend(
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    operation_id: OperationId,
+    spendable_notes: TieredMulti<SpendableNote>,
+    global_context: DynGlobalClientContext,
+) -> TransactionId {
+    let (keys, notes): (Vec<_>, TieredMulti<_>) = spendable_notes
+        .iter_items()
+        .map(|(amt, note)| (note.spend_key, (amt, note.note)))
+        .unzip();
+
+    let input = ClientInput {
+        input: MintInput(notes),
+        keys,
+        state_machines: Arc::new(move |txid, input_idx| {
+            vec![MintInputStateMachine {
+                common: MintInputCommon {
+                    operation_id,
+                    txid,
+                    input_idx,
+                },
+                state: MintInputStates::Created(MintInputStateCreated {
+                    notes: spendable_notes.clone(),
+                }),
+            }]
+        }),
+    };
+
+    global_context.claim_input(dbtx, input).await
+}

--- a/modules/fedimint-mint-common/src/common.rs
+++ b/modules/fedimint-mint-common/src/common.rs
@@ -16,7 +16,6 @@ pub struct BackupRequest {
 impl BackupRequest {
     fn hash(&self) -> sha256::Hash {
         self.consensus_hash()
-            .expect("Encoding to hash engine can't fail")
     }
 
     pub fn sign(self, keypair: &KeyPair) -> anyhow::Result<SignedBackupRequest> {

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -101,7 +101,7 @@ impl CommonModuleGen for MintCommonGen {
     fn hash_client_module(
         config: serde_json::Value,
     ) -> anyhow::Result<bitcoin_hashes::sha256::Hash> {
-        serde_json::from_value::<MintClientConfig>(config)?.consensus_hash()
+        Ok(serde_json::from_value::<MintClientConfig>(config)?.consensus_hash())
     }
 }
 

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -1181,7 +1181,7 @@ mod fedimint_migration_tests {
     use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_MINT;
     use fedimint_core::db::{apply_migrations, DatabaseTransaction};
     use fedimint_core::module::registry::ModuleDecoderRegistry;
-    use fedimint_core::module::DynServerModuleGen;
+    use fedimint_core::module::{CommonModuleGen, DynServerModuleGen};
     use fedimint_core::{Amount, OutPoint, ServerModule, TieredMulti, TransactionId};
     use fedimint_mint_common::db::{
         DbKeyPrefix, ECashUserBackupSnapshot, EcashBackupKey, EcashBackupKeyPrefix,
@@ -1189,7 +1189,9 @@ mod fedimint_migration_tests {
         OutputOutcomeKeyPrefix, ProposedPartialSignatureKey, ProposedPartialSignaturesKeyPrefix,
         ReceivedPartialSignatureKey, ReceivedPartialSignaturesKeyPrefix,
     };
-    use fedimint_mint_common::{MintOutputBlindSignatures, MintOutputSignatureShare, Nonce};
+    use fedimint_mint_common::{
+        MintCommonGen, MintOutputBlindSignatures, MintOutputSignatureShare, Nonce,
+    };
     use fedimint_testing::{prepare_snapshot, validate_migrations, BYTE_32, BYTE_8};
     use futures::StreamExt;
     use rand::rngs::OsRng;
@@ -1286,6 +1288,7 @@ mod fedimint_migration_tests {
             },
             ModuleDecoderRegistry::from_iter([(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                MintCommonGen::KIND,
                 <Mint as ServerModule>::decoder(),
             )]),
         )
@@ -1391,6 +1394,7 @@ mod fedimint_migration_tests {
             },
             ModuleDecoderRegistry::from_iter([(
                 LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                MintCommonGen::KIND,
                 <Mint as ServerModule>::decoder(),
             )]),
         )

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -200,7 +200,7 @@ impl ServerModuleGen for MintGen {
 
         Ok(ModuleConfigResponse {
             client: config.to_client_config(),
-            consensus_hash: config.consensus_hash()?,
+            consensus_hash: config.consensus_hash(),
         })
     }
 

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -191,7 +191,7 @@ impl CommonModuleGen for WalletCommonGen {
     }
 
     fn hash_client_module(config: serde_json::Value) -> anyhow::Result<sha256::Hash> {
-        serde_json::from_value::<WalletClientConfig>(config)?.consensus_hash()
+        Ok(serde_json::from_value::<WalletClientConfig>(config)?.consensus_hash())
     }
 }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -186,7 +186,7 @@ impl ServerModuleGen for WalletGen {
 
         Ok(ModuleConfigResponse {
             client: config.to_client_config(),
-            consensus_hash: config.consensus_hash()?,
+            consensus_hash: config.consensus_hash(),
         })
     }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1740,7 +1740,7 @@ mod fedimint_migration_tests {
     use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
     use fedimint_core::db::{apply_migrations, DatabaseTransaction};
     use fedimint_core::module::registry::ModuleDecoderRegistry;
-    use fedimint_core::module::DynServerModuleGen;
+    use fedimint_core::module::{CommonModuleGen, DynServerModuleGen};
     use fedimint_core::{BitcoinHash, Feerate, OutPoint, ServerModule, TransactionId};
     use fedimint_testing::{prepare_snapshot, validate_migrations, BYTE_20, BYTE_32};
     use fedimint_wallet_common::db::{
@@ -1751,7 +1751,7 @@ mod fedimint_migration_tests {
     };
     use fedimint_wallet_common::{
         PegOutFees, PendingTransaction, Rbf, RoundConsensus, SpendableUTXO, UnsignedTransaction,
-        WalletOutputOutcome,
+        WalletCommonGen, WalletOutputOutcome,
     };
     use futures::StreamExt;
     use rand::rngs::OsRng;
@@ -1922,6 +1922,7 @@ mod fedimint_migration_tests {
             },
             ModuleDecoderRegistry::from_iter([(
                 LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+                WalletCommonGen::KIND,
                 <Wallet as ServerModule>::decoder(),
             )]),
         )
@@ -2033,6 +2034,7 @@ mod fedimint_migration_tests {
             },
             ModuleDecoderRegistry::from_iter([(
                 LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+                WalletCommonGen::KIND,
                 <Wallet as ServerModule>::decoder(),
             )]),
         )

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -16,9 +16,12 @@ use fedimint_core::core::{
 };
 use fedimint_core::db::Database;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_core::module::CommonModuleGen;
 use fedimint_core::ServerModule;
+use fedimint_ln_server::common::LightningCommonGen;
 use fedimint_ln_server::Lightning;
 use fedimint_logging::TracingSetup;
+use fedimint_mint_server::common::MintCommonGen;
 use fedimint_mint_server::Mint;
 use fedimint_rocksdb::RocksDb;
 use fedimint_server::config::io::read_server_config;
@@ -30,7 +33,7 @@ use fedimint_wallet_server::common::db::{UTXOKey, UTXOPrefixKey};
 use fedimint_wallet_server::common::keys::CompressedPublicKey;
 use fedimint_wallet_server::common::tweakable::Tweakable;
 use fedimint_wallet_server::common::{
-    PegInDescriptor, SpendableUTXO, WalletConsensusItem, WalletInput,
+    PegInDescriptor, SpendableUTXO, WalletCommonGen, WalletConsensusItem, WalletInput,
 };
 use fedimint_wallet_server::Wallet;
 use futures::stream::StreamExt;
@@ -165,14 +168,17 @@ async fn main() -> anyhow::Result<()> {
             let decoders = ModuleDecoderRegistry::from_iter([
                 (
                     LEGACY_HARDCODED_INSTANCE_ID_LN,
+                    LightningCommonGen::KIND,
                     <Lightning as ServerModule>::decoder(),
                 ),
                 (
                     LEGACY_HARDCODED_INSTANCE_ID_MINT,
+                    MintCommonGen::KIND,
                     <Mint as ServerModule>::decoder(),
                 ),
                 (
                     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+                    WalletCommonGen::KIND,
                     <Wallet as ServerModule>::decoder(),
                 ),
             ]);


### PR DESCRIPTION
The main change introduced by this PR is the introduction of the `MintClientExt` trait:

https://github.com/fedimint/fedimint/blob/dedf431e2463d644bed2a384194ce7d1606b9c15/modules/fedimint-mint-client/src/lib.rs#L59-L105

It is implemented for the `Client` struct and if in scope assumes that the client contains at least one mint module and that we always want to use the first one. This is the case most of the time and frees the API consumer from worrying about instances.