### PR TITLE
feat(client)!: client backup secret derivation

### DIFF
--- a/fedimint-client/src/secret.rs
+++ b/fedimint-client/src/secret.rs
@@ -1,0 +1,23 @@
+use fedimint_core::core::ModuleInstanceId;
+use fedimint_derive_secret::{ChildId, DerivableSecret};
+
+const TYPE_MODULE: ChildId = ChildId(0);
+const TYPE_BACKUP: ChildId = ChildId(1);
+
+pub trait DeriveableSecretClientExt {
+    fn derive_module_secret(&self, module_instance_id: ModuleInstanceId) -> DerivableSecret;
+    fn derive_backup_secret(&self) -> DerivableSecret;
+}
+
+impl DeriveableSecretClientExt for DerivableSecret {
+    fn derive_module_secret(&self, module_instance_id: ModuleInstanceId) -> DerivableSecret {
+        assert_eq!(self.level(), 0);
+        self.child_key(TYPE_MODULE)
+            .child_key(ChildId(module_instance_id as u64))
+    }
+
+    fn derive_backup_secret(&self) -> DerivableSecret {
+        assert_eq!(self.level(), 0);
+        self.child_key(TYPE_BACKUP)
+    }
+}

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -818,7 +818,7 @@ impl MintClientModule {
         amount: Amount,
         note_idx: NoteIndex,
     ) -> DerivableSecret {
-        assert_eq!(secret.level(), 1);
+        assert_eq!(secret.level(), 2);
         debug!(?secret, %amount, %note_idx, "Deriving new mint note");
         secret
             .child_key(MINT_E_CASH_TYPE_CHILD_ID) // TODO: cache


### PR DESCRIPTION
In the Client NG we would like one backup for all client modules.

BREAKING CHANGE: Derivation path for module secret changed. Now it is prefixed with an additional level, to allow other derivation types without risking a conflict with any module instance id.