### PR TITLE
Allow external modules using Client NG's ClientModule trait to handle fedimint-cli commands

### DIFF
--- a/fedimint-core/src/core/client.rs
+++ b/fedimint-core/src/core/client.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::ffi;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -30,6 +31,15 @@ pub trait ClientModule: Debug {
         &self,
         output: &<Self::Module as ModuleCommon>::Output,
     ) -> TransactionItemAmount;
+
+    async fn handle_cli_command(
+        &self,
+        _args: &[ffi::OsString],
+    ) -> anyhow::Result<serde_json::Value> {
+        Err(anyhow::format_err!(
+            "This module does not implement cli commands"
+        ))
+    }
 }
 
 pub trait IClientModule: Debug {

--- a/fedimint-core/src/core/client.rs
+++ b/fedimint-core/src/core/client.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::ffi;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -31,15 +30,6 @@ pub trait ClientModule: Debug {
         &self,
         output: &<Self::Module as ModuleCommon>::Output,
     ) -> TransactionItemAmount;
-
-    async fn handle_cli_command(
-        &self,
-        _args: &[ffi::OsString],
-    ) -> anyhow::Result<serde_json::Value> {
-        Err(anyhow::format_err!(
-            "This module does not implement cli commands"
-        ))
-    }
 }
 
 pub trait IClientModule: Debug {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -439,6 +439,7 @@ impl MintClientContext {
 
 impl Context for MintClientContext {}
 
+#[apply(async_trait_maybe_send)]
 impl ClientModule for MintClientModule {
     type Common = MintModuleTypes;
     type ModuleStateMachineContext = MintClientContext;


### PR DESCRIPTION
We had a `handle_cli_command` method on the old `ClientModule` trait. This PR moves it to the `ClientModule` trait for the new client.

Like the old method, it just passes `&[ffi::OsString]`. It might be better to utilize some kind of clap sub-command. But I figured that could wait for a future PR.