### PR TITLE
refactor: Future proof arguments to ClientModuleInit::init

### DIFF
--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -18,6 +18,67 @@ use crate::DynGlobalClientContext;
 
 pub type ClientModuleInitRegistry = ModuleInitRegistry<DynClientModuleInit>;
 
+pub struct ClientModuleInitArgs<C>
+where
+    C: ClientModuleInit,
+{
+    federation_id: FederationId,
+    cfg: <<C as ExtendsCommonModuleInit>::Common as CommonModuleInit>::ClientConfig,
+    db: Database,
+    api_version: ApiVersion,
+    module_root_secret: DerivableSecret,
+    notifier: ModuleNotifier<
+        DynGlobalClientContext,
+        <<C as ClientModuleInit>::Module as ClientModule>::States,
+    >,
+    api: DynGlobalApi,
+    module_api: DynModuleApi,
+}
+
+impl<C> ClientModuleInitArgs<C>
+where
+    C: ClientModuleInit,
+{
+    pub fn federation_id(&self) -> &FederationId {
+        &self.federation_id
+    }
+
+    pub fn cfg(
+        &self,
+    ) -> &<<C as ExtendsCommonModuleInit>::Common as CommonModuleInit>::ClientConfig {
+        &self.cfg
+    }
+
+    pub fn db(&self) -> &Database {
+        &self.db
+    }
+
+    pub fn api_version(&self) -> &ApiVersion {
+        &self.api_version
+    }
+
+    pub fn module_root_secret(&self) -> &DerivableSecret {
+        &self.module_root_secret
+    }
+
+    pub fn notifier(
+        &self,
+    ) -> &ModuleNotifier<
+        DynGlobalClientContext,
+        <<C as ClientModuleInit>::Module as ClientModule>::States,
+    > {
+        &self.notifier
+    }
+
+    pub fn api(&self) -> &DynGlobalApi {
+        &self.api
+    }
+
+    pub fn module_api(&self) -> &DynModuleApi {
+        &self.module_api
+    }
+}
+
 #[apply(async_trait_maybe_send!)]
 pub trait ClientModuleInit: ExtendsCommonModuleInit + Sized {
     type Module: ClientModule;
@@ -28,17 +89,7 @@ pub trait ClientModuleInit: ExtendsCommonModuleInit + Sized {
 
     /// Initialize a [`ClientModule`] instance from its config
     #[allow(clippy::too_many_arguments)]
-    async fn init(
-        &self,
-        federation_id: FederationId,
-        cfg: <<Self as ExtendsCommonModuleInit>::Common as CommonModuleInit>::ClientConfig,
-        db: Database,
-        api_version: ApiVersion,
-        module_root_secret: DerivableSecret,
-        notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
-        api: DynGlobalApi,
-        module_api: DynModuleApi,
-    ) -> anyhow::Result<Self::Module>;
+    async fn init(&self, args: &ClientModuleInitArgs<Self>) -> anyhow::Result<Self::Module>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -102,16 +153,16 @@ where
     ) -> anyhow::Result<DynClientModule> {
         let typed_cfg: &<<T as fedimint_core::module::ExtendsCommonModuleInit>::Common as CommonModuleInit>::ClientConfig = cfg.cast()?;
         Ok(self
-            .init(
+            .init(&ClientModuleInitArgs {
                 federation_id,
-                typed_cfg.clone(),
+                cfg: typed_cfg.clone(),
                 db,
                 api_version,
                 module_root_secret,
-                notifier.module_notifier(instance_id),
-                api.clone(),
-                api.with_module(instance_id),
-            )
+                notifier: notifier.module_notifier(instance_id),
+                api: api.clone(),
+                module_api: api.with_module(instance_id),
+            })
             .await?
             .into())
     }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -11,18 +11,17 @@ use async_stream::stream;
 use bitcoin::{KeyPair, Network};
 use bitcoin_hashes::Hash;
 use db::LightningGatewayKey;
-use fedimint_client::derivable_secret::{ChildId, DerivableSecret};
-use fedimint_client::module::init::ClientModuleInit;
+use fedimint_client::derivable_secret::ChildId;
+use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{DynState, ModuleNotifier, OperationId, State, StateTransition};
 use fedimint_client::transaction::{ClientOutput, TransactionBuilder};
 use fedimint_client::{sm_enum_variant_translation, Client, DynGlobalClientContext};
-use fedimint_core::api::{DynGlobalApi, DynModuleApi};
+use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId};
-use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ExtendsCommonModuleInit, ModuleCommon, MultiApiVersion,
@@ -539,24 +538,17 @@ impl ClientModuleInit for LightningClientGen {
             .expect("no version conflicts")
     }
 
