### PR TITLE
 chore: run workspace codecov tests with cargo nextest 

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,8 +2,7 @@
 rustflags = ["--cfg", "tokio_unstable"]
 
 [target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib,-fuse-ld=lld", "--cfg", "tokio_unstable"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Wl,--compress-debug-sections=zlib", "--cfg", "tokio_unstable"]
 
 # mold is currently broken on MacOS
 # [target.aarch64-apple-darwin]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,4 @@
 [profile.ci]
 fail-fast = true
 failure-output = "immediate"
+slow-timeout = { period = "60s", terminate-after = 4 }

--- a/nix/craneBuild.nix
+++ b/nix/craneBuild.nix
@@ -115,7 +115,7 @@ craneLib.overrideScope' (self: prev: {
     pname = "fedimint-workspace-lcov";
     version = "0.0.1";
     cargoArtifacts = self.workspaceDepsCov;
-    buildPhaseCargoCommand = "source <(cargo llvm-cov show-env --export-prefix); cargo build --locked --workspace --all-targets --profile $CARGO_PROFILE; env RUST_BACKTRACE=1 RUST_LOG=info,timing=debug cargo test --locked --workspace --all-targets --profile $CARGO_PROFILE -- --test-threads=$(($(nproc) * 2)); mkdir -p $out ; cargo llvm-cov report --profile $CARGO_PROFILE --lcov --output-path $out/lcov.info";
+    buildPhaseCargoCommand = "source <(cargo llvm-cov show-env --export-prefix); cargo build --locked --workspace --all-targets --profile $CARGO_PROFILE; env RUST_BACKTRACE=1 RUST_LOG=info,timing=debug cargo nextest run --locked --workspace --all-targets --profile $CARGO_PROFILE --test-threads=$(($(nproc) * 2)); mkdir -p $out ; cargo llvm-cov report --profile $CARGO_PROFILE --lcov --output-path $out/lcov.info";
     installPhaseCommand = "true";
     nativeBuildInputs = self.commonArgs.nativeBuildInputs ++ [ pkgs.cargo-llvm-cov ];
     doCheck = false;


### PR DESCRIPTION
`cargo nextest` is soooo much better.

The biggest improvements:

* It will capture outputs of all tests separately and only output ones that failed.
* It can kill a slow test after a timeout (and then display its output).

These alone should make debugging so much easier. Not to mention the whole thing runs faster.