### PR TITLE
feat: fix gateway registration

### DIFF
--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -155,7 +155,6 @@ impl GatewayActor {
         let registration = register_client
             .config()
             .to_gateway_registration_info(route_hints.clone(), GW_ANNOUNCEMENT_TTL);
-        let registration_sent = registration.clone();
         let notify = Arc::new(Notify::new());
         let notfiy_sent = notify.clone();
         task_group
@@ -166,8 +165,13 @@ impl GatewayActor {
                         String::from("Register With Federation"),
                         #[allow(clippy::unit_arg)]
                         || async {
+                            let registration =
+                                register_client.config().to_gateway_registration_info(
+                                    route_hints.clone(),
+                                    GW_ANNOUNCEMENT_TTL,
+                                );
                             Ok(register_client
-                                .register_with_federation(registration_sent.clone())
+                                .register_with_federation(registration)
                                 .await?)
                         },
                         Duration::from_secs(1),

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -173,6 +173,18 @@ pub struct LightningGateway {
     pub valid_until: SystemTime,
 }
 
+impl LightningGateway {
+    /// Check if two gateway registrations are the same except for the expiry
+    /// time
+    pub fn is_same_gateway_registration(&self, other: &LightningGateway) -> bool {
+        self.mint_channel_id == other.mint_channel_id
+            && self.mint_pub_key == other.mint_pub_key
+            && self.node_pub_key == other.node_pub_key
+            && self.api == other.api
+            && self.route_hints == other.route_hints
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub struct LightningConsensusItem {
     pub contract_id: ContractId,

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -45,14 +45,20 @@ async fn can_switch_active_gateway() -> anyhow::Result<()> {
 
     // Client selects a gateway by default
     let gateway1 = fixtures.new_gateway(&fed).await.last_info().registration;
-    assert_eq!(client.select_active_gateway().await?, gateway1);
+    assert!(client
+        .select_active_gateway()
+        .await?
+        .is_same_gateway_registration(&gateway1));
 
     let gateway2 = fixtures.new_gateway(&fed).await.last_info().registration;
     let gateways = client.fetch_registered_gateways().await.unwrap();
     assert_eq!(gateways.len(), 2);
 
     client.set_active_gateway(&gateway2.node_pub_key).await?;
-    assert_eq!(client.select_active_gateway().await?, gateway2);
+    assert!(client
+        .select_active_gateway()
+        .await?
+        .is_same_gateway_registration(&gateway2));
     Ok(())
 }
 


### PR DESCRIPTION
Current code fails because it re-registers with a `valid_until` value that doesn't get updated at all.

@okjodom this would be a great thing to cover in your new gateway tests. Should probably make `GW_ANNOUNCEMENT_TTL` a variable passed in to `gatewayd`. 

This currently doesn't have any test coverage so you have to validate the fix manually (made [issue to add coverage](https://github.com/fedimint/fedimint/issues/2516)). To validate the bug, set `GW_ANNOUNCEMENT_TTL` to 1 second on master and run tmuxinator. Run `gateway-cli list-gateways` and there won't be any. Do the same on this branch and there should be 2.