### PR TITLE
cleanup: remove ability to return multiple pks per input

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -43,7 +43,7 @@ use crate::{
 #[derive(Debug, PartialEq)]
 pub struct InputMeta {
     pub amount: TransactionItemAmount,
-    pub pub_keys: Vec<XOnlyPublicKey>,
+    pub pub_key: XOnlyPublicKey,
 }
 
 /// Information about the amount represented by an input or output.

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -30,10 +30,10 @@ pub async fn process_transaction_with_dbtx(
             .map_err(TransactionError::Input)?;
 
         funding_verifier.add_input(meta.amount);
-        public_keys.push(meta.pub_keys);
+        public_keys.push(meta.pub_key);
     }
 
-    transaction.validate_signature(public_keys.into_iter().flatten())?;
+    transaction.validate_signature(public_keys.into_iter())?;
 
     for (output, out_idx) in transaction.outputs.iter().zip(0u64..) {
         let amount = modules

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -245,7 +245,7 @@ impl ServerModule for Dummy {
                 fee: self.cfg.consensus.tx_fee,
             },
             // IMPORTANT: include the pubkey to validate the user signed this tx
-            pub_keys: vec![input.account],
+            pub_key: input.account,
         })
     }
 

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -619,7 +619,7 @@ impl ServerModule for Lightning {
                 amount: input.amount,
                 fee: self.cfg.consensus.fee_consensus.contract_input,
             },
-            pub_keys: vec![pub_key],
+            pub_key,
         })
     }
 
@@ -1309,9 +1309,9 @@ mod tests {
                 amount,
                 fee: Amount { msats: 0 },
             },
-            pub_keys: vec![preimage
+            pub_key: preimage
                 .to_public_key()
-                .expect("should create Schnorr pubkey from preimage")],
+                .expect("should create Schnorr pubkey from preimage"),
         };
 
         assert_eq!(processed_input_meta, expected_input_meta);
@@ -1371,7 +1371,7 @@ mod tests {
                 amount,
                 fee: Amount { msats: 0 },
             },
-            pub_keys: vec![gateway_key],
+            pub_key: gateway_key,
         };
 
         assert_eq!(processed_input_meta, expected_input_meta);

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -349,7 +349,7 @@ impl ServerModule for Mint {
                 amount: input.amount,
                 fee: self.cfg.consensus.fee_consensus.note_spend_abs,
             },
-            pub_keys: vec![*input.note.spend_key()],
+            pub_key: *input.note.spend_key(),
         })
     }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -513,7 +513,7 @@ impl ServerModule for Wallet {
                 amount: fedimint_core::Amount::from_sats(input.tx_output().value),
                 fee: self.cfg.consensus.fee_consensus.peg_in_abs,
             },
-            pub_keys: vec![*input.tweak_contract_key()],
+            pub_key: *input.tweak_contract_key(),
         })
     }
 


### PR DESCRIPTION
We previously had to return multiple keys per input since we had multiple ecash notes within the same input. However, we switched to single ecash note per input to reduce complexity - furthermore it seems like partially spendable inputs are generally not a good idea which is why we want to enforce it by only allowing a single pub key per input now.