### PR TITLE
chore: improve json encoding of some fields

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -905,7 +905,10 @@ pub trait ServerModule: Debug + Sized {
 /// that holds the data as serialized
 // bytes internally.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct SerdeModuleEncoding<T: Encodable + Decodable>(Vec<u8>, #[serde(skip)] PhantomData<T>);
+pub struct SerdeModuleEncoding<T: Encodable + Decodable>(
+    #[serde(with = "::fedimint_core::encoding::as_hex")] Vec<u8>,
+    #[serde(skip)] PhantomData<T>,
+);
 
 impl<T: Encodable + Decodable> From<&T> for SerdeModuleEncoding<T> {
     fn from(value: &T) -> Self {

--- a/modules/fedimint-mint-common/src/common.rs
+++ b/modules/fedimint-mint-common/src/common.rs
@@ -32,6 +32,7 @@ impl BackupRequest {
 pub struct SignedBackupRequest {
     #[serde(flatten)]
     request: BackupRequest,
+    #[serde(with = "::fedimint_core::encoding::as_hex")]
     pub signature: secp256k1::schnorr::Signature,
 }
 


### PR DESCRIPTION
I've noticed somewhere during debugging some very inefficient
encodings of `Vec<u8>` in jsonrpc calls. I'm not sure exactly,
but I think these might have been it.

Re #2762 