### PR TITLE
feature: improve the dummy module for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
  "fedimint-dummy-common",
  "rand",
  "secp256k1",
+ "threshold_crypto",
  "tracing",
 ]
 

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -19,4 +19,4 @@ fedimint-core ={ path = "../../fedimint-core" }
 rand = "0.8.5"
 secp256k1 = "0.24.2"
 tracing = "0.1.37"
-
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }

--- a/modules/fedimint-dummy-client/src/api.rs
+++ b/modules/fedimint-dummy-client/src/api.rs
@@ -1,15 +1,14 @@
 use fedimint_core::api::{FederationApiExt, FederationResult, IFederationApi};
+use fedimint_core::epoch::SerdeSignature;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::{apply, async_trait_maybe_send, Amount};
-use fedimint_dummy_common::DummyPrintMoneyRequest;
-use secp256k1::XOnlyPublicKey;
+use fedimint_core::{apply, async_trait_maybe_send};
 
 #[apply(async_trait_maybe_send!)]
 pub trait DummyFederationApi {
-    async fn print_money(&self, request: DummyPrintMoneyRequest) -> FederationResult<()>;
+    async fn sign_message(&self, message: String) -> FederationResult<()>;
 
-    async fn wait_for_money(&self, account: XOnlyPublicKey) -> FederationResult<Amount>;
+    async fn wait_signed(&self, message: String) -> FederationResult<SerdeSignature>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -17,13 +16,13 @@ impl<T: ?Sized> DummyFederationApi for T
 where
     T: IFederationApi + MaybeSend + MaybeSync + 'static,
 {
-    async fn print_money(&self, request: DummyPrintMoneyRequest) -> FederationResult<()> {
-        self.request_current_consensus("print_money".to_string(), ApiRequestErased::new(request))
+    async fn sign_message(&self, message: String) -> FederationResult<()> {
+        self.request_current_consensus("sign_message".to_string(), ApiRequestErased::new(message))
             .await
     }
 
-    async fn wait_for_money(&self, account: XOnlyPublicKey) -> FederationResult<Amount> {
-        self.request_current_consensus("wait_for_money".to_string(), ApiRequestErased::new(account))
+    async fn wait_signed(&self, message: String) -> FederationResult<SerdeSignature> {
+        self.request_current_consensus("wait_signed".to_string(), ApiRequestErased::new(message))
             .await
     }
 }

--- a/modules/fedimint-dummy-common/src/config.rs
+++ b/modules/fedimint-dummy-common/src/config.rs
@@ -7,7 +7,7 @@ use fedimint_core::module::ModuleConsensusVersion;
 use fedimint_core::Amount;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::serde_impl::SerdeSecret;
-use threshold_crypto::{PublicKeySet, SecretKeyShare};
+use threshold_crypto::{PublicKey, PublicKeySet, SecretKeyShare};
 
 use crate::{CONSENSUS_VERSION, KIND};
 
@@ -23,6 +23,7 @@ pub struct DummyConfig {
 pub struct DummyClientConfig {
     /// Accessible to clients
     pub tx_fee: Amount,
+    pub fed_public_key: PublicKey,
 }
 
 /// Will be the same for every federation member

--- a/modules/fedimint-dummy-server/src/db.rs
+++ b/modules/fedimint-dummy-server/src/db.rs
@@ -1,12 +1,13 @@
 use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::epoch::SerdeSignature;
 use fedimint_core::{impl_db_lookup, impl_db_record, Amount, OutPoint};
 use futures::StreamExt;
 use secp256k1::XOnlyPublicKey;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
-use crate::{DummyOutputOutcome, DummyPrintMoneyRequest};
+use crate::DummyOutputOutcome;
 
 /// Namespaces DB keys for this module
 #[repr(u8)]
@@ -14,7 +15,7 @@ use crate::{DummyOutputOutcome, DummyPrintMoneyRequest};
 pub enum DbKeyPrefix {
     Funds = 0x01,
     Outcome = 0x02,
-    Print = 0x03,
+    Sign = 0x03,
 }
 
 // TODO: Boilerplate-code
@@ -87,21 +88,21 @@ impl_db_record!(
     key = DummyFundsKeyV1,
     value = Amount,
     db_prefix = DbKeyPrefix::Funds,
-    // Allows us to listen for notifications on this key
-    notify_on_modify = true
 );
 impl_db_lookup!(key = DummyFundsKeyV1, query_prefix = DummyFundsKeyV1Prefix);
 
-/// Lookup print money requests by key or prefix
+/// Lookup signature requests by key or prefix
 #[derive(Debug, Clone, Encodable, Decodable, Eq, PartialEq, Hash, Serialize)]
-pub struct DummyPrintKeyV1(pub DummyPrintMoneyRequest);
+pub struct DummySignKeyV1(pub String);
 
 #[derive(Debug, Encodable, Decodable)]
-pub struct DummyPrintKeyV1Prefix;
+pub struct DummySignV1Prefix;
 
 impl_db_record!(
-    key = DummyPrintKeyV1,
-    value = (),
-    db_prefix = DbKeyPrefix::Print,
+    key = DummySignKeyV1,
+    value = Option<SerdeSignature>,
+    db_prefix = DbKeyPrefix::Sign,
+    // Allows us to listen for notifications on this key
+    notify_on_modify = true
 );
-impl_db_lookup!(key = DummyPrintKeyV1, query_prefix = DummyPrintKeyV1Prefix);
+impl_db_lookup!(key = DummySignKeyV1, query_prefix = DummySignV1Prefix);

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -2,12 +2,10 @@ use fedimint_core::{sats, Amount};
 use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
 use fedimint_dummy_common::DummyConfigGenParams;
 use fedimint_dummy_server::DummyGen;
-use fedimint_logging::TracingSetup;
 use fedimint_testing::federation::FederationFixture;
 use fedimint_testing::fixtures::test;
 
 fn fixture() -> FederationFixture {
-    TracingSetup::default().init().unwrap();
     let params = DummyConfigGenParams {
         tx_fee: Amount::ZERO,
     };
@@ -28,6 +26,16 @@ async fn can_print_and_send_money() {
         client2.receive_money(outpoint.unwrap()).await.unwrap();
         assert_eq!(client1.total_funds().await, sats(750));
         assert_eq!(client2.total_funds().await, sats(250));
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_threshold_sign_message() {
+    test(fixture(), |_fed, client| async move {
+        let message = "Hello fed!";
+        let sig = client.fed_signature(message).await.unwrap();
+        assert!(client.fed_public_key().verify(&sig, message));
     })
     .await
 }


### PR DESCRIPTION
Improved some of the issues with the dummy module:

- Printing money is now a tx so it can output to any client primary module (e.g. for testing ecash) and will be faster
- The signature shares now sign a returned message to demonstrate consensus signing better