### PR TITLE
fix: LN Outgoing Payments not idempotent

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -192,7 +192,8 @@ impl Federation {
                 ))
             }
         };
-        cmd!(self, "switch-gateway", pub_key).run().await?;
+        cmd!(self, "switch-gateway", pub_key.clone()).run().await?;
+        cmd!(self, "ng", "switch-gateway", pub_key).run().await?;
         info!(
             "Using {name} gateway",
             name = gw.ln.as_ref().unwrap().name()

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -607,6 +607,124 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .unwrap();
     assert_eq!(client_ng_reissue_amt, reissue_amount);
 
+    // OUTGOING: fedimint-cli NG pays LND via CLN gateway
+    fed.use_gateway(&gw_cln).await?;
+
+    let initial_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
+        .as_u64()
+        .unwrap();
+    let initial_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
+        .out_json()
+        .await?
+        .as_u64()
+        .unwrap();
+    let add_invoice = lnd
+        .client_lock()
+        .await?
+        .add_invoice(tonic_lnd::lnrpc::Invoice {
+            value_msat: 3000,
+            ..Default::default()
+        })
+        .await?
+        .into_inner();
+    let invoice = add_invoice.payment_request;
+    let payment_hash = add_invoice.r_hash;
+    cmd!(fed, "ng", "ln-pay", invoice).run().await?;
+
+    let invoice_status = lnd
+        .client_lock()
+        .await?
+        .lookup_invoice(tonic_lnd::lnrpc::PaymentHash {
+            r_hash: payment_hash,
+            ..Default::default()
+        })
+        .await?
+        .into_inner()
+        .state();
+    anyhow::ensure!(invoice_status == tonic_lnd::lnrpc::invoice::InvoiceState::Settled);
+
+    // Assert balances changed by 3000 msat (amount sent) + 30 msat (fee)
+    let final_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
+        .as_u64()
+        .unwrap();
+    let final_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
+        .out_json()
+        .await?
+        .as_u64()
+        .unwrap();
+    anyhow::ensure!(
+        initial_client_ng_balance - final_client_ng_balance == 3030,
+        "Client balance changed by {}, expected 1010",
+        initial_client_ng_balance - final_client_ng_balance
+    );
+    anyhow::ensure!(
+        final_gateway_balance - initial_gateway_balance == 3030,
+        "Gateway balance changed by {}, expected 1010",
+        final_gateway_balance - initial_gateway_balance
+    );
+
+    // LND gateway tests
+    fed.use_gateway(&gw_lnd).await?;
+
+    // OUTGOING: fedimint-cli NG pays CLN via LND gateaway
+    let initial_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
+        .as_u64()
+        .unwrap();
+    let initial_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
+        .out_json()
+        .await?
+        .as_u64()
+        .unwrap();
+    let invoice = cln
+        .request(cln_rpc::model::InvoiceRequest {
+            amount_msat: AmountOrAny::Amount(ClnRpcAmount::from_msat(1000)),
+            description: "lnd-gw-to-cln".to_string(),
+            label: "test-client-ng".to_string(),
+            expiry: Some(60),
+            fallbacks: None,
+            preimage: None,
+            exposeprivatechannels: None,
+            cltv: None,
+            deschashonly: None,
+        })
+        .await?
+        .bolt11;
+    tokio::try_join!(cln.await_block_processing(), lnd.await_block_processing())?;
+    cmd!(fed, "ng", "ln-pay", invoice.clone()).run().await?;
+    let fed_id = fed.federation_id().await;
+
+    let invoice_status = cln
+        .request(cln_rpc::model::WaitanyinvoiceRequest {
+            lastpay_index: None,
+            timeout: None,
+        })
+        .await?
+        .status;
+    anyhow::ensure!(matches!(
+        invoice_status,
+        cln_rpc::model::WaitanyinvoiceStatus::PAID
+    ));
+
+    // Assert balances changed by 1000 msat (amount sent) + 10 msat (fee)
+    let final_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
+        .as_u64()
+        .unwrap();
+    let final_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
+        .out_json()
+        .await?
+        .as_u64()
+        .unwrap();
+    anyhow::ensure!(
+        initial_client_ng_balance - final_client_ng_balance == 1010,
+        "Client balance changed by {}, expected 1010",
+        initial_client_balance - final_client_balance
+    );
+    anyhow::ensure!(
+        final_gateway_balance - initial_gateway_balance == 1010,
+        "Gateway balance changed by {}, expected 1010",
+        final_gateway_balance - initial_gateway_balance
+    );
+
     // TODO: test cancel/timeout
 
     Ok(())

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -320,7 +320,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .unwrap();
     anyhow::ensure!(
         initial_client_balance - final_client_balance == 101_000,
-        "Client balance changed by {}, expected 101000",
+        "Legacy Client balance changed by {}, expected 101000",
         initial_client_balance - final_client_balance
     );
     anyhow::ensure!(
@@ -419,7 +419,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .unwrap();
     anyhow::ensure!(
         initial_client_balance - final_client_balance == 101_000,
-        "Client balance changed by {}, expected 101000",
+        "Legacy Client balance changed by {}, expected 101000",
         initial_client_balance - final_client_balance
     );
     anyhow::ensure!(
@@ -613,7 +613,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     let initial_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
         .as_u64()
         .unwrap();
-    let initial_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
+    let initial_cln_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
         .out_json()
         .await?
         .as_u64()
@@ -647,20 +647,20 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     let final_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
         .as_u64()
         .unwrap();
-    let final_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
+    let final_cln_gateway_balance = cmd!(gw_cln, "balance", "--federation-id={fed_id}")
         .out_json()
         .await?
         .as_u64()
         .unwrap();
     anyhow::ensure!(
         initial_client_ng_balance - final_client_ng_balance == 3030,
-        "Client balance changed by {}, expected 1010",
+        "Client NG balance changed by {}, expected 1010",
         initial_client_ng_balance - final_client_ng_balance
     );
     anyhow::ensure!(
-        final_gateway_balance - initial_gateway_balance == 3030,
-        "Gateway balance changed by {}, expected 1010",
-        final_gateway_balance - initial_gateway_balance
+        final_cln_gateway_balance - initial_cln_gateway_balance == 3030,
+        "CLN Gateway balance changed by {}, expected 1010",
+        final_cln_gateway_balance - initial_cln_gateway_balance
     );
 
     // LND gateway tests
@@ -670,7 +670,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     let initial_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
         .as_u64()
         .unwrap();
-    let initial_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
+    let initial_lnd_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
         .out_json()
         .await?
         .as_u64()
@@ -709,20 +709,20 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     let final_client_ng_balance = cmd!(fed, "ng", "info").out_json().await?["total_msat"]
         .as_u64()
         .unwrap();
-    let final_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
+    let final_lnd_gateway_balance = cmd!(gw_lnd, "balance", "--federation-id={fed_id}")
         .out_json()
         .await?
         .as_u64()
         .unwrap();
     anyhow::ensure!(
         initial_client_ng_balance - final_client_ng_balance == 1010,
-        "Client balance changed by {}, expected 1010",
-        initial_client_balance - final_client_balance
+        "Client NG balance changed by {}, expected 1010",
+        initial_client_ng_balance - final_client_ng_balance
     );
     anyhow::ensure!(
-        final_gateway_balance - initial_gateway_balance == 1010,
-        "Gateway balance changed by {}, expected 1010",
-        final_gateway_balance - initial_gateway_balance
+        final_lnd_gateway_balance - initial_lnd_gateway_balance == 1010,
+        "LND Gateway balance changed by {}, expected 1010",
+        final_lnd_gateway_balance - initial_lnd_gateway_balance
     );
 
     // TODO: test cancel/timeout

--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -10,7 +10,7 @@ use fedimint_core::config::ClientConfig;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::Decodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::{Amount, ParseAmountError, TieredMulti, TieredSummary, OutPoint};
+use fedimint_core::{Amount, OutPoint, ParseAmountError, TieredMulti, TieredSummary};
 use fedimint_ln_client::{LightningClientExt, LnPayState, LnReceiveState};
 use fedimint_mint_client::{MintClientExt, MintClientModule, SpendableNote};
 use futures::StreamExt;
@@ -154,7 +154,9 @@ pub async fn handle_ng_command(
             while let Some(update) = updates.next().await {
                 match update {
                     LnPayState::Success { preimage } => {
-                        client.await_mint_change(operation_id, OutPoint {txid, out_idx: 1 }).await?;
+                        client
+                            .await_mint_change(operation_id, OutPoint { txid, out_idx: 1 })
+                            .await?;
                         return Ok(serde_json::to_value(PayInvoiceResponse {
                             operation_id: operation_id.to_hex(),
                             preimage,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -26,7 +26,7 @@ use fedimint_core::config::FederationId;
 use fedimint_core::core::{
     Decoder, IntoDynInstance, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
-use fedimint_core::db::{Database};
+use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     CommonModuleGen, ExtendsCommonModuleGen, ModuleCommon, TransactionItemAmount,
@@ -185,7 +185,7 @@ impl LightningClientExt for Client {
             )
             .await?;
 
-        let tx = TransactionBuilder::new().with_output(output.into_dyn(ln_client_id));
+        let tx = TransactionBuilder::new().with_output(output.into_dyn(instance.id));
         let operation_meta_gen = |txid| LightningMeta::Pay {
             out_point: OutPoint { txid, out_idx: 0 },
         };

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -16,15 +16,17 @@ use bitcoin_hashes::Hash;
 use db::LightningGatewayKey;
 use fedimint_client::derivable_secret::DerivableSecret;
 use fedimint_client::module::gen::ClientModuleGen;
-use fedimint_client::module::ClientModule;
+use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, ModuleNotifier, OperationId, State, StateTransition};
 use fedimint_client::transaction::{ClientOutput, TransactionBuilder};
 use fedimint_client::{sm_enum_variant_translation, Client, DynGlobalClientContext};
 use fedimint_core::api::IFederationApi;
 use fedimint_core::config::FederationId;
-use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
-use fedimint_core::db::Database;
+use fedimint_core::core::{
+    Decoder, IntoDynInstance, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
+};
+use fedimint_core::db::{Database};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     CommonModuleGen, ExtendsCommonModuleGen, ModuleCommon, TransactionItemAmount,
@@ -75,7 +77,7 @@ pub trait LightningClientExt {
         &self,
         fed_id: FederationId,
         invoice: Invoice,
-    ) -> anyhow::Result<OperationId>;
+    ) -> anyhow::Result<(OperationId, TransactionId)>;
 
     async fn subscribe_ln_pay_updates(
         &self,
@@ -167,7 +169,7 @@ impl LightningClientExt for Client {
         &self,
         fed_id: FederationId,
         invoice: Invoice,
-    ) -> anyhow::Result<OperationId> {
+    ) -> anyhow::Result<(OperationId, TransactionId)> {
         let (lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
         let operation_id = invoice.payment_hash().into_inner();
         let active_gateway = self.select_active_gateway().await?;
@@ -183,8 +185,10 @@ impl LightningClientExt for Client {
             )
             .await?;
 
-        let tx = TransactionBuilder::new().with_output(output.into_dyn(instance.id));
-        let operation_meta_gen = |txid| OutPoint { txid, out_idx: 0 };
+        let tx = TransactionBuilder::new().with_output(output.into_dyn(ln_client_id));
+        let operation_meta_gen = |txid| LightningMeta::Pay {
+            out_point: OutPoint { txid, out_idx: 0 },
+        };
 
         let txid = self
             .finalize_and_submit_transaction(
@@ -195,19 +199,7 @@ impl LightningClientExt for Client {
             )
             .await?;
 
-        let mut dbtx = self.db().begin_transaction().await;
-        self.add_operation_log_entry(
-            &mut dbtx,
-            operation_id,
-            LightningCommonGen::KIND.as_str(),
-            LightningMeta::Pay {
-                out_point: OutPoint { txid, out_idx: 0 },
-            },
-        )
-        .await;
-        dbtx.commit_tx().await;
-
-        Ok(operation_id)
+        Ok((operation_id, txid))
     }
 
     async fn create_bolt11_invoice_and_receive(
@@ -338,7 +330,7 @@ impl LightningClientExt for Client {
                     // await success or waiting for refund
                     match payment_success.await {
                         Ok(preimage) => {
-                            yield LnPayState::Success {preimage };
+                            yield LnPayState::Success {preimage};
                         }
                         Err(LightningPayError::Refundable(refundable)) => {
                             yield LnPayState::WaitingForRefund{ block_height: refundable };
@@ -418,7 +410,9 @@ impl ClientModuleGen for LightningClientGen {
     }
 }
 #[derive(Debug, Clone)]
-pub struct LightningClientContext {}
+pub struct LightningClientContext {
+    pub ln_decoder: Decoder,
+}
 
 impl Context for LightningClientContext {}
 
@@ -435,7 +429,9 @@ impl ClientModule for LightningClientModule {
     type States = LightningClientStateMachines;
 
     fn context(&self) -> Self::ModuleStateMachineContext {
-        LightningClientContext {}
+        LightningClientContext {
+            ln_decoder: self.decoder(),
+        }
     }
 
     fn input_amount(&self, input: &<Self::Common as ModuleCommon>::Input) -> TransactionItemAmount {


### PR DESCRIPTION
The current LN outgoing payment state machine has a few bugs:

 - It calls the gateway's `pay_invoice` in the trigger function. Trigger functions need to be idempotent. Paying an invoice by calling the gateway is not idempotent. This can cause `pay_invoice` to be called multiple times if a different state is executed before `pay_invoice` completes. 
 - `LnPay` does not wait for the change from the `MintOutput`. When executing from the CLI, this will cause the change to not be reflected after the outgoing payment, which causes the test to fail.

This PR changes:
 - Moves calling the gateway's `pay_invoice` from the trigger function to the transition function.
 - Outgoing payment state machine will not transition to funded until after the `LightningOutpoutOutcome` is accepted, so that the workflow can call `pay_invoice` immediately after (instead of just waiting for the tx to be accepted).
 - Adds LN outgoing tests to the CLI tests.