### PR TITLE
Client NG Join Federation

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashSet};
+use std::fs;
 
 use anyhow::{bail, Context};
 use bitcoincore_rpc::bitcoin::Network;
@@ -138,6 +139,12 @@ impl Federation {
         ]);
         let client = UserClient::new(cfg, decoders, module_gens, db, Default::default()).await;
         Ok(client)
+    }
+
+    pub fn invite_code(&self) -> Result<String> {
+        let workdir: PathBuf = env::var("FM_DATA_DIR")?.parse()?;
+        let invite_code = fs::read_to_string(workdir.join("invite-code"))?;
+        Ok(invite_code)
     }
 
     /// Fork the built-in client of `Federation` and give it a name

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -203,11 +203,8 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
     fed.pegin_gateway(99_999, &gw_cln).await?;
 
-    let invite = fs::read_to_string(format!("{data_dir}/invite-code")).await?;
-    fs::remove_file(format!("{data_dir}/client.json")).await?;
-    cmd!(fed, "join-federation", invite.clone()).run().await?;
-
     let fed_id = fed.federation_id().await;
+    let invite = fed.invite_code()?;
     let invite_code = cmd!(fed, "dev", "decode-invite-code", invite.clone())
         .out_json()
         .await?;

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -667,6 +667,7 @@ async fn cli_load_test_tool_test(dev_fed: DevFed) -> Result<()> {
     let data_dir = env::var("FM_DATA_DIR")?;
     let load_test_temp = PathBuf::from(data_dir).join("load-test-temp");
     dev_fed.fed.pegin(10_000).await?;
+    let invite_code = dev_fed.fed.invite_code()?;
     let output = cmd!(
         "fedimint-load-test-tool",
         "--archive-dir",
@@ -677,7 +678,9 @@ async fn cli_load_test_tool_test(dev_fed: DevFed) -> Result<()> {
         "--notes-per-user",
         "1",
         "--generate-invoice-with",
-        "cln-lightning-cli"
+        "cln-lightning-cli",
+        "--invite-code",
+        invite_code.clone()
     )
     .out_string()
     .await?;

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -21,9 +21,9 @@ use fedimint_client::{ClientBuilder, ClientSecret};
 use fedimint_core::admin_client::WsAdminClient;
 use fedimint_core::api::{
     ClientConfigDownloadToken, FederationApiExt, FederationError, GlobalFederationApi,
-    IFederationApi, IGlobalFederationApi, InviteCode, WsFederationApi,
+    IFederationApi, InviteCode, WsFederationApi,
 };
-use fedimint_core::config::{load_from_file, ClientConfig, FederationId};
+use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::db::DatabaseValue;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::{SerdeEpochHistory, SignedEpochOutcome};
@@ -259,13 +259,12 @@ impl Opts {
             .ok_or_cli_msg(CliErrorKind::IOError, "`--data-dir=` argument not set.")
     }
 
-    fn admin_client(&self) -> CliResult<WsAdminClient> {
+    fn admin_client(&self, cfg: &ClientConfig) -> CliResult<WsAdminClient> {
         let our_id = &self
             .our_id
             .ok_or_cli_msg(CliErrorKind::MissingAuth, "Admin client needs our-id set")?;
 
-        let url = self
-            .load_config()?
+        let url = cfg
             .api_endpoints
             .get(our_id)
             .expect("Endpoint exists")
@@ -280,11 +279,6 @@ impl Opts {
             .clone()
             .ok_or_cli_msg(CliErrorKind::MissingAuth, "CLI needs password set")?;
         Ok(ApiAuth(password))
-    }
-
-    fn load_config(&self) -> CliResult<ClientConfig> {
-        let cfg_path = self.workdir()?.join("client.json");
-        load_from_file(&cfg_path).map_err_cli_msg(CliErrorKind::IOError, "could not load config")
     }
 
     fn load_rocks_db(&self) -> CliResult<fedimint_rocksdb::RocksDb> {
@@ -318,8 +312,11 @@ impl Opts {
     async fn build_client_ng(
         &self,
         module_gens: &ClientModuleGenRegistry,
+        invite_code: Option<InviteCode>,
     ) -> CliResult<fedimint_client::Client> {
-        let client_builder = self.build_client_ng_builder(module_gens).await?;
+        let client_builder = self
+            .build_client_ng_builder(module_gens, invite_code)
+            .await?;
         client_builder
             .build::<PlainRootSecretStrategy>()
             .await
@@ -329,14 +326,16 @@ impl Opts {
     async fn build_client_ng_builder(
         &self,
         module_gens: &ClientModuleGenRegistry,
+        invite_code: Option<InviteCode>,
     ) -> CliResult<fedimint_client::ClientBuilder> {
-        let cfg = self.load_config()?;
         let db = self.load_rocks_db()?;
 
         let mut client_builder = ClientBuilder::default();
         client_builder.with_module_gens(module_gens.clone());
         client_builder.with_primary_module(1);
-        client_builder.with_config(cfg);
+        if let Some(invite_code) = invite_code {
+            client_builder.with_invite_code(invite_code);
+        }
         client_builder.with_database(db);
 
         Ok(client_builder)
@@ -464,6 +463,7 @@ struct PayRequest {
 
 pub struct FedimintCli {
     module_gens: ClientModuleGenRegistry,
+    invite_code: Option<InviteCode>,
 }
 
 impl FedimintCli {
@@ -484,6 +484,7 @@ impl FedimintCli {
 
         Ok(Self {
             module_gens: ClientModuleGenRegistry::new(),
+            invite_code: None,
         })
     }
 
@@ -501,9 +502,8 @@ impl FedimintCli {
             .with_module(WalletClientGen::default())
     }
 
-    pub async fn run(self) {
+    pub async fn run(&mut self) {
         let cli = Opts::parse();
-
         match self.handle_command(cli).await {
             Ok(output) => {
                 // ignore if there's anyone reading the stuff we're writing out
@@ -516,27 +516,20 @@ impl FedimintCli {
         }
     }
 
-    async fn handle_command(&self, cli: Opts) -> CliOutputResult {
+    async fn handle_command(&mut self, cli: Opts) -> CliOutputResult {
         match cli.command.clone() {
             Command::JoinFederation { invite_code } => {
                 let invite: InviteCode = InviteCode::from_str(&invite_code)
                     .map_err_cli_msg(CliErrorKind::InvalidValue, "invalid invite code")?;
-                let api = Arc::new(WsFederationApi::from_invite_code(&[invite.clone()]))
-                    as Arc<dyn IGlobalFederationApi + Send + Sync + 'static>;
-                let cfg: ClientConfig = api.download_client_config(&invite).await.map_err_cli_msg(
-                    CliErrorKind::NetworkError,
-                    "couldn't download config from peer",
-                )?;
-                std::fs::create_dir_all(cli.workdir()?)
-                    .map_err_cli_msg(CliErrorKind::IOError, "failed to create config directory")?;
-                let cfg_path = cli.workdir()?.join("client.json");
-                let writer = std::fs::File::options()
-                    .create_new(true)
-                    .write(true)
-                    .open(cfg_path)
-                    .map_err_cli_msg(CliErrorKind::IOError, "couldn't create config.json")?;
-                serde_json::to_writer_pretty(writer, &cfg)
-                    .map_err_cli_msg(CliErrorKind::IOError, "couldn't write config")?;
+
+                // Build client and store config in DB
+                let _client = cli
+                    .build_client_ng(&self.module_gens, Some(invite.clone()))
+                    .await
+                    .map_err_cli_msg(CliErrorKind::GeneralFailure, "failed to build client")?;
+
+                self.invite_code = Some(invite);
+
                 Ok(CliOutput::JoinFederation {
                     joined: invite_code,
                 })
@@ -546,7 +539,7 @@ impl FedimintCli {
             }),
             Command::Client(ClientCmd::Restore { secret }) => {
                 let (client, metadata) = cli
-                    .build_client_ng_builder(&self.module_gens)
+                    .build_client_ng_builder(&self.module_gens, None)
                     .await
                     .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?
                     .build_restoring_from_backup(ClientSecret::<PlainRootSecretStrategy>::new(
@@ -565,11 +558,11 @@ impl FedimintCli {
                 Ok(CliOutput::Raw(serde_json::to_value(metadata).unwrap()))
             }
             Command::Client(command) => {
-                let config = cli.load_config()?;
                 let client = cli
-                    .build_client_ng(&self.module_gens)
+                    .build_client_ng(&self.module_gens, None)
                     .await
                     .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?;
+                let config = client.get_config().clone();
                 Ok(CliOutput::Raw(
                     client::handle_ng_command(command, config, client)
                         .await
@@ -577,16 +570,26 @@ impl FedimintCli {
                 ))
             }
             Command::Admin(AdminCmd::Status) => {
-                let status = cli.admin_client()?.status().await?;
+                let user = cli
+                    .build_client_ng(&self.module_gens, None)
+                    .await
+                    .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?;
+
+                let status = cli.admin_client(user.get_config())?.status().await?;
                 Ok(CliOutput::Raw(
                     serde_json::to_value(status)
                         .map_err_cli_msg(CliErrorKind::GeneralFailure, "invalid response")?,
                 ))
             }
             Command::Admin(AdminCmd::LastEpoch) => {
-                let cfg = cli.load_config()?;
+                let user = cli
+                    .build_client_ng(&self.module_gens, None)
+                    .await
+                    .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?;
+                let cfg = user.get_config().clone();
+
                 let decoders = cli.load_decoders(&cfg, &self.module_gens);
-                let client = cli.admin_client()?;
+                let client = cli.admin_client(&cfg)?;
                 let last_epoch = client
                     .fetch_last_epoch_history(cfg.epoch_pk, &decoders)
                     .await?;
@@ -595,21 +598,33 @@ impl FedimintCli {
                 Ok(CliOutput::LastEpoch { hex_outcome })
             }
             Command::Admin(AdminCmd::ForceEpoch { hex_outcome }) => {
-                let cfg = cli.load_config()?;
-                let decoders = cli.load_decoders(&cfg, &self.module_gens);
+                let user = cli
+                    .build_client_ng(&self.module_gens, None)
+                    .await
+                    .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?;
+                let cfg = user.get_config();
+
+                let decoders = cli.load_decoders(cfg, &self.module_gens);
                 let outcome: SignedEpochOutcome = Decodable::consensus_decode_hex(
                     &hex_outcome,
                     &decoders,
                 )
                 .map_err_cli_msg(CliErrorKind::SerializationError, "failed to decode outcome")?;
-                let client = cli.admin_client()?;
+                let client = cli.admin_client(cfg)?;
                 client
                     .force_process_epoch(SerdeEpochHistory::from(&outcome), cli.auth()?)
                     .await?;
                 Ok(CliOutput::ForceEpoch)
             }
             Command::Admin(AdminCmd::SignalUpgrade) => {
-                cli.admin_client()?.signal_upgrade(cli.auth()?).await?;
+                let user = cli
+                    .build_client_ng(&self.module_gens, None)
+                    .await
+                    .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?;
+
+                cli.admin_client(user.get_config())?
+                    .signal_upgrade(cli.auth()?)
+                    .await?;
                 Ok(CliOutput::SignalUpgrade)
             }
             Command::Dev(DevCmd::Api {
@@ -621,7 +636,9 @@ impl FedimintCli {
                     .map_err_cli_msg(CliErrorKind::InvalidValue, "Invalid JSON-RPC parameters")?;
                 let params = ApiRequestErased::new(params);
                 let ws_api: Arc<_> = WsFederationApi::from_config(
-                    cli.build_client_ng(&self.module_gens).await?.get_config(),
+                    cli.build_client_ng(&self.module_gens, None)
+                        .await?
+                        .get_config(),
                 )
                 .into();
                 let response: Value = match peer_id {
@@ -642,22 +659,15 @@ impl FedimintCli {
                 Ok(CliOutput::UntypedApiOutput { value: response })
             }
             Command::Dev(DevCmd::InviteCode) => {
-                let path = cli.workdir()?.join("invite-code");
-                let string = fs::read_to_string(path).map_err_cli_msg(
-                    CliErrorKind::GeneralFederationError,
-                    "cannot read invite code",
+                let invite_code = self.invite_code.clone().ok_or_cli_msg(
+                    CliErrorKind::GeneralFailure,
+                    "fedimint-cli not connected to a federation",
                 )?;
-
-                let invite_code = InviteCode::from_str(&string).map_err_cli_msg(
-                    CliErrorKind::GeneralFederationError,
-                    "cannot parse invite code",
-                )?;
-
                 Ok(CliOutput::InviteCode { invite_code })
             }
             Command::Dev(DevCmd::WaitBlockCount { count: target }) => {
                 task::timeout(Duration::from_secs(30), async move {
-                    let client = cli.build_client_ng(&self.module_gens).await?;
+                    let client = cli.build_client_ng(&self.module_gens, None).await?;
                     loop {
                         let (_, instance) = client
                             .get_first_module::<WalletClientModule>(&fedimint_wallet_client::KIND);
@@ -698,7 +708,7 @@ impl FedimintCli {
             }),
             Command::Dev(DevCmd::EpochCount) => {
                 let count = cli
-                    .build_client_ng(&self.module_gens)
+                    .build_client_ng(&self.module_gens, None)
                     .await?
                     .api()
                     .fetch_epoch_count()
@@ -752,7 +762,9 @@ impl FedimintCli {
 
                 let tx = fedimint_core::transaction::Transaction::from_bytes(
                     &bytes,
-                    cli.build_client_ng(&self.module_gens).await?.decoders(),
+                    cli.build_client_ng(&self.module_gens, None)
+                        .await?
+                        .decoders(),
                 )
                 .map_err_cli_msg(
                     CliErrorKind::SerializationError,

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -2,6 +2,7 @@ use std::io::{Error, Read, Write};
 use std::marker::PhantomData;
 
 use fedimint_core::api::ApiVersionSet;
+use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{impl_db_lookup, impl_db_record};
@@ -20,6 +21,7 @@ pub enum DbKeyPrefix {
     OperationLog = 0x2c,
     ChronologicalOperationLog = 0x2d,
     CommonApiVersionCache = 0x2e,
+    ClientConfig = 0x2f,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -105,3 +107,19 @@ impl_db_record!(
     value = CachedApiVersionSet,
     db_prefix = DbKeyPrefix::CommonApiVersionCache
 );
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ClientConfigKey {
+    pub id: FederationId,
+}
+
+#[derive(Debug, Encodable)]
+pub struct ClientConfigKeyPrefix;
+
+impl_db_record!(
+    key = ClientConfigKey,
+    value = ClientConfig,
+    db_prefix = DbKeyPrefix::ClientConfig
+);
+
+impl_db_lookup!(key = ClientConfigKey, query_prefix = ClientConfigKeyPrefix);

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1358,9 +1358,7 @@ impl ClientBuilder {
                     ModuleKind::from_static_str("tx_submission"),
                     tx_submission_sm_decoder(),
                 );
-
-                // TODO: Should we reinitialize / update DB, providing the right client decoders
-                // let db = Database::new_from_box(db, decoders.clone());
+                let db = db.new_with_decoders(decoders.clone());
 
                 (config, decoders, db)
             }

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1476,7 +1476,14 @@ async fn get_config(
         .next()
         .await
     {
-        Some((_, config)) => Ok(config),
+        Some((_, config)) => {
+            // TODO: Enable after <https://github.com/fedimint/fedimint/pull/2855>
+            // assert!(
+            //     config_source.is_none(),
+            //     "Alternative config source provided but config was found in DB"
+            // );
+            Ok(config)
+        }
         None => {
             let config = match config_source
                 .clone()

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -10,7 +10,7 @@ use fedimint_client::secret::PlainRootSecretStrategy;
 use fedimint_client::sm::OperationId;
 use fedimint_client::transaction::TransactionBuilder;
 use fedimint_client::{Client, ClientBuilder};
-use fedimint_core::config::ClientConfig;
+use fedimint_core::api::InviteCode;
 use fedimint_core::core::IntoDynInstance;
 use fedimint_core::encoding::Decodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -121,13 +121,18 @@ pub async fn await_spend_notes_finish(
     Ok(())
 }
 
-pub async fn build_client(cfg: &ClientConfig, rocksdb: Option<&PathBuf>) -> anyhow::Result<Client> {
+pub async fn build_client(
+    invite_code: Option<InviteCode>,
+    rocksdb: Option<&PathBuf>,
+) -> anyhow::Result<Client> {
     let mut client_builder = ClientBuilder::default();
     client_builder.with_module(MintClientGen);
     client_builder.with_module(LightningClientGen);
     client_builder.with_module(WalletClientGen::default());
     client_builder.with_primary_module(1);
-    client_builder.with_config(cfg.clone());
+    if let Some(invite_code) = invite_code {
+        client_builder.with_invite_code(invite_code);
+    }
     if let Some(rocksdb) = rocksdb {
         client_builder.with_database(fedimint_rocksdb::RocksDb::open(rocksdb)?)
     } else {

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -1,20 +1,18 @@
 use anyhow::Result;
 use fedimint_client::secret::PlainRootSecretStrategy;
-use fedimint_core::api::{GlobalFederationApi, InviteCode, WsFederationApi};
+use fedimint_core::api::InviteCode;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_ln_client::LightningClientGen;
 use fedimint_mint_client::MintClientGen;
 use fedimint_wallet_client::WalletClientGen;
 
 async fn client(invite_code: &InviteCode) -> Result<fedimint_client::Client> {
-    let client = WsFederationApi::from_invite_code(&[invite_code.clone()]);
-    let cfg = client.download_client_config(invite_code).await?;
     let mut builder = fedimint_client::ClientBuilder::default();
     builder.with_module(LightningClientGen);
     builder.with_module(MintClientGen);
     builder.with_module(WalletClientGen::default());
     builder.with_primary_module(1);
-    builder.with_config(cfg);
+    builder.with_invite_code(invite_code.clone());
     builder.with_database(MemDatabase::default());
     builder.build_stopped::<PlainRootSecretStrategy>().await
 }


### PR DESCRIPTION
Adds ability for client builder to download config from Federation when building clients. The builder saves any successfully downloaded configs in client database. It skips re-downloads when building a client with a previously-used db, and prefers loading the config from the db.

Next:
- [x] Migrate `fedimint-cli` to `with_invite_code`
- [ ] Migrate gateway client builder to `with_invite_code` : https://github.com/fedimint/fedimint/pull/2855
- [ ] #2769 after moving all tests fixtures from `with_config` to `with_invite_code`