### PR TITLE
Add snake_case attribute to fedimint-In-client for JSON serilaization [Fixes @3332]

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -374,7 +374,7 @@ pub async fn handle_command(
         }
         ClientCmd::ListOperations { limit } => {
             #[derive(Serialize)]
-            #[serde(rename_all(serialize = "snake_case"))]
+            #[serde(rename_all = "snake_case")]
             struct OperationOutput {
                 id: OperationId,
                 creation_time: String,
@@ -492,7 +492,7 @@ async fn get_note_summary(client: &Client) -> anyhow::Result<serde_json::Value> 
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 struct InfoResponse {
     federation_id: FederationId,
     network: Network,
@@ -513,7 +513,7 @@ pub fn parse_fedimint_amount(s: &str) -> Result<fedimint_core::Amount, ParseAmou
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 struct PayInvoiceResponse {
     operation_id: OperationId,
     contract_id: ContractId,

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -46,7 +46,7 @@ use crate::client::ClientCmd;
 
 /// Type of output the cli produces
 #[derive(Serialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 enum CliOutput {
     VersionHash {
@@ -98,7 +98,7 @@ impl fmt::Display for CliOutput {
 
 /// Types of error the cli return
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 enum CliErrorKind {
     NetworkError,
     IOError,
@@ -429,7 +429,7 @@ Examples:
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 struct PayRequest {
     notes: TieredMulti<SpendableNote>,
     invoice: lightning_invoice::Bolt11Invoice,
@@ -742,7 +742,7 @@ fn salt_from_file_path(file_path: &Path) -> PathBuf {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub struct LnInvoiceResponse {
     pub operation_id: OperationId,
     pub invoice: String,

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -97,6 +97,7 @@ impl State for IncomingStateMachine {
 }
 
 #[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub enum IncomingSmError {
     #[error("Violated fee policy. Offer amount {offer_amount} Payment amount: {payment_amount}")]
     ViolatedFeePolicy {

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -97,7 +97,7 @@ impl State for IncomingStateMachine {
 }
 
 #[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub enum IncomingSmError {
     #[error("Violated fee policy. Offer amount {offer_amount} Payment amount: {payment_amount}")]
     ViolatedFeePolicy {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -121,7 +121,7 @@ pub trait LightningClientExt {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub enum PayType {
     // Payment from this client to another user within the federation
     Internal(OperationId),
@@ -132,7 +132,7 @@ pub enum PayType {
 /// The high-level state of an pay operation internal to the federation,
 /// started with [`LightningClientExt::pay_bolt11_invoice`].
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub enum InternalPayState {
     Funding,
     Preimage(Preimage),
@@ -153,7 +153,7 @@ pub enum InternalPayState {
 /// The high-level state of a pay operation over lightning,
 /// started with [`LightningClientExt::pay_bolt11_invoice`].
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub enum LnPayState {
     Created,
     Canceled,
@@ -177,7 +177,7 @@ pub enum LnPayState {
 /// The high-level state of a reissue operation started with
 /// [`LightningClientExt::create_bolt11_invoice`].
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub enum LnReceiveState {
     Created,
     WaitingForPayment { invoice: String, timeout: Duration },
@@ -559,7 +559,7 @@ impl LightningClientExt for Client {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub enum LightningOperationMeta {
     Pay {
         out_point: OutPoint,
@@ -687,7 +687,7 @@ impl ClientModule for LightningClientModule {
 }
 
 #[derive(Error, Debug, Serialize, Deserialize)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 enum PayError {
     #[error("Lightning payment was canceled")]
     Canceled,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -121,6 +121,7 @@ pub trait LightningClientExt {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub enum PayType {
     // Payment from this client to another user within the federation
     Internal(OperationId),
@@ -131,6 +132,7 @@ pub enum PayType {
 /// The high-level state of an pay operation internal to the federation,
 /// started with [`LightningClientExt::pay_bolt11_invoice`].
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub enum InternalPayState {
     Funding,
     Preimage(Preimage),
@@ -151,6 +153,7 @@ pub enum InternalPayState {
 /// The high-level state of a pay operation over lightning,
 /// started with [`LightningClientExt::pay_bolt11_invoice`].
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub enum LnPayState {
     Created,
     Canceled,
@@ -174,6 +177,7 @@ pub enum LnPayState {
 /// The high-level state of a reissue operation started with
 /// [`LightningClientExt::create_bolt11_invoice`].
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub enum LnReceiveState {
     Created,
     WaitingForPayment { invoice: String, timeout: Duration },
@@ -555,6 +559,7 @@ impl LightningClientExt for Client {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub enum LightningOperationMeta {
     Pay {
         out_point: OutPoint,
@@ -682,6 +687,7 @@ impl ClientModule for LightningClientModule {
 }
 
 #[derive(Error, Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "snake_case"))]
 enum PayError {
     #[error("Lightning payment was canceled")]
     Canceled,

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -209,7 +209,7 @@ pub struct LightningPayFunded {
 }
 
 #[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub enum GatewayPayError {
     #[error("Lightning Gateway failed to pay invoice. ErrorCode: {error_code:?} ErrorMessage: {error_message}")]
     GatewayInternalError {
@@ -479,7 +479,7 @@ impl LightningPayRefund {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub struct PayInvoicePayload {
     pub federation_id: FederationId,
     pub contract_id: ContractId,

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -209,6 +209,7 @@ pub struct LightningPayFunded {
 }
 
 #[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub enum GatewayPayError {
     #[error("Lightning Gateway failed to pay invoice. ErrorCode: {error_code:?} ErrorMessage: {error_message}")]
     GatewayInternalError {
@@ -478,6 +479,7 @@ impl LightningPayRefund {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub struct PayInvoicePayload {
     pub federation_id: FederationId,
     pub contract_id: ContractId,

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -89,6 +89,7 @@ pub struct LightningReceiveSubmittedOffer {
 }
 
 #[derive(Error, Clone, Debug, Serialize, Deserialize, Encodable, Decodable, Eq, PartialEq)]
+#[serde(rename_all(serialize = "snake_case"))]
 pub enum LightningReceiveError {
     #[error("Offer transaction was rejected")]
     Rejected,

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -89,7 +89,7 @@ pub struct LightningReceiveSubmittedOffer {
 }
 
 #[derive(Error, Clone, Debug, Serialize, Deserialize, Encodable, Decodable, Eq, PartialEq)]
-#[serde(rename_all(serialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub enum LightningReceiveError {
     #[error("Offer transaction was rejected")]
     Rejected,


### PR DESCRIPTION
Hopefully fixes @3332

As pointed out by @elsirion, the merged PR #3360 did not completely solve the scope of the issue. I have added the rename to snake_case attribute to all the relevant enums and structs in the `fedimint-In-client` module. 

As I am pretty new to `fedimint`, I would greatly appreciate it if you could help me with these queries along with reviewing this PR:
- Are there any commands I can run to verify the changed nature of the JSON output as shown in the original issue description?
- Is there any documentation of which libraries/modules perform what? This would help me understand the codebase better. 

Thanks!