### PR TITLE
feat: await primary module change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,6 +1362,7 @@ dependencies = [
  "fedimint-client",
  "fedimint-core",
  "fedimint-dummy-common",
+ "futures",
  "rand",
  "secp256k1",
  "threshold_crypto",

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -84,7 +84,8 @@ use fedimint_core::time::now;
 use fedimint_core::transaction::Transaction;
 use fedimint_core::util::{BoxStream, NextOrPending};
 use fedimint_core::{
-    apply, async_trait_maybe_send, dyn_newtype_define, maybe_add_send_sync, Amount, TransactionId,
+    apply, async_trait_maybe_send, dyn_newtype_define, maybe_add_send_sync, Amount, OutPoint,
+    TransactionId,
 };
 pub use fedimint_derive_secret as derivable_secret;
 use fedimint_derive_secret::DerivableSecret;
@@ -166,7 +167,7 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         input: InstancelessDynClientInput,
-    ) -> TransactionId;
+    ) -> (TransactionId, Option<OutPoint>);
 
     /// This function is mostly meant for internal use, you are probably looking
     /// for [`DynGlobalClientContext::fund_output`].
@@ -174,7 +175,7 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         output: InstancelessDynClientOutput,
-    ) -> anyhow::Result<TransactionId>;
+    ) -> anyhow::Result<(TransactionId, Option<OutPoint>)>;
 
     /// Adds a state machine to the executor.
     async fn add_state_machine_dyn(
@@ -247,7 +248,7 @@ impl DynGlobalClientContext {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         input: ClientInput<I, S>,
-    ) -> TransactionId
+    ) -> (TransactionId, Option<OutPoint>)
     where
         I: IInput + MaybeSend + MaybeSync + 'static,
         S: IState<DynGlobalClientContext> + MaybeSend + MaybeSync + 'static,
@@ -275,7 +276,7 @@ impl DynGlobalClientContext {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         output: ClientOutput<O, S>,
-    ) -> anyhow::Result<TransactionId>
+    ) -> anyhow::Result<(TransactionId, Option<OutPoint>)>
     where
         O: IOutput + MaybeSend + MaybeSync + 'static,
         S: IState<DynGlobalClientContext> + MaybeSend + MaybeSync + 'static,
