### PR TITLE
refactor: eliminate redundant info in gateway-cli info

### DIFF
--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -132,7 +132,7 @@ impl Gatewayd {
 
     pub async fn gateway_id(&self) -> Result<String> {
         let info = cmd!(self, "info").out_json().await?;
-        let gateway_id = info["federations"][0]["registration"]["gateway_id"]
+        let gateway_id = info["gateway_id"]
             .as_str()
             .context("gateway_id must be a string")?
             .to_owned();

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -795,7 +795,7 @@ async fn get_gateway_id(generate_invoice_with: LnInvoiceGeneration) -> anyhow::R
             cmd!(GatewayClnCli, "info").out_json().await
         }
     }?;
-    let gateway_id = gateway_json["federations"][0]["registration"]["gateway_id"]
+    let gateway_id = gateway_json["gateway_id"]
         .as_str()
         .context("Missing gateway_id field")?;
 

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -11,7 +11,7 @@ use fedimint_core::task::TaskGroup;
 use fedimint_core::Amount;
 use fedimint_ln_client::contracts::Preimage;
 use fedimint_ln_client::pay::PayInvoicePayload;
-use fedimint_ln_common::{serde_routing_fees, LightningGateway};
+use fedimint_ln_common::{route_hints, serde_routing_fees};
 use futures::Future;
 use lightning::routing::gossip::RoutingFees;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -60,8 +60,6 @@ pub struct WithdrawPayload {
 pub struct FederationInfo {
     /// Unique identifier of the fed
     pub federation_id: FederationId,
-    /// Information we registered with the fed
-    pub registration: LightningGateway,
     pub balance_msat: Amount,
 }
 
@@ -73,6 +71,8 @@ pub struct GatewayInfo {
     pub lightning_alias: String,
     #[serde(with = "serde_routing_fees")]
     pub fees: RoutingFees,
+    pub route_hints: Vec<route_hints::RouteHint>,
+    pub gateway_id: secp256k1::PublicKey,
 }
 
 #[derive(Debug)]

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -37,10 +37,12 @@ async fn can_switch_active_gateway() -> anyhow::Result<()> {
     let mut gateway2 = fixtures.new_gateway(fixtures.cln().await).await;
 
     // Client selects a gateway by default
-    let key1 = gateway1.connect_fed(&fed).await.registration.gateway_id;
+    gateway1.connect_fed(&fed).await;
+    let key1 = gateway1.get_gateway_id();
     assert_eq!(client.select_active_gateway().await?.gateway_id, key1);
 
-    let key2 = gateway2.connect_fed(&fed).await.registration.gateway_id;
+    gateway2.connect_fed(&fed).await;
+    let key2 = gateway1.get_gateway_id();
     let gateways = client.fetch_registered_gateways().await.unwrap();
     assert_eq!(gateways.len(), 2);
 


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/2651

Eliminates redundant information in the `gateway-cli info` command.

Before:

![image](https://github.com/fedimint/fedimint/assets/1859166/a27d12aa-f6df-4c90-b68e-3b90a87ed07a)

After:

![image](https://github.com/fedimint/fedimint/assets/1859166/ae8bccb3-0e89-4c85-aef3-1309ac65b114)
