### PR TITLE
fix: skip test_gateway_client_pay_invalid_invoice without mocks

### DIFF
--- a/gateway/ln-gateway/src/ng/tests.rs
+++ b/gateway/ln-gateway/src/ng/tests.rs
@@ -34,6 +34,7 @@ use ln_gateway::ng::{
     GatewayClientExt, GatewayClientModule, GatewayClientStateMachines, GatewayExtPayStates,
     GatewayExtReceiveStates, GatewayMeta, Htlc, GW_ANNOUNCEMENT_TTL,
 };
+use tracing::info;
 use url::Url;
 
 fn fixtures() -> Fixtures {
@@ -189,6 +190,11 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_client_pay_invalid_invoice() -> anyhow::Result<()> {
+    if Fixtures::is_real_test() {
+        info!("Skipping test meant to run only with mocks");
+        return Ok(());
+    }
+
     gateway_test(
         |gateway, other_lightning_client, fed, user_client| async move {
             let gateway = gateway.remove_client(&fed).await;


### PR DESCRIPTION
This test relies on mock LND node that treats invoices with `INVALID` description as invalid.

How is it even working right now is unclear.

![image](https://github.com/fedimint/fedimint/assets/9209/0ffc77fe-698c-4983-88c7-555734902b25)
