### PR TITLE
fix 'withdraw all' feature

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -425,11 +425,15 @@ pub async fn handle_command(
                 // the amount we are withdrawing
                 BitcoinAmountOrAll::All => {
                     let balance =
-                        bitcoin::Amount::from_sat(client.get_balance().await.msats * 1000);
+                        bitcoin::Amount::from_sat(client.get_balance().await.msats / 1000);
                     let fees = wallet_module
                         .get_withdraw_fees(address.clone(), balance)
                         .await?;
-                    (balance - fees.amount(), fees)
+                    let amount = balance.checked_sub(fees.amount());
+                    if amount.is_none() {
+                        bail!("Not enough funds to pay fees");
+                    }
+                    (amount.unwrap(), fees)
                 }
                 BitcoinAmountOrAll::Amount(amount) => (
                     amount,


### PR DESCRIPTION
- Closes https://github.com/fedimint/fedimint/issues/3754
- Closes https://github.com/fedimint/fedimint/issues/3752, which was caused by multiplying by 1000 instead of dividing when doing msats -> sats conversions
- Trying but currently failing to fix `BitcoinAmountOrAll::All` de/serialization. Currently it can't deserialize `all`. Demands `All`. Can't figure out how to serialize this lowercase 😭. 