### PR TITLE
fix(gateway): re-introduce post info API endpoint

### DIFF
--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -34,6 +34,8 @@ pub async fn run_webserver(
 
         // Authenticated, public routes used for gateway administration
         let admin_routes = Router::new()
+            // FIXME: deprecated >= 0.3.0
+            .route("/info", post(info))
             .route("/info", get(info))
             .route("/config", post(configuration))
             .route("/balance", post(balance))
@@ -50,6 +52,8 @@ pub async fn run_webserver(
         let routes = Router::new()
             .route("/set_configuration", post(set_configuration))
             .route("/config", get(configuration))
+            // FIXME: deprecated >= 0.3.0
+            .route("/info", post(info))
             .route("/info", get(info));
         (routes, Router::new())
     };


### PR DESCRIPTION
We changed it to be a `get` endpoint (#3847) but didn't think about backwards compatibility. We'll have to keep the post version around in addition to the get version for a while to ensure compatibility.

Hopefully unblocks #4010.