### PR TITLE
chore: rename WsClientConenctionInfo and related params, methods, comments, etc

### DIFF
--- a/devimint/src/bin/faucet.rs
+++ b/devimint/src/bin/faucet.rs
@@ -21,8 +21,8 @@ struct Cmd {
     bitcoind_rpc: String,
     #[clap(long, env = "FM_CLN_SOCKET")]
     cln_socket: String,
-    #[clap(long, env = "FM_CONNECT_STRING")]
-    connect_string: Option<String>,
+    #[clap(long, env = "FM_INVITE_CODE")]
+    invite_code: Option<String>,
 }
 
 #[derive(Clone)]
@@ -95,13 +95,13 @@ impl Faucet {
     }
 }
 
-fn get_connect_string(connect_string: Option<String>) -> anyhow::Result<String> {
-    match connect_string {
+fn get_invite_code(invite_code: Option<String>) -> anyhow::Result<String> {
+    match invite_code {
         Some(s) => Ok(s),
         None => {
             let data_dir = std::env::var("FM_DATA_DIR")?;
             Ok(std::fs::read_to_string(
-                PathBuf::from(data_dir).join("client-connect"),
+                PathBuf::from(data_dir).join("invite-code"),
             )?)
         }
     }
@@ -116,7 +116,7 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/connect-string",
             get(|| async move {
-                get_connect_string(cmd.connect_string)
+                get_invite_code(cmd.invite_code)
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{e:?}")))
             }),
         )

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -106,8 +106,8 @@ impl Federation {
         let cfg_dir = utf8(cfg_dir);
         // copy configs to config directory
         tokio::fs::rename(
-            format!("{out_dir}/client-connect"),
-            format!("{cfg_dir}/client-connect"),
+            format!("{out_dir}/invite-code"),
+            format!("{cfg_dir}/invite-code"),
         )
         .await?;
         tokio::fs::rename(

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -140,12 +140,12 @@ impl Gatewayd {
     }
 
     pub async fn connect_fed(&self, fed: &Federation) -> Result<()> {
-        let connect_str = poll_value("connect info", || async {
-            match cmd!(fed, "dev", "connect-info").out_json().await {
+        let connect_str = poll_value("invite code", || async {
+            match cmd!(fed, "dev", "invite-code").out_json().await {
                 Ok(info) => Ok(Some(
-                    info["connect_info"]
+                    info["invite_code"]
                         .as_str()
-                        .context("connect_info must be string")?
+                        .context("invite_code must be string")?
                         .to_owned(),
                 )),
                 Err(_) => Ok(None),

--- a/docs/dev-running.md
+++ b/docs/dev-running.md
@@ -179,7 +179,7 @@ Commands:
   print-secret     Print the secret key of the client
   admin
   dev
-  join-federation  Join a federation using it's ConnectInfo
+  join-federation  Join a federation using it's InviteCode
   completion
   help             Print this message or the help of the given subcommand(s)
 

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -26,7 +26,7 @@ pub const LOCAL_CONFIG: &str = "local";
 pub const CONSENSUS_CONFIG: &str = "consensus";
 
 /// Client connection string file
-pub const CLIENT_CONNECT_FILE: &str = "client-connect";
+pub const CLIENT_INVITE_CODE_FILE: &str = "invite-code";
 
 /// Salt backup for combining with the private key
 pub const SALT_FILE: &str = "private.salt";
@@ -83,7 +83,10 @@ pub fn write_server_config(
     let client_config = server.consensus.to_client_config(module_config_gens)?;
     plaintext_json_write(&server.local, path.join(LOCAL_CONFIG))?;
     plaintext_json_write(&server.consensus, path.join(CONSENSUS_CONFIG))?;
-    plaintext_display_write(&server.get_connect_info(), &path.join(CLIENT_CONNECT_FILE))?;
+    plaintext_display_write(
+        &server.get_invite_code(),
+        &path.join(CLIENT_INVITE_CODE_FILE),
+    )?;
     plaintext_json_write(&client_config, path.join(CLIENT_CONFIG))?;
     encrypted_json_write(&server.private, &key, path.join(PRIVATE_CONFIG))
 }

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::{bail, format_err};
 use fedimint_core::admin_client::ConfigGenParamsConsensus;
-use fedimint_core::api::{ClientConfigDownloadToken, WsClientConnectInfo};
+use fedimint_core::api::{ClientConfigDownloadToken, InviteCode};
 use fedimint_core::cancellable::Cancelled;
 pub use fedimint_core::config::*;
 use fedimint_core::config::{
@@ -264,14 +264,14 @@ impl ServerConfig {
         cfg
     }
 
-    pub fn get_connect_info(&self) -> WsClientConnectInfo {
+    pub fn get_invite_code(&self) -> InviteCode {
         let id = FederationId(self.consensus.auth_pk_set.public_key());
         let url = self.consensus.api_endpoints[&self.local.identity]
             .url
             .clone();
         let download_token = self.local.download_token.clone();
 
-        WsClientConnectInfo {
+        InviteCode {
             url,
             download_token,
             id,

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -4,7 +4,7 @@ use fedimint_client::module::gen::ClientModuleGenRegistry;
 use fedimint_client::secret::PlainRootSecretStrategy;
 use fedimint_client::{Client, ClientBuilder};
 use fedimint_core::admin_client::{ConfigGenParamsConsensus, PeerServerParams};
-use fedimint_core::api::WsClientConnectInfo;
+use fedimint_core::api::InviteCode;
 use fedimint_core::config::{
     ClientConfig, FederationId, ServerModuleGenParamsRegistry, ServerModuleGenRegistry,
     META_FEDERATION_NAME_KEY,
@@ -61,9 +61,9 @@ impl FederationTest {
             .expect("Failed to build client")
     }
 
-    /// Return first connection code for gateways
-    pub fn connection_code(&self) -> WsClientConnectInfo {
-        self.configs[&PeerId::from(0)].get_connect_info()
+    /// Return first invite code for gateways
+    pub fn invite_code(&self) -> InviteCode {
+        self.configs[&PeerId::from(0)].get_invite_code()
     }
 
     ///  Return first id for gateways

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -53,9 +53,9 @@ impl GatewayTest {
 
     /// Connects to a new federation and stores the info
     pub async fn connect_fed(&mut self, fed: &FederationTest) -> FederationInfo {
-        let connect = fed.connection_code().to_string();
+        let invite_code = fed.invite_code().to_string();
         let rpc = self.get_rpc().await;
-        rpc.connect_federation(ConnectFedPayload { connect })
+        rpc.connect_federation(ConnectFedPayload { invite_code })
             .await
             .unwrap()
     }

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -52,8 +52,8 @@ pub enum Commands {
     },
     /// Register federation with the gateway
     ConnectFed {
-        /// ConnectInfo code to connect to the federation
-        connect: String,
+        /// InviteCode code to connect to the federation
+        invite_code: String,
     },
     /// Make a backup of snapshot of all ecash
     Backup {
@@ -115,9 +115,9 @@ async fn main() -> anyhow::Result<()> {
 
             print_response(response).await;
         }
-        Commands::ConnectFed { connect } => {
+        Commands::ConnectFed { invite_code } => {
             let response = client()
-                .connect_federation(ConnectFedPayload { connect })
+                .connect_federation(ConnectFedPayload { invite_code })
                 .await?;
 
             print_response(response).await;

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use fedimint_client::module::gen::ClientModuleGenRegistry;
 use fedimint_client::secret::PlainRootSecretStrategy;
 use fedimint_client::ClientBuilder;
-use fedimint_core::api::{DynGlobalApi, GlobalFederationApi, WsClientConnectInfo, WsFederationApi};
+use fedimint_core::api::{DynGlobalApi, GlobalFederationApi, InviteCode, WsFederationApi};
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::task::TaskGroup;
@@ -82,11 +82,11 @@ impl StandardGatewayClientBuilder {
 
     pub async fn create_config(
         &self,
-        connect: WsClientConnectInfo,
+        connect: InviteCode,
         mint_channel_id: u64,
         fees: RoutingFees,
     ) -> Result<FederationConfig> {
-        let api: DynGlobalApi = WsFederationApi::from_connect_info(&[connect.clone()]).into();
+        let api: DynGlobalApi = WsFederationApi::from_invite_code(&[connect.clone()]).into();
         let client_config = api.download_client_config(&connect).await?;
         Ok(FederationConfig {
             mint_channel_id,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -29,7 +29,7 @@ use clap::{Parser, Subcommand};
 use client::StandardGatewayClientBuilder;
 use db::{FederationRegistrationKey, GatewayPublicKey};
 use fedimint_client::module::gen::{ClientModuleGen, ClientModuleGenRegistry};
-use fedimint_core::api::{FederationError, WsClientConnectInfo};
+use fedimint_core::api::{FederationError, InviteCode};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{
     ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_MINT,
@@ -640,7 +640,7 @@ impl Gateway {
         &mut self,
         payload: ConnectFedPayload,
     ) -> Result<FederationInfo> {
-        let connect = WsClientConnectInfo::from_str(&payload.connect).map_err(|e| {
+        let invite_code = InviteCode::from_str(&payload.invite_code).map_err(|e| {
             GatewayError::InvalidMetadata(format!("Invalid federation member string {e}"))
         })?;
 
@@ -658,7 +658,7 @@ impl Gateway {
         let gw_client_cfg = loop {
             match self
                 .client_builder
-                .create_config(connect.clone(), channel_id, self.fees)
+                .create_config(invite_code.clone(), channel_id, self.fees)
                 .await
             {
                 Ok(gw_client_cfg) => break gw_client_cfg,

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -21,7 +21,7 @@ use crate::{Gateway, Result};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ConnectFedPayload {
-    pub connect: String,
+    pub invite_code: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/gateway/ln-gateway/tests/authentication_tests.rs
+++ b/gateway/ln-gateway/tests/authentication_tests.rs
@@ -26,12 +26,12 @@ async fn gatewayd_api_authentication() -> anyhow::Result<()> {
     let client2 = &rpc.with_password("bad password".to_string());
 
     // Create a test federation ID
-    let connection_code = fed1.connection_code();
-    let federation_id = fed1.connection_code().id;
+    let invite_code = fed1.invite_code();
+    let federation_id = fed1.invite_code().id;
 
     // Test gateway authentication on `connect_federation` function
     let payload = ConnectFedPayload {
-        connect: connection_code.to_string(),
+        invite_code: invite_code.to_string(),
     };
     auth_success(|| client1.connect_federation(payload.clone())).await;
     auth_fails(|| client2.connect_federation(payload.clone())).await;

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -18,24 +18,24 @@ async fn gatewayd_supports_connecting_multiple_federations() {
 
     assert_eq!(rpc.get_info().await.unwrap().federations.len(), 0);
 
-    let connection1 = fed1.connection_code();
+    let invite1 = fed1.invite_code();
     let info = rpc
         .connect_federation(ConnectFedPayload {
-            connect: connection1.to_string(),
+            invite_code: invite1.to_string(),
         })
         .await
         .unwrap();
 
-    assert_eq!(info.federation_id, connection1.id);
+    assert_eq!(info.federation_id, invite1.id);
 
-    let connection2 = fed2.connection_code();
+    let invite2 = fed2.invite_code();
     let info = rpc
         .connect_federation(ConnectFedPayload {
-            connect: connection2.to_string(),
+            invite_code: invite2.to_string(),
         })
         .await
         .unwrap();
-    assert_eq!(info.federation_id, connection2.id);
+    assert_eq!(info.federation_id, invite2.id);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -44,8 +44,8 @@ async fn gatewayd_shows_info_about_all_connected_federations() {
 
     assert_eq!(rpc.get_info().await.unwrap().federations.len(), 0);
 
-    let id1 = fed1.connection_code().id;
-    let id2 = fed2.connection_code().id;
+    let id1 = fed1.invite_code().id;
+    let id2 = fed2.invite_code().id;
 
     connect_federations(&rpc, &[fed1, fed2]).await.unwrap();
 
@@ -66,8 +66,8 @@ async fn gatewayd_shows_info_about_all_connected_federations() {
 async fn gatewayd_shows_balance_for_any_connected_federation() {
     let (gateway, rpc, fed1, fed2, _) = fixtures::fixtures().await;
 
-    let id1 = fed1.connection_code().id;
-    let id2 = fed2.connection_code().id;
+    let id1 = fed1.invite_code().id;
+    let id2 = fed2.invite_code().id;
 
     connect_federations(&rpc, &[fed1, fed2]).await.unwrap();
 
@@ -147,8 +147,8 @@ pub async fn connect_federations(
     feds: &[FederationTest],
 ) -> anyhow::Result<()> {
     for fed in feds {
-        let connect = fed.connection_code().to_string();
-        rpc.connect_federation(ConnectFedPayload { connect })
+        let invite_code = fed.invite_code().to_string();
+        rpc.connect_federation(ConnectFedPayload { invite_code })
             .await?;
     }
     Ok(())

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -15,7 +15,7 @@ use fedimint_client::module::gen::{ClientModuleGenRegistry, DynClientModuleGen};
 use fedimint_client_legacy::mint::SpendableNote;
 use fedimint_client_legacy::{module_decode_stubs, UserClientConfig};
 use fedimint_core::admin_client::{ConfigGenParamsConsensus, PeerServerParams};
-use fedimint_core::api::WsClientConnectInfo;
+use fedimint_core::api::InviteCode;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::cancellable::Cancellable;
 use fedimint_core::config::{
@@ -427,7 +427,7 @@ pub struct FederationTest {
     pub mint_id: ModuleInstanceId,
     pub ln_id: ModuleInstanceId,
     pub wallet_id: ModuleInstanceId,
-    pub connect_info: WsClientConnectInfo,
+    pub invite_code: InviteCode,
 }
 
 struct ServerTest {
@@ -561,7 +561,7 @@ impl FederationTest {
             mint_id: self.mint_id,
             ln_id: self.ln_id,
             wallet_id: self.wallet_id,
-            connect_info: self.connect_info.clone(),
+            invite_code: self.invite_code.clone(),
         }
     }
 
@@ -1052,7 +1052,7 @@ impl FederationTest {
             mint_id: LEGACY_HARDCODED_INSTANCE_ID_MINT,
             ln_id: LEGACY_HARDCODED_INSTANCE_ID_LN,
             wallet_id: LEGACY_HARDCODED_INSTANCE_ID_WALLET,
-            connect_info: cfg.get_connect_info(),
+            invite_code: cfg.get_invite_code(),
         }
     }
 }

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -465,8 +465,8 @@ async fn ecash_can_be_recovered() -> Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn limits_client_config_downloads() -> Result<()> {
     test(2, |fed, user, _| async move {
-        let connect = &fed.connect_info.clone();
-        let api = WsFederationApi::from_connect_info(&[connect.clone()]);
+        let connect = &fed.invite_code.clone();
+        let api = WsFederationApi::from_invite_code(&[connect.clone()]);
 
         // consensus hash should be the same among all peers
         let res = api.consensus_config_hash().await;


### PR DESCRIPTION
rename clarifies what the code is and what it's used for