### PR TITLE
feature: Allow forcing processing an epoch

### DIFF
--- a/fedimint-bin-tests/src/main.rs
+++ b/fedimint-bin-tests/src/main.rs
@@ -572,6 +572,21 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     .run()
     .await?;
 
+    // Test load last epoch with admin client
+    let epoch_json = cmd!(fed, "last-epoch")
+        .env("FM_SALT_PATH", format!("{data_dir}/server-0/private.salt"))
+        .env("FM_PASSWORD", "pass0")
+        .env("FM_OUR_ID", "0")
+        .out_json()
+        .await?;
+    let epoch_hex = epoch_json["hex_outcome"].as_str().unwrap();
+    let _force_epoch = cmd!(fed, "force-epoch", epoch_hex)
+        .env("FM_SALT_PATH", format!("{data_dir}/server-0/private.salt"))
+        .env("FM_PASSWORD", "pass0")
+        .env("FM_OUR_ID", "0")
+        .out_json()
+        .await?;
+
     let plaintext_one =
         fs::read_to_string(format!("{data_dir}/server-0/config-plaintext.json")).await?;
     let plaintext_two =

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -37,7 +37,8 @@ use fedimint_core::api::{
 use fedimint_core::config::{load_from_file, ClientConfig, FederationId};
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{Database, DatabaseValue};
-use fedimint_core::encoding::Encodable;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::epoch::{SerdeEpochHistory, SignedEpochOutcome};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{ApiAuth, ApiRequestErased};
 use fedimint_core::query::EventuallyConsistent;
@@ -154,6 +155,12 @@ enum CliOutput {
         count: u64,
     },
 
+    LastEpoch {
+        hex_outcome: String,
+    },
+
+    ForceEpoch,
+
     Raw(serde_json::Value),
 }
 
@@ -176,6 +183,7 @@ enum CliErrorKind {
     InsufficientBalance,
     SerializationError,
     GeneralFailure,
+    MissingAuth,
 }
 
 /// `Result` with `CliError` as `Error`
@@ -296,6 +304,18 @@ struct Opts {
     #[arg(long = "data-dir", alias = "workdir", env = "FM_DATA_DIR")]
     workdir: Option<PathBuf>,
 
+    /// Location of the salt file
+    #[arg(env = "FM_SALT_PATH")]
+    salt_path: Option<PathBuf>,
+
+    /// Peer id of the guardian
+    #[arg(env = "FM_OUR_ID", value_parser = parse_peer_id)]
+    our_id: Option<PeerId>,
+
+    /// Guardian password for authentication
+    #[arg(long, env = "FM_PASSWORD")]
+    password: Option<String>,
+
     #[clap(subcommand)]
     command: Command,
 }
