### PR TITLE
refactor: migrate peg in and out test

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -48,7 +48,7 @@ use crate::module::{ApiRequestErased, ApiVersion, SupportedApiVersionsSummary};
 use crate::outcome::TransactionStatus;
 use crate::query::{
     CurrentConsensus, DiscoverApiVersionSet, EventuallyConsistent, QueryStep, QueryStrategy,
-    UnionResponses, UnionResponsesSingle, VerifiableResponse,
+    UnionResponsesSingle, VerifiableResponse,
 };
 use crate::task;
 use crate::transaction::{SerdeTransaction, Transaction};
@@ -268,22 +268,6 @@ pub trait FederationApiExt: IFederationApi {
                 None => return Err(FederationError(BTreeMap::new())),
             }
         }
-    }
-
-    async fn request_union<Ret>(
-        &self,
-        method: String,
-        params: ApiRequestErased,
-    ) -> FederationResult<Vec<Ret>>
-    where
-        Ret: serde::de::DeserializeOwned + Eq + Debug + Clone + MaybeSend,
-    {
-        self.request_with_strategy(
-            UnionResponses::new(self.all_members().one_honest()),
-            method,
-            params,
-        )
-        .await
     }
 
     async fn request_current_consensus<Ret>(

--- a/fedimint-testing/src/btc/mod.rs
+++ b/fedimint-testing/src/btc/mod.rs
@@ -39,5 +39,6 @@ pub trait BitcoinTest {
     /// received to an address
     async fn mine_block_and_get_received(&self, address: &Address) -> Amount;
 
+    /// Waits till tx is found in mempool and returns the fees
     async fn get_mempool_tx_fee(&self, txid: &Txid) -> Amount;
 }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -22,7 +22,7 @@ use fedimint_core::config::{
     ClientConfig, ServerModuleGenParamsRegistry, ServerModuleGenRegistry, META_FEDERATION_NAME_KEY,
 };
 use fedimint_core::core::{
-    DynModuleConsensusItem, ModuleConsensusItem, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_LN,
+    DynModuleConsensusItem, ModuleInstanceId, LEGACY_HARDCODED_INSTANCE_ID_LN,
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_core::db::mem_impl::MemDatabase;
@@ -1087,14 +1087,4 @@ impl FederationTest {
             connect_info: cfg.get_connect_info(),
         }
     }
-}
-
-/// Unwraps a dyn consensus item into a specific one for making assertions
-#[track_caller]
-pub fn unwrap_item<M: ModuleConsensusItem>(mci: &Option<DynModuleConsensusItem>) -> &M {
-    mci.as_ref()
-        .expect("Module item exists")
-        .as_any()
-        .downcast_ref()
-        .expect("Unexpected type found")
 }

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -35,7 +35,8 @@ where
         address: &Address,
         amount: bitcoin::Amount,
     ) -> FederationResult<Option<PegOutFees>> {
-        self.request_eventually_consistent(
+        self.request_with_strategy(
+            EventuallyConsistent::new(self.all_members().threshold()),
             "peg_out_fees".to_string(),
             ApiRequestErased::new((address, amount.to_sat())),
         )

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -94,7 +94,7 @@ pub enum DepositState {
     Failed(String),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum WithdrawState {
     Created,
     Succeeded(bitcoin::Txid),

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1,13 +1,12 @@
 use std::time::SystemTime;
 
-use bitcoin::Amount;
 use fedimint_core::sats;
 use fedimint_core::util::NextOrPending;
 use fedimint_dummy_client::DummyClientGen;
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyGen;
 use fedimint_testing::fixtures::{Fixtures, TIMEOUT};
-use fedimint_wallet_client::{DepositState, WalletClientExt, WalletClientGen};
+use fedimint_wallet_client::{DepositState, WalletClientExt, WalletClientGen, WithdrawState};
 use fedimint_wallet_common::config::WalletGenParams;
 use fedimint_wallet_server::WalletGen;
 
@@ -18,8 +17,12 @@ fn fixtures() -> Fixtures {
     fixtures.with_module(wallet_client, WalletGen, wallet_params)
 }
 
+fn bsats(satoshi: u64) -> bitcoin::Amount {
+    bitcoin::Amount::from_sat(satoshi)
+}
+
 #[tokio::test(flavor = "multi_thread")]
-async fn on_chain_deposits() -> anyhow::Result<()> {
+async fn on_chain_peg_in_and_peg_out() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
     let client = fed.new_client().await;
@@ -29,9 +32,7 @@ async fn on_chain_deposits() -> anyhow::Result<()> {
     let valid_until = SystemTime::now() + TIMEOUT;
 
     let (op, address) = client.get_deposit_address(valid_until).await?;
-    bitcoin
-        .send_and_mine_block(&address, Amount::from_sat(1000))
-        .await;
+    bitcoin.send_and_mine_block(&address, bsats(5000)).await;
     let sub = client.subscribe_deposit_updates(op).await?;
     let mut sub = sub.into_stream();
     assert_eq!(sub.ok().await?, DepositState::WaitingForTransaction);
@@ -41,6 +42,24 @@ async fn on_chain_deposits() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     assert_eq!(sub.ok().await?, DepositState::Confirmed);
     assert_eq!(sub.ok().await?, DepositState::Claimed);
-    assert_eq!(client.get_balance().await, sats(1000));
+    assert_eq!(client.get_balance().await, sats(5000));
+
+    // Peg-out test, requires block to recognize change UTXOs
+    let address = bitcoin.get_new_address().await;
+    let peg_out = bsats(1000);
+    let fees = client.get_withdraw_fee(address.clone(), peg_out).await?;
+    let op = client.withdraw(address.clone(), peg_out, fees).await?;
+
+    let sub = client.subscribe_withdraw_updates(op).await?;
+    let mut sub = sub.into_stream();
+    assert_eq!(sub.ok().await?, WithdrawState::Created);
+    let txid = match sub.ok().await? {
+        WithdrawState::Succeeded(txid) => txid,
+        _ => panic!("Unexpected state"),
+    };
+    bitcoin.get_mempool_tx_fee(&txid).await;
+
+    let received = bitcoin.mine_block_and_get_received(&address).await;
+    assert_eq!(received, peg_out.into());
     Ok(())
 }


### PR DESCRIPTION
Migrates peg-in and peg-out tests to new test framework.