### PR TITLE
Internal Payment With Markers

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -92,7 +92,7 @@ pub use fedimint_derive_secret as derivable_secret;
 use fedimint_derive_secret::DerivableSecret;
 use futures::StreamExt;
 use rand::thread_rng;
-use secp256k1_zkp::Secp256k1;
+use secp256k1_zkp::{PublicKey, Secp256k1};
 use secret::DeriveableSecretClientExt;
 use serde::Serialize;
 use tracing::info;
@@ -483,6 +483,14 @@ impl Client {
 
     pub fn federation_id(&self) -> FederationId {
         self.inner.federation_id
+    }
+
+    pub fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)> {
+        Ok((
+            self.federation_id()
+                .to_fake_ln_pub_key(&self.inner.secp_ctx)?,
+            0,
+        ))
     }
 
     pub fn get_meta(&self, key: &str) -> Option<String> {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -265,7 +265,18 @@ impl LightningClientExt for Client {
         expiry_time: Option<u64>,
     ) -> anyhow::Result<(OperationId, Invoice)> {
         let (lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
-        let active_gateway = self.select_active_gateway().await?;
+        let (src_node_id, short_channel_id, route_hints) = match self.select_active_gateway().await
+        {
+            Ok(active_gateway) => (
+                active_gateway.node_pub_key,
+                active_gateway.mint_channel_id,
+                active_gateway.route_hints,
+            ),
+            Err(_) => {
+                let markers = self.get_internal_payment_markers()?;
+                (markers.0, markers.1, vec![])
+            }
+        };
 
         let (operation_id, invoice, output) = lightning
             .create_lightning_receive_output(
@@ -273,7 +284,9 @@ impl LightningClientExt for Client {
                 description,
                 rand::rngs::OsRng,
                 expiry_time,
-                active_gateway,
+                src_node_id,
+                short_channel_id,
+                route_hints,
                 lightning.cfg.network,
             )
             .await?;
@@ -792,13 +805,16 @@ impl LightningClientModule {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_lightning_receive_output<'a>(
         &'a self,
         amount: Amount,
         description: String,
         mut rng: impl RngCore + CryptoRng + 'a,
         expiry_time: Option<u64>,
-        gateway: LightningGateway,
+        src_node_id: secp256k1::PublicKey,
+        short_channel_id: u64,
+        route_hints: Vec<fedimint_ln_common::route_hints::RouteHint>,
         network: Network,
     ) -> anyhow::Result<(
         OperationId,
@@ -814,8 +830,8 @@ impl LightningClientModule {
 
         // Route hint instructing payer how to route to gateway
         let route_hint_last_hop = RouteHintHop {
-            src_node_id: gateway.node_pub_key,
-            short_channel_id: gateway.mint_channel_id,
+            src_node_id,
+            short_channel_id,
             fees: RoutingFees {
                 base_msat: 0,
                 proportional_millionths: 0,
@@ -824,11 +840,10 @@ impl LightningClientModule {
             htlc_minimum_msat: None,
             htlc_maximum_msat: None,
         };
-        let route_hints = if gateway.route_hints.is_empty() {
+        let route_hints = if route_hints.is_empty() {
             vec![RouteHint(vec![route_hint_last_hop])]
         } else {
-            gateway
-                .route_hints
+            route_hints
                 .iter()
                 .map(|rh| {
                     RouteHint(


### PR DESCRIPTION
Implements a [proposal allowing clients to create invoices when there are no gateways connected](https://github.com/fedimint/fedimint/issues/2618).

In this scenario, invoices have a node pubkey and short channel id markers which make them payable within the current federation only, but not from an external payer

closes #2618 