### PR TITLE
fix: change state machines execution from quadratic to linear time

### DIFF
--- a/fedimint-client/src/sm/state.rs
+++ b/fedimint-client/src/sm/state.rs
@@ -89,8 +89,9 @@ where
 }
 
 type TriggerFuture = Pin<Box<maybe_add_send!(dyn Future<Output = serde_json::Value> + 'static)>>;
+
 // TODO: remove Arc, maybe make it a fn pointer?
-type StateTransitionFunction<S> = Arc<
+pub(super) type StateTransitionFunction<S> = Arc<
     maybe_add_send_sync!(
         dyn for<'a> Fn(
             &'a mut ClientSMDatabaseTransaction<'_, '_>,


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/2696

This reduces the execution time of a transaction with 250 outputs from 1 hour to just 30 seconds.

The idea is to not throw away the trigger/transitions futures we have created after some state transition happens. We just add the next transitions to the list and keep polling them until completion.