### PR TITLE
fix(mint-client): allow injecting user-specified meta into operations

### DIFF
--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -77,7 +77,7 @@ pub async fn handle_ng_command<D: IDatabase>(
         ClientNg::Reissue { notes } => {
             let amount = notes.total_amount();
 
-            let operation_id = client.reissue_external_notes(notes).await?;
+            let operation_id = client.reissue_external_notes(notes, ()).await?;
             let mut updates = client
                 .subscribe_reissue_external_notes_updates(operation_id)
                 .await
@@ -94,7 +94,9 @@ pub async fn handle_ng_command<D: IDatabase>(
             Ok(serde_json::to_value(amount).unwrap())
         }
         ClientNg::Spend { amount } => {
-            let (operation, notes) = client.spend_notes(amount, Duration::from_secs(30)).await?;
+            let (operation, notes) = client
+                .spend_notes(amount, Duration::from_secs(30), ())
+                .await?;
             info!("Spend e-cash operation: {operation:?}");
 
             Ok(serde_json::to_value(notes).unwrap())

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1062,3 +1062,41 @@ impl Decodable for OperationLogEntry {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    use crate::OperationLogEntry;
+
+    #[test]
+    fn test_operation_log_entry_serde() {
+        let op_log = OperationLogEntry {
+            operation_type: "test".to_string(),
+            meta: serde_json::to_value(()).unwrap(),
+        };
+
+        op_log.meta::<()>();
+    }
+
+    #[test]
+    fn test_operation_log_entry_serde_extra_meta() {
+        #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+        struct Meta {
+            foo: String,
+            extra_meta: serde_json::Value,
+        }
+
+        let meta = Meta {
+            foo: "bar".to_string(),
+            extra_meta: serde_json::to_value(()).unwrap(),
+        };
+
+        let op_log = OperationLogEntry {
+            operation_type: "test".to_string(),
+            meta: serde_json::to_value(meta.clone()).unwrap(),
+        };
+
+        assert_eq!(op_log.meta::<Meta>(), meta);
+    }
+}


### PR DESCRIPTION
Proof-of-concept for adding more meta data to operations, needs to be done for other ext traits too.