### PR TITLE
feat: create a span for traceability of tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,6 +1574,7 @@ dependencies = [
  "fedimint-testing",
  "threshold_crypto",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/fedimint-atomic-broadcast/tests/integration.rs
+++ b/fedimint-atomic-broadcast/tests/integration.rs
@@ -10,6 +10,7 @@ use fedimint_core::task::{sleep, spawn};
 use fedimint_core::PeerId;
 use secp256k1_zkp::{rand, Secp256k1, SecretKey};
 use tokio::task::JoinHandle;
+use tracing::instrument;
 
 fn to_peer_id(peer_index: usize) -> PeerId {
     u16::try_from(peer_index)
@@ -177,6 +178,7 @@ impl Federation {
 }
 
 #[tokio::test]
+#[instrument(level = "info")]
 #[ignore] // https://github.com/fedimint/fedimint/issues/2741 too slow
 async fn crash_recovery() {
     let subscriber = tracing_subscriber::FmtSubscriber::new();

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -341,6 +341,7 @@ mod tests {
     use fedimint_core::db::Database;
     use futures::stream::StreamExt;
     use serde::{Deserialize, Serialize};
+    use tracing::instrument;
 
     use super::UpdateStreamOrOutcome;
     use crate::db::ChronologicalOperationLogKey;
@@ -381,6 +382,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_operation_log_update() {
         let op_id = OperationId([0x32; 32]);
 
@@ -419,6 +421,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_operation_log_update_from_stream() {
         let op_id = OperationId([0x32; 32]);
 
@@ -445,6 +448,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_pagination() {
         let db = Database::new(MemDatabase::new(), Default::default());
         let op_log = OperationLog::new(db.clone());

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -935,7 +935,7 @@ mod tests {
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::task::{self};
     use tokio::sync::broadcast::Sender;
-    use tracing::{info, trace};
+    use tracing::{info, instrument, trace};
 
     use crate::sm::state::{Context, DynContext, DynState};
     use crate::sm::{Executor, Notifier, OperationId, State, StateTransition};
@@ -1067,6 +1067,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     #[tracing_test::traced_test]
     async fn test_executor() {
         const MOCK_INSTANCE_1: ModuleInstanceId = 42;

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -255,6 +255,7 @@ mod tests {
     use serde_json::Value;
     use tokio::sync::Mutex;
     use tokio::time::timeout;
+    use tracing::instrument;
 
     use crate::sm::{ClientSMDatabaseTransaction, Executor, Notifier, OperationId, OperationState};
     use crate::transaction::{
@@ -436,6 +437,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     #[tracing_test::traced_test]
     async fn test_submission() {
         let db = Database::new(

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -1632,6 +1632,7 @@ mod test_utils {
     use std::time::Duration;
 
     use futures::{Future, FutureExt, StreamExt};
+    use tracing::instrument;
 
     use super::{
         apply_migrations, Database, DatabaseTransaction, DatabaseVersion, DatabaseVersionKey,
@@ -2212,6 +2213,7 @@ mod test_utils {
 
     #[cfg(test)]
     #[tokio::test]
+    #[instrument(level = "info")]
     pub async fn verify_test_migration() {
         // Insert a bunch of old dummy data that needs to be migrated to a new version
         let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
@@ -2276,6 +2278,7 @@ mod test_utils {
 
     #[cfg(test)]
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_autocommit() {
         use std::marker::PhantomData;
 
@@ -2425,6 +2428,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_wait_key_before_transaction() {
         let key = TestKey(1);
         let val = TestVal(2);
@@ -2444,6 +2448,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_wait_key_before_insert() {
         let key = TestKey(1);
         let val = TestVal(2);
@@ -2462,6 +2467,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_wait_key_after_insert() {
         let key = TestKey(1);
         let val = TestVal(2);
@@ -2482,6 +2488,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_wait_key_after_commit() {
         let key = TestKey(1);
         let val = TestVal(2);
@@ -2500,6 +2507,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_wait_key_isolated_db() {
         let module_instance_id = 10;
         let key = TestKey(1);
@@ -2521,6 +2529,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_wait_key_isolated_tx() {
         let module_instance_id = 10;
         let key = TestKey(1);
@@ -2543,6 +2552,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_wait_key_no_transaction() {
         let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
 

--- a/fedimint-core/src/db/notifications.rs
+++ b/fedimint-core/src/db/notifications.rs
@@ -188,10 +188,12 @@ impl<'a> ISingleUseDatabaseTransaction<'a> for NotifyingTransaction<'a> {
 #[cfg(test)]
 mod tests {
     use fedimint_core::db::test_utils::future_returns_shortly;
+    use tracing::instrument;
 
     use super::*;
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_notification_after_notify() {
         let notifs = Notifications::new();
         let key = 1;
@@ -201,6 +203,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_no_notification_without_notify() {
         let notifs = Notifications::new();
         let key = 1;
@@ -212,6 +215,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_multi() {
         let notifs = Notifications::new();
         let key1 = 1;
@@ -231,6 +235,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_notify_queue() {
         let notifs = Notifications::new();
         let key1 = 1;

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -214,6 +214,7 @@ mod tests {
 
     use fedimint_core::task::Elapsed;
     use futures::FutureExt;
+    use tracing::instrument;
 
     use crate::task::timeout;
     use crate::util::{NextOrPending, SafeUrl};
@@ -266,6 +267,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_next_or_pending() {
         let mut stream = futures::stream::iter(vec![1, 2]);
         assert_eq!(stream.next_or_pending().now_or_never(), Some(1));

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -311,6 +311,7 @@ mod fedimint_rocksdb_tests {
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::{impl_db_lookup, impl_db_record};
     use futures::StreamExt;
+    use tracing::instrument;
 
     use super::*;
 
@@ -327,12 +328,14 @@ mod fedimint_rocksdb_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_insert_elements() {
         fedimint_core::db::verify_insert_elements(open_temp_db("fcb-rocksdb-test-insert-elements"))
             .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_remove_nonexisting() {
         fedimint_core::db::verify_remove_nonexisting(open_temp_db(
             "fcb-rocksdb-test-remove-nonexisting",
@@ -341,18 +344,21 @@ mod fedimint_rocksdb_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_remove_existing() {
         fedimint_core::db::verify_remove_existing(open_temp_db("fcb-rocksdb-test-remove-existing"))
             .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_read_own_writes() {
         fedimint_core::db::verify_read_own_writes(open_temp_db("fcb-rocksdb-test-read-own-writes"))
             .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_prevent_dirty_reads() {
         fedimint_core::db::verify_prevent_dirty_reads(open_temp_db(
             "fcb-rocksdb-test-prevent-dirty-reads",
@@ -361,17 +367,20 @@ mod fedimint_rocksdb_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_find_by_prefix() {
         fedimint_core::db::verify_find_by_prefix(open_temp_db("fcb-rocksdb-test-find-by-prefix"))
             .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_commit() {
         fedimint_core::db::verify_commit(open_temp_db("fcb-rocksdb-test-commit")).await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_prevent_nonrepeatable_reads() {
         fedimint_core::db::verify_prevent_nonrepeatable_reads(open_temp_db(
             "fcb-rocksdb-test-prevent-nonrepeatable-reads",
@@ -380,6 +389,7 @@ mod fedimint_rocksdb_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_rollback_to_savepoint() {
         fedimint_core::db::verify_rollback_to_savepoint(open_temp_db(
             "fcb-rocksdb-test-rollback-to-savepoint",
@@ -388,18 +398,21 @@ mod fedimint_rocksdb_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_phantom_entry() {
         fedimint_core::db::verify_phantom_entry(open_temp_db("fcb-rocksdb-test-phantom-entry"))
             .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_write_conflict() {
         fedimint_core::db::expect_write_conflict(open_temp_db("fcb-rocksdb-test-write-conflict"))
             .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_dbtx_remove_by_prefix() {
         fedimint_core::db::verify_remove_by_prefix(open_temp_db(
             "fcb-rocksdb-test-remove-by-prefix",
@@ -408,12 +421,14 @@ mod fedimint_rocksdb_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_module_dbtx() {
         fedimint_core::db::verify_module_prefix(open_temp_db("fcb-rocksdb-test-module-prefix"))
             .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_module_db() {
         let module_instance_id = 1;
         let path = tempfile::Builder::new()
@@ -434,6 +449,7 @@ mod fedimint_rocksdb_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     #[should_panic(expected = "Cannot isolate and already isolated database.")]
     async fn test_cannot_isolate_already_isolated_db() {
         let module_instance_id = 1;
@@ -502,6 +518,7 @@ mod fedimint_rocksdb_tests {
     impl_db_lookup!(key = TestKey2, query_prefix = DbPrefixTestPrefixMax);
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_retrieve_descending_order() {
         let path = tempfile::Builder::new()
             .prefix("fcb-rocksdb-test-descending-order")

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -156,6 +156,7 @@ mod fedimint_migration_tests {
     use secp256k1_zkp::Message;
     use strum::IntoEnumIterator;
     use threshold_crypto::SignatureShare;
+    use tracing::instrument;
 
     use super::{
         AcceptedTransactionKey, ClientConfigSignatureKey, ClientConfigSignatureSharePrefix,
@@ -263,6 +264,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn prepare_db_migration_snapshots() -> anyhow::Result<()> {
         prepare_db_migration_snapshot(
             "global-v0",
@@ -281,6 +283,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_migrations() -> anyhow::Result<()> {
         validate_migrations(
             "global",

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -733,10 +733,12 @@ mod tests {
     use std::time::Duration;
 
     use fedimint_core::task;
+    use tracing::instrument;
 
     use crate::net::api::ExpiringCache;
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_expiring_cache() {
         let cache = ExpiringCache::new(Duration::from_secs(1));
         let mut counter = 0;

--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -268,7 +268,7 @@ pub mod mock {
     use tokio::sync::mpsc::Sender;
     use tokio::sync::Mutex;
     use tokio_util::sync::CancellationToken;
-    use tracing::error;
+    use tracing::{error, instrument};
 
     use crate::net::connect::{parse_host_port, ConnectResult, Connector};
     use crate::net::framed::{BidiFramed, FramedTransport};
@@ -714,6 +714,7 @@ pub mod mock {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_mock_network() {
         let bind_addr: SocketAddr = "127.0.0.1:7000".parse().unwrap();
         let url: SafeUrl = "ws://127.0.0.1:7000".parse().unwrap();
@@ -746,6 +747,7 @@ pub mod mock {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_unreliable_components() {
         assert!(!FailureRate::new(0f64).random_fail());
         assert!(FailureRate::new(1f64).random_fail());
@@ -789,6 +791,7 @@ pub mod mock {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_large_messages() {
         let bind_addr: SocketAddr = "127.0.0.1:7000".parse().unwrap();
         let url: SafeUrl = "ws://127.0.0.1:7000".parse().unwrap();
@@ -839,6 +842,7 @@ mod tests {
     use fedimint_core::util::SafeUrl;
     use fedimint_core::PeerId;
     use futures::{SinkExt, StreamExt};
+    use tracing::instrument;
 
     use crate::config::gen_cert_and_key;
     use crate::net::connect::{ConnectionListener, Connector, TlsConfig};
@@ -872,6 +876,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn connect_success() {
         // FIXME: don't actually bind here, probably requires yet another Box<dyn Trait>
         // layer :(
@@ -909,6 +914,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn connect_reject() {
         let bind_addr: SocketAddr = "127.0.0.1:7001".parse().unwrap();
         let url: SafeUrl = "wss://127.0.0.1:7001".parse().unwrap();

--- a/fedimint-server/src/net/framed.rs
+++ b/fedimint-server/src/net/framed.rs
@@ -245,10 +245,12 @@ mod tests {
     use futures::{SinkExt, StreamExt};
     use serde::{Deserialize, Serialize};
     use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, ReadHalf, WriteHalf};
+    use tracing::instrument;
 
     use crate::net::framed::BidiFramed;
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_roundtrip() {
         #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
         enum TestEnum {
@@ -279,6 +281,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn test_not_try_parse_partial() {
         #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
         enum TestEnum {

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -112,12 +112,12 @@ impl Fixtures {
     }
 
     /// Starts a new federation with default number of peers for testing
-    pub async fn new_fed(&self) -> FederationTest {
-        self.new_fed_with_peers(self.num_peers).await
+    pub async fn new_fed(&self, span: tracing::Span) -> FederationTest {
+        self.new_fed_with_peers(self.num_peers, span).await
     }
 
     /// Starts a new federation with number of peers
-    pub async fn new_fed_with_peers(&self, num_peers: u16) -> FederationTest {
+    pub async fn new_fed_with_peers(&self, num_peers: u16, span: tracing::Span) -> FederationTest {
         FederationTest::new(
             num_peers,
             tokio::task::block_in_place(|| fedimint_portalloc::port_alloc(num_peers * 2))
@@ -126,6 +126,7 @@ impl Fixtures {
             ServerModuleInitRegistry::from(self.servers.clone()),
             ClientModuleInitRegistry::from(self.clients.clone()),
             self.primary_client,
+            span,
         )
         .await
     }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -25,7 +25,7 @@ use fedimint_server::FedimintServer;
 use fedimint_wallet_server::WalletGen;
 use futures::FutureExt;
 use tokio::select;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, debug_span, error, info, warn};
 
 use crate::attach_default_module_init_params;
 
@@ -302,15 +302,16 @@ async fn run(
         },
         db,
     };
+    let span = debug_span!("fedimintd");
     if let Some(bind_metrics_api) = opts.bind_metrics_api.as_ref() {
         let (api_result, metrics_api_result) = futures::join!(
-            api.run(task_group.clone()),
+            api.run(task_group.clone(), span),
             spawn_metrics_server(bind_metrics_api, task_group)
         );
         api_result?;
         metrics_api_result?;
     } else {
-        api.run(task_group).await?;
+        api.run(task_group, span).await?;
     }
     Ok(())
 }

--- a/gateway/ln-gateway/src/utils.rs
+++ b/gateway/ln-gateway/src/utils.rs
@@ -50,10 +50,12 @@ mod tests {
     use std::time::Duration;
 
     use anyhow::anyhow;
+    use tracing::instrument;
 
     use super::retry;
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn retry_succeed_with_one_attempt() {
         let counter = AtomicU8::new(0);
         let closure = || async {
@@ -68,6 +70,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[instrument(level = "info")]
     async fn retry_fail_with_three_attempts() {
         let counter = AtomicU8::new(0);
         let closure = || async {

--- a/gateway/ln-gateway/tests/fixtures.rs
+++ b/gateway/ln-gateway/tests/fixtures.rs
@@ -33,8 +33,10 @@ pub async fn fixtures() -> (
         .await
         .with_password(Some(DEFAULT_GATEWAY_PASSWORD.to_string()));
 
-    let fed1 = fixtures.new_fed().await;
-    let fed2 = fixtures.new_fed().await;
+    let span = tracing::info_span!("test_gateway_configuration");
+    let fed1 = fixtures.new_fed(span.clone()).await;
+    let fed2 = fixtures.new_fed(span.clone()).await;
+    let _enter = span.enter();
 
     (gateway, client, fed1, fed2, fixtures.bitcoin())
 }

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -11,8 +11,10 @@ use fedimint_testing::federation::FederationTest;
 use fedimint_testing::gateway::GatewayTest;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{BalancePayload, ConnectFedPayload};
+use tracing::instrument;
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_supports_connecting_multiple_federations() {
     let (_, rpc, fed1, fed2, _) = fixtures::fixtures().await;
 
@@ -39,6 +41,7 @@ async fn gatewayd_supports_connecting_multiple_federations() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_shows_info_about_all_connected_federations() {
     let (_, rpc, fed1, fed2, _) = fixtures::fixtures().await;
 
@@ -63,6 +66,7 @@ async fn gatewayd_shows_info_about_all_connected_federations() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_shows_balance_for_any_connected_federation() {
     let (gateway, rpc, fed1, fed2, _) = fixtures::fixtures().await;
 
@@ -85,6 +89,7 @@ async fn gatewayd_shows_balance_for_any_connected_federation() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_allows_deposit_to_any_connected_federation() -> anyhow::Result<()> {
     // todo: implement test case
 
@@ -92,6 +97,7 @@ async fn gatewayd_allows_deposit_to_any_connected_federation() -> anyhow::Result
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_allows_withdrawal_from_any_connected_federation() -> anyhow::Result<()> {
     // todo: implement test case
 
@@ -99,6 +105,7 @@ async fn gatewayd_allows_withdrawal_from_any_connected_federation() -> anyhow::R
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_supports_backup_of_any_connected_federation() -> anyhow::Result<()> {
     // todo: implement test case
 
@@ -106,6 +113,7 @@ async fn gatewayd_supports_backup_of_any_connected_federation() -> anyhow::Resul
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_supports_restore_of_any_connected_federation() -> anyhow::Result<()> {
     // todo: implement test case
 
@@ -115,6 +123,7 @@ async fn gatewayd_supports_restore_of_any_connected_federation() -> anyhow::Resu
 // Internal payments within a federation should not involve the gateway. See
 // Issue #613: Federation facilitates internal payments w/o involving gateway
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_pays_internal_invoice_within_a_connected_federation() -> anyhow::Result<()> {
     // todo: implement test case
 
@@ -122,6 +131,7 @@ async fn gatewayd_pays_internal_invoice_within_a_connected_federation() -> anyho
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_pays_outgoing_invoice_to_generic_ln() -> anyhow::Result<()> {
     // todo: implement test case
 
@@ -129,6 +139,7 @@ async fn gatewayd_pays_outgoing_invoice_to_generic_ln() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_pays_outgoing_invoice_between_federations_connected() -> anyhow::Result<()> {
     // todo: implement test case
 
@@ -136,6 +147,7 @@ async fn gatewayd_pays_outgoing_invoice_between_federations_connected() -> anyho
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn gatewayd_intercepts_htlc_and_settles_to_connected_federation() -> anyhow::Result<()> {
     // todo: implement test case
 

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -68,7 +68,7 @@ use rand::rngs::OsRng;
 use rand::RngCore;
 use tokio::sync::{Mutex, OnceCell};
 use tokio_rustls::rustls;
-use tracing::info;
+use tracing::{info, info_span};
 
 use crate::fixtures::user::ILegacyTestClient;
 use crate::ConsensusItem;
@@ -873,10 +873,12 @@ impl FederationTest {
     /// Runs the consensus APIs for clients to communicate with, returning the
     /// API handles
     pub async fn run_consensus_apis(&self) -> Vec<FedimintApiHandler> {
+        let span = info_span!("integration tests");
         let mut handles = vec![];
         for server in &self.servers {
             let s = server.lock().await;
-            handles.push(FedimintServer::spawn_consensus_api(&s.fedimint, true).await);
+            handles
+                .push(FedimintServer::spawn_consensus_api(&s.fedimint, true, span.clone()).await);
         }
         handles
     }

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -28,10 +28,12 @@ use fedimint_core::{msats, sats};
 use fedimint_server::epoch::ConsensusItem;
 use futures::future::{join_all, Either};
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
 
 use crate::fixtures::{peers, test};
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn wallet_peg_outs_must_wait_for_available_utxos() -> Result<()> {
     test(2, |fed, user, bitcoin| async move {
         // at least one epoch needed to establish fees
@@ -75,11 +77,13 @@ async fn wallet_peg_outs_must_wait_for_available_utxos() -> Result<()> {
 // this test had to be removed to switch to aleph bft and should be ported to
 // the new testing framework.
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn ecash_cannot_double_spent_with_different_nodes() -> Result<()> {
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn ecash_in_wallet_can_sent_through_a_tx() -> Result<()> {
     test(2, |fed, user_send, bitcoin| async move {
         let dummy_user = user_send.new_client_with_peers(peers(&[0]));
@@ -128,6 +132,7 @@ async fn ecash_in_wallet_can_sent_through_a_tx() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn runs_consensus_if_tx_submitted() -> Result<()> {
     test(2, |fed, user_send, bitcoin| async move {
         fed.run_consensus_epochs(1).await;
@@ -156,6 +161,7 @@ async fn runs_consensus_if_tx_submitted() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn runs_consensus_if_new_block() -> Result<()> {
     test(2, |fed, user, bitcoin| async move {
         // to assert we have no pending epochs, we need to make sure
@@ -194,6 +200,7 @@ async fn runs_consensus_if_new_block() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 #[should_panic]
 async fn audit_negative_balance_sheet_panics() {
     test(2, |fed, user, _| async move {
@@ -205,6 +212,7 @@ async fn audit_negative_balance_sheet_panics() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn unbalanced_transactions_get_rejected() -> Result<()> {
     test(2, |fed, user, _| async move {
         // cannot make change for this invoice (results in unbalanced tx)
@@ -217,6 +225,7 @@ async fn unbalanced_transactions_get_rejected() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn can_have_federations_with_one_peer() -> Result<()> {
     test(1, |fed, user, bitcoin| async move {
         bitcoin.mine_blocks(110).await;
@@ -228,6 +237,7 @@ async fn can_have_federations_with_one_peer() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn can_get_signed_epoch_history() -> Result<()> {
     test(2, |fed, user, bitcoin| async move {
         fed.mine_and_mint(&*user, &*bitcoin, sats(1000)).await;
@@ -245,6 +255,7 @@ async fn can_get_signed_epoch_history() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn rejoin_consensus_single_peer() -> Result<()> {
     test(4, |fed, user, bitcoin| async move {
         let bitcoin = bitcoin.lock_exclusive().await;
@@ -285,6 +296,7 @@ async fn rejoin_consensus_single_peer() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn rejoin_consensus_threshold_peers() -> Result<()> {
     test(2, |fed, _user, bitcoin| async move {
         // Simulate a rejoin where all nodes stop
@@ -299,6 +311,7 @@ async fn rejoin_consensus_threshold_peers() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn rejoin_consensus_split_peers() -> Result<()> {
     test(4, |fed, user, bitcoin| async move {
         // Simulate a rejoin where half the nodes didn't process the outcomes
@@ -326,6 +339,7 @@ async fn rejoin_consensus_split_peers() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn ecash_backup_can_recover_metadata() -> Result<()> {
     test(2, |_fed, user_send, _bitcoin| async move {
         #[derive(Serialize, Deserialize)]
@@ -359,11 +373,13 @@ async fn ecash_backup_can_recover_metadata() -> Result<()> {
 // this test had to be removed to switch to aleph bft and should be ported to
 // the new testing framework.
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn ecash_can_be_recovered() -> Result<()> {
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn limits_client_config_downloads() -> Result<()> {
     test(2, |fed, user, _| async move {
         let connect = &fed.invite_code.clone();
@@ -386,6 +402,7 @@ async fn limits_client_config_downloads() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn cannot_replay_transactions() -> Result<()> {
     test(4, |fed, user, bitcoin| async move {
         fed.mine_and_mint(&*user, &*bitcoin, sats(5000)).await;

--- a/modules/fedimint-dummy-tests/Cargo.toml
+++ b/modules/fedimint-dummy-tests/Cargo.toml
@@ -17,10 +17,11 @@ fedimint-dummy-client = { path = "../fedimint-dummy-client" }
 fedimint-dummy-server = { path = "../fedimint-dummy-server" }
 fedimint-testing = { path = "../../fedimint-testing" }
 fedimint-client = { path = "../../fedimint-client" }
-fedimint-core ={ path = "../../fedimint-core" }
+fedimint-core = { path = "../../fedimint-core" }
 fedimint-server = { path = "../../fedimint-server" }
 fedimint-logging = { path = "../../fedimint-logging" }
 tokio = { version = "1.26.0", features = ["sync"] }
+tracing = "0.1.37"
 
 [dev-dependencies]
 threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -6,14 +6,18 @@ use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
 use fedimint_dummy_common::config::{DummyClientConfig, DummyGenParams};
 use fedimint_dummy_server::DummyGen;
 use fedimint_testing::fixtures::Fixtures;
+use tracing::{info_span, instrument};
 
 fn fixtures() -> Fixtures {
     Fixtures::new_primary(DummyClientGen, DummyGen, DummyGenParams::default())
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn can_print_and_send_money() -> anyhow::Result<()> {
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures()
+        .new_fed(info_span!("can_print_and_send_money"))
+        .await;
     let (client1, client2) = fed.two_clients().await;
 
     let (_, outpoint) = client1.print_money(sats(1000)).await?;
@@ -28,8 +32,11 @@ async fn can_print_and_send_money() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn can_threshold_sign_message() {
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures()
+        .new_fed(info_span!("can_threshold_sign_message"))
+        .await;
     let client = fed.new_client().await;
 
     let message = "Hello fed!";
@@ -38,8 +45,11 @@ async fn can_threshold_sign_message() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn client_ignores_unknown_module() {
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures()
+        .new_fed(info_span!("client_ignores_unknown_module"))
+        .await;
     let client = fed.new_client().await;
 
     let mut cfg = client.get_config().clone();

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1347,6 +1347,7 @@ mod fedimint_migration_tests {
     use rand::rngs::OsRng;
     use strum::IntoEnumIterator;
     use threshold_crypto::G1Projective;
+    use tracing::instrument;
 
     use crate::{
         ContractAccount, Lightning, LightningGateway, LightningGen, LightningOutputOutcome,
@@ -1475,6 +1476,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn prepare_db_migration_snapshots() -> anyhow::Result<()> {
         prepare_db_migration_snapshot(
             "lightning-v0",
@@ -1493,6 +1495,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_migrations() -> anyhow::Result<()> {
         validate_migrations(
             "lightning",

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -15,6 +15,7 @@ use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing::gateway::DEFAULT_GATEWAY_PASSWORD;
 use lightning_invoice::Bolt11Invoice;
+use tracing::{info_span, instrument};
 
 fn fixtures() -> Fixtures {
     let fixtures = Fixtures::new_primary(DummyClientGen, DummyGen, DummyGenParams::default());
@@ -32,9 +33,12 @@ async fn gateway(fixtures: &Fixtures, fed: &FederationTest) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn can_switch_active_gateway() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures
+        .new_fed(info_span!("can_switch_active_gateway"))
+        .await;
     let client = fed.new_client().await;
     let mut gateway1 = fixtures
         .new_gateway(
@@ -67,9 +71,12 @@ async fn can_switch_active_gateway() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures
+        .new_fed(info_span!("makes_internal_payments_within_federation"))
+        .await;
     let (client1, client2) = fed.two_clients().await;
 
     // Print money for client2
@@ -122,9 +129,12 @@ async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn rejects_wrong_network_invoice() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures
+        .new_fed(info_span!("rejects_wrong_network_invoice"))
+        .await;
     let client1 = fed.new_client().await;
     gateway(&fixtures, &fed).await;
 

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -958,6 +958,7 @@ mod fedimint_migration_tests {
         blind_message, combine_valid_shares, sign_blinded_msg, BlindingKey, FromRandom, Message,
         Scalar, SecretKeyShare,
     };
+    use tracing::instrument;
 
     use crate::{Mint, MintGen};
 
@@ -1038,6 +1039,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn prepare_db_migration_snapshots() -> anyhow::Result<()> {
         prepare_db_migration_snapshot(
             "mint-v0",
@@ -1056,6 +1058,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_migrations() {
         validate_migrations(
             "mint",

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -9,6 +9,7 @@ use fedimint_mint_client::{
 use fedimint_mint_common::config::MintGenParams;
 use fedimint_mint_server::MintGen;
 use fedimint_testing::fixtures::{Fixtures, TIMEOUT};
+use tracing::instrument;
 
 fn fixtures() -> Fixtures {
     let fixtures = Fixtures::new_primary(MintClientGen, MintGen, MintGenParams::default());
@@ -16,9 +17,13 @@ fn fixtures() -> Fixtures {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_fed().await;
+    let fixtures = fixtures();
+    let span = tracing::info_span!("sends_ecash_out_of_band");
+    let fed = fixtures.new_fed(span.clone()).await;
+    let _enter = span.enter();
     let (client1, client2) = fed.two_clients().await;
     let (op, outpoint) = client1.print_money(sats(1000)).await?;
     client1.await_primary_module_output(op, outpoint).await?;

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1654,6 +1654,7 @@ mod fedimint_migration_tests {
     use rand::rngs::OsRng;
     use secp256k1::Message;
     use strum::IntoEnumIterator;
+    use tracing::instrument;
 
     use crate::{Wallet, WalletGen};
 
@@ -1813,6 +1814,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn prepare_db_migration_snapshots() -> anyhow::Result<()> {
         prepare_db_migration_snapshot(
             "wallet-v0",
@@ -1831,6 +1833,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[instrument(level = "info")]
     async fn test_migrations() -> anyhow::Result<()> {
         validate_migrations(
             "wallet",

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -29,7 +29,7 @@ use fedimint_wallet_common::{PegOutFees, Rbf};
 use fedimint_wallet_server::WalletGen;
 use futures::stream::StreamExt;
 use miniscript::ToPublicKey;
-use tracing::info;
+use tracing::{info, info_span, instrument};
 
 fn fixtures() -> Fixtures {
     let fixtures = Fixtures::new_primary(DummyClientGen, DummyGen, DummyGenParams::default());
@@ -102,9 +102,12 @@ async fn await_consensus_to_catch_up(client: &Client, block_count: u64) -> anyho
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn sanity_check_bitcoin_blocks() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures
+        .new_fed(info_span!("sanity_check_bitcoin_blocks"))
+        .await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     // Avoid other tests from interfering here
@@ -144,9 +147,12 @@ async fn sanity_check_bitcoin_blocks() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures
+        .new_fed(info_span!("on_chain_peg_in_and_peg_out_happy_case"))
+        .await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
@@ -187,9 +193,10 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn peg_out_fail_refund() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_fed(info_span!("peg_out_fail_refund")).await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
@@ -232,9 +239,10 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn peg_outs_support_rbf() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_fed(info_span!("peg_outs_support_rbf")).await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     // Need lock to keep tx in mempool from getting mined
@@ -307,6 +315,7 @@ async fn peg_outs_support_rbf() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[instrument(level = "info")]
 async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let bitcoin = fixtures.bitcoin();


### PR DESCRIPTION
Now we now which test is generating which log, even if they run at the same time:
```
2023-09-14T21:17:28.790892Z  INFO on_chain_peg_in_and_peg_out_happy_case: fedimint_wallet_tests: Peg-in transaction claimed height=1415 tx=Transaction { version: 2, lock_time: PackedLockTime(1414), input: [TxIn { previous_output: OutPoint { txid: 37c7dbc03954476ac7f5e5990c550467f3b75ae72625e1df58d270bc2fa6235d, vout: 0 }, script_sig: Script(), sequence: Sequence(4294967293), witness: Witness { content: [64, 10, 230, 137, 46, 253, 53, 206, 47, 129, 55, 237, 34, 38, 34, 80, 127, 74, 175, 196, 42, 236, 87, 31, 210, 33, 170, 223, 182, 248, 54, 16, 150, 229, 253, 217, 201, 101, 110, 161, 136, 4, 168, 102, 36, 60, 242, 112, 217, 104, 30, 219, 58, 10, 6, 76, 29, 62, 68, 125, 183, 39, 156, 27, 11], witness_elements: 1, last: 0, second_to_last: 0 } }], output: [TxOut { value: 5000, script_pubkey: Script(OP_0 OP_PUSHBYTES_32 61443d44882b34a73e9e8661682f6f10c25f3b9a686f2eca78edf333119b5dc5) }, TxOut { value: 78062760, script_pubkey: Script(OP_PUSHNUM_1 OP_PUSHBYTES_32 6eeaf2ea46ee310f301975e9570d592711b17e9057cc8489021cddcb45ed2d89) }] }
2023-09-14T21:17:28.790965Z  INFO on_chain_peg_in_and_peg_out_happy_case: fedimint_wallet_tests: Peg-in finished for test on_chain_peg_in_and_peg_out_happy_case
2023-09-14T21:17:28.792862Z  INFO on_chain_peg_in_and_peg_out_happy_case: fedimint_wallet_server: Creating peg-out tx inputs=1 input_sats=5000 peg_out_sats=1000 fees_sats=730 fee_rate=1000 change_sats=3270
2023-09-14T21:17:28.792862Z  INFO on_chain_peg_in_and_peg_out_happy_case: fedimint_wallet_server: Creating peg-out tx inputs=1 input_sats=5000 peg_out_sats=1000 fees_sats=730 fee_rate=1000 change_sats=3270
2023-09-14T21:17:28.792910Z  INFO on_chain_peg_in_and_peg_out_happy_case: fedimint_wallet_server: Creating peg-out tx txid=2ae728b9c2c41279bea18f5fa5233b7ed5a296962765c1ba4a5f26cb92914e88
2023-09-14T21:17:28.792916Z  INFO on_chain_peg_in_and_peg_out_happy_case: fedimint_wallet_server: Creating peg-out tx txid=2ae728b9c2c41279bea18f5fa5233b7ed5a296962765c1ba4a5f26cb92914e88
2023-09-14T21:17:28.794953Z DEBUG on_chain_peg_in_and_peg_out_happy_case: timing: Operation timing name=autocmmit - commit_tx duration_ms=0
2023-09-14T21:17:29.029553Z DEBUG sanity_check_bitcoin_blocks: timing: Operation timing name=sign last epoch key duration_ms=3
2023-09-14T21:17:29.042543Z DEBUG sanity_check_bitcoin_blocks: timing: Operation timing name=sign last epoch key duration_ms=2
2023-09-14T21:17:29.045441Z DEBUG peg_outs_support_rbf: timing: Operation timing name=sign last epoch key duration_ms=2
2023-09-14T21:17:29.053717Z DEBUG peg_outs_support_rbf: timing: Operation timing name=sign last epoch key duration_ms=1
2023-09-14T21:17:29.242081Z  INFO sanity_check_bitcoin_blocks: consensus: 
```

Note it includes server module api calls.