### PR TITLE
feat(shell): wait for background processes to exit

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -11,5 +11,5 @@ function auto_kill_last_cmd() {
 
   # For shellcheck - we want these expanded right away
   # shellcheck disable=SC2064
-  trap ">&2 echo 'Auto-killing ${1:-}(PID: $pid)'; kill $pid" EXIT  
+  trap ">&2 echo 'Auto-killing ${1:-}(PID: $pid) and waiting it to finish...'; kill $pid; wait $pid" EXIT  
 }


### PR DESCRIPTION
It's inconvenient when a script exits but still leaves stuff running (even if these processes have just received a signal and will hopefully die soon). This can cause failures if some other script starts right away and uses the same resources.