### PR TITLE
refactor: one route_htlcs instead of per-actor

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -135,7 +135,20 @@ pub struct ClientConfigResponse {
 ///
 /// Stable id so long as guardians membership does not change
 /// Unique id so long as guardians do not all collude
-#[derive(Debug, Copy, Serialize, Deserialize, Clone, Eq, Hash, PartialEq, Encodable, Decodable)]
+#[derive(
+    Debug,
+    Copy,
+    Serialize,
+    Deserialize,
+    Clone,
+    Eq,
+    Hash,
+    PartialEq,
+    Encodable,
+    Decodable,
+    Ord,
+    PartialOrd,
+)]
 pub struct FederationId(pub threshold_crypto::PublicKey);
 
 impl Display for FederationId {

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -74,6 +74,7 @@ impl GatewayTest {
             module_gens.clone(),
             DEFAULT_FEES,
             gatewayd_db,
+            &mut task,
         )
         .await
         .unwrap();

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -13,7 +13,6 @@ use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::ConnectFedPayload;
 use ln_gateway::{Gateway, DEFAULT_FEES};
 use tempfile::TempDir;
-use tokio::sync::RwLock;
 use tracing::log::warn;
 use url::Url;
 
@@ -69,18 +68,19 @@ impl GatewayTest {
 
         let gatewayd_db = Database::new(MemDatabase::new(), decoders.clone());
         let gateway = Gateway::new_with_lightning_connection(
-            Arc::new(RwLock::new(lightning)),
+            Arc::new(lightning),
             client_builder.clone(),
             decoders.clone(),
             module_gens.clone(),
-            task.make_subgroup().await,
             DEFAULT_FEES,
             gatewayd_db,
         )
         .await
         .unwrap();
 
-        gateway.spawn_webserver(listen, password.clone()).await;
+        gateway
+            .spawn_webserver(listen, password.clone(), &mut task)
+            .await;
         task.spawn("gatewayd", move |handle| async {
             if let Err(err) = gateway.run(handle).await {
                 warn!("Gateway stopped with error {:?}", err);

--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -15,7 +15,7 @@ use lightning_invoice::{
     DEFAULT_EXPIRY_TIME,
 };
 use ln_gateway::gatewaylnrpc::{
-    self, CompleteHtlcResponse, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse,
+    self, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
     PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
 use ln_gateway::lnrpc_client::{ILnRpcClient, RouteHtlcStream};
@@ -132,7 +132,7 @@ impl ILnRpcClient for FakeLightningTest {
 
     async fn route_htlcs<'a>(
         &mut self,
-        events: ReceiverStream<CompleteHtlcResponse>,
+        events: ReceiverStream<InterceptHtlcResponse>,
         task_group: &mut TaskGroup,
     ) -> Result<RouteHtlcStream<'a>, GatewayError> {
         task_group

--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -15,8 +15,8 @@ use lightning_invoice::{
     DEFAULT_EXPIRY_TIME,
 };
 use ln_gateway::gatewaylnrpc::{
-    self, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
-    PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    self, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceRequest,
+    PayInvoiceResponse,
 };
 use ln_gateway::lnrpc_client::{ILnRpcClient, RouteHtlcStream};
 use ln_gateway::GatewayError;
@@ -121,13 +121,6 @@ impl ILnRpcClient for FakeLightningTest {
         Ok(PayInvoiceResponse {
             preimage: [0; 32].to_vec(),
         })
-    }
-
-    async fn subscribe_mint_htlcs(
-        &self,
-        _subscribe_request: SubscribeInterceptHtlcsRequest,
-    ) -> Result<EmptyResponse, GatewayError> {
-        Ok(EmptyResponse {})
     }
 
     async fn route_htlcs<'a>(

--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -15,8 +15,8 @@ use lightning_invoice::{
     DEFAULT_EXPIRY_TIME,
 };
 use ln_gateway::gatewaylnrpc::{
-    self, GetNodeInfoResponse, GetRouteHintsResponse, PayInvoiceRequest, PayInvoiceResponse,
-    RouteHtlcRequest,
+    self, CompleteHtlcResponse, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse,
+    PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
 use ln_gateway::lnrpc_client::{ILnRpcClient, RouteHtlcStream};
 use ln_gateway::GatewayError;
@@ -33,7 +33,6 @@ pub struct FakeLightningTest {
     pub gateway_node_pub_key: secp256k1::PublicKey,
     gateway_node_sec_key: secp256k1::SecretKey,
     amount_sent: Arc<Mutex<u64>>,
-    task_group: TaskGroup,
 }
 
 impl FakeLightningTest {
@@ -47,7 +46,6 @@ impl FakeLightningTest {
             gateway_node_sec_key: SecretKey::from_keypair(&kp),
             gateway_node_pub_key: PublicKey::from_keypair(&kp),
             amount_sent,
-            task_group: TaskGroup::new(),
         }
     }
 }
@@ -125,11 +123,19 @@ impl ILnRpcClient for FakeLightningTest {
         })
     }
 
+    async fn subscribe_mint_htlcs(
+        &self,
+        _subscribe_request: SubscribeInterceptHtlcsRequest,
+    ) -> Result<EmptyResponse, GatewayError> {
+        Ok(EmptyResponse {})
+    }
+
     async fn route_htlcs<'a>(
         &mut self,
-        events: ReceiverStream<RouteHtlcRequest>,
+        events: ReceiverStream<CompleteHtlcResponse>,
+        task_group: &mut TaskGroup,
     ) -> Result<RouteHtlcStream<'a>, GatewayError> {
-        self.task_group
+        task_group
             .spawn("FakeRoutingThread", |handle| async move {
                 let mut stream = events.into_inner();
                 while let Some(route_htlc) = stream.recv().await {

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -12,8 +12,8 @@ use fedimint_core::task::TaskGroup;
 use fedimint_core::Amount;
 use lightning_invoice::Invoice;
 use ln_gateway::gatewaylnrpc::{
-    EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
-    PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceRequest,
+    PayInvoiceResponse,
 };
 use ln_gateway::lnd::GatewayLndClient;
 use ln_gateway::lnrpc_client::{ILnRpcClient, NetworkLnRpcClient, RouteHtlcStream};
@@ -114,17 +114,6 @@ impl ILnRpcClient for ClnLightningTest {
             .write()
             .await
             .route_htlcs(events, task_group)
-            .await
-    }
-
-    async fn subscribe_mint_htlcs(
-        &self,
-        subscribe_request: SubscribeInterceptHtlcsRequest,
-    ) -> Result<EmptyResponse, GatewayError> {
-        self.lnrpc
-            .read()
-            .await
-            .subscribe_mint_htlcs(subscribe_request)
             .await
     }
 }
@@ -273,17 +262,6 @@ impl ILnRpcClient for LndLightningTest {
             .write()
             .await
             .route_htlcs(events, task_group)
-            .await
-    }
-
-    async fn subscribe_mint_htlcs(
-        &self,
-        subscribe_request: SubscribeInterceptHtlcsRequest,
-    ) -> Result<EmptyResponse, GatewayError> {
-        self.lnrpc
-            .read()
-            .await
-            .subscribe_mint_htlcs(subscribe_request)
             .await
     }
 }

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -12,7 +12,7 @@ use fedimint_core::task::TaskGroup;
 use fedimint_core::Amount;
 use lightning_invoice::Invoice;
 use ln_gateway::gatewaylnrpc::{
-    CompleteHtlcResponse, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse,
+    EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
     PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
 use ln_gateway::lnd::GatewayLndClient;
@@ -107,7 +107,7 @@ impl ILnRpcClient for ClnLightningTest {
 
     async fn route_htlcs<'a>(
         &mut self,
-        events: ReceiverStream<CompleteHtlcResponse>,
+        events: ReceiverStream<InterceptHtlcResponse>,
         task_group: &mut TaskGroup,
     ) -> Result<RouteHtlcStream<'a>, GatewayError> {
         self.lnrpc
@@ -266,7 +266,7 @@ impl ILnRpcClient for LndLightningTest {
 
     async fn route_htlcs<'a>(
         &mut self,
-        events: ReceiverStream<CompleteHtlcResponse>,
+        events: ReceiverStream<InterceptHtlcResponse>,
         task_group: &mut TaskGroup,
     ) -> Result<RouteHtlcStream<'a>, GatewayError> {
         self.lnrpc

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -7,9 +7,8 @@ use fedimint_logging::TracingSetup;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
-    LightningReconnectPayload, RestorePayload, WithdrawPayload,
+    RestorePayload, WithdrawPayload,
 };
-use ln_gateway::LightningMode;
 use serde::Serialize;
 use url::Url;
 
@@ -78,11 +77,6 @@ pub enum Commands {
     Restore {
         #[clap(long)]
         federation_id: FederationId,
-    },
-    // Reconnect to the Lightning Node
-    ReconnectLightning {
-        #[clap(subcommand)]
-        lightning_mode: LightningMode,
     },
 }
 
@@ -156,25 +150,6 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Restore { federation_id } => {
             client.restore(RestorePayload { federation_id }).await?;
-        }
-        Commands::ReconnectLightning { lightning_mode } => {
-            let payload = match lightning_mode {
-                LightningMode::Cln { cln_extension_addr } => LightningReconnectPayload {
-                    node_type: Some(LightningMode::Cln { cln_extension_addr }),
-                },
-                LightningMode::Lnd {
-                    lnd_rpc_addr,
-                    lnd_tls_cert,
-                    lnd_macaroon,
-                } => LightningReconnectPayload {
-                    node_type: Some(LightningMode::Lnd {
-                        lnd_rpc_addr,
-                        lnd_tls_cert,
-                        lnd_macaroon,
-                    }),
-                },
-            };
-            client.reconnect(payload).await?;
         }
     }
 

--- a/gateway/ln-gateway/proto/gatewaylnrpc.proto
+++ b/gateway/ln-gateway/proto/gatewaylnrpc.proto
@@ -24,10 +24,14 @@ service GatewayLightning {
    * GatewayLightning implementations should respond with a channel stream
    * over which intercepted HTLCs are continually sent to the client.
    */
-  rpc RouteHtlcs(stream RouteHtlcRequest) returns (stream RouteHtlcResponse) {}
+  rpc RouteHtlcs(stream CompleteHtlcResponse) returns (stream InterceptHtlcRequest) {}
+
+  rpc SubscribeMintHtlcs(SubscribeInterceptHtlcsRequest) returns (EmptyResponse) {}
 }
 
 message EmptyRequest {}
+
+message EmptyResponse {}
 
 message GetNodeInfoResponse {
   // The public key of the associated lightning node
@@ -50,22 +54,6 @@ message PayInvoiceResponse {
   bytes preimage = 1;
 }
 
-// Request to begin intercepting HTLCs or to complete
-// a specific HTLC.
-message RouteHtlcRequest {
-  oneof action {
-    SubscribeInterceptHtlcsRequest subscribe_request = 1;
-    CompleteHtlcsRequest complete_request = 2;
-  }
-}
-
-message RouteHtlcResponse {
-  oneof action {
-    SubscribeInterceptHtlcsResponse subscribe_response = 1;
-    CompleteHtlcsResponse complete_response = 2;
-  }
-}
-
 // Request to subscribe to HTLCs with a specific short channel id
 //
 // Send this request when the gateway just assigned a new channel id to a
@@ -76,7 +64,7 @@ message SubscribeInterceptHtlcsRequest {
   uint64 short_channel_id = 1;
 }
 
-message SubscribeInterceptHtlcsResponse {
+message InterceptHtlcRequest {
   // The HTLC payment hash.
   // Value is not guaranteed to be unique per intercepted HTLC
   bytes payment_hash = 1;
@@ -110,7 +98,7 @@ message SubscribeInterceptHtlcsResponse {
   uint64 htlc_id = 13;
 }
 
-message CompleteHtlcsRequest {
+message CompleteHtlcResponse {
   message Settle {
     // The preimage for settling an intercepted HTLC
     bytes preimage = 1;
@@ -120,6 +108,8 @@ message CompleteHtlcsRequest {
     // The reason for the cancellation of an intercepted HTLC
     string reason = 1;
   }
+
+  message Forward {}
 
   oneof action {
     // Request to complete an intercepted HTLC with success result after
@@ -137,6 +127,9 @@ message CompleteHtlcsRequest {
     // intercepted HTLC. GatewayLightning will fail/cancel the intercepted HTLC
     // with reason provided.
     Cancel cancel = 2;
+
+    // Request to just forward the HTLC without failing or settling it.
+    Forward forward = 3;
   }
 
   // The id of the incoming channel
@@ -145,8 +138,6 @@ message CompleteHtlcsRequest {
   // The index of the incoming htlc in the incoming channel
   uint64 htlc_id = 5;
 }
-
-message CompleteHtlcsResponse {}
 
 message GetRouteHintsResponse {
   message RouteHintHop {

--- a/gateway/ln-gateway/proto/gatewaylnrpc.proto
+++ b/gateway/ln-gateway/proto/gatewaylnrpc.proto
@@ -24,7 +24,7 @@ service GatewayLightning {
    * GatewayLightning implementations should respond with a channel stream
    * over which intercepted HTLCs are continually sent to the client.
    */
-  rpc RouteHtlcs(stream CompleteHtlcResponse) returns (stream InterceptHtlcRequest) {}
+  rpc RouteHtlcs(stream InterceptHtlcResponse) returns (stream InterceptHtlcRequest) {}
 
   rpc SubscribeMintHtlcs(SubscribeInterceptHtlcsRequest) returns (EmptyResponse) {}
 }
@@ -98,7 +98,7 @@ message InterceptHtlcRequest {
   uint64 htlc_id = 13;
 }
 
-message CompleteHtlcResponse {
+message InterceptHtlcResponse {
   message Settle {
     // The preimage for settling an intercepted HTLC
     bytes preimage = 1;

--- a/gateway/ln-gateway/proto/gatewaylnrpc.proto
+++ b/gateway/ln-gateway/proto/gatewaylnrpc.proto
@@ -2,8 +2,10 @@ syntax = "proto3";
 
 package gatewaylnrpc;
 
-/* GatewayLightning is a service that provides limited access and functionality
- * from a lightning node to Fedimint gateways */
+/* 
+ * GatewayLightning is a service that provides limited access and functionality
+ * from a lightning node to Fedimint gateways
+ */
 service GatewayLightning {
   /* GetNodeInfo returns the public key and alias of the associated lightning node */
   rpc GetNodeInfo(EmptyRequest) returns (GetNodeInfoResponse) {}
@@ -11,27 +13,22 @@ service GatewayLightning {
   /* GetRouteHints returns the route hints to the associated lightning node */
   rpc GetRouteHints(EmptyRequest) returns (GetRouteHintsResponse) {}
 
-  /* PayInvoice attempts to pay an invoice using the associated lightning node
+  /* 
+   * PayInvoice attempts to pay an invoice using the associated lightning node
    */
   rpc PayInvoice(PayInvoiceRequest) returns (PayInvoiceResponse) {}
 
-  /* RouteHtlcs opens a stream for a client to receive specific
-   * HTLCs that have a specific short channel id and receives a stream as input. 
-   * For every HTLC intercepted and processed, the client can send a CompleteHtlcsRequest
-   * over the input stream to complete the HTLC.
-   *
-   * Recommendation:
-   * GatewayLightning implementations should respond with a channel stream
-   * over which intercepted HTLCs are continually sent to the client.
+  /* 
+   * RouteHtlcs opens a bi-directional stream for the client to receive intercepted
+   * HTLCs. `InterceptHtlcRequest` is sent from the server to alert the client that
+   * an HTLC has been intercepted and needs to be processed. The client is expected
+   * to response with `InterceptHtlcResponse` after the HTLC has been processed with
+   * the appropriate action (Settle, Forward, Cancel).
    */
   rpc RouteHtlcs(stream InterceptHtlcResponse) returns (stream InterceptHtlcRequest) {}
-
-  rpc SubscribeMintHtlcs(SubscribeInterceptHtlcsRequest) returns (EmptyResponse) {}
 }
 
 message EmptyRequest {}
-
-message EmptyResponse {}
 
 message GetNodeInfoResponse {
   // The public key of the associated lightning node
@@ -52,16 +49,6 @@ message PayInvoiceRequest {
 message PayInvoiceResponse {
   // The preimage of the invoice
   bytes preimage = 1;
-}
-
-// Request to subscribe to HTLCs with a specific short channel id
-//
-// Send this request when the gateway just assigned a new channel id to a
-// newly connected federation. GatewayLightning should respond with a
-// stream over which intercepted HTLCs are continually sent to the client.
-message SubscribeInterceptHtlcsRequest {
-  // The short channel id of HTLCs to intercept
-  uint64 short_channel_id = 1;
 }
 
 message InterceptHtlcRequest {

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -18,7 +18,6 @@ use tracing::{debug, info, instrument, warn};
 use crate::gatewaylnrpc::intercept_htlc_response::{Action, Cancel, Settle};
 use crate::gatewaylnrpc::{
     InterceptHtlcRequest, InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
-    SubscribeInterceptHtlcsRequest,
 };
 use crate::lnrpc_client::ILnRpcClient;
 use crate::rpc::FederationInfo;
@@ -96,12 +95,6 @@ impl GatewayActor {
             .await;
         // Block until we have registered to return
         notify.notified().await;
-
-        lnrpc
-            .subscribe_mint_htlcs(SubscribeInterceptHtlcsRequest {
-                short_channel_id: client.config().mint_channel_id,
-            })
-            .await?;
 
         let actor = Self {
             client,

--- a/gateway/ln-gateway/src/actor.rs
+++ b/gateway/ln-gateway/src/actor.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -8,25 +7,21 @@ use fedimint_client_legacy::mint::backup::Metadata;
 use fedimint_client_legacy::modules::ln::contracts::{ContractId, Preimage};
 use fedimint_client_legacy::modules::ln::route_hints::RouteHint;
 use fedimint_client_legacy::{GatewayClient, PaymentParameters};
-use fedimint_core::task::{self, RwLock, TaskGroup};
+use fedimint_core::task::{self, TaskGroup};
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::{Amount, OutPoint, TransactionId};
 use fedimint_ln_common::LightningGateway;
-use futures::stream::{BoxStream, StreamExt};
 use rand::{CryptoRng, RngCore};
-use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::Notify;
-use tonic::Status;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
-use crate::gatewaylnrpc::complete_htlcs_request::{Action, Cancel, Settle};
+use crate::gatewaylnrpc::complete_htlc_response::{Action, Cancel, Settle};
 use crate::gatewaylnrpc::{
-    route_htlc_request, route_htlc_response, CompleteHtlcsRequest, PayInvoiceRequest,
-    PayInvoiceResponse, RouteHtlcRequest, RouteHtlcResponse, SubscribeInterceptHtlcsRequest,
-    SubscribeInterceptHtlcsResponse,
+    CompleteHtlcResponse, InterceptHtlcRequest, PayInvoiceRequest, PayInvoiceResponse,
+    SubscribeInterceptHtlcsRequest,
 };
 use crate::lnrpc_client::ILnRpcClient;
-use crate::rpc::{FederationInfo, GatewayRpcSender, LightningReconnectPayload};
+use crate::rpc::FederationInfo;
 use crate::utils::retry;
 use crate::{GatewayError, Result};
 
@@ -36,10 +31,7 @@ const GW_ANNOUNCEMENT_TTL: Duration = Duration::from_secs(600);
 #[derive(Clone)]
 pub struct GatewayActor {
     client: Arc<GatewayClient>,
-    pub lnrpc: Arc<RwLock<dyn ILnRpcClient>>,
-    task_group: TaskGroup,
-    gw_rpc: GatewayRpcSender,
-    pub sender: Sender<Arc<AtomicBool>>,
+    pub lnrpc: Arc<dyn ILnRpcClient>,
     registration: Arc<Mutex<LightningGateway>>,
 }
 
@@ -49,107 +41,12 @@ pub enum BuyPreimage {
     External(Preimage),
 }
 
-#[derive(Clone)]
-struct LightningSenderStream {
-    /// Channel used to stream subscribe and complete requests back to the
-    /// Lightning implementation
-    ln_sender: Sender<RouteHtlcRequest>,
-    /// Reference to an ILnRpcClient used for setting up the htlc stream
-    lnrpc: Arc<RwLock<dyn ILnRpcClient>>,
-}
-
-type RouteHTLCStream = BoxStream<'static, std::result::Result<RouteHtlcResponse, Status>>;
-
-impl LightningSenderStream {
-    async fn subscribe_to_htlcs(
-        &self,
-        short_channel_id: u64,
-        ln_receiver: Receiver<RouteHtlcRequest>,
-    ) -> Result<RouteHTLCStream> {
-        let stream = self
-            .lnrpc
-            .write()
-            .await
-            .route_htlcs(ln_receiver.into())
-            .await?;
-
-        self.ln_sender
-            .send(RouteHtlcRequest {
-                action: Some(route_htlc_request::Action::SubscribeRequest(
-                    SubscribeInterceptHtlcsRequest { short_channel_id },
-                )),
-            })
-            .await
-            .map_err(|_| GatewayError::Other(anyhow::anyhow!("Failed to subscribe to HTLCs")))?;
-
-        info!(?short_channel_id, "Subscribed to HTLCs",);
-        Ok(stream)
-    }
-
-    async fn settle_htlc(
-        &self,
-        preimage: Preimage,
-        incoming_chan_id: u64,
-        htlc_id: u64,
-    ) -> Result<()> {
-        info!(
-            ?incoming_chan_id,
-            ?htlc_id,
-            "Successfully processed intercepted HTLC"
-        );
-        self.ln_sender
-            .send(RouteHtlcRequest {
-                action: Some(route_htlc_request::Action::CompleteRequest(
-                    CompleteHtlcsRequest {
-                        action: Some(Action::Settle(Settle {
-                            preimage: preimage.0.to_vec(),
-                        })),
-                        incoming_chan_id,
-                        htlc_id,
-                    },
-                )),
-            })
-            .await
-            .map_err(|_| GatewayError::Other(anyhow::anyhow!("Failed to complete to HTLC")))
-    }
-
-    async fn cancel_htlc(
-        &self,
-        error_message: &str,
-        incoming_chan_id: u64,
-        htlc_id: u64,
-    ) -> Result<()> {
-        // Note: this specific complete htlc requires no further action.
-        // If we fail to send the complete htlc message, or get an error
-        // result, lightning node will still
-        // cancel HTCL after expiry period lapses.
-        // Result can be safely ignored.
-        // TODO: make sure this succeeded?
-        error!("{}", error_message);
-        self.ln_sender
-            .send(RouteHtlcRequest {
-                action: Some(route_htlc_request::Action::CompleteRequest(
-                    CompleteHtlcsRequest {
-                        action: Some(Action::Cancel(Cancel {
-                            reason: error_message.to_string(),
-                        })),
-                        incoming_chan_id,
-                        htlc_id,
-                    },
-                )),
-            })
-            .await
-            .map_err(|_| GatewayError::Other(anyhow::anyhow!("Failed to cancel to HTLC")))
-    }
-}
-
 impl GatewayActor {
     pub async fn new(
         client: Arc<GatewayClient>,
-        lnrpc: Arc<RwLock<dyn ILnRpcClient>>,
+        lnrpc: Arc<dyn ILnRpcClient>,
         route_hints: Vec<RouteHint>,
-        mut task_group: TaskGroup,
-        gw_rpc: GatewayRpcSender,
+        task_group: &mut TaskGroup,
     ) -> Result<Self> {
         let register_client = client.clone();
         let registration = Arc::new(Mutex::new(
@@ -200,74 +97,26 @@ impl GatewayActor {
         // Block until we have registered to return
         notify.notified().await;
 
-        // Create a channel that will be used to shutdown the HTLC thread
-        let (sender, receiver) = mpsc::channel::<Arc<AtomicBool>>(100);
+        lnrpc
+            .subscribe_mint_htlcs(SubscribeInterceptHtlcsRequest {
+                short_channel_id: client.config().mint_channel_id,
+            })
+            .await?;
 
-        let mut actor = Self {
+        let actor = Self {
             client,
             lnrpc,
-            task_group,
-            gw_rpc,
-            sender,
             registration,
         };
-
-        actor.route_htlcs(receiver).await?;
 
         Ok(actor)
     }
 
-    pub async fn stop_subscribing_htlcs(&mut self) -> Result<()> {
-        self.sender
-            .send(Arc::new(AtomicBool::new(true)))
-            .await
-            .map_err(|e| {
-                GatewayError::Other(anyhow::anyhow!(
-                    "Couldn't send shutdown signal to HTLC thread: {:?}",
-                    e
-                ))
-            })
-    }
-
-    async fn wait_for_htlc_or_shutdown(
-        stream: &mut RouteHTLCStream,
-        receiver: &mut Receiver<Arc<AtomicBool>>,
-        gw_rpc_copy: GatewayRpcSender,
-    ) -> Option<RouteHtlcResponse> {
-        tokio::select! {
-            msg = stream.next() => match msg {
-                Some(Ok(msg)) => Some(msg),
-                Some(Err(e)) => {
-                    warn!("Error sent over HTLC subscription: {}. Sending reconnect RPC", e);
-                    // Sending a `LightningReconnectPayload` with `node_type` as None will use the existing
-                    // credentials to reconnect to the same node.
-                    let reconnect_req = LightningReconnectPayload { node_type: None };
-
-                    // We swallow the error here and simply return `None` to alert the subscription thread that
-                    // it should shutdown since we received an error from the lightning node.
-                    let _ = gw_rpc_copy.send(reconnect_req).await.map_err(|e| {
-                        warn!("Error sending reconnect RPC to gatewayd: {:?}", e);
-                    });
-                    None
-                }
-                None => {
-                    warn!("HTLC stream closed by service");
-                    None
-                }
-            },
-            _ = receiver.recv() => {
-                tracing::info!("Received signal to shutdown HTLC thread");
-                None
-            }
-        }
-    }
-
-    async fn handle_intercepted_htlc(
-        htlc: SubscribeInterceptHtlcsResponse,
-        ln_sender: LightningSenderStream,
-        actor: GatewayActor,
-    ) -> Result<()> {
-        let SubscribeInterceptHtlcsResponse {
+    pub async fn handle_intercepted_htlc(
+        &self,
+        htlc: InterceptHtlcRequest,
+    ) -> CompleteHtlcResponse {
+        let InterceptHtlcRequest {
             payment_hash,
             outgoing_amount_msat,
             incoming_chan_id,
@@ -285,105 +134,51 @@ impl GatewayActor {
         let hash = match sha256::Hash::from_slice(&payment_hash) {
             Ok(hash) => hash,
             Err(_) => {
-                return ln_sender
-                    .cancel_htlc("Failed to parse payment hash", incoming_chan_id, htlc_id)
-                    .await;
+                return CompleteHtlcResponse {
+                    action: Some(Action::Cancel(Cancel {
+                        reason: "Failed to parse payment hash".to_string(),
+                    })),
+                    incoming_chan_id,
+                    htlc_id,
+                };
             }
         };
 
         let amount_msat = Amount::from_msats(outgoing_amount_msat);
 
-        let (outpoint, contract_id) = match actor
-            .buy_preimage_from_federation(&hash, &amount_msat)
-            .await
-        {
-            Ok((outpoint, contract_id)) => (outpoint, contract_id),
-            Err(_) => {
-                return ln_sender
-                    .cancel_htlc("Failed to buy preimage", incoming_chan_id, htlc_id)
-                    .await;
-            }
-        };
+        let (outpoint, contract_id) =
+            match self.buy_preimage_from_federation(&hash, &amount_msat).await {
+                Ok((outpoint, contract_id)) => (outpoint, contract_id),
+                Err(_) => {
+                    return CompleteHtlcResponse {
+                        action: Some(Action::Cancel(Cancel {
+                            reason: "Failed to buy preimage".to_string(),
+                        })),
+                        incoming_chan_id,
+                        htlc_id,
+                    };
+                }
+            };
 
-        match actor
+        match self
             .pay_invoice_buy_preimage_finalize(BuyPreimage::Internal((outpoint, contract_id)))
             .await
         {
-            Ok(preimage) => {
-                return ln_sender
-                    .settle_htlc(preimage, incoming_chan_id, htlc_id)
-                    .await;
-            }
-            Err(_) => {
-                return ln_sender
-                    .cancel_htlc(
-                        "Failed to process intercepted HTLC",
-                        incoming_chan_id,
-                        htlc_id,
-                    )
-                    .await;
-            }
+            Ok(preimage) => CompleteHtlcResponse {
+                action: Some(Action::Settle(Settle {
+                    preimage: preimage.0.to_vec(),
+                })),
+                incoming_chan_id,
+                htlc_id,
+            },
+            Err(_) => CompleteHtlcResponse {
+                action: Some(Action::Cancel(Cancel {
+                    reason: "Failed to process intercepted HTLC".to_string(),
+                })),
+                incoming_chan_id,
+                htlc_id,
+            },
         }
-    }
-
-    pub async fn route_htlcs(
-        &mut self,
-        mut shutdown_receiver: Receiver<Arc<AtomicBool>>,
-    ) -> Result<()> {
-        let short_channel_id = self.client.config().mint_channel_id;
-
-        // Create a stream used to communicate with the Lightning implementation
-        let (sender, ln_receiver) = mpsc::channel::<RouteHtlcRequest>(100);
-        let ln_sender = LightningSenderStream {
-            ln_sender: sender,
-            lnrpc: self.lnrpc.clone(),
-        };
-
-        let mut stream = ln_sender
-            .subscribe_to_htlcs(short_channel_id, ln_receiver)
-            .await?;
-
-        let actor = self.to_owned();
-        let gw_rpc_copy = self.gw_rpc.clone();
-
-        self.task_group
-            .spawn(
-                "Subscribe to intercepted HTLCs in stream",
-                move |handle| async move {
-                    while let Some(RouteHtlcResponse {
-                        action
-                    }) = Self::wait_for_htlc_or_shutdown(
-                        &mut stream,
-                        &mut shutdown_receiver,
-                        gw_rpc_copy.clone(),
-                    )
-                    .await
-                    {
-                        if handle.is_shutting_down() {
-                            info!("Shutting down HTLC subscription");
-                            break;
-                        }
-
-                        match action {
-                            Some(route_htlc_response::Action::SubscribeResponse(htlc)) => {
-                                // Swallow result so that we continue processing HTLCs
-                                let _ = Self::handle_intercepted_htlc(htlc, ln_sender.clone(), actor.clone()).await.map_err(|e| {
-                                    error!("Error occurred while handling intercepted HTLC: {:?}", e);
-                                });
-                            }
-                            Some(route_htlc_response::Action::CompleteResponse(_complete_response)) => {
-                                // TODO: Might need to add some error handling here
-                                info!("Successfully handled HTLC");
-                            }
-                            None => {
-                                error!("Error: Action received from Lightning node was None. This should never happen");
-                            }
-                        }
-                    }
-                }
-            )
-            .await;
-        Ok(())
     }
 
     async fn fetch_all_notes(&self) {
@@ -556,8 +351,6 @@ impl GatewayActor {
     ) -> Result<Preimage> {
         match self
             .lnrpc
-            .read()
-            .await
             .pay(PayInvoiceRequest {
                 invoice: invoice.to_string(),
                 max_delay: payment_params.max_delay,
@@ -633,7 +426,8 @@ impl GatewayActor {
         Ok(())
     }
 
-    pub async fn restore(&self, mut task_group: TaskGroup) -> Result<()> {
+    pub async fn restore(&self) -> Result<()> {
+        let mut task_group = TaskGroup::new();
         self.client
             .mint_client()
             .restore_ecash_from_federation(10, &mut task_group)

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -1,5 +1,5 @@
 use std::array::TryFromSliceError;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -15,15 +15,14 @@ use cln_rpc::primitives::ShortChannelId;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::Amount;
 use futures::stream::StreamExt;
-use ln_gateway::gatewaylnrpc::complete_htlcs_request::{Action, Cancel, Settle};
+use ln_gateway::gatewaylnrpc::complete_htlc_response::{Action, Cancel, Forward, Settle};
 use ln_gateway::gatewaylnrpc::gateway_lightning_server::{
     GatewayLightning, GatewayLightningServer,
 };
 use ln_gateway::gatewaylnrpc::get_route_hints_response::{RouteHint, RouteHintHop};
 use ln_gateway::gatewaylnrpc::{
-    route_htlc_request, route_htlc_response, CompleteHtlcsRequest, CompleteHtlcsResponse,
-    EmptyRequest, GetNodeInfoResponse, GetRouteHintsResponse, PayInvoiceRequest,
-    PayInvoiceResponse, RouteHtlcRequest, RouteHtlcResponse, SubscribeInterceptHtlcsResponse,
+    CompleteHtlcResponse, EmptyRequest, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse,
+    InterceptHtlcRequest, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
 use secp256k1::PublicKey;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -239,11 +238,10 @@ impl ClnRpcService {
     }
 
     async fn complete_htlc(
-        complete_request: CompleteHtlcsRequest,
+        complete_request: CompleteHtlcResponse,
         interceptors: Arc<ClnHtlcInterceptor>,
-        sender: mpsc::Sender<Result<RouteHtlcResponse, Status>>,
     ) -> Result<(), Status> {
-        let CompleteHtlcsRequest {
+        let CompleteHtlcResponse {
             action,
             incoming_chan_id,
             htlc_id,
@@ -272,6 +270,9 @@ impl ClnRpcService {
                     // See: https://github.com/lightning/bolts/blob/master/04-onion-routing.md#failure-messages
                     htlc_processing_failure()
                 }
+                Some(Action::Forward(Forward {})) => {
+                    serde_json::json!({ "result": "continue" })
+                }
                 None => {
                     error!(
                         ?incoming_chan_id,
@@ -287,18 +288,7 @@ impl ClnRpcService {
             // Send translated response to the HTLC interceptor for submission
             // to the cln rpc
             match outcome.send(htlca_res) {
-                Ok(_) => {
-                    let _ = sender
-                        .send(Ok(RouteHtlcResponse {
-                            action: Some(route_htlc_response::Action::CompleteResponse(
-                                CompleteHtlcsResponse {},
-                            )),
-                        }))
-                        .await
-                        .map_err(|e| {
-                            error!("Failed to send CompleteResponse to gatewayd: {:?}", e);
-                        });
-                }
+                Ok(_) => {}
                 Err(e) => {
                     error!(
                         "Failed to send htlc_accepted response to interceptor: {:?}",
@@ -482,50 +472,49 @@ impl GatewayLightning for ClnRpcService {
         Ok(tonic::Response::new(outcome))
     }
 
-    type RouteHtlcsStream = ReceiverStream<Result<RouteHtlcResponse, Status>>;
+    type RouteHtlcsStream = ReceiverStream<Result<InterceptHtlcRequest, Status>>;
 
     async fn route_htlcs(
         &self,
-        request: tonic::Request<tonic::Streaming<RouteHtlcRequest>>,
+        request: tonic::Request<tonic::Streaming<CompleteHtlcResponse>>,
     ) -> Result<tonic::Response<Self::RouteHtlcsStream>, Status> {
         let mut stream = request.into_inner();
 
         // First create new channel that we will use to send responses back to gatewayd
         let (gatewayd_sender, gatewayd_receiver) =
-            mpsc::channel::<Result<RouteHtlcResponse, Status>>(100);
+            mpsc::channel::<Result<InterceptHtlcRequest, Status>>(100);
+
+        let mut sender = self.interceptor.sender.lock().await;
+        *sender = Some(gatewayd_sender.clone());
 
         // Spawn new thread that listens for events from the input stream
         let interceptors = self.interceptor.clone();
         tokio::spawn(async move {
             while let Some(res) = stream.next().await {
-                if let Ok(route_request) = res {
-                    match route_request.action {
-                        Some(route_htlc_request::Action::SubscribeRequest(subscribe_request)) => {
-                            interceptors.subscriptions.lock().await.insert(
-                                subscribe_request.short_channel_id,
-                                gatewayd_sender.clone(),
-                            );
-                        }
-                        Some(route_htlc_request::Action::CompleteRequest(complete_request)) => {
-                            let _ = Self::complete_htlc(
-                                complete_request,
-                                interceptors.clone(),
-                                gatewayd_sender.clone(),
-                            )
-                            .await
-                            .map_err(|e| {
-                                error!("CLN extension failed to complete HTLC: {:?}", e);
-                            });
-                        }
-                        None => {
-                            error!("No action was sent as part of RouteHtlcRequest");
-                        }
-                    }
+                if let Ok(complete_request) = res {
+                    let _ = Self::complete_htlc(complete_request, interceptors.clone())
+                        .await
+                        .map_err(|e| {
+                            error!("CLN extension failed to complete HTLC: {:?}", e);
+                        });
                 }
             }
         });
 
         Ok(tonic::Response::new(ReceiverStream::new(gatewayd_receiver)))
+    }
+
+    async fn subscribe_mint_htlcs(
+        &self,
+        request: tonic::Request<SubscribeInterceptHtlcsRequest>,
+    ) -> Result<tonic::Response<EmptyResponse>, tonic::Status> {
+        let SubscribeInterceptHtlcsRequest { short_channel_id } = request.into_inner();
+        self.interceptor
+            .subscriptions
+            .lock()
+            .await
+            .insert(short_channel_id);
+        Ok(tonic::Response::new(EmptyResponse {}))
     }
 }
 
@@ -559,22 +548,24 @@ fn htlc_processing_failure() -> serde_json::Value {
     })
 }
 
-type HtlcSubscriptionSender = mpsc::Sender<Result<RouteHtlcResponse, Status>>;
+type HtlcSubscriptionSender = mpsc::Sender<Result<InterceptHtlcRequest, Status>>;
 type HtlcOutcomeSender = oneshot::Sender<serde_json::Value>;
 
 /// Functional structure to filter intercepted HTLCs into subscription streams.
 /// Used as a CLN plugin
 #[derive(Clone)]
 pub struct ClnHtlcInterceptor {
-    subscriptions: Arc<Mutex<HashMap<u64, HtlcSubscriptionSender>>>,
+    subscriptions: Arc<Mutex<BTreeSet<u64>>>,
     pub outcomes: Arc<Mutex<BTreeMap<(u64, u64), HtlcOutcomeSender>>>,
+    sender: Arc<Mutex<Option<HtlcSubscriptionSender>>>,
 }
 
 impl ClnHtlcInterceptor {
     fn new() -> Self {
         Self {
-            subscriptions: Arc::new(Mutex::new(HashMap::new())),
             outcomes: Arc::new(Mutex::new(BTreeMap::new())),
+            subscriptions: Arc::new(Mutex::new(BTreeSet::new())),
+            sender: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -607,61 +598,59 @@ impl ClnHtlcInterceptor {
 
         info!(?short_channel_id, "Intercepted htlc with SCID");
 
-        if let Some(subscription) = self.subscriptions.lock().await.get(&short_channel_id) {
-            let payment_hash = payload.htlc.payment_hash.to_vec();
+        if let Some(sender) = &*self.sender.lock().await {
+            if self.subscriptions.lock().await.contains(&short_channel_id) {
+                let payment_hash = payload.htlc.payment_hash.to_vec();
 
-            let incoming_chan_id =
-                match Self::convert_short_channel_id(payload.htlc.short_channel_id.as_str()) {
-                    Ok(scid) => scid,
-                    // Failed to parse incoming_chan_id, just forward the HTLC
-                    Err(_) => return serde_json::json!({ "result": "continue" }),
-                };
+                let incoming_chan_id =
+                    match Self::convert_short_channel_id(payload.htlc.short_channel_id.as_str()) {
+                        Ok(scid) => scid,
+                        // Failed to parse incoming_chan_id, just forward the HTLC
+                        Err(_) => return serde_json::json!({ "result": "continue" }),
+                    };
 
-            let htlc_ret = match subscription
-                .send(Ok(RouteHtlcResponse {
-                    action: Some(route_htlc_response::Action::SubscribeResponse(
-                        SubscribeInterceptHtlcsResponse {
-                            payment_hash: payment_hash.clone(),
-                            incoming_amount_msat: payload.htlc.amount_msat.msats,
-                            outgoing_amount_msat: payload.onion.forward_msat.msats,
-                            incoming_expiry: htlc_expiry,
-                            short_channel_id,
-                            incoming_chan_id,
-                            htlc_id: payload.htlc.id,
-                        },
-                    )),
-                }))
-                .await
-            {
-                Ok(_) => {
-                    // Open a channel to receive the outcome of the HTLC processing
-                    let (sender, receiver) = oneshot::channel::<serde_json::Value>();
-                    self.outcomes
-                        .lock()
+                let htlc_ret = match sender
+                    .send(Ok(InterceptHtlcRequest {
+                        payment_hash: payment_hash.clone(),
+                        incoming_amount_msat: payload.htlc.amount_msat.msats,
+                        outgoing_amount_msat: payload.onion.forward_msat.msats,
+                        incoming_expiry: htlc_expiry,
+                        short_channel_id,
+                        incoming_chan_id,
+                        htlc_id: payload.htlc.id,
+                    }))
+                    .await
+                {
+                    Ok(_) => {
+                        // Open a channel to receive the outcome of the HTLC processing
+                        let (sender, receiver) = oneshot::channel::<serde_json::Value>();
+                        self.outcomes
+                            .lock()
+                            .await
+                            .insert((incoming_chan_id, payload.htlc.id), sender);
+
+                        // If the gateway does not respond within the HTLC expiry,
+                        // Automatically respond with a failure message.
+                        tokio::time::timeout(Duration::from_secs(30), async {
+                            receiver.await.unwrap_or_else(|e| {
+                                error!("Failed to receive outcome of intercepted htlc: {:?}", e);
+                                htlc_processing_failure()
+                            })
+                        })
                         .await
-                        .insert((incoming_chan_id, payload.htlc.id), sender);
-
-                    // If the gateway does not respond within the HTLC expiry,
-                    // Automatically respond with a failure message.
-                    tokio::time::timeout(Duration::from_secs(30), async {
-                        receiver.await.unwrap_or_else(|e| {
-                            error!("Failed to receive outcome of intercepted htlc: {:?}", e);
+                        .unwrap_or_else(|e| {
+                            error!("await_htlc_processing error {:?}", e);
                             htlc_processing_failure()
                         })
-                    })
-                    .await
-                    .unwrap_or_else(|e| {
-                        error!("await_htlc_processing error {:?}", e);
+                    }
+                    Err(e) => {
+                        error!("Failed to send htlc to subscription: {:?}", e);
                         htlc_processing_failure()
-                    })
-                }
-                Err(e) => {
-                    error!("Failed to send htlc to subscription: {:?}", e);
-                    htlc_processing_failure()
-                }
-            };
+                    }
+                };
 
-            return htlc_ret;
+                return htlc_ret;
+            }
         }
 
         // We have no subscription for this HTLC.

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -15,14 +15,14 @@ use cln_rpc::primitives::ShortChannelId;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::Amount;
 use futures::stream::StreamExt;
-use ln_gateway::gatewaylnrpc::complete_htlc_response::{Action, Cancel, Forward, Settle};
 use ln_gateway::gatewaylnrpc::gateway_lightning_server::{
     GatewayLightning, GatewayLightningServer,
 };
 use ln_gateway::gatewaylnrpc::get_route_hints_response::{RouteHint, RouteHintHop};
+use ln_gateway::gatewaylnrpc::intercept_htlc_response::{Action, Cancel, Forward, Settle};
 use ln_gateway::gatewaylnrpc::{
-    CompleteHtlcResponse, EmptyRequest, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse,
-    InterceptHtlcRequest, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    EmptyRequest, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
+    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
 use secp256k1::PublicKey;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -238,10 +238,10 @@ impl ClnRpcService {
     }
 
     async fn complete_htlc(
-        complete_request: CompleteHtlcResponse,
+        complete_request: InterceptHtlcResponse,
         interceptors: Arc<ClnHtlcInterceptor>,
     ) -> Result<(), Status> {
-        let CompleteHtlcResponse {
+        let InterceptHtlcResponse {
             action,
             incoming_chan_id,
             htlc_id,
@@ -476,7 +476,7 @@ impl GatewayLightning for ClnRpcService {
 
     async fn route_htlcs(
         &self,
-        request: tonic::Request<tonic::Streaming<CompleteHtlcResponse>>,
+        request: tonic::Request<tonic::Streaming<InterceptHtlcResponse>>,
     ) -> Result<tonic::Response<Self::RouteHtlcsStream>, Status> {
         let mut stream = request.into_inner();
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::net::SocketAddr;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -38,10 +38,12 @@ use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::{self, RwLock, TaskGroup, TaskHandle};
 use fedimint_core::{Amount, TransactionId};
 use fedimint_ln_client::contracts::Preimage;
-use gatewaylnrpc::GetNodeInfoResponse;
+use futures::stream::StreamExt;
+use gatewaylnrpc::complete_htlc_response::Action;
+use gatewaylnrpc::{CompleteHtlcResponse, GetNodeInfoResponse};
 use lightning::routing::gossip::RoutingFees;
-use lnrpc_client::ILnRpcClient;
-use rpc::{FederationInfo, LightningReconnectPayload};
+use lnrpc_client::{ILnRpcClient, RouteHtlcStream};
+use rpc::FederationInfo;
 use secp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -51,6 +53,7 @@ use url::Url;
 
 use crate::actor::GatewayActor;
 use crate::client::DynGatewayClientBuilder;
+use crate::gatewaylnrpc::complete_htlc_response::Forward;
 use crate::lnd::GatewayLndClient;
 use crate::lnrpc_client::NetworkLnRpcClient;
 use crate::rpc::rpc_server::run_webserver;
@@ -130,13 +133,13 @@ impl IntoResponse for GatewayError {
 pub struct Gateway {
     decoders: ModuleDecoderRegistry,
     module_gens: ClientModuleGenRegistry,
-    lnrpc: Arc<RwLock<dyn ILnRpcClient>>,
+    lnrpc: Arc<dyn ILnRpcClient>,
     lightning_mode: Option<LightningMode>,
-    actors: Arc<RwLock<BTreeMap<String, GatewayActor>>>,
+    actors: Arc<RwLock<BTreeMap<FederationId, GatewayActor>>>,
+    scid_to_federation: Arc<RwLock<BTreeMap<u64, FederationId>>>,
     client_builder: DynGatewayClientBuilder,
     sender: mpsc::Sender<GatewayRequest>,
     receiver: mpsc::Receiver<GatewayRequest>,
-    task_group: TaskGroup,
     channel_id_generator: AtomicU64,
     fees: RoutingFees,
     gatewayd_db: Database,
@@ -149,24 +152,22 @@ impl Gateway {
         client_builder: DynGatewayClientBuilder,
         decoders: ModuleDecoderRegistry,
         module_gens: ClientModuleGenRegistry,
-        task_group: TaskGroup,
+        task_group: &mut TaskGroup,
         fees: RoutingFees,
         gatewayd_db: Database,
     ) -> Result<Self> {
         // Create message channels for the webserver
         let (sender, receiver) = mpsc::channel::<GatewayRequest>(100);
 
-        let lnrpc =
-            Self::create_lightning_client(lightning_mode.clone(), task_group.make_subgroup().await)
-                .await?;
+        let lnrpc = Self::create_lightning_client(lightning_mode.clone()).await?;
 
         let mut gw = Self {
             lnrpc,
             actors: Arc::new(RwLock::new(BTreeMap::new())),
+            scid_to_federation: Arc::new(RwLock::new(BTreeMap::new())),
             sender,
             receiver,
             client_builder,
-            task_group,
             channel_id_generator: AtomicU64::new(INITIAL_SCID),
             decoders: decoders.clone(),
             module_gens: module_gens.clone(),
@@ -176,17 +177,17 @@ impl Gateway {
         };
 
         gw.load_actors(decoders, module_gens).await?;
+        gw.route_htlcs(task_group).await?;
 
         Ok(gw)
     }
 
     #[allow(clippy::too_many_arguments)]
     pub async fn new_with_lightning_connection(
-        lnrpc: Arc<RwLock<dyn ILnRpcClient>>,
+        lnrpc: Arc<dyn ILnRpcClient>,
         client_builder: DynGatewayClientBuilder,
         decoders: ModuleDecoderRegistry,
         module_gens: ClientModuleGenRegistry,
-        task_group: TaskGroup,
         fees: RoutingFees,
         gatewayd_db: Database,
     ) -> Result<Self> {
@@ -196,10 +197,10 @@ impl Gateway {
         let mut gw = Self {
             lnrpc,
             actors: Arc::new(RwLock::new(BTreeMap::new())),
+            scid_to_federation: Arc::new(RwLock::new(BTreeMap::new())),
             sender,
             receiver,
             client_builder,
-            task_group,
             channel_id_generator: AtomicU64::new(INITIAL_SCID),
             decoders: decoders.clone(),
             module_gens: module_gens.clone(),
@@ -213,19 +214,14 @@ impl Gateway {
         Ok(gw)
     }
 
-    async fn create_lightning_client(
-        mode: LightningMode,
-        task_group: TaskGroup,
-    ) -> Result<Arc<RwLock<dyn ILnRpcClient>>> {
-        let lnrpc: Arc<RwLock<dyn ILnRpcClient>> = match mode {
+    async fn create_lightning_client(mode: LightningMode) -> Result<Arc<dyn ILnRpcClient>> {
+        let lnrpc: Arc<dyn ILnRpcClient> = match mode {
             LightningMode::Cln { cln_extension_addr } => {
                 info!(
                     "Gateway configured to connect to remote LnRpcClient at \n cln extension address: {:?} ",
                     cln_extension_addr
                 );
-                Arc::new(RwLock::new(
-                    NetworkLnRpcClient::new(cln_extension_addr).await?,
-                ))
+                Arc::new(NetworkLnRpcClient::new(cln_extension_addr).await?)
             }
             LightningMode::Lnd {
                 lnd_rpc_addr,
@@ -236,14 +232,91 @@ impl Gateway {
                     "Gateway configured to connect to LND LnRpcClient at \n address: {:?},\n tls cert path: {:?},\n macaroon path: {} ",
                     lnd_rpc_addr, lnd_tls_cert, lnd_macaroon
                 );
-                Arc::new(RwLock::new(
-                    GatewayLndClient::new(lnd_rpc_addr, lnd_tls_cert, lnd_macaroon, task_group)
-                        .await?,
-                ))
+                Arc::new(GatewayLndClient::new(lnd_rpc_addr, lnd_tls_cert, lnd_macaroon).await?)
             }
         };
 
         Ok(lnrpc)
+    }
+
+    pub async fn route_htlcs(&mut self, task_group: &mut TaskGroup) -> Result<()> {
+        // Create a stream used to communicate with the Lightning implementation
+        let (sender, ln_receiver) = mpsc::channel::<CompleteHtlcResponse>(100);
+
+        let mut lnrpc: Box<dyn ILnRpcClient> = match &self.lightning_mode {
+            Some(LightningMode::Cln { cln_extension_addr }) => {
+                info!(
+                    "Gateway configured to connect to remote LnRpcClient at \n cln extension address: {:?} ",
+                    cln_extension_addr
+                );
+                Box::new(NetworkLnRpcClient::new(cln_extension_addr.clone()).await?)
+            }
+            Some(LightningMode::Lnd {
+                lnd_rpc_addr,
+                lnd_tls_cert,
+                lnd_macaroon,
+            }) => Box::new(
+                GatewayLndClient::new(
+                    lnd_rpc_addr.clone(),
+                    lnd_tls_cert.clone(),
+                    lnd_macaroon.clone(),
+                )
+                .await?,
+            ),
+            _ => panic!("Invalid Lightning mode for routing HTLCs"),
+        };
+
+        let mut stream: RouteHtlcStream = lnrpc.route_htlcs(ln_receiver.into(), task_group).await?;
+
+        let scid_to_federation = self.scid_to_federation.clone();
+        let actors = self.actors.clone();
+        task_group
+            .spawn(
+                "Subscribe to intercepted HTLCs in stream",
+                move |handle| async move {
+                    // TODO: Need to recreate the lightning connection if it breaks while processing
+                    // HTLCs
+                    while let Some(Ok(htlc)) = stream.next().await {
+                        if handle.is_shutting_down() {
+                            break;
+                        }
+
+                        let scid_to_feds = scid_to_federation.read().await;
+                        let federation_id = scid_to_feds.get(&htlc.short_channel_id);
+                        let outcome = {
+                            // Just forward the HTLC if we do not have a federation that
+                            // corresponds to the short channel id
+                            if let Some(federation_id) = federation_id {
+                                let actors = actors.read().await;
+                                let actor = actors.get(federation_id);
+                                // Just forward the HTLC if we do not have an actor that
+                                // corresponds to the federation id
+                                if let Some(actor) = actor {
+                                    actor.handle_intercepted_htlc(htlc).await
+                                } else {
+                                    CompleteHtlcResponse {
+                                        action: Some(Action::Forward(Forward {})),
+                                        incoming_chan_id: htlc.incoming_chan_id,
+                                        htlc_id: htlc.htlc_id,
+                                    }
+                                }
+                            } else {
+                                CompleteHtlcResponse {
+                                    action: Some(Action::Forward(Forward {})),
+                                    incoming_chan_id: htlc.incoming_chan_id,
+                                    htlc_id: htlc.htlc_id,
+                                }
+                            }
+                        };
+
+                        if let Err(error) = sender.send(outcome).await {
+                            error!("Error sending HTLC response to lightning node: {error:?}");
+                        }
+                    }
+                },
+            )
+            .await;
+        Ok(())
     }
 
     async fn load_actors(
@@ -254,15 +327,14 @@ impl Gateway {
         // Fetch route hints form the LN node
         let mut num_retries = 0;
         let (route_hints, node_pub_key) = loop {
-            let lightning = self.lnrpc.read().await;
-            let route_hints: Vec<RouteHint> = lightning
+            let route_hints: Vec<RouteHint> = self.lnrpc
                 .routehints()
                 .await
                 .expect("Could not fetch route hints")
                 .try_into()
                 .expect("Could not parse route hints");
 
-            let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.read().await.info().await?;
+            let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.info().await?;
             let node_pub_key = PublicKey::from_slice(&pub_key)
                 .map_err(|e| GatewayError::Other(anyhow!("Invalid node pubkey {}", e)))?;
 
@@ -290,7 +362,14 @@ impl Gateway {
                     .await
                     .expect("Could not build federation client");
 
-                if let Err(e) = self.load_actor(Arc::new(client), route_hints.clone()).await {
+                if let Err(e) = self
+                    .load_actor(
+                        Arc::new(client),
+                        route_hints.clone(),
+                        config.mint_channel_id,
+                    )
+                    .await
+                {
                     error!("Failed to connect federation: {}", e);
                 }
 
@@ -310,20 +389,25 @@ impl Gateway {
         &mut self,
         client: Arc<GatewayClient>,
         route_hints: Vec<RouteHint>,
+        scid: u64,
     ) -> Result<GatewayActor> {
         let actor = GatewayActor::new(
             client.clone(),
             self.lnrpc.clone(),
             route_hints,
-            self.task_group.clone(),
-            GatewayRpcSender::new(self.sender.clone()),
+            // TODO: This task group will go away with the new client
+            &mut TaskGroup::new(),
         )
         .await?;
 
-        self.actors.write().await.insert(
-            client.config().client_config.federation_id.to_string(),
-            actor.clone(),
-        );
+        self.actors
+            .write()
+            .await
+            .insert(client.config().client_config.federation_id, actor.clone());
+        self.scid_to_federation
+            .write()
+            .await
+            .insert(scid, client.config().client_config.federation_id);
         Ok(actor)
     }
 
@@ -331,7 +415,7 @@ impl Gateway {
         self.actors
             .read()
             .await
-            .get(&federation_id.to_string())
+            .get(&federation_id)
             .cloned()
             .ok_or(GatewayError::Other(anyhow::anyhow!(
                 "No federation with id {}",
@@ -354,7 +438,7 @@ impl Gateway {
             return actor.get_info();
         }
 
-        let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.read().await.info().await?;
+        let GetNodeInfoResponse { pub_key, alias: _ } = self.lnrpc.info().await?;
         let node_pub_key = PublicKey::from_slice(&pub_key)
             .map_err(|e| GatewayError::Other(anyhow!("Invalid node pubkey {}", e)))?;
 
@@ -380,7 +464,7 @@ impl Gateway {
         );
 
         let actor = self
-            .load_actor(client.clone(), route_hints)
+            .load_actor(client.clone(), route_hints, channel_id)
             .await
             .map_err(|e| {
                 GatewayError::Other(anyhow::anyhow!("Failed to connect federation {}", e))
@@ -410,7 +494,7 @@ impl Gateway {
             federations.push(actor.get_info()?);
         }
 
-        let ln_info = self.lnrpc.read().await.info().await?;
+        let ln_info = self.lnrpc.info().await?;
 
         Ok(GatewayInfo {
             federations,
@@ -486,72 +570,23 @@ impl Gateway {
         &self,
         RestorePayload { federation_id }: RestorePayload,
     ) -> Result<()> {
-        self.select_actor(federation_id)
-            .await?
-            .restore(self.task_group.make_subgroup().await)
-            .await
+        self.select_actor(federation_id).await?.restore().await
     }
 
-    async fn handle_lightning_reconnect(
-        &mut self,
-        payload: LightningReconnectPayload,
-    ) -> Result<()> {
-        let LightningReconnectPayload { node_type } = payload;
-
-        let mut actors = self.actors.write().await;
-
-        // Stop all threads that are listening for HTLCs
-        tracing::info!("Stopping all HTLC subscription threads.");
-        for actor in actors.values_mut() {
-            actor.stop_subscribing_htlcs().await?;
-        }
-
-        self.lnrpc = match node_type {
-            Some(node_type) => {
-                Self::create_lightning_client(node_type, self.task_group.make_subgroup().await)
-                    .await?
-            }
-            None => {
-                // `lightning_mode` can be None during tests
-                if self.lightning_mode.is_some() {
-                    Self::create_lightning_client(
-                        self.lightning_mode.clone().unwrap(),
-                        self.task_group.make_subgroup().await,
-                    )
-                    .await?
-                } else {
-                    self.lnrpc.clone()
-                }
-            }
-        };
-
-        // Restart the subscription of HTLCs for each actor
-        tracing::info!("Restarting HTLC subscription threads.");
-
-        // Create a channel that will be used to shutdown the HTLC thread
-        for actor in actors.values_mut() {
-            let (sender, receiver) = mpsc::channel::<Arc<AtomicBool>>(100);
-            actor.route_htlcs(receiver).await?;
-            actor.sender = sender;
-        }
-
-        Ok(())
-    }
-
-    pub async fn spawn_webserver(&self, listen: SocketAddr, password: String) {
+    pub async fn spawn_webserver(
+        &self,
+        listen: SocketAddr,
+        password: String,
+        task_group: &mut TaskGroup,
+    ) {
         let sender = GatewayRpcSender::new(self.sender.clone());
-        let tx = run_webserver(
-            password,
-            listen,
-            sender,
-            self.task_group.make_subgroup().await,
-        )
-        .await
-        .expect("Failed to start webserver");
+        let tx = run_webserver(password, listen, sender, task_group)
+            .await
+            .expect("Failed to start webserver");
 
         // TODO: try to drive forward outgoing and incoming payments that were
         // interrupted
-        let loop_ctrl = self.task_group.make_handle();
+        let loop_ctrl = task_group.make_handle();
         let shutdown_sender = self.sender.clone();
         loop_ctrl
             .on_shutdown(Box::new(|| {
@@ -585,8 +620,7 @@ impl Gateway {
                         .await;
                 }
                 GatewayRequest::ConnectFederation(inner) => {
-                    let route_hints: Vec<RouteHint> =
-                        self.lnrpc.read().await.routehints().await?.try_into()?;
+                    let route_hints: Vec<RouteHint> = self.lnrpc.routehints().await?.try_into()?;
                     let fees = self.fees;
 
                     inner
@@ -641,13 +675,6 @@ impl Gateway {
                     inner
                         .handle(&mut self, |gateway, payload| {
                             gateway.handle_restore_msg(payload)
-                        })
-                        .await;
-                }
-                GatewayRequest::LightningReconnect(inner) => {
-                    inner
-                        .handle(&mut self, |gateway, payload| {
-                            gateway.handle_lightning_reconnect(payload)
                         })
                         .await;
                 }

--- a/gateway/ln-gateway/src/lnd.rs
+++ b/gateway/ln-gateway/src/lnd.rs
@@ -18,8 +18,8 @@ use tracing::{error, info, trace};
 use crate::gatewaylnrpc::get_route_hints_response::{RouteHint, RouteHintHop};
 use crate::gatewaylnrpc::intercept_htlc_response::{Action, Cancel, Forward, Settle};
 use crate::gatewaylnrpc::{
-    EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
-    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest, InterceptHtlcResponse,
+    PayInvoiceRequest, PayInvoiceResponse,
 };
 use crate::lnrpc_client::{ILnRpcClient, RouteHtlcStream};
 use crate::GatewayError;
@@ -367,12 +367,5 @@ impl ILnRpcClient for GatewayLndClient {
         .await;
 
         Ok(Box::pin(ReceiverStream::new(actor_receiver)))
-    }
-
-    async fn subscribe_mint_htlcs(
-        &self,
-        _subscribe_request: SubscribeInterceptHtlcsRequest,
-    ) -> Result<EmptyResponse, GatewayError> {
-        Ok(EmptyResponse {})
     }
 }

--- a/gateway/ln-gateway/src/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/lnrpc_client.rs
@@ -13,8 +13,8 @@ use url::Url;
 
 use crate::gatewaylnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gatewaylnrpc::{
-    EmptyRequest, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
-    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    EmptyRequest, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
+    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
 };
 use crate::{GatewayError, Result};
 
@@ -37,11 +37,6 @@ pub trait ILnRpcClient: Debug + Send + Sync {
         events: ReceiverStream<InterceptHtlcResponse>,
         task_group: &mut TaskGroup,
     ) -> Result<RouteHtlcStream<'a>>;
-
-    async fn subscribe_mint_htlcs(
-        &self,
-        subscribe_request: SubscribeInterceptHtlcsRequest,
-    ) -> Result<EmptyResponse>;
 }
 
 /// An `ILnRpcClient` that wraps around `GatewayLightningClient` for
@@ -112,14 +107,5 @@ impl ILnRpcClient for NetworkLnRpcClient {
         let mut client = self.client.clone();
         let res = client.route_htlcs(events).await?;
         Ok(Box::pin(res.into_inner()))
-    }
-
-    async fn subscribe_mint_htlcs(
-        &self,
-        subscribe_request: SubscribeInterceptHtlcsRequest,
-    ) -> Result<EmptyResponse> {
-        let mut client = self.client.clone();
-        let res = client.subscribe_mint_htlcs(subscribe_request).await?;
-        Ok(res.into_inner())
     }
 }

--- a/gateway/ln-gateway/src/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/lnrpc_client.rs
@@ -13,8 +13,8 @@ use url::Url;
 
 use crate::gatewaylnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gatewaylnrpc::{
-    CompleteHtlcResponse, EmptyRequest, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse,
-    InterceptHtlcRequest, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
+    EmptyRequest, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
+    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse, SubscribeInterceptHtlcsRequest,
 };
 use crate::{GatewayError, Result};
 
@@ -34,7 +34,7 @@ pub trait ILnRpcClient: Debug + Send + Sync {
 
     async fn route_htlcs<'a>(
         &mut self,
-        events: ReceiverStream<CompleteHtlcResponse>,
+        events: ReceiverStream<InterceptHtlcResponse>,
         task_group: &mut TaskGroup,
     ) -> Result<RouteHtlcStream<'a>>;
 
@@ -106,7 +106,7 @@ impl ILnRpcClient for NetworkLnRpcClient {
 
     async fn route_htlcs<'a>(
         &mut self,
-        events: ReceiverStream<CompleteHtlcResponse>,
+        events: ReceiverStream<InterceptHtlcResponse>,
         _task_group: &mut TaskGroup,
     ) -> Result<RouteHtlcStream<'a>> {
         let mut client = self.client.clone();

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -39,7 +39,7 @@ use thiserror::Error;
 use url::Url;
 
 use self::pay::{GatewayPayCommon, GatewayPayInvoice, GatewayPayStateMachine, GatewayPayStates};
-use crate::gatewaylnrpc::{GetNodeInfoResponse, SubscribeInterceptHtlcsResponse};
+use crate::gatewaylnrpc::{GetNodeInfoResponse, InterceptHtlcRequest};
 use crate::lnrpc_client::ILnRpcClient;
 
 const GW_ANNOUNCEMENT_TTL: Duration = Duration::from_secs(600);
@@ -531,10 +531,10 @@ pub struct Htlc {
     pub htlc_id: u64,
 }
 
-impl TryFrom<SubscribeInterceptHtlcsResponse> for Htlc {
+impl TryFrom<InterceptHtlcRequest> for Htlc {
     type Error = anyhow::Error;
 
-    fn try_from(s: SubscribeInterceptHtlcsResponse) -> Result<Self, Self::Error> {
+    fn try_from(s: InterceptHtlcRequest) -> Result<Self, Self::Error> {
         Ok(Self {
             payment_hash: sha256::Hash::from_slice(&s.payment_hash)?,
             incoming_amount_msat: Amount::from_msats(s.incoming_amount_msat),

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tokio::sync::{mpsc, oneshot};
 use tracing::error;
 
-use crate::{Gateway, GatewayError, LightningMode, Result};
+use crate::{Gateway, GatewayError, Result};
 
 #[derive(Debug, Clone)]
 pub struct GatewayRpcSender {
@@ -75,13 +75,6 @@ pub struct BackupPayload {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RestorePayload {
     pub federation_id: FederationId,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct LightningReconnectPayload {
-    // Sending `None` for node_type will be interpreted as just reconnecting using the existing
-    // settings
-    pub node_type: Option<LightningMode>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -143,7 +136,6 @@ pub enum GatewayRequest {
     Withdraw(GatewayRequestInner<WithdrawPayload>),
     Backup(GatewayRequestInner<BackupPayload>),
     Restore(GatewayRequestInner<RestorePayload>),
-    LightningReconnect(GatewayRequestInner<LightningReconnectPayload>),
     Shutdown,
 }
 
@@ -190,11 +182,6 @@ impl_gateway_request_trait!(DepositPayload, TransactionId, GatewayRequest::Depos
 impl_gateway_request_trait!(WithdrawPayload, TransactionId, GatewayRequest::Withdraw);
 impl_gateway_request_trait!(BackupPayload, (), GatewayRequest::Backup);
 impl_gateway_request_trait!(RestorePayload, (), GatewayRequest::Restore);
-impl_gateway_request_trait!(
-    LightningReconnectPayload,
-    (),
-    GatewayRequest::LightningReconnect
-);
 
 impl<T> GatewayRequestInner<T>
 where

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use super::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, DepositPayload,
-    LightningReconnectPayload, RestorePayload, WithdrawPayload,
+    RestorePayload, WithdrawPayload,
 };
 use crate::rpc::{FederationInfo, GatewayInfo};
 
@@ -83,11 +83,6 @@ impl GatewayRpcClient {
 
     pub async fn restore(&self, payload: RestorePayload) -> GatewayRpcResult<()> {
         let url = self.base_url.join("/restore").expect("invalid base url");
-        self.call(url, payload).await
-    }
-
-    pub async fn reconnect(&self, payload: LightningReconnectPayload) -> GatewayRpcResult<()> {
-        let url = self.base_url.join("/connect-ln").expect("invalid base url");
         self.call(url, payload).await
     }
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -267,7 +267,6 @@ pub async fn fixtures(num_peers: u16, gateway_node: LightningNodeType) -> anyhow
 
             // Create the gateway's lightning connection and the "other" node's lightning
             // connection.
-            // TODO: Helper function
             let (gateway_ln, other_ln) = match &gateway_node {
                 LightningNodeType::Cln => {
                     let gw_ln: Arc<dyn ILnRpcClient> = Arc::new(ClnLightningTest::new(&dir).await);
@@ -334,6 +333,7 @@ pub async fn fixtures(num_peers: u16, gateway_node: LightningNodeType) -> anyhow
                 gateway_node,
                 DEFAULT_FEES,
                 gatewayd_db,
+                &mut task_group,
             )
             .await;
 
@@ -385,7 +385,7 @@ pub async fn fixtures(num_peers: u16, gateway_node: LightningNodeType) -> anyhow
                 &bitcoin_rpc,
                 &connect_gen,
                 server_module_inits.clone(),
-                &mut task_group.clone(),
+                &mut task_group,
             )
             .await;
             let handles = fed.run_consensus_apis().await;
@@ -412,6 +412,7 @@ pub async fn fixtures(num_peers: u16, gateway_node: LightningNodeType) -> anyhow
                 gateway_node.clone(),
                 DEFAULT_FEES,
                 gatewayd_db,
+                &mut task_group,
             )
             .await;
 
@@ -581,6 +582,7 @@ impl GatewayTest {
         node: LightningNodeType,
         fees: RoutingFees,
         database: Database,
+        task_group: &mut TaskGroup,
     ) -> Self {
         let mut rng = OsRng;
         let ctx = bitcoin::secp256k1::Secp256k1::new();
@@ -628,6 +630,7 @@ impl GatewayTest {
             module_gens.clone(),
             fees,
             database,
+            task_group,
         )
         .await
         .unwrap();


### PR DESCRIPTION
We are moving away from `GatewayActor` and instead `Gatewayd` will keep a map of federation clients. To prepare for this change, this PR refactors a bunch of logic away from `GatewayActor` but does not instantiate the new client yet.

Changes:
 - Remove Lightning re-connection logic (can be added back in once we have the new client) https://github.com/fedimint/fedimint/issues/2625
 - `ILnRpcClient` has changed from `Arc<RwLock<dyn ILnRpcClient>>` to `Arc<dyn ILnRpcClient>`. The new client accepts the later.
 - `route_htlcs` has moved from `GatewayActor` to `Gatewayd`. This means we will only have one gRPC channel between the lightning node and `Gatewayd` instead of per-actor.
 - Subscribing to HTLCs has been removed. All HTLCs are sent from the lightning implementations to `gatewayd`. https://github.com/fedimint/fedimint/issues/2626
 - Streaming logic has been simplified. The "server" will send `InterceptHtlcRequest` when an HTLC is intercepted and the "client" (i.e `Gatewayd`) will send `CompleteHtlcResponse` in response to the intercepted HTLC. No other messages are allowed currently.
 - All `TaskGroup`s have been changed to be passed by mutable reference (except the ones that will eventually go away with the new client).