### PR TITLE
chore: minor debugability tweaks

### DIFF
--- a/nix/craneBuild.nix
+++ b/nix/craneBuild.nix
@@ -110,7 +110,7 @@ craneLib.overrideScope' (self: prev: {
     pnameSuffix = "-lcov";
     version = "0.0.1";
     cargoArtifacts = self.workspaceDepsCov;
-    buildPhaseCargoCommand = "mkdir -p $out ; env RUST_LOG=info,timing=debug cargo llvm-cov --locked --workspace --profile $CARGO_PROFILE --lcov --all-targets --tests --output-path $out/lcov.info --  --test-threads=$(($(nproc) * 2))";
+    buildPhaseCargoCommand = "mkdir -p $out ; env RUST_BACKTRACE=1 RUST_LOG=info,timing=debug cargo llvm-cov --locked --workspace --profile $CARGO_PROFILE --lcov --all-targets --tests --output-path $out/lcov.info --  --test-threads=$(($(nproc) * 2))";
     installPhaseCommand = "true";
     nativeBuildInputs = self.commonArgs.nativeBuildInputs ++ [ self.cargo-llvm-cov ];
     doCheck = false;


### PR DESCRIPTION
Investigating intermittent CI failures:

```
fedimint-lcov> thread 'test_gateway_cannot_claim_invalid_preimage' panicked at 'Could not start API server: Bind address: 127.0.0.1:38222
fedimint-lcov> Caused by:
fedimint-lcov>     0: Networking or low-level protocol error: Address already in use (os error 98)
fedimint-lcov>     1: Address already in use (os error 98)', /build/source/fedimint-server/src/lib.rs:197:14
fedimint-lcov> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fedimint-lcov> failures:
fedimint-lcov>     test_gateway_cannot_claim_invalid_preimage
```

I wish these changes were already there.