### PR TITLE
feat: set task names

### DIFF
--- a/.semgrep.all.yaml
+++ b/.semgrep.all.yaml
@@ -45,6 +45,13 @@ rules:
     - pattern: tokio::fs::File::create
   severity: WARNING
 
+- id: ban-tokio-spawn
+  languages:
+    - rust
+  message: "`tokio::spawn` won't set task name by default. use `fedimint_core::task::spawn` instead"
+  pattern: tokio::spawn
+  severity: WARNING
+
 - id: ban-tokio-sleep
   languages:
     - rust

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -32,7 +32,7 @@ ln-gateway = { path = "../gateway/ln-gateway" }
 nix = { version = "0.26.2", features = ["signal"] }
 rand = "0.8.5"
 serde_json = "1.0.94"
-tokio = { version = "1.26.0", features = ["full"] }
+tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tonic_lnd = { git = "https://github.com/fedimint/tonic_lnd", branch="master", features = ["lightningrpc", "routerrpc"] }
 tower-http = { version = "0.4.3", features = ["cors", "auth"] }
 tracing = "0.1.37"

--- a/fedimint-atomic-broadcast/src/spawner.rs
+++ b/fedimint-atomic-broadcast/src/spawner.rs
@@ -8,18 +8,18 @@ impl Spawner {
 }
 
 impl aleph_bft::SpawnHandle for Spawner {
-    fn spawn(&self, _name: &str, task: impl futures::Future<Output = ()> + Send + 'static) {
-        tokio::spawn(task);
+    fn spawn(&self, name: &str, task: impl futures::Future<Output = ()> + Send + 'static) {
+        fedimint_core::task::spawn(name, task);
     }
 
     fn spawn_essential(
         &self,
-        _: &str,
+        name: &str,
         task: impl futures::Future<Output = ()> + Send + 'static,
     ) -> aleph_bft::TaskHandle {
         let (res_tx, res_rx) = futures::channel::oneshot::channel();
 
-        tokio::spawn(async move {
+        fedimint_core::task::spawn(name, async move {
             task.await;
             res_tx.send(()).expect("We own the rx.");
         });

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -37,7 +37,7 @@ fedimint-server = { path = "../fedimint-server" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 thiserror = "1.0.39"
-tokio = { version = "1.26.0", features = ["full"] }
+tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tracing ="0.1.37"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 serde_json = { version = "1.0.91", features = ["preserve_order"] }

--- a/fedimint-client-legacy/Cargo.toml
+++ b/fedimint-client-legacy/Cargo.toml
@@ -60,6 +60,6 @@ jsonrpsee-wasm-client = { version = "0.18.0" }
 ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js", "wasm32_c"] }
 
 [dev-dependencies]
-tokio = { version = "1.26.0", features = ["full"] }
+tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 once_cell = "1.16.0"

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -270,7 +270,7 @@ where
         );
 
         let task_runner_inner = self.inner.clone();
-        let _handle = spawn(async move {
+        let _handle = spawn("client state machine", async move {
             let executor_runner = task_runner_inner.run(context_gen);
             select! {
                 shutdown_happened_sender = shutdown_receiver => {

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -51,7 +51,7 @@ bitvec = "1.0.1"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 jsonrpsee-ws-client = { version = "0.18.0", features = ["webpki-tls"], default-features = false }
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.25.0", features = ["full", "tracing"] }
 tokio-rustls = "0.23.4"
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -2409,15 +2409,17 @@ mod tests {
 
     use super::mem_impl::MemDatabase;
     use super::*;
+    use crate::task::spawn;
 
     async fn waiter(db: &Database, key: TestKey) -> tokio::task::JoinHandle<TestVal> {
         let db = db.clone();
         let (tx, rx) = oneshot::channel::<()>();
-        let join_handle = tokio::spawn(async move {
+        let join_handle = spawn("wait key exists", async move {
             let sub = db.wait_key_exists(&key);
             tx.send(()).unwrap();
             sub.await
-        });
+        })
+        .expect("some handle on non-wasm");
         rx.await.unwrap();
         join_handle
     }

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -30,7 +30,7 @@ lightning-invoice = { version = "0.24.0", features = [ "serde" ] }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full", "tracing"] }
 tracing = "0.1"
 url = { version = "2.3.1", features = ["serde"] }
 

--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -77,6 +77,7 @@ impl TracingSetup {
         };
 
         let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_thread_names(false) // can be enabled for debugging
             .with_writer(fmt_writer)
             .with_filter(filter_layer);
 

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -39,7 +39,7 @@ tracing ="0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
-tokio = { version = "1.26.0", features = ["full"] }
+tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tokio-stream = "0.1.11"
 tokio-rustls = "0.23.4"
 tokio-util = { version = "0.7.4", features = [ "codec" ] }

--- a/fedimint-server/src/config/distributedgen.rs
+++ b/fedimint-server/src/config/distributedgen.rs
@@ -11,6 +11,7 @@ use fedimint_core::config::{DkgGroup, DkgMessage, DkgPeerMsg, DkgResult, ISuppor
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::module::PeerHandle;
 use fedimint_core::net::peers::MuxPeerConnections;
+use fedimint_core::task::spawn;
 use fedimint_core::{BitcoinHash, PeerId};
 use hbbft::crypto::poly::Commitment;
 use hbbft::crypto::{G1Projective, G2Projective, PublicKeySet, SecretKeyShare};
@@ -315,7 +316,7 @@ where
                 let key = serde_json::to_string(&key).expect("serialization can't fail");
                 let send = send.clone();
 
-                tokio::spawn(async move {
+                spawn("dkg runner", async move {
                     let (dkg, step) = Dkg::new(group, our_id, peers, threshold, &mut OsRng);
                     let result =
                         Self::run_dkg_key((module_id, key.clone()), connections, dkg, step).await;

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 use async_trait::async_trait;
 use fedimint_core::cancellable::{Cancellable, Cancelled};
 use fedimint_core::net::peers::{IMuxPeerConnections, PeerConnections};
+use fedimint_core::task::spawn;
 use fedimint_logging::LOG_NET_PEER;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -79,13 +80,16 @@ where
         let (receive_callbacks_tx, receive_callbacks_rx) = channel(1000);
         let (peer_bans_tx, peer_bans_rx) = channel(1000);
 
-        tokio::spawn(Self::run(
-            connections,
-            Default::default(),
-            send_requests_rx,
-            receive_callbacks_rx,
-            peer_bans_rx,
-        ));
+        spawn(
+            "peer connection multiplexer",
+            Self::run(
+                connections,
+                Default::default(),
+                send_requests_rx,
+                receive_callbacks_rx,
+                peer_bans_rx,
+            ),
+        );
 
         Self {
             send_requests_tx,

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1.0.149", features = [ "derive" ] }
 tracing ="0.1.37"
 rand = "0.8"
 tokio-rustls = "0.23.4"
-tokio = { version = "1.26.0", features = ["full"] }
+tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tokio-stream = "0.1.11"
 tonic_lnd = { git = "https://github.com/fedimint/tonic_lnd", branch="lnd-client-features", features = ["lightningrpc", "routerrpc"] }
 url = "2.3.1"

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -40,7 +40,7 @@ fedimint-client-legacy = { path = "../fedimint-client-legacy" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"
-tokio = { version = "1.26.0", features = ["full"] }
+tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tokio-rustls = "0.23.4"
 tokio-stream = "0.1.11"
 tracing ="0.1.37"


### PR DESCRIPTION
This helps debugging by giving tasks some meaningful name, which will show by tokio on trace debugging level.

It doesn't fully acomplish my original goal that was setting a name for threads, but it's a improvement nonetheless.