### PR TITLE
chore: rename "module gen" to "module init"

### DIFF
--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use bitcoincore_rpc::RpcApi;
 use federation::Federation;
-use fedimint_client::module::gen::{ClientModuleGenRegistry, DynClientModuleGen};
+use fedimint_client::module::init::{ClientModuleInitRegistry, DynClientModuleInit};
 use fedimint_client_legacy::modules::mint::MintClientGen;
 use fedimint_client_legacy::{module_decode_stubs, UserClient, UserClientConfig};
 use fedimint_core::admin_client::WsAdminClient;

--- a/docs/building-new-modules.md
+++ b/docs/building-new-modules.md
@@ -3,7 +3,7 @@ One way to think of Fedimint is as a framework for building federated applicatio
 In order to build such an application, you need to fork the `fedimint` git repo. Create a new crate in the `modules` folder - you can use the [`fedimint-dummy-*`](https://github.com/fedimint/fedimint/tree/master/modules) crates as inspiration. Next `impl` two traits:
 
 * [ServerModule](https://github.com/fedimint/fedimint/blob/3a808c44c94856c80d4b716ed853a882e83cb5c3/fedimint-core/src/module/mod.rs#L737-L892): defines how your module will interact with Fedimint consensus.
-* [ServerModuleGen](https://github.com/fedimint/fedimint/blob/3a808c44c94856c80d4b716ed853a882e83cb5c3/fedimint-core/src/module/mod.rs#L517-L585): defines how configuration for your module will be generated.
+* [ServerModuleInit](https://github.com/fedimint/fedimint/blob/3a808c44c94856c80d4b716ed853a882e83cb5c3/fedimint-core/src/module/mod.rs#L517-L585): defines how configuration for your module will be generated.
 
 Lastly, plug your module into [fedimintd](https://github.com/fedimint/fedimint/blob/master/fedimintd/src/bin/main.rs)
 

--- a/fedimint-client-legacy/src/lib.rs
+++ b/fedimint-client-legacy/src/lib.rs
@@ -24,7 +24,7 @@ use api::{LnFederationApi, WalletFederationApi};
 use bitcoin::util::key::KeyPair;
 use bitcoin::{secp256k1, Address, Transaction as BitcoinTransaction};
 use bitcoin_hashes::{sha256, Hash};
-use fedimint_client::module::gen::ClientModuleGenRegistry;
+use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_core::api::{
     DynGlobalApi, FederationError, GlobalFederationApi, OutputOutcomeError, PeerError,
     WsFederationApi,
@@ -38,7 +38,7 @@ use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::SignedEpochOutcome;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::module::{CommonModuleGen, ModuleCommon};
+use fedimint_core::module::{CommonModuleInit, ModuleCommon};
 use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::task::{self, sleep, MaybeSend};
 use fedimint_core::tiered::InvalidAmountTierError;
@@ -182,8 +182,8 @@ impl<C> Client<C> {
         &self.context.decoders
     }
 
-    pub fn module_gens(&self) -> &ClientModuleGenRegistry {
-        &self.context.module_gens
+    pub fn module_inits(&self) -> &ClientModuleInitRegistry {
+        &self.context.module_inits
     }
 
     pub fn context(&self) -> &Arc<ClientContext> {
@@ -293,18 +293,18 @@ impl<T: AsRef<ClientConfig> + Clone + MaybeSend> Client<T> {
     pub async fn new(
         config: T,
         decoders: ModuleDecoderRegistry,
-        module_gens: ClientModuleGenRegistry,
+        module_inits: ClientModuleInitRegistry,
         db: Database,
         secp: Secp256k1<All>,
     ) -> Self {
         let api = WsFederationApi::from_config(config.as_ref());
-        Self::new_with_api(config, decoders, module_gens, db, api.into(), secp).await
+        Self::new_with_api(config, decoders, module_inits, db, api.into(), secp).await
     }
 
     pub async fn new_with_api(
         config: T,
         decoders: ModuleDecoderRegistry,
-        module_gens: ClientModuleGenRegistry,
+        module_inits: ClientModuleInitRegistry,
         db: Database,
         api: DynGlobalApi,
         secp: Secp256k1<All>,
@@ -315,7 +315,7 @@ impl<T: AsRef<ClientConfig> + Clone + MaybeSend> Client<T> {
             config,
             context: Arc::new(ClientContext {
                 decoders,
-                module_gens,
+                module_inits,
                 db,
                 api,
                 secp,

--- a/fedimint-client-legacy/src/utils.rs
+++ b/fedimint-client-legacy/src/utils.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use bitcoin::{secp256k1, Network};
 use bitcoin_hashes::hex::FromHex;
-use fedimint_client::module::gen::ClientModuleGenRegistry;
+use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_core::api::DynGlobalApi;
 use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -68,7 +68,7 @@ pub fn parse_peer_id(s: &str) -> Result<PeerId, ParseIntError> {
 #[derive(Debug)]
 pub struct ClientContext {
     pub decoders: ModuleDecoderRegistry,
-    pub module_gens: ClientModuleGenRegistry,
+    pub module_inits: ClientModuleInitRegistry,
     pub db: Database,
     pub api: DynGlobalApi,
     pub secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -19,7 +19,7 @@ use crate::sm::{Context, DynContext, DynState, Executor, OperationId, State};
 use crate::transaction::{ClientInput, ClientOutput};
 use crate::{Client, DynGlobalClientContext};
 
-pub mod gen;
+pub mod init;
 
 pub type ClientModuleRegistry = ModuleRegistry<DynClientModule>;
 

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -13,7 +13,7 @@ use crate::api::{
     DynGlobalApi, FederationApiExt, FederationResult, GlobalFederationApi, ServerStatus,
     StatusResponse, WsFederationApi,
 };
-use crate::config::ServerModuleGenParamsRegistry;
+use crate::config::ServerModuleConfigGenParamsRegistry;
 use crate::epoch::{SerdeEpochHistory, SignedEpochOutcome};
 use crate::module::registry::ModuleDecoderRegistry;
 use crate::module::{ApiAuth, ApiRequestErased};
@@ -264,8 +264,8 @@ pub struct ConfigGenParamsConsensus {
     pub peers: BTreeMap<PeerId, PeerServerParams>,
     /// Guardian-defined key-value pairs that will be passed to the client
     pub meta: BTreeMap<String, String>,
-    /// Config gen params (also contains local params from us)
-    pub modules: ServerModuleGenParamsRegistry,
+    /// Module init params (also contains local params from us)
+    pub modules: ServerModuleConfigGenParamsRegistry,
 }
 
 /// The config gen params response which includes our peer id
@@ -283,7 +283,7 @@ pub struct ConfigGenParamsRequest {
     /// Guardian-defined key-value pairs that will be passed to the client
     pub meta: BTreeMap<String, String>,
     /// Set the params (if leader) or just the local params (if follower)
-    pub modules: ServerModuleGenParamsRegistry,
+    pub modules: ServerModuleConfigGenParamsRegistry,
 }
 
 mod serde_tls_cert {

--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -429,7 +429,7 @@ macro_rules! module_plugin_static_trait_define{
 #[macro_export]
 macro_rules! plugin_types_trait_impl_config {
     ($common_gen:ty, $gen:ty, $gen_local:ty, $gen_consensus:ty, $cfg:ty, $cfg_local:ty, $cfg_private:ty, $cfg_consensus:ty, $cfg_client:ty) => {
-        impl fedimint_core::config::ModuleGenParams for $gen {
+        impl fedimint_core::config::ModuleInitParams for $gen {
             type Local = $gen_local;
             type Consensus = $gen_consensus;
 
@@ -444,11 +444,11 @@ macro_rules! plugin_types_trait_impl_config {
 
         impl fedimint_core::config::TypedServerModuleConsensusConfig for $cfg_consensus {
             fn kind(&self) -> fedimint_core::core::ModuleKind {
-                <$common_gen as fedimint_core::module::CommonModuleGen>::KIND
+                <$common_gen as fedimint_core::module::CommonModuleInit>::KIND
             }
 
             fn version(&self) -> fedimint_core::module::ModuleConsensusVersion {
-                <$common_gen as fedimint_core::module::CommonModuleGen>::CONSENSUS_VERSION
+                <$common_gen as fedimint_core::module::CommonModuleInit>::CONSENSUS_VERSION
             }
         }
 
@@ -471,7 +471,7 @@ macro_rules! plugin_types_trait_impl_config {
 
             fn to_parts(self) -> (ModuleKind, Self::Local, Self::Private, Self::Consensus) {
                 (
-                    <$common_gen as fedimint_core::module::CommonModuleGen>::KIND,
+                    <$common_gen as fedimint_core::module::CommonModuleInit>::KIND,
                     self.local,
                     self.private,
                     self.consensus,

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -6,7 +6,7 @@ use fedimint_client_legacy::db as ClientRange;
 use fedimint_client_legacy::ln::db as ClientLightningRange;
 use fedimint_client_legacy::mint::db as ClientMintRange;
 use fedimint_client_legacy::wallet::db as ClientWalletRange;
-use fedimint_core::config::ServerModuleGenRegistry;
+use fedimint_core::config::ServerModuleInitRegistry;
 use fedimint_core::db::notifications::Notifications;
 use fedimint_core::db::{DatabaseTransaction, DatabaseVersionKey, SingleUseDatabaseTransaction};
 use fedimint_core::encoding::Encodable;
@@ -41,7 +41,7 @@ pub struct DatabaseDump<'a> {
     modules: Vec<String>,
     prefixes: Vec<String>,
     cfg: Option<ServerConfig>,
-    module_inits: ServerModuleGenRegistry,
+    module_inits: ServerModuleInitRegistry,
 }
 
 impl<'a> DatabaseDump<'a> {
@@ -49,7 +49,7 @@ impl<'a> DatabaseDump<'a> {
         cfg_dir: PathBuf,
         data_dir: String,
         password: String,
-        module_gens: ServerModuleGenRegistry,
+        module_inits: ServerModuleInitRegistry,
         modules: Vec<String>,
         prefixes: Vec<String>,
     ) -> DatabaseDump<'a> {
@@ -80,7 +80,7 @@ impl<'a> DatabaseDump<'a> {
         }
 
         let cfg = read_server_config(&password, cfg_dir).unwrap();
-        let decoders = module_gens
+        let decoders = module_inits
             .available_decoders(cfg.iter_module_instances())
             .unwrap()
             .with_fallback();
@@ -92,7 +92,7 @@ impl<'a> DatabaseDump<'a> {
             modules,
             prefixes,
             cfg: Some(cfg),
-            module_inits: module_gens,
+            module_inits,
         }
     }
 }

--- a/fedimint-dbtool/src/main.rs
+++ b/fedimint-dbtool/src/main.rs
@@ -5,9 +5,9 @@ use anyhow::Result;
 use bitcoin_hashes::hex::ToHex;
 use bytes::Bytes;
 use clap::{Parser, Subcommand};
-use fedimint_core::config::ServerModuleGenRegistry;
+use fedimint_core::config::ServerModuleInitRegistry;
 use fedimint_core::db::IDatabase;
-use fedimint_core::module::DynServerModuleGen;
+use fedimint_core::module::DynServerModuleInit;
 use fedimint_ln_server::LightningGen;
 use fedimint_logging::TracingSetup;
 use fedimint_mint_server::MintGen;
@@ -140,13 +140,13 @@ async fn main() -> Result<()> {
                 None => Vec::new(),
             };
 
-            let module_gens = ServerModuleGenRegistry::from(if options.no_modules {
+            let module_inits = ServerModuleInitRegistry::from(if options.no_modules {
                 vec![]
             } else {
                 vec![
-                    DynServerModuleGen::from(WalletGen),
-                    DynServerModuleGen::from(MintGen),
-                    DynServerModuleGen::from(LightningGen),
+                    DynServerModuleInit::from(WalletGen),
+                    DynServerModuleInit::from(MintGen),
+                    DynServerModuleInit::from(LightningGen),
                 ]
             });
 
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
                 cfg_dir,
                 options.database,
                 password,
-                module_gens,
+                module_inits,
                 modules,
                 prefix_names,
             );

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -14,7 +14,7 @@ use fedimint_core::api::InviteCode;
 use fedimint_core::core::IntoDynInstance;
 use fedimint_core::encoding::Decodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::module::CommonModuleGen;
+use fedimint_core::module::CommonModuleInit;
 use fedimint_core::{Amount, OutPoint, TieredMulti, TieredSummary};
 use fedimint_ln_client::{LightningClientExt, LightningClientGen, LnPayState};
 use fedimint_mint_client::{

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use fedimint_aead::{encrypted_read, encrypted_write, get_encryption_key, LessSafeKey};
-use fedimint_core::config::ServerModuleGenRegistry;
+use fedimint_core::config::ServerModuleInitRegistry;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -75,7 +75,7 @@ pub fn write_server_config(
     server: &ServerConfig,
     path: PathBuf,
     password: &str,
-    module_config_gens: &ServerModuleGenRegistry,
+    module_config_gens: &ServerModuleInitRegistry,
 ) -> anyhow::Result<()> {
     let salt = fs::read_to_string(path.join(SALT_FILE))?;
     let key = get_encryption_key(password, &salt)?;

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -10,11 +10,11 @@ use fedimint_core::cancellable::Cancelled;
 pub use fedimint_core::config::*;
 use fedimint_core::config::{
     ClientConfig, DkgPeerMsg, FederationId, JsonWithKind, PeerUrl, ServerModuleConfig,
-    ServerModuleGenRegistry, TypedServerModuleConfig,
+    ServerModuleInitRegistry, TypedServerModuleConfig,
 };
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, MODULE_INSTANCE_ID_GLOBAL};
 use fedimint_core::module::{
-    ApiAuth, ApiVersion, CoreConsensusVersion, DynServerModuleGen, MultiApiVersion, PeerHandle,
+    ApiAuth, ApiVersion, CoreConsensusVersion, DynServerModuleInit, MultiApiVersion, PeerHandle,
     SupportedApiVersionsSummary, SupportedCoreApiVersions,
 };
 use fedimint_core::net::peers::{IMuxPeerConnections, IPeerConnections, PeerConnections};
@@ -73,7 +73,7 @@ impl ServerConfig {
 
     pub(crate) fn supported_api_versions_summary(
         modules: &BTreeMap<ModuleInstanceId, ServerModuleConsensusConfig>,
-        module_inits: &ServerModuleGenRegistry,
+        module_inits: &ServerModuleInitRegistry,
     ) -> SupportedApiVersionsSummary {
         SupportedApiVersionsSummary {
             core: Self::supported_api_versions(),
@@ -186,7 +186,7 @@ impl ServerConfigConsensus {
 
     pub fn to_client_config(
         &self,
-        module_config_gens: &ModuleGenRegistry<DynServerModuleGen>,
+        module_config_gens: &ModuleInitRegistry<DynServerModuleInit>,
     ) -> Result<ClientConfig, anyhow::Error> {
         let client = ClientConfig {
             federation_id: FederationId(self.auth_pk_set.public_key()),
@@ -369,7 +369,7 @@ impl ServerConfig {
     pub fn validate_config(
         &self,
         identity: &PeerId,
-        module_config_gens: &ServerModuleGenRegistry,
+        module_config_gens: &ServerModuleInitRegistry,
     ) -> anyhow::Result<()> {
         let peers = self.local.p2p_endpoints.clone();
         let consensus = self.consensus.clone();
@@ -413,7 +413,7 @@ impl ServerConfig {
 
     pub fn trusted_dealer_gen(
         params: &HashMap<PeerId, ConfigGenParams>,
-        registry: ServerModuleGenRegistry,
+        registry: ServerModuleInitRegistry,
     ) -> BTreeMap<PeerId, Self> {
         let mut rng = OsRng;
         let peer0 = &params[&PeerId::from(0)];
@@ -479,7 +479,7 @@ impl ServerConfig {
     /// Runs the distributed key gen algorithm
     pub async fn distributed_gen(
         params: &ConfigGenParams,
-        registry: ServerModuleGenRegistry,
+        registry: ServerModuleInitRegistry,
         delay_calculator: DelayCalculator,
         task_group: &mut TaskGroup,
     ) -> DkgResult<Self> {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
 
 use anyhow::bail;
-use fedimint_core::config::ServerModuleGenRegistry;
+use fedimint_core::config::ServerModuleInitRegistry;
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseTransaction};
 use fedimint_core::epoch::*;
@@ -76,7 +76,7 @@ pub struct FedimintConsensus {
     /// Configuration describing the federation and containing our secrets
     pub cfg: ServerConfig,
     /// Modules config gen information
-    pub module_inits: ServerModuleGenRegistry,
+    pub module_inits: ServerModuleInitRegistry,
     /// Modules registered with the federation
     pub modules: ServerModuleRegistry,
     /// Database storing the result of processing consensus outcomes

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use anyhow::bail;
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi, WsFederationApi};
 use fedimint_core::cancellable::Cancellable;
-use fedimint_core::config::ServerModuleGenRegistry;
+use fedimint_core::config::ServerModuleInitRegistry;
 use fedimint_core::db::{apply_migrations, Database};
 use fedimint_core::encoding::DecodeError;
 use fedimint_core::epoch::{
@@ -109,7 +109,7 @@ impl ConsensusServer {
     pub async fn new(
         cfg: ServerConfig,
         db: Database,
-        module_inits: ServerModuleGenRegistry,
+        module_inits: ServerModuleInitRegistry,
         task_group: &mut TaskGroup,
     ) -> anyhow::Result<Self> {
         let connector: PeerConnector<EpochMessage> =
@@ -132,7 +132,7 @@ impl ConsensusServer {
     pub async fn new_with(
         cfg: ServerConfig,
         db: Database,
-        module_inits: ServerModuleGenRegistry,
+        module_inits: ServerModuleInitRegistry,
         connector: PeerConnector<EpochMessage>,
         delay_calculator: DelayCalculator,
         task_group: &mut TaskGroup,

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -141,7 +141,7 @@ mod fedimint_migration_tests {
         SignedEpochOutcome,
     };
     use fedimint_core::module::registry::ModuleDecoderRegistry;
-    use fedimint_core::module::CommonModuleGen;
+    use fedimint_core::module::CommonModuleInit;
     use fedimint_core::transaction::Transaction;
     use fedimint_core::{Amount, PeerId, ServerModule, TransactionId};
     use fedimint_dummy_common::{DummyCommonGen, DummyInput, DummyOutput};

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use fedimint_client::module::gen::ClientModuleGenRegistry;
+use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::Client;
 use fedimint_client_legacy::modules::ln::config::GatewayFee;
 use fedimint_core::config::FederationId;
@@ -74,7 +74,7 @@ impl GatewayTest {
         password: String,
         lightning: Box<dyn LightningTest>,
         decoders: ModuleDecoderRegistry,
-        registry: ClientModuleGenRegistry,
+        registry: ClientModuleInitRegistry,
     ) -> Self {
         let listen: SocketAddr = format!("127.0.0.1:{base_port}").parse().unwrap();
         let address: Url = format!("http://{listen}").parse().unwrap();

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -1,11 +1,11 @@
 use bitcoin::Network;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
-use fedimint_core::config::ServerModuleGenParamsRegistry;
+use fedimint_core::config::ServerModuleConfigGenParamsRegistry;
 use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
-use fedimint_core::module::ServerModuleGen;
+use fedimint_core::module::ServerModuleInit;
 use fedimint_core::{Amount, Tiered};
 use fedimint_ln_server::common::config::{
     LightningGenParams, LightningGenParamsConsensus, LightningGenParamsLocal,
@@ -23,14 +23,14 @@ use url::Url;
 pub mod fedimintd;
 
 /// Generates the configuration for the modules configured in the server binary
-pub fn attach_default_module_gen_params(
+pub fn attach_default_module_init_params(
     bitcoin_rpc: BitcoinRpcConfig,
-    module_gen_params: &mut ServerModuleGenParamsRegistry,
+    module_init_params: &mut ServerModuleConfigGenParamsRegistry,
     max_denomination: Amount,
     network: Network,
     finality_delay: u32,
 ) {
-    module_gen_params
+    module_init_params
         .attach_config_gen_params(
             LEGACY_HARDCODED_INSTANCE_ID_WALLET,
             WalletGen::kind(),

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use fedimint_client::module::gen::ClientModuleGenRegistry;
+use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::secret::PlainRootSecretStrategy;
 use fedimint_client::ClientBuilder;
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi, InviteCode, WsFederationApi};
@@ -20,14 +20,14 @@ use crate::{GatewayError, Result};
 #[derive(Debug, Clone)]
 pub struct StandardGatewayClientBuilder {
     work_dir: PathBuf,
-    registry: ClientModuleGenRegistry,
+    registry: ClientModuleInitRegistry,
     primary_module: ModuleInstanceId,
 }
 
 impl StandardGatewayClientBuilder {
     pub fn new(
         work_dir: PathBuf,
-        registry: ClientModuleGenRegistry,
+        registry: ClientModuleInitRegistry,
         primary_module: ModuleInstanceId,
     ) -> Self {
         Self {
@@ -58,7 +58,7 @@ impl StandardGatewayClientBuilder {
         });
 
         let mut client_builder = ClientBuilder::default();
-        client_builder.with_module_gens(registry);
+        client_builder.with_module_inits(registry);
         client_builder.with_primary_module(self.primary_module);
         client_builder.with_config(config.config);
         if let Some(old_client) = old_client {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -28,7 +28,7 @@ use bitcoin_hashes::hex::ToHex;
 use clap::{Parser, Subcommand};
 use client::StandardGatewayClientBuilder;
 use db::{FederationRegistrationKey, GatewayPublicKey};
-use fedimint_client::module::gen::{ClientModuleGen, ClientModuleGenRegistry};
+use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitRegistry};
 use fedimint_core::api::{FederationError, InviteCode};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{
@@ -36,7 +36,7 @@ use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_core::db::Database;
-use fedimint_core::module::CommonModuleGen;
+use fedimint_core::module::CommonModuleInit;
 use fedimint_core::task::{sleep, RwLock, TaskGroup, TaskHandle, TaskShutdownToken};
 use fedimint_core::time::now;
 use fedimint_core::Amount;
@@ -128,7 +128,7 @@ pub struct GatewayOpts {
 }
 
 pub struct Gatewayd {
-    registry: ClientModuleGenRegistry,
+    registry: ClientModuleInitRegistry,
     lightning_mode: LightningMode,
     data_dir: PathBuf,
     listen: SocketAddr,
@@ -164,7 +164,7 @@ impl Gatewayd {
         );
 
         Ok(Self {
-            registry: ClientModuleGenRegistry::new(),
+            registry: ClientModuleInitRegistry::new(),
             lightning_mode: mode,
             data_dir,
             listen,
@@ -176,7 +176,7 @@ impl Gatewayd {
 
     pub fn with_module<T>(mut self, gen: T) -> Self
     where
-        T: ClientModuleGen + 'static + Send + Sync,
+        T: ClientModuleInit + 'static + Send + Sync,
     {
         self.registry.attach(gen);
         self

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use async_stream::stream;
 use bitcoin_hashes::{sha256, Hash};
 use fedimint_client::derivable_secret::{ChildId, DerivableSecret};
-use fedimint_client::module::gen::ClientModuleGen;
+use fedimint_client::module::init::ClientModuleInit;
 use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
@@ -20,7 +20,7 @@ use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId};
 use fedimint_core::db::{AutocommitError, Database, DatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
-    ApiVersion, ExtendsCommonModuleGen, MultiApiVersion, TransactionItemAmount,
+    ApiVersion, ExtendsCommonModuleInit, MultiApiVersion, TransactionItemAmount,
 };
 use fedimint_core::{apply, async_trait_maybe_send, Amount, OutPoint, TransactionId};
 use fedimint_ln_client::contracts::ContractId;
@@ -329,12 +329,12 @@ pub struct GatewayClientGen {
     pub fees: RoutingFees,
 }
 
-impl ExtendsCommonModuleGen for GatewayClientGen {
+impl ExtendsCommonModuleInit for GatewayClientGen {
     type Common = LightningCommonGen;
 }
 
 #[apply(async_trait_maybe_send!)]
-impl ClientModuleGen for GatewayClientGen {
+impl ClientModuleInit for GatewayClientGen {
     type Module = GatewayClientModule;
 
     fn supported_api_versions(&self) -> MultiApiVersion {

--- a/integrationtests/tests/fixtures/legacy.rs
+++ b/integrationtests/tests/fixtures/legacy.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
 use bitcoin::{Address, Transaction as BitcoinTransaction, Txid};
-use fedimint_client::module::gen::ClientModuleGenRegistry;
+use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client_legacy::ln::incoming::ConfirmedInvoice;
 use fedimint_client_legacy::ln::outgoing::OutgoingContractAccount;
 use fedimint_client_legacy::mint::backup::Metadata;
@@ -49,7 +49,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> LegacyTestUser<T> {
     pub fn new(
         config: T,
         decoders: ModuleDecoderRegistry,
-        module_gens: ClientModuleGenRegistry,
+        module_inits: ClientModuleInitRegistry,
         peers: Vec<PeerId>,
         db: Database,
     ) -> LegacyTestUser<T> {
@@ -67,7 +67,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> LegacyTestUser<T> {
         let client = Arc::new(block_on(Client::new_with_api(
             config.clone(),
             decoders,
-            module_gens,
+            module_inits,
             db,
             api,
             Default::default(),
@@ -359,7 +359,7 @@ impl ILegacyTestClient for LegacyTestUser<UserClientConfig> {
         Box::new(LegacyTestUser::new(
             self.config.clone(),
             self.client.decoders().clone(),
-            self.client.module_gens().clone(),
+            self.client.module_inits().clone(),
             peers,
             Database::new(MemDatabase::new(), module_decode_stubs()),
         ))

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::{format_err, Context as _};
 use fedimint_client::derivable_secret::DerivableSecret;
-use fedimint_client::module::gen::ClientModuleGen;
+use fedimint_client::module::init::ClientModuleInit;
 use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::sm::{Context, ModuleNotifier, OperationId};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
@@ -12,7 +12,7 @@ use fedimint_core::api::{DynGlobalApi, DynModuleApi, GlobalFederationApi};
 use fedimint_core::core::{Decoder, IntoDynInstance, KeyPair};
 use fedimint_core::db::{Database, ModuleDatabaseTransaction};
 use fedimint_core::module::{
-    ApiVersion, CommonModuleGen, ExtendsCommonModuleGen, ModuleCommon, MultiApiVersion,
+    ApiVersion, CommonModuleInit, ExtendsCommonModuleInit, ModuleCommon, MultiApiVersion,
     TransactionItemAmount,
 };
 use fedimint_core::util::{BoxStream, NextOrPending};
@@ -316,13 +316,13 @@ async fn get_funds(dbtx: &mut ModuleDatabaseTransaction<'_>) -> Amount {
 pub struct DummyClientGen;
 
 // TODO: Boilerplate-code
-impl ExtendsCommonModuleGen for DummyClientGen {
+impl ExtendsCommonModuleInit for DummyClientGen {
     type Common = DummyCommonGen;
 }
 
 /// Generates the client module
 #[apply(async_trait_maybe_send!)]
-impl ClientModuleGen for DummyClientGen {
+impl ClientModuleInit for DummyClientGen {
     type Module = DummyClientModule;
 
     fn supported_api_versions(&self) -> MultiApiVersion {

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -4,7 +4,7 @@ use config::DummyClientConfig;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::SerdeSignatureShare;
-use fedimint_core::module::{CommonModuleGen, ModuleCommon, ModuleConsensusVersion};
+use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::{plugin_types_trait_impl_common, Amount};
 use secp256k1::{KeyPair, Secp256k1, XOnlyPublicKey};
 use serde::{Deserialize, Serialize};
@@ -72,7 +72,7 @@ plugin_types_trait_impl_common!(
 #[derive(Debug)]
 pub struct DummyCommonGen;
 
-impl CommonModuleGen for DummyCommonGen {
+impl CommonModuleInit for DummyCommonGen {
     const CONSENSUS_VERSION: ModuleConsensusVersion = CONSENSUS_VERSION;
     const KIND: ModuleKind = KIND;
 

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -11,8 +11,8 @@ use fedimint_core::db::{Database, DatabaseVersion, MigrationMap, ModuleDatabaseT
 use fedimint_core::epoch::{SerdeSignature, SerdeSignatureShare};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    api_endpoint, ApiEndpoint, ConsensusProposal, CoreConsensusVersion, ExtendsCommonModuleGen,
-    InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError, PeerHandle, ServerModuleGen,
+    api_endpoint, ApiEndpoint, ConsensusProposal, CoreConsensusVersion, ExtendsCommonModuleInit,
+    InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError, PeerHandle, ServerModuleInit,
     SupportedModuleApiVersions, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
@@ -47,13 +47,13 @@ mod db;
 pub struct DummyGen;
 
 // TODO: Boilerplate-code
-impl ExtendsCommonModuleGen for DummyGen {
+impl ExtendsCommonModuleInit for DummyGen {
     type Common = DummyCommonGen;
 }
 
 /// Implementation of server module non-consensus functions
 #[async_trait]
-impl ServerModuleGen for DummyGen {
+impl ServerModuleInit for DummyGen {
     type Params = DummyGenParams;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(1);
 

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -12,7 +12,7 @@ use bitcoin::{KeyPair, Network};
 use bitcoin_hashes::Hash;
 use db::LightningGatewayKey;
 use fedimint_client::derivable_secret::{ChildId, DerivableSecret};
-use fedimint_client::module::gen::ClientModuleGen;
+use fedimint_client::module::init::ClientModuleInit;
 use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
@@ -25,7 +25,7 @@ use fedimint_core::core::{IntoDynInstance, ModuleInstanceId};
 use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
-    ApiVersion, CommonModuleGen, ExtendsCommonModuleGen, ModuleCommon, MultiApiVersion,
+    ApiVersion, CommonModuleInit, ExtendsCommonModuleInit, ModuleCommon, MultiApiVersion,
     TransactionItemAmount,
 };
 use fedimint_core::{apply, async_trait_maybe_send, Amount, OutPoint, TransactionId};
@@ -526,12 +526,12 @@ pub enum LightningMeta {
 #[derive(Debug, Clone)]
 pub struct LightningClientGen;
 
-impl ExtendsCommonModuleGen for LightningClientGen {
+impl ExtendsCommonModuleInit for LightningClientGen {
     type Common = LightningCommonGen;
 }
 
 #[apply(async_trait_maybe_send!)]
-impl ClientModuleGen for LightningClientGen {
+impl ClientModuleInit for LightningClientGen {
     type Module = LightningClientModule;
 
     fn supported_api_versions(&self) -> MultiApiVersion {

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -26,7 +26,7 @@ use fedimint_client::Client;
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::module::{CommonModuleGen, ModuleCommon, ModuleConsensusVersion};
+use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::task::timeout;
 use fedimint_core::{plugin_types_trait_impl_common, Amount};
 use lightning::routing::gossip::RoutingFees;
@@ -221,7 +221,7 @@ impl std::fmt::Display for LightningConsensusItem {
 #[derive(Debug)]
 pub struct LightningCommonGen;
 
-impl CommonModuleGen for LightningCommonGen {
+impl CommonModuleInit for LightningCommonGen {
     const CONSENSUS_VERSION: ModuleConsensusVersion = CONSENSUS_VERSION;
     const KIND: ModuleKind = KIND;
 

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -19,7 +19,7 @@ use anyhow::{anyhow, bail, Context as AnyhowContext};
 use async_stream::stream;
 use backup::recovery::{MintRestoreStateMachine, MintRestoreStates};
 use bitcoin_hashes::{sha256, sha256t, Hash, HashEngine as BitcoinHashEngine};
-use fedimint_client::module::gen::ClientModuleGen;
+use fedimint_client::module::init::ClientModuleInit;
 use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client::sm::util::MapStateTransitions;
@@ -36,7 +36,7 @@ use fedimint_core::db::{
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{
-    ApiVersion, CommonModuleGen, ExtendsCommonModuleGen, ModuleCommon, MultiApiVersion,
+    ApiVersion, CommonModuleInit, ExtendsCommonModuleInit, ModuleCommon, MultiApiVersion,
     TransactionItemAmount,
 };
 use fedimint_core::util::{BoxStream, NextOrPending};
@@ -450,12 +450,12 @@ pub enum MintMetaVariants {
 #[derive(Debug, Clone)]
 pub struct MintClientGen;
 
-impl ExtendsCommonModuleGen for MintClientGen {
+impl ExtendsCommonModuleInit for MintClientGen {
     type Common = MintCommonGen;
 }
 
 #[apply(async_trait_maybe_send!)]
-impl ClientModuleGen for MintClientGen {
+impl ClientModuleInit for MintClientGen {
     type Module = MintClientModule;
 
     fn supported_api_versions(&self) -> MultiApiVersion {

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -4,7 +4,7 @@ pub use common::{BackupRequest, SignedBackupRequest};
 use config::MintClientConfig;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::module::{CommonModuleGen, ModuleCommon, ModuleConsensusVersion};
+use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::tiered::InvalidAmountTierError;
 use fedimint_core::{plugin_types_trait_impl_common, Amount, OutPoint, PeerId, TieredMulti};
 use impl_tools::autoimpl;
@@ -103,7 +103,7 @@ pub struct BlindNonce(pub tbs::BlindedMessage);
 #[derive(Debug)]
 pub struct MintCommonGen;
 
-impl CommonModuleGen for MintCommonGen {
+impl CommonModuleInit for MintCommonGen {
     const CONSENSUS_VERSION: ModuleConsensusVersion = CONSENSUS_VERSION;
     const KIND: ModuleKind = KIND;
 

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -10,8 +10,8 @@ use fedimint_core::db::{Database, DatabaseVersion, ModuleDatabaseTransaction};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiError, ConsensusProposal, CoreConsensusVersion,
-    ExtendsCommonModuleGen, InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError,
-    PeerHandle, ServerModuleGen, SupportedModuleApiVersions, TransactionItemAmount,
+    ExtendsCommonModuleInit, InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError,
+    PeerHandle, ServerModuleInit, SupportedModuleApiVersions, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::{MaybeSend, TaskGroup};
@@ -54,12 +54,12 @@ use tracing::{debug, info};
 #[derive(Debug, Clone)]
 pub struct MintGen;
 
-impl ExtendsCommonModuleGen for MintGen {
+impl ExtendsCommonModuleInit for MintGen {
     type Common = MintCommonGen;
 }
 
 #[apply(async_trait_maybe_send!)]
-impl ServerModuleGen for MintGen {
+impl ServerModuleInit for MintGen {
     type Params = MintGenParams;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
@@ -766,7 +766,7 @@ mod test {
     use fedimint_core::config::{ClientModuleConfig, ConfigGenModuleParams, ServerModuleConfig};
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::Database;
-    use fedimint_core::module::{ModuleConsensusVersion, ServerModuleGen};
+    use fedimint_core::module::{ModuleConsensusVersion, ServerModuleInit};
     use fedimint_core::{Amount, PeerId, ServerModule};
     use fedimint_mint_common::config::FeeConsensus;
     use fedimint_mint_common::{MintInput, Nonce, Note};
@@ -930,7 +930,7 @@ mod fedimint_migration_tests {
     use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_MINT;
     use fedimint_core::db::{apply_migrations, DatabaseTransaction};
     use fedimint_core::module::registry::ModuleDecoderRegistry;
-    use fedimint_core::module::{CommonModuleGen, DynServerModuleGen};
+    use fedimint_core::module::{CommonModuleInit, DynServerModuleInit};
     use fedimint_core::time::now;
     use fedimint_core::{Amount, OutPoint, ServerModule, TieredMulti, TransactionId};
     use fedimint_mint_common::db::{
@@ -1054,7 +1054,7 @@ mod fedimint_migration_tests {
         validate_migrations(
             "mint",
             |db| async move {
-                let module = DynServerModuleGen::from(MintGen);
+                let module = DynServerModuleInit::from(MintGen);
                 apply_migrations(
                     &db,
                     module.module_kind().to_string(),

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -12,7 +12,7 @@ use async_stream::stream;
 use bitcoin::{Address, Network};
 use fedimint_bitcoind::{create_bitcoind, DynBitcoindRpc};
 use fedimint_client::derivable_secret::{ChildId, DerivableSecret};
-use fedimint_client::module::gen::ClientModuleGen;
+use fedimint_client::module::init::ClientModuleInit;
 use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
@@ -25,7 +25,7 @@ use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId};
 use fedimint_core::db::{AutocommitError, Database, ModuleDatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
-    ApiVersion, CommonModuleGen, ExtendsCommonModuleGen, ModuleCommon, MultiApiVersion,
+    ApiVersion, CommonModuleInit, ExtendsCommonModuleInit, ModuleCommon, MultiApiVersion,
     TransactionItemAmount,
 };
 use fedimint_core::task::TaskGroup;
@@ -422,12 +422,12 @@ impl WalletClientGen {
     }
 }
 
-impl ExtendsCommonModuleGen for WalletClientGen {
+impl ExtendsCommonModuleInit for WalletClientGen {
     type Common = WalletCommonGen;
 }
 
 #[apply(async_trait_maybe_send!)]
-impl ClientModuleGen for WalletClientGen {
+impl ClientModuleInit for WalletClientGen {
     type Module = WalletClientModule;
 
     fn supported_api_versions(&self) -> MultiApiVersion {

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -7,7 +7,7 @@ use bitcoin::{Amount, BlockHash, Network, Script, Transaction, Txid};
 use config::WalletClientConfig;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable, UnzipConsensus};
-use fedimint_core::module::{CommonModuleGen, ModuleCommon, ModuleConsensusVersion};
+use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::{plugin_types_trait_impl_common, Feerate, PeerId};
 use impl_tools::autoimpl;
 use miniscript::Descriptor;
@@ -178,7 +178,7 @@ impl std::fmt::Display for WalletOutputOutcome {
 #[derive(Debug)]
 pub struct WalletCommonGen;
 
-impl CommonModuleGen for WalletCommonGen {
+impl CommonModuleInit for WalletCommonGen {
     const CONSENSUS_VERSION: ModuleConsensusVersion = CONSENSUS_VERSION;
     const KIND: ModuleKind = KIND;
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -35,8 +35,8 @@ use fedimint_core::db::{
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    api_endpoint, ApiEndpoint, ConsensusProposal, CoreConsensusVersion, ExtendsCommonModuleGen,
-    InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError, PeerHandle, ServerModuleGen,
+    api_endpoint, ApiEndpoint, ConsensusProposal, CoreConsensusVersion, ExtendsCommonModuleInit,
+    InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError, PeerHandle, ServerModuleInit,
     SupportedModuleApiVersions, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
@@ -71,12 +71,12 @@ use tracing::{debug, info, instrument, trace, warn};
 #[derive(Debug, Clone)]
 pub struct WalletGen;
 
-impl ExtendsCommonModuleGen for WalletGen {
+impl ExtendsCommonModuleInit for WalletGen {
     type Common = WalletCommonGen;
 }
 
 #[apply(async_trait_maybe_send!)]
-impl ServerModuleGen for WalletGen {
+impl ServerModuleInit for WalletGen {
     type Params = WalletGenParams;
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
@@ -1574,7 +1574,7 @@ mod fedimint_migration_tests {
     use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
     use fedimint_core::db::{apply_migrations, DatabaseTransaction};
     use fedimint_core::module::registry::ModuleDecoderRegistry;
-    use fedimint_core::module::{CommonModuleGen, DynServerModuleGen};
+    use fedimint_core::module::{CommonModuleInit, DynServerModuleInit};
     use fedimint_core::{BitcoinHash, Feerate, OutPoint, PeerId, ServerModule, TransactionId};
     use fedimint_testing::db::{
         prepare_db_migration_snapshot, validate_migrations, BYTE_20, BYTE_32,
@@ -1775,7 +1775,7 @@ mod fedimint_migration_tests {
         validate_migrations(
             "wallet",
             |db| async move {
-                let module = DynServerModuleGen::from(WalletGen);
+                let module = DynServerModuleInit::from(WalletGen);
                 apply_migrations(
                     &db,
                     module.module_kind().to_string(),

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -18,7 +18,7 @@ use fedimint_core::core::{
 use fedimint_core::db::Database;
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::module::CommonModuleGen;
+use fedimint_core::module::CommonModuleInit;
 use fedimint_core::{BitcoinHash, ServerModule};
 use fedimint_ln_server::common::LightningCommonGen;
 use fedimint_ln_server::Lightning;


### PR DESCRIPTION
"Module Gen" was a shorthand for "Module Config Generator", but with time the whole thing took on more responsibilities, with config generation being only one of them.

Seems like all of them have something to do with
"module instance initialization", so "module init" seems like the best candidate.

Fix #2055