### PR TITLE
feat: Use `SafeUrl` to avoid exposing passwords in logs & UI

### DIFF
--- a/.semgrep.all.yaml
+++ b/.semgrep.all.yaml
@@ -51,3 +51,10 @@ rules:
   message: "`tokio::time::sleep` doesn't work in WASM. Use `fedimint_core::task::sleep` instead."
   pattern: tokio::time::sleep
   severity: WARNING
+
+- id: ban-raw-url
+  languages:
+    - rust
+  message: "`url::Url` may expose confidential username + passwords to logs etc. Use `fedimint_core::SafeUrl` instead."
+  pattern: url::Url
+  severity: WARNING

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -10,6 +10,7 @@ use fedimint_core::config::ServerModuleConfigGenParamsRegistry;
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::module::ApiAuth;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, PeerId};
 use fedimint_server::config::ConfigGenParams;
 use fedimint_testing::federation::local_config_gen_params;
@@ -18,7 +19,6 @@ use fedimintd::attach_default_module_init_params;
 use fedimintd::fedimintd::FM_EXTRA_DKG_META_VAR;
 use futures::future::join_all;
 use rand::Rng;
-use url::Url;
 
 use super::*; // TODO: remove this
 
@@ -98,7 +98,7 @@ impl Federation {
                 peer.to_usize(),
                 Fedimintd::new(process_mgr, bitcoind.clone(), peer.to_usize(), &var).await?,
             );
-            let admin_client = WsAdminClient::new(Url::parse(&var.FM_API_URL)?);
+            let admin_client = WsAdminClient::new(SafeUrl::parse(&var.FM_API_URL)?);
             admin_clients.insert(*peer, admin_client);
             vars.insert(peer.to_usize(), var);
         }

--- a/fedimint-bitcoind/src/electrum.rs
+++ b/fedimint-bitcoind/src/electrum.rs
@@ -6,9 +6,9 @@ use bitcoin_hashes::hex::ToHex;
 use electrum_client::ElectrumApi;
 use fedimint_core::task::{block_in_place, TaskHandle};
 use fedimint_core::txoproof::TxOutProof;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Feerate};
 use tracing::{info, warn};
-use url::Url;
 
 use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
 
