### PR TITLE
feat(cli): Add command for outputting config

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -791,7 +791,7 @@ impl FedimintCli {
                 let mut modules = BTreeMap::new();
                 for (instance_id, module) in &config.modules {
                     modules.insert(
-                        instance_id.clone(),
+                        *instance_id,
                         format!("{}", module.config.expect_decoded_ref()),
                     );
                 }


### PR DESCRIPTION
This is an unofficial stab at issue #3074 based on @justinmoon suggesting I take a stab at it, I just saw PR #3079 for a more extensive solution, which is necessary to get nicer output formatting.

Without significantly changing the types declared outside of this single file, this is the least bad thing I could come up with - using `format!` + Display to convert module configs to `String`s. Using `Debug` gives cleaner output but I'm not sure that's okay in committed code. I cannot use `serde_json::to_value()` as `DynClientConfig` doesn't implement the `Serializable` trait and I didn't want the code in fedimint-cli to `match` on the module kind and explicitly cast to concrete types (like `LightningClientConfig` which is `Serializable`).