### PR TITLE
Improvements to the config APIs

### DIFF
--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -122,7 +122,7 @@ impl WsAdminClient {
     /// DKG.
     pub async fn get_consensus_config_gen_params(
         &self,
-    ) -> FederationResult<ConfigGenParamsConsensus> {
+    ) -> FederationResult<ConfigGenParamsResponse> {
         self.request(
             "get_consensus_config_gen_params",
             ApiRequestErased::default(),
@@ -218,6 +218,15 @@ pub struct ConfigGenParamsConsensus {
     pub peers: BTreeMap<PeerId, PeerServerParams>,
     /// Params that were configured by the leader
     pub requested: ConfigGenParamsRequest,
+}
+
+/// The config gen params response which includes our peer id
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct ConfigGenParamsResponse {
+    /// The same for all peers
+    pub consensus: ConfigGenParamsConsensus,
+    /// Our id (might change if new peers join)
+    pub our_current_id: PeerId,
 }
 
 /// Config gen values that can be configured by the config gen leader

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -537,9 +537,13 @@ where
             },
         );
 
-        self.request_with_strategy(qs, "config".to_owned(), ApiRequestErased::new(info.clone()))
-            .await
-            .map(|cfg: ClientConfigResponse| cfg.client_config)
+        self.request_with_strategy(
+            qs,
+            "config".to_owned(),
+            ApiRequestErased::new(info.to_string()),
+        )
+        .await
+        .map(|cfg: ClientConfigResponse| cfg.client_config)
     }
 
     async fn consensus_config_hash(&self) -> FederationResult<sha256::Hash> {

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -136,6 +136,7 @@ pub struct ServerConfigConsensus {
     /// All configuration that needs to be the same for modules
     pub modules: BTreeMap<ModuleInstanceId, ServerModuleConsensusConfig>,
     #[encodable_ignore]
+    // FIXME: Make modules encodable or we will not check module keys
     /// Human readable representation of [`Self::modules`]
     pub modules_json: BTreeMap<ModuleInstanceId, JsonWithKind>,
     /// Additional config the federation wants to transmit to the clients

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -265,10 +265,7 @@ impl ConsensusServer {
 
     /// Loop `run_conensus_epoch` until shut down
     pub async fn run_consensus(mut self, task_handle: TaskHandle) -> anyhow::Result<()> {
-        let our_hash = self
-            .cfg
-            .consensus
-            .consensus_hash();
+        let our_hash = self.cfg.consensus.consensus_hash();
 
         // Confirm our hash matches with peers
         loop {

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -268,8 +268,6 @@ impl ConsensusServer {
         let our_hash = self
             .cfg
             .consensus
-            .to_config_response(&self.consensus.module_inits)
-            .client_config
             .consensus_hash();
 
         // Confirm our hash matches with peers

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -498,8 +498,16 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             }
         },
         api_endpoint! {
+            "connection_code",
+            async |fedimint: &ConsensusApi, _context,  _v: ()| -> String {
+                Ok(fedimint.cfg.get_connect_info().to_string())
+            }
+        },
+        api_endpoint! {
             "config",
-            async |fedimint: &ConsensusApi, context, info: WsClientConnectInfo| -> ClientConfigResponse {
+            async |fedimint: &ConsensusApi, context, connection_code: String| -> ClientConfigResponse {
+                let info = connection_code.parse()
+                    .map_err(|_| ApiError::bad_request("Could not parse connection code".to_string()))?;
                 fedimint.download_config_with_token(info, &mut context.dbtx()).await
             }
         },

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -1,5 +1,5 @@
 //! Implements the client API through which users interact with the federation
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use std::time::{Duration, Instant, UNIX_EPOCH};
@@ -31,7 +31,7 @@ use tokio::sync::RwLock;
 use tracing::debug;
 
 use super::peers::PeerStatusChannels;
-use crate::config::api::ApiResult;
+use crate::config::api::{get_verification_hashes, ApiResult};
 use crate::config::ServerConfig;
 use crate::consensus::interconnect::FedimintInterconnect;
 use crate::consensus::server::LatestContributionByPeer;
@@ -42,6 +42,7 @@ use crate::db::{
     AcceptedTransactionKey, ClientConfigDownloadKey, ClientConfigSignatureKey, EpochHistoryKey,
     LastEpochKey, RejectedTransactionKey,
 };
+use crate::fedimint_core::encoding::Encodable;
 use crate::transaction::SerdeTransaction;
 use crate::HasApiContext;
 
@@ -504,8 +505,8 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
         },
         api_endpoint! {
             "config_hash",
-            async |fedimint: &ConsensusApi, context, _v: ()| -> sha256::Hash {
-                Ok(fedimint.get_config_with_sig(&mut context.dbtx()).await.client_config.consensus_hash())
+            async |fedimint: &ConsensusApi, _context, _v: ()| -> sha256::Hash {
+                Ok(fedimint.cfg.consensus.consensus_hash())
             }
         },
         api_endpoint! {
@@ -542,6 +543,16 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                     server: ServerStatus::ConsensusRunning,
                     consensus: Some(consensus_status)
                 })
+            }
+        },
+        api_endpoint! {
+            "get_verify_config_hash",
+            async |fedimint: &ConsensusApi, context, _v: ()| -> BTreeMap<PeerId, sha256::Hash> {
+                if context.has_auth() {
+                    Ok(get_verification_hashes(&fedimint.cfg))
+                } else {
+                    Err(ApiError::unauthorized())
+                }
             }
         },
     ]


### PR DESCRIPTION
Based on UI feedback:
- Add current_id to “get_consensus_config_params”
- Make “get_verify_config_hash” available after start_consensus
- New “connection_code” endpoint, passed into “config” endpoint
- Write password to disk once configs are verified