### PR TITLE
CLI: split and combine e-cash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "fedimint-wallet-client",
  "fs-lock",
  "futures",
+ "itertools 0.12.0",
  "lightning-invoice 0.26.0",
  "lnurl-rs",
  "rand",
@@ -3034,6 +3035,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -26,6 +26,7 @@ bitcoin_hashes = "0.11.0"
 time = { version = "0.3.25", features = [ "formatting" ] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
 futures = "0.3.28"
+itertools = "0.12.0"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
 fedimint-bip39 = { version = "0.3.0-alpha", path = "../fedimint-bip39" }

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -221,6 +221,12 @@ pub struct FederationId(pub sha256::Hash);
 /// happen.
 pub struct FederationIdPrefix([u8; 4]);
 
+impl Display for FederationIdPrefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        format_hex(&self.0, f)
+    }
+}
+
 impl Display for FederationId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         format_hex(&self.0, f)


### PR DESCRIPTION
Adds two functions that can be used to manipulate serialized e-cash bags.