### PR TITLE
fix(devimint): use correct protocol in logging

### DIFF
--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -1045,7 +1045,7 @@ async fn run_ui(
                 Ok(TcpStream::connect(server_addr).await.is_ok())
             })
             .await?;
-            info!(LOG_DEVIMINT, "Started ui/api on http://{server_addr}");
+
             anyhow::Ok(fm)
         }
     }))

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -197,6 +197,7 @@ impl FedimintServer {
             .expect("Could not start API server")
             .start(module)
             .expect("Could not start API server");
+        info!(target: LOG_NET_API, "Starting api on ws://{api_bind}");
 
         FedimintApiHandler { handle, runtime }
     }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -247,6 +247,7 @@ async fn run(
                 .await;
             })
             .await;
+        info!(target: "old-ui", "Started ui on http://{listen_ui}");
 
         // If federation configs (e.g. local.json) missing, wait for admin UI to report
         // DKG completion


### PR DESCRIPTION
If it's the new UI, then we want ws:// instead of http://
The logging would be confusing for anyone unfamiliar with this nuance.