### PR TITLE
fix: show backtrace when there is a config error

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -322,8 +322,7 @@ impl ConfigGenModuleParams {
         json: Option<serde_json::Value>,
     ) -> anyhow::Result<P> {
         let json = json.ok_or(format_err!("{name} config gen params missing"))?;
-        serde_json::from_value(json)
-            .map_err(|e| anyhow::Error::new(e).context("Invalid module params"))
+        serde_json::from_value(json).context("Invalid module params")
     }
 
     pub fn from_typed<P: ModuleGenParams>(p: P) -> anyhow::Result<Self> {

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -511,7 +511,7 @@ impl ConfigGenState {
             let module = self.settings.registry.get(kind).expect("Module exists");
             module
                 .validate_params(&combined)
-                .map_err(|e| ApiError::bad_request(format!("Module params invalid {e}")))?;
+                .map_err(|e| ApiError::bad_request(format!("Module params invalid {e:?}")))?;
             combined_params.push((id, kind.clone(), combined));
         }
         consensus.modules = ServerModuleGenParamsRegistry::from_iter(combined_params.into_iter());


### PR DESCRIPTION
Use `{e:?}` when formatting an error so we can have the backtrace