### PR TITLE
feat: `FederationIdPrefix` in `OOBNotes` to save on the encoding size

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -208,6 +208,27 @@ pub struct ClientConfigResponse {
 )]
 pub struct FederationId(pub threshold_crypto::PublicKey);
 
+#[derive(
+    Debug,
+    Copy,
+    Serialize,
+    Deserialize,
+    Clone,
+    Eq,
+    Hash,
+    PartialEq,
+    Encodable,
+    Decodable,
+    Ord,
+    PartialOrd,
+)]
+/// Prefix of the [`FederationId`], useful for UX improvements
+///
+/// Intentionally compact to save on the encoding. With 4 billion
+/// combinations real-life non-malicious collisions should never
+/// happen.
+pub struct FederationIdPrefix([u8; 4]);
+
 impl Display for FederationId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         format_hex(&self.0.to_bytes(), f)
@@ -224,6 +245,10 @@ impl FederationId {
 
     fn try_from_bytes(bytes: [u8; 48]) -> Option<Self> {
         Some(Self(threshold_crypto::PublicKey::from_bytes(bytes).ok()?))
+    }
+
+    pub fn to_prefix(&self) -> FederationIdPrefix {
+        FederationIdPrefix(self.0.to_bytes()[..4].try_into().expect("can't fail"))
     }
 
     /// Converts a federation id to a public key to which we know but discard

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -72,7 +72,7 @@ async fn error_zero_value_oob_receive() -> anyhow::Result<()> {
     let err_msg = client1
         .reissue_external_notes(
             OOBNotes {
-                federation_id: client1.federation_id(),
+                federation_id_prefix: client1.federation_id().to_prefix(),
                 notes: Default::default(),
             },
             (),


### PR DESCRIPTION
`fedimint-cli spend 1msat` before and after:

```
"notes": "kf/I9C5lwlSndrUo7dt5NEVy2Ecb8bx4G5bmbQdtG7ujGhTEaHZNniHnu/pgZ6X0AQEBiqT2DVKCg51ljiQk1NGjDRD2r+cKnq1JQwE2NZcQdLGLU5NLNe5AwmdLIanj2tVRC0mxXBpXNI6dh1lS6KNgPj5X0ZBclEEUMelLFbbh9wQqOhavjMzKF4QUzTQWC+IuxBT8zgmMrVl4mg1lmlyC+w=="
"notes": "kDZuAwEBAdBrqIwRc3GWVTdKgWoWpGSsNb3lYLBHKsy4stBUI5UmljLvjux7kce+MwhYKl4FBNUrpaR83qRDJ98Ii4gZpl5WNTFLSHVaBZOYyoKfMHp4s3QO85GzCV2beKdQ+3weIQ0TRNiSmGnxoNsY0eDZ5bY="
```
Re #3342