### PR TITLE
chore: pre-populate setup ui using env vars

### DIFF
--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -225,6 +225,9 @@ async fn post_guardians(
 struct UrlConnection {
     ro_bitcoin_rpc_type: &'static str,
     ro_bitcoin_rpc_url: String,
+    bitcoin_network: String,
+    federation_name: String,
+    guardians_count: String,
     bind_p2p: String,
     p2p_url: String,
     bind_api: String,
@@ -253,6 +256,9 @@ async fn params_page(
     UrlConnection {
         ro_bitcoin_rpc_type,
         ro_bitcoin_rpc_url,
+        bitcoin_network: env::var("FM_BITCOIN_NETWORK").unwrap_or("".to_string()),
+        federation_name: env::var("FM_FED_NAME").unwrap_or("".to_string()),
+        guardians_count: env::var("FM_FED_SIZE").unwrap_or("".to_string()),
         bind_p2p: env::var("FM_BIND_P2P").unwrap_or("".to_string()),
         p2p_url: env::var("FM_P2P_URL").unwrap_or("".to_string()),
         bind_api: env::var("FM_BIND_API").unwrap_or("".to_string()),

--- a/fedimintd/templates/params.html
+++ b/fedimintd/templates/params.html
@@ -21,6 +21,7 @@ content %}
         id="federation_name"
         name="federation_name"
         placeholder="Cypherpunk Federation"
+        value="{{federation_name}}"
       />
     </div>
     <div class="form-group">
@@ -34,6 +35,7 @@ content %}
         required
         placeholder="4"
         min="1"
+        value="{{guardians_count}}"
       />
     </div>
     <h5>Network connectivity</h5>
@@ -122,6 +124,9 @@ content %}
         name="network"
         value="regtest"
         required
+        {% if bitcoin_network == "regtest" %}
+        checked
+        {% endif %}
       />
       <label for="network1">Regtest</label>
       <input
@@ -130,6 +135,9 @@ content %}
         name="network"
         value="testnet"
         required
+        {% if bitcoin_network == "testnet" %}
+        checked
+        {% endif %}
       />
       <label for="network2">Testnet</label>
       <input
@@ -138,6 +146,9 @@ content %}
         name="network"
         value="bitcoin"
         required
+        {% if bitcoin_network == "bitcoin" %}
+        checked
+        {% endif %}
       />
       <label for="network3">Mainnet</label>
     </div>

--- a/scripts/run-ui.sh
+++ b/scripts/run-ui.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
+export FM_BITCOIN_NETWORK="regtest"
 export FM_FED_SIZE=${1:-2}
+export FM_FED_NAME=${2:-"Cypherpunk Federation"}
 
 source scripts/build.sh $FM_FED_SIZE
 


### PR DESCRIPTION
This aims to resolve #1532 by pre-populating the remaining fields in the setup UI using environment variables.

@dpc As discussed, I've followed the same approach as used in #1683. Please let me know if more robust checks of the environment variables are required.

I haven't pre-populated the guardian name as I believe that would require changing the code in https://github.com/fedimint/fedimint/blob/master/fedimint-testing/src/bin/fixtures.rs#L345, which might be out of scope here, but please let me know otherwise.