@@ -377,7 +378,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         input: InstancelessDynClientInput,
-    ) -> TransactionId {
+    ) -> (TransactionId, Option<OutPoint>) {
         let instance_input = ClientInput {
             input: DynInput::from_parts(self.module_instance_id, input.input),
             keys: input.keys,
@@ -398,7 +399,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
         output: InstancelessDynClientOutput,
-    ) -> anyhow::Result<TransactionId> {
+    ) -> anyhow::Result<(TransactionId, Option<OutPoint>)> {
         let instance_output = ClientOutput {
             output: DynOutput::from_parts(self.module_instance_id, output.output),
             state_machines: states_add_instance(self.module_instance_id, output.state_machines),
@@ -497,7 +498,7 @@ impl Client {
         tx_builder: TransactionBuilder,
     ) -> anyhow::Result<TransactionId>
     where
-        F: Fn(TransactionId) -> M + Clone + MaybeSend + MaybeSync,
+        F: Fn(TransactionId, Option<OutPoint>) -> M + Clone + MaybeSend + MaybeSync,
         M: serde::Serialize + MaybeSend,
     {
         let operation_type = operation_type.to_owned();
@@ -515,7 +516,7 @@ impl Client {
                             bail!("There already exists an operation with id {operation_id:?}")
                         }
 
-                        let txid = self
+                        let (txid, change_outpoint) = self
                             .inner
                             .finalize_and_submit_transaction(dbtx, operation_id, tx_builder)
                             .await?;
@@ -524,7 +525,7 @@ impl Client {
                             dbtx,
                             operation_id,
                             &operation_type,
-                            operation_meta(txid),
+                            operation_meta(txid, change_outpoint),
                         )
                         .await;
 
@@ -694,6 +695,16 @@ impl Client {
     {
         get_client_root_secret_encoding::<S>(self.db()).await
     }
+
+    pub async fn await_primary_module_output_finalized(
+        &self,
+        operation_id: OperationId,
+        out_point: OutPoint,
+    ) -> anyhow::Result<()> {
+        self.inner
+            .await_primary_module_output_finalized(operation_id, out_point)
+            .await
+    }
 }
 
 /// Resources particular to a module instance
@@ -801,7 +812,11 @@ impl ClientInner {
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         mut partial_transaction: TransactionBuilder,
-    ) -> anyhow::Result<(Transaction, Vec<DynState<DynGlobalClientContext>>)> {
+    ) -> anyhow::Result<(
+        Transaction,
+        Vec<DynState<DynGlobalClientContext>>,
+        Option<u64>,
+    )> {
         if let TransactionBuilderBalance::Underfunded(missing_amount) =
             self.transaction_builder_balance(&partial_transaction)
         {
@@ -817,6 +832,7 @@ impl ClientInner {
             partial_transaction.inputs.push(input);
         }
 
+        let mut change_idx: Option<u64> = None;
         if let TransactionBuilderBalance::Overfunded(excess_amount) =
             self.transaction_builder_balance(&partial_transaction)
         {
@@ -829,6 +845,7 @@ impl ClientInner {
                     excess_amount,
                 )
                 .await;
+            change_idx = Some(partial_transaction.outputs.len() as u64);
             partial_transaction.outputs.push(output);
         }
 
@@ -840,7 +857,9 @@ impl ClientInner {
             "Transaction is balanced after the previous two operations"
         );
 
-        Ok(partial_transaction.build(&self.secp_ctx, thread_rng()))
+        let (tx, states) = partial_transaction.build(&self.secp_ctx, thread_rng());
+
+        Ok((tx, states, change_idx))
     }
 
     async fn finalize_and_submit_transaction(
@@ -848,11 +867,12 @@ impl ClientInner {
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<TransactionId> {
-        let (transaction, mut states) = self
+    ) -> anyhow::Result<(TransactionId, Option<OutPoint>)> {
+        let (transaction, mut states, change_idx) = self
             .finalize_transaction(dbtx, operation_id, tx_builder)
             .await?;
         let txid = transaction.tx_hash();
+        let change_outpoint = change_idx.map(|out_idx| OutPoint { txid, out_idx });
 
         let tx_submission_sm = DynState::from_typed(
             TRANSACTION_SUBMISSION_MODULE_INSTANCE,
@@ -869,7 +889,7 @@ impl ClientInner {
 
         self.executor.add_state_machines_dbtx(dbtx, states).await?;
 
-        Ok(txid)
+        Ok((txid, change_outpoint))
     }
 
     async fn transaction_update_stream(
@@ -910,6 +930,16 @@ impl ClientInner {
             .is_some();
 
         active_state_exists || inactive_state_exists
+    }
+
+    pub async fn await_primary_module_output_finalized(
+        &self,
+        operation_id: OperationId,
+        out_point: OutPoint,
+    ) -> anyhow::Result<()> {
+        self.primary_module
+            .await_primary_module_output_finalized(operation_id, out_point)
+            .await
     }
 }
 

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -163,6 +163,8 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
 
     /// This function is mostly meant for internal use, you are probably looking
     /// for [`DynGlobalClientContext::claim_input`].
+    /// Returns transaction id of the funding transaction and an optional
+    /// `OutPoint` that represents change if change was added.
     async fn claim_input_dyn(
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
@@ -171,6 +173,8 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
 
     /// This function is mostly meant for internal use, you are probably looking
     /// for [`DynGlobalClientContext::fund_output`].
+    /// Returns transaction id of the funding transaction and an optional
+    /// `OutPoint` that represents change if change was added.
     async fn fund_output_dyn(
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
@@ -696,11 +700,13 @@ impl Client {
         get_client_root_secret_encoding::<S>(self.db()).await
     }
 
+    /// Waits for an output from the primary module to reach its final
+    /// state.
     pub async fn await_primary_module_output_finalized(
         &self,
         operation_id: OperationId,
         out_point: OutPoint,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Amount> {
         self.inner
             .await_primary_module_output_finalized(operation_id, out_point)
             .await
@@ -936,7 +942,7 @@ impl ClientInner {
         &self,
         operation_id: OperationId,
         out_point: OutPoint,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Amount> {
         self.primary_module
             .await_primary_module_output_finalized(operation_id, out_point)
             .await

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -293,7 +293,7 @@ pub trait PrimaryClientModule: ClientModule {
         &self,
         operation_id: OperationId,
         out_point: OutPoint,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<Amount>;
 }
 
 /// Type-erased version of [`PrimaryClientModule`]
@@ -319,7 +319,7 @@ pub trait IPrimaryClientModule: IClientModule {
         &self,
         operation_id: OperationId,
         out_point: OutPoint,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<Amount>;
 
     fn as_client(&self) -> &(maybe_add_send_sync!(dyn IClientModule + 'static));
 }
@@ -367,7 +367,7 @@ where
         &self,
         operation_id: OperationId,
         out_point: OutPoint,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Amount> {
         T::await_primary_module_output_finalized(self, operation_id, out_point).await
     }
 

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -10,7 +10,8 @@ use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{ModuleCommon, TransactionItemAmount};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{
-    apply, async_trait_maybe_send, dyn_newtype_define, maybe_add_send_sync, Amount, TransactionId,
+    apply, async_trait_maybe_send, dyn_newtype_define, maybe_add_send_sync, Amount, OutPoint,
+    TransactionId,
 };
 
 use crate::sm::{Context, DynContext, DynState, Executor, OperationId, State};
@@ -287,6 +288,12 @@ pub trait PrimaryClientModule: ClientModule {
         operation_id: OperationId,
         amount: Amount,
     ) -> ClientOutput<<Self::Common as ModuleCommon>::Output, Self::States>;
+
+    async fn await_primary_module_output_finalized(
+        &self,
+        operation_id: OperationId,
+        out_point: OutPoint,
+    ) -> anyhow::Result<()>;
 }
 
 /// Type-erased version of [`PrimaryClientModule`]
@@ -307,6 +314,12 @@ pub trait IPrimaryClientModule: IClientModule {
         operation_id: OperationId,
         amount: Amount,
     ) -> ClientOutput;
+
+    async fn await_primary_module_output_finalized(
+        &self,
+        operation_id: OperationId,
+        out_point: OutPoint,
+    ) -> anyhow::Result<()>;
 
     fn as_client(&self) -> &(maybe_add_send_sync!(dyn IClientModule + 'static));
 }
@@ -348,6 +361,14 @@ where
         )
         .await
         .into_dyn(module_instance)
+    }
+
+    async fn await_primary_module_output_finalized(
+        &self,
+        operation_id: OperationId,
+        out_point: OutPoint,
+    ) -> anyhow::Result<()> {
+        T::await_primary_module_output_finalized(self, operation_id, out_point).await
     }
 
     fn as_client(&self) -> &(maybe_add_send_sync!(dyn IClientModule + 'static)) {

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -240,7 +240,7 @@ mod tests {
     use fedimint_core::task::TaskGroup;
     use fedimint_core::transaction::SerdeTransaction;
     use fedimint_core::util::BoxStream;
-    use fedimint_core::{maybe_add_send_sync, PeerId, TransactionId};
+    use fedimint_core::{maybe_add_send_sync, OutPoint, PeerId, TransactionId};
     use rand::thread_rng;
     use serde_json::Value;
     use tokio::sync::Mutex;
@@ -389,7 +389,7 @@ mod tests {
             &self,
             _dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
             _input: InstancelessDynClientInput,
-        ) -> TransactionId {
+        ) -> (TransactionId, Option<OutPoint>) {
             unimplemented!()
         }
 
@@ -397,7 +397,7 @@ mod tests {
             &self,
             _dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
             _output: InstancelessDynClientOutput,
-        ) -> anyhow::Result<TransactionId> {
+        ) -> anyhow::Result<(TransactionId, Option<OutPoint>)> {
             unimplemented!()
         }
 

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.66"
 fedimint-dummy-common ={ path = "../fedimint-dummy-common" }
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-core ={ path = "../../fedimint-core" }
+futures = "0.3"
 rand = "0.8.5"
 secp256k1 = "0.24.2"
 tracing = "0.1.37"

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -16,6 +16,7 @@ use fedimint_core::db::{Database, ModuleDatabaseTransaction};
 use fedimint_core::module::{
     CommonModuleGen, ExtendsCommonModuleGen, ModuleCommon, TransactionItemAmount,
 };
+use fedimint_core::util::NextOrPending;
 use fedimint_core::{apply, async_trait_maybe_send, Amount, OutPoint};
 pub use fedimint_dummy_common as common;
 use fedimint_dummy_common::config::DummyClientConfig;
@@ -23,6 +24,7 @@ use fedimint_dummy_common::{
     fed_key_pair, fed_public_key, DummyCommonGen, DummyInput, DummyModuleTypes, DummyOutput,
     DummyOutputOutcome, KIND,
 };
+use futures::{pin_mut, StreamExt};
 use secp256k1::{Secp256k1, XOnlyPublicKey};
 use states::DummyStateMachine;
 use threshold_crypto::{PublicKey, Signature};
@@ -80,12 +82,12 @@ impl DummyClientExt for Client {
         // Build and send tx to the fed
         // Will output to our primary client module
         let tx = TransactionBuilder::new().with_input(input.into_dyn(instance.id));
-        let outpoint = |txid| OutPoint { txid, out_idx: 0 };
+        let outpoint = |txid, _| OutPoint { txid, out_idx: 0 };
         let txid = self
             .finalize_and_submit_transaction(op_id, KIND.as_str(), outpoint, tx)
             .await?;
 
-        Ok((op_id, outpoint(txid)))
+        Ok((op_id, OutPoint { txid, out_idx: 0 }))
     }
 
     async fn send_money(
@@ -114,7 +116,7 @@ impl DummyClientExt for Client {
         let tx = TransactionBuilder::new()
             .with_input(input.into_dyn(instance.id))
             .with_output(output.into_dyn(instance.id));
-        let outpoint = |txid| OutPoint { txid, out_idx: 0 };
+        let outpoint = |txid, _| OutPoint { txid, out_idx: 0 };
         let txid = self
             .finalize_and_submit_transaction(op_id, DummyCommonGen::KIND.as_str(), outpoint, tx)
             .await?;
@@ -122,7 +124,7 @@ impl DummyClientExt for Client {
         let tx_subscription = self.transaction_updates(op_id).await;
         tx_subscription.await_tx_accepted(txid).await?;
 
-        Ok(outpoint(txid))
+        Ok(OutPoint { txid, out_idx: 0 })
     }
 
     async fn receive_money(&self, outpoint: OutPoint) -> anyhow::Result<()> {
@@ -172,6 +174,7 @@ impl DummyClientExt for Client {
 pub struct DummyClientModule {
     cfg: DummyClientConfig,
     key: KeyPair,
+    notifier: ModuleNotifier<DynGlobalClientContext, DummyStateMachine>,
 }
 
 /// Data needed by the state machine
@@ -255,6 +258,29 @@ impl PrimaryClientModule for DummyClientModule {
             }),
         }
     }
+
+    async fn await_primary_module_output_finalized(
+        &self,
+        operation_id: OperationId,
+        _out_point: OutPoint,
+    ) -> anyhow::Result<()> {
+        let stream = self
+            .notifier
+            .subscribe(operation_id)
+            .await
+            .filter_map(|state| async move {
+                let DummyStateMachine::Done = state else { return None };
+                if let DummyStateMachine::Done = state {
+                    Some(Ok(()))
+                } else {
+                    None
+                }
+            });
+
+        pin_mut!(stream);
+
+        stream.next_or_pending().await
+    }
 }
 
 async fn get_funds(dbtx: &mut ModuleDatabaseTransaction<'_>) -> Amount {
@@ -295,11 +321,12 @@ impl ClientModuleGen for DummyClientGen {
         cfg: Self::Config,
         _db: Database,
         module_root_secret: DerivableSecret,
-        _notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
+        notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
     ) -> anyhow::Result<Self::Module> {
         Ok(DummyClientModule {
             cfg,
             key: module_root_secret.to_secp_key(&Secp256k1::new()),
+            notifier,
         })
     }
 }

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -263,18 +263,14 @@ impl PrimaryClientModule for DummyClientModule {
         &self,
         operation_id: OperationId,
         _out_point: OutPoint,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Amount> {
         let stream = self
             .notifier
             .subscribe(operation_id)
             .await
             .filter_map(|state| async move {
-                let DummyStateMachine::Done = state else { return None };
-                if let DummyStateMachine::Done = state {
-                    Some(Ok(()))
-                } else {
-                    None
-                }
+                let DummyStateMachine::Done(amount) = state else { return None };
+                Some(Ok(amount))
             });
 
         pin_mut!(stream);

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -14,7 +14,7 @@ use crate::{get_funds, DummyClientContext};
 pub enum DummyStateMachine {
     Input(Amount, TransactionId, OperationId),
     Output(Amount, TransactionId, OperationId),
-    Done,
+    Done(Amount),
 }
 
 impl State for DummyStateMachine {
@@ -31,7 +31,7 @@ impl State for DummyStateMachine {
                 await_tx_accepted(global_context.clone(), id, txid),
                 move |dbtx, res, _state: Self| match res {
                     // accepted, we are done
-                    Ok(_) => Box::pin(async { DummyStateMachine::Done }),
+                    Ok(_) => Box::pin(async move { DummyStateMachine::Done(amount) }),
                     // tx rejected, we refund ourselves
                     Err(_) => Box::pin(add_funds(amount, dbtx.module_tx())),
                 },
@@ -40,12 +40,12 @@ impl State for DummyStateMachine {
                 await_tx_accepted(global_context.clone(), id, txid),
                 move |dbtx, res, _state: Self| match res {
                     // rejected, we don't get any funds
-                    Ok(_) => Box::pin(async { DummyStateMachine::Done }),
+                    Ok(_) => Box::pin(async move { DummyStateMachine::Done(amount) }),
                     // tx accepted, add to our funds
                     Err(_) => Box::pin(add_funds(amount, dbtx.module_tx())),
                 },
             )],
-            DummyStateMachine::Done => vec![],
+            DummyStateMachine::Done(_) => vec![],
         }
     }
 
@@ -53,7 +53,7 @@ impl State for DummyStateMachine {
         match self {
             DummyStateMachine::Input(_, _, id) => *id,
             DummyStateMachine::Output(_, _, id) => *id,
-            DummyStateMachine::Done => OperationId([0; 32]),
+            DummyStateMachine::Done(_) => OperationId([0; 32]),
         }
     }
 }
@@ -61,7 +61,7 @@ impl State for DummyStateMachine {
 async fn add_funds(amount: Amount, mut dbtx: ModuleDatabaseTransaction<'_>) -> DummyStateMachine {
     let funds = get_funds(&mut dbtx).await + amount;
     dbtx.insert_entry(&DummyClientFundsKeyV0, &funds).await;
-    DummyStateMachine::Done
+    DummyStateMachine::Done(amount)
 }
 
 // TODO: Boiler-plate, should return OutputOutcome

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -254,7 +254,7 @@ impl LightningReceiveConfirmedInvoice {
             state_machines: Arc::new(|_, _| vec![]),
         };
 
-        let txid = global_context.claim_input(dbtx, client_input).await;
+        let (txid, _) = global_context.claim_input(dbtx, client_input).await;
         OutPoint { txid, out_idx: 0 }
     }
 

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -153,7 +153,7 @@ impl MintInputStateCreated {
             state_machines: Arc::new(|_, _| vec![]),
         };
 
-        let refund_txid = global_context.claim_input(dbtx, refund_input).await;
+        let (refund_txid, _) = global_context.claim_input(dbtx, refund_input).await;
 
         MintInputStateMachine {
             common: old_state.common,

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -676,7 +676,7 @@ impl PrimaryClientModule for MintClientModule {
         &self,
         operation_id: OperationId,
         out_point: OutPoint,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Amount> {
         self.await_output_finalized(operation_id, out_point).await
     }
 }
@@ -759,7 +759,7 @@ impl MintClientModule {
         &self,
         operation_id: OperationId,
         out_point: OutPoint,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Amount> {
         let stream = self
             .notifier
             .subscribe(operation_id)
@@ -772,7 +772,7 @@ impl MintClientModule {
                 }
 
                 match state.state {
-                    MintOutputStates::Succeeded(_) => Some(Ok(())),
+                    MintOutputStates::Succeeded(succeeded) => Some(Ok(succeeded.amount)),
                     MintOutputStates::Aborted(_) => Some(Err(anyhow!("Transaction was rejected"))),
                     MintOutputStates::Failed(failed) => Some(Err(anyhow!(
                         "Failed to finalize transaction: {}",

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -207,5 +207,5 @@ async fn try_cancel_oob_spend(
         }),
     };
 
-    global_context.claim_input(dbtx, input).await
+    global_context.claim_input(dbtx, input).await.0
 }

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -240,7 +240,7 @@ pub struct MintOutputStatesFailed {
 /// See [`MintOutputStates`]
 #[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
 pub struct MintOutputStatesSucceeded {
-    amount: Amount,
+    pub amount: Amount,
 }
 
 /// Single [`Note`] issuance request to the mint.f

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -21,7 +21,9 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     let fed = fixtures().new_fed().await;
     let (client1, client2) = fed.two_clients().await;
     let (op, outpoint) = client1.print_money(sats(1000)).await?;
-    client1.await_claim_notes(op, outpoint.txid).await?;
+    client1
+        .await_primary_module_output_finalized(op, outpoint)
+        .await?;
 
     // Spend from client1 to client2
     let (op, notes) = client1.spend_notes(sats(750), TIMEOUT, ()).await?;

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -1,5 +1,6 @@
 use bitcoin::Address;
 use fedimint_core::api::{FederationApiExt, FederationResult, IFederationApi};
+use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::query::EventuallyConsistent;
 use fedimint_core::task::{MaybeSend, MaybeSync};
@@ -22,12 +23,16 @@ where
     T: IFederationApi + MaybeSend + MaybeSync + 'static,
 {
     async fn fetch_consensus_block_height(&self) -> FederationResult<u64> {
-        self.request_with_strategy(
-            EventuallyConsistent::new(self.all_members().one_honest()),
-            "block_height".to_string(),
-            ApiRequestErased::default(),
-        )
-        .await
+        // TODO: This is still necessary since the Lightning module also uses this
+        // to query the block height. Modules should not be dependent on each other
+        // so this should be refactored
+        self.with_module(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
+            .request_with_strategy(
+                EventuallyConsistent::new(self.all_members().one_honest()),
+                "block_height".to_string(),
+                ApiRequestErased::default(),
+            )
+            .await
     }
 
     async fn fetch_peg_out_fees(


### PR DESCRIPTION
This PR adds a generic way of awaiting a primary modules output to be finalized. Often times, after the output outcome happens on the server side, the client needs to wait on some additional operations on the client side (like claiming ecash notes as change from a Lightning transaction).

Right now we don't have a good way to wait on change. This PR adds a function `await_primary_module_output_finalized` that awaits on an outpoint to be finalized. This PR also changes `finalize_and_submit_transaction` to return an `Option<OutPoint>` which will contain the `OutPoint` of the change (if there is change).

Fixes: https://github.com/fedimint/fedimint/issues/2495