### PR TITLE
Fix: Add permissions for open-issue bot

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -3,11 +3,11 @@ on:
   pull_request_target:
     # Run on merge (close) or if label is added after merging
     types: [closed, labeled]
-permissions:
-  contents: write # so it can comment
-  pull-requests: write # so it can create pull requests
 jobs:
   backport:
+    permissions:
+      contents: write # so it can comment
+      pull-requests: write # so it can create pull requests
     name: Backport pull request
     runs-on: ubuntu-latest
     # Don't run on closed unmerged pull requests
@@ -19,6 +19,9 @@ jobs:
         with:
           github_token: ${{ secrets.BACKPORT_TOKEN }}
   open-issue:
+    permissions:
+      contents: read
+      issues: write
     name: Open issue for failed backports
     runs-on: ubuntu-latest
     needs: backport


### PR DESCRIPTION
Followup to https://github.com/fedimint/fedimint/pull/3185.

- The GH action that creates an issue if opening a backport PR fails doesn't have the correct permissions (missing `issues: write`)
- Updated permissions are referenced from the README of the [action](https://github.com/JasonEtco/create-an-issue#usage)
- Example of a failed [run](https://github.com/fedimint/fedimint/actions/runs/6484651314/job/17608968397?pr=3348)

```
Error: An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check .github/templates/failed-backport-issue.md!

Resource not accessible by integration
```