### PR TITLE
build(deps): update rocksdb

### DIFF
--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.66"
 async-trait = "0.1"
 fedimint-core ={ path = "../fedimint-core" }
 futures = "0.3.24"
-rocksdb = { version = "0.20.1" }
+rocksdb = { version = "0.21.0" }
 tracing = "0.1.37"
 
 [dev-dependencies]


### PR DESCRIPTION
New rust-rocksdb update dropped a few days ago: https://github.com/rust-rocksdb/rust-rocksdb/releases/tag/v0.21.0

Just a minor version bump so shouldn't be too bad but one fix in particular makes `fedimint-rocksdb` more compatible as a dependency when building binaries that target iOS

Probably should review some of the other fixes in the release before bumping this dependency