### PR TITLE
refactor: Rename `SafeUrl::reap_guts()` -> `SafeUrl::to_unsafe()`

### DIFF
--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -85,7 +85,7 @@ impl SafeUrl {
 
     /// Warning: This removes the safety.
     // nosemgrep: ban-raw-url
-    pub fn reap_guts(self) -> Url {
+    pub fn to_unsafe(self) -> Url {
         self.0
     }
 
@@ -148,6 +148,15 @@ impl Debug for SafeUrl {
         write!(f, ", has_username={}", !self.0.username().is_empty())?;
         write!(f, ")")?;
         Ok(())
+    }
+}
+
+/// Only ease conversions from unsafe into safe version.
+/// We want to protect leakage of sensitive credentials unless code explicitly
+/// calls `to_unsafe()`.
+impl From<Url> for SafeUrl {
+    fn from(u: Url) -> Self {
+        SafeUrl(u)
     }
 }
 
@@ -263,6 +272,9 @@ mod tests {
                 "Debug implementation out of spec"
             );
         }
+
+        // Exercise `From`-trait via `Into`
+        let _: SafeUrl = url::Url::parse("http://1.2.3.4:80/foo").unwrap().into();
     }
 
     #[tokio::test]

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -100,7 +100,7 @@ impl GatewayRpcClient {
     where
         P: Serialize,
     {
-        let mut builder = self.client.post(url.reap_guts());
+        let mut builder = self.client.post(url.to_unsafe());
         if let Some(password) = self.password.clone() {
             builder = builder.bearer_auth(password);
         }


### PR DESCRIPTION
Also add one-way `From`-trait implementation.

Per discussions in #1298.