### PR TITLE
fix: supply LN invoice features to LN gateway node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
+name = "ahash"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
@@ -526,6 +532,8 @@ dependencies = [
  "base64 0.13.1",
  "bech32",
  "bitcoin_hashes 0.11.0",
+ "core2",
+ "hashbrown 0.8.2",
  "secp256k1 0.24.3",
  "serde",
 ]
@@ -555,6 +563,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -927,6 +936,15 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1673,6 +1691,7 @@ dependencies = [
  "fedimint-threshold-crypto",
  "futures",
  "itertools 0.10.5",
+ "lightning 0.0.118",
  "lightning-invoice 0.26.0",
  "rand",
  "secp256k1 0.24.3",
@@ -1722,6 +1741,7 @@ dependencies = [
  "fedimint-tonic-lnd",
  "fedimint-wallet-client",
  "futures",
+ "lightning 0.0.118",
  "lightning-invoice 0.26.0",
  "prost 0.12.3",
  "rand",
@@ -2689,6 +2709,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "ahash 0.3.8",
+ "autocfg",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -3360,6 +3390,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52cec5fa9382154fe9671e8df93095b800c7d77abc66e2a5ef839d672521c5e"
 dependencies = [
  "bitcoin 0.29.2",
+ "core2",
+ "hashbrown 0.8.2",
 ]
 
 [[package]]

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -76,6 +76,7 @@ fedimint-ln-common = { path = "../../modules/fedimint-ln-common" }
 fedimint-mint-client = { path = "../../modules/fedimint-mint-client" }
 fedimint-wallet-client = { path = "../../modules/fedimint-wallet-client" }
 fedimint-testing = { path = "../../fedimint-testing" }
+lightning = "0.0.118"
 threshold_crypto = { workspace = true }
 assert_matches = "1.5.0"
 

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -26,6 +26,7 @@ bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
 futures = "0.3.24"
 itertools = "0.10.5"
+lightning = { version = "0.0.118", default-features = false, features = ["no-std"] }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }


### PR DESCRIPTION
Without this, private payments to non-public nodes are failing. Fixes #3895

## Completeness
Let's go through the field list of [`SendPaymentV2`](https://lightning.engineering/api-docs/api/lnd/router/send-payment-v2/index.html) to avoid missing any other required fields (I originally went by the docs *"If no payment request is specified, the following fields are required: dest, amt and payment_hash."* but that obviously didn't go that well).

* `dest`: we supply :white_check_mark:
* `amt`: redundant with the next one :+1: 
* `amt_msat`: we supply :white_check_mark: 
* `payment_hash`: we supply :white_check_mark:
* `final_cltv_delta`: we supply :white_check_mark:
* `payment_addr`: we supply, turns out to be the payment secret :white_check_mark:
* `payment_request`: not needed, we supply all necessary arguments manually :+1: 
* `timeout_seconds`: we supply :white_check_mark:
* `fee_limit_sat`: redundant with the next one :+1: 
* `fee_limit_msat`: we supply :white_check_mark:
* `outgoing_chan_id`: unnecessary, we don't want to control the outgoing channel :+1: 
* `outgoing_chan_ids`: unnecessary, we don't want to control the outgoing channel :+1: 
* `last_hop_pubkey`: unnecessary, we don't want to control the last hop :+1: 
* `cltv_limit`: we supply :white_check_mark:
* `route_hints`: we supply :white_check_mark:
* `dest_custom_records`: we aren't interested in passing additional TLV records :+1: 
* `allow_self_payment`: defaults to false how we  want it :+1: 
* `dest_features`: that's what this PR is about :white_check_mark:
* `max_parts`: I think the defaults will do, this is mostly about performance optimization afaik :+1: 
* `no_inflight_updates`: set to false :white_check_mark: 
* `max_shard_size_msat`: we don't want to influence MPP splitting behavior :+1: 
* `amp`: `false` seems like a good default :+1: 
* `time_pref`: we should make this configurable, but good enough for now given that `pay` also doesn't set it :+1: 

## Compatibility

On the API level this change is made backwards-compatible by using the empty feature set as default (as was the case so far). Outgoing LN state machines in the state `Funding` will cause a panic when trying to decode them. If we don't backport to the unreleased 0.2 (#3897) this would require a state machine migration.

## Alternatives

Deactivating private payments for now. 