### PR TITLE
 refactor: Future proof arguments to ServerModuleInit::init

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -5,7 +5,7 @@ pub mod version;
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
 use std::io::Read;
-use std::marker::PhantomData;
+use std::marker::{self, PhantomData};
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -541,6 +541,33 @@ pub trait CommonModuleInit: Debug + Sized {
     fn decoder() -> Decoder;
 }
 
+pub struct ServerModuleInitArgs<S>
+where
+    S: ServerModuleInit,
+{
+    cfg: ServerModuleConfig,
+    db: Database,
+    task_group: TaskGroup,
+    // ClientModuleInitArgs needs a bound because sometimes we need
+    // to pass associated-types data, so let's just put it here right away
+    _marker: marker::PhantomData<S>,
+}
+
+impl<S> ServerModuleInitArgs<S>
+where
+    S: ServerModuleInit,
+{
+    pub fn cfg(&self) -> &ServerModuleConfig {
+        &self.cfg
+    }
+    pub fn db(&self) -> &Database {
+        &self.db
+    }
+
+    pub fn task_group(&self) -> &TaskGroup {
+        &self.task_group
+    }
+}
 /// Module Generation trait with associated types
 ///
 /// Needs to be implemented by module generation type
@@ -580,12 +607,7 @@ pub trait ServerModuleInit: ExtendsCommonModuleInit + Sized {
     }
 
     /// Initialize the [`DynServerModule`] instance from its config
-    async fn init(
-        &self,
-        cfg: ServerModuleConfig,
-        db: Database,
-        task_group: &mut TaskGroup,
-    ) -> anyhow::Result<DynServerModule>;
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule>;
 
     /// Retrieves the `MigrationMap` from the module to be applied to the
     /// database before the module is initialized. The `MigrationMap` is
@@ -648,7 +670,16 @@ where
         db: Database,
         task_group: &mut TaskGroup,
     ) -> anyhow::Result<DynServerModule> {
-        <Self as ServerModuleInit>::init(self, cfg, db, task_group).await
+        <Self as ServerModuleInit>::init(
+            self,
+            &ServerModuleInitArgs {
+                cfg,
+                db,
+                task_group: task_group.clone(),
+                _marker: Default::default(),
+            },
+        )
+        .await
     }
 
     fn get_database_migrations(&self) -> MigrationMap {

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -8,16 +8,15 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{Database, DatabaseVersion, MigrationMap, ModuleDatabaseTransaction};
+use fedimint_core::db::{DatabaseVersion, MigrationMap, ModuleDatabaseTransaction};
 use fedimint_core::epoch::{SerdeSignature, SerdeSignatureShare};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ConsensusProposal, CoreConsensusVersion, ExtendsCommonModuleInit,
     InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError, PeerHandle, ServerModuleInit,
-    SupportedModuleApiVersions, TransactionItemAmount,
+    ServerModuleInitArgs, SupportedModuleApiVersions, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
-use fedimint_core::task::TaskGroup;
 use fedimint_core::{push_db_pair_items, Amount, NumPeers, OutPoint, PeerId, ServerModule};
 use fedimint_dummy_common::config::{
     DummyClientConfig, DummyConfig, DummyConfigConsensus, DummyConfigLocal, DummyConfigPrivate,
@@ -68,13 +67,8 @@ impl ServerModuleInit for DummyGen {
     }
 
     /// Initialize the module
-    async fn init(
-        &self,
-        cfg: ServerModuleConfig,
-        _db: Database,
-        _task_group: &mut TaskGroup,
-    ) -> anyhow::Result<DynServerModule> {
-        Ok(Dummy::new(cfg.to_typed()?).into())
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
+        Ok(Dummy::new(args.cfg().to_typed()?).into())
     }
 
     /// DB migrations to move from old to newer versions

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -9,13 +9,14 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{Database, DatabaseVersion, ModuleDatabaseTransaction};
+use fedimint_core::db::{DatabaseVersion, ModuleDatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiEndpointContext, ConsensusProposal, CoreConsensusVersion,
     ExtendsCommonModuleInit, InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError,
-    PeerHandle, ServerModuleInit, SupportedModuleApiVersions, TransactionItemAmount,
+    PeerHandle, ServerModuleInit, ServerModuleInitArgs, SupportedModuleApiVersions,
+    TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
 use fedimint_core::task::{sleep, TaskGroup};
@@ -123,17 +124,12 @@ impl ServerModuleInit for LightningGen {
         SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
     }
 
-    async fn init(
-        &self,
-        cfg: ServerModuleConfig,
-        _db: Database,
-        task_group: &mut TaskGroup,
-    ) -> anyhow::Result<DynServerModule> {
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
         // Ensure all metrics are initialized
         for metric in ALL_METRICS.iter() {
             metric.collect();
         }
-        Ok(Lightning::new(cfg.to_typed()?, task_group)?.into())
+        Ok(Lightning::new(args.cfg().to_typed()?, &mut args.task_group().clone())?.into())
     }
 
     fn trusted_dealer_gen(

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -7,15 +7,16 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{Database, DatabaseVersion, ModuleDatabaseTransaction};
+use fedimint_core::db::{DatabaseVersion, ModuleDatabaseTransaction};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiError, ConsensusProposal, CoreConsensusVersion,
     ExtendsCommonModuleInit, InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError,
-    PeerHandle, ServerModuleInit, SupportedModuleApiVersions, TransactionItemAmount,
+    PeerHandle, ServerModuleInit, ServerModuleInitArgs, SupportedModuleApiVersions,
+    TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
-use fedimint_core::task::{MaybeSend, TaskGroup};
+use fedimint_core::task::MaybeSend;
 use fedimint_core::{
     apply, async_trait_maybe_send, push_db_key_items, push_db_pair_items, Amount, NumPeers,
     OutPoint, PeerId, ServerModule, Tiered, TieredMulti, TieredMultiZip,
@@ -71,13 +72,8 @@ impl ServerModuleInit for MintGen {
         SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
     }
 
-    async fn init(
-        &self,
-        cfg: ServerModuleConfig,
-        _db: Database,
-        _task_group: &mut TaskGroup,
-    ) -> anyhow::Result<DynServerModule> {
-        Ok(Mint::new(cfg.to_typed()?).into())
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
+        Ok(Mint::new(args.cfg().to_typed()?).into())
     }
 
     fn trusted_dealer_gen(

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -38,7 +38,7 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ConsensusProposal, CoreConsensusVersion, ExtendsCommonModuleInit,
     InputMeta, IntoModuleError, ModuleConsensusVersion, ModuleError, PeerHandle, ServerModuleInit,
-    SupportedModuleApiVersions, TransactionItemAmount,
+    ServerModuleInitArgs, SupportedModuleApiVersions, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
 #[cfg(not(target_family = "wasm"))]
@@ -89,13 +89,14 @@ impl ServerModuleInit for WalletGen {
         SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
     }
 
-    async fn init(
-        &self,
-        cfg: ServerModuleConfig,
-        db: Database,
-        task_group: &mut TaskGroup,
-    ) -> anyhow::Result<DynServerModule> {
-        Ok(Wallet::new(cfg.to_typed()?, db, task_group).await?.into())
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
+        Ok(Wallet::new(
+            args.cfg().to_typed()?,
+            args.db().clone(),
+            &mut args.task_group().clone(),
+        )
+        .await?
+        .into())
     }
 
     fn trusted_dealer_gen(


### PR DESCRIPTION
Like #3254 but for server modules.
Re #3025

I'm not sure if this is not over-engineering, but it seems likely that since client side needs it, server side will need it too. We were already thinking about passing `identity: PeerId` etc. through it.