### PR TITLE
refactor: move incoming state machine into lightning client crate

### DIFF
--- a/gateway/ln-gateway/src/state_machine/complete.rs
+++ b/gateway/ln-gateway/src/state_machine/complete.rs
@@ -1,8 +1,8 @@
 use fedimint_client::sm::{OperationId, State, StateTransition};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_ln_client::incoming::IncomingSmStates;
 use fedimint_ln_common::contracts::Preimage;
-use fedimint_ln_common::incoming::IncomingSmStates;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -24,16 +24,17 @@ use fedimint_core::module::{
 };
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Amount, OutPoint, TransactionId};
+use fedimint_ln_client::create_incoming_contract_output;
+use fedimint_ln_client::incoming::{
+    FundingOfferState, IncomingSmCommon, IncomingSmError, IncomingSmStates, IncomingStateMachine,
+};
 use fedimint_ln_common::api::LnFederationApi;
 use fedimint_ln_common::config::LightningClientConfig;
 use fedimint_ln_common::contracts::{ContractId, Preimage};
-use fedimint_ln_common::incoming::{
-    FundingOfferState, IncomingSmCommon, IncomingSmError, IncomingSmStates, IncomingStateMachine,
-};
 use fedimint_ln_common::route_hints::RouteHint;
 use fedimint_ln_common::{
-    create_incoming_contract_output, ln_operation, LightningClientContext, LightningCommonGen,
-    LightningGateway, LightningModuleTypes, LightningOutput, KIND,
+    ln_operation, LightningClientContext, LightningCommonGen, LightningGateway,
+    LightningModuleTypes, LightningOutput, KIND,
 };
 use futures::StreamExt;
 use lightning::routing::gossip::RoutingFees;

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -18,15 +18,16 @@ use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
 use fedimint_core::{Amount, OutPoint, TransactionId};
+use fedimint_ln_common::api::LnFederationApi;
+use fedimint_ln_common::contracts::incoming::IncomingContractAccount;
+use fedimint_ln_common::contracts::{ContractId, DecryptedPreimage, Preimage};
+use fedimint_ln_common::{LightningInput, LightningOutputOutcome};
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
 
-use crate::api::LnFederationApi;
-use crate::contracts::incoming::IncomingContractAccount;
-use crate::contracts::{ContractId, DecryptedPreimage, Preimage};
-use crate::{LightningClientContext, LightningInput, LightningOutputOutcome};
+use crate::LightningClientContext;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// State machine that executes a transaction between two users

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -13,21 +13,17 @@ pub mod api;
 pub mod config;
 pub mod contracts;
 pub mod db;
-pub mod incoming;
 
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use anyhow::bail;
-use bitcoin_hashes::sha256;
 use config::LightningClientConfig;
 use fedimint_client::oplog::OperationLogEntry;
 use fedimint_client::sm::{Context, OperationId};
 use fedimint_client::Client;
-use fedimint_core::api::DynModuleApi;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
-use fedimint_core::task::timeout;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{plugin_types_trait_impl_common, Amount};
 use lightning::routing::gossip::RoutingFees;
@@ -35,13 +31,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
 
-use crate::api::LnFederationApi;
-use crate::contracts::incoming::{IncomingContract, IncomingContractOffer, OfferId};
-use crate::contracts::{
-    Contract, ContractId, ContractOutcome, DecryptedPreimage, IdentifiableContract, Preimage,
-    PreimageDecryptionShare,
-};
-use crate::incoming::IncomingSmError;
+use crate::contracts::incoming::OfferId;
+use crate::contracts::{Contract, ContractId, ContractOutcome, Preimage, PreimageDecryptionShare};
 
 pub const KIND: ModuleKind = ModuleKind::from_static_str("ln");
 const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
@@ -451,55 +442,4 @@ pub async fn ln_operation(
     }
 
     Ok(operation)
-}
-
-async fn fetch_and_validate_offer(
-    module_api: &DynModuleApi,
-    payment_hash: sha256::Hash,
-    amount_msat: Amount,
-) -> anyhow::Result<IncomingContractOffer, IncomingSmError> {
-    let offer = timeout(Duration::from_secs(5), module_api.fetch_offer(payment_hash))
-        .await
-        .map_err(|_| IncomingSmError::TimeoutFetchingOffer { payment_hash })?
-        .map_err(|e| IncomingSmError::FetchContractError {
-            payment_hash,
-            error_message: e.to_string(),
-        })?;
-
-    if offer.amount > amount_msat {
-        return Err(IncomingSmError::ViolatedFeePolicy {
-            offer_amount: offer.amount,
-            payment_amount: amount_msat,
-        });
-    }
-    if offer.hash != payment_hash {
-        return Err(IncomingSmError::InvalidOffer {
-            offer_hash: offer.hash,
-            payment_hash,
-        });
-    }
-    Ok(offer)
-}
-
-pub async fn create_incoming_contract_output(
-    module_api: &DynModuleApi,
-    payment_hash: sha256::Hash,
-    amount_msat: Amount,
-    redeem_key: secp256k1::KeyPair,
-) -> Result<(LightningOutput, ContractId), IncomingSmError> {
-    let offer = fetch_and_validate_offer(module_api, payment_hash, amount_msat).await?;
-    let our_pub_key = secp256k1::XOnlyPublicKey::from_keypair(&redeem_key).0;
-    let contract = IncomingContract {
-        hash: offer.hash,
-        encrypted_preimage: offer.encrypted_preimage.clone(),
-        decrypted_preimage: DecryptedPreimage::Pending,
-        gateway_key: our_pub_key,
-    };
-    let contract_id = contract.contract_id();
-    let incoming_output = LightningOutput::Contract(ContractOutput {
-        amount: offer.amount,
-        contract: Contract::Incoming(contract),
-    });
-
-    Ok((incoming_output, contract_id))
 }


### PR DESCRIPTION
`ln-common` is for sharing code across client/server boundary. `Incoming` state machine is never used on the server side, it is just shared between the client and the gateway. The gateway already depends on the client, so it is fine to just move the state machine into `ln-client`