### PR TITLE
fix: add `nodejs` to ui dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -456,7 +456,7 @@
 
               fedimint-ui = pkgs.mkShell (shellCommonNative
                 // {
-                nativeBuildInputs = shellCommonNative.nativeBuildInputs ++ [ pkgs.yarn ];
+                nativeBuildInputs = shellCommonNative.nativeBuildInputs ++ [ pkgs.yarn pkgs.nodejs ];
               });
             };
         in


### PR DESCRIPTION
Otherwise `yarn install` fails, I suppose everyone working on the UI had `nodejs` installed outside nix.