### PR TITLE
fix: no more flakiness on federation_should_abort_if_balance_sheet_is_negative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "rand",
  "secp256k1 0.24.3",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/modules/fedimint-dummy-tests/Cargo.toml
+++ b/modules/fedimint-dummy-tests/Cargo.toml
@@ -23,6 +23,7 @@ fedimint-testing = { path = "../../fedimint-testing" }
 rand = "0.8"
 secp256k1 = "0.24.2"
 tokio = { version = "1.26.0", features = ["sync"] }
+tracing = "0.1.37"
 
 [dev-dependencies]
 threshold_crypto = { workspace = true }


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/3258

Previously the test would suppose the transaction isn't accepted, but it seems that's not the case. Now we only suppose the consensus will never produce an outcome.