### PR TITLE
chore: name fields in module dyn newtypes

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -344,7 +344,7 @@ where
     T: IGlobalClientContext,
 {
     fn from(inner: Arc<T>) -> Self {
-        DynGlobalClientContext(inner)
+        DynGlobalClientContext { inner }
     }
 }
 

--- a/fedimint-client/src/module/gen.rs
+++ b/fedimint-client/src/module/gen.rs
@@ -121,12 +121,12 @@ dyn_newtype_define!(
 
 impl AsRef<dyn IDynCommonModuleGen + Send + Sync + 'static> for DynClientModuleGen {
     fn as_ref(&self) -> &(dyn IDynCommonModuleGen + Send + Sync + 'static) {
-        self.0.as_common()
+        self.inner.as_common()
     }
 }
 
 impl AsRef<dyn IClientModuleGen + 'static> for DynClientModuleGen {
     fn as_ref(&self) -> &(dyn IClientModuleGen + 'static) {
-        self.0.as_ref()
+        self.inner.as_ref()
     }
 }

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -410,7 +410,7 @@ dyn_newtype_define!(
 
 impl AsRef<maybe_add_send_sync!(dyn IClientModule + 'static)> for DynClientModule {
     fn as_ref(&self) -> &maybe_add_send_sync!(dyn IClientModule + 'static) {
-        self.0.as_ref()
+        self.inner.as_ref()
     }
 }
 

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -342,7 +342,7 @@ dyn_newtype_define! {
 
 impl AsRef<dyn IGlobalFederationApi + 'static> for DynGlobalApi {
     fn as_ref(&self) -> &(dyn IGlobalFederationApi + 'static) {
-        self.0.as_ref()
+        self.inner.as_ref()
     }
 }
 

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -101,8 +101,8 @@ macro_rules! module_dyn_newtype_impl_encode_decode {
                 &self,
                 writer: &mut W,
             ) -> Result<usize, std::io::Error> {
-                self.1.consensus_encode(writer)?;
-                self.0.consensus_encode_dyn(writer)
+                self.module_instance_id.consensus_encode(writer)?;
+                self.inner.consensus_encode_dyn(writer)
             }
         }
 
@@ -164,8 +164,8 @@ macro_rules! module_plugin_trait_define{
             where
                 H: std::hash::Hasher
             {
-                self.1.hash(state);
-                self.0.dyn_hash().hash(state);
+                self.module_instance_id.hash(state);
+                self.inner.dyn_hash().hash(state);
             }
         }
     };
@@ -310,7 +310,7 @@ macro_rules! newtype_impl_eq_passthrough_with_instance_id {
     ($newtype:ty) => {
         impl PartialEq for $newtype {
             fn eq(&self, other: &Self) -> bool {
-                if self.1 != other.1 {
+                if self.module_instance_id != other.module_instance_id {
                     return false;
                 }
                 self.erased_eq_no_instance_id(other)
@@ -327,7 +327,7 @@ macro_rules! newtype_impl_display_passthrough {
     ($newtype:ty) => {
         impl std::fmt::Display for $newtype {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                std::fmt::Display::fmt(&self.0, f)
+                std::fmt::Display::fmt(&self.inner, f)
             }
         }
     };
@@ -337,7 +337,7 @@ macro_rules! newtype_impl_display_passthrough_with_instance_id {
     ($newtype:ty) => {
         impl std::fmt::Display for $newtype {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.write_fmt(format_args!("{}-{}", self.1, self.0))
+                f.write_fmt(format_args!("{}-{}", self.module_instance_id, self.inner))
             }
         }
     };

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -497,13 +497,13 @@ dyn_newtype_define!(
 
 impl AsRef<maybe_add_send_sync!(dyn IDynCommonModuleGen + 'static)> for DynCommonModuleGen {
     fn as_ref(&self) -> &(maybe_add_send_sync!(dyn IDynCommonModuleGen + 'static)) {
-        self.0.as_ref()
+        self.inner.as_ref()
     }
 }
 
 impl DynCommonModuleGen {
     pub fn from_inner(inner: Arc<maybe_add_send_sync!(dyn IDynCommonModuleGen + 'static)>) -> Self {
-        DynCommonModuleGen(inner)
+        DynCommonModuleGen { inner }
     }
 }
 
@@ -514,7 +514,7 @@ dyn_newtype_define!(
 
 impl AsRef<dyn IDynCommonModuleGen + Send + Sync + 'static> for DynServerModuleGen {
     fn as_ref(&self) -> &(dyn IDynCommonModuleGen + Send + Sync + 'static) {
-        self.0.as_common()
+        self.inner.as_common()
     }
 }
 pub trait CommonModuleGen: Debug + Sized {


### PR DESCRIPTION
They are hard to trace, anonymous, scattered accross all the macros.