### PR TITLE
Guardian UI - Setup completion flow

### DIFF
--- a/guardian-ui/src/GuardianApi.ts
+++ b/guardian-ui/src/GuardianApi.ts
@@ -17,7 +17,7 @@ export interface ApiInterface {
   testPassword: (password: string) => Promise<boolean>;
 
   // Shared RPC methods
-  status: () => Promise<ServerStatus>;
+  status: () => Promise<StatusResponse>;
 
   // Setup RPC methods (only exist during setup)
   setPassword: (password: string) => Promise<void>;
@@ -35,7 +35,6 @@ export interface ApiInterface {
   // Running RPC methods (only exist after run_consensus)
   version: () => Promise<Versions>;
   fetchEpochCount: () => Promise<number>;
-  consensusStatus: () => Promise<ConsensusStatus>;
 }
 
 const SESSION_STORAGE_KEY = 'guardian-ui-key';
@@ -124,9 +123,8 @@ export class GuardianApi implements ApiInterface {
 
   /*** Shared RPC methods */
 
-  status = async (): Promise<ServerStatus> => {
-    const statusResponse: StatusResponse = await this.rpc('status');
-    return statusResponse.server;
+  status = (): Promise<StatusResponse> => {
+    return this.rpc('status');
   };
 
   /*** Setup RPC methods ***/
@@ -192,7 +190,7 @@ export class GuardianApi implements ApiInterface {
       // Confirm satus.
       try {
         const status = await this.status();
-        if (status === ServerStatus.ConsensusRunning) {
+        if (status.server === ServerStatus.ConsensusRunning) {
           return;
         } else {
           throw new Error(`Expected status ConsensusRunning, got ${status}`);

--- a/guardian-ui/src/GuardianApi.ts
+++ b/guardian-ui/src/GuardianApi.ts
@@ -91,6 +91,9 @@ export class GuardianApi implements ApiInterface {
   };
 
   shutdown = async (): Promise<boolean> => {
+    if (this.connectPromise) {
+      this.connectPromise = null;
+    }
     if (this.websocket) {
       const evt: CloseEvent = await this.websocket.close();
       this.websocket = null;
@@ -170,22 +173,44 @@ export class GuardianApi implements ApiInterface {
     return this.rpc('run_dkg');
   };
 
-  startConsensus = (): Promise<void> => {
-    // Special case: start_consensus kills the server. Set a timeout and restart after short period.
-    const rpcPromise = this.rpc<null>('start_consensus');
-    const timeoutPromise = new Promise((resolve) =>
-      setTimeout(() => resolve(true), 5000)
-    );
+  startConsensus = async (): Promise<void> => {
+    const sleep = (time: number) =>
+      new Promise((resolve) => setTimeout(resolve, time));
 
-    return Promise.any([rpcPromise, timeoutPromise]).then(async () => {
-      // Restart a fresh socket and make sure the status is correct.
+    // Special case: start_consensus kills the server, which sometimes causes it not to respond.
+    // If it doesn't respond within 5 seconds, continue on with status checks.
+    await Promise.any([this.rpc<null>('start_consensus'), sleep(5000)]);
+
+    // Try to reconnect and confirm that status is ConsensusRunning. Retry multiple
+    // times, but eventually give up and just throw.
+    let tries = 0;
+    const maxTries = 10;
+    const attempConfirmConsensusRunning = async (): Promise<void> => {
+      // Explicitly start a fresh socket.
       await this.shutdown();
       await this.connect();
-      const status = await this.status();
-      if (status !== ServerStatus.ConsensusRunning) {
+      // Confirm satus.
+      try {
+        const status = await this.status();
+        if (status === ServerStatus.ConsensusRunning) {
+          return;
+        } else {
+          throw new Error(`Expected status ConsensusRunning, got ${status}`);
+        }
+      } catch (err) {
+        console.warn('Failed to confirm consensus running:', err);
+      }
+      // Retry after a delay if we haven't exceeded the max number of tries, otherwise give up.
+      if (tries < maxTries) {
+        tries++;
+        await sleep(1000);
+        return attempConfirmConsensusRunning();
+      } else {
         throw new Error('Failed to start consensus, see logs for more info.');
       }
-    });
+    };
+
+    return attempConfirmConsensusRunning();
   };
 
   /*** Running RPC methods */

--- a/guardian-ui/src/GuardianApi.ts
+++ b/guardian-ui/src/GuardianApi.ts
@@ -187,13 +187,15 @@ export class GuardianApi implements ApiInterface {
       // Explicitly start a fresh socket.
       await this.shutdown();
       await this.connect();
-      // Confirm satus.
+      // Confirm status.
       try {
         const status = await this.status();
         if (status.server === ServerStatus.ConsensusRunning) {
           return;
         } else {
-          throw new Error(`Expected status ConsensusRunning, got ${status}`);
+          throw new Error(
+            `Expected status ConsensusRunning, got ${status.server}`
+          );
         }
       } catch (err) {
         console.warn('Failed to confirm consensus running:', err);

--- a/guardian-ui/src/GuardianContext.tsx
+++ b/guardian-ui/src/GuardianContext.tsx
@@ -167,6 +167,13 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
             payload: SetupProgress.VerifyGuardians,
           });
         }
+        // If consensus is running, skip past all setup
+        if (status === ServerStatus.ConsensusRunning) {
+          dispatch({
+            type: SETUP_ACTION_TYPE.SET_IS_SETUP_COMPLETE,
+            payload: true,
+          });
+        }
       })
       .catch((err) => {
         // Missing password error

--- a/guardian-ui/src/GuardianContext.tsx
+++ b/guardian-ui/src/GuardianContext.tsx
@@ -134,7 +134,7 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
       .then((status) => {
         // If we're still waiting for a password, restart the whole thing.
         // Otherwise, fetch the password and indicate if we need auth.
-        if (status === ServerStatus.AwaitingPassword) {
+        if (status.server === ServerStatus.AwaitingPassword) {
           dispatch({
             type: SETUP_ACTION_TYPE.SET_INITIAL_STATE,
             payload: null,
@@ -154,21 +154,21 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
           }
         }
         // If we're ready for DKG, move them to approve the config to start.
-        if (status === ServerStatus.ReadyForConfigGen) {
+        if (status.server === ServerStatus.ReadyForConfigGen) {
           dispatch({
             type: SETUP_ACTION_TYPE.SET_PROGRESS,
             payload: SetupProgress.ConnectGuardians,
           });
         }
         // If we're supposed to be verifying, jump to peer validation screen
-        if (status === ServerStatus.VerifyingConfigs) {
+        if (status.server === ServerStatus.VerifyingConfigs) {
           dispatch({
             type: SETUP_ACTION_TYPE.SET_PROGRESS,
             payload: SetupProgress.VerifyGuardians,
           });
         }
         // If consensus is running, skip past all setup
-        if (status === ServerStatus.ConsensusRunning) {
+        if (status.server === ServerStatus.ConsensusRunning) {
           dispatch({
             type: SETUP_ACTION_TYPE.SET_IS_SETUP_COMPLETE,
             payload: true,

--- a/guardian-ui/src/components/FederationDashboard.tsx
+++ b/guardian-ui/src/components/FederationDashboard.tsx
@@ -1,0 +1,89 @@
+import {
+  Flex,
+  Card,
+  CardBody,
+  CardHeader,
+  Table,
+  Tbody,
+  Tr,
+  Td,
+  Thead,
+  Th,
+} from '@chakra-ui/react';
+import React, { useEffect, useState } from 'react';
+import { useGuardianContext } from '../hooks';
+import { StatusResponse, Versions } from '../types';
+
+export const FederationDashboard: React.FC = () => {
+  const { api } = useGuardianContext();
+  const [versions, setVersions] = useState<Versions>();
+  const [epochCount, setEpochCount] = useState<number>();
+  const [status, setStatus] = useState<StatusResponse>();
+
+  useEffect(() => {
+    api.version().then(setVersions).catch(console.error);
+    api.fetchEpochCount().then(setEpochCount).catch(console.error);
+    api.status().then(setStatus).catch(console.error);
+  }, [api]);
+
+  const apiVersion = versions?.core.api.length
+    ? `${versions.core.api[0].major}.${versions.core.api[0].minor}`
+    : '';
+  const consensusVersion =
+    versions?.core.consensus !== undefined ? `${versions.core.consensus}` : '';
+
+  return (
+    <Flex gap={4}>
+      <Card flex='1'>
+        <CardHeader>Federation info</CardHeader>
+        <CardBody>
+          <Table>
+            <Tbody>
+              <Tr>
+                <Td>Your status</Td>
+                <Td>{status?.server}</Td>
+              </Tr>
+              <Tr>
+                <Td>Epoch count</Td>
+                <Td>{epochCount}</Td>
+              </Tr>
+              <Tr>
+                <Td>API Version</Td>
+                <Td>{apiVersion}</Td>
+              </Tr>
+              <Tr>
+                <Td>Consensus version</Td>
+                <Td>{consensusVersion}</Td>
+              </Tr>
+            </Tbody>
+          </Table>
+        </CardBody>
+      </Card>
+      <Card flex='1'>
+        <CardHeader>Peer info</CardHeader>
+        <CardBody>
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>Name</Th>
+                <Th>Status</Th>
+              </Tr>
+            </Thead>
+            {status && (
+              <Tbody>
+                {Object.entries(status?.consensus.status_by_peer).map(
+                  ([peerId, peerStatus]) => (
+                    <Tr>
+                      <Td>Peer {peerId}</Td>
+                      <Td>{peerStatus.connection_status}</Td>
+                    </Tr>
+                  )
+                )}
+              </Tbody>
+            )}
+          </Table>
+        </CardBody>
+      </Card>
+    </Flex>
+  );
+};

--- a/guardian-ui/src/components/RunDKG.tsx
+++ b/guardian-ui/src/components/RunDKG.tsx
@@ -36,7 +36,7 @@ export const RunDKG: React.FC<Props> = ({ next }) => {
       try {
         const status = await api.status();
         if (canceled) return;
-        switch (status) {
+        switch (status.server) {
           case ServerStatus.SharingConfigGenParams:
             await api.runDkg().catch((err) => {
               // If we timed out, np just try again

--- a/guardian-ui/src/components/Setup.tsx
+++ b/guardian-ui/src/components/Setup.tsx
@@ -18,6 +18,7 @@ import { Login } from './Login';
 import { ConnectGuardians } from './ConnectGuardians';
 import { RunDKG } from './RunDKG';
 import { VerifyGuardians } from './VerifyGuardians';
+import { SetupComplete } from './SetupComplete';
 
 const PROGRESS_ORDER: SetupProgress[] = [
   SetupProgress.Start,
@@ -53,14 +54,8 @@ export const Setup: React.FC = () => {
 
   let title: React.ReactNode;
   let subtitle: React.ReactNode;
-  let canGoBack = true;
-  let content: React.ReactNode = (
-    <>
-      {/* TODO: Remove these defaults */}
-      <Heading>Nothing here yet!</Heading>
-      <Button onClick={handleNext}>Next</Button>
-    </>
-  );
+  let canGoBack = false;
+  let content: React.ReactNode;
   if (isInitializing) {
     content = <Spinner />;
   } else if (needsAuth && !password) {
@@ -80,6 +75,7 @@ export const Setup: React.FC = () => {
           ? 'Your Federation Followers will confirm this information on their end.'
           : 'Your Federation Leader will be setting up main Federation details. You’ll confirm them soon.';
         content = <SetConfiguration next={handleNext} />;
+        canGoBack = true;
         break;
       case SetupProgress.ConnectGuardians:
         title = isHost
@@ -89,6 +85,7 @@ export const Setup: React.FC = () => {
           ? 'Share the link with the other Guardians to get everyone on the same page. Once all the Guardians join, you’ll automatically move on to the next step.'
           : 'Make sure that the information here looks right, and that the Federation Guardians are correct. Click the Approve button when you’re sure it looks good.';
         content = <ConnectGuardians next={handleNext} />;
+        canGoBack = true;
         break;
       case SetupProgress.RunDKG:
         title = 'Boom! Sharing info between Guardians';
@@ -101,12 +98,9 @@ export const Setup: React.FC = () => {
         subtitle =
           'Ask each Guardian for their verification code, and paste them below to check validity. We’re almost done!';
         content = <VerifyGuardians next={handleNext} />;
-        canGoBack = false;
         break;
       case SetupProgress.SetupComplete:
-        title = 'Your Federation is now set up!';
-        subtitle = 'Get connected and start inviting members.';
-        canGoBack = false;
+        content = <SetupComplete />;
         break;
       default:
         title = 'Unknown step';

--- a/guardian-ui/src/components/Setup.tsx
+++ b/guardian-ui/src/components/Setup.tsx
@@ -19,6 +19,7 @@ import { ConnectGuardians } from './ConnectGuardians';
 import { RunDKG } from './RunDKG';
 import { VerifyGuardians } from './VerifyGuardians';
 import { SetupComplete } from './SetupComplete';
+import { FederationDashboard } from './FederationDashboard';
 
 const PROGRESS_ORDER: SetupProgress[] = [
   SetupProgress.Start,
@@ -31,7 +32,14 @@ const PROGRESS_ORDER: SetupProgress[] = [
 
 export const Setup: React.FC = () => {
   const {
-    state: { progress, role, password, needsAuth, isInitializing },
+    state: {
+      progress,
+      role,
+      password,
+      needsAuth,
+      isInitializing,
+      isSetupComplete,
+    },
     dispatch,
   } = useGuardianContext();
 
@@ -62,6 +70,8 @@ export const Setup: React.FC = () => {
     title = 'Welcome back!';
     subtitle = 'Please enter your password.';
     content = <Login />;
+  } else if (isSetupComplete) {
+    content = <FederationDashboard />;
   } else {
     switch (progress) {
       case SetupProgress.Start:

--- a/guardian-ui/src/components/SetupComplete.tsx
+++ b/guardian-ui/src/components/SetupComplete.tsx
@@ -1,0 +1,36 @@
+import { Flex, Heading, Text, Button, Icon } from '@chakra-ui/react';
+import React, { useCallback } from 'react';
+import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';
+import { useGuardianContext } from '../hooks';
+import { SETUP_ACTION_TYPE } from '../types';
+
+export const SetupComplete: React.FC = () => {
+  const { dispatch } = useGuardianContext();
+
+  const handleContinue = useCallback(() => {
+    dispatch({ type: SETUP_ACTION_TYPE.SET_IS_SETUP_COMPLETE, payload: true });
+  }, [dispatch]);
+
+  return (
+    <Flex
+      direction='column'
+      justify='center'
+      align='center'
+      textAlign='center'
+      pt={10}
+    >
+      <Heading size='sm' fontSize='42px' mb={8}>
+        🎉 🎉 🎉
+      </Heading>
+      <Heading size='md' fontWeight='medium' mb={2}>
+        Congratualations
+      </Heading>
+      <Text mb={16} fontWeight='medium'>
+        All Guardians’ verification codes have been verified.
+      </Text>
+      <Button leftIcon={<Icon as={ArrowRightIcon} />} onClick={handleContinue}>
+        Continue
+      </Button>
+    </Flex>
+  );
+};

--- a/guardian-ui/src/components/SetupComplete.tsx
+++ b/guardian-ui/src/components/SetupComplete.tsx
@@ -23,7 +23,7 @@ export const SetupComplete: React.FC = () => {
         🎉 🎉 🎉
       </Heading>
       <Heading size='md' fontWeight='medium' mb={2}>
-        Congratualations
+        Congratulations
       </Heading>
       <Text mb={16} fontWeight='medium'>
         All Guardians’ verification codes have been verified.

--- a/guardian-ui/src/types.tsx
+++ b/guardian-ui/src/types.tsx
@@ -77,10 +77,17 @@ export interface ConsensusState {
 
 export interface Versions {
   core: {
-    consensus: string;
-    api: string;
+    consensus: number;
+    api: { major: number; minor: number }[];
   };
-  modules: Record<number, { core: string; module: string; api: string }>;
+  modules: Record<
+    number,
+    {
+      core: string;
+      module: string;
+      api: { major: number; minor: number }[];
+    }
+  >;
 }
 
 export interface PeerStatus {

--- a/guardian-ui/src/types.tsx
+++ b/guardian-ui/src/types.tsx
@@ -83,8 +83,8 @@ export interface Versions {
   modules: Record<
     number,
     {
-      core: string;
-      module: string;
+      core: number;
+      module: number;
       api: { major: number; minor: number }[];
     }
   >;


### PR DESCRIPTION
### What This Does

* Implements a `SetupComplete` component for after you've run consensus
* Implements a placeholder `FederationDashboard` component that renders when your federation is running
  * When you visit the page after setup, you will always be directed to this page
  * We will need more APIs to actually make this page useful, but hopefully it will provide the federation join code and some basic status information going forward, maybe even administrative actions? #2451
* Fixes and improves `GuardianApi.startConsensus()`
  * Properly tears down and restarts socket, previously it would keep trying to use the busted socket
  * Retries up to 10 times with 1 second intervals to allow for slower restarts
* Returns the full `StatusResponse` from `GuardianApi.status()`
  * Updated all places in code we used this from `status` to `status.server`

## Screenshots


https://user-images.githubusercontent.com/649992/236887394-5c93f3f6-fd33-4b0a-b6da-1b4f59c23132.mp4

