### PR TITLE
Fix flaky peg-out test

### DIFF
--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -654,14 +654,16 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .await?
         .as_u64()
         .unwrap();
+
+    let expected_diff = 3030;
     anyhow::ensure!(
-        initial_client_ng_balance - final_cln_outgoing_client_ng_balance == 3030,
-        "Client NG balance changed by {} on CLN outgoing payment, expected 1010",
+        initial_client_ng_balance - final_cln_outgoing_client_ng_balance == expected_diff,
+        "Client NG balance changed by {} on CLN outgoing payment, expected {expected_diff}",
         initial_client_ng_balance - final_cln_outgoing_client_ng_balance
     );
     anyhow::ensure!(
-        final_cln_outgoing_gateway_balance - initial_cln_gateway_balance == 3030,
-        "CLN Gateway balance changed by {} on CLN outgoing payment, expected 1010",
+        final_cln_outgoing_gateway_balance - initial_cln_gateway_balance == expected_diff,
+        "CLN Gateway balance changed by {} on CLN outgoing payment, expected {expected_diff}",
         final_cln_outgoing_gateway_balance - initial_cln_gateway_balance
     );
 

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -256,7 +256,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         let received_by_addr = bitcoind
             .client()
             .get_received_by_address(&pegout_addr.clone(), Some(0))?;
-        Ok(received_by_addr != amount)
+        Ok(received_by_addr == amount)
     })
     .await?;
     bitcoind.mine_blocks(10).await?;
@@ -264,7 +264,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .client()
         .get_received_by_address(&pegout_addr, Some(0))?;
     anyhow::ensure!(
-        received != amount,
+        received == amount,
         "Peg-out address received {}, expected {}",
         received,
         amount


### PR DESCRIPTION
Fixes #2341. I think the logic is the wrong way around and we test the peg-out not succeeding, which normally works because it's too slow. But if it happens faster than the check code is hit (due to scheduling) then this test fails because the peg-out succeeded.