### PR TITLE
chore: don't strip release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ threshold_crypto = { opt-level = 3 }
 inherits = "dev"
 debug = "line-tables-only"
 
+[profile.release]
+debug = "line-tables-only"
+
 [patch.crates-io]
 secp256k1-zkp = { git = "https://github.com/dpc/rust-secp256k1-zkp/", branch = "sanket-pr" }
 ring = { git = "https://github.com/dpc/ring", rev = "5493e7e76d0d8fb1d3cbb0be9c4944700741b802" }

--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,7 @@
               inherit name;
 
               dontUnpack = true;
+              dontStrip = true;
 
               installPhase = ''
                 cp -a ${package} $out
@@ -132,6 +133,7 @@
               name = bin;
 
               dontUnpack = true;
+              dontStrip = true;
 
               installPhase = ''
                 mkdir -p $out/bin

--- a/nix/craneCommon.nix
+++ b/nix/craneCommon.nix
@@ -130,6 +130,11 @@ craneLib.overrideScope' (self: prev: {
       which
     ];
 
+    # we carefully optimize our debug symbols on cargo level,
+    # and in case of errors and panics, would like to see the
+    # line numbers etc.
+    dontStrip = true;
+
 
     # https://github.com/ipetkov/crane/issues/76#issuecomment-1296025495
     installCargoArtifactsMode = "use-zstd";


### PR DESCRIPTION
Before:

```
-r-xr-xr-x 2 root root  37M Dec 31  1969 fedimint-cli
-r-xr-xr-x 2 root root  43M Dec 31  1969 fedimintd
-r-xr-xr-x 2 root root  31M Dec 31  1969 fedimint-dbtool
```

after

```
-r-xr-xr-x 2 root root  57M Dec 31  1969 fedimint-cli
-r-xr-xr-x 2 root root  67M Dec 31  1969 fedimintd
-r-xr-xr-x 3 root root  53M Dec 31  1969 fedimint-dbtool
```

There's a cost, but we should get line numbers in panics/errors working.

