### PR TITLE
feat(shell): wait for background processes to exit

### DIFF
--- a/scripts/dev/mprocs/run.sh
+++ b/scripts/dev/mprocs/run.sh
@@ -16,7 +16,12 @@ source scripts/build.sh
 mkdir -p $FM_LOGS_DIR
 
 devimint dev-fed 2>$FM_LOGS_DIR/devimint-outer.log &
-auto_kill_last_cmd dev-fed
+pid=$!
+kill_on_exit $pid dev-fed
+PIDS+=( "$pid" )
+
 eval "$(devimint env)"
 
 mprocs -c misc/mprocs.yaml
+kill "${PIDS[@]}"
+wait "${PIDS[@]}"

--- a/scripts/dev/tmuxinator/run.sh
+++ b/scripts/dev/tmuxinator/run.sh
@@ -21,9 +21,14 @@ source scripts/build.sh
 mkdir -p $FM_LOGS_DIR
 
 devimint dev-fed 2>$FM_LOGS_DIR/devimint-outer.log &
-auto_kill_last_cmd dev-fed
+pid=$!
+kill_on_exit $pid dev-fed
+PIDS+=( "$pid" )
 
 eval "$(devimint env)"
 
 SHELL=$(which bash) tmuxinator local
 tmux -L fedimint-dev kill-session -t fedimint-dev || true
+
+kill "${PIDS[@]}"
+wait "${PIDS[@]}"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -4,12 +4,20 @@
 #
 # Functions only, please don't put any code that actually does things.
 
-# kill the last command spawned in the background (with '&') at the end of a script
+# kill the pid running on background (with '&') at the end of a script
 # optionally can have name passed
-function auto_kill_last_cmd() {
-  pid=$!
+function kill_on_exit() {
+  pid=$1
 
+  cmd="{ \
+    if kill -0 $pid >& /dev/null; then \
+      >&2 echo 'Auto-killing ${2:-}(PID: $pid)'; \
+      kill $pid; \
+    else \
+      >&2 echo 'Process ${2:-}(PID: $pid) already finished'; \
+    fi \
+  }"
   # For shellcheck - we want these expanded right away
   # shellcheck disable=SC2064
-  trap ">&2 echo 'Auto-killing ${1:-}(PID: $pid)'; kill $pid" EXIT  
+  trap "$cmd" EXIT
 }

--- a/scripts/tests/rust-tests.sh
+++ b/scripts/tests/rust-tests.sh
@@ -16,7 +16,9 @@ if [ "${RUST_LOG,,}" = "none" ]; then
 else
   devimint external-daemons &
 fi
-auto_kill_last_cmd external-daemons
+pid=$!
+kill_on_exit $pid external-daemons
+PIDS+=( "$pid" )
 
 STATUS=$(devimint wait)
 if [ "$STATUS" = "ERROR" ]
@@ -72,3 +74,6 @@ if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "esplora" ]; then
 fi
 
 echo "fm success: rust-tests"
+
+kill "${PIDS[@]}"
+wait "${PIDS[@]}"

--- a/scripts/tests/wasm-tests.sh
+++ b/scripts/tests/wasm-tests.sh
@@ -8,7 +8,9 @@ source ./scripts/lib.sh
 source ./scripts/build.sh
 
 devimint dev-fed &
-auto_kill_last_cmd
+pid=$!
+kill_on_exit $pid dev-fed
+PIDS+=( "$pid" )
 
 eval "$(devimint env)"
 devimint wait
@@ -16,3 +18,6 @@ devimint wait
 echo Funding LND gateway e-cash wallet ...
 
 wasm-pack test --firefox --headless fedimint-wasm-tests
+
+kill "${PIDS[@]}"
+wait "${PIDS[@]}"


### PR DESCRIPTION
It's inconvenient when a script exits but still leaves stuff running (even if these processes have just received a signal and will hopefully die soon). This can cause failures if some other script starts right away and uses the same resources.