### PR TITLE
chore: add backport bot

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,18 @@
+name: Backport merged pull request
+on:
+  pull_request_target:
+    # Run on merge (close) or if label is added after merging
+    types: [closed, labeled]
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+    # Don't run on closed unmerged pull requests
+    if: github.event.pull_request.merged
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v1


### PR DESCRIPTION
This workflow is intended to automate the backport process in cases where cherry-picking succeeds without merge conflicts. For more details see [the action's README](https://github.com/korthout/backport-action#how-it-works).

## How it works

I created a tag `backport releases/v0.1`. If this is added before merging it should work according to the docs. I also changed the reference workflow slightly so that it should also work if the tag is added after merging.