### PR TITLE
[Backport releases/v0.1] fix(client): retry RPC requests on `JsonRpcError::RestartNeeded`

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -81,6 +81,7 @@ impl PeerError {
                 JsonRpcError::Transport(_) => true,
                 JsonRpcError::MaxSlotsExceeded => true,
                 JsonRpcError::RequestTimeout => true,
+                JsonRpcError::RestartNeeded(_) => true,
                 JsonRpcError::Call(e) => e.code() == 404,
                 _ => false,
             },


### PR DESCRIPTION
# Description
Backport of #3421 to `releases/v0.1`.