### PR TITLE
fix: increase limit of max number of concurrent requests

### DIFF
--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -9,7 +9,7 @@ use fedimint_core::task::sleep;
 use fedimint_core::time::now;
 use fedimint_core::transaction::Transaction;
 use fedimint_core::TransactionId;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::sm::{Context, DynContext, OperationState, State, StateTransition};
 use crate::{DynGlobalClientContext, DynState};
@@ -171,6 +171,7 @@ async fn trigger_created_submit(
     loop {
         match context.api().submit_transaction(tx.clone()).await {
             Err(e) if e.is_retryable() => {
+                debug!("Got {e} while submitting transaction, will sleep for {RESUBMISSION_INTERVAL:?}");
                 sleep(RESUBMISSION_INTERVAL).await;
             }
             res => return res.map_err(|e| e.to_string()),

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -712,11 +712,13 @@ impl JsonRpcClient for WsClient {
         #[cfg(not(target_family = "wasm"))]
         return WsClientBuilder::default()
             .use_webpki_rustls()
+            .max_concurrent_requests(u16::MAX as usize)
             .build(url_to_string_with_default_port(url)) // Hack for default ports, see fn docs
             .await;
 
         #[cfg(target_family = "wasm")]
         WsClientBuilder::default()
+            .max_concurrent_requests(u16::MAX as usize)
             .build(url_to_string_with_default_port(url)) // Hack for default ports, see fn docs
             .await
     }


### PR DESCRIPTION
Originally by @douglaz as #3470 to 0.1, but we want to bring it to master first.