@@ -16,7 +16,11 @@ use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
 pub struct ElectrumFactory;
 
 impl IBitcoindRpcFactory for ElectrumFactory {
-    fn create_connection(&self, url: &Url, handle: TaskHandle) -> anyhow::Result<DynBitcoindRpc> {
+    fn create_connection(
+        &self,
+        url: &SafeUrl,
+        handle: TaskHandle,
+    ) -> anyhow::Result<DynBitcoindRpc> {
         Ok(RetryClient::new(ElectrumClient::new(url)?, handle).into())
     }
 }
@@ -24,7 +28,7 @@ impl IBitcoindRpcFactory for ElectrumFactory {
 pub struct ElectrumClient(electrum_client::Client);
 
 impl ElectrumClient {
-    fn new(url: &Url) -> anyhow::Result<Self> {
+    fn new(url: &SafeUrl) -> anyhow::Result<Self> {
         Ok(Self(electrum_client::Client::new(url.as_str())?))
     }
 }

--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -5,9 +5,9 @@ use bitcoin::{BlockHash, Network, Script, Transaction, Txid};
 use bitcoin_hashes::hex::ToHex;
 use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Feerate};
 use tracing::{info, warn};
-use url::Url;
 
 use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
 
@@ -15,7 +15,11 @@ use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
 pub struct EsploraFactory;
 
 impl IBitcoindRpcFactory for EsploraFactory {
-    fn create_connection(&self, url: &Url, handle: TaskHandle) -> anyhow::Result<DynBitcoindRpc> {
+    fn create_connection(
+        &self,
+        url: &SafeUrl,
+        handle: TaskHandle,
+    ) -> anyhow::Result<DynBitcoindRpc> {
         Ok(RetryClient::new(EsploraClient::new(url)?, handle).into())
     }
 }
@@ -24,8 +28,8 @@ impl IBitcoindRpcFactory for EsploraFactory {
 pub struct EsploraClient(esplora_client::AsyncClient);
 
 impl EsploraClient {
-    fn new(url: &Url) -> anyhow::Result<Self> {
-        // Url needs to have any trailing path including '/' removed
+    fn new(url: &SafeUrl) -> anyhow::Result<Self> {
+        // URL needs to have any trailing path including '/' removed
         let without_trailing = url.as_str().trim_end_matches('/');
 
         let builder = esplora_client::Builder::new(without_trailing);

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -11,11 +11,11 @@ use bitcoin::{BlockHash, Network, Script, Transaction, Txid};
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, dyn_newtype_define, Feerate};
 use fedimint_logging::LOG_BLOCKCHAIN;
 use lazy_static::lazy_static;
 use tracing::info;
-use url::Url;
 
 #[cfg(feature = "bitcoincore-rpc")]
 pub mod bitcoincore;
@@ -70,7 +70,7 @@ pub fn register_bitcoind(kind: String, factory: DynBitcoindRpcFactory) {
 /// Trait for creating new bitcoin RPC clients
 pub trait IBitcoindRpcFactory: Debug + Send + Sync {
     /// Creates a new bitcoin RPC client connection
-    fn create_connection(&self, url: &Url, handle: TaskHandle) -> Result<DynBitcoindRpc>;
+    fn create_connection(&self, url: &SafeUrl, handle: TaskHandle) -> Result<DynBitcoindRpc>;
 }
 
 dyn_newtype_define! {

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -32,6 +32,7 @@ use fedimint_core::epoch::{SerdeEpochHistory, SignedEpochOutcome};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{ApiAuth, ApiRequestErased};
 use fedimint_core::query::ThresholdConsensus;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{task, PeerId, TieredMulti};
 use fedimint_ln_client::LightningClientGen;
 use fedimint_logging::TracingSetup;
@@ -43,7 +44,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use thiserror::Error;
 use tracing::{debug, info};
-use url::Url;
 use utils::{from_hex, parse_peer_id};
 
 use crate::client::ClientCmd;
@@ -70,7 +70,7 @@ enum CliOutput {
     },
 
     DecodeInviteCode {
-        url: Url,
+        url: SafeUrl,
         download_token: String,
         id: FederationId,
     },
@@ -414,7 +414,7 @@ enum DevCmd {
     /// Encode connection info from its constituent parts
     EncodeInviteCode {
         #[clap(long = "url")]
-        url: Url,
+        url: SafeUrl,
         #[clap(long = "download-token", value_parser = from_hex::<ClientConfigDownloadToken>)]
         download_token: ClientConfigDownloadToken,
         #[clap(long = "id")]

--- a/fedimint-client-legacy/src/lib.rs
+++ b/fedimint-client-legacy/src/lib.rs
@@ -43,6 +43,7 @@ use fedimint_core::outcome::TransactionStatus;
 use fedimint_core::task::{self, sleep, MaybeSend};
 use fedimint_core::tiered::InvalidAmountTierError;
 use fedimint_core::txoproof::TxOutProof;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, OutPoint, TieredMulti, TieredSummary, TransactionId};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_ln_client::{
@@ -74,7 +75,6 @@ use thiserror::Error;
 use threshold_crypto::PublicKey;
 use tokio::sync::{Mutex, MutexGuard};
 use tracing::{debug, info, instrument, trace};
-use url::Url;
 
 use crate::db::ClientSecretKey;
 use crate::ln::db::{
@@ -130,7 +130,7 @@ pub struct GatewayClientConfig {
     #[serde(with = "serde_keypair")]
     pub redeem_key: bitcoin::KeyPair,
     pub timelock_delta: u64,
-    pub api: Url,
+    pub api: SafeUrl,
     pub node_pub_key: bitcoin::secp256k1::PublicKey,
     pub lightning_alias: String,
     /// Channel identifier assigned to the mint by the gateway.

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -4,10 +4,10 @@ use std::fmt::Debug;
 use bitcoin_hashes::sha256;
 use fedimint_core::module::audit::AuditSummary;
 use fedimint_core::task::MaybeSend;
+use fedimint_core::util::SafeUrl;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::PublicKey;
 use tokio_rustls::rustls;
-use url::Url;
 
 use crate::api::{
     DynGlobalApi, FederationApiExt, FederationResult, GlobalFederationApi, ServerStatus,
@@ -23,11 +23,11 @@ use crate::PeerId;
 // TODO: Maybe should have it's own CLI client so it doesn't need to be in core
 pub struct WsAdminClient {
     inner: DynGlobalApi,
-    pub url: Url,
+    pub url: SafeUrl,
 }
 
 impl WsAdminClient {
-    pub fn new(url: Url) -> Self {
+    pub fn new(url: SafeUrl) -> Self {
         // The peer ids given to the federation API are only useful when connected to
         // multiple peers so errors can be attributed. The admin client has no use for
         // them.
@@ -235,9 +235,9 @@ impl WsAdminClient {
 pub struct ConfigGenConnectionsRequest {
     /// Our guardian name
     pub our_name: String,
-    /// Url of "leader" guardian to send our connection info to
+    /// URL of "leader" guardian to send our connection info to
     /// Will be `None` if we are the leader
-    pub leader_api_url: Option<Url>,
+    pub leader_api_url: Option<SafeUrl>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -247,9 +247,9 @@ pub struct PeerServerParams {
     #[serde(with = "serde_tls_cert")]
     pub cert: rustls::Certificate,
     /// P2P is the network for running DKG and consensus
-    pub p2p_url: Url,
+    pub p2p_url: SafeUrl,
     /// API for secure websocket requests
-    pub api_url: Url,
+    pub api_url: SafeUrl,
     /// Name of the peer, used in TLS auth
     pub name: String,
     /// Status of the peer if known

--- a/fedimint-core/src/bitcoinrpc.rs
+++ b/fedimint-core/src/bitcoinrpc.rs
@@ -1,10 +1,10 @@
 use std::env;
 
 use anyhow::Context;
+use fedimint_core::util::SafeUrl;
 use fedimint_derive::{Decodable, Encodable};
 use jsonrpsee_core::Serialize;
 use serde::Deserialize;
-use url::Url;
 
 /// Env var for bitcoin RPC kind
 pub const FM_BITCOIN_RPC_KIND: &str = "FM_BITCOIN_RPC_KIND";
@@ -18,7 +18,7 @@ pub const FM_BITCOIND_COOKIE_FILE_VAR_NAME: &str = "FM_BITCOIND_COOKIE_FILE";
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct BitcoinRpcConfig {
     pub kind: String,
-    pub url: Url,
+    pub url: SafeUrl,
 }
 
 impl BitcoinRpcConfig {

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -15,6 +15,7 @@ use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{DynRawFallback, Encodable};
 use fedimint_core::epoch::SerdeSignature;
 use fedimint_core::module::registry::ModuleRegistry;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{BitcoinHash, ModuleDecoderRegistry};
 use fedimint_logging::LOG_CORE;
 use serde::de::DeserializeOwned;
@@ -25,7 +26,6 @@ use thiserror::Error;
 use threshold_crypto::group::{Curve, Group, GroupEncoding};
 use threshold_crypto::{G1Projective, G2Projective};
 use tracing::warn;
-use url::Url;
 
 use crate::core::DynClientConfig;
 use crate::encoding::Decodable;
@@ -101,7 +101,7 @@ impl JsonWithKind {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
 pub struct PeerUrl {
     /// The peer's public URL (e.g. `wss://fedimint-server-1:5000`)
-    pub url: Url,
+    pub url: SafeUrl,
     /// The peer's name
     pub name: String,
 }

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -23,10 +23,10 @@ pub use fedimint_derive::{Decodable, Encodable, UnzipConsensus};
 use lightning::util::ser::{Readable, Writeable};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use url::Url;
 
 use crate::core::ModuleInstanceId;
 use crate::module::registry::ModuleDecoderRegistry;
+use crate::util::SafeUrl;
 
 /// Object-safe trait for things that can encode themselves
 ///
@@ -122,19 +122,19 @@ pub trait Decodable: Sized {
     }
 }
 
-impl Encodable for Url {
+impl Encodable for SafeUrl {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         self.to_string().consensus_encode(writer)
     }
 }
 
-impl Decodable for Url {
+impl Decodable for SafeUrl {
     fn consensus_decode<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         String::consensus_decode(d, modules)?
-            .parse::<Url>()
+            .parse::<SafeUrl>()
             .map_err(DecodeError::from_err)
     }
 }

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -16,7 +16,7 @@ use devimint::util::{GatewayClnCli, GatewayLndCli};
 use fedimint_client::Client;
 use fedimint_core::api::{GlobalFederationApi, InviteCode, WsFederationApi};
 use fedimint_core::module::ApiRequestErased;
-use fedimint_core::util::BoxFuture;
+use fedimint_core::util::{BoxFuture, SafeUrl};
 use fedimint_core::Amount;
 use fedimint_mint_client::OOBNotes;
 use lightning_invoice::Invoice;
@@ -568,7 +568,7 @@ async fn test_connect_raw_client(
         .collect())
 }
 
-fn url_to_string_with_default_port(url: &url::Url) -> String {
+fn url_to_string_with_default_port(url: &SafeUrl) -> String {
     format!(
         "{}://{}:{}{}",
         url.scheme(),

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -18,6 +18,7 @@ use fedimint_core::api::PeerConnectionStatus;
 use fedimint_core::cancellable::{Cancellable, Cancelled};
 use fedimint_core::net::peers::IPeerConnections;
 use fedimint_core::task::{sleep_until, TaskGroup, TaskHandle};
+use fedimint_core::util::SafeUrl;
 use fedimint_core::PeerId;
 use fedimint_logging::LOG_NET_PEER;
 use futures::future::select_all;
@@ -30,7 +31,6 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio::time::Instant;
 use tracing::{debug, info, instrument, trace, warn};
-use url::Url;
 
 use crate::net::connect::{AnyConnector, SharedAnyConnector};
 use crate::net::framed::AnyFramedTransport;
@@ -70,7 +70,7 @@ pub struct NetworkConfig {
     /// members
     pub bind_addr: SocketAddr,
     /// Map of all peers' connection information we want to be connected to
-    pub peers: HashMap<PeerId, Url>,
+    pub peers: HashMap<PeerId, SafeUrl>,
 }
 
 /// Internal message type for [`ReconnectPeerConnections`], just public because
@@ -179,7 +179,7 @@ struct CommonPeerConnectionState<M> {
     outgoing: Receiver<M>,
     our_id: PeerId,
     peer_id: PeerId,
-    peer_address: Url,
+    peer_address: SafeUrl,
     delay_calculator: DelayCalculator,
     connect: SharedAnyConnector<PeerMessage<M>>,
     incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,
@@ -726,7 +726,7 @@ where
     async fn new(
         our_id: PeerId,
         peer_id: PeerId,
-        peer_address: Url,
+        peer_address: SafeUrl,
         delay_calculator: DelayCalculator,
         connect: SharedAnyConnector<PeerMessage<M>>,
         incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,
@@ -778,7 +778,7 @@ where
         outgoing: Receiver<M>,
         our_id: PeerId,
         peer_id: PeerId,
-        peer_address: Url,
+        peer_address: SafeUrl,
         delay_calculator: DelayCalculator,
         connect: SharedAnyConnector<PeerMessage<M>>,
         incoming_connections: Receiver<AnyFramedTransport<PeerMessage<M>>>,

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -20,10 +20,10 @@ use fedimint_bitcoind::{
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::task::{sleep, TaskHandle};
 use fedimint_core::txoproof::TxOutProof;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, Feerate};
 use rand::rngs::OsRng;
 use tracing::debug;
-use url::Url;
 
 use super::BitcoinTest;
 
@@ -50,7 +50,11 @@ impl FakeBitcoinFactory {
 }
 
 impl IBitcoindRpcFactory for FakeBitcoinFactory {
-    fn create_connection(&self, _url: &Url, _handle: TaskHandle) -> anyhow::Result<DynBitcoindRpc> {
+    fn create_connection(
+        &self,
+        _url: &SafeUrl,
+        _handle: TaskHandle,
+    ) -> anyhow::Result<DynBitcoindRpc> {
         Ok(self.bitcoin.clone().into())
     }
 }

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -10,10 +10,10 @@ use fedimint_core::encoding::Decodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::sleep;
 use fedimint_core::txoproof::TxOutProof;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{task, Amount};
 use lazy_static::lazy_static;
 use tracing::trace;
-use url::Url;
 
 use crate::btc::BitcoinTest;
 
@@ -144,7 +144,7 @@ pub struct RealBitcoinTest {
 impl RealBitcoinTest {
     const ERROR: &'static str = "Bitcoin RPC returned an error";
 
-    pub fn new(url: &Url, rpc: DynBitcoindRpc) -> Self {
+    pub fn new(url: &SafeUrl, rpc: DynBitcoindRpc) -> Self {
         let (host, auth) =
             fedimint_bitcoind::bitcoincore::from_url_to_url_auth(url).expect("correct url");
         let client = Arc::new(Client::new(&host, auth).expect(Self::ERROR));

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -11,6 +11,7 @@ use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::Database;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::sleep;
+use fedimint_core::util::SafeUrl;
 use lightning::routing::gossip::RoutingFees;
 use ln_gateway::client::StandardGatewayClientBuilder;
 use ln_gateway::lnrpc_client::{ILnRpcClient, LightningBuilder};
@@ -19,7 +20,6 @@ use ln_gateway::rpc::{ConnectFedPayload, FederationInfo};
 use ln_gateway::{Gateway, GatewayState};
 use secp256k1::PublicKey;
 use tempfile::TempDir;
-use url::Url;
 
 use crate::federation::FederationTest;
 use crate::fixtures::{test_dir, Fixtures};
@@ -32,7 +32,7 @@ pub struct GatewayTest {
     /// Password for the RPC
     pub password: String,
     /// URL for the RPC
-    api: Url,
+    api: SafeUrl,
     /// Handle of the running gateway
     gateway: Gateway,
     /// Temporary dir that stores the gateway config
@@ -80,7 +80,7 @@ impl GatewayTest {
         num_route_hints: usize,
     ) -> Self {
         let listen: SocketAddr = format!("127.0.0.1:{base_port}").parse().unwrap();
-        let address: Url = format!("http://{listen}").parse().unwrap();
+        let address: SafeUrl = format!("http://{listen}").parse().unwrap();
         let (path, _config_dir) = test_dir(&format!("gateway-{}", rand::random::<u64>()));
 
         // Create federation client builder for the gateway

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -9,6 +9,7 @@ use bitcoin::{secp256k1, Network};
 use cln_rpc::primitives::{Amount as ClnRpcAmount, AmountOrAny};
 use cln_rpc::{model, ClnRpc, Request, Response};
 use fedimint_core::task::TaskGroup;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::Amount;
 use ldk_node::io::SqliteStore;
 use ldk_node::{Builder, Event, LogLevel, NetAddress, Node};
@@ -26,7 +27,6 @@ use tokio::sync::Mutex;
 use tonic_lnd::lnrpc::{GetInfoRequest, Invoice as LndInvoice, ListChannelsRequest};
 use tonic_lnd::{connect, LndClient};
 use tracing::{error, info, warn};
-use url::Url;
 
 use crate::btc::BitcoinTest;
 use crate::gateway::LightningNodeType;
@@ -156,7 +156,7 @@ impl ClnLightningTest {
 
         let lnrpc_addr = env::var("FM_GATEWAY_LIGHTNING_ADDR")
             .expect("FM_GATEWAY_LIGHTNING_ADDR not set")
-            .parse::<Url>()
+            .parse::<SafeUrl>()
             .expect("Invalid FM_GATEWAY_LIGHTNING_ADDR");
         let lnrpc: Box<dyn ILnRpcClient> = Box::new(NetworkLnRpcClient::new(lnrpc_addr).await);
 

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -14,7 +14,7 @@ use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::Database;
 use fedimint_core::module::ServerModuleInit;
 use fedimint_core::task::{sleep, TaskGroup};
-use fedimint_core::util::write_overwrite;
+use fedimint_core::util::{write_overwrite, SafeUrl};
 use fedimint_core::{timing, Amount};
 use fedimint_ln_server::LightningGen;
 use fedimint_logging::TracingSetup;
@@ -26,7 +26,6 @@ use fedimint_wallet_server::WalletGen;
 use futures::FutureExt;
 use tokio::select;
 use tracing::{debug, error, info, warn};
-use url::Url;
 
 use crate::attach_default_module_init_params;
 
@@ -57,13 +56,13 @@ pub struct ServerOpts {
     bind_p2p: SocketAddr,
     /// Our external address for communicating with our peers
     #[arg(long, env = "FM_P2P_URL", default_value = "fedimint://127.0.0.1:8173")]
-    p2p_url: Url,
+    p2p_url: SafeUrl,
     /// Address we bind to for exposing the API
     #[arg(long, env = "FM_BIND_API", default_value = "127.0.0.1:8174")]
     bind_api: SocketAddr,
     /// Our API address for clients to connect to us
     #[arg(long, env = "FM_API_URL", default_value = "ws://127.0.0.1:8174")]
-    api_url: Url,
+    api_url: SafeUrl,
     /// Max denomination of notes issued by the federation (in millisats)
     /// default = 10 BTC
     #[arg(long, env = "FM_MAX_DENOMINATION", default_value = "1000000000000")]

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -6,6 +6,7 @@ use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_core::module::ServerModuleInit;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, Tiered};
 use fedimint_ln_server::common::config::{
     LightningGenParams, LightningGenParamsConsensus, LightningGenParamsLocal,
@@ -17,7 +18,6 @@ use fedimint_wallet_server::common::config::{
     WalletGenParams, WalletGenParamsConsensus, WalletGenParamsLocal,
 };
 use fedimint_wallet_server::WalletGen;
-use url::Url;
 
 /// Module for creating `fedimintd` binary with custom modules
 pub mod fedimintd;
@@ -72,14 +72,13 @@ pub fn attach_default_module_init_params(
 
 pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
     let url = match network {
-        Network::Bitcoin => Url::parse("https://blockstream.info/api/")
+        Network::Bitcoin => SafeUrl::parse("https://blockstream.info/api/")
             .expect("Failed to parse default esplora server"),
-        Network::Testnet => Url::parse("https://blockstream.info/testnet/api/")
+        Network::Testnet => SafeUrl::parse("https://blockstream.info/testnet/api/")
             .expect("Failed to parse default esplora server"),
-        Network::Regtest => {
-            Url::parse("http://127.0.0.1:50002/").expect("Failed to parse default esplora server")
-        }
-        Network::Signet => Url::parse("https://mutinynet.com/api/")
+        Network::Regtest => SafeUrl::parse("http://127.0.0.1:50002/")
+            .expect("Failed to parse default esplora server"),
+        Network::Signet => SafeUrl::parse("https://mutinynet.com/api/")
             .expect("Failed to parse default esplora server"),
     };
     BitcoinRpcConfig {

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -1,6 +1,7 @@
 use bitcoin::{Address, Amount};
 use clap::{CommandFactory, Parser, Subcommand};
 use fedimint_core::config::FederationId;
+use fedimint_core::util::SafeUrl;
 use fedimint_logging::TracingSetup;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{
@@ -8,14 +9,13 @@ use ln_gateway::rpc::{
     WithdrawPayload,
 };
 use serde::Serialize;
-use url::Url;
 
 #[derive(Parser)]
 #[command(version)]
 struct Cli {
     /// The address of the gateway webserver
     #[clap(short, long, default_value = "http://127.0.0.1:8175")]
-    address: Url,
+    address: SafeUrl,
     #[command(subcommand)]
     command: Commands,
     /// WARNING: Passing in a password from the command line may be less secure!

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -40,6 +40,7 @@ use fedimint_core::db::Database;
 use fedimint_core::module::CommonModuleInit;
 use fedimint_core::task::{sleep, RwLock, TaskGroup, TaskHandle, TaskShutdownToken};
 use fedimint_core::time::now;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::Amount;
 use fedimint_ln_client::contracts::Preimage;
 use fedimint_ln_client::pay::PayInvoicePayload;
@@ -62,7 +63,6 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
-use url::Url;
 
 use crate::gateway_lnrpc::intercept_htlc_response::Forward;
 use crate::lnrpc_client::GatewayLightningBuilder;
@@ -114,7 +114,7 @@ pub struct GatewayOpts {
 
     /// Public URL from which the webserver API is reachable
     #[arg(long = "api-addr", env = "FM_GATEWAY_API_ADDR")]
-    pub api_addr: Url,
+    pub api_addr: SafeUrl,
 
     /// Gateway webserver authentication password
     #[arg(long = "password", env = "FM_GATEWAY_PASSWORD")]
@@ -155,7 +155,7 @@ pub enum GatewayState {
 pub struct Gateway {
     lightning_builder: Arc<dyn LightningBuilder + Send + Sync>,
     listen: SocketAddr,
-    api_addr: Url,
+    api_addr: SafeUrl,
     password: String,
     num_route_hints: usize,
     pub state: Arc<RwLock<GatewayState>>,
@@ -174,7 +174,7 @@ impl Gateway {
         lightning_builder: Arc<dyn LightningBuilder + Send + Sync>,
         client_builder: StandardGatewayClientBuilder,
         listen: SocketAddr,
-        api_addr: Url,
+        api_addr: SafeUrl,
         password: String,
         fees: RoutingFees,
         num_route_hints: usize,
@@ -853,7 +853,7 @@ pub enum LightningMode {
     #[clap(name = "cln")]
     Cln {
         #[arg(long = "cln-extension-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
-        cln_extension_addr: Url,
+        cln_extension_addr: SafeUrl,
     },
 }
 

--- a/gateway/ln-gateway/src/lnrpc_client.rs
+++ b/gateway/ln-gateway/src/lnrpc_client.rs
@@ -5,13 +5,13 @@ use std::time::Duration;
 use async_trait::async_trait;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::{sleep, TaskGroup};
+use fedimint_core::util::SafeUrl;
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tonic::transport::{Channel, Endpoint};
 use tonic::Request;
 use tracing::info;
-use url::Url;
 
 use crate::gateway_lnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gateway_lnrpc::{
@@ -84,11 +84,11 @@ pub trait ILnRpcClient: Debug + Send + Sync {
 /// `GatewayLightningServer`.
 #[derive(Debug)]
 pub struct NetworkLnRpcClient {
-    connection_url: Url,
+    connection_url: SafeUrl,
 }
 
 impl NetworkLnRpcClient {
-    pub async fn new(url: Url) -> Self {
+    pub async fn new(url: SafeUrl) -> Self {
         info!(
             "Gateway configured to connect to remote LnRpcClient at \n cln extension address: {} ",
             url.to_string()
@@ -99,7 +99,7 @@ impl NetworkLnRpcClient {
     }
 
     async fn connect(
-        connection_url: Url,
+        connection_url: SafeUrl,
     ) -> Result<GatewayLightningClient<Channel>, LightningRpcError> {
         let mut retries = 0;
         let client = loop {

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -22,6 +22,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     ApiVersion, ExtendsCommonModuleInit, MultiApiVersion, TransactionItemAmount,
 };
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Amount, OutPoint, TransactionId};
 use fedimint_ln_client::contracts::ContractId;
 use fedimint_ln_common::api::LnFederationApi;
@@ -41,7 +42,6 @@ use secp256k1::{KeyPair, PublicKey, Secp256k1};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::info;
-use url::Url;
 
 use self::complete::GatewayCompleteStateMachine;
 use self::pay::{
@@ -122,7 +122,7 @@ pub trait GatewayClientExt {
     /// Register gateway with federation
     async fn register_with_federation(
         &self,
-        gateway_api: Url,
+        gateway_api: SafeUrl,
         route_hints: Vec<RouteHint>,
         time_to_live: Duration,
         gateway_id: secp256k1::PublicKey,
@@ -246,7 +246,7 @@ impl GatewayClientExt for Client {
     /// Register this gateway with the federation
     async fn register_with_federation(
         &self,
-        gateway_api: Url,
+        gateway_api: SafeUrl,
         route_hints: Vec<RouteHint>,
         time_to_live: Duration,
         gateway_id: secp256k1::PublicKey,
@@ -456,7 +456,7 @@ impl GatewayClientModule {
         &self,
         route_hints: Vec<RouteHint>,
         time_to_live: Duration,
-        api: Url,
+        api: SafeUrl,
         gateway_id: secp256k1::PublicKey,
     ) -> LightningGateway {
         LightningGateway {

--- a/gateway/ln-gateway/src/ng/tests.rs
+++ b/gateway/ln-gateway/src/ng/tests.rs
@@ -9,7 +9,7 @@ use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder
 use fedimint_client::Client;
 use fedimint_core::core::IntoDynInstance;
 use fedimint_core::task::sleep;
-use fedimint_core::util::NextOrPending;
+use fedimint_core::util::{NextOrPending, SafeUrl};
 use fedimint_core::{sats, Amount, OutPoint, TransactionId};
 use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
 use fedimint_dummy_common::config::DummyGenParams;
@@ -38,7 +38,6 @@ use ln_gateway::ng::{
     GatewayExtReceiveStates, GatewayMeta, Htlc, GW_ANNOUNCEMENT_TTL,
 };
 use secp256k1::PublicKey;
-use url::Url;
 
 fn fixtures() -> Fixtures {
     let fixtures = Fixtures::new_primary(DummyClientGen, DummyGen, DummyGenParams::default());
@@ -502,7 +501,7 @@ async fn test_gateway_register_with_federation() -> anyhow::Result<()> {
     gateway_test.connect_fed(&fed).await;
     let gateway = gateway_test.remove_client(&fed).await;
 
-    let mut fake_api = Url::from_str("http://127.0.0.1:8175").unwrap();
+    let mut fake_api = SafeUrl::from_str("http://127.0.0.1:8175").unwrap();
     let fake_route_hints = Vec::new();
     // Register with the federation with a low TTL to verify it will re-register
     gateway
@@ -517,7 +516,7 @@ async fn test_gateway_register_with_federation() -> anyhow::Result<()> {
     assert!(gateways.into_iter().any(|gateway| gateway.api == fake_api));
 
     // Update the URI for the gateway then re-register
-    fake_api = Url::from_str("http://127.0.0.1:8176").unwrap();
+    fake_api = SafeUrl::from_str("http://127.0.0.1:8176").unwrap();
 
     gateway
         .register_with_federation(

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -28,12 +28,12 @@ use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::task::timeout;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{plugin_types_trait_impl_common, Amount};
 use lightning::routing::gossip::RoutingFees;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
-use url::Url;
 
 use crate::api::LnFederationApi;
 use crate::contracts::incoming::{IncomingContract, IncomingContractOffer, OfferId};
@@ -188,7 +188,7 @@ pub struct LightningGateway {
     pub gateway_redeem_key: secp256k1::XOnlyPublicKey,
     pub node_pub_key: secp256k1::PublicKey,
     pub lightning_alias: String,
-    pub api: Url,
+    pub api: SafeUrl,
     /// Route hints to reach the LN node of the gateway.
     ///
     /// These will be appended with the route hint of the recipient's virtual

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1318,6 +1318,7 @@ mod fedimint_migration_tests {
     use fedimint_core::encoding::Encodable;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::module::{CommonModuleInit, DynServerModuleInit};
+    use fedimint_core::util::SafeUrl;
     use fedimint_core::{OutPoint, PeerId, ServerModule, TransactionId};
     use fedimint_ln_common::contracts::incoming::{
         FundedIncomingContract, IncomingContract, IncomingContractOffer, OfferId,
@@ -1346,7 +1347,6 @@ mod fedimint_migration_tests {
     use rand::rngs::OsRng;
     use strum::IntoEnumIterator;
     use threshold_crypto::G1Projective;
-    use url::Url;
 
     use crate::{
         ContractAccount, Lightning, LightningGateway, LightningGen, LightningOutputOutcome,
@@ -1440,7 +1440,7 @@ mod fedimint_migration_tests {
             gateway_redeem_key: pk.x_only_public_key().0,
             node_pub_key: pk,
             lightning_alias: "FakeLightningAlias".to_string(),
-            api: Url::parse("http://example.com")
+            api: SafeUrl::parse("http://example.com")
                 .expect("Could not parse URL to generate GatewayClientConfig API endpoint"),
             route_hints: vec![],
             valid_until: fedimint_core::time::now(),

--- a/modules/fedimint-wallet-common/src/config.rs
+++ b/modules/fedimint-wallet-common/src/config.rs
@@ -5,11 +5,11 @@ use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::__reexports::serde_json;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{plugin_types_trait_impl_config, Feerate, PeerId};
 use miniscript::descriptor::Wsh;
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 use crate::keys::CompressedPublicKey;
 use crate::{PegInDescriptor, WalletCommonGen};
@@ -29,7 +29,7 @@ impl WalletGenParams {
                 finality_delay: 10,
                 client_default_bitcoin_rpc: BitcoinRpcConfig {
                     kind: "esplora".to_string(),
-                    url: Url::parse("http://127.0.0.1:50002/")
+                    url: SafeUrl::parse("http://127.0.0.1:50002/")
                         .expect("Failed to parse default esplora server"),
                 },
             },


### PR DESCRIPTION
Implements #1298.

Renames pre-existing `SanitizedUrl` -> `SafeUrl` and applies it across the code base.

Removed minor `Cow`-complexity which `SanitizedUrl` had for now.

Adds semgrep rule to catch uses of `url::Url`.