### PR TITLE
fix: make consensus fast again

### DIFF
--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -328,12 +328,12 @@ impl ConsensusServer {
     pub async fn run_session(&self, session_index: u64) -> anyhow::Result<()> {
         // if all nodes are correct the session will take 45 to 60 seconds. The
         // more nodes go offline the longer the session will take to complete.
-        const EXPECTED_ROUNDS_PER_SESSION: usize = 45 * 4;
+        const EXPECTED_ROUNDS_PER_SESSION: usize = 45 * 20;
         // this constant needs to be 3000 or less to guarantee that the session
         // can never reach MAX_ROUNDs.
         const EXPONENTIAL_SLOWDOWN_OFFSET: usize = 3 * EXPECTED_ROUNDS_PER_SESSION;
-        const MAX_ROUND: u16 = 5000;
-        const ROUND_DELAY: f64 = 250.0;
+        const MAX_ROUND: u16 = 5_000;
+        const ROUND_DELAY: f64 = 50.0;
         const BASE: f64 = 1.01;
 
         // this is the minimum number of unit data that will be ordered before we reach


### PR DESCRIPTION
Payment latency on current master (4a6a580f4eeccc7f95baa8c693c2f5ae52900a24):

```
18 gateway_pay_invoice_success: avg 5.68456783s, median 5.652043845s, max 11.529719549s, min 4.11351511s
18 gateway_create_invoice: avg 1.168869878s, median 2.123909154s, max 3.395704957s, min 19.291994ms
9 gateway_payment_received_started: avg 4.464089591s, median 4.046802124s, max 9.151851322s, min 3.32866744s
2 reissue_notes: avg 2.494038092s, median 2.630916954s, max 2.630916954s, min 2.35715923s
```

Payment latency with 95deafc7b529836785059617ace5ffc49a9ea64c:

```
2 reissue_notes: avg 1.481310515s, median 1.600800859s, max 1.600800859s, min 1.361820172s
17 gateway_payment_received_started: avg 1.958627338s, median 1.884378943s, max 2.91291775s, min 1.761244498s
34 gateway_create_invoice: avg 636.523164ms, median 1.181066008s, max 1.281812029s, min 18.758735ms
34 gateway_pay_invoice_success: avg 2.957889402s, median 3.209708471s, max 4.322514205s, min 2.326591537s
```

Fixes #3682