### PR TITLE
[Backport releases/v0.2] fix: dont require muc.xmpp as a traefik router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1235,7 +1235,7 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1276,14 +1276,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.11.0",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-cli"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "bitcoin_hashes 0.11.0",
 ]
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-gateway"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "base64 0.20.0",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -1989,7 +1989,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "bitcoin 0.29.2",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "aleph-bft",
  "aleph-bft-types",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "bincode",
  "bitcoin_hashes 0.11.0",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ resolver = "2"
 
 [workspace.metadata]
 name = "fedimint"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint is a prototype Federated Chaumian E-Cash Mint implementation, natively compatible with Bitcoin & the Lightning Network. This project is under heavy development, DO NOT USE WITH REAL FUNDS."

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-aead"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "aead utilities on top of ring "

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-derive-secret"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint derivable secret implementation"
@@ -18,8 +18,8 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.66"
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-hkdf = { package = "fedimint-hkdf", version = "0.2.1-rc2", path = "../../crypto/hkdf" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+hkdf = { package = "fedimint-hkdf", version = "0.2.1-rc3", path = "../../crypto/hkdf" }
 ring = "0.17.5"
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
-tbs = { package = "fedimint-tbs", version = "0.2.1-rc2", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.2.1-rc3", path = "../../crypto/tbs" }

--- a/crypto/hkdf/Cargo.toml
+++ b/crypto/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-hkdf"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "RFC5869 HKDF implementation on top of bitcoin_hashes"

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-tbs"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "tbs is a helper cryptography library for threshold blind signatures"

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devimint"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 edition = "2021"
 license = "MIT"
 publish = false
@@ -42,4 +42,4 @@ url = "2.3.1"
 fedimint-portalloc = { path = "../utils/portalloc" }
 
 [build-dependencies]
-fedimint-build = { version = "0.2.1-rc2", path = "../fedimint-build" }
+fedimint-build = { version = "0.2.1-rc3", path = "../fedimint-build" }

--- a/docker/full-tls-mutinynet/docker-compose.yaml
+++ b/docker/full-tls-mutinynet/docker-compose.yaml
@@ -403,7 +403,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.xmpp.loadbalancer.server.port=5280"
-      - "traefik.http.routers.xmpp.rule=Host(`xmpp.fedimint.my-super-host.com`) || Host(`muc.xmpp.fedimint.my-super-host.com`)"
+      - "traefik.http.routers.xmpp.rule=Host(`xmpp.fedimint.my-super-host.com`)"
       - "traefik.http.routers.xmpp.entrypoints=websecure"
       - "traefik.http.routers.xmpp.tls.certresolver=myresolver"
 

--- a/fedimint-bip39/Cargo.toml
+++ b/fedimint-bip39/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-bip39"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 edition = "2021"
 license = "MIT"
 description = "Allows using bip39 mnemonic phrases to generate fedimint client keys"
@@ -17,6 +17,6 @@ path = "./src/lib.rs"
 
 [dependencies]
 bip39 = { version = "2.0.0", features = ["rand"] }
-fedimint-client = { version = "0.2.1-rc2", path = "../fedimint-client" }
-fedimint-core = { version = "0.2.1-rc2", path = "../fedimint-core" }
+fedimint-client = { version = "0.2.1-rc3", path = "../fedimint-client" }
+fedimint-core = { version = "0.2.1-rc3", path = "../fedimint-core" }
 rand = "0.8.5"

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-bitcoind"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Bitcoin Core connectivity used by Fedimint"
@@ -24,8 +24,8 @@ bitcoincore-rpc = { version = "0.16.0", optional = true }
 electrum-client = {version = "0.12.0", optional = true }
 esplora-client = { version = "0.5.0", default-features = false, features = ["async", "async-https-rustls"], optional = true }
 lazy_static = "1.4.0"
-fedimint-core  = { version = "0.2.1-rc2", path = "../fedimint-core" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging" }
+fedimint-core  = { version = "0.2.1-rc3", path = "../fedimint-core" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 tracing = "0.1.37"

--- a/fedimint-build/Cargo.toml
+++ b/fedimint-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-build"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint is the main consensus code for processing transactions and REST API"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-cli"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-cli is a command line interface wrapper for the client library."
@@ -30,18 +30,18 @@ time = { version = "0.3.25", features = [ "formatting" ] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
 futures = "0.3.28"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-aead = { version = "0.2.1-rc2", path = "../crypto/aead" }
-fedimint-bip39 = { version = "0.2.1-rc2", path = "../fedimint-bip39" }
-fedimint-client = { version = "0.2.1-rc2", path = "../fedimint-client" }
-fedimint-core = { version = "0.2.1-rc2", path = "../fedimint-core" }
-fedimint-rocksdb = { version = "0.2.1-rc2", path = "../fedimint-rocksdb" }
-fedimint-mint-client = { version = "0.2.1-rc2", path = "../modules/fedimint-mint-client" }
-fedimint-mint-common = { version = "0.2.1-rc2", path = "../modules/fedimint-mint-common" }
-fedimint-ln-client = { version = "0.2.1-rc2", path = "../modules/fedimint-ln-client" }
-fedimint-ln-common = { version = "0.2.1-rc2", path = "../modules/fedimint-ln-common" }
-fedimint-wallet-client = { version = "0.2.1-rc2", path = "../modules/fedimint-wallet-client" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging" }
-fedimint-server = { version = "0.2.1-rc2", path = "../fedimint-server" }
+fedimint-aead = { version = "0.2.1-rc3", path = "../crypto/aead" }
+fedimint-bip39 = { version = "0.2.1-rc3", path = "../fedimint-bip39" }
+fedimint-client = { version = "0.2.1-rc3", path = "../fedimint-client" }
+fedimint-core = { version = "0.2.1-rc3", path = "../fedimint-core" }
+fedimint-rocksdb = { version = "0.2.1-rc3", path = "../fedimint-rocksdb" }
+fedimint-mint-client = { version = "0.2.1-rc3", path = "../modules/fedimint-mint-client" }
+fedimint-mint-common = { version = "0.2.1-rc3", path = "../modules/fedimint-mint-common" }
+fedimint-ln-client = { version = "0.2.1-rc3", path = "../modules/fedimint-ln-client" }
+fedimint-ln-common = { version = "0.2.1-rc3", path = "../modules/fedimint-ln-common" }
+fedimint-wallet-client = { version = "0.2.1-rc3", path = "../modules/fedimint-wallet-client" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging" }
+fedimint-server = { version = "0.2.1-rc3", path = "../fedimint-server" }
 fs-lock = "0.1.0"
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
@@ -56,4 +56,4 @@ lnurl-rs = { version = "0.3.1", features = ["async"], default-features = false }
 reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }
 
 [build-dependencies]
-fedimint-build = { version = "0.2.1-rc2", path = "../fedimint-build" }
+fedimint-build = { version = "0.2.1-rc3", path = "../fedimint-build" }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-client provides a library for sending transactions to the federation."
@@ -25,10 +25,10 @@ async-stream = "0.3.5"
 async-trait = "0.1.73"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
-fedimint-core  = { version = "0.2.1-rc2", path = "../fedimint-core/" }
-fedimint-derive-secret = { version = "0.2.1-rc2", path = "../crypto/derive-secret" }
-fedimint-aead = { version = "0.2.1-rc2", path = "../crypto/aead" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging" }
+fedimint-core  = { version = "0.2.1-rc3", path = "../fedimint-core/" }
+fedimint-derive-secret = { version = "0.2.1-rc3", path = "../crypto/derive-secret" }
+fedimint-aead = { version = "0.2.1-rc3", path = "../crypto/aead" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging" }
 futures = "0.3.26"
 itertools = "0.10.5"
 rand = "0.8.5"
@@ -48,4 +48,4 @@ ring = { version = "0.17.5", features = ["wasm32_unknown_unknown_js"] }
 tracing-test = "0.2.4"
 
 [build-dependencies]
-fedimint-build = { version = "0.2.1-rc2", path = "../fedimint-build" }
+fedimint-build = { version = "0.2.1-rc3", path = "../fedimint-build" }

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-core"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-core provides common code used by both client and server."
@@ -30,7 +30,7 @@ strum = "0.24"
 strum_macros = "0.24"
 hex = { version = "0.4.3", features = [ "serde"] }
 sha3 = "0.10.5"
-tbs = { package = "fedimint-tbs", version = "0.2.1-rc2", path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.2.1-rc3", path = "../crypto/tbs" }
 tokio = { version = "1.26.0", features = ["sync", "io-util"] }
 thiserror = "1.0.39"
 tracing ="0.1.37"
@@ -42,8 +42,8 @@ bitcoin_hashes = { version = "0.11", features = ["serde"] }
 erased-serde = "0.3"
 lightning = "0.0.118"
 lightning-invoice = "0.26.0"
-fedimint-derive = { version = "0.2.1-rc2", path = "../fedimint-derive" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging" }
+fedimint-derive = { version = "0.2.1-rc3", path = "../fedimint-derive" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging" }
 rand = "0.8.5"
 miniscript = { version = "9.0.2", features = [ "compiler", "serde" ] }
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dbtool"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 edition = "2021"
 license = "MIT"
 description = "Tool to inspect Fedimint client and server databases"
@@ -17,25 +17,25 @@ name = "fedimint-dbtool"
 
 [dependencies]
 anyhow = "1.0.68"
-fedimint-aead = { version = "0.2.1-rc2", path = "../crypto/aead" }
+fedimint-aead = { version = "0.2.1-rc3", path = "../crypto/aead" }
 bitcoin_hashes = "0.11.0"
 bytes = "1.4.0"
 clap = { version = "4.1.6", features = ["derive", "env"] }
-fedimint-core = { version = "0.2.1-rc2", path = "../fedimint-core" }
-fedimint-client = { version = "0.2.1-rc2", path = "../fedimint-client" }
-fedimint-server = { version = "0.2.1-rc2", path = "../fedimint-server" }
-fedimint-rocksdb = { version = "0.2.1-rc2", path = "../fedimint-rocksdb" }
-fedimint-mint-server = { version = "0.2.1-rc2", path = "../modules/fedimint-mint-server" }
-fedimint-mint-client = { version = "0.2.1-rc2", path = "../modules/fedimint-mint-client" }
-fedimint-ln-server = { version = "0.2.1-rc2", path = "../modules/fedimint-ln-server" }
-fedimint-ln-client = { version = "0.2.1-rc2", path = "../modules/fedimint-ln-client" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging" }
-fedimint-wallet-server = { version = "0.2.1-rc2", path = "../modules/fedimint-wallet-server" }
-fedimint-wallet-client = { version = "0.2.1-rc2", path = "../modules/fedimint-wallet-client" }
+fedimint-core = { version = "0.2.1-rc3", path = "../fedimint-core" }
+fedimint-client = { version = "0.2.1-rc3", path = "../fedimint-client" }
+fedimint-server = { version = "0.2.1-rc3", path = "../fedimint-server" }
+fedimint-rocksdb = { version = "0.2.1-rc3", path = "../fedimint-rocksdb" }
+fedimint-mint-server = { version = "0.2.1-rc3", path = "../modules/fedimint-mint-server" }
+fedimint-mint-client = { version = "0.2.1-rc3", path = "../modules/fedimint-mint-client" }
+fedimint-ln-server = { version = "0.2.1-rc3", path = "../modules/fedimint-ln-server" }
+fedimint-ln-client = { version = "0.2.1-rc3", path = "../modules/fedimint-ln-client" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging" }
+fedimint-wallet-server = { version = "0.2.1-rc3", path = "../modules/fedimint-wallet-server" }
+fedimint-wallet-client = { version = "0.2.1-rc3", path = "../modules/fedimint-wallet-client" }
 futures = "0.3.24"
 erased-serde = "0.3"
 hex = { version = "0.4.3", features = ["serde"] }
-ln-gateway = { package = "fedimint-ln-gateway", version = "0.2.1-rc2", path = "../gateway/ln-gateway" }
+ln-gateway = { package = "fedimint-ln-gateway", version = "0.2.1-rc3", path = "../gateway/ln-gateway" }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.91"
 strum = "0.24"

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-derive"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-derive provides helper macros for serialization."

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-load-test-tool"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-load-test-tool is a tool to load test the fedimint server and gateway."
@@ -16,14 +16,14 @@ anyhow = "1"
 base64 = "0.20.0"
 bitcoin = "0.29.2"
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
-devimint = { version = "0.2.1-rc2", path = "../devimint" }
-fedimint-client = { version = "0.2.1-rc2", path = "../fedimint-client" }
-fedimint-core = { version = "0.2.1-rc2", path = "../fedimint-core" }
-fedimint-ln-client = { version = "0.2.1-rc2", path = "../modules/fedimint-ln-client" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging" }
-fedimint-mint-client = { version = "0.2.1-rc2", path = "../modules/fedimint-mint-client" }
-fedimint-rocksdb = { version = "0.2.1-rc2", path = "../fedimint-rocksdb" }
-fedimint-wallet-client = { version = "0.2.1-rc2", path = "../modules/fedimint-wallet-client" }
+devimint = { version = "0.2.1-rc3", path = "../devimint" }
+fedimint-client = { version = "0.2.1-rc3", path = "../fedimint-client" }
+fedimint-core = { version = "0.2.1-rc3", path = "../fedimint-core" }
+fedimint-ln-client = { version = "0.2.1-rc3", path = "../modules/fedimint-ln-client" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging" }
+fedimint-mint-client = { version = "0.2.1-rc3", path = "../modules/fedimint-mint-client" }
+fedimint-rocksdb = { version = "0.2.1-rc3", path = "../fedimint-rocksdb" }
+fedimint-wallet-client = { version = "0.2.1-rc3", path = "../modules/fedimint-wallet-client" }
 futures = "0.3"
 jsonrpsee-core = { version = "0.20.0", features = [ "client" ] }
 jsonrpsee-types = { version = "0.20.0" }
@@ -39,4 +39,4 @@ url = { version = "2.3.1", features = ["serde"] }
 jsonrpsee-ws-client = { version = "0.20.0", features = ["webpki-tls"], default-features = false }
 
 [build-dependencies]
-fedimint-build = { version = "0.2.1-rc2", path = "../fedimint-build" }
+fedimint-build = { version = "0.2.1-rc3", path = "../fedimint-build" }

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-logging"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "contains some utilities for logging and tracing"

--- a/fedimint-metrics/Cargo.toml
+++ b/fedimint-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-metrics"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 edition = "2021"
 license = "MIT"
 description = "fedimint-metrics allows exporting prometheus metrics from Fedimint."
@@ -16,7 +16,7 @@ path = "./src/lib.rs"
 [dependencies]
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 axum = "0.6.18"
-fedimint-core = { version = "0.2.1-rc2", path = "../fedimint-core" }
+fedimint-core = { version = "0.2.1-rc3", path = "../fedimint-core" }
 lazy_static = "1.4.0"
 prometheus = "0.13.3"
 tokio = "1"

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-rocksdb"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-rocksdb provides a rocksdb-backed database implementation for Fedimint."
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.73"
-fedimint-core = { version = "0.2.1-rc2", path = "../fedimint-core" }
+fedimint-core = { version = "0.2.1-rc3", path = "../fedimint-core" }
 futures = "0.3.24"
 rocksdb = { version = "0.21.0" }
 tracing = "0.1.37"

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint is the main consensus code for processing transactions and REST API"
@@ -17,7 +17,7 @@ name = "fedimint_server"
 path = "src/lib.rs"
 
 [dependencies]
-fedimint-aead = { version = "0.2.1-rc2", path = "../crypto/aead" }
+fedimint-aead = { version = "0.2.1-rc3", path = "../crypto/aead" }
 anyhow = "1.0.66"
 async-channel = "1.8.0"
 async-trait = "0.1.73"
@@ -28,8 +28,8 @@ bytes = "1.4.0"
 hbbft = { workspace = true }
 futures = "0.3.24"
 itertools = "0.10.5"
-fedimint-core = { version = "0.2.1-rc2", path = "../fedimint-core" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging" }
+fedimint-core = { version = "0.2.1-rc3", path = "../fedimint-core" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging" }
 rand = "0.8"
 rcgen = "=0.10.0"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
@@ -38,7 +38,7 @@ serde_json = "1.0.91"
 sha3 = "0.10.5"
 strum = "0.24"
 strum_macros = "0.24"
-tbs = { package = "fedimint-tbs", version = "0.2.1-rc2", path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.2.1-rc3", path = "../crypto/tbs" }
 thiserror = "1.0.39"
 tracing ="0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
@@ -64,4 +64,4 @@ fedimint-testing = { path = "../fedimint-testing" }
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 
 [build-dependencies]
-fedimint-build = { version = "0.2.1-rc2", path = "../fedimint-build" }
+fedimint-build = { version = "0.2.1-rc3", path = "../fedimint-build" }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-testing"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-testing provides a library of shared objects and utilities for testing fedimint components"
@@ -24,15 +24,15 @@ bitcoin = "0.29.2"
 bitcoincore-rpc = "0.16.0"
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions" ], default-features = false }
 cln-rpc = { workspace = true }
-fedimint-core  = { version = "0.2.1-rc2", path = "../fedimint-core" }
-fedimint-client  = { version = "0.2.1-rc2", path = "../fedimint-client" }
-fedimint-server  = { version = "0.2.1-rc2", path = "../fedimint-server" }
-fedimint-bitcoind = { version = "0.2.1-rc2", path = "../fedimint-bitcoind" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging" }
-fedimint-rocksdb = { version = "0.2.1-rc2", path = "../fedimint-rocksdb" }
+fedimint-core  = { version = "0.2.1-rc3", path = "../fedimint-core" }
+fedimint-client  = { version = "0.2.1-rc3", path = "../fedimint-client" }
+fedimint-server  = { version = "0.2.1-rc3", path = "../fedimint-server" }
+fedimint-bitcoind = { version = "0.2.1-rc3", path = "../fedimint-bitcoind" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging" }
+fedimint-rocksdb = { version = "0.2.1-rc3", path = "../fedimint-rocksdb" }
 fs-lock = "0.1.0"
 lazy_static = "1.4.0"
-ln-gateway = { version = "0.2.1-rc2", package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
+ln-gateway = { version = "0.2.1-rc3", package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 ldk-node = { package = "fedimint-ldk-node", version = "0.1.0" }
 futures = "0.3"
 lightning-invoice = "0.26.0"
@@ -47,4 +47,4 @@ tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tokio-stream = "0.1.11"
 tonic_lnd = { workspace = true }
 url = "2.3.1"
-fedimint-portalloc = { version = "0.2.1-rc2", path = "../utils/portalloc" }
+fedimint-portalloc = { version = "0.2.1-rc3", path = "../utils/portalloc" }

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimintd"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint is the main consensus code for processing transactions and REST API"
@@ -23,7 +23,7 @@ name = "fedimintd"
 path = "src/lib.rs"
 
 [dependencies]
-fedimint-aead = { version = "0.2.1-rc2", path = "../crypto/aead" }
+fedimint-aead = { version = "0.2.1-rc3", path = "../crypto/aead" }
 ring = "0.17.5"
 anyhow = "1.0.66"
 async-trait = "0.1.73"
@@ -35,23 +35,23 @@ clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error
 futures = "0.3.24"
 itertools = "0.10.5"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
-fedimint-bitcoind = { version = "0.2.1-rc2", path = "../fedimint-bitcoind" }
-fedimint-core = { version = "0.2.1-rc2", path = "../fedimint-core" }
-fedimint-ln-common = { version = "0.2.1-rc2", path = "../modules/fedimint-ln-common" }
-fedimint-ln-server = { version = "0.2.1-rc2", path = "../modules/fedimint-ln-server" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging", features = ["telemetry"] }
-fedimint-metrics = { version = "0.2.1-rc2", path = "../fedimint-metrics" }
-fedimint-mint-server = { version = "0.2.1-rc2", path = "../modules/fedimint-mint-server" }
-fedimint-rocksdb = { version = "0.2.1-rc2", path = "../fedimint-rocksdb" }
-fedimint-server = { version = "0.2.1-rc2", path = "../fedimint-server" }
-fedimint-wallet-server = { version = "0.2.1-rc2", path = "../modules/fedimint-wallet-server" }
+fedimint-bitcoind = { version = "0.2.1-rc3", path = "../fedimint-bitcoind" }
+fedimint-core = { version = "0.2.1-rc3", path = "../fedimint-core" }
+fedimint-ln-common = { version = "0.2.1-rc3", path = "../modules/fedimint-ln-common" }
+fedimint-ln-server = { version = "0.2.1-rc3", path = "../modules/fedimint-ln-server" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging", features = ["telemetry"] }
+fedimint-metrics = { version = "0.2.1-rc3", path = "../fedimint-metrics" }
+fedimint-mint-server = { version = "0.2.1-rc3", path = "../modules/fedimint-mint-server" }
+fedimint-rocksdb = { version = "0.2.1-rc3", path = "../fedimint-rocksdb" }
+fedimint-server = { version = "0.2.1-rc3", path = "../fedimint-server" }
+fedimint-wallet-server = { version = "0.2.1-rc3", path = "../modules/fedimint-wallet-server" }
 rand = "0.8"
 rcgen = "=0.10.0"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"
 sha3 = "0.10.5"
-tbs = { package = "fedimint-tbs", version = "0.2.1-rc2", path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.2.1-rc3", path = "../crypto/tbs" }
 thiserror = "1.0.39"
 tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tokio-rustls = "0.23.4"
@@ -69,4 +69,4 @@ tower = { version = "0.4", features = ["util"] }
 console-subscriber = "0.1.8"
 
 [build-dependencies]
-fedimint-build = { version = "0.2.1-rc2", path = "../fedimint-build" }
+fedimint-build = { version = "0.2.1-rc3", path = "../fedimint-build" }

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-gateway-cli"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 edition = "2021"
 license = "MIT"
 description = "CLI tool to control lightning gateway"
@@ -22,9 +22,9 @@ axum = "0.6.4"
 axum-macros = "0.3.1"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
-ln-gateway = { version = "0.2.1-rc2", package = "fedimint-ln-gateway", path= "../ln-gateway" }
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../../fedimint-logging" }
+ln-gateway = { version = "0.2.1-rc3", package = "fedimint-ln-gateway", path= "../ln-gateway" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../../fedimint-logging" }
 reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
@@ -34,4 +34,4 @@ url = { version = "2.3.1", features = ["serde"] }
 clap_complete = "4.3.1"
 
 [build-dependencies]
-fedimint-build = { version = "0.2.1-rc2", path = "../../fedimint-build" }
+fedimint-build = { version = "0.2.1-rc3", path = "../../fedimint-build" }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-gateway"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "ln-gateway is a core lightning plugin which allows a Lightning node operator to receive or pay Lightning invoices on behalf of fedimint users."
@@ -37,15 +37,15 @@ bitcoin_hashes = "0.11.0"
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
 cln-plugin = "0.1.5"
 cln-rpc = { workspace = true }
-fedimint-client = { version = "0.2.1-rc2", path = "../../fedimint-client" }
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../../fedimint-logging" }
-fedimint-rocksdb = { version = "0.2.1-rc2", path = "../../fedimint-rocksdb" }
-fedimint-ln-client = { version = "0.2.1-rc2", path = "../../modules/fedimint-ln-client" }
-fedimint-ln-common = { version = "0.2.1-rc2", path = "../../modules/fedimint-ln-common" }
-fedimint-mint-client = { version = "0.2.1-rc2", path = "../../modules/fedimint-mint-client" }
-fedimint-dummy-client = { version = "0.2.1-rc2", path = "../../modules/fedimint-dummy-client" }
-fedimint-wallet-client = { version = "0.2.1-rc2", path = "../../modules/fedimint-wallet-client" }
+fedimint-client = { version = "0.2.1-rc3", path = "../../fedimint-client" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../../fedimint-logging" }
+fedimint-rocksdb = { version = "0.2.1-rc3", path = "../../fedimint-rocksdb" }
+fedimint-ln-client = { version = "0.2.1-rc3", path = "../../modules/fedimint-ln-client" }
+fedimint-ln-common = { version = "0.2.1-rc3", path = "../../modules/fedimint-ln-common" }
+fedimint-mint-client = { version = "0.2.1-rc3", path = "../../modules/fedimint-mint-client" }
+fedimint-dummy-client = { version = "0.2.1-rc3", path = "../../modules/fedimint-dummy-client" }
+fedimint-wallet-client = { version = "0.2.1-rc3", path = "../../modules/fedimint-wallet-client" }
 futures = "0.3.24"
 erased-serde = "0.3"
 lightning-invoice = "0.26.0"
@@ -81,5 +81,5 @@ threshold_crypto = { workspace = true }
 assert_matches = "1.5.0"
 
 [build-dependencies]
-fedimint-build = { version = "0.2.1-rc2", path = "../../fedimint-build" }
+fedimint-build = { version = "0.2.1-rc3", path = "../../fedimint-build" }
 tonic-build = "0.10.2"

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
@@ -17,9 +17,9 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = "0.1.73"
 anyhow = "1.0.66"
-fedimint-dummy-common = { version = "0.2.1-rc2", path = "../fedimint-dummy-common" }
-fedimint-client = { version = "0.2.1-rc2", path = "../../fedimint-client" }
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
+fedimint-dummy-common = { version = "0.2.1-rc3", path = "../fedimint-dummy-common" }
+fedimint-client = { version = "0.2.1-rc3", path = "../../fedimint-client" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
 futures = "0.3"
 erased-serde = "0.3"
 rand = "0.8.5"

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-common"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
@@ -20,7 +20,7 @@ async-trait = "0.1.73"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3"
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 secp256k1 = "0.24.2"

--- a/modules/fedimint-dummy-server/Cargo.toml
+++ b/modules/fedimint-dummy-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
@@ -20,8 +20,8 @@ async-trait = "0.1.73"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3"
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-fedimint-dummy-common = { version = "0.2.1-rc2", path = "../fedimint-dummy-common" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+fedimint-dummy-common = { version = "0.2.1-rc3", path = "../fedimint-dummy-common" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 secp256k1 = "0.24.2"

--- a/modules/fedimint-dummy-tests/Cargo.toml
+++ b/modules/fedimint-dummy-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-tests"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
@@ -32,9 +32,9 @@ erased-serde = "0.3"
 futures = "0.3.24"
 itertools = "0.10.5"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-client = { version = "0.2.1-rc2", path = "../../fedimint-client" }
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-fedimint-ln-common = { version = "0.2.1-rc2", path = "../fedimint-ln-common" }
+fedimint-client = { version = "0.2.1-rc3", path = "../../fedimint-client" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+fedimint-ln-common = { version = "0.2.1-rc3", path = "../fedimint-ln-common" }
 secp256k1 = { version="0.24.2", default-features=false }
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
 serde = {version = "1.0.149", features = [ "derive" ] }

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-common"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
@@ -31,8 +31,8 @@ futures = "0.3.24"
 itertools = "0.10.5"
 lightning = { version = "0.0.118", default-features = false, features = ["no-std"] }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-client = { version = "0.2.1-rc2", path = "../../fedimint-client" }
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
+fedimint-client = { version = "0.2.1-rc3", path = "../../fedimint-client" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
 secp256k1 = { version="0.24.2", default-features=false }
 serde = {version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
@@ -26,10 +26,10 @@ futures = "0.3.24"
 itertools = "0.10.5"
 lightning = "0.0.118"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-bitcoind = { version = "0.2.1-rc2", path = "../../fedimint-bitcoind" }
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-fedimint-ln-common = { version = "0.2.1-rc2", path = "../fedimint-ln-common" }
-fedimint-metrics = { version = "0.2.1-rc2", path = "../../fedimint-metrics" }
+fedimint-bitcoind = { version = "0.2.1-rc3", path = "../../fedimint-bitcoind" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+fedimint-ln-common = { version = "0.2.1-rc3", path = "../fedimint-ln-common" }
+fedimint-metrics = { version = "0.2.1-rc3", path = "../../fedimint-metrics" }
 secp256k1 = { version="0.24.2", default-features=false }
 serde = {version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"
@@ -42,7 +42,7 @@ tracing = "0.1.37"
 rand = "0.8"
 url = { version = "2.3.1", features = ["serde"] }
 hbbft = { workspace = true }
-fedimint-server = { version = "0.2.1-rc2", path = "../../fedimint-server" }
+fedimint-server = { version = "0.2.1-rc3", path = "../../fedimint-server" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-tests"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln-tests contains integration tests for the lightning module"

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
@@ -26,11 +26,11 @@ bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3"
 itertools = "0.10.5"
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-fedimint-client = { version = "0.2.1-rc2", path = "../../fedimint-client" }
-fedimint-derive-secret = { version = "0.2.1-rc2", path = "../../crypto/derive-secret"}
-fedimint-mint-common ={ version = "0.2.1-rc2", path = "../fedimint-mint-common" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../../fedimint-logging" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+fedimint-client = { version = "0.2.1-rc3", path = "../../fedimint-client" }
+fedimint-derive-secret = { version = "0.2.1-rc3", path = "../../crypto/derive-secret"}
+fedimint-mint-common ={ version = "0.2.1-rc3", path = "../fedimint-mint-common" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../../fedimint-logging" }
 rand = "0.8"
 secp256k1 = "0.24.2"
 secp256k1-zkp = "0.7.0"
@@ -39,7 +39,7 @@ serde-big-array = "0.5.1"
 serde_json = "1.0.96"
 strum = "0.24"
 strum_macros = "0.24"
-tbs = { package = "fedimint-tbs", version = "0.2.1-rc2", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.2.1-rc3", path = "../../crypto/tbs" }
 thiserror = "1.0.39"
 threshold_crypto = { workspace = true }
 tokio = { version = "1.27.0", features = [ "sync" ] }

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-common"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
@@ -22,14 +22,14 @@ bincode = "1.3.1"
 bitcoin_hashes = "0.11.0"
 futures = "0.3"
 itertools = "0.10.5"
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
 rand = "0.8"
 secp256k1 = "0.24.2"
 secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.149", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
-tbs = { package = "fedimint-tbs", version = "0.2.1-rc2", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.2.1-rc3", path = "../../crypto/tbs" }
 thiserror = "1.0.39"
 threshold_crypto = { workspace = true }
 tracing ="0.1.37"

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
@@ -24,20 +24,20 @@ bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3"
 itertools = "0.10.5"
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-fedimint-mint-common = { version = "0.2.1-rc2", path = "../fedimint-mint-common" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+fedimint-mint-common = { version = "0.2.1-rc3", path = "../fedimint-mint-common" }
 rand = "0.8"
 secp256k1 = "0.24.2"
 secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.149", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
-tbs = { package = "fedimint-tbs", version = "0.2.1-rc2", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.2.1-rc3", path = "../../crypto/tbs" }
 thiserror = "1.0.39"
 threshold_crypto = { workspace = true }
 tracing ="0.1.37"
 impl-tools = "0.8.0"
-fedimint-server = { version = "0.2.1-rc2", path = "../../fedimint-server" }
+fedimint-server = { version = "0.2.1-rc3", path = "../../fedimint-server" }
 
 [dev-dependencies]
 fedimint-testing = { path = "../../fedimint-testing" }

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-tests"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint-tests contains integration tests for the mint module"

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-client"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
@@ -21,10 +21,10 @@ async-stream = "0.3.5"
 async-trait = "0.1.73"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
-fedimint-bitcoind = { version = "0.2.1-rc2", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client", "bitcoincore-rpc"] }
-fedimint-client = { version = "0.2.1-rc2", path = "../../fedimint-client" }
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-fedimint-wallet-common = { version = "0.2.1-rc2", path = "../fedimint-wallet-common" }
+fedimint-bitcoind = { version = "0.2.1-rc3", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client", "bitcoincore-rpc"] }
+fedimint-client = { version = "0.2.1-rc3", path = "../../fedimint-client" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+fedimint-wallet-common = { version = "0.2.1-rc3", path = "../fedimint-wallet-common" }
 futures = "0.3"
 miniscript = { version = "9.0.2", features = [ "compiler", "serde" ] }
 impl-tools = "0.8.0"

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-common"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
@@ -19,7 +19,7 @@ anyhow = "1.0.66"
 async-trait = "0.1.73"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
 futures = "0.3"
 miniscript = { version = "9.0.2", features = [ "compiler", "serde" ] }
 impl-tools = "0.8.0"

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-server"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
@@ -19,9 +19,9 @@ anyhow = "1.0.66"
 async-trait = "0.1"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
-fedimint-wallet-common = { version = "0.2.1-rc2", path = "../fedimint-wallet-common" }
-fedimint-bitcoind = { version = "0.2.1-rc2", path = "../../fedimint-bitcoind" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }
+fedimint-wallet-common = { version = "0.2.1-rc3", path = "../fedimint-wallet-common" }
+fedimint-bitcoind = { version = "0.2.1-rc3", path = "../../fedimint-bitcoind" }
 futures = "0.3"
 miniscript = { version = "9.0.2", features = [ "compiler", "serde" ] }
 impl-tools = "0.8.0"
@@ -35,7 +35,7 @@ tokio = { version = "1.26.0", features = ["sync"], optional = true }
 tracing ="0.1.37"
 url = "2.3.1"
 validator = { version = "0.16", features = ["derive"] }
-fedimint-server = { version = "0.2.1-rc2", path = "../../fedimint-server" }
+fedimint-server = { version = "0.2.1-rc3", path = "../../fedimint-server" }
 
 [dev-dependencies]
 fedimint-testing = { path = "../../fedimint-testing" }

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-tests"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet-tests contains integration tests for the lightning module"

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -183,7 +183,7 @@ let
     (craneLib'.overrideArgs (commonEnvsBuild // commonArgs // {
       src = filterWorkspaceBuildFiles commonSrc;
       pname = "fedimint";
-      version = "0.2.1-rc2";
+      version = "0.2.1-rc3";
     })).overrideArgs'' (craneLib: args:
       pkgs.lib.optionalAttrs (!(builtins.elem (craneLib.toolchainName or null) [ null "default" "stable" "nightly" ])) commonEnvsShellRocksdbLinkCross
     );

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-recoverytool"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 edition = "2021"
 authors = ["The Fedimint Developers"]
 description = "recoverytool allows retrieving on-chain funds from a offline federation"
@@ -18,15 +18,15 @@ path = "src/main.rs"
 anyhow = "1.0.69"
 bitcoin = "0.29.2"
 clap = { version = "4.4.7", features = [ "derive", "env" ] }
-fedimint-aead = { version = "0.2.1-rc2", path = "../crypto/aead" }
-fedimint-core = { version = "0.2.1-rc2", path = "../fedimint-core" }
-fedimint-rocksdb = { version = "0.2.1-rc2", path = "../fedimint-rocksdb" }
-fedimint-server = { version = "0.2.1-rc2", path = "../fedimint-server" }
-fedimint-wallet-server = { version = "0.2.1-rc2", path = "../modules/fedimint-wallet-server" }
-fedimint-logging = { version = "0.2.1-rc2", path = "../fedimint-logging" }
-fedimint-ln-common = { version = "0.2.1-rc2", path = "../modules/fedimint-ln-common" }
-fedimint-ln-server = { version = "0.2.1-rc2", path = "../modules/fedimint-ln-server" }
-fedimint-mint-server = { version = "0.2.1-rc2", path = "../modules/fedimint-mint-server" }
+fedimint-aead = { version = "0.2.1-rc3", path = "../crypto/aead" }
+fedimint-core = { version = "0.2.1-rc3", path = "../fedimint-core" }
+fedimint-rocksdb = { version = "0.2.1-rc3", path = "../fedimint-rocksdb" }
+fedimint-server = { version = "0.2.1-rc3", path = "../fedimint-server" }
+fedimint-wallet-server = { version = "0.2.1-rc3", path = "../modules/fedimint-wallet-server" }
+fedimint-logging = { version = "0.2.1-rc3", path = "../fedimint-logging" }
+fedimint-ln-common = { version = "0.2.1-rc3", path = "../modules/fedimint-ln-common" }
+fedimint-ln-server = { version = "0.2.1-rc3", path = "../modules/fedimint-ln-server" }
+fedimint-mint-server = { version = "0.2.1-rc3", path = "../modules/fedimint-mint-server" }
 futures = "0.3.26"
 miniscript = { version = "9.0.2" }
 secp256k1 = { version = "0.24.3", features = [ "serde", "global-context" ] }

--- a/utils/portalloc/Cargo.toml
+++ b/utils/portalloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-portalloc"
-version = "0.2.1-rc2"
+version = "0.2.1-rc3"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Port allocation utility for Fedimint"
@@ -22,4 +22,4 @@ serde_json = { version = "1.0.91", features = ["preserve_order"] }
 tracing = "0.1.37"
 rand = "0.8"
 dirs = "5.0.1"
-fedimint-core = { version = "0.2.1-rc2", path = "../../fedimint-core" }
+fedimint-core = { version = "0.2.1-rc3", path = "../../fedimint-core" }


### PR DESCRIPTION
# Description
Backport of #3800 to `releases/v0.2`.