### PR TITLE
simplification: always propose block height and feerate votes

### DIFF
--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -381,9 +381,7 @@ impl ServerModule for Lightning {
             .await;
 
         if let Ok(block_count_vote) = self.block_count().await {
-            if block_count_vote != self.consensus_block_count(dbtx).await {
-                items.push(LightningConsensusItem::BlockCount(block_count_vote));
-            }
+            items.push(LightningConsensusItem::BlockCount(block_count_vote));
         }
 
         items

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -340,16 +340,11 @@ impl ServerModule for Wallet {
                 ?current_vote,
                 ?block_count_vote,
                 ?block_count,
-                "Considering proposing block count"
+                "Proposing block count"
             );
 
             items.push(WalletConsensusItem::BlockCount(block_count_vote));
         }
-
-        let current_fee_rate_vote = dbtx
-            .get_value(&FeeRateVoteKey(self.our_peer_id))
-            .await
-            .unwrap_or(self.cfg.consensus.default_fee);
 
         // If there's an error getting the fee rate from the node we default to the most
         // recent fee rate vote. Using an alternative fee rate may cause unwanted
@@ -361,7 +356,10 @@ impl ServerModule for Wallet {
                     "Error while calling get_free_rate_opt, using most recent fee rate vote: {:?}",
                     err
                 );
-                current_fee_rate_vote
+
+                dbtx.get_value(&FeeRateVoteKey(self.our_peer_id))
+                    .await
+                    .unwrap_or(self.cfg.consensus.default_fee)
             }
         };
 


### PR DESCRIPTION
Should fix https://github.com/fedimint/fedimint/issues/3744 as block height votes and feerate votes are proposed every session now. The broadcast ordering capacity this consumes is negligible; the filtering in the proposal was a remnant of hbbft. 