### PR TITLE
Introduce module associated type for backups

### DIFF
--- a/fedimint-client/src/backup/tests.rs
+++ b/fedimint-client/src/backup/tests.rs
@@ -1,4 +1,7 @@
+use std::io::Cursor;
+
 use anyhow::Result;
+use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_derive_secret::DerivableSecret;
 
 use crate::backup::{ClientBackup, Metadata};
@@ -22,9 +25,12 @@ fn sanity_ecash_backup_decode_encode() -> Result<()> {
         modules: Default::default(),
     };
 
-    let encoded = orig.encode()?;
+    let encoded = orig.consensus_encode_to_vec()?;
     assert_eq!(encoded.len(), 16 * 1024);
-    assert_eq!(orig, ClientBackup::decode(&encoded)?);
+    assert_eq!(
+        orig,
+        ClientBackup::consensus_decode(&mut Cursor::new(encoded), &Default::default())?
+    );
 
     Ok(())
 }
@@ -42,7 +48,7 @@ fn sanity_ecash_backup_encrypt_decrypt() -> Result<()> {
 
     let encrypted = orig.encrypt_to(&key)?;
 
-    let decrypted = encrypted.decrypt_with(&key)?;
+    let decrypted = encrypted.decrypt_with(&key, &Default::default())?;
 
     assert_eq!(orig, decrypted);
 

--- a/fedimint-client/src/module/recovery.rs
+++ b/fedimint-client/src/module/recovery.rs
@@ -1,0 +1,94 @@
+use std::any::Any;
+use std::fmt::Debug;
+
+use fedimint_core::core::{IntoDynInstance, ModuleInstanceId};
+use fedimint_core::encoding::{Decodable, DynEncodable, Encodable};
+use fedimint_core::task::{MaybeSend, MaybeSync};
+use fedimint_core::{
+    maybe_add_send_sync, module_plugin_dyn_newtype_clone_passthrough,
+    module_plugin_dyn_newtype_define, module_plugin_dyn_newtype_encode_decode,
+    module_plugin_dyn_newtype_eq_passthrough,
+};
+
+pub trait IModuleBackup: Debug + DynEncodable {
+    fn as_any(&self) -> &(maybe_add_send_sync!(dyn Any));
+    fn clone(&self, instance_id: ModuleInstanceId) -> DynModuleBackup;
+    fn erased_eq_no_instance_id(&self, other: &DynModuleBackup) -> bool;
+}
+
+pub trait ModuleBackup:
+    std::fmt::Debug
+    + IntoDynInstance<DynType = DynModuleBackup>
+    + std::cmp::PartialEq
+    + DynEncodable
+    + Decodable
+    + Clone
+    + MaybeSend
+    + MaybeSync
+    + 'static
+{
+}
+
+impl IModuleBackup for ::fedimint_core::core::DynUnknown {
+    fn as_any(&self) -> &(maybe_add_send_sync!(dyn Any)) {
+        self
+    }
+
+    fn clone(&self, instance_id: ::fedimint_core::core::ModuleInstanceId) -> DynModuleBackup {
+        DynModuleBackup::from_typed(instance_id, <Self as Clone>::clone(self))
+    }
+
+    fn erased_eq_no_instance_id(&self, other: &DynModuleBackup) -> bool {
+        let other: &Self = other
+            .as_any()
+            .downcast_ref()
+            .expect("Type is ensured in previous step");
+
+        self == other
+    }
+}
+
+impl<T> IModuleBackup for T
+where
+    T: ModuleBackup,
+{
+    fn as_any(&self) -> &(maybe_add_send_sync!(dyn Any)) {
+        self
+    }
+
+    fn clone(&self, instance_id: ::fedimint_core::core::ModuleInstanceId) -> DynModuleBackup {
+        DynModuleBackup::from_typed(instance_id, <Self as Clone>::clone(self))
+    }
+
+    fn erased_eq_no_instance_id(&self, other: &DynModuleBackup) -> bool {
+        let other: &Self = other
+            .as_any()
+            .downcast_ref()
+            .expect("Type is ensured in previous step");
+
+        self == other
+    }
+}
+
+module_plugin_dyn_newtype_define! {
+    pub DynModuleBackup(Box<IModuleBackup>)
+}
+
+module_plugin_dyn_newtype_encode_decode!(DynModuleBackup);
+
+module_plugin_dyn_newtype_clone_passthrough!(DynModuleBackup);
+
+module_plugin_dyn_newtype_eq_passthrough!(DynModuleBackup);
+
+#[derive(Clone, PartialEq, Eq, Debug, Encodable, Decodable)]
+pub struct NoModuleBackup;
+
+impl ModuleBackup for NoModuleBackup {}
+
+impl IntoDynInstance for NoModuleBackup {
+    type DynType = DynModuleBackup;
+
+    fn into_dyn(self, instance_id: ModuleInstanceId) -> Self::DynType {
+        DynModuleBackup::from_typed(instance_id, self)
+    }
+}

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -181,7 +181,7 @@ impl From<&'static str> for ModuleKind {
 /// This allows parsing and handling of dyn-types of modules which
 /// are not available.
 #[derive(Encodable, Decodable, Debug, Hash, PartialEq, Clone)]
-pub struct DynUnknown(Vec<u8>);
+pub struct DynUnknown(pub Vec<u8>);
 
 impl fmt::Display for DynUnknown {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -320,7 +320,7 @@ macro_rules! module_plugin_dyn_newtype_encode_decode {
                 let val = match modules.get(module_instance_id) {
                     Some(decoder) => {
                         let total_len_u64 = u64::consensus_decode(reader, modules)?;
-                        let mut reader = reader.take(total_len_u64);
+                        let mut reader = std::io::Read::take(reader, total_len_u64);
                         let v = decoder.decode(&mut reader, module_instance_id, modules)?;
 
                         if reader.limit() != 0 {

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -8,6 +8,7 @@ use async_stream::stream;
 use bitcoin_hashes::{sha256, Hash};
 use fedimint_client::derivable_secret::ChildId;
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
+use fedimint_client::module::recovery::NoModuleBackup;
 use fedimint_client::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
@@ -213,6 +214,7 @@ pub struct GatewayClientModule {
 impl ClientModule for GatewayClientModule {
     type Init = LightningClientInit;
     type Common = LightningModuleTypes;
+    type Backup = NoModuleBackup;
     type ModuleStateMachineContext = GatewayClientContext;
     type States = GatewayClientStateMachines;
 

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, format_err, Context as _};
 use common::broken_fed_key_pair;
 use db::DbKeyPrefix;
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
+use fedimint_client::module::recovery::NoModuleBackup;
 use fedimint_client::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client::sm::{Context, ModuleNotifier};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
@@ -57,6 +58,7 @@ impl Context for DummyClientContext {}
 impl ClientModule for DummyClientModule {
     type Init = DummyClientInit;
     type Common = DummyModuleTypes;
+    type Backup = NoModuleBackup;
     type ModuleStateMachineContext = DummyClientContext;
     type States = DummyStateMachine;
 

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -16,6 +16,7 @@ use bitcoin_hashes::{sha256, Hash};
 use db::{DbKeyPrefix, LightningGatewayKey, PaymentResult, PaymentResultKey};
 use fedimint_client::derivable_secret::ChildId;
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
+use fedimint_client::module::recovery::NoModuleBackup;
 use fedimint_client::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
@@ -331,6 +332,7 @@ pub struct LightningClientModule {
 impl ClientModule for LightningClientModule {
     type Init = LightningClientInit;
     type Common = LightningModuleTypes;
+    type Backup = NoModuleBackup;
     type ModuleStateMachineContext = LightningClientContext;
     type States = LightningClientStateMachines;
 

--- a/modules/fedimint-mint-client/src/backup.rs
+++ b/modules/fedimint-mint-client/src/backup.rs
@@ -1,5 +1,7 @@
+use fedimint_client::module::recovery::{DynModuleBackup, ModuleBackup};
 use fedimint_client::module::ClientDbTxContext;
 use fedimint_core::api::GlobalFederationApi;
+use fedimint_core::core::{IntoDynInstance, ModuleInstanceId};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, Tiered, TieredMulti};
 use serde::{Deserialize, Serialize};
@@ -14,7 +16,7 @@ pub mod recovery;
 ///
 /// Used to speed up and improve privacy of ecash recovery,
 /// by avoiding scanning the whole history.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Encodable, Decodable)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug, Encodable, Decodable)]
 pub struct EcashBackup {
     spendable_notes: TieredMulti<SpendableNote>,
     pending_notes: Vec<(OutPoint, Amount, NoteIssuanceRequest)>,
@@ -31,6 +33,16 @@ impl EcashBackup {
             session_count: 0,
             next_note_idx: Tiered::default(),
         }
+    }
+}
+
+impl ModuleBackup for EcashBackup {}
+
+impl IntoDynInstance for EcashBackup {
+    type DynType = DynModuleBackup;
+
+    fn into_dyn(self, instance_id: ModuleInstanceId) -> Self::DynType {
+        DynModuleBackup::from_typed(instance_id, self)
     }
 }
 

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -15,6 +15,7 @@ use client_db::DbKeyPrefix;
 use fedimint_bitcoind::{create_bitcoind, DynBitcoindRpc};
 use fedimint_client::derivable_secret::{ChildId, DerivableSecret};
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
+use fedimint_client::module::recovery::NoModuleBackup;
 use fedimint_client::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
@@ -201,6 +202,7 @@ pub struct WalletClientModule {
 impl ClientModule for WalletClientModule {
     type Init = WalletClientInit;
     type Common = WalletModuleTypes;
+    type Backup = NoModuleBackup;
     type ModuleStateMachineContext = WalletClientContext;
     type States = WalletClientStates;
 


### PR DESCRIPTION
Fixes #3654

* Makes it easier to add versioning to module backups by making them enums
* Probably enables removing `supports_backup` since there's now the `NoBackup` placeholder type (does this sound correct @dpc?)