### PR TITLE
chore: remove musig2 signature compression for transaction signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4368,7 +4368,8 @@ dependencies = [
 [[package]]
 name = "secp256k1-zkp"
 version = "0.7.0"
-source = "git+https://github.com/dpc/rust-secp256k1-zkp/?branch=sanket-pr#f29b1b8c442d4b8a42547ce36d3987aaedf94224"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd403e9f0569b4131ab3fc9fa24a17775331b39382efd2cde851fdca655e3520"
 dependencies = [
  "rand",
  "secp256k1 0.24.3",
@@ -4379,7 +4380,8 @@ dependencies = [
 [[package]]
 name = "secp256k1-zkp-sys"
 version = "0.7.0"
-source = "git+https://github.com/dpc/rust-secp256k1-zkp/?branch=sanket-pr#f29b1b8c442d4b8a42547ce36d3987aaedf94224"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e7a2beac087c1da2d21018a3b7f043fe2f138654ad9c1518d409061a4a0034"
 dependencies = [
  "cc",
  "secp256k1-sys 0.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,3 @@ incremental = false
 
 [profile.release]
 debug = "line-tables-only"
-
-[patch.crates-io]
-secp256k1-zkp = { git = "https://github.com/dpc/rust-secp256k1-zkp/", branch = "sanket-pr" }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -33,7 +33,7 @@ pub async fn process_transaction_with_dbtx(
         public_keys.push(meta.pub_key);
     }
 
-    transaction.validate_signature(public_keys.into_iter())?;
+    transaction.validate_signatures(public_keys)?;
 
     for (output, out_idx) in transaction.outputs.iter().zip(0u64..) {
         let amount = modules

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -151,7 +151,7 @@ mod fedimint_migration_tests {
                 },
             )],
             nonce: [0x42; 8],
-            signature: Some(schnorr),
+            signatures: vec![schnorr],
         };
 
         let module_ids = transaction


### PR DESCRIPTION
The signature compression via musig relied on unstable code. We therefore switch to naive multisignatures for 0.2 and will make the signature an extendible enum to maybe enable a compressed variant in the future. Furthermore this allows us to use PublicKeys instead of XOnlyPublicKeys.