### PR TITLE
chore: ignore uncommitted dbtx writes for endpoint audits

### DIFF
--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -238,6 +238,11 @@ impl ConsensusApi {
 
     async fn get_federation_audit(&self) -> ApiResult<AuditSummary> {
         let mut dbtx = self.db.begin_transaction_nc().await;
+        // Writes are related to compacting audit keys, which we can safely ignore
+        // within an API request since the compaction will happen when constructing an
+        // audit in the consensus server
+        dbtx.ignore_uncommitted();
+
         let mut audit = Audit::default();
         let mut module_instance_id_to_kind: HashMap<ModuleInstanceId, String> = HashMap::new();
         for (module_instance_id, kind, module) in self.modules.iter_modules() {


### PR DESCRIPTION
Fixes #3750 

Please refer to this comment for reasoning behind this approach. https://github.com/fedimint/fedimint/issues/3750#issuecomment-1829242602

Reproduced the WARN log reported in the associated issue and verified these changes no longer log a warning when running `fedimint-cli --our-id 0 --password pass admin audit` in mprocs.

Before

```
nix@lenovo-m75q:/tmp/nix-shell.yafZfU/devimint-175/logs$ rg 'DatabaseTransaction has writes and has not called commit' fedimintd-0.log
78:2023-11-28T05:23:39.844034Z  WARN db: DatabaseTransaction has writes and has not called commit. location=   0: <fedimint_core::db::CommitTracker as core::ops::drop::Drop>::drop
```

After

```
nix@lenovo-m75q:/tmp/nix-shell.yafZfU/devimint-68797/logs$ rg 'DatabaseTransaction has writes and has not called commit' fedimintd-0.log
```