### PR TITLE
fix(server): logs don't claim an epoch was missing if it wasn't

### DIFF
--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -402,7 +402,7 @@ impl ConsensusServer {
                 for (items, epoch, _prev_epoch_hash, rejected_txs) in epochs.drain(..) {
                     info!(
                         target: LOG_CONSENSUS,
-                        "Processing items from missing epoch {}", epoch
+                        "Processing items from epoch {}", epoch
                     );
                     let epoch = self
                         .consensus


### PR DESCRIPTION
This has been annoying me for a while, probably introduced by a refactor a few months ago.