### PR TITLE
feat(mint-client): limit overpayment in OOB spends

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -20,7 +20,7 @@ use fedimint_ln_client::contracts::ContractId;
 use fedimint_ln_client::{
     InternalPayState, LightningClientExt, LnPayState, LnReceiveState, PayType,
 };
-use fedimint_mint_client::{MintClientExt, MintClientModule, OOBNotes};
+use fedimint_mint_client::{MintClientExt, MintClientModule, OOBMaxOverpay, OOBNotes};
 use fedimint_wallet_client::{WalletClientExt, WalletClientModule, WithdrawState};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -170,7 +170,7 @@ pub async fn handle_ng_command(
         }
         ClientCmd::Spend { amount } => {
             let (operation, notes) = client
-                .spend_notes(amount, Duration::from_secs(3600), ())
+                .spend_notes(amount, OOBMaxOverpay::Any, Duration::from_secs(3600), ())
                 .await?;
             info!("Spend e-cash operation: {operation}");
 

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -16,7 +16,7 @@ use fedimint_core::module::CommonModuleInit;
 use fedimint_core::{Amount, OutPoint, TieredSummary};
 use fedimint_ln_client::{LightningClientExt, LightningClientGen, LnPayState};
 use fedimint_mint_client::{
-    MintClientExt, MintClientGen, MintClientModule, MintCommonGen, OOBNotes,
+    MintClientExt, MintClientGen, MintClientModule, MintCommonGen, OOBMaxOverpay, OOBNotes,
 };
 use fedimint_wallet_client::WalletClientGen;
 use futures::StreamExt;
@@ -77,7 +77,7 @@ pub async fn do_spend_notes(
     amount: Amount,
 ) -> anyhow::Result<(OperationId, OOBNotes)> {
     let (operation_id, oob_notes) = client
-        .spend_notes(amount, Duration::from_secs(600), ())
+        .spend_notes(amount, OOBMaxOverpay::Any, Duration::from_secs(600), ())
         .await?;
     let mut updates = client
         .subscribe_spend_notes(operation_id)

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -1,10 +1,10 @@
-use fedimint_core::sats;
 use fedimint_core::util::NextOrPending;
+use fedimint_core::{sats, Amount};
 use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyGen;
 use fedimint_mint_client::{
-    MintClientExt, MintClientGen, ReissueExternalNotesState, SpendOOBState,
+    MintClientExt, MintClientGen, OOBMaxOverpay, ReissueExternalNotesState, SpendOOBState,
 };
 use fedimint_mint_common::config::MintGenParams;
 use fedimint_mint_server::MintGen;
@@ -24,7 +24,9 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     client1.await_primary_module_output(op, outpoint).await?;
 
     // Spend from client1 to client2
-    let (op, notes) = client1.spend_notes(sats(750), TIMEOUT, ()).await?;
+    let (op, notes) = client1
+        .spend_notes(sats(750), OOBMaxOverpay::Any, TIMEOUT, ())
+        .await?;
     let sub1 = &mut client1.subscribe_spend_notes(op).await?.into_stream();
     assert_eq!(sub1.ok().await?, SpendOOBState::Created);
 
@@ -38,5 +40,42 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
 
     assert_eq!(client1.get_balance().await, sats(250));
     assert_eq!(client2.get_balance().await, sats(750));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn oob_ecash_send_fails_if_wrong_denominations() -> anyhow::Result<()> {
+    // Print notes for client1
+    let fed = fixtures().new_fed().await;
+    let (client1, _client2) = fed.two_clients().await;
+    let (op, outpoint) = client1.print_money(sats(1000)).await?;
+    client1.await_primary_module_output(op, outpoint).await?;
+
+    loop {
+        match client1
+            .spend_notes(
+                Amount::from_msats(64),
+                OOBMaxOverpay::Limit {
+                    max_rel: 0.1,
+                    allow_below_abs: Amount::ZERO,
+                },
+                TIMEOUT,
+                (),
+            )
+            .await
+        {
+            Ok((_op_id, notes)) => {
+                assert!(notes.total_amount().msats < 71, "Overpaid by more than 10%");
+            }
+            Err(e) => {
+                assert!(
+                    e.to_string().contains("Would have overpaid"),
+                    "Expected overpayment error, got `{e:?}`"
+                );
+                break;
+            }
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Just mentioning it in the docs might be a bit too little to keep people from shooting themselves into the foot. This PR implements an easy-to-use overpay limit.