### PR TITLE
chore: remove nixpkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,22 +219,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1692174805,
-        "narHash": "sha256-xmNPFDi/AUMIxwgOH/IVom55Dks34u1g7sFKKebxUm0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "caac0eb6bdcad0b32cb2522e03e4002c8975c62e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1692025715,
@@ -260,8 +244,7 @@
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-kitman": "nixpkgs-kitman",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-kitman": "nixpkgs-kitman"
       }
     },
     "rust-analyzer-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-kitman.url = "github:jkitman/nixpkgs/add-esplora-pkg";
     crane.url = "github:ipetkov/crane?rev=116b32c30b5ff28e49f4fcbeeb1bbe3544593204";
     crane.inputs.nixpkgs.follows = "nixpkgs";
@@ -24,15 +23,11 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, nixpkgs-kitman, flake-utils, flake-compat, fenix, crane, advisory-db, android-nixpkgs }:
+  outputs = { self, nixpkgs, nixpkgs-kitman, flake-utils, flake-compat, fenix, crane, advisory-db, android-nixpkgs }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
           pkgs = import nixpkgs {
-            inherit system;
-          };
-
-          pkgs-unstable = import nixpkgs-unstable {
             inherit system;
           };
 
@@ -339,7 +334,7 @@
                     pkgs.rust-analyzer
                     toolchain.fenixToolchainRustfmt
                     cargo-llvm-cov
-                    pkgs-unstable.cargo-udeps
+                    pkgs.cargo-udeps
                     pkgs.parallel
                     pkgs.just
                     typos


### PR DESCRIPTION
While reviewing #2965 it occurred to me that we might be able to remove `nixpkgs-unstable` entirely. Let's see if this works.