### PR TITLE
[Backport releases/v0.2] fix: use 33 byte tweaks in recovery tool parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,6 +1943,7 @@ dependencies = [
  "fedimint-wallet-server",
  "futures",
  "miniscript",
+ "rand",
  "secp256k1 0.24.3",
  "serde",
  "serde_json",

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -31,3 +31,6 @@ serde_json = "1.0.93"
 tokio = { version = "1.26.0", features = [ "rt-multi-thread", "macros" ] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -98,10 +98,10 @@ enum TweakSource {
     },
 }
 
-fn tweak_parser(hex: &str) -> anyhow::Result<[u8; 32]> {
+fn tweak_parser(hex: &str) -> anyhow::Result<[u8; 33]> {
     <Vec<u8> as FromHex>::from_hex(hex)?
         .try_into()
-        .map_err(|_| anyhow!("tasks have to be 32 bytes long"))
+        .map_err(|_| anyhow!("tweaks have to be 33 bytes long"))
 }
 
 #[tokio::main]
@@ -449,4 +449,19 @@ impl Translator<CompressedPublicKey, Key, ()> for SecretKeyInjector {
     ) -> Result<<Key as MiniscriptKey>::Hash160, ()> {
         unimplemented!()
     }
+}
+
+#[test]
+fn parses_valid_length_tweaks() {
+    use bitcoin::hashes::hex::ToHex;
+
+    let bad_length_tweak_hex = rand::random::<[u8; 32]>().to_hex();
+    // rand::random only supports random byte arrays up to 32 bytes
+    let good_length_tweak: [u8; 33] = core::array::from_fn(|_| rand::random::<u8>());
+    let good_length_tweak_hex = good_length_tweak.to_hex();
+    assert_eq!(
+        tweak_parser(good_length_tweak_hex.as_str()).expect("should parse valid length hex"),
+        good_length_tweak
+    );
+    assert!(tweak_parser(bad_length_tweak_hex.as_str()).is_err());
 }


### PR DESCRIPTION
# Description
Backport of #3746 to `releases/v0.2`.