### PR TITLE
fix: remove password requirement for docker image

### DIFF
--- a/misc/fedimintd-container-entrypoint.sh
+++ b/misc/fedimintd-container-entrypoint.sh
@@ -10,11 +10,6 @@ if [ -z "$FM_DATA_DIR" ]; then
   exit 1
 fi
 
-if [ -z "$FM_PASSWORD" ]; then
-  1>&2 echo "Must provide FM_PASSWORD environment variable"
-  exit 1
-fi
-
 if [ ! -e "$FM_DATA_DIR" ]; then
   1>&2 echo "Creating $FM_DATA_DIR"
   mkdir -p "$FM_DATA_DIR" && chmod 0600 "$FM_DATA_DIR"


### PR DESCRIPTION
Since we set the password in the UI, this is no longer needed.

I alos believe this will avoid hitting a bug in (config api)[https://github.com/fedimint/fedimint/blob/5b89c5a71340414e424aaf02235a8edb1af8c832/fedimint-server/src/config/api.rs#LL247C1-L261C6] where writing configs fail if a password is already set.

Resulting in this error during setup:
<img width="1262" alt="Screenshot 2023-05-25 at 10 00 55 PM" src="https://github.com/fedimint/fedimint/assets/133234413/1ded8731-6158-4565-bedf-de3c2338f95a">

This error was found when testing in [this repo](https://github.com/EthnTuttle/fedimint-ui), where I have been working on push button Docker running of a Fedimint. It enables commit hash pegging via the Docker image tag we specify in the setup.

I believe this PR will unlock final testing in that repo so we can populate https://github.com/fedimint/ui and start removing all the dirty javascript from this beautiful Rust project. Then myself and the other javascript degens will ~~go play in our own sandbox~~ use the UI repo for Issue tracking and other development. The new repo also removes Nix which has proven a barrier to entry for many new contributors.


