### PR TITLE
chore: change prepare_db_migration_snapshots justfile command

### DIFF
--- a/justfile
+++ b/justfile
@@ -92,8 +92,12 @@ typos-fix-all:
   just typos -w
 
 # regenerate migration snapshots
+# ex: `just prepare_db_migration_snapshots fedimint-server`
+# ex: `just prepare_db_migration_snapshots fedimint-mint-server`
+# ex: `just prepare_db_migration_snapshots fedimint-ln-server`
+# ex: `just prepare_db_migration_snapshots fedimint-wallet-server`
 prepare_db_migration_snapshots +extra_args:
-  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=1 cargo test ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} prepare_db_migration_snapshots -- {{extra_args}}
+  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo test ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -p {{extra_args}} prepare_db_migration_snapshots
 
 # run code formatters
 format:


### PR DESCRIPTION
@joschisan had some issues using the `just` command for prepare_db_migration_snapshots, so this PR intends to tweak it to make it a tad easier.

First change is to modify the environment variable to always be `force` so that the backup files are generated.

Second change is to re-purpose the `extra_args` to be the package to run, since most of the time when running this command, the user only wants to re-generate the backup for one crate.

Also added some examples.