### PR TITLE
chore: improve naming of mprocs & tmuxinator

### DIFF
--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -635,7 +635,7 @@ async fn reconnect_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Result
 #[derive(Subcommand)]
 enum Cmd {
     ExternalDaemons,
-    Tmuxinator,
+    DevFed,
     RunUi,
     LatencyTests,
     ReconnectTest,
@@ -688,7 +688,7 @@ async fn main() -> Result<()> {
             let _daemons = write_ready_file(external_daemons(&process_mgr).await).await?;
             task_group.make_handle().make_shutdown_rx().await.await?;
         }
-        Cmd::Tmuxinator => {
+        Cmd::DevFed => {
             let _daemons = write_ready_file(dev_fed(&task_group, &process_mgr).await).await?;
             task_group.make_handle().make_shutdown_rx().await.await?;
         }

--- a/justfile
+++ b/justfile
@@ -82,11 +82,11 @@ format:
   nixpkgs-fmt $(echo **.nix)
 
 # start mprocs with a dev federation setup
-fed-shell:
-  ./scripts/fed-shell.sh
+mprocs:
+  ./scripts/mprocs.sh
 
-# exit fed-shell session
-exit-fed-shell:
+# exit mprocs session
+exit-mprocs:
   mprocs --ctl '{c: quit}' --server 127.0.0.1:4050
 
 # start tmuxinator with dev federation setup

--- a/scripts/mprocs.sh
+++ b/scripts/mprocs.sh
@@ -17,7 +17,7 @@ echo "Running in temporary directory $FM_TEST_DIR"
 export FM_READY_FILE=$FM_TMP_DIR/ready
 mkfifo $FM_READY_FILE
 
-devimint tmuxinator &>$FM_LOGS_DIR/devimint.log &
+devimint dev-fed &>$FM_LOGS_DIR/devimint.log &
 echo $! >> $FM_PID_FILE
 
 env | sed -En 's/^(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if [[ -n "${TMUX:-}" ]]; then
-  echo "Can not run tmuxinator in tmux"
+  echo "Can not run inside existing tmux session"
   exit 1
 fi
 
@@ -22,7 +22,7 @@ echo "Running in temporary directory $FM_TEST_DIR"
 export FM_READY_FILE=$FM_TMP_DIR/ready
 mkfifo $FM_READY_FILE
 
-devimint tmuxinator &>$FM_LOGS_DIR/devimint.log &
+devimint dev-fed &>$FM_LOGS_DIR/devimint.log &
 echo $! >> $FM_PID_FILE
 
 env | sed -En 's/^(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv


### PR DESCRIPTION
I sometimes forget the name of the mprocs dev tool (`fed-shell`). Renaming it to `mprocs` because that's easier to remember :)

Also, renamed `devimint tmuxinator` to `devimint dev-fed` since this is also used by `mprocs` and it calls a `dev_fed` function internally which is a nice name.

After the refactors I re-ran both `just mprocs` and `just tmuxinator` and both seemed to still work!