### PR TITLE
[Backport] Gateway Backport Fixes to 0.1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "fedimint-wallet-client",
  "fedimintd",
  "futures",
+ "ln-gateway",
  "nix",
  "rand",
  "serde",
@@ -1942,6 +1943,7 @@ name = "fedimint-testing"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bitcoin 0.29.2",
  "bitcoincore-rpc",
@@ -1949,7 +1951,6 @@ dependencies = [
  "cln-rpc",
  "fedimint-bitcoind",
  "fedimint-client",
- "fedimint-client-legacy",
  "fedimint-core",
  "fedimint-logging",
  "fedimint-rocksdb",

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -28,6 +28,7 @@ fedimint-client-legacy = { path = "../fedimint-client-legacy" }
 fedimint-server = { path = "../fedimint-server" }
 fedimint-testing = { path = "../fedimint-testing" }
 futures = "0.3.24"
+ln-gateway = { path = "../gateway/ln-gateway" }
 nix = { version = "0.26.2", features = ["signal"] }
 rand = "0.8.5"
 serde_json = "1.0.94"

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -11,7 +11,7 @@ use cln_rpc::ClnRpc;
 use fedimint_core::encoding::Encodable;
 use fedimint_core::task::{block_in_place, sleep};
 use fedimint_logging::LOG_DEVIMINT;
-use fedimint_testing::gateway::LightningNodeName;
+use fedimint_testing::gateway::LightningNodeType;
 use futures::executor::block_on;
 use tokio::fs;
 use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
@@ -386,10 +386,10 @@ pub enum LightningNode {
 }
 
 impl LightningNode {
-    pub fn name(&self) -> LightningNodeName {
+    pub fn name(&self) -> LightningNodeType {
         match self {
-            LightningNode::Cln(_) => LightningNodeName::Cln,
-            LightningNode::Lnd(_) => LightningNodeName::Lnd,
+            LightningNode::Cln(_) => LightningNodeType::Cln,
+            LightningNode::Lnd(_) => LightningNodeType::Lnd,
         }
     }
 }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.65"
+async-stream = "0.3.5"
 async-trait = "*"
 bitcoin = "0.29.2"
 bitcoincore-rpc = "0.16.0"
@@ -42,5 +43,3 @@ tokio = { version = "1.26.0", features = ["full"] }
 tokio-stream = "0.1.11"
 tonic_lnd = { git = "https://github.com/fedimint/tonic_lnd", branch="master", features = ["lightningrpc", "routerrpc"] }
 url = "2.3.1"
-# Remove once we modularize the gw
-fedimint-client-legacy = { path = "../fedimint-client-legacy" }

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -164,10 +164,7 @@ impl Fixtures {
     /// Returns the CLN lightning node
     pub async fn cln(&self) -> Box<dyn LightningTest> {
         match Fixtures::is_real_test() {
-            true => {
-                let dir = env::var("FM_TEST_DIR").expect("Real tests require FM_TEST_DIR");
-                Box::new(ClnLightningTest::new(&dir).await)
-            }
+            true => Box::new(ClnLightningTest::new().await),
             false => Box::new(FakeLightningTest::new()),
         }
     }

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -87,13 +87,14 @@ impl GatewayTest {
         let client_builder: StandardGatewayClientBuilder =
             StandardGatewayClientBuilder::new(path.clone(), registry, 0);
 
-        let lightning_builder: Arc<dyn LightningBuilder + Send + Sync> =
-            match Fixtures::is_real_test() {
-                true => Arc::new(RealLightningBuilder {
-                    node_type: lightning.lightning_node_type(),
-                }),
-                false => Arc::new(FakeLightningBuilder {}),
-            };
+        let lightning_builder: Arc<dyn LightningBuilder + Send + Sync> = if Fixtures::is_real_test()
+        {
+            Arc::new(RealLightningBuilder {
+                node_type: lightning.lightning_node_type(),
+            })
+        } else {
+            Arc::new(FakeLightningBuilder {})
+        };
 
         let gateway_db = Database::new(MemDatabase::new(), decoders.clone());
 
@@ -130,12 +131,12 @@ impl GatewayTest {
                 break;
             }
 
-            if gateway_state_iterations > 9 {
+            if gateway_state_iterations >= 30 {
                 panic!("Gateway did not start running after 10 attempts");
             }
 
             gateway_state_iterations += 1;
-            sleep(Duration::from_millis(100)).await;
+            sleep(Duration::from_secs(1)).await;
         }
 
         let listening_addr = lightning.listening_address();

--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -1,14 +1,14 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use async_stream::stream;
 use async_trait::async_trait;
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::{PublicKey, SecretKey};
 use bitcoin::{secp256k1, KeyPair};
-use fedimint_client_legacy::modules::ln::contracts::Preimage;
 use fedimint_core::task::TaskGroup;
+use fedimint_core::util::BoxStream;
 use fedimint_core::Amount;
-use futures::stream;
 use lightning::ln::PaymentSecret;
 use lightning_invoice::{
     Currency, Description, Invoice, InvoiceBuilder, InvoiceDescription, SignedRawInvoice,
@@ -18,19 +18,21 @@ use ln_gateway::gateway_lnrpc::{
     self, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
     PayInvoiceRequest, PayInvoiceResponse,
 };
-use ln_gateway::lnrpc_client::{ILnRpcClient, LightningRpcError, RouteHtlcStream};
+use ln_gateway::lnrpc_client::{HtlcResult, ILnRpcClient, LightningRpcError, RouteHtlcStream};
 use rand::rngs::OsRng;
+use tokio::sync::mpsc;
 
 use super::LightningTest;
+use crate::gateway::LightningNodeType;
 
 pub const INVALID_INVOICE_DESCRIPTION: &str = "INVALID";
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct FakeLightningTest {
-    pub preimage: Preimage,
     pub gateway_node_pub_key: secp256k1::PublicKey,
     gateway_node_sec_key: secp256k1::SecretKey,
     amount_sent: Arc<Mutex<u64>>,
+    receiver: mpsc::Receiver<HtlcResult>,
 }
 
 impl FakeLightningTest {
@@ -38,12 +40,13 @@ impl FakeLightningTest {
         let ctx = bitcoin::secp256k1::Secp256k1::new();
         let kp = KeyPair::new(&ctx, &mut OsRng);
         let amount_sent = Arc::new(Mutex::new(0));
+        let (_, receiver) = mpsc::channel::<HtlcResult>(10);
 
         FakeLightningTest {
-            preimage: Preimage([0; 32]),
             gateway_node_sec_key: SecretKey::from_keypair(&kp),
             gateway_node_pub_key: PublicKey::from_keypair(&kp),
             amount_sent,
+            receiver,
         }
     }
 }
@@ -65,7 +68,7 @@ impl LightningTest for FakeLightningTest {
 
         Ok(InvoiceBuilder::new(Currency::Regtest)
             .description("".to_string())
-            .payment_hash(sha256::Hash::hash(&self.preimage.0))
+            .payment_hash(sha256::Hash::hash(&[0; 32]))
             .current_timestamp()
             .min_final_cltv_expiry(0)
             .payment_secret(PaymentSecret([0; 32]))
@@ -83,6 +86,10 @@ impl LightningTest for FakeLightningTest {
 
     fn listening_address(&self) -> String {
         "FakeListeningAddress".to_string()
+    }
+
+    fn lightning_node_type(&self) -> LightningNodeType {
+        unimplemented!("FakeLightningTest does not have a lightning node type")
     }
 }
 
@@ -128,10 +135,22 @@ impl ILnRpcClient for FakeLightningTest {
     }
 
     async fn route_htlcs<'a>(
-        self: Box<Self>,
-        _task_group: &mut TaskGroup,
+        mut self: Box<Self>,
+        task_group: &mut TaskGroup,
     ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError> {
-        Ok((Box::pin(stream::iter(vec![])), Arc::new(Self::new())))
+        let handle = task_group.make_handle();
+        let shutdown_receiver = handle.make_shutdown_rx().await;
+
+        // `FakeLightningTest` will never intercept any HTLCs because there is no
+        // lightning connection, so instead we just create a stream that blocks
+        // until the task group is shutdown.
+        let stream: BoxStream<'a, HtlcResult> = Box::pin(stream! {
+            shutdown_receiver.await;
+            if let Some(htlc_result) = self.receiver.recv().await {
+                yield htlc_result;
+            }
+        });
+        Ok((stream, Arc::new(Self::new())))
     }
 
     async fn complete_htlc(

--- a/fedimint-testing/src/ln/mod.rs
+++ b/fedimint-testing/src/ln/mod.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use async_trait::async_trait;
 use bitcoin::hashes::sha256;
 use bitcoin::KeyPair;
-use fedimint_client_legacy::modules::ln::contracts::Preimage;
 use fedimint_core::{Amount, BitcoinHash};
 use lightning::ln::PaymentSecret;
 use lightning_invoice::{Currency, Invoice, InvoiceBuilder, DEFAULT_EXPIRY_TIME};
@@ -12,6 +11,7 @@ use rand::rngs::OsRng;
 use secp256k1_zkp::SecretKey;
 
 use self::mock::INVALID_INVOICE_DESCRIPTION;
+use crate::gateway::LightningNodeType;
 
 pub mod mock;
 pub mod real;
@@ -43,7 +43,7 @@ pub trait LightningTest: ILnRpcClient {
         Ok(InvoiceBuilder::new(Currency::Regtest)
             .payee_pub_key(kp.public_key())
             .description(INVALID_INVOICE_DESCRIPTION.to_string())
-            .payment_hash(sha256::Hash::hash(&Preimage([0; 32]).0))
+            .payment_hash(sha256::Hash::hash(&[0; 32]))
             .current_timestamp()
             .min_final_cltv_expiry(0)
             .payment_secret(PaymentSecret([0; 32]))
@@ -59,4 +59,6 @@ pub trait LightningTest: ILnRpcClient {
     fn is_shared(&self) -> bool;
 
     fn listening_address(&self) -> String;
+
+    fn lightning_node_type(&self) -> LightningNodeType;
 }

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -29,6 +29,7 @@ use tracing::{error, info, warn};
 use url::Url;
 
 use crate::btc::BitcoinTest;
+use crate::gateway::LightningNodeType;
 use crate::ln::LightningTest;
 
 const DEFAULT_ESPLORA_SERVER: &str = "http://127.0.0.1:50002";
@@ -103,6 +104,10 @@ impl LightningTest for ClnLightningTest {
     fn listening_address(&self) -> String {
         "127.0.0.1:9000".to_string()
     }
+
+    fn lightning_node_type(&self) -> LightningNodeType {
+        LightningNodeType::Cln
+    }
 }
 
 #[async_trait]
@@ -141,7 +146,8 @@ impl ILnRpcClient for ClnLightningTest {
 }
 
 impl ClnLightningTest {
-    pub async fn new(dir: &str) -> ClnLightningTest {
+    pub async fn new() -> ClnLightningTest {
+        let dir = env::var("FM_TEST_DIR").expect("Real tests require FM_TEST_DIR");
         let socket_cln = PathBuf::from(dir).join("cln/regtest/lightning-rpc");
         let rpc_cln = Arc::new(Mutex::new(ClnRpc::new(socket_cln).await.unwrap()));
 
@@ -245,6 +251,10 @@ impl LightningTest for LndLightningTest {
 
     fn listening_address(&self) -> String {
         "127.0.0.1:9734".to_string()
+    }
+
+    fn lightning_node_type(&self) -> LightningNodeType {
+        LightningNodeType::Lnd
     }
 }
 
@@ -755,5 +765,9 @@ impl LightningTest for LdkLightningTest {
 
     fn listening_address(&self) -> String {
         self.listening_address.clone()
+    }
+
+    fn lightning_node_type(&self) -> LightningNodeType {
+        LightningNodeType::Ldk
     }
 }

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -1,4 +1,6 @@
-use ln_gateway::Gatewayd;
+use fedimint_logging::TracingSetup;
+use ln_gateway::Gateway;
+use tracing::info;
 
 /// Fedimint Gateway Binary
 ///
@@ -8,5 +10,9 @@ use ln_gateway::Gatewayd;
 /// remote Lightning node accessible through a `GatewayLightningServer`.
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    Gatewayd::new()?.with_default_modules().run().await
+    TracingSetup::default().init()?;
+    let shutdown_receiver = Gateway::new_with_default_modules().await?.run().await?;
+    shutdown_receiver.await;
+    info!("Gatewayd exiting...");
+    Ok(())
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -158,7 +158,7 @@ pub struct Gateway {
     api_addr: Url,
     password: String,
     num_route_hints: usize,
-    state: Arc<RwLock<GatewayState>>,
+    pub state: Arc<RwLock<GatewayState>>,
     client_builder: StandardGatewayClientBuilder,
     gateway_db: Database,
     clients: Arc<RwLock<BTreeMap<FederationId, fedimint_client::Client>>>,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -45,14 +45,13 @@ use fedimint_ln_client::contracts::Preimage;
 use fedimint_ln_client::pay::PayInvoicePayload;
 use fedimint_ln_common::config::GatewayFee;
 use fedimint_ln_common::route_hints::RouteHint;
-use fedimint_logging::TracingSetup;
 use fedimint_mint_client::{MintClientGen, MintCommonGen};
 use fedimint_wallet_client::{WalletClientExt, WalletClientGen, WalletCommonGen, WithdrawState};
 use futures::stream::StreamExt;
 use gateway_lnrpc::intercept_htlc_response::Action;
 use gateway_lnrpc::{GetNodeInfoResponse, InterceptHtlcResponse};
 use lightning::routing::gossip::RoutingFees;
-use lnrpc_client::{ILnRpcClient, LightningRpcError, RouteHtlcStream};
+use lnrpc_client::{ILnRpcClient, LightningBuilder, LightningRpcError, RouteHtlcStream};
 use ng::pay::OutgoingPaymentError;
 use ng::GatewayClientExt;
 use rand::rngs::OsRng;
@@ -66,8 +65,7 @@ use tracing::{debug, error, info, warn};
 use url::Url;
 
 use crate::gateway_lnrpc::intercept_htlc_response::Forward;
-use crate::lnd::GatewayLndClient;
-use crate::lnrpc_client::NetworkLnRpcClient;
+use crate::lnrpc_client::GatewayLightningBuilder;
 use crate::ng::GatewayExtPayStates;
 use crate::rpc::rpc_server::run_webserver;
 use crate::rpc::{
@@ -76,7 +74,7 @@ use crate::rpc::{
 };
 
 /// LND HTLC interceptor can't handle SCID of 0, so start from 1
-const INITIAL_SCID: u64 = 1;
+pub const INITIAL_SCID: u64 = 1;
 
 /// How long a gateway announcement stays valid
 pub const GW_ANNOUNCEMENT_TTL: Duration = Duration::from_secs(600);
@@ -132,19 +130,74 @@ pub struct GatewayOpts {
     pub num_route_hints: Option<usize>,
 }
 
-pub struct Gatewayd {
-    registry: ClientModuleInitRegistry,
-    lightning_mode: LightningMode,
-    data_dir: PathBuf,
+/// ```mermaid
+/// graph LR
+/// classDef virtual fill:#fff,stroke-dasharray: 5 5
+///
+/// graph LR
+/// classDef virtual fill:#fff,stroke-dasharray: 5 5
+///    Initializing -- begin intercepting HTLCs --> Running
+///    Running -- disconnected from lightning node --> Disconnected
+///    Disconnected -- re-established lightning connection --> Running
+/// ```
+#[derive(Clone)]
+pub enum GatewayState {
+    Initializing,
+    Running {
+        lnrpc: Arc<dyn ILnRpcClient>,
+        lightning_public_key: PublicKey,
+        lightning_alias: String,
+    },
+    Disconnected,
+}
+
+#[derive(Clone)]
+pub struct Gateway {
+    lightning_builder: Arc<dyn LightningBuilder + Send + Sync>,
     listen: SocketAddr,
     api_addr: Url,
     password: String,
-    fees: Option<GatewayFee>,
     num_route_hints: usize,
+    state: Arc<RwLock<GatewayState>>,
+    client_builder: StandardGatewayClientBuilder,
+    gateway_db: Database,
+    clients: Arc<RwLock<BTreeMap<FederationId, fedimint_client::Client>>>,
+    scid_to_federation: Arc<RwLock<BTreeMap<u64, FederationId>>>,
+    pub gateway_id: secp256k1::PublicKey,
+    channel_id_generator: Arc<Mutex<AtomicU64>>,
+    fees: RoutingFees,
 }
 
-impl Gatewayd {
-    pub fn new() -> anyhow::Result<Gatewayd> {
+impl Gateway {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_with_custom_registry(
+        lightning_builder: Arc<dyn LightningBuilder + Send + Sync>,
+        client_builder: StandardGatewayClientBuilder,
+        listen: SocketAddr,
+        api_addr: Url,
+        password: String,
+        fees: RoutingFees,
+        num_route_hints: usize,
+        gateway_db: Database,
+    ) -> anyhow::Result<Gateway> {
+        Ok(Gateway {
+            lightning_builder,
+            listen,
+            api_addr,
+            password,
+            num_route_hints,
+            state: Arc::new(RwLock::new(GatewayState::Initializing)),
+            client_builder,
+            gateway_db: gateway_db.clone(),
+            clients: Arc::new(RwLock::new(BTreeMap::new())),
+            scid_to_federation: Arc::new(RwLock::new(BTreeMap::new())),
+            gateway_id: Gateway::get_gateway_id(gateway_db).await,
+            channel_id_generator: Arc::new(Mutex::new(AtomicU64::new(INITIAL_SCID))),
+            fees,
+        })
+    }
+
+    pub async fn new_with_default_modules() -> anyhow::Result<Gateway> {
         let mut args = std::env::args();
 
         if let Some(ref arg) = args.nth(1) {
@@ -165,268 +218,51 @@ impl Gatewayd {
             num_route_hints,
         } = GatewayOpts::parse();
 
+        // Gateway module will be attached when the federation clients are created
+        // because the LN RPC will be injected with `GatewayClientGen`.
+        let mut registry = ClientModuleInitRegistry::new();
+        registry.attach(MintClientGen);
+        registry.attach(WalletClientGen::default());
+
+        let decoders = registry.available_decoders(DEFAULT_MODULE_KINDS.iter().cloned())?;
+
+        let gateway_db = Database::new(
+            fedimint_rocksdb::RocksDb::open(data_dir.join(DB_FILE))?,
+            decoders.clone(),
+        );
+
+        let client_builder = StandardGatewayClientBuilder::new(
+            data_dir.clone(),
+            registry.clone(),
+            LEGACY_HARDCODED_INSTANCE_ID_MINT,
+        );
+
         info!(
             "Starting gatewayd (version: {})",
             env!("FEDIMINT_BUILD_CODE_VERSION")
         );
 
         Ok(Self {
-            registry: ClientModuleInitRegistry::new(),
-            lightning_mode: mode,
-            data_dir,
+            lightning_builder: Arc::new(GatewayLightningBuilder {
+                lightning_mode: mode,
+            }),
             listen,
             api_addr,
             password,
-            fees,
+            channel_id_generator: Arc::new(Mutex::new(AtomicU64::new(INITIAL_SCID))),
+            fees: fees.unwrap_or(GatewayFee(DEFAULT_FEES)).0,
             num_route_hints: num_route_hints.unwrap_or(0),
+            state: Arc::new(RwLock::new(GatewayState::Initializing)),
+            client_builder,
+            gateway_id: Self::get_gateway_id(gateway_db.clone()).await,
+            gateway_db,
+            clients: Arc::new(RwLock::new(BTreeMap::new())),
+            scid_to_federation: Arc::new(RwLock::new(BTreeMap::new())),
         })
     }
 
-    pub fn with_module<T>(mut self, gen: T) -> Self
-    where
-        T: ClientModuleInit + 'static + Send + Sync,
-    {
-        self.registry.attach(gen);
-        self
-    }
-
-    pub fn with_default_modules(self) -> Self {
-        // Gateway module will be attached when the federation clients are created
-        // because the LN RPC will be injected with `GatewayClientGen`.
-        self.with_module(MintClientGen)
-            .with_module(WalletClientGen::default())
-    }
-
-    pub async fn run(self) -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
-
-        let decoders = self
-            .registry
-            .available_decoders(DEFAULT_MODULE_KINDS.iter().cloned())?;
-
-        let client_builder = StandardGatewayClientBuilder::new(
-            self.data_dir.clone(),
-            self.registry.clone(),
-            LEGACY_HARDCODED_INSTANCE_ID_MINT,
-        );
-
-        let db = Database::new(
-            fedimint_rocksdb::RocksDb::open(self.data_dir.join(DB_FILE))?,
-            decoders.clone(),
-        );
-
-        let mut tg = TaskGroup::new();
-        let rx = self.start_gateway(&mut tg, client_builder, db).await?;
-        rx.await;
-        info!("Gatewayd exiting...");
-        Ok(())
-    }
-
-    async fn start_gateway(
-        self,
-        task_group: &mut TaskGroup,
-        client_builder: StandardGatewayClientBuilder,
-        database: Database,
-    ) -> Result<TaskShutdownToken> {
-        let mut tg = task_group.make_subgroup().await;
-        task_group
-            .spawn(
-                "Subscribe to intercepted HTLCs in stream",
-                move |handle| async move {
-                    let clients =  Arc::new(RwLock::new(BTreeMap::new()));
-                    let scid_to_federation = Arc::new(RwLock::new(BTreeMap::new()));
-
-                    loop {
-                        if handle.is_shutting_down() {
-                            break;
-                        }
-
-                        let lnrpc_route = Self::create_boxed_lightning_client(self.lightning_mode.clone()).await;
-
-                        // Re-create the HTLC stream if the connection breaks
-                        match lnrpc_route
-                            .route_htlcs(&mut tg)
-                            .await
-                        {
-                            Ok((stream, ln_client)) => {
-                                // Blocks until the connection to the lightning node breaks
-                                info!("Established HTLC stream");
-
-                                // Re-create gateway
-                                let gateway = Gateway::new(
-                                    ln_client.clone(),
-                                    client_builder.clone(),
-                                    self.fees.clone().unwrap_or(GatewayFee(DEFAULT_FEES)).0,
-                                    database.clone(),
-                                    self.api_addr.clone(),
-                                    clients.clone(),
-                                    scid_to_federation.clone(),
-                                    tg.clone(),
-                                    self.num_route_hints,
-                                )
-                                .await.expect("Failed to created Gateway");
-
-                                info!("Successfully created Gateway");
-
-                                let task_group = run_webserver(self.password.clone(), self.listen, gateway)
-                                    .await
-                                    .expect("Failed to start webserver");
-                                info!("Successfully started webserver");
-
-                                Gateway::handle_htlc_stream(stream, ln_client, handle.clone(), scid_to_federation.clone(), clients.clone()).await;
-                                warn!("HTLC Stream Lightning connection broken. Stopping webserver...");
-                                task_group.shutdown();
-                            }
-                            Err(e) => {
-                                error!("Failed to open HTLC stream. Waiting 5 seconds and trying again");
-                                debug!("Error: {e:?}");
-                                sleep(Duration::from_secs(5)).await;
-                            }
-                        }
-                    }
-                },
-            )
-            .await;
-
-        let handle = task_group.make_handle();
-        let shutdown_receiver = handle.make_shutdown_rx().await;
-        Ok(shutdown_receiver)
-    }
-
-    async fn create_boxed_lightning_client(mode: LightningMode) -> Box<dyn ILnRpcClient> {
-        match mode {
-            LightningMode::Cln { cln_extension_addr } => {
-                Box::new(NetworkLnRpcClient::new(cln_extension_addr).await)
-            }
-            LightningMode::Lnd {
-                lnd_rpc_addr,
-                lnd_tls_cert,
-                lnd_macaroon,
-            } => Box::new(
-                GatewayLndClient::new(lnd_rpc_addr, lnd_tls_cert, lnd_macaroon, None).await,
-            ),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]
-pub enum LightningMode {
-    #[clap(name = "lnd")]
-    Lnd {
-        /// LND RPC address
-        #[arg(long = "lnd-rpc-host", env = "FM_LND_RPC_ADDR")]
-        lnd_rpc_addr: String,
-
-        /// LND TLS cert file path
-        #[arg(long = "lnd-tls-cert", env = "FM_LND_TLS_CERT")]
-        lnd_tls_cert: String,
-
-        /// LND macaroon file path
-        #[arg(long = "lnd-macaroon", env = "FM_LND_MACAROON")]
-        lnd_macaroon: String,
-    },
-    #[clap(name = "cln")]
-    Cln {
-        #[arg(long = "cln-extension-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
-        cln_extension_addr: Url,
-    },
-}
-
-#[derive(Debug, Error)]
-pub enum GatewayError {
-    #[error("Federation error: {0:?}")]
-    FederationError(#[from] FederationError),
-    #[error("Other: {0:?}")]
-    ClientStateMachineError(#[from] anyhow::Error),
-    #[error("Failed to open the database: {0:?}")]
-    DatabaseError(anyhow::Error),
-    #[error("Federation client error")]
-    LightningRpcError(#[from] LightningRpcError),
-    #[error("Outgoing Payment Error {0:?}")]
-    OutgoingPaymentError(#[from] Box<OutgoingPaymentError>),
-    #[error("Invalid Metadata: {0}")]
-    InvalidMetadata(String),
-    #[error("Unexpected state: {0}")]
-    UnexpectedState(String),
-}
-
-impl IntoResponse for GatewayError {
-    fn into_response(self) -> Response {
-        // For privacy reasons, we do not return too many details about the failure of
-        // the request back to the client to prevent malicious clients from
-        // deducing state about the gateway/lightning node.
-        let (error_message, status_code) = match self {
-            GatewayError::OutgoingPaymentError(_) => (
-                "Error while paying lightning invoice. Outgoing contract will be refunded."
-                    .to_string(),
-                StatusCode::BAD_REQUEST,
-            ),
-            _ => (
-                "An internal gateway error occurred".to_string(),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ),
-        };
-        let mut err = Cow::<'static, str>::Owned(error_message).into_response();
-        *err.status_mut() = status_code;
-        err
-    }
-}
-
-#[derive(Clone)]
-pub struct Gateway {
-    lnrpc: Arc<dyn ILnRpcClient>,
-    clients: Arc<RwLock<BTreeMap<FederationId, fedimint_client::Client>>>,
-    scid_to_federation: Arc<RwLock<BTreeMap<u64, FederationId>>>,
-    client_builder: StandardGatewayClientBuilder,
-    channel_id_generator: Arc<Mutex<AtomicU64>>,
-    fees: RoutingFees,
-    gatewayd_db: Database,
-    api: Url,
-    task_group: TaskGroup,
-    pub gateway_id: secp256k1::PublicKey,
-    num_route_hints: usize,
-    lightning_public_key: PublicKey,
-    lightning_alias: String,
-}
-
-impl Gateway {
-    #[allow(clippy::too_many_arguments)]
-    pub async fn new(
-        lnrpc: Arc<dyn ILnRpcClient>,
-        client_builder: StandardGatewayClientBuilder,
-        fees: RoutingFees,
-        gatewayd_db: Database,
-        api: Url,
-        clients: Arc<RwLock<BTreeMap<FederationId, fedimint_client::Client>>>,
-        scid_to_federation: Arc<RwLock<BTreeMap<u64, FederationId>>>,
-        task_group: TaskGroup,
-        num_route_hints: usize,
-    ) -> Result<Self> {
-        let (lightning_public_key, lightning_alias) =
-            Self::fetch_lightning_node_info(lnrpc.clone()).await?;
-        let mut gw = Self {
-            lnrpc,
-            clients,
-            scid_to_federation,
-            client_builder,
-            channel_id_generator: Arc::new(Mutex::new(AtomicU64::new(INITIAL_SCID))),
-            fees,
-            gatewayd_db: gatewayd_db.clone(),
-            api,
-            task_group,
-            gateway_id: Self::get_gateway_id(gatewayd_db).await,
-            num_route_hints,
-            lightning_public_key,
-            lightning_alias,
-        };
-
-        gw.load_clients().await?;
-        gw.register_clients_timer().await;
-        Ok(gw)
-    }
-
-    async fn get_gateway_id(gatewayd_db: Database) -> secp256k1::PublicKey {
-        let mut dbtx = gatewayd_db.begin_transaction().await;
+    pub async fn get_gateway_id(gateway_db: Database) -> secp256k1::PublicKey {
+        let mut dbtx = gateway_db.begin_transaction().await;
         if let Some(key_pair) = dbtx.get_value(&GatewayPublicKey {}).await {
             key_pair.public_key()
         } else {
@@ -439,46 +275,484 @@ impl Gateway {
         }
     }
 
-    pub async fn handle_htlc_stream(
-        mut stream: RouteHtlcStream<'_>,
-        lnrpc: Arc<dyn ILnRpcClient>,
-        handle: TaskHandle,
-        scid_to_federation: Arc<RwLock<BTreeMap<u64, FederationId>>>,
-        clients: Arc<RwLock<BTreeMap<FederationId, fedimint_client::Client>>>,
-    ) {
-        while let Some(Ok(htlc_request)) = stream.next().await {
-            if handle.is_shutting_down() {
-                break;
-            }
+    pub async fn run(self) -> anyhow::Result<TaskShutdownToken> {
+        let mut tg = TaskGroup::new();
 
-            let scid_to_feds = scid_to_federation.read().await;
-            let federation_id = scid_to_feds.get(&htlc_request.short_channel_id);
-            // Just forward the HTLC if we do not have a federation that
-            // corresponds to the short channel id
-            if let Some(federation_id) = federation_id {
-                let clients = clients.read().await;
-                let client = clients.get(federation_id);
-                // Just forward the HTLC if we do not have a client that
-                // corresponds to the federation id
-                if let Some(client) = client {
-                    let htlc = htlc_request.clone().try_into();
-                    if let Ok(htlc) = htlc {
-                        if client.gateway_handle_intercepted_htlc(htlc).await.is_ok() {
-                            continue;
+        run_webserver(self.password.clone(), self.listen, self.clone(), &mut tg)
+            .await
+            .expect("Failed to start webserver");
+        info!("Successfully started webserver");
+
+        self.start_gateway(&mut tg).await?;
+        let handle = tg.make_handle();
+        let shutdown_receiver = handle.make_shutdown_rx().await;
+        Ok(shutdown_receiver)
+    }
+
+    async fn start_gateway(mut self, task_group: &mut TaskGroup) -> Result<()> {
+        let mut tg = task_group.make_subgroup().await;
+        task_group
+            .spawn(
+                "Subscribe to intercepted HTLCs in stream",
+                move |handle| async move {
+                    loop {
+                        if handle.is_shutting_down() {
+                            break;
+                        }
+
+                        let lnrpc_route = self.lightning_builder.build().await;
+
+                        // Re-create the HTLC stream if the connection breaks
+                        match lnrpc_route
+                            .route_htlcs(&mut tg)
+                            .await
+                        {
+                            Ok((stream, ln_client)) => {
+                                // Blocks until the connection to the lightning node breaks
+                                info!("Established HTLC stream");
+
+                                let (lightning_public_key, lightning_alias) =
+                                Self::fetch_lightning_node_info(ln_client.clone()).await.expect("Failed to retrieve Lightning info after establishing a connection");
+
+                                self.register_clients_timer(&mut tg).await;
+                                self.set_gateway_state(GatewayState::Running {
+                                    lnrpc: ln_client,
+                                    lightning_public_key,
+                                    lightning_alias,
+
+                                }).await;
+                                self.load_clients().await.expect("Failed to load gateway clients");
+                                info!("Successfully loaded Gateway clients.");
+
+                                self.handle_htlc_stream(stream, handle.clone()).await;
+                                self.set_gateway_state(GatewayState::Disconnected).await;
+                                warn!("HTLC Stream Lightning connection broken. Gateway is disconnected");
+                            }
+                            Err(e) => {
+                                error!("Failed to open HTLC stream. Waiting 5 seconds and trying again");
+                                debug!("Error: {e:?}");
+                                sleep(Duration::from_secs(5)).await;
+                            }
+                        }
+                    }
+                },
+            )
+            .await;
+
+        Ok(())
+    }
+
+    pub async fn handle_htlc_stream(&self, mut stream: RouteHtlcStream<'_>, handle: TaskHandle) {
+        if let GatewayState::Running {
+            lnrpc,
+            lightning_public_key: _,
+            lightning_alias: _,
+        } = self.state.read().await.clone()
+        {
+            while let Some(Ok(htlc_request)) = stream.next().await {
+                if handle.is_shutting_down() {
+                    break;
+                }
+
+                let scid_to_feds = self.scid_to_federation.read().await;
+                let federation_id = scid_to_feds.get(&htlc_request.short_channel_id);
+                // Just forward the HTLC if we do not have a federation that
+                // corresponds to the short channel id
+                if let Some(federation_id) = federation_id {
+                    let clients = self.clients.read().await;
+                    let client = clients.get(federation_id);
+                    // Just forward the HTLC if we do not have a client that
+                    // corresponds to the federation id
+                    if let Some(client) = client {
+                        let htlc = htlc_request.clone().try_into();
+                        if let Ok(htlc) = htlc {
+                            if client.gateway_handle_intercepted_htlc(htlc).await.is_ok() {
+                                continue;
+                            }
                         }
                     }
                 }
+
+                let outcome = InterceptHtlcResponse {
+                    action: Some(Action::Forward(Forward {})),
+                    incoming_chan_id: htlc_request.incoming_chan_id,
+                    htlc_id: htlc_request.htlc_id,
+                };
+
+                if let Err(error) = lnrpc.complete_htlc(outcome).await {
+                    error!("Error sending HTLC response to lightning node: {error:?}");
+                }
+            }
+        }
+    }
+
+    async fn fetch_lightning_node_info(
+        lnrpc: Arc<dyn ILnRpcClient>,
+    ) -> Result<(PublicKey, String)> {
+        let GetNodeInfoResponse { pub_key, alias } = lnrpc.info().await?;
+        let node_pub_key = PublicKey::from_slice(&pub_key)
+            .map_err(|e| GatewayError::InvalidMetadata(format!("Invalid node pubkey {e}")))?;
+        Ok((node_pub_key, alias))
+    }
+
+    async fn set_gateway_state(&mut self, state: GatewayState) {
+        let mut lock = self.state.write().await;
+        *lock = state;
+    }
+
+    pub async fn handle_get_info(&self, _payload: InfoPayload) -> Result<GatewayInfo> {
+        if let GatewayState::Running {
+            lnrpc,
+            lightning_public_key,
+            lightning_alias,
+        } = self.state.read().await.clone()
+        {
+            let mut federations = Vec::new();
+            let federation_clients = self.clients.read().await.clone().into_iter();
+            let route_hints =
+                Self::fetch_lightning_route_hints(lnrpc.clone(), self.num_route_hints).await?;
+            for (federation_id, client) in federation_clients {
+                federations.push(self.make_federation_info(&client, federation_id).await);
             }
 
-            let outcome = InterceptHtlcResponse {
-                action: Some(Action::Forward(Forward {})),
-                incoming_chan_id: htlc_request.incoming_chan_id,
-                htlc_id: htlc_request.htlc_id,
+            return Ok(GatewayInfo {
+                federations,
+                version_hash: env!("FEDIMINT_BUILD_CODE_VERSION").to_string(),
+                lightning_pub_key: Some(lightning_public_key.to_hex()),
+                lightning_alias: Some(lightning_alias.clone()),
+                fees: self.fees,
+                route_hints,
+                gateway_id: self.gateway_id,
+            });
+        }
+
+        Ok(GatewayInfo {
+            federations: vec![],
+            version_hash: env!("FEDIMINT_BUILD_CODE_VERSION").to_string(),
+            lightning_pub_key: None,
+            lightning_alias: None,
+            fees: self.fees,
+            route_hints: vec![],
+            gateway_id: self.gateway_id,
+        })
+    }
+
+    pub async fn handle_balance_msg(&self, payload: BalancePayload) -> Result<Amount> {
+        Ok(self
+            .select_client(payload.federation_id)
+            .await?
+            .get_balance()
+            .await)
+    }
+
+    pub async fn handle_address_msg(&self, payload: DepositAddressPayload) -> Result<Address> {
+        let (_, address) = self
+            .select_client(payload.federation_id)
+            .await?
+            .get_deposit_address(now() + Duration::from_secs(86400 * 365))
+            .await?;
+        Ok(address)
+    }
+
+    pub async fn handle_withdraw_msg(&self, payload: WithdrawPayload) -> Result<Txid> {
+        let WithdrawPayload {
+            amount,
+            address,
+            federation_id,
+        } = payload;
+
+        let client = self.select_client(federation_id).await?;
+        // TODO: This should probably be passed in as a parameter
+        let fees = client.get_withdraw_fee(address.clone(), amount).await?;
+
+        let operation_id = client.withdraw(address, amount, fees).await?;
+        let mut updates = client
+            .subscribe_withdraw_updates(operation_id)
+            .await?
+            .into_stream();
+
+        while let Some(update) = updates.next().await {
+            match update {
+                WithdrawState::Succeeded(txid) => {
+                    return Ok(txid);
+                }
+                WithdrawState::Failed(e) => {
+                    return Err(GatewayError::UnexpectedState(e));
+                }
+                _ => {}
+            }
+        }
+
+        Err(GatewayError::UnexpectedState(
+            "Ran out of state updates while withdrawing".to_string(),
+        ))
+    }
+
+    async fn handle_pay_invoice_msg(&self, payload: PayInvoicePayload) -> Result<Preimage> {
+        if let GatewayState::Running {
+            lnrpc: _,
+            lightning_public_key: _,
+            lightning_alias: _,
+        } = self.state.read().await.clone()
+        {
+            let PayInvoicePayload {
+                federation_id,
+                contract_id,
+            } = payload;
+
+            let client = self.select_client(federation_id).await?;
+            let operation_id = client.gateway_pay_bolt11_invoice(contract_id).await?;
+            let mut updates = client
+                .gateway_subscribe_ln_pay(operation_id)
+                .await?
+                .into_stream();
+
+            while let Some(update) = updates.next().await {
+                match update {
+                    GatewayExtPayStates::Success {
+                        preimage,
+                        outpoint: _,
+                    } => return Ok(preimage),
+                    GatewayExtPayStates::Fail {
+                        error,
+                        error_message,
+                    } => {
+                        error!(error_message);
+                        return Err(GatewayError::OutgoingPaymentError(Box::new(error)));
+                    }
+                    GatewayExtPayStates::Canceled { error } => {
+                        return Err(GatewayError::OutgoingPaymentError(Box::new(error)));
+                    }
+                    _ => {}
+                };
+            }
+
+            return Err(GatewayError::UnexpectedState(
+                "Ran out of state updates while paying invoice".to_string(),
+            ));
+        }
+
+        Err(GatewayError::Disconnected)
+    }
+
+    async fn handle_connect_federation(
+        &mut self,
+        payload: ConnectFedPayload,
+    ) -> Result<FederationInfo> {
+        if let GatewayState::Running {
+            lnrpc,
+            lightning_public_key,
+            lightning_alias: _,
+        } = self.state.read().await.clone()
+        {
+            let invite_code = InviteCode::from_str(&payload.invite_code).map_err(|e| {
+                GatewayError::InvalidMetadata(format!("Invalid federation member string {e}"))
+            })?;
+
+            // The gateway deterministically assigns a channel id (u64) to each federation
+            // connected. TODO: explicitly handle the case where the channel id
+            // overflows
+            let channel_id = self
+                .channel_id_generator
+                .lock()
+                .await
+                .fetch_add(1, Ordering::SeqCst);
+
+            // Downloading the config can fail if another user tries to download at the same
+            // time. Just retry after a small delay
+            let gw_client_cfg = loop {
+                match self
+                    .client_builder
+                    .create_config(invite_code.clone(), channel_id, self.fees)
+                    .await
+                {
+                    Ok(gw_client_cfg) => break gw_client_cfg,
+                    Err(_) => {
+                        let random_delay: f64 = rand::thread_rng().gen();
+                        tracing::warn!(
+                            "Error downloading client config, trying again in {random_delay}"
+                        );
+                        sleep(Duration::from_secs_f64(random_delay)).await;
+                    }
+                }
             };
 
-            if let Err(error) = lnrpc.complete_htlc(outcome).await {
-                error!("Error sending HTLC response to lightning node: {error:?}");
+            let federation_id = gw_client_cfg.config.global.federation_id;
+            let route_hints =
+                Self::fetch_lightning_route_hints(lnrpc.clone(), self.num_route_hints).await?;
+            let old_client = self.clients.read().await.get(&federation_id).cloned();
+
+            let client = self
+                .client_builder
+                .build(
+                    gw_client_cfg.clone(),
+                    lightning_public_key,
+                    lnrpc.clone(),
+                    old_client,
+                )
+                .await?;
+
+            let federation_info = self.make_federation_info(&client, federation_id).await;
+
+            client
+                .register_with_federation(
+                    self.api_addr.clone(),
+                    route_hints,
+                    GW_ANNOUNCEMENT_TTL,
+                    self.gateway_id,
+                )
+                .await?;
+            self.clients.write().await.insert(federation_id, client);
+            self.scid_to_federation
+                .write()
+                .await
+                .insert(channel_id, federation_id);
+
+            let dbtx = self.gateway_db.begin_transaction().await;
+            self.client_builder
+                .save_config(gw_client_cfg.clone(), dbtx)
+                .await?;
+
+            return Ok(federation_info);
+        }
+
+        Err(GatewayError::Disconnected)
+    }
+
+    pub async fn handle_backup_msg(
+        &self,
+        BackupPayload { federation_id: _ }: BackupPayload,
+    ) -> Result<()> {
+        unimplemented!("Backup is not currently supported");
+    }
+
+    pub async fn handle_restore_msg(
+        &self,
+        RestorePayload { federation_id: _ }: RestorePayload,
+    ) -> Result<()> {
+        unimplemented!("Restore is not currently supported");
+    }
+
+    pub async fn remove_client(
+        &self,
+        federation_id: FederationId,
+    ) -> Result<fedimint_client::Client> {
+        let client = self.clients.write().await.remove(&federation_id).ok_or(
+            GatewayError::InvalidMetadata(format!("No federation with id {federation_id}")),
+        )?;
+        let mut dbtx = self.gateway_db.begin_transaction().await;
+        dbtx.remove_entry(&FederationRegistrationKey { id: federation_id })
+            .await;
+        dbtx.commit_tx().await;
+        Ok(client)
+    }
+
+    pub async fn select_client(
+        &self,
+        federation_id: FederationId,
+    ) -> Result<fedimint_client::Client> {
+        self.clients
+            .read()
+            .await
+            .get(&federation_id)
+            .cloned()
+            .ok_or(GatewayError::InvalidMetadata(format!(
+                "No federation with id {federation_id}"
+            )))
+    }
+
+    async fn load_clients(&mut self) -> Result<()> {
+        if let GatewayState::Running {
+            lnrpc,
+            lightning_public_key,
+            lightning_alias: _,
+        } = self.state.read().await.clone()
+        {
+            let dbtx = self.gateway_db.begin_transaction().await;
+            if let Ok(configs) = self.client_builder.load_configs(dbtx).await {
+                let channel_id_generator = self.channel_id_generator.lock().await;
+                let mut next_channel_id = channel_id_generator.load(Ordering::SeqCst);
+
+                for config in configs {
+                    let federation_id = config.config.global.federation_id;
+                    let old_client = self.clients.read().await.get(&federation_id).cloned();
+                    let client = self
+                        .client_builder
+                        .build(
+                            config.clone(),
+                            lightning_public_key,
+                            lnrpc.clone(),
+                            old_client,
+                        )
+                        .await?;
+
+                    // Registering each client happens in the background, since we're loading the
+                    // clients for the first time, just add them to the in-memory
+                    // maps
+                    let scid = config.mint_channel_id;
+                    self.clients.write().await.insert(federation_id, client);
+                    self.scid_to_federation
+                        .write()
+                        .await
+                        .insert(scid, federation_id);
+
+                    if config.mint_channel_id > next_channel_id {
+                        next_channel_id = config.mint_channel_id + 1;
+                    }
+                }
+                channel_id_generator.store(next_channel_id, Ordering::SeqCst);
             }
+            return Ok(());
+        }
+
+        Err(GatewayError::Disconnected)
+    }
+
+    async fn register_clients_timer(&mut self, task_group: &mut TaskGroup) {
+        if let GatewayState::Running {
+            lnrpc,
+            lightning_public_key: _,
+            lightning_alias: _,
+        } = self.state.read().await.clone()
+        {
+            let clients = self.clients.clone();
+            let api = self.api_addr.clone();
+            let gateway_id = self.gateway_id;
+            let num_route_hints = self.num_route_hints;
+            task_group
+                .spawn("register clients", move |handle| async move {
+                    while !handle.is_shutting_down() {
+                        // Allow a 15% buffer of the TTL before the re-registering gateway
+                        // with the federations.
+                        let registration_delay = GW_ANNOUNCEMENT_TTL.mul_f32(0.85);
+                        sleep(registration_delay).await;
+
+                        match Self::fetch_lightning_route_hints(lnrpc.clone(), num_route_hints).await {
+                            Ok(route_hints) => {
+                                for (federation_id, client) in clients.read().await.iter() {
+                                    if client
+                                        .register_with_federation(
+                                            api.clone(),
+                                            route_hints.clone(),
+                                            GW_ANNOUNCEMENT_TTL,
+                                            gateway_id,
+                                        )
+                                        .await
+                                        .is_err()
+                                    {
+                                        error!("Error registering federation {federation_id}");
+                                    }
+                                }
+                            }
+                            Err(_) => {
+                                error!(
+                                    "Could not retrieve route hints, gateway will not be registered."
+                                );
+                            }
+                        }
+                    }
+                })
+                .await;
         }
     }
 
@@ -493,15 +767,6 @@ impl Gateway {
             .expect("Could not parse route hints");
 
         Ok(route_hints)
-    }
-
-    async fn fetch_lightning_node_info(
-        lnrpc: Arc<dyn ILnRpcClient>,
-    ) -> Result<(PublicKey, String)> {
-        let GetNodeInfoResponse { pub_key, alias } = lnrpc.info().await?;
-        let node_pub_key = PublicKey::from_slice(&pub_key)
-            .map_err(|e| GatewayError::InvalidMetadata(format!("Invalid node pubkey {e}")))?;
-        Ok((node_pub_key, alias))
     }
 
     async fn fetch_lightning_route_hints(
@@ -545,328 +810,6 @@ impl Gateway {
         unreachable!();
     }
 
-    async fn register_clients_timer(&mut self) {
-        let clients = self.clients.clone();
-        let api = self.api.clone();
-        let lnrpc = self.lnrpc.clone();
-        let gateway_id = self.gateway_id;
-        let num_route_hints = self.num_route_hints;
-        self.task_group
-            .spawn("register clients", move |handle| async move {
-                while !handle.is_shutting_down() {
-                    match Self::fetch_lightning_route_hints(lnrpc.clone(), num_route_hints).await {
-                        Ok(route_hints) => {
-                            for (federation_id, client) in clients.read().await.iter() {
-                                if client
-                                    .register_with_federation(
-                                        api.clone(),
-                                        route_hints.clone(),
-                                        GW_ANNOUNCEMENT_TTL,
-                                        gateway_id,
-                                    )
-                                    .await
-                                    .is_err()
-                                {
-                                    error!("Error registering federation {federation_id}");
-                                }
-                            }
-                        }
-                        Err(_) => {
-                            error!(
-                                "Could not retrieve route hints, gateway will not be registered."
-                            );
-                        }
-                    }
-
-                    // Allow a 15% buffer of the TTL before the re-registering gateway
-                    // with the federations.
-                    let registration_delay = GW_ANNOUNCEMENT_TTL.mul_f32(0.85);
-                    sleep(registration_delay).await;
-                }
-            })
-            .await;
-    }
-
-    async fn load_clients(&mut self) -> Result<()> {
-        let dbtx = self.gatewayd_db.begin_transaction().await;
-        if let Ok(configs) = self.client_builder.load_configs(dbtx).await {
-            let channel_id_generator = self.channel_id_generator.lock().await;
-            let mut next_channel_id = channel_id_generator.load(Ordering::SeqCst);
-
-            for config in configs {
-                let federation_id = config.config.global.federation_id;
-                let old_client = self.clients.read().await.get(&federation_id).cloned();
-                let client = self
-                    .client_builder
-                    .build(
-                        config.clone(),
-                        self.lightning_public_key,
-                        self.lnrpc.clone(),
-                        old_client,
-                    )
-                    .await?;
-
-                // Registering each client happens in the background, since we're loading the
-                // clients for the first time, just add them to the in-memory
-                // maps
-                let scid = config.mint_channel_id;
-                self.clients.write().await.insert(federation_id, client);
-                self.scid_to_federation
-                    .write()
-                    .await
-                    .insert(scid, federation_id);
-
-                if config.mint_channel_id > next_channel_id {
-                    next_channel_id = config.mint_channel_id + 1;
-                }
-            }
-            channel_id_generator.store(next_channel_id, Ordering::SeqCst);
-        }
-        Ok(())
-    }
-
-    pub async fn register_client(
-        &mut self,
-        client: fedimint_client::Client,
-        federation_id: FederationId,
-        scid: u64,
-        route_hints: Vec<RouteHint>,
-    ) -> Result<()> {
-        client
-            .register_with_federation(
-                self.api.clone(),
-                route_hints,
-                GW_ANNOUNCEMENT_TTL,
-                self.gateway_id,
-            )
-            .await?;
-        self.clients.write().await.insert(federation_id, client);
-        self.scid_to_federation
-            .write()
-            .await
-            .insert(scid, federation_id);
-        Ok(())
-    }
-
-    pub async fn remove_client(
-        &self,
-        federation_id: FederationId,
-    ) -> Result<fedimint_client::Client> {
-        let client = self.clients.write().await.remove(&federation_id).ok_or(
-            GatewayError::InvalidMetadata(format!("No federation with id {federation_id}")),
-        )?;
-        let mut dbtx = self.gatewayd_db.begin_transaction().await;
-        dbtx.remove_entry(&FederationRegistrationKey { id: federation_id })
-            .await;
-        dbtx.commit_tx().await;
-        Ok(client)
-    }
-
-    pub async fn select_client(
-        &self,
-        federation_id: FederationId,
-    ) -> Result<fedimint_client::Client> {
-        self.clients
-            .read()
-            .await
-            .get(&federation_id)
-            .cloned()
-            .ok_or(GatewayError::InvalidMetadata(format!(
-                "No federation with id {federation_id}"
-            )))
-    }
-
-    async fn handle_connect_federation(
-        &mut self,
-        payload: ConnectFedPayload,
-    ) -> Result<FederationInfo> {
-        let invite_code = InviteCode::from_str(&payload.invite_code).map_err(|e| {
-            GatewayError::InvalidMetadata(format!("Invalid federation member string {e}"))
-        })?;
-
-        // The gateway deterministically assigns a channel id (u64) to each federation
-        // connected. TODO: explicitly handle the case where the channel id
-        // overflows
-        let channel_id = self
-            .channel_id_generator
-            .lock()
-            .await
-            .fetch_add(1, Ordering::SeqCst);
-
-        // Downloading the config can fail if another user tries to download at the same
-        // time. Just retry after a small delay
-        let gw_client_cfg = loop {
-            match self
-                .client_builder
-                .create_config(invite_code.clone(), channel_id, self.fees)
-                .await
-            {
-                Ok(gw_client_cfg) => break gw_client_cfg,
-                Err(_) => {
-                    let random_delay: f64 = rand::thread_rng().gen();
-                    tracing::warn!(
-                        "Error downloading client config, trying again in {random_delay}"
-                    );
-                    sleep(Duration::from_secs_f64(random_delay)).await;
-                }
-            }
-        };
-
-        let federation_id = gw_client_cfg.config.global.federation_id;
-        let route_hints =
-            Self::fetch_lightning_route_hints(self.lnrpc.clone(), self.num_route_hints).await?;
-        let old_client = self.clients.read().await.get(&federation_id).cloned();
-
-        let client = self
-            .client_builder
-            .build(
-                gw_client_cfg.clone(),
-                self.lightning_public_key,
-                self.lnrpc.clone(),
-                old_client,
-            )
-            .await?;
-
-        let federation_info = self.make_federation_info(&client, federation_id).await;
-
-        self.register_client(client, federation_id, channel_id, route_hints)
-            .await?;
-
-        let dbtx = self.gatewayd_db.begin_transaction().await;
-        self.client_builder
-            .save_config(gw_client_cfg.clone(), dbtx)
-            .await?;
-
-        Ok(federation_info)
-    }
-
-    pub async fn handle_get_info(&self, _payload: InfoPayload) -> Result<GatewayInfo> {
-        let mut federations = Vec::new();
-        let federation_clients = self.clients.read().await.clone().into_iter();
-        let route_hints =
-            Self::fetch_lightning_route_hints(self.lnrpc.clone(), self.num_route_hints).await?;
-        for (federation_id, client) in federation_clients {
-            federations.push(self.make_federation_info(&client, federation_id).await);
-        }
-
-        Ok(GatewayInfo {
-            federations,
-            version_hash: env!("FEDIMINT_BUILD_CODE_VERSION").to_string(),
-            lightning_pub_key: self.lightning_public_key.to_hex(),
-            lightning_alias: self.lightning_alias.clone(),
-            fees: self.fees,
-            route_hints,
-            gateway_id: self.gateway_id,
-        })
-    }
-
-    async fn handle_pay_invoice_msg(&self, payload: PayInvoicePayload) -> Result<Preimage> {
-        let PayInvoicePayload {
-            federation_id,
-            contract_id,
-        } = payload;
-
-        let client = self.select_client(federation_id).await?;
-        let operation_id = client.gateway_pay_bolt11_invoice(contract_id).await?;
-        let mut updates = client
-            .gateway_subscribe_ln_pay(operation_id)
-            .await?
-            .into_stream();
-
-        while let Some(update) = updates.next().await {
-            match update {
-                GatewayExtPayStates::Success {
-                    preimage,
-                    outpoint: _,
-                } => return Ok(preimage),
-                GatewayExtPayStates::Fail {
-                    error,
-                    error_message,
-                } => {
-                    error!(error_message);
-                    return Err(GatewayError::OutgoingPaymentError(Box::new(error)));
-                }
-                GatewayExtPayStates::Canceled { error } => {
-                    return Err(GatewayError::OutgoingPaymentError(Box::new(error)));
-                }
-                _ => {}
-            };
-        }
-
-        Err(GatewayError::UnexpectedState(
-            "Ran out of state updates while paying invoice".to_string(),
-        ))
-    }
-
-    pub async fn handle_balance_msg(&self, payload: BalancePayload) -> Result<Amount> {
-        Ok(self
-            .select_client(payload.federation_id)
-            .await?
-            .get_balance()
-            .await)
-    }
-
-    pub async fn handle_address_msg(&self, payload: DepositAddressPayload) -> Result<Address> {
-        let (_, address) = self
-            .select_client(payload.federation_id)
-            .await?
-            .get_deposit_address(now() + Duration::from_secs(86400 * 365))
-            .await?;
-        Ok(address)
-    }
-
-    pub async fn handle_withdraw_msg(&self, payload: WithdrawPayload) -> Result<Txid> {
-        let WithdrawPayload {
-            amount,
-            address,
-            federation_id,
-        } = payload;
-
-        let client = self.select_client(federation_id).await?;
-        // TODO: This should probably be passed in as a parameter
-        let fees = client.get_withdraw_fee(address.clone(), amount).await?;
-
-        let operation_id = self
-            .select_client(federation_id)
-            .await?
-            .withdraw(address, amount, fees)
-            .await?;
-        let mut updates = client
-            .subscribe_withdraw_updates(operation_id)
-            .await?
-            .into_stream();
-
-        while let Some(update) = updates.next().await {
-            match update {
-                WithdrawState::Succeeded(txid) => {
-                    return Ok(txid);
-                }
-                WithdrawState::Failed(e) => {
-                    return Err(GatewayError::UnexpectedState(e));
-                }
-                _ => {}
-            }
-        }
-
-        Err(GatewayError::UnexpectedState(
-            "Ran out of state updates while withdrawing".to_string(),
-        ))
-    }
-
-    pub async fn handle_backup_msg(
-        &self,
-        BackupPayload { federation_id: _ }: BackupPayload,
-    ) -> Result<()> {
-        unimplemented!("Backup is not currently supported");
-    }
-
-    pub async fn handle_restore_msg(
-        &self,
-        RestorePayload { federation_id: _ }: RestorePayload,
-    ) -> Result<()> {
-        unimplemented!("Restore is not currently supported");
-    }
-
     async fn make_federation_info(
         &self,
         client: &Client,
@@ -880,5 +823,75 @@ impl Gateway {
             balance_msat,
             config,
         }
+    }
+}
+
+#[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]
+pub enum LightningMode {
+    #[clap(name = "lnd")]
+    Lnd {
+        /// LND RPC address
+        #[arg(long = "lnd-rpc-host", env = "FM_LND_RPC_ADDR")]
+        lnd_rpc_addr: String,
+
+        /// LND TLS cert file path
+        #[arg(long = "lnd-tls-cert", env = "FM_LND_TLS_CERT")]
+        lnd_tls_cert: String,
+
+        /// LND macaroon file path
+        #[arg(long = "lnd-macaroon", env = "FM_LND_MACAROON")]
+        lnd_macaroon: String,
+    },
+    #[clap(name = "cln")]
+    Cln {
+        #[arg(long = "cln-extension-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
+        cln_extension_addr: Url,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum GatewayError {
+    #[error("Federation error: {0:?}")]
+    FederationError(#[from] FederationError),
+    #[error("Other: {0:?}")]
+    ClientStateMachineError(#[from] anyhow::Error),
+    #[error("Failed to open the database: {0:?}")]
+    DatabaseError(anyhow::Error),
+    #[error("Federation client error")]
+    LightningRpcError(#[from] LightningRpcError),
+    #[error("Outgoing Payment Error {0:?}")]
+    OutgoingPaymentError(#[from] Box<OutgoingPaymentError>),
+    #[error("Invalid Metadata: {0}")]
+    InvalidMetadata(String),
+    #[error("Unexpected state: {0}")]
+    UnexpectedState(String),
+    #[error("The gateway is disconnected")]
+    Disconnected,
+}
+
+impl IntoResponse for GatewayError {
+    fn into_response(self) -> Response {
+        // For privacy reasons, we do not return too many details about the failure of
+        // the request back to the client to prevent malicious clients from
+        // deducing state about the gateway/lightning node.
+        let (error_message, status_code) = match self {
+            GatewayError::OutgoingPaymentError(_) => (
+                "Error while paying lightning invoice. Outgoing contract will be refunded."
+                    .to_string(),
+                StatusCode::BAD_REQUEST,
+            ),
+            GatewayError::Disconnected => (
+                "The gateway is disconnected from the Lightning Node".to_string(),
+                StatusCode::NOT_FOUND,
+            ),
+            _ => (
+                "An internal gateway error occurred".to_string(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        };
+
+        let mut err = Cow::<'static, str>::Owned(error_message).into_response();
+        *err.status_mut() = status_code;
+        err
     }
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -37,6 +37,7 @@ use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
 use fedimint_core::db::Database;
+use fedimint_core::fmt_utils::OptStracktrace;
 use fedimint_core::module::CommonModuleInit;
 use fedimint_core::task::{sleep, RwLock, TaskGroup, TaskHandle, TaskShutdownToken};
 use fedimint_core::time::now;
@@ -890,19 +891,19 @@ pub enum LightningMode {
 
 #[derive(Debug, Error)]
 pub enum GatewayError {
-    #[error("Federation error: {0:?}")]
+    #[error("Federation error: {}", OptStracktrace(0))]
     FederationError(#[from] FederationError),
-    #[error("Other: {0:?}")]
+    #[error("Other: {}", OptStracktrace(0))]
     ClientStateMachineError(#[from] anyhow::Error),
-    #[error("Failed to open the database: {0:?}")]
+    #[error("Failed to open the database: {}", OptStracktrace(0))]
     DatabaseError(anyhow::Error),
     #[error("Federation client error")]
     LightningRpcError(#[from] LightningRpcError),
-    #[error("Outgoing Payment Error {0:?}")]
+    #[error("Outgoing Payment Error {}", OptStracktrace(0))]
     OutgoingPaymentError(#[from] Box<OutgoingPaymentError>),
-    #[error("Invalid Metadata: {0}")]
+    #[error("Invalid Metadata: {}", OptStracktrace(0))]
     InvalidMetadata(String),
-    #[error("Unexpected state: {0}")]
+    #[error("Unexpected state: {}", OptStracktrace(0))]
     UnexpectedState(String),
     #[error("The gateway is disconnected")]
     Disconnected,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -681,7 +681,7 @@ impl Gateway {
                 for config in configs {
                     let federation_id = config.config.global.federation_id;
                     let old_client = self.clients.read().await.get(&federation_id).cloned();
-                    let client = self
+                    if let Ok(client) = self
                         .client_builder
                         .build(
                             config.clone(),
@@ -689,17 +689,20 @@ impl Gateway {
                             lnrpc.clone(),
                             old_client,
                         )
-                        .await?;
-
-                    // Registering each client happens in the background, since we're loading the
-                    // clients for the first time, just add them to the in-memory
-                    // maps
-                    let scid = config.mint_channel_id;
-                    self.clients.write().await.insert(federation_id, client);
-                    self.scid_to_federation
-                        .write()
                         .await
-                        .insert(scid, federation_id);
+                    {
+                        // Registering each client happens in the background, since we're loading
+                        // the clients for the first time, just add them to
+                        // the in-memory maps
+                        let scid = config.mint_channel_id;
+                        self.clients.write().await.insert(federation_id, client);
+                        self.scid_to_federation
+                            .write()
+                            .await
+                            .insert(scid, federation_id);
+                    } else {
+                        warn!("Failed to load client for federation: {federation_id}");
+                    }
 
                     if config.mint_channel_id > next_channel_id {
                         next_channel_id = config.mint_channel_id + 1;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -308,32 +308,37 @@ impl Gateway {
                             .await
                         {
                             Ok((stream, ln_client)) => {
-                                // Blocks until the connection to the lightning node breaks
                                 info!("Established HTLC stream");
 
-                                let (lightning_public_key, lightning_alias) =
-                                Self::fetch_lightning_node_info(ln_client.clone()).await.expect("Failed to retrieve Lightning info after establishing a connection");
+                                match Self::fetch_lightning_node_info(ln_client.clone()).await {
+                                    Ok((lightning_public_key, lightning_alias)) => {
+                                        self.register_clients_timer(&mut tg).await;
+                                        self.set_gateway_state(GatewayState::Running {
+                                            lnrpc: ln_client,
+                                            lightning_public_key,
+                                            lightning_alias,
 
-                                self.register_clients_timer(&mut tg).await;
-                                self.set_gateway_state(GatewayState::Running {
-                                    lnrpc: ln_client,
-                                    lightning_public_key,
-                                    lightning_alias,
+                                        }).await;
+                                        self.load_clients().await.expect("Failed to load gateway clients");
+                                        info!("Successfully loaded Gateway clients.");
 
-                                }).await;
-                                self.load_clients().await.expect("Failed to load gateway clients");
-                                info!("Successfully loaded Gateway clients.");
-
-                                self.handle_htlc_stream(stream, handle.clone()).await;
-                                self.set_gateway_state(GatewayState::Disconnected).await;
-                                warn!("HTLC Stream Lightning connection broken. Gateway is disconnected");
+                                        // Blocks until the connection to the lightning node breaks
+                                        self.handle_htlc_stream(stream, handle.clone()).await;
+                                        self.set_gateway_state(GatewayState::Disconnected).await;
+                                        warn!("HTLC Stream Lightning connection broken. Gateway is disconnected");
+                                    }
+                                    Err(e) => {
+                                        error!("Failed to retrieve Lightning info: {e:?}");
+                                    }
+                                }
                             }
                             Err(e) => {
-                                error!("Failed to open HTLC stream. Waiting 5 seconds and trying again");
-                                debug!("Error: {e:?}");
-                                sleep(Duration::from_secs(5)).await;
+                                debug!("Failed to open HTLC stream: {e:?}");
                             }
                         }
+
+                        error!("Disconnected from Lightning Node. Waiting 5 seconds and trying again");
+                        sleep(Duration::from_secs(5)).await;
                     }
                 },
             )
@@ -546,7 +551,7 @@ impl Gateway {
         } = self.state.read().await.clone()
         {
             let invite_code = InviteCode::from_str(&payload.invite_code).map_err(|e| {
-                GatewayError::InvalidMetadata(format!("Invalid federation member string {e}"))
+                GatewayError::InvalidMetadata(format!("Invalid federation member string {e:?}"))
             })?;
 
             // The gateway deterministically assigns a channel id (u64) to each federation
@@ -730,7 +735,7 @@ impl Gateway {
                         match Self::fetch_lightning_route_hints(lnrpc.clone(), num_route_hints).await {
                             Ok(route_hints) => {
                                 for (federation_id, client) in clients.read().await.iter() {
-                                    if client
+                                    if let Err(e) = client
                                         .register_with_federation(
                                             api.clone(),
                                             route_hints.clone(),
@@ -738,15 +743,14 @@ impl Gateway {
                                             gateway_id,
                                         )
                                         .await
-                                        .is_err()
                                     {
-                                        error!("Error registering federation {federation_id}");
+                                        error!("Error registering federation {federation_id}: {e:?}");
                                     }
                                 }
                             }
-                            Err(_) => {
+                            Err(e) => {
                                 error!(
-                                    "Could not retrieve route hints, gateway will not be registered."
+                                    "Could not retrieve route hints, gateway will not be registered: {e:?}"
                                 );
                             }
                         }

--- a/gateway/ln-gateway/src/ng/tests.rs
+++ b/gateway/ln-gateway/src/ng/tests.rs
@@ -653,23 +653,38 @@ async fn test_gateway_filters_route_hints_by_inbound() -> anyhow::Result<()> {
                 }
                 _ => {
                     // If there's more than one route hint, we're expecting the invoice to contain
-                    // `num_route_hints`. Each should have 2 hops.
-                    assert_eq!(route_hints.len(), num_route_hints, "Found {} route hints when {num_route_hints} was expected for {gateway_type} gateway", route_hints.len());
+                    // `num_route_hints` + 1. There should be one single-hop route hint and the rest
+                    // two-hop route hints.
+                    assert_eq!(
+                        route_hints.len(),
+                        num_route_hints + 1,
+                        "Found {} route hints when {} was expected for {gateway_type} gateway",
+                        route_hints.len(),
+                        num_route_hints + 1
+                    );
 
+                    let mut num_one_hops = 0;
                     for route_hint in route_hints {
-                        assert_eq!(
-                            route_hint.0.len(),
-                            2,
-                            "Found {} hops when 2 was expected for {gateway_type} gateway",
-                            route_hint.0.len()
-                        );
-                        for hop in route_hint.0 {
-                            assert!(
-                                all_keys.contains(&hop.src_node_id),
-                                "Public key of route hint hop did not match expected public key"
-                            );
+                        if route_hint.0.len() == 1 {
+                            // If there's only one hop, it should contain the gateway's public key
+                            let route_hint_pub_key = route_hint.0.get(0).unwrap().src_node_id;
+                            assert_eq!(route_hint_pub_key, public_key);
+                            num_one_hops += 1;
+                        } else {
+                            // If there's > 1 hop, it should exist in `all_keys`
+                            for hop in route_hint.0 {
+                                assert!(
+                                    all_keys.contains(&hop.src_node_id),
+                                    "Public key of route hint hop did not match expected public key"
+                                );
+                            }
                         }
                     }
+
+                    assert_eq!(
+                        num_one_hops, 1,
+                        "Found incorrect number of one hop route hints"
+                    );
                 }
             }
         }

--- a/gateway/ln-gateway/src/ng/tests.rs
+++ b/gateway/ln-gateway/src/ng/tests.rs
@@ -28,7 +28,7 @@ use fedimint_ln_server::LightningGen;
 use fedimint_testing::btc::BitcoinTest;
 use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
-use fedimint_testing::gateway::{GatewayTest, LightningNodeName};
+use fedimint_testing::gateway::{GatewayTest, LightningNodeType};
 use fedimint_testing::ln::LightningTest;
 use futures::Future;
 use lightning_invoice::Invoice;
@@ -603,11 +603,12 @@ async fn test_gateway_filters_route_hints_by_inbound() -> anyhow::Result<()> {
     let cln_public_key = PublicKey::from_slice(&pub_key)?;
     let all_keys = vec![lnd_public_key, cln_public_key];
 
-    for gateway_type in vec![LightningNodeName::Cln, LightningNodeName::Lnd] {
+    for gateway_type in vec![LightningNodeType::Cln, LightningNodeType::Lnd] {
         for num_route_hints in 0..=1 {
             let gateway_ln = match gateway_type {
-                LightningNodeName::Cln => fixtures.cln().await,
-                LightningNodeName::Lnd => fixtures.lnd().await,
+                LightningNodeType::Cln => fixtures.cln().await,
+                LightningNodeType::Lnd => fixtures.lnd().await,
+                LightningNodeType::Ldk => unimplemented!("LDK Node is not supported as a gateway"),
             };
 
             let GetNodeInfoResponse { pub_key, alias: _ } = gateway_ln.info().await?;

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -68,8 +68,8 @@ pub struct FederationInfo {
 pub struct GatewayInfo {
     pub version_hash: String,
     pub federations: Vec<FederationInfo>,
-    pub lightning_pub_key: String,
-    pub lightning_alias: String,
+    pub lightning_pub_key: Option<String>,
+    pub lightning_alias: Option<String>,
     #[serde(with = "serde_routing_fees")]
     pub fees: RoutingFees,
     pub route_hints: Vec<route_hints::RouteHint>,


### PR DESCRIPTION
This PR backports 7 commits from master:

- [feat: Decouple web server from Lightning connection ](https://github.com/fedimint/fedimint/commit/b8dcfa1d3b39e2aac1e3a6e2fedb51eab1ae26b3)
- [fix: wait for gateway to be in running state ](https://github.com/fedimint/fedimint/commit/faa45ca26659efd45845c95faeb8310b5856a1d8)
- [fix: always add one hop route hint](https://github.com/fedimint/fedimint/commit/b6806febfe76583e8871c245e7b0ba0d84d48422)
- [fix: add stack traces and retry on lightning info failure](https://github.com/fedimint/fedimint/commit/4cbfe9ec24c81aa066aaf76f0f3ecc85cf42be94)
- [fix: boot when a client fails to initialize](https://github.com/fedimint/fedimint/commit/b1e4f76490f58d02081113e81a4bfa602f379208)
- [fix: update gateway state machine with connected state](https://github.com/fedimint/fedimint/commit/148473bc76ae2a791c6ad89f9ffb324b13f09d03)
- [chore: make gateway rpc error backtraces optional](https://github.com/fedimint/fedimint/commit/8280611ed47d67be9c8f414fadccb18002b8566a)

These seem to be the easiest set of changes that don't touch too many files, outside of the gateway. It contains logic to automatically connect to the lightning node on disconnection, which should fix: https://github.com/fedimint/fedimint/issues/3397