### PR TITLE
feat: improved load-test-metrics

### DIFF
--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -935,6 +935,10 @@ async fn run_ln_circular_load_test(load_test_temp: &Path, invite_code: &str) -> 
         output.contains("gateway_pay_invoice_success"),
         "missing invoice payment"
     );
+    anyhow::ensure!(
+        output.contains("gateway_payment_received_success"),
+        "missing received payment"
+    );
 
     info!("Testing ln-circular-load-test with 'partner-ping-pong' strategy");
     // Note invite code isn't required because we already have an archive dir
@@ -958,8 +962,8 @@ async fn run_ln_circular_load_test(load_test_temp: &Path, invite_code: &str) -> 
         "missing invoice creation"
     );
     anyhow::ensure!(
-        output.contains("gateway_pay_invoice_success"),
-        "missing invoice payment"
+        output.contains("gateway_payment_received_success"),
+        "missing received payment"
     );
 
     info!("Testing ln-circular-load-test with 'self-payment' strategy");
@@ -984,8 +988,8 @@ async fn run_ln_circular_load_test(load_test_temp: &Path, invite_code: &str) -> 
         "missing invoice creation"
     );
     anyhow::ensure!(
-        output.contains("gateway_pay_invoice_success"),
-        "missing invoice payment"
+        output.contains("gateway_payment_received_success"),
+        "missing received payment"
     );
     Ok(())
 }

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -222,6 +222,7 @@ pub async fn lnd_wait_invoice_payment(r_hash: String) -> anyhow::Result<()> {
 
 pub async fn gateway_pay_invoice(
     prefix: &str,
+    gateway_name: &str,
     client: &ClientArc,
     invoice: Bolt11Invoice,
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
@@ -249,6 +250,10 @@ pub async fn gateway_pay_invoice(
                 info!("{prefix} Invoice paid in {elapsed:?}");
                 event_sender.send(MetricEvent {
                     name: "gateway_pay_invoice_success".into(),
+                    duration: elapsed,
+                })?;
+                event_sender.send(MetricEvent {
+                    name: format!("gateway_{gateway_name}_pay_invoice_success"),
                     duration: elapsed,
                 })?;
                 break;


### PR DESCRIPTION
- Segregate `gateway_payment_received_success` and `gateway_pay_invoice_success` to detect asymmetries between receiving and sending payments
- Change `gateway_payment_received_started_{method}` to `gateway_{gateway_name}_payment_received_started` to make sure all the metrics use the same convention of referring to the gateway that is receiving/sending the payment
- Sort metrics output based on metric name