### PR TITLE
feat: add availability check before paying lightning invoice

### DIFF
--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -27,7 +27,9 @@ pub async fn run_webserver(
 ) -> axum::response::Result<()> {
     let (routes, admin_routes) = if let Some(gateway_config) = config {
         // Public routes on gateway webserver
-        let routes = Router::new().route("/pay_invoice", post(pay_invoice));
+        let routes = Router::new()
+            .route("/pay_invoice", post(pay_invoice))
+            .route("/is_available", post(is_available));
 
         // Authenticated, public routes used for gateway administration
         let admin_routes = Router::new()
@@ -161,5 +163,13 @@ async fn set_configuration(
     Json(payload): Json<SetConfigurationPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
     gateway.handle_set_configuration_msg(payload).await?;
+    Ok(Json(json!(())))
+}
+
+#[instrument(skip_all, err)]
+async fn is_available(
+    Extension(_): Extension<Gateway>,
+    Json(_): Json<()>,
+) -> Result<impl IntoResponse, GatewayError> {
     Ok(Json(json!(())))
 }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use axum::response::IntoResponse;
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Extension, Json, Router};
 use axum_macros::debug_handler;
 use bitcoin_hashes::hex::ToHex;
@@ -29,7 +29,7 @@ pub async fn run_webserver(
         // Public routes on gateway webserver
         let routes = Router::new()
             .route("/pay_invoice", post(pay_invoice))
-            .route("/is_available", post(is_available));
+            .route("/id", get(get_gateway_id));
 
         // Authenticated, public routes used for gateway administration
         let admin_routes = Router::new()
@@ -167,9 +167,8 @@ async fn set_configuration(
 }
 
 #[instrument(skip_all, err)]
-async fn is_available(
-    Extension(_): Extension<Gateway>,
-    Json(_): Json<()>,
+async fn get_gateway_id(
+    Extension(gateway): Extension<Gateway>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    Ok(Json(json!(())))
+    Ok(Json(json!(gateway.gateway_id)))
 }


### PR DESCRIPTION
A common footgun is to try and pay an invoice when the "active" lightning gateway is unavailable. This results in funds being locked until the timeout, which is not a good experience. 

An easy mitigation to this is just to ping the gateway before paying the invoice, to verify that it is available. That way, funds should only be stuck if the gateway goes down between the availability check and the funding transaction. 

Partially addresses: https://github.com/fedimint/fedimint/issues/3405

Next is adding retries to paying the invoice after the funding transaction is successful.