### PR TITLE
chore: update to ring 0.17.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ dependencies = [
  "argon2",
  "hex",
  "rand",
- "ring",
+ "ring 0.17.5",
 ]
 
 [[package]]
@@ -1282,7 +1282,7 @@ dependencies = [
  "futures",
  "itertools 0.10.5",
  "rand",
- "ring",
+ "ring 0.17.5",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -1396,7 +1396,7 @@ dependencies = [
  "anyhow",
  "fedimint-core",
  "hkdf",
- "ring",
+ "ring 0.17.5",
  "secp256k1-zkp",
  "tbs",
 ]
@@ -2084,7 +2084,7 @@ dependencies = [
  "gloo-net",
  "js-sys",
  "rand",
- "ring",
+ "ring 0.17.5",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -2124,7 +2124,7 @@ dependencies = [
  "jsonrpsee",
  "rand",
  "rcgen",
- "ring",
+ "ring 0.17.5",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -3052,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libloading"
@@ -3970,7 +3970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
- "ring",
+ "ring 0.16.20",
  "time",
  "yasna",
 ]
@@ -4129,15 +4129,30 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.16.20"
-source = "git+https://github.com/dpc/ring?rev=5493e7e76d0d8fb1d3cbb0be9c4944700741b802#5493e7e76d0d8fb1d3cbb0be9c4944700741b802"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4205,7 +4220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "sct",
  "webpki",
 ]
@@ -4217,7 +4232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "rustls-webpki 0.101.4",
  "sct",
 ]
@@ -4237,8 +4252,8 @@ version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4247,8 +4262,8 @@ version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4281,8 +4296,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -5165,6 +5180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5369,8 +5390,8 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,4 +100,3 @@ debug = "line-tables-only"
 
 [patch.crates-io]
 secp256k1-zkp = { git = "https://github.com/dpc/rust-secp256k1-zkp/", branch = "sanket-pr" }
-ring = { git = "https://github.com/dpc/ring", rev = "5493e7e76d0d8fb1d3cbb0be9c4944700741b802" }

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -13,6 +13,6 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.65"
 argon2 = { version = "0.5.0", features = ["password-hash", "alloc"] }
-ring = "0.16.20"
+ring = "0.17.5"
 hex = "0.4.3"
 rand = "0.8"

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -16,6 +16,6 @@ path = "src/lib.rs"
 anyhow = "1.0.66"
 fedimint-core ={ path = "../../fedimint-core" }
 hkdf = { path = "../../crypto/hkdf" }
-ring = "0.16.20"
+ring = "0.17.5"
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
 tbs = { path = "../../crypto/tbs" }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -38,7 +38,7 @@ tokio = { version = "1.26.0", features = [ "time", "macros" ] }
 tracing = "0.1.37"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js", "wasm32_c"] }
+ring = { version = "0.17.5", features = ["wasm32_unknown_unknown_js"] }
 
 [dev-dependencies]
 tracing-test = "0.2.4"

--- a/fedimint-wasm-tests/Cargo.toml
+++ b/fedimint-wasm-tests/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = [ "rlib", "cdylib" ]
 [dependencies]
 anyhow = "1.0.69"
 futures = "0.3.26"
-ring = { version = "0.16.20", features = ["wasm32_unknown_unknown_js", "wasm32_c"] }
+ring = { version = "0.17.5", features = ["wasm32_unknown_unknown_js"] }
 fedimint-client = { path = "../fedimint-client" }
 fedimint-core = { path = "../fedimint-core" }
 fedimint-mint-client = { path = "../modules/fedimint-mint-client" }

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fedimint-aead = { path = "../crypto/aead" }
-ring = "0.16.20"
+ring = "0.17.5"
 anyhow = "1.0.66"
 async-trait = "0.1.73"
 bincode = "1.3.1"


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/2583

`wasm32_c` feature went away, I removed it, and everything compiled. @Maan2003 is this OK?