### PR TITLE
Gateway leave federation

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -5,8 +5,8 @@ use fedimint_core::util::SafeUrl;
 use fedimint_logging::TracingSetup;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{
-    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, RestorePayload,
-    SetConfigurationPayload, WithdrawPayload,
+    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, LeaveFedPayload,
+    RestorePayload, SetConfigurationPayload, WithdrawPayload,
 };
 use serde::Serialize;
 
@@ -54,6 +54,11 @@ pub enum Commands {
     ConnectFed {
         /// InviteCode code to connect to the federation
         invite_code: String,
+    },
+    /// Leave a federation
+    LeaveFed {
+        #[clap(long)]
+        federation_id: FederationId,
     },
     /// Make a backup of snapshot of all ecash
     Backup {
@@ -134,6 +139,11 @@ async fn main() -> anyhow::Result<()> {
                 .await?;
 
             print_response(response).await;
+        }
+        Commands::LeaveFed { federation_id } => {
+            client()
+                .leave_federation(LeaveFedPayload { federation_id })
+                .await?;
         }
         Commands::Backup { federation_id } => {
             client().backup(BackupPayload { federation_id }).await?;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -28,7 +28,9 @@ use bitcoin::{Address, Network, Txid};
 use bitcoin_hashes::hex::ToHex;
 use clap::{Parser, Subcommand};
 use client::GatewayClientBuilder;
-use db::{DbKeyPrefix, GatewayConfiguration, GatewayConfigurationKey, GatewayPublicKey};
+use db::{
+    DbKeyPrefix, FederationIdKey, GatewayConfiguration, GatewayConfigurationKey, GatewayPublicKey,
+};
 use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::ClientArc;
 use fedimint_core::api::{FederationError, InviteCode};
@@ -59,7 +61,7 @@ use gateway_lnrpc::{GetNodeInfoResponse, InterceptHtlcResponse};
 use lightning_invoice::RoutingFees;
 use lnrpc_client::{ILnRpcClient, LightningBuilder, LightningRpcError, RouteHtlcStream};
 use rand::rngs::OsRng;
-use rpc::{FederationInfo, SetConfigurationPayload};
+use rpc::{FederationInfo, LeaveFedPayload, SetConfigurationPayload};
 use secp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
 use state_machine::pay::OutgoingPaymentError;
@@ -838,6 +840,18 @@ impl Gateway {
         }
 
         Err(GatewayError::Disconnected)
+    }
+
+    async fn handle_leave_federation(&mut self, payload: LeaveFedPayload) -> Result<()> {
+        self.remove_client(payload.federation_id).await?;
+        let mut dbtx = self.gateway_db.begin_transaction().await;
+        dbtx.remove_entry(&FederationIdKey {
+            id: payload.federation_id,
+        })
+        .await;
+        dbtx.commit_tx_result()
+            .await
+            .map_err(GatewayError::DatabaseError)
     }
 
     pub async fn handle_backup_msg(

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -93,10 +93,10 @@ const DEFAULT_NUM_ROUTE_HINTS: u32 = 0;
 pub const DEFAULT_NETWORK: Network = Network::Regtest;
 
 pub const DEFAULT_FEES: RoutingFees = RoutingFees {
-    /// Base routing fee. Default is 0 msat
+    // Base routing fee. Default is 0 msat
     base_msat: 0,
-    /// Liquidity-based routing fee in millionths of a routed amount.
-    /// In other words, 10000 is 1%. The default is 10000 (1%).
+    // Liquidity-based routing fee in millionths of a routed amount.
+    // In other words, 10000 is 1%. The default is 10000 (1%).
     proportional_millionths: 10000,
 };
 

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -24,6 +24,11 @@ pub struct ConnectFedPayload {
     pub invite_code: String,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LeaveFedPayload {
+    pub federation_id: FederationId,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InfoPayload;
 

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -10,8 +10,8 @@ use serde::Serialize;
 use thiserror::Error;
 
 use super::{
-    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, RestorePayload,
-    SetConfigurationPayload, WithdrawPayload,
+    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, LeaveFedPayload,
+    RestorePayload, SetConfigurationPayload, WithdrawPayload,
 };
 use crate::rpc::{FederationInfo, GatewayInfo};
 
@@ -68,6 +68,11 @@ impl GatewayRpcClient {
             .base_url
             .join("/connect-fed")
             .expect("invalid base url");
+        self.call(url, payload).await
+    }
+
+    pub async fn leave_federation(&self, payload: LeaveFedPayload) -> GatewayRpcResult<()> {
+        let url = self.base_url.join("/leave-fed").expect("invalid base url");
         self.call(url, payload).await
     }
 

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -14,7 +14,7 @@ use tracing::{error, instrument};
 
 use super::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, InfoPayload,
-    RestorePayload, SetConfigurationPayload, WithdrawPayload,
+    LeaveFedPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload,
 };
 use crate::db::GatewayConfiguration;
 use crate::{Gateway, GatewayError};
@@ -38,6 +38,7 @@ pub async fn run_webserver(
             .route("/address", post(address))
             .route("/withdraw", post(withdraw))
             .route("/connect-fed", post(connect_fed))
+            .route("/leave-fed", post(leave_fed))
             .route("/backup", post(backup))
             .route("/restore", post(restore))
             .route("/set_configuration", post(set_configuration))
@@ -135,6 +136,16 @@ async fn connect_fed(
 ) -> Result<impl IntoResponse, GatewayError> {
     let fed = gateway.handle_connect_federation(payload).await?;
     Ok(Json(json!(fed)))
+}
+
+/// Leave a federation
+#[instrument(skip_all, err)]
+async fn leave_fed(
+    Extension(mut gateway): Extension<Gateway>,
+    Json(payload): Json<LeaveFedPayload>,
+) -> Result<impl IntoResponse, GatewayError> {
+    gateway.handle_leave_federation(payload).await?;
+    Ok(Json(json!(())))
 }
 
 /// Backup a gateway actor state


### PR DESCRIPTION
Adds RPC command to leave federation.

Leave-fed removes federation key from gateway-db and session-db, if you reconnect to the federation while still having ecash the ecash is still there.

Tested with Eric leaving federation, restarting gateway, and rejoining.

