### PR TITLE
refactor: remove LnRpcAdapter and simplify lightning test clients

### DIFF
--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use anyhow::anyhow;
 use async_trait::async_trait;
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::{PublicKey, SecretKey};
@@ -20,8 +18,6 @@ use ln_gateway::gatewaylnrpc::{
 use ln_gateway::lnrpc_client::{ILnRpcClient, RouteHtlcStream};
 use ln_gateway::GatewayError;
 use rand::rngs::OsRng;
-use tokio::sync;
-use tokio::sync::RwLock;
 use tokio_stream::wrappers::ReceiverStream;
 
 use super::LightningTest;
@@ -132,72 +128,5 @@ impl ILnRpcClient for FakeLightningTest {
             .await;
 
         Ok(Box::pin(stream::iter(vec![])))
-    }
-}
-
-/// A proxy for the underlying LnRpc which can be used to add behavior to it
-/// using the "Decorator pattern"
-#[derive(Debug, Clone)]
-pub struct LnRpcAdapter {
-    /// The actual `ILnRpcClient` that we add behavior to.
-    client: Arc<RwLock<dyn ILnRpcClient>>,
-    /// A pair of [`PayInvoiceRequest`] and `u8` where client.pay() will fail
-    /// `u8` times for each `String` (bolt11 invoice)
-    fail_invoices: Arc<sync::Mutex<HashMap<String, u8>>>,
-}
-
-impl LnRpcAdapter {
-    pub fn new(client: Arc<RwLock<dyn ILnRpcClient>>) -> Self {
-        let fail_invoices = Arc::new(sync::Mutex::new(HashMap::new()));
-
-        LnRpcAdapter {
-            client,
-            fail_invoices,
-        }
-    }
-
-    /// Register `invoice` to fail `times` before (attempt) succeeding. The
-    /// invoice will be dropped from the HashMap after succeeding
-    #[allow(dead_code)]
-    pub async fn fail_invoice(&self, invoice: PayInvoiceRequest, times: u8) {
-        self.fail_invoices
-            .lock()
-            .await
-            .insert(invoice.invoice, times + 1);
-    }
-}
-
-#[async_trait]
-impl ILnRpcClient for LnRpcAdapter {
-    async fn info(&self) -> ln_gateway::Result<GetNodeInfoResponse> {
-        self.client.read().await.info().await
-    }
-
-    async fn routehints(&self) -> ln_gateway::Result<GetRouteHintsResponse> {
-        self.client.read().await.routehints().await
-    }
-
-    async fn pay(&self, invoice: PayInvoiceRequest) -> ln_gateway::Result<PayInvoiceResponse> {
-        self.fail_invoices
-            .lock()
-            .await
-            .entry(invoice.invoice.clone())
-            .and_modify(|counter| {
-                *counter -= 1;
-            });
-        if let Some(counter) = self.fail_invoices.lock().await.get(&invoice.invoice) {
-            if *counter > 0 {
-                return Err(GatewayError::Other(anyhow!("expected test error")));
-            }
-        }
-        self.fail_invoices.lock().await.remove(&invoice.invoice);
-        self.client.read().await.pay(invoice).await
-    }
-
-    async fn route_htlcs<'a>(
-        &mut self,
-        events: ReceiverStream<RouteHtlcRequest>,
-    ) -> Result<RouteHtlcStream<'a>, GatewayError> {
-        self.client.write().await.route_htlcs(events).await
     }
 }

--- a/fedimint-testing/src/ln/mod.rs
+++ b/fedimint-testing/src/ln/mod.rs
@@ -2,12 +2,13 @@ use async_trait::async_trait;
 use clap::ValueEnum;
 use fedimint_core::Amount;
 use lightning_invoice::Invoice;
+use ln_gateway::lnrpc_client::ILnRpcClient;
 
 pub mod mock;
 pub mod real;
 
 #[async_trait]
-pub trait LightningTest {
+pub trait LightningTest: ILnRpcClient {
     /// Creates invoice from a non-gateway LN node
     async fn invoice(
         &self,
@@ -23,16 +24,16 @@ pub trait LightningTest {
 }
 
 #[derive(ValueEnum, Clone, Debug)]
-pub enum GatewayNode {
+pub enum LightningNodeType {
     Cln,
     Lnd,
 }
 
-impl ToString for GatewayNode {
+impl ToString for LightningNodeType {
     fn to_string(&self) -> String {
         match self {
-            GatewayNode::Cln => "cln".to_string(),
-            GatewayNode::Lnd => "lnd".to_string(),
+            LightningNodeType::Cln => "cln".to_string(),
+            LightningNodeType::Lnd => "lnd".to_string(),
         }
     }
 }


### PR DESCRIPTION
This PR attempts to simplify the lightning test clients that are used for the integration tests. Before, there was an `LnRpcAdapter` wrapper struct and fake and real implementations of lightning RPCs, which in my opinion became a bit difficult to reason about. This PR makes the following changes:

- Removes `LnRpcAdapter`
- `LightningTest` is now an extension trait of `ILnRpcClient`. Logically, this means it is a lightning client that the gateway can use, but it also defines some extra functions that are useful for tests (ex: `FakeLightningTest`, `ClnLightningTest`, `LndLightningTest`.
- `RealLightningTest` has been split into CLN and LND. The previous implementation kept connections to both Lightning nodes, but the Fake implementation didn't have this same notion, which caused the fake and real implementations to be different (this was the actual requirement for `LnRpcAdapter`). Splitting these implementations into two simplifies the code and allows for the removal of `LnRpcAdapter`