### PR TITLE
refactor(devimint): run DKG using the apis

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -35,8 +35,12 @@ windows:
       panes:
         - bitcoind:
           - tail -n +0 -F $FM_LOGS_DIR/bitcoind.log
+  - faucet:
+      panes:
+        - log:
+          - tail -n +0 -F $FM_LOGS_DIR/faucet.log
   - devimint:
       panes:
         - log:
-          - tail -n +0 -F $FM_LOGS_DIR/devimint.log
+          - tail -n +0 -F $FM_LOGS_DIR/devimint-outer.log
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -37,3 +37,4 @@ tower-http = { version = "0.3.5", features = ["cors", "auth"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 serde = "1.0.159"
+url = "2.3.1"

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -1,26 +1,27 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use anyhow::{anyhow, Context};
 use bitcoincore_rpc::bitcoin::Network;
-use fedimint_aead::random_salt;
+use fedimint_core::admin_client::{ConfigGenConnectionsRequest, ConfigGenParamsRequest};
+use fedimint_core::api::ServerStatus;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
+use fedimint_core::config::ServerModuleGenParamsRegistry;
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::db::mem_impl::MemDatabase;
-use fedimint_core::util::write_new;
+use fedimint_core::module::ApiAuth;
 use fedimint_core::{Amount, PeerId};
-use fedimint_server::config::io::{write_server_config, PLAINTEXT_PASSWORD, SALT_FILE};
-use fedimint_server::config::ServerConfig;
+use fedimint_server::config::ConfigGenParams;
 use fedimint_testing::federation::local_config_gen_params;
 use fedimint_wallet_client::config::WalletClientConfig;
 use fedimintd::attach_default_module_gen_params;
-use fedimintd::fedimintd::Fedimintd as FedimintBuilder;
-use tokio::fs;
+use futures::future::join_all;
+use rand::Rng;
+use url::Url;
 
 use super::*; // TODO: remove this
 
 pub struct Federation {
     // client is only for internal use, use cli commands instead
-    client: Arc<UserClient>,
     members: BTreeMap<usize, Fedimintd>,
     vars: BTreeMap<usize, vars::Fedimintd>,
     bitcoind: Bitcoind,
@@ -30,16 +31,54 @@ impl Federation {
     pub async fn new(
         process_mgr: &ProcessManager,
         bitcoind: Bitcoind,
-        vars: BTreeMap<usize, vars::Fedimintd>,
+        servers: usize,
     ) -> Result<Self> {
         let mut members = BTreeMap::new();
-        for (peer, var) in &vars {
+        let mut vars = BTreeMap::new();
+
+        let peers: Vec<_> = (0..servers).map(|id| PeerId::from(id as u16)).collect();
+        let params: HashMap<PeerId, ConfigGenParams> =
+            local_config_gen_params(&peers, BASE_PORT, ServerModuleGenParamsRegistry::default())?;
+
+        let mut admin_clients: BTreeMap<PeerId, WsAdminClient> = BTreeMap::new();
+        for (peer, peer_params) in &params {
+            let var = vars::Fedimintd::init(&process_mgr.globals, peer_params.to_owned()).await?;
             members.insert(
-                *peer,
-                Fedimintd::new(process_mgr, bitcoind.clone(), *peer, var).await?,
+                peer.to_usize(),
+                Fedimintd::new(process_mgr, bitcoind.clone(), peer.to_usize(), &var).await?,
             );
+            let admin_client = WsAdminClient::new(Url::parse(&var.FM_API_URL)?);
+            admin_clients.insert(*peer, admin_client);
+            vars.insert(peer.to_usize(), var);
         }
 
+        run_dkg(admin_clients, params).await?;
+
+        let out_dir = &vars[&0].FM_DATA_DIR;
+        let cfg_dir = &process_mgr.globals.FM_DATA_DIR;
+        let out_dir = utf8(out_dir);
+        let cfg_dir = utf8(cfg_dir);
+        // copy configs to config directory
+        tokio::fs::rename(
+            format!("{out_dir}/client-connect"),
+            format!("{cfg_dir}/client-connect"),
+        )
+        .await?;
+        tokio::fs::rename(
+            format!("{out_dir}/client.json"),
+            format!("{cfg_dir}/client.json"),
+        )
+        .await?;
+        info!("copied client configs");
+
+        Ok(Self {
+            members,
+            vars,
+            bitcoind,
+        })
+    }
+
+    pub async fn client(&self) -> Result<UserClient> {
         let workdir: PathBuf = env::var("FM_DATA_DIR")?.parse()?;
         let cfg_path = workdir.join("client.json");
         let mut cfg: UserClientConfig = load_from_file(&cfg_path)?;
@@ -52,12 +91,7 @@ impl Federation {
             DynClientModuleGen::from(LightningClientGen),
         ]);
         let client = UserClient::new(cfg, decoders, module_gens, db, Default::default()).await;
-        Ok(Self {
-            members,
-            vars,
-            bitcoind,
-            client: Arc::new(client),
-        })
+        Ok(client)
     }
 
     pub async fn start_server(&mut self, process_mgr: &ProcessManager, peer: usize) -> Result<()> {
@@ -124,12 +158,18 @@ impl Federation {
     }
 
     pub async fn federation_id(&self) -> String {
-        self.client.config().0.federation_id.to_string()
+        self.client()
+            .await
+            .unwrap()
+            .config()
+            .0
+            .federation_id
+            .to_string()
     }
 
     pub async fn await_block_sync(&self) -> Result<()> {
-        let wallet_cfg: &WalletClientConfig = self
-            .client
+        let client = self.client().await?;
+        let wallet_cfg: &WalletClientConfig = client
             .config_ref()
             .0
             .get_module(LEGACY_HARDCODED_INSTANCE_ID_WALLET)?;
@@ -229,56 +269,177 @@ impl Fedimintd {
 /// Base port for devimint
 const BASE_PORT: u16 = 8173 + 10000;
 
-pub async fn run_config_gen(
-    process_mgr: &ProcessManager,
-    servers: usize,
-    write_password: bool,
-) -> Result<BTreeMap<usize, vars::Fedimintd>> {
-    // TODO: Use proper builder
-    let mut fed = FedimintBuilder::new()?.with_default_modules();
+pub async fn run_dkg(
+    admin_clients: BTreeMap<PeerId, WsAdminClient>,
+    params: HashMap<PeerId, ConfigGenParams>,
+) -> anyhow::Result<()> {
+    let auth_for = |peer: &PeerId| -> ApiAuth { params[peer].local.api_auth.clone() };
+    for (peer_id, client) in &admin_clients {
+        const MAX_RETRIES: usize = 20;
+        poll_max_retries("trying-to-connect-to-peers", MAX_RETRIES, || async {
+            Ok(client.status().await.is_ok())
+        })
+        .await?;
+        info!("Connected to {peer_id}")
+    }
+    for (peer_id, client) in &admin_clients {
+        assert_eq!(
+            client.status().await?.server,
+            fedimint_core::api::ServerStatus::AwaitingPassword,
+            "peer_id isn't waiting for password: {peer_id}"
+        );
+    }
+
+    for (peer_id, client) in &admin_clients {
+        client.set_password(auth_for(peer_id)).await?;
+    }
+    let (leader_id, leader) = admin_clients.iter().next().context("missing peer")?;
+    let followers = admin_clients
+        .iter()
+        .filter(|(id, _)| *id != leader_id)
+        .collect::<BTreeMap<_, _>>();
+
+    let leader_name = "leader".to_string();
+    leader
+        .set_config_gen_connections(
+            ConfigGenConnectionsRequest {
+                our_name: leader_name.clone(),
+                leader_api_url: None,
+            },
+            auth_for(leader_id),
+        )
+        .await?;
+
+    let _ = leader
+        .get_default_config_gen_params(auth_for(leader_id))
+        .await?; // sanity check
+    let server_gen_params = params[leader_id].consensus.modules.clone();
+    set_config_gen_params(leader, auth_for(leader_id), server_gen_params.clone()).await?;
+    let followers_names = followers
+        .keys()
+        .map(|peer_id| {
+            (*peer_id, {
+                // This is to be clear that the name will be unrelated to peer id
+                let random_string = rand::thread_rng()
+                    .sample_iter(&rand::distributions::Alphanumeric)
+                    .take(5)
+                    .map(char::from)
+                    .collect::<String>();
+                format!("random-{random_string}{peer_id}")
+            })
+        })
+        .collect::<BTreeMap<_, _>>();
+    for (peer_id, client) in &followers {
+        let name = followers_names
+            .get(peer_id)
+            .context("missing follower name")?;
+        info!("calling set_config_gen_connections for {peer_id} {name}");
+        client
+            .set_config_gen_connections(
+                ConfigGenConnectionsRequest {
+                    our_name: name.clone(),
+                    leader_api_url: Some(leader.url.clone()),
+                },
+                auth_for(peer_id),
+            )
+            .await?;
+        set_config_gen_params(client, auth_for(peer_id), server_gen_params.clone()).await?;
+    }
+    let found_names = leader
+        .get_config_gen_peers()
+        .await?
+        .into_iter()
+        .map(|peer| peer.name)
+        .collect::<HashSet<_>>();
+    let all_names = {
+        let mut names = followers_names
+            .values()
+            .into_iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+        names.insert(leader_name);
+        names
+    };
+    assert_eq!(found_names, all_names);
+    wait_server_status(leader, ServerStatus::SharingConfigGenParams).await?;
+
+    let mut configs = vec![];
+    for client in admin_clients.values() {
+        configs.push(client.get_consensus_config_gen_params().await?);
+    }
+    // Confirm all consensus configs are the same
+    let mut consensus: Vec<_> = configs.iter().map(|p| p.consensus.clone()).collect();
+    consensus.dedup();
+    assert_eq!(consensus.len(), 1);
+    // Confirm all peer ids are unique
+    let ids = configs
+        .iter()
+        .map(|p| p.our_current_id)
+        .collect::<HashSet<_>>();
+    assert_eq!(ids.len(), admin_clients.len());
+    let dkg_results = admin_clients
+        .iter()
+        .map(|(peer_id, client)| client.run_dkg(auth_for(peer_id)));
+    info!("Running DKG...");
+    let (dkg_results, leader_wait_result) = tokio::join!(
+        join_all(dkg_results),
+        wait_server_status(leader, ServerStatus::ReadyForConfigGen)
+    );
+    for result in dkg_results {
+        result?;
+    }
+    leader_wait_result?;
+
+    // verify config hashes equal for all peers
+    let mut hashes = HashSet::new();
+    for (peer_id, client) in &admin_clients {
+        wait_server_status(client, ServerStatus::VerifyingConfigs).await?;
+        hashes.insert(client.get_verify_config_hash(auth_for(peer_id)).await?);
+    }
+    assert_eq!(hashes.len(), 1);
+    info!("DKG successfully complete. Starting consensus...");
+    for (peer_id, client) in &admin_clients {
+        if let Err(e) = client.start_consensus(auth_for(peer_id)).await {
+            tracing::info!("Error calling start_consensus: {e:?}, trying to continue...")
+        }
+        const RETRIES: usize = 20;
+        poll_max_retries("waiting-consensus-running-for-peer", RETRIES, || async {
+            Ok(client.status().await?.server == ServerStatus::ConsensusRunning)
+        })
+        .await?;
+    }
+    info!("Consensus is running");
+    Ok(())
+}
+
+async fn set_config_gen_params(
+    client: &WsAdminClient,
+    auth: ApiAuth,
+    mut server_gen_params: ServerModuleGenParamsRegistry,
+) -> anyhow::Result<()> {
     attach_default_module_gen_params(
         BitcoinRpcConfig::from_env_vars()?,
-        &mut fed.server_gen_params,
+        &mut server_gen_params,
         Amount::from_sats(100_000_000),
         Network::Regtest,
         10,
     );
+    let request = ConfigGenParamsRequest {
+        meta: BTreeMap::from([("test".to_string(), "testvalue".to_string())]),
+        modules: server_gen_params,
+    };
+    client.set_config_gen_params(request, auth.clone()).await?;
+    Ok(())
+}
 
-    let peers: Vec<_> = (0..servers).map(|id| PeerId::from(id as u16)).collect();
-    let params = local_config_gen_params(&peers, BASE_PORT, fed.server_gen_params.clone())?;
-    let configs = ServerConfig::trusted_dealer_gen(&params, fed.server_gens.clone());
-    let mut fedimintd_envs = BTreeMap::new();
-    for (peer, cfg) in configs {
-        let bind_metrics_api = format!("127.0.0.1:{}", 3510 + peer.to_usize());
-        let envs = vars::Fedimintd::init(&process_mgr.globals, &cfg, bind_metrics_api).await?;
-        let password = cfg.private.api_auth.0.clone();
-        let data_dir = envs.FM_DATA_DIR.clone();
-        fedimintd_envs.insert(peer.to_usize(), envs);
-        write_new(data_dir.join(SALT_FILE), random_salt())?;
-        write_server_config(&cfg, data_dir.clone(), &password, &fed.server_gens)?;
-        if write_password {
-            write_new(data_dir.join(PLAINTEXT_PASSWORD), &password)?;
-        }
-    }
-
-    let out_dir = &fedimintd_envs[&0].FM_DATA_DIR;
-    let cfg_dir = &process_mgr.globals.FM_DATA_DIR;
-    let out_dir = utf8(out_dir);
-    let cfg_dir = utf8(cfg_dir);
-    // copy configs to config directory
-    fs::rename(
-        format!("{out_dir}/client-connect"),
-        format!("{cfg_dir}/client-connect"),
-    )
+async fn wait_server_status(
+    client: &WsAdminClient,
+    expected_status: ServerStatus,
+) -> anyhow::Result<()> {
+    const RETRIES: usize = 60;
+    poll_max_retries("waiting-server-status", RETRIES, || async {
+        Ok(client.status().await?.server == expected_status)
+    })
     .await?;
-    fs::rename(
-        format!("{out_dir}/client.json"),
-        format!("{cfg_dir}/client.json"),
-    )
-    .await?;
-    info!("copied client configs");
-
-    info!("DKG complete");
-
-    Ok(fedimintd_envs)
+    Ok(())
 }

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -152,7 +152,7 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         "--in-file={data_dir}/server-0/private.encrypt",
         "--out-file={data_dir}/server-0/config-plaintext.json"
     )
-    .env("FM_PASSWORD", "pass0")
+    .env("FM_PASSWORD", "pass")
     .run()
     .await?;
 
@@ -181,13 +181,13 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     // Test load last epoch with admin client
     info!("Testing load last epoch with admin client");
     let epoch_json = cmd!(fed, "admin", "last-epoch")
-        .env("FM_PASSWORD", "pass0")
+        .env("FM_PASSWORD", "pass")
         .env("FM_OUR_ID", "0")
         .out_json()
         .await?;
     let epoch_hex = epoch_json["hex_outcome"].as_str().unwrap();
     let _force_epoch = cmd!(fed, "admin", "force-epoch", epoch_hex)
-        .env("FM_PASSWORD", "pass0")
+        .env("FM_PASSWORD", "pass")
         .env("FM_OUR_ID", "0")
         .out_json()
         .await?;
@@ -1119,8 +1119,7 @@ async fn setup(arg: CommonArgs) -> Result<(ProcessManager, TaskGroup)> {
     Ok((process_mgr, task_group))
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+async fn handle_command() -> Result<()> {
     let args = Args::parse();
     match args.command {
         Cmd::ExternalDaemons => {
@@ -1173,6 +1172,18 @@ async fn main() -> Result<()> {
         Cmd::Rpc(rpc) => rpc_command(rpc, args.common).await?,
     }
     Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let ready_file = PathBuf::from(env::var("FM_TEST_DIR")?).join("ready");
+    match handle_command().await {
+        Ok(r) => Ok(r),
+        Err(e) => {
+            write_overwrite_async(ready_file, "ERROR").await?;
+            Err(e)
+        }
+    }
 }
 
 async fn rpc_command(rpc: RpcCmd, common: CommonArgs) -> Result<()> {

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -72,7 +72,7 @@ async fn mkdir(dir: PathBuf) -> anyhow::Result<PathBuf> {
     Ok(dir)
 }
 
-use fedimint_server::config::ServerConfig;
+use fedimint_server::config::ConfigGenParams;
 use format as f;
 
 pub fn utf8(path: &Path) -> &str {
@@ -162,12 +162,12 @@ impl Global {
 //
 // * `id` - ID of the server. Used to calculate port numbers.
 declare_vars! {
-    Fedimintd = (globals: &Global, cfg: &ServerConfig, bind_metrics_api: String) => {
-        FM_BIND_P2P: String = cfg.local.fed_bind.to_string();
-        FM_P2P_URL: String = cfg.local.p2p_endpoints[&cfg.local.identity].url.to_string();
-        FM_BIND_API: String = cfg.local.api_bind.to_string();
-        FM_BIND_METRICS_API: String = bind_metrics_api;
-        FM_API_URL: String = cfg.consensus.api_endpoints[&cfg.local.identity].url.to_string();
-        FM_DATA_DIR: PathBuf = mkdir(globals.FM_DATA_DIR.join(format!("server-{}", cfg.local.identity.to_usize()))).await?;
+    Fedimintd = (globals: &Global, params: ConfigGenParams) => {
+        FM_BIND_P2P: String = params.local.p2p_bind.to_string();
+        FM_BIND_API: String = params.local.api_bind.to_string();
+        FM_P2P_URL: String = params.consensus.peers[&params.local.our_id].p2p_url.to_string();
+        FM_API_URL: String = params.consensus.peers[&params.local.our_id].api_url.to_string();
+        FM_BIND_METRICS_API: String = format!("127.0.0.1:{}", 3510 + params.local.our_id.to_usize());
+        FM_DATA_DIR: PathBuf = mkdir(globals.FM_DATA_DIR.join(format!("server-{}", params.local.our_id.to_usize()))).await?;
     }
 }

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -22,6 +22,7 @@ use crate::PeerId;
 // TODO: Maybe should have it's own CLI client so it doesn't need to be in core
 pub struct WsAdminClient {
     inner: DynGlobalApi,
+    pub url: Url,
 }
 
 impl WsAdminClient {
@@ -30,7 +31,8 @@ impl WsAdminClient {
         // multiple peers so errors can be attributed. The admin client has no use for
         // them.
         Self {
-            inner: WsFederationApi::new(vec![(PeerId(0), url)]).into(),
+            inner: WsFederationApi::new(vec![(PeerId(0), url.clone())]).into(),
+            url,
         }
     }
 

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 use threshold_crypto::{PublicKey, PK_SIZE};
-use tracing::{debug, error, instrument, trace};
+use tracing::{debug, error, instrument, trace, warn};
 use url::Url;
 
 use crate::backup::ClientBackupSnapshot;
@@ -939,7 +939,8 @@ impl<C: JsonRpcClient> FederationMember<C> {
                             .await?
                     }
                     Err(err) => {
-                        error!(
+                        // Warn instead of Error because we will probably retry connecting later
+                        warn!(
                             target: LOG_NET_API,
                             %err, "unable to connect to server");
                         return Err(err)?;

--- a/fedimint-dbtool/README.md
+++ b/fedimint-dbtool/README.md
@@ -71,22 +71,22 @@ just mprocs
 
 Dump the entire database of server-0
 ```shell
-dbtool $FM_DATA_DIR/server-0/database dump -- $FM_DATA_DIR/server-0 pass0
+dbtool $FM_DATA_DIR/server-0/database dump -- $FM_DATA_DIR/server-0 pass
 ```
 
 Dump the consensus db entries of server-0
 ```shell
-dbtool $FM_DATA_DIR/server-0/database dump -- $FM_DATA_DIR/server-0 pass0 consensus
+dbtool $FM_DATA_DIR/server-0/database dump -- $FM_DATA_DIR/server-0 pass consensus
 ```
 
 Dump the blocks from the wallet module of server-1
 ```shell
-dbtool $FM_DATA_DIR/server-1/database dump -- $FM_DATA_DIR/server-1 pass1 consensus blockhash
+dbtool $FM_DATA_DIR/server-1/database dump -- $FM_DATA_DIR/server-1 pass consensus blockhash
 ```
 
 Dump the used notes from the mint module and the accepted transactions from consensus
 ```shell
-dbtool $FM_DATA_DIR/server-1/database dump -- $FM_DATA_DIR/server-1 pass1 consensus,mint notenonce,acceptedtransaction
+dbtool $FM_DATA_DIR/server-1/database dump -- $FM_DATA_DIR/server-1 pass consensus,mint notenonce,acceptedtransaction
 ```
 
 Dump the entire client database (client password can be anything since it doesn't require decryption)

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -176,7 +176,7 @@ pub fn local_config_gen_params(
                 local: ConfigGenParamsLocal {
                     our_id: *peer,
                     our_private_key: tls_keys[peer].1.clone(),
-                    api_auth: ApiAuth(format!("pass{}", peer.to_usize())),
+                    api_auth: ApiAuth("pass".to_string()),
                     p2p_bind: p2p_bind.parse().expect("Valid address"),
                     api_bind: api_bind.parse().expect("Valid address"),
                     download_token_limit: None,

--- a/misc/mprocs.yaml
+++ b/misc/mprocs.yaml
@@ -22,6 +22,6 @@ procs:
   bitcoind:
     shell: tail -n +0 -F $FM_LOGS_DIR/bitcoind.log
   devimint:
-    shell: tail -n +0 -F $FM_LOGS_DIR/devimint.log
+    shell: tail -n +0 -F $FM_LOGS_DIR/devimint-outer.log
   faucet:
     shell: tail -n +0 -F $FM_LOGS_DIR/faucet.log

--- a/scripts/mprocs.sh
+++ b/scripts/mprocs.sh
@@ -12,7 +12,8 @@ export FM_VERBOSE_OUTPUT=0
 
 source scripts/build.sh
 
-devimint dev-fed 2>/dev/null &
+mkdir -p $FM_LOGS_DIR
+devimint dev-fed 2>$FM_LOGS_DIR/devimint-outer.log &
 echo $! >> $FM_PID_FILE
 eval "$(devimint env)"
 

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -17,7 +17,8 @@ export FM_VERBOSE_OUTPUT=0
 
 source scripts/build.sh
 
-devimint dev-fed 2>/dev/null &
+mkdir -p $FM_LOGS_DIR
+devimint dev-fed 2>$FM_LOGS_DIR/devimint-outer.log &
 echo $! >> $FM_PID_FILE
 eval "$(devimint env)"
 


### PR DESCRIPTION
devimint is supposed to test binaries, but currently DKG is using fedimint as a library, making it harder to run tests with custom fedimintd binaries.

This change drops this "library" usage and makes DKG runs as api calls to the underlining fedimintd process.

One difficulty of implementing this is that we don't know before DKG what will be the peer ids. But we need to start everything with the conventional names and configurations.

So it's tricky to set up different passwords for different peers (we don't know exactly which fedimintd will be which peer). To make things simple, we are now using the same password for all the fedimintds.