### PR TITLE
fix: our ring fork not compiling c code for wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.16.20"
-source = "git+https://github.com/Maan2003/ring?rev=52a1294a8fc066cc0656911ec22b8358fb763ef1#52a1294a8fc066cc0656911ec22b8358fb763ef1"
+source = "git+https://github.com/dpc/ring?rev=5493e7e76d0d8fb1d3cbb0be9c4944700741b802#5493e7e76d0d8fb1d3cbb0be9c4944700741b802"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,4 +90,4 @@ debug = 1
 
 [patch.crates-io]
 secp256k1-zkp = { git = "https://github.com/dpc/rust-secp256k1-zkp/", branch = "sanket-pr" }
-ring = { git = "https://github.com/Maan2003/ring", rev = "52a1294a8fc066cc0656911ec22b8358fb763ef1" }
+ring = { git = "https://github.com/dpc/ring", rev = "5493e7e76d0d8fb1d3cbb0be9c4944700741b802" }

--- a/fedimint-client-legacy/Cargo.toml
+++ b/fedimint-client-legacy/Cargo.toml
@@ -57,7 +57,7 @@ jsonrpsee-ws-client = { version = "0.18.0", features = ["webpki-tls"], default-f
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 jsonrpsee-wasm-client = { version = "0.18.0" }
-ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js"] }
+ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js", "wasm32_c"] }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["full"] }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -38,7 +38,7 @@ tokio = { version = "1.26.0", features = [ "time", "macros" ] }
 tracing = "0.1.37"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js"] }
+ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js", "wasm32_c"] }
 
 [dev-dependencies]
 tracing-test = "0.2.4"

--- a/fedimint-wasm-tests/Cargo.toml
+++ b/fedimint-wasm-tests/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = [ "rlib", "cdylib" ]
 [dependencies]
 anyhow = "1.0.69"
 futures = "0.3.26"
-ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js"] }
+ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js", "wasm32_c"] }
 fedimint-client = { path = "../fedimint-client" }
 fedimint-core = { path = "../fedimint-core" }
 fedimint-mint-client = { path = "../modules/fedimint-mint-client" }


### PR DESCRIPTION
The actual fix:

https://github.com/dpc/ring/commit/5493e7e76d0d8fb1d3cbb0be9c4944700741b802

The reason the poly stuff was missing was:

https://github.com/dpc/ring/blob/5493e7e76d0d8fb1d3cbb0be9c4944700741b802/build.rs#L326

which took me embarrassingly long to figure out.

I just re-introduced `wasm32_c`, to keep the changes minimal.

Fix #2843

I confirmed that the "import from env" is gone. Though the repro in it now fails with:

```
Error: non-200 response code: 500
{"value":{"error":"unknown error","message":"Failed to decode response from marionette","stacktrace":""}}
error: test failed, to rerun pass `--lib`
```

but that seems something entirely different.