### PR TITLE
chore: make fedimint-ln-client::db public

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1,4 +1,4 @@
-mod db;
+pub mod db;
 pub mod pay;
 pub mod receive;
 


### PR DESCRIPTION
When integrating with the client, it's nice to have access to db structs.