### PR TITLE
experiment: tests fail when asserting balance sheet sums to zero

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -190,8 +190,8 @@ impl FedimintConsensus {
             .expect("Committing consensus epoch failed");
 
         let audit = self.audit().await;
-        if audit.sum().milli_sat < 0 {
-            panic!("Balance sheet of the fed has gone negative, this should never happen! {audit}")
+        if audit.sum().milli_sat != 0 {
+            panic!("Balance sheet of the fed is non-zero, this should never happen! {audit}")
         }
 
         epoch_history


### PR DESCRIPTION
I don't intend to merge this, just sharing some behavior that seems sus to me.

Our federation audits currently assert that liabilities never exceed assets so that federations have the ability to charge fees which could make assets exceed liabilities. I was wondering what would happen if I asserted that assets and liabilities are strictly equal and ran the tests.

`ecash_in_wallet_can_sent_through_a_tx` fails locally, which doesn't seem to do anything with federation fees ...