### PR TITLE
fix(devimint): better handling of kill/terminate on subprocesses

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -183,8 +183,8 @@ impl Lightningd {
             .to_string())
     }
 
-    pub async fn kill(self) -> Result<()> {
-        self.process.kill().await
+    pub async fn terminate(self) -> Result<()> {
+        self.process.terminate().await
     }
 }
 
@@ -272,8 +272,8 @@ impl Lnd {
         Ok(())
     }
 
-    pub async fn kill(self) -> Result<()> {
-        self.process.kill().await
+    pub async fn terminate(self) -> Result<()> {
+        self.process.terminate().await
     }
 }
 

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -103,8 +103,8 @@ impl Gatewayd {
 
     pub async fn stop_lightning_node(&mut self) -> Result<()> {
         match self.ln.take() {
-            Some(LightningNode::Lnd(lnd)) => lnd.kill().await,
-            Some(LightningNode::Cln(cln)) => cln.kill().await,
+            Some(LightningNode::Lnd(lnd)) => lnd.terminate().await,
+            Some(LightningNode::Cln(cln)) => cln.terminate().await,
             None => Err(anyhow::anyhow!(
                 "Cannot stop an already stopped Lightning Node"
             )),


### PR DESCRIPTION
Based on https://github.com/fedimint/fedimint/pull/2853

This PR introduces SIGKILL on drop and will leave SIGTERM for when graceful/controlled termination is required.

It will also finish earlier when exiting tmux/mprocs, sending a SIGKILL to subprocesses (through drop of `DevFed`/daemons).