### PR TITLE
fix: make wallet tests wait consensus

### DIFF
--- a/fedimint-client-legacy/src/lib.rs
+++ b/fedimint-client-legacy/src/lib.rs
@@ -739,7 +739,9 @@ impl<T: AsRef<ClientConfig> + Clone + MaybeSend> Client<T> {
 
     async fn await_consensus_block_count_inner(&self, requested_count: u64) -> u64 {
         loop {
-            match self.context.api.fetch_consensus_block_count().await {
+            let current_count = self.context.api.fetch_consensus_block_count().await;
+            debug!(target: LOG_WALLET, "awaiting consensus block count: {:?}/{}", current_count, requested_count);
+            match current_count {
                 Ok(current_count) if requested_count <= current_count => return current_count,
                 _ => sleep(Duration::from_millis(100)).await,
             }

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -391,7 +391,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
                 TransactionBuilder::new().with_input(instance_input),
             )
             .await
-            .expect("Can obly fail if additional funding is needed")
+            .expect("Can only fail if additional funding is needed")
     }
 
     async fn fund_output_dyn(

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -22,6 +22,7 @@ use fedimint_core::task::{sleep, TaskHandle};
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::{Amount, Feerate};
 use rand::rngs::OsRng;
+use tracing::debug;
 use url::Url;
 
 use super::BitcoinTest;
@@ -102,6 +103,11 @@ impl FakeBitcoinTest {
     }
 
     fn mine_block(blocks: &mut Vec<Block>, pending: &mut Vec<Transaction>) {
+        debug!(
+            "Mining block: {} transactions, {} blocks",
+            pending.len(),
+            blocks.len()
+        );
         let root = BlockHash::hash(&[0]);
         // all blocks need at least one transaction
         if pending.is_empty() {


### PR DESCRIPTION
Also don't return zero when there is no block count consensus.

Build on https://github.com/fedimint/fedimint/pull/2976 and implements the fix for https://github.com/fedimint/fedimint/issues/2974 in a way that fixes the tests but don't introduce regressions on initial blockchain scanning.