### PR TITLE
Refactor: consensus api

### DIFF
--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -16,7 +16,7 @@ use fedimint_core::db::Database;
 use fedimint_core::module::{ApiAuth, DynServerModuleGen, IServerModuleGen};
 use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup};
 use fedimint_core::PeerId;
-use fedimint_server::config::api::{ConfigGenParamsLocal, ConfigGenSettings};
+use fedimint_server::config::api::ConfigGenParamsLocal;
 use fedimint_server::config::{gen_cert_and_key, ConfigGenParams, ServerConfig};
 use fedimint_server::consensus::server::ConsensusServer;
 use fedimint_server::net::connect::mock::{MockNetwork, StreamReliability};
@@ -145,28 +145,7 @@ impl FederationTest {
             .await
             .expect("Failed to init server");
 
-            // TODO: Refactor to `run_consensus_api` outside `FedimintServer`
-            let api = FedimintServer {
-                data_dir: Default::default(),
-                settings: ConfigGenSettings {
-                    download_token_limit: None,
-                    p2p_bind: config.local.fed_bind,
-                    api_bind: config.local.api_bind,
-                    p2p_url: config.local.p2p_endpoints[&config.local.identity]
-                        .url
-                        .clone(),
-                    api_url: config.consensus.api_endpoints[&config.local.identity]
-                        .url
-                        .clone(),
-                    default_params: Default::default(),
-                    module_gens: Default::default(),
-                    max_connections: config.local.max_connections,
-                    registry: Default::default(),
-                },
-                db,
-            };
-
-            let api_handle = api.run_consensus_api(&server.consensus.api).await;
+            let api_handle = FedimintServer::spawn_consensus_api(&server).await;
             handles.push(api_handle);
             servers.push(server);
         }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -1166,23 +1166,7 @@ impl FederationTest {
         let mut handles = vec![];
         for server in &self.servers {
             let s = server.lock().await;
-            let cfg = s.fedimint.cfg.clone();
-            let api = FedimintServer {
-                data_dir: Default::default(),
-                settings: ConfigGenSettings {
-                    download_token_limit: cfg.local.download_token_limit,
-                    p2p_bind: cfg.local.fed_bind,
-                    api_bind: cfg.local.api_bind,
-                    p2p_url: cfg.local.p2p_endpoints[&cfg.local.identity].url.clone(),
-                    api_url: cfg.consensus.api_endpoints[&cfg.local.identity].url.clone(),
-                    default_params: Default::default(),
-                    module_gens: s.fedimint.consensus.module_inits.legacy_init_modules(),
-                    max_connections: s.fedimint.consensus.cfg.local.max_connections,
-                    registry: s.fedimint.consensus.module_inits.clone(),
-                },
-                db: s.fedimint.consensus.db.clone(),
-            };
-            handles.push(api.run_consensus_api(&s.fedimint.consensus.api).await);
+            handles.push(FedimintServer::spawn_consensus_api(&s.fedimint).await);
         }
         handles
     }


### PR DESCRIPTION
A couple small refactors to the consensus API to eliminate some boilerplate in tests and ensure the check of consensus hash will be tested.