### PR TITLE
Refactor: Inline config functions

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -594,9 +594,6 @@ pub trait TypedServerModuleConsensusConfig:
             &Default::default(),
         )?)
     }
-
-    /// Derive client side config for this module (type-erased)
-    fn to_client_config(&self) -> ClientModuleConfig;
 }
 
 /// Module (server side) config, typed

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -638,9 +638,6 @@ pub trait TypedServerModuleConfig: DeserializeOwned + Serialize {
             ),
         }
     }
-
-    /// Validate the config
-    fn validate_config(&self, identity: &PeerId) -> anyhow::Result<()>;
 }
 
 /// Typed client side module config

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -669,6 +669,7 @@ pub trait ServerModuleGen: ExtendsCommonModuleGen + Sized {
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()>;
 
+    /// Converts the consensus config into the client config
     fn get_client_config(
         &self,
         config: &ServerModuleConsensusConfig,

--- a/modules/fedimint-dummy-common/src/config.rs
+++ b/modules/fedimint-dummy-common/src/config.rs
@@ -1,11 +1,10 @@
-use anyhow::bail;
 use fedimint_core::config::{
     TypedClientModuleConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::ModuleConsensusVersion;
-use fedimint_core::{Amount, PeerId};
+use fedimint_core::Amount;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::serde_impl::SerdeSecret;
 use threshold_crypto::{PublicKeySet, SecretKeyShare};
@@ -67,18 +66,6 @@ impl TypedServerModuleConfig for DummyConfig {
     // TODO: Boilerplate-code (remove local)
     fn to_parts(self) -> (ModuleKind, Self::Local, Self::Private, Self::Consensus) {
         (KIND, (), self.private, self.consensus)
-    }
-
-    /// Checks whether the config should be used
-    fn validate_config(&self, identity: &PeerId) -> anyhow::Result<()> {
-        let our_id = identity.to_usize();
-        let our_share = self.consensus.public_key_set.public_key_share(our_id);
-
-        // Check our private key matches our public key share
-        if self.private.private_key_share.public_key_share() != our_share {
-            bail!("Private key doesn't match public key share");
-        }
-        Ok(())
     }
 }
 

--- a/modules/fedimint-dummy-common/src/config.rs
+++ b/modules/fedimint-dummy-common/src/config.rs
@@ -1,7 +1,6 @@
 use anyhow::bail;
 use fedimint_core::config::{
-    ClientModuleConfig, TypedClientModuleConfig, TypedServerModuleConfig,
-    TypedServerModuleConsensusConfig,
+    TypedClientModuleConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -44,18 +43,6 @@ pub struct DummyConfigPrivate {
 }
 
 impl TypedServerModuleConsensusConfig for DummyConfigConsensus {
-    /// Derives the client config from the consensus config
-    fn to_client_config(&self) -> ClientModuleConfig {
-        ClientModuleConfig::from_typed(
-            KIND,
-            CONSENSUS_VERSION,
-            &(DummyClientConfig {
-                tx_fee: self.tx_fee,
-            }),
-        )
-        .expect("Serialization can't fail")
-    }
-
     // TODO: Boilerplate-code
     fn kind(&self) -> ModuleKind {
         KIND

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -20,7 +20,9 @@ use fedimint_core::module::{
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{push_db_pair_items, Amount, NumPeers, OutPoint, PeerId, ServerModule};
-use fedimint_dummy_common::config::{DummyConfig, DummyConfigConsensus, DummyConfigPrivate};
+use fedimint_dummy_common::config::{
+    DummyClientConfig, DummyConfig, DummyConfigConsensus, DummyConfigPrivate,
+};
 use fedimint_dummy_common::{
     DummyCommonGen, DummyConfigGenParams, DummyConsensusItem, DummyError, DummyInput,
     DummyModuleTypes, DummyOutput, DummyOutputOutcome, DummyPrintMoneyRequest, CONSENSUS_VERSION,
@@ -131,12 +133,20 @@ impl ServerModuleGen for DummyGen {
         .to_erased())
     }
 
-    // TODO: Boilerplate-code
+    /// Converts the consensus config into the client config
     fn get_client_config(
         &self,
         config: &ServerModuleConsensusConfig,
     ) -> anyhow::Result<ClientModuleConfig> {
-        Ok(DummyConfigConsensus::from_erased(config)?.to_client_config())
+        let config = DummyConfigConsensus::from_erased(config)?;
+        Ok(ClientModuleConfig::from_typed(
+            config.kind(),
+            config.version(),
+            &(DummyClientConfig {
+                tx_fee: config.tx_fee,
+            }),
+        )
+        .expect("Serialization can't fail"))
     }
 
     // TODO: Boilerplate-code

--- a/modules/fedimint-ln-common/src/config.rs
+++ b/modules/fedimint-ln-common/src/config.rs
@@ -1,10 +1,8 @@
-use anyhow::bail;
 use fedimint_core::config::{
     TypedClientModuleConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::PeerId;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::serde_impl::SerdeSecret;
 
@@ -78,18 +76,6 @@ impl TypedServerModuleConfig for LightningConfig {
 
     fn to_parts(self) -> (ModuleKind, Self::Local, Self::Private, Self::Consensus) {
         (KIND, (), self.private, self.consensus)
-    }
-
-    fn validate_config(&self, identity: &PeerId) -> anyhow::Result<()> {
-        if self.private.threshold_sec_key.public_key_share()
-            != self
-                .consensus
-                .threshold_pub_keys
-                .public_key_share(identity.to_usize())
-        {
-            bail!("Lightning private key doesn't match pubkey share");
-        }
-        Ok(())
     }
 }
 

--- a/modules/fedimint-ln-common/src/config.rs
+++ b/modules/fedimint-ln-common/src/config.rs
@@ -1,7 +1,6 @@
 use anyhow::bail;
 use fedimint_core::config::{
-    ClientModuleConfig, TypedClientModuleConfig, TypedServerModuleConfig,
-    TypedServerModuleConsensusConfig,
+    TypedClientModuleConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -59,18 +58,6 @@ pub struct LightningClientConfig {
 }
 
 impl TypedServerModuleConsensusConfig for LightningConfigConsensus {
-    fn to_client_config(&self) -> ClientModuleConfig {
-        ClientModuleConfig::from_typed(
-            KIND,
-            CONSENSUS_VERSION,
-            &LightningClientConfig {
-                threshold_pub_key: self.threshold_pub_keys.public_key(),
-                fee_consensus: self.fee_consensus.clone(),
-            },
-        )
-        .expect("Serialization can't fail")
-    }
-
     fn kind(&self) -> ModuleKind {
         KIND
     }

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::OsString;
 use std::ops::Sub;
 
+use anyhow::bail;
 use bitcoin_hashes::Hash as BitcoinHash;
 use fedimint_core::config::{
     ClientModuleConfig, ConfigGenModuleParams, DkgResult, ModuleGenParams, ServerModuleConfig,
@@ -137,9 +138,16 @@ impl ServerModuleGen for LightningGen {
     }
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
-        config
-            .to_typed::<LightningConfig>()?
-            .validate_config(identity)
+        let config = config.to_typed::<LightningConfig>()?;
+        if config.private.threshold_sec_key.public_key_share()
+            != config
+                .consensus
+                .threshold_pub_keys
+                .public_key_share(identity.to_usize())
+        {
+            bail!("Lightning private key doesn't match pubkey share");
+        }
+        Ok(())
     }
 
     fn get_client_config(

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -26,7 +26,8 @@ use fedimint_core::{
 };
 pub use fedimint_ln_common as common;
 use fedimint_ln_common::config::{
-    FeeConsensus, LightningConfig, LightningConfigConsensus, LightningConfigPrivate,
+    FeeConsensus, LightningClientConfig, LightningConfig, LightningConfigConsensus,
+    LightningConfigPrivate,
 };
 use fedimint_ln_common::contracts::incoming::IncomingContractOffer;
 use fedimint_ln_common::contracts::{
@@ -145,7 +146,16 @@ impl ServerModuleGen for LightningGen {
         &self,
         config: &ServerModuleConsensusConfig,
     ) -> anyhow::Result<ClientModuleConfig> {
-        Ok(LightningConfigConsensus::from_erased(config)?.to_client_config())
+        let config = LightningConfigConsensus::from_erased(config)?;
+        Ok(ClientModuleConfig::from_typed(
+            config.kind(),
+            config.version(),
+            &LightningClientConfig {
+                threshold_pub_key: config.threshold_pub_keys.public_key(),
+                fee_consensus: config.fee_consensus,
+            },
+        )
+        .expect("Serialization can't fail"))
     }
 
     async fn dump_database(

--- a/modules/fedimint-mint-common/src/config.rs
+++ b/modules/fedimint-mint-common/src/config.rs
@@ -1,14 +1,12 @@
 use std::collections::BTreeMap;
 
-use anyhow::bail;
 use fedimint_core::config::{
     ClientModuleConfig, TypedClientModuleConfig, TypedServerModuleConfig,
     TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::{Amount, PeerId, Tiered};
-use itertools::Itertools;
+use fedimint_core::{PeerId, Tiered};
 use serde::{Deserialize, Serialize};
 use tbs::{AggregatePublicKey, PublicKeyShare};
 
@@ -84,32 +82,6 @@ impl TypedServerModuleConfig for MintConfig {
 
     fn to_parts(self) -> (ModuleKind, Self::Local, Self::Private, Self::Consensus) {
         (KIND, (), self.private, self.consensus)
-    }
-
-    fn validate_config(&self, identity: &PeerId) -> anyhow::Result<()> {
-        let sks: BTreeMap<Amount, PublicKeyShare> = self
-            .private
-            .tbs_sks
-            .iter()
-            .map(|(amount, sk)| (amount, sk.to_pub_key_share()))
-            .collect();
-        let pks: BTreeMap<Amount, PublicKeyShare> = self
-            .consensus
-            .peer_tbs_pks
-            .get(identity)
-            .unwrap()
-            .as_map()
-            .iter()
-            .map(|(k, v)| (*k, *v))
-            .collect();
-        if sks != pks {
-            bail!("Mint private key doesn't match pubkey share");
-        }
-        if !sks.keys().contains(&Amount::from_msats(1)) {
-            bail!("No msat 1 denomination");
-        }
-
-        Ok(())
     }
 }
 

--- a/modules/fedimint-wallet-common/src/config.rs
+++ b/modules/fedimint-wallet-common/src/config.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use anyhow::{bail, format_err};
 use bitcoin::Network;
 use fedimint_core::config::{
     TypedClientModuleConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
@@ -114,22 +113,6 @@ impl TypedServerModuleConfig for WalletConfig {
 
     fn to_parts(self) -> (ModuleKind, Self::Local, Self::Private, Self::Consensus) {
         (crate::KIND, self.local, self.private, self.consensus)
-    }
-
-    fn validate_config(&self, identity: &PeerId) -> anyhow::Result<()> {
-        let pubkey = secp256k1::PublicKey::from_secret_key_global(&self.private.peg_in_key);
-
-        if self
-            .consensus
-            .peer_peg_in_keys
-            .get(identity)
-            .ok_or_else(|| format_err!("Secret key doesn't match any public key"))?
-            != &CompressedPublicKey::new(pubkey)
-        {
-            bail!(" Bitcoin wallet private key doesn't match multisig pubkey");
-        }
-
-        Ok(())
     }
 }
 

--- a/modules/fedimint-wallet-common/src/config.rs
+++ b/modules/fedimint-wallet-common/src/config.rs
@@ -3,8 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::{bail, format_err};
 use bitcoin::Network;
 use fedimint_core::config::{
-    ClientModuleConfig, TypedClientModuleConfig, TypedServerModuleConfig,
-    TypedServerModuleConsensusConfig,
+    TypedClientModuleConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -91,20 +90,6 @@ impl Default for FeeConsensus {
 }
 
 impl TypedServerModuleConsensusConfig for WalletConfigConsensus {
-    fn to_client_config(&self) -> ClientModuleConfig {
-        ClientModuleConfig::from_typed(
-            crate::KIND,
-            crate::CONSENSUS_VERSION,
-            &WalletClientConfig {
-                peg_in_descriptor: self.peg_in_descriptor.clone(),
-                network: self.network,
-                fee_consensus: self.fee_consensus.clone(),
-                finality_delay: self.finality_delay,
-            },
-        )
-        .expect("Serialization can't fail")
-    }
-
     fn kind(&self) -> ModuleKind {
         crate::KIND
     }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -5,6 +5,7 @@ use std::ops::Sub;
 #[cfg(not(target_family = "wasm"))]
 use std::time::Duration;
 
+use anyhow::{bail, format_err};
 use bitcoin::hashes::{sha256, Hash as BitcoinHash, HashEngine, Hmac, HmacEngine};
 use bitcoin::policy::DEFAULT_MIN_RELAY_TX_FEE;
 use bitcoin::secp256k1::{All, Secp256k1, Verification};
@@ -178,7 +179,20 @@ impl ServerModuleGen for WalletGen {
     }
 
     fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
-        config.to_typed::<WalletConfig>()?.validate_config(identity)
+        let config = config.to_typed::<WalletConfig>()?;
+        let pubkey = secp256k1::PublicKey::from_secret_key_global(&config.private.peg_in_key);
+
+        if config
+            .consensus
+            .peer_peg_in_keys
+            .get(identity)
+            .ok_or_else(|| format_err!("Secret key doesn't match any public key"))?
+            != &CompressedPublicKey::new(pubkey)
+        {
+            bail!(" Bitcoin wallet private key doesn't match multisig pubkey");
+        }
+
+        Ok(())
     }
 
     fn get_client_config(


### PR DESCRIPTION
This refactor inlines some of the config functions to eliminate unnecessary indirection and move implementations to where it makes sense (on the server side).  This will also help us eventually replace the config module boilerplate with macros.