### PR TITLE
fix: dont require muc.xmpp as a traefik router

### DIFF
--- a/docker/full-tls-mutinynet/docker-compose.yaml
+++ b/docker/full-tls-mutinynet/docker-compose.yaml
@@ -403,7 +403,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.xmpp.loadbalancer.server.port=5280"
-      - "traefik.http.routers.xmpp.rule=Host(`xmpp.fedimint.my-super-host.com`) || Host(`muc.xmpp.fedimint.my-super-host.com`)"
+      - "traefik.http.routers.xmpp.rule=Host(`xmpp.fedimint.my-super-host.com`)"
       - "traefik.http.routers.xmpp.entrypoints=websecure"
       - "traefik.http.routers.xmpp.tls.certresolver=myresolver"
 


### PR DESCRIPTION
fixes #3799

in XMPP, the multi-user chat (MUC) component does not strictly require DNS config on the address, only xmpp.example.com is needed since it is a virtual host

more details: https://prosody.im/doc/chatrooms#dns