### PR TITLE
refactor: Merge `status` and `consensus_status` endpoints

### DIFF
--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -9,7 +9,8 @@ use tokio_rustls::rustls;
 use url::Url;
 
 use crate::api::{
-    DynFederationApi, FederationApiExt, FederationResult, GlobalFederationApi, WsFederationApi,
+    DynFederationApi, FederationApiExt, FederationResult, GlobalFederationApi, ServerStatus,
+    StatusResponse, WsFederationApi,
 };
 use crate::config::ServerModuleGenParamsRegistry;
 use crate::epoch::{SerdeEpochHistory, SignedEpochOutcome};
@@ -155,7 +156,7 @@ impl WsAdminClient {
     }
 
     /// Returns the status of the server
-    pub async fn status(&self) -> FederationResult<ServerStatus> {
+    pub async fn status(&self) -> FederationResult<StatusResponse> {
         self.request_auth("status", ApiRequestErased::default())
             .await
     }
@@ -181,26 +182,6 @@ impl WsAdminClient {
             .request_current_consensus(method.to_owned(), params)
             .await
     }
-}
-
-/// The state of the server returned via APIs
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Eq, PartialEq)]
-pub enum ServerStatus {
-    /// Server needs a password to read configs
-    #[default]
-    AwaitingPassword,
-    /// Waiting for peers to share the config gen params
-    SharingConfigGenParams,
-    /// Ready to run config gen once all peers are ready
-    ReadyForConfigGen,
-    /// We failed running config gen
-    ConfigGenFailed,
-    /// Config is generated, peers should verify the config
-    VerifyingConfigs,
-    /// Restarted from a planned upgrade (requires action to start)
-    Upgrading,
-    /// Consensus is running
-    ConsensusRunning,
 }
 
 /// Sent by admin user to the API

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -863,7 +863,7 @@ fn url_to_string_with_default_port(url: &Url) -> String {
 impl<C: JsonRpcClient> WsFederationApi<C> {}
 
 /// The status of a server, including how it views its peers
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConsensusStatus {
     /// The last contribution that this server has made to the consensus, it's
     /// equivalent to [`PeerConsensusStatus::last_contribution`] and
@@ -903,6 +903,32 @@ pub struct ConsensusContribution {
     pub value: u64,
     /// When the contribution was received
     pub time: SystemTime,
+}
+
+/// The state of the server returned via APIs
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Eq, PartialEq)]
+pub enum ServerStatus {
+    /// Server needs a password to read configs
+    #[default]
+    AwaitingPassword,
+    /// Waiting for peers to share the config gen params
+    SharingConfigGenParams,
+    /// Ready to run config gen once all peers are ready
+    ReadyForConfigGen,
+    /// We failed running config gen
+    ConfigGenFailed,
+    /// Config is generated, peers should verify the config
+    VerifyingConfigs,
+    /// Restarted from a planned upgrade (requires action to start)
+    Upgrading,
+    /// Consensus is running
+    ConsensusRunning,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct StatusResponse {
+    pub server: ServerStatus,
+    pub consensus: Option<ConsensusStatus>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
https://github.com/fedimint/fedimint/pull/2375 original goal was to add all the information to a single `status` endpoint, but at the time no good solution was found on how to merge both data. While creating the CLI command this simple and obvious solution appeared:
```rust
pub struct StatusResponse {
    pub server: ServerStatus,
    pub consensus: Option<ConsensusStatus>,
}
```

For instance in json:
```json
{
    "consensus": {
      "last_contribution": 14,
      "peers_flagged": 0,
      "peers_offline": 0,
      "peers_online": 3,
      "status_by_peer": {
        "1": {
          "connection_status": "Connected",
          "flagged": false,
          "last_contribution": 14,
          "last_contribution_timestamp_seconds": 1683215023
        },
        "2": {
          "connection_status": "Connected",
          "flagged": false,
          "last_contribution": 14,
          "last_contribution_timestamp_seconds": 1683215023
        },
        "3": {
          "connection_status": "Connected",
          "flagged": false,
          "last_contribution": 14,
          "last_contribution_timestamp_seconds": 1683215023
        }
      }
    },
    "server": "ConsensusRunning"
  }
```