### PR TITLE
refactor: `ClientModule::handle_cli_command` doesn't need Client

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -469,11 +469,11 @@ pub async fn handle_command(
                     .context("No module with this kind found")?,
             };
 
-            let module_client = client
+            client
                 .get_module_client_dyn(module_instance_id)
-                .context("Module not found")?;
-
-            module_client.handle_cli_command(&client, &args).await
+                .context("Module not found")?
+                .handle_cli_command(&args)
+                .await
         }
         ClientCmd::Config => {
             let config = client.get_config_json();

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -249,7 +249,6 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
 
     async fn handle_cli_command(
         &self,
-        _client: &ClientArc,
         _args: &[ffi::OsString],
     ) -> anyhow::Result<serde_json::Value> {
         Err(anyhow::format_err!(
@@ -475,11 +474,8 @@ pub trait IClientModule: Debug {
 
     fn context(&self, instance: ModuleInstanceId) -> DynContext;
 
-    async fn handle_cli_command(
-        &self,
-        client: &ClientArc,
-        args: &[ffi::OsString],
-    ) -> anyhow::Result<serde_json::Value>;
+    async fn handle_cli_command(&self, args: &[ffi::OsString])
+        -> anyhow::Result<serde_json::Value>;
 
     fn input_amount(&self, input: &DynInput) -> Option<TransactionItemAmount>;
 
@@ -564,10 +560,9 @@ where
 
     async fn handle_cli_command(
         &self,
-        client: &ClientArc,
         args: &[ffi::OsString],
     ) -> anyhow::Result<serde_json::Value> {
-        <T as ClientModule>::handle_cli_command(self, client, args).await
+        <T as ClientModule>::handle_cli_command(self, args).await
     }
 
     fn input_amount(&self, input: &DynInput) -> Option<TransactionItemAmount> {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -29,7 +29,7 @@ use fedimint_client::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, Executor, ModuleNotifier, State, StateTransition};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
-use fedimint_client::{sm_enum_variant_translation, ClientArc, DynGlobalClientContext};
+use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
@@ -438,7 +438,6 @@ impl ClientModule for MintClientModule {
 
     async fn handle_cli_command(
         &self,
-        _client: &ClientArc,
         args: &[ffi::OsString],
     ) -> anyhow::Result<serde_json::Value> {
         if args.is_empty() {


### PR DESCRIPTION
It can take it from the `ClientContext`