### PR TITLE
DO NOT MERGE: feat(dbtool): dump state machines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
  "derivative",
  "futures",
  "futures-timer",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -203,7 +203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d79f0956913d725449e8264e6b460e30d96be324963c666dbf0fa5c2d59149"
 dependencies = [
  "include_dir",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro-error",
  "proc-macro2",
  "quote 1.0.27",
@@ -734,15 +734,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
- "winapi",
+ "wasm-bindgen",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1365,7 +1367,7 @@ dependencies = [
  "fedimint-derive-secret",
  "fedimint-logging",
  "futures",
- "itertools",
+ "itertools 0.10.5",
  "rand",
  "ring",
  "secp256k1-zkp",
@@ -1400,7 +1402,7 @@ dependencies = [
  "fedimint-wallet-common",
  "futures",
  "hkdf",
- "itertools",
+ "itertools 0.10.5",
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
  "jsonrpsee-wasm-client",
@@ -1447,7 +1449,7 @@ dependencies = [
  "getrandom",
  "gloo-timers",
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "js-sys",
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
@@ -1484,9 +1486,11 @@ dependencies = [
  "anyhow",
  "bitcoin_hashes 0.11.0",
  "bytes",
+ "chrono",
  "clap",
  "erased-serde",
  "fedimint-aead",
+ "fedimint-client",
  "fedimint-client-legacy",
  "fedimint-core",
  "fedimint-ln-server",
@@ -1497,6 +1501,8 @@ dependencies = [
  "fedimint-wallet-server",
  "futures",
  "hex",
+ "itertools 0.11.0",
+ "ln-gateway",
  "serde",
  "serde_json",
  "strum",
@@ -1621,7 +1627,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
  "futures",
- "itertools",
+ "itertools 0.10.5",
  "lightning 0.0.113",
  "lightning-invoice 0.21.0",
  "rand",
@@ -1654,7 +1660,7 @@ dependencies = [
  "fedimint-client",
  "fedimint-core",
  "futures",
- "itertools",
+ "itertools 0.10.5",
  "lightning 0.0.113",
  "lightning-invoice 0.21.0",
  "rand",
@@ -1689,7 +1695,7 @@ dependencies = [
  "fedimint-testing",
  "futures",
  "hbbft",
- "itertools",
+ "itertools 0.10.5",
  "lightning 0.0.113",
  "lightning-invoice 0.21.0",
  "rand",
@@ -1805,7 +1811,7 @@ dependencies = [
  "fedimint-logging",
  "fedimint-mint-common",
  "futures",
- "itertools",
+ "itertools 0.10.5",
  "rand",
  "secp256k1 0.24.3",
  "secp256k1-zkp",
@@ -1834,7 +1840,7 @@ dependencies = [
  "fedimint-core",
  "futures",
  "impl-tools",
- "itertools",
+ "itertools 0.10.5",
  "rand",
  "secp256k1 0.24.3",
  "secp256k1-zkp",
@@ -1864,7 +1870,7 @@ dependencies = [
  "fedimint-testing",
  "futures",
  "impl-tools",
- "itertools",
+ "itertools 0.10.5",
  "rand",
  "rayon",
  "secp256k1 0.24.3",
@@ -1949,7 +1955,7 @@ dependencies = [
  "fedimint-testing",
  "futures",
  "hbbft",
- "itertools",
+ "itertools 0.10.5",
  "jsonrpsee",
  "rand",
  "rcgen",
@@ -2038,7 +2044,7 @@ dependencies = [
  "fedimintd",
  "futures",
  "hbbft",
- "itertools",
+ "itertools 0.10.5",
  "lightning 0.0.113",
  "lightning-invoice 0.21.0",
  "ln-gateway",
@@ -2211,7 +2217,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itertools",
+ "itertools 0.10.5",
  "jsonrpsee",
  "rand",
  "rayon",
@@ -2932,6 +2938,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -4010,7 +4025,7 @@ checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
  "heck 0.3.3",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.5.1",
@@ -4028,7 +4043,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -4049,7 +4064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote 1.0.27",
  "syn 1.0.109",
@@ -4062,7 +4077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote 1.0.27",
  "syn 1.0.109",
@@ -4075,7 +4090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote 1.0.27",
  "syn 1.0.109",

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -729,7 +729,7 @@ where
 }
 
 #[derive(Debug)]
-struct ActiveStateKeyPrefix<GC>(PhantomData<GC>);
+pub struct ActiveStateKeyPrefix<GC>(PhantomData<GC>);
 
 impl<GC> ActiveStateKeyPrefix<GC> {
     pub fn new() -> Self {
@@ -872,7 +872,7 @@ where
 }
 
 #[derive(Debug, Clone)]
-struct InactiveStateKeyPrefix<GC>(PhantomData<GC>);
+pub struct InactiveStateKeyPrefix<GC>(PhantomData<GC>);
 
 impl<GC> InactiveStateKeyPrefix<GC> {
     pub fn new() -> Self {

--- a/fedimint-client/src/sm/mod.rs
+++ b/fedimint-client/src/sm/mod.rs
@@ -1,5 +1,5 @@
 mod dbtx;
-pub(crate) mod executor;
+pub mod executor;
 /// State machine state interface
 mod state;
 pub mod util;

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.68"
 fedimint-aead = { path = "../crypto/aead" }
 bitcoin_hashes = "0.11.0"
 bytes = "1.4.0"
+chrono = "0.4.31"
 clap = { version = "4.1.6", features  = [ "derive", "env" ] }
 fedimint-core ={ path = "../fedimint-core" }
 fedimint-server = { path = "../fedimint-server" }
@@ -25,7 +26,10 @@ fedimint-wallet-server = { path = "../modules/fedimint-wallet-server" }
 futures = "0.3.24"
 erased-serde = "0.3"
 hex = { version = "0.4.3", features = [ "serde"] }
+itertools = "0.11.0"
 fedimint-client-legacy = { path = "../fedimint-client-legacy" }
+fedimint-client = { path = "../fedimint-client" }
+ln-gateway = { path = "../gateway/ln-gateway" }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.91"
 strum = "0.24"


### PR DESCRIPTION
Adds a tool to debug state machines from gateway DB dumps (to debug #3478):

```
Lists state machine states from a client database in the format: module instance | active | creation time | state debug print

Usage: fedimint-dbtool --database <DATABASE> list-states [OPTIONS]

Options:
      --active                 List active states
      --inactive               List inactive states
      --pretty                 Print the state debug output on multiple lines
      --operation <OPERATION>  Only show states belonging to operation
      --instance <INSTANCE>    Only show states belonging to this module instance
  -h, --help                   Print help
```

E.g. use in combination with `less -S` to get the following, filtered output:

```
fedimint-dbtool --database <path-to-db> list-states --active --inactive --operation fd64d9c190f180f13eead2bb3361f5bbc618bd727f84c7cd90843dced962c570 | less -S
```

![2023-10-31-193552_5120x1441_scrot](https://github.com/fedimint/fedimint/assets/84478054/a5f6f544-6919-482d-a961-7aedf9db0d29)

TODO:
- [ ] Port to master
- [ ] Add mode for user clients
- [ ] Maybe also add `Serialize` to `DynState` so that the output can be JSON for further filtering