### PR TITLE
feature: config gen modifications based on UI feedback

### DIFF
--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use bitcoin_hashes::sha256;
@@ -73,16 +73,6 @@ impl WsAdminClient {
             .await
     }
 
-    /// During config gen, waits to receive server connections from a number of
-    /// `peers`
-    pub async fn await_config_gen_peers(
-        &self,
-        peers: usize,
-    ) -> FederationResult<Vec<PeerServerParams>> {
-        self.request("await_config_gen_peers", ApiRequestErased::new(peers))
-            .await
-    }
-
     /// Sends a signal to consensus that we are ready to shutdown the federation
     /// and upgrade
     pub async fn signal_upgrade(&self) -> FederationResult<()> {
@@ -142,25 +132,15 @@ impl WsAdminClient {
     /// Runs DKG, can only be called once after configs have been generated in
     /// `get_consensus_config_gen_params`.  If DKG fails this returns a 500
     /// error and config gen must be restarted.
-    pub async fn run_dkg(&self) -> FederationResult<ConfigGenParamsConsensus> {
+    pub async fn run_dkg(&self) -> FederationResult<()> {
         self.request_auth("run_dkg", ApiRequestErased::default())
             .await
     }
 
     /// After DKG, returns the hash of the consensus config tweaked with our id.
     /// We need to share this with all other peers to complete verification.
-    pub async fn get_verify_config_hash(&self) -> FederationResult<sha256::Hash> {
+    pub async fn get_verify_config_hash(&self) -> FederationResult<BTreeMap<PeerId, sha256::Hash>> {
         self.request_auth("get_verify_config_hash", ApiRequestErased::default())
-            .await
-    }
-
-    /// After we exchange verification hashes with other peers, we call this to
-    /// confirm we all have the same consensus configs.
-    pub async fn verify_configs(
-        &self,
-        user_hashes: BTreeSet<sha256::Hash>,
-    ) -> FederationResult<()> {
-        self.request_auth("verify_configs", ApiRequestErased::new(user_hashes))
             .await
     }
 
@@ -208,8 +188,14 @@ impl WsAdminClient {
 pub enum ServerStatus {
     /// Server needs a password to read configs
     AwaitingPassword,
-    /// Configs were not found, need to run config gen
-    GeneratingConfig,
+    /// Waiting for peers to share the config gen params
+    SharingConfigGenParams,
+    /// Ready to run config gen once all peers are ready
+    ReadyForConfigGen,
+    /// We failed running config gen
+    ConfigGenFailed,
+    /// Config is generated, peers should verify the config
+    VerifyingConfigs,
     /// Restarted from a planned upgrade (requires action to start)
     Upgrading,
     /// Consensus is running
@@ -238,6 +224,8 @@ pub struct PeerServerParams {
     pub api_url: Url,
     /// Name of the peer, used in TLS auth
     pub name: String,
+    /// Status of the peer if known
+    pub status: Option<ServerStatus>,
 }
 
 /// The config gen params that need to be in consensus, sent by the config gen

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -82,6 +82,7 @@ pub fn parse_peer_params(url: String) -> anyhow::Result<PeerServerParams> {
         p2p_url,
         api_url,
         name: split[2].to_string(),
+        status: None,
     })
 }
 

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -180,6 +180,7 @@ fn local_config_gen_params(
                 p2p_url: p2p_url.parse().expect("Should parse"),
                 api_url: api_url.parse().expect("Should parse"),
                 name: format!("peer-{}", peer.to_usize()),
+                status: None,
             };
             (*peer, params)
         })

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -451,6 +451,7 @@ pub fn gen_local(
                 p2p_url: p2p_url.parse().expect("Should parse"),
                 api_url: api_url.parse().expect("Should parse"),
                 name: format!("peer-{}", peer.to_usize()),
+                status: None,
             };
             (*peer, params)
         })


### PR DESCRIPTION
- Makes `get_consensus_config_gen_params` return all peers with `ServerStatus`
- Adds new statuses `SharingConfigGenParams`, `ReadyForConfigGen`, `ConfigGenFailed`, `VerifyingConfigs`
- Doesn’t fail when auth is unnecessarily passed in
- Returns all verification codes, leaves checking verification up to the UI

Also simplifies how we handle state.