### PR TITLE
Backport: feat: read git hash from .cargo_vcs_info.json if compiling release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,9 @@ dependencies = [
 [[package]]
 name = "fedimint-build"
 version = "0.2.0-rc2"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "fedimint-cli"

--- a/fedimint-build/Cargo.toml
+++ b/fedimint-build/Cargo.toml
@@ -11,3 +11,4 @@ name = "fedimint_build"
 path = "src/lib.rs"
 
 [dependencies]
+serde_json = "1.0.108"


### PR DESCRIPTION
Backport of #3735, fixes #3745