### PR TITLE
chore: let the ci tests rip in parallel on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1904,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-portalloc"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "fedimint-core",
+ "fs2",
+ "rand",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "fedimint-rocksdb"
 version = "0.1.0"
 dependencies = [
@@ -1955,6 +1990,7 @@ dependencies = [
  "fedimint-client",
  "fedimint-core",
  "fedimint-logging",
+ "fedimint-portalloc",
  "fedimint-rocksdb",
  "fedimint-server",
  "futures",
@@ -1995,6 +2031,7 @@ dependencies = [
  "fedimint-logging",
  "fedimint-mint-client",
  "fedimint-mint-server",
+ "fedimint-portalloc",
  "fedimint-rocksdb",
  "fedimint-server",
  "fedimint-testing",
@@ -2245,6 +2282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3646,6 +3693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,6 +4246,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "modules/fedimint-wallet-client",
     "modules/fedimint-wallet-server",
     "modules/fedimint-wallet-tests",
+    "utils/portalloc",
     "devimint",
     "integrationtests",
     "fedimint-build",

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -43,3 +43,4 @@ tokio = { version = "1.26.0", features = ["full"] }
 tokio-stream = "0.1.11"
 tonic_lnd = { git = "https://github.com/fedimint/tonic_lnd", branch="lnd-client-features", features = ["lightningrpc", "routerrpc"] }
 url = "2.3.1"
+fedimint-portalloc = { path = "../utils/portalloc" }

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -47,3 +47,4 @@ tracing ="0.1.37"
 url = "2.3.1"
 hbbft = { git = "https://github.com/fedimint/hbbft" }
 threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
+fedimint-portalloc = { path = "../utils/portalloc" }

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ check-ulimit:
 
 # run tests
 test: build check-ulimit
-  cargo test
+  cargo nexttest run
 
 # run tests against real services (like bitcoind)
 test-real: check-ulimit
@@ -57,6 +57,7 @@ udeps:
 
 # run all checks recommended before opening a PR
 final-check: lint
+  # can't use nextest due to: https://github.com/nextest-rs/nextest/issues/16
   cargo test --doc
   just check-wasm
   just test

--- a/nix/craneCommon.nix
+++ b/nix/craneCommon.nix
@@ -97,8 +97,6 @@ craneLib.overrideScope' (self: prev: {
       rocksdb
       protobuf
 
-      moreutils-ts
-      parallel
     ] ++ lib.optionals (!stdenv.isDarwin) [
       util-linux
       iproute2
@@ -128,6 +126,9 @@ craneLib.overrideScope' (self: prev: {
       pkgs-kitman.esplora
       procps
       which
+      cargo-nextest
+      moreutils-ts
+      parallel
     ];
 
     # we carefully optimize our debug symbols on cargo level,

--- a/scripts/dev/run-isolated-test/fm-run-isolated-test
+++ b/scripts/dev/run-isolated-test/fm-run-isolated-test
@@ -15,13 +15,8 @@ echo "## START: $test_name"
 
 export FM_TEST_NAME="$test_name"
 
-# We rely on `unshare` to run all tests in separate network namespaces,
-# Not possible on MacOS though
-if [ "$(uname -s)" == "Darwin" ]; then
-    >&2 echo "MacOS hack: no-op run-in-namespace isolation"
-    "$@" 2>&1 | ts -s
-else
-    unshare -rn bash -c "ip link set lo up && exec unshare --user $*" 2>&1 | ts -s
-fi
+# Note: before we fixed port allocation we run in different namespaces like this:
+# unshare -rn bash -c "ip link set lo up && exec unshare --user $*" 2>&1 | ts -s
+"$@" 2>&1 | ts -s
 
 echo "## COMPLETE: $test_name"

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -85,12 +85,6 @@ export -f always_success_test
 
 export parallel_jobs='+0'
 
-if [ "$(uname -s)" == "Darwin" ]; then
-  # We rely on `unshare` to run all tests in separate network namespaces
-  # This is not possible on MacOS, so we run every test serially with a no-op fake 'unshare'
-  parallel_jobs='1'
-fi
-
 tmpdir=$(mktemp --tmpdir -d XXXXX)
 trap 'rm -r $tmpdir' EXIT
 joblog="$tmpdir/joblog"

--- a/utils/portalloc/Cargo.toml
+++ b/utils/portalloc/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "fedimint-portalloc"
+version = "0.1.0"
+authors = ["The Fedimint Developers"]
+edition = "2021"
+description = "Port allocation utility for Fedimint"
+license = "MIT"
+
+[lib]
+name = "fedimint_portalloc"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "1.0.65"
+fs2 = "0.4.3"
+serde = { version = "1.0.149", features = [ "derive" ] }
+serde_json = { version = "1.0.91", features = ["preserve_order"] }
+tracing = "0.1.37"
+rand = "0.8"
+dirs = "5.0.1"
+fedimint-core = { path = "../../fedimint-core" }

--- a/utils/portalloc/src/data.rs
+++ b/utils/portalloc/src/data.rs
@@ -1,0 +1,124 @@
+mod dto;
+
+use std::path::PathBuf;
+use std::time::Duration;
+use std::{fs, thread};
+
+use anyhow::{bail, Result};
+use fs2::FileExt;
+use tracing::{debug, info, warn};
+
+use crate::util;
+
+/// Root directory where we keep the lock & data file
+pub struct DataDir {
+    path: PathBuf,
+    lock_file: fs::File,
+}
+
+impl DataDir {
+    pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        ensure_root_exists(&path)?;
+
+        let lock = util::open_lock_file(&path)?;
+
+        Ok(Self {
+            path,
+            lock_file: lock,
+        })
+    }
+
+    pub fn with_lock<T>(&mut self, f: impl FnOnce(&mut LockedRoot) -> Result<T>) -> Result<T> {
+        f(&mut LockedRoot::new(&self.path, &mut self.lock_file)?)
+    }
+}
+
+fn ensure_root_exists(dir: &PathBuf) -> Result<()> {
+    if !dir.try_exists()? {
+        info!(dir = %dir.display(), "Creating root dir");
+        fs::create_dir_all(dir)?;
+    }
+    Ok(())
+}
+
+/// A handle passed to `with_lock` argument after root was acquired
+pub struct LockedRoot<'a> {
+    path: &'a PathBuf,
+    lock_file: &'a mut fs::File,
+    locked: bool,
+}
+
+impl<'a> Drop for LockedRoot<'a> {
+    fn drop(&mut self) {
+        if self.locked {
+            let Ok(()) = self.lock_file.unlock() else {
+                warn!("Failed to release the lock file");
+                return;
+            };
+            self.locked = false;
+        }
+    }
+}
+
+impl<'a> LockedRoot<'a> {
+    fn new(path: &'a PathBuf, lock_file: &'a mut fs::File) -> Result<Self> {
+        let mut locked_root = Self {
+            path,
+            lock_file,
+            locked: false,
+        };
+        locked_root.lock()?;
+        Ok(locked_root)
+    }
+
+    fn lock(&mut self) -> Result<()> {
+        debug!(path = %self.path.display(), "Acquiring lock...");
+        if self.lock_file.try_lock_exclusive().is_err() {
+            info!("Lock taken, waiting...");
+            self.lock_file.lock_exclusive()?;
+        };
+        debug!("Acquired lock");
+        self.locked = true;
+        Ok(())
+    }
+
+    fn unlock(&mut self) -> Result<()> {
+        self.ensure_locked()?;
+        debug!(path = %self.path.display(), "Releasing lock...");
+        self.lock_file.unlock()?;
+        self.locked = false;
+        Ok(())
+    }
+
+    fn data_file_path(&self) -> PathBuf {
+        self.path.join("fm-portalloc.json")
+    }
+
+    fn ensure_locked(&self) -> anyhow::Result<()> {
+        if !self.locked {
+            bail!("LockedRoot no longer valid");
+        }
+        Ok(())
+    }
+
+    pub fn r#yield(&mut self, duration: Duration) -> Result<()> {
+        self.unlock()?;
+        thread::sleep(duration);
+        self.lock()?;
+        Ok(())
+    }
+    pub fn load_data(&self, now: u64) -> Result<dto::RootData> {
+        self.ensure_locked()?;
+        let path = self.data_file_path();
+        if !path.try_exists()? {
+            return Ok(Default::default());
+        }
+        let root_data: dto::RootData = serde_json::from_reader::<_, _>(std::fs::File::open(path)?)?;
+        Ok(root_data.reclaim(now))
+    }
+
+    pub fn store_data(&mut self, data: &dto::RootData) -> Result<()> {
+        util::store_json_pretty_to_file(&self.data_file_path(), data)
+    }
+}

