### PR TITLE
fix: reintroduce invite_code rpc

### DIFF
--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -36,3 +36,4 @@ pub const AWAIT_OUTGOING_CONTRACT_CANCELLED_ENDPOINT: &str = "await_outgoing_con
 pub const AWAIT_PREIMAGE_DECRYPTION: &str = "await_preimage_decryption";
 pub const AWAIT_OFFER_ENDPOINT: &str = "await_offer";
 pub const AWAIT_TRANSACTION_ENDPOINT: &str = "await_transaction";
+pub const INVITE_CODE_ENDPOINT: &str = "invite_code";

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -21,7 +21,7 @@ use fedimint_core::db::{
 use fedimint_core::endpoint_constants::{
     AUDIT_ENDPOINT, AUTH_ENDPOINT, AWAIT_BLOCK_ENDPOINT, AWAIT_OUTPUT_OUTCOME_ENDPOINT,
     AWAIT_SIGNED_BLOCK_ENDPOINT, AWAIT_TRANSACTION_ENDPOINT, BACKUP_ENDPOINT,
-    CLIENT_CONFIG_ENDPOINT, MODULES_CONFIG_JSON_ENDPOINT, RECOVER_ENDPOINT,
+    CLIENT_CONFIG_ENDPOINT, INVITE_CODE_ENDPOINT, MODULES_CONFIG_JSON_ENDPOINT, RECOVER_ENDPOINT,
     SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT, SESSION_COUNT_ENDPOINT, STATUS_ENDPOINT,
     SUBMIT_TRANSACTION_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT, VERSION_ENDPOINT,
 };
@@ -376,6 +376,12 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                     .map_err(|e| ApiError::bad_request(e.to_string()))?;
 
                 Ok(outcome)
+            }
+        },
+        api_endpoint! {
+            INVITE_CODE_ENDPOINT,
+            async |fedimint: &ConsensusApi, _context,  _v: ()| -> String {
+                Ok(fedimint.cfg.get_invite_code().to_string())
             }
         },
         api_endpoint! {


### PR DESCRIPTION
The api got dropped as part of https://github.com/fedimint/fedimint/pull/3544 but we need it for use in the federation admin UIs

quick validate with `just mprocs` and `fedimint-cli dev api invite_code --peer-id 1`