### PR TITLE
refactor: move common version discovery to module gen (from module)

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -620,10 +620,7 @@ impl FedimintCli {
                     .map_err_cli_msg(CliErrorKind::InvalidValue, "Invalid JSON-RPC parameters")?;
                 let params = ApiRequestErased::new(params);
                 let ws_api: Arc<_> = WsFederationApi::from_config(
-                    cli.build_client_ng(&self.module_gens)
-                        .await?
-                        .get_config()
-                        .await,
+                    cli.build_client_ng(&self.module_gens).await?.get_config(),
                 )
                 .into();
                 let response: Value = match peer_id {

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -686,7 +686,7 @@ impl Client {
     }
 
     /// Returns the config with which the client was initialized.
-    pub async fn get_config(&self) -> &ClientConfig {
+    pub fn get_config(&self) -> &ClientConfig {
         &self.inner.config
     }
 
@@ -729,7 +729,7 @@ impl Client {
             .api()
             .discover_api_version_set(
                 &Self::supported_api_versions_summary_static(
-                    self.get_config().await,
+                    self.get_config(),
                     &self.inner.module_gens,
                 )
                 .await,

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -7,7 +7,7 @@ use fedimint_core::api::DynGlobalApi;
 use fedimint_core::core::{Decoder, DynInput, DynOutput, IntoDynInstance, ModuleInstanceId};
 use fedimint_core::db::{DatabaseTransaction, ModuleDatabaseTransaction};
 use fedimint_core::module::registry::ModuleRegistry;
-use fedimint_core::module::{ModuleCommon, MultiApiVersion, TransactionItemAmount};
+use fedimint_core::module::{ModuleCommon, TransactionItemAmount};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::util::BoxStream;
 use fedimint_core::{
@@ -46,10 +46,6 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
     }
 
     fn context(&self) -> Self::ModuleStateMachineContext;
-
-    /// Api versions of the corresponding serverr side module's API
-    /// that this client module implementation can use.
-    fn supported_api_versions(&self) -> MultiApiVersion;
 
     async fn handle_cli_command(
         &self,
@@ -198,8 +194,6 @@ pub trait IClientModule: Debug {
 
     fn context(&self, instance: ModuleInstanceId) -> DynContext;
 
-    fn supported_api_versions(&self) -> MultiApiVersion;
-
     async fn handle_cli_command(
         &self,
         client: &Client,
@@ -285,11 +279,6 @@ where
 
     fn context(&self, instance: ModuleInstanceId) -> DynContext {
         DynContext::from_typed(instance, <T as ClientModule>::context(self))
-    }
-
-    /// See [`ClientModule::supported_api_versions`]
-    fn supported_api_versions(&self) -> MultiApiVersion {
-        <T as ClientModule>::supported_api_versions(self)
     }
 
     async fn handle_cli_command(

--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -15,7 +15,7 @@ use crate::db::ModuleDatabaseTransaction;
 use crate::maybe_add_send_sync;
 use crate::module::{
     ApiEndpoint, ApiEndpointContext, ApiRequestErased, ConsensusProposal, InputMeta, ModuleCommon,
-    ModuleError, ServerModule, SupportedModuleApiVersions, TransactionItemAmount,
+    ModuleError, ServerModule, TransactionItemAmount,
 };
 use crate::task::{MaybeSend, MaybeSync};
 
@@ -53,8 +53,6 @@ pub trait IServerModule: Debug {
 
     /// Returns the decoder belonging to the server module
     fn decoder(&self) -> Decoder;
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions;
 
     /// Blocks until a new `consensus_proposal` is available.
     async fn await_consensus_proposal(&self, dbtx: &mut ModuleDatabaseTransaction<'_>);
@@ -197,10 +195,6 @@ where
 
     fn as_any(&self) -> &dyn Any {
         self
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        <Self as ServerModule>::supported_api_versions(self)
     }
 
     /// Blocks until a new `consensus_proposal` is available.

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -443,6 +443,8 @@ where
 pub trait IServerModuleGen: IDynCommonModuleGen {
     fn as_common(&self) -> &(dyn IDynCommonModuleGen + Send + Sync + 'static);
 
+    fn supported_api_versions(&self) -> SupportedModuleApiVersions;
+
     fn database_version(&self) -> DatabaseVersion;
 
     /// Initialize the [`DynServerModule`] instance from its config
@@ -860,6 +862,8 @@ pub trait ServerModuleGen: ExtendsCommonModuleGen + Sized {
     /// checking purposes.
     fn versions(&self, core: CoreConsensusVersion) -> &[ModuleConsensusVersion];
 
+    fn supported_api_versions(&self) -> SupportedModuleApiVersions;
+
     fn kind() -> ModuleKind {
         <Self as ExtendsCommonModuleGen>::Common::KIND
     }
@@ -917,6 +921,10 @@ where
 {
     fn as_common(&self) -> &(dyn IDynCommonModuleGen + Send + Sync + 'static) {
         self
+    }
+
+    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
+        <Self as ServerModuleGen>::supported_api_versions(self)
     }
 
     fn database_version(&self) -> DatabaseVersion {
@@ -1080,10 +1088,6 @@ pub trait ServerModule: Debug + Sized {
     fn decoder() -> Decoder {
         Self::Common::decoder_builder().build()
     }
-
-    /// Module consensus version this module is running with and the API
-    /// versions it supports in it
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions;
 
     /// Blocks until a new `consensus_proposal` is available.
     async fn await_consensus_proposal<'a>(&'a self, dbtx: &mut ModuleDatabaseTransaction<'_>);

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -211,13 +211,16 @@ impl ConsensusServer {
         let modules = ModuleRegistry::from(modules);
 
         let latest_contribution_by_peer: Arc<RwLock<LatestContributionByPeer>> = Default::default();
+        let supported_api_versions =
+            ServerConfig::supported_api_versions_summary(&cfg.consensus.modules, &module_inits);
+
         let consensus_api = ConsensusApi {
             cfg: cfg.clone(),
             db: db.clone(),
             modules: modules.clone(),
             client_cfg,
             api_sender,
-            supported_api_versions: ServerConfig::supported_api_versions_summary(&modules),
+            supported_api_versions,
             latest_contribution_by_peer: Arc::clone(&latest_contribution_by_peer),
             peer_status_channels,
             // keep the status for a short time to protect the system against a denial-of-service

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -386,6 +386,11 @@ impl ClientModuleGen for GatewayClientGen {
     type Module = GatewayClientModule;
     type Config = LightningClientConfig;
 
+    fn supported_api_versions(&self) -> MultiApiVersion {
+        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
+            .expect("no version conficts")
+    }
+
     async fn init(
         &self,
         cfg: Self::Config,
@@ -470,11 +475,6 @@ impl ClientModule for GatewayClientModule {
             secp: secp256k1_zkp::Secp256k1::new(),
             ln_decoder: self.decoder(),
         }
-    }
-
-    fn supported_api_versions(&self) -> MultiApiVersion {
-        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
-            .expect("no version conficts")
     }
 
     fn input_amount(

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -256,7 +256,7 @@ impl GatewayClientExt for Client {
                                     operation_id,
                                     time_to_live,
                                     registration_info: registration,
-                                    federation_id: self.get_config().await.federation_id,
+                                    federation_id: self.get_config().federation_id,
                                 },
                                 state: RegisterWithFederationStates::Register(
                                     RegisterWithFederation {

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -395,6 +395,7 @@ impl ClientModuleGen for GatewayClientGen {
         &self,
         cfg: Self::Config,
         _db: Database,
+        _api_version: ApiVersion,
         module_root_secret: DerivableSecret,
         notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
         _api: DynGlobalApi,

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -341,6 +341,7 @@ impl ClientModuleGen for DummyClientGen {
         &self,
         cfg: Self::Config,
         _db: Database,
+        _api_version: ApiVersion,
         module_root_secret: DerivableSecret,
         notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
         _api: DynGlobalApi,

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -202,11 +202,6 @@ impl ClientModule for DummyClientModule {
         }
     }
 
-    fn supported_api_versions(&self) -> MultiApiVersion {
-        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
-            .expect("no version conficts")
-    }
-
     fn input_amount(&self, input: &<Self::Common as ModuleCommon>::Input) -> TransactionItemAmount {
         TransactionItemAmount {
             amount: input.amount,
@@ -336,6 +331,11 @@ impl ExtendsCommonModuleGen for DummyClientGen {
 impl ClientModuleGen for DummyClientGen {
     type Module = DummyClientModule;
     type Config = DummyClientConfig;
+
+    fn supported_api_versions(&self) -> MultiApiVersion {
+        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
+            .expect("no version conficts")
+    }
 
     async fn init(
         &self,

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -62,6 +62,10 @@ impl ServerModuleGen for DummyGen {
         &[CONSENSUS_VERSION]
     }
 
+    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
+        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+    }
+
     /// Initialize the module
     async fn init(
         &self,
@@ -242,10 +246,6 @@ impl ServerModule for Dummy {
     type Common = DummyModuleTypes;
     type Gen = DummyGen;
     type VerificationCache = DummyVerificationCache;
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
-    }
 
     async fn await_consensus_proposal(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) {
         // Wait until we have a proposal

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -42,7 +42,7 @@ async fn client_ignores_unknown_module() {
     let fed = fixtures().new_fed().await;
     let client = fed.new_client().await;
 
-    let mut cfg = client.get_config().await.clone();
+    let mut cfg = client.get_config().clone();
     let extra_mod = ClientModuleConfig {
         kind: ModuleKind::from_static_str("unknown_module"),
         version: ModuleConsensusVersion(0),

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -535,6 +535,7 @@ impl ClientModuleGen for LightningClientGen {
         &self,
         cfg: Self::Config,
         _db: Database,
+        _api_version: ApiVersion,
         module_root_secret: DerivableSecret,
         notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
         _api: DynGlobalApi,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -261,7 +261,7 @@ impl LightningClientExt for Client {
                     instance.api,
                     invoice.clone(),
                     active_gateway,
-                    self.get_config().await.federation_id,
+                    self.get_config().federation_id,
                     rand::rngs::OsRng,
                 )
                 .await?;

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -526,6 +526,11 @@ impl ClientModuleGen for LightningClientGen {
     type Module = LightningClientModule;
     type Config = LightningClientConfig;
 
+    fn supported_api_versions(&self) -> MultiApiVersion {
+        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
+            .expect("no version conficts")
+    }
+
     async fn init(
         &self,
         cfg: Self::Config,
@@ -565,11 +570,6 @@ impl ClientModule for LightningClientModule {
             ln_decoder: self.decoder(),
             redeem_key: self.redeem_key,
         }
-    }
-
-    fn supported_api_versions(&self) -> MultiApiVersion {
-        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
-            .expect("no version conficts")
     }
 
     fn input_amount(&self, input: &<Self::Common as ModuleCommon>::Input) -> TransactionItemAmount {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -66,6 +66,10 @@ impl ServerModuleGen for LightningGen {
         &[ModuleConsensusVersion(0)]
     }
 
+    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
+        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+    }
+
     async fn init(
         &self,
         cfg: ServerModuleConfig,
@@ -289,10 +293,6 @@ impl ServerModule for Lightning {
     type Common = LightningModuleTypes;
     type Gen = LightningGen;
     type VerificationCache = LightningVerificationCache;
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
-    }
 
     async fn await_consensus_proposal(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) {
         while !self.consensus_proposal(dbtx).await.forces_new_epoch() {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -430,6 +430,7 @@ impl ClientModuleGen for MintClientGen {
         &self,
         cfg: Self::Config,
         _db: Database,
+        _api_version: ApiVersion,
         module_root_secret: DerivableSecret,
         notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
         _api: DynGlobalApi,

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -421,6 +421,11 @@ impl ClientModuleGen for MintClientGen {
     type Module = MintClientModule;
     type Config = MintClientConfig;
 
+    fn supported_api_versions(&self) -> MultiApiVersion {
+        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
+            .expect("no version conficts")
+    }
+
     async fn init(
         &self,
         cfg: Self::Config,
@@ -480,11 +485,6 @@ impl ClientModule for MintClientModule {
             secret: self.secret.clone(),
             cancel_oob_payment_bc: self.cancel_oob_payment_bc.clone(),
         }
-    }
-
-    fn supported_api_versions(&self) -> MultiApiVersion {
-        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
-            .expect("no version conficts")
     }
 
     fn input_amount(&self, input: &<Self::Common as ModuleCommon>::Input) -> TransactionItemAmount {

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -67,6 +67,10 @@ impl ServerModuleGen for MintGen {
         &[ModuleConsensusVersion(0)]
     }
 
+    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
+        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+    }
+
     async fn init(
         &self,
         cfg: ServerModuleConfig,
@@ -333,10 +337,6 @@ impl ServerModule for Mint {
         if !self.consensus_proposal(dbtx).await.forces_new_epoch() {
             std::future::pending().await
         }
-    }
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
     }
 
     async fn consensus_proposal(

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -387,6 +387,11 @@ impl ClientModuleGen for WalletClientGen {
     type Module = WalletClientModule;
     type Config = WalletClientConfig;
 
+    fn supported_api_versions(&self) -> MultiApiVersion {
+        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
+            .expect("no version conficts")
+    }
+
     async fn init(
         &self,
         cfg: Self::Config,
@@ -463,11 +468,6 @@ impl ClientModule for WalletClientModule {
             wallet_decoder: self.decoder(),
             secp: Default::default(),
         }
-    }
-
-    fn supported_api_versions(&self) -> MultiApiVersion {
-        MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 0 }])
-            .expect("no version conficts")
     }
 
     fn input_amount(&self, input: &<Self::Common as ModuleCommon>::Input) -> TransactionItemAmount {

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -396,6 +396,7 @@ impl ClientModuleGen for WalletClientGen {
         &self,
         cfg: Self::Config,
         _db: Database,
+        _api_version: ApiVersion,
         _module_root_secret: DerivableSecret,
         notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
         _api: DynGlobalApi,

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -84,6 +84,10 @@ impl ServerModuleGen for WalletGen {
         &[ModuleConsensusVersion(0)]
     }
 
+    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
+        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+    }
+
     async fn init(
         &self,
         cfg: ServerModuleConfig,
@@ -275,10 +279,6 @@ impl ServerModule for Wallet {
     type Common = WalletModuleTypes;
     type Gen = WalletGen;
     type VerificationCache = WalletVerificationCache;
-
-    fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
-    }
 
     async fn await_consensus_proposal(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) {
         while !self.consensus_proposal(dbtx).await.forces_new_epoch() {


### PR DESCRIPTION
This will allow passing the api version to use to the `init` function, so the client module implementation can use it to communicate using right APIs.