### PR TITLE
fix(wallet-client): deactivate secret derivation

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -155,9 +155,16 @@ impl ClientModuleInit for WalletClientInit {
             .0
             .clone()
             .unwrap_or(WalletClientModule::get_rpc_config(args.cfg()));
+
+        // FIXME: reactivate key derivation once we implement recovery
+        let random_root_secret = {
+            let (key, salt): ([u8; 32], [u8; 32]) = thread_rng().gen();
+            DerivableSecret::new_root(&key, &salt)
+        };
+
         Ok(WalletClientModule {
             cfg: args.cfg().clone(),
-            module_root_secret: args.module_root_secret().clone(),
+            module_root_secret: random_root_secret,
             module_api: args.module_api().clone(),
             notifier: args.notifier().clone(),
             rpc: create_bitcoind(&rpc_config, TaskGroup::new().make_handle())?,


### PR DESCRIPTION
Deriving keys from a root key without implementing recovery from backup is dangerous. Keys might be re-used since the last used key index isn't recovered. To avoid such problems we reactivate key derivation till recovery is implemented for the wallet module.

This will take #2977+implementing module recovery for the wallet off the critical path for 0.2.0.