### PR TITLE
refactor: converts ServerModuleGenParamsRegistry to ModuleRegistry

### DIFF
--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -12,12 +12,11 @@ use fedimint_core::admin_client::{
     PeerServerParams, ServerStatus, WsAdminClient,
 };
 use fedimint_core::config::ServerModuleGenRegistry;
-use fedimint_core::core::{ModuleInstanceId, ModuleKind};
+use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::Database;
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::{
     api_endpoint, ApiAuth, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased,
-    DynServerModuleGen,
 };
 use fedimint_core::task::TaskGroup;
 use fedimint_core::util::write_new;
@@ -196,12 +195,10 @@ impl ConfigGenApi {
             }
         };
 
-        let module_gens = self.settings.module_gens.clone();
-
         let mut task_group = self.task_group.make_subgroup().await;
         let config = ServerConfig::distributed_gen(
             &params,
-            module_gens,
+            self.settings.registry.clone(),
             DelayCalculator::PROD_DEFAULT,
             &mut task_group,
         )
@@ -394,8 +391,6 @@ pub struct ConfigGenSettings {
     pub api_url: Url,
     /// The default params for the modules
     pub default_params: ConfigGenParamsRequest,
-    /// Modules that will generate configs
-    pub module_gens: BTreeMap<u16, (ModuleKind, DynServerModuleGen)>,
     /// How many API connections we will accept
     pub max_connections: u32,
     /// Registry for config gen
@@ -745,7 +740,6 @@ mod tests {
                 p2p_url,
                 api_url: api_url.clone(),
                 default_params: Default::default(),
-                module_gens: Default::default(),
                 max_connections: DEFAULT_MAX_CLIENT_CONNECTIONS,
                 registry: Default::default(),
             };

--- a/fedimintd/src/distributed_gen.rs
+++ b/fedimintd/src/distributed_gen.rs
@@ -208,7 +208,7 @@ impl DistributedGen {
                 )?;
                 let server = match ServerConfig::distributed_gen(
                     &params,
-                    self.module_gens.clone().legacy_init_modules(),
+                    self.module_gens.clone(),
                     DelayCalculator::PROD_DEFAULT,
                     &mut task_group,
                 )

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -3,10 +3,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::Parser;
-use fedimint_core::config::{
-    ModuleGenParams, ServerModuleGenParamsRegistry, ServerModuleGenRegistry,
-};
-use fedimint_core::core::ModuleKind;
+use fedimint_core::config::{ServerModuleGenParamsRegistry, ServerModuleGenRegistry};
 use fedimint_core::db::Database;
 use fedimint_core::module::ServerModuleGen;
 use fedimint_core::task::{sleep, TaskGroup};
@@ -107,7 +104,7 @@ impl Fedimintd {
 
         Ok(Self {
             module_gens: ServerModuleGenRegistry::new(),
-            module_gens_params: ServerModuleGenParamsRegistry::new(),
+            module_gens_params: ServerModuleGenParamsRegistry::default(),
             opts,
         })
     }
@@ -117,15 +114,6 @@ impl Fedimintd {
         T: ServerModuleGen + 'static + Send + Sync,
     {
         self.module_gens.attach(gen);
-        self
-    }
-
-    pub fn with_extra_module_gens_params<P>(mut self, kind: ModuleKind, params: P) -> Self
-    where
-        P: ModuleGenParams,
-    {
-        self.module_gens_params
-            .attach_config_gen_params(kind, params);
         self
     }
 
@@ -271,7 +259,6 @@ async fn run(
             p2p_url: cfg.local.p2p_endpoints[&cfg.local.identity].url.clone(),
             api_url: cfg.consensus.api_endpoints[&cfg.local.identity].url.clone(),
             default_params: Default::default(),
-            module_gens: module_gens.legacy_init_modules(),
             max_connections: fedimint_server::config::max_connections(),
             registry: module_gens,
         },

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -1,7 +1,12 @@
 use bitcoin::Network;
 use fedimint_core::config::ServerModuleGenParamsRegistry;
+use fedimint_core::core::{
+    LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
+    LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+};
 use fedimint_core::module::ServerModuleGen;
 use fedimint_core::{Amount, Tiered};
+use fedimint_ln_server::{LightningGen, LightningGenParams};
 use fedimint_mint_server::{MintGen, MintGenParams};
 use fedimint_wallet_server::{WalletGen, WalletGenParams};
 
@@ -21,6 +26,7 @@ pub fn attach_default_module_gen_params(
 ) {
     module_gen_params
         .attach_config_gen_params(
+            LEGACY_HARDCODED_INSTANCE_ID_WALLET,
             WalletGen::kind(),
             WalletGenParams {
                 network,
@@ -30,6 +36,7 @@ pub fn attach_default_module_gen_params(
             },
         )
         .attach_config_gen_params(
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
             MintGen::kind(),
             MintGenParams {
                 mint_amounts: Tiered::gen_denominations(max_denomination)
@@ -37,5 +44,10 @@ pub fn attach_default_module_gen_params(
                     .cloned()
                     .collect(),
             },
+        )
+        .attach_config_gen_params(
+            LEGACY_HARDCODED_INSTANCE_ID_LN,
+            LightningGen::kind(),
+            LightningGenParams,
         );
 }

--- a/fedimintd/src/ui.rs
+++ b/fedimintd/src/ui.rs
@@ -180,7 +180,7 @@ async fn post_guardians(
             ) {
                 Ok(params) => ServerConfig::distributed_gen(
                     &params,
-                    module_gens.clone().legacy_init_modules(),
+                    module_gens.clone(),
                     DelayCalculator::PROD_DEFAULT,
                     &mut dkg_task_group,
                 )

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -347,10 +347,8 @@ pub async fn fixtures(num_peers: u16, gateway_node: GatewayNode) -> anyhow::Resu
                 DynServerModuleGen::from(LightningGen),
             ]);
 
-            let server_config = ServerConfig::trusted_dealer_gen(
-                &params,
-                server_module_inits.clone().legacy_init_modules(),
-            );
+            let server_config =
+                ServerConfig::trusted_dealer_gen(&params, server_module_inits.clone());
             let client_config = server_config[&PeerId::from(0)]
                 .consensus
                 .to_config_response(&server_module_inits)
@@ -543,7 +541,7 @@ async fn distributed_config(
 
             let cfg = ServerConfig::distributed_gen(
                 &our_params,
-                registry.legacy_init_modules(),
+                registry,
                 DelayCalculator::TEST_DEFAULT,
                 &mut task_group,
             );
@@ -1301,7 +1299,6 @@ impl FederationTest {
                     p2p_url: cfg.local.p2p_endpoints[&cfg.local.identity].url.clone(),
                     api_url: cfg.consensus.api_endpoints[&cfg.local.identity].url.clone(),
                     default_params: Default::default(),
-                    module_gens: module_inits.legacy_init_modules(),
                     max_connections: 100,
                     registry: module_inits.clone(),
                 },

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -4,7 +4,7 @@ use std::ops::Sub;
 
 use bitcoin_hashes::Hash as BitcoinHash;
 use fedimint_core::config::{
-    ClientModuleConfig, ConfigGenModuleParams, DkgResult, ServerModuleConfig,
+    ClientModuleConfig, ConfigGenModuleParams, DkgResult, ModuleGenParams, ServerModuleConfig,
     ServerModuleConsensusConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
@@ -57,6 +57,11 @@ pub struct LightningGen;
 impl ExtendsCommonModuleGen for LightningGen {
     type Common = LightningCommonGen;
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LightningGenParams;
+
+impl ModuleGenParams for LightningGenParams {}
 
 #[apply(async_trait_maybe_send!)]
 impl ServerModuleGen for LightningGen {


### PR DESCRIPTION
refactor: converts `ServerModuleGenParamsRegistry` from `ModuleGenRegistry` be `ModuleRegistry`

Eliminates `legacy_init_order_iter` from the server side (almost fully modularized!)
Removes a bunch of ugly code that existed just to pass the module id around.