### PR TITLE
fix: define canonical encoding for `OperationId`

### DIFF
--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use bitcoin::secp256k1;
-use bitcoin_hashes::hex::ToHex;
 use clap::Subcommand;
+use fedimint_client::sm::OperationId;
 use fedimint_client::Client;
 use fedimint_core::config::ClientConfig;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
@@ -158,7 +158,7 @@ pub async fn handle_ng_command(
                             .await_mint_change(operation_id, OutPoint { txid, out_idx: 1 })
                             .await?;
                         return Ok(serde_json::to_value(PayInvoiceResponse {
-                            operation_id: operation_id.to_hex(),
+                            operation_id,
                             preimage,
                         })
                         .unwrap());
@@ -256,6 +256,6 @@ pub fn parse_ecash(s: &str) -> anyhow::Result<TieredMulti<SpendableNote>> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PayInvoiceResponse {
-    operation_id: String,
+    operation_id: OperationId,
     preimage: String,
 }

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -834,7 +834,7 @@ mod tests {
         }
 
         fn operation_id(&self) -> OperationId {
-            [0u8; 32]
+            OperationId([0u8; 32])
         }
     }
 

--- a/fedimint-client/src/sm/mod.rs
+++ b/fedimint-client/src/sm/mod.rs
@@ -8,12 +8,15 @@ pub mod util;
 /// Helper to notify modules about state transitions
 mod notifier;
 
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter};
+use std::str::FromStr;
 
 pub use dbtx::ClientSMDatabaseTransaction;
 pub use executor::{ActiveState, Executor, ExecutorBuilder, InactiveState};
+use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 pub use notifier::{ModuleNotifier, Notifier};
+use serde::{Deserialize, Deserializer, Serialize};
 pub use state::{Context, DynContext, DynState, IState, OperationState, State, StateTransition};
 
 /// Context given to all state machines
@@ -44,4 +47,47 @@ impl GlobalContext for () {}
 /// submitted the transaction's ID can be used as operation ID. If there is no
 /// transaction related to it, it should be generated randomly. Since it is a
 /// 256bit value collisions are impossible for all intents and purposes.
-pub type OperationId = [u8; 32];
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
+pub struct OperationId(pub [u8; 32]);
+
+impl Display for OperationId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        bitcoin_hashes::hex::format_hex(&self.0, f)
+    }
+}
+
+impl FromStr for OperationId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes: [u8; 32] = bitcoin_hashes::hex::FromHex::from_hex(s)?;
+        Ok(OperationId(bytes))
+    }
+}
+
+impl Serialize for OperationId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_string())
+        } else {
+            serializer.serialize_bytes(&self.0)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OperationId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            let operation_id = OperationId::from_str(&s)
+                .map_err(|e| serde::de::Error::custom(format!("invalid operation id: {e}")))?;
+            Ok(operation_id)
+        } else {
+            let bytes: [u8; 32] = <[u8; 32]>::deserialize(deserializer)?;
+            Ok(OperationId(bytes))
+        }
+    }
+}

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -442,7 +442,7 @@ mod tests {
             .start_executor(&mut tg, Arc::new(move |_, _| dyn_context_gen_clone.clone()))
             .await;
 
-        let operation_id = [0x42; 32];
+        let operation_id = OperationId([0x42; 32]);
 
         let tx_builder = TransactionBuilder::new();
 

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -64,7 +64,7 @@ pub trait DummyClientExt {
 impl DummyClientExt for Client {
     async fn print_money(&self, amount: Amount) -> anyhow::Result<(OperationId, OutPoint)> {
         let (_dummy, instance) = self.get_first_module::<DummyClientModule>(&KIND);
-        let op_id = rand::random();
+        let op_id = OperationId(rand::random());
 
         // TODO: Building a tx could be easier
         // Create input using the fed's account
@@ -95,7 +95,7 @@ impl DummyClientExt for Client {
     ) -> anyhow::Result<OutPoint> {
         let (dummy, instance) = self.get_first_module::<DummyClientModule>(&KIND);
         let mut dbtx = instance.db.begin_transaction().await;
-        let op_id = rand::random();
+        let op_id = OperationId(rand::random());
 
         // TODO: Building a tx could be easier
         // Create input using our own account

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -53,7 +53,7 @@ impl State for DummyStateMachine {
         match self {
             DummyStateMachine::Input(_, _, id) => *id,
             DummyStateMachine::Output(_, _, id) => *id,
-            DummyStateMachine::Done => [0; 32],
+            DummyStateMachine::Done => OperationId([0; 32]),
         }
     }
 }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -171,7 +171,7 @@ impl LightningClientExt for Client {
         invoice: Invoice,
     ) -> anyhow::Result<(OperationId, TransactionId)> {
         let (lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
-        let operation_id = invoice.payment_hash().into_inner();
+        let operation_id = OperationId(invoice.payment_hash().into_inner());
         let active_gateway = self.select_active_gateway().await?;
 
         let output = lightning
@@ -711,7 +711,7 @@ impl LightningClientModule {
         let invoice = invoice_builder
             .build_signed(|hash| self.secp.sign_ecdsa_recoverable(hash, &node_secret_key))?;
 
-        let operation_id = invoice.payment_hash().into_inner();
+        let operation_id = OperationId(invoice.payment_hash().into_inner());
 
         let sm_invoice = invoice.clone();
         let sm_gen = Arc::new(move |txid: TransactionId, _input_idx: u64| {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -181,7 +181,7 @@ impl MintClientExt for Client {
     ) -> anyhow::Result<OperationId> {
         let (mint, instance) = self.get_first_module::<MintClientModule>(&KIND);
 
-        let operation_id: OperationId = notes.consensus_hash().into_inner();
+        let operation_id = OperationId(notes.consensus_hash().into_inner());
         if self.get_operation(operation_id).await.is_some() {
             bail!("We already reissued these notes");
         }
@@ -784,7 +784,7 @@ impl MintClientModule {
     )> {
         let spendable_selected_notes = Self::select_notes(dbtx, min_amount).await?;
 
-        let operation_id = spendable_selected_notes.consensus_hash().into_inner();
+        let operation_id = OperationId(spendable_selected_notes.consensus_hash().into_inner());
 
         for (amount, note) in spendable_selected_notes.iter_items() {
             dbtx.remove_entry(&NoteKey {


### PR DESCRIPTION
Originally from #2416 but making this a separate PR since multiple others could use it and I don't want to block.