### PR TITLE
chore: use faster `typos` versions

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,4 @@
 [default.extend-words]
 substituters = "substituters"
+# trips on some base64 string in the test
+wel = "wel"

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -201,6 +201,7 @@ pub async fn dev_fed(process_mgr: &ProcessManager) -> Result<DevFed> {
     cmd!(fed, "join-federation", fed.invite_code()?)
         .run()
         .await?;
+    info!(LOG_DEVIMINT, "await gateways registered");
     fed.await_gateways_registered().await?;
     info!(LOG_DEVIMINT, "gateways registered");
     fed.use_gateway(&gw_cln).await?;

--- a/fedimint-client-legacy/src/mint/backup.rs
+++ b/fedimint-client-legacy/src/mint/backup.rs
@@ -60,7 +60,7 @@ impl MintClient {
         // TODO: If the client attempts any operations between while the recovery is
         // working, the recovery code will most probably miss them, which might
         // lead to incorrect state. We should probably lock everything in some
-        // way during recovery for corectness.
+        // way during recovery for correctness.
         let snapshot = match self
             .restore_current_state_from_backup(&mut task_group, backup, gap_limit)
             .await?

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -2149,7 +2149,7 @@ mod test_utils {
 
         alt_dbtx.commit_tx().await;
 
-        // verfiy test_module_dbtx can only see key/value pairs from its own module
+        // verify test_module_dbtx can only see key/value pairs from its own module
         let mut test_dbtx = db.begin_transaction().await;
         let mut test_module_dbtx = test_dbtx.with_module_prefix(TEST_MODULE_PREFIX);
         assert_eq!(

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
     flake-utils.lib.eachDefaultSystem
       (system:
         let
-
           pkgs-unstable = import nixpkgs-unstable {
             inherit system;
           };
@@ -38,6 +37,20 @@
             overlays = [
               (final: prev: {
                 cargo-udeps = pkgs-unstable.cargo-udeps;
+                # TODO: switch to mainstream after https://github.com/crate-ci/typos/pull/708 is released
+                typos = prev.rustPlatform.buildRustPackage {
+                  pname = "typos";
+                  version = "1.16.9-stdin-inputs";
+
+                  src = prev.fetchFromGitHub {
+                    owner = "dpc";
+                    repo = "typos";
+                    rev = "04059e022c800ef0e1d6376f3a94923b0b697990";
+                    hash = "sha256-5OLq9uevJW1dTGMAkCGx2PyAyemmoiSIJ9DRGiL6gpM=";
+                  };
+
+                  cargoHash = "sha256-wD6D3v6QxMNmULGZY8hSpcXPipzeV00TqyvUgUi4hrI=";
+                };
               })
             ];
           };

--- a/justfile
+++ b/justfile
@@ -72,7 +72,7 @@ typos:
   git_ls_files="$(git ls-files)"
   git_ls_nonbinary_files="$(echo "$git_ls_files" | xargs file --mime | grep -v "; charset=binary" | cut -d: -f1)"
 
-  if ! echo "$git_ls_nonbinary_files" | parallel typos {} ; then
+  if ! echo "$git_ls_nonbinary_files" | typos --stdin-paths ; then
     >&2 echo "Typos found: Valid new words can be added to '_typos.toml'"
     return 1
   fi
@@ -86,7 +86,7 @@ typos-fix-all:
   git_ls_files="$(git ls-files)"
   git_ls_nonbinary_files="$(echo "$git_ls_files" | xargs file --mime | grep -v "; charset=binary" | cut -d: -f1)"
 
-  if ! echo "$git_ls_nonbinary_files" | parallel typos -w {} ; then
+  if ! echo "$git_ls_nonbinary_files" | typos --stdin-paths -w  ; then
     >&2 echo "Typos found: Valid new words can be added to '_typos.toml'"
     # TODO: not enforcing anything right, just being annoying in the CLI
     # return 1

--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -194,7 +194,7 @@ export -f check_cargo_lock
 function check_typos() {
   set -eo pipefail
 
-  if ! echo "$git_ls_nonbinary_files" | parallel typos {} ; then
+  if ! echo "$git_ls_nonbinary_files" | typos --stdin-paths ; then
     >&2 echo "Typos found: Valid new words can be added to '_typos.toml'"
     return 1
   fi


### PR DESCRIPTION
In combination with #3037 it makes commit check even faster, especially on cold cache.

Before (`master` branch):

```
Executed in    4.86 secs    fish           external
   usr time   25.39 secs    0.00 micros   25.39 secs
   sys time   10.23 secs  466.00 micros   10.23 secs
```

After (#3037 + #3038):

```
Executed in    1.33 secs    fish           external
   usr time    8.23 secs   20.29 millis    8.21 secs
   sys time    1.54 secs    4.15 millis    1.54 secs
```