### PR TITLE
chore: make invite codes extensible

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -668,8 +668,8 @@ impl FedimintCli {
             }
             Command::Dev(DevCmd::DecodeInviteCode { invite_code }) => {
                 Ok(CliOutput::DecodeInviteCode {
-                    url: invite_code.url,
-                    federation_id: invite_code.federation_id,
+                    url: invite_code.url(),
+                    federation_id: invite_code.federation_id(),
                 })
             }
             Command::Dev(DevCmd::EncodeInviteCode {
@@ -677,11 +677,7 @@ impl FedimintCli {
                 federation_id,
                 peer,
             }) => Ok(CliOutput::InviteCode {
-                invite_code: InviteCode {
-                    url,
-                    federation_id,
-                    peer,
-                },
+                invite_code: InviteCode::new(url, peer, federation_id),
             }),
             Command::Dev(DevCmd::SessionCount) => {
                 let count = cli

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -240,13 +240,13 @@ impl ServerConfig {
     }
 
     pub fn get_invite_code(&self) -> InviteCode {
-        InviteCode {
-            url: self.consensus.api_endpoints[&self.local.identity]
+        InviteCode::new(
+            self.consensus.api_endpoints[&self.local.identity]
                 .url
                 .clone(),
-            federation_id: FederationId(self.consensus.api_endpoints.consensus_hash()),
-            peer: self.local.identity,
-        }
+            self.local.identity,
+            FederationId(self.consensus.api_endpoints.consensus_hash()),
+        )
     }
 
     pub fn add_modules(&mut self, modules: BTreeMap<ModuleInstanceId, ServerModuleConfig>) {

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -58,7 +58,7 @@ impl GatewayClientBuilder {
             timelock_delta,
             fees,
         } = config;
-        let federation_id = invite_code.federation_id;
+        let federation_id = invite_code.federation_id();
 
         let mut registry = self.registry.clone();
         registry.attach(GatewayClientInit {
@@ -126,7 +126,7 @@ impl GatewayClientBuilder {
         config: FederationConfig,
         mut dbtx: DatabaseTransaction<'_>,
     ) -> Result<()> {
-        let id = config.invite_code.federation_id;
+        let id = config.invite_code.federation_id();
         dbtx.insert_entry(&FederationIdKey { id }, &config).await;
         dbtx.commit_tx_result()
             .await

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -763,7 +763,7 @@ impl Gateway {
                 .await
                 .fetch_add(1, Ordering::SeqCst);
 
-            let federation_id = invite_code.federation_id;
+            let federation_id = invite_code.federation_id();
             let gw_client_cfg = FederationConfig {
                 invite_code,
                 mint_channel_id,
@@ -994,7 +994,7 @@ impl Gateway {
             let mut next_channel_id = channel_id_generator.load(Ordering::SeqCst);
 
             for config in configs {
-                let federation_id = config.invite_code.federation_id;
+                let federation_id = config.invite_code.federation_id();
                 let old_client = self.clients.read().await.get(&federation_id).cloned();
                 let all_clients = self.clients.clone();
                 let all_scids = self.scid_to_federation.clone();

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -954,7 +954,7 @@ async fn test_gateway_configuration() -> anyhow::Result<()> {
     verify_rpc(
         || {
             rpc_client.get_balance(BalancePayload {
-                federation_id: fed.invite_code().federation_id,
+                federation_id: fed.invite_code().federation_id(),
             })
         },
         StatusCode::OK,
@@ -980,7 +980,7 @@ async fn test_gateway_supports_connecting_multiple_federations() -> anyhow::Resu
                 .await
                 .unwrap();
 
-            assert_eq!(info.federation_id, invite1.federation_id);
+            assert_eq!(info.federation_id, invite1.federation_id());
 
             let invite2 = fed2.invite_code();
             let info = rpc
@@ -989,7 +989,7 @@ async fn test_gateway_supports_connecting_multiple_federations() -> anyhow::Resu
                 })
                 .await
                 .unwrap();
-            assert_eq!(info.federation_id, invite2.federation_id);
+            assert_eq!(info.federation_id, invite2.federation_id());
             drop(gateway); // keep until the end to avoid the gateway shutting down too early
             Ok(())
         },
@@ -1004,8 +1004,8 @@ async fn test_gateway_shows_info_about_all_connected_federations() -> anyhow::Re
         |gateway, rpc, fed1, fed2, _| async move {
             assert_eq!(rpc.get_info().await.unwrap().federations.len(), 0);
 
-            let id1 = fed1.invite_code().federation_id;
-            let id2 = fed2.invite_code().federation_id;
+            let id1 = fed1.invite_code().federation_id();
+            let id2 = fed2.invite_code().federation_id();
 
             connect_federations(&rpc, &[fed1, fed2]).await.unwrap();
 
@@ -1032,8 +1032,8 @@ async fn test_gateway_shows_balance_for_any_connected_federation() -> anyhow::Re
     multi_federation_test(
         LightningNodeType::Lnd,
         |gateway, rpc, fed1, fed2, _| async move {
-            let id1 = fed1.invite_code().federation_id;
-            let id2 = fed2.invite_code().federation_id;
+            let id1 = fed1.invite_code().federation_id();
+            let id2 = fed2.invite_code().federation_id();
 
             connect_federations(&rpc, &[fed1, fed2]).await.unwrap();
 
@@ -1059,8 +1059,8 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
     multi_federation_test(
         LightningNodeType::Lnd,
         |gateway, rpc, fed1, fed2, _| async move {
-            let id1 = fed1.invite_code().federation_id;
-            let id2 = fed2.invite_code().federation_id;
+            let id1 = fed1.invite_code().federation_id();
+            let id2 = fed2.invite_code().federation_id();
 
             let client1 = fed1.new_client().await;
             let client2 = fed2.new_client().await;


### PR DESCRIPTION
Builds on #3591, fixes #3567

The core idea is to, instead of having a strict encoding for invite codes, having a list of TLV-encoded data fields and ignoring ones that we cannot understand. This allows to extend invite codes without breaking old clients.

https://github.com/fedimint/fedimint/blob/9cb188e537e9951778cd0c0eb4c9e9b475931eed/fedimint-core/src/api.rs#L599-L600

https://github.com/fedimint/fedimint/blob/9cb188e537e9951778cd0c0eb4c9e9b475931eed/fedimint-core/src/api.rs#L680-L693

The data can be extracted via functions instead of directly reading the fields, e.g.:

https://github.com/fedimint/fedimint/blob/9cb188e537e9951778cd0c0eb4c9e9b475931eed/fedimint-core/src/api.rs#L639-L648