### PR TITLE
feat: tokio::time::sleep -> fedimint_core::task::sleep in Client NG

### DIFF
--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -288,7 +288,7 @@ where
         if active_states.is_empty() {
             // FIXME: what to do in this case? Probably best to subscribe to DB eventually
             debug!("No state transitions available, waiting before re-trying");
-            tokio::time::sleep(EXECUTOR_POLL_INTERVAL).await;
+            fedimint_core::task::sleep(EXECUTOR_POLL_INTERVAL).await;
             return Ok(());
         }
 

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -167,7 +167,7 @@ async fn trigger_created_submit(
     next_submission: SystemTime,
     context: DynGlobalClientContext,
 ) -> Result<(), String> {
-    tokio::time::sleep(
+    fedimint_core::task::sleep(
         next_submission
             .duration_since(now())
             .unwrap_or(Duration::ZERO),


### PR DESCRIPTION
`tokio::time::sleep` doesn't work in WASM