### PR TITLE
[Backport releases/v0.1] fix(wallet-client): timeout can only occur *after* `Created` state

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -206,10 +206,6 @@ impl WalletClientExt for Client {
                         Some(DepositStates::Created(_)) => {
                             yield DepositState::WaitingForTransaction;
                         },
-                        Some(DepositStates::TimedOut(_)) => {
-                            yield DepositState::Failed("Deposit timed out".to_string());
-                            return;
-                        }
                         Some(s) => {
                             panic!("Unexpected state {s:?}")
                         },
@@ -219,6 +215,10 @@ impl WalletClientExt for Client {
                     match next_deposit_state(&mut operation_stream).await {
                         Some(DepositStates::WaitingForConfirmations(_)) => {
                             yield DepositState::WaitingForConfirmation;
+                        },
+                        Some(DepositStates::TimedOut(_)) => {
+                            yield DepositState::Failed("Deposit timed out".to_string());
+                            return;
                         },
                         Some(s) => {
                             panic!("Unexpected state {s:?}")


### PR DESCRIPTION
# Description
Backport of #3117 to `releases/v0.1`.