### PR TITLE
 feat: await_block LRU cache (non-global) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,6 +1440,7 @@ dependencies = [
  "jsonrpsee-ws-client",
  "lightning 0.0.118",
  "lightning-invoice 0.26.0",
+ "lru",
  "macro_rules_attribute",
  "miniscript",
  "once_cell",
@@ -3532,6 +3533,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "lz4-sys"

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -24,8 +24,7 @@ use fedimint_client::secret::{get_default_client_secret, RootSecretStrategy};
 use fedimint_client::{get_invite_code_from_db, Client, ClientArc, ClientBuilder, FederationInfo};
 use fedimint_core::admin_client::WsAdminClient;
 use fedimint_core::api::{
-    FederationApiExt, FederationError, GlobalFederationApi, IFederationApi, InviteCode,
-    WsFederationApi,
+    FederationApiExt, FederationError, IRawFederationApi, InviteCode, WsFederationApi,
 };
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::OperationId;

--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -4,7 +4,7 @@ use std::io::{Cursor, Error, Read, Write};
 
 use anyhow::Result;
 use bitcoin::secp256k1;
-use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
+use fedimint_core::api::DynGlobalApi;
 use fedimint_core::core::backup::{BackupRequest, SignedBackupRequest};
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -84,8 +84,7 @@ use db::{
     EncodedClientSecretKey, InitMode,
 };
 use fedimint_core::api::{
-    ApiVersionSet, DynGlobalApi, DynModuleApi, GlobalFederationApiWithCache, IGlobalFederationApi,
-    InviteCode, WsFederationApi,
+    ApiVersionSet, DynGlobalApi, DynModuleApi, IGlobalFederationApi, InviteCode,
 };
 use fedimint_core::config::{
     ClientConfig, ClientModuleConfig, FederationId, JsonClientConfig, JsonWithKind,
@@ -1637,9 +1636,7 @@ impl FederationInfo {
 
     /// Creates an API client for the federation
     pub fn api(&self) -> DynGlobalApi {
-        DynGlobalApi::from(GlobalFederationApiWithCache::new(
-            WsFederationApi::from_config(&self.config),
-        ))
+        DynGlobalApi::from_config(&self.config)
     }
 
     pub fn federation_id(&self) -> FederationId {
@@ -1792,9 +1789,7 @@ impl ClientBuilder {
         config: ClientConfig,
         invite_code: InviteCode,
     ) -> anyhow::Result<ClientArc> {
-        let api = DynGlobalApi::from(GlobalFederationApiWithCache::new(
-            WsFederationApi::from_config(&config),
-        ));
+        let api = DynGlobalApi::from_config(&config);
         let snapshot = Client::download_backup_from_federation_static(
             &api,
             &Self::federation_root_secret(&root_secret, &config),
@@ -1838,9 +1833,7 @@ impl ClientBuilder {
         let decoders = self.decoders(&config);
         let config = Self::config_decoded(config, &decoders)?;
         let db = self.db.with_decoders(decoders.clone());
-        let api = DynGlobalApi::from(GlobalFederationApiWithCache::new(
-            WsFederationApi::from_config(&config),
-        ));
+        let api = DynGlobalApi::from_config(&config);
 
         let init_state = Self::load_init_state(&db).await;
 
@@ -2133,10 +2126,7 @@ async fn try_download_config(
     max_retries: usize,
 ) -> anyhow::Result<ClientConfig> {
     debug!(target: LOG_CLIENT, "Download client config");
-    let api: DynGlobalApi = GlobalFederationApiWithCache::new(WsFederationApi::from_invite_code(
-        &[invite_code.clone()],
-    ))
-    .into();
+    let api = DynGlobalApi::from_invite_code(&[invite_code.clone()]);
     let mut num_retries = 0;
     let wait_millis = 500;
     loop {

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -84,7 +84,7 @@ use db::{
     EncodedClientSecretKey, InitMode,
 };
 use fedimint_core::api::{
-    ApiVersionSet, DynGlobalApi, DynModuleApi, GlobalFederationApi, IGlobalFederationApi,
+    ApiVersionSet, DynGlobalApi, DynModuleApi, GlobalFederationApiWithCache, IGlobalFederationApi,
     InviteCode, WsFederationApi,
 };
 use fedimint_core::config::{
@@ -191,7 +191,7 @@ pub trait IGlobalClientContext: Debug + MaybeSend + MaybeSync + 'static {
     /// Returns a reference to the client's federation API client. The provided
     /// interface [`IGlobalFederationApi`] typically does not provide the
     /// necessary functionality, for this extension traits like
-    /// [`fedimint_core::api::GlobalFederationApi`] have to be used.
+    /// [`fedimint_core::api::IGlobalFederationApi`] have to be used.
     // TODO: Could be removed in favor of client() except for testing
     fn api(&self) -> &DynGlobalApi;
 
@@ -1637,7 +1637,9 @@ impl FederationInfo {
 
     /// Creates an API client for the federation
     pub fn api(&self) -> DynGlobalApi {
-        DynGlobalApi::from(WsFederationApi::from_config(&self.config))
+        DynGlobalApi::from(GlobalFederationApiWithCache::new(
+            WsFederationApi::from_config(&self.config),
+        ))
     }
 
     pub fn federation_id(&self) -> FederationId {
@@ -1790,7 +1792,9 @@ impl ClientBuilder {
         config: ClientConfig,
         invite_code: InviteCode,
     ) -> anyhow::Result<ClientArc> {
-        let api = DynGlobalApi::from(WsFederationApi::from_config(&config));
+        let api = DynGlobalApi::from(GlobalFederationApiWithCache::new(
+            WsFederationApi::from_config(&config),
+        ));
         let snapshot = Client::download_backup_from_federation_static(
             &api,
             &Self::federation_root_secret(&root_secret, &config),
@@ -1834,7 +1838,9 @@ impl ClientBuilder {
         let decoders = self.decoders(&config);
         let config = Self::config_decoded(config, &decoders)?;
         let db = self.db.with_decoders(decoders.clone());
-        let api = DynGlobalApi::from(WsFederationApi::from_config(&config));
+        let api = DynGlobalApi::from(GlobalFederationApiWithCache::new(
+            WsFederationApi::from_config(&config),
+        ));
 
         let init_state = Self::load_init_state(&db).await;
 
@@ -2127,8 +2133,10 @@ async fn try_download_config(
     max_retries: usize,
 ) -> anyhow::Result<ClientConfig> {
     debug!(target: LOG_CLIENT, "Download client config");
-    let api = Arc::new(WsFederationApi::from_invite_code(&[invite_code.clone()]))
-        as Arc<dyn IGlobalFederationApi + Send + Sync + 'static>;
+    let api: DynGlobalApi = GlobalFederationApiWithCache::new(WsFederationApi::from_invite_code(
+        &[invite_code.clone()],
+    ))
+    .into();
     let mut num_retries = 0;
     let wait_millis = 500;
     loop {

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -2,7 +2,6 @@
 
 use std::time::Duration;
 
-use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -25,6 +25,7 @@ bech32 = "0.9.1"
 itertools = "0.10.5"
 jsonrpsee-types = { version = "0.21.0" }
 jsonrpsee-core = { version = "0.21.0", features = [ "client" ] }
+lru = "0.12.1"
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"
 strum = "0.24"

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -8,10 +8,7 @@ use fedimint_core::util::SafeUrl;
 use serde::{Deserialize, Serialize};
 use tokio_rustls::rustls;
 
-use crate::api::{
-    DynGlobalApi, FederationApiExt, FederationResult, GlobalFederationApiWithCache, ServerStatus,
-    StatusResponse, WsFederationApi,
-};
+use crate::api::{DynGlobalApi, FederationApiExt, FederationResult, ServerStatus, StatusResponse};
 use crate::config::ServerModuleConfigGenParamsRegistry;
 use crate::endpoint_constants::{
     ADD_CONFIG_GEN_PEER_ENDPOINT, AUDIT_ENDPOINT, AUTH_ENDPOINT, CONFIG_GEN_PEERS_ENDPOINT,
@@ -36,11 +33,7 @@ impl WsAdminClient {
         // multiple peers so errors can be attributed. The admin client has no use for
         // them.
         Self {
-            inner: GlobalFederationApiWithCache::new(WsFederationApi::new(vec![(
-                PeerId(0),
-                url.clone(),
-            )]))
-            .into(),
+            inner: DynGlobalApi::from_endpoints(vec![(PeerId(0), url.clone())]),
             url,
         }
     }

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 use tokio_rustls::rustls;
 
 use crate::api::{
-    DynGlobalApi, FederationApiExt, FederationResult, ServerStatus, StatusResponse, WsFederationApi,
+    DynGlobalApi, FederationApiExt, FederationResult, GlobalFederationApiWithCache, ServerStatus,
+    StatusResponse, WsFederationApi,
 };
 use crate::config::ServerModuleConfigGenParamsRegistry;
 use crate::endpoint_constants::{
@@ -35,7 +36,11 @@ impl WsAdminClient {
         // multiple peers so errors can be attributed. The admin client has no use for
         // them.
         Self {
-            inner: WsFederationApi::new(vec![(PeerId(0), url.clone())]).into(),
+            inner: GlobalFederationApiWithCache::new(WsFederationApi::new(vec![(
+                PeerId(0),
+                url.clone(),
+            )]))
+            .into(),
             url,
         }
     }

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -398,6 +398,18 @@ impl AsRef<dyn IGlobalFederationApi + 'static> for DynGlobalApi {
 }
 
 impl DynGlobalApi {
+    pub fn from_endpoints(peers: Vec<(PeerId, SafeUrl)>) -> Self {
+        GlobalFederationApiWithCache::new(WsFederationApi::new(peers)).into()
+    }
+
+    pub fn from_config(config: &ClientConfig) -> Self {
+        GlobalFederationApiWithCache::new(WsFederationApi::from_config(config)).into()
+    }
+
+    pub fn from_invite_code(invite_code: &[InviteCode]) -> Self {
+        GlobalFederationApiWithCache::new(WsFederationApi::from_invite_code(invite_code)).into()
+    }
+
     pub async fn await_output_outcome<R>(
         &self,
         outpoint: OutPoint,
@@ -486,7 +498,7 @@ where
 /// [`IGlobalFederationApi`] wrapping some `T: IRawFederationApi` and adding
 /// a tiny bit of caching.
 #[derive(Debug)]
-pub struct GlobalFederationApiWithCache<T> {
+struct GlobalFederationApiWithCache<T> {
     inner: T,
     /// Small LRU used as [`IGlobalFederationApi::await_block`] cache.
     ///

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::io::{Cursor, Read};
+use std::num::NonZeroUsize;
 use std::ops::Add;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -214,7 +215,7 @@ impl OutputOutcomeError {
 }
 /// An API (module or global) that can query a federation
 #[apply(async_trait_maybe_send!)]
-pub trait IFederationApi: Debug + MaybeSend + MaybeSync {
+pub trait IRawFederationApi: Debug + MaybeSend + MaybeSync {
     /// List of all federation peers for the purpose of iterating each peer
     /// in the federation.
     ///
@@ -245,9 +246,9 @@ pub struct ApiVersionSet {
 }
 
 /// An extension trait allowing to making federation-wide API call on top
-/// [`IFederationApi`].
+/// [`IRawFederationApi`].
 #[apply(async_trait_maybe_send!)]
-pub trait FederationApiExt: IFederationApi {
+pub trait FederationApiExt: IRawFederationApi {
     /// Make an aggregate request to federation, using `strategy` to logically
     /// merge the responses.
     async fn request_with_strategy<PeerRet: serde::de::DeserializeOwned, FedRet: Debug>(
@@ -375,18 +376,15 @@ pub trait FederationApiExt: IFederationApi {
 }
 
 #[apply(async_trait_maybe_send!)]
-impl<T: ?Sized> FederationApiExt for T where T: IFederationApi {}
+impl<T: ?Sized> FederationApiExt for T where T: IRawFederationApi {}
 
 /// Trait marker for the module (non-global) endpoints
-pub trait IModuleFederationApi: IFederationApi {}
+pub trait IModuleFederationApi: IRawFederationApi {}
 
 dyn_newtype_define! {
     #[derive(Clone)]
     pub DynModuleApi(Arc<IModuleFederationApi>)
 }
-
-/// Trait marker for the global (non-module) endpoints
-pub trait IGlobalFederationApi: IFederationApi {}
 
 dyn_newtype_define! {
     #[derive(Clone)]
@@ -399,9 +397,36 @@ impl AsRef<dyn IGlobalFederationApi + 'static> for DynGlobalApi {
     }
 }
 
+impl DynGlobalApi {
+    pub async fn await_output_outcome<R>(
+        &self,
+        outpoint: OutPoint,
+        timeout: Duration,
+        module_decoder: &Decoder,
+    ) -> OutputOutcomeResult<R>
+    where
+        R: OutputOutcome,
+    {
+        fedimint_core::task::timeout(timeout, async move {
+            let outcome: SerdeOutputOutcome = self
+                .inner
+                .request_current_consensus(
+                    AWAIT_OUTPUT_OUTCOME_ENDPOINT.to_owned(),
+                    ApiRequestErased::new(outpoint),
+                )
+                .await
+                .map_err(OutputOutcomeError::Federation)?;
+
+            deserialize_outcome(outcome, module_decoder)
+        })
+        .await
+        .map_err(|_| OutputOutcomeError::Timeout(timeout))?
+    }
+}
+
 /// The API for the global (non-module) endpoints
 #[apply(async_trait_maybe_send!)]
-pub trait GlobalFederationApi {
+pub trait IGlobalFederationApi: IRawFederationApi {
     async fn submit_transaction(
         &self,
         tx: Transaction,
@@ -416,15 +441,6 @@ pub trait GlobalFederationApi {
     async fn session_count(&self) -> FederationResult<u64>;
 
     async fn await_transaction(&self, txid: TransactionId) -> FederationResult<TransactionId>;
-
-    async fn await_output_outcome<R>(
-        &self,
-        outpoint: OutPoint,
-        timeout: Duration,
-        module_decoder: &Decoder,
-    ) -> OutputOutcomeResult<R>
-    where
-        R: OutputOutcome;
 
     /// Fetch client configuration info only if verified against a federation id
     async fn download_client_config(&self, info: &InviteCode) -> FederationResult<ClientConfig>;
@@ -467,11 +483,116 @@ where
     })
 }
 
-#[apply(async_trait_maybe_send!)]
-impl<T: ?Sized> GlobalFederationApi for T
+/// [`IGlobalFederationApi`] wrapping some `T: IRawFederationApi` and adding
+/// a tiny bit of caching.
+#[derive(Debug)]
+pub struct GlobalFederationApiWithCache<T> {
+    inner: T,
+    /// Small LRU used as [`IGlobalFederationApi::await_block`] cache.
+    ///
+    /// This is mostly to avoid multiple client module recovery processes
+    /// re-requesting same blocks and putting burden on the federation.
+    ///
+    /// The LRU can be be fairly small, as if the modules are
+    /// (near-)bottlenecked on fetching blocks they will naturally
+    /// synchronize, or split into a handful of groups. And if they are not,
+    /// no LRU here is going to help them.
+    #[allow(clippy::type_complexity)]
+    await_block_lru: Arc<
+        tokio::sync::Mutex<lru::LruCache<u64, Arc<tokio::sync::Mutex<Option<SessionOutcome>>>>>,
+    >,
+}
+
+impl<T> GlobalFederationApiWithCache<T> {
+    pub fn new(inner: T) -> GlobalFederationApiWithCache<T> {
+        Self {
+            inner,
+            await_block_lru: Arc::new(tokio::sync::Mutex::new(lru::LruCache::new(
+                NonZeroUsize::new(32).expect("is non-zero"),
+            ))),
+        }
+    }
+}
+
+impl<T> GlobalFederationApiWithCache<T>
 where
-    T: IGlobalFederationApi + MaybeSend + MaybeSync + 'static,
+    T: IRawFederationApi + MaybeSend + MaybeSync + 'static,
 {
+    async fn await_block_raw(
+        &self,
+        block_index: u64,
+        decoders: &ModuleDecoderRegistry,
+    ) -> anyhow::Result<SessionOutcome> {
+        debug!(block_index, "Fetching block's outcome from Federation");
+        self.request_current_consensus::<SerdeModuleEncoding<SessionOutcome>>(
+            AWAIT_SESSION_OUTCOME_ENDPOINT.to_string(),
+            ApiRequestErased::new(block_index),
+        )
+        .await?
+        .try_into_inner(decoders)
+        .map_err(|e| anyhow!(e.to_string()))
+    }
+}
+
+#[apply(async_trait_maybe_send!)]
+impl<T> IRawFederationApi for GlobalFederationApiWithCache<T>
+where
+    T: IRawFederationApi + MaybeSend + MaybeSync + 'static,
+{
+    fn all_peers(&self) -> &BTreeSet<PeerId> {
+        self.inner.all_peers()
+    }
+
+    fn with_module(&self, id: ModuleInstanceId) -> DynModuleApi {
+        self.inner.with_module(id)
+    }
+
+    /// Make request to a specific federation peer by `peer_id`
+    async fn request_raw(
+        &self,
+        peer_id: PeerId,
+        method: &str,
+        params: &[Value],
+    ) -> result::Result<Value, JsonRpcClientError> {
+        self.inner.request_raw(peer_id, method, params).await
+    }
+}
+
+#[apply(async_trait_maybe_send!)]
+impl<T> IGlobalFederationApi for GlobalFederationApiWithCache<T>
+where
+    T: IRawFederationApi + MaybeSend + MaybeSync + 'static,
+{
+    async fn await_block(
+        &self,
+        block_index: u64,
+        decoders: &ModuleDecoderRegistry,
+    ) -> anyhow::Result<SessionOutcome> {
+        let mut lru_lock = self.await_block_lru.lock().await;
+
+        let block_entry_arc = lru_lock
+            .get_or_insert(block_index, || Arc::new(tokio::sync::Mutex::new(None)))
+            .clone();
+
+        // we drop the lru lock so requests for other `block_index` can work in parallel
+        drop(lru_lock);
+
+        // but multiple request for the same `block_index` will serialize on the
+        // per-index lock, avoiding doing the same work
+        let mut block_lock = block_entry_arc.lock().await;
+
+        if let Some(cached_res) = block_lock.clone() {
+            debug!(block_index, "Using a cached await_block response");
+            return Ok(cached_res);
+        }
+
+        let block = self.await_block_raw(block_index, decoders).await?;
+
+        *block_lock = Some(block.clone());
+
+        Ok(block)
+    }
+
     /// Submit a transaction for inclusion
     async fn submit_transaction(
         &self,
@@ -482,20 +603,6 @@ where
             ApiRequestErased::new(&SerdeTransaction::from(&tx)),
         )
         .await
-    }
-
-    async fn await_block(
-        &self,
-        block_index: u64,
-        decoders: &ModuleDecoderRegistry,
-    ) -> anyhow::Result<SessionOutcome> {
-        self.request_current_consensus::<SerdeModuleEncoding<SessionOutcome>>(
-            AWAIT_SESSION_OUTCOME_ENDPOINT.to_string(),
-            ApiRequestErased::new(block_index),
-        )
-        .await?
-        .try_into_inner(decoders)
-        .map_err(|e| anyhow!(e.to_string()))
     }
 
     async fn session_count(&self) -> FederationResult<u64> {
@@ -512,31 +619,6 @@ where
             ApiRequestErased::new(txid),
         )
         .await
-    }
-
-    // TODO should become part of the API
-    async fn await_output_outcome<R>(
-        &self,
-        outpoint: OutPoint,
-        timeout: Duration,
-        module_decoder: &Decoder,
-    ) -> OutputOutcomeResult<R>
-    where
-        R: OutputOutcome,
-    {
-        fedimint_core::task::timeout(timeout, async move {
-            let outcome: SerdeOutputOutcome = self
-                .request_current_consensus(
-                    AWAIT_OUTPUT_OUTCOME_ENDPOINT.to_owned(),
-                    ApiRequestErased::new(outpoint),
-                )
-                .await
-                .map_err(OutputOutcomeError::Federation)?;
-
-            deserialize_outcome(outcome, module_decoder)
-        })
-        .await
-        .map_err(|_| OutputOutcomeError::Timeout(timeout))?
     }
 
     async fn download_client_config(
@@ -806,15 +888,13 @@ impl<'de> Deserialize<'de> for InviteCode {
     }
 }
 
-impl<C: JsonRpcClient + Debug + 'static> IGlobalFederationApi for WsFederationApi<C> {}
-
 impl<C: JsonRpcClient + Debug + 'static> IModuleFederationApi for WsFederationApi<C> {}
 
 /// Implementation of API calls over websockets
 ///
 /// Can function as either the global or module API
 #[apply(async_trait_maybe_send!)]
-impl<C: JsonRpcClient + Debug + 'static> IFederationApi for WsFederationApi<C> {
+impl<C: JsonRpcClient + Debug + 'static> IRawFederationApi for WsFederationApi<C> {
     fn all_peers(&self) -> &BTreeSet<PeerId> {
         &self.peer_ids
     }

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 use std::vec;
 
@@ -14,7 +13,7 @@ use common::{
 use devimint::cmd;
 use devimint::util::{GatewayClnCli, GatewayLndCli};
 use fedimint_client::ClientArc;
-use fedimint_core::api::{GlobalFederationApi, InviteCode, WsFederationApi};
+use fedimint_core::api::{DynGlobalApi, GlobalFederationApiWithCache, InviteCode, WsFederationApi};
 use fedimint_core::endpoint_constants::SESSION_COUNT_ENDPOINT;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::spawn;
@@ -1028,7 +1027,10 @@ async fn test_download_config(
     users: u16,
     event_sender: mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<Vec<BoxFuture<'static, anyhow::Result<()>>>> {
-    let api = Arc::new(WsFederationApi::from_invite_code(&[invite_code.clone()]));
+    let api: DynGlobalApi = GlobalFederationApiWithCache::new(WsFederationApi::from_invite_code(
+        &[invite_code.clone()],
+    ))
+    .into();
 
     Ok((0..users)
         .map(|_| {
@@ -1057,7 +1059,10 @@ async fn test_connect_raw_client(
     limit_endpoints: Option<usize>,
     event_sender: mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<Vec<BoxFuture<'static, anyhow::Result<()>>>> {
-    let api = Arc::new(WsFederationApi::from_invite_code(&[invite_code.clone()]));
+    let api: DynGlobalApi = GlobalFederationApiWithCache::new(WsFederationApi::from_invite_code(
+        &[invite_code.clone()],
+    ))
+    .into();
     let mut cfg = api.download_client_config(&invite_code).await?;
 
     if let Some(limit_endpoints) = limit_endpoints {

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -13,7 +13,7 @@ use common::{
 use devimint::cmd;
 use devimint::util::{GatewayClnCli, GatewayLndCli};
 use fedimint_client::ClientArc;
-use fedimint_core::api::{DynGlobalApi, GlobalFederationApiWithCache, InviteCode, WsFederationApi};
+use fedimint_core::api::{DynGlobalApi, InviteCode};
 use fedimint_core::endpoint_constants::SESSION_COUNT_ENDPOINT;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::spawn;
@@ -1027,10 +1027,7 @@ async fn test_download_config(
     users: u16,
     event_sender: mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<Vec<BoxFuture<'static, anyhow::Result<()>>>> {
-    let api: DynGlobalApi = GlobalFederationApiWithCache::new(WsFederationApi::from_invite_code(
-        &[invite_code.clone()],
-    ))
-    .into();
+    let api = DynGlobalApi::from_invite_code(&[invite_code.clone()]);
 
     Ok((0..users)
         .map(|_| {
@@ -1059,10 +1056,7 @@ async fn test_connect_raw_client(
     limit_endpoints: Option<usize>,
     event_sender: mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<Vec<BoxFuture<'static, anyhow::Result<()>>>> {
-    let api: DynGlobalApi = GlobalFederationApiWithCache::new(WsFederationApi::from_invite_code(
-        &[invite_code.clone()],
-    ))
-    .into();
+    let api = DynGlobalApi::from_invite_code(&[invite_code.clone()]);
     let mut cfg = api.download_client_config(&invite_code).await?;
 
     if let Some(limit_endpoints) = limit_endpoints {

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -5,9 +5,7 @@ use std::time::Duration;
 use aleph_bft::Keychain as KeychainTrait;
 use anyhow::{anyhow, bail};
 use async_channel::{Receiver, Sender};
-use fedimint_core::api::{
-    FederationApiExt, GlobalFederationApiWithCache, IGlobalFederationApi, WsFederationApi,
-};
+use fedimint_core::api::{DynGlobalApi, FederationApiExt, WsFederationApi};
 use fedimint_core::config::ServerModuleInitRegistry;
 use fedimint_core::db::{
     apply_migrations, Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
@@ -298,8 +296,7 @@ impl ConsensusServer {
 
     async fn confirm_server_config_consensus_hash(&self) -> anyhow::Result<()> {
         let our_hash = self.cfg.consensus.consensus_hash();
-        let federation_api =
-            GlobalFederationApiWithCache::new(WsFederationApi::new(self.api_endpoints.clone()));
+        let federation_api = DynGlobalApi::from_endpoints(self.api_endpoints.clone());
 
         info!(target: LOG_CONSENSUS, "Waiting for peers config {our_hash}");
 

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use aleph_bft::Keychain as KeychainTrait;
 use anyhow::{anyhow, bail};
 use async_channel::{Receiver, Sender};
-use fedimint_core::api::{FederationApiExt, GlobalFederationApi, WsFederationApi};
+use fedimint_core::api::{
+    FederationApiExt, GlobalFederationApiWithCache, IGlobalFederationApi, WsFederationApi,
+};
 use fedimint_core::config::ServerModuleInitRegistry;
 use fedimint_core::db::{
     apply_migrations, Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
@@ -296,7 +298,8 @@ impl ConsensusServer {
 
     async fn confirm_server_config_consensus_hash(&self) -> anyhow::Result<()> {
         let our_hash = self.cfg.consensus.consensus_hash();
-        let federation_api = WsFederationApi::new(self.api_endpoints.clone());
+        let federation_api =
+            GlobalFederationApiWithCache::new(WsFederationApi::new(self.api_endpoints.clone()));
 
         info!(target: LOG_CONSENSUS, "Waiting for peers config {our_hash}");
 

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -11,7 +11,6 @@ use fedimint_client::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client::sm::{Context, ModuleNotifier};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
 use fedimint_client::DynGlobalClientContext;
-use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::{Decoder, KeyPair, OperationId};
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::{

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use fedimint_client::sm::{DynState, State, StateTransition};
 use fedimint_client::DynGlobalClientContext;
-use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
 use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::bail;
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
-use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::config::ClientModuleConfig;
 use fedimint_core::core::{IntoDynInstance, ModuleKind, OperationId};
 use fedimint_core::module::ModuleConsensusVersion;

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -14,7 +14,6 @@ use bitcoin_hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
-use fedimint_core::api::{GlobalFederationApi, OutputOutcomeError};
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -14,7 +14,7 @@ use bitcoin_hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
-use fedimint_core::api::GlobalFederationApi;
+use fedimint_core::api::{GlobalFederationApi, OutputOutcomeError};
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -5,7 +5,6 @@ use bitcoin_hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
-use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};

--- a/modules/fedimint-mint-client/src/backup.rs
+++ b/modules/fedimint-mint-client/src/backup.rs
@@ -1,6 +1,5 @@
 use fedimint_client::module::recovery::{DynModuleBackup, ModuleBackup};
 use fedimint_client::module::ClientDbTxContext;
-use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint, Tiered, TieredMulti};

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -32,7 +32,7 @@ use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
 use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
-use fedimint_core::api::{DynGlobalApi, GlobalFederationApi};
+use fedimint_core::api::DynGlobalApi;
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
 use fedimint_core::db::{

--- a/modules/fedimint-wallet-client/src/withdraw.rs
+++ b/modules/fedimint-wallet-client/src/withdraw.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use bitcoin::Txid;
 use fedimint_client::sm::{State, StateTransition};
 use fedimint_client::DynGlobalClientContext;
-use fedimint_core::api::GlobalFederationApi;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;


### PR DESCRIPTION
On top of #4035 and #4042.

This is a version #4046 without global statics.

Wasm couldn't handle `lazy_static`, and globals are icky. The price is wrangling with an already overly complicated set of traits in this area.