### PR TITLE
[Backport] add availability check before paying lightning invoice

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -613,6 +613,31 @@ pub enum PayError {
 }
 
 impl LightningClientModule {
+    // Ping gateway endpoint to verify that it is available before locking funds in
+    // OutgoingContract
+    async fn verify_gateway_availability(&self, gateway: &LightningGateway) -> anyhow::Result<()> {
+        let response = reqwest::Client::new()
+            .post(
+                gateway
+                    .api
+                    .join("is_available")
+                    .expect("is_available contains no invalid characters for a URL")
+                    .as_str(),
+            )
+            .json(&())
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("Gateway is not available: {e}"))?;
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Gateway is not available. Returned error code: {}",
+                response.status()
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Create an output that incentivizes a Lightning gateway to pay an invoice
     /// for us. It has time till the block height defined by `timelock`,
     /// after that we can claim our money back.
@@ -636,6 +661,10 @@ impl LightningClientModule {
             federation_currency,
             invoice_currency
         );
+
+        // Do not create the funding transaction if the gateway is not currently
+        // available
+        self.verify_gateway_availability(&gateway).await?;
 
         let consensus_count = api
             .fetch_consensus_block_count()


### PR DESCRIPTION
Backport of https://github.com/fedimint/fedimint/pull/3415 to 1.X release branch.

Couldn't backport the devimint test because the devimint changes haven't been backported.

Needed to change the verification check to explicitly check for `NOT_FOUND` error code instead of `is_success`. Manually have tested in tmuxinator and confirmed that paying invoices works when the gateway is available and the operation is rejected when the gateway is down.