### PR TITLE
fix: Client NG spend persists invalid state machine

### DIFF
--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -11,7 +11,7 @@ use fedimint_mint_common::MintInput;
 use crate::input::{
     MintInputCommon, MintInputStateCreated, MintInputStateMachine, MintInputStates,
 };
-use crate::{MintClientContext, SpendableNote};
+use crate::{MintClientContext, MintClientStateMachines, SpendableNote};
 
 #[aquamarine::aquamarine]
 /// State machine managing e-cash that has been taken out of the wallet for
@@ -194,7 +194,7 @@ async fn try_cancel_oob_spend(
         input: MintInput(notes),
         keys,
         state_machines: Arc::new(move |txid, input_idx| {
-            vec![MintInputStateMachine {
+            vec![MintClientStateMachines::Input(MintInputStateMachine {
                 common: MintInputCommon {
                     operation_id,
                     txid,
@@ -203,7 +203,7 @@ async fn try_cancel_oob_spend(
                 state: MintInputStates::Created(MintInputStateCreated {
                     notes: spendable_notes.clone(),
                 }),
-            }]
+            })]
         }),
     };
 


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/2417

Issue is that `try_cancel_oob_spend` was only creating `MintInputStateMachine` and not `MintClientStateMachines::Input(MintInputStateMachine)`