### PR TITLE
feat: remove run loop to allow payments to be parallel

### DIFF
--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -64,7 +64,6 @@ impl StandardGatewayClientBuilder {
         client_builder.with_config(config.config);
         client_builder.with_database(db);
 
-        tracing::info!("STANDARD CLIENT BUILDING");
         client_builder
             // TODO: make this configurable?
             .build::<PlainRootSecretStrategy>(tg)

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -5,7 +5,6 @@ use axum::routing::post;
 use axum::{Extension, Json, Router};
 use axum_macros::debug_handler;
 use bitcoin_hashes::hex::ToHex;
-use fedimint_core::task::TaskGroup;
 use fedimint_ln_client::pay::PayInvoicePayload;
 use serde_json::json;
 use tokio::sync::oneshot;
@@ -14,17 +13,16 @@ use tower_http::cors::CorsLayer;
 use tracing::{error, instrument};
 
 use super::{
-    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, GatewayRpcSender,
-    InfoPayload, RestorePayload, WithdrawPayload,
+    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, InfoPayload,
+    RestorePayload, WithdrawPayload,
 };
-use crate::GatewayError;
+use crate::{Gateway, GatewayError};
 
 pub async fn run_webserver(
     authkey: String,
     bind_addr: SocketAddr,
-    sender: GatewayRpcSender,
-    tg: &mut TaskGroup,
-) -> axum::response::Result<oneshot::Sender<()>> {
+    mut gateway: Gateway,
+) -> axum::response::Result<oneshot::Receiver<()>> {
     // Public routes on gateway webserver
     let routes = Router::new().route("/pay_invoice", post(pay_invoice));
 
@@ -42,33 +40,49 @@ pub async fn run_webserver(
     let app = Router::new()
         .merge(routes)
         .merge(admin_routes)
-        .layer(Extension(sender))
+        .layer(Extension(gateway.clone()))
         .layer(CorsLayer::permissive());
 
     let (tx, rx) = oneshot::channel::<()>();
     let server = axum::Server::bind(&bind_addr).serve(app.into_make_service());
-    tg.spawn("Gateway Webserver", move |_| async move {
-        let graceful = server.with_graceful_shutdown(async {
-            rx.await.ok();
-        });
+    gateway
+        .task_group
+        .spawn("Gateway Webserver", move |_| async move {
+            let graceful = server.with_graceful_shutdown(async {
+                rx.await.ok();
+            });
 
-        if let Err(e) = graceful.await {
-            error!("Error shutting down gatewayd webserver: {:?}", e);
-        }
-    })
-    .await;
+            if let Err(e) = graceful.await {
+                error!("Error shutting down gatewayd webserver: {:?}", e);
+            }
+        })
+        .await;
 
-    Ok(tx)
+    let handle = gateway.task_group.make_handle();
+    handle
+        .on_shutdown(Box::new(|| {
+            Box::pin(async move {
+                // Send shutdown signal to the webserver
+                let res = tx.send(());
+                if res.is_err() {
+                    error!("Error shutting down gatewayd webserver: {res:?}");
+                }
+            })
+        }))
+        .await;
+    let shutdown_receiver = handle.make_shutdown_rx().await;
+
+    Ok(shutdown_receiver)
 }
 
 /// Display gateway ecash note balance
 #[debug_handler]
 #[instrument(skip_all, err)]
 async fn info(
-    Extension(rpc): Extension<GatewayRpcSender>,
+    Extension(gateway): Extension<Gateway>,
     Json(payload): Json<InfoPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    let info = rpc.send(payload).await?;
+    let info = gateway.handle_get_info(payload).await?;
     Ok(Json(json!(info)))
 }
 
@@ -76,10 +90,10 @@ async fn info(
 #[debug_handler]
 #[instrument(skip_all, err)]
 async fn balance(
-    Extension(rpc): Extension<GatewayRpcSender>,
+    Extension(gateway): Extension<Gateway>,
     Json(payload): Json<BalancePayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    let amount = rpc.send(payload).await?;
+    let amount = gateway.handle_balance_msg(payload).await?;
     Ok(Json(json!(amount)))
 }
 
@@ -87,10 +101,10 @@ async fn balance(
 #[debug_handler]
 #[instrument(skip_all, err)]
 async fn address(
-    Extension(rpc): Extension<GatewayRpcSender>,
+    Extension(gateway): Extension<Gateway>,
     Json(payload): Json<DepositAddressPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    let address = rpc.send(payload).await?;
+    let address = gateway.handle_address_msg(payload).await?;
     Ok(Json(json!(address)))
 }
 
@@ -98,48 +112,48 @@ async fn address(
 #[debug_handler]
 #[instrument(skip_all, err)]
 async fn withdraw(
-    Extension(rpc): Extension<GatewayRpcSender>,
+    Extension(gateway): Extension<Gateway>,
     Json(payload): Json<WithdrawPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    let txid = rpc.send(payload).await?;
+    let txid = gateway.handle_withdraw_msg(payload).await?;
     Ok(Json(json!(txid)))
 }
 
 #[instrument(skip_all, err)]
 async fn pay_invoice(
-    Extension(rpc): Extension<GatewayRpcSender>,
+    Extension(gateway): Extension<Gateway>,
     Json(payload): Json<PayInvoicePayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    let preimage = rpc.send(payload).await?;
+    let preimage = gateway.handle_pay_invoice_msg(payload).await?;
     Ok(Json(json!(preimage.0.to_hex())))
 }
 
 /// Connect a new federation
 #[instrument(skip_all, err)]
 async fn connect_fed(
-    Extension(rpc): Extension<GatewayRpcSender>,
+    Extension(mut gateway): Extension<Gateway>,
     Json(payload): Json<ConnectFedPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    let fed = rpc.send(payload).await?;
+    let fed = gateway.handle_connect_federation(payload).await?;
     Ok(Json(json!(fed)))
 }
 
 /// Backup a gateway actor state
 #[instrument(skip_all, err)]
 async fn backup(
-    Extension(rpc): Extension<GatewayRpcSender>,
+    Extension(gateway): Extension<Gateway>,
     Json(payload): Json<BackupPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    rpc.send(payload).await?;
+    gateway.handle_backup_msg(payload).await?;
     Ok(())
 }
 
 // Restore a gateway actor state
 #[instrument(skip_all, err)]
 async fn restore(
-    Extension(rpc): Extension<GatewayRpcSender>,
+    Extension(gateway): Extension<Gateway>,
     Json(payload): Json<RestorePayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    rpc.send(payload).await?;
+    gateway.handle_restore_msg(payload).await?;
     Ok(())
 }


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/2637

Removes the `run` loop in `gatewayd` to allow each REST request to be processed in parallel. Some changes were needed to make the `Gateway` struct `Clone` so that this is possible.