### PR TITLE
chore: refactor `Client` initialization

### DIFF
--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -1948,8 +1948,12 @@ async fn main() -> Result<()> {
     match handle_command().await {
         Ok(r) => Ok(r),
         Err(e) => {
-            let ready_file = PathBuf::from(env::var("FM_TEST_DIR")?).join("ready");
-            write_overwrite_async(ready_file, "ERROR").await?;
+            if let Ok(test_dir) = env::var("FM_TEST_DIR") {
+                let ready_file = PathBuf::from(test_dir).join("ready");
+                write_overwrite_async(ready_file, "ERROR").await?;
+            } else {
+                warn!(target: LOG_DEVIMINT, "FM_TEST_DIR was not set");
+            }
             Err(e)
         }
     }

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -115,7 +115,8 @@ declare_vars! {
         FM_LND_DIR: PathBuf = mkdir(FM_TEST_DIR.join("lnd")).await?;
         FM_BTC_DIR: PathBuf = mkdir(FM_TEST_DIR.join("bitcoin")).await?;
         FM_DATA_DIR: PathBuf = FM_TEST_DIR.clone();
-        FM_CLIENT_DIR: PathBuf = mkdir(FM_TEST_DIR.join("client")).await?;
+        FM_CLIENT_BASE_DIR: PathBuf = mkdir(FM_TEST_DIR.join("clients")).await?;
+        FM_CLIENT_DIR: PathBuf = mkdir(FM_TEST_DIR.join("clients").join("default")).await?;
         FM_ELECTRS_DIR: PathBuf = mkdir(FM_TEST_DIR.join("electrs")).await?;
         FM_ESPLORA_DIR: PathBuf = mkdir(FM_TEST_DIR.join("esplora")).await?;
         FM_READY_FILE: PathBuf = FM_TEST_DIR.join("ready");

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -10,7 +10,7 @@ use bitcoin_hashes::hex::ToHex;
 use clap::Subcommand;
 use fedimint_client::backup::Metadata;
 use fedimint_client::ClientArc;
-use fedimint_core::config::{ClientConfig, FederationId};
+use fedimint_core::config::FederationId;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::time::now;
@@ -150,7 +150,12 @@ pub enum ClientCmd {
     DiscoverVersion,
     /// Restore the previously created backup of mint notes (with `backup`
     /// command)
-    Restore { mnemonic: String },
+    Restore {
+        #[clap(long)]
+        mnemonic: String,
+        #[clap(long)]
+        invite_code: String,
+    },
     /// Print the secret key of the client
     PrintSecret,
     ListOperations {
@@ -174,7 +179,6 @@ pub fn parse_gateway_id(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Erro
 
 pub async fn handle_command(
     command: ClientCmd,
-    _config: ClientConfig,
     client: ClientArc,
 ) -> anyhow::Result<serde_json::Value> {
     match command {

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -138,12 +138,6 @@ pub enum ClientCmd {
         // TODO: Can we make it `*Map<String, String>` and avoid custom parsing?
         metadata: Vec<String>,
     },
-    /// Wipe the state of the client (mostly for testing purposes)
-    #[clap(hide = true)]
-    Wipe {
-        #[clap(long)]
-        force: bool,
-    },
     /// Discover the common api version to use to communicate with the
     /// federation
     #[clap(hide = true)]
@@ -461,13 +455,6 @@ pub async fn handle_command(
         }
         ClientCmd::Restore { .. } => {
             panic!("Has to be handled before initializing client")
-        }
-        ClientCmd::Wipe { force } => {
-            if !force {
-                bail!("This will wipe the state of the client irrecoverably. Use `--force` to proceed.")
-            }
-            client.wipe_state().await?;
-            Ok(serde_json::to_value(()).unwrap())
         }
         ClientCmd::PrintSecret => {
             let entropy = client.get_decoded_client_secret::<Vec<u8>>().await?;

--- a/fedimint-cli/src/db_locked.rs
+++ b/fedimint-cli/src/db_locked.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use anyhow::Context;
 use fedimint_core::db::IRawDatabase;
 use fedimint_core::{apply, async_trait_maybe_send};
-use tracing::info;
+use fedimint_logging::LOG_CLIENT;
+use tracing::{debug, info};
 
 /// Locked version of database
 ///
@@ -36,9 +37,10 @@ impl LockedBuilder {
 
             // TODO: Use https://github.com/cargo-bins/cargo-binstall/pull/1496 to
             // give user feedback only when the initial `new_try_exclusive` failed.
-            info!("Acquiring database lock");
+            info!(target: LOG_CLIENT, "Acquiring database lock");
             let lock =
                 fs_lock::FileLock::new_exclusive(file).context("Failed to acquire a lock file")?;
+            debug!(target: LOG_CLIENT, "Acquired database lock");
 
             Ok(LockedBuilder { lock })
         })

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -293,6 +293,7 @@ impl Client {
 
     /// Download most recent valid backup found from the Federation
     pub async fn download_backup_from_federation(&self) -> Result<Option<ClientBackup>> {
+        debug!(target: LOG_CLIENT, "Downloading backup from the federation");
         let mut responses: Vec<_> = self
             .api
             .download_backup(&self.get_backup_id())

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -208,36 +208,6 @@ impl Client {
         Ok(())
     }
 
-    /// Wipe the client state (including module state)
-    pub async fn wipe_state(&self) -> Result<()> {
-        let mut dbtx = self.db().begin_transaction().await;
-        info!(target: LOG_CLIENT, "Wiping client state");
-        for (id, kind, module) in self.modules.iter_modules() {
-            if !module.supports_backup() {
-                continue;
-            }
-
-            info!(
-                target: LOG_CLIENT,
-                module_kind = %kind,
-                module_id = id,
-                "Wiping module state"
-            );
-            module
-                .wipe(
-                    &mut dbtx.to_ref_with_prefix_module_id(id).into_nc(),
-                    id,
-                    self.executor.clone(),
-                )
-                .await?;
-        }
-        dbtx.commit_tx().await;
-
-        debug!(target: LOG_CLIENT, "Wiping client state complete");
-
-        Ok(())
-    }
-
     /// Upload `backup` to federation
     pub async fn upload_backup(&self, backup: EncryptedClientBackup) -> Result<()> {
         let size = backup.len();

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -24,7 +24,7 @@ use secp256k1_zkp::PublicKey;
 
 use self::init::ClientModuleInit;
 use crate::module::recovery::{DynModuleBackup, ModuleBackup};
-use crate::sm::{self, ActiveState, Context, DynContext, DynState, Executor, State};
+use crate::sm::{self, ActiveState, Context, DynContext, DynState, State};
 use crate::transaction::{ClientInput, ClientOutput, TransactionBuilder};
 use crate::{
     oplog, AddStateMachinesResult, ClientArc, ClientWeak, DynGlobalClientContext,
@@ -464,15 +464,6 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
         anyhow::bail!("Backup not supported");
     }
 
-    async fn wipe(
-        &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
-        _module_instance_id: ModuleInstanceId,
-        _executor: Executor<DynGlobalClientContext>,
-    ) -> anyhow::Result<()> {
-        anyhow::bail!("Wiping not supported");
-    }
-
     /// Does this module support being a primary module
     ///
     /// If it does it must implement:
@@ -640,13 +631,6 @@ pub trait IClientModule: Debug {
         snapshot: Option<DynModuleBackup>,
     ) -> anyhow::Result<()>;
 
-    async fn wipe(
-        &self,
-        dbtx: &mut DatabaseTransaction<'_>,
-        module_instance_id: ModuleInstanceId,
-        executor: Executor<DynGlobalClientContext>,
-    ) -> anyhow::Result<()>;
-
     fn supports_being_primary(&self) -> bool;
 
     async fn create_sufficient_input(
@@ -757,15 +741,6 @@ where
             .transpose()?;
 
         <T as ClientModule>::restore(self, typed_snapshot).await
-    }
-
-    async fn wipe(
-        &self,
-        dbtx: &mut DatabaseTransaction<'_>,
-        module_instance_id: ModuleInstanceId,
-        executor: Executor<DynGlobalClientContext>,
-    ) -> anyhow::Result<()> {
-        <T as ClientModule>::wipe(self, dbtx, module_instance_id, executor).await
     }
 
     fn supports_being_primary(&self) -> bool {

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -182,6 +182,10 @@ impl ClientConfig {
             ..self
         })
     }
+
+    pub fn federation_id(&self) -> FederationId {
+        self.global.federation_id()
+    }
 }
 
 /// The federation id is a copy of the authentication threshold public key of

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -590,7 +590,7 @@ async fn get_coordinator_client(
     let (client, invite_code) = if let Some(db_path) = db_path {
         let coordinator_db = db_path.join("coordinator.db");
         if coordinator_db.exists() {
-            build_client(None, Some(&coordinator_db)).await?
+            build_client(invite_code.clone(), Some(&coordinator_db)).await?
         } else {
             tokio::fs::create_dir_all(db_path).await?;
             build_client(


### PR DESCRIPTION
Fix #3748

* split the 3 cases of initalization (to be built on later)
* require only needed args, instead of using Option gymnastics