### PR TITLE
fix: rejoin after any number of epochs pass

### DIFF
--- a/fedimint-bin-tests/src/main.rs
+++ b/fedimint-bin-tests/src/main.rs
@@ -942,14 +942,10 @@ async fn reconnect_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Result
 
     // test a peer missing out on epochs and needing to rejoin
     fed.kill_server(0).await?;
-    // FIXME increase this number once we can avoid processing epoch messages too
-    // far in the future
-    fed.generate_epochs(1).await?;
+    fed.generate_epochs(10).await?;
 
     fed.start_server(process_mgr, 0).await?;
-    // FIXME increase this number once we can avoid processing epoch messages too
-    // far in the future
-    fed.generate_epochs(1).await?;
+    fed.generate_epochs(10).await?;
     fed.await_all_peers().await?;
     info!("Server 0 successfully rejoined!");
     bitcoind.mine_blocks(100).await?;


### PR DESCRIPTION
We originally only let a peer rejoin once, however due to the network buffers it's possible they successfully create an outcome but drop HBBFT messages from future epochs, getting them permanently stuck.

This PR allows them to rejoin even after they produce an outcome so long as they determine from a threshold of peers that they are behind.

We can probably close some old issues such as #1080 and #1136.  However, we still need to do #229 since it can stall the entire federation if a peer is offline for too long.

Once we switch to AlpehBFT we can drop a lot of this hacky logic since we will no longer have to deal with the concept of epochs or verifying signed epochs using signatures from produced outcomes.