### PR TITLE
chore: ensure prefix `fedimint` on all published crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ dependencies = [
  "fedimint-client",
  "fedimint-cln-rpc",
  "fedimint-core",
+ "fedimint-ln-gateway",
  "fedimint-logging",
  "fedimint-portalloc",
  "fedimint-server",
@@ -983,7 +984,6 @@ dependencies = [
  "fedimint-wallet-client",
  "fedimintd",
  "futures",
- "ln-gateway",
  "nix",
  "rand",
  "serde",
@@ -1314,6 +1314,7 @@ dependencies = [
  "erased-serde",
  "fedimint-derive",
  "fedimint-logging",
+ "fedimint-tbs",
  "fedimint-threshold-crypto",
  "futures",
  "getrandom",
@@ -1338,7 +1339,6 @@ dependencies = [
  "sha3",
  "strum",
  "strum_macros",
- "tbs",
  "test-log",
  "thiserror",
  "tokio",
@@ -1362,6 +1362,7 @@ dependencies = [
  "fedimint-client",
  "fedimint-core",
  "fedimint-ln-client",
+ "fedimint-ln-gateway",
  "fedimint-ln-server",
  "fedimint-logging",
  "fedimint-mint-client",
@@ -1372,7 +1373,6 @@ dependencies = [
  "fedimint-wallet-server",
  "futures",
  "hex",
- "ln-gateway",
  "serde",
  "serde_json",
  "strum",
@@ -1397,10 +1397,10 @@ version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
- "hkdf",
+ "fedimint-hkdf",
+ "fedimint-tbs",
  "ring 0.17.5",
  "secp256k1-zkp",
- "tbs",
 ]
 
 [[package]]
@@ -1486,6 +1486,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-gateway-cli"
+version = "0.2.0-alpha"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "axum-macros",
+ "bitcoin 0.29.2",
+ "clap",
+ "clap_complete",
+ "fedimint-build",
+ "fedimint-core",
+ "fedimint-ln-gateway",
+ "fedimint-logging",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "fedimint-hbbft"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1528,13 @@ dependencies = [
  "serde",
  "thiserror",
  "tiny-keccak",
+]
+
+[[package]]
+name = "fedimint-hkdf"
+version = "0.2.0-alpha"
+dependencies = [
+ "bitcoin_hashes 0.11.0",
 ]
 
 [[package]]
@@ -1595,6 +1625,60 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "fedimint-ln-gateway"
+version = "0.2.0-alpha"
+dependencies = [
+ "anyhow",
+ "aquamarine",
+ "assert_matches",
+ "async-stream",
+ "async-trait",
+ "axum",
+ "axum-macros",
+ "bitcoin 0.29.2",
+ "bitcoin_hashes 0.11.0",
+ "clap",
+ "cln-plugin",
+ "erased-serde",
+ "fedimint-build",
+ "fedimint-client",
+ "fedimint-cln-rpc",
+ "fedimint-core",
+ "fedimint-dummy-client",
+ "fedimint-dummy-common",
+ "fedimint-dummy-server",
+ "fedimint-ln-client",
+ "fedimint-ln-common",
+ "fedimint-ln-server",
+ "fedimint-logging",
+ "fedimint-mint-client",
+ "fedimint-rocksdb",
+ "fedimint-testing",
+ "fedimint-threshold-crypto",
+ "fedimint-tonic-lnd",
+ "fedimint-wallet-client",
+ "futures",
+ "lightning-invoice 0.26.0",
+ "prost 0.12.1",
+ "rand",
+ "reqwest",
+ "secp256k1 0.24.3",
+ "secp256k1-zkp",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.10.2",
+ "tonic-build",
+ "tower-http",
+ "tracing",
  "url",
 ]
 
@@ -1732,6 +1816,7 @@ dependencies = [
  "fedimint-derive-secret",
  "fedimint-logging",
  "fedimint-mint-common",
+ "fedimint-tbs",
  "fedimint-threshold-crypto",
  "futures",
  "itertools 0.10.5",
@@ -1743,7 +1828,6 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "tbs",
  "test-log",
  "thiserror",
  "tokio",
@@ -1760,6 +1844,7 @@ dependencies = [
  "bincode",
  "bitcoin_hashes 0.11.0",
  "fedimint-core",
+ "fedimint-tbs",
  "fedimint-threshold-crypto",
  "futures",
  "itertools 0.10.5",
@@ -1769,7 +1854,6 @@ dependencies = [
  "serde",
  "strum",
  "strum_macros",
- "tbs",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -1788,6 +1872,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-mint-common",
  "fedimint-server",
+ "fedimint-tbs",
  "fedimint-testing",
  "fedimint-threshold-crypto",
  "futures",
@@ -1799,7 +1884,6 @@ dependencies = [
  "serde",
  "strum",
  "strum_macros",
- "tbs",
  "test-log",
  "thiserror",
  "tokio",
@@ -1842,6 +1926,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-recoverytool"
+version = "0.2.0-alpha"
+dependencies = [
+ "anyhow",
+ "bitcoin 0.29.2",
+ "clap",
+ "fedimint-aead",
+ "fedimint-core",
+ "fedimint-ln-common",
+ "fedimint-ln-server",
+ "fedimint-logging",
+ "fedimint-mint-server",
+ "fedimint-rocksdb",
+ "fedimint-server",
+ "fedimint-wallet-server",
+ "futures",
+ "miniscript",
+ "secp256k1 0.24.3",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "fedimint-rocksdb"
 version = "0.2.0-alpha"
 dependencies = [
@@ -1878,6 +1988,7 @@ dependencies = [
  "fedimint-dummy-server",
  "fedimint-hbbft",
  "fedimint-logging",
+ "fedimint-tbs",
  "fedimint-testing",
  "fedimint-threshold-crypto",
  "futures",
@@ -1892,7 +2003,6 @@ dependencies = [
  "sha3",
  "strum",
  "strum_macros",
- "tbs",
  "tempfile",
  "test-log",
  "thiserror",
@@ -1903,6 +2013,22 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "fedimint-tbs"
+version = "0.2.0-alpha"
+dependencies = [
+ "bincode",
+ "bitcoin_hashes 0.11.0",
+ "bls12_381",
+ "clap",
+ "ff",
+ "group",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "sha3",
 ]
 
 [[package]]
@@ -1920,6 +2046,7 @@ dependencies = [
  "fedimint-cln-rpc",
  "fedimint-core",
  "fedimint-ldk-node",
+ "fedimint-ln-gateway",
  "fedimint-logging",
  "fedimint-portalloc",
  "fedimint-rocksdb",
@@ -1929,7 +2056,6 @@ dependencies = [
  "futures",
  "lazy_static",
  "lightning-invoice 0.26.0",
- "ln-gateway",
  "rand",
  "secp256k1 0.24.3",
  "secp256k1-zkp",
@@ -2142,6 +2268,7 @@ dependencies = [
  "fedimint-mint-server",
  "fedimint-rocksdb",
  "fedimint-server",
+ "fedimint-tbs",
  "fedimint-threshold-crypto",
  "fedimint-wallet-server",
  "futures",
@@ -2157,7 +2284,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "tbs",
  "thiserror",
  "tokio",
  "tokio-rustls 0.23.4",
@@ -2341,29 +2467,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "gateway-cli"
-version = "0.2.0-alpha"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "axum-macros",
- "bitcoin 0.29.2",
- "clap",
- "clap_complete",
- "fedimint-build",
- "fedimint-core",
- "fedimint-logging",
- "ln-gateway",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -2593,13 +2696,6 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
-
-[[package]]
-name = "hkdf"
-version = "0.2.0-alpha"
-dependencies = [
- "bitcoin_hashes 0.11.0",
-]
 
 [[package]]
 name = "home"
@@ -3257,60 +3353,6 @@ name = "linux-raw-sys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
-
-[[package]]
-name = "ln-gateway"
-version = "0.2.0-alpha"
-dependencies = [
- "anyhow",
- "aquamarine",
- "assert_matches",
- "async-stream",
- "async-trait",
- "axum",
- "axum-macros",
- "bitcoin 0.29.2",
- "bitcoin_hashes 0.11.0",
- "clap",
- "cln-plugin",
- "erased-serde",
- "fedimint-build",
- "fedimint-client",
- "fedimint-cln-rpc",
- "fedimint-core",
- "fedimint-dummy-client",
- "fedimint-dummy-common",
- "fedimint-dummy-server",
- "fedimint-ln-client",
- "fedimint-ln-common",
- "fedimint-ln-server",
- "fedimint-logging",
- "fedimint-mint-client",
- "fedimint-rocksdb",
- "fedimint-testing",
- "fedimint-threshold-crypto",
- "fedimint-tonic-lnd",
- "fedimint-wallet-client",
- "futures",
- "lightning-invoice 0.26.0",
- "prost 0.12.1",
- "rand",
- "reqwest",
- "secp256k1 0.24.3",
- "secp256k1-zkp",
- "serde",
- "serde_json",
- "strum",
- "strum_macros",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tonic 0.10.2",
- "tonic-build",
- "tower-http",
- "tracing",
- "url",
-]
 
 [[package]]
 name = "lock_api"
@@ -4013,32 +4055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "recoverytool"
-version = "0.2.0-alpha"
-dependencies = [
- "anyhow",
- "bitcoin 0.29.2",
- "clap",
- "fedimint-aead",
- "fedimint-core",
- "fedimint-ln-common",
- "fedimint-ln-server",
- "fedimint-logging",
- "fedimint-mint-server",
- "fedimint-rocksdb",
- "fedimint-server",
- "fedimint-wallet-server",
- "futures",
- "miniscript",
- "secp256k1 0.24.3",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4658,22 +4674,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tbs"
-version = "0.2.0-alpha"
-dependencies = [
- "bincode",
- "bitcoin_hashes 0.11.0",
- "bls12_381",
- "clap",
- "ff",
- "group",
- "rand",
- "rand_chacha",
- "serde",
- "sha3",
-]
 
 [[package]]
 name = "tempfile"

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.66"
 fedimint-core ={ path = "../../fedimint-core" }
-hkdf = { path = "../../crypto/hkdf" }
+hkdf = { package = "fedimint-hkdf", path = "../../crypto/hkdf" }
 ring = "0.17.5"
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
-tbs = { path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", path = "../../crypto/tbs" }

--- a/crypto/hkdf/Cargo.toml
+++ b/crypto/hkdf/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hkdf"
+name = "fedimint-hkdf"
 version = "0.2.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tbs"
+name = "fedimint-tbs"
 version = "0.2.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -3,6 +3,7 @@ name = "devimint"
 version = "0.2.0-alpha"
 edition = "2021"
 license = "MIT"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -27,7 +28,7 @@ fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
 fedimint-server = { path = "../fedimint-server" }
 fedimint-testing = { path = "../fedimint-testing" }
 futures = "0.3.24"
-ln-gateway = { path = "../gateway/ln-gateway" }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 nix = { version = "0.26.2", features = ["signal"] }
 rand = "0.8.5"
 serde_json = "1.0.94"

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -29,7 +29,7 @@ strum = "0.24"
 strum_macros = "0.24"
 hex = { version = "0.4.3", features = [ "serde"] }
 sha3 = "0.10.5"
-tbs = { path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", path = "../crypto/tbs" }
 tokio = { version = "1.26.0", features = ["sync", "io-util"] }
 thiserror = "1.0.39"
 tracing ="0.1.37"

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -30,7 +30,7 @@ fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
 futures = "0.3.24"
 erased-serde = "0.3"
 hex = { version = "0.4.3", features = ["serde"] }
-ln-gateway = { path = "../gateway/ln-gateway" }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.91"
 strum = "0.24"

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-load-test-tool is a tool to load test the fedimint server and gateway."
 license = "MIT"
+publish = false
 
 [[bin]]
 name = "fedimint-load-test-tool"

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0.91"
 sha3 = "0.10.5"
 strum = "0.24"
 strum_macros = "0.24"
-tbs = { path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", path = "../crypto/tbs" }
 thiserror = "1.0.39"
 tracing ="0.1.37"
 url = { version = "2.3.1", features = ["serde"] }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -28,7 +28,7 @@ fedimint-logging = { path = "../fedimint-logging" }
 fedimint-rocksdb = { path = "../fedimint-rocksdb" }
 fs-lock = "0.1.0"
 lazy_static = "1.4.0"
-ln-gateway = { path = "../gateway/ln-gateway" }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 ldk-node = { package = "fedimint-ldk-node", version = "0.1.0" }
 futures = "0.3"
 lightning-invoice = "0.26.0"

--- a/fedimint-wasm-tests/Cargo.toml
+++ b/fedimint-wasm-tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "fedimint-wasm-tests"
 version = "0.0.0"
 edition = "2021"
 license = "MIT"
+publish = false
 
 [lib]
 crate-type = [ "rlib", "cdylib" ]

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -47,7 +47,7 @@ secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_has
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"
 sha3 = "0.10.5"
-tbs = { path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", path = "../crypto/tbs" }
 thiserror = "1.0.39"
 tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tokio-rustls = "0.23.4"

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gateway-cli"
+name = "fedimint-gateway-cli"
 version = "0.2.0-alpha"
 edition = "2021"
 license = "MIT"
@@ -17,7 +17,7 @@ axum = "0.6.4"
 axum-macros = "0.3.1"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
-ln-gateway = { path= "../ln-gateway" }
+ln-gateway = { package = "fedimint-ln-gateway", path= "../ln-gateway" }
 fedimint-core ={ path = "../../fedimint-core" }
 fedimint-logging = { path = "../../fedimint-logging" }
 reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ln-gateway"
+name = "fedimint-ln-gateway"
 version = "0.2.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"

--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -59,7 +59,7 @@ function check_check_forbidden_dependencies() {
       >&2 echo "fedimint-server/Cargo.toml must not depend on modules"
       return 1
     fi
-    if grep -E "(fedimint-mint|fedimint-wallet|fedimint-ln)" fedimint-testing/Cargo.toml >&2 ; then
+    if grep -E "(fedimint-mint|fedimint-wallet|fedimint-ln-(server|common|client))" fedimint-testing/Cargo.toml >&2 ; then
       >&2 echo "fedimint-testing/Cargo.toml must not depend on modules"
       return 1
     fi

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln-tests contains integration tests for the lightning module"
 license = "MIT"
+publish = false
 
 [[test]]
 name = "fedimint_ln_tests"

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -35,7 +35,7 @@ serde-big-array = "0.5.1"
 serde_json = "1.0.96"
 strum = "0.24"
 strum_macros = "0.24"
-tbs = { path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", path = "../../crypto/tbs" }
 thiserror = "1.0.39"
 threshold_crypto = { workspace = true }
 tokio = { version = "1.27.0", features = [ "sync" ] }

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -25,7 +25,7 @@ secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.149", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
-tbs = { path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", path = "../../crypto/tbs" }
 thiserror = "1.0.39"
 threshold_crypto = { workspace = true }
 tracing ="0.1.37"

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -28,7 +28,7 @@ secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.149", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
-tbs = { path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", path = "../../crypto/tbs" }
 thiserror = "1.0.39"
 threshold_crypto = { workspace = true }
 tracing ="0.1.37"

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint-tests contains integration tests for the mint module"
 license = "MIT"
+publish = false
 
 [[test]]
 name = "fedimint_mint_tests"

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet-tests contains integration tests for the lightning module"
 license = "MIT"
+publish = false
 
 [[test]]
 name = "fedimint_wallet_tests"

--- a/nix/check-forbidden-deps.sh
+++ b/nix/check-forbidden-deps.sh
@@ -6,7 +6,7 @@ if grep -E "(fedimint-mint|fedimint-wallet|fedimint-ln)" fedimint-server/Cargo.t
   >&2 echo "fedimint-server/Cargo.toml must not depend on modules"
   return 1
 fi
-if grep -E "(fedimint-mint|fedimint-wallet|fedimint-ln)" fedimint-testing/Cargo.toml >&2 ; then
+if grep -E "(fedimint-mint|fedimint-wallet|fedimint-ln-(server|common|client))" fedimint-testing/Cargo.toml >&2 ; then
   >&2 echo "fedimint-testing/Cargo.toml must not depend on modules"
   return 1
 fi

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -398,8 +398,8 @@ rec {
     pname = "gateway-pkgs";
 
     packages = [
-      "ln-gateway"
-      "gateway-cli"
+      "fedimint-ln-gateway"
+      "fedimint-gateway-cli"
     ];
   };
 

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "recoverytool"
+name = "fedimint-recoverytool"
 version = "0.2.0-alpha"
 edition = "2021"
 authors = ["The Fedimint Developers"]


### PR DESCRIPTION
We don't want to pollute the crates.io namespace and also don't need all the crates published.