### PR TITLE
Revert "Revert "chore: use a new incremental zstd crane mode""

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,17 +47,17 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1691422976,
-        "narHash": "sha256-A8krh8yi73R8mSUk63EwM4liaqXk1dws44D4aueNOEw=",
-        "owner": "ipetkov",
+        "lastModified": 1694936751,
+        "narHash": "sha256-bKZa7bMnrMbDTvhC3Fv+0SO3EQhmOiOjih4fLlbeRUs=",
+        "owner": "dpc",
         "repo": "crane",
-        "rev": "6c25eff4edca8556df21f55c63e49f20efe4be95",
+        "rev": "0fd1a6da318194d7d035b393bceff3942fcfc111",
         "type": "github"
       },
       "original": {
-        "owner": "ipetkov",
+        "owner": "dpc",
         "repo": "crane",
-        "rev": "6c25eff4edca8556df21f55c63e49f20efe4be95",
+        "rev": "0fd1a6da318194d7d035b393bceff3942fcfc111",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -47,17 +47,17 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1694936751,
-        "narHash": "sha256-bKZa7bMnrMbDTvhC3Fv+0SO3EQhmOiOjih4fLlbeRUs=",
+        "lastModified": 1695159108,
+        "narHash": "sha256-Uaav5HU0aDePH8uPHauUXIabJzeHxVu3em6SQXr40w8=",
         "owner": "dpc",
         "repo": "crane",
-        "rev": "0fd1a6da318194d7d035b393bceff3942fcfc111",
+        "rev": "60dcbcab46446bb852473a995fb0008d74c8b78d",
         "type": "github"
       },
       "original": {
         "owner": "dpc",
         "repo": "crane",
-        "rev": "0fd1a6da318194d7d035b393bceff3942fcfc111",
+        "rev": "60dcbcab46446bb852473a995fb0008d74c8b78d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-kitman.url = "github:jkitman/nixpkgs/add-esplora-pkg";
-    crane.url = "github:ipetkov/crane?rev=6c25eff4edca8556df21f55c63e49f20efe4be95";
+    crane.url = "github:dpc/crane?rev=0fd1a6da318194d7d035b393bceff3942fcfc111";
     crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     fenix = {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-kitman.url = "github:jkitman/nixpkgs/add-esplora-pkg";
-    crane.url = "github:dpc/crane?rev=0fd1a6da318194d7d035b393bceff3942fcfc111";
+    crane.url = "github:dpc/crane?rev=60dcbcab46446bb852473a995fb0008d74c8b78d";
     crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     fenix = {


### PR DESCRIPTION
Our build deps being the worst case scenario, and MacOS always a snowflake, we've hit some unforeseen problems after we've landed.

Has been quickly reverted and now I fixed it, so we unrevert it.