### PR TITLE
feat: Add Preimage Authentication to Gateway

### DIFF
--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -50,6 +50,7 @@ impl GatewayClientBuilder {
         all_clients: FederationToClientMap,
         all_scids: ScidToFederationMap,
         old_client: Option<fedimint_client::ClientArc>,
+        gateway_db: Database,
     ) -> Result<fedimint_client::ClientArc> {
         let FederationConfig {
             invite_code,
@@ -69,6 +70,7 @@ impl GatewayClientBuilder {
             fees,
             timelock_delta,
             mint_channel_id,
+            gateway_db,
         });
 
         let mut client_builder = ClientBuilder::default();

--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -1,4 +1,5 @@
 use bitcoin::Network;
+use bitcoin_hashes::sha256;
 use fedimint_core::api::InviteCode;
 use fedimint_core::config::FederationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -15,6 +16,7 @@ pub enum DbKeyPrefix {
     FederationRegistration = 0x05,
     GatewayPublicKey = 0x06,
     GatewayConfiguration = 0x07,
+    PreimageAuthentication = 0x08,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -74,4 +76,15 @@ impl_db_record!(
     value = GatewayConfiguration,
     db_prefix = DbKeyPrefix::GatewayConfiguration,
     notify_on_modify = true,
+);
+
+#[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable)]
+pub struct PreimageAuthentication {
+    pub payment_hash: sha256::Hash,
+}
+
+impl_db_record!(
+    key = PreimageAuthentication,
+    value = sha256::Hash,
+    db_prefix = DbKeyPrefix::PreimageAuthentication
 );

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -693,13 +693,8 @@ impl Gateway {
             lightning_alias: _,
         } = self.state.read().await.clone()
         {
-            let PayInvoicePayload {
-                federation_id,
-                contract_id,
-            } = payload;
-
-            let client = self.select_client(federation_id).await?;
-            let operation_id = client.gateway_pay_bolt11_invoice(contract_id).await?;
+            let client = self.select_client(payload.federation_id).await?;
+            let operation_id = client.gateway_pay_bolt11_invoice(payload).await?;
             let mut updates = client
                 .gateway_subscribe_ln_pay(operation_id)
                 .await?
@@ -785,6 +780,7 @@ impl Gateway {
                     all_clients,
                     all_scids,
                     old_client,
+                    self.gateway_db.clone(),
                 )
                 .await?;
 
@@ -990,6 +986,7 @@ impl Gateway {
                         all_clients,
                         all_scids,
                         old_client,
+                        self.gateway_db.clone(),
                     )
                     .await
                 {

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -19,6 +19,7 @@ use fedimint_core::{msats, sats, Amount, OutPoint, TransactionId};
 use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyGen;
+use fedimint_ln_client::pay::PayInvoicePayload;
 use fedimint_ln_client::{
     LightningClientExt, LightningClientGen, LightningClientModule, LightningClientStateMachines,
     LightningOperationMeta, LnPayState, LnReceiveState, OutgoingLightningPayment, PayType,
@@ -150,7 +151,14 @@ async fn pay_valid_invoice(
             let funded = pay_sub.ok().await?;
             assert_matches!(funded, LnPayState::Funded);
 
-            let gw_pay_op = gateway.gateway_pay_bolt11_invoice(contract_id).await?;
+            let payload = PayInvoicePayload {
+                federation_id: user_client.federation_id(),
+                contract_id,
+                payment_hash: *invoice.payment_hash(),
+                preimage_auth: Hash::hash(&[0; 32]),
+            };
+
+            let gw_pay_op = gateway.gateway_pay_bolt11_invoice(payload).await?;
             let mut gw_pay_sub = gateway
                 .gateway_subscribe_ln_pay(gw_pay_op)
                 .await?
@@ -325,7 +333,14 @@ async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
                     let funded = pay_sub.ok().await?;
                     assert_matches!(funded, LnPayState::Funded);
 
-                    let gw_pay_op = gateway.gateway_pay_bolt11_invoice(contract_id).await?;
+                    let payload = PayInvoicePayload {
+                        federation_id: user_client.federation_id(),
+                        contract_id,
+                        payment_hash: *invoice.payment_hash(),
+                        preimage_auth: Hash::hash(&[0; 32]),
+                    };
+
+                    let gw_pay_op = gateway.gateway_pay_bolt11_invoice(payload).await?;
                     let mut gw_pay_sub = gateway
                         .gateway_subscribe_ln_pay(gw_pay_op)
                         .await?
@@ -648,7 +663,14 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
                     let funded = pay_sub.ok().await?;
                     assert_matches!(funded, LnPayState::Funded);
 
-                    let gw_pay_op = gateway.gateway_pay_bolt11_invoice(contract_id).await?;
+                    let payload = PayInvoicePayload {
+                        federation_id: user_client.federation_id(),
+                        contract_id,
+                        payment_hash: *invoice.payment_hash(),
+                        preimage_auth: Hash::hash(&[0; 32]),
+                    };
+
+                    let gw_pay_op = gateway.gateway_pay_bolt11_invoice(payload).await?;
                     let mut gw_pay_sub = gateway
                         .gateway_subscribe_ln_pay(gw_pay_op)
                         .await?


### PR DESCRIPTION
This PR adds a "preimage authentication" as part of the payload that is sent to the gateway. The gateway will save the first secret that it sees. If a subsequent request does not send this same preimage authentication, the gateway will throw an error. This prevents clients that did not pay the invoice from retrieving the preimage.

Fixes: https://github.com/fedimint/fedimint/issues/2746