### PR TITLE
feat(gateway-cli): show balance for each federation

### DIFF
--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -655,11 +655,13 @@ impl GatewayActor {
         Ok(self.client.summary().await.total_amount())
     }
 
-    pub fn get_info(&self) -> Result<FederationInfo> {
+    pub async fn get_info(&self) -> Result<FederationInfo> {
         let cfg = self.client.config();
+        let registration = self.registration.lock().expect("poisoned").clone();
         Ok(FederationInfo {
             federation_id: cfg.client_config.federation_id,
-            registration: self.registration.lock().expect("poisoned").clone(),
+            registration,
+            total_msat: self.get_balance().await?,
         })
     }
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -338,7 +338,7 @@ impl Gateway {
 
         if let Ok(actor) = self.select_actor(connect.id).await {
             info!("Federation {} already connected", connect.id);
-            return actor.get_info();
+            return actor.get_info().await;
         }
 
         let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.read().await.info().await?;
@@ -386,7 +386,7 @@ impl Gateway {
             );
         }
 
-        let federation_info = actor.get_info()?;
+        let federation_info = actor.get_info().await?;
 
         Ok(federation_info)
     }
@@ -395,7 +395,7 @@ impl Gateway {
         let actors = self.actors.read().await;
         let mut federations: Vec<FederationInfo> = Vec::new();
         for actor in actors.values() {
-            federations.push(actor.get_info()?);
+            federations.push(actor.get_info().await?);
         }
 
         let ln_info = self.lnrpc.read().await.info().await?;

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -120,6 +120,8 @@ pub struct FederationInfo {
     pub federation_id: FederationId,
     /// Information we registered with the fed
     pub registration: LightningGateway,
+    /// Federation balance in msat
+    pub total_msat: Amount,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
This is to resolve #2508.

I've added a `total_msat` field to the `FederationInfo` struct, which is the same name used in the output of `fedimint-cli ng info`.

It was suggested in https://github.com/fedimint/fedimint/issues/2508#issuecomment-1546471869 to remove the `balance` command, which I could do here or separately as required.