### PR TITLE
Refactor: Gateway Client Builder

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -579,7 +579,7 @@ struct FederationPeer<C> {
 /// Information required for client to construct [`WsFederationApi`] instance
 ///
 /// Can be used to download the configs and bootstrap a client
-#[derive(Clone, Debug, Eq, PartialEq, Encodable)]
+#[derive(Clone, Debug, Eq, PartialEq, Encodable, Decodable)]
 pub struct InviteCode {
     /// URL to reach an API that we can download configs from
     pub url: SafeUrl,

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -5,12 +5,11 @@ use std::sync::Arc;
 
 use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::secret::PlainRootSecretStrategy;
-use fedimint_client::ClientBuilder;
-use fedimint_core::api::{DynGlobalApi, GlobalFederationApi, InviteCode, WsFederationApi};
+use fedimint_client::{get_config_from_db, ClientBuilder};
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::DatabaseTransaction;
+use fedimint_core::db::{Database, DatabaseTransaction};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
 use futures::StreamExt;
-use lightning::routing::gossip::RoutingFees;
 
 use crate::db::{FederationConfig, FederationIdKey, FederationIdKeyPrefix};
 use crate::lnrpc_client::ILnRpcClient;
@@ -47,30 +46,47 @@ impl StandardGatewayClientBuilder {
         lnrpc: Arc<dyn ILnRpcClient>,
         old_client: Option<fedimint_client::Client>,
     ) -> Result<fedimint_client::Client> {
-        let federation_id = config.config.global.federation_id;
+        let FederationConfig {
+            invite_code,
+            mint_channel_id,
+            timelock_delta,
+            fees,
+        } = config;
+        let federation_id = invite_code.id;
 
         let mut registry = self.registry.clone();
         registry.attach(GatewayClientGen {
             lnrpc,
             node_pub_key,
             lightning_alias,
-            fees: config.fees,
-            timelock_delta: config.timelock_delta,
-            mint_channel_id: config.mint_channel_id,
+            fees,
+            timelock_delta,
+            mint_channel_id,
         });
 
         let mut client_builder = ClientBuilder::default();
         client_builder.with_module_inits(registry);
         client_builder.with_primary_module(self.primary_module);
-        client_builder.with_config(config.config);
         if let Some(old_client) = old_client {
             client_builder.with_old_client_database(old_client);
         } else {
             let db_path = self.work_dir.join(format!("{federation_id}.db"));
-            let db = fedimint_rocksdb::RocksDb::open(db_path).map_err(|e| {
+            {
+                let rocksdb = fedimint_rocksdb::RocksDb::open(db_path.clone()).map_err(|e| {
+                    GatewayError::DatabaseError(anyhow::anyhow!("Error opening rocksdb: {e:?}"))
+                })?;
+
+                // Initialize a client database to check if a config was previously saved in it
+                let db = Database::new(rocksdb, ModuleDecoderRegistry::default());
+                if (get_config_from_db(&db).await).is_none() {
+                    client_builder.with_invite_code(invite_code);
+                }
+            }
+
+            let rocksdb = fedimint_rocksdb::RocksDb::open(db_path.clone()).map_err(|e| {
                 GatewayError::DatabaseError(anyhow::anyhow!("Error opening rocksdb: {e:?}"))
             })?;
-            client_builder.with_database(db);
+            client_builder.with_database(rocksdb);
         }
 
         client_builder
@@ -80,28 +96,12 @@ impl StandardGatewayClientBuilder {
             .map_err(GatewayError::ClientStateMachineError)
     }
 
-    pub async fn create_config(
-        &self,
-        connect: InviteCode,
-        mint_channel_id: u64,
-        fees: RoutingFees,
-    ) -> Result<FederationConfig> {
-        let api: DynGlobalApi = WsFederationApi::from_invite_code(&[connect.clone()]).into();
-        let client_config = api.download_client_config(&connect).await?;
-        Ok(FederationConfig {
-            mint_channel_id,
-            timelock_delta: 10,
-            fees,
-            config: client_config,
-        })
-    }
-
     pub async fn save_config(
         &self,
         config: FederationConfig,
         mut dbtx: DatabaseTransaction<'_>,
     ) -> Result<()> {
-        let id = config.config.global.federation_id;
+        let id = config.invite_code.id;
         dbtx.insert_entry(&FederationIdKey { id }, &config).await;
         dbtx.commit_tx_result()
             .await

--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -1,4 +1,5 @@
-use fedimint_core::config::{ClientConfig, FederationId};
+use fedimint_core::api::InviteCode;
+use fedimint_core::config::FederationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use fedimint_ln_common::{serde_routing_fees, LightningGateway};
@@ -32,10 +33,10 @@ pub struct FederationIdKeyPrefix;
 
 #[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable)]
 pub struct FederationConfig {
+    pub invite_code: InviteCode,
     pub mint_channel_id: u64,
     pub timelock_delta: u64,
     pub fees: RoutingFees,
-    pub config: ClientConfig,
 }
 
 impl Serialize for FederationConfig {
@@ -44,9 +45,9 @@ impl Serialize for FederationConfig {
         S: serde::Serializer,
     {
         let mut state = serializer.serialize_struct("FederationConfig", 5)?;
+        state.serialize_field("invite_code", &self.invite_code)?;
         state.serialize_field("mint_channel_id", &self.mint_channel_id)?;
         state.serialize_field("timelock_delta", &self.timelock_delta)?;
-        state.serialize_field("config", &self.config)?;
         state.serialize_field("base_msat", &self.fees.base_msat)?;
         state.serialize_field(
             "proportional_millionths",


### PR DESCRIPTION
Refactor gateway client builder to persist only the connection info, channel id, fees and timelock in gateway db.
The gateway client builder delegates registration with the federation to the common `ClientBuilder`, to which it provides a connection info the first time a client is registered

depends on #2734 