### PR TITLE
feat: `just backport-pr`

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,12 @@
+{
+  // Required
+  "repoOwner": "fedimint",
+  "repoName": "fedimint",
+
+  // the branches available to backport to
+  "targetBranchChoices": ["releases/v0.1", "releases/v0.2"],
+
+  // Optional: automatically merge backport PR
+  "autoMerge": false,
+  "autoMergeMethod": "merge"
+}

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -59,3 +59,7 @@ tmuxinator:
 # exit tmuxinator session
 exit-tmuxinator:
   tmux kill-session -t fedimint-dev
+
+# backport a PR
+backport-pr pr:
+  nix shell nixpkgs#nodejs -c npx backport --pr-filter {{pr}}


### PR DESCRIPTION
Using https://github.com/sqren/backport

Requires creating an access token and putting it in a local configuration file.

I think it uses the same code our backport bot is using, but will execute it locally using `npx`.