### PR TITLE
Client refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
  "fedimint-ln-client",
  "fedimint-logging",
  "fedimint-mint-client",
+ "fedimint-mint-common",
  "fedimint-rocksdb",
  "fedimint-wallet-client",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-test",

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -29,6 +29,7 @@ fedimint-client = { path = "../fedimint-client" }
 fedimint-core ={ path = "../fedimint-core" }
 fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 fedimint-mint-client = { path = "../modules/fedimint-mint-client" }
+fedimint-mint-common = { path = "../modules/fedimint-mint-common" }
 fedimint-ln-client = { path = "../modules/fedimint-ln-client" }
 fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
 fedimint-logging = { path = "../fedimint-logging" }

--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -7,7 +7,7 @@ use bitcoin_hashes::hex::ToHex;
 use clap::Subcommand;
 use fedimint_client::Client;
 use fedimint_core::config::ClientConfig;
-use fedimint_core::core::{ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_MINT};
+use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::Decodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{Amount, ParseAmountError, TieredMulti, TieredSummary};
@@ -216,9 +216,7 @@ pub async fn handle_ng_command(
 }
 
 async fn get_note_summary(client: &Client) -> anyhow::Result<serde_json::Value> {
-    let mint_client = client
-        .get_module_client::<MintClientModule>(LEGACY_HARDCODED_INSTANCE_ID_MINT)
-        .unwrap();
+    let (mint_client, _) = client.get_first_module::<MintClientModule>(&fedimint_mint_client::KIND);
     let summary = mint_client
         .get_wallet_summary(&mut client.db().begin_transaction().await.with_module_prefix(1))
         .await;

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -30,6 +30,7 @@ serde = "1.0.152"
 serde_json = "1.0.91"
 strum = "0.24.1"
 strum_macros = "0.24.1"
+thiserror = "1.0.39"
 tokio = { version = "1.26.0", features = [ "time", "macros" ] }
 tracing = "0.1.37"
 

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -9,6 +9,8 @@ use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::time::now;
 use fedimint_core::transaction::Transaction;
 use fedimint_core::TransactionId;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tracing::warn;
 
 use crate::sm::{Context, DynContext, OperationId, OperationState, State, StateTransition};
@@ -78,9 +80,16 @@ pub enum TxSubmissionStates {
     /// **This state is final**
     Rejected {
         txid: TransactionId,
-        // TODO: enable again after awaiting DB prefix writes becomes available
-        //error: String
+        error: TxSubmissionError,
     },
+}
+
+#[derive(Debug, Error, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+pub enum TxSubmissionError {
+    #[error("Tx submission rejected: {0}")]
+    SubmitRejected(String),
+    #[error("Tx rejected by consensus: {0}")]
+    ConsensusRejected(String),
 }
 
 impl State for TxSubmissionStates {
@@ -117,12 +126,15 @@ impl State for TxSubmissionStates {
                                 };
 
                                 match res {
-                                    Ok(()) => TxSubmissionStates::Created {
+                                    Ok(txid) => TxSubmissionStates::Created {
                                         txid,
                                         tx,
                                         next_submission: next_submission + RESUBMISSION_INTERVAL,
                                     },
-                                    Err(_e) => TxSubmissionStates::Rejected { txid },
+                                    Err(error) => TxSubmissionStates::Rejected {
+                                        txid,
+                                        error: TxSubmissionError::SubmitRejected(error),
+                                    },
                                 }
                             })
                         },
@@ -133,7 +145,10 @@ impl State for TxSubmissionStates {
                             Box::pin(async move {
                                 match res {
                                     Ok(_epoch) => TxSubmissionStates::Accepted { txid },
-                                    Err(_error) => TxSubmissionStates::Rejected { txid },
+                                    Err(error) => TxSubmissionStates::Rejected {
+                                        txid,
+                                        error: TxSubmissionError::ConsensusRejected(error),
+                                    },
                                 }
                             })
                         },
