### PR TITLE
feat: Support re-attempt LN invoice payment

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -17,7 +17,8 @@ use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::time::now;
 use fedimint_core::{Amount, ParseAmountError, TieredSummary};
 use fedimint_ln_client::{
-    InternalPayState, LightningClientExt, LnPayState, LnReceiveState, PayType,
+    InternalPayState, LightningClientExt, LnPayState, LnReceiveState, OutgoingLightningPayment,
+    PayType,
 };
 use fedimint_ln_common::contracts::ContractId;
 use fedimint_mint_client::{MintClientExt, MintClientModule, OOBNotes};
@@ -231,10 +232,14 @@ pub async fn handle_command(
         ClientCmd::LnPay { bolt11 } => {
             client.select_active_gateway().await?;
 
-            let (pay_type, contract_id, fee) = client.pay_bolt11_invoice(bolt11).await?;
+            let OutgoingLightningPayment {
+                payment_type,
+                contract_id,
+                fee,
+            } = client.pay_bolt11_invoice(bolt11).await?;
             info!("Gateway fee: {fee}");
 
-            match pay_type {
+            match payment_type {
                 PayType::Internal(operation_id) => {
                     let mut updates = client
                         .subscribe_internal_pay(operation_id)

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -957,6 +957,10 @@ impl Client {
 
         Ok(common_api_versions)
     }
+
+    pub async fn has_active_states(&self, operation_id: OperationId) -> bool {
+        self.inner.has_active_states(operation_id).await
+    }
 }
 
 /// Resources particular to a module instance
@@ -1204,6 +1208,13 @@ impl ClientInner {
         self.primary_module()
             .await_primary_module_output(operation_id, out_point)
             .await
+    }
+
+    pub async fn has_active_states(&self, operation_id: OperationId) -> bool {
+        let all_active_states = self.executor.get_active_states().await;
+        all_active_states
+            .into_iter()
+            .any(|context| context.0.operation_id() == operation_id)
     }
 }
 

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -14,7 +14,9 @@ use fedimint_core::api::InviteCode;
 use fedimint_core::core::IntoDynInstance;
 use fedimint_core::module::CommonModuleInit;
 use fedimint_core::{Amount, OutPoint, TieredSummary};
-use fedimint_ln_client::{LightningClientExt, LightningClientGen, LnPayState};
+use fedimint_ln_client::{
+    LightningClientExt, LightningClientGen, LnPayState, OutgoingLightningPayment,
+};
 use fedimint_mint_client::{
     MintClientExt, MintClientGen, MintClientModule, MintCommonGen, OOBNotes,
 };
@@ -172,8 +174,12 @@ pub async fn gateway_pay_invoice(
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<()> {
     let m = fedimint_core::time::now();
-    let (pay_type, _, _fee) = client.pay_bolt11_invoice(invoice).await?;
-    let operation_id = match pay_type {
+    let OutgoingLightningPayment {
+        payment_type,
+        contract_id: _,
+        fee: _,
+    } = client.pay_bolt11_invoice(invoice).await?;
+    let operation_id = match payment_type {
         fedimint_ln_client::PayType::Internal(_) => bail!("Internal payment not expected"),
         fedimint_ln_client::PayType::Lightning(operation_id) => operation_id,
     };

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -61,7 +61,9 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 mod tests {
     use fedimint_client::derivable_secret::DerivableSecret;
     use fedimint_core::Amount;
-    use fedimint_ln_client::{LightningClientExt, LnPayState, LnReceiveState, PayType};
+    use fedimint_ln_client::{
+        LightningClientExt, LnPayState, LnReceiveState, OutgoingLightningPayment, PayType,
+    };
     use futures::StreamExt;
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -144,8 +146,12 @@ mod tests {
         }
 
         let bolt11 = faucet::generate_invoice(11).await?;
-        let (pay_types, _contract_id, _fee) = client.pay_bolt11_invoice(bolt11.parse()?).await?;
-        let PayType::Lightning(operation_id) = pay_types else {
+        let OutgoingLightningPayment {
+            payment_type,
+            contract_id: _,
+            fee: _,
+        } = client.pay_bolt11_invoice(bolt11.parse()?).await?;
+        let PayType::Lightning(operation_id) = payment_type else {
             unreachable!("paying invoice over lightning");
         };
 

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -513,6 +513,7 @@ impl GatewayClientModule {
                         common: IncomingSmCommon {
                             operation_id,
                             contract_id,
+                            payment_hash: htlc.payment_hash,
                         },
                         state: IncomingSmStates::FundingOffer(FundingOfferState { txid }),
                     }),

--- a/modules/fedimint-ln-client/src/db.rs
+++ b/modules/fedimint-ln-client/src/db.rs
@@ -48,7 +48,7 @@ pub struct PaymentResultPrefix;
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct PaymentResult {
     pub index: u16,
-    pub completed_payment: Option<(PayType, ContractId)>,
+    pub completed_payment: Option<(PayType, ContractId, Amount)>,
 }
 
 impl_db_record!(

--- a/modules/fedimint-ln-client/src/db.rs
+++ b/modules/fedimint-ln-client/src/db.rs
@@ -1,13 +1,18 @@
+use bitcoin_hashes::sha256;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
+use fedimint_ln_common::contracts::ContractId;
 use fedimint_ln_common::LightningGatewayRegistration;
 use serde::Serialize;
 use strum_macros::EnumIter;
+
+use crate::PayType;
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
     LightningGateway = 0x28,
+    PaymentResult = 0x29,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -31,3 +36,25 @@ impl_db_lookup!(
     key = LightningGatewayKey,
     query_prefix = LightningGatewayKeyPrefix
 );
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct PaymentResultKey {
+    pub payment_hash: sha256::Hash,
+}
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct PaymentResultPrefix;
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct PaymentResult {
+    pub index: u16,
+    pub completed_payment: Option<(PayType, ContractId)>,
+}
+
+impl_db_record!(
+    key = PaymentResultKey,
+    value = PaymentResult,
+    db_prefix = DbKeyPrefix::PaymentResult,
+);
+
+impl_db_lookup!(key = PaymentResultKey, query_prefix = PaymentResultPrefix);

--- a/modules/fedimint-ln-client/src/db.rs
+++ b/modules/fedimint-ln-client/src/db.rs
@@ -1,12 +1,11 @@
 use bitcoin_hashes::sha256;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
-use fedimint_ln_common::contracts::ContractId;
 use fedimint_ln_common::LightningGatewayRegistration;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
-use crate::PayType;
+use crate::OutgoingLightningPayment;
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -48,7 +47,7 @@ pub struct PaymentResultPrefix;
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct PaymentResult {
     pub index: u16,
-    pub completed_payment: Option<(PayType, ContractId, Amount)>,
+    pub completed_payment: Option<OutgoingLightningPayment>,
 }
 
 impl_db_record!(

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -271,6 +271,7 @@ impl DecryptingPreimageState {
                     payment_hash,
                     PayType::Internal(old_state.common.operation_id),
                     contract_id,
+                    Amount::from_msats(0),
                 )
                 .await;
 

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -864,6 +864,7 @@ impl LightningClientModule {
                         operation_id,
                         federation_id: fed_id,
                         contract: outgoing_payment.clone(),
+                        gateway_fee: Amount::from_msats(base_fee + margin_fee),
                     },
                     state: LightningPayStates::CreatedOutgoingLnContract(
                         LightningPayCreatedOutgoingLnContract {
@@ -1258,9 +1259,10 @@ async fn set_payment_result(
     payment_hash: sha256::Hash,
     payment_type: PayType,
     contract_id: ContractId,
+    fee: Amount,
 ) {
     if let Some(mut payment_result) = dbtx.get_value(&PaymentResultKey { payment_hash }).await {
-        payment_result.completed_payment = Some((payment_type, contract_id));
+        payment_result.completed_payment = Some((payment_type, contract_id, fee));
         dbtx.insert_entry(&PaymentResultKey { payment_hash }, &payment_result)
             .await;
     }

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -138,7 +138,7 @@ async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
     assert_eq!(sub1.ok().await?, LnReceiveState::Created);
     assert_matches!(sub1.ok().await?, LnReceiveState::WaitingForPayment { .. });
 
-    let (pay_type, _) = client2.pay_bolt11_invoice(invoice.clone()).await?;
+    let (pay_type, _, _) = client2.pay_bolt11_invoice(invoice.clone()).await?;
     match pay_type {
         PayType::Internal(op_id) => {
             let mut sub2 = client2.subscribe_internal_pay(op_id).await?.into_stream();
@@ -154,7 +154,7 @@ async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
     // Pay the invoice again and verify that it does not deduct the balance, but it
     // does return the preimage
     let prev_balance = client2.get_balance().await;
-    let (pay_type, _) = client2.pay_bolt11_invoice(invoice).await?;
+    let (pay_type, _, _) = client2.pay_bolt11_invoice(invoice).await?;
     match pay_type {
         PayType::Internal(op_id) => {
             let mut sub2 = client2.subscribe_internal_pay(op_id).await?.into_stream();
@@ -185,7 +185,7 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
     let invoice = cln.invoice(Amount::from_sats(100), None).await?;
 
     // Pay the invoice for the first time
-    let (pay_type, _) = client.pay_bolt11_invoice(invoice.clone()).await?;
+    let (pay_type, _, _) = client.pay_bolt11_invoice(invoice.clone()).await?;
     match pay_type {
         PayType::Lightning(operation_id) => {
             let mut sub = client.subscribe_ln_pay(operation_id).await?.into_stream();
@@ -201,7 +201,7 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
 
     // Pay the invoice again and verify that it does not deduct the balance, but it
     // does return the preimage
-    let (pay_type, _) = client.pay_bolt11_invoice(invoice).await?;
+    let (pay_type, _, _) = client.pay_bolt11_invoice(invoice).await?;
     match pay_type {
         PayType::Lightning(operation_id) => {
             let mut sub = client.subscribe_ln_pay(operation_id).await?.into_stream();

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -2,13 +2,13 @@ use std::str::FromStr;
 
 use anyhow::bail;
 use assert_matches::assert_matches;
-use fedimint_core::sats;
 use fedimint_core::util::NextOrPending;
+use fedimint_core::{sats, Amount};
 use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyGen;
 use fedimint_ln_client::{
-    InternalPayState, LightningClientExt, LightningClientGen, LightningOperationMeta,
+    InternalPayState, LightningClientExt, LightningClientGen, LightningOperationMeta, LnPayState,
     LnReceiveState, PayType,
 };
 use fedimint_ln_common::config::LightningGenParams;
@@ -16,7 +16,7 @@ use fedimint_ln_common::ln_operation;
 use fedimint_ln_server::LightningGen;
 use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
-use fedimint_testing::gateway::DEFAULT_GATEWAY_PASSWORD;
+use fedimint_testing::gateway::{GatewayTest, DEFAULT_GATEWAY_PASSWORD};
 use lightning_invoice::Bolt11Invoice;
 
 fn fixtures() -> Fixtures {
@@ -26,12 +26,13 @@ fn fixtures() -> Fixtures {
 }
 
 /// Setup a gateway connected to the fed and client
-async fn gateway(fixtures: &Fixtures, fed: &FederationTest) {
+async fn gateway(fixtures: &Fixtures, fed: &FederationTest) -> GatewayTest {
     let lnd = fixtures.lnd().await;
     let mut gateway = fixtures
         .new_gateway(lnd, 0, Some(DEFAULT_GATEWAY_PASSWORD.to_string()))
         .await;
     gateway.connect_fed(fed).await;
+    gateway
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -120,6 +121,107 @@ async fn test_can_attach_extra_meta_to_receive_operation() -> anyhow::Result<()>
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed().await;
+    let (client1, client2) = fed.two_clients().await;
+
+    // Print money for client2
+    let (op, outpoint) = client2.print_money(sats(1000)).await?;
+    client2.await_primary_module_output(op, outpoint).await?;
+
+    // TEST internal payment when there are no gateways registered
+    let (op, invoice) = client1
+        .create_bolt11_invoice(sats(250), "with-markers".to_string(), None, ())
+        .await?;
+    let mut sub1 = client1.subscribe_ln_receive(op).await?.into_stream();
+    assert_eq!(sub1.ok().await?, LnReceiveState::Created);
+    assert_matches!(sub1.ok().await?, LnReceiveState::WaitingForPayment { .. });
+
+    let (pay_type, _) = client2.pay_bolt11_invoice(invoice.clone()).await?;
+    match pay_type {
+        PayType::Internal(op_id) => {
+            let mut sub2 = client2.subscribe_internal_pay(op_id).await?.into_stream();
+            assert_eq!(sub2.ok().await?, InternalPayState::Funding);
+            assert_matches!(sub2.ok().await?, InternalPayState::Preimage { .. });
+            assert_eq!(sub1.ok().await?, LnReceiveState::Funded);
+            assert_eq!(sub1.ok().await?, LnReceiveState::AwaitingFunds);
+            assert_eq!(sub1.ok().await?, LnReceiveState::Claimed);
+        }
+        _ => panic!("Expected internal payment!"),
+    }
+
+    // Pay the invoice again and verify that it does not deduct the balance, but it
+    // does return the preimage
+    let prev_balance = client2.get_balance().await;
+    let (pay_type, _) = client2.pay_bolt11_invoice(invoice).await?;
+    match pay_type {
+        PayType::Internal(op_id) => {
+            let mut sub2 = client2.subscribe_internal_pay(op_id).await?.into_stream();
+            assert_eq!(sub2.ok().await?, InternalPayState::Funding);
+            assert_matches!(sub2.ok().await?, InternalPayState::Preimage { .. });
+        }
+        _ => panic!("Expected internal payment!"),
+    }
+
+    let same_balance = client2.get_balance().await;
+    assert_eq!(prev_balance, same_balance);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed().await;
+    let client = fed.new_client().await;
+    let gw = gateway(&fixtures, &fed).await;
+
+    // Print money for client
+    let (op, outpoint) = client.print_money(sats(1000)).await?;
+    client.await_primary_module_output(op, outpoint).await?;
+
+    let cln = fixtures.cln().await;
+    let invoice = cln.invoice(Amount::from_sats(100), None).await?;
+
+    // Pay the invoice for the first time
+    let (pay_type, _) = client.pay_bolt11_invoice(invoice.clone()).await?;
+    match pay_type {
+        PayType::Lightning(operation_id) => {
+            let mut sub = client.subscribe_ln_pay(operation_id).await?.into_stream();
+
+            assert_eq!(sub.ok().await?, LnPayState::Created);
+            assert_eq!(sub.ok().await?, LnPayState::Funded);
+            assert_matches!(sub.ok().await?, LnPayState::Success { .. });
+        }
+        _ => panic!("Expected lightning payment!"),
+    }
+
+    let prev_balance = client.get_balance().await;
+
+    // Pay the invoice again and verify that it does not deduct the balance, but it
+    // does return the preimage
+    let (pay_type, _) = client.pay_bolt11_invoice(invoice).await?;
+    match pay_type {
+        PayType::Lightning(operation_id) => {
+            let mut sub = client.subscribe_ln_pay(operation_id).await?.into_stream();
+
+            assert_eq!(sub.ok().await?, LnPayState::Created);
+            assert_eq!(sub.ok().await?, LnPayState::Funded);
+            assert_matches!(sub.ok().await?, LnPayState::Success { .. });
+        }
+        _ => panic!("Expected lightning payment!"),
+    }
+
+    let same_balance = client.get_balance().await;
+    assert_eq!(prev_balance, same_balance);
+
+    drop(gw);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
@@ -144,6 +246,8 @@ async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
             assert_eq!(sub2.ok().await?, InternalPayState::Funding);
             assert_matches!(sub2.ok().await?, InternalPayState::Preimage { .. });
             assert_eq!(sub1.ok().await?, LnReceiveState::Funded);
+            assert_eq!(sub1.ok().await?, LnReceiveState::AwaitingFunds);
+            assert_eq!(sub1.ok().await?, LnReceiveState::Claimed);
         }
         _ => panic!("Expected internal payment!"),
     }


### PR DESCRIPTION
Builds on: https://github.com/fedimint/fedimint/pull/3318 https://github.com/fedimint/fedimint/pull/3319

Fixes: https://github.com/fedimint/fedimint/issues/3248

Intuition: adds an `index` into the `OperationId` hash so that multiple attempts to pay the same invoice are allowed. When creating the contract, the client checks to see if the contract (incoming or outgoing) already exists, and returns an error if it already does. If it does not, the `index` is incremented and committed to the database (this serves as a de-facto lock which prevents multiple threads from payment the same invoice at the same time).

When the payment is successful, the `PayType` and `ContractId` are stored in the database, which allows subsequent payment attempts to just lookup the succuessful payment in the operation log, rather than re-initiating the payment.

Open to suggestions on how to better test this.