### PR TITLE
chore: move fedimint-dbtool into `fedimint-pkgs`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -157,7 +157,6 @@
             fedimint-pkgs = craneLib.fedimint-pkgs;
             gateway-pkgs = craneLib.gateway-pkgs;
             client-pkgs = craneLib.client-pkgs { };
-            fedimint-dbtool-pkgs = craneLib.fedimint-dbtool-pkgs;
             devimint = craneLib.devimint;
             fedimint-load-test-tool = craneLib.fedimint-load-test-tool;
           };
@@ -197,6 +196,11 @@
               {
                 pkg = (rustPackageOutputsFinal craneLib).fedimint-pkgs;
                 bin = "fedimint-cli";
+              };
+            fedimint-dbtool = pickBinary
+              {
+                pkg = (rustPackageOutputsFinal craneLib).fedimint-pkgs;
+                bin = "fedimint-dbtool";
               };
             gatewayd = pickBinary
               {

--- a/nix/craneBuild.nix
+++ b/nix/craneBuild.nix
@@ -266,6 +266,7 @@ craneLib.overrideScope' (self: prev: {
       fedimintd = { };
       fedimint-cli = { };
       fedimint-tests = { };
+      fedimint-dbtool = { };
     };
 
     defaultBin = "fedimintd";
@@ -288,13 +289,6 @@ craneLib.overrideScope' (self: prev: {
     pkgs = {
       fedimint-client-legacy = { };
       fedimint-client = { };
-    };
-  };
-
-  fedimint-dbtool-pkgs = self.pkgsBuild {
-    name = "fedimint-dbtool-pkgs";
-    pkgs = {
-      fedimint-dbtool = { };
     };
   };
 


### PR DESCRIPTION
`*-pkgs` are mostly about building bunch of crates together in one go, so they only really need to be split if certain packages can't build in certain places (for us: wasm).

Fix #2774