--- a/utils/portalloc/src/data/dto.rs
+++ b/utils/portalloc/src/data/dto.rs
@@ -1,0 +1,49 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct RangeData {
+    size: u16,
+    /// local time unix timestamp
+    expires: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct RootData {
+    pub keys: BTreeMap<u16, RangeData>,
+}
+
+impl RootData {
+    pub fn reclaim(self, now: u64) -> Self {
+        Self {
+            keys: self
+                .keys
+                .into_iter()
+                .filter(|(_k, v)| now < v.expires)
+                .collect(),
+        }
+    }
+
+    pub fn contains(&self, range: &std::ops::Range<u16>) -> bool {
+        self.keys.iter().any(|(k, v)| {
+            let start = *k;
+            let end = start + v.size;
+
+            start < range.end && range.start < end
+        })
+    }
+
+    pub fn insert(&mut self, range: std::ops::Range<u16>, now_ts: u64) {
+        assert!(!self.contains(&range));
+        self.keys.insert(
+            range.start,
+            RangeData {
+                size: range.len() as u16,
+                expires: now_ts,
+            },
+        );
+    }
+}

--- a/utils/portalloc/src/lib.rs
+++ b/utils/portalloc/src/lib.rs
@@ -1,0 +1,104 @@
+//! A library for cooperative port allocation between multiple processes.
+//!
+//! Fedimint tests in many places need to allocate ranges of unused ports for
+//! Federations and other software under tests, without being able to `bind`
+//! them beforehand.
+//!
+//! We used to mitigate that using a global per-process atomic counter, as
+//! as simple port allocation mechanism. But this does not prevent conflicts
+//! between different processes.
+//!
+//! Normally this would prevent us from running multiple tests at the same time,
+//! which also makes it impossible to use `cargo nextest`.
+//!
+//! This library keeps track of allocated ports (with an expiration timeout) in
+//! a shared file, protected by an advisory fs lock, and uses `bind` to make
+//! sure a given port is actually free
+
+pub mod data;
+pub mod util;
+
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::time::{Duration, UNIX_EPOCH};
+
+use anyhow::bail;
+use rand::{thread_rng, Rng};
+use tracing::warn;
+
+use crate::data::DataDir;
+
+type UnixTimstap = u64;
+
+pub fn now_ts() -> UnixTimstap {
+    fedimint_core::time::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("localt time out of valid range")
+        .as_secs()
+}
+
+pub fn data_dir() -> anyhow::Result<PathBuf> {
+    if let Some(env) = std::env::var_os("FM_PORTALLOC_DATA_DIR") {
+        Ok(PathBuf::from(env))
+    } else if let Some(dir) = dirs::cache_dir() {
+        Ok(dir.join("fm-portalloc"))
+    } else {
+        bail!("Could not determine port alloc data dir. Try setting FM_PORTALLOC_DATA_DIR");
+    }
+}
+pub fn port_alloc(range_size: u16) -> anyhow::Result<u16> {
+    if range_size == 0 {
+        bail!("Can't allocate range of 0 bytes");
+    }
+
+    let mut data_dir = DataDir::new(data_dir()?)?;
+
+    // ports below 10k are typically used by normal software increasing change they
+    // would get in a way
+    const LOW: u16 = 10000;
+    // ports above 32k are typically ephmeral increasing a chance of random conflict
+    // after port was already tried
+    const HIGH: u16 = 32000;
+
+    data_dir.with_lock(|data_dir| {
+        // `_listeners` are here only to prevent other processes from binding until
+        // the port was allocated
+        Ok('retry: loop {
+            let mut data = data_dir.load_data(now_ts())?;
+
+            let base_port: u16 = thread_rng().gen_range(LOW..HIGH - range_size);
+            let range = base_port..base_port + range_size;
+            if data.contains(&range) {
+                warn!(
+                    base_port,
+                    range_size,
+                    "Could not use a port (already reserved). Will try a different range."
+                );
+                data_dir.r#yield(Duration::from_millis(100))?;
+                continue 'retry;
+            }
+
+            for port in range.clone() {
+                match TcpListener::bind(("127.0.0.1", port)) {
+                    Err(error) => {
+                        warn!(
+                            ?error,
+                            port, "Could not use a port. Will try a different range"
+                        );
+                        data_dir.r#yield(Duration::from_millis(100))?;
+                        continue 'retry;
+                    }
+                    Ok(l) => l,
+                };
+            }
+
+            // The caller gets 120 seconds to use the port (`bind`), to prevent
+            // other callers from re-using it.
+            data.insert(range, now_ts() + 120);
+
+            data_dir.store_data(&data)?;
+
+            break base_port;
+        })
+    })
+}

