### PR TITLE
fix: calculate tx fees using vbytes

### DIFF
--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -272,7 +272,7 @@ impl IBitcoindRpc for FakeBitcoinTest {
     }
 
     async fn get_fee_rate(&self, _confirmation_target: u16) -> BitcoinRpcResult<Option<Feerate>> {
-        Ok(None)
+        Ok(Some(Feerate { sats_per_kvb: 2000 }))
     }
 
     async fn submit_transaction(&self, transaction: Transaction) {

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1336,6 +1336,7 @@ impl<'a> StatelessWallet<'a> {
             inputs = selected_utxos.len(),
             input_sats = total_selected_value.to_sat(),
             peg_out_sats = peg_out_amount.to_sat(),
+            ?total_weight,
             fees_sats = fees.to_sat(),
             fee_rate = fee_rate.sats_per_kvb,
             change_sats = change.to_sat(),
@@ -1566,8 +1567,11 @@ mod tests {
         let weight = 875;
 
         // not enough SpendableUTXO
+        // tx fee = ceil(875 / 4) * 1 sat/vb = 219
+        // change script dust = 330
+        // spendable sats = 3000 - 219 - 330 = 2451
         let tx = wallet.create_tx(
-            Amount::from_sat(2000),
+            Amount::from_sat(2452),
             recipient.script_pubkey(),
             vec![],
             vec![(UTXOKey(OutPoint::null()), spendable.clone())],


### PR DESCRIPTION
Fixes #3534 

- A user reported observing 4x the fees for an on-chain withdrawal compared to what should have been paid using `bitcoin-cli estimatesmartfee`
- We've been calculating the tx fee as `sats_per_vbyte * tx weight` instead of `sats_per_vbyte * tx_vbytes`
- `tx_weight ~== 4 * tx_vbytes`, hence we're overpaying fees 4x