### PR TITLE
refactor: expose auth in api context

### DIFF
--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -31,7 +31,7 @@ impl WsAdminClient {
     ///
     /// Must be called first before any other calls to the API
     pub async fn set_password(&self) -> FederationResult<()> {
-        self.request_auth("set_password", ApiRequestErased::new(self.auth.clone()))
+        self.request_auth("set_password", ApiRequestErased::default())
             .await
     }
 
@@ -146,7 +146,7 @@ impl WsAdminClient {
     /// Clients may receive an error due to forced shutdown, should call the
     /// `server_status` to see if consensus has started.
     pub async fn start_consensus(&self) -> FederationResult<()> {
-        self.request_auth("start_consensus", ApiRequestErased::new(self.auth.clone()))
+        self.request_auth("start_consensus", ApiRequestErased::default())
             .await
     }
 

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -148,18 +148,35 @@ pub struct ApiEndpointContext<'a> {
     db: Database,
     dbtx: DatabaseTransaction<'a>,
     has_auth: bool,
+    request_auth: Option<ApiAuth>,
 }
 
 impl<'a> ApiEndpointContext<'a> {
     /// `db` and `dbtx` should be isolated.
-    pub fn new(db: Database, dbtx: DatabaseTransaction<'a>, has_auth: bool) -> Self {
-        Self { db, dbtx, has_auth }
+    pub fn new(
+        db: Database,
+        dbtx: DatabaseTransaction<'a>,
+        has_auth: bool,
+        request_auth: Option<ApiAuth>,
+    ) -> Self {
+        Self {
+            db,
+            dbtx,
+            has_auth,
+            request_auth,
+        }
     }
 
     /// Database tx handle, will be committed
     pub fn dbtx(&mut self) -> ModuleDatabaseTransaction<'_> {
         // dbtx is already isolated.
         self.dbtx.get_isolated()
+    }
+
+    /// Returns the auth set on the request (regardless of whether it was
+    /// correct)
+    pub fn request_auth(&self) -> Option<ApiAuth> {
+        self.request_auth.clone()
     }
 
     /// Whether the request was authenticated as the guardian who controls this

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -306,6 +306,7 @@ impl HasApiContext<ConsensusApi> for ConsensusApi {
                 db,
                 dbtx,
                 request.auth == Some(self.cfg.private.api_auth.clone()),
+                request.auth.clone(),
             ),
         )
     }


### PR DESCRIPTION
Makes it so we don't have to pass in auth twice in endpoints that need to read it.