### PR TITLE
fix: make client compatible with old federations

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -97,7 +97,7 @@ use secp256k1_zkp::Secp256k1;
 use secret::DeriveableSecretClientExt;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use tracing::{error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 use crate::backup::Metadata;
 use crate::db::{
@@ -1242,6 +1242,7 @@ impl ClientBuilder {
             let mut modules = ClientModuleRegistry::default();
             let mut primary_module = None;
             for (module_instance, module_config) in config.modules.clone() {
+                debug!("Initializing module {module_instance} config {module_config:?}");
                 let kind = module_config.kind().clone();
                 if module_instance == primary_module_instance {
                     let module = self


### PR DESCRIPTION
So I would like to use the newest client, with all the goodies and bugfixes, in an existing federation, like fedi alpha.

Basically we have new configuration variables that are not present on older federations. The idea is that we can provide this "manually" through environment variables.

The alternative is to cherry pick bugfixes and features, but it would be so much easier to be able to use the master client.