### PR TITLE
feat(fedimint-cli): lock the database with advisory fs locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ name = "fedimint-cli"
 version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.20.0",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
@@ -1233,6 +1234,7 @@ dependencies = [
  "fedimint-rocksdb",
  "fedimint-server",
  "fedimint-wallet-client",
+ "fs-lock",
  "futures",
  "lightning-invoice 0.26.0",
  "rand",

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.66"
+async-trait = "0.1.73"
 base64 = "0.20.0"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
@@ -35,6 +36,7 @@ fedimint-ln-common = { path = "../modules/fedimint-ln-common" }
 fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
 fedimint-logging = { path = "../fedimint-logging" }
 fedimint-server = { path = "../fedimint-server" }
+fs-lock = "0.1.0"
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 thiserror = "1.0.39"

--- a/fedimint-cli/src/db_locked.rs
+++ b/fedimint-cli/src/db_locked.rs
@@ -1,0 +1,68 @@
+use std::path::Path;
+
+use anyhow::Context;
+use fedimint_core::db::IRawDatabase;
+use fedimint_core::{apply, async_trait_maybe_send};
+use tracing::info;
+
+/// Locked version of database
+///
+/// This will use file-system advisory locks to prevent to
+/// serialize opening and using the `DB`.
+///
+/// Use [`LockedBuilder`] to create.
+#[derive(Debug)]
+pub struct Locked<DB> {
+    inner: DB,
+    #[allow(dead_code)] // only for `Drop`
+    lock: fs_lock::FileLock,
+}
+
+/// Builder for [`Locked`]
+pub struct LockedBuilder {
+    lock: fs_lock::FileLock,
+}
+
+impl LockedBuilder {
+    /// Create a [`Self`] by acquiring a lock file
+    pub async fn new(lock_path: &Path) -> anyhow::Result<LockedBuilder> {
+        tokio::task::block_in_place(|| {
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(lock_path)
+                .with_context(|| format!("Failed to open {}", lock_path.display()))?;
+
+            // TODO: Use https://github.com/cargo-bins/cargo-binstall/pull/1496 to
+            // give user feedback only when the initial `new_try_exclusive` failed.
+            info!("Acquiring database lock");
+            let lock =
+                fs_lock::FileLock::new_exclusive(file).context("Failed to acquire a lock file")?;
+
+            Ok(LockedBuilder { lock })
+        })
+    }
+
+    /// Create [`Locked`] by giving it the database to wrap
+    pub fn with_db<DB>(self, db: DB) -> Locked<DB> {
+        Locked {
+            inner: db,
+            lock: self.lock,
+        }
+    }
+}
+
+#[apply(async_trait_maybe_send!)]
+impl<DB> IRawDatabase for Locked<DB>
+where
+    DB: IRawDatabase,
+{
+    type Transaction<'a> = DB::Transaction<'a>;
+
+    async fn begin_transaction<'a>(
+        &'a self,
+    ) -> <Locked<DB> as fedimint_core::db::IRawDatabase>::Transaction<'_> {
+        self.inner.begin_transaction().await
+    }
+}


### PR DESCRIPTION
This makes semi-concurrent use possible, as `fedimint-cli` will just wait for a different process to finish.

Can be tested in `just mprocs` by running a couple of `for i in $(seq 100); do fedimint-cli info ;done &` at the same time.