--- a/utils/portalloc/src/util.rs
+++ b/utils/portalloc/src/util.rs
@@ -1,0 +1,50 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+
+use serde::Serialize;
+use tracing::debug;
+
+pub fn open_lock_file(root_path: &Path) -> anyhow::Result<fs::File> {
+    let path = root_path.join("lock");
+    debug!(path = %path.display(), "Opening lock file...");
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .write(true)
+        .read(true)
+        .open(path.clone())?;
+    debug!(path = %path.display(), "Opened lock file");
+    Ok(file)
+}
+
+pub fn store_json_pretty_to_file<T>(path: &Path, val: &T) -> anyhow::Result<()>
+where
+    T: Serialize,
+{
+    Ok(store_to_file_with(path, |f| {
+        serde_json::to_writer_pretty(f, val).map_err(Into::into)
+    })
+    .and_then(|res| res)?)
+}
+
+pub fn store_to_file_with<E, F>(path: &Path, f: F) -> io::Result<Result<(), E>>
+where
+    F: Fn(&mut dyn io::Write) -> Result<(), E>,
+{
+    std::fs::create_dir_all(path.parent().expect("Not a root path"))?;
+    let tmp_path = path.with_extension("tmp");
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&tmp_path)?;
+    if let Err(e) = f(&mut file) {
+        return Ok(Err(e));
+    }
+    file.flush()?;
+    file.sync_data()?;
+    drop(file);
+    std::fs::rename(tmp_path, path)?;
+    Ok(Ok(()))
+}


### PR DESCRIPTION
On top of #3156

As the port allocation was fixed and we should no longer have any
port allocation failures, we don't need to use `unshare` to isolate
CI tests, enabling MacOS to run them in parallel as well.

You still should consider using freedom preserving software like Linux instead.