### PR TITLE
fix: temporarily disable flaky peg_outs_support_rbf

### DIFF
--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -161,7 +161,12 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
     Ok(())
 }
 
+// FIXME: This test is flaky, it fails with:
+// left: `Amount { msats: 3270000 }`,
+// right: `Amount { msats: 2540000 }`',
+// modules/fedimint-wallet-tests/tests/tests.rs:222:5
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn peg_outs_support_rbf() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;


### PR DESCRIPTION
This was added recently by https://github.com/fedimint/fedimint/pull/2967

It fails like 5-10% of time. Will disable until a proper fix.