### PR TITLE
cleanup: consolidate validation and application of transaction inputs and outputs

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -841,17 +841,6 @@ pub trait ServerModule: Debug + Sized {
         verification_cache: &Self::VerificationCache,
     ) -> Result<InputMeta, ModuleError>;
 
-    /// Validate a transaction output before submitting it to the unconfirmed
-    /// transaction pool. This function has no side effects and may be
-    /// called at any time. False positives due to outdated database state
-    /// are ok since they get filtered out after consensus has been reached on
-    /// them and merely generate a warning.
-    async fn validate_output(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
-        output: &<Self::Common as ModuleCommon>::Output,
-    ) -> Result<TransactionItemAmount, ModuleError>;
-
     /// Try to create an output (e.g. issue notes, peg-out BTC, …). On success
     /// all necessary updates to the database will be part of the database
     /// transaction. On failure (e.g. double spend) the database transaction
@@ -860,7 +849,7 @@ pub trait ServerModule: Debug + Sized {
     /// The supplied `out_point` identifies the operation (e.g. a peg-out or
     /// note issuance) and can be used to retrieve its outcome later using
     /// `output_status`.
-    async fn apply_output<'a, 'b>(
+    async fn process_output<'a, 'b>(
         &'a self,
         dbtx: &mut ModuleDatabaseTransaction<'b>,
         output: &'a <Self::Common as ModuleCommon>::Output,

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -830,23 +830,11 @@ pub trait ServerModule: Debug + Sized {
         inputs: impl Iterator<Item = &'a <Self::Common as ModuleCommon>::Input> + MaybeSend,
     ) -> Self::VerificationCache;
 
-    /// Validate a transaction input before submitting it to the unconfirmed
-    /// transaction pool. This function has no side effects and may be
-    /// called at any time. False positives due to outdated database state
-    /// are ok since they get filtered out after consensus has been reached on
-    /// them and merely generate a warning.
-    async fn validate_input<'a, 'b>(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
-        verification_cache: &Self::VerificationCache,
-        input: &'a <Self::Common as ModuleCommon>::Input,
-    ) -> Result<InputMeta, ModuleError>;
-
     /// Try to spend a transaction input. On success all necessary updates will
     /// be part of the database transaction. On failure (e.g. double spend)
     /// the database transaction is rolled back and the operation will take
     /// no effect.
-    async fn apply_input<'a, 'b, 'c>(
+    async fn process_input<'a, 'b, 'c>(
         &'a self,
         dbtx: &mut ModuleDatabaseTransaction<'c>,
         input: &'b <Self::Common as ModuleCommon>::Input,

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -88,8 +88,8 @@ pub struct FedimintConsensus {
 }
 
 #[derive(Debug)]
-struct VerificationCaches {
-    caches: HashMap<ModuleInstanceId, DynVerificationCache>,
+pub struct VerificationCaches {
+    pub caches: HashMap<ModuleInstanceId, DynVerificationCache>,
 }
 
 pub struct FundingVerifier {
@@ -99,7 +99,7 @@ pub struct FundingVerifier {
 }
 
 impl VerificationCaches {
-    fn get_cache(&self, module_key: ModuleInstanceId) -> &DynVerificationCache {
+    pub(crate) fn get_cache(&self, module_key: ModuleInstanceId) -> &DynVerificationCache {
         self.caches
             .get(&module_key)
             .expect("Verification caches were built for all modules")
@@ -258,7 +258,7 @@ impl FedimintConsensus {
                     let amount = self
                         .modules
                         .get_expect(output.module_instance_id())
-                        .apply_output(
+                        .process_output(
                             &mut dbtx.with_module_prefix(output.module_instance_id()),
                             output,
                             OutPoint { txid, out_idx },
@@ -514,8 +514,6 @@ impl FedimintConsensus {
             .into_iter()
             .into_group_map_by(|input| input.module_instance_id());
 
-        // TODO: should probably run in parallel, but currently only the mint does
-        // anything at all
         let caches = module_inputs
             .into_iter()
             .map(|(module_key, inputs)| {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -241,7 +241,7 @@ impl FedimintConsensus {
                     let meta = self
                         .modules
                         .get_expect(input.module_instance_id())
-                        .apply_input(
+                        .process_input(
                             &mut dbtx.with_module_prefix(input.module_instance_id()),
                             input,
                             caches.get_cache(input.module_instance_id()),

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -115,10 +115,10 @@ impl ConsensusApi {
 
             let cache = module.build_verification_cache(&[input.clone()]);
             let meta = module
-                .validate_input(
+                .process_input(
                     &mut dbtx.with_module_prefix(input.module_instance_id()),
-                    &cache,
                     input,
+                    &cache,
                 )
                 .await?;
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -708,7 +708,7 @@ impl FederationTest {
                 .consensus
                 .modules
                 .get_expect(self.mint_id)
-                .apply_output(
+                .process_output(
                     &mut dbtx.with_module_prefix(self.mint_id),
                     &core::DynOutput::from_typed(self.mint_id, MintOutput(notes.clone())),
                     out_point,

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -615,12 +615,13 @@ impl ServerModule for Lightning {
         })
     }
 
-    async fn validate_output(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
-        output: &LightningOutput,
+    async fn process_output<'a, 'b>(
+        &'a self,
+        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        output: &'a LightningOutput,
+        out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
-        match output {
+        let amount = match output {
             LightningOutput::Contract(contract) => {
                 // Incoming contracts are special, they need to match an offer
                 if let Contract::Incoming(incoming) = &contract.contract {
@@ -684,16 +685,7 @@ impl ServerModule for Lightning {
 
                 Ok(TransactionItemAmount::ZERO)
             }
-        }
-    }
-
-    async fn apply_output<'a, 'b>(
-        &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
-        output: &'a LightningOutput,
-        out_point: OutPoint,
-    ) -> Result<TransactionItemAmount, ModuleError> {
-        let amount = self.validate_output(dbtx, output).await?;
+        }?;
 
         match output {
             LightningOutput::Contract(contract) => {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -391,8 +391,8 @@ impl ServerModule for Lightning {
                     bail!("Already received a valid decryption share for this peer");
                 }
 
-                let account = self
-                    .get_contract_account(dbtx, contract_id)
+                let account = dbtx
+                    .get_value(&ContractKey(contract_id))
                     .await
                     .context("Contract account for this decryption share does not exist")?;
 


### PR DESCRIPTION
The reduction in computational load from splitting the functions is negligible.