### PR TITLE
feature: validate params and use defaults

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -252,13 +252,17 @@ impl<M> Default for ModuleGenRegistry<M> {
 /// during config gen
 #[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ConfigGenModuleParams {
-    local: Option<serde_json::Value>,
-    consensus: Option<serde_json::Value>,
+    pub local: Option<serde_json::Value>,
+    pub consensus: Option<serde_json::Value>,
 }
 
 pub type ServerModuleGenRegistry = ModuleGenRegistry<DynServerModuleGen>;
 
 impl ConfigGenModuleParams {
+    pub fn new(local: Option<serde_json::Value>, consensus: Option<serde_json::Value>) -> Self {
+        Self { local, consensus }
+    }
+
     /// Converts the JSON into typed version, errors unless both `local` and
     /// `consensus` values are defined
     pub fn to_typed<P: ModuleGenParams>(&self) -> anyhow::Result<P> {
@@ -275,14 +279,6 @@ impl ConfigGenModuleParams {
         let json = json.ok_or(format_err!("{name} config gen params missing"))?;
         serde_json::from_value(json)
             .map_err(|e| anyhow::Error::new(e).context("Invalid module params"))
-    }
-
-    /// Copies these params with local params from another module
-    pub fn with_local(&self, other: &ConfigGenModuleParams) -> Self {
-        ConfigGenModuleParams {
-            local: other.local.clone(),
-            consensus: self.consensus.clone(),
-        }
     }
 
     pub fn from_typed<P: ModuleGenParams>(p: P) -> anyhow::Result<Self> {

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -245,9 +245,7 @@ impl FedimintServer {
                         let (state, context) =
                             rpc_context.context(&request, module_instance_id).await;
 
-                        let res = (handler)(state, context, request).await;
-
-                        res
+                        (handler)(state, context, request).await
                     }))
                     .catch_unwind()
                     .await

--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -170,10 +170,9 @@ where
             )
             .expect("Failed to create TLS config");
 
-        let sanitized_name =
-            self.peer_names[&peer].replace(|c: char| !c.is_ascii_alphanumeric(), "_");
         let fake_domain =
-            rustls::ServerName::try_from(sanitized_name.as_str()).expect("Always a valid DNS name");
+            rustls::ServerName::try_from(dns_sanitize(&self.peer_names[&peer]).as_str())
+                .expect("Always a valid DNS name");
 
         let connector = TlsConnector::from(Arc::new(cfg));
         let tls_conn = connector
@@ -225,6 +224,12 @@ where
         });
         Ok(Box::pin(stream))
     }
+}
+
+/// Sanitizes name as valid domain name
+pub fn dns_sanitize(name: &str) -> String {
+    let sanitized = name.replace(|c: char| !c.is_ascii_alphanumeric(), "_");
+    format!("peer{sanitized}")
 }
 
 /// Parses the host and port from a url

--- a/fedimint-ui/apps/guardian-ui/src/components/SetConfiguration.tsx
+++ b/fedimint-ui/apps/guardian-ui/src/components/SetConfiguration.tsx
@@ -121,7 +121,6 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
             meta: { federation_name: federationName },
             modules: {
               // TODO: figure out way to not hard-code modules here
-              0: ['ln', { consensus: {}, local: {} }],
               1: [
                 'mint',
                 { consensus: { mint_amounts: mintAmounts }, local: {} },
@@ -152,18 +151,6 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
             meta: {},
             modules: {
               // TODO: figure out way to not hard-code modules here
-              0: [
-                'ln',
-                {
-                  local: {},
-                },
-              ],
-              1: [
-                'mint',
-                {
-                  local: {},
-                },
-              ],
               2: [
                 'wallet',
                 {

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -54,6 +54,7 @@ impl ExtendsCommonModuleGen for DummyGen {
 /// Implementation of server module non-consensus functions
 #[async_trait]
 impl ServerModuleGen for DummyGen {
+    type Params = DummyGenParams;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(1);
 
     /// Returns the version of this module
@@ -84,8 +85,7 @@ impl ServerModuleGen for DummyGen {
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
-        // Coerce config gen params into type
-        let params = params.to_typed::<DummyGenParams>().unwrap();
+        let params = self.parse_params(params).unwrap();
         // Create trusted set of threshold keys
         let sks = SecretKeySet::random(peers.degree(), &mut OsRng);
         let pks: PublicKeySet = sks.public_keys();
@@ -115,8 +115,7 @@ impl ServerModuleGen for DummyGen {
         peers: &PeerHandle,
         params: &ConfigGenModuleParams,
     ) -> DkgResult<ServerModuleConfig> {
-        // Coerce config gen params into type
-        let params = params.to_typed::<DummyGenParams>().unwrap();
+        let params = self.parse_params(params).unwrap();
         // Runs distributed key generation
         // Could create multiple keys, here we use '()' to create one
         let g1 = peers.run_dkg_g1(()).await?;

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -27,7 +27,7 @@ use fedimint_core::{
 pub use fedimint_ln_common as common;
 use fedimint_ln_common::config::{
     FeeConsensus, LightningClientConfig, LightningConfig, LightningConfigConsensus,
-    LightningConfigLocal, LightningConfigPrivate,
+    LightningConfigLocal, LightningConfigPrivate, LightningGenParams,
 };
 use fedimint_ln_common::contracts::incoming::IncomingContractOffer;
 use fedimint_ln_common::contracts::{
@@ -61,6 +61,7 @@ impl ExtendsCommonModuleGen for LightningGen {
 
 #[apply(async_trait_maybe_send!)]
 impl ServerModuleGen for LightningGen {
+    type Params = LightningGenParams;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -63,6 +63,7 @@ impl ExtendsCommonModuleGen for MintGen {
 
 #[apply(async_trait_maybe_send!)]
 impl ServerModuleGen for MintGen {
+    type Params = MintGenParams;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
@@ -83,9 +84,7 @@ impl ServerModuleGen for MintGen {
         peers: &[PeerId],
         params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
-        let params = params
-            .to_typed::<MintGenParams>()
-            .expect("Invalid mint params");
+        let params = self.parse_params(params).unwrap();
 
         let tbs_keys = params
             .consensus
@@ -144,9 +143,7 @@ impl ServerModuleGen for MintGen {
         peers: &PeerHandle,
         params: &ConfigGenModuleParams,
     ) -> DkgResult<ServerModuleConfig> {
-        let params = params
-            .to_typed::<MintGenParams>()
-            .expect("Invalid mint gen params");
+        let params = self.parse_params(params).unwrap();
 
         let g2 = peers
             .run_dkg_multi_g2(params.consensus.mint_amounts.to_vec())


### PR DESCRIPTION
- Uses the default params if params are not supplied
- Validates the params can be parsed upon calling `set_config_gen_params`
- Sanitizes guardian names that are numeric

Fixes #2545