### PR TITLE
Start externals with `devimint run-ui`

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -271,13 +271,16 @@ impl Lnd {
         .await?;
 
         poll("lnd_connect", || async {
-            Ok(tonic_lnd::connect(
+            let result = tonic_lnd::connect(
                 lnd_rpc_addr.clone(),
                 lnd_tls_cert.clone(),
                 lnd_macaroon.clone(),
             )
-            .await
-            .is_ok())
+            .await;
+            if let Err(e) = &result {
+                info!("lnd_connect failed: {:?}", e);
+            }
+            Ok(result.is_ok())
         })
         .await?;
 


### PR DESCRIPTION
It's handy to have things like esplora and the lightning nodes in our development testing, so this starts them with `run-ui` just like `dev-fed` does.

Also added a bit of extra logging to when LND fails to connect, since that dragged me down for ~30m trying to figure that out since it fails silently.