### PR TITLE
fix: db commit failures on `/config` endpoint

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -639,7 +639,7 @@ pub struct InviteCode {
 const CONFIG_DOWNLOAD_TOKEN_BYTES: usize = 12;
 
 /// Allows a client to download the config
-#[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable, PartialOrd, Ord)]
 pub struct ClientConfigDownloadToken(pub [u8; CONFIG_DOWNLOAD_TOKEN_BYTES]);
 
 serde_as_encodable_hex!(ClientConfigDownloadToken);

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -38,7 +38,7 @@ use crate::consensus::{
 use crate::db::{get_global_database_migrations, LastEpochKey, GLOBAL_DATABASE_VERSION};
 use crate::fedimint_core::encoding::Encodable;
 use crate::fedimint_core::net::peers::IPeerConnections;
-use crate::net::api::{ConsensusApi, ExpiringCache};
+use crate::net::api::{ConsensusApi, ExpiringCache, InvitationCodesTracker};
 use crate::net::connect::{Connector, TlsTcpConnector};
 use crate::net::peers::{DelayCalculator, PeerConnector, PeerSlice, ReconnectPeerConnections};
 use crate::{LOG_CONSENSUS, LOG_CORE};
@@ -215,6 +215,7 @@ impl ConsensusServer {
 
         let consensus_api = ConsensusApi {
             cfg: cfg.clone(),
+            invitation_codes_tracker: InvitationCodesTracker::new(db.clone(), task_group).await,
             db: db.clone(),
             modules: modules.clone(),
             client_cfg,

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -109,7 +109,7 @@ impl_db_record!(
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ClientConfigDownloadKeyPrefix;
 
-#[derive(Debug, Encodable, Decodable, Serialize)]
+#[derive(Debug, Encodable, Decodable, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ClientConfigDownloadKey(pub ClientConfigDownloadToken);
 
 impl_db_record!(


### PR DESCRIPTION
Serialize db writes to these fields using a worker thread. Theoretical missed writes are not an issue, so seems like an elegant solution.

Fix #3016