### PR TITLE
feature(gateway): add ClientConfig to FederationInfo for /info api endpoint

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -29,6 +29,7 @@ use clap::{Parser, Subcommand};
 use client::StandardGatewayClientBuilder;
 use db::{FederationRegistrationKey, GatewayPublicKey};
 use fedimint_client::module::init::ClientModuleInitRegistry;
+use fedimint_client::Client;
 use fedimint_core::api::{FederationError, InviteCode};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{
@@ -416,12 +417,7 @@ impl Gateway {
             let route_hints =
                 Self::fetch_lightning_route_hints(lnrpc.clone(), self.num_route_hints).await?;
             for (federation_id, client) in federation_clients {
-                let balance_msat = client.get_balance().await;
-
-                federations.push(FederationInfo {
-                    federation_id,
-                    balance_msat,
-                });
+                federations.push(self.make_federation_info(&client, federation_id).await);
             }
 
             return Ok(GatewayInfo {
@@ -601,7 +597,7 @@ impl Gateway {
                 )
                 .await?;
 
-            let balance_msat = client.get_balance().await;
+            let federation_info = self.make_federation_info(&client, federation_id).await;
 
             client
                 .register_with_federation(
@@ -622,10 +618,7 @@ impl Gateway {
                 .save_config(gw_client_cfg.clone(), dbtx)
                 .await?;
 
-            return Ok(FederationInfo {
-                federation_id,
-                balance_msat,
-            });
+            return Ok(federation_info);
         }
 
         Err(GatewayError::Disconnected)
@@ -819,6 +812,21 @@ impl Gateway {
         }
 
         unreachable!();
+    }
+
+    async fn make_federation_info(
+        &self,
+        client: &Client,
+        federation_id: FederationId,
+    ) -> FederationInfo {
+        let balance_msat = client.get_balance().await;
+        let config = client.get_config().clone();
+
+        FederationInfo {
+            federation_id,
+            balance_msat,
+            config,
+        }
     }
 }
 

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -6,7 +6,7 @@ use std::io::Cursor;
 
 use bitcoin::{Address, Txid};
 use bitcoin_hashes::hex::{FromHex, ToHex};
-use fedimint_core::config::FederationId;
+use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::task::TaskGroup;
 use fedimint_core::Amount;
 use fedimint_ln_client::contracts::Preimage;
@@ -61,6 +61,7 @@ pub struct FederationInfo {
     /// Unique identifier of the fed
     pub federation_id: FederationId,
     pub balance_msat: Amount,
+    pub config: ClientConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Closes #3089.

Adds `{ config: ClientConfig; }` to the `federations: FederationInfo[]` array we get from `/info`. Unfortunately this includes the hex encoded module configs, so it might be nice to add a `modules_config_json` in the future ala #3072, but for now it's not necessary for anything we've got in the designs for the gateway UI.

Could be nice to backport this to 0.1.0 so that gateway config can incorporate this into the gateway admin for release too, but the merge is a little messy due to some refactoring that's been done here.