### PR TITLE
feat(gateway-cli): Show balance per federation in info

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -569,6 +569,8 @@ impl Gateway {
             self.api.clone(),
         );
 
+        let balance = client.get_balance().await;
+
         self.register_client(client, federation_id, channel_id, route_hints)
             .await?;
 
@@ -580,6 +582,7 @@ impl Gateway {
         Ok(FederationInfo {
             federation_id,
             registration,
+            balance,
         })
     }
 
@@ -597,10 +600,12 @@ impl Gateway {
                 GW_ANNOUNCEMENT_TTL,
                 self.api.clone(),
             );
+            let balance = client.get_balance().await;
 
             federations.push(FederationInfo {
                 federation_id,
                 registration,
+                balance,
             });
         }
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -569,7 +569,7 @@ impl Gateway {
             self.api.clone(),
         );
 
-        let balance = client.get_balance().await;
+        let balance_msat = client.get_balance().await;
 
         self.register_client(client, federation_id, channel_id, route_hints)
             .await?;
@@ -582,7 +582,7 @@ impl Gateway {
         Ok(FederationInfo {
             federation_id,
             registration,
-            balance,
+            balance_msat,
         })
     }
 
@@ -600,12 +600,12 @@ impl Gateway {
                 GW_ANNOUNCEMENT_TTL,
                 self.api.clone(),
             );
-            let balance = client.get_balance().await;
+            let balance_msat = client.get_balance().await;
 
             federations.push(FederationInfo {
                 federation_id,
                 registration,
-                balance,
+                balance_msat,
             });
         }
 

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -62,7 +62,7 @@ pub struct FederationInfo {
     pub federation_id: FederationId,
     /// Information we registered with the fed
     pub registration: LightningGateway,
-    pub balance: Amount,
+    pub balance_msat: Amount,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -62,6 +62,7 @@ pub struct FederationInfo {
     pub federation_id: FederationId,
     /// Information we registered with the fed
     pub registration: LightningGateway,
+    pub balance: Amount,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -75,7 +75,7 @@ pub async fn run_webserver(
     Ok(shutdown_receiver)
 }
 
-/// Display gateway ecash note balance
+/// Display high-level information about the Gateway
 #[debug_handler]
 #[instrument(skip_all, err)]
 async fn info(

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -52,11 +52,11 @@ async fn gatewayd_shows_info_about_all_connected_federations() {
     assert!(info
         .federations
         .iter()
-        .any(|info| info.federation_id == id1 && info.balance == Amount::ZERO));
+        .any(|info| info.federation_id == id1 && info.balance_msat == Amount::ZERO));
     assert!(info
         .federations
         .iter()
-        .any(|info| info.federation_id == id2 && info.balance == Amount::ZERO));
+        .any(|info| info.federation_id == id2 && info.balance_msat == Amount::ZERO));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -4,6 +4,7 @@
 //! and business logic.
 mod fixtures;
 
+use fedimint_core::Amount;
 use fedimint_testing::federation::FederationTest;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::ConnectFedPayload;
@@ -51,11 +52,11 @@ async fn gatewayd_shows_info_about_all_connected_federations() {
     assert!(info
         .federations
         .iter()
-        .any(|info| info.federation_id == id1));
+        .any(|info| info.federation_id == id1 && info.balance == Amount::ZERO));
     assert!(info
         .federations
         .iter()
-        .any(|info| info.federation_id == id2));
+        .any(|info| info.federation_id == id2 && info.balance == Amount::ZERO));
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/2508

TODO
- [ ] Adding an integration test for `gatewayd_shows_balance_for_any_connected_federation` that can test more meaningful balances.
- [ ] Removing the `balance` command from `gateway-cli`. But will do this separately in a different PR if we prefer.

