### PR TITLE
fix: save output from the backport create-pr step to job outputs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,9 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     # Don't run on closed unmerged pull requests
     if: github.event.pull_request.merged
+    # Save the output from the create-pr step so it can be used in downstream jobs
+    # https://github.com/korthout/backport-action/blob/e53c7b292aa9985d372c178a89d416ef2176c091/README.md#outputs
+    outputs:
+      was_successful: ${{ steps.create-pr.outputs.was_successful }}
     steps:
       - uses: actions/checkout@v4
-      - name: Create backport pull requests
+      - id: create-pr
+        name: Create backport pull requests
         uses: korthout/backport-action@v1
         with:
           github_token: ${{ secrets.BACKPORT_TOKEN }}
@@ -26,7 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: backport
     # Open an issue only if the backport job failed
-    # https://github.com/korthout/backport-action/blob/e53c7b292aa9985d372c178a89d416ef2176c091/README.md#outputs
     if: ${{ needs.backport.outputs.was_successful == 'false' }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adding a backport label [failed](https://github.com/fedimint/fedimint/pull/3156#issuecomment-1764786458) to create a PR, but didn't create an associated issue.

I reproduced a failing backport on my fork and was able to [verify](https://github.com/bradleystachurski/fedimint/pull/23) an issue was created once these changes were included. The root cause is the [outputs](https://github.com/korthout/backport-action/blob/e53c7b292aa9985d372c178a89d416ef2176c091/README.md#outputs) from the backport action are available at the step level, but are not automatically included in the outputs for the job.

Once this PR is merged, I'll verify the fix by removing/re-adding the `backport releases/v0.1` label to https://github.com/fedimint/fedimint/pull/3156. This will trigger the backport workflow and should create an issue once the backport PR fails to create.