### PR TITLE
refactor: rename fetch_contract -> wait_contract

### DIFF
--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -169,7 +169,7 @@ impl GatewayPayInvoice {
     ) -> Result<(OutgoingContractAccount, PaymentParameters), OutgoingPaymentError> {
         let account = global_context
             .module_api()
-            .fetch_contract(contract_id)
+            .wait_contract(contract_id)
             .await
             .map_err(|_| OutgoingPaymentError::OutgoingContractDoesNotExist { contract_id })?;
 

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -248,7 +248,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
             let (gateway_module, instance) =
                 gateway.get_first_module::<GatewayClientModule>(&fedimint_ln_common::KIND);
 
-            let account = instance.api.fetch_contract(contract_id).await?;
+            let account = instance.api.wait_contract(contract_id).await?;
             let outgoing_contract = match account.contract {
                 FundedContract::Outgoing(contract) => OutgoingContractAccount {
                     amount: account.amount,


### PR DESCRIPTION
`fetch_contract` is currently confusingly named, since it actually blocks and waits for a contract to exist. It is useful to have both `wait_contract` and `fetch_contract` since we also will want to validate when a contract does not exist.