@@ -166,7 +181,7 @@ async fn trigger_created_submit(
     tx: Transaction,
     next_submission: SystemTime,
     context: DynGlobalClientContext,
-) -> Result<(), String> {
+) -> Result<TransactionId, String> {
     fedimint_core::task::sleep(
         next_submission
             .duration_since(now())
@@ -178,7 +193,6 @@ async fn trigger_created_submit(
         .api()
         .submit_transaction(tx)
         .await
-        .map(|_| ())
         .map_err(|e| e.to_string())
 }
 

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -356,6 +356,10 @@ mod tests {
             &self.api
         }
 
+        fn module_api(&self) -> DynFederationApi {
+            unimplemented!()
+        }
+
         async fn claim_input_dyn(
             &self,
             _dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -120,11 +120,7 @@ impl DummyClientExt for Client {
             .await?;
 
         let tx_subscription = self.transaction_updates(op_id).await;
-        // TODO: Return actual API error if any
-        tx_subscription
-            .await_tx_accepted(txid)
-            .await
-            .expect("Tx failed");
+        tx_subscription.await_tx_accepted(txid).await?;
 
         Ok(outpoint(txid))
     }

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -1,4 +1,5 @@
 use fedimint_client::sm::{DynState, OperationId, State, StateTransition};
+use fedimint_client::transaction::TxSubmissionError;
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId};
 use fedimint_core::db::ModuleDatabaseTransaction;
@@ -68,7 +69,7 @@ async fn await_tx_accepted(
     context: DynGlobalClientContext,
     id: OperationId,
     txid: TransactionId,
-) -> Result<(), ()> {
+) -> Result<(), TxSubmissionError> {
     context.await_tx_accepted(id, txid).await
 }
 

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 pub mod config;
 
 /// Unique name for this module
-const KIND: ModuleKind = ModuleKind::from_static_str("dummy");
+pub const KIND: ModuleKind = ModuleKind::from_static_str("dummy");
 
 /// Modules are non-compatible with older versions
 pub const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -359,7 +359,7 @@ impl LightningClientExt for Client {
                     }
 
                 },
-                Err(()) => {
+                Err(_) => {
                     yield LnPayState::Canceled;
                 }
             }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -123,10 +123,9 @@ pub enum LnReceiveState {
 #[apply(async_trait_maybe_send!)]
 impl LightningClientExt for Client {
     async fn select_active_gateway(&self) -> anyhow::Result<LightningGateway> {
-        let (ln_client_id, _) = ln_client(self);
-        let mut dbtx = self.db().begin_transaction().await;
-        let mut isolated_dbtx = dbtx.with_module_prefix(ln_client_id);
-        match isolated_dbtx.get_value(&LightningGatewayKey).await {
+        let (_lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
+        let mut dbtx = instance.db.begin_transaction().await;
+        match dbtx.get_value(&LightningGatewayKey).await {
             Some(active_gateway) => Ok(active_gateway),
             None => self
                 .fetch_registered_gateways()
@@ -139,8 +138,8 @@ impl LightningClientExt for Client {
 
     /// Switches the clients active gateway to a registered gateway.
     async fn set_active_gateway(&self, node_pub_key: &secp256k1::PublicKey) -> anyhow::Result<()> {
-        let (ln_client_id, _) = ln_client(self);
-        let mut dbtx = self.db().begin_transaction().await;
+        let (_lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
+        let mut dbtx = instance.db.begin_transaction().await;
 
         let gateways = self.fetch_registered_gateways().await?;
         if gateways.is_empty() {
@@ -154,20 +153,14 @@ impl LightningClientExt for Client {
                 anyhow::anyhow!("Could not find gateway with public key {:?}", node_pub_key)
             })?;
 
-        dbtx.with_module_prefix(ln_client_id)
-            .insert_entry(&LightningGatewayKey, &gateway)
-            .await;
+        dbtx.insert_entry(&LightningGatewayKey, &gateway).await;
         dbtx.commit_tx().await;
         Ok(())
     }
 
     async fn fetch_registered_gateways(&self) -> anyhow::Result<Vec<LightningGateway>> {
-        let (ln_client_id, _) = ln_client(self);
-        Ok(self
-            .api()
-            .with_module(ln_client_id)
-            .fetch_gateways()
-            .await?)
+        let (_lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
+        Ok(instance.api.fetch_gateways().await?)
     }
 
     async fn pay_bolt11_invoice(
@@ -175,11 +168,11 @@ impl LightningClientExt for Client {
         fed_id: FederationId,
         invoice: Invoice,
     ) -> anyhow::Result<OperationId> {
+        let (lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
         let operation_id = invoice.payment_hash().into_inner();
-        let (ln_client_id, ln_client) = ln_client(self);
         let active_gateway = self.select_active_gateway().await?;
 
-        let output = ln_client
+        let output = lightning
             .create_outgoing_output(
                 operation_id,
                 self.api(),
@@ -190,7 +183,7 @@ impl LightningClientExt for Client {
             )
             .await?;
 
-        let tx = TransactionBuilder::new().with_output(output.into_dyn(ln_client_id));
+        let tx = TransactionBuilder::new().with_output(output.into_dyn(instance.id));
         let operation_meta_gen = |txid| OutPoint { txid, out_idx: 0 };
 
         let txid = self
@@ -223,14 +216,14 @@ impl LightningClientExt for Client {
         description: String,
         expiry_time: Option<u64>,
     ) -> anyhow::Result<(OperationId, Invoice)> {
-        let (ln_client_id, ln_client) = ln_client(self);
+        let (lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
         let active_gateway = self.select_active_gateway().await?;
 
         // TODO: This gets the `bitcoin::Network` from the wallet module. Ideally
         // modules should not be dependent on each other. This should be moved
         // to the global config.
         let network = self.get_network();
-        let (operation_id, invoice, output) = ln_client
+        let (operation_id, invoice, output) = lightning
             .create_lightning_receive_output(
                 amount,
                 description,
@@ -240,7 +233,7 @@ impl LightningClientExt for Client {
                 network,
             )
             .await?;
-        let tx = TransactionBuilder::new().with_output(output.into_dyn(ln_client_id));
+        let tx = TransactionBuilder::new().with_output(output.into_dyn(instance.id));
         let operation_meta_gen = |txid| OutPoint { txid, out_idx: 0 };
         let txid = self
             .finalize_and_submit_transaction(
@@ -271,20 +264,19 @@ impl LightningClientExt for Client {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<BoxStream<LnReceiveState>> {
+        let (lightning, _instance) = self.get_first_module::<LightningClientModule>(&KIND);
         let (out_point, invoice) = match ln_operation(self, operation_id).await? {
             LightningMeta::Receive { out_point, invoice } => (out_point, invoice),
             _ => bail!("Operation is not a lightning payment"),
         };
-
-        let (_, lightning_client) = ln_client(self);
 
         let tx_accepted_future = self
             .transaction_updates(operation_id)
             .await
             .await_tx_accepted(out_point.txid);
 
-        let receive_success = lightning_client.await_receive_success(operation_id);
-        let claim_success = lightning_client.await_claim_acceptance(operation_id);
+        let receive_success = lightning.await_receive_success(operation_id);
+        let claim_success = lightning.await_claim_acceptance(operation_id);
 
         Ok(Box::pin(stream! {
             yield LnReceiveState::Created;
@@ -322,20 +314,19 @@ impl LightningClientExt for Client {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<BoxStream<LnPayState>> {
+        let (lightning, _instance) = self.get_first_module::<LightningClientModule>(&KIND);
         let out_point = match ln_operation(self, operation_id).await? {
             LightningMeta::Pay { out_point } => out_point,
             _ => bail!("Operation is not a lightning payment"),
         };
 
-        let (_, lightning_client) = ln_client(self);
-
         let tx_accepted_future = self
             .transaction_updates(operation_id)
             .await
             .await_tx_accepted(out_point.txid);
-        let payment_success = lightning_client.await_payment_success(operation_id);
+        let payment_success = lightning.await_payment_success(operation_id);
 
-        let refund_success = lightning_client.await_refund(operation_id);
+        let refund_success = lightning.await_refund(operation_id);
 
         Ok(Box::pin(stream! {
             yield LnPayState::Created;
@@ -374,18 +365,6 @@ impl LightningClientExt for Client {
             }
         }))
     }
-}
-
-fn ln_client(client: &Client) -> (ModuleInstanceId, &LightningClientModule) {
-    let ln_client_instance = client
-        .get_first_instance(&LightningCommonGen::KIND)
-        .expect("No ln module attached to client");
-
-    let ln_client = client
-        .get_module_client::<LightningClientModule>(ln_client_instance)
-        .expect("Instance ID exists, we just fetched it");
-
-    (ln_client_instance, ln_client)
 }
 
 async fn ln_operation(client: &Client, operation_id: OperationId) -> anyhow::Result<LightningMeta> {

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -5,7 +5,6 @@ use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, State
 use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::config::FederationId;
-use fedimint_core::core::{LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_WALLET};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
 use fedimint_core::{Amount, TransactionId};
@@ -296,8 +295,7 @@ impl LightningPayFunded {
             },
             Err(GatewayPayError::GatewayInternalError) => {
                 let contract = global_context
-                    .api()
-                    .with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
+                    .module_api()
                     .get_outgoing_contract(contract_id)
                     .await;
                 let timelock = match contract {
@@ -406,8 +404,7 @@ impl LightningPayRefundable {
         // TODO: Remove polling
         loop {
             let contract = global_context
-                .api()
-                .with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
+                .module_api()
                 .get_outgoing_contract(contract_id)
                 .await;
             if let Ok(contract) = contract {
@@ -424,8 +421,7 @@ impl LightningPayRefundable {
         // TODO: Remove polling
         loop {
             let consensus_block_height = global_context
-                .api()
-                .with_module(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
+                .module_api()
                 .fetch_consensus_block_height()
                 .await
                 .map_err(|_| anyhow::anyhow!("ApiError"));

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ClientInput, TxSubmissionError};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::config::FederationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -135,14 +135,14 @@ impl LightningPayCreatedOutgoingLnContract {
         common: LightningPayCommon,
         global_context: DynGlobalClientContext,
         txid: TransactionId,
-    ) -> Result<(), ()> {
+    ) -> Result<(), TxSubmissionError> {
         global_context
             .await_tx_accepted(common.operation_id, txid)
             .await
     }
 
     async fn transition_outgoing_contract_funded(
-        result: Result<(), ()>,
+        result: Result<(), TxSubmissionError>,
         old_state: LightningPayStateMachine,
         common: LightningPayCommon,
         contract_id: ContractId,
@@ -465,14 +465,14 @@ impl LightningPayRefund {
         common: LightningPayCommon,
         global_context: DynGlobalClientContext,
         refund_txid: TransactionId,
-    ) -> Result<(), ()> {
+    ) -> Result<(), TxSubmissionError> {
         global_context
             .await_tx_accepted(common.operation_id, refund_txid)
             .await
     }
 
     async fn transition_refund_success(
-        result: Result<(), ()>,
+        result: Result<(), TxSubmissionError>,
         old_state: LightningPayStateMachine,
         refund_txid: TransactionId,
     ) -> LightningPayStateMachine {

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use bitcoin::util::key::KeyPair;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ClientInput, TxSubmissionError};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
@@ -127,12 +127,12 @@ impl LightningReceiveSubmittedOffer {
         global_context: DynGlobalClientContext,
         operation_id: OperationId,
         txid: TransactionId,
-    ) -> Result<(), ()> {
+    ) -> Result<(), TxSubmissionError> {
         global_context.await_tx_accepted(operation_id, txid).await
     }
 
     async fn transition_confirmed_invoice(
-        result: Result<(), ()>,
+        result: Result<(), TxSubmissionError>,
         old_state: LightningReceiveStateMachine,
         invoice: Invoice,
         keypair: KeyPair,
@@ -300,12 +300,12 @@ impl LightningReceiveFunded {
         operation_id: OperationId,
         global_context: DynGlobalClientContext,
         txid: TransactionId,
-    ) -> Result<(), ()> {
+    ) -> Result<(), TxSubmissionError> {
         global_context.await_tx_accepted(operation_id, txid).await
     }
 
     async fn transition_claim_success(
-        result: Result<(), ()>,
+        result: Result<(), TxSubmissionError>,
         old_state: LightningReceiveStateMachine,
         txid: TransactionId,
     ) -> LightningReceiveStateMachine {

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -6,7 +6,6 @@ use bitcoin::util::key::KeyPair;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, StateTransition};
 use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
-use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
 use fedimint_core::{Amount, OutPoint, TransactionId};
@@ -197,8 +196,7 @@ impl LightningReceiveConfirmedInvoice {
         loop {
             let contract_id = (*invoice.payment_hash()).into();
             let contract = global_context
-                .api()
-                .with_module(LEGACY_HARDCODED_INSTANCE_ID_LN)
+                .module_api()
                 .get_incoming_contract(contract_id)
                 .await;
 

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -26,7 +26,7 @@ use url::Url;
 use crate::contracts::incoming::OfferId;
 use crate::contracts::{Contract, ContractId, ContractOutcome, Preimage, PreimageDecryptionShare};
 
-const KIND: ModuleKind = ModuleKind::from_static_str("ln");
+pub const KIND: ModuleKind = ModuleKind::from_static_str("ln");
 const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ClientInput, TxSubmissionError};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{TieredMulti, TransactionId};
@@ -101,14 +101,14 @@ impl MintInputStateCreated {
     async fn await_success(
         common: MintInputCommon,
         global_context: DynGlobalClientContext,
-    ) -> Result<(), ()> {
+    ) -> Result<(), TxSubmissionError> {
         global_context
             .await_tx_accepted(common.operation_id, common.txid)
             .await
     }
 
     async fn transition_success(
-        result: Result<(), ()>,
+        result: Result<(), TxSubmissionError>,
         old_state: MintInputStateMachine,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         global_context: DynGlobalClientContext,
@@ -183,14 +183,14 @@ impl MintInputStateRefund {
         common: MintInputCommon,
         global_context: DynGlobalClientContext,
         refund_txid: TransactionId,
-    ) -> Result<(), ()> {
+    ) -> Result<(), TxSubmissionError> {
         global_context
             .await_tx_accepted(common.operation_id, refund_txid)
             .await
     }
 
     async fn transition_refund_success(
-        result: Result<(), ()>,
+        result: Result<(), TxSubmissionError>,
         old_state: MintInputStateMachine,
     ) -> MintInputStateMachine {
         let refund_txid = match old_state.state {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -231,8 +231,8 @@ impl MintClientExt for Client {
                 Ok(()) => {
                     yield ReissueExternalNotesState::Issuing;
                 },
-                Err(()) => {
-                    yield ReissueExternalNotesState::Failed("Transaction not accepted".to_string());
+                Err(e) => {
+                    yield ReissueExternalNotesState::Failed(format!("Transaction not accepted {e:?}"));
                 }
             }
 
@@ -337,7 +337,7 @@ impl MintClientExt for Client {
                     Ok(()) => {
                         yield SpendOOBState::UserCanceledSuccess;
                     },
-                    Err(()) => {
+                    Err(_) => {
                         yield SpendOOBState::UserCanceledFailure;
                     }
                 }
@@ -346,7 +346,7 @@ impl MintClientExt for Client {
                     Ok(()) => {
                         yield SpendOOBState::Refunded;
                     },
-                    Err(()) => {
+                    Err(_) => {
                         yield SpendOOBState::Success;
                     }
                 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -164,7 +164,7 @@ impl MintClientExt for Client {
         notes: TieredMulti<SpendableNote>,
         extra_meta: M,
     ) -> anyhow::Result<OperationId> {
-        let (mint_client_instance, mint_client) = mint_client(self);
+        let (mint, instance) = self.get_first_module::<MintClientModule>(&KIND);
 
         let operation_id: OperationId = notes.consensus_hash().into_inner();
         if self.get_operation(operation_id).await.is_some() {
@@ -172,11 +172,9 @@ impl MintClientExt for Client {
         }
 
         let amount = notes.total_amount();
-        let mint_input = mint_client
-            .create_input_from_notes(operation_id, notes)
-            .await?;
+        let mint_input = mint.create_input_from_notes(operation_id, notes).await?;
 
-        let tx = TransactionBuilder::new().with_input(mint_input.into_dyn(mint_client_instance));
+        let tx = TransactionBuilder::new().with_input(mint_input.into_dyn(instance.id));
 
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientExt::reissue_external_notes extra_meta is serializable");
@@ -205,29 +203,26 @@ impl MintClientExt for Client {
         operation_id: OperationId,
         txid: TransactionId,
     ) -> anyhow::Result<()> {
-        let (_, mint_client) = mint_client(self);
+        let (mint, _instance) = self.get_first_module::<MintClientModule>(&KIND);
         let out_point = OutPoint { txid, out_idx: 0 };
-        mint_client
-            .await_output_finalized(operation_id, out_point)
-            .await
+        mint.await_output_finalized(operation_id, out_point).await
     }
 
     async fn subscribe_reissue_external_notes_updates(
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<BoxStream<ReissueExternalNotesState>> {
+        let (mint, _instance) = self.get_first_module::<MintClientModule>(&KIND);
         let out_point = match mint_operation(self, operation_id).await?.variant {
             MintMetaVariants::Reissuance { out_point } => out_point,
             _ => bail!("Operation is not a reissuance"),
         };
 
-        let (_, mint_client) = mint_client(self);
-
         let tx_accepted_future = self
             .transaction_updates(operation_id)
             .await
             .await_tx_accepted(out_point.txid);
-        let output_finalized_future = mint_client.await_output_finalized(operation_id, out_point);
+        let output_finalized_future = mint.await_output_finalized(operation_id, out_point);
 
         Ok(Box::pin(stream! {
             yield ReissueExternalNotesState::Created;
@@ -258,7 +253,7 @@ impl MintClientExt for Client {
         try_cancel_after: Duration,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, TieredMulti<SpendableNote>)> {
-        let (mint_client_instance, mint_client) = mint_client(self);
+        let (mint, instance) = self.get_first_module::<MintClientModule>(&KIND);
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientExt::spend_notes extra_meta is serializable");
 
@@ -267,9 +262,9 @@ impl MintClientExt for Client {
                 move |dbtx| {
                     let extra_meta = extra_meta.clone();
                     Box::pin(async move {
-                        let (operation_id, states, notes) = mint_client
+                        let (operation_id, states, notes) = mint
                             .spend_notes_oob(
-                                &mut dbtx.with_module_prefix(mint_client_instance),
+                                &mut dbtx.with_module_prefix(instance.id),
                                 min_amount,
                                 try_cancel_after,
                             )
@@ -277,7 +272,7 @@ impl MintClientExt for Client {
 
                         let dyn_states = states
                             .into_iter()
-                            .map(|s| s.into_dyn(mint_client_instance))
+                            .map(|s| s.into_dyn(instance.id))
                             .collect();
 
                         self.add_state_machines(dbtx, dyn_states).await?;
@@ -310,16 +305,17 @@ impl MintClientExt for Client {
     }
 
     async fn try_cancel_spend_notes(&self, operation_id: OperationId) {
-        let (_, mint_client) = mint_client(self);
+        let (mint, _instance) = self.get_first_module::<MintClientModule>(&KIND);
 
         // TODO: make robust by writing to the DB, this can fail
-        let _ = mint_client.cancel_oob_payment_bc.send(operation_id);
+        let _ = mint.cancel_oob_payment_bc.send(operation_id);
     }
 
     async fn subscribe_spend_notes_updates(
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<BoxStream<SpendOOBState>> {
+        let (mint, _instance) = self.get_first_module::<MintClientModule>(&KIND);
         if !matches!(
             mint_operation(self, operation_id).await?.variant,
             MintMetaVariants::SpendOOB { .. }
@@ -328,7 +324,7 @@ impl MintClientExt for Client {
         };
 
         let tx_subscription = self.transaction_updates(operation_id).await;
-        let refund_future = mint_client(self).1.await_spend_oob_refund(operation_id);
+        let refund_future = mint.await_spend_oob_refund(operation_id);
 
         // TODO: check if operation exists and is a spend operation
         Ok(Box::pin(stream! {
@@ -357,18 +353,6 @@ impl MintClientExt for Client {
             }
         }))
     }
-}
-
-fn mint_client(client: &Client) -> (ModuleInstanceId, &MintClientModule) {
-    let mint_client_instance = client
-        .get_first_instance(&MintCommonGen::KIND)
-        .expect("No mint module attached to client");
-
-    let mint_client = client
-        .get_module_client::<MintClientModule>(mint_client_instance)
-        .expect("Instance ID exists, we just fetched it");
-
-    (mint_client_instance, mint_client)
 }
 
 async fn mint_operation(client: &Client, operation_id: OperationId) -> anyhow::Result<MintMeta> {

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -16,7 +16,7 @@ pub mod config;
 pub mod common;
 pub mod db;
 
-const KIND: ModuleKind = ModuleKind::from_static_str("mint");
+pub const KIND: ModuleKind = ModuleKind::from_static_str("mint");
 const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
 
 /// By default, the maximum notes per denomination when change-making for users

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -9,9 +9,7 @@ use fedimint_client::{Client, DynGlobalClientContext};
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId};
 use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::module::{
-    CommonModuleGen, ExtendsCommonModuleGen, ModuleCommon, TransactionItemAmount,
-};
+use fedimint_core::module::{ExtendsCommonModuleGen, ModuleCommon, TransactionItemAmount};
 use fedimint_core::{apply, async_trait_maybe_send};
 use fedimint_wallet_common::config::WalletClientConfig;
 pub use fedimint_wallet_common::*;
@@ -22,21 +20,9 @@ pub trait WalletClientExt {
 
 impl WalletClientExt for Client {
     fn get_network(&self) -> Network {
-        let (_, wallet_client) = wallet_client(self);
-        wallet_client.get_network()
+        let (wallet, _instance) = self.get_first_module::<WalletClientModule>(&KIND);
+        wallet.get_network()
     }
-}
-
-fn wallet_client(client: &Client) -> (ModuleInstanceId, &WalletClientModule) {
-    let wallet_client_instance = client
-        .get_first_instance(&WalletCommonGen::KIND)
-        .expect("No ln module attached to client");
-
-    let wallet_client = client
-        .get_module_client::<WalletClientModule>(wallet_client_instance)
-        .expect("Instance ID exists, we just fetched it");
-
-    (wallet_client_instance, wallet_client)
 }
 
 #[derive(Debug, Clone)]

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -24,7 +24,7 @@ pub mod keys;
 pub mod tweakable;
 pub mod txoproof;
 
-const KIND: ModuleKind = ModuleKind::from_static_str("wallet");
+pub const KIND: ModuleKind = ModuleKind::from_static_str("wallet");
 const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
 
 pub const CONFIRMATION_TARGET: u16 = 10;


### PR DESCRIPTION
- Returns the tx submit error so clients can see why a tx failed
- Refactors out common instance resources to eliminate boilerplate and help remove more legacy ids