### PR TITLE
fix: boot when a client fails to initialize

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -688,7 +688,7 @@ impl Gateway {
                 for config in configs {
                     let federation_id = config.config.federation_id;
                     let old_client = self.clients.read().await.get(&federation_id).cloned();
-                    let client = self
+                    if let Ok(client) = self
                         .client_builder
                         .build(
                             config.clone(),
@@ -696,17 +696,20 @@ impl Gateway {
                             lnrpc.clone(),
                             old_client,
                         )
-                        .await?;
-
-                    // Registering each client happens in the background, since we're loading the
-                    // clients for the first time, just add them to the in-memory
-                    // maps
-                    let scid = config.mint_channel_id;
-                    self.clients.write().await.insert(federation_id, client);
-                    self.scid_to_federation
-                        .write()
                         .await
-                        .insert(scid, federation_id);
+                    {
+                        // Registering each client happens in the background, since we're loading
+                        // the clients for the first time, just add them to
+                        // the in-memory maps
+                        let scid = config.mint_channel_id;
+                        self.clients.write().await.insert(federation_id, client);
+                        self.scid_to_federation
+                            .write()
+                            .await
+                            .insert(scid, federation_id);
+                    } else {
+                        warn!("Failed to load client for federation: {federation_id}");
+                    }
 
                     if config.mint_channel_id > next_channel_id {
                         next_channel_id = config.mint_channel_id + 1;


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/2857

Instead of failing the whole gateway init, now we catch the error and emit a warning. Gateway operator can check which federations are currently connected by doing `gateway-cli info`