### PR TITLE
chore: build both client-legacy and client in `.#client-pkgs`

### DIFF
--- a/nix/craneBuild.nix
+++ b/nix/craneBuild.nix
@@ -287,6 +287,7 @@ craneLib.overrideScope' (self: prev: {
 
     pkgs = {
       fedimint-client-legacy = { };
+      fedimint-client = { };
     } // lib.optionalAttrs (target == null || target.name != "wasm32-unknown-unknown") {
       # broken on wasm32
       fedimint-sqlite = { };


### PR DESCRIPTION
The goal there is to validate the client builds for a given architecture.