### PR TITLE
Make devimint tmp dir much smaller

### DIFF
--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -148,6 +148,8 @@ declare_vars! {
         FM_TEST_BITCOIND_RPC: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}");
         FM_BITCOIN_RPC_URL: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}");
         FM_BITCOIN_RPC_KIND: String = "bitcoind";
+
+        FM_ROCKSDB_WRITE_BUFFER_SIZE : String = (1 << 20).to_string();
     }
 }
 

--- a/nix/esplora-electrs.nix
+++ b/nix/esplora-electrs.nix
@@ -18,10 +18,17 @@ rustPlatform.buildRustPackage {
   version = "20230218";
 
   src = fetchFromGitHub {
-    owner = "Blockstream";
-    repo = "electrs";
-    rev = "adedee15f1fe460398a7045b292604df2161adc0";
-    hash = "sha256-KnN5C7wFtDF10yxf+1dqIMUb8Q+UuCz4CMQrUFAChuA=";
+    # original:
+    # owner = "Blockstream";
+    # repo = "electrs";
+    # rev = "adedee15f1fe460398a7045b292604df2161adc0";
+    # hash = "sha256-KnN5C7wFtDF10yxf+1dqIMUb8Q+UuCz4CMQrUFAChuA=";
+
+    # pre-allocation size patch:
+    owner = "dpc";
+    repo = "esplora-electrs";
+    rev = "8186331b7ca33668d838dab91e2dc52c388ac689";
+    hash = "sha256-D+ZdtZ57RoQsqebW0f2KsWz5/Di4Joy6walqGvGm/4o=";
   };
 
 


### PR DESCRIPTION
Fix https://github.com/fedimint/fedimint/issues/3665

This shrinks each devimint tmp directory from 1.3GB to 83MB. This was caused be excessive default rocksdb pre-allocation, especially in esplora-electrs, which is not useful for tiny testing setups.