### PR TITLE
fix: remove leftover FM_POLL_INTERVAL variable in build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,6 @@ fi
 export FM_TEST_DIR
 export FM_PID_FILE="$FM_TEST_DIR/.pid"
 export FM_LOGS_DIR="$FM_TEST_DIR/logs"
-export FM_POLL_INTERVAL=1
 
 echo "Setting up env variables in $FM_TEST_DIR"
 


### PR DESCRIPTION
I think this was added while refactoring shell scripts to prepare way for devimint. That's all ancient history now!