### PR TITLE
chore: Make MintMetaVariants public

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -391,13 +391,13 @@ async fn mint_operation(
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MintMeta {
-    variant: MintMetaVariants,
-    amount: Amount,
-    extra_meta: serde_json::Value,
+    pub variant: MintMetaVariants,
+    pub amount: Amount,
+    pub extra_meta: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-enum MintMetaVariants {
+pub enum MintMetaVariants {
     Reissuance {
         out_point: OutPoint,
     },


### PR DESCRIPTION
When integrating with the client, it is helpful for this to be public