### PR TITLE
fix(client): only list operation ids with associated operations as active

### DIFF
--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
 use std::io::{Error, Read, Write};
 use std::marker::PhantomData;
@@ -229,16 +229,6 @@ where
             .db
             .wait_key_exists(&ActiveStateKey::from_state(state))
             .await
-    }
-
-    /// Returns all IDs of operations that have active state machines
-    pub async fn get_active_operations(&self) -> HashSet<OperationId> {
-        self.inner
-            .get_active_states()
-            .await
-            .into_iter()
-            .map(|(state, _)| state.operation_id())
-            .collect()
     }
 
     /// Starts the background thread that runs the state machines. This cannot


### PR DESCRIPTION
Fixes #3687. Tl;dr: `get_active_operations` returned the recovery operation id for which no operation log entry exists.

@dpc since you want to replace the state machines for recovery anyway and @Maan2003 has a workaround for now, do we want this fix? It likely makes the function much slower, but also prevents this from happening again in the future if SMs get used for other tasks.