### PR TITLE
Backport: fix(github-actions): login to publish tagged dockers images

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -285,7 +285,7 @@ jobs:
           echo "gateway-cli_container_tag=$(docker load < result | awk '{ print $3 }')" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.ref_type == 'tag'
         uses: docker/login-action@v2
         with:
           username: fedimint


### PR DESCRIPTION
Backport of #3058 

(cherry picked from commit df26e32380c8272af2c941a63f5db1918daac595)