### PR TITLE
chore: bump tonic-lnd dep in devimint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tonic_lnd 0.5.0",
+ "tonic_lnd 0.5.1",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -32,7 +32,7 @@ nix = { version = "0.26.2", features = ["signal"] }
 rand = "0.8.5"
 serde_json = "1.0.94"
 tokio = { version = "1.26.0", features = ["full"] }
-tonic_lnd = { git = "https://github.com/fedimint/tonic_lnd", branch="lnd-client-features", features = ["lightningrpc", "routerrpc"] }
+tonic_lnd = { git = "https://github.com/fedimint/tonic_lnd", branch="master", features = ["lightningrpc", "routerrpc"] }
 tower-http = { version = "0.3.5", features = ["cors", "auth"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -15,7 +15,7 @@ use tokio::fs;
 use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
 use tokio::time::sleep;
 use tonic_lnd::lnrpc::GetInfoRequest;
-use tonic_lnd::LndClient;
+use tonic_lnd::Client as LndClient;
 use tracing::{info, warn};
 
 use crate::cmd;
@@ -190,7 +190,7 @@ impl Lightningd {
 
 #[derive(Clone)]
 pub struct Lnd {
-    pub(crate) client: Arc<Mutex<tonic_lnd::LndClient>>,
+    pub(crate) client: Arc<Mutex<LndClient>>,
     pub(crate) process: ProcessHandle,
     pub(crate) _bitcoind: Bitcoind,
 }


### PR DESCRIPTION
Realized Devimint also has a direct dependency on `tonic_lnd` that we should've bumped in #2755 