### PR TITLE
chore: change some errors to warns/infos

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -521,7 +521,7 @@ impl Gateway {
                                         }
                                     }
                                     Err(e) => {
-                                        error!("Failed to retrieve Lightning info: {e:?}");
+                                        warn!("Failed to retrieve Lightning info: {e:?}");
                                     }
                                 }
                             }
@@ -532,7 +532,7 @@ impl Gateway {
 
                         self.handle_disconnect(htlc_task_group).await;
 
-                        error!("Disconnected from Lightning Node. Waiting 5 seconds and trying again");
+                        warn!("Disconnected from Lightning Node. Waiting 5 seconds and trying again");
                         sleep(Duration::from_secs(5)).await;
                     }
                 },
@@ -1119,13 +1119,13 @@ impl Gateway {
                                                 )
                                                 .await
                                             {
-                                                error!("Error registering federation {federation_id}: {e:?}");
+                                                warn!("Error registering federation {federation_id}: {e:?}");
                                             }
                                         }
                                     }
                                     Err(e) => {
-                                        error!(
-                                            "Could not retrieve route hints, gateway will not be registered: {e:?}"
+                                        warn!(
+                                            "Could not retrieve route hints, gateway will not be registered for now: {e:?}"
                                         );
                                     }
                                 }

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -16,7 +16,7 @@ use fedimint_ln_common::{LightningClientContext, LightningInput};
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::error;
+use tracing::{error, info, warn};
 
 use crate::LightningClientStateMachines;
 
@@ -211,8 +211,11 @@ impl LightningReceiveConfirmedInvoice {
                 },
                 // FIXME: should we filter for retryable errors here to not swallow implementation
                 // bugs? (there exist more places like this)
+                Err(error) if error.is_retryable() => {
+                    info!("External LN payment retryable error waiting for preimage decryption: {error:?}");
+                }
                 Err(error) => {
-                    error!("External LN payment error waiting for preimage decryption: {error:?}");
+                    warn!("External LN payment non-retryable error waiting for preimage decryption: {error:?}");
                 }
             }
 


### PR DESCRIPTION
If the error is retryable or expected to happen then we shouldn't log it as an error. Better use warn/info.