### PR TITLE
fix: more robust lightning receive

### DIFF
--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -33,6 +33,7 @@ pub const VERSION_ENDPOINT: &str = "version";
 pub const AWAIT_ACCOUNT_ENDPOINT: &str = "await_account";
 pub const AWAIT_BLOCK_HEIGHT_ENDPOINT: &str = "await_block_height";
 pub const AWAIT_OUTGOING_CONTRACT_CANCELLED_ENDPOINT: &str = "await_outgoing_contract_cancelled";
+pub const GET_DECRYPTED_PREIMAGE_STATUS: &str = "get_decrypted_preimage_status";
 pub const AWAIT_PREIMAGE_DECRYPTION: &str = "await_preimage_decryption";
 pub const AWAIT_OFFER_ENDPOINT: &str = "await_offer";
 pub const AWAIT_TRANSACTION_ENDPOINT: &str = "await_transaction";

--- a/fedimint-core/src/time.rs
+++ b/fedimint-core/src/time.rs
@@ -12,3 +12,10 @@ pub fn now() -> SystemTime {
     SystemTime::UNIX_EPOCH
         + std::time::Duration::from_secs_f64(js_sys::Date::new_0().get_time() / 1000.)
 }
+
+/// Returns the duration since the Unix epoch
+pub fn duration_since_epoch() -> std::time::Duration {
+    now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("time to work")
+}

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -1121,10 +1121,7 @@ async fn handle_metrics_summary(
     opts: Opts,
     mut event_receiver: mpsc::UnboundedReceiver<MetricEvent>,
 ) -> anyhow::Result<()> {
-    let timestamp_seconds = fedimint_core::time::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let timestamp_seconds = fedimint_core::time::duration_since_epoch().as_secs();
     let mut metrics_json_output_files = vec![];
     let mut previous_metrics = vec![];
     let mut comparison_output = None;

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use std::iter::once;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use anyhow::{bail, ensure, format_err, Context};
 use async_stream::stream;
@@ -760,9 +760,7 @@ impl LightningClientModule {
             final_route_hints.append(&mut two_hop_route_hints);
         }
 
-        let duration_since_epoch = fedimint_core::time::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap();
+        let duration_since_epoch = fedimint_core::time::duration_since_epoch();
 
         let mut invoice_builder = InvoiceBuilder::new(network.into())
             .amount_milli_satoshis(amount.msats)

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::{Duration, UNIX_EPOCH};
+use std::time::Duration;
 
 use bitcoin_hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
@@ -10,7 +10,7 @@ use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
-use fedimint_core::time::now;
+use fedimint_core::time::duration_since_epoch;
 use fedimint_core::{Amount, OutPoint, TransactionId};
 use fedimint_ln_common::api::LnFederationApi;
 use fedimint_ln_common::contracts::outgoing::OutgoingContractData;
@@ -643,13 +643,7 @@ impl PaymentData {
     }
 
     pub fn is_expired(&self) -> bool {
-        let Some(now) = now().duration_since(UNIX_EPOCH).map(|t| t.as_secs()).ok() else {
-            // Something is very wrong (time out of bounds), we'll not attempt too pay the
-            // invoice
-            return true;
-        };
-
-        self.expiry_timestamp() < now
+        self.expiry_timestamp() < duration_since_epoch().as_secs()
     }
 
     /// Returns the expiry timestamp in seconds since the UNIX epoch

--- a/modules/fedimint-ln-common/src/api.rs
+++ b/modules/fedimint-ln-common/src/api.rs
@@ -8,7 +8,8 @@ use fedimint_core::api::{
 use fedimint_core::endpoint_constants::{
     ACCOUNT_ENDPOINT, AWAIT_ACCOUNT_ENDPOINT, AWAIT_BLOCK_HEIGHT_ENDPOINT, AWAIT_OFFER_ENDPOINT,
     AWAIT_OUTGOING_CONTRACT_CANCELLED_ENDPOINT, AWAIT_PREIMAGE_DECRYPTION, BLOCK_COUNT_ENDPOINT,
-    LIST_GATEWAYS_ENDPOINT, OFFER_ENDPOINT, REGISTER_GATEWAY_ENDPOINT,
+    GET_DECRYPTED_PREIMAGE_STATUS, LIST_GATEWAYS_ENDPOINT, OFFER_ENDPOINT,
+    REGISTER_GATEWAY_ENDPOINT,
 };
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::query::UnionResponses;
@@ -18,7 +19,7 @@ use itertools::Itertools;
 
 use crate::contracts::incoming::{IncomingContractAccount, IncomingContractOffer};
 use crate::contracts::outgoing::OutgoingContractAccount;
-use crate::contracts::{ContractId, FundedContract, Preimage};
+use crate::contracts::{ContractId, DecryptedPreimageStatus, FundedContract, Preimage};
 use crate::{ContractAccount, LightningGateway, LightningGatewayAnnouncement};
 
 #[apply(async_trait_maybe_send!)]
@@ -31,6 +32,10 @@ pub trait LnFederationApi {
         &self,
         contract: ContractId,
     ) -> FederationResult<ContractAccount>;
+    async fn get_decrypted_preimage_status(
+        &self,
+        contract: ContractId,
+    ) -> FederationResult<(IncomingContractAccount, DecryptedPreimageStatus)>;
     async fn wait_preimage_decrypted(
         &self,
         contract: ContractId,
@@ -100,6 +105,17 @@ where
     ) -> FederationResult<ContractAccount> {
         self.request_current_consensus(
             AWAIT_OUTGOING_CONTRACT_CANCELLED_ENDPOINT.to_string(),
+            ApiRequestErased::new(contract),
+        )
+        .await
+    }
+
+    async fn get_decrypted_preimage_status(
+        &self,
+        contract: ContractId,
+    ) -> FederationResult<(IncomingContractAccount, DecryptedPreimageStatus)> {
+        self.request_current_consensus(
+            GET_DECRYPTED_PREIMAGE_STATUS.to_string(),
             ApiRequestErased::new(contract),
         )
         .await

--- a/modules/fedimint-ln-common/src/contracts/mod.rs
+++ b/modules/fedimint-ln-common/src/contracts/mod.rs
@@ -136,6 +136,17 @@ impl PreimageKey {
     }
 }
 
+/// Current status of preimage decryption
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+pub enum DecryptedPreimageStatus {
+    /// There aren't enough decryption shares yet
+    Pending,
+    /// The decrypted preimage was valid
+    Some(Preimage),
+    /// The decrypted preimage was invalid
+    Invalid,
+}
+
 /// Possible outcomes of preimage decryption
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub enum DecryptedPreimage {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -14,7 +14,8 @@ use fedimint_core::encoding::Encodable;
 use fedimint_core::endpoint_constants::{
     ACCOUNT_ENDPOINT, AWAIT_ACCOUNT_ENDPOINT, AWAIT_BLOCK_HEIGHT_ENDPOINT, AWAIT_OFFER_ENDPOINT,
     AWAIT_OUTGOING_CONTRACT_CANCELLED_ENDPOINT, AWAIT_PREIMAGE_DECRYPTION, BLOCK_COUNT_ENDPOINT,
-    LIST_GATEWAYS_ENDPOINT, OFFER_ENDPOINT, REGISTER_GATEWAY_ENDPOINT,
+    GET_DECRYPTED_PREIMAGE_STATUS, LIST_GATEWAYS_ENDPOINT, OFFER_ENDPOINT,
+    REGISTER_GATEWAY_ENDPOINT,
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -34,8 +35,9 @@ use fedimint_ln_common::config::{
 };
 use fedimint_ln_common::contracts::incoming::{IncomingContractAccount, IncomingContractOffer};
 use fedimint_ln_common::contracts::{
-    Contract, ContractId, ContractOutcome, DecryptedPreimage, EncryptedPreimage, FundedContract,
-    IdentifiableContract, Preimage, PreimageDecryptionShare, PreimageKey,
+    Contract, ContractId, ContractOutcome, DecryptedPreimage, DecryptedPreimageStatus,
+    EncryptedPreimage, FundedContract, IdentifiableContract, Preimage, PreimageDecryptionShare,
+    PreimageKey,
 };
 use fedimint_ln_common::db::{
     AgreedDecryptionShareContractIdPrefix, AgreedDecryptionShareKey,
@@ -889,6 +891,12 @@ impl ServerModule for Lightning {
                 }
             },
             api_endpoint! {
+                GET_DECRYPTED_PREIMAGE_STATUS,
+                async |module: &Lightning, context, contract_id: ContractId| -> (IncomingContractAccount, DecryptedPreimageStatus) {
+                    Ok(module.get_decrypted_preimage_status(context, contract_id).await)
+                }
+            },
+            api_endpoint! {
                 AWAIT_PREIMAGE_DECRYPTION,
                 async |module: &Lightning, context, contract_id: ContractId| -> (IncomingContractAccount, Option<Preimage>) {
                     Ok(module.wait_preimage_decrypted(context, contract_id).await)
@@ -1029,6 +1037,28 @@ impl Lightning {
                 }
             });
         future.await
+    }
+
+    async fn get_decrypted_preimage_status(
+        &self,
+        context: &mut ApiEndpointContext<'_>,
+        contract_id: ContractId,
+    ) -> (IncomingContractAccount, DecryptedPreimageStatus) {
+        let f_contract = context.wait_key_exists(ContractKey(contract_id));
+        let contract = f_contract.await;
+        let incoming_contract_account = Self::get_incoming_contract_account(contract);
+        match &incoming_contract_account.contract.decrypted_preimage {
+            DecryptedPreimage::Some(key) => (
+                incoming_contract_account.to_owned(),
+                DecryptedPreimageStatus::Some(Preimage(sha256::Hash::hash(&key.0).into_inner())),
+            ),
+            DecryptedPreimage::Pending => {
+                (incoming_contract_account, DecryptedPreimageStatus::Pending)
+            }
+            DecryptedPreimage::Invalid => {
+                (incoming_contract_account, DecryptedPreimageStatus::Invalid)
+            }
+        }
     }
 
     async fn wait_preimage_decrypted(

--- a/utils/portalloc/src/lib.rs
+++ b/utils/portalloc/src/lib.rs
@@ -20,7 +20,7 @@ pub mod util;
 
 use std::net::TcpListener;
 use std::path::PathBuf;
-use std::time::{Duration, UNIX_EPOCH};
+use std::time::Duration;
 
 use anyhow::bail;
 use rand::{thread_rng, Rng};
@@ -28,13 +28,10 @@ use tracing::warn;
 
 use crate::data::DataDir;
 
-type UnixTimstap = u64;
+type UnixTimestamp = u64;
 
-pub fn now_ts() -> UnixTimstap {
-    fedimint_core::time::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("localt time out of valid range")
-        .as_secs()
+pub fn now_ts() -> UnixTimestamp {
+    fedimint_core::time::duration_since_epoch().as_secs()
 }
 
 pub fn data_dir() -> anyhow::Result<PathBuf> {


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/3881

Timeout now will happen at the right time: when we're sure the preimage decryption is pending and the expiry time relative to the invoice timestamp has passed.

There are no risks anymore of the timeout not happening because the state machines have been interrupted or it incorrectly happening while the client is dealing with network issues.