### PR TITLE
fix(guardian-ui): Correctly order module instance IDs

### DIFF
--- a/guardian-ui/src/components/SetConfiguration.tsx
+++ b/guardian-ui/src/components/SetConfiguration.tsx
@@ -113,15 +113,15 @@ export const SetConfiguration: React.FC<Props> = ({ next }) => {
             meta: { federation_name: federationName },
             modules: {
               // TODO: figure out way to not hard-code modules here
-              0: ['mint', { mint_amounts: mintAmounts }],
-              1: [
+              0: ['ln', null],
+              1: ['mint', { mint_amounts: mintAmounts }],
+              2: [
                 'wallet',
                 {
                   finality_delay: parseInt(blockConfirmations, 10),
                   network: network as Network,
                 },
               ],
-              2: ['ln', null],
             },
           },
         });


### PR DESCRIPTION
Frontend had them ordered incorrectly which caused a panic when consensus was run:

```
2023-05-07T21:09:48.533139Z ERROR fedimint_core::db: error=Other decoding error: Error decoding blind message
thread 'main' panicked at 'Unrecoverable error when decoding the database value: Other(Error decoding blind message)', /Users/justin/work/fedimint-2/fedimint-core/src/db/mod.rs:1116:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

We need to get smarter about typing the module instance IDs on the frontend.