### PR TITLE
chore: improve gatewayd error messages

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -202,7 +202,9 @@ pub async fn handle_ng_command(
                 info!("Update: {:?}", update);
             }
 
-            return Err(anyhow::anyhow!("Lightning receive failed"));
+            return Err(anyhow::anyhow!(
+                "Unexpected end of update stream. Lightning receive failed"
+            ));
         }
         ClientCmd::LnPay { bolt11 } => {
             client.select_active_gateway().await?;
@@ -226,13 +228,13 @@ pub async fn handle_ng_command(
                                 })
                                 .unwrap());
                             }
-                            InternalPayState::RefundSuccess(outpoint) => {
+                            InternalPayState::RefundSuccess { outpoint, error } => {
                                 let e = format!(
-                                    "Internal payment failed. A refund was issued to {outpoint}"
+                                    "Internal payment failed. A refund was issued to {outpoint} Error: {error}"
                                 );
                                 return Err(anyhow!(e));
                             }
-                            InternalPayState::Error(e) => {
+                            InternalPayState::UnexpectedError(e) => {
                                 return Err(anyhow!(e));
                             }
                             _ => {}

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -16,8 +16,9 @@ use ln_gateway::gatewaylnrpc::{
     PayInvoiceRequest, PayInvoiceResponse,
 };
 use ln_gateway::lnd::GatewayLndClient;
-use ln_gateway::lnrpc_client::{ILnRpcClient, NetworkLnRpcClient, RouteHtlcStream};
-use ln_gateway::GatewayError;
+use ln_gateway::lnrpc_client::{
+    ILnRpcClient, LightningRpcError, NetworkLnRpcClient, RouteHtlcStream,
+};
 use tokio::sync::Mutex;
 use tonic_lnd::lnrpc::{GetInfoRequest, Invoice as LndInvoice, ListChannelsRequest};
 use tonic_lnd::{connect, LndClient};
@@ -91,29 +92,32 @@ impl LightningTest for ClnLightningTest {
 
 #[async_trait]
 impl ILnRpcClient for ClnLightningTest {
-    async fn info(&self) -> Result<GetNodeInfoResponse, GatewayError> {
+    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError> {
         self.lnrpc.info().await
     }
 
-    async fn routehints(&self) -> Result<GetRouteHintsResponse, GatewayError> {
+    async fn routehints(&self) -> Result<GetRouteHintsResponse, LightningRpcError> {
         self.lnrpc.routehints().await
     }
 
-    async fn pay(&self, invoice: PayInvoiceRequest) -> Result<PayInvoiceResponse, GatewayError> {
+    async fn pay(
+        &self,
+        invoice: PayInvoiceRequest,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
         self.lnrpc.pay(invoice).await
     }
 
     async fn route_htlcs<'a>(
         self: Box<Self>,
         task_group: &mut TaskGroup,
-    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), GatewayError> {
+    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError> {
         self.lnrpc.route_htlcs(task_group).await
     }
 
     async fn complete_htlc(
         &self,
         htlc: InterceptHtlcResponse,
-    ) -> Result<EmptyResponse, GatewayError> {
+    ) -> Result<EmptyResponse, LightningRpcError> {
         self.lnrpc.complete_htlc(htlc).await
     }
 }
@@ -238,29 +242,32 @@ impl fmt::Debug for LndLightningTest {
 
 #[async_trait]
 impl ILnRpcClient for LndLightningTest {
-    async fn info(&self) -> Result<GetNodeInfoResponse, GatewayError> {
+    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError> {
         self.lnrpc.info().await
     }
 
-    async fn routehints(&self) -> Result<GetRouteHintsResponse, GatewayError> {
+    async fn routehints(&self) -> Result<GetRouteHintsResponse, LightningRpcError> {
         self.lnrpc.routehints().await
     }
 
-    async fn pay(&self, invoice: PayInvoiceRequest) -> Result<PayInvoiceResponse, GatewayError> {
+    async fn pay(
+        &self,
+        invoice: PayInvoiceRequest,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
         self.lnrpc.pay(invoice).await
     }
 
     async fn route_htlcs<'a>(
         self: Box<Self>,
         task_group: &mut TaskGroup,
-    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), GatewayError> {
+    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError> {
         self.lnrpc.route_htlcs(task_group).await
     }
 
     async fn complete_htlc(
         &self,
         htlc: InterceptHtlcResponse,
-    ) -> Result<EmptyResponse, GatewayError> {
+    ) -> Result<EmptyResponse, LightningRpcError> {
         self.lnrpc.complete_htlc(htlc).await
     }
 }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -77,10 +77,7 @@ impl StandardGatewayClientBuilder {
             // TODO: make this configurable?
             .build::<PlainRootSecretStrategy>(tg)
             .await
-            .map_err(|error| {
-                tracing::warn!("Error building client: {:?}", error);
-                GatewayError::ClientNgError
-            })
+            .map_err(GatewayError::ClientStateMachineError)
     }
 
     pub async fn create_config(

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -20,7 +20,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::anyhow;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use bitcoin::{Address, Txid};
@@ -43,7 +42,8 @@ use futures::stream::StreamExt;
 use gatewaylnrpc::intercept_htlc_response::Action;
 use gatewaylnrpc::{GetNodeInfoResponse, InterceptHtlcResponse};
 use lightning::routing::gossip::RoutingFees;
-use lnrpc_client::{ILnRpcClient, RouteHtlcStream};
+use lnrpc_client::{ILnRpcClient, LightningRpcError, RouteHtlcStream};
+use ng::pay::OutgoingPaymentError;
 use ng::GatewayClientExt;
 use rand::rngs::OsRng;
 use rand::Rng;
@@ -58,7 +58,7 @@ use url::Url;
 use crate::gatewaylnrpc::intercept_htlc_response::Forward;
 use crate::lnd::GatewayLndClient;
 use crate::lnrpc_client::NetworkLnRpcClient;
-use crate::ng::{GatewayExtPayStates, Htlc};
+use crate::ng::GatewayExtPayStates;
 use crate::rpc::rpc_server::run_webserver;
 use crate::rpc::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, GatewayInfo,
@@ -109,31 +109,40 @@ pub enum LightningMode {
 
 #[derive(Debug, Error)]
 pub enum GatewayError {
-    #[error("Lightning rpc operation error: {0:?}")]
-    LnRpcError(#[from] tonic::Status),
     #[error("Federation error: {0:?}")]
     FederationError(#[from] FederationError),
     #[error("Other: {0:?}")]
-    Other(#[from] anyhow::Error),
-    #[error("Failed to fetch route hints")]
-    FailedToFetchRouteHints,
+    ClientStateMachineError(#[from] anyhow::Error),
     #[error("Failed to open the database: {0:?}")]
     DatabaseError(anyhow::Error),
     #[error("Federation client error")]
-    ClientNgError,
-}
-
-impl GatewayError {
-    pub fn other(msg: String) -> Self {
-        error!(msg);
-        GatewayError::Other(anyhow!(msg))
-    }
+    LightningRpcError(#[from] LightningRpcError),
+    #[error("Outgoing Payment Error {0:?}")]
+    OutgoingPaymentError(#[from] Box<OutgoingPaymentError>),
+    #[error("Invalid Metadata: {0}")]
+    InvalidMetadata(String),
+    #[error("Unexpected state: {0}")]
+    UnexpectedState(String),
 }
 
 impl IntoResponse for GatewayError {
     fn into_response(self) -> Response {
-        let mut err = Cow::<'static, str>::Owned(format!("{self:?}")).into_response();
-        *err.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        // For privacy reasons, we do not return too many details about the failure of
+        // the request back to the client to prevent malicious clients from
+        // deducing state about the gateway/lightning node.
+        let (error_message, status_code) = match self {
+            GatewayError::OutgoingPaymentError(_) => (
+                "Error while paying lightning invoice. Outgoing contract will be refunded."
+                    .to_string(),
+                StatusCode::BAD_REQUEST,
+            ),
+            _ => (
+                "An internal gateway error occurred".to_string(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        };
+        let mut err = Cow::<'static, str>::Owned(error_message).into_response();
+        *err.status_mut() = status_code;
         err
     }
 }
@@ -317,10 +326,7 @@ impl Gateway {
                 // Just forward the HTLC if we do not have a client that
                 // corresponds to the federation id
                 if let Some(client) = client {
-                    let htlc: Result<Htlc> = htlc_request
-                        .clone()
-                        .try_into()
-                        .map_err(|_| GatewayError::ClientNgError);
+                    let htlc = htlc_request.clone().try_into();
                     if let Ok(htlc) = htlc {
                         if client.gateway_handle_intercepted_htlc(htlc).await.is_ok() {
                             continue;
@@ -354,7 +360,7 @@ impl Gateway {
 
             let GetNodeInfoResponse { pub_key, alias } = lnrpc.info().await?;
             let node_pub_key = PublicKey::from_slice(&pub_key)
-                .map_err(|e| GatewayError::Other(anyhow!("Invalid node pubkey {}", e)))?;
+                .map_err(|e| GatewayError::InvalidMetadata(format!("Invalid node pubkey {e}")))?;
 
             if !route_hints.is_empty() || num_retries == ROUTE_HINT_RETRIES {
                 break (route_hints, node_pub_key, alias);
@@ -480,15 +486,9 @@ impl Gateway {
         &self,
         federation_id: FederationId,
     ) -> Result<fedimint_client::Client> {
-        let client =
-            self.clients
-                .write()
-                .await
-                .remove(&federation_id)
-                .ok_or(GatewayError::Other(anyhow::anyhow!(
-                    "No federation with id {}",
-                    federation_id.to_string()
-                )))?;
+        let client = self.clients.write().await.remove(&federation_id).ok_or(
+            GatewayError::InvalidMetadata(format!("No federation with id {federation_id}")),
+        )?;
         let mut dbtx = self.gatewayd_db.begin_transaction().await;
         dbtx.remove_entry(&FederationRegistrationKey { id: federation_id })
             .await;
@@ -505,9 +505,8 @@ impl Gateway {
             .await
             .get(&federation_id)
             .cloned()
-            .ok_or(GatewayError::Other(anyhow::anyhow!(
-                "No federation with id {}",
-                federation_id.to_string()
+            .ok_or(GatewayError::InvalidMetadata(format!(
+                "No federation with id {federation_id}"
             )))
     }
 
@@ -516,7 +515,7 @@ impl Gateway {
         payload: ConnectFedPayload,
     ) -> Result<FederationInfo> {
         let connect = WsClientConnectInfo::from_str(&payload.connect).map_err(|e| {
-            GatewayError::Other(anyhow::anyhow!("Invalid federation member string {}", e))
+            GatewayError::InvalidMetadata(format!("Invalid federation member string {e}"))
         })?;
 
         // The gateway deterministically assigns a channel id (u64) to each federation
@@ -623,19 +622,23 @@ impl Gateway {
                     preimage,
                     outpoint: _,
                 } => return Ok(preimage),
-                GatewayExtPayStates::Fail => {
-                    return Err(GatewayError::Other(anyhow!("Payment failed")))
+                GatewayExtPayStates::Fail {
+                    error,
+                    error_message,
+                } => {
+                    error!(error_message);
+                    return Err(GatewayError::OutgoingPaymentError(Box::new(error)));
                 }
-                GatewayExtPayStates::Canceled => {
-                    return Err(GatewayError::Other(anyhow!("Outgoing contract canceled")))
+                GatewayExtPayStates::Canceled { error } => {
+                    return Err(GatewayError::OutgoingPaymentError(Box::new(error)));
                 }
                 _ => {}
             };
         }
 
-        return Err(GatewayError::Other(anyhow!(
-            "Unexpected error occurred while paying the invoice"
-        )));
+        Err(GatewayError::UnexpectedState(
+            "Ran out of state updates while paying invoice".to_string(),
+        ))
     }
 
     pub async fn handle_balance_msg(&self, payload: BalancePayload) -> Result<Amount> {
@@ -682,15 +685,15 @@ impl Gateway {
                     return Ok(txid);
                 }
                 WithdrawState::Failed(e) => {
-                    return Err(GatewayError::Other(anyhow!(e)));
+                    return Err(GatewayError::UnexpectedState(e));
                 }
                 _ => {}
             }
         }
 
-        return Err(GatewayError::Other(anyhow!(
-            "Unexpected error occurred while withdrawing"
-        )));
+        Err(GatewayError::UnexpectedState(
+            "Ran out of state updates while withdrawing".to_string(),
+        ))
     }
 
     pub async fn handle_backup_msg(

--- a/gateway/ln-gateway/src/ng/complete.rs
+++ b/gateway/ln-gateway/src/ng/complete.rs
@@ -107,10 +107,10 @@ impl WaitForPreimageState {
                     IncomingSmStates::Preimage(preimage) => {
                         return Ok(preimage);
                     }
-                    IncomingSmStates::RefundSubmitted(_) => {
+                    IncomingSmStates::RefundSubmitted { txid: _, error: _ } => {
                         return Err(CompleteHtlcError::IncomingContractNotFunded);
                     }
-                    IncomingSmStates::FundingFailed(_) => {
+                    IncomingSmStates::FundingFailed { error: _ } => {
                         return Err(CompleteHtlcError::IncomingContractNotFunded);
                     }
                     _ => {}

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -259,7 +259,10 @@ impl LightningPayFunded {
         if !response.status().is_success() {
             return Err(GatewayPayError::GatewayInternalError {
                 error_code: Some(response.status().as_u16()),
-                error_message: response.status().to_string(),
+                error_message: response
+                    .text()
+                    .await
+                    .expect("Could not retrieve text from response"),
             });
         }
 


### PR DESCRIPTION
Error messages in the gateway are not structured correctly right now, we frequently swallow the underlying error and just output a vague string that something went wrong. This makes debugging hard.

This PR improves the error handling logic to attach errors in different states in the gateway. Fixes: https://github.com/fedimint/fedimint/issues/2827

CLI output after PR:
![image](https://github.com/fedimint/fedimint/assets/1859166/3af7b144-473d-47a0-9396-8fddb884e9f6)


Gateway output after PR:
![image](https://github.com/fedimint/fedimint/assets/1859166/75ef17c7-2ac8-408b-8be1-54b1cef74702)

Gateway output contains the underlying error message now (e.g `FailureReasonNoRoute`). Client is returned a user friendly message that gives a bit of a description on what went wrong.