### PR TITLE
chore: client module recovery refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-test",
 ]
@@ -5059,6 +5060,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -1114,7 +1114,7 @@ async fn cli_tests_backup_and_restore(fed: &Federation, reference_client: &Clien
     {
         let client = Client::create("restore-without-backup").await?;
 
-        let post_balance = cmd!(
+        let _ = cmd!(
             client,
             "restore",
             "--mnemonic",
@@ -1123,11 +1123,10 @@ async fn cli_tests_backup_and_restore(fed: &Federation, reference_client: &Clien
             fed.invite_code()?
         )
         .out_json()
-        .await?
-        .as_u64()
-        .unwrap();
+        .await?;
 
         let post_notes = cmd!(client, "info").out_json().await?;
+        let post_balance = post_notes["total_amount_msat"].as_u64().unwrap();
 
         debug!(%post_notes, post_balance, "State after backup");
         assert_eq!(pre_balance, post_balance);

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -1125,6 +1125,7 @@ async fn cli_tests_backup_and_restore(fed: &Federation, reference_client: &Clien
         .out_json()
         .await?;
 
+        let _ = cmd!(client, "dev", "wait-complete").out_json().await?;
         let post_notes = cmd!(client, "info").out_json().await?;
         let post_balance = post_notes["total_amount_msat"].as_u64().unwrap();
 
@@ -1148,6 +1149,7 @@ async fn cli_tests_backup_and_restore(fed: &Federation, reference_client: &Clien
         .out_json()
         .await?;
 
+        let _ = cmd!(client, "dev", "wait-complete").out_json().await?;
         let post_notes = cmd!(client, "info").out_json().await?;
         let post_balance = post_notes["total_amount_msat"].as_u64().unwrap();
 

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -18,8 +18,8 @@ use clap::{CommandFactory, Parser, Subcommand};
 use db_locked::LockedBuilder;
 use fedimint_aead::{encrypted_read, encrypted_write, get_encryption_key};
 use fedimint_bip39::Bip39RootSecretStrategy;
-use fedimint_client::backup::Metadata;
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitRegistry};
+use fedimint_client::module::ClientModule as _;
 use fedimint_client::secret::{get_default_client_secret, RootSecretStrategy};
 use fedimint_client::{get_invite_code_from_db, Client, ClientArc, ClientBuilder, FederationInfo};
 use fedimint_core::admin_client::WsAdminClient;
@@ -575,7 +575,7 @@ impl FedimintCli {
         cli: &Opts,
         mnemonic: Mnemonic,
         invite_code: InviteCode,
-    ) -> CliResult<(ClientArc, Metadata)> {
+    ) -> CliResult<ClientArc> {
         let builder = self.make_client_builder(cli).await?;
 
         let federation_info = FederationInfo::from_invite_code(invite_code.clone())
@@ -647,19 +647,17 @@ impl FedimintCli {
                 let mnemonic = Mnemonic::from_str(&mnemonic).map_err_cli_general()?;
                 let client = self.client_recover(&cli, mnemonic, invite_code).await?;
 
-                info!("Waiting for restore to complete");
-                let restored_amount = client
-                    .0
-                    .get_first_module::<MintClientModule>()
-                    .await_restore_finished()
+                // TODO: until we implement recovery for other modules we can't really wait
+                // for more than this one
+                debug!("Waiting for mint module recovery to finish");
+                client
+                    .wait_for_module_kind_recovery(MintClientModule::kind())
                     .await
-                    .map_err_cli_msg(CliErrorKind::GeneralFailure, "failure")?;
+                    .map_err_cli_general()?;
 
-                debug!("Restore complete");
+                debug!("Recovery complete");
 
-                Ok(CliOutput::Raw(
-                    serde_json::to_value(restored_amount.msats).unwrap(),
-                ))
+                Ok(CliOutput::Raw(serde_json::to_value(()).unwrap()))
             }
             Command::Client(command) => {
                 let client = self.client_open(&cli).await?;

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -24,7 +24,8 @@ use fedimint_client::secret::{get_default_client_secret, RootSecretStrategy};
 use fedimint_client::{get_invite_code_from_db, Client, ClientArc, ClientBuilder, FederationInfo};
 use fedimint_core::admin_client::WsAdminClient;
 use fedimint_core::api::{
-    FederationApiExt, FederationError, GlobalFederationApi, IFederationApi, InviteCode, WsFederationApi,
+    FederationApiExt, FederationError, GlobalFederationApi, IFederationApi, InviteCode,
+    WsFederationApi,
 };
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::OperationId;

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -24,8 +24,7 @@ use fedimint_client::secret::{get_default_client_secret, RootSecretStrategy};
 use fedimint_client::{get_invite_code_from_db, Client, ClientArc, ClientBuilder, FederationInfo};
 use fedimint_core::admin_client::WsAdminClient;
 use fedimint_core::api::{
-    FederationApiExt, FederationError, GlobalFederationApi, IFederationApi, InviteCode,
-    JsonRpcClient, WsFederationApi,
+    FederationApiExt, FederationError, GlobalFederationApi, IFederationApi, InviteCode, WsFederationApi,
 };
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::OperationId;

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -39,6 +39,7 @@ strum = "0.24.1"
 strum_macros = "0.24.1"
 thiserror = "1.0.39"
 tokio = { version = "1.26.0", features = [ "time", "macros" ] }
+tokio-stream = { version = "0.1.14", features = [ "time", "sync" ] }
 tracing = "0.1.37"
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -1,11 +1,13 @@
 use fedimint_core::api::{ApiVersionSet, InviteCode};
 use fedimint_core::config::{ClientConfig, FederationId};
-use fedimint_core::core::OperationId;
+use fedimint_core::core::{ModuleInstanceId, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use serde::Serialize;
 use strum_macros::EnumIter;
 
+use crate::backup::{ClientBackup, Metadata};
+use crate::module::recovery::RecoveryProgress;
 use crate::oplog::OperationLogEntry;
 
 #[repr(u8)]
@@ -18,6 +20,8 @@ pub enum DbKeyPrefix {
     CommonApiVersionCache = 0x2e,
     ClientConfig = 0x2f,
     ClientInviteCode = 0x30,
+    ClientInitState = 0x31,
+    ClientMetadata = 0x32,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -117,4 +121,144 @@ impl_db_record!(
 impl_db_lookup!(
     key = ClientInviteCodeKey,
     query_prefix = ClientInviteCodeKeyPrefix
+);
+
+/// Client metadata that will be stored/restored on backup&recovery
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ClientMetadataKey;
+
+#[derive(Debug, Encodable)]
+pub struct ClientMetadataPrefix;
+
+impl_db_record!(
+    key = ClientMetadataKey,
+    value = Metadata,
+    db_prefix = DbKeyPrefix::ClientMetadata
+);
+
+impl_db_lookup!(key = ClientMetadataKey, query_prefix = ClientMetadataPrefix);
+
+/// Does the client modules need to run recovery before being usable?
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ClientInitStateKey;
+
+#[derive(Debug, Encodable)]
+pub struct ClientInitStatePrefix;
+
+/// Client initialization mode
+#[derive(Debug, Encodable, Decodable)]
+pub enum InitMode {
+    /// Should only be used with freshly generated root secret
+    Fresh,
+    /// Should be used with root secrets provided by the user to recover a
+    /// (even if just possibly) already used secret.
+    Recover { snapshot: Option<ClientBackup> },
+}
+
+/// Like `InitMode`, but without no longer required data.
+///
+/// This is distinct from `InitMode` to prevent holding on to `snapshot`
+/// forever both for user's privacy and space use. In case user get hacked
+/// or phone gets stolen.
+#[derive(Debug, Encodable, Decodable)]
+pub enum InitModeComplete {
+    Fresh,
+    Recover,
+}
+
+/// The state of the client initialization
+#[derive(Debug, Encodable, Decodable)]
+pub enum InitState {
+    /// Client data initialization might still require some work (e.g. client
+    /// recovery)
+    Pending(InitMode),
+    /// Client initialization was complete
+    Complete(InitModeComplete),
+}
+
+impl InitState {
+    pub fn into_complete(self) -> Self {
+        match self {
+            InitState::Pending(p) => InitState::Complete(match p {
+                InitMode::Fresh => InitModeComplete::Fresh,
+                InitMode::Recover { .. } => InitModeComplete::Recover,
+            }),
+            InitState::Complete(t) => InitState::Complete(t),
+        }
+    }
+
+    pub fn does_require_recovery(&self) -> Option<Option<ClientBackup>> {
+        match self {
+            InitState::Pending(p) => match p {
+                InitMode::Fresh => None,
+                InitMode::Recover { snapshot } => Some(snapshot.clone()),
+            },
+            InitState::Complete(_) => None,
+        }
+    }
+
+    pub fn is_pending(&self) -> bool {
+        match self {
+            InitState::Pending(_) => true,
+            InitState::Complete(_) => false,
+        }
+    }
+}
+
+impl_db_record!(
+    key = ClientInitStateKey,
+    value = InitState,
+    db_prefix = DbKeyPrefix::ClientInitState
+);
+
+impl_db_lookup!(
+    key = ClientInitStateKey,
+    query_prefix = ClientInitStatePrefix
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ClientRecoverySnapshot;
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ClientRecoverySnapshotPrefix;
+
+impl_db_record!(
+    key = ClientRecoverySnapshot,
+    value = Option<ClientBackup>,
+    db_prefix = DbKeyPrefix::ClientInitState
+);
+
+impl_db_lookup!(
+    key = ClientRecoverySnapshot,
+    query_prefix = ClientRecoverySnapshotPrefix
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ClientModuleRecovery {
+    pub module_instance_id: ModuleInstanceId,
+}
+
+#[derive(Debug, Encodable)]
+pub struct ClientModuleRecoveryPrefix;
+
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct ClientModuleRecoveryState {
+    pub progress: RecoveryProgress,
+}
+
+impl ClientModuleRecoveryState {
+    pub fn is_done(&self) -> bool {
+        self.progress.is_done()
+    }
+}
+
+impl_db_record!(
+    key = ClientModuleRecovery,
+    value = ClientModuleRecoveryState,
+    db_prefix = DbKeyPrefix::ClientInitState,
+);
+
+impl_db_lookup!(
+    key = ClientModuleRecovery,
+    query_prefix = ClientModuleRecoveryPrefix
 );

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -838,16 +838,6 @@ impl Client {
         self.executor.add_state_machines_dbtx(dbtx, states).await
     }
 
-    pub async fn add_state_machines_inactive(
-        &self,
-        dbtx: &mut DatabaseTransaction<'_>,
-        states: Vec<DynState<DynGlobalClientContext>>,
-    ) -> AddStateMachinesResult {
-        self.executor
-            .add_state_machines_inactive_dbtx(dbtx, states)
-            .await
-    }
-
     // TODO: implement as part of [`OperationLog`]
     pub async fn get_active_operations(&self) -> HashSet<OperationId> {
         let active_states = self.executor.get_active_states().await;

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1763,6 +1763,17 @@ impl ClientBuilder {
         Ok(client)
     }
 
+    /// Join a new Federation
+    ///
+    /// **Warning**: Calling `join` with a `root_secret` key that was used
+    /// previous to `join` a Federation will lead to all sorts of malfunctions
+    /// including likely loss of funds.
+    ///
+    /// This should be generally called only if the `root_secret` key is known
+    /// not to have been used before (e.g. just randomly generated). For keys
+    /// that might have been previous used (e.g. provided by the user),
+    /// it's safer to call [`Self::recover`] which will attempt to recover
+    /// client module states for the Federation.
     pub async fn join(
         self,
         root_secret: DerivableSecret,
@@ -1773,6 +1784,16 @@ impl ClientBuilder {
             .await
     }
 
+    /// Join a (possibly) previous joined Federation
+    ///
+    /// Unlike [`Self::join`], `recover` will run client module recovery for
+    /// each client module attempting to recover any previous module state.
+    ///
+    /// Recovery process takes time during which each recovering client module
+    /// will not be available for use.
+    ///
+    /// Calling `recovery` with a `root_secret` that was not actually previous
+    /// used in a given Federation is safe.
     pub async fn recover(
         self,
         root_secret: DerivableSecret,

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -838,6 +838,16 @@ impl Client {
         self.executor.add_state_machines_dbtx(dbtx, states).await
     }
 
+    pub async fn add_state_machines_inactive(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        states: Vec<DynState<DynGlobalClientContext>>,
+    ) -> AddStateMachinesResult {
+        self.executor
+            .add_state_machines_inactive_dbtx(dbtx, states)
+            .await
+    }
+
     // TODO: implement as part of [`OperationLog`]
     pub async fn get_active_operations(&self) -> HashSet<OperationId> {
         let active_states = self.executor.get_active_states().await;
@@ -1976,6 +1986,10 @@ impl ClientBuilder {
 
             for (module_instance_id, _, module) in modules.iter_modules() {
                 executor_builder.with_module_dyn(module.context(module_instance_id));
+            }
+
+            for (module_instance_id, _) in module_recoveries.iter() {
+                executor_builder.with_valid_module_id(*module_instance_id);
             }
 
             executor_builder.build(db.clone(), notifier).await

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1455,6 +1455,16 @@ impl Client {
         Ok(())
     }
 
+    pub async fn wait_for_all_active_state_machines(&self) -> anyhow::Result<()> {
+        loop {
+            if self.executor.get_active_states().await.is_empty() {
+                break;
+            }
+            fedimint_core::task::sleep(Duration::from_millis(100)).await;
+        }
+        Ok(())
+    }
+
     /// Set the client [`Metadata`]
     pub async fn set_metadata_dbtx(dbtx: &mut DatabaseTransaction<'_>, metadata: &Metadata) {
         dbtx.insert_new_entry(&ClientMetadataKey, metadata).await;

--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -12,7 +12,10 @@ use fedimint_core::module::{
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{apply, async_trait_maybe_send, dyn_newtype_define};
 use fedimint_derive_secret::DerivableSecret;
+use tokio::sync::watch;
+use tracing::warn;
 
+use super::recovery::{DynModuleBackup, RecoveryProgress};
 use super::{ClientContext, FinalClient};
 use crate::module::{ClientModule, DynClientModule};
 use crate::sm::{ModuleNotifier, Notifier};
@@ -90,6 +93,91 @@ where
     }
 }
 
+// TODO: remove
+#[allow(dead_code)]
+pub struct ClientModuleRecoverArgs<C>
+where
+    C: ClientModuleInit,
+{
+    federation_id: FederationId,
+    cfg: <<C as ModuleInit>::Common as CommonModuleInit>::ClientConfig,
+    db: Database,
+    api_version: ApiVersion,
+    module_root_secret: DerivableSecret,
+    notifier: ModuleNotifier<
+        DynGlobalClientContext,
+        <<C as ClientModuleInit>::Module as ClientModule>::States,
+    >,
+    api: DynGlobalApi,
+    module_api: DynModuleApi,
+    context: ClientContext<<C as ClientModuleInit>::Module>,
+    progress_tx: tokio::sync::watch::Sender<RecoveryProgress>,
+}
+
+impl<C> ClientModuleRecoverArgs<C>
+where
+    C: ClientModuleInit,
+{
+    pub fn federation_id(&self) -> &FederationId {
+        &self.federation_id
+    }
+
+    pub fn cfg(&self) -> &<<C as ModuleInit>::Common as CommonModuleInit>::ClientConfig {
+        &self.cfg
+    }
+
+    pub fn db(&self) -> &Database {
+        &self.db
+    }
+
+    pub fn api_version(&self) -> &ApiVersion {
+        &self.api_version
+    }
+
+    pub fn module_root_secret(&self) -> &DerivableSecret {
+        &self.module_root_secret
+    }
+
+    pub fn notifier(
+        &self,
+    ) -> &ModuleNotifier<
+        DynGlobalClientContext,
+        <<C as ClientModuleInit>::Module as ClientModule>::States,
+    > {
+        &self.notifier
+    }
+
+    pub fn api(&self) -> &DynGlobalApi {
+        &self.api
+    }
+
+    pub fn module_api(&self) -> &DynModuleApi {
+        &self.module_api
+    }
+
+    /// Get the [`ClientContext`]
+    ///
+    /// Notably `ClientContext`, unlike [`ClientModuleInitArgs::context`],
+    /// the client context is guaranteed to be usable immediately.
+    pub fn context(&self) -> ClientContext<<C as ClientModuleInit>::Module> {
+        self.context.clone()
+    }
+
+    pub async fn update_recovery_progress(&self, progress: RecoveryProgress) {
+        if progress.is_done() {
+            // Recovery is complete when the recovery function finishes. To avoid
+            // confusing any downstream code, we never send completed process.
+            warn!("Module trying to send a completed recovery progress. Ignoring");
+        } else if progress.is_none() {
+            // Recovery starts with "none" none progress. To avoid
+            // confusing any downstream code, we never send none process afterwards.
+            warn!("Module trying to send a none recovery progress. Ignoring");
+        } else if self.progress_tx.send(progress).is_err() {
+            warn!("Module trying to send a recovery progress but nothing is listening");
+        }
+    }
+}
+
 #[apply(async_trait_maybe_send!)]
 pub trait ClientModuleInit: ModuleInit + Sized {
     type Module: ClientModule;
@@ -97,6 +185,23 @@ pub trait ClientModuleInit: ModuleInit + Sized {
     /// Api versions of the corresponding server side module's API
     /// that this client module implementation can use.
     fn supported_api_versions(&self) -> MultiApiVersion;
+
+    /// Recover the state of the client module, optionally from an existing
+    /// snapshot.
+    ///
+    /// If `Err` is returned, the higher level client/application might try
+    /// again at a different time (client restarted, code version changed, etc.)
+    async fn recover(
+        &self,
+        _args: &ClientModuleRecoverArgs<Self>,
+        _snapshot: Option<&<Self::Module as ClientModule>::Backup>,
+    ) -> anyhow::Result<()> {
+        warn!(
+            kind = %<Self::Module as ClientModule>::kind(),
+            "Module does not support recovery, completing without doing anything"
+        );
+        Ok(())
+    }
 
     /// Initialize a [`ClientModule`] instance from its config
     async fn init(&self, args: &ClientModuleInitArgs<Self>) -> anyhow::Result<Self::Module>;
@@ -114,13 +219,28 @@ pub trait IClientModuleInit: IDynCommonModuleInit + Debug + MaybeSend + MaybeSyn
     fn supported_api_versions(&self) -> MultiApiVersion;
 
     #[allow(clippy::too_many_arguments)]
+    async fn recover(
+        &self,
+        final_client: FinalClient,
+        federation_id: FederationId,
+        cfg: ClientModuleConfig,
+        db: Database,
+        instance_id: ModuleInstanceId,
+        api_version: ApiVersion,
+        module_root_secret: DerivableSecret,
+        notifier: Notifier<DynGlobalClientContext>,
+        api: DynGlobalApi,
+        snapshot: Option<&DynModuleBackup>,
+        progress_tx: watch::Sender<RecoveryProgress>,
+    ) -> anyhow::Result<()>;
+
+    #[allow(clippy::too_many_arguments)]
     async fn init(
         &self,
         final_client: FinalClient,
         federation_id: FederationId,
         cfg: ClientModuleConfig,
         db: Database,
-        // FIXME: don't make modules aware of their instance id
         instance_id: ModuleInstanceId,
         api_version: ApiVersion,
         module_root_secret: DerivableSecret,
@@ -148,6 +268,53 @@ where
 
     fn supported_api_versions(&self) -> MultiApiVersion {
         <Self as ClientModuleInit>::supported_api_versions(self)
+    }
+
+    async fn recover(
+        &self,
+        final_client: FinalClient,
+        federation_id: FederationId,
+        cfg: ClientModuleConfig,
+        db: Database,
+        instance_id: ModuleInstanceId,
+        api_version: ApiVersion,
+        module_root_secret: DerivableSecret,
+        // TODO: make dyn type for notifier
+        notifier: Notifier<DynGlobalClientContext>,
+        api: DynGlobalApi,
+        snapshot: Option<&DynModuleBackup>,
+        progress_tx: watch::Sender<RecoveryProgress>,
+    ) -> anyhow::Result<()> {
+        let typed_cfg: &<<T as fedimint_core::module::ModuleInit>::Common as CommonModuleInit>::ClientConfig = cfg.cast()?;
+        let snapshot: Option<&<<Self as ClientModuleInit>::Module as ClientModule>::Backup> =
+            snapshot.map(|s| {
+                s.as_any()
+                    .downcast_ref()
+                    .expect("can't convert client module backup to desired type")
+            });
+
+        Ok(self
+            .recover(
+                &ClientModuleRecoverArgs {
+                    federation_id,
+                    cfg: typed_cfg.clone(),
+                    db: db.with_prefix_module_id(instance_id),
+                    api_version,
+                    module_root_secret,
+                    notifier: notifier.module_notifier(instance_id),
+                    api: api.clone(),
+                    module_api: api.with_module(instance_id),
+                    context: ClientContext {
+                        client: final_client,
+                        module_instance_id: instance_id,
+                        module_db: db.with_prefix_module_id(instance_id),
+                        _marker: marker::PhantomData,
+                    },
+                    progress_tx,
+                },
+                snapshot,
+            )
+            .await?)
     }
 
     async fn init(

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -146,17 +146,6 @@ where
             .await
     }
 
-    pub async fn add_state_machines_inactive(
-        &mut self,
-        dyn_states: Vec<DynState<DynGlobalClientContext>>,
-    ) -> AddStateMachinesResult {
-        self.client
-            .client
-            .get()
-            .add_state_machines_inactive(self.dbtx, dyn_states)
-            .await
-    }
-
     pub fn decoders(&self) -> ModuleDecoderRegistry {
         self.client.client.get().decoders().clone()
     }

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -146,6 +146,17 @@ where
             .await
     }
 
+    pub async fn add_state_machines_inactive(
+        &mut self,
+        dyn_states: Vec<DynState<DynGlobalClientContext>>,
+    ) -> AddStateMachinesResult {
+        self.client
+            .client
+            .get()
+            .add_state_machines_inactive(self.dbtx, dyn_states)
+            .await
+    }
+
     pub fn decoders(&self) -> ModuleDecoderRegistry {
         self.client.client.get().decoders().clone()
     }

--- a/fedimint-client/src/module/recovery.rs
+++ b/fedimint-client/src/module/recovery.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId};
 use fedimint_core::encoding::{Decodable, DynEncodable, Encodable};
@@ -100,5 +100,53 @@ impl IntoDynInstance for NoModuleBackup {
 
     fn into_dyn(self, instance_id: ModuleInstanceId) -> Self::DynType {
         DynModuleBackup::from_typed(instance_id, self)
+    }
+}
+
+/// Progress of the recovery
+///
+/// This includes "magic" value: if `total` is `0` the progress is "not started
+/// yet"/"empty"/"none"
+#[derive(Debug, Copy, Clone, Encodable, Decodable)]
+pub struct RecoveryProgress {
+    pub complete: u32,
+    pub total: u32,
+}
+
+impl RecoveryProgress {
+    pub fn is_done(self) -> bool {
+        !self.is_none() && self.total <= self.complete
+    }
+
+    pub fn none() -> RecoveryProgress {
+        Self {
+            complete: 0,
+            total: 0,
+        }
+    }
+
+    pub fn is_none(self) -> bool {
+        self.total == 0
+    }
+
+    pub fn to_complete(self) -> RecoveryProgress {
+        if self.is_none() {
+            // Since we don't have a valid "total", we make up a 1 out of 1
+            Self {
+                complete: 1,
+                total: 1,
+            }
+        } else {
+            Self {
+                complete: self.total,
+                total: self.total,
+            }
+        }
+    }
+}
+
+impl fmt::Display for RecoveryProgress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}/{}", self.complete, self.total))
     }
 }

--- a/fedimint-core/src/module/registry.rs
+++ b/fedimint-core/src/module/registry.rs
@@ -76,10 +76,16 @@ impl<M, State> ModuleRegistry<M, State> {
         }
     }
 
+    /// Is registry empty?
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
     /// Return an iterator over all module data
     pub fn iter_modules(&self) -> impl Iterator<Item = (ModuleInstanceId, &ModuleKind, &M)> {
         self.inner.iter().map(|(id, (kind, m))| (*id, kind, m))
     }
+
     /// Return an iterator over all module data
     pub fn iter_modules_mut(
         &mut self,
@@ -87,6 +93,11 @@ impl<M, State> ModuleRegistry<M, State> {
         self.inner
             .iter_mut()
             .map(|(id, (kind, m))| (*id, &*kind, m))
+    }
+
+    /// Return an iterator over all module data
+    pub fn into_iter_modules(self) -> impl Iterator<Item = (ModuleInstanceId, ModuleKind, M)> {
+        self.inner.into_iter().map(|(id, (kind, m))| (id, kind, m))
     }
 
     /// Get module data by instance id

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -620,7 +620,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn shutdown_task_group_after() -> anyhow::Result<()> {
-        let mut tg = TaskGroup::new();
+        let tg = TaskGroup::new();
         tg.spawn("shutdown waiter", |handle| async move {
             handle.make_shutdown_rx().await.await
         })
@@ -632,7 +632,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn shutdown_task_group_before() -> anyhow::Result<()> {
-        let mut tg = TaskGroup::new();
+        let tg = TaskGroup::new();
         tg.spawn("shutdown waiter", |handle| async move {
             sleep(Duration::from_millis(10)).await;
             handle.make_shutdown_rx().await.await

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -170,7 +170,7 @@ impl TaskGroup {
 
     #[cfg(not(target_family = "wasm"))]
     pub async fn spawn<Fut, R>(
-        &mut self,
+        &self,
         name: impl Into<String>,
         f: impl FnOnce(TaskHandle) -> Fut + Send + 'static,
     ) -> oneshot::Receiver<R>
@@ -208,7 +208,7 @@ impl TaskGroup {
 
     #[cfg(not(target_family = "wasm"))]
     pub async fn spawn_local<Fut>(
-        &mut self,
+        &self,
         name: impl Into<String>,
         f: impl FnOnce(TaskHandle) -> Fut + 'static,
     ) where
@@ -232,7 +232,7 @@ impl TaskGroup {
     // TODO: Send vs lack of Send bound; do something about it
     #[cfg(target_family = "wasm")]
     pub async fn spawn<Fut, R>(
-        &mut self,
+        &self,
         name: impl Into<String>,
         f: impl FnOnce(TaskHandle) -> Fut + 'static,
     ) -> oneshot::Receiver<R>

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -238,7 +238,7 @@ impl ConfigGenApi {
         self.update_leader().await?;
 
         let self_clone = self.clone();
-        let mut sub_group = self.task_group.make_subgroup().await;
+        let sub_group = self.task_group.make_subgroup().await;
         sub_group
             .spawn("run dkg", move |_handle| async move {
                 // Followers wait for leader to signal readiness for DKG
@@ -466,7 +466,7 @@ impl ConfigGenApi {
         // Followers wait for leader to signal that all peers have restarted setup
         // The leader will signal this by setting it's status to AwaitingPassword
         let self_clone = self.clone();
-        let mut sub_group = self.task_group.make_subgroup().await;
+        let sub_group = self.task_group.make_subgroup().await;
         sub_group
             .spawn("restart", move |_handle| async move {
                 if let Some(client) = leader {

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -217,7 +217,7 @@ pub mod test {
         const NUM_REPEAT_TEST: usize = 10;
 
         for _ in 0..NUM_REPEAT_TEST {
-            let mut task_group = TaskGroup::new();
+            let task_group = TaskGroup::new();
             let task_handle = task_group.make_handle();
 
             let peer1 = PeerId::from(0);

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -126,7 +126,7 @@ impl GatewayTest {
         .expect("Failed to create gateway");
 
         let gateway_run = gateway.clone();
-        let mut root_group = TaskGroup::new();
+        let root_group = TaskGroup::new();
         let mut tg = root_group.clone();
         root_group
             .spawn("Gateway Run", |_handle| async move {

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -197,7 +197,7 @@ impl Fedimintd {
             .init()
             .unwrap();
 
-        let mut root_task_group = TaskGroup::new();
+        let root_task_group = TaskGroup::new();
         root_task_group.install_kill_handler();
 
         let timing_total_runtime = timing::TimeReporter::new("total-runtime").info();

--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -5,6 +5,7 @@ use fedimint_mint_common::Nonce;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
+use crate::backup::recovery::MintRecoveryState;
 use crate::SpendableNote;
 
 #[repr(u8)]
@@ -13,6 +14,7 @@ pub enum DbKeyPrefix {
     Note = 0x20,
     NextECashNoteIndex = 0x2a,
     CancelledOOBSpend = 0x2b,
+    RestoreState = 0x2c,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -53,6 +55,17 @@ impl_db_lookup!(
     query_prefix = NextECashNoteIndexKeyPrefix
 );
 
+#[derive(Debug, Clone, Encodable, Decodable, Serialize)]
+pub struct RestoreStateKey;
+
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct RestoreStateKeyPrefix;
+
+impl_db_record!(
+    key = RestoreStateKey,
+    value = MintRecoveryState,
+    db_prefix = DbKeyPrefix::RestoreState,
+);
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct CancelledOOBSpendKey(pub OperationId);
 

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -430,6 +430,15 @@ impl MintClientInit {
             .await
         }
 
+        Self::finalize_state_restore(state, client_ctx).await?;
+
+        Ok(())
+    }
+
+    async fn finalize_state_restore(
+        state: MintRecoveryState,
+        client_ctx: ClientContext<MintClientModule>,
+    ) -> Result<(), anyhow::Error> {
         debug!(
             target: LOG_CLIENT_RECOVERY_MINT,
             ?state,
@@ -490,7 +499,7 @@ impl MintClientInit {
 
                         for (out_point, amount, issuance_request) in finalized.unconfirmed_notes {
                             let client_ctx = dbtx.client_ctx();
-                            dbtx.add_state_machines(
+                            dbtx.add_state_machines_inactive(
                                 client_ctx
                                     .map_dyn(vec![MintClientStateMachines::Output(
                                         MintOutputStateMachine {
@@ -522,10 +531,10 @@ impl MintClientInit {
                 None,
             )
             .await?;
-
         Ok(())
     }
 }
+
 /// The `MintClientModule` is responsible for handling e-cash minting
 /// operations. It interacts with the mint server to issue, reissue, and
 /// validate e-cash notes.

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -20,11 +20,13 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, ensure, Context as _};
 use async_stream::stream;
-use backup::recovery::{MintRestoreStateMachine, MintRestoreStates};
 use bitcoin_hashes::{sha256, sha256t, Hash, HashEngine as BitcoinHashEngine};
 use client_db::DbKeyPrefix;
-use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
-use fedimint_client::module::{ClientContext, ClientDbTxContext, ClientModule, IClientModule};
+use fedimint_client::module::init::{
+    ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
+};
+use fedimint_client::module::recovery::RecoveryProgress;
+use fedimint_client::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
@@ -47,6 +49,7 @@ use fedimint_core::{
     TieredMulti, TieredSummary, TransactionId,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
+use fedimint_logging::LOG_CLIENT_RECOVERY_MINT;
 pub use fedimint_mint_common as common;
 use fedimint_mint_common::config::MintClientConfig;
 pub use fedimint_mint_common::*;
@@ -58,11 +61,11 @@ use tbs::AggregatePublicKey;
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
-use crate::backup::recovery::MintRestoreInProgressState;
+use crate::backup::recovery::MintRecoveryState;
 use crate::backup::{EcashBackup, EcashBackupV0};
 use crate::client_db::{
     CancelledOOBSpendKey, CancelledOOBSpendKeyPrefix, NextECashNoteIndexKey,
-    NextECashNoteIndexKeyPrefix, NoteKey, NoteKeyPrefix,
+    NextECashNoteIndexKeyPrefix, NoteKey, NoteKeyPrefix, RestoreStateKey,
 };
 use crate::input::{
     MintInputCommon, MintInputStateCreated, MintInputStateMachine, MintInputStates,
@@ -74,8 +77,6 @@ use crate::output::{
 };
 
 const MINT_E_CASH_TYPE_CHILD_ID: ChildId = ChildId(0);
-
-const MINT_BACKUP_RESTORE_OPERATION_ID: OperationId = OperationId([0x01; 32]);
 
 pub const LOG_TARGET: &str = "client::module::mint";
 
@@ -324,6 +325,7 @@ impl ModuleInit for MintClientInit {
                         "CancelledOOBSpendKey"
                     );
                 }
+                DbKeyPrefix::RestoreState => {}
             }
         }
 
@@ -341,6 +343,11 @@ impl ClientModuleInit for MintClientInit {
     }
 
     async fn init(&self, args: &ClientModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
+        assert!(
+            Self::load_recovery_state(args.db()).await.is_none(),
+            "recovery state must be empty on mint init"
+        );
+
         Ok(MintClientModule {
             federation_id: *args.federation_id(),
             cfg: args.cfg().clone(),
@@ -350,8 +357,175 @@ impl ClientModuleInit for MintClientInit {
             client_ctx: args.context(),
         })
     }
+
+    async fn recover(
+        &self,
+        args: &ClientModuleRecoverArgs<Self>,
+        snapshot: Option<&<Self::Module as ClientModule>::Backup>,
+    ) -> anyhow::Result<()> {
+        let snapshot_v0 = match snapshot {
+            Some(EcashBackup::V0(snapshot_v0)) => Some(snapshot_v0),
+            Some(EcashBackup::Default { variant, .. }) => {
+                return Err(anyhow!("Unsupported backup variant: {variant}"))
+            }
+            None => None,
+        };
+
+        Self::recover_inner(args, snapshot_v0.cloned()).await
+    }
 }
 
+impl MintClientInit {
+    async fn load_recovery_state(db: &Database) -> Option<MintRecoveryState> {
+        db.begin_transaction_nc()
+            .await
+            .get_value(&RestoreStateKey)
+            .await
+    }
+
+    async fn recover_inner(
+        args: &ClientModuleRecoverArgs<Self>,
+        snapshot: Option<EcashBackupV0>,
+    ) -> anyhow::Result<()> {
+        let snapshot = snapshot.unwrap_or(EcashBackupV0::new_empty());
+        let client_ctx = args.context();
+        let config = args.cfg();
+        let db = args.db().clone();
+
+        let current_session_count = client_ctx.global_api().session_count().await?;
+        let secret = args.module_root_secret().clone();
+
+        let mut state = if let Some(state) = Self::load_recovery_state(&db).await {
+            state
+        } else {
+            MintRecoveryState::from_backup(
+                current_session_count,
+                snapshot,
+                30,
+                config.tbs_pks.clone(),
+                config.peer_tbs_pks.clone(),
+                &secret,
+            )
+        };
+
+        debug!(target: LOG_TARGET, "Creating MintRestoreStateMachine");
+
+        while !state.is_done() {
+            state = state
+                .make_progress(args.api().clone(), client_ctx.decoders(), secret.clone())
+                .await;
+
+            let mut dbtx = db.begin_transaction().await;
+
+            dbtx.insert_entry(&RestoreStateKey, &state).await;
+            dbtx.commit_tx().await;
+            args.update_recovery_progress(RecoveryProgress {
+                complete: (state.next_epoch - state.start_epoch)
+                    .try_into()
+                    .unwrap_or(u32::MAX),
+                total: (state.end_epoch - state.start_epoch)
+                    .try_into()
+                    .unwrap_or(u32::MAX),
+            })
+            .await
+        }
+
+        debug!(
+            target: LOG_CLIENT_RECOVERY_MINT,
+            ?state,
+            "Finalizing restore"
+        );
+
+        let finalized = state.finalize();
+
+        let restored_amount = finalized
+            .unconfirmed_notes
+            .iter()
+            .map(|entry| entry.1)
+            .sum::<Amount>()
+            + finalized.spendable_notes.total_amount();
+
+        info!(amount = %restored_amount, "Finalizing mint recovery");
+
+        let finalized = &finalized;
+
+        client_ctx
+            .clone()
+            .module_autocommit_2(
+                move |dbtx, _| {
+                    Box::pin(async move {
+                        let finalized = finalized.clone();
+                        dbtx.module_dbtx().remove_entry(&RestoreStateKey).await;
+
+                        debug!(
+                            target: LOG_CLIENT_RECOVERY_MINT,
+                            len = finalized.spendable_notes.count_items(),
+                            "Restoring spendable notes"
+                        );
+                        for (amount, note) in finalized.spendable_notes {
+                            let key = NoteKey {
+                                amount,
+                                nonce: note.nonce(),
+                            };
+                            dbtx.module_dbtx().insert_new_entry(&key, &note).await;
+                        }
+
+                        for (amount, note_idx) in finalized.next_note_idx.iter() {
+                            debug!(
+                                target: LOG_CLIENT_RECOVERY_MINT,
+                                %amount,
+                                %note_idx,
+                                "Restoring NextECashNodeIndex"
+                            );
+                            dbtx.module_dbtx()
+                                .insert_entry(&NextECashNoteIndexKey(amount), &note_idx.as_u64())
+                                .await;
+                        }
+
+                        debug!(
+                            target: LOG_CLIENT_RECOVERY_MINT,
+                            len = finalized.unconfirmed_notes.len(),
+                            "Restoring unconfigured notes state machines"
+                        );
+
+                        for (out_point, amount, issuance_request) in finalized.unconfirmed_notes {
+                            let client_ctx = dbtx.client_ctx();
+                            dbtx.add_state_machines(
+                                client_ctx
+                                    .map_dyn(vec![MintClientStateMachines::Output(
+                                        MintOutputStateMachine {
+                                            common: MintOutputCommon {
+                                                operation_id: OperationId::new_random(),
+                                                out_point,
+                                            },
+                                            state: crate::output::MintOutputStates::Created(
+                                                MintOutputStatesCreated {
+                                                    amount,
+                                                    issuance_request,
+                                                },
+                                            ),
+                                        },
+                                    )])
+                                    .collect(),
+                            )
+                            .await?;
+                        }
+
+                        debug!(
+                            target: LOG_CLIENT_RECOVERY_MINT,
+                            "Mint module recovery finalized"
+                        );
+
+                        Ok(())
+                    })
+                },
+                None,
+            )
+            .await?;
+
+        Ok(())
+    }
+}
 /// The `MintClientModule` is responsible for handling e-cash minting
 /// operations. It interacts with the mint server to issue, reissue, and
 /// validate e-cash notes.
@@ -524,32 +698,6 @@ impl ClientModule for MintClientModule {
             })
     }
 
-    async fn restore(&self, snapshot: Option<EcashBackup>) -> anyhow::Result<()> {
-        let snapshot_v0 = match snapshot {
-            Some(EcashBackup::V0(snapshot_v0)) => Some(snapshot_v0),
-            Some(EcashBackup::Default { variant, .. }) => {
-                return Err(anyhow!("Unsupported backup variant: {variant}"))
-            }
-            None => None,
-        };
-
-        self.client_ctx
-            .module_autocommit(
-                move |dbtx_ctx, _| {
-                    let snapshot_inner = snapshot_v0.clone();
-                    Box::pin(async move { self.restore_inner(dbtx_ctx, snapshot_inner).await })
-                },
-                None,
-            )
-            .await
-            .map_err(|e| match e {
-                AutocommitError::ClosureError { error, .. } => error,
-                AutocommitError::CommitFailed { last_error, .. } => {
-                    anyhow!("Commit to DB failed: {last_error}")
-                }
-            })
-    }
-
     fn supports_being_primary(&self) -> bool {
         true
     }
@@ -604,13 +752,6 @@ impl ClientModule for MintClientModule {
                         // output state
                         MintClientStateMachines::OOB(MintOOBStateMachine {
                             state: MintOOBStates::Created(_),
-                            ..
-                        }) => Some(()),
-                        // We don't want to scare users, so we only trigger on success instead of
-                        // showing incremental progress. Ideally the balance isn't shown to them
-                        // during recovery anyway.
-                        MintClientStateMachines::Restore(MintRestoreStateMachine {
-                            state: MintRestoreStates::Success(_),
                             ..
                         }) => Some(()),
                         _ => None,
@@ -883,32 +1024,6 @@ impl MintClientModule {
         )
         .next_or_pending()
         .await
-    }
-
-    pub async fn await_restore_finished(&self) -> anyhow::Result<Amount> {
-        let mut restore_stream = self
-            .notifier
-            .subscribe(MINT_BACKUP_RESTORE_OPERATION_ID)
-            .await;
-        while let Some(restore_step) = restore_stream.next().await {
-            match restore_step {
-                MintClientStateMachines::Restore(MintRestoreStateMachine {
-                    state: MintRestoreStates::Success(amount),
-                    ..
-                }) => {
-                    return Ok(amount);
-                }
-                MintClientStateMachines::Restore(MintRestoreStateMachine {
-                    state: MintRestoreStates::Failed(error),
-                    ..
-                }) => {
-                    return Err(anyhow!("Restore failed: {}", error.reason));
-                }
-                _ => {}
-            }
-        }
-
-        Err(anyhow!("Restore stream closed without success or failure"))
     }
 
     /// Select notes with `requested_amount` using `notes_selector`.
@@ -1311,56 +1426,6 @@ impl MintClientModule {
 
         Ok(operation)
     }
-
-    async fn restore_inner(
-        &self,
-        dbtx_ctx: &'_ mut ClientDbTxContext<'_, '_, Self>,
-        maybe_snapshot: Option<EcashBackupV0>,
-    ) -> anyhow::Result<()> {
-        if !Self::get_all_spendable_notes(&mut dbtx_ctx.module_dbtx())
-            .await
-            .is_empty()
-        {
-            warn!(
-                target: LOG_TARGET,
-                "Can not start recovery - existing spendable notes found"
-            );
-            bail!("Found existing spendable notes. Mint module recovery must be started on an empty state.")
-        }
-
-        if !self.client_ctx.get_own_active_states().await.is_empty() {
-            warn!(
-                target: LOG_TARGET,
-                "Can not start recovery - existing state machines found"
-            );
-            bail!("Found existing active state machines. Mint module recovery must be started on an empty state.")
-        }
-
-        let snapshot = maybe_snapshot.unwrap_or(EcashBackupV0::new_empty());
-
-        let current_session_count = self.client_ctx.global_api().session_count().await?;
-        let state = MintRestoreInProgressState::from_backup(
-            current_session_count,
-            snapshot,
-            30,
-            self.cfg.tbs_pks.clone(),
-            self.cfg.peer_tbs_pks.clone(),
-            &self.secret,
-        );
-
-        debug!(target: LOG_TARGET, "Creating MintRestoreStateMachine");
-
-        dbtx_ctx
-            .add_state_machines_dbtx(vec![self.client_ctx.make_dyn_state(
-                MintClientStateMachines::Restore(MintRestoreStateMachine {
-                    operation_id: MINT_BACKUP_RESTORE_OPERATION_ID,
-                    state: MintRestoreStates::InProgress(state),
-                }),
-            )])
-            .await?;
-
-        Ok(())
-    }
 }
 
 pub fn spendable_notes_to_operation_id(
@@ -1526,7 +1591,6 @@ pub enum MintClientStateMachines {
     Output(MintOutputStateMachine),
     Input(MintInputStateMachine),
     OOB(MintOOBStateMachine),
-    Restore(MintRestoreStateMachine),
 }
 
 impl IntoDynInstance for MintClientStateMachines {
@@ -1565,12 +1629,6 @@ impl State for MintClientStateMachines {
                     MintClientStateMachines::OOB
                 )
             }
-            MintClientStateMachines::Restore(restore_state) => {
-                sm_enum_variant_translation!(
-                    restore_state.transitions(context, global_context),
-                    MintClientStateMachines::Restore
-                )
-            }
         }
     }
 
@@ -1579,7 +1637,6 @@ impl State for MintClientStateMachines {
             MintClientStateMachines::Output(issuance_state) => issuance_state.operation_id(),
             MintClientStateMachines::Input(redemption_state) => redemption_state.operation_id(),
             MintClientStateMachines::OOB(oob_state) => oob_state.operation_id(),
-            MintClientStateMachines::Restore(state) => state.operation_id(),
         }
     }
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -499,7 +499,7 @@ impl MintClientInit {
 
                         for (out_point, amount, issuance_request) in finalized.unconfirmed_notes {
                             let client_ctx = dbtx.client_ctx();
-                            dbtx.add_state_machines_inactive(
+                            dbtx.add_state_machines(
                                 client_ctx
                                     .map_dyn(vec![MintClientStateMachines::Output(
                                         MintOutputStateMachine {

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -360,6 +360,7 @@ rec {
   ciTestAll = craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-all";
     cargoArtifacts = workspaceBuild;
+
     # One normal run, then if succeeded, modify the "always success test" to fail,
     # and make sure we detect it (happened too many times that we didn't).
     # Thanks to early termination, this should be all very quick, as we actually


### PR DESCRIPTION
Re #2977

This is a initial step towards client module recovery system described/agreed on in #2977.

### Most notable points of the new design:

Module recoveries work as just standalone function (future): `ClientModuleInit::recover` called instead of usual `ClientModuleInit::init`. This makes module job easier (in a sense at least), as it is not constantly being interrupted (will help with efficient streaming through blocks). It's up to the implementation to periodically save state and send progress updates, but a follow up changes will introduce helper functions to set the module implementation on the right track. It also avoids saving tons of in-progress data in the state machine execuation log. Conceptually module recovery is not a client state machine.

Module recovery state is persisted and tracked and modules become available as they complete their recovery (on the next client start). A slow module will not block recovery of other modules.

### Follow-up work

* [ ] Mint recovery should be refactored into a framework-function that will take care of saving progress and sending updates (a method on `ClientmoduleRecoverArgs`)
* [x] Add streaming of blocks like in #4019, but this time for the whole range all at once (should lead to much better performance): https://github.com/fedimint/fedimint/pull/4042
* [x] Caching of `api.await_block` in a transparent LRU: https://github.com/fedimint/fedimint/pull/4080