### PR TITLE
refactor: simplify database traits/handling

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -481,7 +481,13 @@ async fn get_note_summary(client: &ClientArc) -> anyhow::Result<serde_json::Valu
     let (wallet_client, _) =
         client.get_first_module::<WalletClientModule>(&fedimint_wallet_client::KIND);
     let summary = mint_client
-        .get_wallet_summary(&mut client.db().begin_transaction().await.with_module_prefix(1))
+        .get_wallet_summary(
+            &mut client
+                .db()
+                .begin_transaction()
+                .await
+                .dbtx_ref_with_prefix_module_id(1),
+        )
         .await;
     Ok(serde_json::to_value(InfoResponse {
         federation_id: client.federation_id(),

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -324,7 +324,7 @@ impl Opts {
                     .map_err_cli_general()?,
             );
         }
-        client_builder.with_database(db);
+        client_builder.with_raw_database(db);
 
         Ok(client_builder)
     }

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -146,7 +146,7 @@ impl Client {
             if module.supports_backup() {
                 let backup = module
                     .backup(
-                        &mut dbtx.with_module_prefix(id),
+                        &mut dbtx.dbtx_ref_with_prefix_module_id(id),
                         self.executor.clone(),
                         self.api.clone(),
                         id,
@@ -204,7 +204,11 @@ impl Client {
                 "Wiping module state"
             );
             module
-                .wipe(&mut dbtx.with_module_prefix(id), id, self.executor.clone())
+                .wipe(
+                    &mut dbtx.dbtx_ref_with_prefix_module_id(id),
+                    id,
+                    self.executor.clone(),
+                )
                 .await?;
         }
         dbtx.commit_tx().await;

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -968,7 +968,7 @@ impl Client {
             .unwrap_or_else(|| panic!("Module is not of type {}", std::any::type_name::<M>()));
         let instance = ClientModuleInstance {
             id,
-            db: self.db().new_isolated(id),
+            db: self.db().with_prefix_module_id(id),
             api: self.api().with_module(id),
         };
         (module, instance)
@@ -1508,7 +1508,7 @@ impl ClientBuilder {
                     ModuleKind::from_static_str("tx_submission"),
                     tx_submission_sm_decoder(),
                 );
-                let db = db.new_with_decoders(decoders.clone());
+                let db = db.with_decoders(decoders.clone());
 
                 (config, decoders, db)
             }

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1388,7 +1388,7 @@ impl ClientBuilder {
 
     /// Uses this database to store the client state
     pub fn with_raw_database<D: IRawDatabase + 'static>(&mut self, db: D) {
-        self.with_database(Database::new(db, Default::default()));
+        self.with_database(db.into());
     }
 
     // /// Uses this database to store the client state, allowing for flexibility

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 
 use async_stream::stream;
 use fedimint_core::core::OperationId;
-use fedimint_core::db::{Database, DatabaseTransaction};
+use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::{MaybeSend, MaybeSync};

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -339,7 +339,7 @@ where
 mod tests {
     use fedimint_core::core::OperationId;
     use fedimint_core::db::mem_impl::MemDatabase;
-    use fedimint_core::db::Database;
+    use fedimint_core::db::{Database, IRawDatabaseExt};
     use futures::stream::StreamExt;
     use serde::{Deserialize, Serialize};
 
@@ -422,7 +422,7 @@ mod tests {
     async fn test_operation_log_update_from_stream() {
         let op_id = OperationId([0x32; 32]);
 
-        let db = Database::new(MemDatabase::new(), Default::default());
+        let db = MemDatabase::new().into_database();
         let op_log = OperationLog::new(db.clone());
 
         let mut dbtx = db.begin_transaction().await;

--- a/fedimint-client/src/sm/dbtx.rs
+++ b/fedimint-client/src/sm/dbtx.rs
@@ -1,5 +1,5 @@
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{DatabaseTransaction, ModuleDatabaseTransaction};
+use fedimint_core::db::{DatabaseTransaction, DatabaseTransactionRef};
 
 /// A transaction that acts as isolated for module code but can be accessed as a
 /// normal transaction in this crate.
@@ -20,8 +20,9 @@ impl<'inner, 'parent> ClientSMDatabaseTransaction<'inner, 'parent> {
     }
 
     /// Returns the isolated database transaction for the module.
-    pub fn module_tx(&mut self) -> ModuleDatabaseTransaction<'_> {
-        self.dbtx.with_module_prefix(self.module_instance)
+    pub fn module_tx(&mut self) -> DatabaseTransactionRef<'_> {
+        self.dbtx
+            .dbtx_ref_with_prefix_module_id(self.module_instance)
     }
 
     /// Returns the non-isolated database transaction only accessible to the

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -7,7 +7,10 @@ use std::time::{Duration, SystemTime};
 
 use anyhow::bail;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{AutocommitError, Database, DatabaseKeyWithNotify, DatabaseTransaction};
+use fedimint_core::db::{
+    AutocommitError, Database, DatabaseKeyWithNotify, DatabaseTransaction,
+    IDatabaseTransactionOpsCoreTyped,
+};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_core::fmt_utils::AbbreviateJson;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -935,7 +938,7 @@ mod tests {
     use fedimint_core::db::Database;
     use fedimint_core::encoding::{Decodable, Encodable};
     use fedimint_core::module::registry::ModuleDecoderRegistry;
-    use fedimint_core::task::{self};
+    use fedimint_core::task;
     use tokio::sync::broadcast::Sender;
     use tracing::{info, trace};
 

--- a/fedimint-client/src/sm/notifier.rs
+++ b/fedimint-client/src/sm/notifier.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use fedimint_core::core::{ModuleInstanceId, OperationId};
-use fedimint_core::db::Database;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::util::broadcaststream::BroadcastStream;
 use fedimint_core::util::BoxStream;
 use futures::StreamExt;

--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -11,7 +11,7 @@ use fedimint_core::module::audit::Audit;
 use fedimint_core::{apply, async_trait_maybe_send, OutPoint, PeerId};
 
 use crate::core::{Any, Decoder, DynInput, DynModuleConsensusItem, DynOutput, DynOutputOutcome};
-use crate::db::ModuleDatabaseTransaction;
+use crate::db::DatabaseTransactionRef;
 use crate::dyn_newtype_define;
 use crate::module::registry::ModuleInstanceId;
 use crate::module::{
@@ -32,7 +32,7 @@ pub trait IServerModule: Debug {
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         module_instance_id: ModuleInstanceId,
     ) -> Vec<DynModuleConsensusItem>;
 
@@ -41,7 +41,7 @@ pub trait IServerModule: Debug {
     /// our state and therefore may be safely discarded by the atomic broadcast.
     async fn process_consensus_item<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a>,
+        dbtx: &mut DatabaseTransactionRef<'a>,
         consensus_item: DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()>;
@@ -52,7 +52,7 @@ pub trait IServerModule: Debug {
     /// no effect.
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'c>,
+        dbtx: &mut DatabaseTransactionRef<'c>,
         input: &'b DynInput,
     ) -> Result<InputMeta, ModuleError>;
 
@@ -66,7 +66,7 @@ pub trait IServerModule: Debug {
     /// `output_status`.
     async fn process_output<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a>,
+        dbtx: &mut DatabaseTransactionRef<'a>,
         output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError>;
@@ -77,7 +77,7 @@ pub trait IServerModule: Debug {
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome>;
@@ -89,7 +89,7 @@ pub trait IServerModule: Debug {
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     );
@@ -122,7 +122,7 @@ where
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         module_instance_id: ModuleInstanceId,
     ) -> Vec<DynModuleConsensusItem> {
         <Self as ServerModule>::consensus_proposal(self, dbtx)
@@ -137,7 +137,7 @@ where
     /// our state and therefore may be safely discarded by the atomic broadcast.
     async fn process_consensus_item<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a>,
+        dbtx: &mut DatabaseTransactionRef<'a>,
         consensus_item: DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -160,7 +160,7 @@ where
     /// no effect.
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'c>,
+        dbtx: &mut DatabaseTransactionRef<'c>,
         input: &'b DynInput,
     ) -> Result<InputMeta, ModuleError> {
         <Self as ServerModule>::process_input(
@@ -185,7 +185,7 @@ where
     /// `output_status`.
     async fn process_output<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a>,
+        dbtx: &mut DatabaseTransactionRef<'a>,
         output: &DynOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -207,7 +207,7 @@ where
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome> {
@@ -223,7 +223,7 @@ where
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {

--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -199,15 +199,14 @@ impl<'a> IRawDatabaseTransaction for MemTransaction<'a> {
 mod tests {
     use super::MemDatabase;
     use crate::core::ModuleInstanceId;
-    use crate::db::Database;
-    use crate::module::registry::ModuleDecoderRegistry;
+    use crate::db::{Database, IRawDatabaseExt};
 
     fn database() -> Database {
-        Database::new(MemDatabase::new(), ModuleDecoderRegistry::default())
+        MemDatabase::new().into()
     }
 
     fn module_database(module_instance_id: ModuleInstanceId) -> Database {
-        let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
+        let db = MemDatabase::new().into_database();
         db.new_isolated(module_instance_id)
     }
 

--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -8,8 +8,7 @@ use futures::{stream, StreamExt};
 use macro_rules_attribute::apply;
 
 use super::{
-    IDatabase, IDatabaseTransaction, IDatabaseTransactionOps, ISingleUseDatabaseTransaction,
-    SingleUseDatabaseTransaction,
+    IDatabaseTransactionOps, IDatabaseTransactionOpsCore, IRawDatabase, IRawDatabaseTransaction,
 };
 use crate::async_trait_maybe_send;
 use crate::db::PrefixStream;
@@ -64,8 +63,9 @@ impl MemDatabase {
 }
 
 #[apply(async_trait_maybe_send!)]
-impl IDatabase for MemDatabase {
-    async fn begin_transaction<'a>(&'a self) -> Box<dyn ISingleUseDatabaseTransaction<'a>> {
+impl IRawDatabase for MemDatabase {
+    type Transaction<'a> = MemTransaction<'a>;
+    async fn begin_transaction<'a>(&'a self) -> MemTransaction<'a> {
         let db_copy = self.data.lock().unwrap().clone();
         let mut memtx = MemTransaction {
             operations: Vec::new(),
@@ -77,15 +77,14 @@ impl IDatabase for MemDatabase {
         };
 
         memtx.set_tx_savepoint().await.expect("can't fail");
-        let single_use = SingleUseDatabaseTransaction::new(memtx);
-        Box::new(single_use)
+        memtx
     }
 }
 
 // In-memory database transaction should only be used for test code and never
 // for production as it doesn't properly implement MVCC
 #[apply(async_trait_maybe_send!)]
-impl<'a> IDatabaseTransactionOps<'a> for MemTransaction<'a> {
+impl<'a> IDatabaseTransactionOpsCore for MemTransaction<'a> {
     async fn raw_insert_bytes(&mut self, key: &[u8], value: &[u8]) -> Result<Option<Vec<u8>>> {
         let val = self.raw_get_bytes(key).await;
         // Insert data from copy so we can read our own writes
@@ -151,7 +150,10 @@ impl<'a> IDatabaseTransactionOps<'a> for MemTransaction<'a> {
 
         Ok(Box::pin(stream::iter(data)))
     }
+}
 
+#[apply(async_trait_maybe_send!)]
+impl<'a> IDatabaseTransactionOps for MemTransaction<'a> {
     async fn rollback_tx_to_savepoint(&mut self) -> Result<()> {
         self.tx_data = self.savepoint.clone();
 
@@ -172,7 +174,7 @@ impl<'a> IDatabaseTransactionOps<'a> for MemTransaction<'a> {
 }
 
 #[apply(async_trait_maybe_send!)]
-impl<'a> IDatabaseTransaction<'a> for MemTransaction<'a> {
+impl<'a> IRawDatabaseTransaction for MemTransaction<'a> {
     async fn commit_tx(self) -> Result<()> {
         for op in self.operations {
             match op {

--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -207,7 +207,7 @@ mod tests {
 
     fn module_database(module_instance_id: ModuleInstanceId) -> Database {
         let db = MemDatabase::new().into_database();
-        db.new_isolated(module_instance_id)
+        db.with_prefix_module_id(module_instance_id)
     }
 
     #[test_log::test(tokio::test)]

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -6,7 +6,11 @@ use futures::StreamExt;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::db::{DatabaseKey, DatabaseLookup, DatabaseRecord, ModuleDatabaseTransaction};
+use crate::db::{
+    DatabaseKey, DatabaseLookup, DatabaseRecord, IDatabaseTransactionOpsCoreTyped,
+    ModuleDatabaseTransaction,
+};
+use crate::task::{MaybeSend, MaybeSync};
 
 #[derive(Default)]
 pub struct Audit {
@@ -29,7 +33,7 @@ impl Audit {
         key_prefix: &KP,
         to_milli_sat: F,
     ) where
-        KP: DatabaseLookup + 'static,
+        KP: DatabaseLookup + 'static + MaybeSend + MaybeSync,
         KP::Record: DatabaseKey,
         F: Fn(KP::Record, <<KP as DatabaseLookup>::Record as DatabaseRecord>::Value) -> i64,
     {

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -7,8 +7,8 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::db::{
-    DatabaseKey, DatabaseLookup, DatabaseRecord, IDatabaseTransactionOpsCoreTyped,
-    ModuleDatabaseTransaction,
+    DatabaseKey, DatabaseLookup, DatabaseRecord, DatabaseTransactionRef,
+    IDatabaseTransactionOpsCoreTyped,
 };
 use crate::task::{MaybeSend, MaybeSync};
 
@@ -28,7 +28,7 @@ impl Audit {
 
     pub async fn add_items<KP, F>(
         &mut self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         module_instance_id: ModuleInstanceId,
         key_prefix: &KP,
         to_milli_sat: F,

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -29,7 +29,7 @@ use crate::core::{
 };
 use crate::db::{
     Database, DatabaseKey, DatabaseKeyWithNotify, DatabaseRecord, DatabaseTransaction,
-    DatabaseVersion, MigrationMap, ModuleDatabaseTransaction,
+    DatabaseTransactionRef, DatabaseVersion, MigrationMap,
 };
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::audit::Audit;
@@ -178,13 +178,13 @@ impl<'a> ApiEndpointContext<'a> {
     }
 
     /// Database tx handle, will be committed
-    pub fn dbtx<'s, 'mtx>(&'s mut self) -> ModuleDatabaseTransaction<'mtx>
+    pub fn dbtx<'s, 'mtx>(&'s mut self) -> DatabaseTransactionRef<'mtx>
     where
         'a: 'mtx,
         's: 'mtx,
     {
         // dbtx is already isolated.
-        self.dbtx.get_isolated()
+        self.dbtx.dbtx_ref()
     }
 
     /// Returns the auth set on the request (regardless of whether it was
@@ -433,7 +433,7 @@ pub trait IDynCommonModuleInit: Debug {
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_>;
 }
@@ -444,7 +444,7 @@ pub trait ExtendsCommonModuleInit: Debug + Clone + Send + Sync + 'static {
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_>;
 }
@@ -468,7 +468,7 @@ where
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         <Self as ExtendsCommonModuleInit>::dump_database(self, dbtx, prefix_names).await
@@ -801,7 +801,7 @@ pub trait ServerModule: Debug + Sized {
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal<'a>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> Vec<<Self::Common as ModuleCommon>::ConsensusItem>;
 
     /// This function is called once for every consensus item. The function
@@ -809,7 +809,7 @@ pub trait ServerModule: Debug + Sized {
     /// our state and therefore may be safely discarded by the atomic broadcast.
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransactionRef<'b>,
         consensus_item: <Self::Common as ModuleCommon>::ConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()>;
@@ -820,7 +820,7 @@ pub trait ServerModule: Debug + Sized {
     /// no effect.
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'c>,
+        dbtx: &mut DatabaseTransactionRef<'c>,
         input: &'b <Self::Common as ModuleCommon>::Input,
     ) -> Result<InputMeta, ModuleError>;
 
@@ -834,7 +834,7 @@ pub trait ServerModule: Debug + Sized {
     /// `output_status`.
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransactionRef<'b>,
         output: &'a <Self::Common as ModuleCommon>::Output,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError>;
@@ -845,7 +845,7 @@ pub trait ServerModule: Debug + Sized {
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         out_point: OutPoint,
     ) -> Option<<Self::Common as ModuleCommon>::OutputOutcome>;
 
@@ -856,7 +856,7 @@ pub trait ServerModule: Debug + Sized {
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     );

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -7,8 +7,9 @@ use fedimint_client::db::ClientConfigKeyPrefix;
 use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_core::config::{ClientConfig, CommonModuleInitRegistry, ServerModuleInitRegistry};
 use fedimint_core::core::ModuleKind;
-use fedimint_core::db::notifications::Notifications;
-use fedimint_core::db::{DatabaseTransaction, DatabaseVersionKey, SingleUseDatabaseTransaction};
+use fedimint_core::db::{
+    Database, DatabaseVersionKey, IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped,
+};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::epoch::SerdeSignatureShare;
 use fedimint_core::module::__reexports::serde_json;
@@ -36,9 +37,9 @@ impl SerdeWrapper {
 
 /// Structure to hold the deserialized structs from the database.
 /// Also includes metadata on which sections of the database to read.
-pub struct DatabaseDump<'a> {
+pub struct DatabaseDump {
     serialized: BTreeMap<String, Box<dyn Serialize>>,
-    read_only: DatabaseTransaction<'a>,
+    read_only: Database,
     modules: Vec<String>,
     prefixes: Vec<String>,
     cfg: Option<ServerConfig>,
@@ -47,7 +48,7 @@ pub struct DatabaseDump<'a> {
     client_module_inits: ClientModuleInitRegistry,
 }
 
-impl<'a> DatabaseDump<'a> {
+impl DatabaseDump {
     pub async fn new(
         cfg_dir: PathBuf,
         data_dir: String,
@@ -56,17 +57,13 @@ impl<'a> DatabaseDump<'a> {
         client_module_inits: ClientModuleInitRegistry,
         modules: Vec<String>,
         prefixes: Vec<String>,
-    ) -> anyhow::Result<DatabaseDump<'a>> {
+    ) -> anyhow::Result<DatabaseDump> {
         let read_only = match RocksDbReadOnly::open_read_only(data_dir.clone()) {
-            Ok(db) => db,
+            Ok(db) => Database::new(db, Default::default()),
             Err(_) => {
                 panic!("Error reading RocksDB database. Quitting...");
             }
         };
-        let single_use = SingleUseDatabaseTransaction::new(read_only);
-
-        // leak here is OK, it only happens once.
-        let notifications = Box::leak(Box::new(Notifications::new()));
 
         let (server_cfg, client_cfg, decoders) = if let Ok(cfg) =
             read_server_config(&password, cfg_dir).context("Failed to read server config")
@@ -81,19 +78,14 @@ impl<'a> DatabaseDump<'a> {
         } else {
             // Check if this database is a client database by reading the `ClientConfig`
             // from the database.
-            let read_only_client = match RocksDbReadOnly::open_read_only(data_dir) {
-                Ok(db) => db,
+            let db = match RocksDbReadOnly::open_read_only(data_dir) {
+                Ok(db) => Database::new(db, Default::default()),
                 Err(_) => {
                     panic!("Error reading RocksDB database. Quitting...");
                 }
             };
 
-            let single_use = SingleUseDatabaseTransaction::new(read_only_client);
-            let mut dbtx = DatabaseTransaction::new(
-                Box::new(single_use),
-                ModuleDecoderRegistry::default(),
-                notifications,
-            );
+            let mut dbtx = db.begin_transaction().await;
             let client_cfg = dbtx
                 .find_by_prefix(&ClientConfigKeyPrefix)
                 .await
@@ -114,11 +106,9 @@ impl<'a> DatabaseDump<'a> {
             }
         };
 
-        let dbtx = DatabaseTransaction::new(Box::new(single_use), decoders, notifications);
-
         Ok(DatabaseDump {
             serialized: BTreeMap::new(),
-            read_only: dbtx,
+            read_only: read_only.new_with_decoders(decoders),
             modules,
             prefixes,
             cfg: server_cfg,
@@ -129,7 +119,7 @@ impl<'a> DatabaseDump<'a> {
     }
 }
 
-impl<'a> DatabaseDump<'a> {
+impl DatabaseDump {
     /// Prints the contents of the BTreeMap to a pretty JSON string
     fn print_database(&self) {
         let json = serde_json::to_string_pretty(&self.serialized).unwrap();
@@ -145,7 +135,8 @@ impl<'a> DatabaseDump<'a> {
         if !self.modules.is_empty() && !self.modules.contains(&kind.to_string()) {
             return Ok(());
         }
-        let mut isolated_dbtx = self.read_only.with_module_prefix(*module_id);
+        let mut dbtx = self.read_only.begin_transaction().await;
+        let mut isolated_dbtx = dbtx.with_module_prefix(*module_id);
 
         match inits.get(kind) {
             None => {
@@ -200,7 +191,8 @@ impl<'a> DatabaseDump<'a> {
     }
 
     async fn serialize_gateway(&mut self) -> anyhow::Result<()> {
-        let mut dbtx = self.read_only.get_isolated();
+        let mut dbtx = self.read_only.begin_transaction().await;
+        let mut dbtx = dbtx.get_isolated();
         let gateway_serialized = Gateway::dump_database(&mut dbtx, self.prefixes.clone())
             .await
             .collect::<BTreeMap<String, _>>();
@@ -254,7 +246,8 @@ impl<'a> DatabaseDump<'a> {
     /// retrieves the corresponding data.
     async fn retrieve_consensus_data(&mut self) {
         let mut consensus: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
-        let dbtx = &mut self.read_only;
+        let mut dbtx = self.read_only.begin_transaction().await;
+        let dbtx = &mut dbtx;
         let prefix_names = &self.prefixes;
 
         let filtered_prefixes = ConsensusRange::DbKeyPrefix::iter().filter(|f| {

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -108,7 +108,7 @@ impl DatabaseDump {
 
         Ok(DatabaseDump {
             serialized: BTreeMap::new(),
-            read_only: read_only.new_with_decoders(decoders),
+            read_only: read_only.with_decoders(decoders),
             modules,
             prefixes,
             cfg: server_cfg,
@@ -136,7 +136,7 @@ impl DatabaseDump {
             return Ok(());
         }
         let mut dbtx = self.read_only.begin_transaction().await;
-        let mut isolated_dbtx = dbtx.with_module_prefix(*module_id);
+        let mut isolated_dbtx = dbtx.dbtx_ref_with_prefix_module_id(*module_id);
 
         match inits.get(kind) {
             None => {
@@ -192,7 +192,7 @@ impl DatabaseDump {
 
     async fn serialize_gateway(&mut self) -> anyhow::Result<()> {
         let mut dbtx = self.read_only.begin_transaction().await;
-        let mut dbtx = dbtx.get_isolated();
+        let mut dbtx = dbtx.dbtx_ref();
         let gateway_serialized = Gateway::dump_database(&mut dbtx, self.prefixes.clone())
             .await
             .collect::<BTreeMap<String, _>>();

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -131,9 +131,9 @@ pub async fn build_client(
         client_builder.with_federation_info(FederationInfo::from_invite_code(invite_code).await?);
     }
     if let Some(rocksdb) = rocksdb {
-        client_builder.with_database(fedimint_rocksdb::RocksDb::open(rocksdb)?)
+        client_builder.with_raw_database(fedimint_rocksdb::RocksDb::open(rocksdb)?)
     } else {
-        client_builder.with_database(fedimint_core::db::mem_impl::MemDatabase::new())
+        client_builder.with_raw_database(fedimint_core::db::mem_impl::MemDatabase::new())
     }
 
     let client_secret = match client_builder

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -255,7 +255,13 @@ pub fn parse_gateway_id(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Erro
 pub async fn get_note_summary(client: &ClientArc) -> anyhow::Result<TieredSummary> {
     let (mint_client, _) = client.get_first_module::<MintClientModule>(&fedimint_mint_client::KIND);
     let summary = mint_client
-        .get_wallet_summary(&mut client.db().begin_transaction().await.with_module_prefix(1))
+        .get_wallet_summary(
+            &mut client
+                .db()
+                .begin_transaction()
+                .await
+                .dbtx_ref_with_prefix_module_id(1),
+        )
         .await;
     Ok(summary)
 }
@@ -268,7 +274,7 @@ pub async fn remint_denomination(
     let (mint_client, client_module_instance) =
         client.get_first_module::<MintClientModule>(&fedimint_mint_client::KIND);
     let mut dbtx = client.db().begin_transaction().await;
-    let mut module_transaction = dbtx.with_module_prefix(client_module_instance.id);
+    let mut module_transaction = dbtx.dbtx_ref_with_prefix_module_id(client_module_instance.id);
     let mut tx = TransactionBuilder::new();
     let operation_id = OperationId::new_random();
     for _ in 0..quantity {

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -446,7 +446,7 @@ mod fedimint_rocksdb_tests {
 
         fedimint_core::db::verify_module_db(
             open_temp_db("fcb-rocksdb-test-module-db"),
-            module_db.new_isolated(module_instance_id),
+            module_db.with_prefix_module_id(module_instance_id),
         )
         .await;
     }

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use anyhow::Result;
 use async_trait::async_trait;
 use fedimint_core::db::{
-    IDatabase, IDatabaseTransaction, IDatabaseTransactionOps, ISingleUseDatabaseTransaction,
-    PrefixStream, SingleUseDatabaseTransaction,
+    IDatabaseTransactionOps, IDatabaseTransactionOpsCore, IRawDatabase, IRawDatabaseTransaction,
+    PrefixStream,
 };
 use futures::stream;
 pub use rocksdb;
@@ -13,8 +13,6 @@ use rocksdb::{OptimisticTransactionDB, OptimisticTransactionOptions, WriteOption
 
 #[derive(Debug)]
 pub struct RocksDb(rocksdb::OptimisticTransactionDB);
-
-pub struct RocksDbReadOnly(rocksdb::DB);
 
 pub struct RocksDbTransaction<'a>(rocksdb::Transaction<'a, rocksdb::OptimisticTransactionDB>);
 
@@ -29,6 +27,11 @@ impl RocksDb {
         &self.0
     }
 }
+
+#[derive(Debug)]
+pub struct RocksDbReadOnly(rocksdb::DB);
+
+pub struct RocksDbReadOnlyTransaction<'a>(&'a rocksdb::DB);
 
 impl RocksDbReadOnly {
     pub fn open_read_only(db_path: impl AsRef<Path>) -> Result<RocksDbReadOnly, rocksdb::Error> {
@@ -75,8 +78,9 @@ fn next_prefix(prefix: &[u8]) -> Option<Vec<u8>> {
 }
 
 #[async_trait]
-impl IDatabase for RocksDb {
-    async fn begin_transaction<'a>(&'a self) -> Box<dyn ISingleUseDatabaseTransaction<'a>> {
+impl IRawDatabase for RocksDb {
+    type Transaction<'a> = RocksDbTransaction<'a>;
+    async fn begin_transaction<'a>(&'a self) -> RocksDbTransaction {
         let mut optimistic_options = OptimisticTransactionOptions::default();
         optimistic_options.set_snapshot(true);
         let mut rocksdb_tx = RocksDbTransaction(
@@ -87,13 +91,21 @@ impl IDatabase for RocksDb {
             .set_tx_savepoint()
             .await
             .expect("setting tx savepoint failed");
-        let single_use = SingleUseDatabaseTransaction::new(rocksdb_tx);
-        Box::new(single_use)
+
+        rocksdb_tx
     }
 }
 
 #[async_trait]
-impl<'a> IDatabaseTransactionOps<'a> for RocksDbTransaction<'a> {
+impl IRawDatabase for RocksDbReadOnly {
+    type Transaction<'a> = RocksDbReadOnlyTransaction<'a>;
+    async fn begin_transaction<'a>(&'a self) -> RocksDbReadOnlyTransaction<'a> {
+        RocksDbReadOnlyTransaction(&self.0)
+    }
+}
+
+#[async_trait]
+impl<'a> IDatabaseTransactionOpsCore for RocksDbTransaction<'a> {
     async fn raw_insert_bytes(&mut self, key: &[u8], value: &[u8]) -> Result<Option<Vec<u8>>> {
         fedimint_core::task::block_in_place(|| {
             let val = self.0.get(key).unwrap();
@@ -202,7 +214,10 @@ impl<'a> IDatabaseTransactionOps<'a> for RocksDbTransaction<'a> {
             Box::pin(stream::iter(rocksdb_iter))
         }))
     }
+}
 
+#[async_trait]
+impl<'a> IDatabaseTransactionOps for RocksDbTransaction<'a> {
     async fn rollback_tx_to_savepoint(&mut self) -> Result<()> {
         Ok(fedimint_core::task::block_in_place(|| {
             self.0.rollback_to_savepoint()
@@ -217,7 +232,7 @@ impl<'a> IDatabaseTransactionOps<'a> for RocksDbTransaction<'a> {
 }
 
 #[async_trait]
-impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
+impl<'a> IRawDatabaseTransaction for RocksDbTransaction<'a> {
     async fn commit_tx(self) -> Result<()> {
         fedimint_core::task::block_in_place(|| {
             self.0.commit()?;
@@ -227,7 +242,7 @@ impl<'a> IDatabaseTransaction<'a> for RocksDbTransaction<'a> {
 }
 
 #[async_trait]
-impl IDatabaseTransactionOps<'_> for RocksDbReadOnly {
+impl<'a> IDatabaseTransactionOpsCore for RocksDbReadOnlyTransaction<'a> {
     async fn raw_insert_bytes(&mut self, _key: &[u8], _value: &[u8]) -> Result<Option<Vec<u8>>> {
         panic!("Cannot insert into a read only transaction");
     }
@@ -287,7 +302,10 @@ impl IDatabaseTransactionOps<'_> for RocksDbReadOnly {
             Box::pin(stream::iter(rocksdb_iter))
         }))
     }
+}
 
+#[async_trait]
+impl<'a> IDatabaseTransactionOps for RocksDbReadOnlyTransaction<'a> {
     async fn rollback_tx_to_savepoint(&mut self) -> Result<()> {
         panic!("Cannot rollback a read only transaction");
     }
@@ -298,7 +316,7 @@ impl IDatabaseTransactionOps<'_> for RocksDbReadOnly {
 }
 
 #[async_trait]
-impl IDatabaseTransaction<'_> for RocksDbReadOnly {
+impl<'a> IRawDatabaseTransaction for RocksDbReadOnlyTransaction<'a> {
     async fn commit_tx(self) -> Result<()> {
         panic!("Cannot commit a read only transaction");
     }
@@ -306,7 +324,7 @@ impl IDatabaseTransaction<'_> for RocksDbReadOnly {
 
 #[cfg(test)]
 mod fedimint_rocksdb_tests {
-    use fedimint_core::db::{notifications, Database};
+    use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
     use fedimint_core::encoding::{Decodable, Encodable};
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::{impl_db_lookup, impl_db_record};
@@ -433,17 +451,6 @@ mod fedimint_rocksdb_tests {
         .await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    #[should_panic(expected = "Cannot isolate and already isolated database.")]
-    async fn test_cannot_isolate_already_isolated_db() {
-        let module_instance_id = 1;
-        let db = open_temp_db("rocksdb-test-already-isolated").new_isolated(module_instance_id);
-
-        // try to isolate the database again
-        let module_instance_id = 2;
-        db.new_isolated(module_instance_id);
-    }
-
     #[test]
     fn test_next_prefix() {
         // Note: although we are testing the general case of a vector with N elements,
@@ -555,13 +562,8 @@ mod fedimint_rocksdb_tests {
         }
         // Test readonly implementation
         let db_readonly = RocksDbReadOnly::open_read_only(path).unwrap();
-        let single_use = SingleUseDatabaseTransaction::new(db_readonly);
-        let notifications = notifications::Notifications::new();
-        let mut dbtx = fedimint_core::db::DatabaseTransaction::new(
-            Box::new(single_use),
-            ModuleDecoderRegistry::default(),
-            &notifications,
-        );
+        let db_readonly = Database::new(db_readonly, Default::default());
+        let mut dbtx = db_readonly.begin_transaction().await;
         let query = dbtx
             .find_by_prefix_sorted_descending(&DbPrefixTestPrefix)
             .await

--- a/fedimint-server/src/atomic_broadcast/backup.rs
+++ b/fedimint-server/src/atomic_broadcast/backup.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use fedimint_core::db::Database;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 
 use crate::db::AlephUnitsKey;
 use crate::LOG_CONSENSUS;

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -556,8 +556,8 @@ impl HasApiContext<ConfigGenApi> for ConfigGenApi {
         let mut db = self.db.clone();
         let mut dbtx = self.db.begin_transaction().await;
         if let Some(id) = id {
-            db = self.db.new_isolated(id);
-            dbtx = dbtx.new_module_tx(id)
+            db = self.db.with_prefix_module_id(id);
+            dbtx = dbtx.with_prefix_module_id(id)
         }
         let state = self.state.lock().expect("locks");
         let auth = request.auth.as_ref();

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -691,8 +691,7 @@ mod tests {
     use fedimint_core::api::{FederationResult, ServerStatus, StatusResponse};
     use fedimint_core::config::{ServerModuleConfigGenParamsRegistry, ServerModuleInitRegistry};
     use fedimint_core::db::mem_impl::MemDatabase;
-    use fedimint_core::db::Database;
-    use fedimint_core::module::registry::ModuleDecoderRegistry;
+    use fedimint_core::db::IRawDatabaseExt;
     use fedimint_core::module::ApiAuth;
     use fedimint_core::task::{sleep, spawn, TaskGroup};
     use fedimint_core::util::SafeUrl;
@@ -730,7 +729,7 @@ mod tests {
             name_suffix: u16,
             data_dir: PathBuf,
         ) -> (TestConfigApi, FedimintServer) {
-            let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
+            let db = MemDatabase::new().into_database();
 
             let name = format!("peer{name_suffix}");
             let api_bind = format!("127.0.0.1:{port}").parse().expect("parses");

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -22,7 +22,7 @@ pub async fn process_transaction_with_dbtx(
         let meta = modules
             .get_expect(input.module_instance_id())
             .process_input(
-                &mut dbtx.with_module_prefix(input.module_instance_id()),
+                &mut dbtx.dbtx_ref_with_prefix_module_id(input.module_instance_id()),
                 input,
             )
             .await?;
@@ -37,7 +37,7 @@ pub async fn process_transaction_with_dbtx(
         let amount = modules
             .get_expect(output.module_instance_id())
             .process_output(
-                &mut dbtx.with_module_prefix(output.module_instance_id()),
+                &mut dbtx.dbtx_ref_with_prefix_module_id(output.module_instance_id()),
                 output,
                 OutPoint { txid, out_idx },
             )

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -9,7 +9,9 @@ use bitcoin_hashes::sha256;
 use fedimint_core::api::{FederationApiExt, GlobalFederationApi, WsFederationApi};
 use fedimint_core::block::{AcceptedItem, Block, SchnorrSignature, SignedBlock};
 use fedimint_core::config::ServerModuleInitRegistry;
-use fedimint_core::db::{apply_migrations, Database, DatabaseTransaction};
+use fedimint_core::db::{
+    apply_migrations, Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
+};
 use fedimint_core::encoding::Decodable;
 use fedimint_core::endpoint_constants::AWAIT_SIGNED_BLOCK_ENDPOINT;
 use fedimint_core::epoch::{ConsensusItem, SerdeSignature, SerdeSignatureShare};

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -148,7 +148,9 @@ mod fedimint_migration_tests {
     use fedimint_core::api::ClientConfigDownloadToken;
     use fedimint_core::block::{Block, SignedBlock};
     use fedimint_core::core::{DynInput, DynOutput};
-    use fedimint_core::db::{apply_migrations, DatabaseTransaction};
+    use fedimint_core::db::{
+        apply_migrations, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
+    };
     use fedimint_core::epoch::{ConsensusItem, SerdeSignature, SerdeSignatureShare};
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::module::CommonModuleInit;

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -16,7 +16,9 @@ use fedimint_core::block::{Block, SignedBlock};
 use fedimint_core::config::{ClientConfig, ClientConfigResponse, JsonWithKind};
 use fedimint_core::core::backup::SignedBackupRequest;
 use fedimint_core::core::{DynOutputOutcome, ModuleInstanceId};
-use fedimint_core::db::{Database, DatabaseTransaction, ModuleDatabaseTransaction};
+use fedimint_core::db::{
+    Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction,
+};
 use fedimint_core::endpoint_constants::{
     AUDIT_ENDPOINT, AUTH_ENDPOINT, AWAIT_BLOCK_ENDPOINT, AWAIT_OUTPUT_OUTCOME_ENDPOINT,
     AWAIT_SIGNED_BLOCK_ENDPOINT, BACKUP_ENDPOINT, CONFIG_ENDPOINT, CONFIG_HASH_ENDPOINT,
@@ -411,9 +413,9 @@ impl ConsensusApi {
         ))
     }
 
-    async fn handle_backup_request(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+    async fn handle_backup_request<'s, 'dbtx, 'a>(
+        &'s self,
+        dbtx: &'dbtx mut ModuleDatabaseTransaction<'a>,
         request: SignedBackupRequest,
     ) -> Result<(), ApiError> {
         let request = request

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -17,7 +17,7 @@ use fedimint_core::config::{ClientConfig, ClientConfigResponse, JsonWithKind};
 use fedimint_core::core::backup::SignedBackupRequest;
 use fedimint_core::core::{DynOutputOutcome, ModuleInstanceId};
 use fedimint_core::db::{
-    Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction,
+    Database, DatabaseTransaction, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::endpoint_constants::{
     AUDIT_ENDPOINT, AUTH_ENDPOINT, AWAIT_BLOCK_ENDPOINT, AWAIT_OUTPUT_OUTCOME_ENDPOINT,
@@ -231,7 +231,7 @@ impl ConsensusApi {
                 .modules
                 .get_expect(input.module_instance_id())
                 .process_input(
-                    &mut dbtx.with_module_prefix(input.module_instance_id()),
+                    &mut dbtx.dbtx_ref_with_prefix_module_id(input.module_instance_id()),
                     input,
                 )
                 .await?;
@@ -247,7 +247,7 @@ impl ConsensusApi {
                 .modules
                 .get_expect(output.module_instance_id())
                 .process_output(
-                    &mut dbtx.with_module_prefix(output.module_instance_id()),
+                    &mut dbtx.dbtx_ref_with_prefix_module_id(output.module_instance_id()),
                     output,
                     OutPoint { txid, out_idx },
                 )
@@ -285,7 +285,11 @@ impl ConsensusApi {
         let outcome = self
             .modules
             .get_expect(module_id)
-            .output_status(&mut dbtx.with_module_prefix(module_id), outpoint, module_id)
+            .output_status(
+                &mut dbtx.dbtx_ref_with_prefix_module_id(module_id),
+                outpoint,
+                module_id,
+            )
             .await
             .expect("The transaction is accepted");
 
@@ -401,7 +405,7 @@ impl ConsensusApi {
             module_instance_id_to_kind.insert(module_instance_id, kind.as_str().to_string());
             module
                 .audit(
-                    &mut dbtx.with_module_prefix(module_instance_id),
+                    &mut dbtx.dbtx_ref_with_prefix_module_id(module_instance_id),
                     &mut audit,
                     module_instance_id,
                 )
@@ -415,7 +419,7 @@ impl ConsensusApi {
 
     async fn handle_backup_request<'s, 'dbtx, 'a>(
         &'s self,
-        dbtx: &'dbtx mut ModuleDatabaseTransaction<'a>,
+        dbtx: &'dbtx mut DatabaseTransactionRef<'a>,
         request: SignedBackupRequest,
     ) -> Result<(), ApiError> {
         let request = request
@@ -445,7 +449,7 @@ impl ConsensusApi {
 
     async fn handle_recover_request(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         id: secp256k1_zkp::XOnlyPublicKey,
     ) -> Option<ClientBackupSnapshot> {
         dbtx.get_value(&ClientBackupKey(id)).await
@@ -462,8 +466,8 @@ impl HasApiContext<ConsensusApi> for ConsensusApi {
         let mut db = self.db.clone();
         let mut dbtx = self.db.begin_transaction().await;
         if let Some(id) = id {
-            db = self.db.new_isolated(id);
-            dbtx = dbtx.new_module_tx(id)
+            db = self.db.with_prefix_module_id(id);
+            dbtx = dbtx.with_prefix_module_id(id)
         }
         (
             self,

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -59,7 +59,7 @@ impl FederationTest {
         client_builder.with_primary_module(self.primary_client);
         client_builder
             .with_federation_info(FederationInfo::from_config(client_config).await.unwrap());
-        client_builder.with_database(MemDatabase::new());
+        client_builder.with_raw_database(MemDatabase::new());
         let client_secret = match client_builder
             .load_decodable_client_secret::<[u8; 64]>()
             .await

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -15,7 +15,7 @@ async fn client(invite_code: &InviteCode) -> Result<fedimint_client::ClientArc> 
     builder.with_module(WalletClientGen::default());
     builder.with_primary_module(1);
     builder.with_federation_info(FederationInfo::from_invite_code(invite_code.clone()).await?);
-    builder.with_database(MemDatabase::default());
+    builder.with_raw_database(MemDatabase::default());
     let client_secret = match builder.load_decodable_client_secret::<[u8; 64]>().await {
         Ok(secret) => secret,
         Err(_) => {

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -7,7 +7,7 @@ use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::{get_config_from_db, ClientBuilder, FederationInfo};
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{Database, DatabaseTransaction};
+use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use futures::StreamExt;
 use rand::thread_rng;
@@ -96,7 +96,7 @@ impl GatewayClientBuilder {
             let rocksdb = fedimint_rocksdb::RocksDb::open(db_path.clone()).map_err(|e| {
                 GatewayError::DatabaseError(anyhow::anyhow!("Error opening rocksdb: {e:?}"))
             })?;
-            client_builder.with_database(rocksdb);
+            client_builder.with_raw_database(rocksdb);
         }
 
         let client_secret = match client_builder

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -37,7 +37,7 @@ use fedimint_core::core::{
     ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
-use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction};
+use fedimint_core::db::{Database, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::fmt_utils::OptStacktrace;
 use fedimint_core::module::CommonModuleInit;
 use fedimint_core::task::{sleep, RwLock, TaskGroup, TaskHandle, TaskShutdownToken};
@@ -343,7 +343,7 @@ impl Gateway {
     }
 
     pub async fn dump_database<'a>(
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + 'a> {
         let mut gateway_items: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -37,7 +37,7 @@ use fedimint_core::core::{
     ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
-use fedimint_core::db::{Database, ModuleDatabaseTransaction};
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction};
 use fedimint_core::fmt_utils::OptStacktrace;
 use fedimint_core::module::CommonModuleInit;
 use fedimint_core::task::{sleep, RwLock, TaskGroup, TaskHandle, TaskShutdownToken};

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -17,7 +17,7 @@ use fedimint_client::{sm_enum_variant_translation, ClientArc, DynGlobalClientCon
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{AutocommitError, Database, ModuleDatabaseTransaction};
+use fedimint_core::db::{AutocommitError, Database, DatabaseTransactionRef};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     ApiVersion, ExtendsCommonModuleInit, MultiApiVersion, TransactionItemAmount,
@@ -365,7 +365,7 @@ impl ExtendsCommonModuleInit for GatewayClientGen {
 
     async fn dump_database(
         &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_>,
+        _dbtx: &mut DatabaseTransactionRef<'_>,
         _prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         Box::new(vec![].into_iter())

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -8,6 +8,7 @@ use fedimint_client::transaction::{ClientInput, ClientOutput};
 use fedimint_client::{ClientArc, DynGlobalClientContext};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
+use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, TransactionId};
 use fedimint_ln_client::pay::PayInvoicePayload;

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -12,7 +12,7 @@ use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder
 use fedimint_client::{ClientArc, DynGlobalClientContext};
 use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::{Decoder, IntoDynInstance, KeyPair, OperationId};
-use fedimint_core::db::ModuleDatabaseTransaction;
+use fedimint_core::db::{IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ExtendsCommonModuleInit, ModuleCommon, MultiApiVersion,
     TransactionItemAmount,

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -4,7 +4,7 @@ use fedimint_client::sm::{DynState, State, StateTransition};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction};
+use fedimint_core::db::{DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, TransactionId};
 use fedimint_dummy_common::DummyOutputOutcome;
@@ -79,7 +79,7 @@ impl State for DummyStateMachine {
     }
 }
 
-async fn add_funds(amount: Amount, mut dbtx: ModuleDatabaseTransaction<'_>) {
+async fn add_funds(amount: Amount, mut dbtx: DatabaseTransactionRef<'_>) {
     let funds = get_funds(&mut dbtx).await + amount;
     dbtx.insert_entry(&DummyClientFundsKeyV0, &funds).await;
 }

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -4,7 +4,7 @@ use fedimint_client::sm::{DynState, State, StateTransition};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::ModuleDatabaseTransaction;
+use fedimint_core::db::{IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, TransactionId};
 use fedimint_dummy_common::DummyOutputOutcome;

--- a/modules/fedimint-dummy-server/src/db.rs
+++ b/modules/fedimint-dummy-server/src/db.rs
@@ -1,4 +1,4 @@
-use fedimint_core::db::DatabaseTransaction;
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::{SerdeSignature, SerdeSignatureShare};
 use fedimint_core::{impl_db_lookup, impl_db_record, Amount, OutPoint, PeerId};

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -8,7 +8,9 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{DatabaseVersion, MigrationMap, ModuleDatabaseTransaction};
+use fedimint_core::db::{
+    DatabaseVersion, IDatabaseTransactionOpsCoreTyped, MigrationMap, ModuleDatabaseTransaction,
+};
 use fedimint_core::endpoint_constants::{SIGN_MESSAGE_ENDPOINT, WAIT_SIGNED_ENDPOINT};
 use fedimint_core::epoch::{SerdeSignature, SerdeSignatureShare};
 use fedimint_core::module::audit::Audit;

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -9,7 +9,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    DatabaseVersion, IDatabaseTransactionOpsCoreTyped, MigrationMap, ModuleDatabaseTransaction,
+    DatabaseTransactionRef, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, MigrationMap,
 };
 use fedimint_core::endpoint_constants::{SIGN_MESSAGE_ENDPOINT, WAIT_SIGNED_ENDPOINT};
 use fedimint_core::epoch::{SerdeSignature, SerdeSignatureShare};
@@ -57,7 +57,7 @@ impl ExtendsCommonModuleInit for DummyGen {
     /// Dumps all database items for debugging
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         // TODO: Boilerplate-code
@@ -242,7 +242,7 @@ impl ServerModule for Dummy {
 
     async fn consensus_proposal(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> Vec<DummyConsensusItem> {
         // Sign and send the print requests to consensus
         let sign_requests: Vec<_> = dbtx
@@ -263,7 +263,7 @@ impl ServerModule for Dummy {
 
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransactionRef<'b>,
         consensus_item: DummyConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -326,7 +326,7 @@ impl ServerModule for Dummy {
 
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'c>,
+        dbtx: &mut DatabaseTransactionRef<'c>,
         input: &'b DummyInput,
     ) -> Result<InputMeta, ModuleError> {
         let current_funds = dbtx
@@ -367,7 +367,7 @@ impl ServerModule for Dummy {
 
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransactionRef<'b>,
         output: &'a DummyOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -390,7 +390,7 @@ impl ServerModule for Dummy {
 
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         out_point: OutPoint,
     ) -> Option<DummyOutputOutcome> {
         // check whether or not the output has been processed
@@ -399,7 +399,7 @@ impl ServerModule for Dummy {
 
     async fn audit(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -25,7 +25,9 @@ use fedimint_client::{sm_enum_variant_translation, ClientArc, DynGlobalClientCon
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{DatabaseTransaction, ModuleDatabaseTransaction};
+use fedimint_core::db::{
+    DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction,
+};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ExtendsCommonModuleInit, ModuleCommon, MultiApiVersion,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -26,7 +26,7 @@ use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
 use fedimint_core::db::{
-    DatabaseTransaction, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction,
+    DatabaseTransaction, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
@@ -638,7 +638,7 @@ impl ExtendsCommonModuleInit for LightningClientGen {
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut ln_client_items: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =
@@ -1322,7 +1322,7 @@ pub struct OutgoingLightningPayment {
 }
 
 async fn set_payment_result(
-    dbtx: &mut ModuleDatabaseTransaction<'_>,
+    dbtx: &mut DatabaseTransactionRef<'_>,
     payment_hash: sha256::Hash,
     payment_type: PayType,
     contract_id: ContractId,

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -10,7 +10,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    DatabaseVersion, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction,
+    DatabaseTransactionRef, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::Encodable;
 use fedimint_core::endpoint_constants::{
@@ -118,7 +118,7 @@ impl ExtendsCommonModuleInit for LightningGen {
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut lightning: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =
@@ -369,7 +369,7 @@ impl ServerModule for Lightning {
 
     async fn consensus_proposal(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> Vec<LightningConsensusItem> {
         let mut items: Vec<LightningConsensusItem> = dbtx
             .find_by_prefix(&ProposeDecryptionShareKeyPrefix)
@@ -391,7 +391,7 @@ impl ServerModule for Lightning {
 
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransactionRef<'b>,
         consensus_item: LightningConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -543,7 +543,7 @@ impl ServerModule for Lightning {
 
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'c>,
+        dbtx: &mut DatabaseTransactionRef<'c>,
         input: &'b LightningInput,
     ) -> Result<InputMeta, ModuleError> {
         let mut account = dbtx
@@ -630,7 +630,7 @@ impl ServerModule for Lightning {
 
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransactionRef<'b>,
         output: &'a LightningOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -829,7 +829,7 @@ impl ServerModule for Lightning {
 
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         out_point: OutPoint,
     ) -> Option<LightningOutputOutcome> {
         dbtx.get_value(&ContractUpdateKey(out_point)).await
@@ -837,7 +837,7 @@ impl ServerModule for Lightning {
 
     async fn audit(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {
@@ -942,7 +942,7 @@ impl Lightning {
             .expect("bitcoind rpc failed")
     }
 
-    async fn consensus_block_count(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) -> u64 {
+    async fn consensus_block_count(&self, dbtx: &mut DatabaseTransactionRef<'_>) -> u64 {
         let peer_count = 3 * (self.cfg.consensus.threshold() / 2) + 1;
 
         let mut counts = dbtx
@@ -963,7 +963,7 @@ impl Lightning {
         counts[peer_count / 2]
     }
 
-    async fn wait_block_height(&self, block_height: u64, dbtx: &mut ModuleDatabaseTransaction<'_>) {
+    async fn wait_block_height(&self, block_height: u64, dbtx: &mut DatabaseTransactionRef<'_>) {
         while block_height >= self.consensus_block_count(dbtx).await {
             sleep(Duration::from_secs(5)).await;
         }
@@ -984,7 +984,7 @@ impl Lightning {
 
     async fn get_offer(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         payment_hash: bitcoin_hashes::sha256::Hash,
     ) -> Option<IncomingContractOffer> {
         dbtx.get_value(&OfferKey(payment_hash)).await
@@ -1001,7 +1001,7 @@ impl Lightning {
 
     async fn get_contract_account(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         contract_id: ContractId,
     ) -> Option<ContractAccount> {
         dbtx.get_value(&ContractKey(contract_id)).await
@@ -1074,7 +1074,7 @@ impl Lightning {
 
     async fn list_gateways(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> Vec<LightningGatewayAnnouncement> {
         let stream = dbtx.find_by_prefix(&LightningGatewayKeyPrefix).await;
         stream
@@ -1094,7 +1094,7 @@ impl Lightning {
 
     async fn register_gateway(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         gateway: LightningGatewayAnnouncement,
     ) {
         // Garbage collect expired gateways (since we're already writing to the DB)
@@ -1111,7 +1111,7 @@ impl Lightning {
         .await;
     }
 
-    async fn delete_expired_gateways(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) {
+    async fn delete_expired_gateways(&self, dbtx: &mut DatabaseTransactionRef<'_>) {
         let expired_gateway_keys = dbtx
             .find_by_prefix(&LightningGatewayKeyPrefix)
             .await
@@ -1231,7 +1231,11 @@ mod tests {
         let mut dbtx = db.begin_transaction().await;
 
         server
-            .process_output(&mut dbtx.with_module_prefix(42), &output, out_point)
+            .process_output(
+                &mut dbtx.dbtx_ref_with_prefix_module_id(42),
+                &output,
+                out_point,
+            )
             .await
             .expect("First time works");
 
@@ -1250,7 +1254,11 @@ mod tests {
 
         assert_matches!(
             server
-                .process_output(&mut dbtx.with_module_prefix(42), &output2, out_point2)
+                .process_output(
+                    &mut dbtx.dbtx_ref_with_prefix_module_id(42),
+                    &output2,
+                    out_point2
+                )
                 .await,
             Err(_)
         );
@@ -1261,7 +1269,7 @@ mod tests {
         let (server_cfg, client_cfg) = build_configs();
         let db = Database::new(MemDatabase::new(), Default::default());
         let mut dbtx = db.begin_transaction().await;
-        let mut module_dbtx = dbtx.with_module_prefix(42);
+        let mut module_dbtx = dbtx.dbtx_ref_with_prefix_module_id(42);
         let mut tg = TaskGroup::new();
         let server = Lightning::new(server_cfg[0].clone(), &mut tg).unwrap();
 
@@ -1326,7 +1334,7 @@ mod tests {
         let (server_cfg, _) = build_configs();
         let db = Database::new(MemDatabase::new(), Default::default());
         let mut dbtx = db.begin_transaction().await;
-        let mut module_dbtx = dbtx.with_module_prefix(42);
+        let mut module_dbtx = dbtx.dbtx_ref_with_prefix_module_id(42);
         let mut tg = TaskGroup::new();
         let server = Lightning::new(server_cfg[0].clone(), &mut tg).unwrap();
 

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -9,7 +9,9 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{DatabaseVersion, ModuleDatabaseTransaction};
+use fedimint_core::db::{
+    DatabaseVersion, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction,
+};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::endpoint_constants::{
     ACCOUNT_ENDPOINT, BLOCK_COUNT_ENDPOINT, LIST_GATEWAYS_ENDPOINT, OFFER_ENDPOINT,
@@ -1136,7 +1138,7 @@ mod tests {
     use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
     use fedimint_core::config::ConfigGenModuleParams;
     use fedimint_core::db::mem_impl::MemDatabase;
-    use fedimint_core::db::Database;
+    use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
     use fedimint_core::encoding::Encodable;
     use fedimint_core::module::{InputMeta, ServerModuleInit, TransactionItemAmount};
     use fedimint_core::task::TaskGroup;
@@ -1387,7 +1389,9 @@ mod fedimint_migration_tests {
     use anyhow::{ensure, Context};
     use bitcoin_hashes::Hash;
     use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_LN;
-    use fedimint_core::db::{apply_migrations, DatabaseTransaction};
+    use fedimint_core::db::{
+        apply_migrations, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
+    };
     use fedimint_core::encoding::Encodable;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::module::{CommonModuleInit, DynServerModuleInit};

--- a/modules/fedimint-mint-client/src/backup.rs
+++ b/modules/fedimint-mint-client/src/backup.rs
@@ -2,7 +2,7 @@ use fedimint_client::sm::Executor;
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::ModuleDatabaseTransaction;
+use fedimint_core::db::DatabaseTransactionRef;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, Tiered, TieredMulti};
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ impl EcashBackup {
 impl MintClientModule {
     pub async fn prepare_plaintext_ecash_backup(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         executor: Executor<DynGlobalClientContext>,
         api: DynGlobalApi,
         module_instance_id: ModuleInstanceId,

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -7,6 +7,7 @@ use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::block::Block;
 use fedimint_core::core::{OperationId, LEGACY_HARDCODED_INSTANCE_ID_MINT};
+use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::registry::ModuleDecoderRegistry;

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -33,8 +33,7 @@ use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
 use fedimint_core::db::{
-    AutocommitError, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
-    ModuleDatabaseTransaction,
+    AutocommitError, DatabaseTransaction, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -390,7 +389,7 @@ impl MintClientExt for ClientArc {
                     Box::pin(async move {
                         let (operation_id, states, notes) = mint
                             .spend_notes_oob(
-                                &mut dbtx.with_module_prefix(instance.id),
+                                &mut dbtx.dbtx_ref_with_prefix_module_id(instance.id),
                                 notes_selector,
                                 requested_amount,
                                 try_cancel_after,
@@ -585,7 +584,7 @@ impl ExtendsCommonModuleInit for MintClientGen {
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut mint_client_items: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =
@@ -789,7 +788,7 @@ impl ClientModule for MintClientModule {
 
     async fn backup(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         executor: Executor<DynGlobalClientContext>,
         api: DynGlobalApi,
         module_instance_id: ModuleInstanceId,
@@ -810,9 +809,11 @@ impl ClientModule for MintClientModule {
         api: DynGlobalApi,
         snapshot: Option<&[u8]>,
     ) -> anyhow::Result<()> {
-        if !Self::get_all_spendable_notes(&mut dbtx.with_module_prefix(module_instance_id))
-            .await
-            .is_empty()
+        if !Self::get_all_spendable_notes(
+            &mut dbtx.dbtx_ref_with_prefix_module_id(module_instance_id),
+        )
+        .await
+        .is_empty()
         {
             warn!(
                 target: LOG_TARGET,
@@ -869,7 +870,7 @@ impl ClientModule for MintClientModule {
 
     async fn wipe(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         _module_instance_id: ModuleInstanceId,
         _executor: Executor<DynGlobalClientContext>,
     ) -> anyhow::Result<()> {
@@ -885,7 +886,7 @@ impl ClientModule for MintClientModule {
 
     async fn create_sufficient_input(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         operation_id: OperationId,
         min_amount: Amount,
     ) -> anyhow::Result<Vec<ClientInput<MintInput, MintClientStateMachines>>> {
@@ -894,7 +895,7 @@ impl ClientModule for MintClientModule {
 
     async fn create_exact_output(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         operation_id: OperationId,
         amount: Amount,
     ) -> Vec<ClientOutput<MintOutput, MintClientStateMachines>> {
@@ -910,7 +911,7 @@ impl ClientModule for MintClientModule {
         self.await_output_finalized(operation_id, out_point).await
     }
 
-    async fn get_balance(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) -> Amount {
+    async fn get_balance(&self, dbtx: &mut DatabaseTransactionRef<'_>) -> Amount {
         self.get_wallet_summary(dbtx).await.total_amount()
     }
 
@@ -950,7 +951,7 @@ impl ClientModule for MintClientModule {
 
     async fn leave(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         module_instance_id: ModuleInstanceId,
         executor: Executor<DynGlobalClientContext>,
         _api: DynGlobalApi,
@@ -974,10 +975,7 @@ impl ClientModule for MintClientModule {
 
 impl MintClientModule {
     /// Returns the number of held e-cash notes per denomination
-    pub async fn get_wallet_summary(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
-    ) -> TieredSummary {
+    pub async fn get_wallet_summary(&self, dbtx: &mut DatabaseTransactionRef<'_>) -> TieredSummary {
         dbtx.find_by_prefix(&NoteKeyPrefix)
             .await
             .fold(
@@ -996,7 +994,7 @@ impl MintClientModule {
     /// e-cash note denomination held.
     pub async fn create_output(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         operation_id: OperationId,
         notes_per_denomination: u16,
         exact_amount: Amount,
@@ -1090,7 +1088,7 @@ impl MintClientModule {
     /// Creates a mint input of at least `min_amount`.
     pub async fn create_input(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         operation_id: OperationId,
         min_amount: Amount,
     ) -> anyhow::Result<Vec<ClientInput<MintInput, MintClientStateMachines>>> {
@@ -1161,7 +1159,7 @@ impl MintClientModule {
 
     async fn spend_notes_oob(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         notes_selector: &impl NotesSelector<SpendableNote>,
         requested_amount: Amount,
         try_cancel_after: Duration,
@@ -1259,7 +1257,7 @@ impl MintClientModule {
 
     /// Select notes with `requested_amount` using `notes_selector`.
     async fn select_notes(
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         notes_selector: &impl NotesSelector<SpendableNote>,
         requested_amount: Amount,
     ) -> anyhow::Result<TieredMulti<SpendableNote>> {
@@ -1273,7 +1271,7 @@ impl MintClientModule {
     }
 
     async fn get_all_spendable_notes(
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> TieredMulti<SpendableNote> {
         TieredMulti::from_iter(
             (dbtx
@@ -1286,7 +1284,7 @@ impl MintClientModule {
         )
     }
 
-    async fn wipe_all_spendable_notes(dbtx: &mut ModuleDatabaseTransaction<'_>) {
+    async fn wipe_all_spendable_notes(dbtx: &mut DatabaseTransactionRef<'_>) {
         debug!(target: LOG_TARGET, "Wiping all spendable notes");
         dbtx.remove_by_prefix(&NoteKeyPrefix).await;
         assert!(Self::get_all_spendable_notes(dbtx).await.is_empty());
@@ -1294,7 +1292,7 @@ impl MintClientModule {
 
     async fn get_next_note_index(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         amount: Amount,
     ) -> NoteIndex {
         NoteIndex(
@@ -1338,7 +1336,7 @@ impl MintClientModule {
     async fn new_note_secret(
         &self,
         amount: Amount,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> DerivableSecret {
         let new_idx = self.get_next_note_index(dbtx, amount).await;
         dbtx.insert_entry(&NextECashNoteIndexKey(amount), &new_idx.next().as_u64())
@@ -1349,7 +1347,7 @@ impl MintClientModule {
     pub async fn new_ecash_note(
         &self,
         amount: Amount,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> (NoteIssuanceRequest, BlindNonce) {
         let secret = self.new_note_secret(amount, dbtx).await;
         NoteIssuanceRequest::new(&self.secp, secret)

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -32,7 +32,10 @@ use fedimint_client::{sm_enum_variant_translation, ClientArc, DynGlobalClientCon
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{AutocommitError, DatabaseTransaction, ModuleDatabaseTransaction};
+use fedimint_core::db::{
+    AutocommitError, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
+    ModuleDatabaseTransaction,
+};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -6,6 +6,7 @@ use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::{deserialize_outcome, FederationApiExt, SerdeOutputOutcome};
 use fedimint_core::core::{Decoder, OperationId};
+use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::endpoint_constants::AWAIT_OUTPUT_OUTCOME_ENDPOINT;
 use fedimint_core::module::ApiRequestErased;

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -8,7 +8,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    DatabaseVersion, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction,
+    DatabaseTransactionRef, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::endpoint_constants::{BACKUP_ENDPOINT, RECOVER_ENDPOINT};
 use fedimint_core::module::audit::Audit;
@@ -58,7 +58,7 @@ impl ExtendsCommonModuleInit for MintGen {
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut mint: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> = BTreeMap::new();
@@ -302,14 +302,14 @@ impl ServerModule for Mint {
 
     async fn consensus_proposal(
         &self,
-        _dbtx: &mut ModuleDatabaseTransaction<'_>,
+        _dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> Vec<MintConsensusItem> {
         Vec::new()
     }
 
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        _dbtx: &mut ModuleDatabaseTransaction<'b>,
+        _dbtx: &mut DatabaseTransactionRef<'b>,
         _consensus_item: MintConsensusItem,
         _peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -318,7 +318,7 @@ impl ServerModule for Mint {
 
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'c>,
+        dbtx: &mut DatabaseTransactionRef<'c>,
         input: &'b MintInput,
     ) -> Result<InputMeta, ModuleError> {
         let amount_key = self
@@ -356,7 +356,7 @@ impl ServerModule for Mint {
 
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransactionRef<'b>,
         output: &'a MintOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -383,7 +383,7 @@ impl ServerModule for Mint {
 
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         out_point: OutPoint,
     ) -> Option<MintOutputOutcome> {
         dbtx.get_value(&MintOutputOutcomeKey(out_point)).await
@@ -391,7 +391,7 @@ impl ServerModule for Mint {
 
     async fn audit(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {
@@ -460,7 +460,7 @@ impl ServerModule for Mint {
 impl Mint {
     async fn handle_backup_request(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         request: SignedBackupRequest,
     ) -> Result<(), ApiError> {
         let request = request
@@ -490,7 +490,7 @@ impl Mint {
 
     async fn handle_recover_request(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         id: secp256k1_zkp::XOnlyPublicKey,
     ) -> Option<ECashUserBackupSnapshot> {
         dbtx.get_value(&EcashBackupKey(id)).await
@@ -685,11 +685,11 @@ mod test {
 
         // Double spend in same epoch is detected
         let mut dbtx = db.begin_transaction().await;
-        mint.process_input(&mut dbtx.with_module_prefix(42), &input)
+        mint.process_input(&mut dbtx.dbtx_ref_with_prefix_module_id(42), &input)
             .await
             .expect("Spend of valid e-cash works");
         assert_matches!(
-            mint.process_input(&mut dbtx.with_module_prefix(42), &input,)
+            mint.process_input(&mut dbtx.dbtx_ref_with_prefix_module_id(42), &input,)
                 .await,
             Err(_)
         );

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -7,7 +7,9 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{DatabaseVersion, ModuleDatabaseTransaction};
+use fedimint_core::db::{
+    DatabaseVersion, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction,
+};
 use fedimint_core::endpoint_constants::{BACKUP_ENDPOINT, RECOVER_ENDPOINT};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -699,7 +701,9 @@ mod fedimint_migration_tests {
     use anyhow::{ensure, Context};
     use bitcoin_hashes::Hash;
     use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_MINT;
-    use fedimint_core::db::{apply_migrations, DatabaseTransaction};
+    use fedimint_core::db::{
+        apply_migrations, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
+    };
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::module::{CommonModuleInit, DynServerModuleInit};
     use fedimint_core::time::now;

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -24,7 +24,9 @@ use fedimint_client::{sm_enum_variant_translation, ClientArc, DynGlobalClientCon
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{AutocommitError, ModuleDatabaseTransaction};
+use fedimint_core::db::{
+    AutocommitError, IDatabaseTransactionOpsCoreTyped, ModuleDatabaseTransaction,
+};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ExtendsCommonModuleInit, ModuleCommon, MultiApiVersion,

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -31,7 +31,8 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    Database, DatabaseTransaction, DatabaseVersion, ModuleDatabaseTransaction,
+    Database, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
+    ModuleDatabaseTransaction,
 };
 use fedimint_core::encoding::Encodable;
 use fedimint_core::endpoint_constants::{
@@ -1628,7 +1629,9 @@ mod fedimint_migration_tests {
         WPubkeyHash,
     };
     use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
-    use fedimint_core::db::{apply_migrations, DatabaseTransaction};
+    use fedimint_core::db::{
+        apply_migrations, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
+    };
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::module::{CommonModuleInit, DynServerModuleInit};
     use fedimint_core::{BitcoinHash, Feerate, OutPoint, PeerId, ServerModule, TransactionId};

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -31,8 +31,8 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    Database, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
-    ModuleDatabaseTransaction,
+    Database, DatabaseTransaction, DatabaseTransactionRef, DatabaseVersion,
+    IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::Encodable;
 use fedimint_core::endpoint_constants::{
@@ -81,7 +81,7 @@ impl ExtendsCommonModuleInit for WalletGen {
 
     async fn dump_database(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut wallet: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> = BTreeMap::new();
@@ -307,7 +307,7 @@ impl ServerModule for Wallet {
 
     async fn consensus_proposal<'a>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> Vec<WalletConsensusItem> {
         let mut items = dbtx
             .find_by_prefix(&PegOutTxSignatureCIPrefix)
@@ -356,7 +356,7 @@ impl ServerModule for Wallet {
 
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransactionRef<'b>,
         consensus_item: WalletConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -460,7 +460,7 @@ impl ServerModule for Wallet {
 
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'c>,
+        dbtx: &mut DatabaseTransactionRef<'c>,
         input: &'b WalletInput,
     ) -> Result<InputMeta, ModuleError> {
         if !self.block_is_known(dbtx, input.proof_block()).await {
@@ -499,7 +499,7 @@ impl ServerModule for Wallet {
 
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut ModuleDatabaseTransaction<'b>,
+        dbtx: &mut DatabaseTransactionRef<'b>,
         output: &'a WalletOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, ModuleError> {
@@ -576,7 +576,7 @@ impl ServerModule for Wallet {
 
     async fn output_status(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         out_point: OutPoint,
     ) -> Option<WalletOutputOutcome> {
         dbtx.get_value(&PegOutBitcoinTransaction(out_point)).await
@@ -584,7 +584,7 @@ impl ServerModule for Wallet {
 
     async fn audit(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {
@@ -871,7 +871,7 @@ impl Wallet {
 
     pub async fn consensus_block_count(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> Option<u32> {
         let peer_count = self.cfg.consensus.peer_peg_in_keys.total();
 
@@ -892,7 +892,7 @@ impl Wallet {
         counts[peer_count / 2]
     }
 
-    pub async fn consensus_fee_rate(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) -> Feerate {
+    pub async fn consensus_fee_rate(&self, dbtx: &mut DatabaseTransactionRef<'_>) -> Feerate {
         let peer_count = self.cfg.consensus.peer_peg_in_keys.total();
 
         let mut rates = dbtx
@@ -913,7 +913,7 @@ impl Wallet {
         rates[peer_count / 2]
     }
 
-    pub async fn consensus_nonce(&self, dbtx: &mut ModuleDatabaseTransaction<'_>) -> [u8; 32] {
+    pub async fn consensus_nonce(&self, dbtx: &mut DatabaseTransactionRef<'_>) -> [u8; 32] {
         let nonce = dbtx.get_value(&PegOutNonceKey).await.unwrap_or(0);
         dbtx.insert_entry(&PegOutNonceKey, &(nonce + 1)).await;
 
@@ -922,7 +922,7 @@ impl Wallet {
 
     async fn sync_up_to_consensus_height<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a>,
+        dbtx: &mut DatabaseTransactionRef<'a>,
         old_height: u32,
         new_height: u32,
     ) {
@@ -993,7 +993,7 @@ impl Wallet {
     /// in a block that we got consensus on.
     async fn recognize_change_utxo<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a>,
+        dbtx: &mut DatabaseTransactionRef<'a>,
         pending_tx: &PendingTransaction,
     ) {
         self.remove_rbf_transactions(dbtx, pending_tx).await;
@@ -1024,7 +1024,7 @@ impl Wallet {
     /// Removes the `PendingTransaction` and any transactions tied to it via RBF
     async fn remove_rbf_transactions<'a>(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'a>,
+        dbtx: &mut DatabaseTransactionRef<'a>,
         pending_tx: &PendingTransaction,
     ) {
         let mut all_transactions: BTreeMap<Txid, PendingTransaction> = dbtx
@@ -1061,7 +1061,7 @@ impl Wallet {
 
     async fn block_is_known(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         block_hash: BlockHash,
     ) -> bool {
         dbtx.get_value(&BlockHashKey(block_hash)).await.is_some()
@@ -1069,7 +1069,7 @@ impl Wallet {
 
     async fn create_peg_out_tx(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
         output: &WalletOutput,
         change_tweak: &[u8; 32],
     ) -> Result<UnsignedTransaction, WalletError> {
@@ -1104,7 +1104,7 @@ impl Wallet {
 
     async fn available_utxos(
         &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransactionRef<'_>,
     ) -> Vec<(UTXOKey, SpendableUTXO)> {
         dbtx.find_by_prefix(&UTXOPrefixKey)
             .await
@@ -1112,10 +1112,7 @@ impl Wallet {
             .await
     }
 
-    pub async fn get_wallet_value(
-        &self,
-        dbtx: &mut ModuleDatabaseTransaction<'_>,
-    ) -> bitcoin::Amount {
+    pub async fn get_wallet_value(&self, dbtx: &mut DatabaseTransactionRef<'_>) -> bitcoin::Amount {
         let sat_sum = self
             .available_utxos(dbtx)
             .await

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -9,7 +9,7 @@ use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::ClientArc;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::db::mem_impl::MemDatabase;
-use fedimint_core::db::{Database, ModuleDatabaseTransaction};
+use fedimint_core::db::{IRawDatabaseExt, ModuleDatabaseTransaction};
 use fedimint_core::task::sleep;
 use fedimint_core::util::{BoxStream, NextOrPending};
 use fedimint_core::{sats, Amount, Feerate, PeerId, ServerModule};
@@ -398,7 +398,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     let bitcoin = fixtures.bitcoin();
     let server_bitcoin_rpc_config = fixtures.bitcoin_server();
     let dyn_bitcoin_rpc = fixtures.dyn_bitcoin_rpc();
-    let db = Database::new(MemDatabase::new(), Default::default());
+    let db = MemDatabase::new().into_database();
     let mut task_group = fedimint_core::task::TaskGroup::new();
     info!("Starting test peg_ins_that_are_unconfirmed_are_rejected");
 

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -9,7 +9,7 @@ use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::ClientArc;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::db::mem_impl::MemDatabase;
-use fedimint_core::db::{IRawDatabaseExt, ModuleDatabaseTransaction};
+use fedimint_core::db::{DatabaseTransactionRef, IRawDatabaseExt};
 use fedimint_core::task::sleep;
 use fedimint_core::util::{BoxStream, NextOrPending};
 use fedimint_core::{sats, Amount, Feerate, PeerId, ServerModule};
@@ -435,7 +435,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
 
     let block_count = dyn_bitcoin_rpc.get_block_count().await?;
     sync_wallet_to_block(
-        &mut dbtx.with_module_prefix(module_instance_id),
+        &mut dbtx.dbtx_ref_with_prefix_module_id(module_instance_id),
         &mut wallet,
         block_count.try_into()?,
     )
@@ -465,7 +465,10 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     )?));
 
     match wallet
-        .process_input(&mut dbtx.with_module_prefix(module_instance_id), &input)
+        .process_input(
+            &mut dbtx.dbtx_ref_with_prefix_module_id(module_instance_id),
+            &input,
+        )
         .await
     {
         Ok(_) => bail!("Expected peg-in to fail"),
@@ -480,7 +483,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         .await;
     let block_count = dyn_bitcoin_rpc.get_block_count().await?;
     sync_wallet_to_block(
-        &mut dbtx.with_module_prefix(module_instance_id),
+        &mut dbtx.dbtx_ref_with_prefix_module_id(module_instance_id),
         &mut wallet,
         block_count.try_into()?,
     )
@@ -488,7 +491,10 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
 
     assert_matches!(
         wallet
-            .process_input(&mut dbtx.with_module_prefix(module_instance_id), &input,)
+            .process_input(
+                &mut dbtx.dbtx_ref_with_prefix_module_id(module_instance_id),
+                &input,
+            )
             .await,
         Ok(_)
     );
@@ -497,7 +503,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
 }
 
 async fn sync_wallet_to_block(
-    dbtx: &mut ModuleDatabaseTransaction<'_>,
+    dbtx: &mut DatabaseTransactionRef<'_>,
     wallet: &mut fedimint_wallet_server::Wallet,
     block_count: u32,
 ) -> anyhow::Result<()> {

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -14,7 +14,7 @@ use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
-use fedimint_core::db::Database;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::CommonModuleInit;
 use fedimint_core::transaction::Transaction;

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -139,7 +139,7 @@ async fn main() -> anyhow::Result<()> {
             let db = if legacy {
                 db
             } else {
-                db.new_isolated(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
+                db.with_prefix_module_id(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
             };
 
             let utxos: Vec<ImportableWallet> = db


### PR DESCRIPTION
During work on passing client context to client modules, I've hit some problems/limitations w.r.t. the database traits, and I started digging, finding little things that I didn't like or thought were wrong, and decided to take a stab and see if it can be improved. Took forever and required great attention to details of generics and lifetimes, but here is the result.

There are some other things that I might bring up for debate (e.g. do we even need `ModuleDatabaseTransaction` at all now?), but I wanted to limit the changes at the first point where changes are coherent and  actually work.

#### Notable changes:

"single use" and "notifying" database transaction structs are gone. It was all merged into a single `BaseDatabaseTransaction`.

The database implementations are only concerned with producing `IRawDatabase`, then it gets wrapped with `BaseDatabase` to make it `impl IDatabase`, then the whole `IDatabase` is the composable interface that we can nest. We wrap it in `Database` for UX.

Everything about handling prefixes is handled by `PrefixDatabase`, and nesting prefixes is unlimited now. The special cases of `module_instance_id` on a database level was weird.

I moved typed dbtx queries to a trait that gets automatically implemented for any type that implements raw queries. Upside: we get typed queries everywhere where we get raw queries. Downside: we need to import a trait.


Some update docs: https://github.com/dpc/fedimint/blob/refactor-db/docs/database.md#base-implementations