### PR TITLE
fix: missing ln module id in ln client

### DIFF
--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -5,7 +5,7 @@ use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, State
 use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::config::FederationId;
-use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
+use fedimint_core::core::{LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
 use fedimint_core::{Amount, TransactionId};
@@ -297,6 +297,7 @@ impl LightningPayFunded {
             Err(GatewayPayError::GatewayInternalError) => {
                 let contract = global_context
                     .api()
+                    .with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
                     .get_outgoing_contract(contract_id)
                     .await;
                 let timelock = match contract {
@@ -406,6 +407,7 @@ impl LightningPayRefundable {
         loop {
             let contract = global_context
                 .api()
+                .with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
                 .get_outgoing_contract(contract_id)
                 .await;
             if let Ok(contract) = contract {

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -6,6 +6,7 @@ use bitcoin::util::key::KeyPair;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, StateTransition};
 use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
+use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
 use fedimint_core::{Amount, OutPoint, TransactionId};
@@ -197,6 +198,7 @@ impl LightningReceiveConfirmedInvoice {
             let contract_id = (*invoice.payment_hash()).into();
             let contract = global_context
                 .api()
+                .with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
                 .get_incoming_contract(contract_id)
                 .await;
 


### PR DESCRIPTION
Follow on after https://github.com/fedimint/fedimint/pull/2400

https://github.com/fedimint/fedimint/pull/2390 broke new client and we didn't notice it because it's not well-tested yet.

You have to manually test this in mprocs / tmuxinator. Before this commit, `fedimint-cli ng ln-invoice` will never succeed. After this commit, it succeeds right after the invoice is paid.