### PR TITLE
feat: Lightning Gateway Registration DB Garbage Collection

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -216,7 +216,7 @@ impl LightningClientExt for Client {
                 .fetch_registered_gateways()
                 .await?
                 .into_iter()
-                .filter(|gw| gw.valid_until > fedimint_core::time::now())
+                .filter(|gw| !gw.is_expired())
                 .choose(&mut rand::thread_rng())
                 .ok_or(anyhow::anyhow!("Could not find any gateways")),
         }

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -202,6 +202,12 @@ pub struct LightningGateway {
     pub gateway_id: secp256k1::PublicKey,
 }
 
+impl LightningGateway {
+    pub fn is_expired(&self) -> bool {
+        self.valid_until < fedimint_core::time::now()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub enum LightningConsensusItem {
     DecryptPreimage(ContractId, PreimageDecryptionShare),

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1021,7 +1021,7 @@ impl Lightning {
         stream
             .filter_map(|(_, gw)| async {
                 // FIXME: actually remove from DB
-                if gw.valid_until > fedimint_core::time::now() {
+                if !gw.is_expired() {
                     Some(gw)
                 } else {
                     None

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1020,7 +1020,6 @@ impl Lightning {
         let stream = dbtx.find_by_prefix(&LightningGatewayKeyPrefix).await;
         stream
             .filter_map(|(_, gw)| async {
-                // FIXME: actually remove from DB
                 if !gw.is_expired() {
                     Some(gw)
                 } else {
@@ -1036,8 +1035,34 @@ impl Lightning {
         dbtx: &mut ModuleDatabaseTransaction<'_>,
         gateway: LightningGateway,
     ) {
+        // Garbage collect expired gateways (since we're already writing to the DB)
+        // Note: A "gotcha" of doing this here is that if two gateways are registered
+        // at the same time, they will both attempt to delete the same expired gateways
+        // and one of them will fail. This should be fine, since the other one will
+        // succeed and the failed one will just try again.
+        self.delete_expired_gateways(dbtx).await;
+
         dbtx.insert_entry(&LightningGatewayKey(gateway.node_pub_key), &gateway)
             .await;
+    }
+
+    async fn delete_expired_gateways(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) {
+        let expired_gateway_keys = dbtx
+            .find_by_prefix(&LightningGatewayKeyPrefix)
+            .await
+            .filter_map(|(key, gw)| async move {
+                if gw.is_expired() {
+                    Some(key)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<LightningGatewayKey>>()
+            .await;
+
+        for key in expired_gateway_keys {
+            dbtx.remove_entry(&key).await;
+        }
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Encodable, Decodable, Serialize, Deserialize)]


### PR DESCRIPTION
Previously we've been indefinitely storing all Lightning Gateway registrations and filtering any expired registrations when calling `list_gateways()`. Now, we delete expired registrations on every write of a new registration. We're deleting on write instead of on read for two reasons:

1. To optimize for read speed (since reads will likely be much higher qps).
2. To avoid potential write conflicts during a read-only API call. If `delete_expired_gateways()` is called twice at the same time (where each call opens a separate dbtx), the call that commits second will fail since they're both attempting to delete the same keys. A read-only API call that sometimes returns a DB write error would be confusing.