### PR TITLE
feat: Switch to vanilla cln-plugin instead of custom fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,8 +809,9 @@ checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "cln-plugin"
-version = "0.1.2"
-source = "git+https://github.com/fedimint/lightning?rev=2db131d5#2db131d531922771c3d2e7d2a34e685786bcea2b"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1098794b7562120ec5caa7b768847655fd5249088676a8d8ba9110a01becf97b"
 dependencies = [
  "anyhow",
  "bytes",

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -42,7 +42,7 @@ aquamarine = "0.3.0"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 bitcoin_hashes = "0.11.0"
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
-cln-plugin = { git = "https://github.com/fedimint/lightning", rev = "2db131d5" }
+cln-plugin = "0.1.5"
 cln-rpc = "0.1.1"
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-core = { path = "../../fedimint-core" }


### PR DESCRIPTION
Fix for #1978

Switch from fedimint's own fork to official release incorporating needed API addition https://github.com/ElementsProject/lightning/commit/57d21206dbeb05f085e288b9324c7bb8d76b7180.

TODO after merging: Retire fedimint's own fork?

## Testing ~whoes~ woes

**Pointers for what to test are welcome!**

I've gone through the manual lightning invoice back-and-forth flows described in `docs/dev-running.md` successfully. But when running `cargo test ` I get several different errors both with and without my changes:

```
ERROR connection{remote_addr=127.0.0.1:53786 conn_id=0}: jsonrpsee_server::transport::ws: WS transport error: i/o error: Broken pipe (os error 32); terminate connection: 0
```
```
ERROR pay_invoice: ln_gateway::rpc::rpc_server: error=Invalid Metadata: No federation with id adb87a50f6169fca08e15de953a1857fd8185ae51b3a5b5a33da9e243481546d3923d8cbe64b708a3cc53ad5118c92d2
```
```
ERROR fedimint_client: Error while awaiting client shutdown confirmation
```
I've also tried `$ nix build -L .#workspaceTest` with the same result.