### PR TITLE
Let us properly pay HOLD invoices

### DIFF
--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -24,7 +24,10 @@ use secp256k1_zkp::PublicKey;
 use self::init::ClientModuleInit;
 use crate::sm::{Context, DynContext, DynState, Executor, State};
 use crate::transaction::{ClientInput, ClientOutput, TransactionBuilder};
-use crate::{oplog, ClientArc, ClientWeak, DynGlobalClientContext, TransactionUpdates};
+use crate::{
+    oplog, AddStateMachinesResult, ClientArc, ClientWeak, DynGlobalClientContext,
+    TransactionUpdates,
+};
 
 pub mod init;
 
@@ -225,7 +228,7 @@ where
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
         dyn_states: Vec<DynState<DynGlobalClientContext>>,
-    ) -> anyhow::Result<()> {
+    ) -> AddStateMachinesResult {
         self.client.get().add_state_machines(dbtx, dyn_states).await
     }
 

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
+use anyhow::bail;
 use fedimint_core::time::now;
 use fedimint_logging::LOG_TASK;
 #[cfg(target_family = "wasm")]
@@ -268,9 +269,7 @@ impl TaskGroup {
             Ok(())
         } else {
             let num_errors = errors.len();
-            Err(anyhow::Error::msg(format!(
-                "{num_errors} tasks did not finish cleanly: {errors:?}"
-            )))
+            bail!("{num_errors} tasks did not finish cleanly: {errors:?}")
         }
     }
 

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -72,7 +72,7 @@ pub async fn reissue_notes(
         .into_stream();
     while let Some(update) = updates.next().await {
         if let fedimint_mint_client::ReissueExternalNotesState::Failed(e) = update {
-            return Err(anyhow::Error::msg(format!("Reissue failed: {e}")));
+            bail!("Reissue failed: {e}")
         }
     }
     event_sender.send(MetricEvent {
@@ -99,7 +99,7 @@ pub async fn do_spend_notes(
             fedimint_mint_client::SpendOOBState::Created
             | fedimint_mint_client::SpendOOBState::Success => {}
             other => {
-                return Err(anyhow::Error::msg(format!("Spend failed: {other:?}")));
+                bail!("Spend failed: {other:?}");
             }
         }
     }
@@ -121,7 +121,7 @@ pub async fn await_spend_notes_finish(
             fedimint_mint_client::SpendOOBState::Created
             | fedimint_mint_client::SpendOOBState::Success => {}
             other => {
-                return Err(anyhow::Error::msg(format!("Spend failed: {other:?}")));
+                bail!("Spend failed: {other:?}");
             }
         }
     }

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -334,7 +334,7 @@ async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
             dummy_module.receive_money(outpoint).await?;
             assert_eq!(user_client.get_balance().await, sats(1000));
 
-            // Create invoice that cannout be paid
+            // Create invoice that cannot be paid
             let invoice = other_lightning_client
                 .unpayable_invoice(sats(250), None)
                 .unwrap();

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -292,7 +292,7 @@ impl LightningPayFunded {
             match Self::try_gateway_pay_invoice(gateway.clone(), payload.clone()).await {
                 Ok(preimage) => return Ok(preimage),
                 Err(e) => {
-                    warn!("Error while trying to reach gateway: {}", e);
+                    warn!("Error while trying to reach gateway: {e}");
                     last_error = Some(e);
                     sleep(RETRY_DELAY).await;
                 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -473,7 +473,7 @@ impl ClientModule for MintClientModule {
 
                 while let Some(update) = updates.next().await {
                     if let ReissueExternalNotesState::Failed(e) = update {
-                        return Err(anyhow::Error::msg(format!("Reissue failed: {e}")));
+                        bail!("Reissue failed: {e}");
                     }
 
                     info!("Update: {:?}", update);


### PR DESCRIPTION
- Moves the ln payment from the state transition to the trigger, avoiding all the state machines to get stuck while paying HOLD invoices
Closes https://github.com/fedimint/fedimint/issues/3478
- Adds a devimint test where we pay HOLD invoices and test the above scenario
- Adds `--finish-in-background` flag to `fedimint-cli ln-pay` to let us pay HOLD invoices without blocking the terminal
- Adds a `fedimint-cli await-ln-pay` to let us get the result of a ln payment in case it was interrupted or called using the above flag
- Fixes an error on the gateway when we try to resume a ln payment
Closes https://github.com/fedimint/fedimint/issues/3639
- Minor code cleanups