### PR TITLE
chore: `nonce` is redundant in `snote`

### DIFF
--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -200,7 +200,7 @@ impl MintRestoreInProgressState {
                             for (amount, note) in finalized.spendable_notes {
                                 let key = NoteKey {
                                     amount,
-                                    nonce: note.note.0,
+                                    nonce: note.nonce(),
                                 };
                                 dbtx.insert_new_entry(&key, &note).await;
                             }
@@ -350,7 +350,7 @@ impl MintRestoreInProgressState {
             spendable_note_by_nonce: backup
                 .notes
                 .into_iter()
-                .map(|(amount, note)| (note.note.0, (amount, note)))
+                .map(|(amount, note)| (note.nonce(), (amount, note)))
                 .collect(),
             pending_outputs: backup
                 .pending_notes
@@ -420,7 +420,7 @@ impl MintRestoreInProgressState {
     pub fn handle_input(&mut self, input: &MintInput) {
         // We attempt to delete any nonce we see as spent, simple
         for (_amt, note) in input.0.iter_items() {
-            self.spendable_note_by_nonce.remove(&note.0);
+            self.spendable_note_by_nonce.remove(&note.nonce);
         }
     }
 

--- a/modules/fedimint-mint-client/src/backup/recovery/tests.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery/tests.rs
@@ -110,7 +110,7 @@ impl MicroMintClient {
         MintInput(TieredMulti::from_iter(
             spendable_notes
                 .into_iter()
-                .map(|(amount, snote)| (amount, snote.note)),
+                .map(|(amount, snote)| (amount, snote.note())),
         ))
     }
 }
@@ -376,7 +376,7 @@ fn sanity_check_recovery_fresh_backup() {
         tracker.spendable_note_by_nonce,
         notes_c1_a
             .iter()
-            .map(|(amount, spendable_note)| (spendable_note.note.0, (*amount, *spendable_note)))
+            .map(|(amount, spendable_note)| (spendable_note.nonce(), (*amount, *spendable_note)))
             .collect()
     );
 
@@ -501,7 +501,7 @@ fn sanity_check_recovery_non_empty_backup() {
     for snote in notes_c1_a1 {
         assert!(tracker
             .spendable_note_by_nonce
-            .contains_key(&snote.1.note.0));
+            .contains_key(&snote.1.nonce()));
     }
 }
 
@@ -712,6 +712,6 @@ fn sanity_check_recovery_bn_reuse_with_valid_amount() {
     for snote in notes_c1_b {
         assert!(tracker
             .spendable_note_by_nonce
-            .contains_key(&snote.1.note.0));
+            .contains_key(&snote.1.nonce()));
     }
 }

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -140,13 +140,13 @@ impl MintInputStateCreated {
             _ => panic!("Invalid state transition"),
         };
 
-        let (spend_keys, notes): (Vec<_>, TieredMulti<_>) = notes
+        let (spend_keys, snotes): (Vec<_>, TieredMulti<_>) = notes
             .into_iter_items()
