### PR TITLE
chore(ci): increase linux build timeout

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -56,7 +56,7 @@ jobs:
           - on: linux
             runs-on: buildjet-8vcpu-ubuntu-2004
             build-in-pr: true
-            timeout: 30
+            timeout: 60
             run-tests: true
           - host: macos
             runs-on: macos-12


### PR DESCRIPTION
We are [seeing a lot of tests time out](https://github.com/fedimint/fedimint/actions/runs/5953944182/job/16149367352?pr=3008) while fetching from our nix caches, there might be temporary network congestion, but that shouldn't make our tests fail.