### PR TITLE
chore: update 'check-wasm' command to check fedimint-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ dependencies = [
  "futures",
  "itertools",
  "rand",
+ "ring",
  "secp256k1-zkp",
  "serde",
  "serde_json",

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -37,5 +37,8 @@ thiserror = "1.0.39"
 tokio = { version = "1.26.0", features = [ "time", "macros" ] }
 tracing = "0.1.37"
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js"] }
+
 [dev-dependencies]
 tracing-test = "0.2.4"

--- a/justfile
+++ b/justfile
@@ -62,7 +62,7 @@ final-check: lint
   just test
 
 check-wasm:
-  nix develop .#crossWasm -c cargo check --target wasm32-unknown-unknown --package fedimint-client-legacy
+  nix develop .#crossWasm -c cargo check --target wasm32-unknown-unknown --package fedimint-client
 
 [no-exit-message]
 typos:


### PR DESCRIPTION
Locally I get the following error, @douglaz said he gets the same on linux:

```
error[E0432]: unresolved import `super::sysrand_chunk`
   --> /Users/justin/.cargo/git/checkouts/ring-236810bb234b0c6b/52a1294/src/rand.rs:307:16
    |
307 |     use super::sysrand_chunk::chunk;
    |                ^^^^^^^^^^^^^ could not find `sysrand_chunk` in `super`
```