### PR TITLE
fix: don't accumulate empty epochs on rejoin requests

### DIFF
--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -1,4 +1,4 @@
-use std::cmp::min;
+use std::cmp::{max, min};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -572,11 +572,12 @@ impl ConsensusServer {
 
                 Ok(self.handle_step(step).await?)
             }
-            (_, EpochMessage::RejoinRequest(epoch)) => {
-                self.run_empty_epochs += min(NUM_EPOCHS_REJOIN_AHEAD, epoch);
+            (_, EpochMessage::RejoinRequest(epochs)) => {
+                let capped_empty_epochs = min(NUM_EPOCHS_REJOIN_AHEAD, epochs);
+                self.run_empty_epochs = max(self.run_empty_epochs, capped_empty_epochs);
                 info!(
                     target: LOG_CONSENSUS,
-                    "Requested to run {} epochs, running {} epochs", epoch, self.run_empty_epochs
+                    "Requested to run {} epochs, running {} epochs", epochs, self.run_empty_epochs
                 );
                 Ok(vec![])
             }

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -96,8 +96,9 @@ pub struct ConsensusServer {
     /// Under the HBBFT consensus algorithm, this will track the latest epoch
     /// message received by each peer and when it was received
     pub latest_contribution_by_peer: Arc<RwLock<LatestContributionByPeer>>,
-    /// How many empty epochs peers requested we run
-    pub run_empty_epochs: u64,
+    /// Number of pending forced epochs (requested by peers to help join
+    /// consensus faster)
+    pub pending_forced_epochs: u64,
     /// Tracks the last epoch outcome from consensus
     pub last_processed_epoch: Option<SignedEpochOutcome>,
     /// Used for decoding module specific-values
@@ -245,7 +246,7 @@ impl ConsensusServer {
             other_peers,
             rejoin_at_epoch: Default::default(),
             latest_contribution_by_peer,
-            run_empty_epochs: 0,
+            pending_forced_epochs: 0,
             last_processed_epoch: None,
             decoders: modules.decoder_registry(),
         })
@@ -537,8 +538,8 @@ impl ConsensusServer {
     }
 
     async fn await_next_epoch(&mut self) -> anyhow::Result<EpochTriggerEvent> {
-        if self.run_empty_epochs > 0 {
-            self.run_empty_epochs = self.run_empty_epochs.saturating_sub(1);
+        if self.pending_forced_epochs > 0 {
+            self.pending_forced_epochs = self.pending_forced_epochs.saturating_sub(1);
             return Ok(EpochTriggerEvent::RunEpochRequest);
         }
 
@@ -573,11 +574,15 @@ impl ConsensusServer {
                 Ok(self.handle_step(step).await?)
             }
             (_, EpochMessage::RejoinRequest(epochs)) => {
-                let capped_empty_epochs = min(NUM_EPOCHS_REJOIN_AHEAD, epochs);
-                self.run_empty_epochs = max(self.run_empty_epochs, capped_empty_epochs);
+                let requested_forced_epochs_capped = min(NUM_EPOCHS_REJOIN_AHEAD, epochs);
+                self.pending_forced_epochs =
+                    max(self.pending_forced_epochs, requested_forced_epochs_capped);
                 info!(
                     target: LOG_CONSENSUS,
-                    "Requested to run {} epochs, running {} epochs", epochs, self.run_empty_epochs
+                    "Peer {} requested to run {} epochs. Set pending forced epochs to {}",
+                    msg.0,
+                    epochs,
+                    self.pending_forced_epochs
                 );
                 Ok(vec![])
             }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -1011,7 +1011,7 @@ impl FederationTest {
     /// Runs consensus epochs even if the epochs are empty
     pub async fn run_empty_epochs(&self, epochs: usize) {
         for server in &self.servers {
-            server.lock().await.fedimint.run_empty_epochs = epochs as u64;
+            server.lock().await.fedimint.pending_forced_epochs = epochs as u64;
         }
 
         self.run_consensus_epochs_wait(epochs).await.unwrap();


### PR DESCRIPTION
In Fedi Alpha deployement, probably caused by #2605 , we've noticed Federations accumulating hundreds of empty epochs to be created, due to how currently they are being accumulated (`+=`) on every request.

Change the code to cap the pending epochs to a max value (10).

While at it, do some renaming.