### PR TITLE
chore: open issue when backport bot fails

### DIFF
--- a/.github/templates/failed-backport-issue.md
+++ b/.github/templates/failed-backport-issue.md
@@ -1,0 +1,4 @@
+---
+title: Backport #{{ env.PR_NUMBER }}
+---
+The backport bot was unable to open a pull request to backport changes from PR #{{ env.PR_NUMBER }}. Please open a PR to backport these changes.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,3 +18,18 @@ jobs:
         uses: korthout/backport-action@v1
         with:
           github_token: ${{ secrets.BACKPORT_TOKEN }}
+  open-issue:
+    name: Open issue for failed backports
+    runs-on: ubuntu-latest
+    needs: backport
+    steps:
+      - uses: actions/checkout@v4
+        # Open an issue only if the backport job failed
+        if: ${{ needs.backport.outputs.was_successful }} == 'false'
+      - name: Create issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+        with:
+          filename: .github/templates/failed-backport-issue.md


### PR DESCRIPTION
Addresses what was [discussed](https://github.com/fedimint/fedimint/issues/3137#issuecomment-1714229910) on the dev call to open an issue automatically when the backport bot fails.

I'm not sure how to test this prior to merging. Perhaps a sane strategy is to carefully review then quickly revert if we notice unwanted behavior?

Useful for reviewing
- `create-an-issue` GH [action](https://github.com/marketplace/actions/create-an-issue)
- backport action [outputs](https://github.com/korthout/backport-action#outputs) (specifically `was_successful`)
- Consuming outputs from previous jobs [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs)
  - outputs are unicode strings
- Referencing PR number
  - GH [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow)
  - [SO](https://stackoverflow.com/a/62436027)