### PR TITLE
docs: remove outdated dkg section in dev-env docs

### DIFF
--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -175,8 +175,5 @@ $ docker run -it -v $PWD/demo:/var/fedimint -p 17240:17240 fedimintd:iqviraxy2cz
 write the files to the host file-system (e.g. config generation). `-p` is used to bind the host's port 17240 as the
 container's port 17240.
 
-To generate federation configs and run the federation please see the `run_dkg` and `start_federation` helper functions in [lib.sh](https://github.com/fedimint/fedimint/blob/master/scripts/lib.sh), as well as the `--help` output of
-`distributedgen` and `fedimintd`. If you'd like to run function like `run_dkg` and `start_federation` from inside nix shell, run `source scripts/build.sh` and then `source scripts/lib.sh` and they will be available.
-
 Note that you can also start a "fake" 1-of-1 "federation" that will allow you to test most aspects of Fedimint without
 having to run e.g. 4 instances.


### PR DESCRIPTION
Fixes a broken link to `lib.sh`. If someone knows how the config generation should be done in a container context idiomatically now (I suppose via UI?) feel free to take over this PR or open another one. I mainly want to fix the broken link so CI is green again.