### PR TITLE
fix: bring back reliable network layer for config generation

### DIFF
--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -37,7 +37,8 @@ use crate::fedimint_core::NumPeers;
 use crate::multiplexed::PeerConnectionMultiplexer;
 use crate::net::connect::{dns_sanitize, Connector, TlsConfig};
 use crate::net::peers::{DelayCalculator, NetworkConfig};
-use crate::{ReconnectPeerConnections, TlsTcpConnector};
+use crate::net::peers_reliable::ReconnectPeerConnectionsReliable;
+use crate::TlsTcpConnector;
 
 pub mod api;
 pub mod distributedgen;
@@ -674,7 +675,8 @@ where
 {
     let connector = TlsTcpConnector::new(certs, network.identity).into_dyn();
     let (connections, _) =
-        ReconnectPeerConnections::new(network, delay_calculator, connector, task_group).await;
+        ReconnectPeerConnectionsReliable::new(network, delay_calculator, connector, task_group)
+            .await;
     connections.into_dyn()
 }
 

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -34,7 +34,6 @@ use crate::config::api::{ConfigGenApi, ConfigGenSettings};
 use crate::consensus::server::ConsensusServer;
 use crate::net::api::{ConsensusApi, RpcHandlerCtx};
 use crate::net::connect::TlsTcpConnector;
-use crate::net::peers::ReconnectPeerConnections;
 
 pub mod atomic_broadcast;
 

--- a/fedimint-server/src/net/mod.rs
+++ b/fedimint-server/src/net/mod.rs
@@ -2,3 +2,5 @@ pub mod api;
 pub mod connect;
 pub mod framed;
 pub mod peers;
+pub mod peers_reliable;
+pub mod queue;

--- a/fedimint-server/src/net/queue.rs
+++ b/fedimint-server/src/net/queue.rs
@@ -1,0 +1,108 @@
+use std::collections::VecDeque;
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, trace};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct MessageQueue<M> {
+    pub(super) queue: VecDeque<UniqueMessage<M>>,
+    pub(super) next_id: MessageId,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
+pub struct MessageId(pub u64);
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
+pub struct UniqueMessage<M> {
+    pub id: MessageId,
+    pub msg: M,
+}
+
+impl MessageId {
+    pub fn increment(self) -> MessageId {
+        MessageId(self.0 + 1)
+    }
+}
+
+impl<M> Default for MessageQueue<M> {
+    fn default() -> Self {
+        MessageQueue {
+            queue: Default::default(),
+            next_id: MessageId(1),
+        }
+    }
+}
+
+impl<M> MessageQueue<M>
+where
+    M: Clone,
+{
+    pub fn push(&mut self, msg: M) -> UniqueMessage<M> {
+        let id_msg = UniqueMessage {
+            id: self.next_id,
+            msg,
+        };
+
+        self.queue.push_back(id_msg.clone());
+        self.next_id = self.next_id.increment();
+
+        id_msg
+    }
+
+    pub fn ack(&mut self, msg_id: MessageId) {
+        debug!("Received ACK for {:?}", msg_id);
+        while self
+            .queue
+            .front()
+            .map(|msg| msg.id <= msg_id)
+            .unwrap_or(false)
+        {
+            let msg = self.queue.pop_front().expect("Checked in while head");
+            trace!("Removing message {:?} from resend buffer", msg.id);
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &UniqueMessage<M>> {
+        self.queue.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::net::queue::{MessageId, MessageQueue};
+
+    #[test]
+    fn test_queue() {
+        let mut queue = MessageQueue::default();
+
+        for i in 0u64..10 {
+            let umsg = queue.push(42 * i);
+            assert_eq!(umsg.msg, 42 * i);
+            assert_eq!(umsg.id.0, i + 1);
+        }
+
+        fn assert_contains(queue: &MessageQueue<u64>, iter: impl Iterator<Item = u64>) {
+            let mut queue_iter = queue.iter();
+
+            for i in iter {
+                let umsg = queue_iter.next().unwrap();
+                assert_eq!(umsg.msg, 42 * i);
+                assert_eq!(umsg.id.0, i + 1);
+            }
+
+            assert_eq!(queue_iter.next(), None);
+        }
+
+        assert_eq!(queue.iter().count(), 10);
+        assert_contains(&queue, 0..10);
+
+        queue.ack(MessageId(1));
+        assert_contains(&queue, 1..10);
+
+        queue.ack(MessageId(4));
+        assert_contains(&queue, 4..10);
+
+        queue.ack(MessageId(2)); // TODO: should that throw an error?
+        assert_contains(&queue, 4..10);
+    }
+}


### PR DESCRIPTION
When we switched to Aleph BFT we removed the reliability from the network layer which guarantees that all messages are eventually delivered in order. However, the config generation seems to require this reliability and has probably not failed in the tests (yet) since the connections our p2p network stack is build on are themselves already reliable enough. To prevent the config gen to fail in bad network conditions we bring the old reliable network layer back and now have to separate network layers since we keep the unreliable network layer for running consensus once we have finished the config gen. In the future we may do the config gen over the atomic broadcast which would allow us to remove the reliable network layer again.