-            .map(|(amt, note)| (note.spend_key, (amt, note.note)))
+            .map(|(amt, snote)| (snote.spend_key, (amt, snote.note())))
             .unzip();
 
         let refund_input = ClientInput::<MintInput, MintClientStateMachines> {
-            input: MintInput(notes),
+            input: MintInput(snotes),
             keys: spend_keys,
             // The input of the refund tx is managed by this state machine, so no new state machines
             // need to be created

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -185,13 +185,13 @@ async fn try_cancel_oob_spend(
     spendable_notes: TieredMulti<SpendableNote>,
     global_context: DynGlobalClientContext,
 ) -> TransactionId {
-    let (keys, notes): (Vec<_>, TieredMulti<_>) = spendable_notes
+    let (keys, snotes): (Vec<_>, TieredMulti<_>) = spendable_notes
         .iter_items()
-        .map(|(amt, note)| (note.spend_key, (amt, note.note)))
+        .map(|(amt, snote)| (snote.spend_key, (amt, snote.note())))
         .unzip();
 
     let input = ClientInput {
-        input: MintInput(notes),
+        input: MintInput(snotes),
         keys,
         state_machines: Arc::new(move |txid, input_idx| {
             vec![MintClientStateMachines::Input(MintInputStateMachine {

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -218,7 +218,7 @@ impl MintOutputStatesCreated {
                         .insert_entry(
                             &NoteKey {
                                 amount,
-                                nonce: note.note.0,
+                                nonce: note.nonce(),
                             },
                             note,
                         )
@@ -315,11 +315,14 @@ impl NoteIssuanceRequest {
         bsig: BlindedSignature,
         mint_pub_key: AggregatePublicKey,
     ) -> std::result::Result<SpendableNote, NoteFinalizationError> {
-        let sig = unblind_signature(self.blinding_key, bsig);
-        let note = Note(self.nonce(), sig);
+        let signature = unblind_signature(self.blinding_key, bsig);
+        let note = Note {
+            nonce: self.nonce(),
+            signature,
+        };
         if note.verify(mint_pub_key) {
             let spendable_note = SpendableNote {
-                note,
+                signature: note.signature,
                 spend_key: self.spend_key,
             };
 

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -64,7 +64,10 @@ pub struct MintOutputBlindSignatures(pub TieredMulti<tbs::BlindedSignature>);
 /// In this form it can only be validated, not spent since for that the
 /// corresponding secret spend key is required.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
-pub struct Note(pub Nonce, pub tbs::Signature);
+pub struct Note {
+    pub nonce: Nonce,
+    pub signature: tbs::Signature,
+}
 
 /// Unique ID of a mint note.
 ///
@@ -171,12 +174,12 @@ pub struct MintModuleTypes;
 impl Note {
     /// Verify the note's validity under a mit key `pk`
     pub fn verify(&self, pk: tbs::AggregatePublicKey) -> bool {
-        tbs::verify(self.0.to_message(), self.1, pk)
+        tbs::verify(self.nonce.to_message(), self.signature, pk)
     }
 
     /// Access the nonce as the public key to the spend key
     pub fn spend_key(&self) -> &secp256k1_zkp::XOnlyPublicKey {
-        &self.0 .0
+        &self.nonce.0
     }
 }
 

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -499,11 +499,15 @@ impl ServerModule for Mint {
         }
 
         for (amount, note) in input.iter_items() {
-            if dbtx.insert_entry(&NonceKey(note.0), &()).await.is_some() {
+            if dbtx
+                .insert_entry(&NonceKey(note.nonce), &())
+                .await
+                .is_some()
+            {
                 return Err(MintError::SpentCoin).into_module_error_other();
             }
 
-            dbtx.insert_new_entry(&MintAuditItemKey::Redemption(NonceKey(note.0)), &amount)
+            dbtx.insert_new_entry(&MintAuditItemKey::Redemption(NonceKey(note.nonce)), &amount)
                 .await;
         }
 
@@ -852,9 +856,9 @@ mod test {
             bsig_shares,
             server_cfgs.len() - ((server_cfgs.len() - 1) / 3),
         );
-        let sig = tbs::unblind_signature(blinding_key, blind_signature);
+        let signature = tbs::unblind_signature(blinding_key, blind_signature);
 
-        (note_key, Note(nonce, sig))
+        (note_key, Note { nonce, signature })
     }
 
     #[test_log::test(tokio::test)]


### PR DESCRIPTION
Re #3342

`fedimint-cli spend 1msat` before and after:

```
"notes": "kf/I9C5lwlSndrUo7dt5NEVy2Ecb8bx4G5bmbQdtG7ujGhTEaHZNniHnu/pgZ6X0AQEBiqT2DVKCg51ljiQk1NGjDRD2r+cKnq1JQwE2NZcQdLGLU5NLNe5AwmdLIanj2tVRC0mxXBpXNI6dh1lS6KNgPj5X0ZBclEEUMelLFbbh9wQqOhavjMzKF4QUzTQWC+IuxBT8zgmMrVl4mg1lmlyC+w=="
"notes": "hXJ4oRcR5NkaBxZLpbf0CpojFH/vuPCxHDz0PuhVUY+lqk8P6Wle8hHGvbELY/L4AQEBj3Rgkjis+a5zc0GLFmZjPwAQgC60MX8pYhiPXaB14ZCXiGIGJxvhTvPpeB8vpQKKHFBtPCg4sxokJ0nRunbo2Gk9gnsakzaKFB/0Ky7xGA4="
```