### PR TITLE
fix: Symlink FM_TEST_DIR so they're easier to find

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,6 +25,10 @@ echo "Setting up env variables in $FM_TEST_DIR"
 mkdir -p "$FM_TEST_DIR"
 touch "$FM_PID_FILE"
 
+# Symlink $FM_TEST_DIR to local gitignored target/ directory so they're easier to find
+rm target/devimint &> /dev/null || true
+ln -s $FM_TEST_DIR target/devimint
+
 # Builds the rust executables and sets environment variables
 SRC_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 cd $SRC_DIR || exit 1


### PR DESCRIPTION
Before this PR, if you wanted to inspect say `config.json` while running `just mprocs` you would need to enter user shell, and run something like `echo $FM_TEST_DIR` to find the path containing configs and logs.

Now you can just run `ls target/devimint/`:

```
$ ls target/devimint/
bitcoin/  cfg/  cln/  electrs/  env  esplora/  gw-cln/  gw-lnd/  lnd/  logs/
```

Should we add a new gitignored path for this? Or just re-use `target/` like I do here?