### PR TITLE
feat: make guardian identity available in `ServerModuleInit::init`

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -490,6 +490,7 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
         cfg: ServerModuleConfig,
         db: Database,
         task_group: &mut TaskGroup,
+        our_peer_id: PeerId,
     ) -> anyhow::Result<DynServerModule>;
 
     /// Retrieves the `MigrationMap` from the module to be applied to the
@@ -567,6 +568,7 @@ where
     cfg: ServerModuleConfig,
     db: Database,
     task_group: TaskGroup,
+    our_peer_id: PeerId,
     // ClientModuleInitArgs needs a bound because sometimes we need
     // to pass associated-types data, so let's just put it here right away
     _marker: marker::PhantomData<S>,
@@ -585,6 +587,10 @@ where
 
     pub fn task_group(&self) -> &TaskGroup {
         &self.task_group
+    }
+
+    pub fn our_peer_id(&self) -> PeerId {
+        self.our_peer_id
     }
 }
 /// Module Generation trait with associated types
@@ -682,6 +688,7 @@ where
         cfg: ServerModuleConfig,
         db: Database,
         task_group: &mut TaskGroup,
+        our_peer_id: PeerId,
     ) -> anyhow::Result<DynServerModule> {
         <Self as ServerModuleInit>::init(
             self,
@@ -689,6 +696,7 @@ where
                 cfg,
                 db,
                 task_group: task_group.clone(),
+                our_peer_id,
                 _marker: Default::default(),
             },
         )

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -118,7 +118,12 @@ impl ConsensusServer {
             .await?;
 
             let module = init
-                .init(cfg.get_module_config(*module_id)?, isolated_db, task_group)
+                .init(
+                    cfg.get_module_config(*module_id)?,
+                    isolated_db,
+                    task_group,
+                    cfg.local.identity,
+                )
                 .await?;
 
             modules.insert(*module_id, (kind, module));


### PR DESCRIPTION
Precursor to #3368