### PR TITLE
Update tls-download-mutinynet.sh to reflect snake case awaiting_password

### DIFF
--- a/docker/tls-download-mutinynet.sh
+++ b/docker/tls-download-mutinynet.sh
@@ -202,7 +202,7 @@ wait_fedimintd_ready() {
   flags=$1
   while true; do 
     status=$(curl $flags -s -q -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0", "method": "status", "params": [{"params":null}],"id":1}'  "https://fedimintd.${host_name[*]}" | jq -r .result.server )
-    if [[ $status == "AwaitingPassword" ]]; then
+    if [[ $status == "awaiting_password" ]]; then
       echo
       break
     else


### PR DESCRIPTION
Testing out rc5, it looks like snake_case has been introduced. 

https://github.com/fedimint/fedimint/blob/ba94be6398da889acc1e89bd5ae8375b0ca999db/fedimint-core/src/api.rs#L979-L996

Note, not sure how you're handling `master` and `0.2` releases when it comes to these docker notes. I think @Kodylow is on point for that so I'll defer how to handle this PR to him. 