### PR TITLE
feat: module (mint in particular) backup for new client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
@@ -114,7 +114,7 @@ dependencies = [
  "itertools",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -170,7 +170,7 @@ dependencies = [
  "mime_guess",
  "nom",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "serde",
  "syn 2.0.15",
 ]
@@ -214,7 +214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 2.0.15",
 ]
 
@@ -225,7 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 2.0.15",
 ]
 
@@ -257,9 +257,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b70caf9f1b0c045f7da350636435b775a9733adf2df56e8aa2a29210fbc335d4"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -314,7 +314,7 @@ checksum = "2bb524613be645939e280b7279f7b017f98cf7f5ef084ec374df373530e73277"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 2.0.15",
 ]
 
@@ -413,7 +413,7 @@ dependencies = [
  "peeking_take_while",
  "prettyplease 0.2.4",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "regex",
  "rustc-hash",
  "shlex",
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "bytemuck"
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -636,7 +636,7 @@ checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 2.0.15",
 ]
 
@@ -695,21 +695,21 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console-api"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
  "prost 0.11.9",
  "prost-types 0.11.9",
- "tonic 0.8.3",
+ "tonic 0.9.2",
  "tracing-core",
 ]
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+checksum = "57ab2224a0311582eb03adba4caaf18644f7b1f10a760803a803b9b605187fc7"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -723,7 +723,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.8.3",
+ "tonic 0.9.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -877,7 +877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -1158,7 +1158,9 @@ dependencies = [
  "anyhow",
  "aquamarine",
  "async-trait",
+ "bitcoin",
  "bitcoin_hashes",
+ "fedimint-aead",
  "fedimint-core",
  "fedimint-derive-secret",
  "fedimint-logging",
@@ -1203,8 +1205,8 @@ dependencies = [
  "futures",
  "hkdf 0.1.0",
  "itertools",
- "jsonrpsee-core 0.18.0",
- "jsonrpsee-types 0.18.0",
+ "jsonrpsee-core 0.18.2",
+ "jsonrpsee-types 0.18.2",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "lightning",
@@ -1252,8 +1254,8 @@ dependencies = [
  "hex",
  "itertools",
  "js-sys",
- "jsonrpsee-core 0.18.0",
- "jsonrpsee-types 0.18.0",
+ "jsonrpsee-core 0.18.2",
+ "jsonrpsee-types 0.18.2",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "lightning-invoice",
@@ -1312,7 +1314,7 @@ version = "0.1.0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -1561,6 +1563,7 @@ dependencies = [
  "fedimint-client",
  "fedimint-core",
  "fedimint-derive-secret",
+ "fedimint-logging",
  "fedimint-mint-common",
  "futures",
  "itertools",
@@ -1568,6 +1571,7 @@ dependencies = [
  "secp256k1",
  "secp256k1-zkp",
  "serde",
+ "serde-big-array",
  "serde_json",
  "strum",
  "strum_macros",
@@ -1998,12 +2002,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.6.2",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2105,7 +2109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 2.0.15",
 ]
 
@@ -2604,7 +2608,7 @@ checksum = "4ffdf3b0bdfaa18798f4df71bc965704f63fba521b24d425cd61fb2bc771a77b"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -2624,7 +2628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
 ]
 
 [[package]]
@@ -2713,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2745,15 +2749,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831fcac9c366bb42a29316f3acb5e4647c79421c365b0d51858cc23bed5e45ff"
+checksum = "11aa5766d5c430b89cb26a99b88f3245eb91534be8126102cea9e45ee3891b22"
 dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
  "http",
- "jsonrpsee-core 0.18.0",
+ "jsonrpsee-core 0.18.2",
  "pin-project",
  "soketto",
  "thiserror",
@@ -2792,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff51260f9ba35587abb042bff2dd52abec8fa720c7539bf6c9dacf1689694fd"
+checksum = "64c6832a55f662b5a6ecc844db24b8b9c387453f923de863062c60ce33d62b81"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -2802,7 +2806,7 @@ dependencies = [
  "beef",
  "futures-timer",
  "futures-util",
- "jsonrpsee-types 0.18.0",
+ "jsonrpsee-types 0.18.2",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2851,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a88d44a6e9ced3fa614df1f8dcfb5ebd01145ec9f53dc5695227fd972cd0f54"
+checksum = "6e5bf6c75ce2a4217421154adfc65a24d2b46e77286e59bba5d9fa6544ccc8f4"
 dependencies = [
  "anyhow",
  "beef",
@@ -2865,32 +2869,32 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14b280d2a33e3a367dcad9e415daccbc55850763b61c204014d7ae5c0364253"
+checksum = "34e6ea7c6d862e60f8baebd946c037b70c6808a4e4e31e792a4029184e3ce13a"
 dependencies = [
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.18.0",
- "jsonrpsee-types 0.18.0",
+ "jsonrpsee-core 0.18.2",
+ "jsonrpsee-types 0.18.2",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5763897a1983625e24a7e9913cb8465603bf9ceb9c976d44bbd3dc600bd3e54c"
+checksum = "a64b2589680ba1ad7863f279cd2d5083c1dc0a7c0ea959d22924553050f8ab9f"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.18.0",
- "jsonrpsee-types 0.18.0",
+ "jsonrpsee-core 0.18.2",
+ "jsonrpsee-types 0.18.2",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -2912,9 +2916,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -2961,9 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2995,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "ln-gateway"
@@ -3079,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "macro_rules_attribute"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862"
+checksum = "7d60fb588bc69c63ca73ef13a72f297b190b2bcdcbfeb3426c47f46a8b52c00a"
 dependencies = [
  "macro_rules_attribute-proc_macro",
  "paste",
@@ -3089,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "macro_rules_attribute-proc_macro"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+checksum = "89b794c7110bd4f9dcc86c766de9af20ff10aa4517c3651f7320b38cd121dbca"
 
 [[package]]
 name = "matchers"
@@ -3565,7 +3569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -3605,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "png"
@@ -3665,7 +3669,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
  "version_check",
 ]
@@ -3677,7 +3681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "version_check",
 ]
 
@@ -3769,7 +3773,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -3782,7 +3786,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -3795,7 +3799,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -3843,9 +3847,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -4030,9 +4034,9 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4148,9 +4152,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.14"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -4187,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
  "log",
  "ring",
@@ -4303,21 +4307,30 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.160"
+name = "serde-big-array"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 2.0.15",
 ]
 
@@ -4390,9 +4403,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -4579,7 +4592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc85657a884039f91145da1adbf2922fd759e3bbc58f60113a9e2263511531f5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "sqlx-core",
  "sqlx-macros-core",
  "syn 1.0.109",
@@ -4597,7 +4610,7 @@ dependencies = [
  "hex",
  "once_cell",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "serde",
  "serde_json",
  "sha2",
@@ -4747,7 +4760,7 @@ checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -4776,7 +4789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "unicode-ident",
 ]
 
@@ -4787,7 +4800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "unicode-ident",
 ]
 
@@ -4857,7 +4870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -4877,7 +4890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 2.0.15",
 ]
 
@@ -4903,7 +4916,7 @@ dependencies = [
 [[package]]
 name = "threshold_crypto"
 version = "0.4.0"
-source = "git+https://github.com/fedimint/threshold_crypto#f5b283e74268f566eae7439a2b82bef14cdd0b2a"
+source = "git+https://github.com/fedimint/threshold_crypto#9b0eeec8f23f41a385174c0d84290cbf8d88a656"
 dependencies = [
  "bls12_381",
  "byteorder",
@@ -4936,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "serde",
  "time-core",
@@ -4946,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "tiny-keccak"
@@ -4976,9 +4989,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5011,7 +5024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 2.0.15",
 ]
 
@@ -5043,7 +5056,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
- "rustls 0.21.0",
+ "rustls 0.21.1",
  "tokio",
 ]
 
