### PR TITLE
fix: remove old github ref from docker branch whitelist

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -254,14 +254,14 @@ jobs:
           echo "gateway-cli_container_tag=$(docker load < result | awk '{ print $3 }')" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/kody-setup-rebase'
+        if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v2
         with:
           username: fedimint
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Publish
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/kody-setup-rebase'
+        if: github.ref == 'refs/heads/master'
         run: |
           nix_tag=${{ env.fedimintd_container_tag }} && hub_tag="fedimint/fedimintd:${LAST_COMMIT_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.fedimint_cli_container_tag }} && hub_tag="fedimint/fedimint-cli:${LAST_COMMIT_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"


### PR DESCRIPTION
I think this was added a long time ago when we were first developing the setup UI or something. Only master should post to docker.