### PR TITLE
Client-side ecash aggregation

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -379,7 +379,7 @@ pub trait GlobalFederationApi {
     ) -> FederationResult<ApiVersionSet>;
 }
 
-fn deserialize_outcome<R>(
+pub fn deserialize_outcome<R>(
     outcome: SerdeOutputOutcome,
     module_decoder: &Decoder,
 ) -> OutputOutcomeResult<R>

--- a/fedimint-core/src/query.rs
+++ b/fedimint-core/src/query.rs
@@ -129,7 +129,9 @@ impl ErrorStrategy {
     }
 }
 
-/// Returns first response with a valid signature
+/// Returns the first valid response. The response of a peer is
+/// assumed to be final, hence this query strategy does not implement retry
+/// logic.
 pub struct FilterMap<R, T> {
     filter_map: Box<maybe_add_send_sync!(dyn Fn(R) -> anyhow::Result<T>)>,
     error_strategy: ErrorStrategy,
@@ -156,6 +158,55 @@ impl<R: Debug + Eq + Clone, T> QueryStrategy<R, T> for FilterMap<R, T> {
         match result {
             Ok(response) => match (self.filter_map)(response) {
                 Ok(value) => QueryStep::Success(value),
+                Err(error) => self
+                    .error_strategy
+                    .process(peer, PeerError::InvalidResponse(error.to_string())),
+            },
+            Err(error) => self.error_strategy.process(peer, error),
+        }
+    }
+}
+
+/// Returns when a threshold of valid responses. The response of a peer is
+/// assumed to be final, hence this query strategy does not implement retry
+/// logic.
+pub struct FilterMapThreshold<R, T> {
+    filter_map: Box<maybe_add_send_sync!(dyn Fn(PeerId, R) -> anyhow::Result<T>)>,
+    error_strategy: ErrorStrategy,
+    filtered_responses: BTreeMap<PeerId, T>,
+    threshold: usize,
+}
+
+impl<R, T> FilterMapThreshold<R, T> {
+    pub fn new(
+        verifier: impl Fn(PeerId, R) -> anyhow::Result<T> + MaybeSend + MaybeSync + 'static,
+        total_peers: usize,
+    ) -> Self {
+        let max_evil = (total_peers - 1) / 3;
+        let threshold = total_peers - max_evil;
+
+        Self {
+            filter_map: Box::new(verifier),
+            error_strategy: ErrorStrategy::new(max_evil + 1),
+            filtered_responses: BTreeMap::new(),
+            threshold,
+        }
+    }
+}
+
+impl<R: Eq + Clone + Debug, T> QueryStrategy<R, BTreeMap<PeerId, T>> for FilterMapThreshold<R, T> {
+    fn process(&mut self, peer: PeerId, result: PeerResult<R>) -> QueryStep<BTreeMap<PeerId, T>> {
+        match result {
+            Ok(response) => match (self.filter_map)(peer, response) {
+                Ok(response) => {
+                    self.filtered_responses.insert(peer, response);
+
+                    if self.filtered_responses.len() == self.threshold {
+                        QueryStep::Success(mem::take(&mut self.filtered_responses))
+                    } else {
+                        QueryStep::Continue
+                    }
+                }
                 Err(error) => self
                     .error_strategy
                     .process(peer, PeerError::InvalidResponse(error.to_string())),

--- a/fedimint-core/src/query.rs
+++ b/fedimint-core/src/query.rs
@@ -4,6 +4,7 @@ use std::mem;
 use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, format_err};
+use fedimint_core::api::PeerResult;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::time::now;
 use fedimint_core::{maybe_add_send_sync, PeerId};
@@ -154,7 +155,7 @@ impl<R, T> FilterMap<R, T> {
 }
 
 impl<R: Debug + Eq + Clone, T> QueryStrategy<R, T> for FilterMap<R, T> {
-    fn process(&mut self, peer: PeerId, result: api::PeerResult<R>) -> QueryStep<T> {
+    fn process(&mut self, peer: PeerId, result: PeerResult<R>) -> QueryStep<T> {
         match result {
             Ok(response) => match (self.filter_map)(response) {
                 Ok(value) => QueryStep::Success(value),

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -41,8 +41,8 @@ use fedimint_core::module::{
 };
 use fedimint_core::util::{BoxStream, NextOrPending};
 use fedimint_core::{
-    apply, async_trait_maybe_send, push_db_pair_items, Amount, OutPoint, Tiered, TieredMulti,
-    TieredSummary, TransactionId,
+    apply, async_trait_maybe_send, push_db_pair_items, Amount, OutPoint, PeerId, Tiered,
+    TieredMulti, TieredSummary, TransactionId,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 pub use fedimint_mint_common as common;
@@ -655,7 +655,8 @@ pub struct MintClientModule {
 #[derive(Debug, Clone)]
 pub struct MintClientContext {
     pub mint_decoder: Decoder,
-    pub mint_keys: Tiered<AggregatePublicKey>,
+    pub tbs_pks: Tiered<AggregatePublicKey>,
+    pub peer_tbs_pks: BTreeMap<PeerId, Tiered<tbs::PublicKeyShare>>,
     pub secret: DerivableSecret,
     pub cancel_oob_payment_bc: tokio::sync::broadcast::Sender<OperationId>,
 }
@@ -677,7 +678,8 @@ impl ClientModule for MintClientModule {
     fn context(&self) -> Self::ModuleStateMachineContext {
         MintClientContext {
             mint_decoder: self.decoder(),
-            mint_keys: self.cfg.tbs_pks.clone(),
+            tbs_pks: self.cfg.tbs_pks.clone(),
+            peer_tbs_pks: self.cfg.peer_tbs_pks.clone(),
             secret: self.secret.clone(),
             cancel_oob_payment_bc: self.cancel_oob_payment_bc.clone(),
         }

--- a/modules/fedimint-mint-common/src/db.rs
+++ b/modules/fedimint-mint-common/src/db.rs
@@ -1,18 +1,16 @@
 use std::time::SystemTime;
 
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::{impl_db_lookup, impl_db_record, Amount, OutPoint, PeerId};
+use fedimint_core::{impl_db_lookup, impl_db_record, Amount, OutPoint};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
-use crate::{MintOutputBlindSignature, MintOutputSignatureShare, Nonce};
+use crate::{MintOutputOutcome, Nonce};
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
     NoteNonce = 0x10,
-    ProposedPartialSig = 0x11,
-    ReceivedPartialSig = 0x12,
     OutputOutcome = 0x13,
     MintAuditItem = 0x14,
     EcashBackup = 0x15,
@@ -37,57 +35,21 @@ impl_db_record!(
 );
 impl_db_lookup!(key = NonceKey, query_prefix = NonceKeyPrefix);
 
-#[derive(Debug, Encodable, Decodable, Serialize)]
-pub struct ProposedPartialSignatureKey(pub OutPoint);
-
-#[derive(Debug, Encodable, Decodable)]
-pub struct ProposedPartialSignaturesKeyPrefix;
-
-impl_db_record!(
-    key = ProposedPartialSignatureKey,
-    value = MintOutputSignatureShare,
-    db_prefix = DbKeyPrefix::ProposedPartialSig,
-);
-impl_db_lookup!(
-    key = ProposedPartialSignatureKey,
-    query_prefix = ProposedPartialSignaturesKeyPrefix
-);
-
-#[derive(Debug, Encodable, Decodable, Serialize)]
-pub struct ReceivedPartialSignatureKey(pub OutPoint, pub PeerId);
-
-#[derive(Debug, Encodable, Decodable)]
-pub struct ReceivedPartialSignaturesKeyPrefix;
-
-#[derive(Debug, Encodable, Decodable)]
-pub struct ReceivedPartialSignatureKeyOutputPrefix(pub OutPoint);
-
-impl_db_record!(
-    key = ReceivedPartialSignatureKey,
-    value = MintOutputSignatureShare,
-    db_prefix = DbKeyPrefix::ReceivedPartialSig,
-);
-impl_db_lookup!(
-    key = ReceivedPartialSignatureKey,
-    query_prefix = ReceivedPartialSignaturesKeyPrefix,
-    query_prefix = ReceivedPartialSignatureKeyOutputPrefix
-);
-
 /// Transaction id and output index identifying an output outcome
 #[derive(Debug, Clone, Copy, Encodable, Decodable, Serialize)]
-pub struct OutputOutcomeKey(pub OutPoint);
+pub struct MintOutputOutcomeKey(pub OutPoint);
 
 #[derive(Debug, Encodable, Decodable)]
-pub struct OutputOutcomeKeyPrefix;
+pub struct MintOutputOutcomePrefix;
 
 impl_db_record!(
-    key = OutputOutcomeKey,
-    value = MintOutputBlindSignature,
+    key = MintOutputOutcomeKey,
+    value = MintOutputOutcome,
     db_prefix = DbKeyPrefix::OutputOutcome,
 );
 impl_db_lookup!(
-    key = OutputOutcomeKey,
-    query_prefix = OutputOutcomeKeyPrefix
+    key = MintOutputOutcomeKey,
+    query_prefix = MintOutputOutcomePrefix
 );
 
 /// Represents the amounts of issued (signed) and redeemed (verified) notes for

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -6,7 +6,7 @@ use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::tiered::InvalidAmountTierError;
-use fedimint_core::{plugin_types_trait_impl_common, Amount, OutPoint, PeerId};
+use fedimint_core::{plugin_types_trait_impl_common, Amount, PeerId};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
@@ -24,24 +24,13 @@ pub const DEFAULT_MAX_NOTES_PER_DENOMINATION: u16 = 3;
 
 /// Data structures taking into account different amount tiers
 
-/// A consenus item from one of the federation members contributing partials
-/// signatures to blind nonces submitted in it
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
-pub struct MintConsensusItem {
-    /// Reference to a Federation Transaction containing an [`MintOutput`] with
-    /// `BlindNonce`s the signatures` are for
-    pub out_point: OutPoint,
-    /// (Partial) signatures
-    pub signature_share: MintOutputSignatureShare,
-}
+pub struct MintConsensusItem;
 
-// FIXME: optimize out blinded msg by making the mint remember it
-/// Blind signature share from one Federation peer for a single [`MintOutput`]
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
-pub struct MintOutputSignatureShare {
-    pub amount: Amount,
-    pub message: tbs::BlindedMessage,
-    pub signature_share: tbs::BlindedSignatureShare,
+impl std::fmt::Display for MintConsensusItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MintConsensusItem")
+    }
 }
 
 /// Result of Federation members confirming [`MintOutput`] by contributing
@@ -143,21 +132,11 @@ impl std::fmt::Display for MintOutput {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
-pub struct MintOutputOutcome(pub Option<MintOutputBlindSignature>);
+pub struct MintOutputOutcome(pub tbs::BlindedSignatureShare);
 
 impl std::fmt::Display for MintOutputOutcome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Minted note")
-    }
-}
-
-impl std::fmt::Display for MintConsensusItem {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Mint Blind Signature Shares worth {} for {}",
-            self.signature_share.amount, self.out_point
-        )
+        write!(f, "MintOutputOutcome")
     }
 }
 


### PR DESCRIPTION
Instead of collecting, verifying and aggregating the ecash blind signature shares via the guardians over the broadcast we move this functionality in the client. This significantly simplifies the mint server module aus it simply returns its own signature share for every accepted mint output and is done. Most importantly though it reduces the compute and disk consumption of the mint module - and therefore the federation as whole - to a fraction. Furthermore, the compute and disk consumption is now constant instead of linear in the number of guardians. 