### PR TITLE
fix: run_dkg in background task instead of blocking

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -457,7 +457,7 @@ pub async fn run_dkg(
     info!("Running DKG...");
     let (dkg_results, leader_wait_result) = tokio::join!(
         join_all(dkg_results),
-        wait_server_status(leader, ServerStatus::ReadyForConfigGen)
+        wait_server_status(leader, ServerStatus::VerifyingConfigs)
     );
     for result in dkg_results {
         result?;

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -70,7 +70,7 @@ impl TaskGroupInner {
 /// A group of task working together
 ///
 /// Using this struct it is possible to spawn one or more
-/// main thread collabarating, which can cooperatively gracefully
+/// main thread collaborating, which can cooperatively gracefully
 /// shut down, either due to external request, or failure of
 /// one of them.
 ///


### PR DESCRIPTION
Closes #2815 

These changes update the `run_dkg` API to set the server status to `ReadyForConfigGen`, then return after spawning a background task to handle the rest of coordinating DKG.

Previously, calls to `run_dkg` would block until DKG completed amongst all peers. This is troublesome for clients since there was no way to gracefully recover if a client experienced connectivity issues or elapsed a timeout.

### UI

These changes are not guaranteed to be backwards compatible for all clients, however testing against the UI repo (https://github.com/fedimint/ui/tree/c0cf511902f9e33cd66bb6438e4a56c95a395991), I verified these changes fix the issue without required changes.

#### Before

_Introduces a 100s sleep in `distributed_gen`, simulating poor network behavior which causes clients to timeout_

![Screenshot 2023-09-16 at 6 06 56 PM](https://github.com/fedimint/fedimint/assets/11034691/7eedcb3a-70e8-4680-ae5d-146312173199)

#### After

_Same 100s sleep as before, along with closing tabs for all followers and reconnecting_

https://github.com/fedimint/fedimint/assets/11034691/cb8417b7-a1e3-4526-b92d-2a75ef0818bc




