### PR TITLE
 fix: DBTransaction::cancel doesn't handle errors well

### DIFF
--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -210,6 +210,8 @@ impl ConsensusApi {
 
         // Create read-only DB tx so that the read state is consistent
         let mut dbtx = self.db.begin_transaction().await;
+        // We ignore any writes, as we only verify if the transaction is valid here
+        dbtx.ignore_uncommitted();
 
         let txid = transaction.tx_hash();
         let caches = self.build_verification_caches(transaction.clone());
@@ -253,8 +255,6 @@ impl ConsensusApi {
         self.api_sender
             .send(ApiEvent::Transaction(transaction))
             .await?;
-
-        dbtx.cancel();
 
         Ok(())
     }

--- a/integrationtests/tests/fixtures/legacy.rs
+++ b/integrationtests/tests/fixtures/legacy.rs
@@ -427,13 +427,17 @@ impl ILegacyTestClient for LegacyTestUser<UserClientConfig> {
         );
         let mut builder = TransactionBuilder::default();
         builder.output(Output::LN(offer_output));
-        block_on(builder.build_with_change(
+        let res = block_on(builder.build_with_change(
             self.client.mint_client(),
             &mut dbtx,
             rng(),
             vec![],
             &fixtures::secp(),
         ))
-        .into_type_erased()
+        .into_type_erased();
+
+        block_on(dbtx.commit_tx());
+
+        res
     }
 }


### PR DESCRIPTION
Instead of trying to cancel dbtx at the end (which can be skipped
by an early return like `?`), mark uncommited writes as expected
upfront.