### PR TITLE
Abort database transaction in `submit_transaction`

### DIFF
--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -250,6 +250,12 @@ impl ConsensusApi {
 
         funding_verifier.verify_funding()?;
 
+        // We use the DBTX as a scratch pad to evaluate if a transaction, if it was
+        // applied to the current federation state, would succeed. Since we don't
+        // actually want to accept it yet before generating consensus on it we need to
+        // abort here.
+        dbtx.abort();
+
         self.api_sender
             .send(ApiEvent::Transaction(transaction))
             .await?;


### PR DESCRIPTION
The database transaction is used as scratch space to evaluate the validity of the fedimint transaction and we *want* to drop it. Doing so implicitly leads to a warning though, which this PR fixes by making the abort explicit.