### PR TITLE
chore: remove `our_peer_id` from wallet config

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -490,6 +490,7 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
         cfg: ServerModuleConfig,
         db: Database,
         task_group: &mut TaskGroup,
+        our_peer_id: PeerId,
     ) -> anyhow::Result<DynServerModule>;
 
     /// Retrieves the `MigrationMap` from the module to be applied to the
@@ -567,6 +568,7 @@ where
     cfg: ServerModuleConfig,
     db: Database,
     task_group: TaskGroup,
+    our_peer_id: PeerId,
     // ClientModuleInitArgs needs a bound because sometimes we need
     // to pass associated-types data, so let's just put it here right away
     _marker: marker::PhantomData<S>,
@@ -585,6 +587,10 @@ where
 
     pub fn task_group(&self) -> &TaskGroup {
         &self.task_group
+    }
+
+    pub fn our_peer_id(&self) -> PeerId {
+        self.our_peer_id
     }
 }
 /// Module Generation trait with associated types
@@ -682,6 +688,7 @@ where
         cfg: ServerModuleConfig,
         db: Database,
         task_group: &mut TaskGroup,
+        our_peer_id: PeerId,
     ) -> anyhow::Result<DynServerModule> {
         <Self as ServerModuleInit>::init(
             self,
@@ -689,6 +696,7 @@ where
                 cfg,
                 db,
                 task_group: task_group.clone(),
+                our_peer_id,
                 _marker: Default::default(),
             },
         )

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -118,7 +118,12 @@ impl ConsensusServer {
             .await?;
 
             let module = init
-                .init(cfg.get_module_config(*module_id)?, isolated_db, task_group)
+                .init(
+                    cfg.get_module_config(*module_id)?,
+                    isolated_db,
+                    task_group,
+                    cfg.local.identity,
+                )
                 .await?;
 
             modules.insert(*module_id, (kind, module));

--- a/modules/fedimint-wallet-common/src/config.rs
+++ b/modules/fedimint-wallet-common/src/config.rs
@@ -64,8 +64,6 @@ pub struct WalletConfig {
 pub struct WalletConfigLocal {
     /// Configures which bitcoin RPC to use
     pub bitcoin_rpc: BitcoinRpcConfig,
-    /// Our own peer_id
-    pub our_peer_id: PeerId,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -146,7 +144,6 @@ impl WalletConfig {
     pub fn new(
         pubkeys: BTreeMap<PeerId, CompressedPublicKey>,
         sk: SecretKey,
-        our_peer_id: PeerId,
         threshold: usize,
         network: Network,
         finality_delay: u32,
@@ -158,10 +155,7 @@ impl WalletConfig {
         );
 
         Self {
-            local: WalletConfigLocal {
-                bitcoin_rpc,
-                our_peer_id,
-            },
+            local: WalletConfigLocal { bitcoin_rpc },
             private: WalletConfigPrivate { peg_in_key: sk },
             consensus: WalletConfigConsensus {
                 network,

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -422,6 +422,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         db.clone(),
         dyn_bitcoin_rpc.clone(),
         &mut task_group,
+        PeerId::from(0),
     )
     .await?;
 


### PR DESCRIPTION
Builds on #3367 