### PR TITLE
fix: give gateway test more time to send/receive money

### DIFF
--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -1207,7 +1207,7 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
                     Ok(post_balances)
                 },
                 Duration::from_secs(1),
-                5,
+                15,
             )
             .await?;
             assert_eq!(


### PR DESCRIPTION
We know that we have high tail latencies in LN payments, let's just give that test a bit more time to avoid flakiness: https://github.com/fedimint/fedimint/issues/2825#issuecomment-1828975140