### PR TITLE
Update to thunderhub v0.13.20 with signet support

### DIFF
--- a/docker/gateway-mutinynet/docker-compose.yaml
+++ b/docker/gateway-mutinynet/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
     restart: always
 
   thunderhub:
-    image: apotdevin/thunderhub:base-v0.13.19
+    image: apotdevin/thunderhub:base-v0.13.20
     environment:
       - ACCOUNT_CONFIG_PATH=/thconfig/accounts.yaml
       - HOST=0.0.0.0


### PR DESCRIPTION
thunderhub before v0.13.20 does not have signet support and therefore fails. This upgrades to v0.13.20.