### PR TITLE
chore: print more useful error message on enum decode errors

### DIFF
--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -1088,7 +1088,7 @@ mod tests {
 
         match decode_res {
             Ok(_) => panic!("Should return error"),
-            Err(e) => assert!(e.to_string().contains("invalid enum variant")),
+            Err(e) => assert!(e.to_string().contains("Invalid enum variant")),
         }
     }
 

--- a/fedimint-derive/src/lib.rs
+++ b/fedimint-derive/src/lib.rs
@@ -278,8 +278,8 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
         }
     } else {
         quote! {
-            _ => {
-                return Err(::fedimint_core::encoding::DecodeError::from_str("invalid enum variant"));
+            variant => {
+                return Err(::fedimint_core::encoding::DecodeError::new_custom(anyhow::anyhow!("Invalid enum variant {} while decoding {}", variant, stringify!(#ident))));
             }
         }
     };


### PR DESCRIPTION
This was debugging a decoding bug in LN NG.