### PR TITLE
chore: disable incremental builds in ci build profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ threshold_crypto = { opt-level = 3 }
 [profile.ci]
 inherits = "dev"
 debug = "line-tables-only"
+incremental = false
 
 [profile.release]
 debug = "line-tables-only"


### PR DESCRIPTION
For storage and compute savings.