### PR TITLE
feat: Add snake-casing for all the serde serialized structs [Fixes #3332]

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -374,6 +374,7 @@ pub async fn handle_command(
         }
         ClientCmd::ListOperations { limit } => {
             #[derive(Serialize)]
+            #[serde(rename_all(serialize = "snake_case"))]
             struct OperationOutput {
                 id: OperationId,
                 creation_time: String,
@@ -491,6 +492,7 @@ async fn get_note_summary(client: &Client) -> anyhow::Result<serde_json::Value> 
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 struct InfoResponse {
     federation_id: FederationId,
     network: Network,
@@ -511,6 +513,7 @@ pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_core::Amount, ParseAmou
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 struct PayInvoiceResponse {
     operation_id: OperationId,
     contract_id: ContractId,

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -98,6 +98,7 @@ impl fmt::Display for CliOutput {
 
 /// Types of error the cli return
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 enum CliErrorKind {
     NetworkError,
     IOError,
@@ -428,6 +429,7 @@ Examples:
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 struct PayRequest {
     notes: TieredMulti<SpendableNote>,
     invoice: lightning_invoice::Bolt11Invoice,
@@ -740,6 +742,7 @@ fn salt_from_file_path(file_path: &Path) -> PathBuf {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub struct LnInvoiceResponse {
     pub operation_id: OperationId,
     pub invoice: String,


### PR DESCRIPTION
Fixes #3332 

I have added the `#[serde(rename_all(serialize = "snake_case"))]` attribute to all the structs and enums  in the `fedimint-cli` package, even if they have all their attributes in snake_case (to ensure that if in future if some attributes are added to them, they do not break this stylistic guideline). 