### PR TITLE
chore: don't use `Task::on_shutdown` for `Task::make_shutdown_rx`

### DIFF
--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -1134,7 +1134,7 @@ async fn cleanup_on_exit<T>(
             match result {
                 Ok(v) => {
                     info!("Main process finished successfully, will wait for shutdown signal");
-                    task_group.make_handle().make_shutdown_rx().await.await?;
+                    task_group.make_handle().make_shutdown_rx().await.await;
                     info!("Received shutdown signal, shutting down");
                     drop(v); // execute destructors
                     Ok(())
@@ -1156,7 +1156,7 @@ async fn handle_command() -> Result<()> {
             let _daemons =
                 write_ready_file(&process_mgr.globals, external_daemons(&process_mgr).await)
                     .await?;
-            task_group.make_handle().make_shutdown_rx().await.await?;
+            task_group.make_handle().make_shutdown_rx().await.await;
         }
         Cmd::DevFed => {
             let (process_mgr, task_group) = setup(args.common).await?;

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -101,7 +101,7 @@ impl FedimintServer {
         handler.stop().await;
 
         info!(target: LOG_CONSENSUS, "Shutting down tasks");
-        task_group.shutdown().await;
+        task_group.shutdown();
 
         Ok(())
     }

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -904,7 +904,7 @@ mod tests {
             assert!(status.values().all(|s| s.is_ok()));
         }
 
-        task_group.shutdown().await;
+        task_group.shutdown();
         task_group.join_all(None).await.unwrap();
     }
 

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -188,7 +188,7 @@ impl Fedimintd {
                     Ok(()) => {}
                     Err(error) => {
                         error!(?error, "Main task returned error, shutting down");
-                        task_group.shutdown().await;
+                        task_group.shutdown();
                     }
                 }
             })
@@ -296,9 +296,6 @@ async fn spawn_metrics_server(
 ) -> anyhow::Result<()> {
     let rx = fedimint_metrics::run_api_server(bind_address, &mut task_group).await?;
     info!("Metrics API listening on {bind_address}");
-    let res = rx.await;
-    if res.is_err() {
-        error!("Error shutting down metric api server: {res:?}");
-    }
+    rx.await;
     Ok(())
 }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -51,7 +51,7 @@ pub async fn run_webserver(
         .task_group
         .spawn("Gateway Webserver", move |_| async move {
             let graceful = server.with_graceful_shutdown(async {
-                let _ = shutdown_rx.await;
+                shutdown_rx.await;
             });
 
             if let Err(e) = graceful.await {


### PR DESCRIPTION
It makes it easy to leak memory.

Instead, use `tokio::sync::watch` to update tasks that might be waiting for shutdown signal.