### PR TITLE
fix(devimint): off-by-one error for mempool transactions

### DIFF
--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -152,7 +152,7 @@ pub async fn dev_fed(process_mgr: &ProcessManager) -> Result<DevFed> {
             .run()
             .await?;
         info!(target: LOG_DEVIMINT, "Generating first epoch");
-        fed.generate_first_epoch().await?;
+        fed.mine_then_wait_blocks_sync(10).await?;
         Ok(())
     })?;
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -935,7 +935,7 @@ impl Wallet {
     ) {
         info!(
             new_height,
-            block_to_go = new_height - old_height,
+            blocks_to_go = new_height - old_height,
             "New consensus height, syncing up",
         );
 


### PR DESCRIPTION
Fixes #3884

- Add helper to mine enough blocks to finalize mempool transactions
- Remove `generate_epochs` since epochs are no longer part of consensus