### PR TITLE
Reactivate tests

### DIFF
--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 pub use anyhow::Result;
 use bitcoin::{BlockHash, Network, Script, Transaction, Txid};
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
+use fedimint_core::fmt_utils::OptStacktrace;
 use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
@@ -175,7 +176,7 @@ impl<C> RetryClient<C> {
                         return Err(e);
                     }
 
-                    info!(target: LOG_BLOCKCHAIN, "Bitcoind error {:?}, retrying", e);
+                    info!(target: LOG_BLOCKCHAIN, "Bitcoind error {}, retrying", OptStacktrace(e));
                     std::thread::sleep(retry_time);
                     retry_time = min(RETRY_SLEEP_MAX_MS, retry_time * 2);
                 }

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -144,7 +144,7 @@ dyn_newtype_define! {
 }
 
 const RETRY_SLEEP_MIN_MS: Duration = Duration::from_millis(10);
-const RETRY_SLEEP_MAX_MS: Duration = Duration::from_millis(1000);
+const RETRY_SLEEP_MAX_MS: Duration = Duration::from_millis(5000);
 
 /// Wrapper around [`IBitcoindRpc`] that will retry failed calls
 #[derive(Debug)]

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -14,6 +14,7 @@ use fedimint_core::config::{
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::module::{DynServerModuleInit, IServerModuleInit};
 use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup};
+use fedimint_core::util::SafeUrl;
 use fedimint_logging::{TracingSetup, LOG_TEST};
 use tempfile::TempDir;
 use tracing::info;
@@ -193,7 +194,11 @@ impl Fixtures {
         match Fixtures::is_real_test() {
             true => BitcoinRpcConfig {
                 kind: "esplora".to_string(),
-                url: "http://127.0.0.1:50002".parse().unwrap(),
+                url: SafeUrl::parse(&format!(
+                    "http://127.0.0.1:{}/",
+                    env::var("FM_PORT_ESPLORA").unwrap_or(String::from("50002"))
+                ))
+                .expect("Failed to parse default esplora server"),
             },
             false => self.bitcoin_rpc.clone(),
         }

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -36,15 +36,15 @@ if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "bitcoind" ]; then
   >&2 echo "### Testing against bitcoind"
 
   # Note: Ideally `-E` flags can be used together, but that seems to trigger lots of problems
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+-profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
     -E 'package(fedimint-dummy-tests)'
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+-profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
     -E 'package(fedimint-mint-tests)'
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+-profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
     -E 'package(fedimint-wallet-tests)'
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+-profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
     -E 'package(fedimint-ln-tests)'
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+-profile ${CARGO_PROFILE}} --test-threads=1 \
+  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=1 \
     -E 'package(ln-gateway)'
   >&2 echo "### Testing against bitcoind - complete"
 fi
@@ -55,7 +55,7 @@ export FM_BITCOIN_RPC_URL="tcp://127.0.0.1:50001"
 
 if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "electrs" ]; then
   >&2 echo "### Testing against electrs"
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+-profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
     -E 'package(fedimint-wallet-tests)'
   >&2 echo "### Testing against electrs - complete"
 fi
@@ -66,7 +66,7 @@ export FM_BITCOIN_RPC_URL="http://127.0.0.1:50002"
 
 if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "esplora" ]; then
   >&2 echo "### Testing against esplora"
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+-profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
     -E 'package(fedimint-wallet-tests)'
   >&2 echo "### Testing against esplora - complete"
 fi

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -9,7 +9,7 @@ source scripts/build.sh ""
 
 TEST_ARGS="${TEST_ARGS:-}"
 TEST_ARGS_SERIALIZED="${TEST_ARGS:-$TEST_ARGS}"
-TEST_ARGS_THREADED="${TEST_ARGS:-$TEST_ARGS ---test-threads=$(($(nproc) * 2))}"
+TEST_ARGS_THREADED="${TEST_ARGS:-$TEST_ARGS --test-threads=$(($(nproc) * 2))}"
 
 >&2 echo "### Setting up tests"
 

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -7,6 +7,10 @@ export RUST_LOG="${RUST_LOG:-info,timing=debug}"
 source scripts/lib.sh
 source scripts/build.sh ""
 
+TEST_ARGS="${TEST_ARGS:-}"
+TEST_ARGS_SERIALIZED="${TEST_ARGS:-$TEST_ARGS}"
+TEST_ARGS_THREADED="${TEST_ARGS:-$TEST_ARGS ---test-threads=$(($(nproc) * 2))}"
+
 >&2 echo "### Setting up tests"
 
 # Convert RUST_LOG to lowercase
