### PR TITLE
fix: remove 8176 port used by old admin UI

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -5,6 +5,5 @@ Default ports:
 * fedimintd p2p: 8173
 * fedimint API: 8174
 * ln-gateway API: 8175
-* fedimint Admin: 8176
 
 To be expanded.

--- a/flake.nix
+++ b/flake.nix
@@ -278,7 +278,6 @@
                       ExposedPorts = {
                         "${builtins.toString 8173}/tcp" = { };
                         "${builtins.toString 8174}/tcp" = { };
-                        "${builtins.toString 8176}/tcp" = { };
                       };
                     };
                   };


### PR DESCRIPTION
We forgot to remove these when the old admin UI was removed.