### PR TITLE
fix(client): retry RPC requests on `JsonRpcError::RestartNeeded`

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -88,6 +88,7 @@ impl PeerError {
                 JsonRpcError::Transport(_) => true,
                 JsonRpcError::MaxSlotsExceeded => true,
                 JsonRpcError::RequestTimeout => true,
+                JsonRpcError::RestartNeeded(_) => true,
                 JsonRpcError::Call(e) => e.code() == 404,
                 _ => false,
             },


### PR DESCRIPTION
Fixes #3410 