### PR TITLE
Refactor ClientBuilder to take in DerivableSecret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ dependencies = [
  "futures",
  "gloo-net",
  "js-sys",
+ "rand",
  "ring",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -9,7 +9,6 @@ use bitcoin_hashes::hex;
 use bitcoin_hashes::hex::ToHex;
 use clap::Subcommand;
 use fedimint_client::backup::Metadata;
-use fedimint_client::secret::PlainRootSecretStrategy;
 use fedimint_client::Client;
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
@@ -369,7 +368,7 @@ pub async fn handle_command(
             Ok(serde_json::to_value(()).unwrap())
         }
         ClientCmd::PrintSecret => {
-            let secret = client.get_secret::<PlainRootSecretStrategy>().await;
+            let secret = client.get_decoded_client_secret::<[u8; 64]>().await?;
             let hex_secret = hex::ToHex::to_hex(&secret[..]);
 
             Ok(json!({

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -292,6 +292,7 @@ impl Opts {
         {
             Ok(secret) => secret,
             Err(_) => {
+                info!("Generating secret and writing to client storage");
                 let secret = PlainRootSecretStrategy::random(&mut thread_rng());
                 client_builder
                     .store_encodable_client_secret(secret)
@@ -547,6 +548,7 @@ impl FedimintCli {
                         .map_err_cli_general()
                     }
                     Err(_) => {
+                        info!("Generating secret and writing to client storage");
                         let new_secret = PlainRootSecretStrategy::random(&mut thread_rng());
                         client_builder
                             .store_encodable_client_secret(new_secret)

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
 use super::Client;
-use crate::get_client_root_secret_encoding;
-use crate::secret::{DeriveableSecretClientExt, RootSecretStrategy};
+use crate::get_decoded_client_secret;
+use crate::secret::DeriveableSecretClientExt;
 
 /// Backup metadata
 ///
@@ -355,11 +355,8 @@ impl Client {
         Self::get_derived_backup_signing_key_static(&self.root_secret())
     }
 
-    pub async fn get_secret<S>(&self) -> S::Encoding
-    where
-        S: RootSecretStrategy,
-    {
-        get_client_root_secret_encoding::<S>(self.db()).await
+    pub async fn get_decoded_client_secret<T: Decodable>(&self) -> anyhow::Result<T> {
+        get_decoded_client_secret::<T>(self.db()).await
     }
 }
 

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -12,7 +12,7 @@ use crate::oplog::OperationLogEntry;
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
     EncodedClientSecret = 0x28,
-    ClientSecret = 0x29,
+    ClientSecret = 0x29, // Unused
     OperationLog = 0x2c,
     ChronologicalOperationLog = 0x2d,
     CommonApiVersionCache = 0x2e,

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -1,22 +1,17 @@
-use std::io::{Error, Read, Write};
-use std::marker::PhantomData;
-
 use fedimint_core::api::{ApiVersionSet, InviteCode};
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::OperationId;
-use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
-use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::Serialize;
 use strum_macros::EnumIter;
 
 use crate::oplog::OperationLogEntry;
-use crate::secret::RootSecretStrategy;
-use crate::ClientSecret;
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
+    EncodedClientSecret = 0x28,
     ClientSecret = 0x29,
     OperationLog = 0x2c,
     ChronologicalOperationLog = 0x2d,
@@ -31,39 +26,21 @@ impl std::fmt::Display for DbKeyPrefix {
     }
 }
 
-#[derive(Debug, Serialize)]
-pub struct ClientSecretKey<S>(PhantomData<S>);
+#[derive(Debug, Encodable, Decodable)]
+pub struct EncodedClientSecretKey;
 
-impl<S> Default for ClientSecretKey<S> {
-    fn default() -> Self {
-        Self(PhantomData)
-    }
-}
+#[derive(Debug, Encodable, Decodable)]
+pub struct EncodedClientSecretKeyPrefix;
 
-impl<S> Encodable for ClientSecretKey<S> {
-    fn consensus_encode<W: Write>(&self, _writer: &mut W) -> Result<usize, Error> {
-        Ok(0)
-    }
-}
-
-impl<S> Decodable for ClientSecretKey<S> {
-    fn consensus_decode<R: Read>(
-        _r: &mut R,
-        _modules: &ModuleDecoderRegistry,
-    ) -> Result<Self, DecodeError> {
-        Ok(ClientSecretKey::default())
-    }
-}
-
-impl<S> ::fedimint_core::db::DatabaseRecord for ClientSecretKey<S>
-where
-    S: RootSecretStrategy,
-{
-    const DB_PREFIX: u8 = DbKeyPrefix::ClientSecret as u8;
-
-    type Key = Self;
-    type Value = ClientSecret<S>;
-}
+impl_db_record!(
+    key = EncodedClientSecretKey,
+    value = Vec<u8>,
+    db_prefix = DbKeyPrefix::EncodedClientSecret,
+);
+impl_db_lookup!(
+    key = EncodedClientSecretKey,
+    query_prefix = EncodedClientSecretKeyPrefix
+);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct OperationLogKey {

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -78,7 +78,7 @@ use anyhow::{anyhow, bail, ensure};
 use async_stream::stream;
 use db::{
     CachedApiVersionSet, CachedApiVersionSetKey, ClientConfigKey, ClientConfigKeyPrefix,
-    ClientInviteCodeKey, ClientInviteCodeKeyPrefix, EncodedClientSecretKey
+    ClientInviteCodeKey, ClientInviteCodeKeyPrefix, EncodedClientSecretKey,
 };
 use fedimint_core::api::{
     ApiVersionSet, DynGlobalApi, DynModuleApi, GlobalFederationApi, IGlobalFederationApi,

--- a/fedimint-wasm-tests/Cargo.toml
+++ b/fedimint-wasm-tests/Cargo.toml
@@ -21,3 +21,4 @@ wasm-bindgen = "=0.2.87" # must match the nix provided wasm-bindgen-cli version
 wasm-bindgen-futures = "0.4.34"
 wasm-bindgen-test = "0.3.34"
 gloo-net = "0.2.6"
+rand = "0.8.5"

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -11,6 +11,7 @@ use fedimint_core::db::{Database, DatabaseTransaction};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use futures::StreamExt;
 use rand::thread_rng;
+use tracing::info;
 
 use crate::db::{FederationConfig, FederationIdKey, FederationIdKeyPrefix};
 use crate::lnrpc_client::ILnRpcClient;
@@ -101,6 +102,7 @@ impl GatewayClientBuilder {
         {
             Ok(secret) => secret,
             Err(_) => {
+                info!("Generating secret and writing to client storage");
                 let secret = PlainRootSecretStrategy::random(&mut thread_rng());
                 client_builder
                     .store_encodable_client_secret(secret)

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -4,12 +4,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use fedimint_client::module::init::ClientModuleInitRegistry;
-use fedimint_client::secret::PlainRootSecretStrategy;
+use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::{get_config_from_db, ClientBuilder};
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseTransaction};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use futures::StreamExt;
+use rand::thread_rng;
 
 use crate::db::{FederationConfig, FederationIdKey, FederationIdKeyPrefix};
 use crate::lnrpc_client::ILnRpcClient;
@@ -94,9 +95,23 @@ impl GatewayClientBuilder {
             client_builder.with_database(rocksdb);
         }
 
+        let client_secret = match client_builder
+            .load_decodable_client_secret::<[u8; 64]>()
+            .await
+        {
+            Ok(secret) => secret,
+            Err(_) => {
+                let secret = PlainRootSecretStrategy::random(&mut thread_rng());
+                client_builder
+                    .store_encodable_client_secret(secret)
+                    .await
+                    .map_err(GatewayError::ClientStateMachineError)?;
+                secret
+            }
+        };
         client_builder
             // TODO: make this configurable?
-            .build::<PlainRootSecretStrategy>()
+            .build(PlainRootSecretStrategy::to_root_secret(&client_secret))
             .await
             .map_err(GatewayError::ClientStateMachineError)
     }


### PR DESCRIPTION
Closes #3451 

There are certain limitations with how root secret management works in `fedimint-client` today:
- A root secret cannot be provided externally. This makes `fedimint-client` difficult to compose in another application that wishes to manage the secret.
- Root secret management occurs implicitly within the `build()` call, with very little transparency to the caller. Here is the sequence of events:
  - Caller simply specifies the `RootSecretStrategy` ZST flavor to use as a generic argument on the `build()` call. This is typically one of the two pre-defined types: `Plain<>` or `Bip39<>`, or some custom external flavor.
  -  Using this strategy, root secret is generated by either (1) loading the secret material from the `fedimint-client` DB or (2) producing a random secret material as per the strategy's "encoding" and storing it in the DB—and then using the secret material to output a `DerivableSecret` which becomes the root secret.

This PR aims to decouple the process of root secret generation from the `build()` operation as follows:
- `build()` now takes as input a `DerivableSecret`. No secret storing/loading happens within `build()`. This has the following benefits:
  - A composer of `fedimint-client` can manage and transparently provide the root secret
  - `build()` no longer needs a generic strategy parameter
- There are separate methods exposed on `ClientBuilder` to store/load secret material as `Encodable`/`Decodable` generic types. This makes `fedimint-client`'s secret management service opt-in, further increasing flexibility to consumers.

`RootSecretStrategy` and its variants are still left as-is for convenience for `fedimint-cli`, `ln-gateway`, and some testing packages. It could be removed/simplified in a follow-up PR if desired, since now we don't have to play within the constraints of ZSTs.

**Note that we don't lose anything by moving away from the strategy pattern towards `Encodable`/`Decodable` types for storing/loading secret material.** This is because a consumer of `fedimint-client` may very well provide the wrong strategy type for loading a secret in the old implementation, just as they might provide the wrong `Decodable` type for loading a secret in the new implementation.