### PR TITLE
chore(flake): provide `git`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -357,6 +357,7 @@
                     }))
                     docker-compose
                     pkgs.tokio-console
+                    pkgs.git
                     moreutils-ts
 
                     # Nix


### PR DESCRIPTION
cargo and some other scripts here and there require it, so technically dev env should provide it as well. Otherwise when running `nix develop --ignore-environment` things fail.