### PR TITLE
fix: BASE_PORT should not be in ephmeral ports range

### DIFF
--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -28,8 +28,7 @@ use crate::ln::LightningTest;
 /// A default timeout for things happening in tests
 pub const TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Offset from the normal port by 30000 to avoid collisions
-static BASE_PORT: AtomicU16 = AtomicU16::new(38173);
+static BASE_PORT: AtomicU16 = AtomicU16::new(18173);
 
 /// A tool for easily writing fedimint integration tests
 pub struct Fixtures {


### PR DESCRIPTION
Ports above 32k are generally used by kernel for ephemeral ports

https://en.wikipedia.org/wiki/Ephemeral_port

which means they can get allocated for almost anything at any time.

That would explain random failures.