### PR TITLE
fix: make client db mod public

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -53,7 +53,7 @@ use crate::transaction::{
 };
 
 /// Database keys used by the client
-mod db;
+pub mod db;
 /// Module client interface definitions
 pub mod module;
 /// Client state machine interfaces and executor implementation


### PR DESCRIPTION
Public `fedimint-client` functions return things like `ChronologicalOperationLogKey` and `OperationLogEntry` so it would be nice if these were public as well.