### PR TITLE
chore: write ready file in run-ui command

### DIFF
--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -1011,11 +1011,10 @@ async fn write_ready_file<T>(global: &vars::Global, result: Result<T>) -> Result
     result
 }
 
-async fn run_ui(process_mgr: &ProcessManager, task_group: &TaskGroup) -> Result<()> {
+async fn run_ui(process_mgr: &ProcessManager) -> Result<Vec<Fedimintd>> {
     let bitcoind = Bitcoind::new(process_mgr).await?;
     let fed_size = process_mgr.globals.FM_FED_SIZE;
-    // don't drop fedimintds
-    let _fedimintds = futures::future::try_join_all((0..fed_size).into_iter().map(|peer| {
+    let fedimintds = futures::future::try_join_all((0..fed_size).into_iter().map(|peer| {
         let bitcoind = bitcoind.clone();
         async move {
             let peer_port = 10000 + 8137 + peer * 2;
@@ -1046,8 +1045,7 @@ async fn run_ui(process_mgr: &ProcessManager, task_group: &TaskGroup) -> Result<
     }))
     .await?;
 
-    task_group.make_handle().make_shutdown_rx().await.await?;
-    Ok(())
+    Ok(fedimintds)
 }
 
 use std::fmt::Write;
@@ -1105,7 +1103,9 @@ async fn main() -> Result<()> {
         }
         Cmd::RunUi => {
             let (process_mgr, task_group) = setup(args.common).await?;
-            run_ui(&process_mgr, &task_group).await?
+            let fedimintds = run_ui(&process_mgr).await?;
+            let _daemons = write_ready_file(&process_mgr.globals, Ok(fedimintds)).await?;
+            task_group.make_handle().make_shutdown_rx().await.await?;
         }
         Cmd::LatencyTests => {
             let (process_mgr, _) = setup(args.common).await?;


### PR DESCRIPTION
This is useful when you're in an external repo waiting for devimint to start up

You can test it with this script:

```
export FM_TEST_DIR="${2-$TMP}/fm-$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 4 || true)"
export FM_FED_SIZE=4
export FM_PID_FILE="$FM_TEST_DIR/.pid"
export FM_LOGS_DIR="$FM_TEST_DIR/logs"

cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}}
export PATH=$PATH:target/debug/

devimint run-ui 2>/dev/null &

STATUS="$(devimint wait)"
echo "Status: $STATUS"
```

Should output: `Status: READY`