### PR TITLE
feat(ui): turbo dev

### DIFF
--- a/fedimint-ui/README.md
+++ b/fedimint-ui/README.md
@@ -24,9 +24,11 @@ From root repo directory:
 1. `yarn install` (First time only)
 1. You can run any of the following commands from `fedimint-ui/` directory
 
-> - `yarn test` - Tests all apps and packages in the project
-> - `yarn build` - Build all apps and packages in the project
-> - `yarn clean` - Cleans previous build outputs from all apps and packages in the project
-> - `yarn format` - Fixes formatting in all apps and packages in the project
-
-Alternatively, you can navigate to a specific app or package within `fedimint-ui/` directory and run it's respective development commands
+- `yarn dev` - Starts development servers and file watchers for all apps and packages
+  - Due to port conflicts, there are dev commands for each app to run individually
+    - `yarn dev:gateway-ui`
+    - `yarn dev:guardian-ui`
+- `yarn test` - Tests all apps and packages in the project
+- `yarn build` - Build all apps and packages in the project
+- `yarn clean` - Cleans previous build outputs from all apps and packages in the project
+- `yarn format` - Fixes formatting in all apps and packages in the project

--- a/fedimint-ui/package.json
+++ b/fedimint-ui/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
   "scripts": {
+    "dev": "turbo run dev",
+    "dev:gateway-ui": "turbo run dev --filter=gateway-ui...",
+    "dev:guardian-ui": "turbo run dev --filter=guardian-ui...",
     "build": "turbo run build",
     "clean": "turbo run clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/fedimint-ui/package.json
+++ b/fedimint-ui/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "scripts": {
     "dev": "turbo run dev",
-    "dev:gateway-ui": "turbo run dev --filter=gateway-ui...",
-    "dev:guardian-ui": "turbo run dev --filter=guardian-ui...",
+    "dev:gateway-ui": "turbo run dev --parallel --filter=gateway-ui...",
+    "dev:guardian-ui": "turbo run dev --parallel --filter=guardian-ui...",
     "build": "turbo run build",
     "clean": "turbo run clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/fedimint-ui/packages/ui/package.json
+++ b/fedimint-ui/packages/ui/package.json
@@ -7,9 +7,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "yarn run tsup",
+    "build": "tsup",
     "clean": "rm -rf dist",
-    "dev": "yanr run tsup --watch",
+    "dev": "tsup --watch",
     "lint": "eslint \"src/**/*.ts*\""
   },
   "devDependencies": {

--- a/fedimint-ui/turbo.json
+++ b/fedimint-ui/turbo.json
@@ -24,11 +24,14 @@
       "cache": false,
       "persistent": true
     },
-    "guardian-ui#dev": {
-      "dependsOn": ["ui#dev"]
+    "@fedimint/ui#dev": {
+      "dependsOn": ["^build"]
     },
-    "gateway-ui#dev": {
-      "dependsOn": ["ui#dev"]
+    "@fedimint/guardian-ui#dev": {
+      "dependsOn": ["@fedimint/ui#build"]
+    },
+    "@fedimint/gateway-ui#dev": {
+      "dependsOn": ["@fedimint/ui#build"]
     },
     "clean": {
       "cache": false

--- a/fedimint-ui/turbo.json
+++ b/fedimint-ui/turbo.json
@@ -24,6 +24,12 @@
       "cache": false,
       "persistent": true
     },
+    "guardian-ui#dev": {
+      "dependsOn": ["ui#dev"]
+    },
+    "gateway-ui#dev": {
+      "dependsOn": ["ui#dev"]
+    },
     "clean": {
       "cache": false
     }


### PR DESCRIPTION
### What This Does

* Adds `yarn dev` to `fedimint-ui/` to run all `dev` commands
  * Due to there being port conflicts amongst apps, I also added `yarn dev:[app-name]` commands to only run one app at a time, along with any packages it depends on. You can specify different ports in each command to run multiple.
    * E.g. `yarn dev:guardian-ui` in one terminal, `PORT=4000 yarn dev:gateway-ui` in another terminal
    * Alternatively, we could hard-code in different ports for each app, and make them all runnable via one command?
* Fixes `yarn dev` command in `packages/ui`, a typo was causing it to fail

## Steps to Test

1. cd into `fedimint-ui` and run `yarn dev`, confirm it all runs but apps die due to port conflicts
2. run `yarn dev:guardian-ui`, confirm it runs properly on port 3000 and also runs dev for `ui`
3. run `PORT=4000 yarn dev:gateway-ui`, confirm it runs properly on port 4000 and also runs dev for `ui`