### PR TITLE
fix(devimint): activate rust backtraces by default

### DIFF
--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -228,7 +228,7 @@ macro_rules! cmd {
             $this.cmd().await
                 $(.arg($arg))*
                 .kill_on_drop(true)
-
+                .env("RUST_BACKTRACE", "1")
         }
     };
 }


### PR DESCRIPTION
Many of the executables called using the `cmd!(…)` macro are our own, if one panics having a backtrace is useful for debugging, thus setting the environment variable `RUST_BACKTRACE=1` for all calls seems reasonable (it shouldn't hurt other executables we call).