### PR TITLE
fix: remove flaky lightning reconnect test

### DIFF
--- a/scripts/lightning-reconnect-test.sh
+++ b/scripts/lightning-reconnect-test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Runs a test to see what happens if a lightning node that is connected to a gateway dies
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+source ./scripts/build.sh
+
+devimint lightning-reconnect-test

--- a/scripts/test-ci-all.sh
+++ b/scripts/test-ci-all.sh
@@ -37,6 +37,16 @@ function cli_test_reconnect() {
 }
 export -f cli_test_reconnect
 
+function cli_test_lightning_reconnect() {
+  set -eo pipefail # pipefail must be set manually again
+  trap 'echo "## FAILED: ${FUNCNAME[0]}"' ERR 
+
+  echo "## START: ${FUNCNAME[0]}"
+  unshare -rn bash -c "ip link set lo up && exec unshare --user ./scripts/lightning-reconnect-test.sh" 2>&1 | ts -s
+  echo "## COMPLETE: ${FUNCNAME[0]}"
+}
+export -f cli_test_lightning_reconnect
+
 function cli_test_latency() {
   set -eo pipefail # pipefail must be set manually again
   trap 'echo "## FAILED: ${FUNCNAME[0]}"' ERR 
@@ -124,6 +134,7 @@ if parallel \
   cli_test_rust_tests_esplora \
   cli_test_latency \
   cli_test_reconnect \
+  cli_test_lightning_reconnect \
   cli_test_cli ; then
   >&2 echo "All tests successful"
 else


### PR DESCRIPTION
This PR removes the flakey lightning gateway reconnect test and re-writes it using `devimint`.