### PR TITLE
fix: broken building in .#cross and .#crossWasm

### DIFF
--- a/flake.toolchain.nix
+++ b/flake.toolchain.nix
@@ -166,19 +166,19 @@ let
     "cargo"
   ];
 
-  fenixToolchainCrossAll = wrapToolchain (fenixPkgs.combine ([
+  fenixToolchainCrossAll = fenixPkgs.combine ([
     fenixStableChannel.cargo
     fenixStableChannel.rustc
   ] ++ (lib.attrsets.mapAttrsToList
-    (attr: target: fenixPkgs.${target.name}.stable.rust-std)
-    crossTargets)));
+    (attr: target: fenixPkgs.targets.${target.name}.stable.rust-std)
+    crossTargets));
 
   fenixToolchainCross = builtins.mapAttrs
-    (attr: target: wrapToolchain (fenixPkgs.combine [
+    (attr: target: fenixPkgs.combine [
       fenixStableChannel.cargo
       fenixStableChannel.rustc
       fenixPkgs.targets.${target.name}.stable.rust-std
-    ]))
+    ])
     crossTargets;
 
   fenixToolchainCrossWasm = fenixToolchainCross.wasm32-unknown-unknown;


### PR DESCRIPTION
Due to double symlinking `wrapToolchain` seems incompatible with current method of combining toolchain targets.

It's probably fixable, but we don't use it RN anyway.