### PR TITLE
chore: get rid of `DatabaseTransactionRef`

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -588,10 +588,9 @@ async fn get_note_summary(client: &ClientArc) -> anyhow::Result<serde_json::Valu
         .get_wallet_summary(
             &mut client
                 .db()
-                .begin_transaction()
+                .begin_transaction_nc()
                 .await
-                .to_ref_with_prefix_module_id(1)
-                .into_non_committable(),
+                .to_ref_with_prefix_module_id(1),
         )
         .await;
     Ok(serde_json::to_value(InfoResponse {

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -590,7 +590,8 @@ async fn get_note_summary(client: &ClientArc) -> anyhow::Result<serde_json::Valu
                 .db()
                 .begin_transaction()
                 .await
-                .dbtx_ref_with_prefix_module_id(1),
+                .to_ref_with_prefix_module_id(1)
+                .into_non_committable(),
         )
         .await;
     Ok(serde_json::to_value(InfoResponse {

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -146,7 +146,7 @@ impl Client {
             if module.supports_backup() {
                 let backup = module
                     .backup(
-                        &mut dbtx.dbtx_ref_with_prefix_module_id(id),
+                        &mut dbtx.to_ref_with_prefix_module_id(id).into_non_committable(),
                         self.executor.clone(),
                         self.api.clone(),
                         id,
@@ -205,7 +205,7 @@ impl Client {
             );
             module
                 .wipe(
-                    &mut dbtx.dbtx_ref_with_prefix_module_id(id),
+                    &mut dbtx.to_ref_with_prefix_module_id(id).into_non_committable(),
                     id,
                     self.executor.clone(),
                 )
@@ -277,7 +277,7 @@ impl Client {
             );
             module
                 .restore(
-                    &mut dbtx,
+                    &mut dbtx.to_ref_non_committable(),
                     id,
                     self.executor.clone(),
                     self.api.clone(),

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -146,7 +146,7 @@ impl Client {
             if module.supports_backup() {
                 let backup = module
                     .backup(
-                        &mut dbtx.to_ref_with_prefix_module_id(id).into_non_committable(),
+                        &mut dbtx.to_ref_with_prefix_module_id(id).into_nc(),
                         self.executor.clone(),
                         self.api.clone(),
                         id,
@@ -205,7 +205,7 @@ impl Client {
             );
             module
                 .wipe(
-                    &mut dbtx.to_ref_with_prefix_module_id(id).into_non_committable(),
+                    &mut dbtx.to_ref_with_prefix_module_id(id).into_nc(),
                     id,
                     self.executor.clone(),
                 )
@@ -277,7 +277,7 @@ impl Client {
             );
             module
                 .restore(
-                    &mut dbtx.to_ref_non_committable(),
+                    &mut dbtx.to_ref_nc(),
                     id,
                     self.executor.clone(),
                     self.api.clone(),

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -404,7 +404,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
 
         self.client
             .finalize_and_submit_transaction_inner(
-                &mut dbtx.global_tx().to_ref_non_committable(),
+                &mut dbtx.global_tx().to_ref_nc(),
                 self.operation,
                 TransactionBuilder::new().with_input(instance_input),
             )
@@ -424,7 +424,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
 
         self.client
             .finalize_and_submit_transaction_inner(
-                &mut dbtx.global_tx().to_ref_non_committable(),
+                &mut dbtx.global_tx().to_ref_nc(),
                 self.operation,
                 TransactionBuilder::new().with_output(instance_output),
             )
@@ -440,7 +440,7 @@ impl IGlobalClientContext for ModuleGlobalClientContext {
 
         self.client
             .executor
-            .add_state_machines_dbtx(&mut dbtx.global_tx().to_ref_non_committable(), vec![state])
+            .add_state_machines_dbtx(&mut dbtx.global_tx().to_ref_nc(), vec![state])
             .await
     }
 
@@ -912,7 +912,7 @@ impl Client {
         tx_builder: TransactionBuilder,
     ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)> {
         let (transaction, mut states, change_range) = self
-            .finalize_transaction(&mut dbtx.to_ref_non_committable(), operation_id, tx_builder)
+            .finalize_transaction(&mut dbtx.to_ref_nc(), operation_id, tx_builder)
             .await?;
         let txid = transaction.tx_hash();
         let change_outpoints = change_range
@@ -1119,7 +1119,7 @@ impl Client {
         self.primary_module()
             .get_balance(
                 self.primary_module_instance,
-                &mut self.db().begin_transaction().await.into_non_committable(),
+                &mut self.db().begin_transaction_nc().await,
             )
             .await
     }
@@ -1137,9 +1137,9 @@ impl Client {
             yield initial_balance;
             let mut prev_balance = initial_balance;
             while let Some(()) = balance_changes.next().await {
-                let dbtx = db.begin_transaction().await;
+                let mut dbtx = db.begin_transaction_nc().await;
                 let balance = primary_module
-                    .get_balance(primary_module_instance, &mut dbtx.into_non_committable())
+                    .get_balance(primary_module_instance, &mut dbtx)
                     .await;
 
                 // Deduplicate in case modules cannot always tell if the balance actually changed

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -106,7 +106,7 @@ impl OperationLog {
 
     pub async fn get_operation(&self, operation_id: OperationId) -> Option<OperationLogEntry> {
         Self::get_operation_inner(
-            &mut self.db.begin_transaction().await.into_non_committable(),
+            &mut self.db.begin_transaction().await.into_nc(),
             operation_id,
         )
         .await
@@ -129,10 +129,9 @@ impl OperationLog {
         let outcome_json = serde_json::to_value(outcome).expect("Outcome is not serializable");
 
         let mut dbtx = db.begin_transaction().await;
-        let mut operation =
-            Self::get_operation_inner(&mut dbtx.to_ref_non_committable(), operation_id)
-                .await
-                .expect("Operation exists");
+        let mut operation = Self::get_operation_inner(&mut dbtx.to_ref_nc(), operation_id)
+            .await
+            .expect("Operation exists");
         operation.outcome = Some(outcome_json);
         dbtx.insert_entry(&OperationLogKey { operation_id }, &operation)
             .await;
@@ -394,7 +393,7 @@ mod tests {
 
         let mut dbtx = db.begin_transaction().await;
         op_log
-            .add_operation_log_entry(&mut dbtx.to_ref_non_committable(), op_id, "foo", "bar")
+            .add_operation_log_entry(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
             .await;
         dbtx.commit_tx().await;
 
@@ -432,7 +431,7 @@ mod tests {
 
         let mut dbtx = db.begin_transaction().await;
         op_log
-            .add_operation_log_entry(&mut dbtx.to_ref_non_committable(), op_id, "foo", "bar")
+            .add_operation_log_entry(&mut dbtx.to_ref_nc(), op_id, "foo", "bar")
             .await;
         dbtx.commit_tx().await;
 
@@ -458,7 +457,7 @@ mod tests {
             let mut dbtx = db.begin_transaction().await;
             op_log
                 .add_operation_log_entry(
-                    &mut dbtx.to_ref_non_committable(),
+                    &mut dbtx.to_ref_nc(),
                     OperationId([operation_idx; 32]),
                     "foo",
                     operation_idx,

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -105,7 +105,11 @@ impl OperationLog {
     }
 
     pub async fn get_operation(&self, operation_id: OperationId) -> Option<OperationLogEntry> {
-        Self::get_operation_inner(&mut self.db.begin_transaction().await, operation_id).await
+        Self::get_operation_inner(
+            &mut self.db.begin_transaction().await.into_non_committable(),
+            operation_id,
+        )
+        .await
     }
 
     async fn get_operation_inner(
@@ -125,9 +129,10 @@ impl OperationLog {
         let outcome_json = serde_json::to_value(outcome).expect("Outcome is not serializable");
 
         let mut dbtx = db.begin_transaction().await;
-        let mut operation = Self::get_operation_inner(&mut dbtx, operation_id)
-            .await
-            .expect("Operation exists");
+        let mut operation =
+            Self::get_operation_inner(&mut dbtx.to_ref_non_committable(), operation_id)
+                .await
+                .expect("Operation exists");
         operation.outcome = Some(outcome_json);
         dbtx.insert_entry(&OperationLogKey { operation_id }, &operation)
             .await;
@@ -389,7 +394,7 @@ mod tests {
 
         let mut dbtx = db.begin_transaction().await;
         op_log
-            .add_operation_log_entry(&mut dbtx, op_id, "foo", "bar")
+            .add_operation_log_entry(&mut dbtx.to_ref_non_committable(), op_id, "foo", "bar")
             .await;
         dbtx.commit_tx().await;
 
@@ -427,7 +432,7 @@ mod tests {
 
         let mut dbtx = db.begin_transaction().await;
         op_log
-            .add_operation_log_entry(&mut dbtx, op_id, "foo", "bar")
+            .add_operation_log_entry(&mut dbtx.to_ref_non_committable(), op_id, "foo", "bar")
             .await;
         dbtx.commit_tx().await;
 
@@ -453,7 +458,7 @@ mod tests {
             let mut dbtx = db.begin_transaction().await;
             op_log
                 .add_operation_log_entry(
-                    &mut dbtx,
+                    &mut dbtx.to_ref_non_committable(),
                     OperationId([operation_idx; 32]),
                     "foo",
                     operation_idx,

--- a/fedimint-client/src/sm/dbtx.rs
+++ b/fedimint-client/src/sm/dbtx.rs
@@ -23,7 +23,7 @@ impl<'inner, 'parent> ClientSMDatabaseTransaction<'inner, 'parent> {
     pub fn module_tx(&mut self) -> DatabaseTransaction<'_> {
         self.dbtx
             .to_ref_with_prefix_module_id(self.module_instance)
-            .into_non_committable()
+            .into_nc()
     }
 
     /// Returns the non-isolated database transaction only accessible to the

--- a/fedimint-client/src/sm/dbtx.rs
+++ b/fedimint-client/src/sm/dbtx.rs
@@ -1,5 +1,5 @@
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{DatabaseTransaction, DatabaseTransactionRef};
+use fedimint_core::db::DatabaseTransaction;
 
 /// A transaction that acts as isolated for module code but can be accessed as a
 /// normal transaction in this crate.
@@ -20,9 +20,10 @@ impl<'inner, 'parent> ClientSMDatabaseTransaction<'inner, 'parent> {
     }
 
     /// Returns the isolated database transaction for the module.
-    pub fn module_tx(&mut self) -> DatabaseTransactionRef<'_> {
+    pub fn module_tx(&mut self) -> DatabaseTransaction<'_> {
         self.dbtx
-            .dbtx_ref_with_prefix_module_id(self.module_instance)
+            .to_ref_with_prefix_module_id(self.module_instance)
+            .into_non_committable()
     }
 
     /// Returns the non-isolated database transaction only accessible to the

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -96,7 +96,7 @@ where
         self.inner
             .db
             .autocommit(
-                |dbtx| Box::pin(self.add_state_machines_dbtx(dbtx, states.clone())),
+                |dbtx, _| Box::pin(self.add_state_machines_dbtx(dbtx, states.clone())),
                 MAX_DB_ATTEMPTS,
             )
             .await
@@ -454,14 +454,14 @@ where
             let active_or_inactive_state = self
                 .db
                 .autocommit(
-                    |dbtx| {
+                    |dbtx, _| {
                         let state = state.clone();
                         let transition_fn = transition_fn.clone();
                         let transition_outcome = transition_outcome.clone();
                         Box::pin(async move {
                             let new_state = transition_fn(
                                 &mut ClientSMDatabaseTransaction::new(
-                                    dbtx,
+                                    &mut dbtx.to_ref(),
                                     state.module_instance_id(),
                                 ),
                                 transition_outcome,

--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -14,7 +14,7 @@ use crate::core::{
     Any, Decoder, DynInput, DynInputError, DynModuleConsensusItem, DynOutput, DynOutputError,
     DynOutputOutcome,
 };
-use crate::db::DatabaseTransactionRef;
+use crate::db::DatabaseTransaction;
 use crate::dyn_newtype_define;
 use crate::module::registry::ModuleInstanceId;
 use crate::module::{
@@ -35,7 +35,7 @@ pub trait IServerModule: Debug {
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         module_instance_id: ModuleInstanceId,
     ) -> Vec<DynModuleConsensusItem>;
 
@@ -44,7 +44,7 @@ pub trait IServerModule: Debug {
     /// our state and therefore may be safely discarded by the atomic broadcast.
     async fn process_consensus_item<'a>(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'a>,
+        dbtx: &mut DatabaseTransaction<'a>,
         consensus_item: DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()>;
@@ -55,7 +55,7 @@ pub trait IServerModule: Debug {
     /// no effect.
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'c>,
+        dbtx: &mut DatabaseTransaction<'c>,
         input: &'b DynInput,
         module_instance_id: ModuleInstanceId,
     ) -> Result<InputMeta, DynInputError>;
@@ -70,7 +70,7 @@ pub trait IServerModule: Debug {
     /// `output_status`.
     async fn process_output<'a>(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'a>,
+        dbtx: &mut DatabaseTransaction<'a>,
         output: &DynOutput,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
@@ -82,7 +82,7 @@ pub trait IServerModule: Debug {
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome>;
@@ -94,7 +94,7 @@ pub trait IServerModule: Debug {
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     );
@@ -127,7 +127,7 @@ where
     /// This module's contribution to the next consensus proposal
     async fn consensus_proposal(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         module_instance_id: ModuleInstanceId,
     ) -> Vec<DynModuleConsensusItem> {
         <Self as ServerModule>::consensus_proposal(self, dbtx)
@@ -142,7 +142,7 @@ where
     /// our state and therefore may be safely discarded by the atomic broadcast.
     async fn process_consensus_item<'a>(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'a>,
+        dbtx: &mut DatabaseTransaction<'a>,
         consensus_item: DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -165,7 +165,7 @@ where
     /// no effect.
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'c>,
+        dbtx: &mut DatabaseTransaction<'c>,
         input: &'b DynInput,
         module_instance_id: ModuleInstanceId,
     ) -> Result<InputMeta, DynInputError> {
@@ -192,7 +192,7 @@ where
     /// `output_status`.
     async fn process_output<'a>(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'a>,
+        dbtx: &mut DatabaseTransaction<'a>,
         output: &DynOutput,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
@@ -216,7 +216,7 @@ where
     /// output is unknown, **NOT** if it is just not ready yet.
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
         module_instance_id: ModuleInstanceId,
     ) -> Option<DynOutputOutcome> {
@@ -232,7 +232,7 @@ where
     /// occurred in the database and consensus should halt.
     async fn audit(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {

--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::db::{
-    DatabaseKey, DatabaseLookup, DatabaseRecord, DatabaseTransactionRef,
+    DatabaseKey, DatabaseLookup, DatabaseRecord, DatabaseTransaction,
     IDatabaseTransactionOpsCoreTyped,
 };
 use crate::task::{MaybeSend, MaybeSync};
@@ -28,7 +28,7 @@ impl Audit {
 
     pub async fn add_items<KP, F>(
         &mut self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         module_instance_id: ModuleInstanceId,
         key_prefix: &KP,
         to_milli_sat: F,

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -169,10 +169,7 @@ impl DatabaseDump {
             }
             Some(init) => {
                 let mut module_serialized = init
-                    .dump_database(
-                        &mut isolated_dbtx.to_ref_non_committable(),
-                        self.prefixes.clone(),
-                    )
+                    .dump_database(&mut isolated_dbtx.to_ref_nc(), self.prefixes.clone())
                     .await
                     .collect::<BTreeMap<String, _>>();
 
@@ -193,12 +190,11 @@ impl DatabaseDump {
     }
 
     async fn serialize_gateway(&mut self) -> anyhow::Result<()> {
-        let mut dbtx = self.read_only.begin_transaction().await;
-        let dbtx = dbtx.to_ref();
-        let gateway_serialized =
-            Gateway::dump_database(&mut dbtx.into_non_committable(), self.prefixes.clone())
-                .await
-                .collect::<BTreeMap<String, _>>();
+        let mut dbtx = self.read_only.begin_transaction_nc().await;
+        let mut dbtx = dbtx.to_ref();
+        let gateway_serialized = Gateway::dump_database(&mut dbtx, self.prefixes.clone())
+            .await
+            .collect::<BTreeMap<String, _>>();
         self.serialized
             .insert("gateway".to_string(), Box::new(gateway_serialized));
         Ok(())

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -314,10 +314,9 @@ pub async fn get_note_summary(client: &ClientArc) -> anyhow::Result<TieredSummar
         .get_wallet_summary(
             &mut client
                 .db()
-                .begin_transaction()
+                .begin_transaction_nc()
                 .await
-                .to_ref_with_prefix_module_id(1)
-                .into_non_committable(),
+                .to_ref_with_prefix_module_id(1),
         )
         .await;
     Ok(summary)
@@ -336,7 +335,7 @@ pub async fn remint_denomination(
     for _ in 0..quantity {
         let outputs = mint_client
             .create_output(
-                &mut module_transaction.to_ref_non_committable(),
+                &mut module_transaction.to_ref_nc(),
                 operation_id,
                 1,
                 denomination,

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -316,7 +316,8 @@ pub async fn get_note_summary(client: &ClientArc) -> anyhow::Result<TieredSummar
                 .db()
                 .begin_transaction()
                 .await
-                .dbtx_ref_with_prefix_module_id(1),
+                .to_ref_with_prefix_module_id(1)
+                .into_non_committable(),
         )
         .await;
     Ok(summary)
@@ -329,12 +330,17 @@ pub async fn remint_denomination(
 ) -> anyhow::Result<()> {
     let mint_client = client.get_first_module::<MintClientModule>();
     let mut dbtx = client.db().begin_transaction().await;
-    let mut module_transaction = dbtx.dbtx_ref_with_prefix_module_id(mint_client.id);
+    let mut module_transaction = dbtx.to_ref_with_prefix_module_id(mint_client.id);
     let mut tx = TransactionBuilder::new();
     let operation_id = OperationId::new_random();
     for _ in 0..quantity {
         let outputs = mint_client
-            .create_output(&mut module_transaction, operation_id, 1, denomination)
+            .create_output(
+                &mut module_transaction.to_ref_non_committable(),
+                operation_id,
+                1,
+                denomination,
+            )
             .await
             .into_iter()
             .map(|output| output.into_dyn(mint_client.id))

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -22,7 +22,7 @@ pub async fn process_transaction_with_dbtx(
         let meta = modules
             .get_expect(input.module_instance_id())
             .process_input(
-                &mut dbtx.dbtx_ref_with_prefix_module_id(input.module_instance_id()),
+                &mut dbtx.to_ref_with_prefix_module_id(input.module_instance_id()),
                 input,
                 input.module_instance_id(),
             )
@@ -39,7 +39,7 @@ pub async fn process_transaction_with_dbtx(
         let amount = modules
             .get_expect(output.module_instance_id())
             .process_output(
-                &mut dbtx.dbtx_ref_with_prefix_module_id(output.module_instance_id()),
+                &mut dbtx.to_ref_with_prefix_module_id(output.module_instance_id()),
                 output,
                 OutPoint { txid, out_idx },
                 output.module_instance_id(),

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -572,12 +572,8 @@ impl ConsensusServer {
             bail!("Item was discarded before we recovered");
         }
 
-        self.process_consensus_item_with_db_transaction(
-            &mut dbtx.to_ref_non_committable(),
-            item.clone(),
-            peer,
-        )
-        .await?;
+        self.process_consensus_item_with_db_transaction(&mut dbtx.to_ref_nc(), item.clone(), peer)
+            .await?;
 
         dbtx.insert_entry(&AcceptedItemKey(item_index), &AcceptedItem { item, peer })
             .await;
@@ -591,7 +587,7 @@ impl ConsensusServer {
                 .audit(
                     &mut dbtx
                         .to_ref_with_prefix_module_id(module_instance_id)
-                        .into_non_committable(),
+                        .into_nc(),
                     &mut audit,
                     module_instance_id,
                 )
@@ -722,9 +718,7 @@ async fn submit_module_consensus_items(
                     for (instance_id, _, module) in modules.iter_modules() {
                         let module_consensus_items = module
                             .consensus_proposal(
-                                &mut dbtx
-                                    .to_ref_with_prefix_module_id(instance_id)
-                                    .into_non_committable(),
+                                &mut dbtx.to_ref_with_prefix_module_id(instance_id).into_nc(),
                                 instance_id,
                             )
                             .await;

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -572,8 +572,12 @@ impl ConsensusServer {
             bail!("Item was discarded before we recovered");
         }
 
-        self.process_consensus_item_with_db_transaction(&mut dbtx, item.clone(), peer)
-            .await?;
+        self.process_consensus_item_with_db_transaction(
+            &mut dbtx.to_ref_non_committable(),
+            item.clone(),
+            peer,
+        )
+        .await?;
 
         dbtx.insert_entry(&AcceptedItemKey(item_index), &AcceptedItem { item, peer })
             .await;
@@ -585,7 +589,9 @@ impl ConsensusServer {
                 TimeReporter::new(format!("audit module {module_instance_id}"));
             module
                 .audit(
-                    &mut dbtx.dbtx_ref_with_prefix_module_id(module_instance_id),
+                    &mut dbtx
+                        .to_ref_with_prefix_module_id(module_instance_id)
+                        .into_non_committable(),
                     &mut audit,
                     module_instance_id,
                 )
@@ -616,7 +622,7 @@ impl ConsensusServer {
         match consensus_item {
             ConsensusItem::Module(module_item) => {
                 let instance_id = module_item.module_instance_id();
-                let module_dbtx = &mut dbtx.dbtx_ref_with_prefix_module_id(instance_id);
+                let module_dbtx = &mut dbtx.to_ref_with_prefix_module_id(instance_id);
 
                 self.modules
                     .get_expect(instance_id)
@@ -716,7 +722,9 @@ async fn submit_module_consensus_items(
                     for (instance_id, _, module) in modules.iter_modules() {
                         let module_consensus_items = module
                             .consensus_proposal(
-                                &mut dbtx.dbtx_ref_with_prefix_module_id(instance_id),
+                                &mut dbtx
+                                    .to_ref_with_prefix_module_id(instance_id)
+                                    .into_non_committable(),
                                 instance_id,
                             )
                             .await;

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -85,7 +85,7 @@ impl_db_record!(
 );
 impl_db_lookup!(key = AlephUnitsKey, query_prefix = AlephUnitsPrefix);
 
-pub fn get_global_database_migrations<'a>() -> MigrationMap<'a> {
+pub fn get_global_database_migrations() -> MigrationMap {
     MigrationMap::new()
 }
 
@@ -184,8 +184,6 @@ mod fedimint_migration_tests {
             .await;
 
         let _consensus_items = vec![ConsensusItem::Transaction(transaction)];
-
-        dbtx.commit_tx().await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/fedimint-testing/src/db.rs
+++ b/fedimint-testing/src/db.rs
@@ -64,8 +64,9 @@ where
                 .with_context(|| format!("Preparing snapshot in {}", snapshot_dir.display()))?,
             decoders,
         );
-        let dbtx = db.begin_transaction().await;
-        prepare_fn(dbtx).await;
+        let mut dbtx = db.begin_transaction().await;
+        prepare_fn(dbtx.to_ref_non_committable()).await;
+        dbtx.commit_tx().await;
         Ok(())
     }
 

--- a/fedimint-testing/src/db.rs
+++ b/fedimint-testing/src/db.rs
@@ -65,7 +65,7 @@ where
             decoders,
         );
         let mut dbtx = db.begin_transaction().await;
-        prepare_fn(dbtx.to_ref_non_committable()).await;
+        prepare_fn(dbtx.to_ref_nc()).await;
         dbtx.commit_tx().await;
         Ok(())
     }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -7,7 +7,9 @@ use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::{get_config_from_db, ClientBuilder, FederationInfo};
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::db::{
+    Committable, Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
+};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use futures::StreamExt;
 use rand::thread_rng;
@@ -124,7 +126,7 @@ impl GatewayClientBuilder {
     pub async fn save_config(
         &self,
         config: FederationConfig,
-        mut dbtx: DatabaseTransaction<'_>,
+        mut dbtx: DatabaseTransaction<'_, Committable>,
     ) -> Result<()> {
         let id = config.invite_code.federation_id();
         dbtx.insert_entry(&FederationIdKey { id }, &config).await;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1027,10 +1027,7 @@ impl Gateway {
     ) -> Result<()> {
         if let GatewayState::Connected = self.state.read().await.clone() {
             let dbtx = self.gateway_db.begin_transaction().await;
-            let configs = self
-                .client_builder
-                .load_configs(dbtx.into_non_committable())
-                .await?;
+            let configs = self.client_builder.load_configs(dbtx.into_nc()).await?;
             let channel_id_generator = self.channel_id_generator.lock().await;
             let mut next_channel_id = channel_id_generator.load(Ordering::SeqCst);
 

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -17,7 +17,7 @@ use fedimint_client::{sm_enum_variant_translation, AddStateMachinesError, DynGlo
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{AutocommitError, Database, DatabaseTransactionRef};
+use fedimint_core::db::{AutocommitError, Database, DatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{ApiVersion, ModuleInit, MultiApiVersion, TransactionItemAmount};
 use fedimint_core::util::SafeUrl;
@@ -125,7 +125,7 @@ impl ModuleInit for GatewayClientInit {
 
     async fn dump_database(
         &self,
-        _dbtx: &mut DatabaseTransactionRef<'_>,
+        _dbtx: &mut DatabaseTransaction<'_>,
         _prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         Box::new(vec![].into_iter())
@@ -515,7 +515,7 @@ impl GatewayClientModule {
         self.client_ctx
             .global_db()
             .autocommit(
-                |dbtx| {
+                |dbtx, _| {
                     Box::pin(async {
                         let operation_id = OperationId(payload.contract_id.into_inner());
 

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -246,7 +246,7 @@ impl DummyClientModule {
         // Create input using our own account
         let inputs = fedimint_client::module::ClientModule::create_sufficient_input(
             self,
-            &mut dbtx.to_ref_non_committable(),
+            &mut dbtx.to_ref_nc(),
             op_id,
             amount,
         )

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -4,7 +4,7 @@ use fedimint_client::sm::{DynState, State, StateTransition};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::{GlobalFederationApi, OutputOutcomeError};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
 use fedimint_core::{Amount, OutPoint, TransactionId};
@@ -83,7 +83,7 @@ impl State for DummyStateMachine {
     }
 }
 
-async fn add_funds(amount: Amount, mut dbtx: DatabaseTransactionRef<'_>) {
+async fn add_funds(amount: Amount, mut dbtx: DatabaseTransaction<'_>) {
     let funds = get_funds(&mut dbtx).await + amount;
     dbtx.insert_entry(&DummyClientFundsKeyV0, &funds).await;
 }

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -9,7 +9,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    DatabaseTransactionRef, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, MigrationMap,
+    DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, MigrationMap,
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -49,7 +49,7 @@ impl ModuleInit for DummyInit {
     /// Dumps all database items for debugging
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         // TODO: Boilerplate-code
@@ -194,14 +194,14 @@ impl ServerModule for Dummy {
 
     async fn consensus_proposal(
         &self,
-        _dbtx: &mut DatabaseTransactionRef<'_>,
+        _dbtx: &mut DatabaseTransaction<'_>,
     ) -> Vec<DummyConsensusItem> {
         Vec::new()
     }
 
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        _dbtx: &mut DatabaseTransactionRef<'b>,
+        _dbtx: &mut DatabaseTransaction<'b>,
         _consensus_item: DummyConsensusItem,
         _peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -210,7 +210,7 @@ impl ServerModule for Dummy {
 
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'c>,
+        dbtx: &mut DatabaseTransaction<'c>,
         input: &'b DummyInput,
     ) -> Result<InputMeta, DummyInputError> {
         let current_funds = dbtx
@@ -251,7 +251,7 @@ impl ServerModule for Dummy {
 
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'b>,
+        dbtx: &mut DatabaseTransaction<'b>,
         output: &'a DummyOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, DummyOutputError> {
@@ -274,7 +274,7 @@ impl ServerModule for Dummy {
 
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<DummyOutputOutcome> {
         // check whether or not the output has been processed
@@ -283,7 +283,7 @@ impl ServerModule for Dummy {
 
     async fn audit(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -25,9 +25,7 @@ use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{
-    DatabaseTransaction, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped,
-};
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion, TransactionItemAmount,
@@ -224,7 +222,7 @@ impl ModuleInit for LightningClientInit {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut ln_client_items: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =
@@ -848,7 +846,7 @@ impl LightningClientModule {
     ) -> anyhow::Result<OutgoingLightningPayment> {
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
         let prev_payment_result = self
-            .get_prev_payment_result(invoice.payment_hash(), &mut dbtx)
+            .get_prev_payment_result(invoice.payment_hash(), &mut dbtx.to_ref_non_committable())
             .await;
 
         if let Some(completed_payment) = prev_payment_result.completed_payment {
@@ -1340,7 +1338,7 @@ pub struct OutgoingLightningPayment {
 }
 
 async fn set_payment_result(
-    dbtx: &mut DatabaseTransactionRef<'_>,
+    dbtx: &mut DatabaseTransaction<'_>,
     payment_hash: sha256::Hash,
     payment_type: PayType,
     contract_id: ContractId,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -846,7 +846,7 @@ impl LightningClientModule {
     ) -> anyhow::Result<OutgoingLightningPayment> {
         let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
         let prev_payment_result = self
-            .get_prev_payment_result(invoice.payment_hash(), &mut dbtx.to_ref_non_committable())
+            .get_prev_payment_result(invoice.payment_hash(), &mut dbtx.to_ref_nc())
             .await;
 
         if let Some(completed_payment) = prev_payment_result.completed_payment {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -857,14 +857,14 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 BLOCK_COUNT_ENDPOINT,
                 async |module: &Lightning, context, _v: ()| -> Option<u64> {
-                    Ok(Some(module.consensus_block_count(&mut context.dbtx().into_non_committable()).await))
+                    Ok(Some(module.consensus_block_count(&mut context.dbtx().into_nc()).await))
                 }
             },
             api_endpoint! {
                 ACCOUNT_ENDPOINT,
                 async |module: &Lightning, context, contract_id: ContractId| -> Option<ContractAccount> {
                     Ok(module
-                        .get_contract_account(&mut context.dbtx().into_non_committable(), contract_id)
+                        .get_contract_account(&mut context.dbtx().into_nc(), contract_id)
                         .await)
                 }
             },
@@ -879,7 +879,7 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 AWAIT_BLOCK_HEIGHT_ENDPOINT,
                 async |module: &Lightning, context, block_height: u64| -> () {
-                    module.wait_block_height(block_height, &mut context.dbtx().into_non_committable()).await;
+                    module.wait_block_height(block_height, &mut context.dbtx().into_nc()).await;
                     Ok(())
                 }
             },
@@ -899,7 +899,7 @@ impl ServerModule for Lightning {
                 OFFER_ENDPOINT,
                 async |module: &Lightning, context, payment_hash: bitcoin_hashes::sha256::Hash| -> Option<IncomingContractOffer> {
                     Ok(module
-                        .get_offer(&mut context.dbtx().into_non_committable(), payment_hash)
+                        .get_offer(&mut context.dbtx().into_nc(), payment_hash)
                         .await)
                }
             },
@@ -914,13 +914,13 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 LIST_GATEWAYS_ENDPOINT,
                 async |module: &Lightning, context, _v: ()| -> Vec<LightningGatewayAnnouncement> {
-                    Ok(module.list_gateways(&mut context.dbtx().into_non_committable()).await)
+                    Ok(module.list_gateways(&mut context.dbtx().into_nc()).await)
                 }
             },
             api_endpoint! {
                 REGISTER_GATEWAY_ENDPOINT,
                 async |module: &Lightning, context, gateway: LightningGatewayAnnouncement| -> () {
-                    module.register_gateway(&mut context.dbtx().into_non_committable(), gateway).await;
+                    module.register_gateway(&mut context.dbtx().into_nc(), gateway).await;
                     Ok(())
                 }
             },
@@ -1232,7 +1232,7 @@ mod tests {
 
         server
             .process_output(
-                &mut dbtx.to_ref_with_prefix_module_id(42).into_non_committable(),
+                &mut dbtx.to_ref_with_prefix_module_id(42).into_nc(),
                 &output,
                 out_point,
             )
@@ -1255,7 +1255,7 @@ mod tests {
         assert_matches!(
             server
                 .process_output(
-                    &mut dbtx.to_ref_with_prefix_module_id(42).into_non_committable(),
+                    &mut dbtx.to_ref_with_prefix_module_id(42).into_nc(),
                     &output2,
                     out_point2
                 )
@@ -1306,7 +1306,7 @@ mod tests {
             .await;
 
         let processed_input_meta = server
-            .process_input(&mut module_dbtx.to_ref_non_committable(), &lightning_input)
+            .process_input(&mut module_dbtx.to_ref_nc(), &lightning_input)
             .await
             .expect("should process valid incoming contract");
         let expected_input_meta = InputMeta {
@@ -1363,7 +1363,7 @@ mod tests {
             .await;
 
         let processed_input_meta = server
-            .process_input(&mut module_dbtx.to_ref_non_committable(), &lightning_input)
+            .process_input(&mut module_dbtx.to_ref_nc(), &lightning_input)
             .await
             .expect("should process valid outgoing contract");
 

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -9,9 +9,7 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{
-    DatabaseTransactionRef, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
-};
+use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::endpoint_constants::{
     ACCOUNT_ENDPOINT, AWAIT_ACCOUNT_ENDPOINT, AWAIT_BLOCK_HEIGHT_ENDPOINT, AWAIT_OFFER_ENDPOINT,
@@ -119,7 +117,7 @@ impl ModuleInit for LightningInit {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut lightning: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =
@@ -370,7 +368,7 @@ impl ServerModule for Lightning {
 
     async fn consensus_proposal(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
     ) -> Vec<LightningConsensusItem> {
         let mut items: Vec<LightningConsensusItem> = dbtx
             .find_by_prefix(&ProposeDecryptionShareKeyPrefix)
@@ -392,7 +390,7 @@ impl ServerModule for Lightning {
 
     async fn process_consensus_item<'a, 'b>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'b>,
+        dbtx: &mut DatabaseTransaction<'b>,
         consensus_item: LightningConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {
@@ -548,7 +546,7 @@ impl ServerModule for Lightning {
 
     async fn process_input<'a, 'b, 'c>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'c>,
+        dbtx: &mut DatabaseTransaction<'c>,
         input: &'b LightningInput,
     ) -> Result<InputMeta, LightningInputError> {
         let input = input.ensure_v0_ref()?;
@@ -632,7 +630,7 @@ impl ServerModule for Lightning {
 
     async fn process_output<'a, 'b>(
         &'a self,
-        dbtx: &mut DatabaseTransactionRef<'b>,
+        dbtx: &mut DatabaseTransaction<'b>,
         output: &'a LightningOutput,
         out_point: OutPoint,
     ) -> Result<TransactionItemAmount, LightningOutputError> {
@@ -828,7 +826,7 @@ impl ServerModule for Lightning {
 
     async fn output_status(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         out_point: OutPoint,
     ) -> Option<LightningOutputOutcome> {
         dbtx.get_value(&ContractUpdateKey(out_point))
@@ -838,7 +836,7 @@ impl ServerModule for Lightning {
 
     async fn audit(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {
@@ -859,14 +857,14 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 BLOCK_COUNT_ENDPOINT,
                 async |module: &Lightning, context, _v: ()| -> Option<u64> {
-                    Ok(Some(module.consensus_block_count(&mut context.dbtx()).await))
+                    Ok(Some(module.consensus_block_count(&mut context.dbtx().into_non_committable()).await))
                 }
             },
             api_endpoint! {
                 ACCOUNT_ENDPOINT,
                 async |module: &Lightning, context, contract_id: ContractId| -> Option<ContractAccount> {
                     Ok(module
-                        .get_contract_account(&mut context.dbtx(), contract_id)
+                        .get_contract_account(&mut context.dbtx().into_non_committable(), contract_id)
                         .await)
                 }
             },
@@ -881,7 +879,7 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 AWAIT_BLOCK_HEIGHT_ENDPOINT,
                 async |module: &Lightning, context, block_height: u64| -> () {
-                    module.wait_block_height(block_height, &mut context.dbtx()).await;
+                    module.wait_block_height(block_height, &mut context.dbtx().into_non_committable()).await;
                     Ok(())
                 }
             },
@@ -901,7 +899,7 @@ impl ServerModule for Lightning {
                 OFFER_ENDPOINT,
                 async |module: &Lightning, context, payment_hash: bitcoin_hashes::sha256::Hash| -> Option<IncomingContractOffer> {
                     Ok(module
-                        .get_offer(&mut context.dbtx(), payment_hash)
+                        .get_offer(&mut context.dbtx().into_non_committable(), payment_hash)
                         .await)
                }
             },
@@ -916,13 +914,13 @@ impl ServerModule for Lightning {
             api_endpoint! {
                 LIST_GATEWAYS_ENDPOINT,
                 async |module: &Lightning, context, _v: ()| -> Vec<LightningGatewayAnnouncement> {
-                    Ok(module.list_gateways(&mut context.dbtx()).await)
+                    Ok(module.list_gateways(&mut context.dbtx().into_non_committable()).await)
                 }
             },
             api_endpoint! {
                 REGISTER_GATEWAY_ENDPOINT,
                 async |module: &Lightning, context, gateway: LightningGatewayAnnouncement| -> () {
-                    module.register_gateway(&mut context.dbtx(), gateway).await;
+                    module.register_gateway(&mut context.dbtx().into_non_committable(), gateway).await;
                     Ok(())
                 }
             },
@@ -944,7 +942,7 @@ impl Lightning {
         res
     }
 
-    async fn consensus_block_count(&self, dbtx: &mut DatabaseTransactionRef<'_>) -> u64 {
+    async fn consensus_block_count(&self, dbtx: &mut DatabaseTransaction<'_>) -> u64 {
         let peer_count = 3 * (self.cfg.consensus.threshold() / 2) + 1;
 
         let mut counts = dbtx
@@ -965,7 +963,7 @@ impl Lightning {
         counts[peer_count / 2]
     }
 
-    async fn wait_block_height(&self, block_height: u64, dbtx: &mut DatabaseTransactionRef<'_>) {
+    async fn wait_block_height(&self, block_height: u64, dbtx: &mut DatabaseTransaction<'_>) {
         while block_height >= self.consensus_block_count(dbtx).await {
             sleep(Duration::from_secs(5)).await;
         }
@@ -986,7 +984,7 @@ impl Lightning {
 
     async fn get_offer(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         payment_hash: bitcoin_hashes::sha256::Hash,
     ) -> Option<IncomingContractOffer> {
         dbtx.get_value(&OfferKey(payment_hash)).await
@@ -1003,7 +1001,7 @@ impl Lightning {
 
     async fn get_contract_account(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         contract_id: ContractId,
     ) -> Option<ContractAccount> {
         dbtx.get_value(&ContractKey(contract_id)).await
@@ -1076,7 +1074,7 @@ impl Lightning {
 
     async fn list_gateways(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
     ) -> Vec<LightningGatewayAnnouncement> {
         let stream = dbtx.find_by_prefix(&LightningGatewayKeyPrefix).await;
         stream
@@ -1096,7 +1094,7 @@ impl Lightning {
 
     async fn register_gateway(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         gateway: LightningGatewayAnnouncement,
     ) {
         // Garbage collect expired gateways (since we're already writing to the DB)
@@ -1113,7 +1111,7 @@ impl Lightning {
         .await;
     }
 
-    async fn delete_expired_gateways(&self, dbtx: &mut DatabaseTransactionRef<'_>) {
+    async fn delete_expired_gateways(&self, dbtx: &mut DatabaseTransaction<'_>) {
         let expired_gateway_keys = dbtx
             .find_by_prefix(&LightningGatewayKeyPrefix)
             .await
@@ -1234,7 +1232,7 @@ mod tests {
 
         server
             .process_output(
-                &mut dbtx.dbtx_ref_with_prefix_module_id(42),
+                &mut dbtx.to_ref_with_prefix_module_id(42).into_non_committable(),
                 &output,
                 out_point,
             )
@@ -1257,7 +1255,7 @@ mod tests {
         assert_matches!(
             server
                 .process_output(
-                    &mut dbtx.dbtx_ref_with_prefix_module_id(42),
+                    &mut dbtx.to_ref_with_prefix_module_id(42).into_non_committable(),
                     &output2,
                     out_point2
                 )
@@ -1271,7 +1269,7 @@ mod tests {
         let (server_cfg, client_cfg) = build_configs();
         let db = Database::new(MemDatabase::new(), Default::default());
         let mut dbtx = db.begin_transaction().await;
-        let mut module_dbtx = dbtx.dbtx_ref_with_prefix_module_id(42);
+        let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42);
         let mut tg = TaskGroup::new();
         let server = Lightning::new(server_cfg[0].clone(), &mut tg).unwrap();
 
@@ -1308,7 +1306,7 @@ mod tests {
             .await;
 
         let processed_input_meta = server
-            .process_input(&mut module_dbtx, &lightning_input)
+            .process_input(&mut module_dbtx.to_ref_non_committable(), &lightning_input)
             .await
             .expect("should process valid incoming contract");
         let expected_input_meta = InputMeta {
@@ -1332,7 +1330,7 @@ mod tests {
         let (server_cfg, _) = build_configs();
         let db = Database::new(MemDatabase::new(), Default::default());
         let mut dbtx = db.begin_transaction().await;
-        let mut module_dbtx = dbtx.dbtx_ref_with_prefix_module_id(42);
+        let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42);
         let mut tg = TaskGroup::new();
         let server = Lightning::new(server_cfg[0].clone(), &mut tg).unwrap();
 
@@ -1365,7 +1363,7 @@ mod tests {
             .await;
 
         let processed_input_meta = server
-            .process_input(&mut module_dbtx, &lightning_input)
+            .process_input(&mut module_dbtx.to_ref_non_committable(), &lightning_input)
             .await
             .expect("should process valid outgoing contract");
 
@@ -1548,8 +1546,6 @@ mod fedimint_migration_tests {
             &amount,
         )
         .await;
-
-        dbtx.commit_tx().await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/modules/fedimint-mint-client/src/backup.rs
+++ b/modules/fedimint-mint-client/src/backup.rs
@@ -2,7 +2,7 @@ use fedimint_client::sm::Executor;
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::DatabaseTransactionRef;
+use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, Tiered, TieredMulti};
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ impl EcashBackup {
 impl MintClientModule {
     pub async fn prepare_plaintext_ecash_backup(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         executor: Executor<DynGlobalClientContext>,
         api: DynGlobalApi,
         module_instance_id: ModuleInstanceId,

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -33,9 +33,7 @@ use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
 use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{
-    AutocommitError, DatabaseTransaction, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped,
-};
+use fedimint_core::db::{AutocommitError, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{
@@ -281,7 +279,7 @@ impl ModuleInit for MintClientInit {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut mint_client_items: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =
@@ -493,7 +491,7 @@ impl ClientModule for MintClientModule {
 
     async fn backup(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         executor: Executor<DynGlobalClientContext>,
         api: DynGlobalApi,
         module_instance_id: ModuleInstanceId,
@@ -515,7 +513,7 @@ impl ClientModule for MintClientModule {
         snapshot: Option<&[u8]>,
     ) -> anyhow::Result<()> {
         if !Self::get_all_spendable_notes(
-            &mut dbtx.dbtx_ref_with_prefix_module_id(module_instance_id),
+            &mut dbtx.to_ref_with_prefix_module_id(module_instance_id),
         )
         .await
         .is_empty()
@@ -575,7 +573,7 @@ impl ClientModule for MintClientModule {
 
     async fn wipe(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         _module_instance_id: ModuleInstanceId,
         _executor: Executor<DynGlobalClientContext>,
     ) -> anyhow::Result<()> {
@@ -591,7 +589,7 @@ impl ClientModule for MintClientModule {
 
     async fn create_sufficient_input(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         min_amount: Amount,
     ) -> anyhow::Result<Vec<ClientInput<MintInput, MintClientStateMachines>>> {
@@ -600,7 +598,7 @@ impl ClientModule for MintClientModule {
 
     async fn create_exact_output(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         amount: Amount,
     ) -> Vec<ClientOutput<MintOutput, MintClientStateMachines>> {
@@ -616,7 +614,7 @@ impl ClientModule for MintClientModule {
         self.await_output_finalized(operation_id, out_point).await
     }
 
-    async fn get_balance(&self, dbtx: &mut DatabaseTransactionRef<'_>) -> Amount {
+    async fn get_balance(&self, dbtx: &mut DatabaseTransaction<'_>) -> Amount {
         self.get_wallet_summary(dbtx).await.total_amount()
     }
 
@@ -656,7 +654,7 @@ impl ClientModule for MintClientModule {
 
     async fn leave(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         module_instance_id: ModuleInstanceId,
         executor: Executor<DynGlobalClientContext>,
         _api: DynGlobalApi,
@@ -680,7 +678,7 @@ impl ClientModule for MintClientModule {
 
 impl MintClientModule {
     /// Returns the number of held e-cash notes per denomination
-    pub async fn get_wallet_summary(&self, dbtx: &mut DatabaseTransactionRef<'_>) -> TieredSummary {
+    pub async fn get_wallet_summary(&self, dbtx: &mut DatabaseTransaction<'_>) -> TieredSummary {
         dbtx.find_by_prefix(&NoteKeyPrefix)
             .await
             .fold(
@@ -699,7 +697,7 @@ impl MintClientModule {
     /// e-cash note denomination held.
     pub async fn create_output(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         notes_per_denomination: u16,
         exact_amount: Amount,
@@ -790,7 +788,7 @@ impl MintClientModule {
     /// Creates a mint input of at least `min_amount`.
     pub async fn create_input(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
         min_amount: Amount,
     ) -> anyhow::Result<Vec<ClientInput<MintInput, MintClientStateMachines>>> {
@@ -861,7 +859,7 @@ impl MintClientModule {
 
     async fn spend_notes_oob(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         notes_selector: &impl NotesSelector<SpendableNote>,
         requested_amount: Amount,
         try_cancel_after: Duration,
@@ -959,7 +957,7 @@ impl MintClientModule {
 
     /// Select notes with `requested_amount` using `notes_selector`.
     async fn select_notes(
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         notes_selector: &impl NotesSelector<SpendableNote>,
         requested_amount: Amount,
     ) -> anyhow::Result<TieredMulti<SpendableNote>> {
@@ -973,7 +971,7 @@ impl MintClientModule {
     }
 
     async fn get_all_spendable_notes(
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
     ) -> TieredMulti<SpendableNote> {
         TieredMulti::from_iter(
             (dbtx
@@ -986,7 +984,7 @@ impl MintClientModule {
         )
     }
 
-    async fn wipe_all_spendable_notes(dbtx: &mut DatabaseTransactionRef<'_>) {
+    async fn wipe_all_spendable_notes(dbtx: &mut DatabaseTransaction<'_>) {
         debug!(target: LOG_TARGET, "Wiping all spendable notes");
         dbtx.remove_by_prefix(&NoteKeyPrefix).await;
         assert!(Self::get_all_spendable_notes(dbtx).await.is_empty());
@@ -994,7 +992,7 @@ impl MintClientModule {
 
     async fn get_next_note_index(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         amount: Amount,
     ) -> NoteIndex {
         NoteIndex(
@@ -1038,7 +1036,7 @@ impl MintClientModule {
     async fn new_note_secret(
         &self,
         amount: Amount,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
     ) -> DerivableSecret {
         let new_idx = self.get_next_note_index(dbtx, amount).await;
         dbtx.insert_entry(&NextECashNoteIndexKey(amount), &new_idx.next().as_u64())
@@ -1049,7 +1047,7 @@ impl MintClientModule {
     pub async fn new_ecash_note(
         &self,
         amount: Amount,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
     ) -> (NoteIssuanceRequest, BlindNonce) {
         let secret = self.new_note_secret(amount, dbtx).await;
         NoteIssuanceRequest::new(&self.secp, secret)
@@ -1202,12 +1200,12 @@ impl MintClientModule {
         self.client_ctx
             .global_db()
             .autocommit(
-                move |dbtx| {
+                move |dbtx, _| {
                     let extra_meta = extra_meta.clone();
                     Box::pin(async move {
                         let (operation_id, states, notes) = self
                             .spend_notes_oob(
-                                &mut dbtx.dbtx_ref_with_prefix_module_id(mint_id),
+                                &mut dbtx.to_ref_with_prefix_module_id(mint_id),
                                 notes_selector,
                                 requested_amount,
                                 try_cancel_after,

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -24,9 +24,7 @@ use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
 use fedimint_core::api::DynModuleApi;
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{
-    AutocommitError, DatabaseTransactionRef, IDatabaseTransactionOpsCoreTyped,
-};
+use fedimint_core::db::{AutocommitError, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion, TransactionItemAmount,
@@ -118,7 +116,7 @@ impl ModuleInit for WalletClientInit {
 
     async fn dump_database(
         &self,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
         prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
         let mut wallet_client_items: BTreeMap<String, Box<dyn erased_serde::Serialize + Send>> =
@@ -271,7 +269,7 @@ impl WalletClientModule {
     pub async fn get_deposit_address_inner(
         &self,
         valid_until: SystemTime,
-        dbtx: &mut DatabaseTransactionRef<'_>,
+        dbtx: &mut DatabaseTransaction<'_>,
     ) -> (OperationId, WalletClientStates, Address) {
         let tweak_key = self
             .module_root_secret
@@ -375,12 +373,12 @@ impl WalletClientModule {
             .client_ctx
             .global_db()
             .autocommit(
-                |dbtx| {
+                |dbtx, _| {
                     Box::pin(async {
                         let (operation_id, sm, address) = self
                             .get_deposit_address_inner(
                                 valid_until,
-                                &mut dbtx.dbtx_ref_with_prefix_module_id(
+                                &mut dbtx.to_ref_with_prefix_module_id(
                                     self.client_ctx.module_instance_id(),
                                 ),
                             )
@@ -648,7 +646,7 @@ fn check_address(address: &Address, network: Network) -> anyhow::Result<()> {
 }
 
 /// Returns the child index to derive the next peg-in tweak key from.
-async fn get_next_peg_in_tweak_child_id(dbtx: &mut DatabaseTransactionRef<'_>) -> ChildId {
+async fn get_next_peg_in_tweak_child_id(dbtx: &mut DatabaseTransaction<'_>) -> ChildId {
     let index = dbtx.get_value(&NextPegInTweakIndexKey).await.unwrap_or(0);
     dbtx.insert_entry(&NextPegInTweakIndexKey, &(index + 1))
         .await;

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -462,7 +462,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     sync_wallet_to_block(
         &mut dbtx
             .to_ref_with_prefix_module_id(module_instance_id)
-            .into_non_committable(),
+            .into_nc(),
         &mut wallet,
         block_count.try_into()?,
     )
@@ -495,7 +495,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         .process_input(
             &mut dbtx
                 .to_ref_with_prefix_module_id(module_instance_id)
-                .into_non_committable(),
+                .into_nc(),
             &input,
         )
         .await
@@ -514,7 +514,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     sync_wallet_to_block(
         &mut dbtx
             .to_ref_with_prefix_module_id(module_instance_id)
-            .into_non_committable(),
+            .into_nc(),
         &mut wallet,
         block_count.try_into()?,
     )
@@ -525,7 +525,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
             .process_input(
                 &mut dbtx
                     .to_ref_with_prefix_module_id(module_instance_id)
-                    .into_non_committable(),
+                    .into_nc(),
                 &input,
             )
             .await,


### PR DESCRIPTION
A (hopefully) better approach than #3644.

Having a separate type for commitable vs non-commitable is a bit of a pain that I've hit during refactoring, as there's no good way to generalize over the two, and adding another layer of traits seems like a nightmare.

This change unifies `DatabaseTransactionRef`
with `DatabseTransaction` using session types to express committability.

This makes generalizing overr `DatabaseTransaction` easier, though it's not exactly perfect either. But I believe it's a bit better.