### PR TITLE
fix: purge "block height", use "block count"

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -225,9 +225,9 @@ impl Federation {
             .0
             .get_module(LEGACY_HARDCODED_INSTANCE_ID_WALLET)?;
         let finality_delay = wallet_cfg.finality_delay;
-        let btc_height = self.bitcoind.client().get_blockchain_info()?.blocks;
-        let expected = btc_height - (finality_delay as u64);
-        cmd!(self, "dev", "wait-block-height", expected)
+        let bitcoind_block_count = self.bitcoind.client().get_blockchain_info()?.blocks;
+        let expected = bitcoind_block_count - (finality_delay as u64);
+        cmd!(self, "dev", "wait-block-count", expected)
             .run()
             .await?;
         Ok(())
@@ -250,7 +250,7 @@ impl Federation {
             self,
             "dev",
             "api",
-            "module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_block_height"
+            "module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_block_count"
         )
         .run()
         .await?;

--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -49,7 +49,7 @@ impl IBitcoindRpc for BitcoinClient {
         })
     }
 
-    async fn get_block_height(&self) -> anyhow::Result<u64> {
+    async fn get_block_count(&self) -> anyhow::Result<u64> {
         block_in_place(|| self.0.get_block_count()).map_err(anyhow::Error::from)
     }
 

--- a/fedimint-bitcoind/src/electrum.rs
+++ b/fedimint-bitcoind/src/electrum.rs
@@ -50,8 +50,8 @@ impl IBitcoindRpc for ElectrumClient {
         })
     }
 
