### PR TITLE
fix: make fedimint-ln-client::receive public

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1,7 +1,7 @@
 mod db;
 pub mod incoming;
 pub mod pay;
-mod receive;
+pub mod receive;
 
 use std::collections::BTreeMap;
 use std::iter::once;


### PR DESCRIPTION
this should be public like other client state machine modules.

this was broken by https://github.com/fedimint/fedimint/pull/3287