### PR TITLE
Document preventing out-of-memory when compiling

### DIFF
--- a/docs/dev-running.md
+++ b/docs/dev-running.md
@@ -12,6 +12,13 @@ The following command will setup a local environment for you to play around with
 just mprocs
 ```
 
+> [!NOTE]
+> In a memory-constrained environments you might want to [set the `CARGO_BUILD_JOBS` environment variable](https://doc.rust-lang.org/cargo/reference/config.html#buildjobs) to a lower number (defaults to number of logical CPU cores):
+> ```shell
+> CARGO_BUILD_JOBS=2 just mprocs
+> ```
+> As a rule of thumb expect each parallel job to require 2-2.5GB of memory. Running the build less parallel will lead to longer build times but can prevent the process from being [killed by the OOM killer](https://www.kernel.org/doc/gorman/html/understand/understand016.html), leading to hard to debug errors.
+
 This uses a tool called [mprocs](https://github.com/pvolok/mprocs) to spawn working local federation, displays logs for all daemons involved, as well as a shell with some convenient aliases and environment variables already setup so you can start tinkering. Click the tabs on the left nav to inspect the different processes. You can see available keyboard commands on the bottom -- for example, when you select text you'll see a `c` command that can be used to copy the text. To quit, type `ctrl-a` then `q` then `y`. If you're a tmux user, you can also use `just tmuxinator` to setup a tmux session with a running federation. But this is a little less user-friendly.
 
 ![screenshot of the federation running in mprocs](mprocs.png)


### PR DESCRIPTION
Adding https://github.com/fedimint/fedimint/pull/2960#issuecomment-1693692234 to the docs for future reference.

For anyone wondering about the `[!Note]` syntax: https://github.com/orgs/community/discussions/16925#discussioncomment-6506860