### PR TITLE
Make bitcoin blockchain API used by the client configurable

### DIFF
--- a/fedimint-core/src/bitcoinrpc.rs
+++ b/fedimint-core/src/bitcoinrpc.rs
@@ -12,7 +12,7 @@ pub const FM_BITCOIN_RPC_KIND: &str = "FM_BITCOIN_RPC_KIND";
 pub const FM_BITCOIN_RPC_URL: &str = "FM_BITCOIN_RPC_URL";
 
 /// Configuration for the bitcoin RPC
-#[derive(Debug, Clone, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct BitcoinRpcConfig {
     pub kind: String,
     pub url: Url,

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -17,6 +17,7 @@ use fedimint_wallet_server::common::config::{
     WalletGenParams, WalletGenParamsConsensus, WalletGenParamsLocal,
 };
 use fedimint_wallet_server::WalletGen;
+use url::Url;
 
 /// Module for creating `fedimintd` binary with custom modules
 pub mod fedimintd;
@@ -42,6 +43,7 @@ pub fn attach_default_module_gen_params(
                     // TODO this is not very elegant, but I'm planning to get rid of it in a next
                     // commit anyway
                     finality_delay,
+                    client_default_bitcoin_rpc: default_esplora_server(network),
                 },
             },
         )
@@ -66,4 +68,22 @@ pub fn attach_default_module_gen_params(
                 consensus: LightningGenParamsConsensus { network },
             },
         );
+}
+
+pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
+    let url = match network {
+        Network::Bitcoin => Url::parse("https://blockstream.info/api/")
+            .expect("Failed to parse default esplora server"),
+        Network::Testnet => Url::parse("https://blockstream.info/testnet/api/")
+            .expect("Failed to parse default esplora server"),
+        Network::Regtest => {
+            Url::parse("http://127.0.0.1:50002/").expect("Failed to parse default esplora server")
+        }
+        Network::Signet => Url::parse("https://mutinynet.com/api/")
+            .expect("Failed to parse default esplora server"),
+    };
+    BitcoinRpcConfig {
+        kind: "esplora".to_string(),
+        url,
+    }
 }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -37,7 +37,6 @@ use miniscript::ToPublicKey;
 use rand::{thread_rng, Rng};
 use secp256k1::{All, KeyPair, Secp256k1};
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 use crate::api::WalletFederationApi;
 use crate::deposit::{CreatedDepositState, DepositStateMachine, DepositStates};
@@ -401,34 +400,13 @@ impl ClientModuleGen for WalletClientGen {
         _api: DynGlobalApi,
         module_api: DynModuleApi,
     ) -> anyhow::Result<Self::Module> {
-        let rpc_config = self
-            .0
-            .clone()
-            .unwrap_or(default_esplora_server(cfg.network));
+        let rpc_config = self.0.clone().unwrap_or(cfg.default_bitcoin_rpc.clone());
         Ok(WalletClientModule {
             cfg,
             module_api,
             notifier,
             rpc: create_bitcoind(&rpc_config, TaskGroup::new().make_handle())?,
         })
-    }
-}
-
-pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
-    let url = match network {
-        Network::Bitcoin => Url::parse("https://blockstream.info/api/")
-            .expect("Failed to parse default esplora server"),
-        Network::Testnet => Url::parse("https://blockstream.info/testnet/api/")
-            .expect("Failed to parse default esplora server"),
-        Network::Regtest => {
-            Url::parse("http://127.0.0.1:50002/").expect("Failed to parse default esplora server")
-        }
-        Network::Signet => Url::parse("https://mutinynet.com/api/")
-            .expect("Failed to parse default esplora server"),
-    };
-    BitcoinRpcConfig {
-        kind: "esplora".to_string(),
-        url,
     }
 }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -123,6 +123,7 @@ impl ServerModuleGen for WalletGen {
                     params.consensus.network,
                     params.consensus.finality_delay,
                     params.local.bitcoin_rpc.clone(),
+                    params.consensus.client_default_bitcoin_rpc.clone(),
                 );
                 (*id, cfg)
             })
@@ -157,6 +158,7 @@ impl ServerModuleGen for WalletGen {
             params.consensus.network,
             params.consensus.finality_delay,
             params.local.bitcoin_rpc.clone(),
+            params.consensus.client_default_bitcoin_rpc.clone(),
         );
 
         Ok(wallet_cfg.to_erased())
@@ -185,10 +187,11 @@ impl ServerModuleGen for WalletGen {
     ) -> anyhow::Result<WalletClientConfig> {
         let config = WalletConfigConsensus::from_erased(config)?;
         Ok(WalletClientConfig {
-            peg_in_descriptor: config.peg_in_descriptor.clone(),
+            peg_in_descriptor: config.peg_in_descriptor,
             network: config.network,
-            fee_consensus: config.fee_consensus.clone(),
+            fee_consensus: config.fee_consensus,
             finality_delay: config.finality_delay,
+            default_bitcoin_rpc: config.client_default_bitcoin_rpc,
         })
     }
 


### PR DESCRIPTION
This should allow using custom signets/regtests networks and setting alternative defaults for mainnet.

If we want to expose the parameter in the UI I can open an issue there.