### PR TITLE
[Backport releases/v0.1] feat: make guardian identity available in `ServerModuleInit::init`

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -463,6 +463,7 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
         cfg: ServerModuleConfig,
         db: Database,
         task_group: &mut TaskGroup,
+        our_peer_id: PeerId,
     ) -> anyhow::Result<DynServerModule>;
 
     /// Retrieves the `MigrationMap` from the module to be applied to the
@@ -544,6 +545,7 @@ where
     cfg: ServerModuleConfig,
     db: Database,
     task_group: TaskGroup,
+    our_peer_id: PeerId,
     // ClientModuleInitArgs needs a bound because sometimes we need
     // to pass associated-types data, so let's just put it here right away
     _marker: marker::PhantomData<S>,
@@ -562,6 +564,10 @@ where
 
     pub fn task_group(&self) -> &TaskGroup {
         &self.task_group
+    }
+
+    pub fn our_peer_id(&self) -> PeerId {
+        self.our_peer_id
     }
 }
 /// Module Generation trait with associated types
@@ -665,6 +671,7 @@ where
         cfg: ServerModuleConfig,
         db: Database,
         task_group: &mut TaskGroup,
+        our_peer_id: PeerId,
     ) -> anyhow::Result<DynServerModule> {
         <Self as ServerModuleInit>::init(
             self,
@@ -672,6 +679,7 @@ where
                 cfg,
                 db,
                 task_group: task_group.clone(),
+                our_peer_id,
                 _marker: Default::default(),
             },
         )

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -166,7 +166,12 @@ impl ConsensusServer {
             .await?;
 
             let module = init
-                .init(cfg.get_module_config(*module_id)?, isolated_db, task_group)
+                .init(
+                    cfg.get_module_config(*module_id)?,
+                    isolated_db,
+                    task_group,
+                    cfg.local.identity,
+                )
                 .await?;
             modules.insert(*module_id, (kind, module));
         }


### PR DESCRIPTION
# Description
Backport of #3367 to `releases/v0.1`.