### PR TITLE
 fix: properly shutdown the gateway

### DIFF
--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -1,3 +1,4 @@
+use fedimint_core::task::TaskGroup;
 use fedimint_logging::TracingSetup;
 use ln_gateway::Gateway;
 use tracing::info;
@@ -11,7 +12,12 @@ use tracing::info;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     TracingSetup::default().init()?;
-    let shutdown_receiver = Gateway::new_with_default_modules().await?.run().await?;
+    let mut tg = TaskGroup::new();
+    tg.install_kill_handler();
+    let shutdown_receiver = Gateway::new_with_default_modules()
+        .await?
+        .run(&mut tg)
+        .await?;
     shutdown_receiver.await;
     info!("Gatewayd exiting...");
     Ok(())


### PR DESCRIPTION
Fix a infinite loop on `test_gateway_filters_route_hints_by_inbound`  where a `GatewayTest` will run, then another `GatewayTest` will start but all tasks and HTLC interceptors from the previous one are still running.

This is specially problematic for LND because you can't have two or more HTLC interceptors (both will fail).

So the solution is to properly shutdown the `GatewayTest` on `Drop`. This required to review all "blocking" calls to also select `handle.make_shutdown_rx()`.

I also added new debugging logs that helped find and solve the issue.

This improves https://github.com/fedimint/fedimint/issues/3259
