### PR TITLE
chore: specify rustfmt edition

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -2,3 +2,4 @@ group_imports = "StdExternalCrate"
 wrap_comments = true
 format_code_in_doc_comments = true
 imports_granularity = "Module"
+edition="2021"


### PR DESCRIPTION
The default edition used by rustfmt is 2015, leading to the formatter not working on files containing syntax of later versions. See [rustfmt](https://github.com/rust-lang/rustfmt)