### PR TITLE
chore(docker): use 0.1 docker tags for ui images to always use latest 0.1.x release

### DIFF
--- a/docker/fedimintd-mutinynet/docker-compose.yaml
+++ b/docker/fedimintd-mutinynet/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
     platform: linux/amd64
 
   guardian-ui:
-    image: fedimintui/guardian-ui:v0.1.1
+    image: fedimintui/guardian-ui:v0.1
     ports:
       - "0.0.0.0:3000:3000"
     environment:

--- a/docker/fedimintd-mutinynet/docker-compose.yaml
+++ b/docker/fedimintd-mutinynet/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
     platform: linux/amd64
 
   guardian-ui:
-    image: fedimintui/guardian-ui:v0.1
+    image: fedimintui/guardian-ui:0.1
     ports:
       - "0.0.0.0:3000:3000"
     environment:

--- a/docker/full-tls-mutinynet/docker-compose.yaml
+++ b/docker/full-tls-mutinynet/docker-compose.yaml
@@ -54,7 +54,7 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
-    image: fedimintui/guardian-ui:0.1.2
+    image: fedimintui/guardian-ui:0.1
     environment:
       - PORT=80
       - REACT_APP_FM_CONFIG_API=wss://fedimintd.fedimint.my-super-host.com
@@ -104,7 +104,7 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   gateway-ui:
-    image: fedimintui/gateway-ui:0.1.2
+    image: fedimintui/gateway-ui:0.1
     environment:
       - PORT=80
       - REACT_APP_FM_GATEWAY_API=https://gatewayd.fedimint.my-super-host.com

--- a/docker/gateway-mutinynet/docker-compose.yaml
+++ b/docker/gateway-mutinynet/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     platform: linux/amd64
 
   gateway-ui:
-    image: fedimintui/gateway-ui:v0.1
+    image: fedimintui/gateway-ui:0.1
     # image: gateway-ui
     ports:
       - "0.0.0.0:3001:3001"

--- a/docker/gateway-mutinynet/docker-compose.yaml
+++ b/docker/gateway-mutinynet/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     platform: linux/amd64
 
   gateway-ui:
-    image: fedimintui/gateway-ui:v0.1.1
+    image: fedimintui/gateway-ui:v0.1
     # image: gateway-ui
     ports:
       - "0.0.0.0:3001:3001"


### PR DESCRIPTION
Updates all the docker configs to use `0.1` instead of `0.1.x` so that when people run these, they're always running the latest version of the 0.1 UI. The one downside here is that if you've pulled an old image (0.1.3) and we push a new one (0.1.4) I _think_ by default Docker will just use what it has around, you'd need to run `docker-compose pull` to grab the upgraded image.

I'll let @douglaz decide which he'd prefer, otherwise I can just update all of them to use 0.1.4.

Also, fixed some that were still trying to use non-existent `v` prefixed tags.