### PR TITLE
Refactor Audit RPC (module instance IDs and defaults)

### DIFF
--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -122,7 +122,12 @@ pub trait IServerModule: Debug {
     ///
     /// Summing over all modules, if liabilities > assets then an error has
     /// occurred in the database and consensus should halt.
-    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit);
+    async fn audit(
+        &self,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        audit: &mut Audit,
+        module_instance_id: ModuleInstanceId,
+    );
 
     /// Returns a list of custom API endpoints defined by the module. These are
     /// made available both to users as well as to other modules. They thus
@@ -276,8 +281,13 @@ where
     ///
     /// Summing over all modules, if liabilities > assets then an error has
     /// occurred in the database and consensus should halt.
-    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
-        <Self as ServerModule>::audit(self, dbtx, audit).await
+    async fn audit(
+        &self,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        audit: &mut Audit,
+        module_instance_id: ModuleInstanceId,
+    ) {
+        <Self as ServerModule>::audit(self, dbtx, audit, module_instance_id).await
     }
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<DynServerModule>> {

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
+use fedimint_core::core::ModuleInstanceId;
 use futures::StreamExt;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -17,14 +18,14 @@ impl Audit {
         AuditItem {
             name: "Net assets (sats)".to_string(),
             milli_sat: calculate_net_assets(self.items.iter()),
-            module_name: "".to_string(),
+            module_instance_id: None,
         }
     }
 
     pub async fn add_items<KP, F>(
         &mut self,
         dbtx: &mut ModuleDatabaseTransaction<'_>,
-        module_name: &str,
+        module_instance_id: ModuleInstanceId,
         key_prefix: &KP,
         to_milli_sat: F,
     ) where
@@ -41,7 +42,7 @@ impl Audit {
                 AuditItem {
                     name,
                     milli_sat,
-                    module_name: module_name.to_string(),
+                    module_instance_id: Some(module_instance_id),
                 }
             })
             .collect::<Vec<AuditItem>>()
