### PR TITLE
Revert "chore: use a new incremental zstd crane mode"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,17 +47,17 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1694936751,
-        "narHash": "sha256-bKZa7bMnrMbDTvhC3Fv+0SO3EQhmOiOjih4fLlbeRUs=",
-        "owner": "dpc",
+        "lastModified": 1691422976,
+        "narHash": "sha256-A8krh8yi73R8mSUk63EwM4liaqXk1dws44D4aueNOEw=",
+        "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0fd1a6da318194d7d035b393bceff3942fcfc111",
+        "rev": "6c25eff4edca8556df21f55c63e49f20efe4be95",
         "type": "github"
       },
       "original": {
-        "owner": "dpc",
+        "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0fd1a6da318194d7d035b393bceff3942fcfc111",
+        "rev": "6c25eff4edca8556df21f55c63e49f20efe4be95",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-kitman.url = "github:jkitman/nixpkgs/add-esplora-pkg";
-    crane.url = "github:dpc/crane?rev=0fd1a6da318194d7d035b393bceff3942fcfc111";
+    crane.url = "github:ipetkov/crane?rev=6c25eff4edca8556df21f55c63e49f20efe4be95";
     crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     fenix = {


### PR DESCRIPTION
This reverts commit 1fdd29036ad49fd03beca7041cfaa27fbcca8301.

Broke MacOS: https://github.com/fedimint/fedimint/actions/runs/6237745739