### PR TITLE
Make client root secret encoding flexible using strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
+dependencies = [
+ "bitcoin_hashes",
+ "rand",
+ "rand_core",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "bitcoin"
 version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1105,16 @@ dependencies = [
  "hex",
  "rand",
  "ring",
+]
+
+[[package]]
+name = "fedimint-bip39"
+version = "0.1.0"
+dependencies = [
+ "bip39",
+ "fedimint-client",
+ "fedimint-core",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "gateway/ln-gateway",
     "gateway/cli",
     "fedimintd",
+    "fedimint-bip39",
     "fedimint-bitcoind",
     "fedimint-core",
     "fedimint-client",

--- a/fedimint-bip39/Cargo.toml
+++ b/fedimint-bip39/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fedimint-bip39"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bip39 = { version = "2.0.0", features = ["rand"] }
+fedimint-client = { path = "../fedimint-client" }
+fedimint-core = { path = "../fedimint-core" }
+rand = "0.8.5"

--- a/fedimint-bip39/src/lib.rs
+++ b/fedimint-bip39/src/lib.rs
@@ -1,0 +1,48 @@
+//! BIP39 client secret support crate
+
+use std::io::{Read, Write};
+
+use fedimint_client::derivable_secret::DerivableSecret;
+use fedimint_client::secret::RootSecretStrategy;
+use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
+use rand::{CryptoRng, RngCore};
+
+/// BIP39 root secret encoding strategy allowing retrieval of the seed phrase.
+#[derive(Debug)]
+pub struct Bip39RootSecretStrategy<const WORD_COUNT: usize = 12>;
+
+impl<const WORD_COUNT: usize> RootSecretStrategy for Bip39RootSecretStrategy<WORD_COUNT> {
+    type Encoding = bip39::Mnemonic;
+
+    fn to_root_secret(secret: &Self::Encoding) -> DerivableSecret {
+        const FEDIMINT_CLIENT_NONCE: &[u8] = b"Fedimint Client Salt";
+        const EMPTY_PASSPHRASE: &str = "";
+
+        DerivableSecret::new_root(
+            secret.to_seed_normalized(EMPTY_PASSPHRASE).as_ref(),
+            FEDIMINT_CLIENT_NONCE,
+        )
+    }
+
+    fn consensus_encode(
+        secret: &Self::Encoding,
+        writer: &mut impl Write,
+    ) -> std::io::Result<usize> {
+        secret.to_entropy().consensus_encode(writer)
+    }
+
+    fn consensus_decode(
+        reader: &mut impl Read,
+    ) -> Result<Self::Encoding, fedimint_core::encoding::DecodeError> {
+        let bytes = Vec::<u8>::consensus_decode(reader, &Default::default())?;
+        bip39::Mnemonic::from_entropy(&bytes).map_err(DecodeError::from_err)
+    }
+
+    fn random<R>(rng: &mut R) -> Self::Encoding
+    where
+        R: RngCore + CryptoRng,
+    {
+        bip39::Mnemonic::generate_in_with(rng, bip39::Language::English, WORD_COUNT)
+            .expect("Failed to generate mnemonic, bad word count")
+    }
+}

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -14,6 +14,7 @@ use bitcoin::{secp256k1, Address, Network, Transaction};
 use clap::{Parser, Subcommand};
 use fedimint_aead::get_password_hash;
 use fedimint_client::module::gen::{ClientModuleGen, ClientModuleGenRegistry, IClientModuleGen};
+use fedimint_client::secret::PlainRootSecretStrategy;
 use fedimint_client::ClientBuilder;
 use fedimint_client_legacy::mint::backup::Metadata;
 use fedimint_client_legacy::mint::SpendableNote;
@@ -417,7 +418,10 @@ impl Opts {
         client_builder.with_config(cfg.clone());
         client_builder.with_database(db);
 
-        client_builder.build(&mut tg).await.map_err_cli_general()
+        client_builder
+            .build::<PlainRootSecretStrategy>(&mut tg)
+            .await
+            .map_err_cli_general()
     }
 }
 

--- a/fedimint-client/src/secret.rs
+++ b/fedimint-client/src/secret.rs
@@ -1,5 +1,10 @@
+use std::fmt::Debug;
+use std::io::{Read, Write};
+
 use fedimint_core::core::ModuleInstanceId;
+use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
+use rand::{CryptoRng, Rng, RngCore};
 
 const TYPE_MODULE: ChildId = ChildId(0);
 const TYPE_BACKUP: ChildId = ChildId(1);
@@ -19,5 +24,70 @@ impl DeriveableSecretClientExt for DerivableSecret {
     fn derive_backup_secret(&self) -> DerivableSecret {
         assert_eq!(self.level(), 0);
         self.child_key(TYPE_BACKUP)
+    }
+}
+
+/// Trait defining a way to generate, serialize and deserialize a root secret.
+/// It defines a `Encoding` associated type which represents a specific
+/// representation of a secret (e.g. a bip39, slip39, CODEX32, … struct) and
+/// then defines the methods necessary for the client to interact with it.
+///
+/// We use a strategy pattern (i.e. implementing the trait on a zero sized type
+/// with the actual secret struct as an associated type instead of implementing
+/// the necessary functions directly on the secret struct) to allow external
+/// implementations on third-party types without wrapping them in newtypes.
+pub trait RootSecretStrategy: Debug {
+    /// Type representing the secret
+    type Encoding: Clone;
+
+    /// Conversion function from the external encoding to the internal one
+    #[allow(clippy::wrong_self_convention)]
+    fn to_root_secret(secret: &Self::Encoding) -> DerivableSecret;
+
+    /// Serialization function for the external encoding
+    fn consensus_encode(
+        secret: &Self::Encoding,
+        writer: &mut impl std::io::Write,
+    ) -> std::io::Result<usize>;
+
+    /// Deserialization function for the external encoding
+    fn consensus_decode(reader: &mut impl std::io::Read) -> Result<Self::Encoding, DecodeError>;
+
+    /// Random generation function for the external secret type
+    fn random<R>(rng: &mut R) -> Self::Encoding
+    where
+        R: rand::RngCore + rand::CryptoRng;
+}
+
+/// Just uses 64 random bytes and derives the secret from them
+#[derive(Debug)]
+pub struct PlainRootSecretStrategy;
+
+impl RootSecretStrategy for PlainRootSecretStrategy {
+    type Encoding = [u8; 64];
+
+    fn to_root_secret(secret: &Self::Encoding) -> DerivableSecret {
+        const FEDIMINT_CLIENT_NONCE: &[u8] = b"Fedimint Client Salt";
+        DerivableSecret::new_root(secret.as_ref(), FEDIMINT_CLIENT_NONCE)
+    }
+
+    fn consensus_encode(
+        secret: &Self::Encoding,
+        writer: &mut impl Write,
+    ) -> std::io::Result<usize> {
+        secret.consensus_encode(writer)
+    }
+
+    fn consensus_decode(reader: &mut impl Read) -> Result<Self::Encoding, DecodeError> {
+        Self::Encoding::consensus_decode(reader, &Default::default())
+    }
+
+    fn random<R>(rng: &mut R) -> Self::Encoding
+    where
+        R: RngCore + CryptoRng,
+    {
+        let mut secret = [0u8; 64];
+        rng.fill(&mut secret);
+        secret
     }
 }

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use fedimint_client::module::gen::ClientModuleGenRegistry;
+use fedimint_client::secret::PlainRootSecretStrategy;
 use fedimint_client::{Client, ClientBuilder};
 use fedimint_core::admin_client::{
     ConfigGenParamsConsensus, ConfigGenParamsRequest, PeerServerParams,
@@ -53,7 +54,7 @@ impl FederationTest {
         client_builder.with_config(client_config);
         client_builder.with_database(MemDatabase::new());
         client_builder
-            .build(&mut self.task.make_subgroup().await)
+            .build::<PlainRootSecretStrategy>(&mut self.task.make_subgroup().await)
             .await
             .expect("Failed to build client")
     }


### PR DESCRIPTION
Fixes #2478 in a different way than originally intended. The problem we are trying to solve is that there are many possible encoding of a master private key (e.g. BIP39, SLIP39, …) and we don't want to choose for the user. Since we cannot convert our root secret back to these encodings the original encoding needs to be saved.

The simple fix would be making the one constructing a client give us a `DerivableSecret` instead of managing it ourselves, but that puts more work on the implementers of clients and allows for more mistakes

This PR instead introduces a strategy pattern that lets us build strategies using different encoding schemes and let the implementers of client apps choose which one to use (or even roll their own).