### PR TITLE
chore(nix): fix needless rebuilds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
               inherit pkgs pkgs-kitman clightning-dev advisory-db lib moreutils-ts;
 
               src = ./.;
+              srcDotCargo = ./.cargo;
             };
 
           craneExtendBuild = import ./nix/craneBuild.nix

--- a/nix/craneCommon.nix
+++ b/nix/craneCommon.nix
@@ -5,7 +5,7 @@
 # * build inputs
 # * env variables
 
-{ src, pkgs, lib, clightning-dev, pkgs-kitman, moreutils-ts, ... }:
+{ src, srcDotCargo, pkgs, lib, clightning-dev, pkgs-kitman, moreutils-ts, ... }:
 craneLib:
 craneLib.overrideScope' (self: prev: {
 
@@ -141,7 +141,7 @@ craneLib.overrideScope' (self: prev: {
     dummySrc = self.mkDummySrc {
       src = self.filterWorkspaceDepsBuildFiles self.commonSrc;
       extraDummyScript = ''
-        cp -ar ${src}/.cargo --no-target-directory $out/.cargo
+        cp -ar ${srcDotCargo} --no-target-directory $out/.cargo
       '';
     };
   };


### PR DESCRIPTION
Using `${src}` where `src = ./.;` causes whole dependency build to depend on every file in the project directory.