### PR TITLE
feat: fund client ng from devimint dev-fed

### DIFF
--- a/scripts/user-shell.sh
+++ b/scripts/user-shell.sh
@@ -35,7 +35,7 @@ then
     exit 1
 fi
 
-scripts/pegin.sh 20000.0 | show_verbose_output
+scripts/pegin.sh 10000.0 | show_verbose_output
 
 use_cln_gw
 
@@ -43,10 +43,6 @@ echo Funding CLN gateway e-cash wallet ...
 scripts/pegin.sh 20000.0 1 | show_verbose_output
 echo Funding LND gateway e-cash wallet ...
 scripts/pegin.sh 20000.0 1 "LND" | show_verbose_output
-
-echo Funding ClientNG
-ECASH=$($FM_MINT_CLIENT spend 10000000 | jq -e -r '.note')
-fedimint-cli ng reissue $ECASH
 
 echo Done!
 echo


### PR DESCRIPTION
This is to resolve #2507.

I've created a new method `pegin_ng` based on the changes from #2416. This is called as part of `devimint dev-fed` to fund the new client and also as part of the CLI tests where I took the original code from.

I've updated some CLI tests to reflect the non-zero initial balance of the new client.

I've also reverted the changes from #2509.