### PR TITLE
feat: can pass --auth flag to `fedimint-cli dev api`

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -395,6 +395,8 @@ Examples:
         /// Which server to send request to
         #[clap(long = "peer-id")]
         peer_id: Option<u16>,
+        /// Guardian password in case authenticated API endpoints are being
+        /// called. Only use together with --peer-id.
         #[clap(long = "auth")]
         auth: Option<String>,
     },

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -395,6 +395,8 @@ Examples:
         /// Which server to send request to
         #[clap(long = "peer-id")]
         peer_id: Option<u16>,
+        #[clap(long = "auth")]
+        auth: Option<String>,
     },
 
     /// Wait for the fed to reach a consensus block count
@@ -629,10 +631,14 @@ impl FedimintCli {
                 method,
                 params,
                 peer_id,
+                auth,
             }) => {
                 let params: Value = serde_json::from_str(&params)
                     .map_err_cli_msg(CliErrorKind::InvalidValue, "Invalid JSON-RPC parameters")?;
-                let params = ApiRequestErased::new(params);
+                let mut params = ApiRequestErased::new(params);
+                if let Some(auth) = auth {
+                    params = params.with_auth(ApiAuth(auth))
+                }
                 let ws_api: Arc<_> = WsFederationApi::from_config(
                     cli.build_client_ng(&self.module_inits, None)
                         .await?


### PR DESCRIPTION
I couldn't figure out how to make authenticated RPC requests using `fedimint-cli dev api` and formatting the `params` argument correctly. Tried many variations on `'[{"auth":"pass","params":null}]'` and gave up!

Now you can invoke like:

```
fedimint-cli dev api --peer-id 0 --auth pass audit
```