### PR TITLE
chore: add module dkg message

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -747,11 +747,11 @@ pub trait TypedServerModuleConfig: DeserializeOwned + Serialize {
 }
 
 /// Things that a `distributed_gen` config can send between peers
-// TODO: Needs to be modularized in case modules want to send new message types for DKG
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DkgPeerMsg {
     PublicKey(secp256k1::PublicKey),
     DistributedGen(SupportedDkgMessage),
+    Module(Vec<u8>),
     // Dkg completed on our side
     Done,
 }
@@ -772,6 +772,8 @@ pub enum DkgError {
     ModuleNotFound(ModuleKind),
     #[error("Params for modules were not found {0:?}")]
     ParamsNotFound(BTreeSet<ModuleKind>),
+    #[error("Failed to decode module message {0:?}")]
+    ModuleDecodeError(ModuleKind),
 }
 
 /// Supported (by Fedimint's code) `DkgMessage<T>` types

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -122,6 +122,14 @@ pub trait Decodable: Sized {
         let mut reader = std::io::Cursor::new(bytes);
         Decodable::consensus_decode(&mut reader, modules)
     }
+
+    fn consensus_decode_vec(
+        bytes: Vec<u8>,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        let mut reader = std::io::Cursor::new(bytes);
+        Decodable::consensus_decode(&mut reader, modules)
+    }
 }
 
 impl Encodable for SafeUrl {


### PR DESCRIPTION
For the Nostr federated client module that @EthnTuttle and I are building, I need to be able to exchange some messages during DKG to setup the Frost key. There might be a better way to implement FROST directly into Fedimint, but I think it also might be helpful to allow modules to exchange arbitrary messages during DKG. This PR adds `DkgPeerMsg::Module(Vec<u8>)` that allows modules to exchange any type of message during DKG.

Note: `exchange_public_keys` could probably be replaced with `exchange_with_peers<PublicKey>` but I'm not sure if that's backwards compatible, so I left the existing function.