### PR TITLE
chore: give build instructions to docs.rs

### DIFF
--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -7,6 +7,9 @@ description = "aead utilities on top of ring "
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_aead"
 path = "src/lib.rs"

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -7,6 +7,9 @@ description = "Fedimint derivable secret implementation"
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "fedimint_derive_secret"

--- a/fedimint-bip39/Cargo.toml
+++ b/fedimint-bip39/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT"
 description = "Allows using bip39 mnemonic phrases to generate fedimint client keys"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -7,6 +7,9 @@ description = "Bitcoin Core connectivity used by Fedimint"
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "fedimint_bitcoind"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-cli is a command line interface wrapper for the client l
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]
 name = "fedimint-cli"

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/fedimint/fedimint"
 # cargo udeps can't detect that one
 normal = ["aquamarine"]
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_client"
 path = "src/lib.rs"

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT"
 description = "Tool to inspect Fedimint client and server databases"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]

--- a/fedimint-metrics/Cargo.toml
+++ b/fedimint-metrics/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT"
 description = "fedimint-metrics allows exporting prometheus metrics from Fedimint."
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_metrics"
 path = "./src/lib.rs"

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-rocksdb provides a rocksdb-backed database implementatio
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_rocksdb"
 path = "src/lib.rs"

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint is the main consensus code for processing transactions a
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-testing provides a library of shared objects and utiliti
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "fedimint_testing"

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint is the main consensus code for processing transactions a
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT"
 description = "CLI tool to control lightning gateway"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-dummy is a dummy example fedimint module."
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_dummy_client"
 path = "src/lib.rs"

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-dummy is a dummy example fedimint module."
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_dummy_common"
 path = "src/lib.rs"

--- a/modules/fedimint-dummy-server/Cargo.toml
+++ b/modules/fedimint-dummy-server/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-dummy is a dummy example fedimint module."
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_dummy_server"
 path = "src/lib.rs"

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/fedimint/fedimint"
 # cargo udeps can't detect that one
 normal = ["aquamarine"]
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_ln_client"
 path = "src/lib.rs"

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/fedimint/fedimint"
 # cargo udeps can't detect that one
 normal = ["aquamarine"]
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_ln_common"
 path = "src/lib.rs"

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-ln is a lightning payment service module."
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-mint is a chaumian ecash mint module."
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "fedimint_mint_client"

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-mint is a chaumian ecash mint module."
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "fedimint_mint_common"

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-mint is a chaumian ecash mint module."
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "fedimint_mint_server"

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a 
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_wallet_client"
 path = "src/lib.rs"

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a 
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_wallet_common"
 path = "src/lib.rs"

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -7,6 +7,9 @@ description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a 
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_wallet_server"
 path = "src/lib.rs"

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -7,6 +7,9 @@ description = "recoverytool allows retrieving on-chain funds from a offline fede
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [[bin]]
 name = "recoverytool"
 path = "src/main.rs"

--- a/utils/portalloc/Cargo.toml
+++ b/utils/portalloc/Cargo.toml
@@ -7,6 +7,9 @@ description = "Port allocation utility for Fedimint"
 license = "MIT"
 repository = "https://github.com/fedimint/fedimint"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
 [lib]
 name = "fedimint_portalloc"
 path = "src/lib.rs"


### PR DESCRIPTION
Fixes #3946 and hopefully makes docs.rs work. See how e.g. `fedimintd` fails to build and thus doesn't have docs shown: https://docs.rs/crate/fedimintd/0.2.0/builds/1062229

I added the meta field to all crates that might remotely depend on something in Fedimint that uses the task builder. I probably over-did it a bit, but it shouldn't hurt and once #3951 is fixed we can roll it back anyway.