### PR TITLE
chore: *do* strip symbols on MacOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,7 +119,7 @@
               inherit name;
 
               dontUnpack = true;
-              dontStrip = true;
+              dontStrip = !pkgs.stdenv.isDarwin;
 
               installPhase = ''
                 cp -a ${package} $out
@@ -146,7 +146,7 @@
               name = bin;
 
               dontUnpack = true;
-              dontStrip = true;
+              dontStrip = !pkgs.stdenv.isDarwin;
 
               installPhase = ''
                 mkdir -p $out/bin

--- a/nix/craneCommon.nix
+++ b/nix/craneCommon.nix
@@ -133,7 +133,7 @@ craneLib.overrideScope' (self: prev: {
     # we carefully optimize our debug symbols on cargo level,
     # and in case of errors and panics, would like to see the
     # line numbers etc.
-    dontStrip = true;
+    dontStrip = !pkgs.stdenv.isDarwin;
 
 
     # https://github.com/ipetkov/crane/issues/76#issuecomment-1296025495


### PR DESCRIPTION
It was reported that it trips something somewhere on Macs which leads to segfault.