### PR TITLE
chore: make `TaskGroup::on_shutdown` private

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.27",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1281,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-lock",
+ "async-recursion",
  "async-trait",
  "bech32",
  "bincode",

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -13,6 +13,7 @@ name = "fedimint_core"
 path = "src/lib.rs"
 
 [dependencies]
+async-recursion = "1.0.4"
 anyhow = "1.0.65"
 async-trait = "0.1.64"
 futures = "0.3.24"

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use fedimint_core::time::now;
 use fedimint_logging::LOG_TASK;
@@ -19,11 +19,13 @@ use thiserror::Error;
 #[cfg(not(target_family = "wasm"))]
 use tokio::sync::oneshot;
 #[cfg(not(target_family = "wasm"))]
-use tokio::task::JoinHandle;
+use tokio::task::{JoinError, JoinHandle};
 use tracing::{error, info, warn};
 
 #[cfg(target_family = "wasm")]
 type JoinHandle<T> = futures::future::Ready<anyhow::Result<T>>;
+#[cfg(target_family = "wasm")]
+type JoinError = anyhow::Error;
 
 #[derive(Debug, Error)]
 #[error("deadline has elapsed")]
@@ -37,6 +39,7 @@ struct TaskGroupInner {
     #[allow(clippy::type_complexity)]
     on_shutdown: Mutex<Vec<Box<dyn FnOnce() -> BoxFuture<'static, ()> + Send + 'static>>>,
     join: Mutex<VecDeque<(String, JoinHandle<()>)>>,
+    subgroups: Mutex<Vec<TaskGroup>>,
 }
 
 impl TaskGroupInner {
@@ -96,6 +99,7 @@ impl TaskGroup {
     /// detect any panics in the tasks spawned by the subgroup.
     pub async fn make_subgroup(&self) -> TaskGroup {
         let new_tg = Self::new();
+        self.inner.subgroups.lock().await.push(new_tg.clone());
         self.make_handle()
             .on_shutdown({
                 let new_tg = self.clone();
@@ -246,9 +250,29 @@ impl TaskGroup {
     }
 
     pub async fn join_all(self, timeout: Option<Duration>) -> Result<(), anyhow::Error> {
+        let deadline = timeout.map(|timeout| now() + timeout);
         let mut errors = vec![];
 
-        let deadline = timeout.map(|timeout| now() + timeout);
+        self.join_all_inner(deadline, &mut errors).await;
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            let num_errors = errors.len();
+            Err(anyhow::Error::msg(format!(
+                "{num_errors} tasks did not finish cleanly: {errors:?}"
+            )))
+        }
+    }
+
+    #[cfg_attr(not(target_family = "wasm"), ::async_recursion::async_recursion)]
+    #[cfg_attr(target_family = "wasm", ::async_recursion::async_recursion(?Send))]
+    pub async fn join_all_inner(self, deadline: Option<SystemTime>, errors: &mut Vec<JoinError>) {
+        for subgroup in self.inner.subgroups.lock().await.clone() {
+            info!(target: LOG_TASK, "Waiting for subgroup to finish");
+            subgroup.join_all_inner(deadline, errors).await;
+            info!(target: LOG_TASK, "Subgroup finished");
+        }
 
         while let Some((name, join)) = self.inner.join.lock().await.pop_front() {
             info!(target: LOG_TASK, task=%name, "Waiting for task to finish");
@@ -289,15 +313,6 @@ impl TaskGroup {
                     )
                 }
             }
-        }
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            let num_errors = errors.len();
-            Err(anyhow::Error::msg(format!(
-                "{num_errors} tasks did not finish cleanly: {errors:?}"
-            )))
         }
     }
 }

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -343,7 +343,7 @@ impl TaskHandle {
     /// Run `f` on shutdown.
     ///
     /// If TaskGroup is already shutting down, run the function immediately.
-    pub async fn on_shutdown(
+    async fn on_shutdown(
         &self,
         // f: FnOnce() -> BoxFuture<'static, ()> + Send + 'static
         f: Box<dyn FnOnce() -> BoxFuture<'static, ()> + Send + 'static>,

--- a/fedimint-metrics/src/lib.rs
+++ b/fedimint-metrics/src/lib.rs
@@ -33,29 +33,18 @@ pub async fn run_api_server(
     let app = Router::new().route("/metrics", get(get_metrics));
     let server = axum::Server::bind(bind_address).serve(app.into_make_service());
 
-    let (tx, rx) = oneshot::channel::<()>();
+    let handle = task_group.make_handle();
+    let shutdown_rx = handle.make_shutdown_rx().await;
     task_group
         .spawn("Metrics Api", move |_| async move {
             let graceful = server.with_graceful_shutdown(async {
-                rx.await.ok();
+                shutdown_rx.await.ok();
             });
 
             if let Err(e) = graceful.await {
                 error!("Error shutting down metrics api: {e:?}");
             }
         })
-        .await;
-    let handle = task_group.make_handle();
-    handle
-        .on_shutdown(Box::new(|| {
-            Box::pin(async move {
-                // Send shutdown signal to the webserver
-                let res = tx.send(());
-                if res.is_err() {
-                    error!("Error shutting down metrics api: {res:?}");
-                }
-            })
-        }))
         .await;
     let shutdown_receiver = handle.make_shutdown_rx().await;
 

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -5,9 +5,9 @@ use axum::routing::post;
 use axum::{Extension, Json, Router};
 use axum_macros::debug_handler;
 use bitcoin_hashes::hex::ToHex;
+use fedimint_core::task::TaskGroup;
 use fedimint_ln_client::pay::PayInvoicePayload;
 use serde_json::json;
-use tokio::sync::mpsc;
 use tower_http::cors::CorsLayer;
 use tower_http::validate_request::ValidateRequestHeaderLayer;
 use tracing::{error, instrument};
@@ -22,7 +22,7 @@ pub async fn run_webserver(
     authkey: String,
     bind_addr: SocketAddr,
     mut gateway: Gateway,
-) -> axum::response::Result<mpsc::Sender<()>> {
+) -> axum::response::Result<TaskGroup> {
     // Public routes on gateway webserver
     let routes = Router::new().route("/pay_invoice", post(pay_invoice));
 
@@ -43,13 +43,15 @@ pub async fn run_webserver(
         .layer(Extension(gateway.clone()))
         .layer(CorsLayer::permissive());
 
-    let (tx, mut rx) = mpsc::channel::<()>(100);
+    let task_group = gateway.task_group.make_subgroup().await;
+    let handle = task_group.make_handle();
+    let shutdown_rx = handle.make_shutdown_rx().await;
     let server = axum::Server::bind(&bind_addr).serve(app.into_make_service());
     gateway
         .task_group
         .spawn("Gateway Webserver", move |_| async move {
             let graceful = server.with_graceful_shutdown(async {
-                rx.recv().await;
+                let _ = shutdown_rx.await;
             });
 
             if let Err(e) = graceful.await {
@@ -58,21 +60,7 @@ pub async fn run_webserver(
         })
         .await;
 
-    let handle = gateway.task_group.make_handle();
-    let shutdown_tx = tx.clone();
-    handle
-        .on_shutdown(Box::new(|| {
-            Box::pin(async move {
-                // Send shutdown signal to the webserver
-                let res = shutdown_tx.send(()).await;
-                if res.is_err() {
-                    error!("Error shutting down gatewayd webserver: {res:?}");
-                }
-            })
-        }))
-        .await;
-
-    Ok(tx)
+    Ok(task_group)
 }
 
 /// Display high-level information about the Gateway


### PR DESCRIPTION
Using a future to signal shutdown condition is much more composable, and doesn't involve "callbacks" that can hold to resources accidentally.

As a first step to remove `on_shutdown` - just make it private, so it's only used internally inside `TaskGroup`. We might replace it with something like `tokio_util::CancellationToken` etc. later.


This revealed a problem where `shutdown_join_all` does not wait for tasks spawned in the subgroup, so we fix that as well.