### PR TITLE
fix: client detects too big transactions and rejects them

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -34,6 +34,10 @@ use crate::module::{
 };
 use crate::{maybe_add_send_sync, PeerId};
 
+// TODO: make configurable
+/// This limits the RAM consumption of a AlephBFT Unit to roughly 50kB
+pub const ALEPH_BFT_UNIT_BYTE_LIMIT: usize = 50_000;
+
 /// [`serde_json::Value`] that must contain `kind: String` field
 ///
 /// TODO: enforce at ser/deserialization

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -6,6 +6,7 @@ use fedimint_core::{Amount, TransactionId};
 use secp256k1_zkp::schnorr;
 use thiserror::Error;
 
+use crate::config::ALEPH_BFT_UNIT_BYTE_LIMIT;
 use crate::core::{DynInputError, DynOutputError};
 
 /// An atomic value transfer operation within the Fedimint system and consensus
@@ -34,6 +35,19 @@ pub struct Transaction {
 pub type SerdeTransaction = SerdeModuleEncoding<Transaction>;
 
 impl Transaction {
+    /// Maximum size that a transaction can have while still fitting into an
+    /// AlephBFT unit. Subtracting 32 bytes is overly conservative, even in the
+    /// worst case the CI serialization around the transaction should never add
+    /// that much overhead. But since the byte limit is 50kb right now a few
+    /// bytes more or less won't make a difference and we can afford the safety
+    /// margin.
+    ///
+    /// A realistic value would be 7:
+    ///  * 1 byte for length of vector of CIs
+    ///  * 1 byte for the CI enum variant
+    ///  * 5 byte for the CI enum variant length
+    pub const MAX_TX_SIZE: usize = ALEPH_BFT_UNIT_BYTE_LIMIT - 32;
+
     /// Hash of the transaction (excluding the signature).
     ///
     /// Transaction signature commits to this hash.


### PR DESCRIPTION
Fixes #3868. While the increase of `BYTE_LIMIT` prevents oversized transactions from being generated through standard usage patterns, there is still a risk of third party modules or hand crafted transactions exceeding the limit. This makes the client throw an error in these cases.