### PR TITLE
feat: devimint's run-ui command has an option to drive the new UI

### DIFF
--- a/scripts/run-ui.sh
+++ b/scripts/run-ui.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 export FM_BITCOIN_NETWORK="regtest"
-export FM_FED_SIZE=${1:-2}
-export FM_FED_NAME=${2:-"Cypherpunk Federation"}
+export FM_UI_KIND=${1:-"old"}
+export FM_FED_SIZE=${2:-2}
+export FM_FED_NAME=${3:-"Cypherpunk Federation"}
 
 source scripts/build.sh $FM_FED_SIZE
 
@@ -11,4 +12,4 @@ echo $! >> $FM_PID_FILE
 tail -n +0 -F $FM_LOGS_DIR/fedimintd-1.log &
 echo $! >> $FM_PID_FILE
 
-devimint run-ui
+devimint run-ui $FM_UI_KIND


### PR DESCRIPTION
This new option doesn't set the password because UI will need to set this, or `FM_LISTEN_UI` because this will block the config API from running.

Leaving as "draft" because fedimintd's password is currently required. So not setting `FM_PASSWORD` currently causes `fedimintd` to fail.