### PR TITLE
fix: hardcode finality delay in tmux/dev shell

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -23,7 +23,7 @@ function open_channel() {
 
 function await_fedimint_block_sync() {
   BLOCKS="$($FM_BTC_CLIENT getblockchaininfo | jq -e -r '.blocks')"
-  FINALITY_DELAY=$(get_finality_delay)
+  FINALITY_DELAY=10
   AWAIT="$((BLOCKS - FINALITY_DELAY))"
   echo "await_fedimint_block_sync $AWAIT"
   $FM_MINT_CLIENT wait-block-height "$AWAIT"
@@ -58,10 +58,6 @@ function kill_fedimint_processes {
     kill $PIDS 2>/dev/null
   fi
   rm -f $FM_PID_FILE
-}
-
-function get_finality_delay() {
-    cat $FM_DATA_DIR/client.json | jq -e -r ".modules.\"${LEGACY_HARDCODED_INSTANCE_ID_WALLET}\".config.finality_delay"
 }
 
 function sat_to_btc() {

--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -13,7 +13,7 @@ GATEWAY_TYPE=${3:-"CLN"}
 
 if [ "$GATEWAY_TYPE" == "CLN" ]; then GATEWAY_CLI=$FM_GWCLI_CLN; else GATEWAY_CLI=$FM_GWCLI_LND; fi
 
-FINALITY_DELAY=$(get_finality_delay)
+FINALITY_DELAY=10
 echo "Pegging in $PEG_IN_AMOUNT with confirmation in $FINALITY_DELAY blocks"
 
 FED_ID="$(get_federation_id)"


### PR DESCRIPTION
A recent change to the encoding of the wallet config caused the `config` section of `client.json` to be encoded as json. This broke the `pegin.sh` script since it relied on retrieving the `finality_delay` from the config.

These scripts are going away soon away with the shift to the rust based dev shells. This PR just hard codes the `finality_delay` in the bash scripts for now so that tmuxinator and fed-shell are not broken.