### PR TITLE
Prevent `extra-docker-images` GH workflow on forks

### DIFF
--- a/.github/workflows/extra-docker-images.yml
+++ b/.github/workflows/extra-docker-images.yml
@@ -9,6 +9,7 @@ on:
       - 'v*'
 jobs:
   docker:
+    if: github.repository == 'fedimint/fedimint'
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/3113

- the `extra-docker-images` workflow attempts to access secrets to login to docker hub which will fail on forks
- see: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository