### PR TITLE
refactor: amount improvements

### DIFF
--- a/modules/fedimint-mint-common/src/config.rs
+++ b/modules/fedimint-mint-common/src/config.rs
@@ -24,7 +24,7 @@ pub struct MintGenParamsConsensus {
 // The maximum size of an E-Cash note (1,000,000 coins)
 // Changing this value is considered a breaking change because it is not saved
 // in `MintGenParamsConsensus` but instead is hardcoded here
-const MAX_DENOMINATION_SIZE: Amount = Amount::from_sats(1_000_000 * 100_000_000);
+const MAX_DENOMINATION_SIZE: Amount = Amount::from_bitcoins(1_000_000);
 
 impl MintGenParamsConsensus {
     pub fn new(denomination_base: u16) -> Self {


### PR DESCRIPTION
The initial motivation for this PR was making `gateway-cli withdraw --amount` (which was using `bitcoin::Amount` through `BitcoinAmountOrAll`) accept a similar syntax to other commands that accept an `amount` (most use `fedimint_core::Amount` or `parse_fedimint_amount`).

Now we upgrade `fedimint_core::Amount` and let its `from_str` accept what `parse_fedimint_amount` was able and what `bitcoin::Amount::from_str` was able to do.

We also make `fedimint_core::Amount` serializable through  `#[serde(with = "amount::serde::as_sat")` which  is analogous to `#[serde(with = "bitcoin::util::amount::serde::as_sat")]`.

The final result is that every command line is backwards compatible but also accepts the new syntax.