### PR TITLE
refactor: make a primary module a runtime concept, not type system one

### DIFF
--- a/fedimint-core/src/module/registry.rs
+++ b/fedimint-core/src/module/registry.rs
@@ -47,6 +47,11 @@ impl<M> ModuleRegistry<M> {
     pub fn get(&self, id: ModuleInstanceId) -> Option<&M> {
         self.0.get(&id).map(|m| &m.1)
     }
+
+    /// Get module data by instance id, including [`ModuleKind`]
+    pub fn get_with_kind(&self, id: ModuleInstanceId) -> Option<&(ModuleKind, M)> {
+        self.0.get(&id)
+    }
 }
 
 impl<M: std::fmt::Debug> ModuleRegistry<M> {


### PR DESCRIPTION
The fact that primary modules implement a separate trait generate a lot of friction, for rather small gains.

In particular the fact that primary module is not present in the client's `modules` makes functionality that need to something on "all module instances" error prone, and require extra ceremony.

![image](https://github.com/fedimint/fedimint/assets/9209/8c8c8d62-ca46-43ab-b303-a87d547be49f)

