### PR TITLE
chore(ci): skip some steps on MacOS

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -106,11 +106,11 @@ jobs:
         run: nix build -L .#ci.workspaceClippy
 
       - name: Run cargo doc
-        if: github.ref == 'refs/heads/master' || matrix.build-in-pr
+        if: (github.ref == 'refs/heads/master' || matrix.build-in-pr) && (matrix.host != 'macos')
         run: nix build -L .#ci.workspaceDoc
 
       - name: Test docs
-        if: github.ref == 'refs/heads/master' || matrix.build-in-pr
+        if: (github.ref == 'refs/heads/master' || matrix.build-in-pr) && (matrix.host != 'macos')
         run: nix build -L .#ci.workspaceTestDoc
 
       - name: Tests
@@ -119,7 +119,7 @@ jobs:
           nix build -L .#ci.test.all --keep-failed
 
       - name: Wasm Tests
-        if: (github.ref == 'refs/heads/master' || matrix.build-in-pr) && matrix.run-tests
+        if: (github.ref == 'refs/heads/master' || matrix.build-in-pr) && matrix.run-tests && (matrix.host != 'macos')
         run: nix build -L .#ci.wasm-test --keep-failed
 
       - name: Prepare failed test build dirs

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -66,7 +66,7 @@ jobs:
           - linux
           - macos
         include:
-          - on: linux
+          - host: linux
             runs-on: buildjet-8vcpu-ubuntu-2004
             build-in-pr: true
             timeout: 60


### PR DESCRIPTION
The MacOS build is already struggling. Disabling these two steps should save around 15 minutes of build time for it, and they are both unlikely to fail, and even if they somehow did - it shouldn't matter.