### PR TITLE
chore: remove unused peer id argument from admin client constructor

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -272,7 +272,7 @@ impl Opts {
             .expect("Endpoint exists")
             .url
             .clone();
-        Ok(WsAdminClient::new(url, *our_id))
+        Ok(WsAdminClient::new(url))
     }
 
     fn auth(&self) -> CliResult<ApiAuth> {

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -25,9 +25,12 @@ pub struct WsAdminClient {
 }
 
 impl WsAdminClient {
-    pub fn new(url: Url, our_id: PeerId) -> Self {
+    pub fn new(url: Url) -> Self {
+        // The peer ids given to the federation API are only useful when connected to
+        // multiple peers so errors can be attributed. The admin client has no use for
+        // them.
         Self {
-            inner: WsFederationApi::new(vec![(our_id, url)]).into(),
+            inner: WsFederationApi::new(vec![(PeerId(0), url)]).into(),
         }
     }
 


### PR DESCRIPTION
Fixes #2801