### PR TITLE
fix: rederive root_secret using federation ID

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1589,6 +1589,14 @@ impl ClientBuilder {
 
         let final_client = FinalClient::default();
 
+        // Re-derive client's root_secret using raw bytes from the provided root_secret
+        // and salt from the federation ID. This eliminates the possibility of having
+        // the same client root_secret across multiple federations.
+        let root_secret = DerivableSecret::new_root(
+            &root_secret.to_random_bytes::<32>(),
+            &config.global.federation_id().0,
+        );
+
         let modules = {
             let mut modules = ClientModuleRegistry::default();
             for (module_instance, module_config) in config.modules.clone() {

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -108,7 +108,7 @@ use fedimint_core::{
     TransactionId,
 };
 pub use fedimint_derive_secret as derivable_secret;
-use fedimint_derive_secret::{ChildId, DerivableSecret};
+use fedimint_derive_secret::DerivableSecret;
 use futures::StreamExt;
 use module::{DynClientModule, FinalClient};
 use rand::thread_rng;
@@ -153,8 +153,6 @@ pub mod secret;
 pub mod sm;
 /// Structs and interfaces to construct Fedimint transactions
 pub mod transaction;
-
-const EXTERNAL_SECRET_CHILD_ID: ChildId = ChildId((ModuleInstanceId::MAX as u64) + 1);
 
 pub type InstancelessDynClientInput = ClientInput<
     Box<maybe_add_send_sync!(dyn IInput + 'static)>,
@@ -746,14 +744,6 @@ impl Client {
 
     fn root_secret(&self) -> DerivableSecret {
         self.root_secret.clone()
-    }
-
-    /// Secret that is derived from the seed used by the client and cannot
-    /// collide with secrets used by the client itself. It's intended to be used
-    /// by integrators of the client library so they don't have to implement
-    /// their own secret derivation scheme.
-    pub fn external_secret(&self) -> DerivableSecret {
-        self.root_secret().child_key(EXTERNAL_SECRET_CHILD_ID)
     }
 
     pub async fn add_state_machines(


### PR DESCRIPTION
Closes #3508

Also removes `Client::external_secret` because we can now supply a derivable secret `root->child_client_0` to the client while we use `root->other_use_case` for our external needs. When the client still managed the secret this function was the only way to use the same secret as the client.