### PR TITLE
fix(fedimint-cli): clean shutdown

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -319,10 +319,10 @@ impl Opts {
         &self,
         module_gens: &ClientModuleGenRegistry,
     ) -> CliResult<fedimint_client::Client> {
-        let mut tg = TaskGroup::new();
+        let tg = TaskGroup::new();
         let client_builder = self.build_client_ng_builder(module_gens).await?;
         client_builder
-            .build::<PlainRootSecretStrategy>(&mut tg)
+            .build::<PlainRootSecretStrategy>(tg)
             .await
             .map_err_cli_general()
     }
@@ -547,13 +547,13 @@ impl FedimintCli {
                 hash: env!("FEDIMINT_BUILD_CODE_VERSION").to_string(),
             }),
             Command::Client(ClientCmd::Restore { secret }) => {
-                let mut tg = TaskGroup::new();
+                let tg = TaskGroup::new();
                 let (client, metadata) = cli
                     .build_client_ng_builder(&self.module_gens)
                     .await
                     .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?
                     .build_restoring_from_backup(
-                        &mut tg,
+                        tg,
                         ClientSecret::<PlainRootSecretStrategy>::new(secret),
                     )
                     .await

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -124,7 +124,7 @@ pub async fn await_spend_notes_finish(
 
 pub async fn build_client(
     cfg: &ClientConfig,
-    tg: &mut TaskGroup,
+    tg: TaskGroup,
     rocksdb: Option<&PathBuf>,
 ) -> anyhow::Result<Client> {
     let mut client_builder = ClientBuilder::default();

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -330,7 +330,7 @@ async fn run_load_test(
     invoice_amount: Amount,
     event_sender: mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<Vec<BoxFuture<'static, anyhow::Result<()>>>> {
-    let mut tg = TaskGroup::new();
+    let tg = TaskGroup::new();
     let db_path = archive_dir.as_ref().map(|p| p.join("db"));
     let coordinator_db = if let Some(db_path) = &db_path {
         tokio::fs::create_dir_all(db_path).await?;
@@ -338,13 +338,13 @@ async fn run_load_test(
     } else {
         None
     };
-    let coordinator = build_client(&cfg, &mut tg, coordinator_db.as_ref()).await?;
+    let coordinator = build_client(&cfg, tg.make_subgroup().await, coordinator_db.as_ref()).await?;
     let mut users_clients = Vec::with_capacity(users.into());
     for u in 0..users {
         let user_db = db_path
             .as_ref()
             .map(|db_path| db_path.join(format!("user_{u}.db")));
-        let client = build_client(&cfg, &mut tg, user_db.as_ref()).await?;
+        let client = build_client(&cfg, tg.make_subgroup().await, user_db.as_ref()).await?;
         if let Some(gateway_id) = &gateway_id {
             switch_default_gateway(&client, gateway_id).await?;
         }
@@ -527,8 +527,8 @@ async fn _test_connect_std_client(
     }
     let clients = (0..users)
         .map(|_| async {
-            let mut tg = TaskGroup::new();
-            let client = build_client(&cfg, &mut tg, None).await?;
+            let tg = TaskGroup::new();
+            let client = build_client(&cfg, tg, None).await?;
             Ok::<_, anyhow::Error>(client)
         })
         .collect::<Vec<_>>();

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -56,7 +56,7 @@ impl FederationTest {
         client_builder.with_config(client_config);
         client_builder.with_database(MemDatabase::new());
         client_builder
-            .build::<PlainRootSecretStrategy>(&mut self.task.make_subgroup().await)
+            .build::<PlainRootSecretStrategy>(self.task.make_subgroup().await)
             .await
             .expect("Failed to build client")
     }

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -71,8 +71,8 @@ mod tests {
     #[wasm_bindgen_test]
     async fn receive() -> Result<()> {
         let client = client(&faucet::connect_string().await?.parse()?).await?;
-        let mut tg = TaskGroup::new();
-        client.start_executor(&mut tg).await;
+        let tg = TaskGroup::new();
+        client.start_executor(tg).await;
         let gws = client.fetch_registered_gateways().await?;
         let lnd_gw = gws
             .into_iter()
@@ -101,8 +101,8 @@ mod tests {
     #[wasm_bindgen_test]
     async fn receive_and_pay() -> Result<()> {
         let client = client(&faucet::connect_string().await?.parse()?).await?;
-        let mut tg = TaskGroup::new();
-        client.start_executor(&mut tg).await;
+        let tg = TaskGroup::new();
+        client.start_executor(tg).await;
         let gws = client.fetch_registered_gateways().await?;
         let lnd_gw = gws
             .into_iter()

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -45,7 +45,7 @@ impl StandardGatewayClientBuilder {
         config: FederationConfig,
         node_pub_key: secp256k1::PublicKey,
         lnrpc: Arc<dyn ILnRpcClient>,
-        tg: &mut TaskGroup,
+        tg: TaskGroup,
         old_client: Option<fedimint_client::Client>,
     ) -> Result<fedimint_client::Client> {
         let federation_id = config.config.federation_id;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -429,7 +429,7 @@ impl Gateway {
                         config.clone(),
                         node_pub_key,
                         self.lnrpc.clone(),
-                        &mut self.task_group,
+                        self.task_group.make_subgroup().await,
                         old_client,
                     )
                     .await?;
@@ -558,7 +558,7 @@ impl Gateway {
                 gw_client_cfg.clone(),
                 node_pub_key,
                 self.lnrpc.clone(),
-                &mut self.task_group,
+                self.task_group.make_subgroup().await,
                 old_client,
             )
             .await?;


### PR DESCRIPTION
Previously tokio would complain that it's awaiting futures while the runtime is shut down.