### PR TITLE
chore: set consensus version on master to `u32::MAX`

### DIFF
--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -209,7 +209,7 @@ impl ServerConfigConsensus {
     }
 }
 
-pub const CORE_CONSENSUS_VERSION: CoreConsensusVersion = CoreConsensusVersion(0);
+pub const CORE_CONSENSUS_VERSION: CoreConsensusVersion = CoreConsensusVersion(u32::MAX);
 
 impl ServerConfig {
     /// Api versions supported by this server

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -63,7 +63,7 @@ impl ServerModuleInit for DummyGen {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
     }
 
     /// Initialize the module

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -119,7 +119,7 @@ impl ServerModuleInit for LightningGen {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
     }
 
     async fn init(

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -68,7 +68,7 @@ impl ServerModuleInit for MintGen {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
     }
 
     async fn init(

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -85,7 +85,7 @@ impl ServerModuleInit for WalletGen {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
     }
 
     async fn init(


### PR DESCRIPTION
This will prevent accidentally using master with deployed federations.

Related to #3052