@@ -305,6 +325,32 @@ impl Opts {
         self.workdir
             .as_ref()
             .ok_or_cli_msg(CliErrorKind::IOError, "`--data-dir=` argument not set.")
+    }
+
+    async fn admin_client(&self) -> CliResult<WsAdminClient> {
+        let salt_path = self.salt_path.clone().ok_or_cli_msg(
+            CliErrorKind::MissingAuth,
+            "Admin client needs salt-path set",
+        )?;
+        let password = self
+            .password
+            .clone()
+            .ok_or_cli_msg(CliErrorKind::MissingAuth, "Admin client needs password set")?;
+        let our_id = &self
+            .our_id
+            .ok_or_cli_msg(CliErrorKind::MissingAuth, "Admin client needs our-id set")?;
+        let salt = fs::read_to_string(salt_path)
+            .map_err_cli_msg(CliErrorKind::IOError, "Unable to open salt file")?;
+        let auth = ApiAuth(get_password_hash(&password, &salt).map_err_cli_io()?);
+        let url = self
+            .load_config()?
+            .0
+            .api_endpoints
+            .get(our_id)
+            .expect("Endpoint exists")
+            .url
+            .clone();
+        Ok(WsAdminClient::new(url, *our_id, auth))
     }
 
     fn load_config(&self) -> CliResult<UserClientConfig> {
@@ -500,20 +546,16 @@ enum Command {
     DecodeTransaction { hex_string: String },
 
     /// Signal a consensus upgrade
-    SignalUpgrade {
-        /// Location of the salt file
-        #[clap(long)]
-        salt_path: PathBuf,
-        /// Peer id of the guardian
-        #[arg(long, value_parser = parse_peer_id)]
-        our_id: PeerId,
-        /// Guardian password for authentication
-        #[arg(long, env = "FM_PASSWORD")]
-        password: String,
-    },
+    SignalUpgrade,
 
     /// Gets the current epoch count
     EpochCount,
+
+    /// Gets the last epoch
+    LastEpoch,
+
+    /// Force processing an epoch
+    ForceEpoch { hex_outcome: String },
 
     /// Call module-specific commands
     Module {
@@ -968,26 +1010,8 @@ impl FedimintCli {
                     transaction: (format!("{tx:?}")),
                 })
             }
-            Command::SignalUpgrade {
-                password,
-                salt_path,
-                our_id,
-            } => {
-                let salt = fs::read_to_string(salt_path)
-                    .map_err_cli_msg(CliErrorKind::IOError, "Unable to open salt file")?;
-                let auth = ApiAuth(get_password_hash(&password, &salt).map_err_cli_io()?);
-                let url = cli
-                    .build_client(&self.module_gens)
-                    .await?
-                    .config()
-                    .as_ref()
-                    .api_endpoints
-                    .get(&our_id)
-                    .expect("Endpoint exists")
-                    .url
-                    .clone();
-                let auth_api = WsAdminClient::new(url, our_id, auth);
-                auth_api.signal_upgrade().await?;
+            Command::SignalUpgrade => {
+                cli.admin_client().await?.signal_upgrade().await?;
                 Ok(CliOutput::SignalUpgrade)
             }
             Command::EpochCount => {
@@ -999,6 +1023,31 @@ impl FedimintCli {
                     .fetch_epoch_count()
                     .await?;
                 Ok(CliOutput::EpochCount { count })
+            }
+            Command::LastEpoch => {
+                let cfg = cli.load_config()?;
+                let decoders = cli.load_decoders(&cfg, &self.module_gens);
+                let client = cli.admin_client().await?;
+                let last_epoch = client
+                    .fetch_last_epoch_history(cfg.0.epoch_pk, &decoders)
+                    .await?;
+
+                let hex_outcome = last_epoch.consensus_encode_to_hex().map_err_cli_io()?;
+                Ok(CliOutput::LastEpoch { hex_outcome })
+            }
+            Command::ForceEpoch { hex_outcome } => {
+                let cfg = cli.load_config()?;
+                let decoders = cli.load_decoders(&cfg, &self.module_gens);
+                let outcome: SignedEpochOutcome = Decodable::consensus_decode_hex(
+                    &hex_outcome,
+                    &decoders,
+                )
+                .map_err_cli_msg(CliErrorKind::SerializationError, "failed to decode outcome")?;
+                let client = cli.admin_client().await?;
+                client
+                    .force_process_epoch(SerdeEpochHistory::from(&outcome))
+                    .await?;
+                Ok(CliOutput::ForceEpoch)
             }
             Command::Module { id, arg } => {
                 let cfg = cli.load_config()?;

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -15,7 +15,7 @@ use std::io::{Error, Read, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::format_err;
-use bitcoin_hashes::hex::ToHex;
+use bitcoin_hashes::hex::{FromHex, ToHex};
 use bitcoin_hashes::sha256::HashEngine;
 use bitcoin_hashes::{sha256, Hash};
 pub use fedimint_derive::{Decodable, Encodable, UnzipConsensus};
@@ -98,6 +98,18 @@ pub trait Decodable: Sized {
         r: &mut R,
         _modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError>;
+
+    /// Decode an object from hex
+    fn consensus_decode_hex(
+        hex: &str,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        let bytes = Vec::<u8>::from_hex(hex)
+            .map_err(anyhow::Error::from)
+            .map_err(DecodeError::new_custom)?;
+        let mut reader = std::io::Cursor::new(bytes);
+        Decodable::consensus_decode(&mut reader, modules)
+    }
 }
 
 impl Encodable for Url {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -71,6 +71,7 @@ pub struct ConsensusProposal {
 pub enum ApiEvent {
     Transaction(Transaction),
     UpgradeSignal,
+    ForceProcessOutcome(EpochOutcome),
 }
 
 // TODO: we should make other fields private and get rid of this
@@ -493,9 +494,10 @@ impl FedimintConsensus {
             .api_event_cache
             .iter()
             .cloned()
-            .map(|event| match event {
-                ApiEvent::Transaction(tx) => ConsensusItem::Transaction(tx),
-                ApiEvent::UpgradeSignal => ConsensusItem::ConsensusUpgrade(ConsensusUpgrade),
+            .filter_map(|event| match event {
+                ApiEvent::Transaction(tx) => Some(ConsensusItem::Transaction(tx)),
+                ApiEvent::UpgradeSignal => Some(ConsensusItem::ConsensusUpgrade(ConsensusUpgrade)),
+                ApiEvent::ForceProcessOutcome(_) => None,
             })
             .collect();
         let mut force_new_epoch = false;

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -387,7 +387,8 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
         api_endpoint! {
             "fetch_epoch_history",
             async |fedimint: &ConsensusApi, _context, epoch: u64| -> SerdeEpochHistory {
-                let epoch = fedimint.epoch_history(epoch).await.ok_or_else(|| ApiError::not_found(String::from("epoch not found")))?;
+                let epoch = fedimint.epoch_history(epoch).await
+                  .ok_or_else(|| ApiError::not_found(format!("epoch {epoch} not found")))?;
                 Ok((&epoch).into())
             }
         },

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -285,6 +285,17 @@ impl ConsensusApi {
     pub async fn signal_upgrade(&self) -> Result<(), SendError<ApiEvent>> {
         self.api_sender.send(ApiEvent::UpgradeSignal).await
     }
+
+    /// Force process an outcome
+    pub async fn force_process_outcome(&self, outcome: SerdeEpochHistory) -> ApiResult<()> {
+        let event = outcome
+            .try_into_inner(&self.modules.decoder_registry())
+            .map_err(|_| ApiError::bad_request("Unable to decode outcome".to_string()))?;
+        self.api_sender
+            .send(ApiEvent::ForceProcessOutcome(event.outcome))
+            .await
+            .map_err(|_| ApiError::server_error("Unable send event".to_string()))
+    }
 }
 
 #[async_trait]
@@ -403,6 +414,18 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             async |fedimint: &ConsensusApi, context, _v: ()| -> () {
                 if context.has_auth() {
                     fedimint.signal_upgrade().await.map_err(|_| ApiError::server_error("Unable to send signal to server".to_string()))?;
+                    Ok(())
+                } else {
+                    Err(ApiError::unauthorized())
+                }
+            }
+        },
+        api_endpoint! {
+            "process_outcome",
+            async |fedimint: &ConsensusApi, context, outcome: SerdeEpochHistory| -> () {
+                if context.has_auth() {
+                    fedimint.force_process_outcome(outcome).await
+                      .map_err(|_| ApiError::server_error("Unable to send signal to server".to_string()))?;
                     Ok(())
                 } else {
                     Err(ApiError::unauthorized())


### PR DESCRIPTION
Fixes #2309

Note we upload the entire serialized epoch (which can be downloaded from the API), because it's both easier to get from the API and doesn't require additional P2P calls (we don't really know who to query).