### PR TITLE
fix(lightning): proper handle timeouts while receiving a payment

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1094,11 +1094,9 @@ impl LightningClientModule {
         };
 
         // Verify that no other outgoing contract exists or the value is empty
-        if let Ok(contract) = self.module_api.fetch_contract(contract_id).await {
+        if let Ok(Some(contract)) = self.module_api.fetch_contract(contract_id).await {
             if contract.amount.msats != 0 {
-                return Err(anyhow::anyhow!(
-                    "Funded contract already exists. ContractId: {contract_id}"
-                ));
+                anyhow::bail!("Funded contract already exists. ContractId: {contract_id}");
             }
         }
 

--- a/modules/fedimint-ln-common/src/api.rs
+++ b/modules/fedimint-ln-common/src/api.rs
@@ -25,7 +25,10 @@ use crate::{ContractAccount, LightningGateway, LightningGatewayAnnouncement};
 #[apply(async_trait_maybe_send!)]
 pub trait LnFederationApi {
     async fn fetch_consensus_block_count(&self) -> FederationResult<Option<u64>>;
-    async fn fetch_contract(&self, contract: ContractId) -> FederationResult<ContractAccount>;
+    async fn fetch_contract(
+        &self,
+        contract: ContractId,
+    ) -> FederationResult<Option<ContractAccount>>;
     async fn wait_contract(&self, contract: ContractId) -> FederationResult<ContractAccount>;
     async fn wait_block_height(&self, block_height: u64) -> FederationResult<()>;
     async fn wait_outgoing_contract_cancelled(
@@ -75,7 +78,10 @@ where
         .await
     }
 
-    async fn fetch_contract(&self, contract: ContractId) -> FederationResult<ContractAccount> {
+    async fn fetch_contract(
+        &self,
+        contract: ContractId,
+    ) -> FederationResult<Option<ContractAccount>> {
         self.request_current_consensus(
             ACCOUNT_ENDPOINT.to_string(),
             ApiRequestErased::new(contract),


### PR DESCRIPTION
https://github.com/fedimint/fedimint/pull/3929 was a mess:

1) It required https://github.com/fedimint/fedimint/pull/3955

2) It still doesn't fully solve the timeout handling as it calls `context.wait_key_exists(ContractKey(contract_id))` which will block until a payment has been received.
In this situation the client will never timeout because a timeout will be considered an error and it will keep retrying.

3)  It still considers that a `DecryptedPreimage::Pending` is a good moment to timeout. But in fact if we got `DecryptedPreimage::Pending` the payment may still succeed, so we can't timeout here.

This PR tries to fix these issues. It also introduces tests for the expiration time check.

Note: this PR should be fully compatible with previous releases. We are just properly using an existing endpoint to solve the issue on the client-side.