### PR TITLE
refactor: remove legacy ids from the apis

### DIFF
--- a/fedimint-client-legacy/src/api.rs
+++ b/fedimint-client-legacy/src/api.rs
@@ -38,45 +38,47 @@ where
     T: IFederationApi + MaybeSend + MaybeSync + 'static,
 {
     async fn fetch_contract(&self, contract: ContractId) -> FederationResult<ContractAccount> {
-        self.request_current_consensus(
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_wait_account"),
-            ApiRequestErased::new(contract),
-        )
-        .await
+        self.with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
+            .request_current_consensus("wait_account".to_string(), ApiRequestErased::new(contract))
+            .await
     }
     async fn fetch_offer(
         &self,
         payment_hash: Sha256Hash,
     ) -> FederationResult<IncomingContractOffer> {
-        self.request_current_consensus(
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_wait_offer"),
-            ApiRequestErased::new(payment_hash),
-        )
-        .await
+        self.with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
+            .request_current_consensus(
+                "wait_offer".to_string(),
+                ApiRequestErased::new(payment_hash),
+            )
+            .await
     }
 
     async fn fetch_gateways(&self) -> FederationResult<Vec<LightningGateway>> {
-        self.request_with_strategy(
-            UnionResponses::new(self.all_members().threshold()),
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_list_gateways"),
-            ApiRequestErased::default(),
-        )
-        .await
+        self.with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
+            .request_with_strategy(
+                UnionResponses::new(self.all_members().threshold()),
+                "list_gateways".to_string(),
+                ApiRequestErased::default(),
+            )
+            .await
     }
 
     async fn register_gateway(&self, gateway: &LightningGateway) -> FederationResult<()> {
-        self.request_with_strategy(
-            CurrentConsensus::new(self.all_members().threshold()),
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_register_gateway"),
-            ApiRequestErased::new(gateway),
-        )
-        .await
+        self.with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
+            .request_with_strategy(
+                CurrentConsensus::new(self.all_members().threshold()),
+                "register_gateway".to_string(),
+                ApiRequestErased::new(gateway),
+            )
+            .await
     }
 
     async fn offer_exists(&self, payment_hash: Sha256Hash) -> FederationResult<bool> {
         Ok(self
+            .with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
             .request_current_consensus::<Option<IncomingContractOffer>>(
-                format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_offer"),
+                "offer".to_string(),
                 ApiRequestErased::new(payment_hash),
             )
             .await?
@@ -105,23 +107,25 @@ where
         &self,
         request: &fedimint_mint_client::SignedBackupRequest,
     ) -> FederationResult<()> {
-        self.request_with_strategy(
-            CurrentConsensus::new(self.all_members().threshold()),
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_MINT}_backup"),
-            ApiRequestErased::new(request),
-        )
-        .await
+        self.with_module(LEGACY_HARDCODED_INSTANCE_ID_MINT)
+            .request_with_strategy(
+                CurrentConsensus::new(self.all_members().threshold()),
+                "backup".to_string(),
+                ApiRequestErased::new(request),
+            )
+            .await
     }
     async fn download_ecash_backup(
         &self,
         id: &secp256k1::XOnlyPublicKey,
     ) -> FederationResult<Vec<ECashUserBackupSnapshot>> {
         Ok(self
+            .with_module(LEGACY_HARDCODED_INSTANCE_ID_MINT)
             .request_with_strategy(
                 UnionResponsesSingle::<Option<ECashUserBackupSnapshot>>::new(
                     self.all_members().threshold(),
                 ),
-                format!("module_{LEGACY_HARDCODED_INSTANCE_ID_MINT}_recover"),
+                "recover".to_string(),
                 ApiRequestErased::new(id),
             )
             .await?
@@ -147,12 +151,13 @@ where
     T: IFederationApi + MaybeSend + MaybeSync + 'static,
 {
     async fn fetch_consensus_block_height(&self) -> FederationResult<u64> {
-        self.request_with_strategy(
-            EventuallyConsistent::new(self.all_members().one_honest()),
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_block_height"),
-            ApiRequestErased::default(),
-        )
-        .await
+        self.with_module(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
+            .request_with_strategy(
+                EventuallyConsistent::new(self.all_members().one_honest()),
+                "block_height".to_string(),
+                ApiRequestErased::default(),
+            )
+            .await
     }
 
     async fn fetch_peg_out_fees(
@@ -160,10 +165,11 @@ where
         address: &Address,
         amount: bitcoin::Amount,
     ) -> FederationResult<Option<PegOutFees>> {
-        self.request_eventually_consistent(
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_peg_out_fees"),
-            ApiRequestErased::new((address, amount.to_sat())),
-        )
-        .await
+        self.with_module(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
+            .request_eventually_consistent(
+                "peg_out_fees".to_string(),
+                ApiRequestErased::new((address, amount.to_sat())),
+            )
+            .await
     }
 }

--- a/fedimint-client-legacy/src/api/fake.rs
+++ b/fedimint-client-legacy/src/api/fake.rs
@@ -4,7 +4,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use fedimint_core::api::{IFederationApi, JsonRpcResult};
+use fedimint_core::api::{DynFederationApi, IFederationApi, JsonRpcResult};
+use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::module::ApiRequest;
 use fedimint_core::PeerId;
 use futures::Future;
@@ -101,6 +102,10 @@ where
 {
     fn all_members(&self) -> &BTreeSet<PeerId> {
         &self.members
+    }
+
+    fn with_module(&self, _id: ModuleInstanceId) -> DynFederationApi {
+        unimplemented!()
     }
 
     async fn request_raw(

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -216,8 +216,8 @@ mod tests {
     use std::time::{Duration, SystemTime};
 
     use async_trait::async_trait;
-    use fedimint_core::api::{IFederationApi, JsonRpcResult};
-    use fedimint_core::core::{IntoDynInstance, ModuleKind};
+    use fedimint_core::api::{DynFederationApi, IFederationApi, JsonRpcResult};
+    use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, ModuleKind};
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::Database;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -260,6 +260,10 @@ mod tests {
     impl IFederationApi for FakeApiClient {
         fn all_members(&self) -> &BTreeSet<PeerId> {
             &self.fake_peers
+        }
+
+        fn with_module(&self, _id: ModuleInstanceId) -> DynFederationApi {
+            unimplemented!()
         }
 
         async fn request_raw(

--- a/modules/fedimint-dummy-client/src/api.rs
+++ b/modules/fedimint-dummy-client/src/api.rs
@@ -2,7 +2,7 @@ use fedimint_core::api::{FederationApiExt, FederationResult, IFederationApi};
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{apply, async_trait_maybe_send, Amount};
-use fedimint_dummy_common::{DummyPrintMoneyRequest, LEGACY_HARDCODED_INSTANCE_ID_DUMMY};
+use fedimint_dummy_common::DummyPrintMoneyRequest;
 use secp256k1::XOnlyPublicKey;
 
 #[apply(async_trait_maybe_send!)]
@@ -18,18 +18,12 @@ where
     T: IFederationApi + MaybeSend + MaybeSync + 'static,
 {
     async fn print_money(&self, request: DummyPrintMoneyRequest) -> FederationResult<()> {
-        self.request_current_consensus(
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_DUMMY}_print_money"),
-            ApiRequestErased::new(request),
-        )
-        .await
+        self.request_current_consensus("print_money".to_string(), ApiRequestErased::new(request))
+            .await
     }
 
     async fn wait_for_money(&self, account: XOnlyPublicKey) -> FederationResult<Amount> {
-        self.request_current_consensus(
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_DUMMY}_wait_for_money"),
-            ApiRequestErased::new(account),
-        )
-        .await
+        self.request_current_consensus("wait_for_money".to_string(), ApiRequestErased::new(account))
+            .await
     }
 }

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -59,8 +59,8 @@ impl DummyClientExt for Client {
         let (id, dummy) = dummy_client(self);
         let account = dummy.key.x_only_public_key().0;
         let request = DummyPrintMoneyRequest { amount, account };
-        self.api().print_money(request).await?;
-        let funds = self.api().wait_for_money(account).await?;
+        self.api().with_module(id).print_money(request).await?;
+        let funds = self.api().with_module(id).wait_for_money(account).await?;
 
         // TODO: Not very nice to get to the module db
         let mod_db = self.db().new_isolated(id);

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -19,10 +19,6 @@ pub mod config;
 /// Unique name for this module
 const KIND: ModuleKind = ModuleKind::from_static_str("dummy");
 
-/// Needed to avoid API path collisions
-// TODO: Remove
-pub const LEGACY_HARDCODED_INSTANCE_ID_DUMMY: ModuleInstanceId = 4;
-
 /// Modules are non-compatible with older versions
 pub const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
 

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -1,20 +1,19 @@
 use fedimint_core::{sats, Amount};
 use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
-use fedimint_dummy_common::{DummyConfigGenParams, LEGACY_HARDCODED_INSTANCE_ID_DUMMY};
+use fedimint_dummy_common::DummyConfigGenParams;
 use fedimint_dummy_server::DummyGen;
 use fedimint_logging::TracingSetup;
 use fedimint_testing::federation::FederationFixture;
 use fedimint_testing::fixtures::test;
 
 fn fixture() -> FederationFixture {
-    let mod_id = LEGACY_HARDCODED_INSTANCE_ID_DUMMY;
     TracingSetup::default().init().unwrap();
     let params = DummyConfigGenParams {
         tx_fee: Amount::ZERO,
     };
     FederationFixture::new_with_peers(2)
-        .with_module(mod_id, DummyClientGen, DummyGen, params)
-        .with_primary_module(mod_id)
+        .with_module(0, DummyClientGen, DummyGen, params)
+        .with_primary_module(0)
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/modules/fedimint-ln-client/src/api.rs
+++ b/modules/fedimint-ln-client/src/api.rs
@@ -1,5 +1,4 @@
 use fedimint_core::api::{FederationApiExt, FederationResult, IFederationApi};
-use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::query::{CurrentConsensus, UnionResponses};
 use fedimint_core::task::{MaybeSend, MaybeSync};
@@ -40,18 +39,15 @@ where
     T: IFederationApi + MaybeSend + MaybeSync + 'static,
 {
     async fn fetch_contract(&self, contract: ContractId) -> FederationResult<ContractAccount> {
-        self.request_current_consensus(
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_wait_account"),
-            ApiRequestErased::new(contract),
-        )
-        .await
+        self.request_current_consensus("wait_account".to_string(), ApiRequestErased::new(contract))
+            .await
     }
     async fn fetch_offer(
         &self,
         payment_hash: Sha256Hash,
     ) -> FederationResult<IncomingContractOffer> {
         self.request_current_consensus(
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_wait_offer"),
+            "wait_offer".to_string(),
             ApiRequestErased::new(payment_hash),
         )
         .await
@@ -60,7 +56,7 @@ where
     async fn fetch_gateways(&self) -> FederationResult<Vec<LightningGateway>> {
         self.request_with_strategy(
             UnionResponses::new(self.all_members().threshold()),
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_list_gateways"),
+            "list_gateways".to_string(),
             ApiRequestErased::default(),
         )
         .await
@@ -69,7 +65,7 @@ where
     async fn register_gateway(&self, gateway: &LightningGateway) -> FederationResult<()> {
         self.request_with_strategy(
             CurrentConsensus::new(self.all_members().threshold()),
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_register_gateway"),
+            "register_gateway".to_string(),
             ApiRequestErased::new(gateway),
         )
         .await
@@ -78,7 +74,7 @@ where
     async fn offer_exists(&self, payment_hash: Sha256Hash) -> FederationResult<bool> {
         Ok(self
             .request_current_consensus::<Option<IncomingContractOffer>>(
-                format!("module_{LEGACY_HARDCODED_INSTANCE_ID_LN}_offer"),
+                "offer".to_string(),
                 ApiRequestErased::new(payment_hash),
             )
             .await?

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -178,7 +178,12 @@ impl LightningClientExt for Client {
     }
 
     async fn fetch_registered_gateways(&self) -> anyhow::Result<Vec<LightningGateway>> {
-        Ok(self.api().fetch_gateways().await?)
+        let (ln_client_id, _) = ln_client(self);
+        Ok(self
+            .api()
+            .with_module(ln_client_id)
+            .fetch_gateways()
+            .await?)
     }
 
     async fn pay_bolt11_invoice(

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -1,6 +1,5 @@
 use bitcoin::Address;
 use fedimint_core::api::{FederationApiExt, FederationResult, IFederationApi};
-use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::query::EventuallyConsistent;
 use fedimint_core::task::{MaybeSend, MaybeSync};
@@ -25,7 +24,7 @@ where
     async fn fetch_consensus_block_height(&self) -> FederationResult<u64> {
         self.request_with_strategy(
             EventuallyConsistent::new(self.all_members().one_honest()),
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_block_height"),
+            "block_height".to_string(),
             ApiRequestErased::default(),
         )
         .await
@@ -37,7 +36,7 @@ where
         amount: bitcoin::Amount,
     ) -> FederationResult<Option<PegOutFees>> {
         self.request_eventually_consistent(
-            format!("module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_peg_out_fees"),
+            "peg_out_fees".to_string(),
             ApiRequestErased::new((address, amount.to_sat())),
         )
         .await


### PR DESCRIPTION
This removes the legacy ids from the new client APIs, one step closer to being fully modular.