### PR TITLE
fix: mprocs doesn't work when nushell is a login shell

### DIFF
--- a/misc/mprocs.yaml
+++ b/misc/mprocs.yaml
@@ -1,7 +1,7 @@
 server: 127.0.0.1:4050
 procs:
   user:
-    shell: bash --init-file scripts/dev/mprocs/user-shell.sh
+    shell: bash -c scripts/dev/mprocs/user-shell.sh
     stop: SIGKILL
   fedimint0:
     shell: tail -n +0 -F $FM_LOGS_DIR/fedimintd-0.log

--- a/scripts/dev/user-shell.sh
+++ b/scripts/dev/user-shell.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
 eval "$(devimint env)"
@@ -26,3 +27,7 @@ echo "  gateway-cln    - cli client for the CLN gateway"
 echo "  gateway-lnd    - cli client for the LND gateway"
 echo
 echo "Use '--help' on each command for more information"
+
+# exec into a new bash instance that will ask for commands
+# --norc to avoid touching the environment in any way
+exec bash --norc


### PR DESCRIPTION
As a new Nushell user, I'll now be fixing all sorts of software just to have stuff that used to work, work again. Everybody makes bad life choices sometimes, right? Right? :shrug:

Before approving, please try `just mprocs` in your shell. BTW. Add to your `~/.gitconfig` this convenient alias:

```
[alias]
pr = "!f() { git fetch -fu ${2:-$(git remote |grep '^upstream$' || echo origin)} refs/pull/$1/head:pr/$1 && git checkout pr/$1; }; f"
```

So you can `git pr 3191` to do it.