### PR TITLE
feat: Return preimage when creating ln invoice

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -303,7 +303,7 @@ pub async fn handle_command(
             let lightning_module = client.get_first_module::<LightningClientModule>();
             lightning_module.select_active_gateway().await?;
 
-            let (operation_id, invoice) = lightning_module
+            let (operation_id, invoice, _) = lightning_module
                 .create_bolt11_invoice(amount, description, expiry_time, ())
                 .await?;
             Ok(serde_json::to_value(LnInvoiceResponse {

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -1011,7 +1011,7 @@ async fn client_create_invoice(
 ) -> anyhow::Result<(fedimint_core::core::OperationId, Bolt11Invoice)> {
     let create_invoice_time = fedimint_core::time::now();
     let lightning_module = client.get_first_module::<LightningClientModule>();
-    let (operation_id, invoice) = lightning_module
+    let (operation_id, invoice, _) = lightning_module
         .create_bolt11_invoice(invoice_amount, "".into(), None, ())
         .await?;
     let elapsed = create_invoice_time.elapsed()?;

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -127,7 +127,7 @@ mod tests {
         client.start_executor().await;
         set_gateway(&client).await?;
         let lightning_module = client.get_first_module::<LightningClientModule>();
-        let (opid, invoice) = lightning_module
+        let (opid, invoice, _) = lightning_module
             .create_bolt11_invoice(Amount::from_sats(21), "test".to_string(), None, ())
             .await?;
         faucet::pay_invoice(&invoice.to_string()).await?;
@@ -166,7 +166,7 @@ mod tests {
         client.start_executor().await;
         set_gateway(&client).await?;
         let lightning_module = client.get_first_module::<LightningClientModule>();
-        let (opid, invoice) = lightning_module
+        let (opid, invoice, _) = lightning_module
             .create_bolt11_invoice(Amount::from_sats(21), "test".to_string(), None, ())
             .await?;
         faucet::pay_invoice(&invoice.to_string()).await?;

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -405,7 +405,7 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
 
         // User client creates invoice in federation
         let invoice_amount = sats(100);
-        let (_invoice_op, invoice) = user_client
+        let (_invoice_op, invoice, _) = user_client
             .get_first_module::<LightningClientModule>()
             .create_bolt11_invoice(
                 invoice_amount,
@@ -492,7 +492,7 @@ async fn test_gateway_client_intercept_htlc_no_funds() -> anyhow::Result<()> {
     single_federation_test(|gateway, _, fed, user_client, _| async move {
         let gateway = gateway.remove_client(&fed).await;
         // User client creates invoice in federation
-        let (_invoice_op, invoice) = user_client
+        let (_invoice_op, invoice, _) = user_client
             .get_first_module::<LightningClientModule>()
             .create_bolt11_invoice(
                 sats(100),
@@ -806,7 +806,7 @@ async fn test_gateway_filters_route_hints_by_inbound() -> anyhow::Result<()> {
             gateway.connect_fed(&fed).await;
 
             let invoice_amount = sats(100);
-            let (_invoice_op, invoice) = user_client
+            let (_invoice_op, invoice, _) = user_client
                 .get_first_module::<LightningClientModule>()
                 .create_bolt11_invoice(
                     invoice_amount,
@@ -1141,7 +1141,7 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
 
             // User creates invoice in federation 2
             let invoice_amt = msats(2_500);
-            let (receive_op, invoice) = client2
+            let (receive_op, invoice, _) = client2
                 .get_first_module::<LightningClientModule>()
                 .create_bolt11_invoice(
                     invoice_amt,

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -112,7 +112,7 @@ async fn test_can_attach_extra_meta_to_receive_operation() -> anyhow::Result<()>
     client2.await_primary_module_output(op, outpoint).await?;
 
     let extra_meta = "internal payment with no gateway registered".to_string();
-    let (op, invoice) = client1
+    let (op, invoice, _) = client1
         .get_first_module::<LightningClientModule>()
         .create_bolt11_invoice(
             sats(250),
@@ -172,7 +172,7 @@ async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
     client2.await_primary_module_output(op, outpoint).await?;
 
     // TEST internal payment when there are no gateways registered
-    let (op, invoice) = client1
+    let (op, invoice, _) = client1
         .get_first_module::<LightningClientModule>()
         .create_bolt11_invoice(sats(250), "with-markers".to_string(), None, ())
         .await?;
@@ -380,7 +380,7 @@ async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
     client2.await_primary_module_output(op, outpoint).await?;
 
     // TEST internal payment when there are no gateways registered
-    let (op, invoice) = client1
+    let (op, invoice, _) = client1
         .get_first_module::<LightningClientModule>()
         .create_bolt11_invoice(sats(250), "with-markers".to_string(), None, ())
         .await?;
@@ -416,7 +416,7 @@ async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
     // TEST internal payment when there is a registered gateway
     gateway(&fixtures, &fed).await;
 
-    let (op, invoice) = client1
+    let (op, invoice, _) = client1
         .get_first_module::<LightningClientModule>()
         .create_bolt11_invoice(sats(250), "with-gateway-hint".to_string(), None, ())
         .await?;


### PR DESCRIPTION
Currently it doesn't seem it is possible (at least non-obvious) for how to get the preimage for your own invoices. This is useful for verifying if people paid your invoices and for things like zaps.

Would be nice if this was backported to 0.2.1 as this isn't a breaking change