@@ -63,50 +64,69 @@ impl Display for Audit {
 pub struct AuditItem {
     pub name: String,
     pub milli_sat: i64,
-    pub module_name: String,
+    pub module_instance_id: Option<ModuleInstanceId>,
 }
 
 impl Display for AuditItem {
     fn fmt(&self, formatter: &mut Formatter) -> std::fmt::Result {
         let sats = (self.milli_sat as f64) / 1000.0;
-        formatter.write_fmt(format_args!(
-            "{:>+15.3}|{:>10}|{}",
-            sats, self.module_name, self.name
-        ))
+        formatter.write_fmt(format_args!("{:>+15.3}|{}", sats, self.name))
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct AuditSummary {
     pub net_assets: i64,
-    pub module_summaries: HashMap<String, ModuleSummary>,
+    pub module_summaries: HashMap<ModuleInstanceId, ModuleSummary>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ModuleSummary {
     pub net_assets: i64,
+    pub kind: String,
 }
 
 impl AuditSummary {
-    pub fn from_audit(audit: &Audit) -> Self {
+    pub fn from_audit(
+        audit: &Audit,
+        module_instance_id_to_kind: &HashMap<ModuleInstanceId, String>,
+    ) -> Self {
+        let empty_module_placeholders = module_instance_id_to_kind
+            .iter()
+            .map(|(id, _)| create_empty_module_placeholder(*id))
+            .collect::<Vec<_>>();
         AuditSummary {
             net_assets: calculate_net_assets(audit.items.iter()),
-            module_summaries: generate_module_summaries(&audit.items),
+            module_summaries: generate_module_summaries(
+                audit.items.iter().chain(&empty_module_placeholders),
+                module_instance_id_to_kind,
+            ),
         }
     }
 }
 
-fn generate_module_summaries(audit_items: &[AuditItem]) -> HashMap<String, ModuleSummary> {
+fn generate_module_summaries<'a>(
+    audit_items: impl Iterator<Item = &'a AuditItem>,
+    module_instance_id_to_kind: &HashMap<ModuleInstanceId, String>,
+) -> HashMap<ModuleInstanceId, ModuleSummary> {
     audit_items
-        .iter()
-        .map(|item| (item.module_name.clone(), item))
+        .filter_map(|item| {
+            item.module_instance_id
+                .as_ref()
+                .map(|module_instance_id| (module_instance_id, item))
+        })
         .into_group_map()
         .into_iter()
-        .map(|(module_name, module_audit_items)| {
+        .map(|(module_instance_id, module_audit_items)| {
+            let kind = module_instance_id_to_kind
+                .get(module_instance_id)
+                .expect("module instance id should have a kind")
+                .to_string();
             (
-                module_name,
+                *module_instance_id,
                 ModuleSummary {
                     net_assets: calculate_net_assets(module_audit_items.into_iter()),
+                    kind,
                 },
             )
         })
@@ -117,6 +137,17 @@ fn calculate_net_assets<'a>(items: impl Iterator<Item = &'a AuditItem>) -> i64 {
     items.map(|item| item.milli_sat).sum()
 }
 
+// Adding a placeholder ensures that a ModuleSummary exists even if the module
+// does not have any AuditItems (e.g. from a lack of activity, db compaction,
+// etc), which is useful for downstream consumers of AuditSummaries.
+fn create_empty_module_placeholder(module_instance_id: ModuleInstanceId) -> AuditItem {
+    AuditItem {
+        name: "Module placeholder".to_string(),
+        milli_sat: 0,
+        module_instance_id: Some(module_instance_id),
+    }
+}
+
 #[test]
 fn creates_audit_summary_from_audit() {
     let audit = Audit {
@@ -124,61 +155,111 @@ fn creates_audit_summary_from_audit() {
             AuditItem {
                 name: "ContractKey(...)".to_string(),
                 milli_sat: -101_000,
-                module_name: "ln".to_string(),
+                module_instance_id: Some(0),
             },
             AuditItem {
                 name: "IssuanceTotal".to_string(),
                 milli_sat: -50_100_000,
-                module_name: "mint".to_string(),
+                module_instance_id: Some(1),
             },
             AuditItem {
                 name: "Redemption(...)".to_string(),
                 milli_sat: 101_000,
-                module_name: "mint".to_string(),
+                module_instance_id: Some(1),
             },
             AuditItem {
                 name: "RedemptionTotal".to_string(),
                 milli_sat: 100_000,
-                module_name: "mint".to_string(),
+                module_instance_id: Some(1),
             },
             AuditItem {
                 name: "UTXOKey(...)".to_string(),
                 milli_sat: 20_000_000,
-                module_name: "wallet".to_string(),
+                module_instance_id: Some(2),
             },
             AuditItem {
                 name: "UTXOKey(...)".to_string(),
                 milli_sat: 10_000_000,
-                module_name: "wallet".to_string(),
+                module_instance_id: Some(2),
             },
             AuditItem {
                 name: "UTXOKey(...)".to_string(),
                 milli_sat: 20_000_000,
-                module_name: "wallet".to_string(),
+                module_instance_id: Some(2),
             },
         ],
     };
 
-    let audit_summary = AuditSummary::from_audit(&audit);
+    let audit_summary = AuditSummary::from_audit(
+        &audit,
+        &HashMap::from([
+            (0, "ln".to_string()),
+            (1, "mint".to_string()),
+            (2, "wallet".to_string()),
+        ]),
+    );
     let expected_audit_summary = AuditSummary {
         net_assets: 0,
         module_summaries: HashMap::from([
             (
-                "ln".to_string(),
+                0,
                 ModuleSummary {
                     net_assets: -101_000,
+                    kind: "ln".to_string(),
                 },
             ),
             (
-                "mint".to_string(),
+                1,
                 ModuleSummary {
                     net_assets: -49_899_000,
+                    kind: "mint".to_string(),
                 },
             ),
             (
-                "wallet".to_string(),
+                2,
                 ModuleSummary {
                     net_assets: 50_000_000,
+                    kind: "wallet".to_string(),
+                },
+            ),
+        ]),
+    };
+
+    assert_eq!(audit_summary, expected_audit_summary);
+}
+
+#[test]
+fn audit_summary_includes_placeholders() {
+    let audit_summary = AuditSummary::from_audit(
+        &Audit::default(),
+        &HashMap::from([
+            (0, "ln".to_string()),
+            (1, "mint".to_string()),
+            (2, "wallet".to_string()),
+        ]),
+    );
+    let expected_audit_summary = AuditSummary {
+        net_assets: 0,
+        module_summaries: HashMap::from([
+            (
+                0,
+                ModuleSummary {
+                    net_assets: 0,
+                    kind: "ln".to_string(),
+                },
+            ),
+            (
+                1,
+                ModuleSummary {
+                    net_assets: 0,
+                    kind: "mint".to_string(),
+                },
+            ),
+            (
+                2,
+                ModuleSummary {
+                    net_assets: 0,
+                    kind: "wallet".to_string(),
                 },
             ),
         ]),

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -874,7 +874,12 @@ pub trait ServerModule: Debug + Sized {
     ///
     /// Summing over all modules, if liabilities > assets then an error has
     /// occurred in the database and consensus should halt.
-    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit);
+    async fn audit(
+        &self,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        audit: &mut Audit,
+        module_instance_id: ModuleInstanceId,
+    );
 
     /// Returns a list of custom API endpoints defined by the module. These are
     /// made available both to users as well as to other modules. They thus

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -536,7 +536,11 @@ impl FedimintConsensus {
         let mut audit = Audit::default();
         for (module_instance_id, _, module) in self.modules.iter_modules() {
             module
-                .audit(&mut dbtx.with_module_prefix(module_instance_id), &mut audit)
+                .audit(
+                    &mut dbtx.with_module_prefix(module_instance_id),
+                    &mut audit,
+                    module_instance_id,
+                )
                 .await
         }
         audit

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -342,12 +342,21 @@ impl ConsensusApi {
     async fn get_federation_audit(&self) -> ApiResult<AuditSummary> {
         let mut dbtx = self.db.begin_transaction().await;
         let mut audit = Audit::default();
-        for (module_instance_id, _, module) in self.modules.iter_modules() {
+        let mut module_instance_id_to_kind: HashMap<ModuleInstanceId, String> = HashMap::new();
+        for (module_instance_id, kind, module) in self.modules.iter_modules() {
+            module_instance_id_to_kind.insert(module_instance_id, kind.as_str().to_string());
             module
-                .audit(&mut dbtx.with_module_prefix(module_instance_id), &mut audit)
+                .audit(
+                    &mut dbtx.with_module_prefix(module_instance_id),
+                    &mut audit,
+                    module_instance_id,
+                )
                 .await
         }
-        Ok(AuditSummary::from_audit(&audit))
+        Ok(AuditSummary::from_audit(
+            &audit,
+            &module_instance_id_to_kind,
+        ))
     }
 
     async fn handle_backup_request(

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -8,6 +8,7 @@ use fedimint_core::config::{
     ConfigGenModuleParams, DkgResult, ServerModuleConfig, ServerModuleConsensusConfig,
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
+use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseVersion, ModuleDatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::audit::Audit;
@@ -819,9 +820,14 @@ impl ServerModule for Lightning {
         dbtx.get_value(&ContractUpdateKey(out_point)).await
     }
 
-    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
+    async fn audit(
+        &self,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        audit: &mut Audit,
+        module_instance_id: ModuleInstanceId,
+    ) {
         audit
-            .add_items(dbtx, common::KIND.as_str(), &ContractKeyPrefix, |_, v| {
+            .add_items(dbtx, module_instance_id, &ContractKeyPrefix, |_, v| {
                 -(v.amount.msats as i64)
             })
             .await;

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -6,6 +6,7 @@ use fedimint_core::config::{
     ConfigGenModuleParams, DkgResult, ServerModuleConfig, ServerModuleConsensusConfig,
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
+use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseVersion, ModuleDatabaseTransaction};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -604,11 +605,16 @@ impl ServerModule for Mint {
         }
     }
 
-    async fn audit(&self, dbtx: &mut ModuleDatabaseTransaction<'_>, audit: &mut Audit) {
+    async fn audit(
+        &self,
+        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        audit: &mut Audit,
+        module_instance_id: ModuleInstanceId,
+    ) {
         audit
             .add_items(
                 dbtx,
-                common::KIND.as_str(),
+                module_instance_id,
                 &MintAuditItemKeyPrefix,
                 |k, v| match k {
                     MintAuditItemKey::Issuance(_) => -(v.msats as i64),


### PR DESCRIPTION
Fixes #3076, fixes #3071 

- update module summaries from module name -> module summary to module instance id -> module summary
  - includes the module `kind` in the summary so consumers can identify the module without additional network round trips
  - this update is necessary since multiple instances of a single module kind can exist (i.e. module kind is not guaranteed to be a singleton)
- add a default placeholder for modules without `AuditItem`s

---
### Updated response payload

Starting devimint without peg-ins

```bash
bash-5.1$ fedimint-cli --our-id 0 --password pass admin audit
{
  "net_assets": 0,
  "module_summaries": {
    "0": {
      "net_assets": 0,
      "kind": "ln"
    },
    "1": {
      "net_assets": 0,
      "kind": "mint"
    },
    "2": {
      "net_assets": 0,
      "kind": "wallet"
    }
  }
}
```