### PR TITLE
feat: WaitInvoice and LN Client NG CLI tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,7 @@ dependencies = [
  "clap",
  "cln-rpc",
  "fedimint-bitcoind",
+ "fedimint-cli",
  "fedimint-client",
  "fedimint-client-legacy",
  "fedimint-core",

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -16,6 +16,7 @@ bitcoincore-rpc = "0.16.0"
 clap = { version = "4.1.6", features = ["derive", "env", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 cln-rpc = "0.1.1"
 fedimint-core  = { path = "../fedimint-core" }
+fedimint-cli  = { path = "../fedimint-cli" }
 fedimint-client  = { path = "../fedimint-client" }
 fedimint-bitcoind = { path = "../fedimint-bitcoind", features = ["bitcoincore-rpc"] }
 fedimint-ln-client = { path = "../modules/fedimint-ln-client" }

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -702,9 +702,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
     // Receive the ecash notes
     let operation_id = ln_invoice_response.operation_id;
-    cmd!(fed, "ng", "wait-invoice", "--operation-id", operation_id)
-        .run()
-        .await?;
+    cmd!(fed, "ng", "wait-invoice", operation_id).run().await?;
 
     // Assert balances changed by 1000 msat
     let final_cln_incoming_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?
@@ -823,9 +821,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
     // Receive the ecash notes
     let operation_id = ln_invoice_response.operation_id;
-    cmd!(fed, "ng", "wait-invoice", "--operation-id", operation_id)
-        .run()
-        .await?;
+    cmd!(fed, "ng", "wait-invoice", operation_id).run().await?;
 
     // Assert balances changed by 1000 msat
     let final_lnd_incoming_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -14,6 +14,7 @@ use devimint::util::{poll, ProcessManager};
 use devimint::{
     cmd, dev_fed, external_daemons, vars, Bitcoind, DevFed, LightningNode, Lightningd, Lnd,
 };
+use fedimint_cli::LnInvoiceResponse;
 use fedimint_core::task::TaskGroup;
 use fedimint_logging::LOG_DEVIMINT;
 use tokio::fs;
@@ -644,32 +645,92 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     anyhow::ensure!(invoice_status == tonic_lnd::lnrpc::invoice::InvoiceState::Settled);
 
     // Assert balances changed by 3000 msat (amount sent) + 30 msat (fee)
-    let final_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
+    let final_cln_outgoing_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?
+        ["total_msat"]
         .as_u64()
         .unwrap();
-    let final_cln_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
+    let final_cln_outgoing_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
         .out_json()
         .await?
         .as_u64()
         .unwrap();
     anyhow::ensure!(
-        initial_client_ng_balance - final_client_ng_balance == 3030,
-        "Client NG balance changed by {}, expected 1010",
-        initial_client_ng_balance - final_client_ng_balance
+        initial_client_ng_balance - final_cln_outgoing_client_ng_balance == 3030,
+        "Client NG balance changed by {} on CLN outgoing payment, expected 1010",
+        initial_client_ng_balance - final_cln_outgoing_client_ng_balance
     );
     anyhow::ensure!(
-        final_cln_gateway_balance - initial_cln_gateway_balance == 3030,
-        "CLN Gateway balance changed by {}, expected 1010",
-        final_cln_gateway_balance - initial_cln_gateway_balance
+        final_cln_outgoing_gateway_balance - initial_cln_gateway_balance == 3030,
+        "CLN Gateway balance changed by {} on CLN outgoing payment, expected 1010",
+        final_cln_outgoing_gateway_balance - initial_cln_gateway_balance
+    );
+
+    let ln_response_val = cmd!(
+        fed,
+        "ng",
+        "ln-invoice",
+        "--amount=1000msat",
+        "--description='incoming-ng-over-cln-gw'"
+    )
+    .out_json()
+    .await?;
+    let ln_invoice_response: LnInvoiceResponse = serde_json::from_value(ln_response_val)?;
+    let invoice = ln_invoice_response.invoice;
+    let payment = lnd
+        .client_lock()
+        .await?
+        .send_payment_sync(tonic_lnd::lnrpc::SendRequest {
+            payment_request: invoice.clone(),
+            ..Default::default()
+        })
+        .await?
+        .into_inner();
+    lnd.client_lock()
+        .await?
+        .list_payments(tonic_lnd::lnrpc::ListPaymentsRequest {
+            include_incomplete: true,
+            ..Default::default()
+        })
+        .await?
+        .into_inner()
+        .payments
+        .into_iter()
+        .find(|p| p.payment_hash == payment.payment_hash.to_hex())
+        .context("payment not in list")?
+        .status();
+    anyhow::ensure!(payment_status == tonic_lnd::lnrpc::payment::PaymentStatus::Succeeded);
+
+    // Receive the ecash notes
+    let operation_id = ln_invoice_response.operation_id;
+    cmd!(fed, "ng", "wait-invoice", "--operation-id", operation_id)
+        .run()
+        .await?;
+
+    // Assert balances changed by 1000 msat
+    let final_cln_incoming_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?
+        ["total_msat"]
+        .as_u64()
+        .unwrap();
+    let final_cln_incoming_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
+        .out_json()
+        .await?
+        .as_u64()
+        .unwrap();
+    anyhow::ensure!(
+        final_cln_incoming_client_ng_balance - final_cln_outgoing_client_ng_balance == 1000,
+        "Client NG balance changed by {} on CLN incoming payment, expected 1000",
+        final_cln_incoming_client_ng_balance - final_cln_outgoing_client_ng_balance
+    );
+    anyhow::ensure!(
+        final_cln_outgoing_gateway_balance - final_cln_incoming_gateway_balance == 1000,
+        "CLN Gateway balance changed by {} on CLN incoming payment, expected 1000",
+        final_cln_outgoing_gateway_balance - final_cln_incoming_gateway_balance
     );
 
     // LND gateway tests
     fed.use_gateway(&gw_lnd).await?;
 
     // OUTGOING: fedimint-cli NG pays CLN via LND gateaway
-    let initial_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
-        .as_u64()
-        .unwrap();
     let initial_lnd_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
         .out_json()
         .await?
@@ -706,23 +767,85 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     ));
 
     // Assert balances changed by 1000 msat (amount sent) + 10 msat (fee)
-    let final_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
+    let final_lnd_outgoing_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?
+        ["total_msat"]
         .as_u64()
         .unwrap();
-    let final_lnd_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
+    let final_lnd_outgoing_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
         .out_json()
         .await?
         .as_u64()
         .unwrap();
     anyhow::ensure!(
-        initial_client_ng_balance - final_client_ng_balance == 1010,
-        "Client NG balance changed by {}, expected 1010",
-        initial_client_ng_balance - final_client_ng_balance
+        final_cln_incoming_client_ng_balance - final_lnd_outgoing_client_ng_balance == 1010,
+        "Client NG balance changed by {} on LND outgoing payment, expected 1010",
+        final_cln_incoming_client_ng_balance - final_lnd_outgoing_client_ng_balance
     );
     anyhow::ensure!(
-        final_lnd_gateway_balance - initial_lnd_gateway_balance == 1010,
-        "LND Gateway balance changed by {}, expected 1010",
-        final_lnd_gateway_balance - initial_lnd_gateway_balance
+        final_lnd_outgoing_gateway_balance - initial_lnd_gateway_balance == 1010,
+        "LND Gateway balance changed by {} on LND outgoing payment, expected 1010",
+        final_lnd_outgoing_gateway_balance - initial_lnd_gateway_balance
+    );
+
+    // INCOMING: fedimint-cli NG receives from CLN via LND gateway
+    let ln_response_val = cmd!(
+        fed,
+        "ng",
+        "ln-invoice",
+        "--amount=1000msat",
+        "--description='incoming-ng-over-lnd-gw'"
+    )
+    .out_json()
+    .await?;
+    let ln_invoice_response: LnInvoiceResponse = serde_json::from_value(ln_response_val)?;
+    let invoice = ln_invoice_response.invoice;
+    let invoice_status = cln
+        .request(cln_rpc::model::PayRequest {
+            bolt11: invoice,
+            amount_msat: None,
+            label: None,
+            riskfactor: None,
+            maxfeepercent: None,
+            retry_for: None,
+            maxdelay: None,
+            exemptfee: None,
+            localinvreqid: None,
+            exclude: None,
+            maxfee: None,
+            description: None,
+        })
+        .await?
+        .status;
+    anyhow::ensure!(matches!(
+        invoice_status,
+        cln_rpc::model::PayStatus::COMPLETE
+    ));
+
+    // Receive the ecash notes
+    let operation_id = ln_invoice_response.operation_id;
+    cmd!(fed, "ng", "wait-invoice", "--operation-id", operation_id)
+        .run()
+        .await?;
+
+    // Assert balances changed by 1000 msat
+    let final_lnd_incoming_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?
+        ["total_msat"]
+        .as_u64()
+        .unwrap();
+    let final_lnd_incoming_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
+        .out_json()
+        .await?
+        .as_u64()
+        .unwrap();
+    anyhow::ensure!(
+        final_lnd_incoming_client_ng_balance - final_lnd_outgoing_client_ng_balance == 1000,
+        "Client NG balance changed by {} on LND incoming payment, expected 1000",
+        final_lnd_incoming_client_ng_balance - final_lnd_outgoing_client_ng_balance
+    );
+    anyhow::ensure!(
+        final_lnd_outgoing_gateway_balance - final_lnd_incoming_gateway_balance == 1000,
+        "LND Gateway balance changed by {} on LND incoming payment, expected 1000",
+        final_lnd_outgoing_gateway_balance - final_lnd_incoming_gateway_balance
     );
 
     // TODO: test cancel/timeout

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -14,6 +14,7 @@ use bitcoin::{secp256k1, Address, Network, Transaction};
 use clap::{Parser, Subcommand};
 use fedimint_aead::get_password_hash;
 use fedimint_client::module::gen::{ClientModuleGen, ClientModuleGenRegistry, IClientModuleGen};
+use fedimint_client::sm::OperationId;
 use fedimint_client::ClientBuilder;
 use fedimint_client_legacy::mint::backup::Metadata;
 use fedimint_client_legacy::mint::SpendableNote;
@@ -1066,7 +1067,7 @@ impl FedimintCli {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LnInvoiceResponse {
-    pub operation_id: String,
+    pub operation_id: OperationId,
     pub invoice: String,
 }
 

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1064,6 +1064,12 @@ impl FedimintCli {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LnInvoiceResponse {
+    pub operation_id: String,
+    pub invoice: String,
+}
+
 /// Convert clap arguments to backup metadata
 fn metadata_from_clap_cli(metadata: Vec<String>) -> Result<BTreeMap<String, String>, CliError> {
     let metadata: BTreeMap<String, String> = metadata


### PR DESCRIPTION
`LnInvoice` in Client NG is currently blocking. It will wait for the invoice to be paid before returning. This is difficult for CLI testing, since it requires a separate thread to pay the invoice. The old client fixed this by having two CLI commands `LnInvoice` and `WaitInvoice`. `LnInvoice` would only generate the payment request and `WaitInvoice` would actually block on the `IncomingContract` to receive the ecash notes.

This PR makes a similar change to the client NG. It adds a new flag `wait_for_payment` that allows `LnInvoice` to either be blocking or non-blocking. `WaitInvoice` will now generate the state machine to wait for the `IncomingContract` to be paid.

This PR also adds lightning client NG tests for sending and receiving from the CLN and LND gateway.