### PR TITLE
experiment: Eliminated `DatabaseTransacationRef` by (ab-)using lifetimes

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -864,7 +864,7 @@ impl Client {
         let autocommit_res = self
             .db
             .autocommit(
-                |dbtx, _| {
+                move |dbtx, _| {
                     let operation_type = operation_type.clone();
                     let tx_builder = tx_builder.clone();
                     let operation_meta = operation_meta.clone();

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -864,7 +864,7 @@ impl Client {
         let autocommit_res = self
             .db
             .autocommit(
-                |dbtx| {
+                |dbtx, _| {
                     let operation_type = operation_type.clone();
                     let tx_builder = tx_builder.clone();
                     let operation_meta = operation_meta.clone();

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -198,7 +198,7 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
     /// `OutPoint` that represents change if change was added.
     async fn claim_input_dyn(
         &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         input: InstancelessDynClientInput,
     ) -> (TransactionId, Vec<OutPoint>);
 
@@ -208,14 +208,14 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
     /// `OutPoint` that represents change if change was added.
     async fn fund_output_dyn(
         &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         output: InstancelessDynClientOutput,
     ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)>;
 
     /// Adds a state machine to the executor.
     async fn add_state_machine_dyn(
         &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         sm: Box<maybe_add_send_sync!(dyn IState<DynGlobalClientContext>)>,
     ) -> AddStateMachinesResult;
 
@@ -263,7 +263,7 @@ impl DynGlobalClientContext {
     /// should there be any required.
     pub async fn claim_input<I, S>(
         &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         input: ClientInput<I, S>,
     ) -> (TransactionId, Vec<OutPoint>)
     where
@@ -291,7 +291,7 @@ impl DynGlobalClientContext {
     /// required.
     pub async fn fund_output<O, S>(
         &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         output: ClientOutput<O, S>,
     ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)>
     where
@@ -313,7 +313,7 @@ impl DynGlobalClientContext {
     /// machine from inside which it was spawned.
     pub async fn add_state_machine<S>(
         &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         sm: S,
     ) -> AddStateMachinesResult
     where
@@ -393,7 +393,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
 
     async fn claim_input_dyn(
         &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         input: InstancelessDynClientInput,
     ) -> (TransactionId, Vec<OutPoint>) {
         let instance_input = ClientInput {
@@ -414,7 +414,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
 
     async fn fund_output_dyn(
         &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         output: InstancelessDynClientOutput,
     ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)> {
         let instance_output = ClientOutput {
@@ -433,7 +433,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
 
     async fn add_state_machine_dyn(
         &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         sm: Box<maybe_add_send_sync!(dyn IState<DynGlobalClientContext>)>,
     ) -> AddStateMachinesResult {
         let state = DynState::from_parts(self.module_instance_id, sm);

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -864,7 +864,7 @@ impl Client {
         let autocommit_res = self
             .db
             .autocommit(
-                |dbtx, _| {
+                |dbtx| {
                     let operation_type = operation_type.clone();
                     let tx_builder = tx_builder.clone();
                     let operation_meta = operation_meta.clone();

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -146,6 +146,42 @@ where
         self.module_instance_id
     }
 
+    /// Turn a typed output into a dyn version
+    pub fn make_dyn_output(&self, output: <M::Common as ModuleCommon>::Output) -> DynOutput {
+        output.into_dyn(self.module_instance_id())
+    }
+
+    /// Turn a typed input into a dyn version
+    pub fn make_dyn_input(&self, input: <M::Common as ModuleCommon>::Input) -> DynInput {
+        input.into_dyn(self.module_instance_id())
+    }
+
+    /// Turn a `typed` into a dyn version
+    pub fn make_dyn<I>(&self, typed: I) -> <I as IntoDynInstance>::DynType
+    where
+        I: IntoDynInstance,
+    {
+        typed.into_dyn(self.module_instance_id())
+    }
+
+    /// Turn a typed [`ClientOutput`] into a dyn version
+    pub fn make_client_output<O, S>(&self, output: ClientOutput<O, S>) -> ClientOutput
+    where
+        O: IntoDynInstance<DynType = DynOutput> + 'static,
+        S: IntoDynInstance<DynType = DynState<DynGlobalClientContext>> + 'static,
+    {
+        IntoDynInstance::into_dyn(output, self.module_instance_id())
+    }
+
+    /// Turn a typed [`ClientInput`] into a dyn version
+    pub fn make_client_input<O, S>(&self, input: ClientInput<O, S>) -> ClientInput
+    where
+        O: IntoDynInstance<DynType = DynInput> + 'static,
+        S: IntoDynInstance<DynType = DynState<DynGlobalClientContext>> + 'static,
+    {
+        IntoDynInstance::into_dyn(input, self.module_instance_id())
+    }
+
     /// See [`crate::Client::finalize_and_submit_transaction`]
     pub async fn finalize_and_submit_transaction<F, Meta>(
         &self,

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -164,6 +164,17 @@ where
         typed.into_dyn(self.module_instance_id())
     }
 
+    pub fn map_dyn<'s, 'i, 'o, I>(
+        &'s self,
+        typed: impl IntoIterator<Item = I> + 'i,
+    ) -> impl Iterator<Item = <I as IntoDynInstance>::DynType> + 'o
+    where
+        I: IntoDynInstance,
+        'i: 'o,
+        's: 'o,
+    {
+        typed.into_iter().map(move |i| self.make_dyn(i))
+    }
     /// Turn a typed [`ClientOutput`] into a dyn version
     pub fn make_client_output<O, S>(&self, output: ClientOutput<O, S>) -> ClientOutput
     where

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -31,7 +31,7 @@ impl OperationLog {
 
     pub async fn add_operation_log_entry(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         operation_id: OperationId,
         operation_type: &str,
         operation_meta: impl serde::Serialize,
@@ -109,7 +109,7 @@ impl OperationLog {
     }
 
     async fn get_operation_inner(
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         operation_id: OperationId,
     ) -> Option<OperationLogEntry> {
         dbtx.get_value(&OperationLogKey { operation_id }).await

--- a/fedimint-client/src/sm/dbtx.rs
+++ b/fedimint-client/src/sm/dbtx.rs
@@ -3,14 +3,14 @@ use fedimint_core::db::DatabaseTransaction;
 
 /// A transaction that acts as isolated for module code but can be accessed as a
 /// normal transaction in this crate.
-pub struct ClientSMDatabaseTransaction<'inner, 'parent> {
-    dbtx: &'inner mut DatabaseTransaction<'static, 'parent>,
+pub struct ClientSMDatabaseTransaction<'parent, 'r, 'tx> {
+    dbtx: &'r mut DatabaseTransaction<'parent, 'tx>,
     module_instance: ModuleInstanceId,
 }
 
-impl<'inner, 'parent> ClientSMDatabaseTransaction<'inner, 'parent> {
+impl<'parent, 'r, 'tx> ClientSMDatabaseTransaction<'parent, 'r, 'tx> {
     pub fn new(
-        dbtx: &'inner mut DatabaseTransaction<'static, 'parent>,
+        dbtx: &'r mut DatabaseTransaction<'parent, 'tx>,
         module_instance: ModuleInstanceId,
     ) -> Self {
         Self {
@@ -29,7 +29,7 @@ impl<'inner, 'parent> ClientSMDatabaseTransaction<'inner, 'parent> {
     /// client internal code. This is useful for submitting Fedimint
     /// transactions from within state transitions.
     #[allow(dead_code)]
-    pub(crate) fn global_tx(&mut self) -> &mut DatabaseTransaction<'static, 'parent> {
+    pub(crate) fn global_tx(&mut self) -> &mut DatabaseTransaction<'parent, 'tx> {
         self.dbtx
     }
 }

--- a/fedimint-client/src/sm/dbtx.rs
+++ b/fedimint-client/src/sm/dbtx.rs
@@ -1,16 +1,16 @@
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{DatabaseTransaction, DatabaseTransactionRef};
+use fedimint_core::db::DatabaseTransaction;
 
 /// A transaction that acts as isolated for module code but can be accessed as a
 /// normal transaction in this crate.
 pub struct ClientSMDatabaseTransaction<'inner, 'parent> {
-    dbtx: &'inner mut DatabaseTransaction<'parent>,
+    dbtx: &'inner mut DatabaseTransaction<'static, 'parent>,
     module_instance: ModuleInstanceId,
 }
 
 impl<'inner, 'parent> ClientSMDatabaseTransaction<'inner, 'parent> {
     pub fn new(
-        dbtx: &'inner mut DatabaseTransaction<'parent>,
+        dbtx: &'inner mut DatabaseTransaction<'static, 'parent>,
         module_instance: ModuleInstanceId,
     ) -> Self {
         Self {
@@ -20,7 +20,7 @@ impl<'inner, 'parent> ClientSMDatabaseTransaction<'inner, 'parent> {
     }
 
     /// Returns the isolated database transaction for the module.
-    pub fn module_tx(&mut self) -> DatabaseTransactionRef<'_> {
+    pub fn module_tx(&mut self) -> DatabaseTransaction<'_, '_> {
         self.dbtx
             .dbtx_ref_with_prefix_module_id(self.module_instance)
     }
@@ -29,7 +29,7 @@ impl<'inner, 'parent> ClientSMDatabaseTransaction<'inner, 'parent> {
     /// client internal code. This is useful for submitting Fedimint
     /// transactions from within state transitions.
     #[allow(dead_code)]
-    pub(crate) fn global_tx(&mut self) -> &mut DatabaseTransaction<'parent> {
+    pub(crate) fn global_tx(&mut self) -> &mut DatabaseTransaction<'static, 'parent> {
         self.dbtx
     }
 }

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -96,7 +96,7 @@ where
         self.inner
             .db
             .autocommit(
-                move |dbtx| Box::pin(self.add_state_machines_dbtx(dbtx, states.clone())),
+                move |dbtx, _| Box::pin(self.add_state_machines_dbtx(dbtx, states.clone())),
                 MAX_DB_ATTEMPTS,
             )
             .await
@@ -454,7 +454,7 @@ where
             let active_or_inactive_state = self
                 .db
                 .autocommit(
-                    move |dbtx| {
+                    move |dbtx, _| {
                         let state = state.clone();
                         let transition_fn = transition_fn.clone();
                         let transition_outcome = transition_outcome.clone();

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -96,7 +96,7 @@ where
         self.inner
             .db
             .autocommit(
-                |dbtx| Box::pin(self.add_state_machines_dbtx(dbtx, states.clone())),
+                move |dbtx, _| Box::pin(self.add_state_machines_dbtx(dbtx, states.clone())),
                 MAX_DB_ATTEMPTS,
             )
             .await
@@ -123,7 +123,7 @@ where
     // TODO: remove warning once finality is an inherent state attribute
     pub async fn add_state_machines_dbtx(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         states: Vec<DynState<GC>>,
     ) -> AddStateMachinesResult {
         for state in states {
@@ -454,7 +454,7 @@ where
             let active_or_inactive_state = self
                 .db
                 .autocommit(
-                    |dbtx| {
+                    move |dbtx, _| {
                         let state = state.clone();
                         let transition_fn = transition_fn.clone();
                         let transition_outcome = transition_outcome.clone();

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -96,7 +96,7 @@ where
         self.inner
             .db
             .autocommit(
-                move |dbtx, _| Box::pin(self.add_state_machines_dbtx(dbtx, states.clone())),
+                move |dbtx| Box::pin(self.add_state_machines_dbtx(dbtx, states.clone())),
                 MAX_DB_ATTEMPTS,
             )
             .await
@@ -454,7 +454,7 @@ where
             let active_or_inactive_state = self
                 .db
                 .autocommit(
-                    move |dbtx, _| {
+                    move |dbtx| {
                         let state = state.clone();
                         let transition_fn = transition_fn.clone();
                         let transition_outcome = transition_outcome.clone();

--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -14,7 +14,7 @@ use crate::core::{
     Any, Decoder, DynInput, DynInputError, DynModuleConsensusItem, DynOutput, DynOutputError,
     DynOutputOutcome,
 };
-use crate::db::DatabaseTransactionRef;
+use crate::db::DatabaseTransaction;
 use crate::dyn_newtype_define;
 use crate::module::registry::ModuleInstanceId;
 use crate::module::{
@@ -35,7 +35,7 @@ pub trait IServerModule: Debug {
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         module_instance_id: ModuleInstanceId,
     ) -> Vec<DynModuleConsensusItem>;
 
@@ -44,7 +44,7 @@ pub trait IServerModule: Debug {
     /// our state and therefore may be safely discarded by the atomic broadcast.
     async fn process_consensus_item<'a>(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'a>,
+        dbtx: &mut DatabaseTransaction<'_, 'a>,
         consensus_item: DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()>;
@@ -55,7 +55,7 @@ pub trait IServerModule: Debug {
     /// no effect.
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'c>,
+        dbtx: &mut DatabaseTransaction<'_, 'c>,
         input: &'b DynInput,
         module_instance_id: ModuleInstanceId,
     ) -> Result<InputMeta, DynInputError>;
@@ -70,7 +70,7 @@ pub trait IServerModule: Debug {
     /// `output_status`.
     async fn process_output<'a>(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'a>,
+        dbtx: &mut DatabaseTransaction<'_, 'a>,
         output: &DynOutput,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
@@ -82,7 +82,7 @@ pub trait IServerModule: Debug {
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome>;
@@ -94,7 +94,7 @@ pub trait IServerModule: Debug {
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     );
@@ -127,7 +127,7 @@ where
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         module_instance_id: ModuleInstanceId,
     ) -> Vec<DynModuleConsensusItem> {
         <Self as ServerModule>::consensus_proposal(self, dbtx)
@@ -142,7 +142,7 @@ where
     /// our state and therefore may be safely discarded by the atomic broadcast.
     async fn process_consensus_item<'a>(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'a>,
+        dbtx: &mut DatabaseTransaction<'_, 'a>,
         consensus_item: DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -165,7 +165,7 @@ where
     /// no effect.
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'c>,
+        dbtx: &mut DatabaseTransaction<'_, 'c>,
         input: &'b DynInput,
         module_instance_id: ModuleInstanceId,
     ) -> Result<InputMeta, DynInputError> {
@@ -192,7 +192,7 @@ where
     /// `output_status`.
     async fn process_output<'a>(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'a>,
+        dbtx: &mut DatabaseTransaction<'_, 'a>,
         output: &DynOutput,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
@@ -216,7 +216,7 @@ where
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome> {
@@ -232,7 +232,7 @@ where
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -263,6 +263,11 @@ impl<RawDatabase: IRawDatabase + MaybeSend + 'static> IDatabase for BaseDatabase
     }
 }
 
+/// Just ignore this type, it's only there to make compiler happy
+///
+/// See <https://users.rust-lang.org/t/argument-requires-that-is-borrowed-for-static/66503/2?u=yandros> for details.
+pub type PhantomBound<'big, 'small> = PhantomData<&'small &'big ()>;
+
 /// A public-facing newtype over `IDatabase`
 ///
 /// Notably carries set of module decoders (`ModuleDecoderRegistry`)
@@ -394,7 +399,10 @@ impl Database {
     ) -> Result<T, AutocommitError<E>>
     where
         's: 'tx,
-        for<'a> F: Fn(&'a mut DatabaseTransaction<'s, 'tx>) -> BoxFuture<'a, Result<T, E>>,
+        for<'a> F: Fn(
+            &'a mut DatabaseTransaction<'s, 'tx>,
+            PhantomBound<'tx, 'a>,
+        ) -> BoxFuture<'a, Result<T, E>>,
     {
         assert_ne!(max_attempts, Some(0));
         let mut curr_attempts: usize = 0;
@@ -409,7 +417,7 @@ impl Database {
                 .expect("db autocommit attempt counter overflowed");
 
             let mut dbtx = self.begin_transaction().await;
-            let tx_fn = tx_fn(&mut dbtx).await;
+            let tx_fn = tx_fn(&mut dbtx, PhantomData).await;
             match tx_fn {
                 Ok(val) => {
                     let _timing /* logs on drop */ = timing::TimeReporter::new("autocommit - commit_tx");
@@ -2540,7 +2548,7 @@ mod test_utils {
 
         let db = Database::new(FakeDatabase, ModuleDecoderRegistry::default());
         let err = db
-            .autocommit::<_, _, ()>(|_dbtx| Box::pin(async { Ok(()) }), Some(5))
+            .autocommit::<_, _, ()>(|_dbtx, _| Box::pin(async { Ok(()) }), Some(5))
             .await
             .unwrap_err();
 

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::db::{
-    DatabaseKey, DatabaseLookup, DatabaseRecord, DatabaseTransactionRef,
+    DatabaseKey, DatabaseLookup, DatabaseRecord, DatabaseTransaction,
     IDatabaseTransactionOpsCoreTyped,
 };
 use crate::task::{MaybeSend, MaybeSync};
@@ -28,7 +28,7 @@ impl Audit {
 
     pub async fn add_items<KP, F>(
         &mut self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         module_instance_id: ModuleInstanceId,
         key_prefix: &KP,
         to_milli_sat: F,

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -28,7 +28,7 @@ use crate::core::{
 };
 use crate::db::{
     Database, DatabaseKey, DatabaseKeyWithNotify, DatabaseRecord, DatabaseTransaction,
-    DatabaseTransactionRef, DatabaseVersion, MigrationMap,
+    DatabaseVersion, MigrationMap,
 };
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::audit::Audit;
@@ -155,7 +155,7 @@ impl ApiError {
 /// State made available to all API endpoints for handling a request
 pub struct ApiEndpointContext<'dbtx> {
     db: Database,
-    dbtx: DatabaseTransaction<'dbtx>,
+    dbtx: DatabaseTransaction<'static, 'dbtx>,
     has_auth: bool,
     request_auth: Option<ApiAuth>,
 }
@@ -164,7 +164,7 @@ impl<'a> ApiEndpointContext<'a> {
     /// `db` and `dbtx` should be isolated.
     pub fn new(
         db: Database,
-        dbtx: DatabaseTransaction<'a>,
+        dbtx: DatabaseTransaction<'static, 'a>,
         has_auth: bool,
         request_auth: Option<ApiAuth>,
     ) -> Self {
@@ -177,7 +177,7 @@ impl<'a> ApiEndpointContext<'a> {
     }
 
     /// Database tx handle, will be committed
-    pub fn dbtx<'s, 'mtx>(&'s mut self) -> DatabaseTransactionRef<'mtx>
+    pub fn dbtx<'s, 'mtx>(&'s mut self) -> DatabaseTransaction<'_, 'mtx>
     where
         'a: 'mtx,
         's: 'mtx,
@@ -401,7 +401,7 @@ pub trait IDynCommonModuleInit: Debug {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_>;
 }
@@ -413,7 +413,7 @@ pub trait ModuleInit: Debug + Clone + Send + Sync + 'static {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_>;
 }
@@ -437,7 +437,7 @@ where
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         <Self as ModuleInit>::dump_database(self, dbtx, prefix_names).await
@@ -776,7 +776,7 @@ pub trait ServerModule: Debug + Sized {
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal<'a>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
     ) -> Vec<<Self::Common as ModuleCommon>::ConsensusItem>;
 
     /// This function is called once for every consensus item. The function
@@ -784,7 +784,7 @@ pub trait ServerModule: Debug + Sized {
     /// our state and therefore may be safely discarded by the atomic broadcast.
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'b>,
+        dbtx: &mut DatabaseTransaction<'_, 'b>,
         consensus_item: <Self::Common as ModuleCommon>::ConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()>;
@@ -795,7 +795,7 @@ pub trait ServerModule: Debug + Sized {
     /// no effect.
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'c>,
+        dbtx: &mut DatabaseTransaction<'_, 'c>,
         input: &'b <Self::Common as ModuleCommon>::Input,
     ) -> Result<InputMeta, <Self::Common as ModuleCommon>::InputError>;
 
@@ -809,7 +809,7 @@ pub trait ServerModule: Debug + Sized {
     /// `output_status`.
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'b>,
+        dbtx: &mut DatabaseTransaction<'_, 'b>,
         output: &'a <Self::Common as ModuleCommon>::Output,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, <Self::Common as ModuleCommon>::OutputError>;
@@ -820,7 +820,7 @@ pub trait ServerModule: Debug + Sized {
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         out_point: OutPoint,
     ) -> Option<<Self::Common as ModuleCommon>::OutputOutcome>;
 
@@ -831,7 +831,7 @@ pub trait ServerModule: Debug + Sized {
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     );

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -191,7 +191,6 @@ impl DatabaseDump {
 
     async fn serialize_gateway(&mut self) -> anyhow::Result<()> {
         let mut dbtx = self.read_only.begin_transaction().await;
-        let mut dbtx = dbtx.dbtx_ref();
         let gateway_serialized = Gateway::dump_database(&mut dbtx, self.prefixes.clone())
             .await
             .collect::<BTreeMap<String, _>>();

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -11,7 +11,7 @@ use fedimint_core::{Amount, OutPoint};
 
 pub async fn process_transaction_with_dbtx(
     modules: ServerModuleRegistry,
-    dbtx: &mut DatabaseTransaction<'_>,
+    dbtx: &mut DatabaseTransaction<'_, '_>,
     transaction: Transaction,
 ) -> Result<(), TransactionError> {
     let txid = transaction.tx_hash();

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -605,7 +605,7 @@ impl ConsensusServer {
 
     async fn process_consensus_item_with_db_transaction(
         &self,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         consensus_item: ConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -128,7 +128,7 @@ mod fedimint_migration_tests {
     /// in future code versions. This function should not be updated when
     /// database keys/values change - instead a new function should be added
     /// that creates a new database backup that can be tested.
-    async fn create_db_with_v0_data(mut dbtx: DatabaseTransaction<'_, '_>) {
+    async fn create_db_with_v0_data(mut dbtx: DatabaseTransaction<'static, '_>) {
         let accepted_tx_id = AcceptedTransactionKey(TransactionId::from_slice(&BYTE_32).unwrap());
 
         let (sk, _) = secp256k1::generate_keypair(&mut OsRng);

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -128,7 +128,7 @@ mod fedimint_migration_tests {
     /// in future code versions. This function should not be updated when
     /// database keys/values change - instead a new function should be added
     /// that creates a new database backup that can be tested.
-    async fn create_db_with_v0_data(mut dbtx: DatabaseTransaction<'_>) {
+    async fn create_db_with_v0_data(mut dbtx: DatabaseTransaction<'_, '_>) {
         let accepted_tx_id = AcceptedTransactionKey(TransactionId::from_slice(&BYTE_32).unwrap());
 
         let (sk, _) = secp256k1::generate_keypair(&mut OsRng);

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -254,9 +254,9 @@ impl ConsensusApi {
         ))
     }
 
-    async fn handle_backup_request<'s, 'dbtx, 'a>(
-        &'s self,
-        dbtx: &'dbtx mut DatabaseTransaction<'_, 'a>,
+    async fn handle_backup_request(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         request: SignedBackupRequest,
     ) -> Result<(), ApiError> {
         let request = request
@@ -437,7 +437,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             BACKUP_ENDPOINT,
             async |fedimint: &ConsensusApi, context, request: SignedBackupRequest| -> () {
                 fedimint
-                    .handle_backup_request(&mut context.dbtx(), request).await?;
+                    .handle_backup_request(context.dbtx(), request).await?;
                 Ok(())
 
             }
@@ -446,7 +446,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             RECOVER_ENDPOINT,
             async |fedimint: &ConsensusApi, context, id: secp256k1_zkp::XOnlyPublicKey| -> Option<ClientBackupSnapshot> {
                 Ok(fedimint
-                    .handle_recover_request(&mut context.dbtx(), id).await)
+                    .handle_recover_request(context.dbtx(), id).await)
             }
         },
         api_endpoint! {

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -15,9 +15,7 @@ use fedimint_core::block::{Block, SignedBlock};
 use fedimint_core::config::{ClientConfig, JsonWithKind};
 use fedimint_core::core::backup::SignedBackupRequest;
 use fedimint_core::core::{DynOutputOutcome, ModuleInstanceId};
-use fedimint_core::db::{
-    Database, DatabaseTransaction, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped,
-};
+use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::endpoint_constants::{
     AUDIT_ENDPOINT, AUTH_ENDPOINT, AWAIT_BLOCK_ENDPOINT, AWAIT_OUTPUT_OUTCOME_ENDPOINT,
     AWAIT_SIGNED_BLOCK_ENDPOINT, AWAIT_TRANSACTION_ENDPOINT, BACKUP_ENDPOINT,
@@ -258,7 +256,7 @@ impl ConsensusApi {
 
     async fn handle_backup_request<'s, 'dbtx, 'a>(
         &'s self,
-        dbtx: &'dbtx mut DatabaseTransactionRef<'a>,
+        dbtx: &'dbtx mut DatabaseTransaction<'_, 'a>,
         request: SignedBackupRequest,
     ) -> Result<(), ApiError> {
         let request = request
@@ -288,7 +286,7 @@ impl ConsensusApi {
 
     async fn handle_recover_request(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         id: secp256k1_zkp::XOnlyPublicKey,
     ) -> Option<ClientBackupSnapshot> {
         dbtx.get_value(&ClientBackupKey(id)).await

--- a/fedimint-testing/src/db.rs
+++ b/fedimint-testing/src/db.rs
@@ -46,7 +46,7 @@ pub async fn prepare_db_migration_snapshot<F>(
     decoders: ModuleDecoderRegistry,
 ) -> anyhow::Result<()>
 where
-    F: for<'a> Fn(DatabaseTransaction<'a>) -> BoxFuture<'a, ()>,
+    F: for<'a> Fn(DatabaseTransaction<'static, 'a>) -> BoxFuture<'a, ()>,
 {
     let project_root = get_project_root().unwrap();
     let snapshot_dir = project_root.join("db/migrations").join(snapshot_name);
@@ -57,7 +57,7 @@ where
         decoders: ModuleDecoderRegistry,
     ) -> anyhow::Result<()>
     where
-        F: for<'a> Fn(DatabaseTransaction<'a>) -> BoxFuture<'a, ()>,
+        F: for<'a> Fn(DatabaseTransaction<'static, 'a>) -> BoxFuture<'a, ()>,
     {
         let db = Database::new(
             RocksDb::open(&snapshot_dir)

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -124,7 +124,7 @@ impl GatewayClientBuilder {
     pub async fn save_config(
         &self,
         config: FederationConfig,
-        mut dbtx: DatabaseTransaction<'_>,
+        mut dbtx: DatabaseTransaction<'_, '_>,
     ) -> Result<()> {
         let id = config.invite_code.federation_id();
         dbtx.insert_entry(&FederationIdKey { id }, &config).await;
@@ -135,7 +135,7 @@ impl GatewayClientBuilder {
 
     pub async fn load_configs(
         &self,
-        mut dbtx: DatabaseTransaction<'_>,
+        mut dbtx: DatabaseTransaction<'_, '_>,
     ) -> Result<Vec<FederationConfig>> {
         Ok(dbtx
             .find_by_prefix(&FederationIdKeyPrefix)

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -124,7 +124,7 @@ impl GatewayClientBuilder {
     pub async fn save_config(
         &self,
         config: FederationConfig,
-        mut dbtx: DatabaseTransaction<'_, '_>,
+        mut dbtx: DatabaseTransaction<'static, '_>,
     ) -> Result<()> {
         let id = config.invite_code.federation_id();
         dbtx.insert_entry(&FederationIdKey { id }, &config).await;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -37,7 +37,7 @@ use fedimint_core::core::{
     ModuleInstanceId, ModuleKind, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
 };
-use fedimint_core::db::{Database, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::fmt_utils::OptStacktrace;
 use fedimint_core::module::CommonModuleInit;
 use fedimint_core::task::{sleep, RwLock, TaskGroup, TaskHandle, TaskShutdownToken};
@@ -346,7 +346,7 @@ impl Gateway {
     }
 
     pub async fn dump_database<'a>(
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + 'a> {
         let mut gateway_items: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -515,7 +515,7 @@ impl GatewayClientModule {
         self.client_ctx
             .global_db()
             .autocommit(
-                |dbtx, _| {
+                |dbtx| {
                     Box::pin(async {
                         let operation_id = OperationId(payload.contract_id.into_inner());
 

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -515,7 +515,7 @@ impl GatewayClientModule {
         self.client_ctx
             .global_db()
             .autocommit(
-                |dbtx| {
+                |dbtx, _| {
                     Box::pin(async {
                         let operation_id = OperationId(payload.contract_id.into_inner());
 

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -17,7 +17,7 @@ use fedimint_client::{sm_enum_variant_translation, AddStateMachinesError, DynGlo
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{AutocommitError, Database, DatabaseTransactionRef};
+use fedimint_core::db::{AutocommitError, Database, DatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{ApiVersion, ModuleInit, MultiApiVersion, TransactionItemAmount};
 use fedimint_core::util::SafeUrl;
@@ -125,7 +125,7 @@ impl ModuleInit for GatewayClientInit {
 
     async fn dump_database(
         &self,
-        _dbtx: &mut DatabaseTransactionRef<'_>,
+        _dbtx: &mut DatabaseTransaction<'_, '_>,
         _prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         Box::new(vec![].into_iter())
@@ -515,7 +515,7 @@ impl GatewayClientModule {
         self.client_ctx
             .global_db()
             .autocommit(
-                |dbtx| {
+                |dbtx, _| {
                     Box::pin(async {
                         let operation_id = OperationId(payload.contract_id.into_inner());
 

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -633,7 +633,7 @@ impl GatewayPayClaimOutgoingContract {
     }
 
     async fn transition_claim_outgoing_contract(
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         global_context: DynGlobalClientContext,
         context: GatewayClientContext,
         common: GatewayPayCommon,
@@ -810,7 +810,7 @@ impl GatewayPayCancelContract {
     }
 
     async fn transition_canceled(
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         contract: OutgoingContractAccount,
         global_context: DynGlobalClientContext,
         context: GatewayClientContext,

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -12,7 +12,7 @@ use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::{Decoder, IntoDynInstance, KeyPair, OperationId};
-use fedimint_core::db::{Database, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion, TransactionItemAmount,
 };
@@ -92,7 +92,7 @@ impl ClientModule for DummyClientModule {
 
     async fn create_sufficient_input(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         id: OperationId,
         amount: Amount,
     ) -> anyhow::Result<Vec<ClientInput<<Self::Common as ModuleCommon>::Input, Self::States>>> {
@@ -121,7 +121,7 @@ impl ClientModule for DummyClientModule {
 
     async fn create_exact_output(
         &self,
-        _dbtx: &mut DatabaseTransactionRef<'_>,
+        _dbtx: &mut DatabaseTransaction<'_, '_>,
         id: OperationId,
         amount: Amount,
     ) -> Vec<ClientOutput<<Self::Common as ModuleCommon>::Output, Self::States>> {
@@ -161,7 +161,7 @@ impl ClientModule for DummyClientModule {
         stream.next_or_pending().await
     }
 
-    async fn get_balance(&self, dbtc: &mut DatabaseTransactionRef<'_>) -> Amount {
+    async fn get_balance(&self, dbtc: &mut DatabaseTransaction<'_, '_>) -> Amount {
         get_funds(dbtc).await
     }
 
@@ -309,7 +309,7 @@ impl DummyClientModule {
     }
 }
 
-async fn get_funds(dbtx: &mut DatabaseTransactionRef<'_>) -> Amount {
+async fn get_funds(dbtx: &mut DatabaseTransaction<'_, '_>) -> Amount {
     let funds = dbtx.get_value(&DummyClientFundsKeyV0).await;
     funds.unwrap_or(Amount::ZERO)
 }
@@ -324,7 +324,7 @@ impl ModuleInit for DummyClientInit {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut items: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> = BTreeMap::new();

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -245,10 +245,7 @@ impl DummyClientModule {
         // TODO: Building a tx could be easier
         // Create input using our own account
         let inputs = fedimint_client::module::ClientModule::create_sufficient_input(
-            self,
-            &mut dbtx.dbtx_ref(),
-            op_id,
-            amount,
+            self, &mut dbtx, op_id, amount,
         )
         .await?
         .into_iter()

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -4,7 +4,7 @@ use fedimint_client::sm::{DynState, State, StateTransition};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::{GlobalFederationApi, OutputOutcomeError};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
 use fedimint_core::{Amount, OutPoint, TransactionId};
@@ -83,7 +83,7 @@ impl State for DummyStateMachine {
     }
 }
 
-async fn add_funds(amount: Amount, mut dbtx: DatabaseTransactionRef<'_>) {
+async fn add_funds(amount: Amount, mut dbtx: DatabaseTransaction<'_, '_>) {
     let funds = get_funds(&mut dbtx).await + amount;
     dbtx.insert_entry(&DummyClientFundsKeyV0, &funds).await;
 }

--- a/modules/fedimint-dummy-server/src/db.rs
+++ b/modules/fedimint-dummy-server/src/db.rs
@@ -53,7 +53,7 @@ impl_db_record!(
 impl_db_lookup!(key = DummyFundsKeyV1, query_prefix = DummyFundsPrefixV1);
 
 /// Example DB migration from version 0 to version 1
-pub async fn migrate_to_v1(dbtx: &mut DatabaseTransaction<'_>) -> Result<(), anyhow::Error> {
+pub async fn migrate_to_v1(dbtx: &mut DatabaseTransaction<'_, '_>) -> Result<(), anyhow::Error> {
     // Select old entries
     let v0_entries = dbtx
         .find_by_prefix(&DummyFundsKeyPrefixV0)

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -9,7 +9,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    DatabaseTransactionRef, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, MigrationMap,
+    DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, MigrationMap,
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -49,7 +49,7 @@ impl ModuleInit for DummyInit {
     /// Dumps all database items for debugging
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         // TODO: Boilerplate-code
@@ -194,14 +194,14 @@ impl ServerModule for Dummy {
 
     async fn consensus_proposal(
         &self,
-        _dbtx: &mut DatabaseTransactionRef<'_>,
+        _dbtx: &mut DatabaseTransaction<'_, '_>,
     ) -> Vec<DummyConsensusItem> {
         Vec::new()
     }
 
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        _dbtx: &mut DatabaseTransactionRef<'b>,
+        _dbtx: &mut DatabaseTransaction<'_, 'b>,
         _consensus_item: DummyConsensusItem,
         _peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -210,7 +210,7 @@ impl ServerModule for Dummy {
 
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'c>,
+        dbtx: &mut DatabaseTransaction<'_, 'c>,
         input: &'b DummyInput,
     ) -> Result<InputMeta, DummyInputError> {
         let current_funds = dbtx
@@ -251,7 +251,7 @@ impl ServerModule for Dummy {
 
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'b>,
+        dbtx: &mut DatabaseTransaction<'_, 'b>,
         output: &'a DummyOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, DummyOutputError> {
@@ -274,7 +274,7 @@ impl ServerModule for Dummy {
 
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         out_point: OutPoint,
     ) -> Option<DummyOutputOutcome> {
         // check whether or not the output has been processed
@@ -283,7 +283,7 @@ impl ServerModule for Dummy {
 
     async fn audit(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -279,7 +279,7 @@ impl DecryptingPreimageState {
     async fn transition_incoming_contract_funded(
         result: Result<Preimage, IncomingSmError>,
         old_state: IncomingStateMachine,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         global_context: DynGlobalClientContext,
         context: LightningClientContext,
     ) -> IncomingStateMachine {
@@ -320,7 +320,7 @@ impl DecryptingPreimageState {
     }
 
     async fn refund_incoming_contract(
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         global_context: DynGlobalClientContext,
         context: LightningClientContext,
         old_state: IncomingStateMachine,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -939,13 +939,12 @@ impl LightningClientModule {
             _ => unreachable!("User client will only create contract outputs on spend"),
         };
 
-        let dyn_client_output = ClientOutput {
+        let output = self.client_ctx.make_client_output(ClientOutput {
             output: LightningOutput::V0(client_output.output),
             state_machines: client_output.state_machines,
-        }
-        .into_dyn(self.client_ctx.module_instance_id());
+        });
 
-        let tx = TransactionBuilder::new().with_output(dyn_client_output);
+        let tx = TransactionBuilder::new().with_output(output);
         let operation_meta_gen = |txid, change| {
             LightningOperationMeta::Pay(LightningOperationMetaPay {
                 out_point: OutPoint { txid, out_idx: 0 },
@@ -1125,8 +1124,7 @@ impl LightningClientModule {
                 self.cfg.network,
             )
             .await?;
-        let tx = TransactionBuilder::new()
-            .with_output(output.into_dyn(self.client_ctx.module_instance_id()));
+        let tx = TransactionBuilder::new().with_output(self.client_ctx.make_client_output(output));
         let extra_meta = serde_json::to_value(extra_meta).expect("extra_meta is serializable");
         let operation_meta_gen = |txid, _| LightningOperationMeta::Receive {
             out_point: OutPoint { txid, out_idx: 0 },

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -25,9 +25,7 @@ use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{
-    DatabaseTransaction, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped,
-};
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion, TransactionItemAmount,
@@ -224,7 +222,7 @@ impl ModuleInit for LightningClientInit {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut ln_client_items: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =
@@ -377,7 +375,7 @@ impl LightningClientModule {
     async fn get_prev_payment_result(
         &self,
         payment_hash: &sha256::Hash,
-        dbtx: &mut DatabaseTransaction<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
     ) -> PaymentResult {
         let prev_result = dbtx
             .get_value(&PaymentResultKey {
@@ -1340,7 +1338,7 @@ pub struct OutgoingLightningPayment {
 }
 
 async fn set_payment_result(
-    dbtx: &mut DatabaseTransactionRef<'_>,
+    dbtx: &mut DatabaseTransaction<'_, '_>,
     payment_hash: sha256::Hash,
     payment_type: PayType,
     contract_id: ContractId,

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -349,7 +349,7 @@ impl LightningPayFunded {
         old_state: LightningPayStateMachine,
         contract_id: ContractId,
         timelock: u32,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         payment_hash: sha256::Hash,
         common: LightningPayCommon,
     ) -> LightningPayStateMachine {
@@ -431,7 +431,7 @@ impl LightningPayRefundable {
     async fn try_refund_outgoing_contract(
         old_state: LightningPayStateMachine,
         common: LightningPayCommon,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         global_context: DynGlobalClientContext,
     ) -> LightningPayStateMachine {
         let contract_data = common.contract;

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -224,7 +224,7 @@ impl LightningReceiveConfirmedInvoice {
         old_state: LightningReceiveStateMachine,
         keypair: KeyPair,
         result: Result<IncomingContractAccount, LightningReceiveError>,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         global_context: DynGlobalClientContext,
     ) -> LightningReceiveStateMachine {
         match result {
@@ -247,7 +247,7 @@ impl LightningReceiveConfirmedInvoice {
     }
 
     async fn claim_incoming_contract(
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         contract: IncomingContractAccount,
         keypair: KeyPair,
         global_context: DynGlobalClientContext,

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -857,14 +857,14 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 BLOCK_COUNT_ENDPOINT,
                 async |module: &Lightning, context, _v: ()| -> Option<u64> {
-                    Ok(Some(module.consensus_block_count(&mut context.dbtx()).await))
+                    Ok(Some(module.consensus_block_count(context.dbtx()).await))
                 }
             },
             api_endpoint! {
                 ACCOUNT_ENDPOINT,
                 async |module: &Lightning, context, contract_id: ContractId| -> Option<ContractAccount> {
                     Ok(module
-                        .get_contract_account(&mut context.dbtx(), contract_id)
+                        .get_contract_account(context.dbtx(), contract_id)
                         .await)
                 }
             },
@@ -879,7 +879,7 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 AWAIT_BLOCK_HEIGHT_ENDPOINT,
                 async |module: &Lightning, context, block_height: u64| -> () {
-                    module.wait_block_height(block_height, &mut context.dbtx()).await;
+                    module.wait_block_height(block_height, context.dbtx()).await;
                     Ok(())
                 }
             },
@@ -899,7 +899,7 @@ impl ServerModule for Lightning {
                 OFFER_ENDPOINT,
                 async |module: &Lightning, context, payment_hash: bitcoin_hashes::sha256::Hash| -> Option<IncomingContractOffer> {
                     Ok(module
-                        .get_offer(&mut context.dbtx(), payment_hash)
+                        .get_offer(context.dbtx(), payment_hash)
                         .await)
                }
             },
@@ -914,13 +914,13 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 LIST_GATEWAYS_ENDPOINT,
                 async |module: &Lightning, context, _v: ()| -> Vec<LightningGatewayAnnouncement> {
-                    Ok(module.list_gateways(&mut context.dbtx()).await)
+                    Ok(module.list_gateways(context.dbtx()).await)
                 }
             },
             api_endpoint! {
                 REGISTER_GATEWAY_ENDPOINT,
                 async |module: &Lightning, context, gateway: LightningGatewayAnnouncement| -> () {
-                    module.register_gateway(&mut context.dbtx(), gateway).await;
+                    module.register_gateway(context.dbtx(), gateway).await;
                     Ok(())
                 }
             },

--- a/modules/fedimint-mint-client/src/backup.rs
+++ b/modules/fedimint-mint-client/src/backup.rs
@@ -2,7 +2,7 @@ use fedimint_client::sm::Executor;
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::DatabaseTransactionRef;
+use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, Tiered, TieredMulti};
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ impl EcashBackup {
 impl MintClientModule {
     pub async fn prepare_plaintext_ecash_backup(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         executor: Executor<DynGlobalClientContext>,
         api: DynGlobalApi,
         module_instance_id: ModuleInstanceId,

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -112,7 +112,7 @@ impl MintInputStateCreated {
     async fn transition_success(
         result: Result<(), String>,
         old_state: MintInputStateMachine,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         global_context: DynGlobalClientContext,
     ) -> MintInputStateMachine {
         assert!(matches!(old_state.state, MintInputStates::Created(_)));
@@ -133,7 +133,7 @@ impl MintInputStateCreated {
     }
 
     async fn refund(
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         old_state: MintInputStateMachine,
         global_context: DynGlobalClientContext,
     ) -> MintInputStateMachine {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1082,14 +1082,10 @@ impl MintClientModule {
         );
 
         let amount = notes.total_amount();
-        let mint_input = self
-            .create_input_from_notes(operation_id, notes)
-            .await?
-            .into_iter()
-            .map(|input| input.into_dyn(self.client_ctx.module_instance_id()))
-            .collect();
+        let mint_input = self.create_input_from_notes(operation_id, notes).await?;
 
-        let tx = TransactionBuilder::new().with_inputs(mint_input);
+        let tx =
+            TransactionBuilder::new().with_inputs(self.client_ctx.map_dyn(mint_input).collect());
 
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientModule::reissue_external_notes extra_meta is serializable");

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1203,7 +1203,7 @@ impl MintClientModule {
         self.client_ctx
             .global_db()
             .autocommit(
-                move |dbtx, _| {
+                move |dbtx| {
                     let extra_meta = extra_meta.clone();
                     Box::pin(async move {
                         let (operation_id, states, notes) = self

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1203,7 +1203,7 @@ impl MintClientModule {
         self.client_ctx
             .global_db()
             .autocommit(
-                move |dbtx| {
+                move |dbtx, _| {
                     let extra_meta = extra_meta.clone();
                     Box::pin(async move {
                         let (operation_id, states, notes) = self

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -131,7 +131,7 @@ async fn await_user_cancels(
 
 async fn transition_user_cancel(
     prev_state: MintOOBStateMachine,
-    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
     global_context: DynGlobalClientContext,
 ) -> MintOOBStateMachine {
     let (amount, spendable_note) = match prev_state.state {
@@ -161,7 +161,7 @@ async fn await_timeout_cancel(deadline: SystemTime) {
 
 async fn transition_timeout_cancel(
     prev_state: MintOOBStateMachine,
-    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
     global_context: DynGlobalClientContext,
 ) -> MintOOBStateMachine {
     let (amount, spendable_note) = match prev_state.state {
@@ -184,7 +184,7 @@ async fn transition_timeout_cancel(
 }
 
 async fn try_cancel_oob_spend(
-    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
     operation_id: OperationId,
     amount: Amount,
     spendable_note: SpendableNote,

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -221,7 +221,7 @@ impl MintOutputStatesCreated {
     }
 
     async fn transition_outcome_ready(
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+        dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
         output_outcomes_result: Result<BTreeMap<PeerId, MintOutputOutcome>, String>,
         old_state: MintOutputStateMachine,
         mint_keys: Tiered<AggregatePublicKey>,

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -442,7 +442,7 @@ impl ServerModule for Mint {
                 BACKUP_ENDPOINT,
                 async |module: &Mint, context, request: SignedBackupRequest| -> () {
                     module
-                        .handle_backup_request(&mut context.dbtx(), request).await?;
+                        .handle_backup_request(context.dbtx(), request).await?;
                     Ok(())
                 }
             },
@@ -450,7 +450,7 @@ impl ServerModule for Mint {
                 RECOVER_ENDPOINT,
                 async |module: &Mint, context, id: secp256k1_zkp::XOnlyPublicKey| -> Option<ECashUserBackupSnapshot> {
                     Ok(module
-                        .handle_recover_request(&mut context.dbtx(), id).await)
+                        .handle_recover_request(context.dbtx(), id).await)
                 }
             },
         ]

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -7,9 +7,7 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{
-    DatabaseTransactionRef, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
-};
+use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::endpoint_constants::{BACKUP_ENDPOINT, RECOVER_ENDPOINT};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -58,7 +56,7 @@ impl ModuleInit for MintInit {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut mint: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> = BTreeMap::new();
@@ -302,14 +300,14 @@ impl ServerModule for Mint {
 
     async fn consensus_proposal(
         &self,
-        _dbtx: &mut DatabaseTransactionRef<'_>,
+        _dbtx: &mut DatabaseTransaction<'_, '_>,
     ) -> Vec<MintConsensusItem> {
         Vec::new()
     }
 
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        _dbtx: &mut DatabaseTransactionRef<'b>,
+        _dbtx: &mut DatabaseTransaction<'_, 'b>,
         _consensus_item: MintConsensusItem,
         _peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -318,7 +316,7 @@ impl ServerModule for Mint {
 
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'c>,
+        dbtx: &mut DatabaseTransaction<'_, 'c>,
         input: &'b MintInput,
     ) -> Result<InputMeta, MintInputError> {
         let input = input.ensure_v0_ref()?;
@@ -357,7 +355,7 @@ impl ServerModule for Mint {
 
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'b>,
+        dbtx: &mut DatabaseTransaction<'_, 'b>,
         output: &'a MintOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, MintOutputError> {
@@ -385,7 +383,7 @@ impl ServerModule for Mint {
 
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         out_point: OutPoint,
     ) -> Option<MintOutputOutcome> {
         dbtx.get_value(&MintOutputOutcomeKey(out_point)).await
@@ -393,7 +391,7 @@ impl ServerModule for Mint {
 
     async fn audit(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {
@@ -462,7 +460,7 @@ impl ServerModule for Mint {
 impl Mint {
     async fn handle_backup_request(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         request: SignedBackupRequest,
     ) -> Result<(), ApiError> {
         let request = request
@@ -492,7 +490,7 @@ impl Mint {
 
     async fn handle_recover_request(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_, '_>,
         id: secp256k1_zkp::XOnlyPublicKey,
     ) -> Option<ECashUserBackupSnapshot> {
         dbtx.get_value(&EcashBackupKey(id)).await

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -729,7 +729,7 @@ mod fedimint_migration_tests {
     /// in future code versions. This function should not be updated when
     /// database keys/values change - instead a new function should be added
     /// that creates a new database backup that can be tested.
-    async fn create_db_with_v0_data(mut dbtx: DatabaseTransaction<'_>) {
+    async fn create_db_with_v0_data(mut dbtx: DatabaseTransaction<'static, '_>) {
         let (_, pk) = secp256k1::generate_keypair(&mut OsRng);
         let nonce_key = NonceKey(Nonce(pk.x_only_public_key().0));
         dbtx.insert_new_entry(&nonce_key, &()).await;

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -255,7 +255,7 @@ async fn await_btc_transaction_confirmed(
 }
 
 async fn transition_btc_tx_confirmed(
-    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_, '_>,
     global_context: DynGlobalClientContext,
     old_state: DepositStateMachine,
     txout_proof: TxOutProof,

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -525,7 +525,7 @@ impl WalletClientModule {
                 .create_withdraw_output(operation_id, address.clone(), amount, fee)
                 .await?;
             let tx_builder = TransactionBuilder::new()
-                .with_output(withdraw_output.into_dyn(self.client_ctx.module_instance_id()));
+                .with_output(self.client_ctx.make_client_output(withdraw_output));
 
             self.client_ctx
                 .finalize_and_submit_transaction(
@@ -556,7 +556,7 @@ impl WalletClientModule {
             .create_rbf_withdraw_output(operation_id, rbf.clone())
             .await?;
         let tx_builder = TransactionBuilder::new()
-            .with_output(withdraw_output.into_dyn(self.client_ctx.module_instance_id()));
+            .with_output(self.client_ctx.make_client_output(withdraw_output));
 
         self.client_ctx
             .finalize_and_submit_transaction(

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -373,7 +373,7 @@ impl WalletClientModule {
             .client_ctx
             .global_db()
             .autocommit(
-                |dbtx| {
+                |dbtx, _| {
                     Box::pin(async {
                         let (operation_id, sm, address) = self
                             .get_deposit_address_inner(

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -373,7 +373,7 @@ impl WalletClientModule {
             .client_ctx
             .global_db()
             .autocommit(
-                |dbtx, _| {
+                |dbtx| {
                     Box::pin(async {
                         let (operation_id, sm, address) = self
                             .get_deposit_address_inner(

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1680,7 +1680,7 @@ mod fedimint_migration_tests {
     /// in future code versions. This function should not be updated when
     /// database keys/values change - instead a new function should be added
     /// that creates a new database backup that can be tested.
-    async fn create_db_with_v0_data(mut dbtx: DatabaseTransaction<'_>) {
+    async fn create_db_with_v0_data(mut dbtx: DatabaseTransaction<'static, '_>) {
         dbtx.insert_new_entry(&BlockHashKey(BlockHash::from_slice(&BYTE_32).unwrap()), &())
             .await;
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -645,7 +645,7 @@ impl ServerModule for Wallet {
                 BLOCK_COUNT_ENDPOINT,
                 async |module: &Wallet, context, _params: ()| -> u32 {
                     // TODO: perhaps change this to an Option
-                    Ok(module.consensus_block_count(&mut context.dbtx()).await.unwrap_or_default())
+                    Ok(module.consensus_block_count( context.dbtx()).await.unwrap_or_default())
                 }
             },
             api_endpoint! {
@@ -658,7 +658,7 @@ impl ServerModule for Wallet {
                 PEG_OUT_FEES_ENDPOINT,
                 async |module: &Wallet, context, params: (Address, u64)| -> Option<PegOutFees> {
                     let (address, sats) = params;
-                    let feerate = module.consensus_fee_rate(&mut context.dbtx()).await;
+                    let feerate = module.consensus_fee_rate( context.dbtx()).await;
 
                     // Since we are only calculating the tx size we can use an arbitrary dummy nonce.
                     let dummy_tweak = [0; 32];
@@ -667,7 +667,7 @@ impl ServerModule for Wallet {
                         bitcoin::Amount::from_sat(sats),
                         address.script_pubkey(),
                         vec![],
-                        module.available_utxos(&mut context.dbtx()).await,
+                        module.available_utxos( context.dbtx()).await,
                         feerate,
                         &dummy_tweak,
                         None

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -9,7 +9,7 @@ use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::ClientArc;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::db::mem_impl::MemDatabase;
-use fedimint_core::db::{DatabaseTransactionRef, IRawDatabaseExt};
+use fedimint_core::db::{DatabaseTransaction, IRawDatabaseExt};
 use fedimint_core::task::sleep;
 use fedimint_core::util::{BoxStream, NextOrPending};
 use fedimint_core::{sats, Amount, Feerate, PeerId, ServerModule};
@@ -521,7 +521,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
 }
 
 async fn sync_wallet_to_block(
-    dbtx: &mut DatabaseTransactionRef<'_>,
+    dbtx: &mut DatabaseTransaction<'_, '_>,
     wallet: &mut fedimint_wallet_server::Wallet,
     block_count: u32,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
On top of #3642

Having a separate type for commitable vs non-commitable is a bit of a pain that I've hit during refactoring, as there's no good way to generalize over the two, and adding another layer of traits seems like a nightmare.

It occurred to me that by keeping an extra lifetime (basically  "to parent tx", where `'static` means "no parent") it would be possible to have `commit(&mut self)` only on `DatabaseTransaction<'static, 'tx>`.

After a lot of grinding I was able to make it work. From the user perspective it's not even a bad UI (an extra `'_` on the type).

Unfortunately when dealing with certain non-trivial core logic around commiting (mostly internal), it gets extremely hard to work with, as it requires dealing with things like: https://users.rust-lang.org/t/argument-requires-that-is-borrowed-for-static/66503/2?u=yandros

I need to sleep on it, and think a bit if this complication is worth it. I also consider just getting rid of `DatabaseTransactionRef` and making the whole thing a `bool`, so trying to `commit` on a reference dbtx just panics. At certain point one needs to side with simplicity/