### PR TITLE
Add RPC to expose audit summary

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -380,6 +380,9 @@ enum AdminCmd {
 
     /// Signal a consensus upgrade
     SignalUpgrade,
+
+    /// Show an audit across all modules
+    Audit,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -567,6 +570,21 @@ impl FedimintCli {
                     client::handle_ng_command(command, config, client)
                         .await
                         .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?,
+                ))
+            }
+            Command::Admin(AdminCmd::Audit) => {
+                let user = cli
+                    .build_client_ng(&self.module_gens, None)
+                    .await
+                    .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?;
+
+                let audit = cli
+                    .admin_client(user.get_config())?
+                    .audit(cli.auth()?)
+                    .await?;
+                Ok(CliOutput::Raw(
+                    serde_json::to_value(audit)
+                        .map_err_cli_msg(CliErrorKind::GeneralFailure, "invalid response")?,
                 ))
             }
             Command::Admin(AdminCmd::Status) => {

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use bitcoin_hashes::sha256;
+use fedimint_core::module::audit::AuditSummary;
 use fedimint_core::task::MaybeSend;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::PublicKey;
@@ -192,6 +193,12 @@ impl WsAdminClient {
     /// Returns the status of the server
     pub async fn status(&self) -> FederationResult<StatusResponse> {
         self.request("status", ApiRequestErased::default()).await
+    }
+
+    /// Show an audit across all modules
+    pub async fn audit(&self, auth: ApiAuth) -> FederationResult<AuditSummary> {
+        self.request("audit", ApiRequestErased::default().with_auth(auth))
+            .await
     }
 
     /// Check auth credentials

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
 use futures::StreamExt;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 use crate::db::{DatabaseKey, DatabaseLookup, DatabaseRecord, ModuleDatabaseTransaction};
 
@@ -10,21 +13,18 @@ pub struct Audit {
 }
 
 impl Audit {
-    pub fn sum(&self) -> AuditItem {
-        let mut sum = 0;
-
-        for item in &self.items {
-            sum += item.milli_sat;
-        }
+    pub fn net_assets(&self) -> AuditItem {
         AuditItem {
-            name: "Total sats".to_string(),
-            milli_sat: sum,
+            name: "Net assets (sats)".to_string(),
+            milli_sat: calculate_net_assets(self.items.iter()),
+            module_name: "".to_string(),
         }
     }
 
     pub async fn add_items<KP, F>(
         &mut self,
         dbtx: &mut ModuleDatabaseTransaction<'_>,
+        module_name: &str,
         key_prefix: &KP,
         to_milli_sat: F,
     ) where
@@ -38,7 +38,11 @@ impl Audit {
             .map(|(key, value)| {
                 let name = format!("{key:?}");
                 let milli_sat = to_milli_sat(key, value);
-                AuditItem { name, milli_sat }
+                AuditItem {
+                    name,
+                    milli_sat,
+                    module_name: module_name.to_string(),
+                }
             })
             .collect::<Vec<AuditItem>>()
             .await;
@@ -52,18 +56,133 @@ impl Display for Audit {
         for item in &self.items {
             formatter.write_fmt(format_args!("\n{item}"))?;
         }
-        formatter.write_fmt(format_args!("\n{}", self.sum()))
+        formatter.write_fmt(format_args!("\n{}", self.net_assets()))
     }
 }
 
 pub struct AuditItem {
     pub name: String,
     pub milli_sat: i64,
+    pub module_name: String,
 }
 
 impl Display for AuditItem {
     fn fmt(&self, formatter: &mut Formatter) -> std::fmt::Result {
         let sats = (self.milli_sat as f64) / 1000.0;
-        formatter.write_fmt(format_args!("{:>+15.3}|{}", sats, self.name))
+        formatter.write_fmt(format_args!(
+            "{:>+15.3}|{:>10}|{}",
+            sats, self.module_name, self.name
+        ))
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AuditSummary {
+    pub net_assets: i64,
+    pub module_summaries: HashMap<String, ModuleSummary>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ModuleSummary {
+    pub net_assets: i64,
+}
+
+impl AuditSummary {
+    pub fn from_audit(audit: &Audit) -> Self {
+        AuditSummary {
+            net_assets: calculate_net_assets(audit.items.iter()),
+            module_summaries: generate_module_summaries(&audit.items),
+        }
+    }
+}
+
+fn generate_module_summaries(audit_items: &[AuditItem]) -> HashMap<String, ModuleSummary> {
+    audit_items
+        .iter()
+        .map(|item| (item.module_name.clone(), item))
+        .into_group_map()
+        .into_iter()
+        .map(|(module_name, module_audit_items)| {
+            (
+                module_name,
+                ModuleSummary {
+                    net_assets: calculate_net_assets(module_audit_items.into_iter()),
+                },
+            )
+        })
+        .collect()
+}
+
+fn calculate_net_assets<'a>(items: impl Iterator<Item = &'a AuditItem>) -> i64 {
+    items.map(|item| item.milli_sat).sum()
+}
+
+#[test]
+fn creates_audit_summary_from_audit() {
+    let audit = Audit {
+        items: vec![
+            AuditItem {
+                name: "ContractKey(...)".to_string(),
+                milli_sat: -101_000,
+                module_name: "ln".to_string(),
+            },
+            AuditItem {
+                name: "IssuanceTotal".to_string(),
+                milli_sat: -50_100_000,
+                module_name: "mint".to_string(),
+            },
+            AuditItem {
+                name: "Redemption(...)".to_string(),
+                milli_sat: 101_000,
+                module_name: "mint".to_string(),
+            },
+            AuditItem {
+                name: "RedemptionTotal".to_string(),
+                milli_sat: 100_000,
+                module_name: "mint".to_string(),
+            },
+            AuditItem {
+                name: "UTXOKey(...)".to_string(),
+                milli_sat: 20_000_000,
+                module_name: "wallet".to_string(),
+            },
+            AuditItem {
+                name: "UTXOKey(...)".to_string(),
+                milli_sat: 10_000_000,
+                module_name: "wallet".to_string(),
+            },
+            AuditItem {
+                name: "UTXOKey(...)".to_string(),
+                milli_sat: 20_000_000,
+                module_name: "wallet".to_string(),
+            },
+        ],
+    };
+
+    let audit_summary = AuditSummary::from_audit(&audit);
+    let expected_audit_summary = AuditSummary {
+        net_assets: 0,
+        module_summaries: HashMap::from([
+            (
+                "ln".to_string(),
+                ModuleSummary {
+                    net_assets: -101_000,
+                },
+            ),
+            (
+                "mint".to_string(),
+                ModuleSummary {
+                    net_assets: -49_899_000,
+                },
+            ),
+            (
+                "wallet".to_string(),
+                ModuleSummary {
+                    net_assets: 50_000_000,
+                },
+            ),
+        ]),
+    };
+
+    assert_eq!(audit_summary, expected_audit_summary);
 }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -201,7 +201,7 @@ impl FedimintConsensus {
 
         let audit = self.audit().await;
 
-        if audit.sum().milli_sat < 0 {
+        if audit.net_assets().milli_sat < 0 {
             panic!("Balance sheet of the fed has gone negative, this should never happen! {audit}")
         }
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -783,7 +783,7 @@ impl FederationTest {
             for (i, server) in self.servers.iter().enumerate() {
                 let server = server.clone();
                 task_group
-                    .spawn(format!("server-{i}-consensu_epoch"), move |_| async {
+                    .spawn(format!("server-{i}-consensus_epoch"), move |_| async {
                         Self::consensus_epoch(server, Duration::from_millis(0)).await
                     })
                     .await;
@@ -962,7 +962,7 @@ impl FederationTest {
             info!("\n{}", audit);
             let bs = std::cmp::max(
                 self.max_balance_sheet.load(Ordering::SeqCst),
-                audit.sum().milli_sat,
+                audit.net_assets().milli_sat,
             );
             self.max_balance_sheet.store(bs, Ordering::SeqCst);
             *last_consensus = new_consensus;

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -24,7 +24,7 @@ use fedimint_dummy_common::config::{
 };
 use fedimint_dummy_common::{
     fed_public_key, DummyCommonGen, DummyConsensusItem, DummyError, DummyInput, DummyModuleTypes,
-    DummyOutput, DummyOutputOutcome, CONSENSUS_VERSION,
+    DummyOutput, DummyOutputOutcome, CONSENSUS_VERSION, KIND,
 };
 use fedimint_server::config::distributedgen::PeerHandleOps;
 use futures::{FutureExt, StreamExt};
@@ -410,7 +410,7 @@ impl ServerModule for Dummy {
 
     async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
         audit
-            .add_items(dbtx, &DummyFundsPrefixV1, |k, v| match k {
+            .add_items(dbtx, KIND.as_str(), &DummyFundsPrefixV1, |k, v| match k {
                 // the fed's test account is considered an asset (positive)
                 // should be the bitcoin we own in a real module
                 DummyFundsKeyV1(key) if key == fed_public_key() => v.msats as i64,

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -821,7 +821,9 @@ impl ServerModule for Lightning {
 
     async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
         audit
-            .add_items(dbtx, &ContractKeyPrefix, |_, v| -(v.amount.msats as i64))
+            .add_items(dbtx, common::KIND.as_str(), &ContractKeyPrefix, |_, v| {
+                -(v.amount.msats as i64)
+            })
             .await;
     }
 

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -606,12 +606,17 @@ impl ServerModule for Mint {
 
     async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
         audit
-            .add_items(dbtx, &MintAuditItemKeyPrefix, |k, v| match k {
-                MintAuditItemKey::Issuance(_) => -(v.msats as i64),
-                MintAuditItemKey::IssuanceTotal => -(v.msats as i64),
-                MintAuditItemKey::Redemption(_) => v.msats as i64,
-                MintAuditItemKey::RedemptionTotal => v.msats as i64,
-            })
+            .add_items(
+                dbtx,
+                common::KIND.as_str(),
+                &MintAuditItemKeyPrefix,
+                |k, v| match k {
+                    MintAuditItemKey::Issuance(_) => -(v.msats as i64),
+                    MintAuditItemKey::IssuanceTotal => -(v.msats as i64),
+                    MintAuditItemKey::Redemption(_) => v.msats as i64,
+                    MintAuditItemKey::RedemptionTotal => v.msats as i64,
+                },
+            )
             .await;
     }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -571,20 +571,33 @@ impl ServerModule for Wallet {
     }
 
     async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
+        let module_name = common::KIND.as_str().to_string();
         audit
-            .add_items(dbtx, &UTXOPrefixKey, |_, v| v.amount.to_sat() as i64 * 1000)
-            .await;
-        audit
-            .add_items(dbtx, &UnsignedTransactionPrefixKey, |_, v| match v.rbf {
-                None => v.change.to_sat() as i64 * 1000,
-                Some(rbf) => rbf.fees.amount().to_sat() as i64 * -1000,
+            .add_items(dbtx, &module_name, &UTXOPrefixKey, |_, v| {
+                v.amount.to_sat() as i64 * 1000
             })
             .await;
         audit
-            .add_items(dbtx, &PendingTransactionPrefixKey, |_, v| match v.rbf {
-                None => v.change.to_sat() as i64 * 1000,
-                Some(rbf) => rbf.fees.amount().to_sat() as i64 * -1000,
-            })
+            .add_items(
+                dbtx,
+                &module_name,
+                &UnsignedTransactionPrefixKey,
+                |_, v| match v.rbf {
+                    None => v.change.to_sat() as i64 * 1000,
+                    Some(rbf) => rbf.fees.amount().to_sat() as i64 * -1000,
+                },
+            )
+            .await;
+        audit
+            .add_items(
+                dbtx,
+                &module_name,
+                &PendingTransactionPrefixKey,
+                |_, v| match v.rbf {
+                    None => v.change.to_sat() as i64 * 1000,
+                    Some(rbf) => rbf.fees.amount().to_sat() as i64 * -1000,
+                },
+            )
             .await;
     }
 


### PR DESCRIPTION
Closes #2948

- Adds an `AuditSummary` that calculates net assets for each module and the federation in aggregate
- Adds an RPC and admin cli command that gets the most recent audit summary
  - To accomplish the goal in the [issue](https://github.com/fedimint/fedimint/issues/2948) for the guardian UI to display the total sats held by the federation, the client can parse the net assets in the wallet module

```bash
bash-5.1$ fedimint-cli --our-id 0 --password pass admin audit
{
  "net_assets": 0,
  "module_summaries": {
    "mint": {
      "net_assets": -50000000
    },
    "wallet": {
      "net_assets": 50000000
    },
    "ln": {
      "net_assets": 0
    }
  }
}
```