### PR TITLE
chore: update aquamarine library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*target/
+/target/
 # in case it's a symlink
 /target
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,10 +97,11 @@ dependencies = [
 
 [[package]]
 name = "aquamarine"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759d98a5db12e9c9d98ef2b92f794ae5c7ded6ec18d21c3fa485c9c65bec237d"
+checksum = "d8d79f0956913d725449e8264e6b460e30d96be324963c666dbf0fa5c2d59149"
 dependencies = [
+ "include_dir",
  "itertools",
  "proc-macro-error",
  "proc-macro2",
@@ -2514,6 +2515,25 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.26",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.26",
 ]
 
 [[package]]

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.69"
-aquamarine = "0.3.0"
+aquamarine = "0.3.1"
 async-trait = "0.1.66"
 bitcoin_hashes = "0.11.0"
 fedimint-core  = { path = "../fedimint-core/" }


### PR DESCRIPTION
It is said to stop writting to source code, so we should not need a `.gitignore` workaround anymore.