### PR TITLE
chore: implement federation_should_abort_if_balance_sheet_is_negative

### DIFF
--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -115,10 +115,22 @@ impl fmt::Display for DummyConsensusItem {
 /// A special key that creates assets for a test/example
 const FED_SECRET_PHRASE: &str = "Money printer go brrr...........";
 
+const BROKEN_FED_SECRET_PHRASE: &str = "Money printer go <boom>........!";
+
 pub fn fed_public_key() -> XOnlyPublicKey {
     fed_key_pair().x_only_public_key().0
 }
 
 pub fn fed_key_pair() -> KeyPair {
     KeyPair::from_seckey_slice(&Secp256k1::new(), FED_SECRET_PHRASE.as_bytes()).expect("32 bytes")
+}
+
+pub fn broken_fed_public_key() -> XOnlyPublicKey {
+    broken_fed_key_pair().x_only_public_key().0
+}
+
+// Like fed, but with a broken accounting
+pub fn broken_fed_key_pair() -> KeyPair {
+    KeyPair::from_seckey_slice(&Secp256k1::new(), BROKEN_FED_SECRET_PHRASE.as_bytes())
+        .expect("32 bytes")
 }

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -59,3 +59,14 @@ async fn client_ignores_unknown_module() {
     // Test that building the client worked
     let _client = fed.new_client_with_config(cfg).await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn federation_should_abort_if_balance_sheet_is_negative() -> anyhow::Result<()> {
+    let fed = fixtures().new_fed().await;
+    let client = fed.new_client().await;
+    // TODO: try to verify that the federation panics with something like
+    // "Balance sheet of the fed has gone negative, this should never happen!"
+    assert!(client.print_liability(sats(1000)).await.is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
A similar test was implemented on the old framework:
https://github.com/fedimint/fedimint/blob/1132d742c2357fd70a0c3691636f80637edc0adb/integrationtests/tests/tests.rs#L157