### PR TITLE
Version hash test

### DIFF
--- a/fedimint-build/src/lib.rs
+++ b/fedimint-build/src/lib.rs
@@ -1,21 +1,31 @@
 use std::env;
-use std::fs::File;
+use std::io::{self, Write};
 use std::process::Command;
+
+const FAKE_COMMIT_HASH: &str = "01234569afbe457afa1d2683a099c7af48a523c1";
 
 pub fn set_code_version() {
     if env::var_os("CODE_VERSION").is_none() {
-        let git_hash = if File::open("./../../.git/HEAD").is_ok() {
-            let output = Command::new("git")
-                .args(["rev-parse", "HEAD"])
-                .output()
-                .unwrap();
-            String::from_utf8(output.stdout).unwrap()
-        } else {
-            // we set a fake hash here and make it easily recognizable
-            // by giving it a prefix (0x0123456)
-            String::from("01234569afbe457afa1d2683a099c7af48a523c1")
-        };
-        println!("cargo:rustc-env=CODE_VERSION={git_hash}");
+        let output = Command::new("git").args(["rev-parse", "HEAD"]).output();
+
+        match output {
+            Ok(output) => {
+                if output.status.success() {
+                    let git_hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                    println!("cargo:rustc-env=CODE_VERSION={}", git_hash);
+                } else {
+                    let error_message = String::from_utf8_lossy(&output.stderr);
+                    io::stderr().write_all(error_message.as_bytes()).unwrap();
+                    println!("cargo:rustc-env=CODE_VERSION={}", FAKE_COMMIT_HASH);
+                }
+            }
+            Err(error) => {
+                io::stderr()
+                    .write_fmt(format_args!("Failed to execute git command: {}", error))
+                    .unwrap();
+                println!("cargo:rustc-env=CODE_VERSION={}", FAKE_COMMIT_HASH);
+            }
+        }
     }
     println!("cargo:rerun-if-env-changed=CODE_VERSION");
 }

--- a/fedimint-build/src/lib.rs
+++ b/fedimint-build/src/lib.rs
@@ -1,31 +1,42 @@
 use std::env;
-use std::io::{self, Write};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 const FAKE_COMMIT_HASH: &str = "01234569afbe457afa1d2683a099c7af48a523c1";
 
 pub fn set_code_version() {
     if env::var_os("CODE_VERSION").is_none() {
-        let output = Command::new("git").args(["rev-parse", "HEAD"]).output();
+        let output = match Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .output()
+        {
+            Ok(o) => o,
+            Err(e) => match env::var("FEDIMINT_BUILD_ALLOW_GIT_FAIL") {
+                Ok(_) => {
+                    eprintln!("Failed to execute git command.");
+                    println!("cargo:rustc-env=CODE_VERSION={FAKE_COMMIT_HASH}");
+                    return;
+                }
+                Err(_) => {
+                    panic!("Failed to execute git command: {e}");
+                }
+            },
+        };
 
-        match output {
-            Ok(output) => {
-                if output.status.success() {
-                    let git_hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                    println!("cargo:rustc-env=CODE_VERSION={}", git_hash);
-                } else {
-                    let error_message = String::from_utf8_lossy(&output.stderr);
-                    io::stderr().write_all(error_message.as_bytes()).unwrap();
-                    println!("cargo:rustc-env=CODE_VERSION={}", FAKE_COMMIT_HASH);
+        let git_hash = if output.status.success() {
+            match String::from_utf8(output.stdout) {
+                Ok(hash) => hash.trim().to_string(),
+                Err(_) => {
+                    eprintln!("Invalid UTF-8 sequence detected.");
+                    FAKE_COMMIT_HASH.to_string()
                 }
             }
-            Err(error) => {
-                io::stderr()
-                    .write_fmt(format_args!("Failed to execute git command: {}", error))
-                    .unwrap();
-                println!("cargo:rustc-env=CODE_VERSION={}", FAKE_COMMIT_HASH);
-            }
-        }
+        } else {
+            FAKE_COMMIT_HASH.to_string()
+        };
+
+        println!("cargo:rustc-env=CODE_VERSION={git_hash}");
     }
     println!("cargo:rerun-if-env-changed=CODE_VERSION");
 }

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::VersionHash => {
-            println!("version: {}", env!("CODE_VERSION"));
+            println!("{}", env!("CODE_VERSION"));
         }
         Commands::Info => {
             let response = client().get_info().await?;

--- a/nix/craneBuild.nix
+++ b/nix/craneBuild.nix
@@ -34,6 +34,10 @@ craneLib.overrideScope' (self: prev: {
 
     cargoClippyExtraArgs = "--all-targets --no-deps -- --deny warnings";
     doInstallCargoArtifacts = false;
+
+    preBuild = ''
+      export FEDIMINT_BUILD_ALLOW_GIT_FAIL=true
+    '';
   });
 
   workspaceDoc = self.mkCargoDerivation (self.commonArgs // {

--- a/nix/craneCommon.nix
+++ b/nix/craneCommon.nix
@@ -72,6 +72,7 @@ craneLib.overrideScope' (self: prev: {
     PROTOC = "${pkgs.protobuf}/bin/protoc";
     PROTOC_INCLUDE = "${pkgs.protobuf}/include";
     CARGO_PROFILE = self.commonProfile;
+    FEDIMINT_BUILD_ALLOW_GIT_FAIL = "true";
   };
 
   commonArgsBase = {

--- a/scripts/version-hash-tests.sh
+++ b/scripts/version-hash-tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Runs a test to verify that all fedimint binaries were built from the current git HEAD hash
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+source ./scripts/build.sh
+
+devimint version-hash-tests


### PR DESCRIPTION
Add a devimint version hash test that compares the result of the `version-hash` command of each binary against the git HEAD commit hash.

This change includes two fixes:
- devimint set_code_version() was failing to set the correct commit hash on a few binaries due to a reliance on a hardcoded relative filepath. The fix was to remove the check for the HEAD file and just run the `git rev-parse HEAD` command directly, writing errors to stderr.
- The gateway-cli binary `version-hash` command returned a different format than all other binaries. The fix was to remove the extraneous "version: " text and only return the hash.