-    async fn init(
-        &self,
-        _federation_id: FederationId,
-        cfg: LightningClientConfig,
-        _db: Database,
-        _api_version: ApiVersion,
-        module_root_secret: DerivableSecret,
-        notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
-        _api: DynGlobalApi,
-        module_api: DynModuleApi,
-    ) -> anyhow::Result<Self::Module> {
+    async fn init(&self, args: &ClientModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
         let secp = Secp256k1::new();
         Ok(LightningClientModule {
-            cfg,
-            notifier,
-            redeem_key: module_root_secret.child_key(ChildId(0)).to_secp_key(&secp),
+            cfg: args.cfg().clone(),
+            notifier: args.notifier().clone(),
+            redeem_key: args
+                .module_root_secret()
+                .child_key(ChildId(0))
+                .to_secp_key(&secp),
             secp,
-            module_api,
+            module_api: args.module_api().clone(),
         })
     }
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -20,7 +20,7 @@ use anyhow::{anyhow, bail, Context as AnyhowContext};
 use async_stream::stream;
 use backup::recovery::{MintRestoreStateMachine, MintRestoreStates};
 use bitcoin_hashes::{sha256, sha256t, Hash, HashEngine as BitcoinHashEngine};
-use fedimint_client::module::init::ClientModuleInit;
+use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client::sm::util::MapStateTransitions;
@@ -29,12 +29,10 @@ use fedimint_client::sm::{
 };
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
 use fedimint_client::{sm_enum_variant_translation, Client, DynGlobalClientContext};
-use fedimint_core::api::{DynGlobalApi, DynModuleApi, GlobalFederationApi};
+use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId};
-use fedimint_core::db::{
-    AutocommitError, Database, DatabaseTransaction, ModuleDatabaseTransaction,
-};
+use fedimint_core::db::{AutocommitError, DatabaseTransaction, ModuleDatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{
@@ -542,24 +540,14 @@ impl ClientModuleInit for MintClientGen {
             .expect("no version conflicts")
     }
 
-    async fn init(
-        &self,
-        federation_id: FederationId,
-        cfg: MintClientConfig,
-        _db: Database,
-        _api_version: ApiVersion,
-        module_root_secret: DerivableSecret,
-        notifier: ModuleNotifier<DynGlobalClientContext, <Self::Module as ClientModule>::States>,
-        _api: DynGlobalApi,
-        _module_api: DynModuleApi,
-    ) -> anyhow::Result<Self::Module> {
+    async fn init(&self, args: &ClientModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
         let (cancel_oob_payment_bc, _) = tokio::sync::broadcast::channel(16);
         Ok(MintClientModule {
-            federation_id,
-            cfg,
-            secret: module_root_secret,
+            federation_id: *args.federation_id(),
+            cfg: args.cfg().clone(),
+            secret: args.module_root_secret().clone(),
             secp: Secp256k1::new(),
-            notifier,
+            notifier: args.notifier().clone(),
             cancel_oob_payment_bc,
         })
     }


### PR DESCRIPTION
Backport of #3254

See #3356 for context.

It's a breaking change for the Rust code API for external modules, but should be invisible for external users.

Original commit message:

Re #3025