### PR TITLE
fix: `nix flake show` broken and missing things in the output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -296,7 +296,10 @@
           # purposes (like `nix build`).
           legacyPackages = craneMultiBuild;
 
-          packages = { };
+          packages = {
+            inherit (craneMultiBuild) gatewayd gateway-cli fedimint-cli fedimintd fedimint-load-test-tool;
+            inherit (craneMultiBuild) client-pkgs gateway-pkgs fedimint-pkgs;
+          };
 
           lib = {
             inherit replaceGitHash devShells;

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -194,6 +194,7 @@ in
 rec {
   inherit commonArgs;
   inherit commonEnvsShell;
+  inherit commonEnvsShellRocksdbLink;
   inherit commonEnvsShellRocksdbLinkCross;
   inherit gitHashPlaceholderValue;
   commonArgsBase = commonArgs;


### PR DESCRIPTION
Run `nix flake show github:fedimint/fedimint` to see the issue, and `nix flake show 'github:fedimint/fedimint?rev=47ed2e92b71b1d0287366f96b47511e7a3f6cf04'` (or nix flake show 'github:dpc/fedimint?rev=47ed2e92b71b1d0287366f96b47511e7a3f6cf04') to see the fix.