### PR TITLE
refactor: clean up gateway rpc client

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -122,7 +122,7 @@ impl Federation {
         let fed_id = self.federation_id().await;
         let pegin_addr = cmd!(gw_cln, "address", "--federation-id={fed_id}")
             .out_json()
-            .await?["address"]
+            .await?
             .as_str()
             .context("address must be a string")?
             .to_owned();

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -279,7 +279,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .unwrap();
     let initial_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
         .out_json()
-        .await?["balance_msat"]
+        .await?
         .as_u64()
         .unwrap();
     let add_invoice = lnd
@@ -313,7 +313,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .unwrap();
     let final_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
         .out_json()
-        .await?["balance_msat"]
+        .await?
         .as_u64()
         .unwrap();
     anyhow::ensure!(
@@ -373,7 +373,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .unwrap();
     let initial_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
         .out_json()
-        .await?["balance_msat"]
+        .await?
         .as_u64()
         .unwrap();
     let invoice = cln
@@ -412,7 +412,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .unwrap();
     let final_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
         .out_json()
-        .await?["balance_msat"]
+        .await?
         .as_u64()
         .unwrap();
     anyhow::ensure!(

--- a/docs/dev-running.md
+++ b/docs/dev-running.md
@@ -104,7 +104,7 @@ The [lightning gateway](../gateway/ln-gateway) connects the federation to the li
 $ gateway-cln balance <FEDERATION-ID>
 
 {
-  "balance_msat": 30000000
+  30000000
 }
 ```
 

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -439,9 +439,11 @@ impl ConsensusServer {
     ) -> anyhow::Result<Vec<HbbftConsensusOutcome>> {
         // for testing federations with one peer
         if self.cfg.local.p2p_endpoints.len() == 1 {
-            tokio::select! {
-              _ = Pin::new(&mut self.api_receiver).peek() => (),
-              () = self.consensus.await_consensus_proposal() => (),
+            if self.hbbft.next_epoch() > 0 {
+                tokio::select! {
+                    _ = Pin::new(&mut self.api_receiver).peek() => (),
+                    () = self.consensus.await_consensus_proposal() => (),
+                }
             }
             let proposal = self.process_events_then_propose(override_proposal).await;
             let epoch = self.hbbft.epoch();

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -6,7 +6,7 @@ use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::TaskGroup;
 use ln_gateway::client::{DynGatewayClientBuilder, MemDbFactory, StandardGatewayClientBuilder};
 use ln_gateway::lnrpc_client::ILnRpcClient;
-use ln_gateway::rpc::rpc_client::RpcClient;
+use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::ConnectFedPayload;
 use ln_gateway::Gateway;
 use tempfile::TempDir;
@@ -18,8 +18,7 @@ use crate::federation::FederationTest;
 use crate::fixtures::test_dir;
 
 pub struct GatewayTest {
-    // TODO: make private and set the password in `RpcClient`
-    pub password: String,
+    password: String,
     address: Url,
     _config_dir: Option<TempDir>,
     _task: TaskGroup,
@@ -27,15 +26,15 @@ pub struct GatewayTest {
 
 impl GatewayTest {
     /// RPC client for communicating with the gateway admin API
-    pub async fn new_client(&self) -> RpcClient {
-        RpcClient::new(self.address.clone())
+    pub async fn new_client(&self) -> GatewayRpcClient {
+        GatewayRpcClient::new(self.address.clone(), self.password.clone())
     }
 
     pub async fn connect_fed(&self, fed: &FederationTest) {
         let connect = fed.connection_code().to_string();
         let client = self.new_client().await;
         client
-            .connect_federation(self.password.clone(), ConnectFedPayload { connect })
+            .connect_federation(ConnectFedPayload { connect })
             .await
             .unwrap();
     }

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -1,124 +1,122 @@
 use std::result::Result;
 
+use bitcoin::Address;
+use fedimint_core::{Amount, TransactionId};
+use reqwest::StatusCode;
 pub use reqwest::{Error, Response};
+use serde::de::DeserializeOwned;
 use serde::Serialize;
+use thiserror::Error;
 use url::Url;
 
 use super::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
     LightningReconnectPayload, RestorePayload, WithdrawPayload,
 };
+use crate::rpc::{FederationInfo, GatewayInfo};
 
-pub struct RpcClient {
+pub struct GatewayRpcClient {
     // Base URL to gateway web server
     base_url: Url,
     // A request client
     client: reqwest::Client,
+    // Password
+    pub password: String,
 }
 
-impl RpcClient {
-    pub fn new(base_url: Url) -> Self {
+impl GatewayRpcClient {
+    pub fn new(base_url: Url, password: String) -> Self {
         Self {
             base_url,
             client: reqwest::Client::new(),
+            password,
         }
     }
 
-    pub async fn get_info(&self, password: String) -> Result<Response, Error> {
-        let url = self.base_url.join("/info").expect("invalid base url");
-        self.call(url, password, ()).await
+    pub fn with_password(&self, password: String) -> Self {
+        GatewayRpcClient::new(self.base_url.clone(), password)
     }
 
-    pub async fn get_balance(
-        &self,
-        password: String,
-        payload: BalancePayload,
-    ) -> Result<Response, Error> {
+    pub async fn get_info(&self) -> GatewayRpcResult<GatewayInfo> {
+        let url = self.base_url.join("/info").expect("invalid base url");
+        self.call(url, ()).await
+    }
+
+    pub async fn get_balance(&self, payload: BalancePayload) -> GatewayRpcResult<Amount> {
         let url = self.base_url.join("/balance").expect("invalid base url");
-        self.call(url, password, payload).await
+        self.call(url, payload).await
     }
 
     pub async fn get_deposit_address(
         &self,
-        password: String,
         payload: DepositAddressPayload,
-    ) -> Result<Response, Error> {
+    ) -> GatewayRpcResult<Address> {
         let url = self.base_url.join("/address").expect("invalid base url");
-        self.call(url, password, payload).await
+        self.call(url, payload).await
     }
 
-    pub async fn deposit(
-        &self,
-        password: String,
-        payload: DepositPayload,
-    ) -> Result<Response, Error> {
+    pub async fn deposit(&self, payload: DepositPayload) -> GatewayRpcResult<TransactionId> {
         let url = self.base_url.join("/deposit").expect("invalid base url");
-        self.call(url, password, payload).await
+        self.call(url, payload).await
     }
 
-    pub async fn withdraw(
-        &self,
-        password: String,
-        payload: WithdrawPayload,
-    ) -> Result<Response, Error> {
+    pub async fn withdraw(&self, payload: WithdrawPayload) -> GatewayRpcResult<TransactionId> {
         let url = self.base_url.join("/withdraw").expect("invalid base url");
-        self.call(url, password, payload).await
+        self.call(url, payload).await
     }
 
     pub async fn connect_federation(
         &self,
-        password: String,
         payload: ConnectFedPayload,
-    ) -> Result<Response, Error> {
+    ) -> GatewayRpcResult<FederationInfo> {
         let url = self
             .base_url
             .join("/connect-fed")
             .expect("invalid base url");
-        self.call(url, password, payload).await
+        self.call(url, payload).await
     }
 
-    pub async fn backup(
-        &self,
-        password: String,
-        payload: BackupPayload,
-    ) -> Result<Response, Error> {
+    pub async fn backup(&self, payload: BackupPayload) -> GatewayRpcResult<()> {
         let url = self.base_url.join("/backup").expect("invalid base url");
-        self.call(url, password, payload).await
+        self.call(url, payload).await
     }
 
-    pub async fn restore(
-        &self,
-        password: String,
-        payload: RestorePayload,
-    ) -> Result<Response, Error> {
+    pub async fn restore(&self, payload: RestorePayload) -> GatewayRpcResult<()> {
         let url = self.base_url.join("/restore").expect("invalid base url");
-        self.call(url, password, payload).await
+        self.call(url, payload).await
     }
 
-    pub async fn reconnect(
-        &self,
-        password: String,
-        payload: LightningReconnectPayload,
-    ) -> Result<Response, Error> {
+    pub async fn reconnect(&self, payload: LightningReconnectPayload) -> GatewayRpcResult<()> {
         let url = self.base_url.join("/connect-ln").expect("invalid base url");
-        self.call(url, password, payload).await
+        self.call(url, payload).await
     }
 
-    async fn call<P>(
-        &self,
-        url: Url,
-        password: String,
-        payload: P,
-    ) -> Result<Response, reqwest::Error>
+    async fn call<P, T: DeserializeOwned>(&self, url: Url, payload: P) -> Result<T, GatewayRpcError>
     where
         P: Serialize,
     {
-        self.client
+        let response = self
+            .client
             .post(url)
-            .bearer_auth(password)
+            .bearer_auth(self.password.clone())
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .json(&payload)
             .send()
-            .await
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response.json().await?),
+            status => Err(GatewayRpcError::BadStatus(status)),
+        }
     }
+}
+
+pub type GatewayRpcResult<T> = Result<T, GatewayRpcError>;
+
+#[derive(Error, Debug)]
+pub enum GatewayRpcError {
+    #[error("Bad status returned {0}")]
+    BadStatus(StatusCode),
+    #[error(transparent)]
+    RequestError(#[from] reqwest::Error),
 }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -82,7 +82,7 @@ async fn balance(
     Json(payload): Json<BalancePayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
     let amount = rpc.send(payload).await?;
-    Ok(Json(json!({ "balance_msat": amount.msats })))
+    Ok(Json(json!(amount)))
 }
 
 /// Generate deposit address
@@ -93,7 +93,7 @@ async fn address(
     Json(payload): Json<DepositAddressPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
     let address = rpc.send(payload).await?;
-    Ok(Json(json!({ "address": address })))
+    Ok(Json(json!(address)))
 }
 
 /// Deposit into a gateway federation.
@@ -104,7 +104,7 @@ async fn deposit(
     Json(payload): Json<DepositPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
     let txid = rpc.send(payload).await?;
-    Ok(Json(json!({ "fedimint_txid": txid.to_string() })))
+    Ok(Json(json!(txid)))
 }
 
 /// Withdraw from a gateway federation.
@@ -115,7 +115,7 @@ async fn withdraw(
     Json(payload): Json<WithdrawPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
     let txid = rpc.send(payload).await?;
-    Ok(Json(json!({ "fedimint_txid": txid.to_string() })))
+    Ok(Json(json!(txid)))
 }
 
 #[instrument(skip_all, err)]

--- a/gateway/ln-gateway/tests/fixtures/mod.rs
+++ b/gateway/ln-gateway/tests/fixtures/mod.rs
@@ -16,7 +16,7 @@ use fedimint_testing::ln::LightningTest;
 use futures::Future;
 use ln_gateway::client::{DynGatewayClientBuilder, MemDbFactory};
 use ln_gateway::lnrpc_client::ILnRpcClient;
-use ln_gateway::rpc::rpc_client::RpcClient;
+use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::Gateway;
 use url::Url;
 
@@ -28,7 +28,7 @@ pub struct Fixtures {
     pub bitcoin: Box<dyn BitcoinTest>,
     pub lightning: Box<dyn LightningTest>,
     pub gateway: Gateway,
-    pub rpc: RpcClient,
+    pub rpc: GatewayRpcClient,
 }
 
 pub async fn fixtures(api_addr: Url) -> Result<Fixtures> {
@@ -59,7 +59,7 @@ pub async fn fixtures(api_addr: Url) -> Result<Fixtures> {
     .await
     .unwrap();
 
-    let rpc = RpcClient::new(api_addr);
+    let rpc = GatewayRpcClient::new(api_addr, "".to_string());
     let bitcoin = Box::new(FakeBitcoinTest::new());
     let lightning = Box::new(FakeLightningTest::new());
 
@@ -78,7 +78,12 @@ pub async fn test<B>(
     api_addr: Url,
     listen: Option<SocketAddr>,
     password: Option<String>,
-    testfn: impl FnOnce(Box<dyn BitcoinTest>, Box<dyn LightningTest>, Option<Gateway>, RpcClient) -> B,
+    testfn: impl FnOnce(
+        Box<dyn BitcoinTest>,
+        Box<dyn LightningTest>,
+        Option<Gateway>,
+        GatewayRpcClient,
+    ) -> B,
 ) -> anyhow::Result<()>
 where
     B: Future<Output = ()>,


### PR DESCRIPTION
Some refactors to improve gateway testing:
- Can run gateway against feds with 1 peer (faster)
- Rename `RpcClient` to `GatewayRpcClient`
- Have `GatewayRpcClient` store the password and return types for easier testing