### PR TITLE
Restore old CLI `info` command output schema with federation details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4575,6 +4575,7 @@ version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -285,7 +285,7 @@ impl Federation {
     }
 
     pub async fn client_balance(&self) -> Result<u64> {
-        Ok(cmd!(self, "info").out_json().await?["total_msat"]
+        Ok(cmd!(self, "info").out_json().await?["total_amount_msat"]
             .as_u64()
             .unwrap())
     }

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -742,7 +742,7 @@ async fn cli_tests_backup_and_restore(fed_cli: &Federation) -> Result<()> {
 
     let pre_notes = cmd!(fed_cli, "info").out_json().await?;
 
-    let pre_balance = pre_notes["total_msat"].as_u64().unwrap();
+    let pre_balance = pre_notes["total_amount_msat"].as_u64().unwrap();
 
     debug!(%pre_notes, pre_balance, "State before backup");
 
@@ -763,14 +763,14 @@ async fn cli_tests_backup_and_restore(fed_cli: &Federation) -> Result<()> {
 
         assert_eq!(
             0,
-            cmd!(client, "info").out_json().await?["total_msat"]
+            cmd!(client, "info").out_json().await?["total_amount_msat"]
                 .as_u64()
                 .unwrap()
         );
         let _ = cmd!(client, "restore", &secret,).out_json().await?;
 
         let post_notes = cmd!(client, "info").out_json().await?;
-        let post_balance = post_notes["total_msat"].as_u64().unwrap();
+        let post_balance = post_notes["total_amount_msat"].as_u64().unwrap();
 
         debug!(%post_notes, post_balance, "State after backup");
         assert_eq!(pre_balance, post_balance);
@@ -785,14 +785,14 @@ async fn cli_tests_backup_and_restore(fed_cli: &Federation) -> Result<()> {
 
         assert_eq!(
             0,
-            cmd!(client, "info").out_json().await?["total_msat"]
+            cmd!(client, "info").out_json().await?["total_amount_msat"]
                 .as_u64()
                 .unwrap()
         );
         let _ = cmd!(client, "restore", &secret,).out_json().await?;
 
         let post_notes = cmd!(client, "info").out_json().await?;
-        let post_balance = post_notes["total_msat"].as_u64().unwrap();
+        let post_balance = post_notes["total_amount_msat"].as_u64().unwrap();
 
         debug!(%post_notes, post_balance, "State after backup");
         assert_eq!(pre_balance, post_balance);

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "1.0.39"
 tokio = { version = "1.26.0", features = ["full"] }
 tracing ="0.1.37"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
-serde_json = "1.0.91"
+serde_json = { version = "1.0.91", features = ["preserve_order"] }
 url = { version = "2.3.1", features = ["serde"] }
 clap_complete = "4.3.1"
 

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -462,9 +462,9 @@ async fn get_note_summary(client: &Client) -> anyhow::Result<serde_json::Value> 
         federation_id: client.federation_id(),
         network: wallet_client.get_network(),
         meta: client.get_config().meta.clone(),
-        total_amount: summary.total_amount(),
+        total_amount_msat: summary.total_amount(),
         total_num_notes: summary.count_items(),
-        details: summary,
+        denominations_msat: summary,
     })
     .unwrap())
 }
@@ -474,9 +474,9 @@ struct InfoResponse {
     federation_id: FederationId,
     network: Network,
     meta: BTreeMap<String, String>,
-    total_amount: Amount,
+    total_amount_msat: Amount,
     total_num_notes: usize,
-    details: TieredSummary,
+    denominations_msat: TieredSummary,
 }
 
 pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_core::Amount, ParseAmountError> {

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -1,8 +1,9 @@
+use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::time::{Duration, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail};
-use bitcoin::secp256k1;
+use bitcoin::{secp256k1, Network};
 use bitcoin_hashes::hex;
 use bitcoin_hashes::hex::ToHex;
 use clap::Subcommand;
@@ -10,7 +11,7 @@ use fedimint_client::backup::Metadata;
 use fedimint_client::secret::PlainRootSecretStrategy;
 use fedimint_client::sm::OperationId;
 use fedimint_client::Client;
-use fedimint_core::config::ClientConfig;
+use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::time::now;
 use fedimint_core::{Amount, ParseAmountError, TieredMulti, TieredSummary};
@@ -21,7 +22,7 @@ use fedimint_ln_client::{
 use fedimint_mint_client::{
     parse_ecash, serialize_ecash, MintClientExt, MintClientModule, SpendableNote,
 };
-use fedimint_wallet_client::{WalletClientExt, WithdrawState};
+use fedimint_wallet_client::{WalletClientExt, WalletClientModule, WithdrawState};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -452,20 +453,30 @@ pub async fn handle_ng_command(
 
 async fn get_note_summary(client: &Client) -> anyhow::Result<serde_json::Value> {
     let (mint_client, _) = client.get_first_module::<MintClientModule>(&fedimint_mint_client::KIND);
+    let (wallet_client, _) =
+        client.get_first_module::<WalletClientModule>(&fedimint_wallet_client::KIND);
     let summary = mint_client
         .get_wallet_summary(&mut client.db().begin_transaction().await.with_module_prefix(1))
         .await;
     Ok(serde_json::to_value(InfoResponse {
-        total_msat: summary.total_amount(),
-        denominations_msat: summary,
+        federation_id: client.federation_id(),
+        network: wallet_client.get_network(),
+        meta: client.get_config().meta.clone(),
+        total_amount: summary.total_amount(),
+        total_num_notes: summary.count_items(),
+        details: summary,
     })
     .unwrap())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct InfoResponse {
-    total_msat: Amount,
-    denominations_msat: TieredSummary,
+    federation_id: FederationId,
+    network: Network,
+    meta: BTreeMap<String, String>,
+    total_amount: Amount,
+    total_num_notes: usize,
+    details: TieredSummary,
 }
 
 pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_core::Amount, ParseAmountError> {


### PR DESCRIPTION
Also adds `preserve_order` feature for `serde_json` to ensure keys appear in the same order in the output as they are defined in the code.

Resolves #2973 