### PR TITLE
refactor: ClientWeak and move logic to ClientInner

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -9,7 +9,7 @@ use bitcoin_hashes::hex;
 use bitcoin_hashes::hex::ToHex;
 use clap::Subcommand;
 use fedimint_client::backup::Metadata;
-use fedimint_client::Client;
+use fedimint_client::ClientArc;
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::time::now;
@@ -147,7 +147,7 @@ fn parse_secret(s: &str) -> Result<[u8; 64], hex::Error> {
 pub async fn handle_command(
     command: ClientCmd,
     _config: ClientConfig,
-    client: Client,
+    client: ClientArc,
 ) -> anyhow::Result<serde_json::Value> {
     match command {
         ClientCmd::Info => get_note_summary(&client).await,
@@ -476,7 +476,7 @@ pub async fn handle_command(
     }
 }
 
-async fn get_note_summary(client: &Client) -> anyhow::Result<serde_json::Value> {
+async fn get_note_summary(client: &ClientArc) -> anyhow::Result<serde_json::Value> {
     let (mint_client, _) = client.get_first_module::<MintClientModule>(&fedimint_mint_client::KIND);
     let (wallet_client, _) =
         client.get_first_module::<WalletClientModule>(&fedimint_wallet_client::KIND);

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -284,7 +284,7 @@ impl Opts {
         &self,
         module_inits: &ClientModuleInitRegistry,
         invite_code: Option<InviteCode>,
-    ) -> CliResult<fedimint_client::Client> {
+    ) -> CliResult<fedimint_client::ClientArc> {
         let mut client_builder = self.build_client_builder(module_inits, invite_code).await?;
         let client_secret = match client_builder
             .load_decodable_client_secret::<[u8; 64]>()

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -14,7 +14,7 @@ use secp256k1_zkp::{KeyPair, Secp256k1};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
-use super::Client;
+use super::ClientArc;
 use crate::get_decoded_client_secret;
 use crate::secret::DeriveableSecretClientExt;
 
@@ -135,7 +135,7 @@ impl EncryptedClientBackup {
     }
 }
 
-impl Client {
+impl ClientArc {
     /// Create a backup, include provided `metadata`
     pub async fn create_backup(&self, metadata: Metadata) -> anyhow::Result<ClientBackup> {
         let fedimint_block_count = self.inner.api.fetch_block_count().await?;

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -69,9 +69,9 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::{Debug, Formatter};
-use std::ops::Range;
+use std::ops::{self, Range};
 use std::sync::atomic::AtomicUsize;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, ensure};
@@ -393,7 +393,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         };
 
         self.client
-            .finalize_and_submit_transaction(
+            .finalize_and_submit_transaction_inner(
                 dbtx.global_tx(),
                 self.operation,
                 TransactionBuilder::new().with_input(instance_input),
@@ -413,7 +413,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
         };
 
         self.client
-            .finalize_and_submit_transaction(
+            .finalize_and_submit_transaction_inner(
                 dbtx.global_tx(),
                 self.operation,
                 TransactionBuilder::new().with_output(instance_output),
@@ -458,9 +458,29 @@ fn states_add_instance(
     })
 }
 
+/// Atomically-counted ([`Arc`]) handle to [`ClientInner`]
+///
+/// Notably it `deref`-s to the [`ClientInner`] where most
+/// methods live.
 #[derive(Debug)]
 pub struct Client {
     inner: Arc<ClientInner>,
+}
+
+impl ops::Deref for Client {
+    type Target = Arc<ClientInner>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl Client {
+    pub fn downgrade(&self) -> ClientWeak {
+        ClientWeak {
+            inner: Arc::downgrade(&self.inner),
+        }
+    }
 }
 
 impl Clone for Client {
@@ -471,6 +491,18 @@ impl Clone for Client {
         Client {
             inner: self.inner.clone(),
         }
+    }
+}
+
+/// Like [`Client`] but using a [`Weak`] handle to [`ClientInner`]
+#[derive(Debug)]
+pub struct ClientWeak {
+    inner: Weak<ClientInner>,
+}
+
+impl ClientWeak {
+    pub fn upgrade(&self) -> Option<Client> {
+        Weak::upgrade(&self.inner).map(|inner| Client { inner })
     }
 }
 
@@ -529,461 +561,6 @@ const SUPPORTED_CORE_API_VERSIONS: &[fedimint_core::module::ApiVersion] =
 
 pub type ModuleGlobalContextGen = ContextGen<DynGlobalClientContext>;
 
-impl Client {
-    /// Initialize a client builder that can be configured to create a new
-    /// client.
-    pub fn builder() -> ClientBuilder {
-        ClientBuilder::default()
-    }
-
-    pub async fn start_executor(&self) {
-        debug!(
-            "Starting fedimint client executor (version: {})",
-            env!("FEDIMINT_BUILD_CODE_VERSION")
-        );
-        self.inner
-            .executor
-            .start_executor(self.inner.context_gen())
-            .await;
-    }
-
-    pub fn api(&self) -> &(dyn IGlobalFederationApi + 'static) {
-        self.inner.api.as_ref()
-    }
-
-    pub fn federation_id(&self) -> FederationId {
-        self.inner.federation_id
-    }
-
-    pub fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)> {
-        Ok((
-            self.federation_id()
-                .to_fake_ln_pub_key(&self.inner.secp_ctx)?,
-            0,
-        ))
-    }
-
-    pub fn get_meta(&self, key: &str) -> Option<String> {
-        self.inner.federation_meta.get(key).cloned()
-    }
-
-    pub fn decoders(&self) -> &ModuleDecoderRegistry {
-        self.inner.decoders()
-    }
-
-    fn root_secret(&self) -> DerivableSecret {
-        self.inner.root_secret.clone()
-    }
-
-    /// Secret that is derived from the seed used by the client and cannot
-    /// collide with secrets used by the client itself. It's intended to be used
-    /// by integrators of the client library so they don't have to implement
-    /// their own secret derivation scheme.
-    pub fn external_secret(&self) -> DerivableSecret {
-        self.root_secret().child_key(EXTERNAL_SECRET_CHILD_ID)
-    }
-
-    /// Add funding and/or change to the transaction builder as needed, finalize
-    /// the transaction and submit it to the federation.
-    ///
-    /// ## Errors
-    /// The function will return an error if the operation with given id already
-    /// exists.
-    ///
-    /// ## Panics
-    /// The function will panic if the the database transaction collides with
-    /// other and fails with others too often, this should not happen except for
-    /// excessively concurrent scenarios.
-    pub async fn finalize_and_submit_transaction<F, M>(
-        &self,
-        operation_id: OperationId,
-        operation_type: &str,
-        operation_meta: F,
-        tx_builder: TransactionBuilder,
-    ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)>
-    where
-        F: Fn(TransactionId, Vec<OutPoint>) -> M + Clone + MaybeSend + MaybeSync,
-        M: serde::Serialize + MaybeSend,
-    {
-        let operation_type = operation_type.to_owned();
-
-        let autocommit_res = self
-            .inner
-            .db
-            .autocommit(
-                |dbtx| {
-                    let operation_type = operation_type.clone();
-                    let tx_builder = tx_builder.clone();
-                    let operation_meta = operation_meta.clone();
-                    Box::pin(async move {
-                        if ClientInner::operation_exists(dbtx, operation_id).await {
-                            bail!("There already exists an operation with id {operation_id:?}")
-                        }
-
-                        let (txid, change) = self
-                            .inner
-                            .finalize_and_submit_transaction(dbtx, operation_id, tx_builder)
-                            .await?;
-
-                        self.operation_log()
-                            .add_operation_log_entry(
-                                dbtx,
-                                operation_id,
-                                &operation_type,
-                                operation_meta(txid, change.clone()),
-                            )
-                            .await;
-
-                        Ok((txid, change))
-                    })
-                },
-                Some(100), // TODO: handle what happens after 100 retries
-            )
-            .await;
-
-        match autocommit_res {
-            Ok(txid) => Ok(txid),
-            Err(AutocommitError::ClosureError { error, .. }) => Err(error),
-            Err(AutocommitError::CommitFailed {
-                attempts,
-                last_error,
-            }) => panic!(
-                "Failed to commit tx submission dbtx after {attempts} attempts: {last_error}"
-            ),
-        }
-    }
-
-    pub async fn add_state_machines(
-        &self,
-        dbtx: &mut DatabaseTransaction<'_>,
-        states: Vec<DynState<DynGlobalClientContext>>,
-    ) -> anyhow::Result<()> {
-        self.inner
-            .executor
-            .add_state_machines_dbtx(dbtx, states)
-            .await
-    }
-
-    // TODO: implement as part of OperationLog
-    pub async fn get_active_operations(&self) -> HashSet<OperationId> {
-        self.inner.executor.get_active_operations().await
-    }
-
-    pub fn operation_log(&self) -> &OperationLog {
-        &self.inner.operation_log
-    }
-
-    /// Returns a reference to a typed module client instance by kind
-    pub fn get_first_module<M: ClientModule>(
-        &self,
-        module_kind: &ModuleKind,
-    ) -> (&M, ClientModuleInstance) {
-        let id = self
-            .get_first_instance(module_kind)
-            .unwrap_or_else(|| panic!("No modules found of kind {module_kind}"));
-        let module: &M = self
-            .inner
-            .try_get_module(id)
-            .unwrap_or_else(|| panic!("Unknown module instance {id}"))
-            .as_any()
-            .downcast_ref::<M>()
-            .unwrap_or_else(|| panic!("Module is not of type {}", std::any::type_name::<M>()));
-        let instance = ClientModuleInstance {
-            id,
-            db: self.db().new_isolated(id),
-            api: self.api().with_module(id),
-        };
-        (module, instance)
-    }
-
-    pub fn get_module_client_dyn(
-        &self,
-        instance_id: ModuleInstanceId,
-    ) -> anyhow::Result<&maybe_add_send_sync!(dyn IClientModule)> {
-        self.inner
-            .try_get_module(instance_id)
-            .ok_or(anyhow!("Unknown module instance {}", instance_id))
-    }
-
-    pub fn db(&self) -> &Database {
-        &self.inner.db
-    }
-
-    /// Returns a stream of transaction updates for the given operation id that
-    /// can later be used to watch for a specific transaction being accepted.
-    pub async fn transaction_updates(&self, operation_id: OperationId) -> TransactionUpdates {
-        TransactionUpdates {
-            update_stream: self.inner.transaction_update_stream(operation_id).await,
-        }
-    }
-
-    /// Returns the instance id of the first module of the given kind. The
-    /// primary module will always be returned before any other modules (which
-    /// themselves are ordered by their instance id).
-    pub fn get_first_instance(&self, module_kind: &ModuleKind) -> Option<ModuleInstanceId> {
-        if &self
-            .inner
-            .modules
-            .get_with_kind(self.inner.primary_module_instance)
-            .expect("must have primary module")
-            .0
-            == module_kind
-        {
-            return Some(self.inner.primary_module_instance);
-        }
-
-        self.inner
-            .modules
-            .iter_modules()
-            .find(|(_, kind, _module)| *kind == module_kind)
-            .map(|(instance_id, _, _)| instance_id)
-    }
-
-    /// Returns the data from which the client's root secret is derived (e.g.
-    /// BIP39 seed phrase struct) if it is stored in the client's DB. If it
-    /// is not present, or if it is present but cannot be decoded, an error
-    /// is returned.
-    pub async fn root_secret_encoding<T: Decodable>(&self) -> anyhow::Result<T> {
-        get_decoded_client_secret::<T>(self.db()).await
-    }
-
-    /// Waits for an output from the primary module to reach its final
-    /// state.
-    pub async fn await_primary_module_output(
-        &self,
-        operation_id: OperationId,
-        out_point: OutPoint,
-    ) -> anyhow::Result<Amount> {
-        self.inner
-            .await_primary_module_output(operation_id, out_point)
-            .await
-    }
-
-    /// Waits for outputs from the primary module to reach its final
-    /// state.
-    pub async fn await_primary_module_outputs(
-        &self,
-        operation_id: OperationId,
-        outputs: Vec<OutPoint>,
-    ) -> anyhow::Result<Amount> {
-        let mut amount = Amount::ZERO;
-
-        for out_point in outputs {
-            amount += self
-                .inner
-                .await_primary_module_output(operation_id, out_point)
-                .await?;
-        }
-
-        Ok(amount)
-    }
-
-    /// Returns the config with which the client was initialized.
-    pub fn get_config(&self) -> &ClientConfig {
-        &self.inner.config
-    }
-
-    /// Returns the config of the client in JSON format.
-    ///
-    /// Compared to the consensus module format where module configs are binary
-    /// encoded this format cannot be cryptographically verified but is easier
-    /// to consume and to some degree human-readable.
-    pub fn get_config_json(&self) -> JsonClientConfig {
-        JsonClientConfig {
-            global: self.get_config().global.clone(),
-            modules: self
-                .get_config()
-                .modules
-                .iter()
-                .map(|(instance_id, ClientModuleConfig { kind, config, .. })| {
-                    (
-                        *instance_id,
-                        JsonWithKind::new(
-                            kind.clone(),
-                            config.clone().expect_decoded().to_json().into(),
-                        ),
-                    )
-                })
-                .collect(),
-        }
-    }
-
-    /// Get the primary module
-    pub fn primary_module(&self) -> &DynClientModule {
-        self.inner
-            .modules
-            .get(self.inner.primary_module_instance)
-            .expect("primary module must be present")
-    }
-
-    /// Balance available to the client for spending
-    pub async fn get_balance(&self) -> Amount {
-        self.primary_module()
-            .get_balance(
-                self.inner.primary_module_instance,
-                &mut self.db().begin_transaction().await,
-            )
-            .await
-    }
-
-    /// Returns a stream that yields the current client balance every time it
-    /// changes.
-    pub async fn subscribe_balance_changes(&self) -> BoxStream<'static, Amount> {
-        let mut balance_changes = self.primary_module().subscribe_balance_changes().await;
-        let initial_balance = self.get_balance().await;
-        let db = self.db().clone();
-        let primary_module = self.primary_module().clone();
-        let primary_module_instance = self.inner.primary_module_instance;
-
-        Box::pin(stream! {
-            yield initial_balance;
-            let mut prev_balance = initial_balance;
-            while let Some(()) = balance_changes.next().await {
-                let mut dbtx = db.begin_transaction().await;
-                let balance = primary_module
-                    .get_balance(primary_module_instance, &mut dbtx)
-                    .await;
-
-                // Deduplicate in case modules cannot always tell if the balance actually changed
-                if balance != prev_balance {
-                    prev_balance = balance;
-                    yield balance;
-                }
-            }
-        })
-    }
-
-    pub async fn discover_common_api_version(&self) -> anyhow::Result<ApiVersionSet> {
-        Ok(self
-            .api()
-            .discover_api_version_set(
-                &Self::supported_api_versions_summary_static(
-                    self.get_config(),
-                    &self.inner.module_inits,
-                )
-                .await,
-            )
-            .await?)
-    }
-
-    /// Query the federation for API version support and then calculate
-    /// the best API version to use (supported by most guardians).
-    pub async fn discover_common_api_version_static(
-        config: &ClientConfig,
-        client_module_init: &ClientModuleInitRegistry,
-        api: &DynGlobalApi,
-    ) -> anyhow::Result<ApiVersionSet> {
-        Ok(api
-            .discover_api_version_set(
-                &Self::supported_api_versions_summary_static(config, client_module_init).await,
-            )
-            .await?)
-    }
-
-    /// [`SupportedApiVersionsSummary`] that the client and its modules support
-    pub async fn supported_api_versions_summary_static(
-        config: &ClientConfig,
-        client_module_init: &ClientModuleInitRegistry,
-    ) -> SupportedApiVersionsSummary {
-        SupportedApiVersionsSummary {
-            core: SupportedCoreApiVersions {
-                core_consensus: config.global.consensus_version,
-                api: MultiApiVersion::try_from_iter(SUPPORTED_CORE_API_VERSIONS.to_owned())
-                    .expect("must not have conflicting versions"),
-            },
-            modules: config
-                .modules
-                .iter()
-                .filter_map(|(&module_instance_id, module_config)| {
-                    client_module_init
-                        .get(module_config.kind())
-                        .map(|module_init| {
-                            (
-                                module_instance_id,
-                                SupportedModuleApiVersions {
-                                    core_consensus: config.global.consensus_version,
-                                    module_consensus: module_config.version,
-                                    api: module_init.supported_api_versions(),
-                                },
-                            )
-                        })
-                })
-                .collect(),
-        }
-    }
-
-    /// Load the common api versions to use from cache and start a background
-    /// process to refresh them.
-    ///
-    /// This is a compromise so we not have to wait for version discovery to
-    /// complete every time a [`Client`] is being built.
-    async fn load_and_refresh_common_api_version_static(
-        config: &ClientConfig,
-        module_inits: &ModuleInitRegistry<DynClientModuleInit>,
-        api: &DynGlobalApi,
-        db: &Database,
-    ) -> anyhow::Result<ApiVersionSet> {
-        if let Some(v) = db
-            .begin_transaction()
-            .await
-            .get_value(&CachedApiVersionSetKey)
-            .await
-        {
-            debug!("Found existing cached common api versions");
-            let config = config.clone();
-            let module_inits = module_inits.clone();
-            let api = api.clone();
-            let db = db.clone();
-            // Separate task group, because we actually don't want to be waiting for this to
-            // finish, and it's just best effort.
-            TaskGroup::new()
-                .spawn("refresh_common_api_version_static", |_| async move {
-                    if let Err(e) =
-                        Self::refresh_common_api_version_static(&config, &module_inits, &api, &db)
-                            .await
-                    {
-                        warn!("Failed to discover common api versions: {e}");
-                    }
-                })
-                .await;
-
-            return Ok(v.0);
-        }
-
-        debug!("No existing cached common api versions found, waiting for initial discovery");
-        Self::refresh_common_api_version_static(config, module_inits, api, db).await
-    }
-
-    async fn refresh_common_api_version_static(
-        config: &ClientConfig,
-        module_inits: &ModuleInitRegistry<DynClientModuleInit>,
-        api: &DynGlobalApi,
-        db: &Database,
-    ) -> anyhow::Result<ApiVersionSet> {
-        debug!("Refreshing common api versions");
-
-        let common_api_versions =
-            Client::discover_common_api_version_static(config, module_inits, api).await?;
-
-        debug!("Updating the cached common api versions");
-        let mut dbtx = db.begin_transaction().await;
-        let _ = dbtx
-            .insert_entry(
-                &CachedApiVersionSetKey,
-                &CachedApiVersionSet(common_api_versions.clone()),
-            )
-            .await;
-
-        dbtx.commit_tx().await;
-
-        Ok(common_api_versions)
-    }
-
-    pub async fn has_active_states(&self, operation_id: OperationId) -> bool {
-        self.inner.has_active_states(operation_id).await
-    }
-}
-
 /// Resources particular to a module instance
 pub struct ClientModuleInstance {
     /// Instance id of the module
@@ -994,7 +571,7 @@ pub struct ClientModuleInstance {
     pub api: DynModuleApi,
 }
 
-struct ClientInner {
+pub struct ClientInner {
     config: ClientConfig,
     decoders: ModuleDecoderRegistry,
     db: Database,
@@ -1018,10 +595,26 @@ struct ClientInner {
 }
 
 impl ClientInner {
-    fn primary_module(&self) -> &DynClientModule {
-        self.modules
-            .get(self.primary_module_instance)
-            .expect("must have primary module")
+    /// Initialize a client builder that can be configured to create a new
+    /// client.
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
+    }
+
+    pub fn api(&self) -> &(dyn IGlobalFederationApi + 'static) {
+        self.api.as_ref()
+    }
+
+    pub async fn start_executor(self: &Arc<Self>) {
+        debug!(
+            "Starting fedimint client executor (version: {})",
+            env!("FEDIMINT_BUILD_CODE_VERSION")
+        );
+        self.executor.start_executor(self.context_gen()).await;
+    }
+
+    pub fn federation_id(&self) -> FederationId {
+        self.federation_id
     }
 
     fn context_gen(self: &Arc<Self>) -> ModuleGlobalContextGen {
@@ -1043,7 +636,7 @@ impl ClientInner {
         &self.config
     }
 
-    fn decoders(&self) -> &ModuleDecoderRegistry {
+    pub fn decoders(&self) -> &ModuleDecoderRegistry {
         &self.decoders
     }
 
@@ -1095,7 +688,44 @@ impl ClientInner {
         }
     }
 
-    /// Adds funding to a transaction or removes overfunding via change.
+    pub fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)> {
+        Ok((self.federation_id().to_fake_ln_pub_key(&self.secp_ctx)?, 0))
+    }
+
+    pub fn get_meta(&self, key: &str) -> Option<String> {
+        self.federation_meta.get(key).cloned()
+    }
+
+    fn root_secret(&self) -> DerivableSecret {
+        self.root_secret.clone()
+    }
+
+    /// Secret that is derived from the seed used by the client and cannot
+    /// collide with secrets used by the client itself. It's intended to be used
+    /// by integrators of the client library so they don't have to implement
+    /// their own secret derivation scheme.
+    pub fn external_secret(&self) -> DerivableSecret {
+        self.root_secret().child_key(EXTERNAL_SECRET_CHILD_ID)
+    }
+
+    pub async fn add_state_machines(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        states: Vec<DynState<DynGlobalClientContext>>,
+    ) -> anyhow::Result<()> {
+        self.executor.add_state_machines_dbtx(dbtx, states).await
+    }
+
+    // TODO: implement as part of [`OperationLog`]
+    pub async fn get_active_operations(&self) -> HashSet<OperationId> {
+        self.executor.get_active_operations().await
+    }
+
+    pub fn operation_log(&self) -> &OperationLog {
+        &self.operation_log
+    }
+
+    /// Adds funding to a transaction or removes over-funding via change.
     async fn finalize_transaction(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
@@ -1160,7 +790,75 @@ impl ClientInner {
         Ok((tx, states, change_range))
     }
 
-    async fn finalize_and_submit_transaction(
+    /// Add funding and/or change to the transaction builder as needed, finalize
+    /// the transaction and submit it to the federation.
+    ///
+    /// ## Errors
+    /// The function will return an error if the operation with given ID already
+    /// exists.
+    ///
+    /// ## Panics
+    /// The function will panic if the database transaction collides with
+    /// other and fails with others too often, this should not happen except for
+    /// excessively concurrent scenarios.
+    pub async fn finalize_and_submit_transaction<F, M>(
+        &self,
+        operation_id: OperationId,
+        operation_type: &str,
+        operation_meta: F,
+        tx_builder: TransactionBuilder,
+    ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)>
+    where
+        F: Fn(TransactionId, Vec<OutPoint>) -> M + Clone + MaybeSend + MaybeSync,
+        M: serde::Serialize + MaybeSend,
+    {
+        let operation_type = operation_type.to_owned();
+
+        let autocommit_res = self
+            .db
+            .autocommit(
+                |dbtx| {
+                    let operation_type = operation_type.clone();
+                    let tx_builder = tx_builder.clone();
+                    let operation_meta = operation_meta.clone();
+                    Box::pin(async move {
+                        if ClientInner::operation_exists(dbtx, operation_id).await {
+                            bail!("There already exists an operation with id {operation_id:?}")
+                        }
+
+                        let (txid, change) = self
+                            .finalize_and_submit_transaction_inner(dbtx, operation_id, tx_builder)
+                            .await?;
+
+                        self.operation_log()
+                            .add_operation_log_entry(
+                                dbtx,
+                                operation_id,
+                                &operation_type,
+                                operation_meta(txid, change.clone()),
+                            )
+                            .await;
+
+                        Ok((txid, change))
+                    })
+                },
+                Some(100), // TODO: handle what happens after 100 retries
+            )
+            .await;
+
+        match autocommit_res {
+            Ok(txid) => Ok(txid),
+            Err(AutocommitError::ClosureError { error, .. }) => Err(error),
+            Err(AutocommitError::CommitFailed {
+                attempts,
+                last_error,
+            }) => panic!(
+                "Failed to commit tx submission dbtx after {attempts} attempts: {last_error}"
+            ),
+        }
+    }
+
+    async fn finalize_and_submit_transaction_inner(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
@@ -1233,6 +931,8 @@ impl ClientInner {
         active_state_exists || inactive_state_exists
     }
 
+    /// Waits for an output from the primary module to reach its final
+    /// state.
     pub async fn await_primary_module_output(
         &self,
         operation_id: OperationId,
@@ -1248,6 +948,289 @@ impl ClientInner {
         all_active_states
             .into_iter()
             .any(|context| context.0.operation_id() == operation_id)
+    }
+
+    /// Returns a reference to a typed module client instance by kind
+    pub fn get_first_module<M: ClientModule>(
+        &self,
+        module_kind: &ModuleKind,
+    ) -> (&M, ClientModuleInstance) {
+        let id = self
+            .get_first_instance(module_kind)
+            .unwrap_or_else(|| panic!("No modules found of kind {module_kind}"));
+        let module: &M = self
+            .try_get_module(id)
+            .unwrap_or_else(|| panic!("Unknown module instance {id}"))
+            .as_any()
+            .downcast_ref::<M>()
+            .unwrap_or_else(|| panic!("Module is not of type {}", std::any::type_name::<M>()));
+        let instance = ClientModuleInstance {
+            id,
+            db: self.db().new_isolated(id),
+            api: self.api().with_module(id),
+        };
+        (module, instance)
+    }
+
+    pub fn get_module_client_dyn(
+        &self,
+        instance_id: ModuleInstanceId,
+    ) -> anyhow::Result<&maybe_add_send_sync!(dyn IClientModule)> {
+        self.try_get_module(instance_id)
+            .ok_or(anyhow!("Unknown module instance {}", instance_id))
+    }
+
+    pub fn db(&self) -> &Database {
+        &self.db
+    }
+
+    /// Returns a stream of transaction updates for the given operation id that
+    /// can later be used to watch for a specific transaction being accepted.
+    pub async fn transaction_updates(&self, operation_id: OperationId) -> TransactionUpdates {
+        TransactionUpdates {
+            update_stream: self.transaction_update_stream(operation_id).await,
+        }
+    }
+
+    /// Returns the instance id of the first module of the given kind. The
+    /// primary module will always be returned before any other modules (which
+    /// themselves are ordered by their instance ID).
+    pub fn get_first_instance(&self, module_kind: &ModuleKind) -> Option<ModuleInstanceId> {
+        if &self
+            .modules
+            .get_with_kind(self.primary_module_instance)
+            .expect("must have primary module")
+            .0
+            == module_kind
+        {
+            return Some(self.primary_module_instance);
+        }
+
+        self.modules
+            .iter_modules()
+            .find(|(_, kind, _module)| *kind == module_kind)
+            .map(|(instance_id, _, _)| instance_id)
+    }
+
+    /// Returns the data from which the client's root secret is derived (e.g.
+    /// BIP39 seed phrase struct).
+    pub async fn root_secret_encoding<T: Decodable>(&self) -> anyhow::Result<T> {
+        get_decoded_client_secret::<T>(self.db()).await
+    }
+
+    /// Waits for outputs from the primary module to reach its final
+    /// state.
+    pub async fn await_primary_module_outputs(
+        &self,
+        operation_id: OperationId,
+        outputs: Vec<OutPoint>,
+    ) -> anyhow::Result<Amount> {
+        let mut amount = Amount::ZERO;
+
+        for out_point in outputs {
+            amount += self
+                .await_primary_module_output(operation_id, out_point)
+                .await?;
+        }
+
+        Ok(amount)
+    }
+
+    /// Returns the config with which the client was initialized.
+    pub fn get_config(&self) -> &ClientConfig {
+        &self.config
+    }
+
+    /// Returns the config of the client in JSON format.
+    ///
+    /// Compared to the consensus module format where module configs are binary
+    /// encoded this format cannot be cryptographically verified but is easier
+    /// to consume and to some degree human-readable.
+    pub fn get_config_json(&self) -> JsonClientConfig {
+        JsonClientConfig {
+            global: self.get_config().global.clone(),
+            modules: self
+                .get_config()
+                .modules
+                .iter()
+                .map(|(instance_id, ClientModuleConfig { kind, config, .. })| {
+                    (
+                        *instance_id,
+                        JsonWithKind::new(
+                            kind.clone(),
+                            config.clone().expect_decoded().to_json().into(),
+                        ),
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    /// Get the primary module
+    pub fn primary_module(&self) -> &DynClientModule {
+        self.modules
+            .get(self.primary_module_instance)
+            .expect("primary module must be present")
+    }
+
+    /// Balance available to the client for spending
+    pub async fn get_balance(&self) -> Amount {
+        self.primary_module()
+            .get_balance(
+                self.primary_module_instance,
+                &mut self.db().begin_transaction().await,
+            )
+            .await
+    }
+
+    /// Returns a stream that yields the current client balance every time it
+    /// changes.
+    pub async fn subscribe_balance_changes(&self) -> BoxStream<'static, Amount> {
+        let mut balance_changes = self.primary_module().subscribe_balance_changes().await;
+        let initial_balance = self.get_balance().await;
+        let db = self.db().clone();
+        let primary_module = self.primary_module().clone();
+        let primary_module_instance = self.primary_module_instance;
+
+        Box::pin(stream! {
+            yield initial_balance;
+            let mut prev_balance = initial_balance;
+            while let Some(()) = balance_changes.next().await {
+                let mut dbtx = db.begin_transaction().await;
+                let balance = primary_module
+                    .get_balance(primary_module_instance, &mut dbtx)
+                    .await;
+
+                // Deduplicate in case modules cannot always tell if the balance actually changed
+                if balance != prev_balance {
+                    prev_balance = balance;
+                    yield balance;
+                }
+            }
+        })
+    }
+
+    pub async fn discover_common_api_version(&self) -> anyhow::Result<ApiVersionSet> {
+        Ok(self
+            .api()
+            .discover_api_version_set(
+                &Self::supported_api_versions_summary_static(self.get_config(), &self.module_inits)
+                    .await,
+            )
+            .await?)
+    }
+
+    /// Query the federation for API version support and then calculate
+    /// the best API version to use (supported by most guardians).
+    pub async fn discover_common_api_version_static(
+        config: &ClientConfig,
+        client_module_init: &ClientModuleInitRegistry,
+        api: &DynGlobalApi,
+    ) -> anyhow::Result<ApiVersionSet> {
+        Ok(api
+            .discover_api_version_set(
+                &Self::supported_api_versions_summary_static(config, client_module_init).await,
+            )
+            .await?)
+    }
+
+    /// [`SupportedApiVersionsSummary`] that the client and its modules support
+    pub async fn supported_api_versions_summary_static(
+        config: &ClientConfig,
+        client_module_init: &ClientModuleInitRegistry,
+    ) -> SupportedApiVersionsSummary {
+        SupportedApiVersionsSummary {
+            core: SupportedCoreApiVersions {
+                core_consensus: config.global.consensus_version,
+                api: MultiApiVersion::try_from_iter(SUPPORTED_CORE_API_VERSIONS.to_owned())
+                    .expect("must not have conflicting versions"),
+            },
+            modules: config
+                .modules
+                .iter()
+                .filter_map(|(&module_instance_id, module_config)| {
+                    client_module_init
+                        .get(module_config.kind())
+                        .map(|module_init| {
+                            (
+                                module_instance_id,
+                                SupportedModuleApiVersions {
+                                    core_consensus: config.global.consensus_version,
+                                    module_consensus: module_config.version,
+                                    api: module_init.supported_api_versions(),
+                                },
+                            )
+                        })
+                })
+                .collect(),
+        }
+    }
+
+    /// Load the common api versions to use from cache and start a background
+    /// process to refresh them.
+    ///
+    /// This is a compromise, so we not have to wait for version discovery to
+    /// complete every time a [`Client`] is being built.
+    async fn load_and_refresh_common_api_version_static(
+        config: &ClientConfig,
+        module_inits: &ModuleInitRegistry<DynClientModuleInit>,
+        api: &DynGlobalApi,
+        db: &Database,
+    ) -> anyhow::Result<ApiVersionSet> {
+        if let Some(v) = db
+            .begin_transaction()
+            .await
+            .get_value(&CachedApiVersionSetKey)
+            .await
+        {
+            debug!("Found existing cached common api versions");
+            let config = config.clone();
+            let module_inits = module_inits.clone();
+            let api = api.clone();
+            let db = db.clone();
+            // Separate task group, because we actually don't want to be waiting for this to
+            // finish, and it's just best effort.
+            TaskGroup::new()
+                .spawn("refresh_common_api_version_static", |_| async move {
+                    if let Err(e) =
+                        Self::refresh_common_api_version_static(&config, &module_inits, &api, &db)
+                            .await
+                    {
+                        warn!("Failed to discover common api versions: {e}");
+                    }
+                })
+                .await;
+
+            return Ok(v.0);
+        }
+
+        debug!("No existing cached common api versions found, waiting for initial discovery");
+        Self::refresh_common_api_version_static(config, module_inits, api, db).await
+    }
+
+    async fn refresh_common_api_version_static(
+        config: &ClientConfig,
+        module_inits: &ModuleInitRegistry<DynClientModuleInit>,
+        api: &DynGlobalApi,
+        db: &Database,
+    ) -> anyhow::Result<ApiVersionSet> {
+        debug!("Refreshing common api versions");
+
+        let common_api_versions =
+            ClientInner::discover_common_api_version_static(config, module_inits, api).await?;
+
+        debug!("Updating the cached common api versions");
+        let mut dbtx = db.begin_transaction().await;
+        let _ = dbtx
+            .insert_entry(
+                &CachedApiVersionSetKey,
+                &CachedApiVersionSet(common_api_versions.clone()),
+            )
+            .await;
+
+        dbtx.commit_tx().await;
+
+        Ok(common_api_versions)
     }
 }
 
@@ -1524,7 +1507,7 @@ impl ClientBuilder {
         let notifier = Notifier::new(db.clone());
         let api = DynGlobalApi::from(WsFederationApi::from_config(&config));
 
-        let common_api_versions = Client::load_and_refresh_common_api_version_static(
+        let common_api_versions = ClientInner::load_and_refresh_common_api_version_static(
             &config,
             &self.module_inits,
             &api,

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -20,7 +20,7 @@ use fedimint_core::{
 
 use crate::sm::{Context, DynContext, DynState, Executor, State};
 use crate::transaction::{ClientInput, ClientOutput};
-use crate::{Client, DynGlobalClientContext};
+use crate::{ClientArc, DynGlobalClientContext};
 
 pub mod init;
 
@@ -52,7 +52,7 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
 
     async fn handle_cli_command(
         &self,
-        _client: &Client,
+        _client: &ClientArc,
         _args: &[ffi::OsString],
     ) -> anyhow::Result<serde_json::Value> {
         Err(anyhow::format_err!(
@@ -263,7 +263,7 @@ pub trait IClientModule: Debug {
 
     async fn handle_cli_command(
         &self,
-        client: &Client,
+        client: &ClientArc,
         args: &[ffi::OsString],
     ) -> anyhow::Result<serde_json::Value>;
 
@@ -350,7 +350,7 @@ where
 
     async fn handle_cli_command(
         &self,
-        client: &Client,
+        client: &ClientArc,
         args: &[ffi::OsString],
     ) -> anyhow::Result<serde_json::Value> {
         <T as ClientModule>::handle_cli_command(self, client, args).await

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -13,7 +13,7 @@ use common::{
 };
 use devimint::cmd;
 use devimint::util::{GatewayClnCli, GatewayLndCli};
-use fedimint_client::Client;
+use fedimint_client::ClientArc;
 use fedimint_core::api::{GlobalFederationApi, InviteCode, WsFederationApi};
 use fedimint_core::endpoint_constants::FETCH_BLOCK_COUNT_ENDPOINT;
 use fedimint_core::module::ApiRequestErased;
@@ -416,7 +416,7 @@ async fn run_load_test(
 
 #[allow(clippy::too_many_arguments)]
 async fn do_user_task(
-    client: Client,
+    client: ClientArc,
     oob_notes: Vec<OOBNotes>,
     generated_invoices_per_user: u16,
     ln_payment_sleep: Duration,

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
-use fedimint_client::{Client, ClientBuilder};
+use fedimint_client::{ClientArc, ClientBuilder};
 use fedimint_core::admin_client::{ConfigGenParamsConsensus, PeerServerParams};
 use fedimint_core::api::InviteCode;
 use fedimint_core::config::{
@@ -38,12 +38,12 @@ pub struct FederationTest {
 
 impl FederationTest {
     /// Create two clients, useful for send/receive tests
-    pub async fn two_clients(&self) -> (Client, Client) {
+    pub async fn two_clients(&self) -> (ClientArc, ClientArc) {
         (self.new_client().await, self.new_client().await)
     }
 
     /// Create a client connected to this fed
-    pub async fn new_client(&self) -> Client {
+    pub async fn new_client(&self) -> ClientArc {
         let client_config = self.configs[&PeerId::from(0)]
             .consensus
             .to_client_config(&self.server_init)
@@ -52,7 +52,7 @@ impl FederationTest {
         self.new_client_with_config(client_config).await
     }
 
-    pub async fn new_client_with_config(&self, client_config: ClientConfig) -> Client {
+    pub async fn new_client_with_config(&self, client_config: ClientConfig) -> ClientArc {
         info!(target: LOG_TEST, "Setting new client with config");
         let mut client_builder = ClientBuilder::default();
         client_builder.with_module_inits(self.client_init.clone());

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fedimint_client::module::init::ClientModuleInitRegistry;
-use fedimint_client::Client;
+use fedimint_client::ClientArc;
 use fedimint_core::config::FederationId;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::Database;
@@ -56,11 +56,11 @@ impl GatewayTest {
     }
 
     /// Removes a client from the gateway
-    pub async fn remove_client(&self, fed: &FederationTest) -> Client {
+    pub async fn remove_client(&self, fed: &FederationTest) -> ClientArc {
         self.gateway.remove_client(fed.id()).await.unwrap()
     }
 
-    pub async fn select_client(&self, federation_id: FederationId) -> Client {
+    pub async fn select_client(&self, federation_id: FederationId) -> ClientArc {
         self.gateway.select_client(federation_id).await.unwrap()
     }
 

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -7,7 +7,7 @@ use fedimint_mint_client::MintClientGen;
 use fedimint_wallet_client::WalletClientGen;
 use rand::thread_rng;
 
-async fn client(invite_code: &InviteCode) -> Result<fedimint_client::Client> {
+async fn client(invite_code: &InviteCode) -> Result<fedimint_client::ClientArc> {
     let mut builder = fedimint_client::ClientBuilder::default();
     builder.with_module(LightningClientGen);
     builder.with_module(MintClientGen);
@@ -86,7 +86,7 @@ mod tests {
         Ok(())
     }
 
-    async fn set_gateway(client: &fedimint_client::Client) -> anyhow::Result<()> {
+    async fn set_gateway(client: &fedimint_client::ClientArc) -> anyhow::Result<()> {
         let gws = client.fetch_registered_gateways().await?;
         let gw_api = faucet::gateway_api().await?;
         let lnd_gw = gws

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -49,8 +49,8 @@ impl GatewayClientBuilder {
         lnrpc: Arc<dyn ILnRpcClient>,
         all_clients: FederationToClientMap,
         all_scids: ScidToFederationMap,
-        old_client: Option<fedimint_client::Client>,
-    ) -> Result<fedimint_client::Client> {
+        old_client: Option<fedimint_client::ClientArc>,
+    ) -> Result<fedimint_client::ClientArc> {
         let FederationConfig {
             invite_code,
             mint_channel_id,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -30,7 +30,7 @@ use clap::{Parser, Subcommand};
 use client::GatewayClientBuilder;
 use db::{DbKeyPrefix, GatewayConfiguration, GatewayConfigurationKey, GatewayPublicKey};
 use fedimint_client::module::init::ClientModuleInitRegistry;
-use fedimint_client::Client;
+use fedimint_client::ClientArc;
 use fedimint_core::api::{FederationError, InviteCode};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{
@@ -199,7 +199,7 @@ impl Display for GatewayState {
 }
 
 pub type ScidToFederationMap = Arc<RwLock<BTreeMap<u64, FederationId>>>;
-pub type FederationToClientMap = Arc<RwLock<BTreeMap<FederationId, fedimint_client::Client>>>;
+pub type FederationToClientMap = Arc<RwLock<BTreeMap<FederationId, fedimint_client::ClientArc>>>;
 
 #[derive(Clone)]
 pub struct Gateway {
@@ -910,7 +910,7 @@ impl Gateway {
     pub async fn remove_client(
         &self,
         federation_id: FederationId,
-    ) -> Result<fedimint_client::Client> {
+    ) -> Result<fedimint_client::ClientArc> {
         let client = self.clients.write().await.remove(&federation_id).ok_or(
             GatewayError::InvalidMetadata(format!("No federation with id {federation_id}")),
         )?;
@@ -920,7 +920,7 @@ impl Gateway {
     pub async fn select_client(
         &self,
         federation_id: FederationId,
-    ) -> Result<fedimint_client::Client> {
+    ) -> Result<fedimint_client::ClientArc> {
         self.clients
             .read()
             .await
@@ -1106,7 +1106,7 @@ impl Gateway {
 
     async fn make_federation_info(
         &self,
-        client: &Client,
+        client: &ClientArc,
         federation_id: FederationId,
     ) -> FederationInfo {
         let balance_msat = client.get_balance().await;

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -13,7 +13,7 @@ use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, ModuleNotifier, State};
 use fedimint_client::transaction::{ClientOutput, TransactionBuilder};
-use fedimint_client::{sm_enum_variant_translation, Client, DynGlobalClientContext};
+use fedimint_client::{sm_enum_variant_translation, ClientArc, DynGlobalClientContext};
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
@@ -150,7 +150,7 @@ pub trait GatewayClientExt {
 }
 
 #[apply(async_trait_maybe_send!)]
-impl GatewayClientExt for Client {
+impl GatewayClientExt for ClientArc {
     /// Pays a LN invoice with our available funds
     async fn gateway_pay_bolt11_invoice(
         &self,

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client::transaction::{ClientInput, ClientOutput};
-use fedimint_client::{Client, DynGlobalClientContext};
+use fedimint_client::{ClientArc, DynGlobalClientContext};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -303,7 +303,7 @@ impl GatewayPayInvoice {
     }
 
     async fn buy_preimage_via_direct_swap(
-        client: Client,
+        client: ClientArc,
         invoice: Bolt11Invoice,
         contract: OutgoingContractAccount,
         common: GatewayPayCommon,
@@ -460,7 +460,7 @@ impl GatewayPayInvoice {
     async fn check_swap_to_federation(
         context: GatewayClientContext,
         invoice: Bolt11Invoice,
-    ) -> Option<Client> {
+    ) -> Option<ClientArc> {
         let rhints = invoice.route_hints();
         match rhints.first().and_then(|rh| rh.0.last()) {
             None => None,

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use assert_matches::assert_matches;
 use bitcoin_hashes::{sha256, Hash};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
-use fedimint_client::Client;
+use fedimint_client::ClientArc;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::task::sleep;
@@ -63,7 +63,7 @@ async fn single_federation_test<B>(
             GatewayTest,
             Box<dyn LightningTest>,
             FederationTest,
-            Client, // User Client
+            ClientArc, // User Client
             Arc<dyn BitcoinTest>,
         ) -> B
         + Copy,
@@ -134,8 +134,8 @@ pub fn sha256(data: &[u8]) -> sha256::Hash {
 
 async fn pay_valid_invoice(
     invoice: Bolt11Invoice,
-    user_client: &Client,
-    gateway: &Client,
+    user_client: &ClientArc,
+    gateway: &ClientArc,
 ) -> anyhow::Result<()> {
     // User client pays test invoice
     let OutgoingLightningPayment {

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -9,7 +9,7 @@ use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::sm::{Context, ModuleNotifier};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
-use fedimint_client::{Client, DynGlobalClientContext};
+use fedimint_client::{ClientArc, DynGlobalClientContext};
 use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::{Decoder, IntoDynInstance, KeyPair, OperationId};
 use fedimint_core::db::ModuleDatabaseTransaction;
@@ -72,7 +72,7 @@ pub trait DummyClientExt {
 }
 
 #[apply(async_trait_maybe_send!)]
-impl DummyClientExt for Client {
+impl DummyClientExt for ClientArc {
     async fn print_using_account(
         &self,
         amount: Amount,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -21,7 +21,7 @@ use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client::transaction::{ClientOutput, TransactionBuilder};
-use fedimint_client::{sm_enum_variant_translation, Client, DynGlobalClientContext};
+use fedimint_client::{sm_enum_variant_translation, ClientArc, DynGlobalClientContext};
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
@@ -219,7 +219,7 @@ async fn invoice_routes_back_to_federation(
 }
 
 #[apply(async_trait_maybe_send!)]
-impl LightningClientExt for Client {
+impl LightningClientExt for ClientArc {
     async fn select_active_gateway(&self) -> anyhow::Result<LightningGateway> {
         let (_lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
         let mut dbtx = instance.db.begin_transaction().await;

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -20,7 +20,7 @@ use anyhow::bail;
 use config::LightningClientConfig;
 use fedimint_client::oplog::OperationLogEntry;
 use fedimint_client::sm::Context;
-use fedimint_client::Client;
+use fedimint_client::ClientArc;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
@@ -474,7 +474,7 @@ pub enum LightningError {
 }
 
 pub async fn ln_operation(
-    client: &Client,
+    client: &ClientArc,
     operation_id: OperationId,
 ) -> anyhow::Result<OperationLogEntry> {
     let operation = client

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -28,7 +28,7 @@ use fedimint_client::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, Executor, ModuleNotifier, State, StateTransition};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
-use fedimint_client::{sm_enum_variant_translation, Client, DynGlobalClientContext};
+use fedimint_client::{sm_enum_variant_translation, ClientArc, DynGlobalClientContext};
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
@@ -239,7 +239,7 @@ pub enum SpendOOBState {
 }
 
 #[apply(async_trait_maybe_send!)]
-impl MintClientExt for Client {
+impl MintClientExt for ClientArc {
     async fn reissue_external_notes<M: Serialize + Send>(
         &self,
         oob_notes: OOBNotes,
@@ -513,7 +513,7 @@ impl MintClientExt for Client {
 }
 
 async fn mint_operation(
-    client: &Client,
+    client: &ClientArc,
     operation_id: OperationId,
 ) -> anyhow::Result<OperationLogEntry> {
     let operation = client
@@ -704,7 +704,7 @@ impl ClientModule for MintClientModule {
 
     async fn handle_cli_command(
         &self,
-        client: &Client,
+        client: &ClientArc,
         args: &[ffi::OsString],
     ) -> anyhow::Result<serde_json::Value> {
         if args.is_empty() {

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -20,7 +20,7 @@ use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client::transaction::{ClientOutput, TransactionBuilder};
-use fedimint_client::{sm_enum_variant_translation, Client, DynGlobalClientContext};
+use fedimint_client::{sm_enum_variant_translation, ClientArc, DynGlobalClientContext};
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
@@ -125,7 +125,7 @@ pub enum WithdrawState {
 }
 
 #[apply(async_trait_maybe_send!)]
-impl WalletClientExt for Client {
+impl WalletClientExt for ClientArc {
     async fn get_deposit_address(
         &self,
         valid_until: SystemTime,

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -6,7 +6,7 @@ use bitcoin::secp256k1::rand::rngs::OsRng;
 use bitcoin::secp256k1::{self, Secp256k1};
 use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
-use fedimint_client::Client;
+use fedimint_client::ClientArc;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::{Database, ModuleDatabaseTransaction};
@@ -47,7 +47,7 @@ const PEG_OUT_AMOUNT_SATS: u64 = 1000;
 const PEG_IN_TIMEOUT: Duration = Duration::from_secs(60);
 
 async fn peg_in<'a>(
-    client: &'a Client,
+    client: &'a ClientArc,
     bitcoin: &dyn BitcoinTest,
     dyn_bitcoin_rpc: &DynBitcoindRpc,
     finality_delay: u64,
@@ -82,7 +82,7 @@ async fn peg_in<'a>(
     Ok(balance_sub)
 }
 
-async fn await_consensus_to_catch_up(client: &Client, block_count: u64) -> anyhow::Result<u64> {
+async fn await_consensus_to_catch_up(client: &ClientArc, block_count: u64) -> anyhow::Result<u64> {
     let (_, instance) =
         client.get_first_module::<WalletClientModule>(&fedimint_wallet_client::KIND);
     loop {


### PR DESCRIPTION
An initial step for #3447

Rationale:

I'd like a `ClientWeak` to be a thing. Easy.

But then I'd also want a way for APIs to use `ClientWeak`, upgrade
it to `Client` (strong Arc), yet not allow the user of such APIs
to store them (to prevent introducing harmful ownership cycles).

For this to not require duplicating forwarding methods manually,
the inner `ClientInner` should just do as much as possible.
So in thie change I'm moving all methods to `ClientInner`,
making it more usable.

Also, now `Client` will just `Deref` to `ClientInner` to make the
whole thing mostly invisible from the user perspective. And
I think that's totally OK and even preferable. After all `Client`
is just a newtype-ed smart-pointer to `ClientInner`.

We can control the visibility of methods of `ClientInner` with
`pub`, `pub(crate)` etc. Importantly, this ends the confusing
and annoying split: some methods being implemented on `Client`,
some on `ClientInner`.

The only thing that bothers me is the naming now.