### PR TITLE
chore: devimint sets federation_name meta field

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -425,7 +425,7 @@ async fn set_config_gen_params(
         10,
     );
     let request = ConfigGenParamsRequest {
-        meta: BTreeMap::from([("test".to_string(), "testvalue".to_string())]),
+        meta: BTreeMap::from([("federation_name".to_string(), "testfed".to_string())]),
         modules: server_gen_params,
     };
     client.set_config_gen_params(request, auth.clone()).await?;


### PR DESCRIPTION
Small fix from https://github.com/fedimint/fedimint/pull/2848. So far we've always set `federation_name` in the meta fields. Let's continue to do this.