### PR TITLE
chore: fix cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,12 @@
+# Example audit config file
+#
+# It may be located in the user home (`~/.cargo/audit.toml`) or in the project
+# root (`.cargo/audit.toml`).
+#
+# All of the options which can be passed via CLI arguments can also be
+# permanently specified in this file.
+#
+#
+# See the full example in: https://raw.githubusercontent.com/rustsec/rustsec/main/cargo-audit/audit.toml.example
+[advisories]
+ignore = ["RUSTSEC-2023-0052"] 

--- a/flake.nix
+++ b/flake.nix
@@ -361,6 +361,7 @@
                     toolchain.fenixToolchainRustfmt
                     cargo-llvm-cov
                     pkgs.cargo-udeps
+                    pkgs.cargo-audit
                     pkgs.parallel
                     pkgs.just
                     typos


### PR DESCRIPTION
This PR is adding cargo-audit inside the nix env but this PR does not solve the issue of the CI because looks like 
there is no upgrade available

```
[vincent@vincent-arch fedimint]$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 562 security advisories (from /home/vincent/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (511 crate dependencies)
Crate:     webpki
Version:   0.21.4
Title:     webpki: CPU denial of service in certificate path building
Date:      2023-08-22
ID:        RUSTSEC-2023-0052
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0052
Severity:  7.5 (high)
Solution:  No fixed upgrade is available!
Dependency tree:
```

But looks like the library is unmaintained https://github.com/briansmith/webpki