### PR TITLE
build(deps): bump `rust-esplora-client` to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,8 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "esplora-client"
-version = "0.4.0"
-source = "git+https://github.com/bitcoindevkit/rust-esplora-client.git?rev=54de8118c40c6a2cf80591d8991cf578bdfb51c4#54de8118c40c6a2cf80591d8991cf578bdfb51c4"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e11244e7fd8b0beee0a3c62137c4bd9f756fe2c492ccf93171f81467b59200"
 dependencies = [
  "bitcoin",
  "log",

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -18,8 +18,7 @@ bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 bitcoincore-rpc = "0.16.0"
 electrum-client = "0.12.0"
-# TODO: change to release version once there is a release that includes the `async-https-rustls` flag
-esplora-client = { git = "https://github.com/bitcoindevkit/rust-esplora-client.git", rev = "54de8118c40c6a2cf80591d8991cf578bdfb51c4", default-features = false, features = ["async", "async-https-rustls"] }
+esplora-client = { version = "0.5.0", default-features = false, features = ["async", "async-https-rustls"] }
 lazy_static = "1.4.0"
 fedimint-core  = { path = "../fedimint-core" }
 fedimint-logging = { path = "../fedimint-logging" }

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -417,8 +417,6 @@ impl IBitcoindRpc for EsploraClient {
             .get_tx_status(&transaction.txid())
             .await
             .map_err(anyhow::Error::from)?;
-        Ok(status
-            .map(|status| status.block_height == Some(height as u32))
-            .unwrap_or(false))
+        Ok(status.block_height == Some(height as u32))
     }
 }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -17,7 +17,7 @@ async-stream = "0.3.5"
 async-trait = "0.1"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
-esplora-client = { git = "https://github.com/bitcoindevkit/rust-esplora-client.git", rev = "54de8118c40c6a2cf80591d8991cf578bdfb51c4", default-features = false, features = ["async", "async-https-rustls"] }
+esplora-client = { version = "0.5.0", default-features = false, features = ["async", "async-https-rustls"] }
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-core = { path = "../../fedimint-core" }
 fedimint-wallet-common ={ path = "../fedimint-wallet-common" }

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -271,7 +271,7 @@ async fn get_tx_block_height(esplora_server: &str, txid: Txid) -> anyhow::Result
     let confirmation_height = esplora_client
         .get_tx_status(&txid)
         .await?
-        .and_then(|status| status.block_height)
+        .block_height
         .map(|height| height as u64);
 
     Ok(confirmation_height)


### PR DESCRIPTION
`rust-esplora-client` v0.5.0 release: https://github.com/bitcoindevkit/rust-esplora-client/releases/tag/v0.5.0

fixes #2325