### PR TITLE
fix: download_client_config

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -528,12 +528,7 @@ where
             false,
             move |config: &ClientConfigResponse| {
                 let hash = config.client_config.consensus_hash();
-
-                if let Some(sig) = &config.signature {
-                    id.0.verify(sig, hash)
-                } else {
-                    false
-                }
+                id.0.verify(&config.signature.0, hash)
             },
         );
 

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -16,6 +16,7 @@ use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_core::encoding::Encodable;
+use fedimint_core::epoch::SerdeSignature;
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::{BitcoinHash, ModuleDecoderRegistry};
 use serde::de::DeserializeOwned;
@@ -24,7 +25,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tbs::{serde_impl, Scalar};
 use thiserror::Error;
 use threshold_crypto::group::{Curve, Group, GroupEncoding};
-use threshold_crypto::{G1Projective, G2Projective, Signature};
+use threshold_crypto::{G1Projective, G2Projective};
 use url::Url;
 
 use crate::encoding::Decodable;
@@ -129,7 +130,7 @@ pub struct ClientConfigResponse {
     /// The client config
     pub client_config: ClientConfig,
     /// Auth key signature over the `client_config`
-    pub signature: Option<Signature>,
+    pub signature: SerdeSignature,
 }
 
 /// The federation id is a copy of the authentication threshold public key of

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -143,10 +143,7 @@ pub fn write_server_config(
     let salt = fs::read_to_string(path.join(SALT_FILE))?;
     let key = get_encryption_key(password, &salt)?;
 
-    let client_config = server
-        .consensus
-        .to_config_response(module_config_gens)
-        .client_config;
+    let client_config = server.consensus.to_client_config(module_config_gens)?;
     plaintext_json_write(&server.local, path.join(LOCAL_CONFIG))?;
     plaintext_json_write(&server.consensus, path.join(CONSENSUS_CONFIG))?;
     plaintext_display_write(&server.get_connect_info(), &path.join(CLIENT_CONNECT_FILE))?;

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -13,8 +13,8 @@ use fedimint_core::api::{ClientConfigDownloadToken, WsClientConnectInfo};
 use fedimint_core::cancellable::Cancelled;
 pub use fedimint_core::config::*;
 use fedimint_core::config::{
-    ClientConfig, ClientConfigResponse, DkgPeerMsg, FederationId, JsonWithKind, PeerUrl,
-    ServerModuleConfig, ServerModuleGenRegistry, TypedServerModuleConfig,
+    ClientConfig, DkgPeerMsg, FederationId, JsonWithKind, PeerUrl, ServerModuleConfig,
+    ServerModuleGenRegistry, TypedServerModuleConfig,
 };
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, MODULE_INSTANCE_ID_GLOBAL};
 use fedimint_core::module::registry::ServerModuleRegistry;
@@ -179,18 +179,7 @@ impl ServerConfigConsensus {
         self.modules.iter().map(|(k, v)| (*k, &v.kind))
     }
 
-    pub fn try_to_config_response(
-        &self,
-        // TODO: remove
-        module_config_gens: &ServerModuleGenRegistry,
-    ) -> anyhow::Result<ClientConfigResponse> {
-        Ok(ClientConfigResponse {
-            client_config: self.to_client_config(module_config_gens)?,
-            signature: None,
-        })
-    }
-
-    fn to_client_config(
+    pub fn to_client_config(
         &self,
         module_config_gens: &ModuleGenRegistry<DynServerModuleGen>,
     ) -> Result<ClientConfig, anyhow::Error> {
@@ -211,14 +200,6 @@ impl ServerConfigConsensus {
             meta: self.meta.clone(),
         };
         Ok(client)
-    }
-
-    pub fn to_config_response(
-        &self,
-        module_config_gens: &ServerModuleGenRegistry,
-    ) -> ClientConfigResponse {
-        self.try_to_config_response(module_config_gens)
-            .expect("configuration mismatch")
     }
 }
 

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -218,7 +218,7 @@ impl ConsensusServer {
 
         // Build API that can handle requests
         let (api_sender, api_receiver) = mpsc::channel(TRANSACTION_BUFFER_SIZE);
-        let client_cfg = cfg.consensus.to_config_response(&module_inits);
+        let client_cfg = cfg.consensus.to_client_config(&module_inits)?;
         let modules = ModuleRegistry::from(modules);
 
         let latest_contribution_by_peer: Arc<RwLock<LatestContributionByPeer>> = Default::default();

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -112,6 +112,7 @@ impl_db_record!(
     key = ClientConfigSignatureKey,
     value = SerdeSignature,
     db_prefix = DbKeyPrefix::ClientConfigSignature,
+    notify_on_modify = true
 );
 impl_db_lookup!(
     key = ClientConfigSignatureKey,

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -101,8 +101,8 @@ impl FederationTest {
     pub async fn new_client(&self) -> Client {
         let client_config = self.configs[&PeerId::from(0)]
             .consensus
-            .to_config_response(&self.server_gen)
-            .client_config;
+            .to_client_config(&self.server_gen)
+            .unwrap();
 
         let mut client_builder = ClientBuilder::default();
         client_builder.with_module_gens(self.client_gen.clone());

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -351,8 +351,8 @@ pub async fn fixtures(num_peers: u16, gateway_node: GatewayNode) -> anyhow::Resu
                 ServerConfig::trusted_dealer_gen(&params, server_module_inits.clone());
             let client_config = server_config[&PeerId::from(0)]
                 .consensus
-                .to_config_response(&server_module_inits)
-                .client_config;
+                .to_client_config(&server_module_inits)
+                .unwrap();
 
             let lightning = FakeLightningTest::new();
             let ln_arc = Arc::new(RwLock::new(lightning.clone()));
@@ -557,7 +557,7 @@ async fn distributed_config(
 
     Ok((
         configs.into_iter().collect(),
-        config.consensus.to_config_response(&registry).client_config,
+        config.consensus.to_client_config(&registry).unwrap(),
     ))
 }
 

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -1209,10 +1209,6 @@ async fn limits_client_config_downloads() -> Result<()> {
         let res = api.consensus_config_hash().await;
         assert!(res.is_ok());
 
-        // fed needs to run an epoch to combine shares and verify sig
-        let res = api.download_client_config(connect).await;
-        assert_matches!(res, Err(_));
-
         fed.run_consensus_epochs(1).await;
         let cfg = api.download_client_config(connect).await.unwrap();
         assert_eq!(cfg, user.config());


### PR DESCRIPTION
Fix-up of download_client_config
- Removes some unused methods
- Always returns a signed config (waits for signatures)
- Fix off-by-one error on download tokens