### PR TITLE
fix: prevent spamming blockchain.info with requests

### DIFF
--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -98,7 +98,7 @@ impl IBitcoindRpc for BitcoinClient {
         Ok(height.map(|h| h as u64))
     }
 
-    async fn watch_script_history(&self, script: &Script) -> anyhow::Result<Vec<Transaction>> {
+    async fn watch_script_history(&self, script: &Script) -> anyhow::Result<()> {
         // start watching for this script in our wallet to avoid the need to rescan the
         // blockchain, labeling it so we can reference it later
         block_in_place(|| {
@@ -106,6 +106,10 @@ impl IBitcoindRpc for BitcoinClient {
                 .import_address_script(script, Some(&script.to_string()), Some(false), None)
         })?;
 
+        Ok(())
+    }
+
+    async fn get_script_history(&self, script: &Script) -> anyhow::Result<Vec<Transaction>> {
         let mut results = vec![];
         let list = block_in_place(|| {
             self.0

--- a/fedimint-bitcoind/src/electrum.rs
+++ b/fedimint-bitcoind/src/electrum.rs
@@ -107,7 +107,12 @@ impl IBitcoindRpc for ElectrumClient {
         }
     }
 
-    async fn watch_script_history(
+    async fn watch_script_history(&self, _: &Script) -> anyhow::Result<()> {
+        // no watching needed on electrs, has all the history already
+        Ok(())
+    }
+
+    async fn get_script_history(
         &self,
         script: &Script,
     ) -> anyhow::Result<Vec<bitcoin::Transaction>> {

--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -101,7 +101,12 @@ impl IBitcoindRpc for EsploraClient {
             .map(|height| height as u64))
     }
 
-    async fn watch_script_history(
+    async fn watch_script_history(&self, _: &Script) -> anyhow::Result<()> {
+        // no watching needed, has all the history already
+        Ok(())
+    }
+
+    async fn get_script_history(
         &self,
         script: &Script,
     ) -> anyhow::Result<Vec<bitcoin::Transaction>> {
@@ -115,7 +120,6 @@ impl IBitcoindRpc for EsploraClient {
 
         Ok(transactions)
     }
-
     async fn get_txout_proof(&self, txid: Txid) -> anyhow::Result<TxOutProof> {
         let proof = self
             .0

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -303,7 +303,11 @@ impl IBitcoindRpc for FakeBitcoinTest {
         Ok(None)
     }
 
-    async fn watch_script_history(&self, script: &Script) -> BitcoinRpcResult<Vec<Transaction>> {
+    async fn watch_script_history(&self, _: &Script) -> BitcoinRpcResult<()> {
+        Ok(())
+    }
+
+    async fn get_script_history(&self, script: &Script) -> BitcoinRpcResult<Vec<Transaction>> {
         let scripts = self.scripts.lock().unwrap();
         let script = scripts.get(script);
         Ok(script.unwrap_or(&vec![]).clone())

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -107,6 +107,13 @@ async fn await_created_btc_transaction_submitted(
         .script_pubkey();
     loop {
         match context.rpc.watch_script_history(&script).await {
+            Ok(_) => break,
+            Err(e) => warn!("Error while awaiting btc tx submitting: {e}"),
+        }
+        sleep(TRANSACTION_STATUS_FETCH_INTERVAL).await;
+    }
+    loop {
+        match context.rpc.get_script_history(&script).await {
             Ok(received) => {
                 // TODO: fix
                 if received.len() > 1 {

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -112,7 +113,13 @@ async fn await_created_btc_transaction_submitted(
         }
         sleep(TRANSACTION_STATUS_FETCH_INTERVAL).await;
     }
-    loop {
+    for attempt in 0u32.. {
+        sleep(cmp::min(
+            TRANSACTION_STATUS_FETCH_INTERVAL * attempt,
+            Duration::from_secs(60 * 15),
+        ))
+        .await;
+
         match context.rpc.get_script_history(&script).await {
             Ok(received) => {
                 // TODO: fix
@@ -143,9 +150,9 @@ async fn await_created_btc_transaction_submitted(
                 warn!("Error fetching transaction history for {script:?}: {e}");
             }
         }
-
-        sleep(TRANSACTION_STATUS_FETCH_INTERVAL).await;
     }
+
+    unreachable!()
 }
 
 async fn transition_tx_seen(


### PR DESCRIPTION
In some circumstances, possibly triggered by a bug or unrelated failure it seems possible
for us to keep calling blockstream.info (or other electrs/esplora backend) from the autocommit loop.

I identified two orthogonal improvements:

* watch needs to be called only once, so calling it again on retries is a waste of time
* watch & get are two separate operations so should be treated as such

Each of them separately is effectively fixing the problem we witnessed, but both make sense, so I guess makes sense to land both.