### PR TITLE
feat: lightning reconnect

### DIFF
--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -47,7 +47,7 @@ pub struct DevFed {
 #[derive(Clone)]
 pub struct Gatewayd {
     _process: ProcessHandle,
-    ln: Option<LightningNode>,
+    pub ln: Option<LightningNode>,
 }
 
 impl Gatewayd {
@@ -95,14 +95,6 @@ impl Gatewayd {
             ln: Some(ln),
             _process: process,
         })
-    }
-
-    pub fn lightning_name(&self) -> String {
-        if let Some(ln) = &self.ln {
-            return ln.name().to_string();
-        }
-
-        "None".to_string()
     }
 
     pub fn set_lightning_node(&mut self, ln_node: LightningNode) {

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -130,9 +130,8 @@ impl ClnLightningTest {
             .expect("FM_GATEWAY_LIGHTNING_ADDR not set")
             .parse::<Url>()
             .expect("Invalid FM_GATEWAY_LIGHTNING_ADDR");
-        let lnrpc: Arc<RwLock<dyn ILnRpcClient>> = Arc::new(RwLock::new(
-            NetworkLnRpcClient::new(lnrpc_addr).await.unwrap(),
-        ));
+        let lnrpc: Arc<RwLock<dyn ILnRpcClient>> =
+            Arc::new(RwLock::new(NetworkLnRpcClient::new(lnrpc_addr).await));
 
         ClnLightningTest {
             rpc_cln,
@@ -283,9 +282,8 @@ impl LndLightningTest {
         let initial_balance = Self::channel_balance(rpc_lnd.clone()).await;
         let node_pub_key = Self::pubkey(rpc_lnd.clone()).await;
 
-        let gateway_lnd_client = GatewayLndClient::new(lnd_rpc_addr, lnd_tls_cert, lnd_macaroon)
-            .await
-            .unwrap();
+        let gateway_lnd_client =
+            GatewayLndClient::new(lnd_rpc_addr, lnd_tls_cert, lnd_macaroon).await;
         let lnrpc = Arc::new(RwLock::new(gateway_lnd_client));
         LndLightningTest {
             rpc_lnd,


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/2625

Allows `gatewayd` to reconnect to the lightning node if the connection drops.

Each `ILnRpcClient` implementation now only holds the connection information and not the actual connect. A connection is created when an RPC is requested. Each implementation will try 10 times to reconnect and fail if it can't connect (so that RPCs don't block indefinitely). 

Since the connections are no longer cached by the `ILnRpcClient` implementation, this might have a small perf overhead.