### PR TITLE
refactor: use gateway public key instead of node public key

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -183,17 +183,13 @@ impl Federation {
     }
 
     pub async fn use_gateway(&self, gw: &Gatewayd) -> Result<()> {
-        let pub_key = match &gw.ln {
-            Some(LightningNode::Cln(cln)) => cln.pub_key().await?,
-            Some(LightningNode::Lnd(lnd)) => lnd.pub_key().await?,
-            None => {
-                return Err(anyhow::anyhow!(
-                    "Gatewayd is disconnected from the Lightning Node"
-                ))
-            }
-        };
-        cmd!(self, "switch-gateway", pub_key.clone()).run().await?;
-        cmd!(self, "ng", "switch-gateway", pub_key).run().await?;
+        let gateway_pub_key = gw.gateway_pub_key().await?;
+        cmd!(self, "switch-gateway", gateway_pub_key.clone())
+            .run()
+            .await?;
+        cmd!(self, "ng", "switch-gateway", gateway_pub_key)
+            .run()
+            .await?;
         info!(
             "Using {name} gateway",
             name = gw.ln.as_ref().unwrap().name()

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -130,6 +130,15 @@ impl Gatewayd {
         }
     }
 
+    pub async fn gateway_pub_key(&self) -> Result<String> {
+        let info = cmd!(self, "info").out_json().await?;
+        let gateway_pub_key = info["federations"][0]["registration"]["gateway_pub_key"]
+            .as_str()
+            .context("gateway_pub_key must be a string")?
+            .to_owned();
+        Ok(gateway_pub_key)
+    }
+
     pub async fn connect_fed(&self, fed: &Federation) -> Result<()> {
         let connect_str = poll_value("connect info", || async {
             match cmd!(fed, "connect-info").out_json().await {

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -22,7 +22,7 @@ use fedimint_client_legacy::mint::SpendableNote;
 use fedimint_client_legacy::modules::ln::contracts::ContractId;
 use fedimint_client_legacy::modules::wallet::WalletClientGen;
 use fedimint_client_legacy::utils::{
-    from_hex, parse_bitcoin_amount, parse_ecash, parse_fedimint_amount, parse_node_pub_key,
+    from_hex, parse_bitcoin_amount, parse_ecash, parse_fedimint_amount, parse_gateway_pub_key,
     parse_peer_id, serialize_ecash,
 };
 use fedimint_client_legacy::{Client, UserClientConfig};
@@ -546,8 +546,8 @@ enum Command {
     /// Switch active gateway
     SwitchGateway {
         /// node public key for a gateway
-        #[clap(value_parser = parse_node_pub_key)]
-        pubkey: secp256k1::PublicKey,
+        #[clap(value_parser = parse_gateway_pub_key)]
+        pubkey: secp256k1::XOnlyPublicKey,
     },
 
     /// Upload the (encrypted) snapshot of mint notes to federation

--- a/fedimint-cli/src/ng.rs
+++ b/fedimint-cli/src/ng.rs
@@ -73,9 +73,8 @@ pub enum ClientNg {
     },
     ListGateways,
     SwitchGateway {
-        /// node public key for a gateway
-        #[clap(value_parser = parse_node_pub_key)]
-        pubkey: secp256k1::PublicKey,
+        #[clap(value_parser = parse_gateway_pub_key)]
+        pubkey: secp256k1::XOnlyPublicKey,
     },
     DepositAddress,
     AwaitDeposit {
@@ -111,8 +110,8 @@ pub enum ClientNg {
     PrintSecret,
 }
 
-pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Error> {
-    secp256k1::PublicKey::from_str(s)
+pub fn parse_gateway_pub_key(s: &str) -> Result<secp256k1::XOnlyPublicKey, secp256k1::Error> {
+    secp256k1::XOnlyPublicKey::from_str(s)
 }
 
 fn parse_secret(s: &str) -> Result<[u8; 64], hex::Error> {

--- a/fedimint-client-legacy/src/lib.rs
+++ b/fedimint-client-legacy/src/lib.rs
@@ -811,20 +811,23 @@ impl Client<UserClientConfig> {
     /// advance.
     pub async fn switch_active_gateway(
         &self,
-        node_pub_key: Option<secp256k1::PublicKey>,
+        gateway_pub_key: Option<secp256k1::XOnlyPublicKey>,
     ) -> Result<LightningGateway> {
         let gateways = self.fetch_registered_gateways().await?;
         if gateways.is_empty() {
             debug!("Could not find any gateways");
             return Err(ClientError::NoGateways);
         };
-        let gateway = match node_pub_key {
+        let gateway = match gateway_pub_key {
             // If a pubkey was provided, try to select and activate a gateway with that pubkey.
             Some(pub_key) => gateways
                 .into_iter()
-                .find(|g| g.node_pub_key == pub_key)
+                .find(|g| g.gateway_pub_key == pub_key)
                 .ok_or_else(|| {
-                    debug!("Could not find gateway with public key {:?}", pub_key);
+                    debug!(
+                        "Could not find gateway with gateway public key {:?}",
+                        gateway_pub_key
+                    );
                     ClientError::GatewayNotFound
                 })?,
             // Otherwise (no pubkey provided), select and activate the first registered gateway.

--- a/fedimint-client-legacy/src/utils.rs
+++ b/fedimint-client-legacy/src/utils.rs
@@ -57,8 +57,8 @@ pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_core::Amount, ParseAmou
     }
 }
 
-pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Error> {
-    secp256k1::PublicKey::from_str(s)
+pub fn parse_gateway_pub_key(s: &str) -> Result<secp256k1::XOnlyPublicKey, secp256k1::Error> {
+    secp256k1::XOnlyPublicKey::from_str(s)
 }
 
 pub fn parse_peer_id(s: &str) -> Result<PeerId, ParseIntError> {

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -239,13 +239,13 @@ pub async fn switch_default_gateway(
     client: &Client,
     gateway_public_key: &str,
 ) -> anyhow::Result<()> {
-    let gateway_public_key = parse_node_pub_key(gateway_public_key)?;
+    let gateway_public_key = parse_gateway_pub_key(gateway_public_key)?;
     client.set_active_gateway(&gateway_public_key).await?;
     Ok(())
 }
 
-pub fn parse_node_pub_key(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Error> {
-    secp256k1::PublicKey::from_str(s)
+pub fn parse_gateway_pub_key(s: &str) -> Result<secp256k1::XOnlyPublicKey, secp256k1::Error> {
+    secp256k1::XOnlyPublicKey::from_str(s)
 }
 
 pub async fn get_note_summary(client: &Client) -> anyhow::Result<TieredSummary> {

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::vec;
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{bail, Context};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use common::{
     cln_create_invoice, cln_wait_invoice_payment, gateway_pay_invoice, get_note_summary,
@@ -774,11 +774,11 @@ async fn get_gateway_public_key(
             cmd!(GatewayClnCli, "info").out_json().await
         }
     }?;
-    let node_pub_key = gateway_json["federations"][0]["registration"]["node_pub_key"]
+    let gateway_pub_key = gateway_json["federations"][0]["registration"]["gateway_pub_key"]
         .as_str()
-        .ok_or_else(|| anyhow!("Missing node_pub_key field"))?;
+        .context("Missing gateway_pub_key field")?;
 
-    Ok(node_pub_key.into())
+    Ok(gateway_pub_key.into())
 }
 
 async fn get_cfg_from_args(args: &ConnectCommonArgs) -> anyhow::Result<ClientConfig> {

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -79,7 +79,7 @@ mod tests {
             .find(|x| x.api.to_string() == "http://127.0.0.1:28175/")
             .expect("no gateway with api http://127.0.0.1:28175");
 
-        client.set_active_gateway(&lnd_gw.node_pub_key).await?;
+        client.set_active_gateway(&lnd_gw.gateway_pub_key).await?;
         let (opid, invoice) = client
             .create_bolt11_invoice(Amount::from_sats(21), "test".to_string(), None)
             .await?;
@@ -109,7 +109,7 @@ mod tests {
             .find(|x| x.api.to_string() == "http://127.0.0.1:28175/")
             .expect("no gateway with api http://127.0.0.1:28175");
 
-        client.set_active_gateway(&lnd_gw.node_pub_key).await?;
+        client.set_active_gateway(&lnd_gw.gateway_pub_key).await?;
         let (opid, invoice) = client
             .create_bolt11_invoice(Amount::from_sats(21), "test".to_string(), None)
             .await?;

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -48,6 +48,7 @@ use lightning::routing::router::{RouteHint, RouteHintHop};
 use lightning_invoice::{Currency, Invoice, InvoiceBuilder, DEFAULT_EXPIRY_TIME};
 use rand::seq::IteratorRandom;
 use rand::{CryptoRng, Rng, RngCore};
+use secp256k1::XOnlyPublicKey;
 use secp256k1_zkp::{All, Secp256k1};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -72,7 +73,7 @@ pub trait LightningClientExt {
     async fn select_active_gateway(&self) -> anyhow::Result<LightningGateway>;
 
     /// Sets the gateway to be used by all other operations
-    async fn set_active_gateway(&self, node_pub_key: &secp256k1::PublicKey) -> anyhow::Result<()>;
+    async fn set_active_gateway(&self, gateway_pub_key: &XOnlyPublicKey) -> anyhow::Result<()>;
 
     /// Gateways actively registered with the fed
     async fn fetch_registered_gateways(&self) -> anyhow::Result<Vec<LightningGateway>>;
@@ -203,7 +204,7 @@ impl LightningClientExt for Client {
     }
 
     /// Switches the clients active gateway to a registered gateway.
-    async fn set_active_gateway(&self, node_pub_key: &secp256k1::PublicKey) -> anyhow::Result<()> {
+    async fn set_active_gateway(&self, gateway_pub_key: &XOnlyPublicKey) -> anyhow::Result<()> {
         let (_lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
         let mut dbtx = instance.db.begin_transaction().await;
 
@@ -214,9 +215,12 @@ impl LightningClientExt for Client {
         };
         let gateway = gateways
             .into_iter()
-            .find(|g| &g.node_pub_key == node_pub_key)
+            .find(|g| &g.gateway_pub_key == gateway_pub_key)
             .ok_or_else(|| {
-                anyhow::anyhow!("Could not find gateway with public key {:?}", node_pub_key)
+                anyhow::anyhow!(
+                    "Could not find gateway with gateway public key {:?}",
+                    gateway_pub_key
+                )
             })?;
 
         dbtx.insert_entry(&LightningGatewayKey, &gateway).await;

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -37,15 +37,23 @@ async fn can_switch_active_gateway() -> anyhow::Result<()> {
     let mut gateway2 = fixtures.new_gateway(fixtures.cln().await).await;
 
     // Client selects a gateway by default
-    let key1 = gateway1.connect_fed(&fed).await.registration.node_pub_key;
-    assert_eq!(client.select_active_gateway().await?.node_pub_key, key1);
+    let key1 = gateway1
+        .connect_fed(&fed)
+        .await
+        .registration
+        .gateway_pub_key;
+    assert_eq!(client.select_active_gateway().await?.gateway_pub_key, key1);
 
-    let key2 = gateway2.connect_fed(&fed).await.registration.node_pub_key;
+    let key2 = gateway2
+        .connect_fed(&fed)
+        .await
+        .registration
+        .gateway_pub_key;
     let gateways = client.fetch_registered_gateways().await.unwrap();
     assert_eq!(gateways.len(), 2);
 
     client.set_active_gateway(&key2).await?;
-    assert_eq!(client.select_active_gateway().await?.node_pub_key, key2);
+    assert_eq!(client.select_active_gateway().await?.gateway_pub_key, key2);
     Ok(())
 }
 

--- a/scripts/user-shell.sh
+++ b/scripts/user-shell.sh
@@ -15,13 +15,13 @@ function show_verbose_output()
 }
 
 function use_cln_gw() {
-    PUBKEY=$($FM_LIGHTNING_CLI getinfo | jq -e -r '.id')
+    PUBKEY=$($FM_GWCLI_CLN info | jq -e -r '.federations[0].registration.gateway_pub_key')
     $FM_MINT_CLIENT switch-gateway $PUBKEY
     echo "Using CLN gateway"
 }
 
 function use_lnd_gw() {
-    PUBKEY=$($FM_LNCLI getinfo | jq -e -r '.identity_pubkey')
+    PUBKEY=$($FM_GWCLI_LND info | jq -e -r '.federations[0].registration.gateway_pub_key')
     $FM_MINT_CLIENT switch-gateway $PUBKEY
     echo "Using LND gateway"
 }


### PR DESCRIPTION
`switch_gateway` currently uses `node_pub_key` as the key for determining which gateway the user desires. This is broken because it is possible multiple gateways could use the same lightning node.

We have `gateway_pub_key` which the gateway uses the redeem contracts from the federations its connected to. This PR changes `switch_gateway` to use that key for switching gateways.