### PR TITLE
Initial Implementation of the atomic broadcast abstraction based on Aleph BFT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "aleph-bft"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e70117d5481f1194ceafcf71d027377717d6fc738fc10a1433f412bb5bdc4d"
+dependencies = [
+ "aleph-bft-rmc",
+ "aleph-bft-types",
+ "anyhow",
+ "async-trait",
+ "derivative",
+ "futures",
+ "futures-timer",
+ "itertools",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
+name = "aleph-bft-crypto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ef65bb0b342d411e32789cdf722cbf163667e1656577ef356221c5aebf75c9"
+dependencies = [
+ "async-trait",
+ "bit-vec",
+ "derive_more",
+ "log",
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "aleph-bft-rmc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a34546c3d75df640c0224294be256fd0c17ed3f7191367124ece4d93753061"
+dependencies = [
+ "aleph-bft-crypto",
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "log",
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "aleph-bft-types"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b39893b3cb3670ade7d8fe3cb807f9b032cd2a2937df88a64b53ad927fc1510"
+dependencies = [
+ "aleph-bft-crypto",
+ "async-trait",
+ "futures",
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +200,17 @@ name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
 
 [[package]]
 name = "async-lock"
@@ -371,12 +442,18 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "rand",
  "rand_core",
  "serde",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
@@ -385,10 +462,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
  "bech32",
- "bitcoin_hashes",
- "secp256k1",
+ "bitcoin_hashes 0.11.0",
+ "secp256k1 0.24.3",
  "serde",
 ]
+
+[[package]]
+name = "bitcoin"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36f4c848f6bd9ff208128f08751135846cc23ae57d66ab10a22efff1c675f3c"
+dependencies = [
+ "bech32",
+ "bitcoin-private",
+ "bitcoin_hashes 0.12.0",
+ "hex_lit",
+ "secp256k1 0.27.0",
+]
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -397,6 +493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
 ]
 
 [[package]]
@@ -418,7 +523,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c231bea28e314879c5aef240f6052e8a72a369e3c9f9b20d9bfbb33ad18029b2"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.29.2",
  "serde",
  "serde_json",
 ]
@@ -497,6 +602,12 @@ name = "bumpalo"
 version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
@@ -622,7 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39f2cc1b4417e08a0b65a62395125998cd5ba5d38af96836dd1bfab3e168105a"
 dependencies = [
  "anyhow",
- "bitcoin",
+ "bitcoin 0.29.2",
  "bytes",
  "futures-util",
  "hex",
@@ -638,6 +749,15 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console-api"
@@ -680,6 +800,12 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "counter"
@@ -828,6 +954,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote 1.0.27",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "devimint"
 version = "0.1.0"
 dependencies = [
@@ -922,7 +1061,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8e1e1e452aef3ee772d19cc6272ef642f22ce0f4a9fb715ffe98010934e2ae1"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.29.2",
  "byteorder",
  "libc",
  "log",
@@ -1005,7 +1144,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e11244e7fd8b0beee0a3c62137c4bd9f756fe2c492ccf93171f81467b59200"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.29.2",
  "log",
  "reqwest",
  "serde",
@@ -1038,6 +1177,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-atomic-broadcast"
+version = "0.1.0"
+dependencies = [
+ "aleph-bft",
+ "anyhow",
+ "async-channel",
+ "async-trait",
+ "bitcoin 0.30.0",
+ "bitcoin_hashes 0.12.0",
+ "fedimint-core",
+ "futures",
+ "parity-scale-codec",
+ "secp256k1 0.27.0",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "fedimint-bip39"
 version = "0.1.0"
 dependencies = [
@@ -1053,8 +1211,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin",
- "bitcoin_hashes",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
  "bitcoincore-rpc",
  "electrum-client",
  "esplora-client",
@@ -1077,8 +1235,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.20.0",
- "bitcoin",
- "bitcoin_hashes",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
  "clap",
  "fedimint-aead",
  "fedimint-build",
@@ -1112,8 +1270,8 @@ dependencies = [
  "aquamarine",
  "async-stream",
  "async-trait",
- "bitcoin",
- "bitcoin_hashes",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
  "fedimint-aead",
  "fedimint-core",
  "fedimint-derive-secret",
@@ -1140,8 +1298,8 @@ dependencies = [
  "async-trait",
  "base64 0.20.0",
  "bincode",
- "bitcoin",
- "bitcoin_hashes",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
  "fedimint-aead",
  "fedimint-client",
  "fedimint-core",
@@ -1165,7 +1323,7 @@ dependencies = [
  "rand",
  "reqwest",
  "ring",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -1189,8 +1347,8 @@ dependencies = [
  "async-trait",
  "bech32",
  "bincode",
- "bitcoin",
- "bitcoin_hashes",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
  "bitvec",
  "erased-serde",
  "fedimint-derive",
@@ -1234,7 +1392,7 @@ name = "fedimint-dbtool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "bytes",
  "clap",
  "erased-serde",
@@ -1289,7 +1447,7 @@ dependencies = [
  "fedimint-dummy-common",
  "futures",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
  "thiserror",
  "threshold_crypto",
@@ -1302,12 +1460,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "erased-serde",
  "fedimint-core",
  "futures",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
  "strum",
  "strum_macros",
@@ -1322,14 +1480,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "erased-serde",
  "fedimint-core",
  "fedimint-dummy-common",
  "fedimint-server",
  "futures",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
  "strum",
  "strum_macros",
@@ -1364,8 +1522,8 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bincode",
- "bitcoin",
- "bitcoin_hashes",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
  "erased-serde",
  "fedimint-client",
  "fedimint-core",
@@ -1376,7 +1534,7 @@ dependencies = [
  "lightning-invoice",
  "rand",
  "reqwest",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -1398,8 +1556,8 @@ dependencies = [
  "aquamarine",
  "async-trait",
  "bincode",
- "bitcoin",
- "bitcoin_hashes",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
  "erased-serde",
  "fedimint-client",
  "fedimint-core",
@@ -1408,7 +1566,7 @@ dependencies = [
  "lightning",
  "lightning-invoice",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
  "serde_json",
  "strum",
@@ -1428,7 +1586,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "erased-serde",
  "fedimint-bitcoind",
  "fedimint-core",
@@ -1441,7 +1599,7 @@ dependencies = [
  "lightning",
  "lightning-invoice",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
  "serde_json",
  "strum",
@@ -1460,7 +1618,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "bitcoin",
+ "bitcoin 0.29.2",
  "fedimint-bitcoind",
  "fedimint-client",
  "fedimint-core",
@@ -1487,7 +1645,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.20.0",
- "bitcoin",
+ "bitcoin 0.29.2",
  "clap",
  "devimint",
  "fedimint-build",
@@ -1534,7 +1692,7 @@ dependencies = [
  "async-trait",
  "base64 0.20.0",
  "bincode",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "erased-serde",
  "fedimint-client",
  "fedimint-core",
@@ -1544,7 +1702,7 @@ dependencies = [
  "futures",
  "itertools",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secp256k1-zkp",
  "serde",
  "serde-big-array",
@@ -1567,13 +1725,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "fedimint-core",
  "futures",
  "impl-tools",
  "itertools",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secp256k1-zkp",
  "serde",
  "strum",
@@ -1592,7 +1750,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "counter",
  "erased-serde",
  "fedimint-core",
@@ -1604,7 +1762,7 @@ dependencies = [
  "itertools",
  "rand",
  "rayon",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secp256k1-zkp",
  "serde",
  "strum",
@@ -1660,8 +1818,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "bitcoin",
- "bitcoin_hashes",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
  "bytes",
  "fedimint-aead",
  "fedimint-build",
@@ -1702,7 +1860,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "fedimint-core",
  "futures",
  "rand",
@@ -1719,7 +1877,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin",
+ "bitcoin 0.29.2",
  "bitcoincore-rpc",
  "clap",
  "cln-rpc",
@@ -1754,7 +1912,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "bitcoin",
+ "bitcoin 0.29.2",
  "cln-rpc",
  "erased-serde",
  "fedimint-bitcoind",
@@ -1798,7 +1956,7 @@ dependencies = [
  "aquamarine",
  "async-stream",
  "async-trait",
- "bitcoin",
+ "bitcoin 0.29.2",
  "erased-serde",
  "fedimint-bitcoind",
  "fedimint-client",
@@ -1808,7 +1966,7 @@ dependencies = [
  "impl-tools",
  "miniscript",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
  "strum",
  "strum_macros",
@@ -1826,14 +1984,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin",
+ "bitcoin 0.29.2",
  "erased-serde",
  "fedimint-core",
  "futures",
  "impl-tools",
  "miniscript",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
  "strum",
  "strum_macros",
@@ -1852,7 +2010,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin",
+ "bitcoin 0.29.2",
  "erased-serde",
  "fedimint-bitcoind",
  "fedimint-core",
@@ -1863,7 +2021,7 @@ dependencies = [
  "impl-tools",
  "miniscript",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
  "strum",
  "strum_macros",
@@ -1881,7 +2039,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin",
+ "bitcoin 0.29.2",
  "erased-serde",
  "fedimint-bitcoind",
  "fedimint-client",
@@ -1906,7 +2064,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bincode",
- "bitcoin",
+ "bitcoin 0.29.2",
  "bytes",
  "clap",
  "console-subscriber",
@@ -2130,7 +2288,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-macros",
- "bitcoin",
+ "bitcoin 0.29.2",
  "clap",
  "fedimint-build",
  "fedimint-client-legacy",
@@ -2379,10 +2537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "hkdf"
 version = "0.1.0"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
 ]
 
 [[package]]
@@ -2544,6 +2708,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ffdf3b0bdfaa18798f4df71bc965704f63fba521b24d425cd61fb2bc771a77b"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
+ "quote 1.0.27",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
  "proc-macro2",
  "quote 1.0.27",
  "syn 1.0.109",
@@ -2917,7 +3092,7 @@ version = "0.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "087add70f81d2fdc6d4409bc0cef69e11ad366ef1d0068550159bd22b3ac8664"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.29.2",
 ]
 
 [[package]]
@@ -2927,10 +3102,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9680857590c3529cf8c7d32b04501f215f2bf1e029fdfa22f4112f66c1741e4"
 dependencies = [
  "bech32",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "lightning",
  "num-traits",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
 ]
 
@@ -2951,8 +3126,8 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-macros",
- "bitcoin",
- "bitcoin_hashes",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
  "clap",
  "cln-plugin",
  "cln-rpc",
@@ -2976,7 +3151,7 @@ dependencies = [
  "prost 0.11.9",
  "rand",
  "reqwest",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -3108,7 +3283,7 @@ name = "miniscript"
 version = "7.0.0"
 source = "git+https://github.com/rust-bitcoin/rust-miniscript/?rev=2f1535e470c75fad85dbad8633986aae36a89a92#2f1535e470c75fad85dbad8633986aae36a89a92"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.29.2",
  "serde",
 ]
 
@@ -3357,6 +3532,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-scale-codec"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.27",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,6 +3756,16 @@ checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
 dependencies = [
  "proc-macro2",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3818,7 +4029,7 @@ name = "recoverytool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitcoin",
+ "bitcoin 0.29.2",
  "clap",
  "fedimint-aead",
  "fedimint-core",
@@ -3830,7 +4041,7 @@ dependencies = [
  "fedimint-wallet-server",
  "futures",
  "miniscript",
- "secp256k1",
+ "secp256k1 0.24.3",
  "serde",
  "serde_json",
  "tokio",
@@ -4030,6 +4241,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4143,10 +4363,21 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "rand",
- "secp256k1-sys",
+ "secp256k1-sys 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "bitcoin_hashes 0.12.0",
+ "rand",
+ "secp256k1-sys 0.8.1",
 ]
 
 [[package]]
@@ -4159,12 +4390,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "secp256k1-zkp"
 version = "0.7.0"
 source = "git+https://github.com/dpc/rust-secp256k1-zkp/?branch=sanket-pr#f29b1b8c442d4b8a42547ce36d3987aaedf94224"
 dependencies = [
  "rand",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secp256k1-zkp-sys",
  "serde",
 ]
@@ -4175,8 +4415,14 @@ version = "0.7.0"
 source = "git+https://github.com/dpc/rust-secp256k1-zkp/?branch=sanket-pr#f29b1b8c442d4b8a42547ce36d3987aaedf94224"
 dependencies = [
  "cc",
- "secp256k1-sys",
+ "secp256k1-sys 0.6.1",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "send_wrapper"
@@ -4703,7 +4949,7 @@ name = "tbs"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "bls12_381",
  "clap",
  "ff",
@@ -4983,6 +5229,23 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -5736,6 +5999,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crypto/tbs",
     "gateway/ln-gateway",
     "gateway/cli",
+    "fedimint-atomic-broadcast",
     "fedimintd",
     "fedimint-bip39",
     "fedimint-bitcoind",

--- a/fedimint-atomic-broadcast/Cargo.toml
+++ b/fedimint-atomic-broadcast/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fedimint-atomic-broadcast"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+aleph-bft = { version = "0.20.5", default-features = false }
+anyhow = "1.0.71"
+async-channel = "1.8.0"
+async-trait = "0.1.68"
+bitcoin = "0.30.0"
+bitcoin_hashes = "0.12.0"
+fedimint-core = { path = "../fedimint-core" }
+futures = "0.3.28"
+parity-scale-codec = "3.5.0"
+secp256k1 = {version = "0.27.0", features=["rand-std","bitcoin-hashes"]}
+tokio = "1.28.1"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"

--- a/fedimint-atomic-broadcast/src/broadcast.rs
+++ b/fedimint-atomic-broadcast/src/broadcast.rs
@@ -1,0 +1,155 @@
+use std::time::Duration;
+
+use fedimint_core::db::Database;
+use fedimint_core::task::sleep;
+use fedimint_core::PeerId;
+use tokio::sync::{mpsc, oneshot, watch};
+
+use crate::keychain::Keychain;
+use crate::{db, session, Decision, Message, OrderedItem, Recipient, Shutdown, SignedBlock};
+
+async fn relay_messages(
+    db: Database,
+    incoming_message_receiver: async_channel::Receiver<(Message, PeerId)>,
+    outgoing_message_sender: async_channel::Sender<(Message, Recipient)>,
+    network_data_sender: async_channel::Sender<Vec<u8>>,
+    signed_block_sender: async_channel::Sender<SignedBlock>,
+) {
+    while let Ok((message, peer_id)) = incoming_message_receiver.recv().await {
+        match message {
+            Message::NetworkData(network_data) => {
+                network_data_sender.send(network_data).await.ok();
+            }
+            Message::BlockRequest(index) => {
+                if let Some(signed_block) = db::load_block(&db, index).await {
+                    outgoing_message_sender
+                        .send((Message::Block(signed_block), Recipient::Peer(peer_id)))
+                        .await
+                        .ok();
+
+                    tracing::info!("Served the block with index {} to peer {}", index, peer_id);
+                }
+            }
+            Message::Block(signed_block) => {
+                signed_block_sender.send(signed_block).await.ok();
+            }
+        }
+    }
+
+    std::future::pending().await
+}
+
+async fn process_signed_block(
+    signed_block: SignedBlock,
+    ordered_item_sender: mpsc::Sender<(OrderedItem, u64, oneshot::Sender<Decision>)>,
+) -> anyhow::Result<()> {
+    let mut decision_receivers = vec![];
+    for ordered_item in signed_block.block.items.into_iter() {
+        let (decision_sender, decision_receiver) = oneshot::channel();
+
+        ordered_item_sender
+            .send((ordered_item, signed_block.block.index, decision_sender))
+            .await?;
+
+        decision_receivers.push(decision_receiver);
+    }
+
+    for decision_receiver in decision_receivers {
+        // The threshold signed blocks items have to be accepted by Fedimint Consensus.
+        assert!(decision_receiver.await? == Decision::Accept);
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    keychain: Keychain,
+    db: Database,
+    mut index: u64,
+    mempool_item_receiver: async_channel::Receiver<Vec<u8>>,
+    incoming_message_receiver: async_channel::Receiver<(Message, PeerId)>,
+    outgoing_message_sender: async_channel::Sender<(Message, Recipient)>,
+    ordered_item_sender: mpsc::Sender<(OrderedItem, u64, oneshot::Sender<Decision>)>,
+    clean_shutdown_receiver: watch::Receiver<Option<(u64, Duration)>>,
+) -> Shutdown {
+    let (network_data_sender, network_data_receiver) = async_channel::bounded(256);
+    let (signed_block_sender, signed_block_receiver) = async_channel::bounded(16);
+
+    let relay_handle = tokio::spawn(relay_messages(
+        db.clone(),
+        incoming_message_receiver,
+        outgoing_message_sender.clone(),
+        network_data_sender,
+        signed_block_sender,
+    ));
+
+    loop {
+        if let Some(signed_block) = db::load_block(&db, index).await {
+            tracing::info!("Loaded block with index {}", index);
+            if process_signed_block(signed_block, ordered_item_sender.clone())
+                .await
+                .is_err()
+            {
+                relay_handle.abort();
+                relay_handle.await.ok();
+
+                return Shutdown::MidSession(index);
+            }
+        } else {
+            tracing::info!("Run session with index {}", index);
+            let (backup_loader, backup_saver) = db::open_session(db.clone(), index).await;
+
+            let session_result = session::run(
+                index,
+                keychain.clone(),
+                backup_loader,
+                backup_saver,
+                mempool_item_receiver.clone(),
+                network_data_receiver.clone(),
+                outgoing_message_sender.clone(),
+                ordered_item_sender.clone(),
+                signed_block_receiver.clone(),
+            );
+
+            match session_result.await {
+                Ok(signed_block) => {
+                    tracing::info!("Completed session with index {}", index);
+                    db::complete_session(&db, index, signed_block.clone()).await;
+
+                    outgoing_message_sender
+                        .send((Message::Block(signed_block), Recipient::Everyone))
+                        .await
+                        .ok();
+                }
+                Err(..) => {
+                    relay_handle.abort();
+                    relay_handle.await.ok();
+
+                    return Shutdown::MidSession(index);
+                }
+            };
+        }
+
+        let clean_shutdown = clean_shutdown_receiver.borrow().to_owned();
+        if let Some((shutdown_index, shutdown_delay)) = clean_shutdown {
+            if index == shutdown_index {
+                tracing::info!("Initiate clean shutdown after index {}", index);
+
+                // prevents the relay loop from hanging if  the channels to become full
+                network_data_receiver.close();
+                signed_block_receiver.close();
+
+                // we delay the shutdown to allow lagging nodes to complete the session as well
+                sleep(shutdown_delay).await;
+
+                relay_handle.abort();
+                relay_handle.await.ok();
+
+                return Shutdown::Clean(index);
+            }
+        }
+
+        index += 1;
+    }
+}

--- a/fedimint-atomic-broadcast/src/conversion.rs
+++ b/fedimint-atomic-broadcast/src/conversion.rs
@@ -1,0 +1,12 @@
+use aleph_bft::NodeIndex;
+use fedimint_core::PeerId;
+
+pub fn to_peer_id(node_index: NodeIndex) -> PeerId {
+    u16::try_from(usize::from(node_index))
+        .expect("The node index corresponds to a valid PeerId")
+        .into()
+}
+
+pub fn to_node_index(peer_id: PeerId) -> NodeIndex {
+    usize::from(u16::from(peer_id)).into()
+}

--- a/fedimint-atomic-broadcast/src/data_provider.rs
+++ b/fedimint-atomic-broadcast/src/data_provider.rs
@@ -1,0 +1,106 @@
+use aleph_bft::Keychain as KeychainTrait;
+use bitcoin_hashes::Hash;
+use tokio::sync::watch;
+
+use crate::consensus_hash_sha256;
+use crate::keychain::Keychain;
+
+type ConsensusItem = Vec<u8>;
+
+// This limits the RAM consumption of a Unit to roughly 12kB
+const ITEM_LIMIT: usize = 100;
+const BYTE_LIMIT: usize = 10_000;
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode,
+)]
+pub enum UnitData {
+    Batch(Vec<ConsensusItem>, [u8; 64], aleph_bft::NodeIndex),
+    Signature([u8; 64], aleph_bft::NodeIndex),
+}
+
+impl UnitData {
+    // in order to bound the RAM consumption of a session we have to bound an
+    // individual units size, hence the size of its attached unit data in memory
+    pub fn is_valid(&self) -> bool {
+        match self {
+            UnitData::Signature(..) => true,
+            UnitData::Batch(items, ..) => {
+                // the lazy evaluation prevents overflow when summing
+                items.len() <= ITEM_LIMIT
+                    && items.iter().all(|item| item.len() <= BYTE_LIMIT)
+                    && items.iter().map(Vec::len).sum::<usize>() <= BYTE_LIMIT
+            }
+        }
+    }
+}
+
+pub struct DataProvider {
+    keychain: Keychain,
+    mempool_item_receiver: async_channel::Receiver<ConsensusItem>,
+    signature_receiver: watch::Receiver<Option<[u8; 64]>>,
+    leftover_item: Option<Vec<u8>>,
+}
+
+impl DataProvider {
+    pub fn new(
+        keychain: Keychain,
+        mempool_item_receiver: async_channel::Receiver<ConsensusItem>,
+        signature_receiver: watch::Receiver<Option<[u8; 64]>>,
+    ) -> Self {
+        Self {
+            keychain,
+            mempool_item_receiver,
+            signature_receiver,
+            leftover_item: None,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl aleph_bft::DataProvider<UnitData> for DataProvider {
+    async fn get_data(&mut self) -> Option<UnitData> {
+        // we only attach our signature as no more items can be ordered in this session
+        if let Some(signature) = *self.signature_receiver.borrow() {
+            return Some(UnitData::Signature(
+                signature,
+                self.keychain.peer_id().to_usize().into(),
+            ));
+        }
+
+        let mut items = vec![];
+
+        if let Some(item) = self.leftover_item.take() {
+            if item.len() <= BYTE_LIMIT {
+                items.push(item);
+            } else {
+                tracing::error!("Consensus item length is over BYTE_LIMIT");
+            }
+        }
+
+        // if the channel is empty we want to return the batch immediatly in order to
+        // not delay the creation of our next unit, even if the batch is empty
+        while let Ok(item) = self.mempool_item_receiver.try_recv() {
+            let n_bytes = items.iter().map(Vec::len).sum::<usize>();
+
+            #[allow(clippy::int_plus_one)]
+            if items.len() + 1 <= ITEM_LIMIT && n_bytes + item.len() <= BYTE_LIMIT {
+                items.push(item);
+            } else {
+                self.leftover_item = Some(item);
+                break;
+            }
+        }
+
+        // enables us to verify which peer has submitted a item
+        let hash = consensus_hash_sha256(&items);
+        let signature = self.keychain.sign(hash.as_byte_array()).await;
+
+        let unit_data =
+            UnitData::Batch(items, signature, self.keychain.peer_id().to_usize().into());
+
+        assert!(unit_data.is_valid());
+
+        Some(unit_data)
+    }
+}

--- a/fedimint-atomic-broadcast/src/db.rs
+++ b/fedimint-atomic-broadcast/src/db.rs
@@ -1,0 +1,131 @@
+use std::io::Cursor;
+
+use fedimint_core::db::Database;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::impl_db_record;
+
+use crate::SignedBlock;
+
+#[derive(Debug, Encodable, Decodable)]
+struct SignedBlockKey(u64);
+
+impl_db_record!(
+    key = SignedBlockKey,
+    value = SignedBlock,
+    db_prefix = 0x00,
+    notify_on_modify = false,
+);
+
+#[derive(Debug, Encodable, Decodable)]
+struct UnitsKey(u64, u64);
+
+impl_db_record!(
+    key = UnitsKey,
+    value = Vec<u8>,
+    db_prefix = 0x01,
+    notify_on_modify = false,
+);
+
+pub async fn load_block(db: &Database, index: u64) -> Option<SignedBlock> {
+    db.begin_transaction()
+        .await
+        .get_value(&SignedBlockKey(index))
+        .await
+}
+
+/// This function loads the aleph bft backup from disk and creates a UnitSaver
+/// instance which allows aleph bft to append further bytes to the existing
+/// backup
+pub async fn open_session(db: Database, session_index: u64) -> (Cursor<Vec<u8>>, UnitSaver) {
+    let mut buffer = vec![];
+    let mut units_index = 0;
+    let mut dbtx = db.begin_transaction().await;
+
+    while let Some(bytes) = dbtx.get_value(&UnitsKey(session_index, units_index)).await {
+        buffer.extend(bytes);
+        units_index += 1;
+    }
+
+    std::mem::drop(dbtx);
+
+    tracing::info!("Loaded aleph buffer with {} bytes", buffer.len());
+
+    // the cursor enables aleph bft to read the units via std::io::Read
+    let unit_loader = Cursor::new(buffer);
+
+    // we pass the first free unit index to the UnitSaver as an offset
+    let unit_saver = UnitSaver::new(db, session_index, units_index);
+
+    (unit_loader, unit_saver)
+}
+
+/// The UnitSaver enables aleph bft to store its local directed acyclic graph of
+/// units on disk in order to recover from a mid session crash. By implementing
+/// std::io::Write we allow aleph bft to append bytes to its existing backup
+/// similar to a open file in append mode.
+pub struct UnitSaver {
+    db: Database,
+    session_index: u64,
+    units_index: u64,
+    buffer: Vec<u8>,
+}
+
+impl UnitSaver {
+    fn new(db: Database, session_index: u64, units_index: u64) -> Self {
+        Self {
+            db,
+            session_index,
+            units_index,
+            buffer: vec![],
+        }
+    }
+}
+
+impl std::io::Write for UnitSaver {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.buffer.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let units_key = UnitsKey(self.session_index, self.units_index);
+
+        futures::executor::block_on(async {
+            let mut dbtx = self.db.begin_transaction().await;
+
+            dbtx.insert_new_entry(&units_key, &self.buffer).await;
+
+            dbtx.commit_tx_result()
+                .await
+                .expect("This is the only place where we write to this key");
+        });
+
+        self.buffer.clear();
+        self.units_index += 1;
+
+        Ok(())
+    }
+}
+
+/// The function removes the units stored by aleph bft and stores the signed
+/// block instead
+pub async fn complete_session(db: &Database, index: u64, signed_block: SignedBlock) {
+    let mut dbtx = db.begin_transaction().await;
+
+    dbtx.insert_new_entry(&SignedBlockKey(index), &signed_block)
+        .await;
+
+    let mut units_index = 0;
+
+    while dbtx
+        .remove_entry(&UnitsKey(index, units_index))
+        .await
+        .is_some()
+    {
+        units_index += 1;
+    }
+
+    dbtx.commit_tx_result()
+        .await
+        .expect("The function is only called after we have terminated the aleph session");
+}

--- a/fedimint-atomic-broadcast/src/finalization_handler.rs
+++ b/fedimint-atomic-broadcast/src/finalization_handler.rs
@@ -1,0 +1,18 @@
+use crate::data_provider::UnitData;
+
+pub struct FinalizationHandler {
+    sender: async_channel::Sender<UnitData>,
+}
+
+impl FinalizationHandler {
+    pub fn new(sender: async_channel::Sender<UnitData>) -> Self {
+        Self { sender }
+    }
+}
+
+impl aleph_bft::FinalizationHandler<UnitData> for FinalizationHandler {
+    fn data_finalized(&mut self, unit_data: UnitData) {
+        // the channel is unbounded - dropping unit data does not risk inconsitent state
+        self.sender.try_send(unit_data).ok();
+    }
+}

--- a/fedimint-atomic-broadcast/src/keychain.rs
+++ b/fedimint-atomic-broadcast/src/keychain.rs
@@ -1,0 +1,108 @@
+use std::collections::BTreeMap;
+
+use aleph_bft::Keychain as KeychainTrait;
+use fedimint_core::PeerId;
+use secp256k1::hashes::sha256;
+use secp256k1::{schnorr, Message};
+
+use crate::conversion;
+
+#[derive(Clone, Debug)]
+pub struct Keychain {
+    peer_id: PeerId,
+    public_keys: BTreeMap<PeerId, secp256k1::XOnlyPublicKey>,
+    keypair: secp256k1::KeyPair,
+    secp: secp256k1::Secp256k1<secp256k1::All>,
+}
+
+impl Keychain {
+    pub fn new(
+        peer_id: PeerId,
+        public_keys: BTreeMap<PeerId, secp256k1::XOnlyPublicKey>,
+        secret_key: secp256k1::SecretKey,
+    ) -> Self {
+        let secp = secp256k1::Secp256k1::new();
+        let keypair = secret_key.keypair(&secp);
+
+        Keychain {
+            peer_id,
+            public_keys,
+            keypair,
+            secp,
+        }
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    pub fn peer_count(&self) -> usize {
+        self.public_keys.len()
+    }
+
+    pub fn threshold(&self) -> usize {
+        (2 * self.peer_count()) / 3 + 1
+    }
+}
+
+impl aleph_bft::Index for Keychain {
+    fn index(&self) -> aleph_bft::NodeIndex {
+        self.peer_id.to_usize().into()
+    }
+}
+
+#[async_trait::async_trait]
+impl aleph_bft::Keychain for Keychain {
+    type Signature = [u8; 64];
+
+    fn node_count(&self) -> aleph_bft::NodeCount {
+        self.peer_count().into()
+    }
+
+    async fn sign(&self, message: &[u8]) -> Self::Signature {
+        let message = Message::from_hashed_data::<sha256::Hash>(message);
+
+        self.secp
+            .sign_schnorr(&message, &self.keypair)
+            .as_ref()
+            .to_owned()
+    }
+
+    fn verify(
+        &self,
+        message: &[u8],
+        signature: &Self::Signature,
+        node_index: aleph_bft::NodeIndex,
+    ) -> bool {
+        let peer_id = conversion::to_peer_id(node_index);
+
+        if let Some(public_key) = self.public_keys.get(&peer_id) {
+            if let Ok(sig) = schnorr::Signature::from_slice(signature) {
+                let message = Message::from_hashed_data::<sha256::Hash>(message);
+
+                return self.secp.verify_schnorr(&sig, &message, public_key).is_ok();
+            }
+        }
+
+        false
+    }
+}
+
+impl aleph_bft::MultiKeychain for Keychain {
+    type PartialMultisignature = aleph_bft::NodeMap<[u8; 64]>;
+
+    fn bootstrap_multi(
+        &self,
+        signature: &Self::Signature,
+        index: aleph_bft::NodeIndex,
+    ) -> Self::PartialMultisignature {
+        let mut partial = aleph_bft::NodeMap::with_size(self.peer_count().into());
+        partial.insert(index, *signature);
+        partial
+    }
+
+    fn is_complete(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool {
+        partial.iter().count() >= self.threshold()
+            && partial.iter().all(|(i, sig)| self.verify(msg, sig, i))
+    }
+}

--- a/fedimint-atomic-broadcast/src/lib.rs
+++ b/fedimint-atomic-broadcast/src/lib.rs
@@ -1,0 +1,240 @@
+//! This module implements fedimints custom atomic broadcast abstraction. A
+//! such, it is responsible for ordering serialized items in the form of byte
+//! vectors. The Broadcast is able to recover from a crash at any time via a
+//! backup that it maintains in the servers [fedimint_core::db::Database]. In
+//! Addition, it stores the history of accepted items in the form of
+//! [SignedBlock]s in the database as well in order to catch up fellow guardians
+//! which have been offline for a prolonged period of time.
+//!
+//! Though the broadcast depends on [fedimint_core] for [fedimint_core::PeerId],
+//! [fedimint_core::encoding::Encodable] and [fedimint_core::db::Database]
+//! it implements no consensus logic specific to Fedimint, to which we will
+//! refer as Fedimint Consensus going forward. To the broadcast a consensus item
+//! is merely a vector of bytes without any further structure.
+//!
+//! # Example Setup
+//!
+//! ```ignore
+//! let block_index = 0;
+//! let (mempool_item_sender, mempool_item_receiver) = async_channel::bounded(256);
+//! let (incoming_message_sender, incoming_message_receiver) = async_channel::bounded(256);
+//! let (outgoing_message_sender, outgoing_message_receiver) = async_channel::bounded(256);
+//! let (ordered_item_sender, ordered_item_receiver) = mpsc::channel(32);
+//! let (shutdown_sender, shutdown_receiver) = watch::channel(None);
+//!
+//! let broadcast_handle = tokio::spawn(fedimint_atomic_broadcast::run(
+//!    keychain,
+//!    db,
+//!    block_index,
+//!    mempool_item_receiver,
+//!    incoming_message_receiver,
+//!    outgoing_message_sender,
+//!    ordered_item_sender,
+//!    shutdown_receiver,
+//! ));
+//! ```
+//!
+//! # The journey of a ConsensusItem
+//!
+//! Let us sketch the journey of an [fedimint_core::epoch::ConsensusItem] into a
+//! signed block.
+//!
+//! * The node which wants to order the item calls consensus_encode to serialize
+//!   it and sends the resulting serialization to its running atomic broadcast
+//!   instance via the mempool item sender.
+//! * Every 250ms the broadcasts currently running session instance creates a
+//!   new batch from its mempool and attaches it to a unit in the form of a
+//!   UnitData::Batch. The size of a batch and therefore the size of a
+//!   serialization is limited to 10kB.
+//! * The unit is then included in a [Message] and send to the network layer via
+//!   the outgoing message sender.
+//! * The network layer receives the message, serializes it via consensus_encode
+//!   and sends it to its peers, which in turn deserialize it via
+//!   consensus_decode and relay it to their broadcast instance via their
+//!   incoming message sender.
+//! * The unit is added to the local subgraph of a common directed acyclic graph
+//!   of units generated cooperatively by all peers for every session.
+//! * As the local subgraph grows the units within it are ordered and so are the
+//!   attached batches. As soon as it is ordered the broadcast instances unpacks
+//!   our batch sends the serialization to Fedimint Consensus in the form of an
+//!   [OrderedItem] .
+//! * Fedimint Consensus then deserializes the item and either accepts the item
+//!   bases on its current consensus state or discards it otherwise. Fedimint
+//!   Consensus transmits its decision to its broadcast instance via the
+//!   decision_sender and processes the next item.
+//! * Assuming our item has been accepted the broadcast instance appends its
+//!   deserialization is added to the block corresponding to the current
+//!   session.
+//! * Roughly every five minutes the session completes. Then the broadcast
+//!   creates a threshold signature for the blocks header and saves both in the
+//!   form of a [SignedBlock] in the local database.
+//!
+//! # Interplay with Fedimint Consensus
+//!
+//! As an item is only recorded in a block if it has been accepted the decision
+//! has to be consisted for all correct nodes in order for them to create
+//! identical blocks for every session. We introduce this complexity in order to
+//! prevent a critical DOS vector were a client submits conflicting items, like
+//! double spending an ecash note for example, to different peers. If Fedimint
+//! Consensus would not be able to discard the conflicting items in such a way
+//! that they do not become part of the broadcasts history all of those items
+//! would need to be maintained on disk indefinitely.
+//!
+//! Therefore it cannot be guaranteed that all broadcast instances return the
+//! exact stream of ordered items. However, if two correct peers obtain two
+//! ordered items from their broadcast instances they are guaranteed to be in
+//! the same order. Furthermore, an ordered items is guaranteed to be seen by
+//! all correct nodes if a correct peer accepts it. Those two guarantees are
+//! sufficient to build consistent replicated state machines like Fedimint
+//! Consensus on top of the broadcast. Such a state machine has to accept an
+//! item if it changes the machines state and should discard it otherwise. Let
+//! us consider the case of an ecash note being double spend by the items
+//! A and B while one peer is offline. First, item A is ordered and all correct
+//! peers include the note as spent in their state. Therfore they also accept
+//! the item A. Then, item B is ordered and all correct nodes notice the double
+//! spend and make no changes to their state. Now they can safely discard the
+//! item B as it did not cause a state transition. When the session completes
+//! only item A is part of the corresponding block. When the offline peer comes
+//! back online it downloads the block. Therefore the recovering peer will only
+//! see Item A but arrives at the same state as its peers at the end of the
+//! session regardless. However, it did so by processing one less ordered item
+//! and without realizing that a double spend had occured.
+//!
+//! Since a state machine may process only a subsequence of a sessions items we
+//! can not simply rely on the last processed items index when recovering from a
+//! crash mid session in order to know how many items from the session have
+//! already been applied to our state. Furthermore, the broadcast instance does
+//! not save the decisions for items processed before the crash to disk so
+//! Fedimint Consensus either has to keep track of the decisions on disk or
+//! recompute them. I think the simplest solution to this is to use a single
+//! database transaction for the entire session for all consensus critical state
+//! and maintain the index of the current session as part of the state machine.
+//! If we crash mid session all intermediate state changes are lost and we
+//! simply process the returned ordered items again without any recovery
+//! specific logic. At the end of a session all state machines will arrive at
+//! the same state regardless of the exact number of ordered items they
+//! processed to arrive there. Hence, when we receive the first ordered item of
+//! the next session which indicates that the current session is complete we can
+//! bump the index of current session and finally commit the transaction.
+
+mod broadcast;
+mod conversion;
+mod data_provider;
+mod db;
+mod finalization_handler;
+mod keychain;
+mod network;
+mod session;
+mod spawner;
+
+use bitcoin::merkle_tree;
+use bitcoin_hashes::{sha256, Hash};
+/// This function runs the broadcast until a shutdown is intiated either via the
+/// shutdown sender or the [OrderedItem] receiver is dropped.
+pub use broadcast::run;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::PeerId;
+/// This keychain implements naive threshold schnorr signatures over secp256k1.
+/// The broadcasts uses this keychain to sign messages for peers and create
+/// the threshold signatures for the signed blocks.
+pub use keychain::Keychain;
+
+/// The majority of these messages need to be delivered to the intended
+/// [Recipient] in order for the broadcast to make progress. However, the
+/// broadcast does not assume a reliable network layer and implements all
+/// necessary retry logic. Therefore, the caller can discard a message
+/// immediatly if its intended recipient is offline.
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub enum Message {
+    NetworkData(Vec<u8>),
+    BlockRequest(u64),
+    Block(SignedBlock),
+}
+
+/// This enum defines the intented destination of a [Message].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Recipient {
+    Everyone,
+    Peer(PeerId),
+}
+
+/// This enum specifies wether an [OrderedItem] has been accepted or discarded
+/// by Fedimint Consensus.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Decision {
+    Accept,
+    Discard,
+}
+
+/// If two correct nodes obtain two ordered items from the broadcast they
+/// are guaranteed to be in the same order. However, an ordered items is
+/// only guaranteed to be seen by all correct nodes if a correct node decides to
+/// accept it.
+#[derive(Clone, Debug, PartialEq, Eq, Encodable, Decodable)]
+pub struct OrderedItem {
+    pub item: Vec<u8>,
+    pub peer_id: PeerId,
+}
+
+/// All items ordered in a session that have been accepted by Fedimint Consensus
+/// are recorded in the corresponding block. A running Federation produces a
+/// [Block] roughly every five minutes.  Therefore, just like in Bitcoin, a
+/// [Block] might be empty if no items are ordered in that time or all ordered
+/// items are discarded by Fedimint Consensus.
+#[derive(Clone, Debug, PartialEq, Eq, Encodable, Decodable)]
+pub struct Block {
+    pub index: u64,
+    pub items: Vec<OrderedItem>,
+}
+
+impl Block {
+    /// A blocks header consists of 40 bytes formed by its index in big endian
+    /// bytes concatenated with the merkle root build from the consensus
+    /// hashes of its [OrderedItem]s or 32 zero bytes if the block is
+    /// empty. The use of a merkle tree allows for efficient inclusion
+    /// proofs of accepted consensus items for clients.
+    pub fn header(&self) -> [u8; 40] {
+        let mut header = [0; 40];
+
+        header[..8].copy_from_slice(&self.index.to_be_bytes());
+
+        let leaf_hashes = self.items.iter().map(consensus_hash_sha256);
+
+        if let Some(root) = merkle_tree::calculate_root(leaf_hashes) {
+            header[8..].copy_from_slice(&root.to_byte_array());
+        }
+
+        header
+    }
+}
+
+/// A signed block combines a block with the naive threshold secp schnorr
+/// signature for its header created by the federation. The signed blocks allow
+/// clients and recovering guardians to verify the federations consensus
+/// history. After a signed block has been created it is stored in the database.
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct SignedBlock {
+    pub block: Block,
+    pub signatures: std::collections::BTreeMap<PeerId, [u8; 64]>,
+}
+
+/// A clean shutdown can be initiated at the end of every session via the
+/// shutdown sender passed to [run]. This can be used for a coordinated shutdown
+/// of a federation in order to upgrade. A mid session shutdown is triggered if
+/// the receiver for the [OrderedItem]s is dropped. This mechanism can be used
+/// if one wants to shut down a single guardian immediatly.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Shutdown {
+    Clean(u64),
+    MidSession(u64),
+}
+
+// TODO: remove this as soon as we bump bitcoin_hashes in fedimint_core to
+// 0.12.0
+fn consensus_hash_sha256<E: Encodable>(encodable: &E) -> sha256::Hash {
+    let mut engine = sha256::HashEngine::default();
+    encodable
+        .consensus_encode(&mut engine)
+        .expect("Writing to HashEngine cannot fail");
+    sha256::Hash::from_engine(engine)
+}

--- a/fedimint-atomic-broadcast/src/network.rs
+++ b/fedimint-atomic-broadcast/src/network.rs
@@ -1,0 +1,82 @@
+use std::io::Write;
+
+use bitcoin_hashes::{sha256, Hash};
+use parity_scale_codec::{Decode, Encode, IoReader};
+
+use crate::conversion::to_peer_id;
+use crate::data_provider::UnitData;
+use crate::keychain::Keychain;
+use crate::{Message, Recipient};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Hasher;
+
+impl aleph_bft::Hasher for Hasher {
+    type Hash = [u8; 32];
+
+    fn hash(input: &[u8]) -> Self::Hash {
+        let mut engine = sha256::HashEngine::default();
+        engine
+            .write_all(input)
+            .expect("Writing to a hash engine cannot fail");
+
+        sha256::Hash::from_engine(engine).to_byte_array()
+    }
+}
+
+pub type NetworkData = aleph_bft::NetworkData<
+    Hasher,
+    UnitData,
+    <Keychain as aleph_bft::Keychain>::Signature,
+    <Keychain as aleph_bft::MultiKeychain>::PartialMultisignature,
+>;
+
+pub struct Network {
+    network_data_receiver: async_channel::Receiver<Vec<u8>>,
+    outgoing_message_sender: async_channel::Sender<(Message, Recipient)>,
+}
+
+impl Network {
+    pub fn new(
+        network_data_receiver: async_channel::Receiver<Vec<u8>>,
+        outgoing_message_sender: async_channel::Sender<(Message, Recipient)>,
+    ) -> Self {
+        Self {
+            network_data_receiver,
+            outgoing_message_sender,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl aleph_bft::Network<NetworkData> for Network {
+    fn send(&self, network_data: NetworkData, recipient: aleph_bft::Recipient) {
+        // convert from aleph_bft::Recipient to session::Recipient
+        let recipient = match recipient {
+            aleph_bft::Recipient::Node(node_index) => Recipient::Peer(to_peer_id(node_index)),
+            aleph_bft::Recipient::Everyone => Recipient::Everyone,
+        };
+
+        // since NetworkData does not implement Encodable we use
+        // parity_scale_codec::Encode to serialize it such that Message can
+        // implement Encodable
+        self.outgoing_message_sender
+            .try_send((Message::NetworkData(network_data.encode()), recipient))
+            .ok();
+    }
+
+    async fn next_event(&mut self) -> Option<NetworkData> {
+        while let Ok(network_data) = self.network_data_receiver.recv().await {
+            if let Ok(network_data) = NetworkData::decode(&mut IoReader(&*network_data)) {
+                // in order to bound the RAM consumption of a session we have to bound an
+                // individual units size, hence the size of its attached unitdata in memory
+                if network_data.included_data().iter().all(UnitData::is_valid) {
+                    return Some(network_data);
+                }
+            }
+        }
+        // this prevents the aleph session from shutting down when the
+        // network data sender is dropped by the message relay task
+        std::future::pending::<Option<NetworkData>>().await
+    }
+}

--- a/fedimint-atomic-broadcast/src/session.rs
+++ b/fedimint-atomic-broadcast/src/session.rs
@@ -1,0 +1,259 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use aleph_bft::Keychain as KeychainTrait;
+use async_channel::{Receiver, Sender};
+use bitcoin_hashes::Hash;
+use fedimint_core::task::sleep;
+use tokio::sync::{mpsc, oneshot, watch};
+
+use crate::conversion::{to_node_index, to_peer_id};
+use crate::data_provider::{DataProvider, UnitData};
+use crate::finalization_handler::FinalizationHandler;
+use crate::keychain::Keychain;
+use crate::network::Network;
+use crate::spawner::Spawner;
+use crate::{
+    consensus_hash_sha256, db, Block, Decision, Message, OrderedItem, Recipient, SignedBlock,
+};
+
+/// this function completes a session with the following steps:
+/// - set up the aleph bft session
+/// - periodically request the corresponding signed block from peers
+/// - combine the accepted items into a block until we reach a preset number of
+///   ordered batches or a signed block arrives
+/// - collect signatures until we reach the threshold or a signed block arrives
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    index: u64,
+    keychain: Keychain,
+    backup_loader: std::io::Cursor<Vec<u8>>,
+    backup_saver: db::UnitSaver,
+    item_receiver: Receiver<Vec<u8>>,
+    network_data_receiver: Receiver<Vec<u8>>,
+    outgoing_message_sender: Sender<(Message, Recipient)>,
+    ordered_item_sender: mpsc::Sender<(OrderedItem, u64, oneshot::Sender<Decision>)>,
+    signed_block_receiver: Receiver<SignedBlock>,
+) -> anyhow::Result<SignedBlock> {
+    const MAX_ROUND: u16 = 5000;
+    const ROUND_DELAY: f64 = 250.0;
+    const EXPONETIAL_SLOWDOWN_OFFSET: usize = 3000;
+    const BASE: f64 = 1.01;
+    const BLOCK_REQUEST_DELAY: Duration = Duration::from_secs(10);
+
+    let mut config = aleph_bft::default_config(
+        keychain.peer_count().into(),
+        keychain.peer_id().to_usize().into(),
+        index,
+    );
+
+    // In order to bound a sessions RAM consumption we need to bound its number of
+    // units and therefore its number of rounds. Since we use a session to
+    // create a threshold signature for the corresponding block we have to
+    // guarantee that an attacker cannot exhaust our memory by preventing the
+    // creation of a threshold signature, thereby keeping the session open
+    // indefinitely. Hence we increase the delay between rounds exponentially
+    // such that MAX_ROUND would only be reached after roughly 350 years.
+    // In case of such an attack the broadcast stops ordering any items until the
+    // attack subsides.
+    config.max_round = MAX_ROUND;
+    config.delay_config.unit_creation_delay = std::sync::Arc::new(|round_index| {
+        let delay = if round_index == 0 {
+            0.0
+        } else {
+            ROUND_DELAY * BASE.powf(round_index.saturating_sub(EXPONETIAL_SLOWDOWN_OFFSET) as f64)
+        };
+
+        Duration::from_millis(delay.round() as u64)
+    });
+
+    // the number of units ordered in a single aleph session is bounded
+    let (unit_data_sender, unit_data_receiver) = async_channel::unbounded();
+    let (signature_sender, signature_receiver) = watch::channel(None);
+    let (terminator_sender, terminator_receiver) = futures::channel::oneshot::channel();
+
+    let aleph_handle = tokio::spawn(aleph_bft::run_session(
+        config,
+        aleph_bft::LocalIO::new(
+            DataProvider::new(keychain.clone(), item_receiver, signature_receiver),
+            FinalizationHandler::new(unit_data_sender),
+            backup_saver,
+            backup_loader,
+        ),
+        Network::new(network_data_receiver, outgoing_message_sender.clone()),
+        keychain.clone(),
+        Spawner::new(),
+        aleph_bft::Terminator::create_root(terminator_receiver, "Terminator"),
+    ));
+
+    // we periodically request the signed block corresponding to the current session
+    // to recover in case we have been left behind by our peers
+    let peer_count = keychain.peer_count();
+    let block_request_handle = tokio::spawn(async move {
+        for peer_id in (0..peer_count)
+            .map(|peer_index| to_peer_id(peer_index.into()))
+            .cycle()
+        {
+            if outgoing_message_sender
+                .send((Message::BlockRequest(index), Recipient::Peer(peer_id)))
+                .await
+                .is_err()
+            {
+                break;
+            }
+
+            sleep(BLOCK_REQUEST_DELAY).await;
+        }
+    });
+
+    // this is the minimum number of unit data that will be ordered before we reach
+    // the EXPONETIAL_SLOWDOWN_OFFSET even if no malicious peer attaches unit
+    // data
+    let batches_per_block = EXPONETIAL_SLOWDOWN_OFFSET * keychain.peer_count() / 3;
+    let mut pending_items = vec![];
+    let mut num_batches = 0;
+
+    // we build a block out of the ordered batches until either we have processed
+    // n_batches_per_block blocks or a signed block arrives from our peers
+    while num_batches < batches_per_block {
+        tokio::select! {
+            unit_data = unit_data_receiver.recv() => {
+                if let UnitData::Batch(items, signature, node_index) = unit_data? {
+                    let hash = consensus_hash_sha256(&items);
+                    if keychain.verify(hash.as_byte_array(), &signature, node_index){
+                        // since the signature is valid the node index can be converted to a peer id
+                        let peer_id = to_peer_id(node_index);
+
+                        for item in items {
+                            let ordered_item = OrderedItem{item, peer_id};
+                            let (decision_sender, decision_receiver) = oneshot::channel();
+
+                            ordered_item_sender.send((
+                                ordered_item.clone(),
+                                index,
+                                decision_sender
+                            )).await?;
+
+                            pending_items.push((ordered_item, decision_receiver));
+                        }
+
+                        num_batches += 1;
+                    }
+                }
+            },
+
+            signed_block = signed_block_receiver.recv() => {
+                let SignedBlock{block, signatures} = signed_block?;
+
+                if block.index == index
+                    && signatures.len() == keychain.threshold()
+                    && signatures.iter().all(|(peer_id, sig)| {
+                        keychain.verify(&block.header(), sig, to_node_index(*peer_id))
+                }){
+                    let mut accepted_items = vec![];
+                    for (ordered_item, decision_receiver) in pending_items{
+                        // we add the item to the block if and only if it is accepted by Fedimint Consensus
+                        if decision_receiver.await? == Decision::Accept {
+                            accepted_items.push(ordered_item);
+                        }
+                    }
+
+                    // The items we have already accepted have to be in the threshold signed block
+                    assert!(accepted_items.iter().eq(block.items.iter().take(accepted_items.len())));
+
+                    // We send the not yet processesed items in the block to Fedimint Consensus
+                    let mut decision_receivers = vec![];
+                    for ordered_item in block.items.iter().skip(accepted_items.len()) {
+                        let (decision_sender, decision_receiver) = oneshot::channel();
+
+                        ordered_item_sender.send((
+                            ordered_item.clone(),
+                            index,
+                            decision_sender
+                        )).await?;
+
+                        decision_receivers.push(decision_receiver);
+                    }
+
+                    for decision_receiver in decision_receivers {
+                        // The threshold signed blocks items have to be accepted by Fedimint Consensus.
+                        assert!(decision_receiver.await? == Decision::Accept);
+                    }
+
+                    terminator_sender.send(()).ok();
+                    block_request_handle.abort();
+                    aleph_handle.await.ok();
+                    block_request_handle.await.ok();
+
+                    return Ok(SignedBlock{block, signatures});
+                }
+            }
+
+            _ = ordered_item_sender.closed() => anyhow::bail!("Ordered Item Receiver has been droppped")
+        }
+    }
+
+    let mut accepted_items = vec![];
+    for (ordered_item, decision_receiver) in pending_items {
+        // we add the item to the block if and only if it is accepted by Fedimint
+        // Consensus
+        if decision_receiver.await? == Decision::Accept {
+            accepted_items.push(ordered_item);
+        }
+    }
+
+    // sign the block and send the signature to the data_provider to order it
+    let block = Block {
+        index,
+        items: accepted_items,
+    };
+    let header = block.header();
+    let single_signature = keychain.sign(&header).await;
+
+    signature_sender.send(Some(single_signature))?;
+
+    let mut signatures = BTreeMap::new();
+
+    // we collect the ordered signatures until we either obtain a threshold
+    // signature or a signed block arrives from our peers
+    while signatures.len() < keychain.threshold() {
+        tokio::select! {
+            unit_data = unit_data_receiver.recv() => {
+                if let UnitData::Signature(single_signature, node_index) = unit_data? {
+                    if keychain.verify(&header, &single_signature, node_index){
+                        // since the signature is valid the node index can be converted to a peer id
+                        signatures.insert(to_peer_id(node_index), single_signature);
+                    }
+                }
+            }
+
+            signed_block = signed_block_receiver.recv() => {
+                let SignedBlock{block, signatures}  = signed_block?;
+
+                if block.index == index
+                    && signatures.len() == keychain.threshold()
+                    && signatures.iter().all(|(peer_id, sig)| {
+                        keychain.verify(&block.header(), sig, to_node_index(*peer_id))
+                }){
+                    // We check that the block we have created agrees with the fedarations consensus
+                    assert!(header == block.header());
+
+                    terminator_sender.send(()).ok();
+                    block_request_handle.abort();
+                    aleph_handle.await.ok();
+                    block_request_handle.await.ok();
+
+                    return Ok(SignedBlock{block, signatures});
+
+                }
+            }
+        }
+    }
+
+    terminator_sender.send(()).ok();
+    block_request_handle.abort();
+    aleph_handle.await.ok();
+    block_request_handle.await.ok();
+
+    Ok(SignedBlock { block, signatures })
+}

--- a/fedimint-atomic-broadcast/src/spawner.rs
+++ b/fedimint-atomic-broadcast/src/spawner.rs
@@ -1,0 +1,29 @@
+#[derive(Clone)]
+pub struct Spawner;
+
+impl Spawner {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl aleph_bft::SpawnHandle for Spawner {
+    fn spawn(&self, _name: &str, task: impl futures::Future<Output = ()> + Send + 'static) {
+        tokio::spawn(task);
+    }
+
+    fn spawn_essential(
+        &self,
+        _: &str,
+        task: impl futures::Future<Output = ()> + Send + 'static,
+    ) -> aleph_bft::TaskHandle {
+        let (res_tx, res_rx) = futures::channel::oneshot::channel();
+
+        tokio::spawn(async move {
+            task.await;
+            res_tx.send(()).expect("We own the rx.");
+        });
+
+        Box::pin(async move { res_rx.await.map_err(|_| ()) })
+    }
+}

--- a/fedimint-atomic-broadcast/tests/integration.rs
+++ b/fedimint-atomic-broadcast/tests/integration.rs
@@ -1,0 +1,302 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use async_channel::{bounded, Receiver, Sender};
+use fedimint_atomic_broadcast::{Decision, Keychain, Message, OrderedItem, Recipient, Shutdown};
+use fedimint_core::db::mem_impl::MemDatabase;
+use fedimint_core::db::Database;
+use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_core::task::sleep;
+use fedimint_core::PeerId;
+use secp256k1::{rand, Secp256k1, SecretKey};
+use tokio::sync::mpsc::channel;
+use tokio::sync::{oneshot, watch};
+use tokio::task::JoinHandle;
+
+fn to_peer_id(peer_index: usize) -> PeerId {
+    u16::try_from(peer_index)
+        .expect("The node index corresponds to a valid PeerId")
+        .into()
+}
+
+pub fn bootstrap_keychains(peer_count: usize) -> Vec<Keychain> {
+    let secp = Secp256k1::new();
+
+    let secret_keys: Vec<(PeerId, SecretKey)> = (0..peer_count)
+        .map(to_peer_id)
+        .map(|peer_id| (peer_id, SecretKey::new(&mut rand::thread_rng())))
+        .collect();
+
+    let public_keys = secret_keys
+        .iter()
+        .map(|(peer_id, secret_key)| (*peer_id, secret_key.x_only_public_key(&secp).0));
+
+    let public_keys = BTreeMap::from_iter(public_keys);
+
+    secret_keys
+        .into_iter()
+        .map(|(peer_id, secret_key)| Keychain::new(peer_id, public_keys.clone(), secret_key))
+        .collect()
+}
+
+#[derive(Clone)]
+pub struct Connection {
+    peer_id: PeerId,
+    peers: BTreeMap<PeerId, Sender<(Message, PeerId)>>,
+    receiver: Receiver<(Message, PeerId)>,
+}
+
+pub fn bootstrap_connections(peer_count: usize) -> Vec<Connection> {
+    let mut senders = vec![];
+    let mut receivers = vec![];
+
+    for peer_id in (0..peer_count).map(to_peer_id) {
+        let (sender, receiver) = async_channel::bounded(1024);
+
+        senders.push((peer_id, sender));
+        receivers.push((peer_id, receiver));
+    }
+
+    let senders = BTreeMap::from_iter(senders.into_iter());
+
+    receivers
+        .into_iter()
+        .map(|(peer_id, receiver)| Connection {
+            peer_id,
+            peers: senders.clone(),
+            receiver,
+        })
+        .collect()
+}
+
+struct Federation {
+    keychains: Vec<Keychain>,
+    connections: Vec<Connection>,
+    databases: Vec<Database>,
+    shutdown_receiver: watch::Receiver<Option<(u64, Duration)>>,
+}
+
+impl Federation {
+    fn bootstrap(
+        peer_count: usize,
+        shutdown_receiver: watch::Receiver<Option<(u64, Duration)>>,
+    ) -> Self {
+        Self {
+            keychains: bootstrap_keychains(peer_count),
+            connections: bootstrap_connections(peer_count),
+            databases: (0..peer_count)
+                .map(|_| Database::new(MemDatabase::new(), ModuleDecoderRegistry::default()))
+                .collect(),
+            shutdown_receiver,
+        }
+    }
+
+    fn reset_connections(&mut self) {
+        self.connections = bootstrap_connections(4);
+    }
+
+    fn start_broadcast(
+        &self,
+        peer_index: usize,
+        session_index: u64,
+    ) -> (JoinHandle<Shutdown>, JoinHandle<()>) {
+        let (incoming_sender, incoming_receiver) = bounded(1024);
+        let (outgoing_sender, outgoing_receiver) = bounded::<(Message, Recipient)>(1024);
+        let (mempool_item_sender, mempool_item_receiver) = bounded(128);
+        let (ordered_item_sender, mut ordered_item_receiver) =
+            channel::<(OrderedItem, u64, oneshot::Sender<Decision>)>(64);
+
+        let connection = self.connections[peer_index].clone();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    message = connection.receiver.recv() => {
+                        if let Ok(message) = message{
+                            if incoming_sender.send(message).await.is_err(){
+                                break;
+                            }
+                        }
+                    }
+
+                    message = outgoing_receiver.recv() => {
+                        if let Ok((message, recipient)) = message{
+                            match recipient{
+                                Recipient::Everyone => {
+                                    for sender in connection.peers.values(){
+                                        sender.try_send((message.clone(), connection.peer_id)).ok();
+                                    }
+                                }
+                                Recipient::Peer(peer_id) => {
+                                    connection
+                                        .peers
+                                        .get(&peer_id)
+                                        .unwrap()
+                                        .try_send((message, connection.peer_id))
+                                        .ok();
+                                }
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        tokio::spawn(async move {
+            let mut item: u64 = 0;
+            while mempool_item_sender
+                .send(item.to_le_bytes().to_vec())
+                .await
+                .is_ok()
+            {
+                item += 1;
+                sleep(std::time::Duration::from_millis(100)).await;
+            }
+        });
+
+        let decision_handle = tokio::spawn(async move {
+            while let Some((ordered_item, .., decision_sender)) = ordered_item_receiver.recv().await
+            {
+                let decision = if ordered_item.item[0] & 1 == 0 {
+                    Decision::Accept
+                } else {
+                    Decision::Discard
+                };
+
+                decision_sender.send(decision).unwrap();
+            }
+        });
+
+        let broadcast_handle = tokio::spawn(fedimint_atomic_broadcast::run(
+            self.keychains[peer_index].clone(),
+            self.databases[peer_index].clone(),
+            session_index,
+            mempool_item_receiver,
+            incoming_receiver,
+            outgoing_sender,
+            ordered_item_sender,
+            self.shutdown_receiver.clone(),
+        ));
+
+        (broadcast_handle, decision_handle)
+    }
+}
+
+#[tokio::test]
+async fn crash_recovery() {
+    //let subscriber = tracing_subscriber::FmtSubscriber::new();
+    //tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    let (shutdown_sender, shutdown_receiver) = watch::channel(None);
+    let mut federation = Federation::bootstrap(4, shutdown_receiver);
+
+    for _ in 0..4 {
+        // we clear the message queues
+        federation.reset_connections();
+
+        let handles = vec![
+            federation.start_broadcast(0, 0),
+            federation.start_broadcast(1, 0),
+            federation.start_broadcast(2, 0),
+        ];
+
+        sleep(Duration::from_secs(60)).await;
+
+        for (broadcast_handle, decision_handle) in handles {
+            decision_handle.abort();
+            assert!(broadcast_handle.await.unwrap() == Shutdown::MidSession(0));
+        }
+    }
+
+    let handles = vec![
+        federation.start_broadcast(0, 0),
+        federation.start_broadcast(1, 0),
+        federation.start_broadcast(2, 0),
+        federation.start_broadcast(3, 0),
+    ];
+
+    shutdown_sender
+        .send(Some((0, Duration::from_secs(30))))
+        .unwrap();
+
+    for (broadcast_handle, ..) in handles {
+        assert!(broadcast_handle.await.unwrap() == fedimint_atomic_broadcast::Shutdown::Clean(0));
+    }
+}
+
+#[tokio::test]
+async fn catch_up_via_block_download() {
+    //let subscriber = tracing_subscriber::FmtSubscriber::new();
+    //tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    let (shutdown_sender, shutdown_receiver) = watch::channel(None);
+    let mut federation = Federation::bootstrap(4, shutdown_receiver);
+
+    let handles = vec![
+        federation.start_broadcast(0, 0),
+        federation.start_broadcast(1, 0),
+        federation.start_broadcast(2, 0),
+    ];
+
+    shutdown_sender
+        .send(Some((0, Duration::from_secs(30))))
+        .unwrap();
+
+    for (broadcast_handle, ..) in handles {
+        assert!(broadcast_handle.await.unwrap() == fedimint_atomic_broadcast::Shutdown::Clean(0));
+    }
+
+    // we clear the message queues
+    federation.reset_connections();
+
+    shutdown_sender
+        .send(Some((1, Duration::from_secs(30))))
+        .unwrap();
+
+    let handles = vec![
+        federation.start_broadcast(0, 0),
+        federation.start_broadcast(1, 0),
+        federation.start_broadcast(2, 0),
+        federation.start_broadcast(3, 0),
+    ];
+
+    for (broadcast_handle, ..) in handles {
+        assert!(broadcast_handle.await.unwrap() == fedimint_atomic_broadcast::Shutdown::Clean(1));
+    }
+}
+
+#[tokio::test]
+async fn shuts_down_on_drop() {
+    let keychain = bootstrap_keychains(4).pop().unwrap();
+    let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
+    let (mempool_item_sender, mempool_item_receiver) = async_channel::bounded(32);
+    let (incoming_message_sender, incoming_message_receiver) = async_channel::bounded(32);
+    let (outgoing_message_sender, outgoing_message_receiver) = async_channel::bounded(32);
+    let (ordered_item_sender, ordered_item_receiver) = tokio::sync::mpsc::channel(1);
+    let (.., shutdown_receiver) = tokio::sync::watch::channel(None);
+
+    let broadcast_handle = tokio::spawn(fedimint_atomic_broadcast::run(
+        keychain,
+        db,
+        0,
+        mempool_item_receiver,
+        incoming_message_receiver,
+        outgoing_message_sender,
+        ordered_item_sender,
+        shutdown_receiver,
+    ));
+
+    std::mem::drop(mempool_item_sender);
+    std::mem::drop(incoming_message_sender);
+    std::mem::drop(outgoing_message_receiver);
+
+    sleep(std::time::Duration::from_millis(1000)).await;
+
+    assert!(!broadcast_handle.is_finished());
+
+    std::mem::drop(ordered_item_receiver);
+
+    assert!(broadcast_handle.await.unwrap() == fedimint_atomic_broadcast::Shutdown::MidSession(0));
+}


### PR DESCRIPTION
# Motivation
Just like the bitcoin network a federation has to agree on a total order of transactions before they can be processed in order to decide which transaction is valid in case of conflicts between transactions. An algorithm which achieves this ordering in a byzantine fault tolerant (BFT) setting, meaning when up to f out of 3f + 1 total nodes are malicious, is called an atomic broadcast. Since its inception, Fedimint used the so called Honey Badger BFT (HBBFT) as its atomic broadcast. However, the algorithm and its implementation have a some critical problems:

* HBBFT trades of transaction latency for throughput by design. Furthermore the transaction latency is very sensitive towards bad network conditions, faulty guardians and number of guardians and all those four factors  compound. @elsirions performance measurements showed that with HBBFT we could only support at most seven guardians in good network condition with at most a thousand users. This was the initial reason that motivated my research into alternative atomic broadcast algorithms and has already been discussed in https://github.com/fedimint/fedimint/discussions/2086 
* If more then f out of 3f + 1 guardians crash a the same time HBBFT may not be able to restart at all.
* HBBFT assumes a reliable network layer, which means that fedimint has to guarantee the delivery of transactions. In case of fellow guardians being offline for a prolonged period this leads to growing in memory message queues.
* HBBFT requires threshold cryptography which relies on a somewhat brittle distributed key generation before the broadcast  can start.

In addition, there is another  problems relating to the broadcast within Fedimint as well. Currently all transactions ever ordered are stored on disk, regardless of them being valid transaction or not. We have to store them in order to catch up crashed nodes or for a guardians recovering from a corruption of its database. This is not only very inefficient as transactions may be submitted by multiple guardians but also opens up an critical DOS vector: any client can sent n pairwise conflicting transactions, such as spending the same cash note, to a guardian each. As all of those transactions are ordered they need to be stored on disk for the entire lifetime of the federation, however, the attacker only pays transaction costs on a single note.

# Design
We will address all these problems at once by switching from using HBBFT directly to our own custom atomic broadcast abstraction based on Aleph BFT, which is an alternative atomic broadcast algorithm. 

The broadcast abstraction orders serialized items in the form of byte vectors. Though the broadcast depends on fedimint_core for PeerId, Encodable and Database it implements no consensus logic specific to Fedimint, to which we will refer as Fedimint Consensus going forward. To the broadcast a consensus item is merely a vector of bytes without any further structure. 

The Broadcast is able to recover from a crash at any time via a backup that it maintains in the servers Database. Furthermore, while we are at it, we will move the recovery for long term offline nodes into this abstraction. The current mechanism is interwoven with the rest of Fedimint, making it difficult to identify which parts of the code are critical for the broadcast to make progress. The broadcast stores the history of items in the form of threshold signed blocks in the database in order to allow for recovery of fellow guardians which have been offline for a prolonged period of time. As our new abstraction now maintains its history on disk we mitigate the described DOS vector by storing an ordered item only on disk long-term if it changes the consensus state. 

This design should solve all problems described previously. Please render the crates documentation for details on the API.

# Context of this pull request
Switching from HBBFT to our abstraction is no trivial matter as Fedimint depends on informal properties of HBBFTs implementation which our new abstraction does not share. The most important example of this the concept of epochs in HBBFT which is for example used to identify and ban malicious peers preventing creation of a threshold signature.

Therefore this pull request is only intended to be the first in a sequence of pull requests, eventually realising the complete switch. As such it is intended to create a first implementation and the abstractions interface and guarantees may still need to be altered. However, it is supposed to be a high-quality solution according to my current understanding of the problem and should be reviewed as such.







