### PR TITLE
chore: make it easier to identify test's tmp dir in log dump

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,7 @@ if [[ "${TMP:-}" == *"/nix-shell."* ]]; then
 else
   FM_TEST_DIR="${2-"$(mktemp --tmpdir -d XXXXX)"}"
 fi
+
 export FM_TEST_DIR
 export FM_PID_FILE="$FM_TEST_DIR/.pid"
 export FM_LOGS_DIR="$FM_TEST_DIR/logs"
@@ -22,6 +23,11 @@ echo "Setting up env variables in $FM_TEST_DIR"
 
 mkdir -p "$FM_TEST_DIR"
 touch "$FM_PID_FILE"
+
+if [ -n "${FM_TEST_NAME:-}" ]; then
+  # make it easy to identify which tmp dir belongs to which test
+  touch "$FM_TEST_DIR-$(echo "$FM_TEST_NAME" |tr -cd '[:alnum:]-_')" || true
+fi
 
 # Symlink $FM_TEST_DIR to local gitignored target/ directory so they're easier to find
 rm -f target/devimint

--- a/scripts/dev/run-isolated-test/fm-run-isolated-test
+++ b/scripts/dev/run-isolated-test/fm-run-isolated-test
@@ -3,7 +3,6 @@
 test_name="$1"
 shift 1
 
-
 if [ -z "$test_name" ]; then
     >&2 "error: no test name"
     exit 1
@@ -13,6 +12,8 @@ set -eo pipefail # pipefail must be set manually again
 trap 'echo "## FAILED: $test_name"' ERR
 
 echo "## START: $test_name"
+
+export FM_TEST_NAME="$test_name"
 
 # We rely on `unshare` to run all tests in separate network namespaces,
 # Not possible on MacOS though


### PR DESCRIPTION
![image](https://github.com/fedimint/fedimint/assets/9209/664205b1-6cfc-47f6-915a-b54885bf5871)
