### PR TITLE
feat: restart federation setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,6 +2069,7 @@ dependencies = [
  "fedimint-dummy-server",
  "fedimint-hbbft",
  "fedimint-logging",
+ "fedimint-portalloc",
  "fedimint-tbs",
  "fedimint-testing",
  "fedimint-threshold-crypto",

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -14,9 +14,10 @@ use crate::api::{
 use crate::config::ServerModuleConfigGenParamsRegistry;
 use crate::endpoint_constants::{
     ADD_CONFIG_GEN_PEER_ENDPOINT, AUDIT_ENDPOINT, AUTH_ENDPOINT, CONFIG_GEN_PEERS_ENDPOINT,
-    CONSENSUS_CONFIG_GEN_PARAMS_ENDPOINT, DEFAULT_CONFIG_GEN_PARAMS_ENDPOINT, RUN_DKG_ENDPOINT,
-    SET_CONFIG_GEN_CONNECTIONS_ENDPOINT, SET_CONFIG_GEN_PARAMS_ENDPOINT, SET_PASSWORD_ENDPOINT,
-    START_CONSENSUS_ENDPOINT, STATUS_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT,
+    CONSENSUS_CONFIG_GEN_PARAMS_ENDPOINT, DEFAULT_CONFIG_GEN_PARAMS_ENDPOINT,
+    RESTART_FEDERATION_SETUP_ENDPOINT, RUN_DKG_ENDPOINT, SET_CONFIG_GEN_CONNECTIONS_ENDPOINT,
+    SET_CONFIG_GEN_PARAMS_ENDPOINT, SET_PASSWORD_ENDPOINT, START_CONSENSUS_ENDPOINT,
+    STATUS_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT,
 };
 use crate::module::{ApiAuth, ApiRequestErased};
 use crate::PeerId;
@@ -179,6 +180,14 @@ impl WsAdminClient {
     pub async fn auth(&self, auth: ApiAuth) -> FederationResult<()> {
         self.request(AUTH_ENDPOINT, ApiRequestErased::default().with_auth(auth))
             .await
+    }
+
+    pub async fn restart_federation_setup(&self, auth: ApiAuth) -> FederationResult<()> {
+        self.request(
+            RESTART_FEDERATION_SETUP_ENDPOINT,
+            ApiRequestErased::default().with_auth(auth),
+        )
+        .await
     }
 
     async fn request<Ret>(&self, method: &str, params: ApiRequestErased) -> FederationResult<Ret>

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -17,7 +17,7 @@ use crate::endpoint_constants::{
     CONSENSUS_CONFIG_GEN_PARAMS_ENDPOINT, DEFAULT_CONFIG_GEN_PARAMS_ENDPOINT,
     RESTART_FEDERATION_SETUP_ENDPOINT, RUN_DKG_ENDPOINT, SET_CONFIG_GEN_CONNECTIONS_ENDPOINT,
     SET_CONFIG_GEN_PARAMS_ENDPOINT, SET_PASSWORD_ENDPOINT, START_CONSENSUS_ENDPOINT,
-    STATUS_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT,
+    STATUS_ENDPOINT, VERIFIED_CONFIGS_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT,
 };
 use crate::module::{ApiAuth, ApiRequestErased};
 use crate::PeerId;
@@ -146,6 +146,19 @@ impl WsAdminClient {
     ) -> FederationResult<BTreeMap<PeerId, sha256::Hash>> {
         self.request(
             VERIFY_CONFIG_HASH_ENDPOINT,
+            ApiRequestErased::default().with_auth(auth),
+        )
+        .await
+    }
+
+    /// Updates local state and notify leader that we have verified configs.
+    /// This allows for a synchronization point, before we start consensus.
+    pub async fn verified_configs(
+        &self,
+        auth: ApiAuth,
+    ) -> FederationResult<BTreeMap<PeerId, sha256::Hash>> {
+        self.request(
+            VERIFIED_CONFIGS_ENDPOINT,
             ApiRequestErased::default().with_auth(auth),
         )
         .await

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -993,6 +993,9 @@ pub enum ServerStatus {
     VerifiedConfigs,
     /// Consensus is running
     ConsensusRunning,
+    /// Restarted setup. All peers need to sync on this state before continuing
+    /// to `SharingConfigGenParams`
+    SetupRestarted,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -37,3 +37,4 @@ pub const AWAIT_PREIMAGE_DECRYPTION: &str = "await_preimage_decryption";
 pub const AWAIT_OFFER_ENDPOINT: &str = "await_offer";
 pub const AWAIT_TRANSACTION_ENDPOINT: &str = "await_transaction";
 pub const INVITE_CODE_ENDPOINT: &str = "invite_code";
+pub const RESTART_FEDERATION_SETUP_ENDPOINT: &str = "restart_federation_setup";

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -58,6 +58,7 @@ tempfile = "3.4.0"
 fedimint-dummy-common = { path = "../modules/fedimint-dummy-common" }
 fedimint-dummy-server = { path = "../modules/fedimint-dummy-server" }
 fedimint-testing = { path = "../fedimint-testing" }
+fedimint-portalloc = { path = "../utils/portalloc" }
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 
 [build-dependencies]

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -892,6 +892,7 @@ mod tests {
     };
     use fedimint_dummy_server::DummyInit;
     use fedimint_logging::TracingSetup;
+    use fedimint_portalloc::port_alloc;
     use fedimint_testing::fixtures::test_dir;
     use futures::future::join_all;
     use itertools::Itertools;
@@ -1092,9 +1093,7 @@ mod tests {
     async fn test_config_api() {
         let _ = TracingSetup::default().init();
         let (data_dir, _maybe_tmp_dir_guard) = test_dir("test-config-api");
-
-        // TODO: Choose port in common way with `fedimint_env`
-        let base_port = 18103;
+        let base_port = port_alloc(1).unwrap();
 
         // let mut join_handles = vec![];
         let mut apis = vec![];
@@ -1326,6 +1325,11 @@ mod tests {
             assert_eq!(dummy.consensus.tx_fee, leader_amount);
             assert_eq!(dummy.local.example, peer.name);
             assert_eq!(cfg.consensus.meta["\"test\""], leader_name);
+        }
+
+        // set verified configs
+        for peer in all_peers.iter() {
+            peer.client.verified_configs(peer.auth.clone()).await.ok();
         }
 
         // start consensus

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -39,6 +39,11 @@ pub const JSON_EXT: &str = "json";
 
 const ENCRYPTED_EXT: &str = "encrypt";
 
+/// Temporary directiry where server configs are stored / removed through the
+/// setup process On setup complete, the configs are moved to the server config
+/// directory and the staging directory is removed
+pub const CONFIG_STAGING_DIR: &str = "cfg_staging";
+
 /// Reads the server from the local, private, and consensus cfg files
 pub fn read_server_config(password: &str, path: PathBuf) -> anyhow::Result<ServerConfig> {
     let salt = fs::read_to_string(path.join(SALT_FILE))?;


### PR DESCRIPTION
After setting config gen params and before starting consensus, any peer can initiate a restart of the federation setup using `restart_federation_setup` rpc.

> **server-side behavior**

- This API sets the peer server in `SetupRestarted` status.
- The Leader server waits for all peers to progress to `SetupRestarted`.
- Leader then automatically makes progress to `AwaitingPassword`.
- Followers watch leader status and when they see `AwaitingPassword`, they also make progress to the same state

All peers can then begin the setup process

> **suggested user experience**

While the server is in any of these states `SharingConfigGenParams` | `ReadyForConfigGen` | `ConfigGenFailed` |  `VerifyingConfigs` | `VerifiedConfigs`, the setup UI should watch peer information in consensus status. Should any peer be in `SetupRestarted`, the setup UI should immediately prompt the user to initiate restart by make a call to `restart_federation_setup`. Suggestion here it to make this some blocking but interactive UX

closes #3535 