### PR TITLE
chore(wallet-client): use btc rpc client from env var

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -468,7 +468,7 @@ impl ClientModuleInit for WalletClientGen {
         let rpc_config = self
             .0
             .clone()
-            .unwrap_or(args.cfg().default_bitcoin_rpc.clone());
+            .unwrap_or(WalletClientModule::get_rpc_config(args.cfg()));
         Ok(WalletClientModule {
             cfg: args.cfg().clone(),
             module_root_secret: args.module_root_secret().clone(),
@@ -557,6 +557,20 @@ pub struct WalletClientContext {
 impl Context for WalletClientContext {}
 
 impl WalletClientModule {
+    fn get_rpc_config(cfg: &WalletClientConfig) -> BitcoinRpcConfig {
+        if let Ok(rpc_config) = BitcoinRpcConfig::from_env_vars() {
+            // TODO: Wallet client cannot support bitcoind RPC until the bitcoin dep is
+            // updated to 0.30
+            if rpc_config.kind != "bitcoind" {
+                rpc_config
+            } else {
+                cfg.default_bitcoin_rpc.clone()
+            }
+        } else {
+            cfg.default_bitcoin_rpc.clone()
+        }
+    }
+
     pub fn get_network(&self) -> Network {
         self.cfg.network
     }


### PR DESCRIPTION
Partially addresses: https://github.com/fedimint/fedimint/issues/2955

This allows the bitcoin rpc method to be overridden using environment variables. 

Set `FM_BITCOIN_RPC_KIND` to `esplora`, or `electrum` (`bitcoind` is not supported yet, see below)
Set `FM_BITCOIN_RPC_URL` to the URL of the esplora or electrum server.

`bitcoind` is not supported yet because we need to update our `bitcoin`, `bitcoin_hashes`, `secp*` crates. We are currently blocked on some downstream dependencies not supporting `bitcoin 0.30.0` yet. https://github.com/fedimint/fedimint/pull/2667