### PR TITLE
Remove boilerplate from our module common libs

### DIFF
--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -174,7 +174,14 @@ macro_rules! module_plugin_trait_define{
 /// `FederationServer` module.
 #[macro_export]
 macro_rules! plugin_types_trait_impl_common {
-    ($input:ty, $output:ty, $outcome:ty, $ci:ty) => {
+    ($types:ty, $input:ty, $output:ty, $outcome:ty, $ci:ty) => {
+        impl fedimint_core::module::ModuleCommon for $types {
+            type Input = $input;
+            type Output = $output;
+            type OutputOutcome = $outcome;
+            type ConsensusItem = $ci;
+        }
+
         impl fedimint_core::core::Input for $input {}
 
         impl fedimint_core::core::IntoDynInstance for $input {

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -170,6 +170,58 @@ macro_rules! module_plugin_trait_define{
     };
 }
 
+/// Implements the necessary traits for all configuration related types of a
+/// `FederationServer` module.
+#[macro_export]
+macro_rules! plugin_types_trait_impl_config {
+    ($common_gen:ty, $gen_params:ty, $cfg:ty, $cfg_private:ty, $cfg_consensus:ty, $cfg_client:ty) => {
+        impl fedimint_core::config::ModuleGenParams for $gen_params {}
+
+        impl fedimint_core::config::TypedServerModuleConsensusConfig for $cfg_consensus {
+            fn kind(&self) -> fedimint_core::core::ModuleKind {
+                <$common_gen as fedimint_core::module::CommonModuleGen>::KIND
+            }
+
+            fn version(&self) -> fedimint_core::module::ModuleConsensusVersion {
+                <$common_gen as fedimint_core::module::CommonModuleGen>::CONSENSUS_VERSION
+            }
+        }
+
+        impl fedimint_core::config::TypedServerModuleConfig for $cfg {
+            type Local = ();
+            type Private = $cfg_private;
+            type Consensus = $cfg_consensus;
+
+            fn from_parts(
+                _: Self::Local,
+                private: Self::Private,
+                consensus: Self::Consensus,
+            ) -> Self {
+                Self { private, consensus }
+            }
+
+            fn to_parts(self) -> (ModuleKind, Self::Local, Self::Private, Self::Consensus) {
+                (
+                    <$common_gen as fedimint_core::module::CommonModuleGen>::KIND,
+                    (),
+                    self.private,
+                    self.consensus,
+                )
+            }
+        }
+
+        impl fedimint_core::config::TypedClientModuleConfig for $cfg_client {
+            fn kind(&self) -> fedimint_core::core::ModuleKind {
+                <$common_gen as fedimint_core::module::CommonModuleGen>::KIND
+            }
+
+            fn version(&self) -> fedimint_core::module::ModuleConsensusVersion {
+                <$common_gen as fedimint_core::module::CommonModuleGen>::CONSENSUS_VERSION
+            }
+        }
+    };
+}
+
 /// Implements the necessary traits for all associated types of a
 /// `FederationServer` module.
 #[macro_export]

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -613,6 +613,7 @@ pub struct SupportedApiVersionsSummary {
 }
 
 pub trait CommonModuleGen: Debug + Sized {
+    const CONSENSUS_VERSION: ModuleConsensusVersion;
     const KIND: ModuleKind;
 
     fn decoder() -> Decoder;

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -6,9 +6,12 @@ use fedimint_core::core::{
 };
 use fedimint_core::module::ServerModuleGen;
 use fedimint_core::{Amount, Tiered};
-use fedimint_ln_server::{LightningGen, LightningGenParams};
-use fedimint_mint_server::{MintGen, MintGenParams};
-use fedimint_wallet_server::{WalletGen, WalletGenParams};
+use fedimint_ln_server::common::config::LightningGenParams;
+use fedimint_ln_server::LightningGen;
+use fedimint_mint_server::common::config::MintGenParams;
+use fedimint_mint_server::MintGen;
+use fedimint_wallet_server::common::config::WalletGenParams;
+use fedimint_wallet_server::WalletGen;
 
 mod ui;
 

--- a/modules/fedimint-dummy-common/src/config.rs
+++ b/modules/fedimint-dummy-common/src/config.rs
@@ -1,15 +1,17 @@
-use fedimint_core::config::{
-    TypedClientModuleConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
-};
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::module::ModuleConsensusVersion;
-use fedimint_core::Amount;
+use fedimint_core::{plugin_types_trait_impl_config, Amount};
 use serde::{Deserialize, Serialize};
 use threshold_crypto::serde_impl::SerdeSecret;
 use threshold_crypto::{PublicKey, PublicKeySet, SecretKeyShare};
 
-use crate::{CONSENSUS_VERSION, KIND};
+use crate::DummyCommonGen;
+
+/// Parameters necessary to generate this module's configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DummyConfigGenParams {
+    pub tx_fee: Amount,
+}
 
 /// Contains all the configuration for the server
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -42,41 +44,12 @@ pub struct DummyConfigPrivate {
     pub private_key_share: SerdeSecret<SecretKeyShare>,
 }
 
-impl TypedServerModuleConsensusConfig for DummyConfigConsensus {
-    // TODO: Boilerplate-code
-    fn kind(&self) -> ModuleKind {
-        KIND
-    }
-
-    // TODO: Boilerplate-code
-    fn version(&self) -> ModuleConsensusVersion {
-        CONSENSUS_VERSION
-    }
-}
-
-impl TypedServerModuleConfig for DummyConfig {
-    type Local = ();
-    type Private = DummyConfigPrivate;
-    type Consensus = DummyConfigConsensus;
-
-    // TODO: Boilerplate-code (remove local)
-    fn from_parts(_: Self::Local, private: Self::Private, consensus: Self::Consensus) -> Self {
-        Self { private, consensus }
-    }
-
-    // TODO: Boilerplate-code (remove local)
-    fn to_parts(self) -> (ModuleKind, Self::Local, Self::Private, Self::Consensus) {
-        (KIND, (), self.private, self.consensus)
-    }
-}
-
-// TODO: Boilerplate-code
-impl TypedClientModuleConfig for DummyClientConfig {
-    fn kind(&self) -> fedimint_core::core::ModuleKind {
-        KIND
-    }
-
-    fn version(&self) -> ModuleConsensusVersion {
-        CONSENSUS_VERSION
-    }
-}
+// Wire together the configs for this module
+plugin_types_trait_impl_config!(
+    DummyCommonGen,
+    DummyConfigGenParams,
+    DummyConfig,
+    DummyConfigPrivate,
+    DummyConfigConsensus,
+    DummyClientConfig
+);

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -68,19 +68,12 @@ pub struct DummyModuleTypes;
 
 // Wire together the types for this module
 plugin_types_trait_impl_common!(
+    DummyModuleTypes,
     DummyInput,
     DummyOutput,
     DummyOutputOutcome,
     DummyConsensusItem
 );
-
-// TODO: Boilerplate-code
-impl ModuleCommon for DummyModuleTypes {
-    type Input = DummyInput;
-    type Output = DummyOutput;
-    type OutputOutcome = DummyOutputOutcome;
-    type ConsensusItem = DummyConsensusItem;
-}
 
 // TODO: Boilerplate-code
 impl ModuleGenParams for DummyConfigGenParams {}

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-use async_trait::async_trait;
-use fedimint_core::config::ModuleGenParams;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::SerdeSignatureShare;
@@ -27,12 +25,6 @@ pub const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
 pub enum DummyConsensusItem {
     /// User's message sign request signed by a single peer
     Sign(String, SerdeSignatureShare),
-}
-
-/// Parameters necessary to generate this module's configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DummyConfigGenParams {
-    pub tx_fee: Amount,
 }
 
 /// Input for a fedimint transaction
@@ -75,16 +67,11 @@ plugin_types_trait_impl_common!(
     DummyConsensusItem
 );
 
-// TODO: Boilerplate-code
-impl ModuleGenParams for DummyConfigGenParams {}
-
-// TODO: Boilerplate-code
 #[derive(Debug)]
 pub struct DummyCommonGen;
 
-// TODO: Boilerplate-code
-#[async_trait]
 impl CommonModuleGen for DummyCommonGen {
+    const CONSENSUS_VERSION: ModuleConsensusVersion = CONSENSUS_VERSION;
     const KIND: ModuleKind = KIND;
 
     fn decoder() -> Decoder {

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -21,11 +21,11 @@ use fedimint_core::server::DynServerModule;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{push_db_pair_items, Amount, NumPeers, OutPoint, PeerId, ServerModule};
 use fedimint_dummy_common::config::{
-    DummyClientConfig, DummyConfig, DummyConfigConsensus, DummyConfigPrivate,
+    DummyClientConfig, DummyConfig, DummyConfigConsensus, DummyConfigGenParams, DummyConfigPrivate,
 };
 use fedimint_dummy_common::{
-    fed_public_key, DummyCommonGen, DummyConfigGenParams, DummyConsensusItem, DummyError,
-    DummyInput, DummyModuleTypes, DummyOutput, DummyOutputOutcome, CONSENSUS_VERSION,
+    fed_public_key, DummyCommonGen, DummyConsensusItem, DummyError, DummyInput, DummyModuleTypes,
+    DummyOutput, DummyOutputOutcome, CONSENSUS_VERSION,
 };
 use fedimint_server::config::distributedgen::PeerHandleOps;
 use futures::{FutureExt, StreamExt};

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -1,6 +1,6 @@
 use fedimint_core::{sats, Amount};
 use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
-use fedimint_dummy_common::DummyConfigGenParams;
+use fedimint_dummy_common::config::DummyConfigGenParams;
 use fedimint_dummy_server::DummyGen;
 use fedimint_testing::federation::FederationFixture;
 use fedimint_testing::fixtures::test;

--- a/modules/fedimint-ln-common/src/config.rs
+++ b/modules/fedimint-ln-common/src/config.rs
@@ -1,12 +1,13 @@
-use fedimint_core::config::{
-    TypedClientModuleConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
-};
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::plugin_types_trait_impl_config;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::serde_impl::SerdeSecret;
 
-use crate::{CONSENSUS_VERSION, KIND};
+use crate::LightningCommonGen;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LightningGenParams;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningConfig {
@@ -39,45 +40,21 @@ pub struct LightningConfigPrivate {
     pub threshold_sec_key: SerdeSecret<threshold_crypto::SecretKeyShare>,
 }
 
-impl TypedClientModuleConfig for LightningClientConfig {
-    fn kind(&self) -> ModuleKind {
-        KIND
-    }
-
-    fn version(&self) -> fedimint_core::module::ModuleConsensusVersion {
-        CONSENSUS_VERSION
-    }
-}
-
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct LightningClientConfig {
     pub threshold_pub_key: threshold_crypto::PublicKey,
     pub fee_consensus: FeeConsensus,
 }
 
-impl TypedServerModuleConsensusConfig for LightningConfigConsensus {
-    fn kind(&self) -> ModuleKind {
-        KIND
-    }
-
-    fn version(&self) -> fedimint_core::module::ModuleConsensusVersion {
-        CONSENSUS_VERSION
-    }
-}
-
-impl TypedServerModuleConfig for LightningConfig {
-    type Local = ();
-    type Private = LightningConfigPrivate;
-    type Consensus = LightningConfigConsensus;
-
-    fn from_parts(_local: Self::Local, private: Self::Private, consensus: Self::Consensus) -> Self {
-        Self { private, consensus }
-    }
-
-    fn to_parts(self) -> (ModuleKind, Self::Local, Self::Private, Self::Consensus) {
-        (KIND, (), self.private, self.consensus)
-    }
-}
+// Wire together the configs for this module
+plugin_types_trait_impl_config!(
+    LightningCommonGen,
+    LightningGenParams,
+    LightningConfig,
+    LightningConfigPrivate,
+    LightningConfigConsensus,
+    LightningClientConfig
+);
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct FeeConsensus {

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -195,14 +195,8 @@ impl CommonModuleGen for LightningCommonGen {
 
 pub struct LightningModuleTypes;
 
-impl ModuleCommon for LightningModuleTypes {
-    type Input = LightningInput;
-    type Output = LightningOutput;
-    type OutputOutcome = LightningOutputOutcome;
-    type ConsensusItem = LightningConsensusItem;
-}
-
 plugin_types_trait_impl_common!(
+    LightningModuleTypes,
     LightningInput,
     LightningOutput,
     LightningOutputOutcome,

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -187,6 +187,7 @@ impl std::fmt::Display for LightningConsensusItem {
 pub struct LightningCommonGen;
 
 impl CommonModuleGen for LightningCommonGen {
+    const CONSENSUS_VERSION: ModuleConsensusVersion = CONSENSUS_VERSION;
     const KIND: ModuleKind = KIND;
     fn decoder() -> Decoder {
         LightningModuleTypes::decoder()

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -5,7 +5,7 @@ use std::ops::Sub;
 use anyhow::bail;
 use bitcoin_hashes::Hash as BitcoinHash;
 use fedimint_core::config::{
-    ClientModuleConfig, ConfigGenModuleParams, DkgResult, ModuleGenParams, ServerModuleConfig,
+    ClientModuleConfig, ConfigGenModuleParams, DkgResult, ServerModuleConfig,
     ServerModuleConsensusConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
@@ -59,11 +59,6 @@ pub struct LightningGen;
 impl ExtendsCommonModuleGen for LightningGen {
     type Common = LightningCommonGen;
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LightningGenParams;
-
-impl ModuleGenParams for LightningGenParams {}
 
 #[apply(async_trait_maybe_send!)]
 impl ServerModuleGen for LightningGen {

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -90,6 +90,7 @@ pub struct BlindNonce(pub tbs::BlindedMessage);
 pub struct MintCommonGen;
 
 impl CommonModuleGen for MintCommonGen {
+    const CONSENSUS_VERSION: ModuleConsensusVersion = CONSENSUS_VERSION;
     const KIND: ModuleKind = KIND;
 
     fn decoder() -> Decoder {

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -151,13 +151,6 @@ impl std::fmt::Display for MintConsensusItem {
 
 pub struct MintModuleTypes;
 
-impl ModuleCommon for MintModuleTypes {
-    type Input = MintInput;
-    type Output = MintOutput;
-    type OutputOutcome = MintOutputOutcome;
-    type ConsensusItem = MintConsensusItem;
-}
-
 impl Note {
     /// Verify the note's validity under a mit key `pk`
     pub fn verify(&self, pk: tbs::AggregatePublicKey) -> bool {
@@ -199,7 +192,13 @@ impl Extend<(Amount, BlindNonce)> for MintOutput {
     }
 }
 
-plugin_types_trait_impl_common!(MintInput, MintOutput, MintOutputOutcome, MintConsensusItem);
+plugin_types_trait_impl_common!(
+    MintModuleTypes,
+    MintInput,
+    MintOutput,
+    MintOutputOutcome,
+    MintConsensusItem
+);
 
 /// Represents an array of mint indexes that delivered faulty shares
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -5,7 +5,7 @@ use std::ops::Sub;
 
 use anyhow::bail;
 use fedimint_core::config::{
-    ClientModuleConfig, ConfigGenModuleParams, DkgResult, ModuleGenParams, ServerModuleConfig,
+    ClientModuleConfig, ConfigGenModuleParams, DkgResult, ServerModuleConfig,
     ServerModuleConsensusConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::db::{Database, DatabaseVersion, ModuleDatabaseTransaction};
@@ -26,6 +26,7 @@ use fedimint_core::{
 pub use fedimint_mint_common as common;
 use fedimint_mint_common::config::{
     FeeConsensus, MintClientConfig, MintConfig, MintConfigConsensus, MintConfigPrivate,
+    MintGenParams,
 };
 use fedimint_mint_common::db::{
     DbKeyPrefix, ECashUserBackupSnapshot, EcashBackupKey, EcashBackupKeyPrefix, MintAuditItemKey,
@@ -46,7 +47,6 @@ use itertools::Itertools;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon::prelude::ParallelBridge;
 use secp256k1_zkp::SECP256K1;
-use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tbs::{
     combine_valid_shares, dealer_keygen, sign_blinded_msg, verify_blind_share, Aggregatable,
@@ -54,13 +54,6 @@ use tbs::{
 };
 use threshold_crypto::group::Curve;
 use tracing::{debug, error, info, warn};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MintGenParams {
-    pub mint_amounts: Vec<Amount>,
-}
-
-impl ModuleGenParams for MintGenParams {}
 
 #[derive(Debug, Clone)]
 pub struct MintGen;

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -183,6 +183,7 @@ impl std::fmt::Display for WalletOutputOutcome {
 pub struct WalletCommonGen;
 
 impl CommonModuleGen for WalletCommonGen {
+    const CONSENSUS_VERSION: ModuleConsensusVersion = CONSENSUS_VERSION;
     const KIND: ModuleKind = KIND;
     fn decoder() -> Decoder {
         WalletModuleTypes::decoder()

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -240,13 +240,6 @@ impl std::fmt::Display for WalletOutput {
 
 pub struct WalletModuleTypes;
 
-impl ModuleCommon for WalletModuleTypes {
-    type Input = WalletInput;
-    type Output = WalletOutput;
-    type OutputOutcome = WalletOutputOutcome;
-    type ConsensusItem = WalletConsensusItem;
-}
-
 pub fn proprietary_tweak_key() -> ProprietaryKey {
     ProprietaryKey {
         prefix: b"fedimint".to_vec(),
@@ -273,6 +266,7 @@ impl PartialEq for PegOutSignatureItem {
 impl Eq for PegOutSignatureItem {}
 
 plugin_types_trait_impl_common!(
+    WalletModuleTypes,
     WalletInput,
     WalletOutput,
     WalletOutputOutcome,

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -30,7 +30,7 @@ use fedimint_core::bitcoin_rpc::{
     FM_ELECTRUM_RPC_ENV, FM_ESPLORA_RPC_ENV,
 };
 use fedimint_core::config::{
-    ClientModuleConfig, ConfigGenModuleParams, DkgResult, ModuleGenParams, ServerModuleConfig,
+    ClientModuleConfig, ConfigGenModuleParams, DkgResult, ServerModuleConfig,
     ServerModuleConsensusConfig, TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::db::{
@@ -54,7 +54,7 @@ use fedimint_core::{
 };
 use fedimint_server::config::distributedgen::PeerHandleOps;
 pub use fedimint_wallet_common as common;
-use fedimint_wallet_common::config::{WalletClientConfig, WalletConfig};
+use fedimint_wallet_common::config::{WalletClientConfig, WalletConfig, WalletGenParams};
 use fedimint_wallet_common::db::{
     BlockHashKey, BlockHashKeyPrefix, PegOutBitcoinTransaction, PegOutBitcoinTransactionPrefix,
     PegOutTxSignatureCI, PegOutTxSignatureCIPrefix, PendingTransactionKey,
@@ -73,14 +73,6 @@ use secp256k1::{Message, Scalar};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tracing::{debug, error, info, instrument, trace, warn};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WalletGenParams {
-    pub network: bitcoin::network::constants::Network,
-    pub finality_delay: u32,
-}
-
-impl ModuleGenParams for WalletGenParams {}
 
 #[derive(Debug, Clone)]
 pub struct WalletGen;


### PR DESCRIPTION
To make life easier for module writers, this modifies a macro and adds a new macro so less boilerplate code is required to implement a module.