### PR TITLE
refactor: Lightning Dir for Gateway

### DIFF
--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -17,7 +17,7 @@ use fedimint_logging::LOG_TEST;
 use futures::executor::block_on;
 use lightning_invoice::RoutingFees;
 use ln_gateway::client::GatewayClientBuilder;
-use ln_gateway::lnrpc_client::{ILnRpcClient, LightningBuilder};
+use ln_gateway::lightning::{ILnRpcClient, LightningBuilder};
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{ConnectFedPayload, FederationConnectionInfo};
 use ln_gateway::{Gateway, GatewayState};

--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -18,7 +18,8 @@ use ln_gateway::gateway_lnrpc::{
     self, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
     PayInvoiceRequest, PayInvoiceResponse,
 };
-use ln_gateway::lnrpc_client::{HtlcResult, ILnRpcClient, LightningRpcError, RouteHtlcStream};
+use ln_gateway::lightning::cln::{HtlcResult, RouteHtlcStream};
+use ln_gateway::lightning::{ILnRpcClient, LightningRpcError};
 use rand::rngs::OsRng;
 use tokio::sync::mpsc;
 use tracing::info;

--- a/fedimint-testing/src/ln/mod.rs
+++ b/fedimint-testing/src/ln/mod.rs
@@ -7,7 +7,7 @@ use fedimint_core::{Amount, BitcoinHash};
 use lightning_invoice::{
     Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, DEFAULT_EXPIRY_TIME,
 };
-use ln_gateway::lnrpc_client::ILnRpcClient;
+use ln_gateway::lightning::ILnRpcClient;
 use rand::rngs::OsRng;
 use secp256k1_zkp::SecretKey;
 

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -19,10 +19,9 @@ use ln_gateway::gateway_lnrpc::{
     EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
     PayInvoiceRequest, PayInvoiceResponse,
 };
-use ln_gateway::lnd::GatewayLndClient;
-use ln_gateway::lnrpc_client::{
-    ILnRpcClient, LightningRpcError, NetworkLnRpcClient, RouteHtlcStream,
-};
+use ln_gateway::lightning::cln::{NetworkLnRpcClient, RouteHtlcStream};
+use ln_gateway::lightning::lnd::GatewayLndClient;
+use ln_gateway::lightning::{ILnRpcClient, LightningRpcError};
 use secp256k1::PublicKey;
 use tokio::sync::Mutex;
 use tonic_lnd::lnrpc::{GetInfoRequest, Invoice as LndInvoice, ListChannelsRequest};

--- a/gateway/ln-gateway/src/lightning/cln.rs
+++ b/gateway/ln-gateway/src/lightning/cln.rs
@@ -3,103 +3,22 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::{sleep, TaskGroup};
 use fedimint_core::util::SafeUrl;
-use fedimint_core::Amount;
-use fedimint_ln_common::PrunedInvoice;
 use futures::stream::BoxStream;
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use tonic::transport::{Channel, Endpoint};
 use tonic::Request;
 use tracing::info;
 
+use super::{ILnRpcClient, LightningRpcError};
 use crate::gateway_lnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gateway_lnrpc::{
     EmptyRequest, EmptyResponse, GetNodeInfoResponse, GetRouteHintsRequest, GetRouteHintsResponse,
     InterceptHtlcRequest, InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
 };
-use crate::lnd::GatewayLndClient;
-use crate::LightningMode;
+use crate::lightning::MAX_LIGHTNING_RETRIES;
 pub type HtlcResult = std::result::Result<InterceptHtlcRequest, tonic::Status>;
 pub type RouteHtlcStream<'a> = BoxStream<'a, HtlcResult>;
