### PR TITLE
chore: pre-compile rust-tests in CI

### DIFF
--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -20,7 +20,7 @@ export FM_TEST_USE_REAL_DAEMONS=1
 
 if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "bitcoind" ]; then
   >&2 echo "### Testing against bitcoind"
-  env RUST_BACKTRACE=1 cargo test -p fedimint-tests -- --test-threads=16 "$@"
+  env RUST_BACKTRACE=1 cargo test -p fedimint-tests ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -- --test-threads=$(($(nproc) * 2)) "$@"
   >&2 echo "### Testing against bitcoind - complete"
 fi
 

--- a/scripts/test-ci-all.sh
+++ b/scripts/test-ci-all.sh
@@ -21,7 +21,11 @@ fi
 
 # Avoid re-building workspace in parallel in all test derivations
 # Note: Respect 'CARGO_PROFILE' that crane uses
+>&2 echo "Pre-building workspace..."
 cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --all --all-targets
+# Avoid re-building tests in parallel in all test derivations
+>&2 echo "Pre-building tests..."
+cargo test --no-run ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -p fedimint-tests
 
 function cli_test_reconnect() {
   set -eo pipefail # pipefail must be set manually again


### PR DESCRIPTION
This avoids rebuilding them 3 or 4 times in parallel, in each test run.