### PR TITLE
feat: overridable binaries and cross test

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -126,6 +126,12 @@ jobs:
         if: (github.event_name != 'pull_request' || matrix.build-in-pr) && matrix.run-tests && (matrix.host != 'macos')
         run: nix build -L .#wasm32-unknown.ci.wasmTest --keep-failed
 
+
+      - name: Cross Tests
+        if: (github.event_name != 'pull_request' || matrix.build-in-pr) && matrix.run-tests
+        run: |
+          ./scripts/tests/cross-test-ci-all.sh
+
       - name: Prepare failed test build dirs
         if: always()
         run:  |

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -43,7 +43,10 @@ impl Bitcoind {
         );
         write_overwrite_async(processmgr.globals.FM_BTC_DIR.join("bitcoin.conf"), conf).await?;
         let process = processmgr
-            .spawn_daemon("bitcoind", cmd!("bitcoind", "-datadir={btc_dir}"))
+            .spawn_daemon(
+                "bitcoind",
+                cmd!(crate::util::Bitcoind, "-datadir={btc_dir}"),
+            )
             .await?;
 
         let url = processmgr.globals.FM_BITCOIN_RPC_URL.parse()?;
@@ -256,7 +259,7 @@ impl Lightningd {
             .context("gateway-cln-extension not on path")?;
         let btc_dir = utf8(&process_mgr.globals.FM_BTC_DIR);
         let cmd = cmd!(
-            "lightningd",
+            crate::util::Lightningd,
             "--dev-fast-gossip",
             "--dev-bitcoind-poll=1",
             format!("--lightning-dir={}", utf8(cln_dir)),
@@ -343,7 +346,7 @@ impl Lnd {
         );
         write_overwrite_async(process_mgr.globals.FM_LND_DIR.join("lnd.conf"), conf).await?;
         let cmd = cmd!(
-            "lnd",
+            crate::util::Lnd,
             format!("--lnddir={}", utf8(&process_mgr.globals.FM_LND_DIR))
         );
 
@@ -617,7 +620,7 @@ impl Electrs {
         )
         .await?;
         let cmd = cmd!(
-            "electrs",
+            crate::util::Electrs,
             "--conf-dir={electrs_dir}",
             "--db-dir={electrs_dir}",
             "--daemon-dir={daemon_dir}"
@@ -655,7 +658,7 @@ impl Esplora {
         let esplora_port = process_mgr.globals.FM_PORT_ESPLORA;
         // spawn esplora
         let cmd = cmd!(
-            "esplora",
+            crate::util::Esplora,
             "--daemon-dir={daemon_dir}",
             "--db-dir={esplora_dir}",
             "--cookie=bitcoin:bitcoin",

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -29,7 +29,7 @@ use tracing::{debug, info};
 use super::external::Bitcoind;
 use super::util::{cmd, parse_map, Command, ProcessHandle, ProcessManager};
 use super::vars::utf8;
-use crate::util::poll;
+use crate::util::{poll, FedimintdCmd};
 use crate::{poll_eq, vars};
 
 pub struct Federation {
@@ -114,7 +114,7 @@ impl Client {
 
     pub async fn cmd(&self) -> Command {
         cmd!(
-            "fedimint-cli",
+            crate::util::get_fedimint_cli_path(),
             format!("--data-dir={}", self.client_dir().display())
         )
     }
@@ -395,7 +395,7 @@ impl Fedimintd {
         let process = process_mgr
             .spawn_daemon(
                 &format!("fedimintd-{peer_id}"),
-                cmd!("fedimintd").envs(env.vars()),
+                cmd!(FedimintdCmd).envs(env.vars()),
             )
             .await?;
 

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -60,7 +60,7 @@ impl Gatewayd {
         let process = process_mgr
             .spawn_daemon(
                 &format!("gatewayd-{ln_name}"),
-                cmd!("gatewayd", ln_name).envs(gateway_env),
+                cmd!(crate::util::Gatewayd, ln_name).envs(gateway_env),
             )
             .await?;
 
@@ -88,7 +88,7 @@ impl Gatewayd {
 
     pub async fn cmd(&self) -> Command {
         cmd!(
-            "gateway-cli",
+            crate::util::get_gateway_cli_path(),
             "--rpcpassword=theresnosecondbest",
             "-a",
             &self.addr

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -11,7 +11,7 @@ use bitcoincore_rpc::{bitcoin, RpcApi};
 use clap::{Parser, Subcommand};
 use cln_rpc::primitives::{Amount as ClnRpcAmount, AmountOrAny};
 use devimint::federation::{Client, Federation, Fedimintd};
-use devimint::util::{poll, ProcessManager};
+use devimint::util::{poll, LoadTestTool, ProcessManager};
 use devimint::{
     cmd, dev_fed, external_daemons, poll_eq, vars, DevFed, ExternalDaemons, Gatewayd,
     LightningNode, Lightningd, Lnd,
@@ -905,7 +905,7 @@ async fn cli_load_test_tool_test(dev_fed: DevFed) -> Result<()> {
 
 async fn run_standard_load_test(load_test_temp: &Path, invite_code: &str) -> anyhow::Result<()> {
     let output = cmd!(
-        "fedimint-load-test-tool",
+        LoadTestTool,
         "--archive-dir",
         load_test_temp.display(),
         "--users",
@@ -930,7 +930,7 @@ async fn run_standard_load_test(load_test_temp: &Path, invite_code: &str) -> any
         "paid different number of invoices than expected"
     );
     let output = cmd!(
-        "fedimint-load-test-tool",
+        LoadTestTool,
         "--archive-dir",
         load_test_temp.display(),
         "--users",
@@ -962,7 +962,7 @@ async fn run_standard_load_test(load_test_temp: &Path, invite_code: &str) -> any
 async fn run_ln_circular_load_test(load_test_temp: &Path, invite_code: &str) -> anyhow::Result<()> {
     info!("Testing ln-circular-load-test with 'two-gateways' strategy");
     let output = cmd!(
-        "fedimint-load-test-tool",
+        LoadTestTool,
         "--archive-dir",
         load_test_temp.display(),
         "--users",
@@ -994,7 +994,7 @@ async fn run_ln_circular_load_test(load_test_temp: &Path, invite_code: &str) -> 
     info!("Testing ln-circular-load-test with 'partner-ping-pong' strategy");
     // Note invite code isn't required because we already have an archive dir
     let output = cmd!(
-        "fedimint-load-test-tool",
+        LoadTestTool,
         "--archive-dir",
         load_test_temp.display(),
         "--users",
@@ -1022,7 +1022,7 @@ async fn run_ln_circular_load_test(load_test_temp: &Path, invite_code: &str) -> 
     info!("Testing ln-circular-load-test with 'self-payment' strategy");
     // Note invite code isn't required because we already have an archive dir
     let output = cmd!(
-        "fedimint-load-test-tool",
+        LoadTestTool,
         "--archive-dir",
         load_test_temp.display(),
         "--users",
@@ -1507,7 +1507,7 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
     let now = fedimint_core::time::now();
     info!("Recovering using utxos method");
     let output = cmd!(
-        "recoverytool",
+        "recoverytool", // FIXME: create a command
         "--readonly",
         "--cfg",
         "{data_dir}/fedimintd-0",
@@ -1874,6 +1874,7 @@ async fn handle_command() -> Result<()> {
                         dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_cln),
                         dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_lnd),
                         async {
+                            // FIXME: create a command
                             let faucet = process_mgr.spawn_daemon("faucet", cmd!("faucet")).await?;
 
                             poll("waiting for faucet startup", None, || async {

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -362,6 +362,14 @@ impl ToCmdExt for &'_ str {
     }
 }
 
+impl ToCmdExt for Vec<String> {
+    type Fut = std::future::Ready<Command>;
+
+    fn cmd(self) -> Self::Fut {
+        std::future::ready(to_command(self))
+    }
+}
+
 pub trait JsonValueExt {
     fn to_typed<T: DeserializeOwned>(self) -> Result<T>;
 }
@@ -372,50 +380,281 @@ impl JsonValueExt for serde_json::Value {
     }
 }
 
-fn get_command_for_alias(alias: &str, default: &str) -> Command {
-    // try to use alias if set
-    let cli = std::env::var(alias)
-        .map(|s| s.split_whitespace().map(ToOwned::to_owned).collect())
-        .unwrap_or_else(|_| vec![default.into()]);
-    let mut cmd = tokio::process::Command::new(&cli[0]);
-    cmd.args(&cli[1..]);
-    Command {
-        cmd,
-        args_debug: cli,
+const GATEWAYD_FALLBACK: &str = "gatewayd";
+// To override gatewayd binary set:
+const ENV_FM_GATEWAYD_BASE_EXECUTABLE: &str = "FM_GATEWAYD_BASE_EXECUTABLE";
+
+const FEDIMINTD_FALLBACK: &str = "fedimintd";
+// To override fedimintd binary set:
+const ENV_FM_FEDIMINTD_BASE_EXECUTABLE: &str = "FM_FEDIMINTD_BASE_EXECUTABLE";
+
+const FEDIMINT_CLI_FALLBACK: &str = "fedimint-cli";
+// To override fedimint-cli binary set:
+const ENV_FM_FEDIMINT_CLI_BASE_EXECUTABLE: &str = "FM_FEDIMINT_CLI_BASE_EXECUTABLE";
+// To override fedimint-cli default command
+// (like "$FM_FEDIMINT_CLI_BASE_EXECUTABLE --data-dir /tmp/xxx ....")
+// set:
+const ENV_FM_MINT_CLIENT: &str = "FM_MINT_CLIENT";
+
+pub fn get_fedimint_cli_path() -> Vec<String> {
+    get_command_str_for_alias(
+        &[ENV_FM_FEDIMINT_CLI_BASE_EXECUTABLE],
+        &[FEDIMINT_CLI_FALLBACK],
+    )
+}
+
+const GATEWAY_CLI_FALLBACK: &str = "gateway-cli";
+// To override gateway-cli binary set:
+const ENV_FM_GATEWAY_CLI_BASE_EXECUTABLE: &str = "FM_GATEWAY_CLI_BASE_EXECUTABLE";
+
+pub fn get_gateway_cli_path() -> Vec<String> {
+    get_command_str_for_alias(
+        &[ENV_FM_GATEWAY_CLI_BASE_EXECUTABLE],
+        &[GATEWAY_CLI_FALLBACK],
+    )
+}
+
+const LOAD_TEST_TOOL_FALLBACK: &str = "fedimint-load-test-tool";
+// To override fedimint-load-test-tool binary set:
+const ENV_FM_LOAD_TEST_TOOL_BASE_EXECUTABLE: &str = "FM_LOAD_TEST_TOOL_BASE_EXECUTABLE";
+
+const LIGHTNING_CLI_FALLBACK: &str = "lightning-cli";
+// To override lightning-cli binary set:
+const ENV_FM_LIGHTNING_CLI_BASE_EXECUTABLE: &str = "FM_LIGHTNING_CLI_BASE_EXECUTABLE";
+// to override lightning-cli default command set:
+const ENV_FM_LIGHTNING_CLI: &str = "FM_LIGHTNING_CLI";
+
+pub fn get_lightning_cli_path() -> Vec<String> {
+    get_command_str_for_alias(
+        &[ENV_FM_LIGHTNING_CLI_BASE_EXECUTABLE],
+        &[LIGHTNING_CLI_FALLBACK],
+    )
+}
+
+const LNCLI_FALLBACK: &str = "lncli";
+// To override lncli binary set:
+const ENV_FM_LNCLI_BASE_EXECUTABLE: &str = "FM_LNCLI_BASE_EXECUTABLE";
+// to override lncli default command set:
+const ENV_FM_LNCLI: &str = "FM_LNCLI";
+
+pub fn get_lncli_path() -> Vec<String> {
+    get_command_str_for_alias(&[ENV_FM_LNCLI_BASE_EXECUTABLE], &[LNCLI_FALLBACK])
+}
+
+const BITCOIN_CLI_FALLBACK: &str = "bitcoin-cli";
+// To override bitcoin-cli binary set:
+const ENV_FM_BITCOIN_CLI_BASE_EXECUTABLE: &str = "FM_BITCOIN_CLI_BASE_EXECUTABLE";
+// to override bitcoin-cli default command set:
+const ENV_FM_BTC_CLIENT: &str = "FM_BTC_CLIENT";
+
+pub fn get_bitcoin_cli_path() -> Vec<String> {
+    get_command_str_for_alias(
+        &[ENV_FM_BITCOIN_CLI_BASE_EXECUTABLE],
+        &[BITCOIN_CLI_FALLBACK],
+    )
+}
+
+const BITCOIND_FALLBACK: &str = "bitcoind";
+// To override bitcoind binary set:
+const ENV_FM_BITCOIND_BASE_EXECUTABLE: &str = "FM_BITCOIND_BASE_EXECUTABLE";
+
+const LIGHTNINGD_FALLBACK: &str = "lightningd";
+// To override lightningd binary set:
+const ENV_FM_LIGHTNINGD_BASE_EXECUTABLE: &str = "FM_LIGHTNINGD_BASE_EXECUTABLE";
+
+const LND_FALLBACK: &str = "lnd";
+// To override lnd binary set:
+const ENV_FM_LND_BASE_EXECUTABLE: &str = "FM_LND_BASE_EXECUTABLE";
+
+const ELECTRS_FALLBACK: &str = "electrs";
+// To override electrs binary set:
+const ENV_FM_ELECTRS_BASE_EXECUTABLE: &str = "FM_ELECTRS_BASE_EXECUTABLE";
+
+const ESPLORA_FALLBACK: &str = "esplora";
+// To override esplora binary set:
+const ENV_FM_ESPLORA_BASE_EXECUTABLE: &str = "FM_ESPLORA_BASE_EXECUTABLE";
+
+pub struct FedimintdCmd;
+impl FedimintdCmd {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_FEDIMINTD_BASE_EXECUTABLE],
+            &[FEDIMINTD_FALLBACK],
+        ))
+    }
+}
+
+pub struct Gatewayd;
+impl Gatewayd {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_GATEWAYD_BASE_EXECUTABLE],
+            &[GATEWAYD_FALLBACK],
+        ))
     }
 }
 
 pub struct FedimintCli;
 impl FedimintCli {
     pub async fn cmd(self) -> Command {
-        get_command_for_alias("FM_MINT_CLIENT", "fedimint-cli")
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_MINT_CLIENT],
+            &get_fedimint_cli_path()
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        ))
     }
 }
 
-pub struct LnCli;
-impl LnCli {
+pub struct LoadTestTool;
+impl LoadTestTool {
     pub async fn cmd(self) -> Command {
-        get_command_for_alias("FM_LNCLI", "lncli")
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_LOAD_TEST_TOOL_BASE_EXECUTABLE],
+            &[LOAD_TEST_TOOL_FALLBACK],
+        ))
     }
 }
 
-pub struct ClnLightningCli;
-impl ClnLightningCli {
+pub struct GatewayCli;
+impl GatewayCli {
     pub async fn cmd(self) -> Command {
-        get_command_for_alias("FM_LIGHTNING_CLI", "lightning-cli")
+        to_command(get_command_str_for_alias(
+            &[],
+            &get_gateway_cli_path()
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        ))
     }
 }
 
 pub struct GatewayClnCli;
 impl GatewayClnCli {
     pub async fn cmd(self) -> Command {
-        get_command_for_alias("FM_GWCLI_CLN", "gateway-cln")
+        to_command(get_command_str_for_alias(
+            &["FM_GWCLI_CLN"],
+            &["gateway-cln"],
+        ))
     }
 }
 
 pub struct GatewayLndCli;
 impl GatewayLndCli {
     pub async fn cmd(self) -> Command {
-        get_command_for_alias("FM_GWCLI_LND", "gateway-lnd")
+        to_command(get_command_str_for_alias(
+            &["FM_GWCLI_LND"],
+            &["gateway-lnd"],
+        ))
+    }
+}
+
+pub struct LnCli;
+impl LnCli {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_LNCLI],
+            &get_lncli_path()
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        ))
+    }
+}
+
+pub struct ClnLightningCli;
+impl ClnLightningCli {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_LIGHTNING_CLI],
+            &get_lightning_cli_path()
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        ))
+    }
+}
+
+pub struct BitcoinCli;
+impl BitcoinCli {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_BTC_CLIENT],
+            &get_bitcoin_cli_path()
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        ))
+    }
+}
+
+pub struct Bitcoind;
+impl Bitcoind {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_BITCOIND_BASE_EXECUTABLE],
+            &[BITCOIND_FALLBACK],
+        ))
+    }
+}
+
+pub struct Lightningd;
+impl Lightningd {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_LIGHTNINGD_BASE_EXECUTABLE],
+            &[LIGHTNINGD_FALLBACK],
+        ))
+    }
+}
+
+pub struct Lnd;
+impl Lnd {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_LND_BASE_EXECUTABLE],
+            &[LND_FALLBACK],
+        ))
+    }
+}
+
+pub struct Electrs;
+impl Electrs {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_ELECTRS_BASE_EXECUTABLE],
+            &[ELECTRS_FALLBACK],
+        ))
+    }
+}
+
+pub struct Esplora;
+impl Esplora {
+    pub async fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[ENV_FM_ESPLORA_BASE_EXECUTABLE],
+            &[ESPLORA_FALLBACK],
+        ))
+    }
+}
+
+fn get_command_str_for_alias(aliases: &[&str], default: &[&str]) -> Vec<String> {
+    // try to use one of the aliases if set
+    for alias in aliases {
+        if let Ok(cmd) = std::env::var(alias) {
+            return cmd.split_whitespace().map(ToOwned::to_owned).collect();
+        }
+    }
+    // otherwise return the default value
+    default.iter().map(|s| s.to_string()).collect()
+}
+
+fn to_command(cli: Vec<String>) -> Command {
+    let mut cmd = tokio::process::Command::new(&cli[0]);
+    cmd.args(&cli[1..]);
+    Command {
+        cmd,
+        args_debug: cli,
     }
 }

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -135,13 +135,24 @@ declare_vars! {
         FM_FAUCET_BIND_ADDR: String = f!("0.0.0.0:{FM_PORT_FAUCET}");
 
         // clients
-        FM_LIGHTNING_CLI: String = f!("lightning-cli --network regtest --lightning-dir={}", utf8(&FM_CLN_DIR));
-        FM_LNCLI: String = f!("lncli -n regtest --lnddir={} --rpcserver=localhost:{FM_PORT_LND_RPC}", utf8(&FM_LND_DIR));
-        FM_BTC_CLIENT: String = f!("bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin -datadir={}", utf8(&FM_BTC_DIR));
-        FM_MINT_CLIENT: String = f!("fedimint-cli --data-dir {}", utf8(&FM_CLIENT_DIR));
+        FM_LIGHTNING_CLI: String = f!("{lightning_cli} --network regtest --lightning-dir={lightning_dir}",
+            lightning_cli = crate::util::get_lightning_cli_path().join(" "),
+            lightning_dir = utf8(&FM_CLN_DIR));
+        FM_LNCLI: String = f!("{lncli} -n regtest --lnddir={lnddir} --rpcserver=localhost:{FM_PORT_LND_RPC}",
+            lncli = crate::util::get_lncli_path().join(" "),
+            lnddir = utf8(&FM_LND_DIR));
+        FM_BTC_CLIENT: String = f!("{bitcoin_cli} -regtest -rpcuser=bitcoin -rpcpassword=bitcoin -datadir={datadir}",
+            bitcoin_cli = crate::util::get_bitcoin_cli_path().join(" "),
+            datadir = utf8(&FM_BTC_DIR));
+        FM_MINT_CLIENT: String = f!("{fedimint_cli} --data-dir {datadir}",
+            fedimint_cli = crate::util::get_fedimint_cli_path().join(" "),
+            datadir = utf8(&FM_CLIENT_DIR));
         FM_MINT_RPC_CLIENT: String = f!("mint-rpc-client");
-        FM_GWCLI_CLN: String = f!("gateway-cli --rpcpassword=theresnosecondbest -a http://127.0.0.1:{FM_PORT_GW_CLN}/");
-        FM_GWCLI_LND: String = f!("gateway-cli --rpcpassword=theresnosecondbest -a http://127.0.0.1:{FM_PORT_GW_LND}/");
+        FM_GWCLI_CLN: String = f!("{gateway_cli} --rpcpassword=theresnosecondbest -a http://127.0.0.1:{FM_PORT_GW_CLN}/",
+            gateway_cli = crate::util::get_gateway_cli_path().join(" "),);
+        FM_GWCLI_LND: String = f!("{gateway_cli} --rpcpassword=theresnosecondbest -a http://127.0.0.1:{FM_PORT_GW_LND}/",
+            gateway_cli = crate::util::get_gateway_cli_path().join(" "),);
+        // FIXME: create a command
         FM_DB_TOOL: String = f!("fedimint-dbtool");
 
         // fedimint config variables

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -376,6 +376,15 @@ rec {
     '';
   };
 
+  # ciCrossTestAll = craneLibTests.mkCargoDerivation {
+  #   pname = "${commonCliTestArgs.pname}-all-cross";
+  #   cargoArtifacts = workspaceBuild;
+  #   buildPhaseCargoCommand = ''
+  #     patchShebangs ./scripts
+  #     ./scripts/tests/cross-test-ci-all.sh || exit 1
+  #   '';
+  # };
+
   alwaysFailTest = craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-always-fail";
     cargoArtifacts = workspaceBuild;

--- a/scripts/tests/cross-test-ci-all.sh
+++ b/scripts/tests/cross-test-ci-all.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+# Test current versions against gatewayd v0.2
+export FM_GATEWAYD_BASE_EXECUTABLE="nix run git+https://github.com/fedimint/fedimint.git?ref=releases/v0.2#gatewayd --"
+# shellcheck disable=SC2260
+$FM_GATEWAYD_BASE_EXECUTABLE --help || true
+./scripts/tests/test-ci-all.sh


### PR DESCRIPTION
Let all binaries from devimint be replaceable through environment variables.

Added a "cross test" as example where we run the master tests against `gatewayd` [v0.2](https://github.com/fedimint/fedimint/tree/releases/v0.2) reproducing https://github.com/fedimint/fedimint/issues/3977 (so the cross test will correctly fail right now)

What we do is just override the `gatewayd` executable with:
```bash
export FM_GATEWAYD_BASE_EXECUTABLE="nix run git+https://github.com/fedimint/fedimint.git?ref=releases/v0.2#gatewayd --"
```

Then if we run `./scripts/tests/test-ci-all.sh` the `gatewayd` binary will come from `releases/v0.2` and the other binaries will come normally from the current repository compilation. Any mix and match is possible.

Also this approach (or something very similar to it) makes it possible to test migrations (for instance start an old fedimintd version, stop it, then upgrade to current master during a test and see if everything is still working)

Will eventually close https://github.com/fedimint/fedimint/issues/3962

Opening now as draft for feedback
@elsirion @dpc @bradleystachurski


Note: CI isn't working right now but you can test locally with `./scripts/tests/cross-test-ci-all.sh`