### PR TITLE
chore: expose `fedimint-bin-tests` as a flake output

### DIFF
--- a/fedimint-bin-tests/Cargo.toml
+++ b/fedimint-bin-tests/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "fedimint-bin-tests"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = { version = "1.0.69", features = ["backtrace"] }
 bitcoincore-rpc = "0.16.0"

--- a/flake.crane.nix
+++ b/flake.crane.nix
@@ -516,5 +516,33 @@ rec {
       "modules"
     ];
   };
+
+  fedimint-bin-tests = pkgsBuild {
+    name = "fedimint-bin-tests";
+    pkgs = {
+      fedimint-bin-tests = { };
+    };
+    dirs = [
+      "client/client-lib"
+      "client/cli"
+      "crypto/aead"
+      "crypto/derive-secret"
+      "crypto/hkdf"
+      "crypto/tbs"
+      "fedimintd"
+      "fedimint-bitcoind"
+      "fedimint-build"
+      "fedimint-client"
+      "fedimint-client-legacy"
+      "fedimint-bin-tests"
+      "fedimint-core"
+      "fedimint-derive"
+      "fedimint-rocksdb"
+      "fedimint-server"
+      "fedimint-logging"
+      "gateway/ln-gateway"
+      "modules"
+    ];
+  };
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,7 @@
             gateway-pkgs = craneBuildNative.gateway-pkgs;
             client-pkgs = craneBuildNative.client-pkgs { };
             fedimint-dbtool-pkgs = craneBuildNative.fedimint-dbtool-pkgs;
+            fedimint-bin-tests = craneBuildNative.fedimint-bin-tests;
           };
 
           # rust packages outputs with git hash replaced


### PR DESCRIPTION
I don't see a big advantage of building it in CI, as it is already used for all tests anyway, but external users might want to consume it as a standalone binary.

Verified with:

```
nix build -L .#fedimint-bin-tests
```
