### PR TITLE
chore: Update ldk to v0.0.118

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
  "fedimint-server",
  "fedimint-wallet-client",
  "futures",
- "lightning-invoice 0.24.0",
+ "lightning-invoice 0.26.0",
  "rand",
  "serde",
  "serde_json",
@@ -1323,8 +1323,8 @@ dependencies = [
  "jsonrpsee-types 0.18.2",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
- "lightning 0.0.116",
- "lightning-invoice 0.24.0",
+ "lightning 0.0.118",
+ "lightning-invoice 0.26.0",
  "macro_rules_attribute",
  "miniscript",
  "once_cell",
@@ -1525,8 +1525,7 @@ dependencies = [
  "fedimint-threshold-crypto",
  "futures",
  "itertools 0.10.5",
- "lightning 0.0.116",
- "lightning-invoice 0.24.0",
+ "lightning-invoice 0.26.0",
  "rand",
  "reqwest",
  "secp256k1 0.24.3",
@@ -1558,8 +1557,7 @@ dependencies = [
  "fedimint-threshold-crypto",
  "futures",
  "itertools 0.10.5",
- "lightning 0.0.116",
- "lightning-invoice 0.24.0",
+ "lightning-invoice 0.26.0",
  "rand",
  "secp256k1 0.24.3",
  "serde",
@@ -1593,8 +1591,8 @@ dependencies = [
  "fedimint-threshold-crypto",
  "futures",
  "itertools 0.10.5",
- "lightning 0.0.116",
- "lightning-invoice 0.24.0",
+ "lightning 0.0.118",
+ "lightning-invoice 0.26.0",
  "rand",
  "secp256k1 0.24.3",
  "serde",
@@ -1628,7 +1626,7 @@ dependencies = [
  "fedimint-logging",
  "fedimint-server",
  "fedimint-testing",
- "lightning-invoice 0.24.0",
+ "lightning-invoice 0.26.0",
  "serde_json",
  "tokio",
  "tracing",
@@ -1655,7 +1653,7 @@ dependencies = [
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
  "jsonrpsee-ws-client",
- "lightning-invoice 0.24.0",
+ "lightning-invoice 0.26.0",
  "rand",
  "serde",
  "serde_json",
@@ -1903,8 +1901,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "ldk-node",
- "lightning 0.0.116",
- "lightning-invoice 0.24.0",
+ "lightning-invoice 0.26.0",
  "ln-gateway",
  "rand",
  "secp256k1 0.24.3",
@@ -3124,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.116"
+version = "0.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a0f2155316f1570446a0447c993480673f840748c8ed25bbc59dfc442ac770"
+checksum = "d52cec5fa9382154fe9671e8df93095b800c7d77abc66e2a5ef839d672521c5e"
 dependencies = [
  "bitcoin 0.29.2",
 ]
@@ -3158,14 +3155,14 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788c0158526ec27a502043c2911ea6ea58fdc656bdf8749484942c07b790d23"
+checksum = "3eb24878b0f4ef75f020976c886d9ad1503867802329cc963e0ab4623ea3b25c"
 dependencies = [
  "bech32",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
- "lightning 0.0.116",
+ "lightning 0.0.118",
  "num-traits",
  "secp256k1 0.24.3",
  "serde",
@@ -3258,8 +3255,7 @@ dependencies = [
  "fedimint-tonic-lnd",
  "fedimint-wallet-client",
  "futures",
- "lightning 0.0.116",
- "lightning-invoice 0.24.0",
+ "lightning-invoice 0.26.0",
  "prost 0.12.1",
  "rand",
  "reqwest",

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -23,7 +23,7 @@ bitcoin_hashes = "0.11.0"
 time = { version = "0.3.25", features = [ "formatting" ] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
 futures = "0.3.28"
-lightning-invoice = { version = "0.24.0", features = [ "serde" ] }
+lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-aead = { path = "../crypto/aead" }
 fedimint-client = { path = "../fedimint-client" }
 fedimint-core ={ path = "../fedimint-core" }

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -40,8 +40,8 @@ bitcoin = { version = "0.29.2", features = [ "rand", "serde" ] }
 bitcoin30 = { package = "bitcoin", version = "0.30.0" }
 bitcoin_hashes = { version = "0.11", features = ["serde"] }
 erased-serde = "0.3"
-lightning = "0.0.116"
-lightning-invoice = "0.24.0"
+lightning = "0.0.118"
+lightning-invoice = "0.26.0"
 fedimint-derive = { path = "../fedimint-derive" }
 fedimint-logging = { path = "../fedimint-logging" }
 rand = "0.8.5"

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -482,7 +482,7 @@ impl Encodable for lightning_invoice::Bolt11Invoice {
     }
 }
 
-impl Encodable for lightning::routing::gossip::RoutingFees {
+impl Encodable for lightning_invoice::RoutingFees {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let mut len = 0;
         len += self.base_msat.consensus_encode(writer)?;
@@ -491,14 +491,14 @@ impl Encodable for lightning::routing::gossip::RoutingFees {
     }
 }
 
-impl Decodable for lightning::routing::gossip::RoutingFees {
+impl Decodable for lightning_invoice::RoutingFees {
     fn consensus_decode<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let base_msat = Decodable::consensus_decode(d, modules)?;
         let proportional_millionths = Decodable::consensus_decode(d, modules)?;
-        Ok(lightning::routing::gossip::RoutingFees {
+        Ok(lightning_invoice::RoutingFees {
             base_msat,
             proportional_millionths,
         })

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -26,7 +26,7 @@ fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
 futures = "0.3"
 jsonrpsee-core = { version = "0.18.0", features = [ "client" ] }
 jsonrpsee-types = { version = "0.18.0" }
-lightning-invoice = { version = "0.24.0", features = [ "serde" ] }
+lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -31,8 +31,7 @@ lazy_static = "1.4.0"
 ln-gateway = { path = "../gateway/ln-gateway" }
 ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "5029b2f88642864ed32835a31c1fa8b1405129dd" }
 futures = "0.3"
-lightning = "0.0.116"
-lightning-invoice = "0.24.0"
+lightning-invoice = "0.26.0"
 tempfile = "3.4.0"
 secp256k1 = "0.24.2"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -15,7 +15,7 @@ use fedimint_core::task::{block_in_place, sleep, TaskGroup};
 use fedimint_core::util::SafeUrl;
 use fedimint_logging::LOG_TEST;
 use futures::executor::block_on;
-use lightning::routing::gossip::RoutingFees;
+use lightning_invoice::RoutingFees;
 use ln_gateway::client::GatewayClientBuilder;
 use ln_gateway::lnrpc_client::{ILnRpcClient, LightningBuilder};
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;

--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -10,9 +10,8 @@ use fedimint_core::task::TaskGroup;
 use fedimint_core::util::BoxStream;
 use fedimint_core::Amount;
 use fedimint_logging::LOG_TEST;
-use lightning::ln::PaymentSecret;
 use lightning_invoice::{
-    Bolt11Invoice, Bolt11InvoiceDescription, Currency, Description, InvoiceBuilder,
+    Bolt11Invoice, Bolt11InvoiceDescription, Currency, Description, InvoiceBuilder, PaymentSecret,
     SignedRawBolt11Invoice, DEFAULT_EXPIRY_TIME,
 };
 use ln_gateway::gateway_lnrpc::{

--- a/fedimint-testing/src/ln/mod.rs
+++ b/fedimint-testing/src/ln/mod.rs
@@ -4,8 +4,9 @@ use async_trait::async_trait;
 use bitcoin::hashes::sha256;
 use bitcoin::KeyPair;
 use fedimint_core::{Amount, BitcoinHash};
-use lightning::ln::PaymentSecret;
-use lightning_invoice::{Bolt11Invoice, Currency, InvoiceBuilder, DEFAULT_EXPIRY_TIME};
+use lightning_invoice::{
+    Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, DEFAULT_EXPIRY_TIME,
+};
 use ln_gateway::lnrpc_client::ILnRpcClient;
 use rand::rngs::OsRng;
 use secp256k1_zkp::SecretKey;

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -47,8 +47,7 @@ fedimint-dummy-client = { path = "../../modules/fedimint-dummy-client" }
 fedimint-wallet-client = { path = "../../modules/fedimint-wallet-client" }
 futures = "0.3.24"
 erased-serde = "0.3"
-lightning = "0.0.116"
-lightning-invoice = "0.24.0"
+lightning-invoice = "0.26.0"
 prost = "0.12.1"
 rand = "0.8"
 reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }

--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -4,7 +4,7 @@ use fedimint_core::config::FederationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use fedimint_ln_common::serde_routing_fees;
-use lightning::routing::gossip::RoutingFees;
+use lightning_invoice::RoutingFees;
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -54,7 +54,7 @@ use fedimint_wallet_client::{WalletClientExt, WalletClientGen, WalletCommonGen, 
 use futures::stream::StreamExt;
 use gateway_lnrpc::intercept_htlc_response::Action;
 use gateway_lnrpc::{GetNodeInfoResponse, InterceptHtlcResponse};
-use lightning::routing::gossip::RoutingFees;
+use lightning_invoice::RoutingFees;
 use lnrpc_client::{ILnRpcClient, LightningBuilder, LightningRpcError, RouteHtlcStream};
 use rand::rngs::OsRng;
 use rpc::{FederationInfo, SetConfigurationPayload};

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -13,7 +13,7 @@ use fedimint_ln_client::pay::PayInvoicePayload;
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::{route_hints, serde_option_routing_fees};
 use futures::Future;
-use lightning::routing::gossip::RoutingFees;
+use lightning_invoice::RoutingFees;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tokio::sync::oneshot;
 

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -37,7 +37,7 @@ use fedimint_ln_common::{
     LightningGatewayAnnouncement, LightningModuleTypes, LightningOutput, KIND,
 };
 use futures::StreamExt;
-use lightning::routing::gossip::RoutingFees;
+use lightning_invoice::RoutingFees;
 use secp256k1::{KeyPair, PublicKey, Secp256k1};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -27,8 +27,7 @@ bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3.24"
 itertools = "0.10.5"
-lightning = "0.0.116"
-lightning-invoice = { version = "0.24.0", features = [ "serde" ] }
+lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-core ={ path = "../../fedimint-core" }
 fedimint-ln-common ={ path = "../fedimint-ln-common" }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -51,10 +51,10 @@ use fedimint_ln_common::{
 };
 use futures::StreamExt;
 use incoming::IncomingSmError;
-use lightning::ln::PaymentSecret;
-use lightning::routing::gossip::RoutingFees;
-use lightning::routing::router::{RouteHint, RouteHintHop};
-use lightning_invoice::{Bolt11Invoice, Currency, InvoiceBuilder, DEFAULT_EXPIRY_TIME};
+use lightning_invoice::{
+    Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, RouteHint, RouteHintHop, RoutingFees,
+    DEFAULT_EXPIRY_TIME,
+};
 use rand::seq::IteratorRandom;
 use rand::{CryptoRng, Rng, RngCore};
 use secp256k1::PublicKey;

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -26,8 +26,7 @@ bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
 futures = "0.3.24"
 itertools = "0.10.5"
-lightning = "0.0.116"
-lightning-invoice = { version = "0.24.0", features = [ "serde" ] }
+lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-core ={ path = "../../fedimint-core" }
 secp256k1 = { version="0.24.2", default-features=false }

--- a/modules/fedimint-ln-common/src/config.rs
+++ b/modules/fedimint-ln-common/src/config.rs
@@ -5,7 +5,7 @@ use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::plugin_types_trait_impl_config;
-use lightning::routing::gossip::RoutingFees;
+use lightning_invoice::RoutingFees;
 use serde::{Deserialize, Serialize};
 use threshold_crypto::serde_impl::SerdeSecret;
 

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -26,7 +26,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{plugin_types_trait_impl_common, Amount};
-use lightning::routing::gossip::RoutingFees;
+use lightning_invoice::RoutingFees;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
@@ -299,7 +299,7 @@ impl Context for LightningClientContext {}
 /// Hack to get a route hint that implements `serde` traits.
 pub mod route_hints {
     use fedimint_core::encoding::{Decodable, Encodable};
-    use lightning::routing::gossip::RoutingFees;
+    use lightning_invoice::RoutingFees;
     use secp256k1::PublicKey;
     use serde::{Deserialize, Serialize};
 
@@ -328,11 +328,11 @@ pub mod route_hints {
     pub struct RouteHint(pub Vec<RouteHintHop>);
 
     impl RouteHint {
-        pub fn to_ldk_route_hint(&self) -> lightning::routing::router::RouteHint {
-            lightning::routing::router::RouteHint(
+        pub fn to_ldk_route_hint(&self) -> lightning_invoice::RouteHint {
+            lightning_invoice::RouteHint(
                 self.0
                     .iter()
-                    .map(|hop| lightning::routing::router::RouteHintHop {
+                    .map(|hop| lightning_invoice::RouteHintHop {
                         src_node_id: hop.src_node_id,
                         short_channel_id: hop.short_channel_id,
                         fees: RoutingFees {
@@ -350,10 +350,10 @@ pub mod route_hints {
 }
 
 // TODO: Upstream serde serialization for
-// lightning::routing::gossip::RoutingFees
+// lightning_invoice::RoutingFees
 // See https://github.com/lightningdevkit/rust-lightning/blob/b8ed4d2608e32128dd5a1dee92911638a4301138/lightning/src/routing/gossip.rs#L1057-L1065
 pub mod serde_routing_fees {
-    use lightning::routing::gossip::RoutingFees;
+    use lightning_invoice::RoutingFees;
     use serde::ser::SerializeStruct;
     use serde::{Deserialize, Deserializer, Serializer};
 
@@ -394,7 +394,7 @@ pub mod serde_routing_fees {
 }
 
 pub mod serde_option_routing_fees {
-    use lightning::routing::gossip::RoutingFees;
+    use lightning_invoice::RoutingFees;
     use serde::ser::SerializeStruct;
     use serde::{Deserialize, Deserializer, Serializer};
 

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -20,8 +20,8 @@ bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3.24"
 itertools = "0.10.5"
-lightning = "0.0.116"
-lightning-invoice = { version = "0.24.0", features = [ "serde" ] }
+lightning = "0.0.118"
+lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-bitcoind = { path = "../../fedimint-bitcoind" }
 fedimint-core ={ path = "../../fedimint-core" }
 fedimint-ln-common = { path = "../fedimint-ln-common" }

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1413,8 +1413,7 @@ mod fedimint_migration_tests {
         prepare_db_migration_snapshot, validate_migrations, BYTE_32, BYTE_8, STRING_64,
     };
     use futures::StreamExt;
-    use lightning::routing::gossip::RoutingFees;
-    use lightning_invoice::Bolt11Invoice;
+    use lightning_invoice::{Bolt11Invoice, RoutingFees};
     use rand::distributions::Standard;
     use rand::prelude::Distribution;
     use rand::rngs::OsRng;

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -26,7 +26,7 @@ fedimint-client = { path = "../../fedimint-client" }
 fedimint-core ={ path = "../../fedimint-core" }
 fedimint-server = { path = "../../fedimint-server" }
 fedimint-logging = { path = "../../fedimint-logging" }
-lightning-invoice = { version = "0.24.0", features = [ "serde" ] }
+lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 tokio = { version = "1.26.0", features = ["sync"] }
 tracing = "0.1.37"
 serde_json = "1.0.91"


### PR DESCRIPTION
Updates LDK to latest version

Recently `lightning_invoice` re-exported some of the stuff that you guys were using from `lightning` so that dep can be removed from some crates