### PR TITLE
fix: avoid rebuilds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ rustflags = ["--cfg", "tokio_unstable"]
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld", "--cfg", "tokio_unstable"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,--compress-debug-sections=zlib", "--cfg", "tokio_unstable"]
 
 # mold is currently broken on MacOS
 # [target.aarch64-apple-darwin]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
 
 [profile.dev]
-split-debuginfo = "packed"
 
 # in dev mode optimize crates that are perf-critical (usually just crypto crates)
 [profile.dev.package]
@@ -84,7 +83,6 @@ threshold_crypto = { opt-level = 3 }
 
 [profile.ci]
 inherits = "dev"
-split-debuginfo = "packed"
 debug = 1
 
 [patch.crates-io]

--- a/nix/craneBuild.nix
+++ b/nix/craneBuild.nix
@@ -6,7 +6,8 @@ craneLib.overrideScope' (self: prev: {
 
   workspaceDeps = self.buildDepsOnly (prev.commonArgsDepsOnly // {
     version = "0.0.1";
-    buildPhaseCargoCommand = "cargo doc --workspace --locked --profile $CARGO_PROFILE ; cargo check --workspace  --locked --profile $CARGO_PROFILE --all-targets ; cargo build --locked --profile $CARGO_PROFILE --workspace --all-targets";
+    # note: cargo doc does not have --all-targets
+    buildPhaseCargoCommand = "cargo doc --workspace --locked --profile $CARGO_PROFILE ; cargo check --workspace --all-targets --locked --profile $CARGO_PROFILE ; cargo build --locked --profile $CARGO_PROFILE --workspace --all-targets";
     doCheck = false;
   });
 
@@ -73,7 +74,7 @@ craneLib.overrideScope' (self: prev: {
     nativeBuildInputs = self.commonArgs.nativeBuildInputs ++ [ pkgs.cargo-udeps ];
     # since we filtered all the actual project source, everything will definitely fail
     # but we only run this step to cache the build artifacts, so we ignore failure with `|| true`
-    buildPhaseCargoCommand = "cargo udeps --all-targets --workspace --profile $CARGO_PROFILE || true";
+    buildPhaseCargoCommand = "cargo udeps --workspace --all-targets --profile $CARGO_PROFILE || true";
     doCheck = false;
   });
 
@@ -84,7 +85,7 @@ craneLib.overrideScope' (self: prev: {
     # about the docs
     cargoArtifacts = self.workspaceCargoUdepsDeps;
     nativeBuildInputs = self.commonArgs.nativeBuildInputs ++ [ pkgs.cargo-udeps ];
-    buildPhaseCargoCommand = "cargo udeps --all-targets --workspace --profile $CARGO_PROFILE";
+    buildPhaseCargoCommand = "cargo udeps --workspace --all-targets --profile $CARGO_PROFILE";
     doInstallCargoArtifacts = false;
     doCheck = false;
   });
@@ -99,7 +100,7 @@ craneLib.overrideScope' (self: prev: {
   workspaceDepsCov = self.buildDepsOnly (self.commonArgsDepsOnly // {
     pnameSuffix = "-lcov-deps";
     version = "0.0.1";
-    buildPhaseCargoCommand = "cargo llvm-cov --locked --workspace --profile $CARGO_PROFILE --no-report";
+    buildPhaseCargoCommand = "cargo llvm-cov --locked --workspace --all-targets --profile $CARGO_PROFILE --no-report";
     cargoBuildCommand = "dontuse";
     cargoCheckCommand = "dontuse";
     nativeBuildInputs = self.commonArgs.nativeBuildInputs ++ [ self.cargo-llvm-cov ];
@@ -110,7 +111,7 @@ craneLib.overrideScope' (self: prev: {
     pnameSuffix = "-lcov";
     version = "0.0.1";
     cargoArtifacts = self.workspaceDepsCov;
-    buildPhaseCargoCommand = "mkdir -p $out ; env RUST_BACKTRACE=1 RUST_LOG=info,timing=debug cargo llvm-cov --locked --workspace --profile $CARGO_PROFILE --lcov --all-targets --tests --output-path $out/lcov.info --  --test-threads=$(($(nproc) * 2))";
+    buildPhaseCargoCommand = "mkdir -p $out ; env RUST_BACKTRACE=1 RUST_LOG=info,timing=debug cargo llvm-cov --locked --workspace --all-targets --profile $CARGO_PROFILE --lcov --tests --output-path $out/lcov.info --  --test-threads=$(($(nproc) * 2))";
     installPhaseCommand = "true";
     nativeBuildInputs = self.commonArgs.nativeBuildInputs ++ [ self.cargo-llvm-cov ];
     doCheck = false;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-echo "Run with 'source ./scripts/build.sh [fed_size] [dir]"
-
 # allow for overriding arguments
 export FM_FED_SIZE=${1:-4}
 

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -24,7 +24,7 @@ fi
 cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --workspace --all-targets
 # Avoid re-building tests in parallel in all test derivations
 >&2 echo "Pre-building tests..."
-cargo test --no-run ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --workspace
+cargo test --no-run ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --workspace --all-targets
 
 function cli_test_reconnect() {
   fm-run-isolated-test "${FUNCNAME[0]}" ./scripts/tests/reconnect-test.sh


### PR DESCRIPTION
From the code itself:

```sh
# 'cargo test' does not have a possibility of building whole workspace (to avoid any rebuilds), yet
# running just a subset of tests from a given package. To overcome it we parse the output of this
# command and run test binaries directly. Not elegant, but works.```