### PR TITLE
fix: fedimintd binaries can set default module gen params

### DIFF
--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -6,7 +6,10 @@ use std::time::Duration;
 use clap::Parser;
 use fedimint_core::admin_client::ConfigGenParamsRequest;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
-use fedimint_core::config::{ServerModuleGenParamsRegistry, ServerModuleGenRegistry};
+use fedimint_core::config::{
+    ModuleGenParams, ServerModuleGenParamsRegistry, ServerModuleGenRegistry,
+};
+use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::Database;
 use fedimint_core::module::ServerModuleGen;
 use fedimint_core::task::{sleep, TaskGroup};
@@ -131,6 +134,20 @@ impl Fedimintd {
         T: ServerModuleGen + 'static + Send + Sync,
     {
         self.server_gens.attach(gen);
+        self
+    }
+
+    pub fn with_extra_module_gens_params<P>(
+        mut self,
+        id: ModuleInstanceId,
+        kind: ModuleKind,
+        params: P,
+    ) -> Self
+    where
+        P: ModuleGenParams,
+    {
+        self.server_gen_params
+            .attach_config_gen_params(id, kind, params);
         self
     }
 


### PR DESCRIPTION
This was inadvertently deleted in https://github.com/fedimint/fedimint/commit/b6dd1c594ac45e08e8377535e742041a9da4a8e5, but impairs the ability of 3rd party modules to run