@@ -36,16 +40,25 @@ if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "bitcoind" ]; then
   >&2 echo "### Testing against bitcoind"
 
   # Note: Ideally `-E` flags can be used together, but that seems to trigger lots of problems
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets \
+    ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+    ${TEST_ARGS_THREADED} \
     -E 'package(fedimint-dummy-tests)'
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets \
+    ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+    ${TEST_ARGS_THREADED} \
     -E 'package(fedimint-mint-tests)'
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets \
+    ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+    ${TEST_ARGS_THREADED} \
     -E 'package(fedimint-wallet-tests)'
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets \
+    ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+    ${TEST_ARGS_THREADED} \
     -E 'package(fedimint-ln-tests)'
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=1 \
-    -E 'package(ln-gateway)'
+  cargo nextest run --locked --workspace --all-targets \
+    ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+    ${TEST_ARGS_SERIALIZED} 'package(ln-gateway)'
   >&2 echo "### Testing against bitcoind - complete"
 fi
 
@@ -55,7 +68,9 @@ export FM_BITCOIN_RPC_URL="tcp://127.0.0.1:$FM_PORT_ELECTRS"
 
 if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "electrs" ]; then
   >&2 echo "### Testing against electrs"
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets \
+    ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+    ${TEST_ARGS_THREADED} \
     -E 'package(fedimint-wallet-tests)'
   >&2 echo "### Testing against electrs - complete"
 fi
@@ -66,7 +81,9 @@ export FM_BITCOIN_RPC_URL="http://127.0.0.1:$FM_PORT_ESPLORA"
 
 if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "esplora" ]; then
   >&2 echo "### Testing against esplora"
-  cargo nextest run --locked --workspace --all-targets ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --test-threads=$(($(nproc) * 2)) \
+  cargo nextest run --locked --workspace --all-targets \
+    ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+    ${TEST_ARGS_THREADED} \
     -E 'package(fedimint-wallet-tests)'
   >&2 echo "### Testing against esplora - complete"
 fi

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -54,7 +54,7 @@ if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "bitcoind" ]; then
     -E 'package(fedimint-wallet-tests)'
   cargo nextest run --locked --workspace --all-targets \
     ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
-    ${TEST_ARGS_THREADED} \
+    ${TEST_ARGS_SERIALIZED} \
     -E 'package(fedimint-ln-tests)'
   cargo nextest run --locked --workspace --all-targets \
     ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -51,7 +51,7 @@ fi
 
 # Switch to electrum and run wallet tests
 export FM_BITCOIN_RPC_KIND="electrum"
-export FM_BITCOIN_RPC_URL="tcp://127.0.0.1:50001"
+export FM_BITCOIN_RPC_URL="tcp://127.0.0.1:$FM_PORT_ELECTRS"
 
 if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "electrs" ]; then
   >&2 echo "### Testing against electrs"
@@ -62,7 +62,7 @@ fi
 
 # Switch to esplora and run wallet tests
 export FM_BITCOIN_RPC_KIND="esplora"
-export FM_BITCOIN_RPC_URL="http://127.0.0.1:50002"
+export FM_BITCOIN_RPC_URL="http://127.0.0.1:$FM_PORT_ESPLORA"
 
 if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "esplora" ]; then
   >&2 echo "### Testing against esplora"


### PR DESCRIPTION
Alternative to  #3589, relevant context for TODOs:

> After using the old `cargo test` based version of running these tests only some gateway tests fail:
> 
> ```
> 00:01:02     can_switch_active_gateway
> 00:01:02     cannot_pay_same_external_invoice_twice
> 00:01:02     makes_internal_payments_within_federation
> 00:01:02     rejects_wrong_network_invoice
> ```
> 
> All fail with the same error:
> 
> ```
> 00:01:02 thread 'can_switch_active_gateway' panicked at /build/source/fedimint-testing/src/gateway.rs:151:10:
> 00:01:02 Gateway failed to start: Gateway did not reach desired state within 30 seconds
> ```
> 
> This indicates we always get stuck here:
> 
> https://github.com/fedimint/fedimint/blob/256bdfada2cfe7716f58e5e119ab248418158a18/fedimint-testing/src/gateway.rs#L145-L151
> 
> Did we maybe change the GW setup flow in a way that silently breaks devimint and just makes the GW not come online @okjodom, @m1sterc001guy?