### PR TITLE
refactor: Only load federation clients when gateway boots

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -21,9 +21,7 @@ use fedimint_bip39::Bip39RootSecretStrategy;
 use fedimint_client::backup::Metadata;
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitRegistry};
 use fedimint_client::secret::{get_default_client_secret, RootSecretStrategy};
-use fedimint_client::{
-    get_invite_code_from_db, Client, ClientArc, ClientBuilder, DatabaseSource, FederationInfo,
-};
+use fedimint_client::{get_invite_code_from_db, Client, ClientArc, ClientBuilder, FederationInfo};
 use fedimint_core::admin_client::WsAdminClient;
 use fedimint_core::api::{
     FederationApiExt, FederationError, GlobalFederationApi, IFederationApi, InviteCode,
@@ -517,7 +515,7 @@ impl FedimintCli {
 
     async fn make_client_builder(&self, cli: &Opts) -> CliResult<ClientBuilder> {
         let db = cli.load_rocks_db().await?;
-        let mut client_builder = Client::builder(DatabaseSource::Fresh(db));
+        let mut client_builder = Client::builder(db);
         client_builder.with_module_inits(self.module_inits.clone());
         client_builder.with_primary_module(1);
 

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -140,7 +140,7 @@ pub async fn build_client(
     } else {
         fedimint_core::db::mem_impl::MemDatabase::new().into()
     };
-    let mut client_builder = Client::builder(fedimint_client::DatabaseSource::Fresh(db));
+    let mut client_builder = Client::builder(db);
     client_builder.with_module(MintClientInit);
     client_builder.with_module(LightningClientInit);
     client_builder.with_module(WalletClientInit::default());

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -53,9 +53,7 @@ impl FederationTest {
 
     pub async fn new_client_with_config(&self, client_config: ClientConfig) -> ClientArc {
         info!(target: LOG_TEST, "Setting new client with config");
-        let mut client_builder = Client::builder(fedimint_client::DatabaseSource::Fresh(
-            MemDatabase::new().into(),
-        ));
+        let mut client_builder = Client::builder(MemDatabase::new().into());
         client_builder.with_module_inits(self.client_init.clone());
         client_builder.with_primary_module(self.primary_client);
         let client_secret = Client::load_or_generate_client_secret(client_builder.db())

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -23,9 +23,7 @@ async fn load_or_generate_mnemonic(db: &Database) -> anyhow::Result<[u8; 64]> {
 
 fn make_client_builder() -> fedimint_client::ClientBuilder {
     let mem_database = MemDatabase::default();
-    let mut builder = fedimint_client::Client::builder(fedimint_client::DatabaseSource::Fresh(
-        mem_database.into(),
-    ));
+    let mut builder = fedimint_client::Client::builder(mem_database.into());
     builder.with_module(LightningClientInit);
     builder.with_module(MintClientInit);
     builder.with_module(WalletClientInit::default());

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
@@ -16,9 +15,8 @@ use rand::thread_rng;
 use tracing::info;
 
 use crate::db::{FederationConfig, FederationIdKey, FederationIdKeyPrefix};
-use crate::lnrpc_client::ILnRpcClient;
 use crate::state_machine::GatewayClientInit;
-use crate::{FederationToClientMap, GatewayError, Result, ScidToFederationMap};
+use crate::{Gateway, GatewayError, Result};
 
 #[derive(Debug, Clone)]
 pub struct GatewayClientBuilder {
@@ -46,13 +44,7 @@ impl GatewayClientBuilder {
     pub async fn build(
         &self,
         config: FederationConfig,
-        node_pub_key: secp256k1::PublicKey,
-        lightning_alias: String,
-        lnrpc: Arc<dyn ILnRpcClient>,
-        all_clients: FederationToClientMap,
-        all_scids: ScidToFederationMap,
-        old_client: Option<fedimint_client::ClientArc>,
-        gateway_db: Database,
+        gateway: Gateway,
     ) -> Result<fedimint_client::ClientArc> {
         let FederationConfig {
             invite_code,
@@ -64,30 +56,19 @@ impl GatewayClientBuilder {
 
         let mut registry = self.registry.clone();
         registry.attach(GatewayClientInit {
-            lnrpc,
-            all_clients,
-            all_scids,
-            node_pub_key,
-            lightning_alias,
             timelock_delta,
             mint_channel_id,
-            gateway_db,
+            gateway,
         });
 
-        let db_source = if let Some(old_client) = old_client {
-            fedimint_client::DatabaseSource::Reuse(old_client)
-        } else {
-            let db_path = self.work_dir.join(format!("{federation_id}.db"));
+        let db_path = self.work_dir.join(format!("{federation_id}.db"));
 
-            let rocksdb = fedimint_rocksdb::RocksDb::open(db_path.clone()).map_err(|e| {
-                GatewayError::DatabaseError(anyhow::anyhow!("Error opening rocksdb: {e:?}"))
-            })?;
-            let db = Database::new(rocksdb, ModuleDecoderRegistry::default());
+        let rocksdb = fedimint_rocksdb::RocksDb::open(db_path.clone()).map_err(|e| {
+            GatewayError::DatabaseError(anyhow::anyhow!("Error opening rocksdb: {e:?}"))
+        })?;
+        let db = Database::new(rocksdb, ModuleDecoderRegistry::default());
 
-            fedimint_client::DatabaseSource::Fresh(db)
-        };
-
-        let mut client_builder = Client::builder(db_source);
+        let mut client_builder = Client::builder(db);
         client_builder.with_module_inits(registry);
         client_builder.with_primary_module(self.primary_module);
 
@@ -136,17 +117,13 @@ impl GatewayClientBuilder {
             .map_err(GatewayError::DatabaseError)
     }
 
-    pub async fn load_configs(
-        &self,
-        mut dbtx: DatabaseTransaction<'_>,
-    ) -> Result<Vec<FederationConfig>> {
-        Ok(dbtx
-            .find_by_prefix(&FederationIdKeyPrefix)
+    pub async fn load_configs(&self, mut dbtx: DatabaseTransaction<'_>) -> Vec<FederationConfig> {
+        dbtx.find_by_prefix(&FederationIdKeyPrefix)
             .await
             .collect::<BTreeMap<FederationIdKey, FederationConfig>>()
             .await
             .values()
             .cloned()
-            .collect::<Vec<_>>())
+            .collect::<Vec<_>>()
     }
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -18,7 +18,6 @@ use std::fmt::Display;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -56,7 +55,6 @@ use fedimint_wallet_client::{
     WalletClientInit, WalletClientModule, WalletCommonInit, WithdrawState,
 };
 use futures::stream::StreamExt;
-use futures::Future;
 use gateway_lnrpc::intercept_htlc_response::Action;
 use gateway_lnrpc::{GetNodeInfoResponse, InterceptHtlcResponse};
 use lightning_invoice::RoutingFees;
@@ -198,12 +196,7 @@ pub enum GatewayState {
     Initializing,
     Configuring,
     Connected,
-    Running {
-        lnrpc: Arc<dyn ILnRpcClient>,
-        lightning_public_key: PublicKey,
-        lightning_alias: String,
-        lightning_network: Network,
-    },
+    Running { lightning_context: LightningContext },
     Disconnected,
 }
 
@@ -221,6 +214,15 @@ impl Display for GatewayState {
 
 pub type ScidToFederationMap = Arc<RwLock<BTreeMap<u64, FederationId>>>;
 pub type FederationToClientMap = Arc<RwLock<BTreeMap<FederationId, fedimint_client::ClientArc>>>;
+
+/// Represents an active connection to the lightning node.
+#[derive(Clone, Debug)]
+pub struct LightningContext {
+    pub lnrpc: Arc<dyn ILnRpcClient>,
+    pub lightning_public_key: PublicKey,
+    pub lightning_alias: String,
+    pub lightning_network: Network,
+}
 
 #[derive(Clone)]
 pub struct Gateway {
@@ -254,7 +256,7 @@ pub struct Gateway {
 
     // ID generator that atomically increments. Used for creation of new short channel ids that
     // represent federations.
-    channel_id_generator: Arc<Mutex<AtomicU64>>,
+    channel_id_generator: Arc<Mutex<u64>>,
 }
 
 impl std::fmt::Debug for Gateway {
@@ -301,7 +303,7 @@ impl Gateway {
             clients: Arc::new(RwLock::new(BTreeMap::new())),
             scid_to_federation: Arc::new(RwLock::new(BTreeMap::new())),
             gateway_id: Gateway::get_gateway_id(gateway_db).await,
-            channel_id_generator: Arc::new(Mutex::new(AtomicU64::new(INITIAL_SCID))),
+            channel_id_generator: Arc::new(Mutex::new(INITIAL_SCID)),
         })
     }
 
@@ -345,7 +347,7 @@ impl Gateway {
             lightning_builder: Arc::new(GatewayLightningBuilder {
                 lightning_mode: opts.mode.clone(),
             }),
-            channel_id_generator: Arc::new(Mutex::new(AtomicU64::new(INITIAL_SCID))),
+            channel_id_generator: Arc::new(Mutex::new(INITIAL_SCID)),
             gateway_parameters: opts.to_gateway_parameters(),
             state: Arc::new(RwLock::new(GatewayState::Initializing)),
             client_builder,
@@ -513,11 +515,14 @@ impl Gateway {
                                         }
 
                                         info!("Successfully loaded Gateway clients.");
-                                        self.set_gateway_state(GatewayState::Running {
+                                        let lightning_context = LightningContext {
                                             lnrpc: ln_client,
                                             lightning_public_key,
                                             lightning_alias,
-                                            lightning_network
+                                            lightning_network,
+                                        };
+                                        self.set_gateway_state(GatewayState::Running {
+                                            lightning_context
                                         }).await;
 
                                         // Blocks until the connection to the lightning node breaks or we receive the shutdown signal
@@ -562,7 +567,7 @@ impl Gateway {
     }
 
     pub async fn handle_htlc_stream(&self, mut stream: RouteHtlcStream<'_>, handle: TaskHandle) {
-        let GatewayState::Running { lnrpc, .. } = self.state.read().await.clone() else {
+        let GatewayState::Running { lightning_context } = self.state.read().await.clone() else {
             panic!("Gateway isn't in a running state")
         };
         loop {
@@ -611,7 +616,7 @@ impl Gateway {
                         htlc_id: htlc_request.htlc_id,
                     };
 
-                    if let Err(error) = lnrpc.complete_htlc(outcome).await {
+                    if let Err(error) = lightning_context.lnrpc.complete_htlc(outcome).await {
                         error!("Error sending HTLC response to lightning node: {error:?}");
                     }
                 }
@@ -629,13 +634,7 @@ impl Gateway {
     }
 
     pub async fn handle_get_info(&self) -> Result<GatewayInfo> {
-        if let GatewayState::Running {
-            lnrpc,
-            lightning_public_key,
-            lightning_alias,
-            ..
-        } = self.state.read().await.clone()
-        {
+        if let GatewayState::Running { lightning_context } = self.state.read().await.clone() {
             // `GatewayConfiguration` should always exist in the database when we are in the
             // `Running` state.
             let gateway_config = self
@@ -644,9 +643,11 @@ impl Gateway {
                 .expect("Gateway configuration should be set");
             let mut federations = Vec::new();
             let federation_clients = self.clients.read().await.clone().into_iter();
-            let route_hints =
-                Self::fetch_lightning_route_hints(lnrpc.clone(), gateway_config.num_route_hints)
-                    .await?;
+            let route_hints = Self::fetch_lightning_route_hints(
+                lightning_context.lnrpc.clone(),
+                gateway_config.num_route_hints,
+            )
+            .await?;
             for (federation_id, client) in federation_clients {
                 federations.push(self.make_federation_info(&client, federation_id).await);
             }
@@ -654,8 +655,8 @@ impl Gateway {
             return Ok(GatewayInfo {
                 federations,
                 version_hash: env!("FEDIMINT_BUILD_CODE_VERSION").to_string(),
-                lightning_pub_key: Some(lightning_public_key.to_hex()),
-                lightning_alias: Some(lightning_alias.clone()),
+                lightning_pub_key: Some(lightning_context.lightning_public_key.to_hex()),
+                lightning_alias: Some(lightning_context.lightning_alias.clone()),
                 fees: Some(gateway_config.routing_fees),
                 route_hints,
                 gateway_id: self.gateway_id,
@@ -824,13 +825,7 @@ impl Gateway {
         &mut self,
         payload: ConnectFedPayload,
     ) -> Result<FederationConnectionInfo> {
-        if let GatewayState::Running {
-            lnrpc,
-            lightning_public_key,
-            lightning_alias,
-            ..
-        } = self.state.read().await.clone()
-        {
+        if let GatewayState::Running { lightning_context } = self.state.read().await.clone() {
             let invite_code = InviteCode::from_str(&payload.invite_code).map_err(|e| {
                 GatewayError::InvalidMetadata(format!("Invalid federation member string {e:?}"))
             })?;
@@ -854,13 +849,14 @@ impl Gateway {
                 .expect("Gateway configuration should be set");
 
             // The gateway deterministically assigns a channel id (u64) to each federation
-            // connected. TODO: explicitly handle the case where the channel id
-            // overflows
-            let mint_channel_id = self
-                .channel_id_generator
-                .lock()
-                .await
-                .fetch_add(1, Ordering::SeqCst);
+            // connected.
+            let mut channel_id_generator = self.channel_id_generator.lock().await;
+            let mint_channel_id = channel_id_generator.checked_add(1).ok_or(
+                GatewayError::GatewayConfigurationError(
+                    "Too many connected federations".to_string(),
+                ),
+            )?;
+            *channel_id_generator = mint_channel_id;
 
             let federation_id = invite_code.federation_id();
             let gw_client_cfg = FederationConfig {
@@ -872,9 +868,11 @@ impl Gateway {
                 fees: gateway_config.routing_fees,
             };
 
-            let route_hints =
-                Self::fetch_lightning_route_hints(lnrpc.clone(), gateway_config.num_route_hints)
-                    .await?;
+            let route_hints = Self::fetch_lightning_route_hints(
+                lightning_context.lnrpc.clone(),
+                gateway_config.num_route_hints,
+            )
+            .await?;
 
             let client = self
                 .client_builder
@@ -895,9 +893,7 @@ impl Gateway {
                     route_hints,
                     GW_ANNOUNCEMENT_TTL,
                     gw_client_cfg.fees,
-                    lightning_public_key,
-                    lightning_alias,
-                    lnrpc.supports_private_payments(),
+                    lightning_context,
                 )
                 .await?;
             self.clients.write().await.insert(federation_id, client);
@@ -956,15 +952,13 @@ impl Gateway {
     ) -> Result<()> {
         let gw_state = self.state.read().await.clone();
         let lightning_network = match gw_state {
-            GatewayState::Running {
-                lightning_network, ..
-            } => {
-                if network.is_some() && network != Some(lightning_network) {
+            GatewayState::Running { lightning_context } => {
+                if network.is_some() && network != Some(lightning_context.lightning_network) {
                     return Err(GatewayError::GatewayConfigurationError(
                         "Cannot change network while connected to a lightning node".to_string(),
                     ));
                 }
-                lightning_network
+                lightning_context.lightning_network
             }
             // In the case the gateway is not yet running and not yet connected to a lightning node,
             // we start off with a default network configuration. This default gets replaced later
@@ -1066,15 +1060,12 @@ impl Gateway {
     /// gateway with each federation.
     async fn register_all_federations(gateway: &Gateway, gateway_config: &GatewayConfiguration) {
         let gateway_state = gateway.state.read().await.clone();
-        if let GatewayState::Running {
-            lnrpc,
-            lightning_public_key,
-            lightning_alias,
-            ..
-        } = gateway_state
-        {
-            match Self::fetch_lightning_route_hints(lnrpc.clone(), gateway_config.num_route_hints)
-                .await
+        if let GatewayState::Running { lightning_context } = gateway_state {
+            match Self::fetch_lightning_route_hints(
+                lightning_context.lnrpc.clone(),
+                gateway_config.num_route_hints,
+            )
+            .await
             {
                 Ok(route_hints) => {
                     for (federation_id, client) in gateway.clients.read().await.iter() {
@@ -1090,9 +1081,7 @@ impl Gateway {
                                     route_hints.clone(),
                                     GW_ANNOUNCEMENT_TTL,
                                     federation_config.fees,
-                                    lightning_public_key,
-                                    lightning_alias.clone(),
-                                    lnrpc.supports_private_payments(),
+                                    lightning_context.clone(),
                                 )
                                 .await
                             {
@@ -1175,8 +1164,8 @@ impl Gateway {
     async fn load_clients(&mut self) {
         let dbtx = self.gateway_db.begin_transaction().await;
         let configs = self.client_builder.load_configs(dbtx.into_nc()).await;
-        let channel_id_generator = self.channel_id_generator.lock().await;
-        let mut next_channel_id = channel_id_generator.load(Ordering::SeqCst);
+        let mut channel_id_generator = self.channel_id_generator.lock().await;
+        let mut next_channel_id = *channel_id_generator;
 
         for config in configs {
             let federation_id = config.invite_code.federation_id();
@@ -1203,7 +1192,8 @@ impl Gateway {
                 next_channel_id = config.mint_channel_id + 1;
             }
         }
-        channel_id_generator.store(next_channel_id, Ordering::SeqCst);
+
+        *channel_id_generator = next_channel_id;
     }
 
     async fn register_clients_timer(&mut self, task_group: &mut TaskGroup) {
@@ -1346,29 +1336,15 @@ impl Gateway {
         Ok(())
     }
 
-    pub async fn execute_with_lightning_connection<F, Fut, T>(&self, func: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(Arc<dyn ILnRpcClient>, PublicKey, String, Network) -> Fut,
-        Fut: Future<Output = anyhow::Result<T>>,
-    {
+    /// Checks the Gateway's current state and returns the proper
+    /// `LightningContext` if it is available. Sometimes the lightning node
+    /// will not be connected and this will return an error.
+    pub async fn get_lightning_context(
+        &self,
+    ) -> std::result::Result<LightningContext, LightningRpcError> {
         match self.state.read().await.clone() {
-            GatewayState::Running {
-                lnrpc,
-                lightning_public_key,
-                lightning_alias,
-                lightning_network,
-            } => {
-                func(
-                    lnrpc,
-                    lightning_public_key,
-                    lightning_alias,
-                    lightning_network,
-                )
-                .await
-            }
-            _ => {
-                anyhow::bail!("Lightning node is not connected");
-            }
+            GatewayState::Running { lightning_context } => Ok(lightning_context),
+            _ => Err(LightningRpcError::FailedToConnect),
         }
     }
 }

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -22,7 +22,6 @@ use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationI
 use fedimint_core::db::{AutocommitError, DatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{ApiVersion, ModuleInit, MultiApiVersion, TransactionItemAmount};
-use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Amount, OutPoint, TransactionId};
 use fedimint_ln_client::incoming::{
     FundingOfferState, IncomingSmCommon, IncomingSmError, IncomingSmStates, IncomingStateMachine,
@@ -247,8 +246,6 @@ impl GatewayClientModule {
         &self,
         route_hints: Vec<RouteHint>,
         ttl: Duration,
-        api: SafeUrl,
-        gateway_id: secp256k1::PublicKey,
         fees: RoutingFees,
         node_pub_key: PublicKey,
         lightning_alias: String,
@@ -260,10 +257,10 @@ impl GatewayClientModule {
                 gateway_redeem_key: self.redeem_key.public_key(),
                 node_pub_key,
                 lightning_alias,
-                api,
+                api: self.gateway.gateway_parameters.api_addr.clone(),
                 route_hints,
                 fees,
-                gateway_id,
+                gateway_id: self.gateway.gateway_id,
                 supports_private_payments,
             },
             ttl,
@@ -368,10 +365,8 @@ impl GatewayClientModule {
     /// Register gateway with federation
     pub async fn register_with_federation(
         &self,
-        gateway_api: SafeUrl,
         route_hints: Vec<RouteHint>,
         time_to_live: Duration,
-        gateway_id: secp256k1::PublicKey,
         fees: RoutingFees,
         node_pub_key: PublicKey,
         lightning_alias: String,
@@ -381,8 +376,6 @@ impl GatewayClientModule {
             let registration_info = self.to_gateway_registration_info(
                 route_hints,
                 time_to_live,
-                gateway_api,
-                gateway_id,
                 fees,
                 node_pub_key,
                 lightning_alias,

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -14,7 +14,7 @@ use fedimint_client::ClientArc;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::task::sleep;
-use fedimint_core::util::{NextOrPending, SafeUrl};
+use fedimint_core::util::NextOrPending;
 use fedimint_core::{msats, sats, Amount, OutPoint, TransactionId};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_common::config::DummyGenParams;
@@ -40,13 +40,15 @@ use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing::gateway::{GatewayTest, LightningNodeType, DEFAULT_GATEWAY_PASSWORD};
 use fedimint_testing::ln::LightningTest;
 use futures::Future;
-use lightning_invoice::Bolt11Invoice;
+use lightning_invoice::{Bolt11Invoice, RoutingFees};
 use ln_gateway::gateway_lnrpc::GetNodeInfoResponse;
 use ln_gateway::rpc::rpc_client::{GatewayRpcClient, GatewayRpcError, GatewayRpcResult};
-use ln_gateway::rpc::{BalancePayload, ConnectFedPayload, SetConfigurationPayload};
+use ln_gateway::rpc::{
+    BalancePayload, ConnectFedPayload, LeaveFedPayload, SetConfigurationPayload,
+};
 use ln_gateway::state_machine::{
     GatewayClientModule, GatewayClientStateMachines, GatewayExtPayStates, GatewayExtReceiveStates,
-    GatewayMeta, Htlc, GW_ANNOUNCEMENT_TTL,
+    GatewayMeta, Htlc,
 };
 use ln_gateway::utils::retry;
 use ln_gateway::{GatewayState, DEFAULT_FEES, DEFAULT_NETWORK};
@@ -696,68 +698,40 @@ async fn test_gateway_register_with_federation() -> anyhow::Result<()> {
         .new_gateway(node, 0, Some(DEFAULT_GATEWAY_PASSWORD.to_string()))
         .await;
     gateway_test.connect_fed(&fed).await;
-    let gateway = gateway_test.remove_client(&fed).await;
 
-    let mut fake_api = SafeUrl::from_str("http://127.0.0.1:8175").unwrap();
-    // Register with the federation with a low TTL to verify it will re-register
-    let register_gw = gateway.clone();
-    let gateway_id = gateway_test.get_gateway_id();
-    let register_fake_api = fake_api.clone();
-    gateway_test
-        .gateway
-        .execute_with_lightning_connection(|lnrpc, pub_key, alias, _| async move {
-            register_gw
-                .get_first_module::<GatewayClientModule>()
-                .register_with_federation(
-                    register_fake_api,
-                    Vec::new(),
-                    GW_ANNOUNCEMENT_TTL,
-                    gateway_id,
-                    DEFAULT_FEES,
-                    pub_key,
-                    alias,
-                    lnrpc.supports_private_payments(),
-                )
-                .await?;
-            Ok(())
-        })
-        .await?;
-
+    let routing_fees = RoutingFees {
+        base_msat: 0,
+        proportional_millionths: 0,
+    };
     let lightning_module = user_client.get_first_module::<LightningClientModule>();
     let gateways = lightning_module.fetch_registered_gateways().await?;
+    assert!(!gateways.is_empty());
     assert!(gateways
         .into_iter()
-        .any(|gateway| gateway.info.api == fake_api));
+        .any(|gateway| gateway.info.fees == routing_fees));
 
-    // Update the URI for the gateway then re-register
-    fake_api = SafeUrl::from_str("http://127.0.0.1:8176").unwrap();
+    // Leave the federation
+    let rpc_client = gateway_test
+        .get_rpc()
+        .await
+        .with_password(Some(DEFAULT_GATEWAY_PASSWORD.to_string()));
+    verify_rpc(
+        || {
+            rpc_client.leave_federation(LeaveFedPayload {
+                federation_id: fed.id(),
+            })
+        },
+        StatusCode::OK,
+    )
+    .await;
 
-    let register_gw = gateway.clone();
-    let register_fake_api = fake_api.clone();
-    gateway_test
-        .gateway
-        .execute_with_lightning_connection(|lnrpc, pub_key, alias, _| async move {
-            register_gw
-                .get_first_module::<GatewayClientModule>()
-                .register_with_federation(
-                    register_fake_api,
-                    Vec::new(),
-                    GW_ANNOUNCEMENT_TTL,
-                    gateway_id,
-                    DEFAULT_FEES,
-                    pub_key,
-                    alias,
-                    lnrpc.supports_private_payments(),
-                )
-                .await?;
-            Ok(())
-        })
-        .await?;
-
+    // Reconnect the federation and verify that the gateway has registered.
     let gateways = lightning_module.fetch_registered_gateways().await?;
+    gateway_test.connect_fed(&fed).await;
+    assert!(!gateways.is_empty());
     assert!(gateways
         .into_iter()
-        .any(|gateway| gateway.info.api == fake_api));
+        .any(|gateway| gateway.info.fees == routing_fees));
 
     Ok(())
 }
@@ -952,6 +926,42 @@ async fn test_gateway_filters_route_hints_by_inbound() -> anyhow::Result<()> {
             }
         }
     }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cannot_connect_same_federation() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+
+    let fed = fixtures.new_fed().await;
+    let lnd = fixtures.lnd().await;
+    let gateway = fixtures
+        .new_gateway(lnd, 0, Some(DEFAULT_GATEWAY_PASSWORD.to_string()))
+        .await;
+    let rpc_client = gateway
+        .get_rpc()
+        .await
+        .with_password(Some(DEFAULT_GATEWAY_PASSWORD.to_string()));
+
+    // Verify that we can't join a federation yet because the configuration is not
+    // set
+    let join_payload = ConnectFedPayload {
+        invite_code: fed.invite_code().to_string(),
+    };
+
+    verify_rpc(
+        || rpc_client.connect_federation(join_payload.clone()),
+        StatusCode::OK,
+    )
+    .await;
+
+    // Try to connect the same federation
+    verify_rpc(
+        || rpc_client.connect_federation(join_payload.clone()),
+        StatusCode::INTERNAL_SERVER_ERROR,
+    )
+    .await;
 
     Ok(())
 }


### PR DESCRIPTION
See https://github.com/fedimint/fedimint/pull/3781#issuecomment-1885878214 for context.

- Removes `DatabaseSource`
- Adds check when connecting a federation if the federation has already been connected
- Wraps every usage of `lnrpc` behind a wrapper function that first checks if the lightning node is connected to the gateway.