-
-pub const MAX_LIGHTNING_RETRIES: u32 = 10;
-
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
-pub enum LightningRpcError {
-    #[error("Failed to connect to Lightning node")]
-    FailedToConnect,
-    #[error("Failed to retrieve node info: {failure_reason}")]
-    FailedToGetNodeInfo { failure_reason: String },
-    #[error("Failed to retrieve route hints: {failure_reason}")]
-    FailedToGetRouteHints { failure_reason: String },
-    #[error("Payment failed: {failure_reason}")]
-    FailedPayment { failure_reason: String },
-    #[error("Failed to route HTLCs: {failure_reason}")]
-    FailedToRouteHtlcs { failure_reason: String },
-    #[error("Failed to complete HTLC: {failure_reason}")]
-    FailedToCompleteHtlc { failure_reason: String },
-    #[error("Failed to open channel: {failure_reason}")]
-    FailedToOpenChannel { failure_reason: String },
-    #[error("Failed to get Invoice: {failure_reason}")]
-    FailedToGetInvoice { failure_reason: String },
-}
-
-#[async_trait]
-pub trait ILnRpcClient: Debug + Send + Sync {
-    /// Get the public key and alias of the lightning node
-    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError>;
-
-    /// Get route hints to the lightning node
-    async fn routehints(
-        &self,
-        num_route_hints: usize,
-    ) -> Result<GetRouteHintsResponse, LightningRpcError>;
-
-    /// Attempt to pay an invoice using the lightning node
-    async fn pay(
-        &self,
-        invoice: PayInvoiceRequest,
-    ) -> Result<PayInvoiceResponse, LightningRpcError>;
-
-    /// Attempt to pay an invoice using the lightning node using a
-    /// [`PrunedInvoice`], increasing the user's privacy by not sending the
-    /// invoice description to the gateway.
-    async fn pay_private(
-        &self,
-        _invoice: PrunedInvoice,
-        _max_delay: u64,
-        _max_fee: Amount,
-    ) -> Result<PayInvoiceResponse, LightningRpcError> {
-        Err(LightningRpcError::FailedPayment {
-            failure_reason: "Private payments not supported".to_string(),
-        })
-    }
-
-    /// Returns true if the lightning backend supports payments without full
-    /// invoices. If this returns true, then [`ILnRpcClient::pay_private`] has
-    /// to be implemented.
-    fn supports_private_payments(&self) -> bool {
-        false
-    }
-
-    // Consumes the current lightning client because `route_htlcs` should only be
-    // called once per client. A stream of intercepted HTLCs and a `Arc<dyn
-    // ILnRpcClient> are returned to the caller. The caller can use this new
-    // client to interact with the lightning node, but since it is an `Arc` is
-    // cannot call `route_htlcs` again.
-    async fn route_htlcs<'a>(
-        self: Box<Self>,
-        task_group: &mut TaskGroup,
-    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError>;
-
-    async fn complete_htlc(
-        &self,
-        htlc: InterceptHtlcResponse,
-    ) -> Result<EmptyResponse, LightningRpcError>;
-}
 
 /// An `ILnRpcClient` that wraps around `GatewayLightningClient` for
 /// convenience, and makes real RPC requests over the wire to a remote lightning
@@ -219,33 +138,5 @@ impl ILnRpcClient for NetworkLnRpcClient {
             }
         })?;
         Ok(res.into_inner())
-    }
-}
-
-#[async_trait]
-pub trait LightningBuilder {
-    async fn build(&self) -> Box<dyn ILnRpcClient>;
-}
-
-#[derive(Clone)]
-pub struct GatewayLightningBuilder {
-    pub lightning_mode: LightningMode,
-}
-
-#[async_trait]
-impl LightningBuilder for GatewayLightningBuilder {
-    async fn build(&self) -> Box<dyn ILnRpcClient> {
-        match self.lightning_mode.clone() {
-            LightningMode::Cln { cln_extension_addr } => {
-                Box::new(NetworkLnRpcClient::new(cln_extension_addr).await)
-            }
-            LightningMode::Lnd {
-                lnd_rpc_addr,
-                lnd_tls_cert,
-                lnd_macaroon,
-            } => Box::new(
-                GatewayLndClient::new(lnd_rpc_addr, lnd_tls_cert, lnd_macaroon, None).await,
-            ),
-        }
     }
 }

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -24,14 +24,13 @@ use tonic_lnd::tonic::Code;
 use tonic_lnd::{connect, Client as LndClient};
 use tracing::{debug, error, info, trace, warn};
 
