### PR TITLE
fix: overwriting existing files will lead to data loss

### DIFF
--- a/.semgrep.all.yaml
+++ b/.semgrep.all.yaml
@@ -11,6 +11,13 @@ rules:
 - id: ban-fs-write
   languages:
     - rust
-  message: Use fedimint-core::util::write_overwrite if you are really sure you want to overwrite existing data or `write_new` if you don't. Alternatively use `fs::File::options` and express intention explicitly.
+  message: Overwritting existing files is rarely a good idea. Use fedimint-core::util::write_overwrite if you are really sure you want to overwrite existing data or `fedimint-core::util::write_overwrite::write_new` if you don't. Alternatively use `fs::File::options` and express intention explicitly.
   pattern: std::fs::write
+  severity: WARNING
+
+- id: ban-file-create
+  languages:
+    - rust
+  message: Overwritting existing files is rarely a good idea. `fs::File::options` and express intention explicitly.
+  pattern: std::fs::File::create
   severity: WARNING

--- a/.semgrep.all.yaml
+++ b/.semgrep.all.yaml
@@ -7,3 +7,10 @@ rules:
   pattern: std::time::SystemTime::now
 
   severity: WARNING
+
+- id: ban-fs-write
+  languages:
+    - rust
+  message: Use fedimint-core::util::write_overwrite if you are really sure you want to overwrite existing data or `write_new` if you don't. Alternatively use `fs::File::options` and express intention explicitly.
+  pattern: std::fs::write
+  severity: WARNING

--- a/crypto/aead/src/lib.rs
+++ b/crypto/aead/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::{bail, format_err, Result};
@@ -53,10 +54,11 @@ pub fn decrypt<'c>(ciphertext: &'c mut [u8], key: &LessSafeKey) -> Result<&'c [u
 /// Write `data` encrypted to a `file` with a random `nonce` that will be
 /// encoded in the file
 pub fn encrypted_write(data: Vec<u8>, key: &LessSafeKey, file: PathBuf) -> Result<()> {
-    let bytes = encrypt(data, key)?;
-    fs::write(file.clone(), hex::encode(bytes))
-        .map_err(|_| format_err!("Unable to write file {:?}", file))?;
-    Ok(())
+    Ok(fs::File::options()
+        .write(true)
+        .create_new(true)
+        .open(file)?
+        .write_all(hex::encode(encrypt(data, key)?).as_bytes())?)
 }
 
 /// Reads encrypted data from a file

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -626,7 +626,10 @@ impl FedimintCli {
                 std::fs::create_dir_all(cli.workdir()?)
                     .map_err_cli_msg(CliErrorKind::IOError, "failed to create config directory")?;
                 let cfg_path = cli.workdir()?.join("client.json");
-                let writer = std::fs::File::create(cfg_path)
+                let writer = std::fs::File::options()
+                    .create_new(true)
+                    .write(true)
+                    .open(cfg_path)
                     .map_err_cli_msg(CliErrorKind::IOError, "couldn't create config.json")?;
                 serde_json::to_writer_pretty(writer, &cfg)
                     .map_err_cli_msg(CliErrorKind::IOError, "couldn't write config")?;

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -4,7 +4,10 @@ pub mod broadcaststream;
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
+use std::io::Write;
+use std::path::Path;
 use std::pin::Pin;
+use std::{fs, io};
 
 use futures::StreamExt;
 use tracing::debug;
@@ -95,6 +98,24 @@ impl<'a> Debug for SanitizedUrl<'a> {
         write!(f, ")")?;
         Ok(())
     }
+}
+
+/// Write out a new file (like [`std::fs::write`] but fails if file already
+/// exists)
+pub fn write_new<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
+    fs::File::options()
+        .write(true)
+        .create_new(true)
+        .open(path)?
+        .write_all(contents.as_ref())
+}
+
+pub fn write_overwrite<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
+    fs::File::options()
+        .write(true)
+        .create(true)
+        .open(path)?
+        .write_all(contents.as_ref())
 }
 
 #[cfg(test)]

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
 use std::iter::once;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -22,6 +21,7 @@ use fedimint_core::module::{
     DynServerModuleGen,
 };
 use fedimint_core::task::TaskGroup;
+use fedimint_core::util::write_new;
 use fedimint_core::PeerId;
 use itertools::Itertools;
 use tokio::sync::mpsc::Sender;
