### PR TITLE
Introduce minor consensus version

### DIFF
--- a/fedimint-core/src/module/version.rs
+++ b/fedimint-core/src/module/version.rs
@@ -68,11 +68,14 @@ use crate::encoding::{Decodable, Encodable};
 /// See [`ModuleConsensusVersion`] for more details on how it interacts with
 /// module's consensus.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Encodable, Decodable, PartialEq, Eq)]
-pub struct CoreConsensusVersion(pub u32);
+pub struct CoreConsensusVersion {
+    pub major: u32,
+    pub minor: u32,
+}
 
-impl From<u32> for CoreConsensusVersion {
-    fn from(value: u32) -> Self {
-        Self(value)
+impl CoreConsensusVersion {
+    pub const fn new(major: u32, minor: u32) -> Self {
+        Self { major, minor }
     }
 }
 
@@ -352,9 +355,9 @@ impl SupportedModuleApiVersions {
     ///
     /// Panics if `api_version` parts conflict as per
     /// [`SupportedModuleApiVersions`] invariants.
-    pub fn from_raw(core: u32, module: (u32, u32), api_versions: &[(u32, u32)]) -> Self {
+    pub fn from_raw(core: (u32, u32), module: (u32, u32), api_versions: &[(u32, u32)]) -> Self {
         Self {
-            core_consensus: CoreConsensusVersion(core),
+            core_consensus: CoreConsensusVersion::new(core.0, core.1),
             module_consensus: ModuleConsensusVersion::new(module.0, module.1),
             api: result::Result::<MultiApiVersion, ApiVersion>::from_iter(
                 api_versions

--- a/fedimint-core/src/module/version.rs
+++ b/fedimint-core/src/module/version.rs
@@ -78,21 +78,21 @@ impl From<u32> for CoreConsensusVersion {
 
 /// Consensus version of a specific module instance
 ///
-/// Any breaking change to the module's consensus rules require incrementing it.
+/// Any breaking change to the module's consensus rules require incrementing the
+/// major part of it.
+///
+/// Any backwards-compatible changes with regards to clients require
+/// incrementing the minor part of it. Backwards compatible changes will
+/// typically be introducing new input/output/consensus item variants that old
+/// clients won't understand but can safely ignore while new clients can use new
+/// functionality. It's akin to soft forks in Bitcoin.
 ///
 /// A module instance can run only in one consensus version, which must be the
-/// same across all corresponding instances on other nodes of the federation.
+/// same (both major and minor) across all corresponding instances on other
+/// nodes of the federation.
 ///
 /// When [`CoreConsensusVersion`] changes, this can but is not requires to be
 /// a breaking change for each module's [`ModuleConsensusVersion`].
-///
-/// Incrementing the module's consensus version can be considered an in-place
-/// upgrade path, similar to a blockchain hard-fork consensus upgrade.
-///
-/// As of time of writing this comment there are no plans to support any kind
-/// of "soft-forks" which mean a consensus minor version. As the set of
-/// federation member's is closed and limited, it is always preferable to
-/// synchronize upgrade and avoid cross-version incompatibilities.
 ///
 /// For many modules it might be preferable to implement a new
 /// [`fedimint_core::core::ModuleKind`] "versions" (to be implemented at the
@@ -101,11 +101,14 @@ impl From<u32> for CoreConsensusVersion {
 /// slowly migrate to a new one. This avoids complex and error-prone server-side
 /// consensus-migration logic.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Encodable, Decodable)]
-pub struct ModuleConsensusVersion(pub u32);
+pub struct ModuleConsensusVersion {
+    pub major: u32,
+    pub minor: u32,
+}
 
-impl From<u32> for ModuleConsensusVersion {
-    fn from(value: u32) -> Self {
-        Self(value)
+impl ModuleConsensusVersion {
+    pub const fn new(major: u32, minor: u32) -> Self {
+        Self { major, minor }
     }
 }
 
@@ -349,10 +352,10 @@ impl SupportedModuleApiVersions {
     ///
     /// Panics if `api_version` parts conflict as per
     /// [`SupportedModuleApiVersions`] invariants.
-    pub fn from_raw(core: u32, module: u32, api_versions: &[(u32, u32)]) -> Self {
+    pub fn from_raw(core: u32, module: (u32, u32), api_versions: &[(u32, u32)]) -> Self {
         Self {
             core_consensus: CoreConsensusVersion(core),
-            module_consensus: ModuleConsensusVersion(module),
+            module_consensus: ModuleConsensusVersion::new(module.0, module.1),
             api: result::Result::<MultiApiVersion, ApiVersion>::from_iter(
                 api_versions
                     .iter()

--- a/fedimint-core/src/query.rs
+++ b/fedimint-core/src/query.rs
@@ -492,7 +492,7 @@ fn discover_common_core_api_version(
         let peers_compatible_num = peer_versions
             .values()
             .filter(|supported_versions| {
-                (supported_versions.core_consensus == client_versions.core_consensus)
+                (supported_versions.core_consensus.major == client_versions.core_consensus.major)
                     .then(|| {
                         supported_versions
                             .api
@@ -517,7 +517,7 @@ fn discover_common_core_api_version(
 fn discover_common_core_api_version_sanity() {
     use fedimint_core::module::MultiApiVersion;
 
-    let core_consensus = 0.into();
+    let core_consensus = crate::module::CoreConsensusVersion::new(0, 0);
     let client_versions = SupportedCoreApiVersions {
         core_consensus,
         api: MultiApiVersion::try_from_iter([
@@ -534,7 +534,7 @@ fn discover_common_core_api_version_sanity() {
             BTreeMap::from([(
                 PeerId(0),
                 SupportedCoreApiVersions {
-                    core_consensus: 0.into(),
+                    core_consensus: crate::module::CoreConsensusVersion::new(0, 0),
                     api: MultiApiVersion::try_from_iter([ApiVersion { major: 2, minor: 4 }])
                         .unwrap(),
                 }
@@ -548,7 +548,21 @@ fn discover_common_core_api_version_sanity() {
             BTreeMap::from([(
                 PeerId(0),
                 SupportedCoreApiVersions {
-                    core_consensus: 1.into(), // wrong consensus version
+                    core_consensus: crate::module::CoreConsensusVersion::new(0, 1), /* different minor consensus version, we don't care */
+                    api: MultiApiVersion::try_from_iter([ApiVersion { major: 2, minor: 4 }])
+                        .unwrap(),
+                }
+            )])
+        ),
+        Some(ApiVersion { major: 2, minor: 3 })
+    );
+    assert_eq!(
+        discover_common_core_api_version(
+            &client_versions,
+            BTreeMap::from([(
+                PeerId(0),
+                SupportedCoreApiVersions {
+                    core_consensus: crate::module::CoreConsensusVersion::new(1, 0), /* wrong consensus version */
                     api: MultiApiVersion::try_from_iter([ApiVersion { major: 2, minor: 4 }])
                         .unwrap(),
                 }
@@ -601,7 +615,7 @@ fn discover_common_module_api_version(
         let peers_compatible_num = peer_versions
             .values()
             .filter(|supported_versions| {
-                (supported_versions.core_consensus == client_versions.core_consensus
+                (supported_versions.core_consensus.major == client_versions.core_consensus.major
                     && supported_versions.module_consensus.major
                         == client_versions.module_consensus.major)
                     .then(|| {

--- a/fedimint-core/src/query.rs
+++ b/fedimint-core/src/query.rs
@@ -602,7 +602,8 @@ fn discover_common_module_api_version(
             .values()
             .filter(|supported_versions| {
                 (supported_versions.core_consensus == client_versions.core_consensus
-                    && supported_versions.module_consensus == client_versions.module_consensus)
+                    && supported_versions.module_consensus.major
+                        == client_versions.module_consensus.major)
                     .then(|| {
                         supported_versions
                             .api

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -185,7 +185,7 @@ impl ServerConfigConsensus {
     }
 }
 
-pub const CORE_CONSENSUS_VERSION: CoreConsensusVersion = CoreConsensusVersion(u32::MAX);
+pub const CORE_CONSENSUS_VERSION: CoreConsensusVersion = CoreConsensusVersion::new(u32::MAX, 0);
 
 impl ServerConfig {
     /// Api versions supported by this server

--- a/modules/fedimint-dummy-common/src/lib.rs
+++ b/modules/fedimint-dummy-common/src/lib.rs
@@ -18,7 +18,7 @@ pub mod config;
 pub const KIND: ModuleKind = ModuleKind::from_static_str("dummy");
 
 /// Modules are non-compatible with older versions
-pub const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
+pub const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(0, 0);
 
 /// Non-transaction items that will be submitted to consensus
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -99,7 +99,7 @@ impl ServerModuleInit for DummyInit {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(u32::MAX, (0, 0), &[(0, 0)])
     }
 
     /// Initialize the module

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -99,7 +99,7 @@ impl ServerModuleInit for DummyInit {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(u32::MAX, (0, 0), &[(0, 0)])
+        SupportedModuleApiVersions::from_raw((u32::MAX, 0), (0, 0), &[(0, 0)])
     }
 
     /// Initialize the module

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -49,7 +49,7 @@ async fn client_ignores_unknown_module() {
     let extra_mod = ClientModuleConfig::from_typed(
         module_id,
         ModuleKind::from_static_str("unknown_module"),
-        ModuleConsensusVersion(0),
+        ModuleConsensusVersion::new(0, 0),
         DummyClientConfig {
             tx_fee: Amount::from_sats(1),
         },

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -35,7 +35,7 @@ use crate::contracts::incoming::OfferId;
 use crate::contracts::{Contract, ContractId, ContractOutcome, Preimage, PreimageDecryptionShare};
 
 pub const KIND: ModuleKind = ModuleKind::from_static_str("ln");
-const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
+const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(0, 0);
 
 extensible_associated_module_type!(
     LightningInput,

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -230,11 +230,12 @@ impl ServerModuleInit for LightningInit {
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
-        &[ModuleConsensusVersion(0)]
+        const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(0, 0);
+        &[MODULE_CONSENSUS_VERSION]
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(u32::MAX, (0, 0), &[(0, 0)])
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -235,7 +235,7 @@ impl ServerModuleInit for LightningInit {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(u32::MAX, (0, 0), &[(0, 0)])
+        SupportedModuleApiVersions::from_raw((u32::MAX, 0), (0, 0), &[(0, 0)])
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -17,7 +17,7 @@ pub mod common;
 pub mod db;
 
 pub const KIND: ModuleKind = ModuleKind::from_static_str("mint");
-const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
+const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(0, 0);
 
 /// By default, the maximum notes per denomination when change-making for users
 pub const DEFAULT_MAX_NOTES_PER_DENOMINATION: u16 = 3;

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -111,11 +111,12 @@ impl ServerModuleInit for MintInit {
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
-        &[ModuleConsensusVersion(0)]
+        const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(0, 0);
+        &[MODULE_CONSENSUS_VERSION]
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(u32::MAX, (0, 0), &[(0, 0)])
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
@@ -595,7 +596,7 @@ mod test {
         let client_cfg = ClientModuleConfig::from_typed(
             0,
             MintInit::kind(),
-            ModuleConsensusVersion(0),
+            ModuleConsensusVersion::new(0, 0),
             MintInit
                 .get_client_config(&mint_cfg[&PeerId::from(0)].consensus)
                 .unwrap(),

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -116,7 +116,7 @@ impl ServerModuleInit for MintInit {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(u32::MAX, (0, 0), &[(0, 0)])
+        SupportedModuleApiVersions::from_raw((u32::MAX, 0), (0, 0), &[(0, 0)])
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -28,7 +28,7 @@ pub mod tweakable;
 pub mod txoproof;
 
 pub const KIND: ModuleKind = ModuleKind::from_static_str("wallet");
-const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion(0);
+const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(0, 0);
 
 pub const CONFIRMATION_TARGET: u16 = 10;
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -182,11 +182,12 @@ impl ServerModuleInit for WalletInit {
     const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {
-        &[ModuleConsensusVersion(0)]
+        const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(0, 0);
+        &[MODULE_CONSENSUS_VERSION]
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(u32::MAX, 0, &[(0, 0)])
+        SupportedModuleApiVersions::from_raw(u32::MAX, (0, 0), &[(0, 0)])
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -187,7 +187,7 @@ impl ServerModuleInit for WalletInit {
     }
 
     fn supported_api_versions(&self) -> SupportedModuleApiVersions {
-        SupportedModuleApiVersions::from_raw(u32::MAX, (0, 0), &[(0, 0)])
+        SupportedModuleApiVersions::from_raw((u32::MAX, 0), (0, 0), &[(0, 0)])
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -578,7 +578,7 @@ fn build_wallet_server_configs(
     let client_cfg = fedimint_core::config::ClientModuleConfig::from_typed(
         0,
         <WalletInit as fedimint_core::module::ServerModuleInit>::kind(),
-        fedimint_core::module::ModuleConsensusVersion(0),
+        fedimint_core::module::ModuleConsensusVersion::new(0, 0),
         fedimint_core::module::ServerModuleInit::get_client_config(
             &WalletInit,
             &wallet_cfg[&PeerId::from(0)].consensus,


### PR DESCRIPTION
This PR only introduces minor consensus versions and makes the client ignore it. Later we'll have to find a way to determine the most recent compatible minor consensus version the client supports, but that has time till we actually release a new minor consensus version.

Fixes #3571 