### PR TITLE
chore: refactor invoice expiration check in client

### DIFF
--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -643,20 +643,13 @@ impl PaymentData {
     }
 
     pub fn is_expired(&self) -> bool {
-        match self {
-            PaymentData::Invoice(invoice) => invoice.is_expired(),
-            PaymentData::PrunedInvoice(PrunedInvoice {
-                expiry_timestamp, ..
-            }) => {
-                let Some(now) = now().duration_since(UNIX_EPOCH).map(|t| t.as_secs()).ok() else {
-                    // Something is very wrong (time out of bounds), we'll not attempt too pay the
-                    // invoice
-                    return true;
-                };
+        let Some(now) = now().duration_since(UNIX_EPOCH).map(|t| t.as_secs()).ok() else {
+            // Something is very wrong (time out of bounds), we'll not attempt too pay the
+            // invoice
+            return true;
+        };
 
-                *expiry_timestamp < now
-            }
-        }
+        self.expiry_timestamp() < now
     }
 
     /// Returns the expiry timestamp in seconds since the UNIX epoch


### PR DESCRIPTION
Fixes one of the things found testing this: https://github.com/fedimint/fedimint/pull/3839#issuecomment-1841085709

`is_expired()` will call LDK's internal function that looks like this (https://github.com/lightningdevkit/rust-lightning/blob/37150b4d697f723f278b6cf3f63892df272b9aa5/lightning-invoice/src/lib.rs#L1376-L1389)

```
	/// Returns whether the invoice has expired.
	#[cfg(feature = "std")]
	pub fn is_expired(&self) -> bool {
		Self::is_expired_from_epoch(&self.timestamp(), self.expiry_time())
	}

	/// Returns whether the expiry time from the given epoch has passed.
	#[cfg(feature = "std")]
	pub(crate) fn is_expired_from_epoch(epoch: &SystemTime, expiry_time: Duration) -> bool {
		match epoch.elapsed() {
			Ok(elapsed) => elapsed > expiry_time,
			Err(_) => false,
		}
	}
```

Which will call `SystemTime::now()`. 
```
    #[stable(feature = "time2", since = "1.8.0")]
    pub fn elapsed(&self) -> Result<Duration, SystemTimeError> {
        SystemTime::now().duration_since(*self)
    }
```

Since `rust-lightning` `std` is not strictly wasm32 safe, there's a few potential gotcha's like expiration checks. I checked the other `invoice` calls in this file and they are all fine and don't require `rust-lightning` `std`. 

The fedimint `expiry_timestamp()` function was already doing all of the work to get the expired time minus the `now()` check. So it can simply be refactored to use that instead. 