### PR TITLE
 refactor: stop ClientModule from accessing own module_id (mostly)

### DIFF
--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -564,13 +564,7 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
     /// Calling code should allow the user to override and ignore any
     /// outstanding errors, after sufficient amount of warnings. Ideally,
     /// this should be done on per-module basis, to avoid mistakes.
-    async fn leave(
-        &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
-        _module_instance_id: ModuleInstanceId,
-        _executor: Executor<DynGlobalClientContext>,
-        _api: DynGlobalApi,
-    ) -> anyhow::Result<()> {
+    async fn leave(&self, _dbtx: &mut DatabaseTransaction<'_>) -> anyhow::Result<()> {
         bail!("Unable to determine if safe to leave the federation: Not implemented")
     }
 }

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -514,8 +514,7 @@ impl GatewayClientModule {
         let payload = pay_invoice_payload.clone();
 
         self.client_ctx
-            .global_db()
-            .autocommit(
+            .module_autocommit(
                 |dbtx, _| {
                     Box::pin(async {
                         let operation_id = OperationId(payload.contract_id.into_inner());
@@ -533,11 +532,10 @@ impl GatewayClientModule {
                             .map(|s| self.client_ctx.make_dyn(s))
                             .collect();
 
-                            match self.client_ctx.add_state_machines(dbtx, dyn_states).await {
+                            match dbtx.add_state_machines( dyn_states).await {
                                 Ok(()) => {
-                                    self.client_ctx
+                                    dbtx
                                         .add_operation_log_entry(
-                                            dbtx,
                                             operation_id,
                                             KIND.as_str(),
                                             GatewayMeta::Pay,

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1176,7 +1176,6 @@ impl MintClientModule {
         try_cancel_after: Duration,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, OOBNotes)> {
-        let mint_id = self.client_ctx.module_instance_id();
         let federation_id_prefix = self.federation_id.to_prefix();
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientModule::spend_notes extra_meta is serializable");
@@ -1196,9 +1195,8 @@ impl MintClientModule {
                             .await?;
                         let oob_notes = OOBNotes::new(federation_id_prefix, notes);
 
-                        let dyn_states = states.into_iter().map(|s| s.into_dyn(mint_id)).collect();
-
-                        dbtx.add_state_machines(dyn_states).await?;
+                        dbtx.add_state_machines(self.client_ctx.map_dyn(states).collect())
+                            .await?;
                         dbtx.add_operation_log_entry(
                             operation_id,
                             MintCommonInit::KIND.as_str(),

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -383,11 +383,9 @@ impl WalletClientModule {
                             .watch_script_history(&address.script_pubkey())
                             .await?;
 
-                        dbtx.add_state_machines(vec![DynState::from_typed(
-                            self.client_ctx.module_instance_id(),
-                            sm,
-                        )])
-                        .await?;
+                        dbtx.add_state_machines(vec![self.client_ctx.make_dyn_state(sm)])
+                            .await?;
+
                         dbtx.add_operation_log_entry(
                             operation_id,
                             WalletCommonInit::KIND.as_str(),


### PR DESCRIPTION
On top of #3650 