### PR TITLE
chore: add Relative path of root README.md

### DIFF
--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "aead utilities on top of ring"
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint derivable secret implementation"
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/crypto/hkdf/Cargo.toml
+++ b/crypto/hkdf/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "RFC5869 HKDF implementation on top of bitcoin_hashes"
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "tbs is a helper cryptography library for threshold blind signatures"
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/fedimint-bip39/Cargo.toml
+++ b/fedimint-bip39/Cargo.toml
@@ -3,6 +3,7 @@ name = "fedimint-bip39"
 version = "0.3.0-alpha"
 edition = "2021"
 license = "MIT"
+readme = "../README.md"
 description = "Allows using bip39 mnemonic phrases to generate fedimint client keys"
 repository = "https://github.com/fedimint/fedimint"
 

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Bitcoin Core connectivity used by Fedimint"
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/fedimint-build/Cargo.toml
+++ b/fedimint-build/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint is the main consensus code for processing transactions and REST API"
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [lib]

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-cli is a command line interface wrapper for the client library."
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-client provides a library for sending transactions to the federation."
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.cargo-udeps.ignore]

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-core provides common code used by both client and server."
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-derive provides helper macros for serialization."
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [lib]

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-load-test-tool is a tool to load test the fedimint server and gateway."
 license = "MIT"
-readme = "README.md"
 publish = false
 
 [[bin]]

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "contains some utilities for logging and tracing"
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-rocksdb provides a rocksdb-backed database implementation for Fedimint."
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint is the main consensus code for processing transactions and REST API"
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-testing provides a library of shared objects and utilities for testing fedimint components"
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint is the main consensus code for processing transactions and REST API"
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "fedimint-gateway-cli"
 version = "0.3.0-alpha"
 edition = "2021"
 license = "MIT"
+readme = "../../README.md"
 description = "CLI tool to control lightning gateway"
 repository = "https://github.com/fedimint/fedimint"
 

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "ln-gateway is a core lightning plugin which allows a Lightning node operator to receive or pay Lightning invoices on behalf of fedimint users."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/modules/fedimint-dummy-server/Cargo.toml
+++ b/modules/fedimint-dummy-server/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]

--- a/utils/portalloc/Cargo.toml
+++ b/utils/portalloc/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Port allocation utility for Fedimint"
 license = "MIT"
+readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Added the relative path of root README.md file to those publishable Crate's Cargo.toml which do not have its own README
#3924