### PR TITLE
fix: skip connecting to federation if already connected

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -318,6 +318,11 @@ impl Gateway {
             GatewayError::Other(anyhow::anyhow!("Invalid federation member string {}", e))
         })?;
 
+        if let Ok(actor) = self.select_actor(connect.id.clone()).await {
+            info!("Federation {} already connected", connect.id);
+            return actor.get_info();
+        }
+
         let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.read().await.info().await?;
         let node_pub_key = PublicKey::from_slice(&pub_key)
             .map_err(|e| GatewayError::Other(anyhow!("Invalid node pubkey {}", e)))?;


### PR DESCRIPTION
Replaces #2099 which was reverted by #2135 due to a compile error on master.

Fixes #1866 