### PR TITLE
refactor: get rid of DummyClientExt

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -477,9 +477,8 @@ pub async fn handle_command(
 }
 
 async fn get_note_summary(client: &ClientArc) -> anyhow::Result<serde_json::Value> {
-    let (mint_client, _) = client.get_first_module::<MintClientModule>(&fedimint_mint_client::KIND);
-    let (wallet_client, _) =
-        client.get_first_module::<WalletClientModule>(&fedimint_wallet_client::KIND);
+    let (mint_client, _) = client.get_first_module::<MintClientModule>();
+    let (wallet_client, _) = client.get_first_module::<WalletClientModule>();
     let summary = mint_client
         .get_wallet_summary(
             &mut client

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -477,8 +477,8 @@ pub async fn handle_command(
 }
 
 async fn get_note_summary(client: &ClientArc) -> anyhow::Result<serde_json::Value> {
-    let (mint_client, _) = client.get_first_module::<MintClientModule>();
-    let (wallet_client, _) = client.get_first_module::<WalletClientModule>();
+    let mint_client = client.get_first_module::<MintClientModule>();
+    let wallet_client = client.get_first_module::<WalletClientModule>();
     let summary = mint_client
         .get_wallet_summary(
             &mut client

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -651,8 +651,7 @@ impl FedimintCli {
                 task::timeout(Duration::from_secs(30), async move {
                     let client = cli.build_client_ng(&self.module_inits, None).await?;
                     loop {
-                        let (_, instance) = client
-                            .get_first_module::<WalletClientModule>(&fedimint_wallet_client::KIND);
+                        let (_, instance) = client.get_first_module::<WalletClientModule>();
                         let count = client
                             .api()
                             .with_module(instance.id)

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -651,10 +651,10 @@ impl FedimintCli {
                 task::timeout(Duration::from_secs(30), async move {
                     let client = cli.build_client_ng(&self.module_inits, None).await?;
                     loop {
-                        let (_, instance) = client.get_first_module::<WalletClientModule>();
+                        let wallet = client.get_first_module::<WalletClientModule>();
                         let count = client
                             .api()
-                            .with_module(instance.id)
+                            .with_module(wallet.id)
                             .fetch_consensus_block_count()
                             .await?;
                         if count >= target {

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -607,6 +607,10 @@ impl Client {
         self.api.as_ref()
     }
 
+    pub fn api_clone(&self) -> DynGlobalApi {
+        self.api.clone()
+    }
+
     pub async fn start_executor(self: &Arc<Self>) {
         debug!(
             "Starting fedimint client executor (version: {})",
@@ -953,12 +957,10 @@ impl Client {
     }
 
     /// Returns a reference to a typed module client instance by kind
-    pub fn get_first_module<M: ClientModule>(
-        &self,
-        module_kind: &ModuleKind,
-    ) -> (&M, ClientModuleInstance) {
+    pub fn get_first_module<M: ClientModule>(&self) -> (&M, ClientModuleInstance) {
+        let module_kind = M::kind();
         let id = self
-            .get_first_instance(module_kind)
+            .get_first_instance(&module_kind)
             .unwrap_or_else(|| panic!("No modules found of kind {module_kind}"));
         let module: &M = self
             .try_get_module(id)

--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -169,7 +169,7 @@ where
             .init(&ClientModuleInitArgs {
                 federation_id,
                 cfg: typed_cfg.clone(),
-                db,
+                db: db.with_prefix_module_id(instance_id),
                 api_version,
                 module_root_secret,
                 notifier: notifier.module_notifier(instance_id),

--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -177,6 +177,7 @@ where
                 module_api: api.with_module(instance_id),
                 context: ClientContext {
                     client: final_client,
+                    module_instance_id: instance_id,
                 },
             })
             .await?

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -261,7 +261,7 @@ pub fn parse_gateway_id(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Erro
 }
 
 pub async fn get_note_summary(client: &ClientArc) -> anyhow::Result<TieredSummary> {
-    let (mint_client, _) = client.get_first_module::<MintClientModule>();
+    let mint_client = client.get_first_module::<MintClientModule>();
     let summary = mint_client
         .get_wallet_summary(
             &mut client
@@ -279,9 +279,9 @@ pub async fn remint_denomination(
     denomination: Amount,
     quantity: u16,
 ) -> anyhow::Result<()> {
-    let (mint_client, client_module_instance) = client.get_first_module::<MintClientModule>();
+    let mint_client = client.get_first_module::<MintClientModule>();
     let mut dbtx = client.db().begin_transaction().await;
-    let mut module_transaction = dbtx.dbtx_ref_with_prefix_module_id(client_module_instance.id);
+    let mut module_transaction = dbtx.dbtx_ref_with_prefix_module_id(mint_client.id);
     let mut tx = TransactionBuilder::new();
     let operation_id = OperationId::new_random();
     for _ in 0..quantity {
@@ -289,7 +289,7 @@ pub async fn remint_denomination(
             .create_output(&mut module_transaction, operation_id, 1, denomination)
             .await
             .into_iter()
-            .map(|output| output.into_dyn(client_module_instance.id))
+            .map(|output| output.into_dyn(mint_client.id))
             .collect();
 
         tx = tx.with_outputs(outputs);

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -261,7 +261,7 @@ pub fn parse_gateway_id(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Erro
 }
 
 pub async fn get_note_summary(client: &ClientArc) -> anyhow::Result<TieredSummary> {
-    let (mint_client, _) = client.get_first_module::<MintClientModule>(&fedimint_mint_client::KIND);
+    let (mint_client, _) = client.get_first_module::<MintClientModule>();
     let summary = mint_client
         .get_wallet_summary(
             &mut client
@@ -279,8 +279,7 @@ pub async fn remint_denomination(
     denomination: Amount,
     quantity: u16,
 ) -> anyhow::Result<()> {
-    let (mint_client, client_module_instance) =
-        client.get_first_module::<MintClientModule>(&fedimint_mint_client::KIND);
+    let (mint_client, client_module_instance) = client.get_first_module::<MintClientModule>();
     let mut dbtx = client.db().begin_transaction().await;
     let mut module_transaction = dbtx.dbtx_ref_with_prefix_module_id(client_module_instance.id);
     let mut tx = TransactionBuilder::new();

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -166,7 +166,7 @@ async fn pay_valid_invoice(
             assert_eq!(gw_pay_sub.ok().await?, GatewayExtPayStates::Created);
             assert_matches!(gw_pay_sub.ok().await?, GatewayExtPayStates::Preimage { .. });
 
-            let (dummy_module, _instance) = client.get_first_module::<DummyClientModule>();
+            let dummy_module = client.get_first_module::<DummyClientModule>();
             if let GatewayExtPayStates::Success { out_points, .. } = gw_pay_sub.ok().await? {
                 for outpoint in out_points {
                     dummy_module.receive_money(outpoint).await?;
@@ -201,7 +201,7 @@ async fn test_gateway_can_pay_ldk_node() -> anyhow::Result<()> {
 
         let gateway = gateway.remove_client(&fed).await;
         // Print money for user_client
-        let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+        let dummy_module = user_client.get_first_module::<DummyClientModule>();
         let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
         dummy_module.receive_money(outpoint).await?;
         assert_eq!(user_client.get_balance().await, sats(1000));
@@ -224,7 +224,7 @@ async fn test_gateway_client_pay_valid_invoice() -> anyhow::Result<()> {
         |gateway, other_lightning_client, fed, user_client, _| async move {
             let gateway = gateway.remove_client(&fed).await;
             // Print money for user_client
-            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+            let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
             dummy_module.receive_money(outpoint).await?;
             assert_eq!(user_client.get_balance().await, sats(1000));
@@ -249,7 +249,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
         |gateway, other_lightning_client, fed, user_client, _| async move {
             let gateway = gateway.remove_client(&fed).await;
             // Print money for user_client
-            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+            let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
             dummy_module.receive_money(outpoint).await?;
             assert_eq!(user_client.get_balance().await, sats(1000));
@@ -263,9 +263,9 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
             } = user_client.pay_bolt11_invoice(invoice.clone()).await?;
 
             // Try to directly claim the outgoing contract with an invalid preimage
-            let (gateway_module, instance) = gateway.get_first_module::<GatewayClientModule>();
+            let gateway_module = gateway.get_first_module::<GatewayClientModule>();
 
-            let account = instance.api.wait_contract(contract_id).await?;
+            let account = gateway_module.api.wait_contract(contract_id).await?;
             let outgoing_contract = match account.contract {
                 FundedContract::Outgoing(contract) => OutgoingContractAccount {
                     amount: account.amount,
@@ -285,7 +285,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
                 keys: vec![gateway_module.redeem_key],
             };
 
-            let tx = TransactionBuilder::new().with_input(client_input.into_dyn(instance.id));
+            let tx = TransactionBuilder::new().with_input(client_input.into_dyn(gateway_module.id));
             let operation_meta_gen = |_: TransactionId, _: Vec<OutPoint>| GatewayMeta::Pay {};
             let operation_id = OperationId(invoice.payment_hash().into_inner());
             let (txid, _) = gateway
@@ -315,7 +315,7 @@ async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
         |gateway, other_lightning_client, fed, user_client, _| async move {
             let gateway = gateway.remove_client(&fed).await;
             // Print money for user client
-            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+            let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
             dummy_module.receive_money(outpoint).await?;
             assert_eq!(user_client.get_balance().await, sats(1000));
@@ -372,7 +372,7 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
         let gateway = gateway.remove_client(&fed).await;
         // Print money for gateway client
         let initial_gateway_balance = sats(1000);
-        let (dummy_module, _instance) = gateway.get_first_module::<DummyClientModule>();
+        let dummy_module = gateway.get_first_module::<DummyClientModule>();
         let (_, outpoint) = dummy_module.print_money(initial_gateway_balance).await?;
         dummy_module.receive_money(outpoint).await?;
         assert_eq!(gateway.get_balance().await, sats(1000));
@@ -424,7 +424,7 @@ async fn test_gateway_client_intercept_offer_does_not_exist() -> anyhow::Result<
         let gateway = gateway.remove_client(&fed).await;
         // Print money for gateway client
         let initial_gateway_balance = sats(1000);
-        let (dummy_module, _instance) = gateway.get_first_module::<DummyClientModule>();
+        let dummy_module = gateway.get_first_module::<DummyClientModule>();
         let (_, outpoint) = dummy_module.print_money(initial_gateway_balance).await?;
         dummy_module.receive_money(outpoint).await?;
         assert_eq!(gateway.get_balance().await, sats(1000));
@@ -495,9 +495,11 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
             let gateway = gateway.remove_client(&fed).await;
             // Print money for gateway client
             let initial_gateway_balance = sats(1000);
-            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
-            let (_, outpoint) = dummy_module.print_money(initial_gateway_balance).await?;
-            dummy_module.receive_money(outpoint).await?;
+            let gateway_dummy_module = gateway.get_first_module::<DummyClientModule>();
+            let (_, outpoint) = gateway_dummy_module
+                .print_money(initial_gateway_balance)
+                .await?;
+            gateway_dummy_module.receive_money(outpoint).await?;
             assert_eq!(gateway.get_balance().await, sats(1000));
 
             // Create test invoice
@@ -505,7 +507,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
 
             // Create offer with a preimage that doesn't correspond to the payment hash of
             // the invoice
-            let (lightning, instance) = user_client.get_first_module::<LightningClientModule>();
+            let user_lightning_module = user_client.get_first_module::<LightningClientModule>();
 
             let amount = sats(100);
             let preimage = sha256(&[0]);
@@ -514,7 +516,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
                 hash: *invoice.payment_hash(),
                 encrypted_preimage: EncryptedPreimage::new(
                     Preimage(preimage.into_inner()),
-                    &lightning.cfg.threshold_pub_key,
+                    &user_lightning_module.cfg.threshold_pub_key,
                 ),
                 expiry_time: None,
             });
@@ -527,7 +529,8 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
                 output: ln_output,
                 state_machines,
             };
-            let tx = TransactionBuilder::new().with_output(client_output.into_dyn(instance.id));
+            let tx = TransactionBuilder::new()
+                .with_output(client_output.into_dyn(user_lightning_module.id));
             let operation_meta_gen = |txid, _| LightningOperationMeta::Receive {
                 out_point: OutPoint { txid, out_idx: 0 },
                 invoice: invoice.clone(),
@@ -575,7 +578,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
                 } => {
                     // Assert that the gateway got it's refund
                     for outpoint in out_points {
-                        dummy_module.receive_money(outpoint).await?;
+                        gateway_dummy_module.receive_money(outpoint).await?;
                     }
 
                     assert_eq!(initial_gateway_balance, gateway.get_balance().await);
@@ -653,7 +656,7 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
             sleep(Duration::from_secs(2)).await;
 
             // Print money for user_client
-            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+            let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let (_, outpoint) = dummy_module.print_money(sats(2000)).await?;
             dummy_module.receive_money(outpoint).await?;
             assert_eq!(user_client.get_balance().await, sats(2000));
@@ -1072,7 +1075,7 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
             assert_eq!(pre_balances[1], 10_000);
 
             let deposit_amt = msats(5_000);
-            let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
+            let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
             let (_, outpoint) = client1_dummy_module.print_money(deposit_amt).await?;
             client1_dummy_module.receive_money(outpoint).await?;
             assert_eq!(client1.get_balance().await, deposit_amt);
@@ -1175,7 +1178,7 @@ async fn get_balances(
 
 async fn send_msats_to_gateway(gateway: &GatewayTest, id: FederationId, msats: u64) {
     let client = gateway.select_client(id).await;
-    let (dummy_module, _instance) = client.get_first_module::<DummyClientModule>();
+    let dummy_module = client.get_first_module::<DummyClientModule>();
     let (_, outpoint) = dummy_module
         .print_money(Amount::from_msats(msats))
         .await

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -16,7 +16,7 @@ use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::task::sleep;
 use fedimint_core::util::{NextOrPending, SafeUrl};
 use fedimint_core::{msats, sats, Amount, OutPoint, TransactionId};
-use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
+use fedimint_dummy_client::{DummyClientGen, DummyClientModule};
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyGen;
 use fedimint_ln_client::pay::PayInvoicePayload;
@@ -136,7 +136,7 @@ pub fn sha256(data: &[u8]) -> sha256::Hash {
 async fn pay_valid_invoice(
     invoice: Bolt11Invoice,
     user_client: &ClientArc,
-    gateway: &ClientArc,
+    client: &ClientArc,
 ) -> anyhow::Result<()> {
     // User client pays test invoice
     let OutgoingLightningPayment {
@@ -158,16 +158,18 @@ async fn pay_valid_invoice(
                 preimage_auth: Hash::hash(&[0; 32]),
             };
 
-            let gw_pay_op = gateway.gateway_pay_bolt11_invoice(payload).await?;
-            let mut gw_pay_sub = gateway
+            let gw_pay_op = client.gateway_pay_bolt11_invoice(payload).await?;
+            let mut gw_pay_sub = client
                 .gateway_subscribe_ln_pay(gw_pay_op)
                 .await?
                 .into_stream();
             assert_eq!(gw_pay_sub.ok().await?, GatewayExtPayStates::Created);
             assert_matches!(gw_pay_sub.ok().await?, GatewayExtPayStates::Preimage { .. });
+
+            let (dummy_module, _instance) = client.get_first_module::<DummyClientModule>();
             if let GatewayExtPayStates::Success { out_points, .. } = gw_pay_sub.ok().await? {
                 for outpoint in out_points {
-                    gateway.receive_money(outpoint).await?;
+                    dummy_module.receive_money(outpoint).await?;
                 }
             } else {
                 panic!("Gateway pay state machine was not successful");
@@ -199,8 +201,9 @@ async fn test_gateway_can_pay_ldk_node() -> anyhow::Result<()> {
 
         let gateway = gateway.remove_client(&fed).await;
         // Print money for user_client
-        let (_, outpoint) = user_client.print_money(sats(1000)).await?;
-        user_client.receive_money(outpoint).await?;
+        let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+        let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
+        dummy_module.receive_money(outpoint).await?;
         assert_eq!(user_client.get_balance().await, sats(1000));
 
         // Create test invoice
@@ -221,8 +224,9 @@ async fn test_gateway_client_pay_valid_invoice() -> anyhow::Result<()> {
         |gateway, other_lightning_client, fed, user_client, _| async move {
             let gateway = gateway.remove_client(&fed).await;
             // Print money for user_client
-            let (_, outpoint) = user_client.print_money(sats(1000)).await?;
-            user_client.receive_money(outpoint).await?;
+            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+            let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
+            dummy_module.receive_money(outpoint).await?;
             assert_eq!(user_client.get_balance().await, sats(1000));
 
             // Create test invoice
@@ -245,8 +249,9 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
         |gateway, other_lightning_client, fed, user_client, _| async move {
             let gateway = gateway.remove_client(&fed).await;
             // Print money for user_client
-            let (_, outpoint) = user_client.print_money(sats(1000)).await?;
-            user_client.receive_money(outpoint).await?;
+            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+            let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
+            dummy_module.receive_money(outpoint).await?;
             assert_eq!(user_client.get_balance().await, sats(1000));
 
             // Fund outgoing contract that the user client expects the gateway to pay
@@ -258,8 +263,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
             } = user_client.pay_bolt11_invoice(invoice.clone()).await?;
 
             // Try to directly claim the outgoing contract with an invalid preimage
-            let (gateway_module, instance) =
-                gateway.get_first_module::<GatewayClientModule>(&fedimint_ln_common::KIND);
+            let (gateway_module, instance) = gateway.get_first_module::<GatewayClientModule>();
 
             let account = instance.api.wait_contract(contract_id).await?;
             let outgoing_contract = match account.contract {
@@ -294,7 +298,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
                 .await?;
 
             // Assert that we did not get paid for claiming a contract with a bogus preimage
-            assert!(gateway
+            assert!(dummy_module
                 .receive_money(OutPoint { txid, out_idx: 0 })
                 .await
                 .is_err());
@@ -311,8 +315,9 @@ async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
         |gateway, other_lightning_client, fed, user_client, _| async move {
             let gateway = gateway.remove_client(&fed).await;
             // Print money for user client
-            let (_, outpoint) = user_client.print_money(sats(1000)).await?;
-            user_client.receive_money(outpoint).await?;
+            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+            let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
+            dummy_module.receive_money(outpoint).await?;
             assert_eq!(user_client.get_balance().await, sats(1000));
 
             // Create invoice that cannout be paid
@@ -367,8 +372,9 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
         let gateway = gateway.remove_client(&fed).await;
         // Print money for gateway client
         let initial_gateway_balance = sats(1000);
-        let (_, outpoint) = gateway.print_money(initial_gateway_balance).await?;
-        gateway.receive_money(outpoint).await?;
+        let (dummy_module, _instance) = gateway.get_first_module::<DummyClientModule>();
+        let (_, outpoint) = dummy_module.print_money(initial_gateway_balance).await?;
+        dummy_module.receive_money(outpoint).await?;
         assert_eq!(gateway.get_balance().await, sats(1000));
 
         // User client creates invoice in federation
@@ -418,8 +424,9 @@ async fn test_gateway_client_intercept_offer_does_not_exist() -> anyhow::Result<
         let gateway = gateway.remove_client(&fed).await;
         // Print money for gateway client
         let initial_gateway_balance = sats(1000);
-        let (_, outpoint) = gateway.print_money(initial_gateway_balance).await?;
-        gateway.receive_money(outpoint).await?;
+        let (dummy_module, _instance) = gateway.get_first_module::<DummyClientModule>();
+        let (_, outpoint) = dummy_module.print_money(initial_gateway_balance).await?;
+        dummy_module.receive_money(outpoint).await?;
         assert_eq!(gateway.get_balance().await, sats(1000));
 
         // Create HTLC that doesn't correspond to an offer in the federation
@@ -488,8 +495,9 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
             let gateway = gateway.remove_client(&fed).await;
             // Print money for gateway client
             let initial_gateway_balance = sats(1000);
-            let (_, outpoint) = gateway.print_money(initial_gateway_balance).await?;
-            gateway.receive_money(outpoint).await?;
+            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+            let (_, outpoint) = dummy_module.print_money(initial_gateway_balance).await?;
+            dummy_module.receive_money(outpoint).await?;
             assert_eq!(gateway.get_balance().await, sats(1000));
 
             // Create test invoice
@@ -497,8 +505,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
 
             // Create offer with a preimage that doesn't correspond to the payment hash of
             // the invoice
-            let (lightning, instance) =
-                user_client.get_first_module::<LightningClientModule>(&fedimint_ln_common::KIND);
+            let (lightning, instance) = user_client.get_first_module::<LightningClientModule>();
 
             let amount = sats(100);
             let preimage = sha256(&[0]);
@@ -568,7 +575,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
                 } => {
                     // Assert that the gateway got it's refund
                     for outpoint in out_points {
-                        gateway.receive_money(outpoint).await?;
+                        dummy_module.receive_money(outpoint).await?;
                     }
 
                     assert_eq!(initial_gateway_balance, gateway.get_balance().await);
@@ -646,8 +653,9 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
             sleep(Duration::from_secs(2)).await;
 
             // Print money for user_client
-            let (_, outpoint) = user_client.print_money(sats(2000)).await?;
-            user_client.receive_money(outpoint).await?;
+            let (dummy_module, _instance) = user_client.get_first_module::<DummyClientModule>();
+            let (_, outpoint) = dummy_module.print_money(sats(2000)).await?;
+            dummy_module.receive_money(outpoint).await?;
             assert_eq!(user_client.get_balance().await, sats(2000));
 
             // User client pays test invoice
@@ -1064,8 +1072,9 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
             assert_eq!(pre_balances[1], 10_000);
 
             let deposit_amt = msats(5_000);
-            let (_, outpoint) = client1.print_money(deposit_amt).await?;
-            client1.receive_money(outpoint).await?;
+            let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
+            let (_, outpoint) = client1_dummy_module.print_money(deposit_amt).await?;
+            client1_dummy_module.receive_money(outpoint).await?;
             assert_eq!(client1.get_balance().await, deposit_amt);
 
             // User creates invoice in federation 2
@@ -1166,6 +1175,10 @@ async fn get_balances(
 
 async fn send_msats_to_gateway(gateway: &GatewayTest, id: FederationId, msats: u64) {
     let client = gateway.select_client(id).await;
-    let (_, outpoint) = client.print_money(Amount::from_msats(msats)).await.unwrap();
-    client.receive_money(outpoint).await.unwrap();
+    let (dummy_module, _instance) = client.get_first_module::<DummyClientModule>();
+    let (_, outpoint) = dummy_module
+        .print_money(Amount::from_msats(msats))
+        .await
+        .unwrap();
+    dummy_module.receive_money(outpoint).await.unwrap();
 }

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -97,6 +97,8 @@ impl ClientModule for DummyClientModule {
         id: OperationId,
         amount: Amount,
     ) -> anyhow::Result<Vec<ClientInput<<Self::Common as ModuleCommon>::Input, Self::States>>> {
+        dbtx.ensure_isolated().expect("must be isolated");
+
         // Check and subtract from our funds
         let funds = get_funds(dbtx).await;
         if funds < amount {
@@ -237,6 +239,7 @@ impl DummyClientModule {
         account: XOnlyPublicKey,
         amount: Amount,
     ) -> anyhow::Result<OutPoint> {
+        self.db.ensure_isolated().expect("must be isolated");
         let mut dbtx = self.db.begin_transaction().await;
         let op_id = OperationId(rand::random());
 

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -49,7 +49,7 @@ use fedimint_ln_common::contracts::{
 use fedimint_ln_common::{
     ln_operation, ContractOutput, LightningClientContext, LightningCommonGen, LightningGateway,
     LightningGatewayAnnouncement, LightningGatewayRegistration, LightningModuleTypes,
-    LightningOutput, KIND,
+    LightningOutput,
 };
 use futures::StreamExt;
 use incoming::IncomingSmError;
@@ -223,7 +223,7 @@ async fn invoice_routes_back_to_federation(
 #[apply(async_trait_maybe_send!)]
 impl LightningClientExt for ClientArc {
     async fn select_active_gateway(&self) -> anyhow::Result<LightningGateway> {
-        let (_lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
+        let (_lightning, instance) = self.get_first_module::<LightningClientModule>();
         let mut dbtx = instance.db.begin_transaction().await;
         match dbtx.get_value(&LightningGatewayKey).await {
             Some(active_gateway) => Ok(active_gateway.info),
@@ -239,7 +239,7 @@ impl LightningClientExt for ClientArc {
 
     /// Switches the clients active gateway to a registered gateway.
     async fn set_active_gateway(&self, gateway_id: &secp256k1::PublicKey) -> anyhow::Result<()> {
-        let (_lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
+        let (_lightning, instance) = self.get_first_module::<LightningClientModule>();
         let mut dbtx = instance.db.begin_transaction().await;
 
         let gateways = self.fetch_registered_gateways().await?;
@@ -261,7 +261,7 @@ impl LightningClientExt for ClientArc {
     }
 
     async fn fetch_registered_gateways(&self) -> anyhow::Result<Vec<LightningGatewayAnnouncement>> {
-        let (_lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
+        let (_lightning, instance) = self.get_first_module::<LightningClientModule>();
         Ok(instance.api.fetch_gateways().await?)
     }
 
@@ -269,7 +269,7 @@ impl LightningClientExt for ClientArc {
         &self,
         invoice: Bolt11Invoice,
     ) -> anyhow::Result<OutgoingLightningPayment> {
-        let (lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
+        let (lightning, instance) = self.get_first_module::<LightningClientModule>();
         let mut dbtx = instance.db.begin_transaction().await;
         let prev_payment_result = lightning
             .get_prev_payment_result(invoice.payment_hash(), &mut dbtx)
@@ -395,7 +395,7 @@ impl LightningClientExt for ClientArc {
         expiry_time: Option<u64>,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, Bolt11Invoice)> {
-        let (lightning, instance) = self.get_first_module::<LightningClientModule>(&KIND);
+        let (lightning, instance) = self.get_first_module::<LightningClientModule>();
         let (src_node_id, short_channel_id, route_hints) = match self.select_active_gateway().await
         {
             Ok(active_gateway) => (
@@ -472,7 +472,7 @@ impl LightningClientExt for ClientArc {
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
                 let lightning = client
-                    .get_first_module::<LightningClientModule>(&KIND)
+                    .get_first_module::<LightningClientModule>()
                     .0;
 
                 yield LnReceiveState::Created;
@@ -525,7 +525,7 @@ impl LightningClientExt for ClientArc {
 
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
-                let lightning = client.get_first_module::<LightningClientModule>(&KIND).0;
+                let lightning = client.get_first_module::<LightningClientModule>().0;
 
                 yield LnPayState::Created;
 
@@ -580,7 +580,7 @@ impl LightningClientExt for ClientArc {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<UpdateStreamOrOutcome<InternalPayState>> {
-        let (lightning, _instance) = self.get_first_module::<LightningClientModule>(&KIND);
+        let (lightning, _instance) = self.get_first_module::<LightningClientModule>();
 
         let operation = ln_operation(self, operation_id).await?;
         let mut stream = lightning.notifier.subscribe(operation_id).await;
@@ -722,6 +722,7 @@ pub struct LightningClientModule {
 }
 
 impl ClientModule for LightningClientModule {
+    type Init = LightningClientGen;
     type Common = LightningModuleTypes;
     type ModuleStateMachineContext = LightningClientContext;
     type States = LightningClientStateMachines;

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -223,8 +223,8 @@ async fn invoice_routes_back_to_federation(
 #[apply(async_trait_maybe_send!)]
 impl LightningClientExt for ClientArc {
     async fn select_active_gateway(&self) -> anyhow::Result<LightningGateway> {
-        let (_lightning, instance) = self.get_first_module::<LightningClientModule>();
-        let mut dbtx = instance.db.begin_transaction().await;
+        let lightning = self.get_first_module::<LightningClientModule>();
+        let mut dbtx = lightning.db.begin_transaction().await;
         match dbtx.get_value(&LightningGatewayKey).await {
             Some(active_gateway) => Ok(active_gateway.info),
             None => self
@@ -239,8 +239,8 @@ impl LightningClientExt for ClientArc {
 
     /// Switches the clients active gateway to a registered gateway.
     async fn set_active_gateway(&self, gateway_id: &secp256k1::PublicKey) -> anyhow::Result<()> {
-        let (_lightning, instance) = self.get_first_module::<LightningClientModule>();
-        let mut dbtx = instance.db.begin_transaction().await;
+        let lightning = self.get_first_module::<LightningClientModule>();
+        let mut dbtx = lightning.db.begin_transaction().await;
 
         let gateways = self.fetch_registered_gateways().await?;
         if gateways.is_empty() {
@@ -261,16 +261,16 @@ impl LightningClientExt for ClientArc {
     }
 
     async fn fetch_registered_gateways(&self) -> anyhow::Result<Vec<LightningGatewayAnnouncement>> {
-        let (_lightning, instance) = self.get_first_module::<LightningClientModule>();
-        Ok(instance.api.fetch_gateways().await?)
+        let lightning = self.get_first_module::<LightningClientModule>();
+        Ok(lightning.api.fetch_gateways().await?)
     }
 
     async fn pay_bolt11_invoice(
         &self,
         invoice: Bolt11Invoice,
     ) -> anyhow::Result<OutgoingLightningPayment> {
-        let (lightning, instance) = self.get_first_module::<LightningClientModule>();
-        let mut dbtx = instance.db.begin_transaction().await;
+        let lightning = self.get_first_module::<LightningClientModule>();
+        let mut dbtx = lightning.db.begin_transaction().await;
         let prev_payment_result = lightning
             .get_prev_payment_result(invoice.payment_hash(), &mut dbtx)
             .await;
@@ -322,10 +322,11 @@ impl LightningClientExt for ClientArc {
             (PayType::Internal(operation_id), output, contract_id)
         } else {
             let active_gateway = self.select_active_gateway().await?;
+            let api = lightning.api.clone();
             let (output, contract_id) = lightning
                 .create_outgoing_output(
                     operation_id,
-                    instance.api,
+                    api,
                     invoice.clone(),
                     active_gateway,
                     self.get_config().global.federation_id(),
@@ -361,7 +362,7 @@ impl LightningClientExt for ClientArc {
             }
             _ => unreachable!("User client will only create contract outputs on spend"),
         };
-        let tx = TransactionBuilder::new().with_output(output.into_dyn(instance.id));
+        let tx = TransactionBuilder::new().with_output(output.into_dyn(lightning.id));
         let operation_meta_gen = |txid, change| LightningOperationMeta::Pay {
             out_point: OutPoint { txid, out_idx: 0 },
             invoice: invoice.clone(),
@@ -395,7 +396,7 @@ impl LightningClientExt for ClientArc {
         expiry_time: Option<u64>,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, Bolt11Invoice)> {
-        let (lightning, instance) = self.get_first_module::<LightningClientModule>();
+        let lightning = self.get_first_module::<LightningClientModule>();
         let (src_node_id, short_channel_id, route_hints) = match self.select_active_gateway().await
         {
             Ok(active_gateway) => (
@@ -421,7 +422,7 @@ impl LightningClientExt for ClientArc {
                 lightning.cfg.network,
             )
             .await?;
-        let tx = TransactionBuilder::new().with_output(output.into_dyn(instance.id));
+        let tx = TransactionBuilder::new().with_output(output.into_dyn(lightning.id));
         let extra_meta = serde_json::to_value(extra_meta).expect("extra_meta is serializable");
         let operation_meta_gen = |txid, _| LightningOperationMeta::Receive {
             out_point: OutPoint { txid, out_idx: 0 },
@@ -472,8 +473,7 @@ impl LightningClientExt for ClientArc {
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
                 let lightning = client
-                    .get_first_module::<LightningClientModule>()
-                    .0;
+                    .get_first_module::<LightningClientModule>();
 
                 yield LnReceiveState::Created;
 
@@ -525,7 +525,7 @@ impl LightningClientExt for ClientArc {
 
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
-                let lightning = client.get_first_module::<LightningClientModule>().0;
+                let lightning = client.get_first_module::<LightningClientModule>();
 
                 yield LnPayState::Created;
 
@@ -580,7 +580,7 @@ impl LightningClientExt for ClientArc {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<UpdateStreamOrOutcome<InternalPayState>> {
-        let (lightning, _instance) = self.get_first_module::<LightningClientModule>();
+        let lightning = self.get_first_module::<LightningClientModule>();
 
         let operation = ln_operation(self, operation_id).await?;
         let mut stream = lightning.notifier.subscribe(operation_id).await;

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -4,7 +4,7 @@ use anyhow::bail;
 use assert_matches::assert_matches;
 use fedimint_core::util::NextOrPending;
 use fedimint_core::{sats, Amount};
-use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
+use fedimint_dummy_client::{DummyClientGen, DummyClientModule};
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyGen;
 use fedimint_ln_client::{
@@ -75,9 +75,10 @@ async fn test_can_attach_extra_meta_to_receive_operation() -> anyhow::Result<()>
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
     let (client1, client2) = fed.two_clients().await;
+    let (client2_dummy_module, _instance) = client2.get_first_module::<DummyClientModule>();
 
     // Print money for client2
-    let (op, outpoint) = client2.print_money(sats(1000)).await?;
+    let (op, outpoint) = client2_dummy_module.print_money(sats(1000)).await?;
     client2.await_primary_module_output(op, outpoint).await?;
 
     let extra_meta = "internal payment with no gateway registered".to_string();
@@ -129,9 +130,10 @@ async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
     let (client1, client2) = fed.two_clients().await;
+    let (client2_dummy_module, _instance) = client2.get_first_module::<DummyClientModule>();
 
     // Print money for client2
-    let (op, outpoint) = client2.print_money(sats(1000)).await?;
+    let (op, outpoint) = client2_dummy_module.print_money(sats(1000)).await?;
     client2.await_primary_module_output(op, outpoint).await?;
 
     // TEST internal payment when there are no gateways registered
@@ -188,13 +190,15 @@ async fn gateway_protects_preimage_for_payment() -> anyhow::Result<()> {
     let fed = fixtures.new_fed().await;
     let (client1, client2) = fed.two_clients().await;
     let gw = gateway(&fixtures, &fed).await;
+    let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
+    let (client2_dummy_module, _instance) = client2.get_first_module::<DummyClientModule>();
 
     // Print money for client1
-    let (op, outpoint) = client1.print_money(sats(10000)).await?;
+    let (op, outpoint) = client1_dummy_module.print_money(sats(10000)).await?;
     client1.await_primary_module_output(op, outpoint).await?;
 
     // Print money for client2
-    let (op, outpoint) = client2.print_money(sats(10000)).await?;
+    let (op, outpoint) = client2_dummy_module.print_money(sats(10000)).await?;
     client2.await_primary_module_output(op, outpoint).await?;
 
     let cln = fixtures.cln().await;
@@ -246,9 +250,10 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
     let fed = fixtures.new_fed().await;
     let client = fed.new_client().await;
     let gw = gateway(&fixtures, &fed).await;
+    let (dummy_module, _instance) = client.get_first_module::<DummyClientModule>();
 
     // Print money for client
-    let (op, outpoint) = client.print_money(sats(1000)).await?;
+    let (op, outpoint) = dummy_module.print_money(sats(1000)).await?;
     client.await_primary_module_output(op, outpoint).await?;
 
     let cln = fixtures.cln().await;
@@ -304,9 +309,10 @@ async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
     let (client1, client2) = fed.two_clients().await;
+    let (client2_dummy_module, _instance) = client2.get_first_module::<DummyClientModule>();
 
     // Print money for client2
-    let (op, outpoint) = client2.print_money(sats(1000)).await?;
+    let (op, outpoint) = client2_dummy_module.print_money(sats(1000)).await?;
     client2.await_primary_module_output(op, outpoint).await?;
 
     // TEST internal payment when there are no gateways registered

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -75,7 +75,7 @@ async fn test_can_attach_extra_meta_to_receive_operation() -> anyhow::Result<()>
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
     let (client1, client2) = fed.two_clients().await;
-    let (client2_dummy_module, _instance) = client2.get_first_module::<DummyClientModule>();
+    let client2_dummy_module = client2.get_first_module::<DummyClientModule>();
 
     // Print money for client2
     let (op, outpoint) = client2_dummy_module.print_money(sats(1000)).await?;
@@ -130,7 +130,7 @@ async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
     let (client1, client2) = fed.two_clients().await;
-    let (client2_dummy_module, _instance) = client2.get_first_module::<DummyClientModule>();
+    let client2_dummy_module = client2.get_first_module::<DummyClientModule>();
 
     // Print money for client2
     let (op, outpoint) = client2_dummy_module.print_money(sats(1000)).await?;
@@ -190,8 +190,8 @@ async fn gateway_protects_preimage_for_payment() -> anyhow::Result<()> {
     let fed = fixtures.new_fed().await;
     let (client1, client2) = fed.two_clients().await;
     let gw = gateway(&fixtures, &fed).await;
-    let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
-    let (client2_dummy_module, _instance) = client2.get_first_module::<DummyClientModule>();
+    let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
+    let client2_dummy_module = client2.get_first_module::<DummyClientModule>();
 
     // Print money for client1
     let (op, outpoint) = client1_dummy_module.print_money(sats(10000)).await?;
@@ -250,7 +250,7 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
     let fed = fixtures.new_fed().await;
     let client = fed.new_client().await;
     let gw = gateway(&fixtures, &fed).await;
-    let (dummy_module, _instance) = client.get_first_module::<DummyClientModule>();
+    let dummy_module = client.get_first_module::<DummyClientModule>();
 
     // Print money for client
     let (op, outpoint) = dummy_module.print_money(sats(1000)).await?;
@@ -309,7 +309,7 @@ async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
     let (client1, client2) = fed.two_clients().await;
-    let (client2_dummy_module, _instance) = client2.get_first_module::<DummyClientModule>();
+    let client2_dummy_module = client2.get_first_module::<DummyClientModule>();
 
     // Print money for client2
     let (op, outpoint) = client2_dummy_module.print_money(sats(1000)).await?;

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -256,7 +256,7 @@ impl MintClientExt for ClientArc {
         oob_notes: OOBNotes,
         extra_meta: M,
     ) -> anyhow::Result<OperationId> {
-        let (mint, instance) = self.get_first_module::<MintClientModule>(&KIND);
+        let (mint, instance) = self.get_first_module::<MintClientModule>();
         let OOBNotes {
             federation_id_prefix,
             notes,
@@ -326,7 +326,7 @@ impl MintClientExt for ClientArc {
 
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
-                let mint = client.get_first_module::<MintClientModule>(&KIND).0;
+                let mint = client.get_first_module::<MintClientModule>().0;
 
                 yield ReissueExternalNotesState::Created;
 
@@ -378,7 +378,7 @@ impl MintClientExt for ClientArc {
         try_cancel_after: Duration,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, OOBNotes)> {
-        let (mint, instance) = self.get_first_module::<MintClientModule>(&KIND);
+        let (mint, instance) = self.get_first_module::<MintClientModule>();
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientExt::spend_notes extra_meta is serializable");
 
@@ -437,7 +437,7 @@ impl MintClientExt for ClientArc {
     }
 
     async fn validate_notes(&self, oob_notes: OOBNotes) -> anyhow::Result<Amount> {
-        let (mint, _instance) = self.get_first_module::<MintClientModule>(&KIND);
+        let (mint, _instance) = self.get_first_module::<MintClientModule>();
         let OOBNotes {
             federation_id_prefix,
             notes,
@@ -468,7 +468,7 @@ impl MintClientExt for ClientArc {
     }
 
     async fn try_cancel_spend_notes(&self, operation_id: OperationId) {
-        let (mint, _instance) = self.get_first_module::<MintClientModule>(&KIND);
+        let (mint, _instance) = self.get_first_module::<MintClientModule>();
 
         // TODO: make robust by writing to the DB, this can fail
         let _ = mint.cancel_oob_payment_bc.send(operation_id);
@@ -490,7 +490,7 @@ impl MintClientExt for ClientArc {
 
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
-                let mint = client.get_first_module::<MintClientModule>(&KIND).0;
+                let mint = client.get_first_module::<MintClientModule>().0;
 
                 yield SpendOOBState::Created;
 
@@ -535,7 +535,7 @@ impl MintClientExt for ClientArc {
 
     /// Waits for the mint backup restoration to finish
     async fn await_restore_finished(&self) -> anyhow::Result<Amount> {
-        let (mint, _instance) = self.get_first_module::<MintClientModule>(&KIND);
+        let (mint, _instance) = self.get_first_module::<MintClientModule>();
         mint.await_restore_finished().await
     }
 }
@@ -699,6 +699,7 @@ impl Context for MintClientContext {}
 
 #[apply(async_trait_maybe_send!)]
 impl ClientModule for MintClientModule {
+    type Init = MintClientGen;
     type Common = MintModuleTypes;
     type ModuleStateMachineContext = MintClientContext;
     type States = MintClientStateMachines;

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -256,7 +256,7 @@ impl MintClientExt for ClientArc {
         oob_notes: OOBNotes,
         extra_meta: M,
     ) -> anyhow::Result<OperationId> {
-        let (mint, instance) = self.get_first_module::<MintClientModule>();
+        let mint = self.get_first_module::<MintClientModule>();
         let OOBNotes {
             federation_id_prefix,
             notes,
@@ -281,7 +281,7 @@ impl MintClientExt for ClientArc {
             .create_input_from_notes(operation_id, notes)
             .await?
             .into_iter()
-            .map(|input| input.into_dyn(instance.id))
+            .map(|input| input.into_dyn(mint.id))
             .collect();
 
         let tx = TransactionBuilder::new().with_inputs(mint_input);
@@ -326,7 +326,7 @@ impl MintClientExt for ClientArc {
 
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
-                let mint = client.get_first_module::<MintClientModule>().0;
+                let mint = client.get_first_module::<MintClientModule>();
 
                 yield ReissueExternalNotesState::Created;
 
@@ -378,7 +378,10 @@ impl MintClientExt for ClientArc {
         try_cancel_after: Duration,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, OOBNotes)> {
-        let (mint, instance) = self.get_first_module::<MintClientModule>();
+        let mint = self.get_first_module::<MintClientModule>();
+        let mint_id = mint.id;
+        let federation_id_prefix = mint.federation_id.to_prefix();
+        let mint = &*mint;
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientExt::spend_notes extra_meta is serializable");
 
@@ -389,21 +392,18 @@ impl MintClientExt for ClientArc {
                     Box::pin(async move {
                         let (operation_id, states, notes) = mint
                             .spend_notes_oob(
-                                &mut dbtx.dbtx_ref_with_prefix_module_id(instance.id),
+                                &mut dbtx.dbtx_ref_with_prefix_module_id(mint_id),
                                 notes_selector,
                                 requested_amount,
                                 try_cancel_after,
                             )
                             .await?;
                         let oob_notes = OOBNotes {
-                            federation_id_prefix: mint.federation_id.to_prefix(),
+                            federation_id_prefix,
                             notes,
                         };
 
-                        let dyn_states = states
-                            .into_iter()
-                            .map(|s| s.into_dyn(instance.id))
-                            .collect();
+                        let dyn_states = states.into_iter().map(|s| s.into_dyn(mint_id)).collect();
 
                         self.add_state_machines(dbtx, dyn_states).await?;
                         self.operation_log()
@@ -437,7 +437,7 @@ impl MintClientExt for ClientArc {
     }
 
     async fn validate_notes(&self, oob_notes: OOBNotes) -> anyhow::Result<Amount> {
-        let (mint, _instance) = self.get_first_module::<MintClientModule>();
+        let mint = self.get_first_module::<MintClientModule>();
         let OOBNotes {
             federation_id_prefix,
             notes,
@@ -468,7 +468,7 @@ impl MintClientExt for ClientArc {
     }
 
     async fn try_cancel_spend_notes(&self, operation_id: OperationId) {
-        let (mint, _instance) = self.get_first_module::<MintClientModule>();
+        let mint = self.get_first_module::<MintClientModule>();
 
         // TODO: make robust by writing to the DB, this can fail
         let _ = mint.cancel_oob_payment_bc.send(operation_id);
@@ -490,7 +490,7 @@ impl MintClientExt for ClientArc {
 
         Ok(operation.outcome_or_updates(self.db(), operation_id, || {
             stream! {
-                let mint = client.get_first_module::<MintClientModule>().0;
+                let mint = client.get_first_module::<MintClientModule>();
 
                 yield SpendOOBState::Created;
 
@@ -535,7 +535,7 @@ impl MintClientExt for ClientArc {
 
     /// Waits for the mint backup restoration to finish
     async fn await_restore_finished(&self) -> anyhow::Result<Amount> {
-        let (mint, _instance) = self.get_first_module::<MintClientModule>();
+        let mint = self.get_first_module::<MintClientModule>();
         mint.await_restore_finished().await
     }
 }

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -20,7 +20,7 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     // Print notes for client1
     let fed = fixtures().new_fed().await;
     let (client1, client2) = fed.two_clients().await;
-    let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
+    let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
     let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
     client1.await_primary_module_output(op, outpoint).await?;
 
@@ -47,7 +47,7 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
     // Print notes for client1
     let fed = fixtures().new_fed().await;
     let (client1, _client2) = fed.two_clients().await;
-    let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
+    let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
     let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
     client1.await_primary_module_output(op, outpoint).await?;
 
@@ -67,7 +67,7 @@ async fn error_zero_value_oob_receive() -> anyhow::Result<()> {
     // Print notes for client1
     let fed = fixtures().new_fed().await;
     let (client1, _client2) = fed.two_clients().await;
-    let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
+    let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
     let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
     client1.await_primary_module_output(op, outpoint).await?;
 

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -1,6 +1,6 @@
 use fedimint_core::util::NextOrPending;
 use fedimint_core::{sats, Amount};
-use fedimint_dummy_client::{DummyClientExt, DummyClientGen};
+use fedimint_dummy_client::{DummyClientGen, DummyClientModule};
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyGen;
 use fedimint_mint_client::{
@@ -20,7 +20,8 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     // Print notes for client1
     let fed = fixtures().new_fed().await;
     let (client1, client2) = fed.two_clients().await;
-    let (op, outpoint) = client1.print_money(sats(1000)).await?;
+    let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
+    let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
     client1.await_primary_module_output(op, outpoint).await?;
 
     // Spend from client1 to client2
@@ -46,7 +47,8 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
     // Print notes for client1
     let fed = fixtures().new_fed().await;
     let (client1, _client2) = fed.two_clients().await;
-    let (op, outpoint) = client1.print_money(sats(1000)).await?;
+    let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
+    let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
     client1.await_primary_module_output(op, outpoint).await?;
 
     // Spend from client1 to client2
@@ -65,7 +67,8 @@ async fn error_zero_value_oob_receive() -> anyhow::Result<()> {
     // Print notes for client1
     let fed = fixtures().new_fed().await;
     let (client1, _client2) = fed.two_clients().await;
-    let (op, outpoint) = client1.print_money(sats(1000)).await?;
+    let (client1_dummy_module, _instance) = client1.get_first_module::<DummyClientModule>();
+    let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
     client1.await_primary_module_output(op, outpoint).await?;
 
     // Spend from client1 to client2

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -132,8 +132,7 @@ impl WalletClientExt for ClientArc {
         &self,
         valid_until: SystemTime,
     ) -> anyhow::Result<(OperationId, Address)> {
-        let (wallet_client, instance) =
-            self.get_first_module::<WalletClientModule>(&WalletCommonGen::KIND);
+        let (wallet_client, instance) = self.get_first_module::<WalletClientModule>();
 
         let (operation_id, address) = self
             .db()
@@ -188,8 +187,7 @@ impl WalletClientExt for ClientArc {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<UpdateStreamOrOutcome<DepositState>> {
-        let (wallet_client, _) =
-            self.get_first_module::<WalletClientModule>(&WalletCommonGen::KIND);
+        let (wallet_client, _) = self.get_first_module::<WalletClientModule>();
 
         let operation_log_entry = self
             .operation_log()
@@ -270,8 +268,7 @@ impl WalletClientExt for ClientArc {
         address: Address,
         amount: bitcoin::Amount,
     ) -> anyhow::Result<PegOutFees> {
-        let (wallet_client, _) =
-            self.get_first_module::<WalletClientModule>(&WalletCommonGen::KIND);
+        let (wallet_client, _) = self.get_first_module::<WalletClientModule>();
 
         wallet_client.get_withdraw_fees(address, amount).await
     }
@@ -282,8 +279,7 @@ impl WalletClientExt for ClientArc {
         amount: bitcoin::Amount,
         fee: PegOutFees,
     ) -> anyhow::Result<OperationId> {
-        let (wallet_client, instance) =
-            self.get_first_module::<WalletClientModule>(&WalletCommonGen::KIND);
+        let (wallet_client, instance) = self.get_first_module::<WalletClientModule>();
 
         let operation_id = OperationId(thread_rng().gen());
 
@@ -310,8 +306,7 @@ impl WalletClientExt for ClientArc {
     }
 
     async fn rbf_withdraw(&self, rbf: Rbf) -> anyhow::Result<OperationId> {
-        let (wallet_client, instance) =
-            self.get_first_module::<WalletClientModule>(&WalletCommonGen::KIND);
+        let (wallet_client, instance) = self.get_first_module::<WalletClientModule>();
 
         let operation_id = OperationId(thread_rng().gen());
 
@@ -339,8 +334,7 @@ impl WalletClientExt for ClientArc {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<UpdateStreamOrOutcome<WithdrawState>> {
-        let (wallet_client, _) =
-            self.get_first_module::<WalletClientModule>(&WalletCommonGen::KIND);
+        let (wallet_client, _) = self.get_first_module::<WalletClientModule>();
 
         let operation = self
             .operation_log()
@@ -523,6 +517,7 @@ pub struct WalletClientModule {
 }
 
 impl ClientModule for WalletClientModule {
+    type Init = WalletClientGen;
     type Common = WalletModuleTypes;
     type ModuleStateMachineContext = WalletClientContext;
     type States = WalletClientStates;

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -132,17 +132,18 @@ impl WalletClientExt for ClientArc {
         &self,
         valid_until: SystemTime,
     ) -> anyhow::Result<(OperationId, Address)> {
-        let (wallet_client, instance) = self.get_first_module::<WalletClientModule>();
+        let wallet_client = self.get_first_module::<WalletClientModule>();
+        let wallet_client_id = wallet_client.id;
 
         let (operation_id, address) = self
             .db()
             .autocommit(
                 |dbtx| {
-                    Box::pin(async move {
+                    Box::pin(async {
                         let (operation_id, sm, address) = wallet_client
                             .get_deposit_address(
                                 valid_until,
-                                &mut dbtx.dbtx_ref_with_prefix_module_id(instance.id),
+                                &mut dbtx.dbtx_ref_with_prefix_module_id(wallet_client_id),
                             )
                             .await;
 
@@ -152,8 +153,11 @@ impl WalletClientExt for ClientArc {
                             .watch_script_history(&address.script_pubkey())
                             .await?;
 
-                        self.add_state_machines(dbtx, vec![DynState::from_typed(instance.id, sm)])
-                            .await?;
+                        self.add_state_machines(
+                            dbtx,
+                            vec![DynState::from_typed(wallet_client.id, sm)],
+                        )
+                        .await?;
                         self.operation_log()
                             .add_operation_log_entry(
                                 dbtx,
@@ -187,7 +191,7 @@ impl WalletClientExt for ClientArc {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<UpdateStreamOrOutcome<DepositState>> {
-        let (wallet_client, _) = self.get_first_module::<WalletClientModule>();
+        let wallet_client = self.get_first_module::<WalletClientModule>();
 
         let operation_log_entry = self
             .operation_log()
@@ -268,7 +272,7 @@ impl WalletClientExt for ClientArc {
         address: Address,
         amount: bitcoin::Amount,
     ) -> anyhow::Result<PegOutFees> {
-        let (wallet_client, _) = self.get_first_module::<WalletClientModule>();
+        let wallet_client = self.get_first_module::<WalletClientModule>();
 
         wallet_client.get_withdraw_fees(address, amount).await
     }
@@ -279,7 +283,7 @@ impl WalletClientExt for ClientArc {
         amount: bitcoin::Amount,
         fee: PegOutFees,
     ) -> anyhow::Result<OperationId> {
-        let (wallet_client, instance) = self.get_first_module::<WalletClientModule>();
+        let wallet_client = self.get_first_module::<WalletClientModule>();
 
         let operation_id = OperationId(thread_rng().gen());
 
@@ -287,7 +291,7 @@ impl WalletClientExt for ClientArc {
             .create_withdraw_output(operation_id, address.clone(), amount, fee)
             .await?;
         let tx_builder =
-            TransactionBuilder::new().with_output(withdraw_output.into_dyn(instance.id));
+            TransactionBuilder::new().with_output(withdraw_output.into_dyn(wallet_client.id));
 
         self.finalize_and_submit_transaction(
             operation_id,
@@ -306,7 +310,7 @@ impl WalletClientExt for ClientArc {
     }
 
     async fn rbf_withdraw(&self, rbf: Rbf) -> anyhow::Result<OperationId> {
-        let (wallet_client, instance) = self.get_first_module::<WalletClientModule>();
+        let wallet_client = self.get_first_module::<WalletClientModule>();
 
         let operation_id = OperationId(thread_rng().gen());
 
@@ -314,7 +318,7 @@ impl WalletClientExt for ClientArc {
             .create_rbf_withdraw_output(operation_id, rbf.clone())
             .await?;
         let tx_builder =
-            TransactionBuilder::new().with_output(withdraw_output.into_dyn(instance.id));
+            TransactionBuilder::new().with_output(withdraw_output.into_dyn(wallet_client.id));
 
         self.finalize_and_submit_transaction(
             operation_id,
@@ -334,7 +338,7 @@ impl WalletClientExt for ClientArc {
         &self,
         operation_id: OperationId,
     ) -> anyhow::Result<UpdateStreamOrOutcome<WithdrawState>> {
-        let (wallet_client, _) = self.get_first_module::<WalletClientModule>();
+        let wallet_client = self.get_first_module::<WalletClientModule>();
 
         let operation = self
             .operation_log()

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -83,8 +83,7 @@ async fn peg_in<'a>(
 }
 
 async fn await_consensus_to_catch_up(client: &ClientArc, block_count: u64) -> anyhow::Result<u64> {
-    let (_, instance) =
-        client.get_first_module::<WalletClientModule>(&fedimint_wallet_client::KIND);
+    let (_, instance) = client.get_first_module::<WalletClientModule>();
     loop {
         let current_consensus = client
             .api()

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -83,11 +83,11 @@ async fn peg_in<'a>(
 }
 
 async fn await_consensus_to_catch_up(client: &ClientArc, block_count: u64) -> anyhow::Result<u64> {
-    let (_, instance) = client.get_first_module::<WalletClientModule>();
+    let wallet = client.get_first_module::<WalletClientModule>();
     loop {
         let current_consensus = client
             .api()
-            .with_module(instance.id)
+            .with_module(wallet.id)
             .fetch_consensus_block_count()
             .await?;
         if current_consensus < block_count {


### PR DESCRIPTION
Now that `ClientModule` has access to its context (`Client`), it can use it instead of exposing `*Ext` trait.

I picked dummy module as a first one to refactor, because I thought it will be the easiest. Didn't realize it's used all over the tests...

Due to lifetimes issues in async context my original idea of exposing only weak pointer didn't work, but I also realized that we probably don't want to expose the whole `Client` anyway, and we should be more selective about what we allow, so decided to just delegate `Client` methods I need on the `ClientContext` for now.

While working on it I noticed lots of possible improvements, and don't want to waste time splitting things into smaller commits, etc. so just did what I need immediate to make things simpler. Will follow through with some more changes.