### PR TITLE
fix: Reduce client log levels

### DIFF
--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -395,7 +395,7 @@ where
         let mut active_state_count = active_states.len();
         if active_states.is_empty() {
             // FIXME: what to do in this case? Probably best to subscribe to DB eventually
-            debug!("No state transitions available, waiting before re-trying");
+            trace!("No state transitions available, waiting before re-trying");
             task::sleep(EXECUTOR_POLL_INTERVAL).await;
             return Ok(());
         }

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -739,7 +739,7 @@ impl<'isolated, T: MaybeSend + Encodable> ModuleDatabaseTransaction<'isolated, T
         KP: DatabaseLookup,
         KP::Record: DatabaseKey,
     {
-        debug!("find by prefix");
+        trace!("find by prefix");
         let decoders = self.decoders.clone();
         let prefix_bytes = key_prefix.to_bytes();
         self.isolated_tx
@@ -1170,7 +1170,7 @@ impl<'parent> DatabaseTransaction<'parent> {
         KP: DatabaseLookup,
         KP::Record: DatabaseKey,
     {
-        debug!("find by prefix");
+        trace!("find by prefix");
         let decoders = self.decoders.clone();
         let prefix_bytes = key_prefix.to_bytes();
         self.tx


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <84944042+niteshbalusu11@users.noreply.github.com>

debug!("find by prefix");
debug!("No state transitions available, waiting before re-trying");

These two logs are creating a lot of noise on the client side, lowering them to trace.