### PR TITLE
Use cookie file for auth when username does not exist

### DIFF
--- a/fedimint-core/src/bitcoinrpc.rs
+++ b/fedimint-core/src/bitcoinrpc.rs
@@ -10,6 +10,9 @@ use url::Url;
 pub const FM_BITCOIN_RPC_KIND: &str = "FM_BITCOIN_RPC_KIND";
 /// Env var for bitcoin URL
 pub const FM_BITCOIN_RPC_URL: &str = "FM_BITCOIN_RPC_URL";
+/// Env var that can be set to point at the bitcoind's cookie file to use for
+/// auth
+pub const FM_BITCOIND_COOKIE_FILE_VAR_NAME: &str = "FM_BITCOIND_COOKIE_FILE";
 
 /// Configuration for the bitcoin RPC
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]


### PR DESCRIPTION
This is a rework of #2612

When `FM_BITCOIND_COOKIE_FILE` env is set, use it as path to
the cookie file.

AFAIK, auth is not required for JsonRPC, so we I don't think we
can do any automatic cookie file detection/fallback if auth
information is missing.