### PR TITLE
feat: gateway checks network on connect federation

### DIFF
--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -114,6 +114,7 @@ impl GatewayTest {
             listen,
             address.clone(),
             cli_password.clone(),
+            None, // Use default Network which is "regtest"
             RoutingFees {
                 base_msat: 0,
                 proportional_millionths: 0,

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -77,6 +77,9 @@ pub enum Commands {
 
         #[clap(long)]
         routing_fees: Option<String>,
+
+        #[clap(long)]
+        network: Option<bitcoin::Network>,
     },
 }
 
@@ -150,12 +153,14 @@ async fn main() -> anyhow::Result<()> {
             password,
             num_route_hints,
             routing_fees,
+            network,
         } => {
             client()
                 .set_configuration(SetConfigurationPayload {
                     password,
                     num_route_hints,
                     routing_fees,
+                    network,
                 })
                 .await?;
         }

--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -1,3 +1,4 @@
+use bitcoin::Network;
 use fedimint_core::api::InviteCode;
 use fedimint_core::config::FederationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -65,6 +66,7 @@ pub struct GatewayConfiguration {
     pub num_route_hints: u32,
     #[serde(with = "serde_routing_fees")]
     pub routing_fees: RoutingFees,
+    pub network: Network,
 }
 
 impl_db_record!(

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -4,7 +4,7 @@ pub mod rpc_server;
 use std::borrow::Cow;
 use std::io::Cursor;
 
-use bitcoin::{Address, Txid};
+use bitcoin::{Address, Network, Txid};
 use bitcoin_hashes::hex::{FromHex, ToHex};
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::task::TaskGroup;
@@ -82,6 +82,7 @@ pub struct SetConfigurationPayload {
     pub password: Option<String>,
     pub num_route_hints: Option<u32>,
     pub routing_fees: Option<String>,
+    pub network: Option<Network>,
 }
 
 #[derive(Debug)]

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -75,6 +75,7 @@ pub struct GatewayInfo {
     pub route_hints: Vec<route_hints::RouteHint>,
     pub gateway_id: secp256k1::PublicKey,
     pub gateway_state: String,
+    pub network: Option<Network>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Adds Network configuration to gatewayd.

Speccd' and implemented behavior:
- gatewayd starts off without a network configuration
- on `set_configuration`, gatewayd assumes network configuration if provides, or defaults to regtest
- `set_configuration` can be used to change the network config when gatewayd is in running state, provided a federation has not been connected. This prevents changing the configured network to a different setting from the connected federations

Gatewayd the only allows (re)connecting a federations whose lightning module is on the same network

Tasks:
- [x] Gatewayd should support configuring of a network
- [x] Gateway should expose it's configured network via info api
- [x] Gatewayd should ensure all connected federations are on the same configured network
- [x] Gatewayd should ensure connected lightning node / service is on the same configured network : #3488