### PR TITLE
chore: suppress tx already submitted error logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "serde",
+ "serde_json",
  "tracing",
  "url",
 ]

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -24,6 +24,7 @@ fedimint-core  = { path = "../fedimint-core" }
 fedimint-logging = { path = "../fedimint-logging" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
+serde_json = "1.0.91"
 tracing = "0.1.37"
 url = "2.3.1"
 

--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -83,6 +83,11 @@ impl IBitcoindRpc for EsploraClient {
 
     async fn submit_transaction(&self, transaction: Transaction) {
         let _ = self.0.broadcast(&transaction).await.map_err(|error| {
+            // `esplora-client` v0.5.0 only surfaces HTTP error codes, which prevents us
+            // from detecting errors for transactions already submitted.
+            // TODO: Suppress `esplora-client` already submitted errors when client is
+            // updated
+            // https://github.com/fedimint/fedimint/issues/3732
             info!(?error, "Error broadcasting transaction");
         });
     }


### PR DESCRIPTION
Closes #3676 

These changes suppress error logs returned when submitting a transaction already in a block, since this is a success case (see issue thread for more details).

We are unable to address the issue with esplora (https://github.com/fedimint/fedimint/issues/3732) and aren't able to handle errors with electrs as gracefully as I'd like (https://github.com/fedimint/fedimint/issues/3731). The associated followup issues will allow us to handle these errors gracefully across all clients but requires upstream PR merges/releases and for us to update our clients.

Relevant discussion from previous PR https://github.com/fedimint/fedimint/pull/2016#discussion_r1146826022