### PR TITLE
chore: set consensus version to 1

### DIFF
--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -209,7 +209,7 @@ impl ServerConfigConsensus {
     }
 }
 
-pub const CORE_CONSENSUS_VERSION: CoreConsensusVersion = CoreConsensusVersion(0);
+pub const CORE_CONSENSUS_VERSION: CoreConsensusVersion = CoreConsensusVersion(1);
 
 impl ServerConfig {
     /// Api versions supported by this server

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -63,7 +63,7 @@ impl ServerModuleInit for DummyGen {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(1, 0, &[(0, 0)])
     }
 
     /// Initialize the module

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -119,7 +119,7 @@ impl ServerModuleInit for LightningGen {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(1, 0, &[(0, 0)])
     }
 
     async fn init(

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -68,7 +68,7 @@ impl ServerModuleInit for MintGen {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(1, 0, &[(0, 0)])
     }
 
     async fn init(

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -85,7 +85,7 @@ impl ServerModuleInit for WalletGen {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(0, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(1, 0, &[(0, 0)])
     }
 
     async fn init(


### PR DESCRIPTION
This will prevent accidentally mixing up the first release with federations previously deployed off random master commits.

Related to #3053 