### PR TITLE
fix: remove FM_PID_FILE

### DIFF
--- a/integrationtests/README.md
+++ b/integrationtests/README.md
@@ -69,5 +69,5 @@ cargo test -p fedimint-tests -- --test-threads=1
 
 If you wish to clean-up the services run:
 ```shell
-kill_fedimint_processes
+pkill devimint
 ```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,13 +17,11 @@ else
   FM_TEST_DIR="${2-"$(mktemp --tmpdir -d XXXXX)"}"
 fi
 export FM_TEST_DIR
-export FM_PID_FILE="$FM_TEST_DIR/.pid"
 export FM_LOGS_DIR="$FM_TEST_DIR/logs"
 
 echo "Setting up env variables in $FM_TEST_DIR"
 
 mkdir -p "$FM_TEST_DIR"
-touch "$FM_PID_FILE"
 
 # Symlink $FM_TEST_DIR to local gitignored target/ directory so they're easier to find
 rm -f target/devimint
@@ -40,16 +38,9 @@ if [ -z "${SKIP_CARGO_BUILD:-}" ]; then
 fi
 export PATH="$PWD/target/${CARGO_PROFILE:-debug}:$PATH"
 
-
-# Function for killing processes stored in FM_PID_FILE in reverse-order they were created in
-function kill_fedimint_processes {
-  echo "Killing fedimint processes"
-  PIDS=$(cat $FM_PID_FILE | sed '1!G;h;$!d') # sed reverses order
-  if [ -n "$PIDS" ]
-  then
-    kill $PIDS 2>/dev/null
-  fi
-  rm -f $FM_PID_FILE
+function kill_devimint {
+  echo "Killing devimint and child processes"
+  pkill devimint
 }
 
-trap kill_fedimint_processes EXIT
+trap kill_devimint EXIT

--- a/scripts/mprocs.sh
+++ b/scripts/mprocs.sh
@@ -14,7 +14,6 @@ source scripts/build.sh
 
 mkdir -p $FM_LOGS_DIR
 devimint dev-fed 2>$FM_LOGS_DIR/devimint-outer.log &
-echo $! >> $FM_PID_FILE
 eval "$(devimint env)"
 
 mprocs -c misc/mprocs.yaml

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -12,10 +12,8 @@ source scripts/build.sh ""
 # if RUST_LOG is none, don't show output of test setup
 if [ "${RUST_LOG,,}" = "none" ]; then
   devimint external-daemons >/dev/null &
-  echo $! >> $FM_PID_FILE
 else
   devimint external-daemons &
-  echo $! >> $FM_PID_FILE
 fi
 
 STATUS=$(devimint wait)

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -19,7 +19,6 @@ source scripts/build.sh
 
 mkdir -p $FM_LOGS_DIR
 devimint dev-fed 2>$FM_LOGS_DIR/devimint-outer.log &
-echo $! >> $FM_PID_FILE
 eval "$(devimint env)"
 
 SHELL=$(which bash) tmuxinator local

--- a/scripts/wasm-tests.sh
+++ b/scripts/wasm-tests.sh
@@ -5,7 +5,6 @@ export RUST_LOG="${RUST_LOG:-info}"
 source ./scripts/build.sh
 
 devimint dev-fed &
-echo $! >> $FM_PID_FILE
 eval "$(devimint env)"
 devimint wait
 


### PR DESCRIPTION
devimint can cleanup the the child processes it spawns, so we don't need a text fill containing these process IDs. We can just kill devimint.

Closes https://github.com/fedimint/fedimint/issues/2236