### PR TITLE
fix: use wl-clipboard and xclip only on linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -368,7 +368,7 @@
                     pkgs.nodePackages.bash-language-server
                   ] ++ lib.optionals (!stdenv.isAarch64 && !stdenv.isDarwin) [
                     pkgs.semgrep
-                  ] ++ lib.optionals (!stdenv.isAarch64) [
+                  ] ++ lib.optionals (stdenv.isLinux) [
                     xclip
                     wl-clipboard
                   ];


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/2798