### PR TITLE
fix: compress debug symbols directive not working

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ rustflags = ["--cfg", "tokio_unstable"]
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,--compress-debug-sections=zlib", "--cfg", "tokio_unstable"]
+rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib,-fuse-ld=lld", "--cfg", "tokio_unstable"]
 
 # mold is currently broken on MacOS
 # [target.aarch64-apple-darwin]


### PR DESCRIPTION
before:

```
-rwxr-xr-x 2 dpc dpc 46M Aug 18 08:38 ./target/release/fedimintd
```

after:

```
-rwxr-xr-x 2 dpc dpc 44M Aug 18 08:46 ./target/release/fedimintd
```