### PR TITLE
fix: use `ci` build profile for publishing docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         continue-on-error: true
 
       - name: Build docs
-        run: nix build -L .#debug.workspaceDocExport
+        run: nix build -L .#ci.workspaceDocExport
 
       - if: github.repository == 'fedimint/fedimint'
         name: Deploy docs


### PR DESCRIPTION
We don't maintain `debug` profile anymore anyway.

Fix #3540