### PR TITLE
fix: LND get info before intercepting HTLCs

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -257,28 +257,19 @@ impl Gateway {
                                     scid_to_federation.clone(),
                                     tg.clone(),
                                 )
-                                .await;
+                                .await.expect("Failed to created Gateway");
 
-                                match gateway {
-                                    Ok(gateway) => {
-                                        info!("Successfully created Gateway");
+                                info!("Successfully created Gateway");
 
-                                        let tx = run_webserver(password.clone(), listen, gateway)
-                                            .await
-                                            .expect("Failed to start webserver");
-                                        info!("Successfully started webserver");
+                                let tx = run_webserver(password.clone(), listen, gateway)
+                                    .await
+                                    .expect("Failed to start webserver");
+                                info!("Successfully started webserver");
 
-                                        Self::handle_htlc_stream(stream, ln_client, handle.clone(), scid_to_federation.clone(), clients.clone()).await;
-                                        warn!("HTLC Stream Lightning connection broken. Stopping webserver...");
-                                        if let Err(e) = tx.send(()).await {
-                                            error!("Error shutting down gatewayd webserver: {e:?}");
-                                        }
-                                    }
-                                    Err(e) => {
-                                        error!("Failed to create Gateway. Waiting 5 seconds and trying again");
-                                        debug!("Error: {e:?}");
-                                        sleep(Duration::from_secs(5)).await;
-                                    }
+                                Self::handle_htlc_stream(stream, ln_client, handle.clone(), scid_to_federation.clone(), clients.clone()).await;
+                                warn!("HTLC Stream Lightning connection broken. Stopping webserver...");
+                                if let Err(e) = tx.send(()).await {
+                                    error!("Error shutting down gatewayd webserver: {e:?}");
                                 }
                             }
                             Err(e) => {


### PR DESCRIPTION
PR contains small fixes for the lightning reconnect logic:

1) We no longer re-try when the gateway fails to be created. This is because the gateway creation should always succeed, if it doesn't, it likely indicates that something is wrong with the db, which will not be fixed by retrying. The retry logic has been replaced with an `expect`.

2) For LND, we try to call `get_info` before attempting to intercept HTLCs. This is because there is a small period of time where the client can connect to LND, but RPCs aren't successful. During this time, we don't want to spawn the new thread to intercept HTLCs. So instead we first wait for `get_info` to succeed, which will increase the probability of `route_htlcs` succeeding. 