@@ -307,7 +307,7 @@ impl ConfigGenApi {
         }
 
         let auth = config.private.api_auth.0.clone();
-        fs::write(self.data_dir.join(SALT_FILE), random_salt())
+        write_new(self.data_dir.join(SALT_FILE), random_salt())
             .map_err(|e| ApiError::server_error(format!("Unable to write to data dir {e:?}")))?;
         write_server_config(
             &config,
@@ -710,6 +710,7 @@ mod tests {
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::module::ApiAuth;
     use fedimint_core::task::{sleep, TaskGroup};
+    use fedimint_core::util::write_new;
     use fedimint_core::PeerId;
     use futures::future::join_all;
     use itertools::Itertools;
@@ -817,7 +818,7 @@ mod tests {
 
         /// Helper for writing the password file to bypass the API
         fn write_password_file(&self) {
-            fs::write(self.dir.join(PLAINTEXT_PASSWORD), &self.auth.0).unwrap();
+            write_new(self.dir.join(PLAINTEXT_PASSWORD), &self.auth.0).unwrap();
         }
     }
 

--- a/fedimintd/src/distributed_gen.rs
+++ b/fedimintd/src/distributed_gen.rs
@@ -233,8 +233,11 @@ impl DistributedGen {
                 let key = get_encryption_key(&password, &salt)?;
                 let decrypted_bytes = encrypted_read(&key, in_file)?;
 
-                let mut out_file_handle =
-                    fs::File::create(out_file).expect("Could not create output cfg file");
+                let mut out_file_handle = fs::File::options()
+                    .create_new(true)
+                    .write(true)
+                    .open(out_file)
+                    .expect("Could not create output cfg file");
                 out_file_handle.write_all(&decrypted_bytes)?;
                 Ok(())
             }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -12,6 +11,7 @@ use fedimint_core::db::Database;
 use fedimint_core::module::ServerModuleGen;
 use fedimint_core::task::{sleep, TaskGroup};
 use fedimint_core::timing;
+use fedimint_core::util::write_new;
 use fedimint_ln_server::LightningGen;
 use fedimint_logging::TracingSetup;
 use fedimint_mint_server::MintGen;
@@ -259,7 +259,7 @@ async fn run(
     );
 
     // TODO: Fedimintd should use the config gen API
-    fs::write(opts.data_dir.join(PLAINTEXT_PASSWORD), opts.password)?;
+    write_new(opts.data_dir.join(PLAINTEXT_PASSWORD), opts.password)?;
     let mut api = FedimintServer {
         data_dir: opts.data_dir,
         settings: ConfigGenSettings {

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -11,7 +11,7 @@ use fedimint_core::db::Database;
 use fedimint_core::module::ServerModuleGen;
 use fedimint_core::task::{sleep, TaskGroup};
 use fedimint_core::timing;
-use fedimint_core::util::write_new;
+use fedimint_core::util::write_overwrite;
 use fedimint_ln_server::LightningGen;
 use fedimint_logging::TracingSetup;
 use fedimint_mint_server::MintGen;
@@ -259,7 +259,9 @@ async fn run(
     );
 
     // TODO: Fedimintd should use the config gen API
-    write_new(opts.data_dir.join(PLAINTEXT_PASSWORD), opts.password)?;
+    // on each run we want to pass the currently passed passsword, so we need to
+    // overwrite
+    write_overwrite(opts.data_dir.join(PLAINTEXT_PASSWORD), opts.password)?;
     let mut api = FedimintServer {
         data_dir: opts.data_dir,
         settings: ConfigGenSettings {

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -183,7 +183,11 @@ impl IGatewayClientBuilder for StandardGatewayClientBuilder {
         }
 
         debug!("Saving gateway cfg in {}", path.display());
-        let file = File::create(path).expect("Could not create gateway cfg file");
+        let file = File::options()
+            .create_new(true)
+            .write(true)
+            .open(path)
+            .expect("Could not create gateway cfg file");
         serde_json::to_writer_pretty(file, &config).expect("Could not write gateway cfg");
 
         Ok(())


### PR DESCRIPTION
I've experienced a federation peer loosing private keys due
to accidentally submitting a setup form on an already running
federation.

Generally we should never overwrite files, unless this is really
the behavior we want, so ban `fs::write` and `File::create` via semgrep.

`#neveragain`