### PR TITLE
Safe Auth

### DIFF
--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -186,8 +186,7 @@ impl WsAdminClient {
 
     /// Returns the status of the server
     pub async fn status(&self) -> FederationResult<StatusResponse> {
-        self.request_auth("status", ApiRequestErased::default())
-            .await
+        self.request("status", ApiRequestErased::default()).await
     }
 
     async fn request_auth<Ret>(

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -94,9 +94,9 @@ impl ApiRequestErased {
         serde_json::to_value(self).expect("parameter serialization error - this should not happen")
     }
 
-    pub fn with_auth(self, auth: &ApiAuth) -> Self {
+    pub fn with_auth(self, auth: ApiAuth) -> Self {
         Self {
-            auth: Some(auth.clone()),
+            auth: Some(auth),
             params: self.params,
         }
     }


### PR DESCRIPTION
Safer auth in guardian webserver by explicitly requiring password on `WsClientAdmin` methods. This prevents accidental password leak when making api calls between guardians