### PR TITLE
chore: make `just mprocs` parametric

### DIFF
--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -44,9 +44,9 @@ check-wasm:
 prepare_db_migration_snapshots +extra_args:
   env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo test ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -p {{extra_args}} prepare_db_migration_snapshots
 
-# start mprocs with a dev federation setup
-mprocs:
-  ./scripts/dev/mprocs/run.sh
+# start mprocs with a dev federation setup. Default: 4 nodes, add `-n 1` argument to start only 1 node
+mprocs *PARAMS:
+  ./scripts/dev/mprocs/run.sh {{PARAMS}}
 
 # exit mprocs session
 exit-mprocs:

--- a/scripts/dev/mprocs/run.sh
+++ b/scripts/dev/mprocs/run.sh
@@ -8,4 +8,4 @@ ensure_in_dev_shell
 build_workspace
 add_target_dir_to_path
 
-devimint --link-test-dir ./target/devimint dev-fed --exec bash -c 'mprocs -c misc/mprocs.yaml 2>$FM_LOGS_DIR/devimint-outer.log'
+devimint --link-test-dir ./target/devimint "$@" dev-fed --exec bash -c 'mprocs -c misc/mprocs.yaml 2>$FM_LOGS_DIR/devimint-outer.log'


### PR DESCRIPTION
This allows running an mprocs with only one guardian using `just mprocs -n 1` for testing single guardian behavior.