### PR TITLE
 feat(ci): verify versions hashes were set 

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -280,9 +280,12 @@ jobs:
     strategy:
       matrix:
         build:
-          - client-pkgs
-          - fedimint-pkgs
-          - gateway-pkgs
+          - pkg: client-pkgs
+            bin: fedimint-cli
+          - pkg: fedimint-pkgs
+            bin: fedimintd
+          - pkg: gateway-pkgs
+            bin: gateway-cli
 
     runs-on: buildjet-4vcpu-ubuntu-2004
     timeout-minutes: 30
@@ -297,8 +300,11 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 
-      - name: Build ${{ matrix.build }}
-        run: nix build -L .#${{ matrix.build }}
+      - name: Build ${{ matrix.build.pkg }}
+        run: nix build -L .#${{ matrix.build.pkg }}
+
+      - name: Check version ${{ matrix.build.bin }}
+        run: nix run .#${{ matrix.build.bin }} version-hash && echo "$GITHUB_SHA" && test "$(nix run .#${{ matrix.build.bin }} version-hash)" = "${GITHUB_SHA}"
 
   notifications:
     # if: github.ref == 'refs/heads/master'

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::VersionHash => {
-            println!("version: {}", env!("CODE_VERSION"));
+            println!("{}", env!("CODE_VERSION"));
         }
         Commands::Info => {
             let response = client().get_info().await?;

--- a/nix/craneBuild.nix
+++ b/nix/craneBuild.nix
@@ -17,7 +17,7 @@ craneLib.overrideScope' (self: prev: {
     doCheck = false;
   });
 
-  workspaceTest = self.cargoTest (prev // {
+  workspaceTest = self.cargoTest (prev.commonArgs // {
     version = "0.0.1";
     cargoArtifacts = self.workspaceDeps;
   });


### PR DESCRIPTION
It will only verify it for binaries built with Nix (like in CI, but unlike `cargo build ...` locally).

It will run only on `master` branch (along the place where when we build & publish release versions of our binaries). I tested it via an extra commit.