### PR TITLE
Expose JSON encoded client config

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -229,6 +229,7 @@ impl Federation {
             .unwrap()
             .config()
             .0
+            .global
             .federation_id
             .to_string()
     }

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -133,6 +133,8 @@ pub enum ClientCmd {
         module: ModuleSelector,
         args: Vec<ffi::OsString>,
     },
+    /// Returns the client config
+    Config,
 }
 
 pub fn parse_gateway_id(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Error> {
@@ -461,6 +463,10 @@ pub async fn handle_ng_command(
                 .context("Module not found")?;
 
             module_client.handle_cli_command(&client, &args).await
+        }
+        ClientCmd::Config => {
+            let config = client.get_config_json();
+            Ok(serde_json::to_value(config).expect("Client config is serializable"))
         }
     }
 }

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -475,7 +475,7 @@ async fn get_note_summary(client: &Client) -> anyhow::Result<serde_json::Value> 
     Ok(serde_json::to_value(InfoResponse {
         federation_id: client.federation_id(),
         network: wallet_client.get_network(),
-        meta: client.get_config().meta.clone(),
+        meta: client.get_config().global.meta.clone(),
         total_amount_msat: summary.total_amount(),
         total_num_notes: summary.count_items(),
         denominations_msat: summary,

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -267,6 +267,7 @@ impl Opts {
             .ok_or_cli_msg(CliErrorKind::MissingAuth, "Admin client needs our-id set")?;
 
         let url = cfg
+            .global
             .api_endpoints
             .get(our_id)
             .expect("Endpoint exists")
@@ -611,7 +612,7 @@ impl FedimintCli {
                 let decoders = cli.load_decoders(&cfg, &self.module_inits);
                 let client = cli.admin_client(&cfg)?;
                 let last_epoch = client
-                    .fetch_last_epoch_history(cfg.epoch_pk, &decoders)
+                    .fetch_last_epoch_history(cfg.global.epoch_pk, &decoders)
                     .await?;
 
                 let hex_outcome = last_epoch.consensus_encode_to_hex().map_err_cli_io()?;

--- a/fedimint-client-legacy/src/lib.rs
+++ b/fedimint-client-legacy/src/lib.rs
@@ -264,7 +264,7 @@ impl<T: AsRef<ClientConfig> + Clone + MaybeSend> Client<T> {
                 .expect("needs mint module client config")
                 .1
                 .clone(),
-            epoch_pk: self.config.as_ref().epoch_pk,
+            epoch_pk: self.config.as_ref().global.epoch_pk,
             context: self.context.clone(),
             secret: Self::mint_secret_static(&self.root_secret),
         }
@@ -1166,7 +1166,7 @@ impl Client<UserClientConfig> {
     ) -> Result<()> {
         let gateway = self.fetch_active_gateway().await?;
 
-        let payload = PayInvoicePayload::new(self.config.0.federation_id, contract_id);
+        let payload = PayInvoicePayload::new(self.config.0.global.federation_id, contract_id);
 
         let future = reqwest::Client::new()
             .post(

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -837,7 +837,7 @@ impl Client {
     ) -> SupportedApiVersionsSummary {
         SupportedApiVersionsSummary {
             core: SupportedCoreApiVersions {
-                core_consensus: config.consensus_version,
+                core_consensus: config.global.consensus_version,
                 api: MultiApiVersion::try_from_iter(SUPPORTED_CORE_API_VERSIONS.to_owned())
                     .expect("must not have conflicting versions"),
             },
@@ -851,7 +851,7 @@ impl Client {
                             (
                                 module_instance_id,
                                 SupportedModuleApiVersions {
-                                    core_consensus: config.consensus_version,
+                                    core_consensus: config.global.consensus_version,
                                     module_consensus: module_config.version,
                                     api: module_init.supported_api_versions(),
                                 },
@@ -1441,7 +1441,7 @@ impl ClientBuilder {
 
                 let module = module_init
                     .init(
-                        config.federation_id,
+                        config.global.federation_id,
                         module_config,
                         db.clone(),
                         module_instance,
@@ -1481,8 +1481,8 @@ impl ClientBuilder {
             config: config.clone(),
             decoders,
             db: db.clone(),
-            federation_id: config.federation_id,
-            federation_meta: config.meta,
+            federation_id: config.global.federation_id,
+            federation_meta: config.global.meta,
             primary_module_instance,
             modules,
             module_inits: self.module_inits.clone(),
@@ -1535,7 +1535,7 @@ async fn get_config(
             let mut dbtx = db.begin_transaction().await;
             dbtx.insert_new_entry(
                 &ClientConfigKey {
-                    id: config.federation_id,
+                    id: config.global.federation_id,
                 },
                 &config,
             )

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -826,6 +826,7 @@ impl WsFederationApi<WsClient> {
     pub fn from_config(config: &ClientConfig) -> Self {
         Self::new(
             config
+                .global
                 .api_endpoints
                 .iter()
                 .map(|(id, peer)| (*id, peer.url.clone()))

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -111,6 +111,14 @@ pub struct PeerUrl {
 /// This includes global settings and client-side module configs.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Encodable, Decodable)]
 pub struct ClientConfig {
+    #[serde(flatten)]
+    pub global: GlobalClientConfig,
+    pub modules: BTreeMap<ModuleInstanceId, ClientModuleConfig>,
+}
+
+/// Federation-wide client config
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Encodable, Decodable)]
+pub struct GlobalClientConfig {
     // Stable and unique id and threshold pubkey of the federation for authenticating configs
     pub federation_id: FederationId,
     /// API endpoints for each federation member
@@ -122,8 +130,6 @@ pub struct ClientConfig {
     // TODO: make it a String -> serde_json::Value map?
     /// Additional config the federation wants to transmit to the clients
     pub meta: BTreeMap<String, String>,
-    /// Configs from other client modules
-    pub modules: BTreeMap<ModuleInstanceId, ClientModuleConfig>,
 }
 
 impl ClientConfig {
@@ -282,7 +288,7 @@ impl ClientConfig {
 
     /// Federation name from config metadata (if set)
     pub fn federation_name(&self) -> Option<&str> {
-        self.meta.get(META_FEDERATION_NAME_KEY).map(|x| &**x)
+        self.global.meta.get(META_FEDERATION_NAME_KEY).map(|x| &**x)
     }
 }
 

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -116,6 +116,14 @@ pub struct ClientConfig {
     pub modules: BTreeMap<ModuleInstanceId, ClientModuleConfig>,
 }
 
+/// Client config that cannot be cryptographically verified but is easier to
+/// parse by external tools
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct JsonClientConfig {
+    pub global: GlobalClientConfig,
+    pub modules: BTreeMap<ModuleInstanceId, JsonWithKind>,
+}
+
 /// Federation-wide client config
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Encodable, Decodable)]
 pub struct GlobalClientConfig {

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -73,6 +73,14 @@ hash_newtype!(
 )]
 pub struct PeerId(u16);
 
+impl FromStr for PeerId {
+    type Err = <u16 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(PeerId)
+    }
+}
+
 /// Represents an amount of BTC inside the system. The base denomination is
 /// milli satoshi for now, this is also why the amount type from rust-bitcoin
 /// isn't used instead.

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -765,7 +765,7 @@ impl<CI> ConsensusProposal<CI> {
 
 /// Module associated types required by both client and server
 pub trait ModuleCommon {
-    type ClientConfig: ClientConfig;
+    type ClientConfig: ClientConfig + Serialize;
     type Input: Input;
     type Output: Output;
     type OutputOutcome: OutputOutcome;

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -519,12 +519,13 @@ async fn test_connect_raw_client(
     let mut cfg = api.download_client_config(&invite_code).await?;
 
     if let Some(limit_endpoints) = limit_endpoints {
-        cfg.api_endpoints = cfg
+        cfg.global.api_endpoints = cfg
+            .global
             .api_endpoints
             .into_iter()
             .take(limit_endpoints)
             .collect();
-        info!("Limiting endpoints to {:?}", cfg.api_endpoints);
+        info!("Limiting endpoints to {:?}", cfg.global.api_endpoints);
     }
     use jsonrpsee_core::client::ClientT;
     use jsonrpsee_ws_client::WsClientBuilder;
@@ -532,7 +533,7 @@ async fn test_connect_raw_client(
     info!("Connecting to {users} clients");
     let clients = (0..users)
         .flat_map(|_| {
-            let clients = cfg.api_endpoints.values().map(|url| async {
+            let clients = cfg.global.api_endpoints.values().map(|url| async {
                 let ws_client = WsClientBuilder::default()
                     .use_webpki_rustls()
                     .request_timeout(timeout)

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -185,10 +185,13 @@ impl ServerConfigConsensus {
         module_config_gens: &ModuleInitRegistry<DynServerModuleInit>,
     ) -> Result<ClientConfig, anyhow::Error> {
         let client = ClientConfig {
-            federation_id: FederationId(self.auth_pk_set.public_key()),
-            epoch_pk: self.epoch_pk_set.public_key(),
-            api_endpoints: self.api_endpoints.clone(),
-            consensus_version: self.version,
+            global: GlobalClientConfig {
+                federation_id: FederationId(self.auth_pk_set.public_key()),
+                epoch_pk: self.epoch_pk_set.public_key(),
+                api_endpoints: self.api_endpoints.clone(),
+                consensus_version: self.version,
+                meta: self.meta.clone(),
+            },
             modules: self
                 .modules
                 .iter()
@@ -199,7 +202,6 @@ impl ServerConfigConsensus {
                     Ok((*k, gen.get_client_config(*k, v)?))
                 })
                 .collect::<anyhow::Result<BTreeMap<_, _>>>()?,
-            meta: self.meta.clone(),
         };
         Ok(client)
     }

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -72,6 +72,7 @@ impl FederationTest {
             .consensus
             .to_client_config(&self.server_init)
             .unwrap()
+            .global
             .federation_id
     }
 

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -47,7 +47,7 @@ impl StandardGatewayClientBuilder {
         lnrpc: Arc<dyn ILnRpcClient>,
         old_client: Option<fedimint_client::Client>,
     ) -> Result<fedimint_client::Client> {
-        let federation_id = config.config.federation_id;
+        let federation_id = config.config.global.federation_id;
 
         let mut registry = self.registry.clone();
         registry.attach(GatewayClientGen {
@@ -101,7 +101,7 @@ impl StandardGatewayClientBuilder {
         config: FederationConfig,
         mut dbtx: DatabaseTransaction<'_>,
     ) -> Result<()> {
-        let id = config.config.federation_id;
+        let id = config.config.global.federation_id;
         dbtx.insert_entry(&FederationIdKey { id }, &config).await;
         dbtx.commit_tx_result()
             .await

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -658,7 +658,7 @@ impl Gateway {
                 }
             };
 
-            let federation_id = gw_client_cfg.config.federation_id;
+            let federation_id = gw_client_cfg.config.global.federation_id;
             let route_hints =
                 Self::fetch_lightning_route_hints(lnrpc.clone(), self.num_route_hints).await?;
             let old_client = self.clients.read().await.get(&federation_id).cloned();
@@ -803,7 +803,7 @@ impl Gateway {
             let mut next_channel_id = channel_id_generator.load(Ordering::SeqCst);
 
             for config in configs {
-                let federation_id = config.config.federation_id;
+                let federation_id = config.config.global.federation_id;
                 let old_client = self.clients.read().await.get(&federation_id).cloned();
                 if let Ok(client) = self
                     .client_builder

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -20,7 +20,7 @@ use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId};
 use fedimint_core::db::{AutocommitError, Database, DatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
-    ApiVersion, ExtendsCommonModuleInit, MultiApiVersion, TransactionItemAmount,
+    ApiVersion, ExtendsCommonModuleInit, ModuleCommon, MultiApiVersion, TransactionItemAmount,
 };
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Amount, OutPoint, TransactionId};
@@ -448,6 +448,10 @@ impl ClientModule for GatewayClientModule {
                 }
             }
         }
+    }
+
+    fn get_config(&self) -> <<Self as ClientModule>::Common as ModuleCommon>::ClientConfig {
+        self.cfg.clone()
     }
 }
 

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -259,7 +259,7 @@ impl GatewayClientExt for Client {
             gateway_id,
         );
 
-        let federation_id = self.get_config().federation_id;
+        let federation_id = self.get_config().global.federation_id;
         let mut dbtx = self.db().begin_transaction().await;
         gateway
             .register_with_federation(&mut dbtx, federation_id, registration_info)

--- a/integrationtests/tests/fixtures/legacy.rs
+++ b/integrationtests/tests/fixtures/legacy.rs
@@ -56,6 +56,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> LegacyTestUser<T> {
         let api = WsFederationApi::new(
             config
                 .as_ref()
+                .global
                 .api_endpoints
                 .iter()
                 .filter(|(id, _)| peers.contains(id))

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -306,6 +306,10 @@ impl ClientModule for DummyClientModule {
                 }),
         )
     }
+
+    fn get_config(&self) -> <<Self as ClientModule>::Common as ModuleCommon>::ClientConfig {
+        self.cfg.clone()
+    }
 }
 
 async fn get_funds(dbtx: &mut ModuleDatabaseTransaction<'_>) -> Amount {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -632,6 +632,10 @@ impl ClientModule for LightningClientModule {
             }
         }
     }
+
+    fn get_config(&self) -> <<Self as ClientModule>::Common as ModuleCommon>::ClientConfig {
+        self.cfg.clone()
+    }
 }
 
 #[derive(Error, Debug, Serialize, Deserialize)]

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -273,7 +273,7 @@ impl LightningClientExt for Client {
                     instance.api,
                     invoice.clone(),
                     active_gateway,
-                    self.get_config().federation_id,
+                    self.get_config().global.federation_id,
                     rand::rngs::OsRng,
                 )
                 .await?;

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -167,7 +167,7 @@ impl MintRestoreInProgressState {
                     .make_progress(
                         global_context.api().clone(),
                         global_context.decoders().clone(),
-                        global_context.client_config().epoch_pk,
+                        global_context.client_config().global.epoch_pk,
                         secret,
                     )
                     .await

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -841,6 +841,10 @@ impl ClientModule for MintClientModule {
                 }),
         )
     }
+
+    fn get_config(&self) -> <<Self as ClientModule>::Common as ModuleCommon>::ClientConfig {
+        self.cfg.clone()
+    }
 }
 
 impl MintClientModule {

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -519,6 +519,10 @@ impl ClientModule for WalletClientModule {
             fee: self.cfg.fee_consensus.peg_out_abs,
         }
     }
+
+    fn get_config(&self) -> <<Self as ClientModule>::Common as ModuleCommon>::ClientConfig {
+        self.cfg.clone()
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Large parts of the client config are binary-encoded, even when transported via JSON RPC, so it is easier to deterministically apply cryptographic operations to them without re-encoding (hashing, signing). Unfortunately this leads to difficulties when debugging or integrating with software that doesn't have access to Fedimint's encoding framework.

This PR exposes a JSON version of the client config both in the CLI as well as via the API:
* CLI: `fedimint-cli config`: fixes #3074 
* ~API: `fedimint-cli dev api config_json`: fixes #3067~ Already done in #3072. Removed commits:
  * 23935ccb5531d7e14e15db500fd625daf9437471: expose config via API
  * 9f29fddce08a3083751822a059f27fcad2f9d6ce: test that API and CLI command return the same config
