### PR TITLE
chore(gateway): log error when config fetching failed

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -571,10 +571,10 @@ impl Gateway {
                     .await
                 {
                     Ok(gw_client_cfg) => break gw_client_cfg,
-                    Err(_) => {
+                    Err(e) => {
                         let random_delay: f64 = rand::thread_rng().gen();
                         tracing::warn!(
-                            "Error downloading client config, trying again in {random_delay}"
+                            "Error downloading client config, trying again in {random_delay}: {e:?}"
                         );
                         sleep(Duration::from_secs_f64(random_delay)).await;
                     }


### PR DESCRIPTION
To debug flaky tests like https://github.com/fedimint/fedimint/actions/runs/6110533406/job/16583747002?pr=3079#step:9:10187