@@ -5061,9 +5074,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cd2598a37719e3cd4c28af93f978506a97a2920ef4d96e4b12e38b8cbc8940"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5166,6 +5179,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.11.9",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5173,7 +5214,7 @@ checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
 dependencies = [
  "proc-macro2",
  "prost-build 0.8.0",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -5186,7 +5227,7 @@ dependencies = [
  "prettyplease 0.1.25",
  "proc-macro2",
  "prost-build 0.11.9",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -5259,10 +5300,11 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -5276,7 +5318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 2.0.15",
 ]
 
@@ -5373,7 +5415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
 dependencies = [
  "lazy_static",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -5493,7 +5535,7 @@ dependencies = [
  "lazy_static",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.26",
+ "quote 1.0.27",
  "regex",
  "syn 1.0.109",
  "validator_types",
@@ -5545,9 +5587,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5555,24 +5597,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
- "quote 1.0.26",
- "syn 1.0.109",
+ "quote 1.0.27",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "083abe15c5d88556b77bdf7aef403625be9e327ad37c62c4e4129af740168163"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5582,38 +5624,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
 dependencies = [
- "quote 1.0.26",
+ "quote 1.0.27",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.26",
- "syn 1.0.109",
+ "quote 1.0.27",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -1,9 +1,10 @@
-use std::ffi;
 use std::str::FromStr;
 use std::time::Duration;
 
+use anyhow::bail;
 use bitcoin::secp256k1;
 use clap::Subcommand;
+use fedimint_client::backup::Metadata;
 use fedimint_client::sm::OperationId;
 use fedimint_client::Client;
 use fedimint_core::config::ClientConfig;
@@ -18,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::info;
 
-use crate::LnInvoiceResponse;
+use crate::{metadata_from_clap_cli, LnInvoiceResponse};
 
 #[derive(Debug, Clone)]
 pub enum ModuleSelector {
@@ -68,15 +69,23 @@ pub enum ClientNg {
         #[clap(value_parser = parse_node_pub_key)]
         pubkey: secp256k1::PublicKey,
     },
-    /// Call module-specific commands
-    Mod {
-        #[clap(long)]
-        id: ModuleSelector,
-
-        /// Command with arguments to call the module with
-        #[clap(long)]
-        arg: Vec<ffi::OsString>,
+    /// Upload the (encrypted) snapshot of mint notes to federation
+    Backup {
+        #[clap(long = "metadata")]
+        /// Backup metadata, encoded as `key=value` (use `--metadata=key=value`,
+        /// possibly multiple times)
+        // TODO: Can we make it `*Map<String, String>` and avoid custom parsing?
+        metadata: Vec<String>,
     },
+    /// Wipe the state of the client (mostly for testing purposes)
+    #[clap(hide = true)]
+    Wipe {
+        #[clap(long)]
+        force: bool,
+    },
+    /// Restore the previously created backup of mint notes (with `backup`
+    /// command)
+    Restore,
 }
 
 pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Error> {
@@ -215,17 +224,22 @@ pub async fn handle_ng_command(
             gateway_json["active"] = json!(true);
             Ok(serde_json::to_value(gateway_json).unwrap())
         }
-        ClientNg::Mod { id, arg } => {
-            let (id, _) = match id {
-                ModuleSelector::Id(id) => (id, config.get_module_cfg(id)?),
-                ModuleSelector::Kind(kind) => config.get_first_module_by_kind_cfg(kind)?,
-            };
 
-            let module = client
-                .get_module_client_dyn(id)
-                .expect("Module exists according to cfg");
+        ClientNg::Backup { metadata } => {
+            let metadata = metadata_from_clap_cli(metadata)?;
 
-            Ok(module.handle_cli_command(&client, &arg).await?)
+            client
+                .backup_to_federation(Metadata::from_json_serialized(metadata))
+                .await?;
+            Ok(serde_json::to_value(()).unwrap())
+        }
+        ClientNg::Restore => Ok(client.restore_from_backup().await?.to_json_value()?),
+        ClientNg::Wipe { force } => {
+            if !force {
+                bail!("This will wipe the state of the client irrecoverably. Use `--force` to proceed.")
+            }
+            client.wipe_state().await?;
+            Ok(serde_json::to_value(()).unwrap())
         }
     }
 }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -18,9 +18,11 @@ path = "src/lib.rs"
 anyhow = "1.0.69"
 aquamarine = "0.3.1"
 async-trait = "0.1.66"
+bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 fedimint-core  = { path = "../fedimint-core/" }
 fedimint-derive-secret = { path = "../crypto/derive-secret" }
+fedimint-aead = { path = "../crypto/aead" }
 fedimint-logging = { path = "../fedimint-logging" }
 futures = "0.3.26"
 itertools = "0.10.5"

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -1,0 +1,421 @@
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use bitcoin::secp256k1;
+use fedimint_core::api::GlobalFederationApi;
+use fedimint_core::core::backup::{BackupRequest, SignedBackupRequest};
+use fedimint_core::core::ModuleInstanceId;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_derive_secret::DerivableSecret;
+use fedimint_logging::{LOG_CLIENT, LOG_CLIENT_BACKUP, LOG_CLIENT_RECOVERY};
+use secp256k1_zkp::{KeyPair, Secp256k1};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+use super::Client;
+use crate::secret::DeriveableSecretClientExt;
+
+/// Backup metadata
+///
+/// A backup can have a blob of extra data encoded in it. We provide methods to
+/// use json encoding, but clients are free to use their own encoding.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Encodable, Decodable, Clone)]
+pub struct Metadata(Vec<u8>);
+
+impl Metadata {
+    /// Create empty metadata
+    pub fn empty() -> Self {
+        Self(vec![])
+    }
+
+    pub fn from_raw(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    pub fn into_raw(self) -> Vec<u8> {
+        self.0
+    }
+
+    /// Is metadata empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Create metadata as json from typed `val`
+    pub fn from_json_serialized<T: Serialize>(val: T) -> Self {
+        Self(serde_json::to_vec(&val).expect("serializing to vec can't fail"))
+    }
+
+    /// Attempt to deserialize metadata as typed json
+    pub fn to_json_deserialized<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
+        Ok(serde_json::from_slice(&self.0)?)
+    }
+
+    /// Attempt to deserialize metadata as untyped json (`serde_json::Value`)
+    pub fn to_json_value(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::from_slice(&self.0)?)
+    }
+}
+
+/// Client state backup
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Encodable, Decodable)]
+pub struct ClientBackup {
+    /// Epoch count taken right before taking the backup
+    epoch_count: u64,
+    /// Application metadata
+    metadata: Metadata,
+    /// Module specific-backup (if supported)
+    modules: BTreeMap<ModuleInstanceId, Vec<u8>>,
+}
+
+impl ClientBackup {
+    /// Align an ecoded message size up for better privacy
+    fn get_alignment_size(len: usize) -> usize {
+        let padding_alignment = 16 * 1024;
+        ((len.saturating_sub(1) / padding_alignment) + 1) * padding_alignment
+    }
+
+    /// Encode `self` to a padded (but still plaintext) message
+    fn encode(&self) -> Result<Vec<u8>> {
+        let mut bytes = self.consensus_encode_to_vec()?;
+
+        let padding_size = Self::get_alignment_size(bytes.len()) - bytes.len();
+
+        bytes.extend(std::iter::repeat(0u8).take(padding_size));
+
+        Ok(bytes)
+    }
+
+    /// Decode from a plaintexet (possibly aligned) message
+    fn decode(msg: &[u8]) -> Result<Self> {
+        Ok(Decodable::consensus_decode(
+            &mut &msg[..],
+            &ModuleDecoderRegistry::default(),
+        )?)
+    }
+
+    /// Encrypt with a key and turn into [`EncryptedClientBackup`]
+    pub fn encrypt_to(&self, key: &fedimint_aead::LessSafeKey) -> Result<EncryptedClientBackup> {
+        let encoded = self.encode()?;
+
+        let encrypted = fedimint_aead::encrypt(encoded, key)?;
+        Ok(EncryptedClientBackup(encrypted))
+    }
+}
+
+/// Encrypted version of [`ClientBackup`].
+pub struct EncryptedClientBackup(Vec<u8>);
+
+impl EncryptedClientBackup {
+    pub fn decrypt_with(mut self, key: &fedimint_aead::LessSafeKey) -> Result<ClientBackup> {
+        let decrypted = fedimint_aead::decrypt(&mut self.0, key)?;
+        ClientBackup::decode(decrypted)
+    }
+
+    pub fn into_backup_request(self, keypair: &KeyPair) -> Result<SignedBackupRequest> {
+        let request = BackupRequest {
+            id: keypair.x_only_public_key().0,
+            timestamp: fedimint_core::time::now(),
+            payload: self.0,
+        };
+
+        request.sign(keypair)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Client {
+    /// Create a backup, include provided `metadata`
+    pub async fn create_backup(&self, metadata: Metadata) -> anyhow::Result<ClientBackup> {
+        let epoch_count = self.inner.api.fetch_epoch_count().await?;
+        let mut modules = BTreeMap::new();
+        let mut dbtx = self.db().begin_transaction().await;
+        for (id, kind, module) in self.inner.modules.iter_modules() {
+            debug!(target: LOG_CLIENT_BACKUP, module_id=id, module_kind=%kind, "Preparing module backup");
+            if module.supports_backup() {
+                let backup = module
+                    .backup(
+                        &mut dbtx.with_module_prefix(id),
+                        self.inner.executor.clone(),
+                        self.inner.api.clone(),
+                        id,
+                    )
+                    .await?;
+
+                info!(target: LOG_CLIENT_BACKUP, module_id=id, module_kind=%kind, size=backup.len(), "Prepared module backup");
+                modules.insert(id, backup);
+            } else {
+                info!(target: LOG_CLIENT_BACKUP, module_id=id, module_kind=%kind, "Module does not support backup");
+            }
+        }
+
+        {
+            let module = &self.inner.primary_module;
+            let id = self.inner.primary_module_instance;
+            let kind = self.inner.primary_module_kind.clone();
+
+            debug!(target: LOG_CLIENT_BACKUP, module_id=id, module_kind=%kind, "Preparing primary module backup");
+            if module.supports_backup() {
+                let backup = module
+                    .backup(
+                        &mut dbtx.with_module_prefix(id),
+                        self.inner.executor.clone(),
+                        self.inner.api.clone(),
+                        id,
+                    )
+                    .await?;
+
+                info!(target: LOG_CLIENT_BACKUP, module_id=id, module_kind=%kind, size=backup.len(), "Prepared primary module backup");
+                modules.insert(id, backup);
+            } else {
+                info!(target: LOG_CLIENT_BACKUP, module_id=id, module_kind=%kind, "Primary module does not support backup");
+            }
+        }
+        dbtx.commit_tx().await;
+
+        Ok(ClientBackup {
+            metadata,
+            modules,
+            epoch_count,
+        })
+    }
+
+    /// Create a backup, include provided `metadata`, and encrypt it with a
+    /// (derived) client root key
+    pub async fn create_encrypted_backup(
+        &self,
+        metadata: Metadata,
+    ) -> Result<EncryptedClientBackup> {
+        let plaintext = self.create_backup(metadata).await?;
+        plaintext.encrypt_to(&self.get_derived_backup_encryption_key())
+    }
+
+    /// Prepare an encrypted backup and send it to federation for storing
+    pub async fn backup_to_federation(&self, metadata: Metadata) -> Result<()> {
+        let backup = self.create_encrypted_backup(metadata).await?;
+
+        self.upload_backup(backup).await?;
+
+        Ok(())
+    }
+
+    /// Wipe the client state (including module state)
+    pub async fn wipe_state(&self) -> Result<()> {
+        let mut dbtx = self.db().begin_transaction().await;
+        for (id, kind, module) in self.inner.modules.iter_modules() {
+            if !module.supports_backup() {
+                continue;
+            }
+
+            info!(
+                target: LOG_CLIENT,
+                module_kind = %kind,
+                module_id = id,
+                "Wiping module state"
+            );
+            module
+                .wipe(
+                    &mut dbtx.with_module_prefix(id),
+                    id,
+                    self.inner.executor.clone(),
+                )
+                .await?;
+        }
+
+        {
+            let module = &self.inner.primary_module;
+            let id = self.inner.primary_module_instance;
+            let kind = self.inner.primary_module_kind.clone();
+
+            if module.supports_backup() {
+                info!(
+                    target: LOG_CLIENT,
+                    module_kind = %kind,
+                    module_id = id,
+                    "Wiping primary module state"
+                );
+                module
+                    .wipe(
+                        &mut dbtx.with_module_prefix(id),
+                        id,
+                        self.inner.executor.clone(),
+                    )
+                    .await?;
+            }
+        }
+        dbtx.commit_tx().await;
+        Ok(())
+    }
+
+    /// Upload `backup` to federation
+    pub async fn upload_backup(&self, backup: EncryptedClientBackup) -> Result<()> {
+        let size = backup.len();
+        info!(
+            target: LOG_CLIENT_BACKUP,
+            size, "Uploading backup to federation"
+        );
+        let backup_request = backup.into_backup_request(&self.get_derived_backup_signing_key())?;
+        self.inner.api.upload_backup(&backup_request).await?;
+        info!(
+            target: LOG_CLIENT_BACKUP,
+            size, "Uploaded backup to federation"
+        );
+        Ok(())
+    }
+
+    /// Restore client state from backup download from federation (if found) or
+    /// from scratch
+    ///
+    /// This will restore (or initialize restoration process) in all sub-modules
+    /// that support it.
+    pub async fn restore_from_backup(&self) -> Result<Metadata> {
+        info!(target: LOG_CLIENT_RECOVERY, "Restoring from backup");
+        let backup = if let Some(backup) = self.download_backup_from_federation().await? {
+            info!(
+                target: LOG_CLIENT_RECOVERY,
+                epoch = backup.epoch_count,
+                "Found backup"
+            );
+            Some(backup)
+        } else {
+            warn!(
+                target: LOG_CLIENT_RECOVERY,
+                id=%self.get_backup_id(),
+                "Could not find any valid existing backup. Will attempt to restore from scratch. This might take a long time."
+            );
+            None
+        };
+
+        let metadata = backup
+            .as_ref()
+            .map(|b| b.metadata.clone())
+            .unwrap_or_else(Metadata::empty);
+
+        let mut dbtx = self.db().begin_transaction().await;
+        for (id, kind, module) in self.inner.modules.iter_modules() {
+            if !module.supports_backup() {
+                continue;
+            }
+            let module_backup = backup.as_ref().and_then(|b| b.modules.get(&id));
+
+            info!(
+                target: LOG_CLIENT_RECOVERY,
+                module_kind = %kind,
+                module_id = id,
+                "Starting recovery from backup for module"
+            );
+            module
+                .restore(
+                    &mut dbtx,
+                    id,
+                    self.inner.executor.clone(),
+                    self.inner.api.clone(),
+                    module_backup.map(Vec::as_slice),
+                )
+                .await?;
+        }
+
+        {
+            let module = &self.inner.primary_module;
+            let id = self.inner.primary_module_instance;
+            let kind = self.inner.primary_module_kind.clone();
+
+            if module.supports_backup() {
+                let module_backup = backup.as_ref().and_then(|b| b.modules.get(&id));
+
+                info!(
+                    target: LOG_CLIENT_RECOVERY,
+                    module_kind = %kind,
+                    module_id = id,
+                    "Starting recovery from backup for primary module"
+                );
+                module
+                    .restore(
+                        &mut dbtx,
+                        id,
+                        self.inner.executor.clone(),
+                        self.inner.api.clone(),
+                        module_backup.map(Vec::as_slice),
+                    )
+                    .await?;
+            }
+        }
+        dbtx.commit_tx().await;
+        Ok(metadata)
+    }
+
+    /// Download most recent valid backup found from the Federation
+    pub async fn download_backup_from_federation(&self) -> Result<Option<ClientBackup>> {
+        let mut responses: Vec<_> = self
+            .inner
+            .api
+            .download_backup(&self.get_backup_id())
+            .await?
+            .into_iter()
+            .filter_map(|backup| {
+                match EncryptedClientBackup(backup.data)
+                    .decrypt_with(&self.get_derived_backup_encryption_key())
+                {
+                    Ok(valid) => Some(valid),
+                    Err(e) => {
+                        warn!(
+                            target: LOG_CLIENT_RECOVERY,
+                            "Invalid backup returned by one of the peers: {e}"
+                        );
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        debug!(
+            target: LOG_CLIENT_RECOVERY,
+            "Received {} valid responses",
+            responses.len()
+        );
+        // Use the newest (highest epoch)
+        responses.sort_by_key(|backup| Reverse(backup.epoch_count));
+
+        Ok(responses.into_iter().next())
+    }
+
+    /// Backup id derived from the root secret key (public key used to self-sign
+    /// backup requests)
+    pub fn get_backup_id(&self) -> bitcoin::XOnlyPublicKey {
+        self.get_derived_backup_signing_key().x_only_public_key().0
+    }
+
+    /// Static version of [`Self::get_derived_backup_encryption_key`] for
+    /// testing without creating whole `MintClient`
+    fn get_derived_backup_encryption_key_static(
+        secret: &DerivableSecret,
+    ) -> fedimint_aead::LessSafeKey {
+        fedimint_aead::LessSafeKey::new(secret.derive_backup_secret().to_chacha20_poly1305_key())
+    }
+
+    /// Static version of [`Self::get_derived_backup_signing_key`] for testing
+    /// without creating whole `MintClient`
+    fn get_derived_backup_signing_key_static(secret: &DerivableSecret) -> secp256k1_zkp::KeyPair {
+        secret
+            .derive_backup_secret()
+            .to_secp_key(&Secp256k1::<secp256k1::SignOnly>::gen_new())
+    }
+
+    fn get_derived_backup_encryption_key(&self) -> fedimint_aead::LessSafeKey {
+        Self::get_derived_backup_encryption_key_static(&self.root_secret())
+    }
+
+    fn get_derived_backup_signing_key(&self) -> secp256k1::KeyPair {
+        Self::get_derived_backup_signing_key_static(&self.root_secret())
+    }
+}

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -75,6 +75,10 @@ where
         ExecutorBuilder::default()
     }
 
+    pub async fn get_active_states(&self) -> Vec<(DynState<GC>, ActiveState)> {
+        self.inner.get_active_states().await
+    }
+
     /// Adds a number of state machines to the executor atomically. They will be
     /// driven to completion automatically in the background.
     ///

--- a/fedimint-client/src/sm/mod.rs
+++ b/fedimint-client/src/sm/mod.rs
@@ -16,6 +16,7 @@ pub use executor::{ActiveState, Executor, ExecutorBuilder, InactiveState};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 pub use notifier::{ModuleNotifier, Notifier};
+use rand::RngCore;
 use serde::{Deserialize, Deserializer, Serialize};
 pub use state::{Context, DynContext, DynState, IState, OperationState, State, StateTransition};
 
@@ -49,6 +50,16 @@ impl GlobalContext for () {}
 /// 256bit value collisions are impossible for all intents and purposes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub struct OperationId(pub [u8; 32]);
+
+impl OperationId {
+    /// Generate random [`OperationId`]
+    pub fn new_random() -> Self {
+        let mut rng = rand::thread_rng();
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+}
 
 impl Display for OperationId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -231,6 +231,7 @@ mod tests {
 
     use async_trait::async_trait;
     use fedimint_core::api::{DynFederationApi, IFederationApi, JsonRpcResult};
+    use fedimint_core::config::ClientConfig;
     use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, ModuleKind};
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::Database;
@@ -255,16 +256,16 @@ mod tests {
         InstancelessDynClientOutput,
     };
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     struct FakeApiClient {
-        txns: Mutex<Vec<TransactionId>>,
+        txns: Arc<Mutex<Vec<TransactionId>>>,
         fake_peers: BTreeSet<PeerId>,
     }
 
     impl Default for FakeApiClient {
         fn default() -> Self {
             FakeApiClient {
-                txns: Mutex::new(vec![]),
+                txns: Arc::new(Mutex::new(vec![])),
                 fake_peers: vec![PeerId::from(0)].into_iter().collect(),
             }
         }
@@ -370,6 +371,14 @@ mod tests {
             &self.api
         }
 
+        fn client_config(&self) -> &ClientConfig {
+            unimplemented!()
+        }
+
+        fn decoders(&self) -> &ModuleDecoderRegistry {
+            unimplemented!()
+        }
+
         fn module_api(&self) -> DynFederationApi {
             unimplemented!()
         }
@@ -433,7 +442,7 @@ mod tests {
             .await;
 
         let context = Arc::new(FakeGlobalContext {
-            api: Default::default(),
+            api: FakeApiClient::default(),
             executor: executor.clone(),
         });
         let dyn_context = DynGlobalClientContext::from(context.clone());

--- a/fedimint-core/src/backup.rs
+++ b/fedimint-core/src/backup.rs
@@ -1,0 +1,29 @@
+use std::time::SystemTime;
+
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::{impl_db_lookup, impl_db_record};
+use serde::{Deserialize, Serialize};
+
+use crate::db::DbKeyPrefix;
+
+/// Key used to store user's ecash backups
+#[derive(Debug, Clone, Copy, Encodable, Decodable, Serialize)]
+pub struct ClientBackupKey(pub secp256k1_zkp::XOnlyPublicKey);
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct ClientBackupKeyPrefix;
+
+impl_db_record!(
+    key = ClientBackupKey,
+    value = ClientBackupSnapshot,
+    db_prefix = DbKeyPrefix::ClientBackup,
+);
+impl_db_lookup!(key = ClientBackupKey, query_prefix = ClientBackupKeyPrefix);
+
+/// User's backup, received at certain time, containing encrypted payload
+#[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
+pub struct ClientBackupSnapshot {
+    pub timestamp: SystemTime,
+    #[serde(with = "fedimint_core::hex::serde")]
+    pub data: Vec<u8>,
+}

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -26,6 +26,8 @@ use crate::{
 pub mod client;
 pub mod server;
 
+pub mod backup;
+
 /// Module instance ID
 ///
 /// This value uniquely identifies a single instance of a module in a

--- a/fedimint-core/src/core/backup.rs
+++ b/fedimint-core/src/core/backup.rs
@@ -1,0 +1,52 @@
+use std::fmt::Debug;
+
+use bitcoin::secp256k1;
+use bitcoin_hashes::sha256;
+use fedimint_core::encoding::{Decodable, Encodable};
+use secp256k1_zkp::{KeyPair, Message, Secp256k1, Signing, Verification};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Encodable, Decodable)]
+pub struct BackupRequest {
+    pub id: secp256k1::XOnlyPublicKey,
+    #[serde(with = "fedimint_core::hex::serde")]
+    pub payload: Vec<u8>,
+    pub timestamp: std::time::SystemTime,
+}
+
+impl BackupRequest {
+    fn hash(&self) -> sha256::Hash {
+        self.consensus_hash()
+    }
+
+    pub fn sign(self, keypair: &KeyPair) -> anyhow::Result<SignedBackupRequest> {
+        let signature = secp256k1::SECP256K1.sign_schnorr(&Message::from(self.hash()), keypair);
+
+        Ok(SignedBackupRequest {
+            request: self,
+            signature,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SignedBackupRequest {
+    #[serde(flatten)]
+    request: BackupRequest,
+    pub signature: secp256k1::schnorr::Signature,
+}
+
+impl SignedBackupRequest {
+    pub fn verify_valid<C>(&self, ctx: &Secp256k1<C>) -> Result<&BackupRequest, secp256k1::Error>
+    where
+        C: Signing + Verification,
+    {
+        ctx.verify_schnorr(
+            &self.signature,
+            &Message::from_slice(&self.request.hash()).expect("Can't fail"),
+            &self.request.id,
+        )?;
+
+        Ok(&self.request)
+    }
+}

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -1447,6 +1447,7 @@ impl std::fmt::Display for DbKeyPrefix {
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
     DatabaseVersion = 0x50,
+    ClientBackup = 0x51,
 }
 
 #[derive(Debug, Error)]

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -691,7 +691,7 @@ impl<'isolated, T: MaybeSend + Encodable> ModuleDatabaseTransaction<'isolated, T
         }
     }
 
-    #[instrument(level = "debug", skip_all, fields(?key), ret)]
+    #[instrument(level = "debug", skip_all, fields(?key))]
     pub async fn get_value<K>(&mut self, key: &K) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,
@@ -1100,7 +1100,7 @@ impl<'parent> DatabaseTransaction<'parent> {
             .expect("Unrecoverable error occurred while committing to the database.");
     }
 
-    #[instrument(level = "debug", skip_all, fields(?key), ret)]
+    #[instrument(level = "debug", skip_all, fields(?key))]
     pub async fn get_value<K>(&mut self, key: &K) -> Option<K::Value>
     where
         K: DatabaseKey + DatabaseRecord,

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -25,6 +25,7 @@ use crate::module::registry::ModuleDecoderRegistry;
 #[cfg(not(target_family = "wasm"))]
 pub mod admin_client;
 pub mod api;
+pub mod backup;
 pub mod cancellable;
 pub mod config;
 pub mod core;
@@ -134,7 +135,20 @@ pub fn sats(amount: u64) -> Amount {
 /// `OutPoint` represents a globally unique output in a transaction
 ///
 /// Hence, a transaction ID and the output index is required.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Deserialize,
+    Serialize,
+    Encodable,
+    Decodable,
+)]
 pub struct OutPoint {
     /// The referenced transaction ID
     pub txid: TransactionId,

--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -22,6 +22,9 @@ pub const LOG_TASK: &str = "task";
 pub const LOG_TEST: &str = "test";
 pub const LOG_TIMING: &str = "timing";
 pub const LOG_WALLET: &str = "wallet";
+pub const LOG_CLIENT: &str = "client";
+pub const LOG_CLIENT_BACKUP: &str = "client::backup";
+pub const LOG_CLIENT_RECOVERY: &str = "client::recovery";
 
 /// Consolidates the setup of server tracing into a helper
 #[derive(Default)]

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -26,10 +26,12 @@ fedimint-core ={ path = "../../fedimint-core" }
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-derive-secret = { path = "../../crypto/derive-secret"}
 fedimint-mint-common ={ path = "../fedimint-mint-common" }
+fedimint-logging ={ path = "../../fedimint-logging" }
 rand = "0.8"
 secp256k1 = "0.24.2"
 secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.149", features = [ "derive" ] }
+serde-big-array = "0.5.1"
 serde_json = "1.0.96"
 strum = "0.24"
 strum_macros = "0.24"

--- a/modules/fedimint-mint-client/src/backup.rs
+++ b/modules/fedimint-mint-client/src/backup.rs
@@ -1,0 +1,94 @@
+use fedimint_client::sm::Executor;
+use fedimint_client::DynGlobalClientContext;
+use fedimint_core::api::{DynFederationApi, GlobalFederationApi};
+use fedimint_core::core::ModuleInstanceId;
+use fedimint_core::db::ModuleDatabaseTransaction;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::{OutPoint, Tiered, TieredMulti};
+use serde::{Deserialize, Serialize};
+
+use super::MintClientModule;
+use crate::output::{MintOutputStateMachine, MultiNoteIssuanceRequest};
+use crate::{MintClientStateMachines, NoteIndex, SpendableNote};
+
+pub mod recovery;
+
+/// Snapshot of a ecash state (notes)
+///
+/// Used to speed up and improve privacy of ecash recovery,
+/// by avoiding scanning the whole history.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Encodable, Decodable)]
+pub struct EcashBackup {
+    notes: TieredMulti<SpendableNote>,
+    pending_notes: Vec<(OutPoint, MultiNoteIssuanceRequest)>,
+    epoch_count: u64,
+    next_note_idx: Tiered<NoteIndex>,
+}
+
+impl EcashBackup {
+    /// An empty backup with, like a one created by a newly created client.
+    pub fn new_empty() -> Self {
+        Self {
+            notes: TieredMulti::default(),
+            pending_notes: vec![],
+            epoch_count: 0,
+            next_note_idx: Tiered::default(),
+        }
+    }
+}
+
+impl MintClientModule {
+    pub async fn prepare_plaintext_ecash_backup(
+        &self,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        executor: Executor<DynGlobalClientContext>,
+        api: DynFederationApi,
+        module_instance_id: ModuleInstanceId,
+    ) -> anyhow::Result<EcashBackup> {
+        // fetch consensus height first - so we dont miss anything when scanning
+        let epoch_count = api.fetch_epoch_count().await?;
+
+        let notes = Self::get_all_spendable_notes(dbtx).await;
+
+        let pending_notes: Vec<(OutPoint, MultiNoteIssuanceRequest)> = executor
+            .get_active_states()
+            .await
+            .into_iter()
+            .filter_map(|(dyn_state, _active_state)| {
+                if dyn_state.module_instance_id() != module_instance_id {
+                    return None;
+                }
+
+                let state: MintClientStateMachines = dyn_state
+                    .as_any()
+                    .downcast_ref()
+                    .cloned()
+                    .expect("Can't downcast mint client state machine state");
+
+                match state {
+                    MintClientStateMachines::Output(MintOutputStateMachine { common, state }) => {
+                        match state {
+                            crate::output::MintOutputStates::Created(state) => Some((common.out_point, state.note_issuance)),
+                            crate::output::MintOutputStates::Succeeded(_) => None /* we back these via get_all_spendable_notes */,
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                }
+            })
+            .collect::<Vec<_>>() ;
+
+        let mut idxes = vec![];
+        for &amount in self.cfg.tbs_pks.tiers() {
+            idxes.push((amount, self.get_next_note_index(dbtx, amount).await));
+        }
+        let next_note_idx = Tiered::from_iter(idxes);
+
+        Ok(EcashBackup {
+            notes,
+            pending_notes,
+            next_note_idx,
+            epoch_count,
+        })
+    }
+}

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -1,0 +1,775 @@
+use std::cmp::{self, max};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::ops::Range;
+
+use fedimint_client::sm::{OperationId, State, StateTransition};
+use fedimint_client::DynGlobalClientContext;
+use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_MINT;
+use fedimint_core::epoch::{ConsensusItem, SignedEpochOutcome};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_core::{Amount, NumPeers, PeerId, TransactionId};
+use fedimint_derive_secret::DerivableSecret;
+use fedimint_logging::LOG_ECASH_RECOVERY;
+use fedimint_mint_common::{MintConsensusItem, MintInput, MintOutput, Nonce};
+use futures::StreamExt;
+use tbs::{
+    combine_valid_shares, verify_blind_share, AggregatePublicKey, BlindedMessage, PublicKeyShare,
+};
+use threshold_crypto::G1Affine;
+use tracing::{debug, error, info, warn};
+
+use super::*;
+use crate::db::{NextECashNoteIndexKey, NoteKey};
+use crate::output::{MintOutputCommon, MintOutputStatesCreated, NoteIssuanceRequest};
+use crate::MintClientContext;
+
+#[derive(Debug)]
+pub struct EcashRecoveryFinalState {
+    /// Nonces that we track that are currently spendable.
+    spendable_notes: Vec<(Amount, SpendableNote)>,
+
+    /// Unsigned notes
+    unconfirmed_notes: Vec<(OutPoint, MultiNoteIssuanceRequest)>,
+
+    /// Note index to derive next note in a given amount tier
+    next_note_idx: Tiered<NoteIndex>,
+}
+
+/// Newtype over [`BlindedMessage`] to enable `Ord`
+#[derive(
+    Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Decodable, Encodable, Serialize, Deserialize,
+)]
+struct CompressedBlindedMessage(#[serde(with = "serde_big_array::BigArray")] [u8; 48]);
+
+impl From<BlindedMessage> for CompressedBlindedMessage {
+    fn from(value: BlindedMessage) -> Self {
+        Self(value.0.to_compressed())
+    }
+}
+
+impl From<CompressedBlindedMessage> for BlindedMessage {
+    fn from(value: CompressedBlindedMessage) -> Self {
+        BlindedMessage(
+            std::convert::Into::<Option<G1Affine>>::into(G1Affine::from_compressed(&value.0))
+                .expect("We never produce invalid compressed blinded messages"),
+        )
+    }
+}
+
+/// The state machine used for fast-forwarding backup from point when it was
+/// taken to the present time by following epoch history items from the time the
+/// snapshot was taken.
+///
+/// The caller is responsible for creating it, and then feeding it in order all
+/// valid consensus items from the epoch history between time taken (or even
+/// somewhat before it) and present time.
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+pub(crate) struct MintRestoreInProgressState {
+    start_epoch: u64,
+    next_epoch: u64,
+    end_epoch: u64,
+
+    /// Nonces that we track that are currently spendable.
+    spendable_note_by_nonce: BTreeMap<Nonce, (Amount, SpendableNote)>,
+
+    /// Outputs (by `OutPoint`) we track federation member confirmations for
+    /// blind nonces.
+    ///
+    /// Once we get enough confirmation (valid shares), these become new
+    /// spendable notes.
+    ///
+    /// Note that `NoteIssuanceRequest` is optional, as sometimes we might need
+    /// to handle a tx where only some of the blind nonces were in the pool.
+    /// A `None` means that this blind nonce/message is there only for
+    /// validation purposes, and will actually not create a
+    /// `spendable_note_by_nonce`
+    #[allow(clippy::type_complexity)]
+    pending_outputs: BTreeMap<
+        OutPoint,
+        (
+            TieredMulti<(CompressedBlindedMessage, Option<NoteIssuanceRequest>)>,
+            BTreeMap<PeerId, Vec<tbs::BlindedSignatureShare>>,
+        ),
+    >,
+
+    /// Next nonces that we expect might soon get used.
+    /// Once we see them, we move the tracking to `pending_outputs`
+    ///
+    /// Note: since looking up nonces is going to be the most common operation
+    /// the pool is kept shared (so only one lookup is enough), and
+    /// replenishment is done each time a note is consumed.
+    pending_nonces: BTreeMap<CompressedBlindedMessage, (NoteIssuanceRequest, NoteIndex, Amount)>,
+
+    /// Tail of `pending`. `pending_notes` is filled by generating note with
+    /// this index and incrementing it.
+    next_pending_note_idx: Tiered<NoteIndex>,
+
+    /// `LastECashNoteIndex` but tracked in flight. Basically max index of any
+    /// note that got a partial sig from the federation (initialled from the
+    /// backup value). TODO: One could imagine a case where the note was
+    /// issued but not get any partial sigs yet. Very unlikely in real life
+    /// scenario, but worth considering.
+    last_mined_nonce_idx: Tiered<NoteIndex>,
+
+    /// Threshold
+    threshold: u64,
+
+    /// Public key shares for each peer
+    ///
+    /// Used to validate contributed consensus items
+    pub_key_shares: BTreeMap<PeerId, Tiered<PublicKeyShare>>,
+
+    /// Aggregate public key for each amount tier
+    tbs_pks: Tiered<AggregatePublicKey>,
+
+    /// The number of nonces we look-ahead when looking for mints (per each
+    /// amount).
+    gap_limit: u64,
+}
+
+impl MintRestoreInProgressState {
+    fn transitions(
+        &self,
+        operation_id: OperationId,
+        context: &MintClientContext,
+        global_context: &DynGlobalClientContext,
+    ) -> Vec<StateTransition<MintRestoreStateMachine>> {
+        let global_context = global_context.clone();
+        let global_context_2 = global_context.clone();
+        let secret = context.secret.clone();
+        let self_clone = self.clone();
+        vec![StateTransition::new(
+            async move {
+                self_clone
+                    .make_progress(
+                        global_context.module_api(),
+                        global_context.decoders().clone(),
+                        global_context.client_config().epoch_pk,
+                        secret,
+                    )
+                    .await
+                    .consensus_encode_to_hex()
+                    .expect("Serialization here can't fail")
+            },
+            move |dbtx, new_state_hex, old_state_machine: MintRestoreStateMachine| {
+                let new_state = MintRestoreInProgressState::consensus_decode_hex(
+                    &new_state_hex,
+                    &Default::default(),
+                )
+                .expect("Deserialization here can't fail");
+                let global_context = global_context_2.clone();
+                Box::pin(async move {
+                    if new_state.is_done() {
+                        let finalized = new_state.finalize();
+
+                        {
+                            let mut dbtx = dbtx.module_tx();
+                            for (amount, note) in finalized.spendable_notes {
+                                let key = NoteKey {
+                                    amount,
+                                    nonce: note.note.0,
+                                };
+                                dbtx.insert_new_entry(&key, &note).await;
+                            }
+                            for (amount, note_idx) in finalized.next_note_idx.iter() {
+                                dbtx.insert_entry(
+                                    &NextECashNoteIndexKey(amount),
+                                    &note_idx.as_u64(),
+                                )
+                                .await;
+                            }
+                        }
+
+                        for (out_point, note_issuance) in finalized.unconfirmed_notes {
+                            global_context
+                                .add_state_machine(
+                                    dbtx,
+                                    MintClientStateMachines::Output(MintOutputStateMachine {
+                                        common: MintOutputCommon {
+                                            operation_id,
+                                            out_point,
+                                        },
+                                        state: crate::output::MintOutputStates::Created(
+                                            MintOutputStatesCreated { note_issuance },
+                                        ),
+                                    }),
+                                )
+                                .await
+                                .expect("Adding state machine can't fail")
+                        }
+
+                        MintRestoreStateMachine {
+                            operation_id: old_state_machine.operation_id,
+                            state: MintRestoreStates::Success,
+                        }
+                    } else {
+                        MintRestoreStateMachine {
+                            operation_id: old_state_machine.operation_id,
+                            state: MintRestoreStates::InProgress(new_state),
+                        }
+                    }
+                })
+            },
+        )]
+    }
+
+    async fn make_progress<'a>(
+        mut self,
+        api: DynFederationApi,
+        decoders: ModuleDecoderRegistry,
+        epoch_pk: threshold_crypto::PublicKey,
+        secret: DerivableSecret,
+    ) -> Self {
+        assert_eq!(secret.level(), 1);
+        let epoch_range =
+            self.next_epoch..cmp::min(self.next_epoch.wrapping_add(100), self.end_epoch);
+        let mut epoch_stream = Self::fetch_epochs_stream(api, epoch_pk, decoders, epoch_range);
+        while let Some((epoch, epoch_history)) = epoch_stream.next().await {
+            assert_eq!(epoch_history.outcome.epoch, epoch);
+
+            info!(target: LOG_ECASH_RECOVERY, epoch, "Processing epoch");
+            let mut processed_txs = Default::default();
+            for (peer_id, items) in &epoch_history.outcome.items {
+                for item in items {
+                    self.handle_consensus_item(
+                        epoch,
+                        *peer_id,
+                        item,
+                        &mut processed_txs,
+                        &epoch_history.outcome.rejected_txs,
+                        &secret,
+                    );
+                }
+            }
+        }
+        self
+    }
+
+    /// Fetch epochs in a given range and send them over `sender`
+    ///
+    /// Since WASM's `spawn` does not support join handles, we indicate
+    /// errors via `sender` itself.
+    ///
+    /// TODO: could be internal to recovery_loop?
+    fn fetch_epochs_stream<'a>(
+        api: DynFederationApi,
+        epoch_pk: threshold_crypto::PublicKey,
+        decoders: ModuleDecoderRegistry,
+        epoch_range: Range<u64>,
+    ) -> impl futures::Stream<Item = (u64, SignedEpochOutcome)> + 'a {
+        futures::stream::iter(epoch_range)
+            .map(move |epoch| {
+                let api = api.clone();
+                let decoders = decoders.clone();
+                Box::pin(async move {
+                    info!(epoch, "Fetching epoch");
+                    (
+                        epoch,
+                        loop {
+                            info!(target: LOG_ECASH_RECOVERY, epoch, "Awaiting epoch");
+                            match api.fetch_epoch_history(epoch, epoch_pk, &decoders).await {
+                                Ok(o) => break o,
+                                Err(e) => {
+                                    info!(e = %e, epoch, "Error trying to fetch epoch history");
+                                }
+                            }
+                        },
+                    )
+                })
+            })
+            .buffered(8)
+    }
+}
+
+impl MintRestoreInProgressState {
+    pub fn from_backup(
+        current_epoch_count: u64,
+        backup: EcashBackup,
+        gap_limit: u64,
+        tbs_pks: Tiered<AggregatePublicKey>,
+        pub_key_shares: BTreeMap<PeerId, Tiered<PublicKeyShare>>,
+        secret: &DerivableSecret,
+    ) -> Self {
+        let amount_tiers: Vec<_> = tbs_pks.tiers().copied().collect();
+        let mut s = Self {
+            start_epoch: backup.epoch_count,
+            next_epoch: backup.epoch_count,
+            end_epoch: current_epoch_count,
+            spendable_note_by_nonce: backup
+                .notes
+                .into_iter()
+                .map(|(amount, note)| (note.note.0, (amount, note)))
+                .collect(),
+            pending_outputs: backup
+                .pending_notes
+                .into_iter()
+                .map(|(out_point, issuance_requests)| {
+                    (
+                        out_point,
+                        (
+                            issuance_requests
+                                .notes
+                                .iter_items()
+                                .map(|(amount, iss_req)| {
+                                    (
+                                        amount,
+                                        (iss_req.recover_blind_nonce().0.into(), Some(*iss_req)),
+                                    )
+                                })
+                                .collect(),
+                            BTreeMap::default(),
+                        ),
+                    )
+                })
+                .collect(),
+            pending_nonces: BTreeMap::default(),
+            next_pending_note_idx: backup.next_note_idx.clone(),
+            last_mined_nonce_idx: backup.next_note_idx,
+            threshold: pub_key_shares.threshold() as u64,
+            gap_limit,
+            tbs_pks,
+            pub_key_shares,
+        };
+
+        for amount in amount_tiers {
+            s.fill_initial_pending_nonces(amount, secret);
+        }
+
+        s
+    }
+
+    /// Fill each tier pool to the gap limit
+    fn fill_initial_pending_nonces(&mut self, amount: Amount, secret: &DerivableSecret) {
+        info!(%amount, count=self.gap_limit, "Generating initial set of nonces for amount tier");
+        for _ in 0..self.gap_limit {
+            self.add_next_pending_nonce_in_pending_pool(amount, secret);
+        }
+    }
+
+    /// Add next nonce from `amount` tier to the `next_pending_note_idx`
+    fn add_next_pending_nonce_in_pending_pool(&mut self, amount: Amount, secret: &DerivableSecret) {
+        let note_idx_ref = self.next_pending_note_idx.get_mut_or_default(amount);
+
+        let (note_issuance_request, blind_nonce) = NoteIssuanceRequest::new(
+            secp256k1::SECP256K1,
+            MintClientModule::new_note_secret_static(secret, amount, *note_idx_ref),
+        );
+        assert!(self
+            .pending_nonces
+            .insert(
+                blind_nonce.0.into(),
+                (note_issuance_request, *note_idx_ref, amount)
+            )
+            .is_none());
+
+        note_idx_ref.advance();
+    }
+
+    pub fn handle_input(&mut self, input: &MintInput) {
+        // We attempt to delete any nonce we see as spent, simple
+        for (_amt, note) in input.0.iter_items() {
+            self.spendable_note_by_nonce.remove(&note.0);
+        }
+    }
+
+    pub fn handle_output(
+        &mut self,
+        out_point: OutPoint,
+        output: &MintOutput,
+        secret: &DerivableSecret,
+    ) {
+        // There is nothing preventing other users from creating valid transactions
+        // mining notes to our own blind nonce, possibly even racing with us.
+        // Including amount in blind nonce derivation helps us avoid accidentally using
+        // a nonce mined for as smaller amount, but it doesn't eliminate completely
+        // the possibility that we might use a note mined in a different transaction,
+        // that our original one.
+        // While it is harmless to us, as such duplicated blind nonces are effective as
+        // good the as the original ones (same amount), it breaks the assumption
+        // that all our blind nonces in an our output need to be in the pending
+        // pool. It forces us to be greedy no matter what and take what we can,
+        // and just report anything suspicious.
+        //
+        // found - all nonces that we found in the pool with the correct amount
+        // missing - all the nonces we have not found in the pool, either because they
+        // are not ours           or were consumed by a previous transaction
+        // using this nonce, or possibly gap           buffer was too small
+        // wrong - nonces that were ours but were mined to a wrong
+        let (found, missing, wrong) = output.0.iter_items().fold(
+            (vec![], vec![], vec![]),
+            |(mut found, mut missing, mut wrong), (amount_from_output, nonce)| {
+                match self.pending_nonces.get(&nonce.0.into()).cloned() {
+                    Some((issuance_request, note_idx, pending_amount)) => {
+                        // the moment we see our blind nonce in the epoch history, correctly or
+                        // incorrectly used, we know that we must have used
+                        // already
+                        self.observe_nonce_idx_being_used(pending_amount, note_idx, secret);
+
+                        if pending_amount == amount_from_output {
+                            found.push((
+                                amount_from_output,
+                                (
+                                    CompressedBlindedMessage::from(nonce.0),
+                                    Some(issuance_request),
+                                ),
+                            ));
+                            (found, missing, wrong)
+                        } else {
+                            // put it back, incorrect amount
+                            self.pending_nonces.insert(
+                                nonce.0.into(),
+                                (issuance_request, note_idx, pending_amount),
+                            );
+                            // report problem
+                            wrong.push((
+                                out_point,
+                                nonce.0,
+                                pending_amount,
+                                amount_from_output,
+                                note_idx,
+                            ));
+                            (found, missing, wrong)
+                        }
+                    }
+                    None => {
+                        missing.push((amount_from_output, (nonce.0.into(), None)));
+                        (found, missing, wrong)
+                    }
+                }
+            },
+        );
+
+        for wrong in &wrong {
+            warn!(output = ?out_point,
+                 blind_nonce = ?wrong.1,
+                 expected_amount = %wrong.2,
+                 found_amount = %wrong.3,
+                 "Transaction output contains blind nonce that looks like ours but is of the wrong amount. Ignoring.");
+            // Any blind nonce mined with a wrong amount means that this
+            // transaction can't be ours
+        }
+
+        if !wrong.is_empty() {
+            return;
+        }
+
+        if found.is_empty() {
+            // If we found nothing, this is not our output
+            return;
+        }
+
+        for &(_amount, (ref nonce, _)) in &missing {
+            warn!(output = ?out_point,
+                 nonce = ?nonce,
+                 "Missing nonce in pending pool for a transaction with other valid nonces that belong to us. This indicate an issue.");
+        }
+
+        // ok, now that we know we track this output as ours and use the nonces we've
+        // found delete them from the pool and replace them
+        for &(_amount, (ref nonce, _)) in &found {
+            assert!(self.pending_nonces.remove(&nonce.clone()).is_some());
+        }
+
+        self.pending_outputs.insert(
+            out_point,
+            (
+                TieredMulti::from_iter(found.into_iter().chain(missing.into_iter())),
+                BTreeMap::new(),
+            ),
+        );
+    }
+
+    /// React to a valid pending nonce being tracked being used in the epoch
+    /// history
+    ///
+    /// (Possibly) increment the `self.last_mined_nonce_idx`, then replenish the
+    /// pending pool to always maintain at least `gap_limit` of pending
+    /// nonces in each amount tier.
+    fn observe_nonce_idx_being_used(
+        &mut self,
+        amount: Amount,
+        note_idx: NoteIndex,
+        secret: &DerivableSecret,
+    ) {
+        *self.last_mined_nonce_idx.entry(amount).or_default() = max(
+            self.last_mined_nonce_idx
+                .get(amount)
+                .copied()
+                .unwrap_or_default(),
+            note_idx,
+        );
+
+        while self.next_pending_note_idx.get_mut_or_default(amount).0
+            < self.gap_limit
+                + self
+                    .last_mined_nonce_idx
+                    .get(amount)
+                    .expect("must be there already")
+                    .0
+        {
+            self.add_next_pending_nonce_in_pending_pool(amount, secret);
+        }
+    }
+
+    pub fn handle_output_confirmation(&mut self, peer_id: PeerId, sigs: &MintConsensusItem) {
+        let enough_shares = if let Some((output_data, peer_shares)) =
+            self.pending_outputs.get_mut(&sigs.out_point)
+        {
+            if !sigs.signatures.0.structural_eq(output_data) {
+                warn!(
+                    peer = %peer_id,
+                    "Peer proposed a sig share of wrong structure (different than out_point)",
+                );
+                return;
+            }
+
+            for ((share_amt, share_sig), (output_item_amt, output_data_item)) in
+                sigs.signatures.0.iter_items().zip(output_data.iter_items())
+            {
+                // Guaranteed by the structural_eq check above
+                assert_eq!(share_amt, output_item_amt);
+
+                let amount_key = match self.pub_key_shares[&peer_id].tier(&share_amt) {
+                    Ok(key) => key,
+                    Err(_) => {
+                        error!(
+                            ?peer_id,
+                            amount = ?share_amt,
+                            "Missing public key for the amount. This should not happen."
+                        );
+                        return;
+                    }
+                };
+
+                if !verify_blind_share(output_data_item.0.clone().into(), share_sig.1, *amount_key)
+                {
+                    warn!(?peer_id, "Ignoring invalid contribution share from peer");
+                    return;
+                }
+            }
+
+            if let Some(_prev) = peer_shares.insert(
+                peer_id,
+                // We compact the shares to a `Vec<BlindedSignatureShare>` like
+                // we eventually want in the consensus itself: https://github.com/fedimint/fedimint/issues/1053#issue-1477111966
+                sigs.signatures
+                    .0
+                    .iter_items()
+                    .map(|(_, (_, sig_share))| *sig_share)
+                    .collect(),
+            ) {
+                warn!(
+                    out_point = %sigs.out_point,
+                    ?peer_id,
+                    "Duplicate signature share for out_point",
+                );
+            }
+
+            self.threshold <= peer_shares.len() as u64
+        } else {
+            false
+        };
+
+        if enough_shares {
+            let (output_data, sig_shares) = self
+                .pending_outputs
+                .remove(&sigs.out_point)
+                .expect("must be in the map already");
+
+            for (item_i, (item_amt, item)) in output_data.iter_items().enumerate() {
+                let iss_request = if let Some(iss_request) = item.1 {
+                    iss_request
+                } else {
+                    // Items without issuance request are ones we don't consider ours
+                    // for some reason, so there's no point combining sigs for them.
+                    continue;
+                };
+
+                let sig = combine_valid_shares(
+                    sig_shares
+                        .iter()
+                        .map(|(peer, shares)| (peer.to_usize(), shares[item_i])),
+                    self.threshold as usize,
+                );
+
+                let note = iss_request
+                    .finalize(
+                        sig,
+                        *self
+                            .tbs_pks
+                            .tier(&item_amt)
+                            .expect("must have keys for all amounts here"),
+                    )
+                    .expect("We can assume all data valid at this point");
+
+                self.spendable_note_by_nonce
+                    .insert(iss_request.nonce(), (item_amt, note));
+            }
+        }
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.next_epoch == self.end_epoch
+    }
+
+    pub(crate) fn handle_consensus_item(
+        &mut self,
+        epoch: u64,
+        peer_id: PeerId,
+        item: &ConsensusItem,
+        processed_txs: &mut HashSet<TransactionId>,
+        rejected_txs: &BTreeSet<TransactionId>,
+        secret: &DerivableSecret,
+    ) {
+        debug!(target: LOG_ECASH_RECOVERY, ?item, "handling consensus item");
+        assert!(epoch == self.next_epoch);
+        self.next_epoch = epoch;
+        match item {
+            ConsensusItem::Transaction(tx) => {
+                let txid = tx.tx_hash();
+
+                if !processed_txs.insert(txid) {
+                    // Just like server side consensus, do not attempt to process the same
+                    // transaction twice.
+                    debug!(target: LOG_ECASH_RECOVERY, ?item, "was already processed");
+                    return;
+                }
+
+                if rejected_txs.contains(&txid) {
+                    debug!(target: LOG_ECASH_RECOVERY, ?item, "was rejected");
+                    // Do not process invalid transactions.
+                    // Consensus history contains all data proposed by each peer, even invalid (e.g.
+                    // due to double spent) transactions. Precisely to save
+                    // downstream users from having to run the consensus themselves,
+                    // each epoch contains a list of transactions  that turned out to be invalid.
+                    return;
+                }
+
+                for input in &tx.inputs {
+                    if input.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_MINT {
+                        let input = input
+                            .as_any()
+                            .downcast_ref::<MintInput>()
+                            .expect("mint key just checked");
+
+                        self.handle_input(input);
+                    }
+                }
+
+                for (out_idx, output) in tx.outputs.iter().enumerate() {
+                    if output.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_MINT {
+                        let output = output
+                            .as_any()
+                            .downcast_ref::<MintOutput>()
+                            .expect("mint key just checked");
+
+                        self.handle_output(
+                            OutPoint {
+                                txid,
+                                out_idx: out_idx as u64,
+                            },
+                            output,
+                            secret,
+                        );
+                    }
+                }
+            }
+            ConsensusItem::Module(module_item) => {
+                if module_item.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_MINT {
+                    let mint_item = module_item
+                        .as_any()
+                        .downcast_ref::<MintConsensusItem>()
+                        .expect("mint key just checked");
+
+                    self.handle_output_confirmation(peer_id, mint_item);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn finalize(self) -> EcashRecoveryFinalState {
+        EcashRecoveryFinalState {
+            spendable_notes: self
+                .spendable_note_by_nonce
+                .into_iter()
+                .map(|(_nonce, (amount, snote))| (amount, snote))
+                .collect(),
+            unconfirmed_notes: self
+                .pending_outputs
+                .into_iter()
+                .map(|(out_point, data)| {
+                    (
+                        out_point,
+                        MultiNoteIssuanceRequest {
+                            notes: TieredMulti::from_iter(data.0.into_iter_items().filter_map(
+                                |(amount, (_bn, opt_note_iss_req))| {
+                                    opt_note_iss_req.map(|iss_req| (amount, iss_req))
+                                },
+                            )),
+                        },
+                    )
+                })
+                .collect(),
+            // next note idx is the last one detected as used + 1
+            next_note_idx: Tiered::from_iter(
+                self.last_mined_nonce_idx
+                    .iter()
+                    .map(|(amount, value)| (amount, value.next())),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+pub(crate) struct MintRestoreFailedState {
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+pub struct MintRestoreStateMachine {
+    pub(crate) operation_id: OperationId,
+    pub(crate) state: MintRestoreStates,
+}
+
+impl State for MintRestoreStateMachine {
+    type ModuleContext = MintClientContext;
+    type GlobalContext = DynGlobalClientContext;
+
+    fn transitions(
+        &self,
+        context: &Self::ModuleContext,
+        global_context: &Self::GlobalContext,
+    ) -> Vec<StateTransition<Self>> {
+        match &self.state {
+            MintRestoreStates::InProgress(state) => {
+                state.transitions(self.operation_id, context, global_context)
+            }
+            MintRestoreStates::Failed(_) => vec![],
+            MintRestoreStates::Success => vec![],
+        }
+    }
+
+    fn operation_id(&self) -> OperationId {
+        self.operation_id
+    }
+}
+
+#[aquamarine::aquamarine]
+/// State machine managing e-cash that has been taken out of the wallet for
+/// out-of-band transmission.
+///
+/// ```mermaid
+/// graph LR
+///     Created -- User triggered refund --> RefundU["User Refund"]
+///     Created -- Timeout triggered refund --> RefundT["Timeout Refund"]
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+pub(crate) enum MintRestoreStates {
+    /// The restore has been started and is processing
+    InProgress(MintRestoreInProgressState),
+    /// Done
+    Success,
+    /// Something went wrong, and restore failed
+    Failed(MintRestoreFailedState),
+}

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -220,7 +220,7 @@ impl MintRestoreInProgressState {
         epoch_pk: threshold_crypto::PublicKey,
         secret: DerivableSecret,
     ) -> Self {
-        assert_eq!(secret.level(), 1);
+        assert_eq!(secret.level(), 2);
         let epoch_range =
             self.next_epoch..cmp::min(self.next_epoch.wrapping_add(100), self.end_epoch);
         let mut epoch_stream = Self::fetch_epochs_stream(api, epoch_pk, decoders, epoch_range);

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -319,7 +319,7 @@ impl NoteIssuanceRequest {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, Encodable, Decodable)]
 pub struct MultiNoteIssuanceRequest {
     /// Finalization data for all note outputs in this request
-    notes: TieredMulti<NoteIssuanceRequest>,
+    pub notes: TieredMulti<NoteIssuanceRequest>,
 }
 
 impl MultiNoteIssuanceRequest {

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -72,7 +72,20 @@ pub struct Note(pub Nonce, pub tbs::Signature);
 ///
 /// Internally a MuSig pub key so that transactions can be signed when being
 /// spent.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Deserialize,
+    Serialize,
+    Encodable,
+    Decodable,
+)]
 pub struct Nonce(pub secp256k1_zkp::XOnlyPublicKey);
 
 /// [`Nonce`] but blinded by the user key


### PR DESCRIPTION
Port of the ecash recovery code to new client, now generalized for all client modules (but implemented only for mint module).

Includes `backup`, `restore`, `wipe` command for `fedimint-cli ng`.

The old-client ecash code is still in place. New client code does not have any tests yet, but since the core logic is largely unmodified it should work OK.

I am able to succesfully backup, wipe and restore with a minor issue of `fedimint-cli` not waiting for all the state machines to finish. But I think we should address it in another PR.