-    async fn get_block_height(&self) -> anyhow::Result<u64> {
-        Ok(block_in_place(|| self.0.block_headers_subscribe_raw())?.height as u64)
+    async fn get_block_count(&self) -> anyhow::Result<u64> {
+        Ok(block_in_place(|| self.0.block_headers_subscribe_raw())?.height as u64 + 1)
     }
 
     async fn get_block_hash(&self, height: u64) -> anyhow::Result<BlockHash> {

--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -53,9 +53,9 @@ impl IBitcoindRpc for EsploraClient {
         Ok(network)
     }
 
-    async fn get_block_height(&self) -> anyhow::Result<u64> {
+    async fn get_block_count(&self) -> anyhow::Result<u64> {
         match self.0.get_height().await {
-            Ok(height) => Ok(height as u64),
+            Ok(height) => Ok(height as u64 + 1),
             Err(e) => Err(e.into()),
         }
     }

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -86,15 +86,15 @@ pub trait IBitcoindRpc: Debug {
     /// Returns the Bitcoin network the node is connected to
     async fn get_network(&self) -> Result<bitcoin::Network>;
 
-    /// Returns the current block height
-    async fn get_block_height(&self) -> Result<u64>;
+    /// Returns the current block count
+    async fn get_block_count(&self) -> Result<u64>;
 
     /// Returns the block hash at a given height
     ///
     /// # Panics
     /// If the node does not know a block for that height. Make sure to only
-    /// query blocks of a height less or equal to the one returned by
-    /// `Self::get_block_height`.
+    /// query blocks of a height less to the one returned by
+    /// `Self::get_block_count`.
     ///
     /// While there is a corner case that the blockchain shrinks between these
     /// two calls (through on average heavier blocks on a fork) this is
@@ -195,8 +195,8 @@ where
             .await
     }
 
-    async fn get_block_height(&self) -> Result<u64> {
-        self.retry_call(|| async { self.inner.get_block_height().await })
+    async fn get_block_count(&self) -> Result<u64> {
+        self.retry_call(|| async { self.inner.get_block_count().await })
             .await
     }
 

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -60,7 +60,7 @@ enum CliOutput {
         value: Value,
     },
 
-    WaitBlockHeight {
+    WaitBlockCount {
         reached: u64,
     },
 
@@ -401,8 +401,8 @@ enum DevCmd {
     /// Config enabling client to establish websocket connection to federation
     InviteCode,
 
-    /// Wait for the fed to reach a consensus block height
-    WaitBlockHeight { height: u64 },
+    /// Wait for the fed to reach a consensus block count
+    WaitBlockCount { count: u64 },
 
     /// Decode connection info into its JSON representation
     DecodeInviteCode { invite_code: InviteCode },
@@ -655,7 +655,7 @@ impl FedimintCli {
 
                 Ok(CliOutput::InviteCode { invite_code })
             }
-            Command::Dev(DevCmd::WaitBlockHeight { height: target }) => {
+            Command::Dev(DevCmd::WaitBlockCount { count: target }) => {
                 task::timeout(Duration::from_secs(30), async move {
                     let client = cli.build_client_ng(&self.module_gens).await?;
                     loop {
@@ -664,10 +664,10 @@ impl FedimintCli {
                         let count = client
                             .api()
                             .with_module(instance.id)
-                            .fetch_consensus_block_height()
+                            .fetch_consensus_block_count()
                             .await?;
                         if count >= target {
-                            break Ok(CliOutput::WaitBlockHeight { reached: count });
+                            break Ok(CliOutput::WaitBlockCount { reached: count });
                         }
                         task::sleep(Duration::from_millis(100)).await;
                     }

--- a/fedimint-client-legacy/src/api.rs
+++ b/fedimint-client-legacy/src/api.rs
@@ -137,7 +137,7 @@ where
 
 #[apply(async_trait_maybe_send!)]
 pub trait WalletFederationApi {
-    async fn fetch_consensus_block_height(&self) -> FederationResult<u64>;
+    async fn fetch_consensus_block_count(&self) -> FederationResult<u64>;
     async fn fetch_peg_out_fees(
         &self,
         address: &Address,
@@ -150,11 +150,11 @@ impl<T: ?Sized> WalletFederationApi for T
 where
     T: IFederationApi + MaybeSend + MaybeSync + 'static,
 {
-    async fn fetch_consensus_block_height(&self) -> FederationResult<u64> {
+    async fn fetch_consensus_block_count(&self) -> FederationResult<u64> {
         self.with_module(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
             .request_with_strategy(
                 EventuallyConsistent::new(self.all_members().one_honest()),
-                "block_height".to_string(),
+                "block_count".to_string(),
                 ApiRequestErased::default(),
             )
             .await

--- a/fedimint-core/src/client.rs
+++ b/fedimint-core/src/client.rs
@@ -1,7 +1,6 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
-use bitcoin_hashes::sha256::Hash as Sha256Hash;
-use fedimint_core::task::{RwLock, RwLockWriteGuard};
-use fedimint_core::{NumPeers, OutPoint, PeerId, TransactionId};
 // use fedimint_core::modules::ln::contracts::incoming::IncomingContractOffer;
 // use fedimint_core::modules::ln::contracts::ContractId;
 // use fedimint_core::modules::ln::{ContractAccount, LightningGateway};
@@ -29,13 +28,14 @@ use fedimint_core::{NumPeers, OutPoint, PeerId, TransactionId};
 //     ValidHistory,
 // };
 use bitcoin::{Address, Amount};
+use bitcoin_hashes::sha256::Hash as Sha256Hash;
+use fedimint_core::task::{RwLock, RwLockWriteGuard};
+use fedimint_core::{NumPeers, OutPoint, PeerId, TransactionId};
 // use fedimint_core::config::ClientConfig;
 // use fedimint_core::epoch::EpochHistory;
 // use fedimint_core::modules::wallet::PegOutFees;
 use futures::stream::FuturesUnordered;
-
 use futures::StreamExt;
-use std::time::Duration;
 use thiserror::Error;
 
 use crate::module::ApiError;
@@ -61,12 +61,13 @@ pub trait FederationApi: Send + Sync {
     /// Fetch preimage offer for incoming lightning payments
     async fn fetch_offer(&self, payment_hash: Sha256Hash) -> Result<IncomingContractOffer>;
 
-    // TODO: find a better abstraction for all our API endpoints that allows different strategies and timeouts
+    // TODO: find a better abstraction for all our API endpoints that allows
+    // different strategies and timeouts
     /// Checks if there exists an offer for a payment hash
     async fn offer_exists(&self, payment_hash: Sha256Hash) -> Result<bool>;
 
     /// Fetch the current consensus block height (trailing actual block height)
-    async fn fetch_consensus_block_height(&self) -> Result<u64>;
+    async fn fetch_consensus_block_count(&self) -> Result<u64>;
 
     /// Fetch the expected peg-out fees given a peg-out tx
     async fn fetch_peg_out_fees(
@@ -75,7 +76,8 @@ pub trait FederationApi: Send + Sync {
         amount: &Amount,
     ) -> Result<Option<PegOutFees>>;
 
-    /// Fetch available lightning gateways (assumes gateways register with all peers)
+    /// Fetch available lightning gateways (assumes gateways register with all
+    /// peers)
     async fn fetch_gateways(&self) -> Result<Vec<LightningGateway>>;
 
     /// Register a gateway with the federation

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -276,13 +276,7 @@ impl ConsensusServer {
         self.start_consensus().await;
 
         while !task_handle.is_shutting_down() {
-            let outcomes = if let Ok(v) = self.run_consensus_epoch(None, &mut rng).await {
-                v
-            } else {
-                // `None` is supposed to mean the process is shutting down
-                debug_assert!(task_handle.is_shutting_down());
-                break;
-            };
+            let outcomes = self.run_consensus_epoch(None, &mut rng).await?;
 
             for outcome in outcomes {
                 info!(

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -243,8 +243,8 @@ impl IBitcoindRpc for FakeBitcoinTest {
         Ok(Network::Regtest)
     }
 
-    async fn get_block_height(&self) -> BitcoinRpcResult<u64> {
-        Ok((self.blocks.lock().unwrap().len() as u64) - 1)
+    async fn get_block_count(&self) -> BitcoinRpcResult<u64> {
+        Ok(self.blocks.lock().unwrap().len() as u64)
     }
 
     async fn get_block_hash(&self, height: u64) -> BitcoinRpcResult<BlockHash> {

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -52,18 +52,14 @@ impl BitcoinTest for RealBitcoinTestNoLock {
             .expect(Self::ERROR)
             .last()
         {
-            let block = self
+            let last_mined_block = self
                 .client
                 .get_block_header_info(block_hash)
                 .expect("rpc failed");
             // waits for the rpc client to catch up to bitcoind
-            loop {
-                let height = self.rpc.get_block_height().await.expect("rpc failed");
-
-                if height >= block.height as u64 {
-                    break;
-                }
-            }
+            while self.rpc.get_block_count().await.expect("rpc failed")
+                < last_mined_block.height as u64
+            {}
         };
     }
 

--- a/gateway/ln-gateway/src/ng/tests.rs
+++ b/gateway/ln-gateway/src/ng/tests.rs
@@ -492,7 +492,8 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
                 .unwrap();
             assert_eq!(invoice.expiry_time(), Duration::from_secs(1));
 
-            sleep(Duration::from_secs(1)).await;
+            // at seconds granularity, must wait `expiry + 1s` to make sure expired
+            sleep(Duration::from_secs(2)).await;
 
             // Print money for user_client
             let (_, outpoint) = user_client.print_money(sats(2000)).await?;

--- a/integrationtests/tests/fixtures/legacy.rs
+++ b/integrationtests/tests/fixtures/legacy.rs
@@ -170,9 +170,9 @@ impl ILegacyWalletClient for LegacyTestUser<UserClientConfig> {
         self.client.rbf_tx(rbf).await.map_err(other)
     }
 
-    async fn await_consensus_block_height(&self, block_height: u64) -> LegacyClientResult<u64> {
+    async fn await_consensus_block_count(&self, block_count: u64) -> LegacyClientResult<u64> {
         self.client
-            .await_consensus_block_height(block_height)
+            .await_consensus_block_count(block_count)
             .await
             .map_err(other)
     }

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -217,7 +217,8 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
                 peers,
                 user_db,
             ));
-            user.client.await_consensus_block_height(0).await?;
+            // just for readiness
+            user.client.await_consensus_block_count(0).await?;
 
             Fixtures {
                 fed,
@@ -276,7 +277,8 @@ pub async fn fixtures(num_peers: u16) -> anyhow::Result<Fixtures> {
                 peers,
                 user_db,
             ));
-            user.client.await_consensus_block_height(0).await?;
+            // just for readiness
+            user.client.await_consensus_block_count(0).await?;
 
             // Always be prepared to fund bitcoin wallet
             factory.bitcoin.prepare_funding_wallet().await;
@@ -466,7 +468,7 @@ impl FederationTest {
                     ConsensusItem::Module(module) if module.module_instance_id() == LEGACY_HARDCODED_INSTANCE_ID_WALLET => {
                         let wallet_item = module.as_any().downcast_ref::<<<Wallet as ServerModule>::Common as ModuleCommon>::ConsensusItem>().expect("test should use fixed module instances");
                         match wallet_item {
-                            WalletConsensusItem::BlockHeight(_) => true,
+                            WalletConsensusItem::BlockCount(_) => true,
                             WalletConsensusItem::Feerate(_) => true,
                             WalletConsensusItem::PegOutSignature(_) => false
                         }

--- a/integrationtests/tests/fixtures/user.rs
+++ b/integrationtests/tests/fixtures/user.rs
@@ -126,11 +126,11 @@ pub trait ILegacyWalletClient {
     /// Helps prevent transactions from getting stuck in the mempool
     async fn rbf_peg_out_tx(&self, rbf: Rbf) -> LegacyClientResult<OutPoint>;
 
-    /// Awaits for the federation's consensus block height to reach a target
+    /// Awaits for the federation's consensus block count to reach a target
     ///
-    /// The consensus block height will be below the actual block height to
+    /// The consensus block count will be below the actual block count to
     /// account for finality delay
-    async fn await_consensus_block_height(&self, block_height: u64) -> LegacyClientResult<u64>;
+    async fn await_consensus_block_count(&self, block_count: u64) -> LegacyClientResult<u64>;
 }
 
 #[async_trait]

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -360,7 +360,7 @@ async fn rejoin_consensus_single_peer() -> Result<()> {
         online_peers.run_consensus_epochs(1).await;
         bitcoin.mine_blocks(100).await;
         online_peers.run_consensus_epochs(1).await;
-        let height = user.await_consensus_block_height(0).await.unwrap();
+        let block_count = user.await_consensus_block_count(1).await.unwrap();
 
         // Run until peer 3 has rejoined
         join_all(vec![
@@ -377,8 +377,11 @@ async fn rejoin_consensus_single_peer() -> Result<()> {
         // Ensure peer 3 rejoined and caught up to consensus
         let client2 = user.new_client_with_peers(peers(&[1, 2, 3]));
 
-        let new_height = client2.await_consensus_block_height(height).await.unwrap();
-        assert_eq!(new_height, height);
+        let new_block_count = client2
+            .await_consensus_block_count(block_count)
+            .await
+            .unwrap();
+        assert_eq!(new_block_count, block_count);
     })
     .await
 }
@@ -416,10 +419,10 @@ async fn rejoin_consensus_split_peers() -> Result<()> {
         fed.run_consensus_epochs(1).await;
 
         // We cannot process a past epoch and reverse the block height
-        let height = user.await_consensus_block_height(0).await.unwrap();
+        let block_count = user.await_consensus_block_count(1).await.unwrap();
         fed.force_process_outcome(epoch);
         fed.run_consensus_epochs_wait(1).await.unwrap();
-        user.await_consensus_block_height(height).await.unwrap();
+        user.await_consensus_block_count(block_count).await.unwrap();
     })
     .await
 }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -641,11 +641,11 @@ impl LightningClientModule {
             invoice_currency
         );
 
-        let consensus_height = api
-            .fetch_consensus_block_height()
+        let consensus_count = api
+            .fetch_consensus_block_count()
             .await?
-            .ok_or(format_err!("Cannot get consensus block height"))?;
-        let absolute_timelock = consensus_height + OUTGOING_LN_CONTRACT_TIMELOCK;
+            .ok_or(format_err!("Cannot get consensus block count"))?;
+        let absolute_timelock = consensus_count + OUTGOING_LN_CONTRACT_TIMELOCK - 1;
 
         // Compute amount to lock in the outgoing contract
         let invoice_amount_msat = invoice

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -400,14 +400,14 @@ impl LightningPayRefundable {
     async fn await_contract_timeout(global_context: DynGlobalClientContext, timelock: u32) {
         // TODO: Remove polling
         loop {
-            let consensus_block_height = global_context
+            let consensus_block_count = global_context
                 .module_api()
-                .fetch_consensus_block_height()
+                .fetch_consensus_block_count()
                 .await
                 .map_err(|e| anyhow::anyhow!("ApiError: {e:?}"));
 
-            if let Ok(Some(current_block_height)) = consensus_block_height {
-                if timelock as u64 <= current_block_height {
+            if let Ok(Some(current_block_count)) = consensus_block_count {
+                if (timelock as u64) < current_block_count {
                     return;
                 }
             }

--- a/modules/fedimint-ln-common/src/api.rs
+++ b/modules/fedimint-ln-common/src/api.rs
@@ -12,7 +12,7 @@ use crate::{ContractAccount, LightningGateway};
 
 #[apply(async_trait_maybe_send!)]
 pub trait LnFederationApi {
-    async fn fetch_consensus_block_height(&self) -> FederationResult<Option<u64>>;
+    async fn fetch_consensus_block_count(&self) -> FederationResult<Option<u64>>;
     async fn fetch_contract(&self, contract: ContractId) -> FederationResult<ContractAccount>;
     async fn fetch_offer(
         &self,
@@ -38,8 +38,8 @@ impl<T: ?Sized> LnFederationApi for T
 where
     T: IModuleFederationApi + MaybeSend + MaybeSync + 'static,
 {
-    async fn fetch_consensus_block_height(&self) -> FederationResult<Option<u64>> {
-        self.request_current_consensus("block_height".to_string(), ApiRequestErased::default())
+    async fn fetch_consensus_block_count(&self) -> FederationResult<Option<u64>> {
+        self.request_current_consensus("block_count".to_string(), ApiRequestErased::default())
             .await
     }
 

--- a/modules/fedimint-ln-common/src/db.rs
+++ b/modules/fedimint-ln-common/src/db.rs
@@ -17,7 +17,7 @@ pub enum DbKeyPrefix {
     AgreedDecryptionShare = 0x43,
     ContractUpdate = 0x44,
     LightningGateway = 0x45,
-    BlockHeightVote = 0x46,
+    BlockCountVote = 0x46,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -127,18 +127,15 @@ impl_db_lookup!(
 );
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
-pub struct BlockHeightVoteKey(pub PeerId);
+pub struct BlockCountVoteKey(pub PeerId);
 
 #[derive(Clone, Debug, Encodable, Decodable)]
-pub struct BlockHeightVotePrefix;
+pub struct BlockCountVotePrefix;
 
 impl_db_record!(
-    key = BlockHeightVoteKey,
+    key = BlockCountVoteKey,
     value = u64,
-    db_prefix = DbKeyPrefix::BlockHeightVote
+    db_prefix = DbKeyPrefix::BlockCountVote
 );
 
-impl_db_lookup!(
-    key = BlockHeightVoteKey,
-    query_prefix = BlockHeightVotePrefix
-);
+impl_db_lookup!(key = BlockCountVoteKey, query_prefix = BlockCountVotePrefix);

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -204,7 +204,7 @@ pub struct LightningGateway {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub enum LightningConsensusItem {
     DecryptPreimage(ContractId, PreimageDecryptionShare),
-    BlockHeight(u64),
+    BlockCount(u64),
 }
 
 impl std::fmt::Display for LightningConsensusItem {
@@ -213,7 +213,7 @@ impl std::fmt::Display for LightningConsensusItem {
             LightningConsensusItem::DecryptPreimage(contract_id, _) => {
                 write!(f, "LN Decryption Share for contract {contract_id}")
             }
-            LightningConsensusItem::BlockHeight(height) => write!(f, "LN block height {height}"),
+            LightningConsensusItem::BlockCount(count) => write!(f, "LN block count {count}"),
         }
     }
 }

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -8,7 +8,7 @@ use fedimint_wallet_common::PegOutFees;
 
 #[apply(async_trait_maybe_send!)]
 pub trait WalletFederationApi {
-    async fn fetch_consensus_block_height(&self) -> FederationResult<u64>;
+    async fn fetch_consensus_block_count(&self) -> FederationResult<u64>;
     async fn fetch_peg_out_fees(
         &self,
         address: &Address,
@@ -21,10 +21,10 @@ impl<T: ?Sized> WalletFederationApi for T
 where
     T: IModuleFederationApi + MaybeSend + MaybeSync + 'static,
 {
-    async fn fetch_consensus_block_height(&self) -> FederationResult<u64> {
+    async fn fetch_consensus_block_count(&self) -> FederationResult<u64> {
         self.request_with_strategy(
             EventuallyConsistent::new(self.all_members().one_honest()),
-            "block_height".to_string(),
+            "block_count".to_string(),
             ApiRequestErased::default(),
         )
         .await

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -192,12 +192,12 @@ async fn await_btc_transaction_confirmed(
         // Wait for confirmation
         let consensus_height = match global_context
             .module_api()
-            .fetch_consensus_block_height()
+            .fetch_consensus_block_count()
             .await
         {
-            Ok(consensus_height) => consensus_height,
+            Ok(consensus_block_count) => consensus_block_count,
             Err(e) => {
-                warn!("Failed to fetch consensus height from federation: {e}");
+                warn!("Failed to fetch consensus block count from federation: {e}");
                 sleep(TRANSACTION_STATUS_FETCH_INTERVAL).await;
                 continue;
             }

--- a/modules/fedimint-wallet-common/src/db.rs
+++ b/modules/fedimint-wallet-common/src/db.rs
@@ -12,7 +12,7 @@ use crate::{PendingTransaction, SpendableUTXO, UnsignedTransaction, WalletOutput
 pub enum DbKeyPrefix {
     BlockHash = 0x30,
     Utxo = 0x31,
-    BlockHeightVote = 0x32,
+    BlockCountVote = 0x32,
     FeeRateVote = 0x33,
     UnsignedTransaction = 0x34,
     PendingTransaction = 0x35,
@@ -119,21 +119,18 @@ impl_db_lookup!(
 );
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
-pub struct BlockHeightVoteKey(pub PeerId);
+pub struct BlockCountVoteKey(pub PeerId);
 
 #[derive(Clone, Debug, Encodable, Decodable)]
-pub struct BlockHeightVotePrefix;
+pub struct BlockCountVotePrefix;
 
 impl_db_record!(
-    key = BlockHeightVoteKey,
+    key = BlockCountVoteKey,
     value = u32,
-    db_prefix = DbKeyPrefix::BlockHeightVote
+    db_prefix = DbKeyPrefix::BlockCountVote
 );
 
-impl_db_lookup!(
-    key = BlockHeightVoteKey,
-    query_prefix = BlockHeightVotePrefix
-);
+impl_db_lookup!(key = BlockCountVoteKey, query_prefix = BlockCountVotePrefix);
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct FeeRateVoteKey(pub PeerId);

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -38,8 +38,8 @@ pub type PegInDescriptor = Descriptor<CompressedPublicKey>;
     Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, UnzipConsensus, Encodable, Decodable,
 )]
 pub enum WalletConsensusItem {
-    BlockHeight(u32), /* FIXME: use block hash instead, but needs more complicated
-                       * * verification logic */
+    BlockCount(u32), /* FIXME: use block hash instead, but needs more complicated
+                      * * verification logic */
     Feerate(Feerate),
     PegOutSignature(PegOutSignatureItem),
 }
@@ -47,8 +47,8 @@ pub enum WalletConsensusItem {
 impl std::fmt::Display for WalletConsensusItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WalletConsensusItem::BlockHeight(height) => {
-                write!(f, "Wallet Block Height {height}")
+            WalletConsensusItem::BlockCount(count) => {
+                write!(f, "Wallet Block Count {count}")
             }
             WalletConsensusItem::Feerate(feerate) => {
                 write!(

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info,timing=debug}"
 
-source scripts/build.sh
+source scripts/build.sh ""
 
 >&2 echo "### Setting up tests"
 


### PR DESCRIPTION
It has been established more than a half-century ago that in computer science and engineering when operating on indexes, ranges and counts it's best to start numbering from 0, and use half-open ranges:

https://www.cs.utexas.edu/users/EWD/transcriptions/EWD08xx/EWD831.html

Mathematicians sometimes disagree, but what do they know. And there's Lua, which is a neat PL, yet most people using it complain precisely about the 1-based indexing (unless they are mathematicians).

Given that block height are 0-based and genesis block is has a height of 0:

https://mempool.space/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f

it is most ergonomic to operate on "block count".

Bitcoin Core did the right thing and has a `getblockcount` call.

It's also worth noting that "block height" (as opposed to a
 "block count") is a misnomer. Which block? "Blockchain height" could
maybe work, so would "last/current/tip height", but bare "block height" is just confusing.

There are situations in which "give me the *content* (or a hash) of the last block" is a useful API to have, but even then a combination of "get block count" and "get content/hash at height N" is a much better API, unless that extra-call latency is really intolerable (which is never).

I guess people "on the streets" (Twitters?), like to talk about "we're at block height X" to meassure blockchain growth, but they also count from 1, so yeah...