### PR TITLE
chore: update zerocopy to fix vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5956,18 +5956,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",


### PR DESCRIPTION
```
fedimint-ci-audit> Crate:     zerocopy
fedimint-ci-audit> Version:   0.7.29
fedimint-ci-audit> Title:     Some Ref methods are unsound with some type parameters
fedimint-ci-audit> Date:      2023-12-14
fedimint-ci-audit> ID:        RUSTSEC-2023-0074
fedimint-ci-audit> URL:       https://rustsec.org/advisories/RUSTSEC-2023-0074
fedimint-ci-audit> Solution:  Upgrade to >=0.2.9, <0.3.0 OR >=0.3.2, <0.4.0 OR >=0.4.1, <0.5.0 OR >=0.5.2, <0.6.0 OR >=0.6.6, <0.7.0 OR >=0.7.31
```