### PR TITLE
Use cookie file for auth when username does not exist

### DIFF
--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fmt;
+use std::{fmt, fs, env};
 
 use ::bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
 use ::bitcoincore_rpc::jsonrpc::error::RpcError;
@@ -12,8 +12,6 @@ use jsonrpc::error::Error as JsonError;
 use serde::Deserialize;
 use tracing::{instrument, warn};
 use url::Url;
-use std::env;
-use std::fs;
 
 use super::*;
 

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -44,7 +44,11 @@ pub fn from_url_to_url_auth(url: &Url) -> Result<(String, Auth)> {
             )
         }),
         if url.username().is_empty() {
-            read_cookie_file()
+            let auth = match read_cookie_file() {
+                Ok(cookie) => Some(Auth::UserPass(url.username().to_owned(), cookie)),
+                Err(_) => None,
+            };
+            auth.unwrap_or(Auth::None)
         } else {
             Auth::UserPass(
                 url.username().to_owned(),

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -44,7 +44,7 @@ pub fn from_url_to_url_auth(url: &Url) -> Result<(String, Auth)> {
             )
         }),
         if url.username().is_empty() {
-            Auth::None
+            read_cookie_file()
         } else {
             Auth::UserPass(
                 url.username().to_owned(),
@@ -54,6 +54,16 @@ pub fn from_url_to_url_auth(url: &Url) -> Result<(String, Auth)> {
             )
         },
     ))
+}
+
+fn read_cookie_file() -> Result<String, std::io::Error> {
+    let cookie_file_path = env::var("FM_BITCOIND_COOKIE_FILE")
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::NotFound, "FM_BITCOIND_COOKIE_FILE environment variable not set"))?;
+
+    let cookie = fs::read_to_string(&cookie_file_path)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to read cookie file: {}", e)))?;
+
+    Ok(cookie)
 }
 
 #[derive(Debug)]

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::{fmt, fs, env};
+use std::{env, fmt, fs};
 
 use ::bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
 use ::bitcoincore_rpc::jsonrpc::error::RpcError;

--- a/fedimint-bitcoind/src/bitcoincore_rpc.rs
+++ b/fedimint-bitcoind/src/bitcoincore_rpc.rs
@@ -12,6 +12,8 @@ use jsonrpc::error::Error as JsonError;
 use serde::Deserialize;
 use tracing::{instrument, warn};
 use url::Url;
+use std::env;
+use std::fs;
 
 use super::*;
 


### PR DESCRIPTION
To use the cookie file for auth when no username is present, as discussed in #1990