### PR TITLE
feat: gateway swap between federations

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -456,6 +456,7 @@ fn states_add_instance(
     })
 }
 
+#[derive(Debug)]
 pub struct Client {
     inner: Arc<ClientInner>,
 }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -14,7 +14,7 @@ use futures::StreamExt;
 use crate::db::{FederationConfig, FederationIdKey, FederationIdKeyPrefix};
 use crate::lnrpc_client::ILnRpcClient;
 use crate::state_machine::GatewayClientGen;
-use crate::{GatewayError, Result};
+use crate::{FederationToClientMap, GatewayError, Result, ScidToFederationMap};
 
 #[derive(Debug, Clone)]
 pub struct GatewayClientBuilder {
@@ -38,12 +38,15 @@ impl GatewayClientBuilder {
 }
 
 impl GatewayClientBuilder {
+    #[allow(clippy::too_many_arguments)]
     pub async fn build(
         &self,
         config: FederationConfig,
         node_pub_key: secp256k1::PublicKey,
         lightning_alias: String,
         lnrpc: Arc<dyn ILnRpcClient>,
+        all_clients: FederationToClientMap,
+        all_scids: ScidToFederationMap,
         old_client: Option<fedimint_client::Client>,
     ) -> Result<fedimint_client::Client> {
         let FederationConfig {
@@ -57,6 +60,8 @@ impl GatewayClientBuilder {
         let mut registry = self.registry.clone();
         registry.attach(GatewayClientGen {
             lnrpc,
+            all_clients,
+            all_scids,
             node_pub_key,
             lightning_alias,
             fees,

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -115,7 +115,7 @@ pub trait GatewayClientExt {
         contract_id: ContractId,
     ) -> anyhow::Result<OperationId>;
 
-    /// Subscribe to update to lightning payment
+    /// Subscribe to updates when the gateway is paying an invoice
     async fn gateway_subscribe_ln_pay(
         &self,
         operation_id: OperationId,
@@ -133,7 +133,16 @@ pub trait GatewayClientExt {
     /// Attempt fulfill HTLC by buying preimage from the federation
     async fn gateway_handle_intercepted_htlc(&self, htlc: Htlc) -> anyhow::Result<OperationId>;
 
-    /// Subscribe to updates when the gateway is handling an intercepted HTLC
+    /// Attempt buying preimage from this federation in order to fulfill a pay
+    /// request in another federation served by this gateway. In direct swap
+    /// scenario, the gateway DOES NOT send payment over the lightning network
+    async fn gateway_handle_direct_swap(
+        &self,
+        swap_params: SwapParameters,
+    ) -> anyhow::Result<OperationId>;
+
+    /// Subscribe to updates when the gateway is handling an intercepted HTLC,
+    /// or direct swap between federations
     async fn gateway_subscribe_ln_receive(
         &self,
         operation_id: OperationId,
@@ -272,7 +281,7 @@ impl GatewayClientExt for Client {
     async fn gateway_handle_intercepted_htlc(&self, htlc: Htlc) -> anyhow::Result<OperationId> {
         let (gateway, instance) = self.get_first_module::<GatewayClientModule>(&KIND);
         let (operation_id, output) = gateway
-            .create_funding_incoming_contract_output(htlc)
+            .create_funding_incoming_contract_output_from_htlc(htlc)
             .await?;
         let tx = TransactionBuilder::new().with_output(output.into_dyn(instance.id));
         let operation_meta_gen = |_: TransactionId, _: Option<OutPoint>| GatewayMeta::Receive;
@@ -317,6 +326,22 @@ impl GatewayClientExt for Client {
                 yield state;
             }
         }))
+    }
+
+    /// Handles a direct swap request by buying a preimage from the federation
+    async fn gateway_handle_direct_swap(
+        &self,
+        swap_params: SwapParameters,
+    ) -> anyhow::Result<OperationId> {
+        let (gateway, instance) = self.get_first_module::<GatewayClientModule>(&KIND);
+        let (operation_id, output) = gateway
+            .create_funding_incoming_contract_output_from_swap(swap_params)
+            .await?;
+        let tx = TransactionBuilder::new().with_output(output.into_dyn(instance.id));
+        let operation_meta_gen = |_: TransactionId, _: Option<OutPoint>| GatewayMeta::Receive;
+        self.finalize_and_submit_transaction(operation_id, KIND.as_str(), operation_meta_gen, tx)
+            .await?;
+        Ok(operation_id)
     }
 }
 
@@ -497,7 +522,7 @@ impl GatewayClientModule {
         Ok(())
     }
 
-    async fn create_funding_incoming_contract_output(
+    async fn create_funding_incoming_contract_output_from_htlc(
         &self,
         htlc: Htlc,
     ) -> Result<
@@ -537,6 +562,42 @@ impl GatewayClientModule {
                         state: GatewayCompleteStates::WaitForPreimage(WaitForPreimageState),
                     }),
                 ]
+            }),
+        };
+        Ok((operation_id, client_output))
+    }
+
+    async fn create_funding_incoming_contract_output_from_swap(
+        &self,
+        swap: SwapParameters,
+    ) -> Result<
+        (
+            OperationId,
+            ClientOutput<LightningOutput, GatewayClientStateMachines>,
+        ),
+        IncomingSmError,
+    > {
+        let payment_hash = swap.payment_hash;
+        let operation_id = OperationId(payment_hash.into_inner());
+        let (incoming_output, contract_id) = create_incoming_contract_output(
+            &self.module_api,
+            payment_hash,
+            swap.amount_msat,
+            self.redeem_key,
+        )
+        .await?;
+
+        let client_output = ClientOutput::<LightningOutput, GatewayClientStateMachines> {
+            output: incoming_output,
+            state_machines: Arc::new(move |txid, _| {
+                vec![GatewayClientStateMachines::Receive(IncomingStateMachine {
+                    common: IncomingSmCommon {
+                        operation_id,
+                        contract_id,
+                        payment_hash,
+                    },
+                    state: IncomingSmStates::FundingOffer(FundingOfferState { txid }),
+                })]
             }),
         };
         Ok((operation_id, client_output))
@@ -634,6 +695,28 @@ impl TryFrom<InterceptHtlcRequest> for Htlc {
             short_channel_id: s.short_channel_id,
             incoming_chan_id: s.incoming_chan_id,
             htlc_id: s.htlc_id,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct SwapParameters {
+    payment_hash: sha256::Hash,
+    amount_msat: Amount,
+}
+
+impl TryFrom<lightning_invoice::Bolt11Invoice> for SwapParameters {
+    type Error = anyhow::Error;
+
+    fn try_from(s: lightning_invoice::Bolt11Invoice) -> Result<Self, Self::Error> {
+        let payment_hash = *s.payment_hash();
+        let amount_msat = s
+            .amount_milli_satoshis()
+            .map(Amount::from_msats)
+            .ok_or_else(|| anyhow::anyhow!("Amountless invoice cannot be used in direct swap"))?;
+        Ok(Self {
+            payment_hash,
+            amount_msat,
         })
     }
 }

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, OperationId, State, StateTransition};
 use fedimint_client::transaction::{ClientInput, ClientOutput};
 use fedimint_client::{Client, DynGlobalClientContext};
+use fedimint_core::config::FederationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, TransactionId};
 use fedimint_ln_common::api::LnFederationApi;
@@ -14,8 +15,11 @@ use futures::future;
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio_stream::StreamExt;
 
-use super::{GatewayClientContext, GatewayClientStateMachines};
+use super::{
+    GatewayClientContext, GatewayClientExt, GatewayClientStateMachines, GatewayExtReceiveStates,
+};
 use crate::fetch_lightning_node_info;
 use crate::gateway_lnrpc::{PayInvoiceRequest, PayInvoiceResponse};
 use crate::lnrpc_client::LightningRpcError;
@@ -31,7 +35,10 @@ use crate::lnrpc_client::LightningRpcError;
 ///    PayInvoice -- fetch contract failed --> Canceled
 ///    PayInvoice -- validate contract failed --> CancelContract
 ///    PayInvoice -- pay invoice unsuccessful --> CancelContract
-///    PayInvoice -- pay invoice successful --> ClaimOutgoingContract
+///    PayInvoice -- pay invoice over Lightning successful --> ClaimOutgoingContract
+///    PayInvoice -- pay invoice via direct swap successful --> WaitForSwapPreimage
+///    WaitForSwapPreimage -- received preimage --> ClaimOutgoingContract
+///    WaitForSwapPreimage -- wait for preimge failed --> Canceled
 ///    ClaimOutgoingContract -- claim tx submission --> Preimage
 ///    CancelContract -- cancel tx submission successful --> Canceled
 ///    CancelContract -- cancel tx submission unsuccessful --> Failed
@@ -47,6 +54,7 @@ pub enum GatewayPayStates {
         contract_id: ContractId,
         error: OutgoingPaymentError,
     },
+    WaitForSwapPreimage(Box<GatewayPayWaitForSwapPreimage>),
     ClaimOutgoingContract(Box<GatewayPayClaimOutgoingContract>),
     Failed {
         error: OutgoingPaymentError,
@@ -81,6 +89,9 @@ impl State for GatewayPayStateMachine {
                 context.clone(),
                 self.common.clone(),
             ),
+            GatewayPayStates::WaitForSwapPreimage(gateway_pay_wait_for_swap_preimage) => {
+                gateway_pay_wait_for_swap_preimage.transitions(context.clone(), self.common.clone())
+            }
             GatewayPayStates::ClaimOutgoingContract(gateway_pay_claim_outgoing_contract) => {
                 gateway_pay_claim_outgoing_contract.transitions(
                     global_context.clone(),
@@ -137,6 +148,11 @@ pub enum OutgoingPaymentError {
     InvalidOutgoingContract {
         error: OutgoingContractError,
         contract: OutgoingContractAccount,
+    },
+    #[error("An error occurred while attempting direct swap between federations.")]
+    SwapFailed {
+        contract: OutgoingContractAccount,
+        swap_error: String,
     },
 }
 
@@ -246,17 +262,25 @@ impl GatewayPayInvoice {
 
     async fn buy_preimage_via_direct_swap(
         client: Client,
-        _buy_preimage: PaymentParameters,
-        _contract: OutgoingContractAccount,
-    ) -> Result<Preimage, OutgoingPaymentError> {
-        tracing::warn!("DIRECT SWAP SCENARIO to: {:?}", client);
+        invoice: Bolt11Invoice,
+        contract: OutgoingContractAccount,
+    ) -> Result<(FederationId, OperationId), OutgoingPaymentError> {
+        let swap_params = invoice
+            .try_into()
+            .map_err(|e| OutgoingPaymentError::SwapFailed {
+                contract: contract.clone(),
+                swap_error: format!("Failed to parse invoice into swap parameters: {}", e),
+            })?;
 
-        Err(OutgoingPaymentError::LightningPayError {
-            contract: _contract,
-            lightning_error: LightningRpcError::FailedPayment {
-                failure_reason: "Direct swap not implemented".to_string(),
-            },
-        })
+        let operation_id = client
+            .gateway_handle_direct_swap(swap_params)
+            .await
+            .map_err(|e| OutgoingPaymentError::SwapFailed {
+                contract: contract.clone(),
+                swap_error: format!("Failed to initiate direct swap: {}", e),
+            })?;
+
+        Ok((client.federation_id(), operation_id))
     }
 
     async fn transition_buy_preimage(
@@ -266,32 +290,45 @@ impl GatewayPayInvoice {
     ) -> GatewayPayStateMachine {
         match result {
             Ok((contract, payment_parameters)) => {
-                let swap_receiver = Self::check_swap_to_federation(
+                if let Some(client) = Self::check_swap_to_federation(
                     context.clone(),
                     payment_parameters.invoice.clone(),
                 )
-                .await;
+                .await
+                {
+                    return match Self::buy_preimage_via_direct_swap(
+                        client,
+                        payment_parameters.invoice.clone(),
+                        contract.clone(),
+                    )
+                    .await
+                    {
+                        Ok((federation_id, operation_id)) => GatewayPayStateMachine {
+                            common,
+                            state: GatewayPayStates::WaitForSwapPreimage(Box::new(
+                                GatewayPayWaitForSwapPreimage {
+                                    contract,
+                                    federation_id,
+                                    operation_id,
+                                },
+                            )),
+                        },
+                        Err(e) => GatewayPayStateMachine {
+                            common,
+                            state: GatewayPayStates::CancelContract(Box::new(
+                                GatewayPayCancelContract { contract, error: e },
+                            )),
+                        },
+                    };
+                }
 
-                let preimage_result = match swap_receiver {
-                    Some(client) => {
-                        Self::buy_preimage_via_direct_swap(
-                            client,
-                            payment_parameters,
-                            contract.clone(),
-                        )
-                        .await
-                    }
-                    None => {
-                        Self::buy_preimage_over_lightning(
-                            context,
-                            payment_parameters,
-                            contract.clone(),
-                        )
-                        .await
-                    }
-                };
-
-                match preimage_result {
+                match Self::buy_preimage_over_lightning(
+                    context,
+                    payment_parameters,
+                    contract.clone(),
+                )
+                .await
+                {
                     Ok(preimage) => GatewayPayStateMachine {
                         common,
                         state: GatewayPayStates::ClaimOutgoingContract(Box::new(
@@ -306,32 +343,42 @@ impl GatewayPayInvoice {
                     },
                 }
             }
-            Err(e) => match e.clone() {
-                OutgoingPaymentError::InvalidOutgoingContract { error: _, contract } => {
-                    GatewayPayStateMachine {
+            Err(e) => {
+                match e.clone() {
+                    OutgoingPaymentError::InvalidOutgoingContract { error: _, contract } => {
+                        GatewayPayStateMachine {
+                            common,
+                            state: GatewayPayStates::CancelContract(Box::new(
+                                GatewayPayCancelContract { contract, error: e },
+                            )),
+                        }
+                    }
+                    OutgoingPaymentError::LightningPayError {
+                        contract,
+                        lightning_error: _,
+                    } => GatewayPayStateMachine {
                         common,
                         state: GatewayPayStates::CancelContract(Box::new(
                             GatewayPayCancelContract { contract, error: e },
                         )),
-                    }
-                }
-                OutgoingPaymentError::LightningPayError {
-                    contract,
-                    lightning_error: _,
-                } => GatewayPayStateMachine {
-                    common,
-                    state: GatewayPayStates::CancelContract(Box::new(GatewayPayCancelContract {
+                    },
+                    OutgoingPaymentError::SwapFailed {
                         contract,
-                        error: e,
-                    })),
-                },
-                OutgoingPaymentError::OutgoingContractDoesNotExist { contract_id } => {
-                    GatewayPayStateMachine {
+                        swap_error: _,
+                    } => GatewayPayStateMachine {
                         common,
-                        state: GatewayPayStates::OfferDoesNotExist(contract_id),
+                        state: GatewayPayStates::CancelContract(Box::new(
+                            GatewayPayCancelContract { contract, error: e },
+                        )),
+                    },
+                    OutgoingPaymentError::OutgoingContractDoesNotExist { contract_id } => {
+                        GatewayPayStateMachine {
+                            common,
+                            state: GatewayPayStates::OfferDoesNotExist(contract_id),
+                        }
                     }
                 }
-            },
+            }
         }
     }
 
@@ -473,6 +520,104 @@ impl GatewayPayClaimOutgoingContract {
         GatewayPayStateMachine {
             common,
             state: GatewayPayStates::Preimage(OutPoint { txid, out_idx: 0 }, preimage),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+pub struct GatewayPayWaitForSwapPreimage {
+    contract: OutgoingContractAccount,
+    federation_id: FederationId,
+    operation_id: OperationId,
+}
+
+impl GatewayPayWaitForSwapPreimage {
+    fn transitions(
+        &self,
+        context: GatewayClientContext,
+        common: GatewayPayCommon,
+    ) -> Vec<StateTransition<GatewayPayStateMachine>> {
+        let federation_id = self.federation_id;
+        let operation_id = self.operation_id;
+        let contract = self.contract.clone();
+        vec![StateTransition::new(
+            Self::await_preimage(context, federation_id, operation_id, contract.clone()),
+            move |_dbtx, result, _old_state| {
+                let c2 = contract.clone();
+                Box::pin(Self::transition_claim_outgoing_contract(
+                    common.clone(),
+                    result,
+                    c2,
+                ))
+            },
+        )]
+    }
+
+    async fn await_preimage(
+        context: GatewayClientContext,
+        federation_id: FederationId,
+        operation_id: OperationId,
+        contract: OutgoingContractAccount,
+    ) -> Result<Preimage, OutgoingPaymentError> {
+        let client = context
+            .all_clients
+            .read()
+            .await
+            .get(&federation_id)
+            .cloned()
+            .ok_or(OutgoingPaymentError::SwapFailed {
+                contract: contract.clone(),
+                swap_error: "Federation client not found".to_string(),
+            })?;
+
+        let mut stream = client
+            .gateway_subscribe_ln_receive(operation_id)
+            .await
+            .map_err(|e| OutgoingPaymentError::SwapFailed {
+                contract: contract.clone(),
+                swap_error: format!("Failed to subscribe to ln receive of direct swap: {}", e),
+            })?
+            .into_stream();
+
+        loop {
+            if let Some(state) = stream.next().await {
+                match state {
+                    GatewayExtReceiveStates::Funding => {
+                        continue;
+                    }
+                    GatewayExtReceiveStates::Preimage(preimage) => {
+                        return Ok(preimage);
+                    }
+                    _ => {
+                        return Err(OutgoingPaymentError::SwapFailed {
+                            contract,
+                            swap_error: "Failed to receive preimage".to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    async fn transition_claim_outgoing_contract(
+        common: GatewayPayCommon,
+        result: Result<Preimage, OutgoingPaymentError>,
+        contract: OutgoingContractAccount,
+    ) -> GatewayPayStateMachine {
+        match result {
+            Ok(preimage) => GatewayPayStateMachine {
+                common,
+                state: GatewayPayStates::ClaimOutgoingContract(Box::new(
+                    GatewayPayClaimOutgoingContract { contract, preimage },
+                )),
+            },
+            Err(e) => GatewayPayStateMachine {
+                common,
+                state: GatewayPayStates::CancelContract(Box::new(GatewayPayCancelContract {
+                    contract,
+                    error: e,
+                })),
+            },
         }
     }
 }


### PR DESCRIPTION
When a gateway is connected to any two federations, it can facilitate a direct e-cash swap between these federations, without routing over lightning.

## Specifics:

`GatewayPayInvoice` state machine checks if a proposed payment can be settled via direct swap. Specifically an LN payment that can be swapped will _have the gateway node pubkey_ and _a short channel id assigned by this gateway_ to one of it's connected federations in the route hint last hop. If these markers are present, the gateway instructs the client for the receiving federation to buy the preimage, and in turn, settles the payment in the originating federation client