### PR TITLE
feat(cli-ng): list operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,6 +1320,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4913,12 +4920,15 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
+ "itoa",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4926,6 +4936,15 @@ name = "time-core"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -318,6 +318,20 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
     fed.pegin(CLIENT_START_AMOUNT / 1000).await?;
 
+    // Check log contains deposit
+    let operation = cmd!(fed, "list-operations")
+        .out_json()
+        .await?
+        .get("operations")
+        .expect("Output didn't contain operation log")
+        .as_array()
+        .unwrap()
+        .first()
+        .unwrap()
+        .to_owned();
+    assert_eq!(operation["operation_kind"].as_str().unwrap(), "wallet");
+    assert_eq!(operation["outcome"].as_str().unwrap(), "Claimed");
+
     info!("Testing backup&restore");
     // TODO: make sure there are no in-progress operations involved
     // This test can't tolerate "spend", but not "reissue"d coins currently,

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.66"
 base64 = "0.20.0"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
+time = { version = "0.3.25", features = [ "formatting" ] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
 futures = "0.3.28"
 lightning-invoice = { version = "0.21.0", features = [ "serde" ] }


### PR DESCRIPTION
Allows inspecting the operation log using the CLI client. Builds on #2594.