### PR TITLE
chore(devimint): increase bitcoin rpc timeout on tests

### DIFF
--- a/devimint/src/cfg/bitcoin.conf
+++ b/devimint/src/cfg/bitcoin.conf
@@ -6,6 +6,8 @@ rpcuser=bitcoin
 rpcpassword=bitcoin
 zmqpubrawblock=tcp://127.0.0.1:{zmq_pub_raw_block}
 zmqpubrawtx=tcp://127.0.0.1:{zmq_pub_raw_tx}
+rpcworkqueue=1024
+rpcthreads=64
 [regtest]
 port={p2p_port}
 rpcport={rpc_port}


### PR DESCRIPTION
Due to this timeout some tests were failing on my local machine. There is no reason for it to be so low.