### PR TITLE
feat(client-ng): fetch active operations

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1,7 +1,7 @@
 //! Client library for fedimintd
 
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::io::{Error, Read, Write};
 use std::sync::Arc;
@@ -481,6 +481,10 @@ impl Client {
         }
 
         operation_entries
+    }
+
+    pub async fn get_active_operations(&self) -> HashSet<OperationId> {
+        self.inner.executor.get_active_operations().await
     }
 
     pub async fn get_operation(&self, operation_id: OperationId) -> Option<OperationLogEntry> {

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::io::{Error, Read, Write};
 use std::marker::PhantomData;
@@ -208,6 +208,16 @@ where
             .db
             .wait_key_exists(&ActiveStateKey::from_state(state))
             .await
+    }
+
+    /// Returns all IDs of operations that have active state machines
+    pub async fn get_active_operations(&self) -> HashSet<OperationId> {
+        self.inner
+            .get_active_states()
+            .await
+            .into_iter()
+            .map(|(state, _)| state.operation_id())
+            .collect()
     }
 
     /// Starts the background thread that runs the state machines. This cannot


### PR DESCRIPTION
Allows clients to subscribe to all operations where progress is expected.