### PR TITLE
refactor: limited reconnection delays using exp backoff

### DIFF
--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -241,7 +241,7 @@ impl ConfigGenApi {
         let config = ServerConfig::distributed_gen(
             &params,
             module_gens,
-            DelayCalculator::default(),
+            DelayCalculator::PROD_DEFAULT,
             &mut task_group,
         )
         .await;

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -113,7 +113,7 @@ impl ConsensusServer {
             db,
             module_inits,
             connector,
-            DelayCalculator::default(),
+            DelayCalculator::PROD_DEFAULT,
             task_group,
         )
         .await

--- a/fedimintd/src/distributed_gen.rs
+++ b/fedimintd/src/distributed_gen.rs
@@ -209,7 +209,7 @@ impl DistributedGen {
                 let server = match ServerConfig::distributed_gen(
                     &params,
                     self.module_gens.clone().legacy_init_modules(),
-                    DelayCalculator::default(),
+                    DelayCalculator::PROD_DEFAULT,
                     &mut task_group,
                 )
                 .await

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -181,7 +181,7 @@ async fn post_guardians(
                 Ok(params) => ServerConfig::distributed_gen(
                     &params,
                     module_gens.clone().legacy_init_modules(),
-                    DelayCalculator::default(),
+                    DelayCalculator::PROD_DEFAULT,
                     &mut dkg_task_group,
                 )
                 .await

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -50,7 +50,7 @@ use fedimint_server::consensus::{
 };
 use fedimint_server::net::connect::mock::{MockNetwork, StreamReliability};
 use fedimint_server::net::connect::{parse_host_port, Connector, TlsTcpConnector};
-use fedimint_server::net::peers::PeerConnector;
+use fedimint_server::net::peers::{DelayCalculator, PeerConnector};
 use fedimint_server::{consensus, FedimintApiHandler, FedimintServer};
 use fedimint_testing::btc::bitcoind::FakeWalletGen;
 use fedimint_testing::btc::fixtures::FakeBitcoinTest;
@@ -569,7 +569,7 @@ async fn distributed_config(
             let cfg = ServerConfig::distributed_gen(
                 &our_params,
                 registry.legacy_init_modules(),
-                Default::default(),
+                DelayCalculator::TEST_DEFAULT,
                 &mut task_group,
             );
             (*peer, cfg.await.expect("generation failed"))
@@ -1298,7 +1298,7 @@ impl FederationTest {
                 db.clone(),
                 module_inits.clone(),
                 connect_gen(cfg),
-                Default::default(),
+                DelayCalculator::TEST_DEFAULT,
                 &mut task_group,
             )
             .await


### PR DESCRIPTION
Alternative to https://github.com/fedimint/fedimint/pull/2267 using exponential backoff and hard min/max values. Will generate the following delays:
TEST_DEFAULT:
```
1: 2.191s
2: 2.198s
3: 2.172s
4: 2.058s
5: 2.141s
6: 4.411s
7: 10.294s
8: 10.781s
(...)
```
Note the high min/floor values to avoid logging flood on tests.

But for production this is a minor issue, so set a lower floor:

PROD_DEFAULT:
```
1: 10ms
2: 16ms
3: 65ms
4: 262ms
5: 1.089s
6: 4.096s
7: 10.852s
8: 10.116s
(...)
```

Closes https://github.com/fedimint/fedimint/issues/2263