### PR TITLE
feat(mint): make `OOBNotes` forwards-compatible

### DIFF
--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -74,10 +74,7 @@ async fn error_zero_value_oob_receive() -> anyhow::Result<()> {
     // Spend from client1 to client2
     let err_msg = client1
         .reissue_external_notes(
-            OOBNotes {
-                federation_id_prefix: client1.federation_id().to_prefix(),
-                notes: Default::default(),
-            },
+            OOBNotes::new(client1.federation_id().to_prefix(), Default::default()),
             (),
         )
         .await


### PR DESCRIPTION
Same idea as #3595, see that for an explanation of the design.

Fixes #3568 (implicit versioning, but even better: extensibility without breaking old clients)