### PR TITLE
feat: reexport lightning_invoice and bitcoin

### DIFF
--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -34,6 +34,7 @@ use lightning_invoice::{Bolt11Invoice, RoutingFees};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
+pub use {bitcoin, lightning_invoice};
 
 use crate::contracts::incoming::OfferId;
 use crate::contracts::{Contract, ContractId, ContractOutcome, Preimage, PreimageDecryptionShare};


### PR DESCRIPTION
If you are using a different version of rust-lightning and rust-bitcoin then you need to import the version that fedimint is using as well. This makes it so you can get if from the ln common module