### PR TITLE
feat: Gatewayd database

### DIFF
--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -1,0 +1,36 @@
+use fedimint_core::config::FederationId;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::{impl_db_lookup, impl_db_record};
+use lightning::routing::gossip::RoutingFees;
+use secp256k1::KeyPair;
+
+#[repr(u8)]
+#[derive(Clone, Debug)]
+pub enum DbKeyPrefix {
+    FederationConfig = 0x04,
+}
+
+#[derive(Debug, Clone, Encodable, Decodable, Eq, PartialEq, Hash)]
+pub struct FederationIdKey {
+    pub id: FederationId,
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct FederationIdKeyPrefix;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
+pub struct FederationConfig {
+    pub mint_channel_id: u64,
+    pub redeem_key: KeyPair,
+    pub timelock_delta: u64,
+    pub connection_string: String,
+    pub fees: RoutingFees,
+}
+
+impl_db_record!(
+    key = FederationIdKey,
+    value = FederationConfig,
+    db_prefix = DbKeyPrefix::FederationConfig,
+);
+
+impl_db_lookup!(key = FederationIdKey, query_prefix = FederationIdKeyPrefix);


### PR DESCRIPTION
This PR changes gatewayd's persistence. Instead of persisting `GatewayClientConfig` for each client, it now stores this metadata in a "gatewayd" database. There is still a database per federation client, but now there is an additional database for gatewayd to store metadata.

Right now, gatewayd stores just enough to reconstruct `GatewayClientConfig`, but the downside is that when it re-creates the actors it needs to contact each federation to get the configuration. Once we migrate off of the old client, we can optimize this and store configuration for the new client. This is just a backwards compatible workaround, but allows for easy changing once the NG client is in place.