### PR TITLE
feat: mprocs setup for guardian-ui dev

### DIFF
--- a/justfile
+++ b/justfile
@@ -96,3 +96,7 @@ tmuxinator:
 # exit tmuxinator session
 exit-tmuxinator:
   tmux kill-session -t fedimint-dev
+
+# starts a 2 guardian federation with setup UI
+run-ui:
+  mprocs -c misc/mprocs-ui.yaml

--- a/misc/mprocs-ui.yaml
+++ b/misc/mprocs-ui.yaml
@@ -1,0 +1,17 @@
+procs:
+  run-ui-federation:
+    shell: ./scripts/run-ui.sh new
+  coordinator:
+    cwd: fedimint-ui/apps/guardian-ui/
+    shell: yarn dev
+    env:
+      PORT: "3000"
+      REACT_APP_FM_CONFIG_API: ws://127.0.0.1:18174
+      BROWSER: none
+  follower: 
+    cwd: fedimint-ui/apps/guardian-ui/
+    shell: yarn dev
+    env:
+      PORT: "3001"
+      REACT_APP_FM_CONFIG_API: ws://127.0.0.1:18184
+      BROWSER: none


### PR DESCRIPTION
`just run-ui` brings up mprocs with a 2 instance federation via `run-ui.sh` and 2 instances of the Guardian UI