### PR TITLE
rename: rename mint_pub_key to gateway_pub_key

### DIFF
--- a/fedimint-client-legacy/src/lib.rs
+++ b/fedimint-client-legacy/src/lib.rs
@@ -150,7 +150,7 @@ impl GatewayClientConfig {
     ) -> LightningGateway {
         LightningGateway {
             mint_channel_id: self.mint_channel_id,
-            mint_pub_key: self.redeem_key.x_only_public_key().0,
+            gateway_pub_key: self.redeem_key.x_only_public_key().0,
             node_pub_key: self.node_pub_key,
             api: self.api.clone(),
             route_hints,

--- a/fedimint-client-legacy/src/ln/mod.rs
+++ b/fedimint-client-legacy/src/ln/mod.rs
@@ -96,7 +96,7 @@ impl LnClient {
 
         let contract = OutgoingContract {
             hash: *invoice.payment_hash(),
-            gateway_key: gateway.mint_pub_key,
+            gateway_key: gateway.gateway_pub_key,
             timelock,
             user_key: user_sk.x_only_public_key().0,
             invoice,

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -508,7 +508,7 @@ impl GatewayClientModule {
     ) -> LightningGateway {
         LightningGateway {
             mint_channel_id: self.mint_channel_id,
-            mint_pub_key: self.redeem_key.x_only_public_key().0,
+            gateway_pub_key: self.redeem_key.x_only_public_key().0,
             node_pub_key: self.node_pub_key,
             api,
             route_hints,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -616,7 +616,7 @@ impl LightningClientModule {
 
         let contract = OutgoingContract {
             hash: *invoice.payment_hash(),
-            gateway_key: gateway.mint_pub_key,
+            gateway_key: gateway.gateway_pub_key,
             timelock: absolute_timelock as u32,
             user_key: user_sk.x_only_public_key().0,
             invoice,

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -184,7 +184,7 @@ pub struct LightningGateway {
     /// gateway.
     pub mint_channel_id: u64,
     /// Key used to pay the gateway
-    pub mint_pub_key: secp256k1::XOnlyPublicKey,
+    pub gateway_pub_key: secp256k1::XOnlyPublicKey,
     pub node_pub_key: secp256k1::PublicKey,
     pub api: Url,
     /// Route hints to reach the LN node of the gateway.

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1083,7 +1083,7 @@ mod fedimint_migration_tests {
 
         let gateway = LightningGateway {
             mint_channel_id: 100,
-            mint_pub_key: pk.x_only_public_key().0,
+            gateway_pub_key: pk.x_only_public_key().0,
             node_pub_key: pk,
             api: Url::parse("http://example.com")
                 .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/2639

`Gatewayd` currently does have a unique identifier, its just confusingly named `mint_pub_key`. This is actually the `redeem_key` that the gateway uses to redeem contracts from a federation, it has nothing to do with the mint or mint module.

This PR just renames it to `gateway_pub_key` to make its purpose a bit more clear.