### PR TITLE
refactor: remove ln gateway `LightningGateway ` db record

### DIFF
--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -2,7 +2,7 @@ use fedimint_core::api::InviteCode;
 use fedimint_core::config::FederationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
-use fedimint_ln_common::{serde_routing_fees, LightningGateway};
+use fedimint_ln_common::serde_routing_fees;
 use lightning::routing::gossip::RoutingFees;
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
@@ -46,25 +46,6 @@ impl_db_record!(
 );
 
 impl_db_lookup!(key = FederationIdKey, query_prefix = FederationIdKeyPrefix);
-
-#[derive(Debug, Clone, Encodable, Decodable, Eq, PartialEq, Hash)]
-pub struct FederationRegistrationKey {
-    pub id: FederationId,
-}
-
-impl_db_record!(
-    key = FederationRegistrationKey,
-    value = LightningGateway,
-    db_prefix = DbKeyPrefix::FederationRegistration,
-);
-
-#[derive(Debug, Encodable, Decodable)]
-pub struct FederationRegistrationKeyPrefix;
-
-impl_db_lookup!(
-    key = FederationRegistrationKey,
-    query_prefix = FederationRegistrationKeyPrefix
-);
 
 #[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable)]
 pub struct GatewayPublicKey;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -28,10 +28,7 @@ use bitcoin::{Address, Txid};
 use bitcoin_hashes::hex::ToHex;
 use clap::{Parser, Subcommand};
 use client::StandardGatewayClientBuilder;
-use db::{
-    DbKeyPrefix, FederationRegistrationKey, GatewayConfiguration, GatewayConfigurationKey,
-    GatewayPublicKey,
-};
+use db::{DbKeyPrefix, GatewayConfiguration, GatewayConfigurationKey, GatewayPublicKey};
 use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::Client;
 use fedimint_core::api::{FederationError, InviteCode};
@@ -922,10 +919,6 @@ impl Gateway {
         let client = self.clients.write().await.remove(&federation_id).ok_or(
             GatewayError::InvalidMetadata(format!("No federation with id {federation_id}")),
         )?;
-        let mut dbtx = self.gateway_db.begin_transaction().await;
-        dbtx.remove_entry(&FederationRegistrationKey { id: federation_id })
-            .await;
-        dbtx.commit_tx().await;
         Ok(client)
     }
 


### PR DESCRIPTION
This ln gateway owned DB record is inserted to and deleted from, but its values are never read. The gateway instead uses stored `FederationConfig`s to reference its registrations with federations: https://github.com/fedimint/fedimint/blob/d63752b79f15455ef3096d19e1fbf38991d250bf/gateway/ln-gateway/src/db.rs#L30-L48

Which makes the record we're deleting here redundant.