### PR TITLE
chore: check in updated Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
Somehow master has an out-of-date `Cargo.lock`, I thought we had a test against that @dpc? Or is something weird with my local env? I already updated the nix shell I'm using.