### PR TITLE
build(deps): bump askama from 0.11.1 to 0.12.0 and askama_axum from 0.2.1 to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,22 +137,11 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "askama"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb98f10f371286b177db5eeb9a6e5396609555686a35e1d4f7b9a9c6d8af0139"
-dependencies = [
- "askama_derive 0.11.2",
- "askama_escape",
- "askama_shared",
-]
-
-[[package]]
-name = "askama"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47cbc3cf73fa8d9833727bbee4835ba5c421a0d65b72daf9a7b5d0e0f9cfb57e"
 dependencies = [
- "askama_derive 0.12.1",
+ "askama_derive",
  "askama_escape",
  "humansize",
  "num-traits",
@@ -161,24 +150,13 @@ dependencies = [
 
 [[package]]
 name = "askama_axum"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780920656d4e3c8fc3999c1059cb036416423376b814fe8690dbd8c04308aba1"
+checksum = "07b336dea26a2eb67f04e1134385721f794b654a870ce5146d2fcb69ea39c3a4"
 dependencies = [
- "askama 0.11.1",
+ "askama",
  "axum-core",
  "http",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bf87e6e8b47264efa9bde63d6225c6276a52e05e91bf37eaa8afd0032d6b71"
-dependencies = [
- "askama_shared",
- "proc-macro2",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -202,21 +180,6 @@ name = "askama_escape"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
-name = "askama_shared"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf722b94118a07fcbc6640190f247334027685d4e218b794dbfe17c32bf38ed0"
-dependencies = [
- "askama_escape",
- "mime",
- "mime_guess",
- "nom",
- "proc-macro2",
- "quote 1.0.26",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "assert_matches"
@@ -1875,7 +1838,7 @@ name = "fedimintd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "askama 0.12.0",
+ "askama",
  "askama_axum",
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,22 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb98f10f371286b177db5eeb9a6e5396609555686a35e1d4f7b9a9c6d8af0139"
 dependencies = [
- "askama_derive",
+ "askama_derive 0.11.2",
  "askama_escape",
  "askama_shared",
+]
+
+[[package]]
+name = "askama"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47cbc3cf73fa8d9833727bbee4835ba5c421a0d65b72daf9a7b5d0e0f9cfb57e"
+dependencies = [
+ "askama_derive 0.12.1",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -152,7 +165,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780920656d4e3c8fc3999c1059cb036416423376b814fe8690dbd8c04308aba1"
 dependencies = [
- "askama",
+ "askama 0.11.1",
  "axum-core",
  "http",
 ]
@@ -169,6 +182,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22fbe0413545c098358e56966ff22cdd039e10215ae213cfbd65032b119fc94"
+dependencies = [
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "nom",
+ "proc-macro2",
+ "quote 1.0.26",
+ "serde",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "askama_escape"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,17 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf722b94118a07fcbc6640190f247334027685d4e218b794dbfe17c32bf38ed0"
 dependencies = [
  "askama_escape",
- "humansize",
  "mime",
  "mime_guess",
  "nom",
- "num-traits",
- "percent-encoding",
  "proc-macro2",
  "quote 1.0.26",
- "serde",
  "syn 1.0.109",
- "toml",
 ]
 
 [[package]]
@@ -376,6 +400,15 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bech32"
@@ -1842,7 +1875,7 @@ name = "fedimintd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.12.0",
  "askama_axum",
  "async-trait",
  "axum",
@@ -2396,9 +2429,12 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humansize"
-version = "1.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -4994,15 +5030,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -60,7 +60,7 @@ threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 
 # setup dependencies
 askama = "0.12.0"
-askama_axum = "0.2.1"
+askama_axum = "0.3.0"
 axum = { version = "0.6.4", default-features = false, features = [ "form", "tokio" ] }
 axum-macros = "0.3.1"
 http = "0.2"

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -59,7 +59,7 @@ url = { version = "2.3.1", features = ["serde"] }
 threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 
 # setup dependencies
-askama = "0.11.1"
+askama = "0.12.0"
 askama_axum = "0.2.1"
 axum = { version = "0.6.4", default-features = false, features = [ "form", "tokio" ] }
 axum-macros = "0.3.1"


### PR DESCRIPTION
## Description

The askama_axum/derive is used by the `Template`, that said at version 0.2.1 it still uses askama 0.11.x, it seems that was the problem that prevented it to build due to conflicts.

## How

- build(deps): bump askama from 0.11.1 to 0.12.0  (cherry-picked and rebased from https://github.com/fedimint/fedimint/pull/1915/commits/dea8a57da0f8352c0d069c8f1e1e032d8f63b132)
- build(deps): bump askama_axum from 0.2.1 to 0.3.0


**NOTE:** I have not tested it yet by running the setup UI locally

   
fixes #1915 