### PR TITLE
chore: remove `Amount::from_coins()`

### DIFF
--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -117,10 +117,6 @@ impl Amount {
         Amount::from_msats(sats * 1000)
     }
 
-    pub const fn from_coins(coins: u64) -> Amount {
-        Amount::from_sats(coins * 100_000_000)
-    }
-
     pub fn from_str_in(s: &str, denom: Denomination) -> Result<Amount, ParseAmountError> {
         if let Denomination::MilliSatoshi = denom {
             return Self::from_str(s);
@@ -147,11 +143,6 @@ pub fn msats(msats: u64) -> Amount {
 /// Shorthand for [`Amount::from_sats`]
 pub fn sats(amount: u64) -> Amount {
     Amount::from_sats(amount)
-}
-
-/// Shorthand for [`Amount::from_coins`]
-pub fn coins(amount: u64) -> Amount {
-    Amount::from_coins(amount)
 }
 
 /// `OutPoint` represents a globally unique output in a transaction

--- a/modules/fedimint-mint-common/src/config.rs
+++ b/modules/fedimint-mint-common/src/config.rs
@@ -21,10 +21,10 @@ pub struct MintGenParamsConsensus {
     denomination_base: u16,
 }
 
-// The maximum size of an E-Cash note
+// The maximum size of an E-Cash note (1,000,000 coins)
 // Changing this value is considered a breaking change because it is not saved
 // in `MintGenParamsConsensus` but instead is hardcoded here
-const MAX_DENOMINATION_SIZE: Amount = Amount::from_coins(1_000_000);
+const MAX_DENOMINATION_SIZE: Amount = Amount::from_sats(1_000_000 * 100_000_000);
 
 impl MintGenParamsConsensus {
     pub fn new(denomination_base: u16) -> Self {


### PR DESCRIPTION
Added in #3401, but deemed unnecessary. See https://github.com/fedimint/fedimint/pull/3401#discussion_r1360960757.