### PR TITLE
feat(nix): yarn install and build when running .#fedimint-ui

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -460,6 +460,9 @@
                 nativeBuildInputs = shellCommonNative.nativeBuildInputs ++ [ pkgs.yarn pkgs.nodejs ];
                 shellHook = ''
                   export FEDIMINT_UI_SHELL=1
+                  cd fedimint-ui
+                  yarn install
+                  yarn build
                 '';
               });
             };


### PR DESCRIPTION
Have a completely functional .#fedimint-ui for nix.
This runs `yarn install` to download all node_modules needed and builds the turbo repo so shared packages are available.

To test, delete 
- `fedimint-ui/node_modules` 
- `fedimint-ui/app/guardian-ui/node_modules`
- `fedimint-ui/app/guardian-ui/build`
- `fedimint-ui/app/gateway-ui/node_modules`
- `fedimint-ui/app/gateway-ui/node_modules`
- `fedimint-ui/packages/eslint-config/node_modules`
- `fedimint-ui/packages/ui/dist`
- `fedimint-ui/packages/ui/node_modules`

This removes all of the dependencies needed to run the UI. 

Then run `nix develop .#fedmint-ui`
You should see logs for `yarn install` and then `yarn build`.
The run `just-ui` and it should "just work"™️