### PR TITLE
feat: versioned gateway api

### DIFF
--- a/devimint/src/bin/faucet.rs
+++ b/devimint/src/bin/faucet.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 use cln_rpc::primitives::{Amount as ClnAmount, AmountOrAny};
 use cln_rpc::ClnRpc;
 use fedimint_logging::TracingSetup;
+use ln_gateway::rpc::V1_API_ENDPOINT;
 use tokio::sync::Mutex;
 use tower_http::cors::CorsLayer;
 
@@ -147,7 +148,9 @@ async fn main() -> anyhow::Result<()> {
         )
         .route(
             "/gateway-api",
-            get(move || async move { format!("http://127.0.0.1:{}/v1", cmd.gw_lnd_port) }),
+            get(move || async move {
+                format!("http://127.0.0.1:{}/{V1_API_ENDPOINT}", cmd.gw_lnd_port)
+            }),
         )
         .layer(CorsLayer::permissive())
         .with_state(faucet);

--- a/devimint/src/bin/faucet.rs
+++ b/devimint/src/bin/faucet.rs
@@ -147,7 +147,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .route(
             "/gateway-api",
-            get(move || async move { format!("http://127.0.0.1:{}/", cmd.gw_lnd_port) }),
+            get(move || async move { format!("http://127.0.0.1:{}/v1", cmd.gw_lnd_port) }),
         )
         .layer(CorsLayer::permissive())
         .with_state(faucet);

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -45,7 +45,7 @@ impl Gatewayd {
             LightningNode::Cln(_) => process_mgr.globals.FM_PORT_GW_CLN,
             LightningNode::Lnd(_) => process_mgr.globals.FM_PORT_GW_LND,
         };
