### PR TITLE
feat: add VerifiedConfigs step to config API state machine

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -1027,6 +1027,8 @@ pub enum ServerStatus {
     ConfigGenFailed,
     /// Config is generated, peers should verify the config
     VerifyingConfigs,
+    /// We have verified all our peer configs
+    VerifiedConfigs,
     /// Restarted from a planned upgrade (requires action to start)
     Upgrading,
     /// Consensus is running


### PR DESCRIPTION
Add another state to config API state machine. This doesn't have any real functional change in terms of the API, but allows peers to signal they've finished verifying peer config hashes. Helps fix https://github.com/fedimint/ui/issues/14.