### PR TITLE
feat(devimint): dev-fed --exec <cmd> 

### DIFF
--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -1,7 +1,7 @@
-use std::env;
 use std::ops::ControlFlow;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
+use std::{env, ffi};
 
 use anyhow::{anyhow, Context, Result};
 use bitcoincore_rpc::bitcoin;
@@ -22,7 +22,7 @@ use fedimint_logging::LOG_DEVIMINT;
 use ln_gateway::rpc::GatewayInfo;
 use tokio::fs;
 use tokio::net::TcpStream;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 pub async fn latency_tests(dev_fed: DevFed) -> Result<()> {
     #[allow(unused_variables)]
@@ -1127,7 +1127,10 @@ enum Cmd {
     /// esplora, and a federation sized from FM_FED_SIZE it opens LN channel
     /// between the two nodes. it connects the gateways to the federation.
     /// it finally switches to use the CLN gateway using the fedimint-cli
-    DevFed,
+    DevFed {
+        #[arg(long, trailing_var_arg = true, allow_hyphen_values = true, num_args=1..)]
+        exec: Option<Vec<ffi::OsString>>,
+    },
     /// Runs bitcoind, spins up FM_FED_SIZE worth of fedimints
     RunUi,
     /// `devfed` then spawns faucet for wasm tests
@@ -1300,17 +1303,25 @@ async fn handle_command() -> Result<()> {
                     .await?;
             task_group.make_handle().make_shutdown_rx().await.await;
         }
-        Cmd::DevFed => {
+        Cmd::DevFed { exec } => {
             let (process_mgr, task_group) = setup(args.common).await?;
-            let main = async move {
-                let dev_fed = dev_fed(&process_mgr).await?;
-                tokio::try_join!(
-                    dev_fed.fed.pegin(10_000),
-                    dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_cln),
-                    dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_lnd),
-                )?;
-                let daemons = write_ready_file(&process_mgr.globals, Ok(dev_fed)).await?;
-                Ok::<_, anyhow::Error>(daemons)
+            let main = {
+                let task_group = task_group.clone();
+                async move {
+                    let dev_fed = dev_fed(&process_mgr).await?;
+                    tokio::try_join!(
+                        dev_fed.fed.pegin(10_000),
+                        dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_cln),
+                        dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_lnd),
+                    )?;
+                    let daemons = write_ready_file(&process_mgr.globals, Ok(dev_fed)).await?;
+
+                    if let Some(exec) = exec {
+                        exec_user_command(exec).await?;
+                        task_group.shutdown();
+                    }
+                    Ok::<_, anyhow::Error>(daemons)
+                }
             };
             cleanup_on_exit(main, task_group).await?;
         }
@@ -1383,6 +1394,26 @@ async fn handle_command() -> Result<()> {
             gw_reboot_test(dev_fed, &process_mgr).await?;
         }
         Cmd::Rpc(rpc) => rpc_command(rpc, args.common).await?,
+    }
+    Ok(())
+}
+
+async fn exec_user_command(exec: Vec<ffi::OsString>) -> Result<(), anyhow::Error> {
+    let cmd_str = exec
+        .join(ffi::OsStr::new(" "))
+        .to_string_lossy()
+        .to_string();
+    info!(cmd = %cmd_str, "Executing user command");
+    if !tokio::process::Command::new(&exec[0])
+        .args(&exec[1..])
+        .kill_on_drop(true)
+        .status()
+        .await
+        .with_context(|| format!("Executing user command failed: {cmd_str}"))?
+        .success()
+    {
+        error!(cmd = %cmd_str, "User command failed");
+        return Err(anyhow!("User command failed: {cmd_str}"));
     }
     Ok(())
 }

--- a/scripts/dev/mprocs/run.sh
+++ b/scripts/dev/mprocs/run.sh
@@ -15,8 +15,4 @@ source scripts/build.sh
 
 mkdir -p $FM_LOGS_DIR
 
-devimint dev-fed 2>$FM_LOGS_DIR/devimint-outer.log &
-auto_kill_last_cmd dev-fed
-eval "$(devimint env)"
-
-mprocs -c misc/mprocs.yaml
+devimint dev-fed --exec mprocs -c misc/mprocs.yaml 2>$FM_LOGS_DIR/devimint-outer.log


### PR DESCRIPTION
This should simplify running scripts against federation.

Setup and cleanup happens automatically, no need to run things in the background, call `env` etc.

Longer scripts can be executed by making them a separate file or using exported bash functions, simulated below:


```bash
#!/usr/bin/env bash

function fake_devimimint_exec() {
  >&2 echo "Starting deviming with: ${*}"
  export FM_DIR=some
  "$@"
}


echo "Starting our test suite"

export EXTERNAL_VARIABLE=yo
function some_test_block() {
  echo "TEST is running with FM_DIR=$FM_DIR EXTERNAL_VARIABLE=$EXTERNAL_VARIABLE"
}
export -f some_test_block

export EXTERNAL_VARIABLE=ye
fake_devimimint_exec bash -c some_test_block```

```> bash test-long.sh
Starting our test suite
Starting deviming with: bash -c some_test_block
TEST is running with FM_DIR=some EXTERNAL_VARIABLE=ye```