### PR TITLE
dev: expose FM_INVITE_CODE in user shells

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -119,7 +119,7 @@ impl Federation {
         let cfg_dir = &process_mgr.globals.FM_DATA_DIR;
         let out_dir = utf8(out_dir);
         let cfg_dir = utf8(cfg_dir);
-        // copy configs to config directory
+        // move configs to config directory
         tokio::fs::rename(
             format!("{out_dir}/invite-code"),
             format!("{cfg_dir}/invite-code"),
@@ -132,7 +132,7 @@ impl Federation {
         )
         .await
         .context("moving client.json")?;
-        info!("copied client configs");
+        info!("moved client configs");
 
         Ok(Self {
             members,

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -1440,6 +1440,20 @@ async fn rpc_command(rpc: RpcCmd, common: CommonArgs) -> Result<()> {
             .await?;
             let env = fs::read_to_string(&ready_file).await?;
             print!("{env}");
+
+            // Append invite code to devimint env
+            let env_file = common.test_dir.join("env");
+            let invite_file = common.test_dir.join("cfg/invite-code");
+            if fs::try_exists(&env_file).await.ok().unwrap_or(false)
+                && fs::try_exists(&invite_file).await.ok().unwrap_or(false)
+            {
+                let invite = fs::read_to_string(&invite_file).await?;
+                let mut env_string = fs::read_to_string(&env_file).await?;
+                writeln!(env_string, r#"export FM_INVITE_CODE="{invite}""#)?;
+                std::env::set_var("FM_INVITE_CODE", invite);
+                write_overwrite_async(common.test_dir.join("env"), env_string).await?;
+            }
+
             Ok(())
         }
     }

--- a/scripts/dev/user-shell.sh
+++ b/scripts/dev/user-shell.sh
@@ -14,6 +14,8 @@ then
     exit 1
 fi
 
+eval "$(devimint env)"
+
 echo Done!
 echo
 echo "This shell provides the following aliases:"


### PR DESCRIPTION
mprocs and tmux user shells get a ready to use `$FM_INVITE_CODE`

fix #3316 