### PR TITLE
devimint cleanup

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -2,7 +2,7 @@ name: fedimint-dev
 root: .
 socket_name: fedimint-dev
 pre_window:
-  - source .tmpenv
+  - eval "$(devimint env)"
   - source scripts/aliases.sh
 tmux_detached: false
 windows:
@@ -35,8 +35,8 @@ windows:
       panes:
         - bitcoind:
           - tail -n +0 -F $FM_LOGS_DIR/bitcoind.log
-  - fedimint_dkg:
+  - devimint:
       panes:
         - log:
-          - tail -n +0 -F $FM_LOGS_DIR/fedimint-dev.log
+          - tail -n +0 -F $FM_LOGS_DIR/devimint.log
 

--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -3,7 +3,6 @@ root: .
 socket_name: fedimint-dev
 pre_window:
   - source .tmpenv
-  - source scripts/lib.sh
   - source scripts/aliases.sh
 tmux_detached: false
 windows:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,7 @@ dependencies = [
  "fedimint-ln-client",
  "fedimint-logging",
  "fedimint-wallet-client",
+ "futures",
  "nix",
  "serde",
  "serde_json",

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { version = "1.0.69", features = ["backtrace"] }
 bitcoincore-rpc = "0.16.0"
-clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
+clap = { version = "4.1.6", features = ["derive", "env", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 cln-rpc = "0.1.1"
 fedimint-core  = { path = "../fedimint-core" }
 fedimint-client  = { path = "../fedimint-client" }

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -21,6 +21,7 @@ fedimint-ln-client = { path = "../modules/fedimint-ln-client" }
 fedimint-logging = { path = "../fedimint-logging" }
 fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
 fedimint-client-legacy = { path = "../fedimint-client-legacy" }
+futures = "0.3.24"
 nix = { version = "0.26.2", features = ["signal"] }
 serde_json = "1.0.94"
 tokio = { version = "1.26.0", features = ["full"] }

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -18,7 +18,6 @@ use fedimint_client_legacy::{module_decode_stubs, UserClient, UserClientConfig};
 use fedimint_core::config::load_from_file;
 use fedimint_core::db::Database;
 use fedimint_core::encoding::Encodable;
-use fedimint_core::task::TaskGroup;
 use fedimint_ln_client::LightningClientGen;
 use fedimint_logging::LOG_DEVIMINT;
 use fedimint_wallet_client::WalletClientGen;
@@ -503,7 +502,7 @@ impl Gatewayd {
     }
 }
 
-pub async fn dev_fed(task_group: &TaskGroup, process_mgr: &ProcessManager) -> Result<DevFed> {
+pub async fn dev_fed(process_mgr: &ProcessManager) -> Result<DevFed> {
     let start_time = fedimint_core::time::now();
     let bitcoind = Bitcoind::new(process_mgr).await?;
     let ((cln, lnd, gw_cln, gw_lnd), electrs, esplora, fed) = tokio::try_join!(
@@ -524,7 +523,7 @@ pub async fn dev_fed(task_group: &TaskGroup, process_mgr: &ProcessManager) -> Re
         Electrs::new(process_mgr, bitcoind.clone()),
         Esplora::new(process_mgr, bitcoind.clone()),
         async {
-            run_dkg(task_group, 4).await?;
+            run_dkg(process_mgr, 4).await?;
             info!(LOG_DEVIMINT, "dkg done");
             Federation::new(process_mgr, bitcoind.clone(), 0..4).await
         },

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fmt::{Display, Formatter};
 use std::future::Future;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -30,7 +30,9 @@ use tonic_lnd::LndClient;
 use tracing::{info, warn};
 
 pub mod util;
+pub mod vars;
 use util::*;
+use vars::utf8;
 pub mod federation;
 
 pub struct DevFed {
@@ -52,12 +54,12 @@ pub struct Bitcoind {
 
 impl Bitcoind {
     pub async fn new(processmgr: &ProcessManager) -> Result<Self> {
-        let btc_dir = env::var("FM_BTC_DIR")?;
+        let btc_dir = utf8(&processmgr.globals.FM_BTC_DIR);
         let process = processmgr
             .spawn_daemon("bitcoind", cmd!("bitcoind", "-datadir={btc_dir}"))
             .await?;
 
-        let url = env::var("FM_TEST_BITCOIND_RPC")?.parse()?;
+        let url = processmgr.globals.FM_TEST_BITCOIND_RPC.parse()?;
         let (host, auth) = fedimint_bitcoind::bitcoincore_rpc::from_url_to_url_auth(&url)?;
         let client = Arc::new(bitcoincore_rpc::Client::new(&host, auth)?);
 
@@ -139,10 +141,10 @@ pub struct Lightningd {
 
 impl Lightningd {
     pub async fn new(process_mgr: &ProcessManager, bitcoind: Bitcoind) -> Result<Self> {
-        let cln_dir = env::var("FM_CLN_DIR")?;
-        let process = Lightningd::start(process_mgr, cln_dir.clone()).await?;
+        let cln_dir = &process_mgr.globals.FM_CLN_DIR;
+        let process = Lightningd::start(process_mgr, cln_dir).await?;
 
-        let socket_cln = PathBuf::from(cln_dir).join("regtest/lightning-rpc");
+        let socket_cln = cln_dir.join("regtest/lightning-rpc");
         poll("lightningd", || async {
             Ok(ClnRpc::new(socket_cln.clone()).await.is_ok())
         })
@@ -155,7 +157,7 @@ impl Lightningd {
         })
     }
 
-    pub async fn start(process_mgr: &ProcessManager, cln_dir: String) -> Result<ProcessHandle> {
+    pub async fn start(process_mgr: &ProcessManager, cln_dir: &Path) -> Result<ProcessHandle> {
         let extension_path = cmd!("which", "gateway-cln-extension")
             .out_string()
             .await
@@ -164,7 +166,7 @@ impl Lightningd {
             "lightningd",
             "--dev-fast-gossip",
             "--dev-bitcoind-poll=1",
-            "--lightning-dir={cln_dir}",
+            format!("--lightning-dir={}", utf8(cln_dir)),
             "--plugin={extension_path}"
         );
 
@@ -226,15 +228,17 @@ impl Lnd {
     }
 
     pub async fn start(process_mgr: &ProcessManager) -> Result<(ProcessHandle, LndClient)> {
-        let lnd_dir = env::var("FM_LND_DIR")?;
-        let cmd = cmd!("lnd", "--lnddir={lnd_dir}");
+        let cmd = cmd!(
+            "lnd",
+            format!("--lnddir={}", utf8(&process_mgr.globals.FM_LND_DIR))
+        );
 
         let process = process_mgr.spawn_daemon("lnd", cmd).await?;
-        let lnd_rpc_addr = env::var("FM_LND_RPC_ADDR")?;
-        let lnd_macaroon = env::var("FM_LND_MACAROON")?;
-        let lnd_tls_cert = env::var("FM_LND_TLS_CERT")?;
+        let lnd_rpc_addr = &process_mgr.globals.FM_LND_RPC_ADDR;
+        let lnd_macaroon = &process_mgr.globals.FM_LND_MACAROON;
+        let lnd_tls_cert = &process_mgr.globals.FM_LND_TLS_CERT;
         poll("lnd", || async {
-            Ok(fs::try_exists(&lnd_tls_cert).await? && fs::try_exists(&lnd_macaroon).await?)
+            Ok(fs::try_exists(lnd_tls_cert).await? && fs::try_exists(lnd_macaroon).await?)
         })
         .await?;
 
@@ -390,12 +394,12 @@ pub struct Gatewayd {
 impl Gatewayd {
     pub async fn new(process_mgr: &ProcessManager, ln: LightningNode) -> Result<Self> {
         let ln_name = ln.name();
-        let test_dir = env::var("FM_TEST_DIR")?;
+        let test_dir = &process_mgr.globals.FM_TEST_DIR;
         let gateway_env: HashMap<String, String> = match ln {
             LightningNode::Cln(_) => HashMap::from_iter([
                 (
                     "FM_GATEWAY_DATA_DIR".to_owned(),
-                    format!("{test_dir}/gw-cln"),
+                    format!("{}/gw-cln", utf8(test_dir)),
                 ),
                 (
                     "FM_GATEWAY_LISTEN_ADDR".to_owned(),
@@ -409,7 +413,7 @@ impl Gatewayd {
             LightningNode::Lnd(_) => HashMap::from_iter([
                 (
                     "FM_GATEWAY_DATA_DIR".to_owned(),
-                    format!("{test_dir}/gw-lnd"),
+                    format!("{}/gw-lnd", utf8(test_dir)),
                 ),
                 (
                     "FM_GATEWAY_LISTEN_ADDR".to_owned(),

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, bail};
 use serde::de::DeserializeOwned;
 use tokio::fs::OpenOptions;
 use tokio::process::Child;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use super::*;
 
@@ -145,7 +145,7 @@ impl Command {
     }
 
     pub async fn run_inner(&mut self) -> Result<std::process::Output> {
-        info!(LOG_DEVIMINT, "> {}", self.command_debug());
+        debug!(LOG_DEVIMINT, "> {}", self.command_debug());
         let output = self.cmd.output().await?;
         if !output.status.success() {
             bail!(

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -51,12 +51,13 @@ impl Drop for ProcessHandleInner {
     }
 }
 
-#[derive(Default)]
-pub struct ProcessManager {}
+pub struct ProcessManager {
+    pub globals: vars::Global,
+}
 
 impl ProcessManager {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(globals: vars::Global) -> Self {
+        Self { globals }
     }
 
     /// Logs to $FM_LOGS_DIR/{name}.{out,err}

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -1,0 +1,131 @@
+#![allow(non_snake_case)]
+
+use std::path::{Path, PathBuf};
+
+pub trait ToEnvVar {
+    fn to_env_value(&self) -> String;
+}
+
+macro_rules! declare_vars {
+    ($name:ident = ($($args:tt)*) =>
+        {
+            $($env_name:ident : $env_ty:ty = $env_value:expr;)*
+        }
+    ) => {
+        pub struct $name {
+            $(
+                #[allow(unused)]
+                pub $env_name: $env_ty
+            ),*
+        }
+
+        impl $name {
+            pub async fn new_vars($($args)*) -> ::anyhow::Result<Self> {
+                $(let $env_name: $env_ty = $env_value.into();)*
+                Ok(Self {
+                    $($env_name),*
+                })
+            }
+
+            pub fn vars<'a>(&'a self) -> impl Iterator<Item = (&'static str, String)> {
+                vec![$((stringify!($env_name), $crate::vars::ToEnvVar::to_env_value(&self.$env_name))),*].into_iter()
+            }
+        }
+    };
+}
+
+impl ToEnvVar for PathBuf {
+    fn to_env_value(&self) -> String {
+        self.as_os_str().to_str().expect("must be utf8").to_owned()
+    }
+}
+
+impl ToEnvVar for String {
+    fn to_env_value(&self) -> String {
+        self.to_owned()
+    }
+}
+
+impl ToEnvVar for usize {
+    fn to_env_value(&self) -> String {
+        self.to_string()
+    }
+}
+
+async fn mkdir(dir: PathBuf) -> anyhow::Result<PathBuf> {
+    if !dir.exists() {
+        tokio::fs::create_dir(&dir).await?;
+    }
+    Ok(dir)
+}
+
+use format as f;
+use tokio::fs;
+pub fn utf8(path: &Path) -> &str {
+    path.as_os_str().to_str().expect("must be valid utf8")
+}
+
+declare_vars! {
+    Global = (test_dir: &Path, fed_size: usize) =>
+    {
+        FM_FED_SIZE: usize = fed_size;
+        FM_TMP_DIR: PathBuf = mkdir(test_dir.into()).await?;
+        FM_TEST_DIR: PathBuf = FM_TMP_DIR.clone();
+        FM_TEST_FAST_WEAK_CRYPTO: String = "1";
+
+        FM_LOGS_DIR: PathBuf = mkdir(FM_TEST_DIR.join("logs")).await?;
+        FM_CLN_DIR: PathBuf = mkdir(FM_TEST_DIR.join("cln")).await?;
+        FM_LND_DIR: PathBuf = mkdir(FM_TEST_DIR.join("lnd")).await?;
+        FM_BTC_DIR: PathBuf = mkdir(FM_TEST_DIR.join("bitcoin")).await?;
+        FM_DATA_DIR: PathBuf = mkdir(FM_TEST_DIR.join("cfg")).await?;
+        FM_ELECTRS_DIR: PathBuf = mkdir(FM_TEST_DIR.join("electrs")).await?;
+        FM_ESPLORA_DIR: PathBuf = mkdir(FM_TEST_DIR.join("esplora")).await?;
+        FM_READY_FILE: PathBuf = FM_TEST_DIR.join("ready");
+
+        FM_LND_RPC_ADDR: String = "http://localhost:11009";
+        FM_LND_TLS_CERT: PathBuf = FM_LND_DIR.join("tls.cert");
+        FM_LND_MACAROON: PathBuf = FM_LND_DIR.join("data/chain/bitcoin/regtest/admin.macaroon");
+
+        FM_GATEWAY_DATA_DIR: PathBuf = mkdir(FM_DATA_DIR.join("gateway")).await?;
+        FM_GATEWAY_LISTEN_ADDR: String = "127.0.0.1:8175";
+        FM_GATEWAY_API_ADDR: String = "http://127.0.0.1:8175";
+        FM_GATEWAY_PASSWORD: String = "theresnosecondbest";
+
+        FM_CLN_EXTENSION_LISTEN_ADDRESS: String = "0.0.0.0:8177";
+        FM_GATEWAY_LIGHTNING_ADDR: String = "http://localhost:8177";
+
+        // clients
+        FM_LIGHTNING_CLI: String = f!("lightning-cli --network regtest --lightning-dir={}", utf8(&FM_CLN_DIR));
+        FM_LNCLI: String = f!("lncli -n regtest --lnddir={} --rpcserver=localhost:11009", utf8(&FM_LND_DIR));
+        FM_BTC_CLIENT: String = "bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin";
+        FM_MINT_CLIENT: String = f!("fedimint-cli --data-dir {}", utf8(&FM_DATA_DIR));
+        FM_MINT_RPC_CLIENT: String = f!("mint-rpc-client");
+        FM_GWCLI_CLN: String = f!("gateway-cli --rpcpassword=theresnosecondbest");
+        FM_GWCLI_LND: String = f!("gateway-cli --rpcpassword=theresnosecondbest -a http://127.0.0.1:28175/");
+        FM_DB_TOOL: String = f!("dbtool");
+        FM_DISTRIBUTEDGEN: String = f!("distributedgen");
+
+        // fedimint config variables
+        FM_TEST_BITCOIND_RPC: String = "http://bitcoin:bitcoin@127.0.0.1:18443";
+        FM_BITCOIND_RPC: String = "http://bitcoin:bitcoin@127.0.0.1:18443";
+    }
+}
+
+impl Global {
+    pub async fn new(test_dir: &Path, fed_size: usize) -> anyhow::Result<Self> {
+        let this = Self::new_vars(test_dir, fed_size).await?;
+        fs::copy(
+            "misc/test/bitcoin.conf",
+            this.FM_BTC_DIR.join("bitcoin.conf"),
+        )
+        .await?;
+        fs::copy("misc/test/lnd.conf", this.FM_LND_DIR.join("lnd.conf")).await?;
+        fs::copy("misc/test/lightningd.conf", this.FM_CLN_DIR.join("config")).await?;
+        fs::copy(
+            "misc/test/electrs.toml",
+            this.FM_ELECTRS_DIR.join("electrs.toml"),
+        )
+        .await?;
+        Ok(this)
+    }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,78 +12,26 @@ export FM_FED_SIZE=${1:-4}
 # so let's not do it.
 
 if [[ "${TMP:-}" == *"/nix-shell."* ]]; then
-  FM_TMP_DIR="${2-$TMP}/fm-$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 4 || true)"
+  FM_TEST_DIR="${2-$TMP}/fm-$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 4 || true)"
 else
-  FM_TMP_DIR="${2-"$(mktemp --tmpdir -d XXXXX)"}"
+  FM_TEST_DIR="${2-"$(mktemp --tmpdir -d XXXXX)"}"
 fi
-export FM_TMP_DIR
-export FM_TEST_FAST_WEAK_CRYPTO="1"
+export FM_TEST_DIR
+export FM_PID_FILE="$FM_TEST_DIR/.pid"
 export FM_POLL_INTERVAL=1
 
-echo "Setting up env variables in $FM_TMP_DIR"
+echo "Setting up env variables in $FM_TEST_DIR"
+
+mkdir -p "$FM_TEST_DIR"
+touch "$FM_PID_FILE"
 
 # Builds the rust executables and sets environment variables
 SRC_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 cd $SRC_DIR || exit 1
 # Note: Respect 'CARGO_PROFILE' that crane uses
 cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}}
+export PATH="$PWD/target/$CARGO_PROFILE:$PATH"
 
-# Define temporary directories to not overwrite manually created config if run locally
-export FM_TEST_DIR=$FM_TMP_DIR
-export FM_BIN_DIR="$SRC_DIR/target/${CARGO_PROFILE:-debug}"
-export PATH="$FM_BIN_DIR:$PATH"
-export FM_PID_FILE="$FM_TMP_DIR/.pid"
-export FM_LOGS_DIR="$FM_TEST_DIR/logs"
-export FM_CLN_DIR="$FM_TEST_DIR/cln"
-export FM_LND_DIR="$FM_TEST_DIR/lnd"
-export FM_BTC_DIR="$FM_TEST_DIR/bitcoin"
-export FM_DATA_DIR="$FM_TEST_DIR/cfg"
-export FM_ELECTRS_DIR="$FM_TEST_DIR/electrs"
-export FM_ESPLORA_DIR="$FM_TEST_DIR/esplora"
-mkdir -p $FM_LOGS_DIR
-mkdir -p $FM_CLN_DIR
-mkdir -p $FM_LND_DIR
-mkdir -p $FM_BTC_DIR
-mkdir -p $FM_DATA_DIR
-mkdir -p $FM_ELECTRS_DIR
-mkdir -p $FM_ESPLORA_DIR
-touch $FM_PID_FILE
-
-# Copy configs to data directories
-cp misc/test/bitcoin.conf $FM_BTC_DIR
-cp misc/test/lnd.conf $FM_LND_DIR
-cp misc/test/lightningd.conf $FM_CLN_DIR/config
-cp misc/test/electrs.toml $FM_ELECTRS_DIR
-
-# LND config variables
-export FM_LND_RPC_ADDR="http://localhost:11009"
-export FM_LND_TLS_CERT=$FM_LND_DIR/tls.cert
-export FM_LND_MACAROON=$FM_LND_DIR/data/chain/bitcoin/regtest/admin.macaroon
-
-# Generate gateway config
-export FM_GATEWAY_DATA_DIR=$FM_DATA_DIR/gateway
-export FM_GATEWAY_LISTEN_ADDR="127.0.0.1:8175"
-export FM_GATEWAY_API_ADDR="http://127.0.0.1:8175"
-export FM_GATEWAY_PASSWORD="theresnosecondbest"
-
-export FM_CLN_EXTENSION_LISTEN_ADDRESS="0.0.0.0:8177"
-export FM_GATEWAY_LIGHTNING_ADDR="http://localhost:8177"
-
-mkdir -p $FM_GATEWAY_DATA_DIR
-
-# Define clients
-export FM_LIGHTNING_CLI="lightning-cli --network regtest --lightning-dir=$FM_CLN_DIR"
-export FM_LNCLI="lncli -n regtest --lnddir=$FM_LND_DIR --rpcserver=localhost:11009"
-export FM_BTC_CLIENT="bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin"
-export FM_MINT_CLIENT="fedimint-cli --data-dir $FM_DATA_DIR"
-export FM_GWCLI_CLN="gateway-cli --rpcpassword=theresnosecondbest"
-export FM_GWCLI_LND="gateway-cli --rpcpassword=theresnosecondbest -a http://127.0.0.1:28175/"
-
-# Fedimint config variables
-export FM_TEST_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
-export FM_BITCOIND_RPC="http://bitcoin:bitcoin@127.0.0.1:18443"
-
-source ./scripts/aliases.sh
 
 # Function for killing processes stored in FM_PID_FILE in reverse-order they were created in
 function kill_fedimint_processes {

--- a/scripts/mprocs.sh
+++ b/scripts/mprocs.sh
@@ -11,17 +11,9 @@ fi
 export FM_VERBOSE_OUTPUT=0
 
 source scripts/build.sh
-echo "Running in temporary directory $FM_TEST_DIR"
 
-# a pipe that rust writes to, and user-shell can wait for it
-export FM_READY_FILE=$FM_TMP_DIR/ready
-mkfifo $FM_READY_FILE
-
-devimint dev-fed &>$FM_LOGS_DIR/devimint.log &
+devimint dev-fed 2>/dev/null &
 echo $! >> $FM_PID_FILE
-
-env | sed -En 's/^(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
+eval "$(devimint env)"
 
 mprocs -c misc/mprocs.yaml
-
-rm .tmpenv

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -8,9 +8,6 @@ source scripts/build.sh
 
 >&2 echo "### Setting up tests"
 
-export FM_READY_FILE=$FM_TMP_DIR/ready
-mkfifo $FM_READY_FILE
-
 # Convert RUST_LOG to lowercase
 # if RUST_LOG is none, don't show output of test setup
 if [ "${RUST_LOG,,}" = "none" ]; then
@@ -21,14 +18,14 @@ else
   echo $! >> $FM_PID_FILE
 fi
 
-# waits for rust to write to this pipe
-STATUS=$(cat $FM_READY_FILE)
+STATUS=$(devimint wait)
 if [ "$STATUS" = "ERROR" ]
 then
     echo "base daemons didn't start correctly"
     exit 1
 fi
 
+eval "$(devimint env)"
 >&2 echo "### Setting up tests - complete"
 
 export FM_TEST_USE_REAL_DAEMONS=1

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -16,18 +16,10 @@ fi
 export FM_VERBOSE_OUTPUT=0
 
 source scripts/build.sh
-echo "Running in temporary directory $FM_TEST_DIR"
 
-# a pipe that rust writes to, and user-shell can wait for it
-export FM_READY_FILE=$FM_TMP_DIR/ready
-mkfifo $FM_READY_FILE
-
-devimint dev-fed &>$FM_LOGS_DIR/devimint.log &
+devimint dev-fed 2>/dev/null &
 echo $! >> $FM_PID_FILE
-
-env | sed -En 's/^(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
+eval "$(devimint env)"
 
 SHELL=$(which bash) tmuxinator local
 tmux -L fedimint-dev kill-session -t fedimint-dev || true
-
-rm .tmpenv

--- a/scripts/user-shell.sh
+++ b/scripts/user-shell.sh
@@ -1,7 +1,6 @@
 # shellcheck shell=bash
 
-source .tmpenv
-
+eval "$(devimint env)"
 source ./scripts/aliases.sh
 
 function show_verbose_output()
@@ -28,8 +27,7 @@ function use_lnd_gw() {
 
 echo Waiting for fedimint start
 
-# waits for rust to write to this pipe
-STATUS=$(cat $FM_READY_FILE)
+STATUS="$(devimint wait)"
 if [ "$STATUS" = "ERROR" ]
 then
     echo "fedimint didn't start correctly"


### PR DESCRIPTION
important change is reducing build.sh and now beautiful typed env variables.

for a dev env prespective:
you can now enter the devimint environment.
say you want to run integration tests with real fixtures. You can do:
`devimint -d /tmp/foo external-daemons`
and in a different shell:
`eval "$(devimint -d /tmp/foo env)"`
and then `cargo test`