### PR TITLE
Cache client operation outcomes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aquamarine",
+ "async-stream",
  "async-trait",
  "bitcoin",
  "bitcoin_hashes",

--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -119,7 +119,8 @@ pub async fn handle_ng_command(
             let mut updates = client
                 .subscribe_reissue_external_notes_updates(operation_id)
                 .await
-                .unwrap();
+                .unwrap()
+                .into_stream();
 
             while let Some(update) = updates.next().await {
                 if let fedimint_mint_client::ReissueExternalNotesState::Failed(e) = update {
@@ -156,7 +157,10 @@ pub async fn handle_ng_command(
             .unwrap())
         }
         ClientNg::WaitInvoice { operation_id } => {
-            let mut updates = client.subscribe_to_ln_receive_updates(operation_id).await?;
+            let mut updates = client
+                .subscribe_to_ln_receive_updates(operation_id)
+                .await?
+                .into_stream();
             while let Some(update) = updates.next().await {
                 match update {
                     LnReceiveState::Claimed => {
@@ -180,7 +184,10 @@ pub async fn handle_ng_command(
                 .pay_bolt11_invoice(config.federation_id, bolt11)
                 .await?;
 
-            let mut updates = client.subscribe_ln_pay_updates(operation_id).await?;
+            let mut updates = client
+                .subscribe_ln_pay_updates(operation_id)
+                .await?
+                .into_stream();
 
             while let Some(update) = updates.next().await {
                 match update {

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.69"
 aquamarine = "0.3.1"
+async-stream = "0.3.5"
 async-trait = "0.1.66"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -73,6 +73,7 @@ use std::io::{Error, Read, Write};
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail};
+use async_stream::stream;
 use fedimint_core::api::{DynFederationApi, IFederationApi, WsFederationApi};
 use fedimint_core::config::{ClientConfig, FederationId, ModuleGenRegistry};
 use fedimint_core::core::{DynInput, DynOutput, IInput, IOutput, ModuleInstanceId, ModuleKind};
@@ -89,12 +90,13 @@ use fedimint_core::{
 };
 pub use fedimint_derive_secret as derivable_secret;
 use fedimint_derive_secret::DerivableSecret;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use rand::thread_rng;
 use secp256k1_zkp::Secp256k1;
 use secret::DeriveableSecretClientExt;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use tracing::{error, instrument, warn};
 
 use crate::backup::Metadata;
 use crate::db::{
@@ -570,12 +572,23 @@ impl Client {
         operation_type: &str,
         operation_meta: impl serde::Serialize,
     ) {
+        Client::add_operation_log_entry_inner(dbtx, operation_id, operation_type, operation_meta)
+            .await
+    }
+
+    async fn add_operation_log_entry_inner(
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: impl serde::Serialize,
+    ) {
         dbtx.insert_new_entry(
             &OperationLogKey { operation_id },
             &OperationLogEntry {
                 operation_type: operation_type.to_string(),
                 meta: serde_json::to_value(operation_meta)
                     .expect("Can only fail if meta is not serializable"),
+                outcome: None,
             },
         )
         .await;
@@ -624,12 +637,50 @@ impl Client {
     }
 
     pub async fn get_operation(&self, operation_id: OperationId) -> Option<OperationLogEntry> {
-        self.inner
-            .db
-            .begin_transaction()
+        Client::get_operation_inner(&mut self.inner.db.begin_transaction().await, operation_id)
             .await
-            .get_value(&OperationLogKey { operation_id })
+    }
+
+    async fn get_operation_inner(
+        dbtx: &mut DatabaseTransaction<'_>,
+        operation_id: OperationId,
+    ) -> Option<OperationLogEntry> {
+        dbtx.get_value(&OperationLogKey { operation_id }).await
+    }
+
+    /// Sets the outcome of an operation
+    #[instrument(skip(db), level = "debug")]
+    pub async fn set_operation_outcome(
+        db: &Database,
+        operation_id: OperationId,
+        outcome: &(impl Serialize + Debug),
+    ) -> anyhow::Result<()> {
+        let outcome_json = serde_json::to_value(outcome).expect("Outcome is not serializable");
+
+        let mut dbtx = db.begin_transaction().await;
+        let mut operation = Client::get_operation_inner(&mut dbtx, operation_id)
             .await
+            .expect("Operation exists");
+        operation.outcome = Some(outcome_json);
+        dbtx.insert_entry(&OperationLogKey { operation_id }, &operation)
+            .await;
+        dbtx.commit_tx_result().await?;
+
+        Ok(())
+    }
+
+    /// Tries to set the outcome of an operation, but only logs an error if it
+    /// fails and does not return it. Since the outcome can always be recomputed
+    /// from an update stream, failing to save it isn't a problem in cases where
+    /// we do this merely for caching.
+    pub async fn optimistically_set_operation_outcome(
+        db: &Database,
+        operation_id: OperationId,
+        outcome: &(impl Serialize + Debug),
+    ) {
+        if let Err(e) = Self::set_operation_outcome(db, operation_id, outcome).await {
+            warn!("Error setting operation outcome: {e}");
+        }
     }
 
     /// Returns a reference to a typed module client instance by kind
@@ -1288,6 +1339,34 @@ where
     S::to_root_secret(&encoding)
 }
 
+/// Wraps an operation update stream such that the last update before it closes
+/// is tried to be written to the operation log entry as its outcome.
+pub fn caching_operation_update_stream<'a, U, S>(
+    db: Database,
+    operation_id: OperationId,
+    stream: S,
+) -> BoxStream<'a, U>
+where
+    U: Clone + Serialize + Debug + MaybeSend + MaybeSync + 'static,
+    S: Stream<Item = U> + MaybeSend + 'a,
+{
+    let mut stream = Box::pin(stream);
+    Box::pin(stream! {
+        let mut last_update = None;
+        while let Some(update) = stream.next().await {
+            yield update.clone();
+            last_update = Some(update);
+        }
+
+        let Some(last_update) = last_update else {
+            error!("Stream ended without any updates, this should not happen!");
+            return;
+        };
+
+        Client::optimistically_set_operation_outcome(&db, operation_id, &last_update).await;
+    })
+}
+
 /// Secret input key material from which the [`DerivableSecret`] used by the
 /// client will be seeded
 pub struct ClientSecret<S: RootSecretStrategy>(S::Encoding);
@@ -1370,6 +1449,8 @@ pub fn client_decoders<'a>(
 pub struct OperationLogEntry {
     operation_type: String,
     meta: serde_json::Value,
+    // TODO: probably change all that JSON to Dyn-types
+    pub(crate) outcome: Option<serde_json::Value>,
 }
 
 impl OperationLogEntry {
@@ -1380,6 +1461,15 @@ impl OperationLogEntry {
     pub fn meta<M: DeserializeOwned>(&self) -> M {
         serde_json::from_value(self.meta.clone()).expect("JSON deserialization should not fail")
     }
+
+    /// Returns the last state update of the operation, if any was cached yet.
+    /// If this hasn't been the case yet and `None` is returned subscribe to the
+    /// appropriate update stream.
+    pub fn outcome<D: DeserializeOwned>(&self) -> Option<D> {
+        self.outcome.as_ref().map(|outcome| {
+            serde_json::from_value(outcome.clone()).expect("JSON deserialization should not fail")
+        })
+    }
 }
 
 impl Encodable for OperationLogEntry {
@@ -1389,6 +1479,14 @@ impl Encodable for OperationLogEntry {
         len += serde_json::to_string(&self.meta)
             .expect("JSON serialization should not fail")
             .consensus_encode(writer)?;
+        len += self
+            .outcome
+            .as_ref()
+            .map(|outcome| {
+                serde_json::to_string(outcome).expect("JSON serialization should not fail")
+            })
+            .consensus_encode(writer)?;
+
         Ok(len)
     }
 }
@@ -1399,27 +1497,38 @@ impl Decodable for OperationLogEntry {
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let operation_type = String::consensus_decode(r, modules)?;
+
         let meta_str = String::consensus_decode(r, modules)?;
         let meta = serde_json::from_str(&meta_str).map_err(DecodeError::from_err)?;
+
+        let outcome_str = Option::<String>::consensus_decode(r, modules)?;
+        let outcome = outcome_str
+            .map(|outcome_str| serde_json::from_str(&outcome_str).map_err(DecodeError::from_err))
+            .transpose()?;
 
         Ok(OperationLogEntry {
             operation_type,
             meta,
+            outcome,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use fedimint_core::db::mem_impl::MemDatabase;
+    use fedimint_core::db::Database;
     use serde::{Deserialize, Serialize};
 
-    use crate::OperationLogEntry;
+    use crate::sm::OperationId;
+    use crate::{Client, OperationLogEntry};
 
     #[test]
     fn test_operation_log_entry_serde() {
         let op_log = OperationLogEntry {
             operation_type: "test".to_string(),
             meta: serde_json::to_value(()).unwrap(),
+            outcome: None,
         };
 
         op_log.meta::<()>();
@@ -1441,8 +1550,37 @@ mod tests {
         let op_log = OperationLogEntry {
             operation_type: "test".to_string(),
             meta: serde_json::to_value(meta.clone()).unwrap(),
+            outcome: None,
         };
 
         assert_eq!(op_log.meta::<Meta>(), meta);
+    }
+
+    #[tokio::test]
+    async fn test_operation_log_update() {
+        let op_id = OperationId([0x32; 32]);
+
+        let db = Database::new(MemDatabase::new(), Default::default());
+        let mut dbtx = db.begin_transaction().await;
+        Client::add_operation_log_entry_inner(&mut dbtx, op_id, "foo", "bar").await;
+        dbtx.commit_tx().await;
+
+        let mut dbtx = db.begin_transaction().await;
+        let op = Client::get_operation_inner(&mut dbtx, op_id)
+            .await
+            .expect("op exists");
+        assert_eq!(op.outcome, None);
+        drop(dbtx);
+
+        Client::set_operation_outcome(&db, op_id, &"baz")
+            .await
+            .unwrap();
+
+        let mut dbtx = db.begin_transaction().await;
+        let op = Client::get_operation_inner(&mut dbtx, op_id)
+            .await
+            .expect("op exists");
+        assert_eq!(op.outcome::<String>(), Some("baz".to_string()));
+        drop(dbtx);
     }
 }

--- a/fedimint-client/src/sm/mod.rs
+++ b/fedimint-client/src/sm/mod.rs
@@ -48,7 +48,7 @@ impl GlobalContext for () {}
 /// submitted the transaction's ID can be used as operation ID. If there is no
 /// transaction related to it, it should be generated randomly. Since it is a
 /// 256bit value collisions are impossible for all intents and purposes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub struct OperationId(pub [u8; 32]);
 
 impl OperationId {
@@ -64,6 +64,12 @@ impl OperationId {
 impl Display for OperationId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         bitcoin_hashes::hex::format_hex(&self.0, f)
+    }
+}
+
+impl Debug for OperationId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "OperationId({self})")
     }
 }
 

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -20,7 +20,9 @@ use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, ModuleNotifier, OperationId, State, StateTransition};
 use fedimint_client::transaction::{ClientOutput, TransactionBuilder};
-use fedimint_client::{sm_enum_variant_translation, Client, DynGlobalClientContext};
+use fedimint_client::{
+    caching_operation_update_stream, sm_enum_variant_translation, Client, DynGlobalClientContext,
+};
 use fedimint_core::api::IFederationApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{
@@ -102,7 +104,7 @@ pub trait LightningClientExt {
 
 /// The high-level state of a reissue operation started with
 /// [`LightningClientExt::pay_bolt11_invoice`].
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum LnPayState {
     Created,
     Canceled,
@@ -123,7 +125,7 @@ pub enum LnPayState {
 
 /// The high-level state of a reissue operation started with
 /// [`LightningClientExt::create_bolt11_invoice`].
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum LnReceiveState {
     Created,
     WaitingForPayment { invoice: String, timeout: Duration },
@@ -280,38 +282,39 @@ impl LightningClientExt for Client {
         let receive_success = lightning.await_receive_success(operation_id);
         let claim_acceptance = lightning.await_claim_acceptance(operation_id);
 
-        let stream = stream! {
-            yield LnReceiveState::Created;
+        Ok(caching_operation_update_stream(
+            self.db().clone(),
+            operation_id,
+            stream! {
+                    yield LnReceiveState::Created;
 
-            if tx_accepted_future.await.is_err() {
-                yield LnReceiveState::Canceled { reason: LightningReceiveError::Rejected };
-                return;
-            }
-
-            yield LnReceiveState::WaitingForPayment { invoice: invoice.to_string(), timeout: invoice.expiry_time() };
-
-            match receive_success.await {
-                Ok(()) => {
-                    yield LnReceiveState::Funded;
-
-                    if let Ok(txid) = claim_acceptance.await {
-                        yield LnReceiveState::AwaitingFunds;
-
-                        if self.await_primary_module_output_finalized(operation_id, OutPoint{ txid, out_idx: 0}).await.is_ok() {
-                            yield LnReceiveState::Claimed;
-                            return;
-                        }
-                    }
-
+                    if tx_accepted_future.await.is_err() {
                     yield LnReceiveState::Canceled { reason: LightningReceiveError::Rejected };
+                        return;
                 }
-                Err(e) => {
-                    yield LnReceiveState::Canceled { reason: e };
-                }
-            }
-        };
+                            yield LnReceiveState::WaitingForPayment { invoice: invoice.to_string(), timeout: invoice.expiry_time() };
 
-        Ok(Box::pin(stream))
+                            match receive_success.await {
+                                Ok(()) => {
+                                    yield LnReceiveState::Funded;
+
+                        if let Ok(txid) = claim_acceptance.await {
+                            yield LnReceiveState::AwaitingFunds;
+
+                            if self.await_primary_module_output_finalized(operation_id, OutPoint{ txid, out_idx: 0}).await.is_ok() {
+                                yield LnReceiveState::Claimed;
+                                return;
+                            }
+                        }
+
+                        yield LnReceiveState::Canceled { reason: LightningReceiveError::Rejected };
+                    }
+                    Err(e) => {
+                        yield LnReceiveState::Canceled { reason: e };
+                    }
+                }
+            },
+        ))
     }
 
     async fn subscribe_ln_pay_updates(
@@ -336,50 +339,51 @@ impl LightningClientExt for Client {
 
         let refund_success = lightning.await_refund(operation_id);
 
-        let stream = stream! {
-            yield LnPayState::Created;
+        Ok(caching_operation_update_stream(
+            self.db().clone(),
+            operation_id,
+            stream! {
+                    yield LnPayState::Created;
 
-            if tx_accepted_future.await.is_err() {
-                yield LnPayState::Canceled;
-                return;
-            }
+                    if tx_accepted_future.await.is_err() {
+                    yield LnPayState::Canceled;
+                        return;
+                }
+                            yield LnPayState::Funded;
 
-            yield LnPayState::Funded;
+                match payment_success.await {
+                    Ok(preimage) => {
+                        if let Some(change) = change_outpoint {
+                            yield LnPayState::AwaitingChange;
+                            match self.await_primary_module_output_finalized(operation_id, change).await {
+                                Ok(_) => {}
+                                Err(_) => {
+                                    yield LnPayState::Failed;
+                                    return;
+                                }
+                            }
+                        }
 
-            match payment_success.await {
-                Ok(preimage) => {
-                    if let Some(change) = change_outpoint {
-                        yield LnPayState::AwaitingChange;
-                        match self.await_primary_module_output_finalized(operation_id, change).await {
-                            Ok(_) => {}
-                            Err(_) => {
-                                yield LnPayState::Failed;
+                        yield LnPayState::Success {preimage};
+                        return;
+                    }
+                    Err(LightningPayError::Refundable(block_height, error)) => {
+                        yield LnPayState::WaitingForRefund{ block_height, gateway_error: error.clone() };
+
+                        if let Ok(refund_txid) = refund_success.await {
+                            // need to await primary module to get refund
+                            if self.await_primary_module_output_finalized(operation_id, OutPoint{ txid: refund_txid, out_idx: 0}).await.is_ok() {
+                                yield LnPayState::Refunded { gateway_error: error };
                                 return;
                             }
                         }
                     }
-
-                    yield LnPayState::Success {preimage};
-                    return;
+                    _ => {}
                 }
-                Err(LightningPayError::Refundable(block_height, error)) => {
-                    yield LnPayState::WaitingForRefund{ block_height, gateway_error: error.clone() };
 
-                    if let Ok(refund_txid) = refund_success.await {
-                        // need to await primary module to get refund
-                        if self.await_primary_module_output_finalized(operation_id, OutPoint{ txid: refund_txid, out_idx: 0}).await.is_ok() {
-                            yield LnPayState::Refunded { gateway_error: error };
-                            return;
-                        }
-                    }
-                }
-                _ => {}
-            }
-
-            yield LnPayState::Failed;
-        };
-
-        Ok(Box::pin(stream))
+                yield LnPayState::Failed;
+            },
+        ))
     }
 }
 

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -84,12 +84,20 @@ async fn makes_internal_payments_within_gateway() -> anyhow::Result<()> {
     let (op, invoice) = client1
         .create_bolt11_invoice(sats(250), "description".to_string(), None)
         .await?;
-    let sub1 = &mut client1.subscribe_to_ln_receive_updates(op).await.unwrap();
+    let sub1 = &mut client1
+        .subscribe_to_ln_receive_updates(op)
+        .await
+        .unwrap()
+        .into_stream();
     assert_eq!(next(sub1).await, LnReceiveState::Created);
     assert_matches!(next(sub1).await, LnReceiveState::WaitingForPayment { .. });
 
     let op = client2.pay_bolt11_invoice(fed_id, invoice).await.unwrap();
-    let sub2 = &mut client2.subscribe_ln_pay_updates(op).await.unwrap();
+    let sub2 = &mut client2
+        .subscribe_ln_pay_updates(op)
+        .await
+        .unwrap()
+        .into_stream();
     assert_eq!(next(sub2).await, LnPayState::Created);
     // TODO: Finish after gw moves from legacy client
     // assert_eq!(next(sub2).await, LnPayState::Funded);

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -27,11 +27,17 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
 
     // Spend from client1 to client2
     let (op, notes) = client1.spend_notes(sats(750), TIMEOUT, ()).await?;
-    let sub1 = &mut client1.subscribe_spend_notes_updates(op).await?;
+    let sub1 = &mut client1
+        .subscribe_spend_notes_updates(op)
+        .await?
+        .into_stream();
     assert_eq!(next(sub1).await, SpendOOBState::Created);
 
     let op = client2.reissue_external_notes(notes, ()).await?;
-    let sub2 = &mut client2.subscribe_reissue_external_notes_updates(op).await?;
+    let sub2 = &mut client2
+        .subscribe_reissue_external_notes_updates(op)
+        .await?
+        .into_stream();
     assert_eq!(next(sub2).await, ReissueExternalNotesState::Created);
     assert_eq!(next(sub2).await, ReissueExternalNotesState::Issuing);
     assert_eq!(next(sub2).await, ReissueExternalNotesState::Done);


### PR DESCRIPTION
Subscribing to operation updates is expensive, if we just want to know what the outcome of a finished operation was we can now read it from the operation log entry.