### PR TITLE
Backport json client module config

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -233,6 +233,7 @@ impl Federation {
             .unwrap()
             .config()
             .0
+            .global
             .federation_id
             .to_string()
     }

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -473,7 +473,7 @@ async fn get_note_summary(client: &Client) -> anyhow::Result<serde_json::Value> 
     Ok(serde_json::to_value(InfoResponse {
         federation_id: client.federation_id(),
         network: wallet_client.get_network(),
-        meta: client.get_config().meta.clone(),
+        meta: client.get_config().global.meta.clone(),
         total_amount_msat: summary.total_amount(),
         total_num_notes: summary.count_items(),
         denominations_msat: summary,

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -131,6 +131,8 @@ pub enum ClientCmd {
         module: ModuleSelector,
         args: Vec<ffi::OsString>,
     },
+    /// Returns the client config
+    Config,
 }
 
 pub fn parse_gateway_id(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Error> {
@@ -459,6 +461,10 @@ pub async fn handle_ng_command(
                 .context("Module not found")?;
 
             module_client.handle_cli_command(&client, &args).await
+        }
+        ClientCmd::Config => {
+            let config = client.get_config_json();
+            Ok(serde_json::to_value(config).expect("Client config is serializable"))
         }
     }
 }

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -267,6 +267,7 @@ impl Opts {
             .ok_or_cli_msg(CliErrorKind::MissingAuth, "Admin client needs our-id set")?;
 
         let url = cfg
+            .global
             .api_endpoints
             .get(our_id)
             .expect("Endpoint exists")
@@ -611,7 +612,7 @@ impl FedimintCli {
                 let decoders = cli.load_decoders(&cfg, &self.module_inits);
                 let client = cli.admin_client(&cfg)?;
                 let last_epoch = client
-                    .fetch_last_epoch_history(cfg.epoch_pk, &decoders)
+                    .fetch_last_epoch_history(cfg.global.epoch_pk, &decoders)
                     .await?;
 
                 let hex_outcome = last_epoch.consensus_encode_to_hex().map_err_cli_io()?;

--- a/fedimint-client-legacy/src/lib.rs
+++ b/fedimint-client-legacy/src/lib.rs
@@ -262,7 +262,7 @@ impl<T: AsRef<ClientConfig> + Clone + MaybeSend> Client<T> {
                 .expect("needs mint module client config")
                 .1
                 .clone(),
-            epoch_pk: self.config.as_ref().epoch_pk,
+            epoch_pk: self.config.as_ref().global.epoch_pk,
             context: self.context.clone(),
             secret: Self::mint_secret_static(&self.root_secret),
         }
@@ -1164,7 +1164,7 @@ impl Client<UserClientConfig> {
     ) -> Result<()> {
         let gateway = self.fetch_active_gateway().await?;
 
-        let payload = PayInvoicePayload::new(self.config.0.federation_id, contract_id);
+        let payload = PayInvoicePayload::new(self.config.0.global.federation_id, contract_id);
 
         let future = reqwest::Client::new()
             .post(

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -81,7 +81,10 @@ use fedimint_core::api::{
     ApiVersionSet, DynGlobalApi, DynModuleApi, GlobalFederationApi, IGlobalFederationApi,
     InviteCode, WsFederationApi,
 };
-use fedimint_core::config::{ClientConfig, FederationId, ModuleInitRegistry};
+use fedimint_core::config::{
+    ClientConfig, ClientModuleConfig, FederationId, JsonClientConfig, JsonWithKind,
+    ModuleInitRegistry,
+};
 use fedimint_core::core::{DynInput, DynOutput, IInput, IOutput, ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{AutocommitError, Database, DatabaseTransaction, IDatabase};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
@@ -756,6 +759,31 @@ impl Client {
     /// Returns the config with which the client was initialized.
     pub fn get_config(&self) -> &ClientConfig {
         &self.inner.config
+    }
+
+    /// Returns the config of the client in JSON format.
+    ///
+    /// Compared to the consensus module format where module configs are binary
+    /// encoded this format cannot be cryptographically verified but is easier
+    /// to consume and to some degree human-readable.
+    pub fn get_config_json(&self) -> JsonClientConfig {
+        JsonClientConfig {
+            global: self.get_config().global.clone(),
+            modules: self
+                .get_config()
+                .modules
+                .iter()
+                .map(|(instance_id, ClientModuleConfig { kind, config, .. })| {
+                    (
+                        *instance_id,
+                        JsonWithKind::new(
+                            kind.clone(),
+                            config.clone().expect_decoded().to_json().into(),
+                        ),
+                    )
+                })
+                .collect(),
+        }
     }
 
     /// Get the primary module

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -837,7 +837,7 @@ impl Client {
     ) -> SupportedApiVersionsSummary {
         SupportedApiVersionsSummary {
             core: SupportedCoreApiVersions {
-                core_consensus: config.consensus_version,
+                core_consensus: config.global.consensus_version,
                 api: MultiApiVersion::try_from_iter(SUPPORTED_CORE_API_VERSIONS.to_owned())
                     .expect("must not have conflicting versions"),
             },
@@ -851,7 +851,7 @@ impl Client {
                             (
                                 module_instance_id,
                                 SupportedModuleApiVersions {
-                                    core_consensus: config.consensus_version,
+                                    core_consensus: config.global.consensus_version,
                                     module_consensus: module_config.version,
                                     api: module_init.supported_api_versions(),
                                 },
@@ -1441,7 +1441,7 @@ impl ClientBuilder {
 
                 let module = module_init
                     .init(
-                        config.federation_id,
+                        config.global.federation_id,
                         module_config,
                         db.clone(),
                         module_instance,
@@ -1481,8 +1481,8 @@ impl ClientBuilder {
             config: config.clone(),
             decoders,
             db: db.clone(),
-            federation_id: config.federation_id,
-            federation_meta: config.meta,
+            federation_id: config.global.federation_id,
+            federation_meta: config.global.meta,
             primary_module_instance,
             modules,
             module_inits: self.module_inits.clone(),
@@ -1535,7 +1535,7 @@ async fn get_config(
             let mut dbtx = db.begin_transaction().await;
             dbtx.insert_new_entry(
                 &ClientConfigKey {
-                    id: config.federation_id,
+                    id: config.global.federation_id,
                 },
                 &config,
             )

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -796,6 +796,7 @@ impl WsFederationApi<WsClient> {
     pub fn from_config(config: &ClientConfig) -> Self {
         Self::new(
             config
+                .global
                 .api_endpoints
                 .iter()
                 .map(|(id, peer)| (*id, peer.url.clone()))

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -111,6 +111,14 @@ pub struct PeerUrl {
 /// This includes global settings and client-side module configs.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Encodable, Decodable)]
 pub struct ClientConfig {
+    #[serde(flatten)]
+    pub global: GlobalClientConfig,
+    pub modules: BTreeMap<ModuleInstanceId, ClientModuleConfig>,
+}
+
+/// Federation-wide client config
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Encodable, Decodable)]
+pub struct GlobalClientConfig {
     // Stable and unique id and threshold pubkey of the federation for authenticating configs
     pub federation_id: FederationId,
     /// API endpoints for each federation member
@@ -122,8 +130,6 @@ pub struct ClientConfig {
     // TODO: make it a String -> serde_json::Value map?
     /// Additional config the federation wants to transmit to the clients
     pub meta: BTreeMap<String, String>,
-    /// Configs from other client modules
-    pub modules: BTreeMap<ModuleInstanceId, ClientModuleConfig>,
 }
 
 impl ClientConfig {
@@ -282,7 +288,7 @@ impl ClientConfig {
 
     /// Federation name from config metadata (if set)
     pub fn federation_name(&self) -> Option<&str> {
-        self.meta.get(META_FEDERATION_NAME_KEY).map(|x| &**x)
+        self.global.meta.get(META_FEDERATION_NAME_KEY).map(|x| &**x)
     }
 }
 

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -116,6 +116,14 @@ pub struct ClientConfig {
     pub modules: BTreeMap<ModuleInstanceId, ClientModuleConfig>,
 }
 
+/// Client config that cannot be cryptographically verified but is easier to
+/// parse by external tools
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct JsonClientConfig {
+    pub global: GlobalClientConfig,
+    pub modules: BTreeMap<ModuleInstanceId, JsonWithKind>,
+}
+
 /// Federation-wide client config
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Encodable, Decodable)]
 pub struct GlobalClientConfig {

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -23,7 +23,7 @@ use crate::{
     erased_eq_no_instance_id, module_plugin_dyn_newtype_clone_passhthrough,
     module_plugin_dyn_newtype_define, module_plugin_dyn_newtype_display_passthrough,
     module_plugin_dyn_newtype_encode_decode, module_plugin_dyn_newtype_eq_passthrough,
-    module_plugin_static_trait_define,
+    module_plugin_static_trait_define, module_plugin_static_trait_define_config,
 };
 
 pub mod client;
@@ -216,13 +216,25 @@ pub trait IClientConfig: Debug + Display + DynEncodable {
     fn clone(&self, instance_id: ModuleInstanceId) -> DynClientConfig;
     fn dyn_hash(&self) -> u64;
     fn erased_eq_no_instance_id(&self, other: &DynClientConfig) -> bool;
+    fn to_json(&self) -> Option<serde_json::Value>;
 }
 
-module_plugin_static_trait_define! {
+module_plugin_static_trait_define_config! {
     DynClientConfig, ClientConfig, IClientConfig,
-    { }
+    { },
     {
         erased_eq_no_instance_id!(DynClientConfig);
+
+        fn to_json(&self) -> Option<serde_json::Value> {
+            Some(serde_json::to_value(self.to_owned()).expect("serialization can't fail"))
+        }
+    },
+    {
+        erased_eq_no_instance_id!(DynClientConfig);
+
+        fn to_json(&self) -> Option<serde_json::Value> {
+            None
+        }
     }
 }
 
@@ -251,7 +263,7 @@ pub trait IInput: Debug + Display + DynEncodable {
 
 module_plugin_static_trait_define! {
     DynInput, Input, IInput,
-    { }
+    { },
     {
         erased_eq_no_instance_id!(DynInput);
     }
@@ -286,7 +298,7 @@ module_plugin_dyn_newtype_define! {
 }
 module_plugin_static_trait_define! {
     DynOutput, Output, IOutput,
-    { }
+    { },
     {
         erased_eq_no_instance_id!(DynOutput);
     }
@@ -316,7 +328,7 @@ module_plugin_dyn_newtype_define! {
 }
 module_plugin_static_trait_define! {
     DynOutputOutcome, OutputOutcome, IOutputOutcome,
-    { }
+    { },
     {
         erased_eq_no_instance_id!(DynOutputOutcome);
     }
@@ -340,7 +352,7 @@ module_plugin_dyn_newtype_define! {
 }
 module_plugin_static_trait_define! {
     DynModuleConsensusItem, ModuleConsensusItem, IModuleConsensusItem,
-    { }
+    { },
     {
         erased_eq_no_instance_id!(DynModuleConsensusItem);
     }

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -73,6 +73,14 @@ hash_newtype!(
 )]
 pub struct PeerId(u16);
 
+impl FromStr for PeerId {
+    type Err = <u16 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(PeerId)
+    }
+}
+
 /// Represents an amount of BTC inside the system. The base denomination is
 /// milli satoshi for now, this is also why the amount type from rust-bitcoin
 /// isn't used instead.

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -517,12 +517,13 @@ async fn test_connect_raw_client(
     let mut cfg = api.download_client_config(&invite_code).await?;
 
     if let Some(limit_endpoints) = limit_endpoints {
-        cfg.api_endpoints = cfg
+        cfg.global.api_endpoints = cfg
+            .global
             .api_endpoints
             .into_iter()
             .take(limit_endpoints)
             .collect();
-        info!("Limiting endpoints to {:?}", cfg.api_endpoints);
+        info!("Limiting endpoints to {:?}", cfg.global.api_endpoints);
     }
     use jsonrpsee_core::client::ClientT;
     use jsonrpsee_ws_client::WsClientBuilder;
@@ -530,7 +531,7 @@ async fn test_connect_raw_client(
     info!("Connecting to {users} clients");
     let clients = (0..users)
         .flat_map(|_| {
-            let clients = cfg.api_endpoints.values().map(|url| async {
+            let clients = cfg.global.api_endpoints.values().map(|url| async {
                 let ws_client = WsClientBuilder::default()
                     .use_webpki_rustls()
                     .request_timeout(timeout)

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -189,10 +189,13 @@ impl ServerConfigConsensus {
         module_config_gens: &ModuleInitRegistry<DynServerModuleInit>,
     ) -> Result<ClientConfig, anyhow::Error> {
         let client = ClientConfig {
-            federation_id: FederationId(self.auth_pk_set.public_key()),
-            epoch_pk: self.epoch_pk_set.public_key(),
-            api_endpoints: self.api_endpoints.clone(),
-            consensus_version: self.version,
+            global: GlobalClientConfig {
+                federation_id: FederationId(self.auth_pk_set.public_key()),
+                epoch_pk: self.epoch_pk_set.public_key(),
+                api_endpoints: self.api_endpoints.clone(),
+                consensus_version: self.version,
+                meta: self.meta.clone(),
+            },
             modules: self
                 .modules
                 .iter()
@@ -203,7 +206,6 @@ impl ServerConfigConsensus {
                     Ok((*k, gen.get_client_config(*k, v)?))
                 })
                 .collect::<anyhow::Result<BTreeMap<_, _>>>()?,
-            meta: self.meta.clone(),
         };
         Ok(client)
     }

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -72,6 +72,7 @@ impl FederationTest {
             .consensus
             .to_client_config(&self.server_init)
             .unwrap()
+            .global
             .federation_id
     }
 

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -46,7 +46,7 @@ impl StandardGatewayClientBuilder {
         lnrpc: Arc<dyn ILnRpcClient>,
         old_client: Option<fedimint_client::Client>,
     ) -> Result<fedimint_client::Client> {
-        let federation_id = config.config.federation_id;
+        let federation_id = config.config.global.federation_id;
 
         let mut registry = self.registry.clone();
         registry.attach(GatewayClientGen {
@@ -99,7 +99,7 @@ impl StandardGatewayClientBuilder {
         config: FederationConfig,
         mut dbtx: DatabaseTransaction<'_>,
     ) -> Result<()> {
-        let id = config.config.federation_id;
+        let id = config.config.global.federation_id;
         dbtx.insert_entry(&FederationIdKey { id }, &config).await;
         dbtx.commit_tx_result()
             .await

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -594,7 +594,7 @@ impl Gateway {
             let mut next_channel_id = channel_id_generator.load(Ordering::SeqCst);
 
             for config in configs {
-                let federation_id = config.config.federation_id;
+                let federation_id = config.config.global.federation_id;
                 let old_client = self.clients.read().await.get(&federation_id).cloned();
                 let client = self
                     .client_builder
@@ -712,7 +712,7 @@ impl Gateway {
             }
         };
 
-        let federation_id = gw_client_cfg.config.federation_id;
+        let federation_id = gw_client_cfg.config.global.federation_id;
         let route_hints =
             Self::fetch_lightning_route_hints(self.lnrpc.clone(), self.num_route_hints).await?;
         let old_client = self.clients.read().await.get(&federation_id).cloned();

--- a/gateway/ln-gateway/src/ng/mod.rs
+++ b/gateway/ln-gateway/src/ng/mod.rs
@@ -259,7 +259,7 @@ impl GatewayClientExt for Client {
             gateway_id,
         );
 
-        let federation_id = self.get_config().federation_id;
+        let federation_id = self.get_config().global.federation_id;
         let mut dbtx = self.db().begin_transaction().await;
         gateway
             .register_with_federation(&mut dbtx, federation_id, registration_info)

--- a/integrationtests/tests/fixtures/legacy.rs
+++ b/integrationtests/tests/fixtures/legacy.rs
@@ -56,6 +56,7 @@ impl<T: AsRef<ClientConfig> + Clone + Send> LegacyTestUser<T> {
         let api = WsFederationApi::new(
             config
                 .as_ref()
+                .global
                 .api_endpoints
                 .iter()
                 .filter(|(id, _)| peers.contains(id))

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -266,7 +266,7 @@ impl LightningClientExt for Client {
                     instance.api,
                     invoice.clone(),
                     active_gateway,
-                    self.get_config().federation_id,
+                    self.get_config().global.federation_id,
                     rand::rngs::OsRng,
                 )
                 .await?;

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -167,7 +167,7 @@ impl MintRestoreInProgressState {
                     .make_progress(
                         global_context.api().clone(),
                         global_context.decoders().clone(),
-                        global_context.client_config().epoch_pk,
+                        global_context.client_config().global.epoch_pk,
                         secret,
                     )
                     .await


### PR DESCRIPTION
Manual backport of #3386 and parts of #3079 (separate client config into global/module top-level keys, add `config` CLI command + function to serialize full client config as JSON) 