### PR TITLE
Make client subscription streams static

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -89,7 +89,7 @@ pub trait MintClientExt {
     async fn subscribe_reissue_external_notes(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<'_, ReissueExternalNotesState>>;
+    ) -> anyhow::Result<UpdateStreamOrOutcome<ReissueExternalNotesState>>;
 
     /// Fetches and removes notes of *at least* amount `min_amount` from the
     /// wallet to be sent to the recipient out of band. These spends can be
@@ -120,7 +120,7 @@ pub trait MintClientExt {
     async fn subscribe_spend_notes(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<'_, SpendOOBState>>;
+    ) -> anyhow::Result<UpdateStreamOrOutcome<SpendOOBState>>;
 
     /// Awaits the backup restoration to complete
     async fn await_restore_finished(&self) -> anyhow::Result<()>;
@@ -212,36 +212,35 @@ impl MintClientExt for Client {
     async fn subscribe_reissue_external_notes(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<'_, ReissueExternalNotesState>> {
-        let (mint, _instance) = self.get_first_module::<MintClientModule>(&KIND);
-
+    ) -> anyhow::Result<UpdateStreamOrOutcome<ReissueExternalNotesState>> {
         let operation = mint_operation(self, operation_id).await?;
         let out_point = match operation.meta::<MintMeta>().variant {
             MintMetaVariants::Reissuance { out_point } => out_point,
             _ => bail!("Operation is not a reissuance"),
         };
-
-        // TODO: move into closure
-        let tx_accepted_future = self
-            .transaction_updates(operation_id)
-            .await
-            .await_tx_accepted(out_point.txid);
-        let output_finalized_future = mint.await_output_finalized(operation_id, out_point);
+        let client = self.clone();
 
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
+                let mint = client.get_first_module::<MintClientModule>(&KIND).0;
+
                 yield ReissueExternalNotesState::Created;
 
-                match tx_accepted_future.await {
+                match client
+                    .transaction_updates(operation_id)
+                    .await
+                    .await_tx_accepted(out_point.txid)
+                    .await
+                {
                     Ok(()) => {
                         yield ReissueExternalNotesState::Issuing;
-                    },
+                    }
                     Err(e) => {
                         yield ReissueExternalNotesState::Failed(format!("Transaction not accepted {e:?}"));
                     }
                 }
 
-                match output_finalized_future.await {
+                match mint.await_output_finalized(operation_id, out_point).await {
                     Ok(_) => {
                         yield ReissueExternalNotesState::Done;
                     },
@@ -322,9 +321,7 @@ impl MintClientExt for Client {
     async fn subscribe_spend_notes(
         &self,
         operation_id: OperationId,
-    ) -> anyhow::Result<UpdateStreamOrOutcome<'_, SpendOOBState>> {
-        let (mint, _instance) = self.get_first_module::<MintClientModule>(&KIND);
-
+    ) -> anyhow::Result<UpdateStreamOrOutcome<SpendOOBState>> {
         let operation = mint_operation(self, operation_id).await?;
         if !matches!(
             operation.meta::<MintMeta>().variant,
@@ -333,17 +330,27 @@ impl MintClientExt for Client {
             bail!("Operation is not a out-of-band spend");
         };
 
-        let tx_subscription = self.transaction_updates(operation_id).await;
-        let refund_future = mint.await_spend_oob_refund(operation_id);
+        let client = self.clone();
 
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
+                let mint = client.get_first_module::<MintClientModule>(&KIND).0;
+
                 yield SpendOOBState::Created;
 
-                let refund = refund_future.await;
+                let refund = mint
+                    .await_spend_oob_refund(operation_id)
+                    .await;
+
                 if refund.user_triggered {
                     yield SpendOOBState::UserCanceledProcessing;
-                    match tx_subscription.await_tx_accepted(refund.transaction_id).await {
+
+                    match client
+                        .transaction_updates(operation_id)
+                        .await
+                        .await_tx_accepted(refund.transaction_id)
+                        .await
+                    {
                         Ok(()) => {
                             yield SpendOOBState::UserCanceledSuccess;
                         },
@@ -352,7 +359,12 @@ impl MintClientExt for Client {
                         }
                     }
                 } else {
-                    match tx_subscription.await_tx_accepted(refund.transaction_id).await {
+                    match client
+                        .transaction_updates(operation_id)
+                        .await
+                        .await_tx_accepted(refund.transaction_id)
+                        .await
+                    {
                         Ok(()) => {
                             yield SpendOOBState::Refunded;
                         },

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -190,6 +190,7 @@ impl WalletClientExt for Client {
 
         let mut operation_stream = wallet_client.notifier.subscribe(operation_id).await;
         let tx_subscriber = self.transaction_updates(operation_id).await;
+        let client = self.clone();
 
         Ok(
             operation_log_entry.outcome_or_updates(self.db(), operation_id, || {
@@ -233,7 +234,7 @@ impl WalletClientExt for Client {
                     }
 
                     if let Some(out_point) = claiming.change.as_ref() {
-                        self.await_primary_module_output(operation_id, *out_point)
+                        client.await_primary_module_output(operation_id, *out_point)
                             .await
                             .expect("Cannot fail if tx was accepted and federation is honest");
                     }
@@ -311,6 +312,7 @@ impl WalletClientExt for Client {
         };
 
         let mut operation_stream = wallet_client.notifier.subscribe(operation_id).await;
+        let client = self.clone();
 
         Ok(
             operation.outcome_or_updates(self.db(), operation_id, move || {
@@ -329,7 +331,7 @@ impl WalletClientExt for Client {
                     if let Some(change_out_point) = change {
                         // Swallowing potential errors since the transaction failing  is handled by
                         // output outcome fetching already
-                        let _ = self
+                        let _ = client
                             .await_primary_module_output(operation_id, change_out_point)
                             .await;
                     }


### PR DESCRIPTION
If update streams have non-static lifetimes they cannot be moved between tasks/captured easily, making them less useful, in particular they cannot be given to front end code that typically doesn't have a lifetime guaranteed to be shorter than that of the client.

To achieve static lifetimes I had to clone the `Client(Arc<ClientInner>)` and move the reference into the stream. This means as long as any of these streams is still around the client will not terminate. Is this a problem @justinmoon? It does mean that, if we want to drop the client and its database (e.g. when wanting to leave and re-join a federation, all UI elements/other objects/tasks referencing these streams need to be dropped.

Fixes #2928 