### PR TITLE
Reproduce deadlock

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -804,6 +804,7 @@ impl JsonRpcClient for WsClient {
         return WsClientBuilder::default()
             .use_webpki_rustls()
             .max_concurrent_requests(u16::MAX as usize)
+            .request_timeout(Duration::from_secs(3600))
             .build(url.as_str())
             .await;
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -269,6 +269,7 @@ impl<'a> IDatabaseTransactionOps for RocksDbTransaction<'a> {
 #[async_trait]
 impl<'a> IRawDatabaseTransaction for RocksDbTransaction<'a> {
     async fn commit_tx(self) -> Result<()> {
+        tokio::task::yield_now().await;
         fedimint_core::task::block_in_place(|| {
             self.0.commit()?;
             Ok(())

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -53,7 +53,7 @@ pub mod config;
 pub mod multiplexed;
 
 /// How long to wait before timing out client connections
-const API_ENDPOINT_TIMEOUT: Duration = Duration::from_secs(60);
+const API_ENDPOINT_TIMEOUT: Duration = Duration::from_secs(3600);
 
 /// Has the context necessary for serving API endpoints
 ///


### PR DESCRIPTION
This is an attempt to reproduce the deadlock issue arised on https://github.com/fedimint/fedimint/pull/3989

We can see it's possible to reproduce the issue with 2 small changes from master:
- Changing the test DB from `MemDatabase` to `RocksDb`
- Adding a `task::yield_now()` to `commit_tx()`

I also increased the timeout of the connection requests just to avoid noise in the logs due to the low 60s default timeout.

One way to see a test deadlocking for debug purposes is to run:
```bash
RUST_LOG=trace,hyper=info,soketto=info,fedimint_server::net::framed=debug cargo test --package fedimint-mint-tests --test fedimint_mint_tests -- sends_ecash_out_of_band --exact --nocapture
```

The goal of this PR is just to show that there is some issue on Fedimint db layer that isn't exclusive to `MemDatabase` and that can be reproduced without adding new tests. Created an issue to track it: https://github.com/fedimint/fedimint/pull/3995