+use super::cln::RouteHtlcStream;
+use super::{ILnRpcClient, LightningRpcError, MAX_LIGHTNING_RETRIES};
 use crate::gateway_lnrpc::get_route_hints_response::{RouteHint, RouteHintHop};
 use crate::gateway_lnrpc::intercept_htlc_response::{Action, Cancel, Forward, Settle};
 use crate::gateway_lnrpc::{
     EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
     InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
-};
-use crate::lnrpc_client::{
-    ILnRpcClient, LightningRpcError, RouteHtlcStream, MAX_LIGHTNING_RETRIES,
 };
 
 type HtlcSubscriptionSender = mpsc::Sender<Result<InterceptHtlcRequest, Status>>;

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -1,0 +1,149 @@
+pub mod cln;
+pub mod lnd;
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use clap::Subcommand;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::task::TaskGroup;
+use fedimint_core::util::SafeUrl;
+use fedimint_core::Amount;
+use fedimint_ln_common::PrunedInvoice;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use self::cln::{NetworkLnRpcClient, RouteHtlcStream};
+use self::lnd::GatewayLndClient;
+use crate::gateway_lnrpc::{
+    EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
+    PayInvoiceRequest, PayInvoiceResponse,
+};
+
+pub const MAX_LIGHTNING_RETRIES: u32 = 10;
+
+#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+pub enum LightningRpcError {
+    #[error("Failed to connect to Lightning node")]
+    FailedToConnect,
+    #[error("Failed to retrieve node info: {failure_reason}")]
+    FailedToGetNodeInfo { failure_reason: String },
+    #[error("Failed to retrieve route hints: {failure_reason}")]
+    FailedToGetRouteHints { failure_reason: String },
+    #[error("Payment failed: {failure_reason}")]
+    FailedPayment { failure_reason: String },
+    #[error("Failed to route HTLCs: {failure_reason}")]
+    FailedToRouteHtlcs { failure_reason: String },
+    #[error("Failed to complete HTLC: {failure_reason}")]
+    FailedToCompleteHtlc { failure_reason: String },
+    #[error("Failed to open channel: {failure_reason}")]
+    FailedToOpenChannel { failure_reason: String },
+    #[error("Failed to get Invoice: {failure_reason}")]
+    FailedToGetInvoice { failure_reason: String },
+}
+
+#[async_trait]
+pub trait ILnRpcClient: Debug + Send + Sync {
+    /// Get the public key and alias of the lightning node
+    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError>;
+
+    /// Get route hints to the lightning node
+    async fn routehints(
+        &self,
+        num_route_hints: usize,
+    ) -> Result<GetRouteHintsResponse, LightningRpcError>;
+
+    /// Attempt to pay an invoice using the lightning node
+    async fn pay(
+        &self,
+        invoice: PayInvoiceRequest,
+    ) -> Result<PayInvoiceResponse, LightningRpcError>;
+
+    /// Attempt to pay an invoice using the lightning node using a
+    /// [`PrunedInvoice`], increasing the user's privacy by not sending the
+    /// invoice description to the gateway.
+    async fn pay_private(
+        &self,
+        _invoice: PrunedInvoice,
+        _max_delay: u64,
+        _max_fee: Amount,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedPayment {
+            failure_reason: "Private payments not supported".to_string(),
+        })
+    }
+
+    /// Returns true if the lightning backend supports payments without full
+    /// invoices. If this returns true, then [`ILnRpcClient::pay_private`] has
+    /// to be implemented.
+    fn supports_private_payments(&self) -> bool {
+        false
+    }
+
+    // Consumes the current lightning client because `route_htlcs` should only be
+    // called once per client. A stream of intercepted HTLCs and a `Arc<dyn
+    // ILnRpcClient> are returned to the caller. The caller can use this new
+    // client to interact with the lightning node, but since it is an `Arc` is
+    // cannot call `route_htlcs` again.
+    async fn route_htlcs<'a>(
+        self: Box<Self>,
+        task_group: &mut TaskGroup,
+    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError>;
+
+    async fn complete_htlc(
+        &self,
+        htlc: InterceptHtlcResponse,
+    ) -> Result<EmptyResponse, LightningRpcError>;
+}
+
+#[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]
+pub enum LightningMode {
+    #[clap(name = "lnd")]
+    Lnd {
+        /// LND RPC address
+        #[arg(long = "lnd-rpc-host", env = "FM_LND_RPC_ADDR")]
+        lnd_rpc_addr: String,
+
+        /// LND TLS cert file path
+        #[arg(long = "lnd-tls-cert", env = "FM_LND_TLS_CERT")]
+        lnd_tls_cert: String,
+
+        /// LND macaroon file path
+        #[arg(long = "lnd-macaroon", env = "FM_LND_MACAROON")]
+        lnd_macaroon: String,
+    },
+    #[clap(name = "cln")]
+    Cln {
+        #[arg(long = "cln-extension-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
+        cln_extension_addr: SafeUrl,
+    },
+}
+
+#[async_trait]
+pub trait LightningBuilder {
+    async fn build(&self) -> Box<dyn ILnRpcClient>;
+}
+
+#[derive(Clone)]
+pub struct GatewayLightningBuilder {
+    pub lightning_mode: LightningMode,
+}
+
+#[async_trait]
+impl LightningBuilder for GatewayLightningBuilder {
+    async fn build(&self) -> Box<dyn ILnRpcClient> {
+        match self.lightning_mode.clone() {
+            LightningMode::Cln { cln_extension_addr } => {
+                Box::new(NetworkLnRpcClient::new(cln_extension_addr).await)
+            }
+            LightningMode::Lnd {
+                lnd_rpc_addr,
+                lnd_tls_cert,
+                lnd_macaroon,
+            } => Box::new(
+                GatewayLndClient::new(lnd_rpc_addr, lnd_tls_cert, lnd_macaroon, None).await,
+            ),
+        }
+    }
+}

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -24,7 +24,7 @@ use tracing::{debug, error, info, warn};
 use super::{GatewayClientContext, GatewayClientStateMachines, GatewayExtReceiveStates};
 use crate::db::PreimageAuthentication;
 use crate::gateway_lnrpc::{PayInvoiceRequest, PayInvoiceResponse};
-use crate::lnrpc_client::LightningRpcError;
+use crate::lightning::LightningRpcError;
 use crate::state_machine::GatewayClientModule;
 use crate::GatewayState;
 


### PR DESCRIPTION
This PR refactors the Gateway's lightning implementations into a `lighting` directory.

Started as a hack to get the gateway to work with the alby api, but halfway through realized this would be a good refactor for adding additional implementations and apis as lightning options for the gateway in the future.