### PR TITLE
chore: pin ldk-node to git hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,7 +3102,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 [[package]]
 name = "ldk-node"
 version = "0.1.0"
-source = "git+https://github.com/lightningdevkit/ldk-node#5029b2f88642864ed32835a31c1fa8b1405129dd"
+source = "git+https://github.com/lightningdevkit/ldk-node?rev=5029b2f88642864ed32835a31c1fa8b1405129dd#5029b2f88642864ed32835a31c1fa8b1405129dd"
 dependencies = [
  "bdk",
  "bip39",

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -27,7 +27,7 @@ fedimint-logging = { path = "../fedimint-logging" }
 fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 lazy_static = "1.4.0"
 ln-gateway = { path = "../gateway/ln-gateway" }
-ldk-node = { git = "https://github.com/lightningdevkit/ldk-node" }
+ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "5029b2f88642864ed32835a31c1fa8b1405129dd" }
 futures = "0.3"
 lightning = "0.0.113"
 lightning-invoice = "0.21.0"


### PR DESCRIPTION
The only thing pinning `ldk-node` to a specific version is our `Cargo.lock`. But if anyone uses `fedimint-testing` as a library, our `Cargo.lock` has no effect and they'll just pull `ldk-node` from master, which will be prone to breaking.