-        let addr = format!("http://127.0.0.1:{port}");
+        let addr = format!("http://127.0.0.1:{port}/v1");
         let gateway_env: HashMap<String, String> = HashMap::from_iter([
             (
                 "FM_GATEWAY_DATA_DIR".to_owned(),

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -4,6 +4,7 @@ use std::ops::ControlFlow;
 use anyhow::{Context, Result};
 use federation::Federation;
 use fedimint_logging::LOG_DEVIMINT;
+use ln_gateway::rpc::V1_API_ENDPOINT;
 use tracing::info;
 
 pub mod util;
@@ -45,7 +46,7 @@ impl Gatewayd {
             LightningNode::Cln(_) => process_mgr.globals.FM_PORT_GW_CLN,
             LightningNode::Lnd(_) => process_mgr.globals.FM_PORT_GW_LND,
         };
-        let addr = format!("http://127.0.0.1:{port}/v1");
+        let addr = format!("http://127.0.0.1:{port}/{V1_API_ENDPOINT}");
         let gateway_env: HashMap<String, String> = HashMap::from_iter([
             (
                 "FM_GATEWAY_DATA_DIR".to_owned(),

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -19,7 +19,7 @@ use lightning_invoice::RoutingFees;
 use ln_gateway::client::GatewayClientBuilder;
 use ln_gateway::lnrpc_client::{ILnRpcClient, LightningBuilder};
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
-use ln_gateway::rpc::{ConnectFedPayload, FederationConnectionInfo};
+use ln_gateway::rpc::{ConnectFedPayload, FederationConnectionInfo, V1_API_ENDPOINT};
 use ln_gateway::{Gateway, GatewayState};
 use secp256k1::PublicKey;
 use tempfile::TempDir;
@@ -91,7 +91,7 @@ impl GatewayTest {
     ) -> Self {
         let listen: SocketAddr = format!("127.0.0.1:{base_port}").parse().unwrap();
         let address: SafeUrl = format!("http://{listen}").parse().unwrap();
-        let versioned_api = address.join("v1").unwrap();
+        let versioned_api = address.join(V1_API_ENDPOINT).unwrap();
 
         let (path, _config_dir) = test_dir(&format!("gateway-{}", rand::random::<u64>()));
 
@@ -165,6 +165,12 @@ impl GatewayTest {
         }
     }
 
+    /// Waits for the webserver to be ready.
+    ///
+    /// This function is used to ensure that the webserver is fully initialized
+    /// and ready to accept incoming requests. It is designed to be used in
+    /// a concurrent environment where the webserver might be initialized in a
+    /// separate thread or task.
     pub async fn wait_for_webserver(
         versioned_api: SafeUrl,
         password: Option<String>,

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -7,7 +7,7 @@ use fedimint_logging::TracingSetup;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{
     BackupPayload, BalancePayload, ConfigPayload, ConnectFedPayload, DepositAddressPayload,
-    LeaveFedPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload,
+    LeaveFedPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload, V1_API_ENDPOINT,
 };
 use serde::Serialize;
 
@@ -99,7 +99,7 @@ async fn main() -> anyhow::Result<()> {
     TracingSetup::default().init()?;
 
     let cli = Cli::parse();
-    let versioned_api = cli.address.join("v1")?;
+    let versioned_api = cli.address.join(V1_API_ENDPOINT)?;
     let client = || GatewayRpcClient::new(versioned_api, cli.rpcpassword);
 
     match cli.command {

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -99,7 +99,8 @@ async fn main() -> anyhow::Result<()> {
     TracingSetup::default().init()?;
 
     let cli = Cli::parse();
-    let client = || GatewayRpcClient::new(cli.address, cli.rpcpassword);
+    let versioned_api = cli.address.join("v1")?;
+    let client = || GatewayRpcClient::new(versioned_api, cli.rpcpassword);
 
     match cli.command {
         Commands::VersionHash => {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -62,7 +62,7 @@ use lnrpc_client::{ILnRpcClient, LightningBuilder, LightningRpcError, RouteHtlcS
 use rand::rngs::OsRng;
 use rpc::{
     FederationConnectionInfo, FederationInfo, GatewayFedConfig, GatewayInfo, LeaveFedPayload,
-    SetConfigurationPayload,
+    SetConfigurationPayload, V1_API_ENDPOINT,
 };
 use secp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
@@ -152,7 +152,7 @@ pub struct GatewayOpts {
 
 impl GatewayOpts {
     fn to_gateway_parameters(&self) -> anyhow::Result<GatewayParameters> {
-        let versioned_api = self.api_addr.join("v1").map_err(|e| {
+        let versioned_api = self.api_addr.join(V1_API_ENDPOINT).map_err(|e| {
             anyhow::anyhow!(
                 "Failed to version gateway API address: {api_addr:?}, error: {e:?}",
                 api_addr = self.api_addr,
@@ -293,9 +293,9 @@ impl Gateway {
         num_route_hints: u32,
         gateway_db: Database,
     ) -> anyhow::Result<Gateway> {
-        let versioned_api = api_addr.join("v1").map_err(|e| {
-            anyhow::anyhow!("Failed to version gateway API address: {api_addr:?}, error: {e:?}")
-        })?;
+        let versioned_api = api_addr
+            .join(V1_API_ENDPOINT)
+            .expect("Failed to version gateway API address");
         Ok(Gateway {
             lightning_builder,
             gateway_parameters: GatewayParameters {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -151,15 +151,21 @@ pub struct GatewayOpts {
 }
 
 impl GatewayOpts {
-    fn to_gateway_parameters(&self) -> GatewayParameters {
-        GatewayParameters {
+    fn to_gateway_parameters(&self) -> anyhow::Result<GatewayParameters> {
+        let versioned_api = self.api_addr.join("v1").map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to version gateway API address: {api_addr:?}, error: {e:?}",
+                api_addr = self.api_addr,
+            )
+        })?;
+        Ok(GatewayParameters {
             listen: self.listen,
-            api_addr: self.api_addr.clone(),
+            versioned_api,
             password: self.password.clone(),
             network: self.network,
             num_route_hints: self.num_route_hints,
             fees: self.fees.clone(),
-        }
+        })
     }
 }
 
@@ -172,7 +178,7 @@ impl GatewayOpts {
 #[derive(Clone, Debug)]
 struct GatewayParameters {
     listen: SocketAddr,
-    api_addr: SafeUrl,
+    versioned_api: SafeUrl,
     password: Option<String>,
     network: Option<Network>,
     num_route_hints: u32,
@@ -287,11 +293,14 @@ impl Gateway {
         num_route_hints: u32,
         gateway_db: Database,
     ) -> anyhow::Result<Gateway> {
+        let versioned_api = api_addr.join("v1").map_err(|e| {
+            anyhow::anyhow!("Failed to version gateway API address: {api_addr:?}, error: {e:?}")
+        })?;
         Ok(Gateway {
             lightning_builder,
             gateway_parameters: GatewayParameters {
                 listen,
-                api_addr,
+                versioned_api,
                 password: cli_password,
                 num_route_hints,
                 fees: Some(GatewayFee(fees)),
@@ -348,7 +357,7 @@ impl Gateway {
                 lightning_mode: opts.mode.clone(),
             }),
             channel_id_generator: Arc::new(Mutex::new(INITIAL_SCID)),
-            gateway_parameters: opts.to_gateway_parameters(),
+            gateway_parameters: opts.to_gateway_parameters()?,
             state: Arc::new(RwLock::new(GatewayState::Initializing)),
             client_builder,
             gateway_id: Self::get_gateway_id(gateway_db.clone()).await,

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -20,6 +20,8 @@ use tokio::sync::oneshot;
 
 use crate::{Gateway, Result};
 
+pub const V1_API_ENDPOINT: &str = "v1";
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ConnectFedPayload {
     pub invite_code: String,

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -16,11 +16,12 @@ use super::{
 };
 
 pub struct GatewayRpcClient {
-    // Base URL to gateway web server
+    /// Base URL to gateway web server
+    /// This should include an applicable API version, e.g. http://localhost:8080/v1
     base_url: SafeUrl,
-    // A request client
+    /// A request client
     client: reqwest::Client,
-    // Password
+    /// Optional gateway password
     password: Option<String>,
 }
 

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -26,9 +26,9 @@ pub struct GatewayRpcClient {
 }
 
 impl GatewayRpcClient {
-    pub fn new(base_url: SafeUrl, password: Option<String>) -> Self {
+    pub fn new(versioned_api: SafeUrl, password: Option<String>) -> Self {
         Self {
-            base_url,
+            base_url: versioned_api,
             client: reqwest::Client::new(),
             password,
         }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -14,7 +14,7 @@ use tracing::{error, instrument};
 
 use super::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, LeaveFedPayload,
-    RestorePayload, SetConfigurationPayload, WithdrawPayload,
+    RestorePayload, SetConfigurationPayload, WithdrawPayload, V1_API_ENDPOINT,
 };
 use crate::db::GatewayConfiguration;
 use crate::rpc::ConfigPayload;
@@ -26,11 +26,11 @@ pub async fn run_webserver(
     gateway: Gateway,
     task_group: &mut TaskGroup,
 ) -> axum::response::Result<()> {
-    let routes = v1_routes(config, gateway.clone());
+    let v1_routes = v1_routes(config, gateway.clone());
     let api_v1 = Router::new()
-        .nest("/v1", routes.clone())
+        .nest(&format!("/{V1_API_ENDPOINT}"), v1_routes.clone())
         // Backwards compatibility: Continue supporting gateway APIs without versioning
-        .merge(routes);
+        .merge(v1_routes);
 
     let handle = task_group.make_handle();
     let shutdown_rx = handle.make_shutdown_rx().await;

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -26,9 +26,34 @@ pub async fn run_webserver(
     gateway: Gateway,
     task_group: &mut TaskGroup,
 ) -> axum::response::Result<()> {
-    let (routes, admin_routes) = if let Some(gateway_config) = config {
+    let routes = v1_routes(config, gateway.clone());
+    let api_v1 = Router::new()
+        .nest("/v1", routes.clone())
+        // Backwards compatibility: Continue supporting gateway APIs without versioning
+        .merge(routes);
+
+    let handle = task_group.make_handle();
+    let shutdown_rx = handle.make_shutdown_rx().await;
+    let server = axum::Server::bind(&bind_addr).serve(api_v1.into_make_service());
+    task_group
+        .spawn("Gateway Webserver", move |_| async move {
+            let graceful = server.with_graceful_shutdown(async {
+                shutdown_rx.await;
+            });
+
+            if let Err(e) = graceful.await {
+                error!("Error shutting down gatewayd webserver: {:?}", e);
+            }
+        })
+        .await;
+
+    Ok(())
+}
+
+fn v1_routes(config: Option<GatewayConfiguration>, gateway: Gateway) -> Router {
+    let (public_routes, admin_routes) = if let Some(gateway_config) = config {
         // Public routes on gateway webserver
-        let routes = Router::new()
+        let public_routes = Router::new()
             .route("/pay_invoice", post(pay_invoice))
             .route("/id", get(get_gateway_id));
 
@@ -45,37 +70,21 @@ pub async fn run_webserver(
             .route("/restore", post(restore))
             .route("/set_configuration", post(set_configuration))
             .layer(ValidateRequestHeaderLayer::bearer(&gateway_config.password));
-        (routes, admin_routes)
+        (public_routes, admin_routes)
     } else {
-        let routes = Router::new()
+        let public_routes = Router::new()
             .route("/set_configuration", post(set_configuration))
             .route("/config", get(configuration))
             .route("/info", get(info));
-        (routes, Router::new())
+        let admin_routes = Router::new();
+        (public_routes, admin_routes)
     };
 
-    let app = Router::new()
-        .merge(routes)
+    Router::new()
+        .merge(public_routes)
         .merge(admin_routes)
-        .layer(Extension(gateway.clone()))
-        .layer(CorsLayer::permissive());
-
-    let handle = task_group.make_handle();
-    let shutdown_rx = handle.make_shutdown_rx().await;
-    let server = axum::Server::bind(&bind_addr).serve(app.into_make_service());
-    task_group
-        .spawn("Gateway Webserver", move |_| async move {
-            let graceful = server.with_graceful_shutdown(async {
-                shutdown_rx.await;
-            });
-
-            if let Err(e) = graceful.await {
-                error!("Error shutting down gatewayd webserver: {:?}", e);
-            }
-        })
-        .await;
-
-    Ok(())
+        .layer(Extension(gateway))
+        .layer(CorsLayer::permissive())
 }
 
 /// Display high-level information about the Gateway

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -255,7 +255,7 @@ impl GatewayClientModule {
                 gateway_redeem_key: self.redeem_key.public_key(),
                 node_pub_key: lightning_context.lightning_public_key,
                 lightning_alias: lightning_context.lightning_alias,
-                api: self.gateway.gateway_parameters.api_addr.clone(),
+                api: self.gateway.gateway_parameters.versioned_api.clone(),
                 route_hints,
                 fees,
                 gateway_id: self.gateway.gateway_id,

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -344,6 +344,8 @@ pub struct LightningGateway {
     pub gateway_redeem_key: secp256k1::PublicKey,
     pub node_pub_key: secp256k1::PublicKey,
     pub lightning_alias: String,
+    /// URL to the gateway's versioned public API
+    /// (e.g. <https://gateway.example.com/v1>)
     pub api: SafeUrl,
     /// Route hints to reach the LN node of the gateway.
     ///


### PR DESCRIPTION
Declares v1 for gateway apis with the following schema: `gateway-http-host/version/endpoint`

After this change, clients should prefer to call `gateway-http-host/v1/endpoint`. The non-versioned api with the format `gateway-http-host/endpoint` is still supported but will likely will deprecate this, or arbitrarily change the apis as necessary

## Consuming api from fedimint-ln-client

This PR proposes that the gateway should register a versioned api url as part of `LightningGateway` payload. The client can
- use the api as is, assuming compatibility. **This is the current client behaviour.**
- check the version before constructing compatible payloads
- ignore a gateway that doesn't have compatible api version

closes #3904 