### PR TITLE
Alby Lightning Gateway Integration using Webhook and Alby API

### DIFF
--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -17,7 +17,7 @@ use fedimint_logging::LOG_TEST;
 use futures::executor::block_on;
 use lightning_invoice::RoutingFees;
 use ln_gateway::client::GatewayClientBuilder;
-use ln_gateway::lnrpc_client::{ILnRpcClient, LightningBuilder};
+use ln_gateway::lightning::{ILnRpcClient, LightningBuilder};
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{ConnectFedPayload, FederationConnectionInfo};
 use ln_gateway::{Gateway, GatewayState};

--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -18,7 +18,8 @@ use ln_gateway::gateway_lnrpc::{
     self, EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
     PayInvoiceRequest, PayInvoiceResponse,
 };
-use ln_gateway::lnrpc_client::{HtlcResult, ILnRpcClient, LightningRpcError, RouteHtlcStream};
+use ln_gateway::lightning::cln::{HtlcResult, RouteHtlcStream};
+use ln_gateway::lightning::{ILnRpcClient, LightningRpcError};
 use rand::rngs::OsRng;
 use tokio::sync::mpsc;
 use tracing::info;

--- a/fedimint-testing/src/ln/mod.rs
+++ b/fedimint-testing/src/ln/mod.rs
@@ -7,7 +7,7 @@ use fedimint_core::{Amount, BitcoinHash};
 use lightning_invoice::{
     Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, DEFAULT_EXPIRY_TIME,
 };
-use ln_gateway::lnrpc_client::ILnRpcClient;
+use ln_gateway::lightning::ILnRpcClient;
 use rand::rngs::OsRng;
 use secp256k1_zkp::SecretKey;
 

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -19,10 +19,9 @@ use ln_gateway::gateway_lnrpc::{
     EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
     PayInvoiceRequest, PayInvoiceResponse,
 };
-use ln_gateway::lnd::GatewayLndClient;
-use ln_gateway::lnrpc_client::{
-    ILnRpcClient, LightningRpcError, NetworkLnRpcClient, RouteHtlcStream,
-};
+use ln_gateway::lightning::cln::{NetworkLnRpcClient, RouteHtlcStream};
+use ln_gateway::lightning::lnd::GatewayLndClient;
+use ln_gateway::lightning::{ILnRpcClient, LightningRpcError};
 use secp256k1::PublicKey;
 use tokio::sync::Mutex;
 use tonic_lnd::lnrpc::{GetInfoRequest, Invoice as LndInvoice, ListChannelsRequest};

--- a/gateway/ln-gateway/src/lightning/alby.rs
+++ b/gateway/ln-gateway/src/lightning/alby.rs
@@ -1,0 +1,172 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fedimint_core::task::TaskGroup;
+use fedimint_core::Amount;
+use fedimint_ln_common::PrunedInvoice;
+use secp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::sync::oneshot::Sender;
+use tokio::sync::{mpsc, Mutex};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::info;
+
+use super::{send_htlc_to_webhook, ILnRpcClient, LightningRpcError, RouteHtlcStream};
+use crate::gateway_lnrpc::{
+    EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
+    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
+};
+use crate::rpc::rpc_webhook_server::run_webhook_server;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct AlbyPayResponse {
+    amount: u64,
+    description: String,
+    destination: String,
+    fee: u64,
+    payment_hash: Vec<u8>,
+    payment_preimage: Vec<u8>,
+    payment_request: String,
+}
+
+#[derive(Clone)]
+pub struct GatewayAlbyClient {
+    bind_addr: SocketAddr,
+    api_key: String,
+    pub outcomes: Arc<Mutex<BTreeMap<u64, Sender<InterceptHtlcResponse>>>>,
+}
+
+impl GatewayAlbyClient {
+    pub async fn new(
+        bind_addr: SocketAddr,
+        api_key: String,
+        outcomes: Arc<Mutex<BTreeMap<u64, Sender<InterceptHtlcResponse>>>>,
+    ) -> Self {
+        info!("Gateway configured to connect to Alby at \n address: {bind_addr:?}");
+        Self {
+            api_key,
+            bind_addr,
+            outcomes,
+        }
+    }
+}
+
+impl fmt::Debug for GatewayAlbyClient {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "AlbyClient")
+    }
+}
+
+#[async_trait]
+impl ILnRpcClient for GatewayAlbyClient {
+    /// Returns the public key of the lightning node to use in route hint
+    ///
+    /// What should we do here with Alby?
+    /// - Is the pubkey always the same?
+    /// - Could change to optional: If Custodial API, hardcode the pubkey for
+    ///   the node
+    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError> {
+        let mainnet = "mainnet";
+        let alias = "getalby.com";
+        let pub_key = PublicKey::from_str(
+            "030a58b8653d32b99200a2334cfe913e51dc7d155aa0116c176657a4f1722677a3",
+        )
+        .unwrap();
+        let pub_key = pub_key.serialize().to_vec();
+
+        return Ok(GetNodeInfoResponse {
+            pub_key,
+            alias: alias.to_string(),
+            network: mainnet.to_string(),
+        });
+    }
+
+    /// We can probably just use the Alby node pubkey here?
+    /// SCID is the short channel ID mapping to the federation
+    async fn routehints(
+        &self,
+        _num_route_hints: usize,
+    ) -> Result<GetRouteHintsResponse, LightningRpcError> {
+        todo!()
+    }
+
+    /// Pay an invoice using the alby api
+    /// Pay needs to be idempotent, this is why we need lookup payment,
+    /// would need to do something similar with Alby
+    async fn pay(
+        &self,
+        request: PayInvoiceRequest,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
+        let client = reqwest::Client::new();
+        let endpoint = "https://api.getalby.com/payments/bolt11";
+
+        let req = json!({
+            "invoice": request.invoice,
+        });
+
+        let response = client
+            .post(endpoint)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&req)
+            .send()
+            .await
+            .unwrap();
+
+        let response = response.json::<AlbyPayResponse>().await.unwrap();
+
+        Ok(PayInvoiceResponse {
+            preimage: response.payment_preimage,
+        })
+    }
+
+    // FIXME: deduplicate implementation with pay
+    async fn pay_private(
+        &self,
+        _invoice: PrunedInvoice,
+        _max_delay: u64,
+        _max_fee: Amount,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
+        todo!()
+
+        // Ok(PayInvoiceResponse { preimage })
+    }
+
+    /// Returns true if the lightning backend supports payments without full
+    /// invoices
+    fn supports_private_payments(&self) -> bool {
+        false
+    }
+
+    async fn route_htlcs<'a>(
+        self: Box<Self>,
+        task_group: &mut TaskGroup,
+    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError> {
+        const CHANNEL_SIZE: usize = 100;
+        let (gateway_sender, gateway_receiver) =
+            mpsc::channel::<Result<InterceptHtlcRequest, tonic::Status>>(CHANNEL_SIZE);
+
+        let new_client =
+            Arc::new(Self::new(self.bind_addr, self.api_key.clone(), self.outcomes.clone()).await);
+
+        run_webhook_server(self.bind_addr, task_group, gateway_sender.clone(), *self)
+            .await
+            .map_err(|_| LightningRpcError::FailedToRouteHtlcs {
+                failure_reason: "Failed to start webhook server".to_string(),
+            })?;
+
+        Ok((Box::pin(ReceiverStream::new(gateway_receiver)), new_client))
+    }
+
+    async fn complete_htlc(
+        &self,
+        htlc: InterceptHtlcResponse,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        send_htlc_to_webhook(&self.outcomes, htlc).await?;
+        Ok(EmptyResponse {})
+    }
+}

--- a/gateway/ln-gateway/src/lightning/cln.rs
+++ b/gateway/ln-gateway/src/lightning/cln.rs
@@ -3,103 +3,22 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::{sleep, TaskGroup};
 use fedimint_core::util::SafeUrl;
-use fedimint_core::Amount;
-use fedimint_ln_common::PrunedInvoice;
 use futures::stream::BoxStream;
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use tonic::transport::{Channel, Endpoint};
 use tonic::Request;
 use tracing::info;
 
+use super::{ILnRpcClient, LightningRpcError};
 use crate::gateway_lnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gateway_lnrpc::{
     EmptyRequest, EmptyResponse, GetNodeInfoResponse, GetRouteHintsRequest, GetRouteHintsResponse,
     InterceptHtlcRequest, InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
 };
-use crate::lnd::GatewayLndClient;
-use crate::LightningMode;
+use crate::lightning::MAX_LIGHTNING_RETRIES;
 pub type HtlcResult = std::result::Result<InterceptHtlcRequest, tonic::Status>;
 pub type RouteHtlcStream<'a> = BoxStream<'a, HtlcResult>;
-
-pub const MAX_LIGHTNING_RETRIES: u32 = 10;
-
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
-pub enum LightningRpcError {
-    #[error("Failed to connect to Lightning node")]
-    FailedToConnect,
-    #[error("Failed to retrieve node info: {failure_reason}")]
-    FailedToGetNodeInfo { failure_reason: String },
-    #[error("Failed to retrieve route hints: {failure_reason}")]
-    FailedToGetRouteHints { failure_reason: String },
-    #[error("Payment failed: {failure_reason}")]
-    FailedPayment { failure_reason: String },
-    #[error("Failed to route HTLCs: {failure_reason}")]
-    FailedToRouteHtlcs { failure_reason: String },
-    #[error("Failed to complete HTLC: {failure_reason}")]
-    FailedToCompleteHtlc { failure_reason: String },
-    #[error("Failed to open channel: {failure_reason}")]
-    FailedToOpenChannel { failure_reason: String },
-    #[error("Failed to get Invoice: {failure_reason}")]
-    FailedToGetInvoice { failure_reason: String },
-}
-
-#[async_trait]
-pub trait ILnRpcClient: Debug + Send + Sync {
-    /// Get the public key and alias of the lightning node
-    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError>;
-
-    /// Get route hints to the lightning node
-    async fn routehints(
-        &self,
-        num_route_hints: usize,
-    ) -> Result<GetRouteHintsResponse, LightningRpcError>;
-
-    /// Attempt to pay an invoice using the lightning node
-    async fn pay(
-        &self,
-        invoice: PayInvoiceRequest,
-    ) -> Result<PayInvoiceResponse, LightningRpcError>;
-
-    /// Attempt to pay an invoice using the lightning node using a
-    /// [`PrunedInvoice`], increasing the user's privacy by not sending the
-    /// invoice description to the gateway.
-    async fn pay_private(
-        &self,
-        _invoice: PrunedInvoice,
-        _max_delay: u64,
-        _max_fee: Amount,
-    ) -> Result<PayInvoiceResponse, LightningRpcError> {
-        Err(LightningRpcError::FailedPayment {
-            failure_reason: "Private payments not supported".to_string(),
-        })
-    }
-
-    /// Returns true if the lightning backend supports payments without full
-    /// invoices. If this returns true, then [`ILnRpcClient::pay_private`] has
-    /// to be implemented.
-    fn supports_private_payments(&self) -> bool {
-        false
-    }
-
-    // Consumes the current lightning client because `route_htlcs` should only be
-    // called once per client. A stream of intercepted HTLCs and a `Arc<dyn
-    // ILnRpcClient> are returned to the caller. The caller can use this new
-    // client to interact with the lightning node, but since it is an `Arc` is
-    // cannot call `route_htlcs` again.
-    async fn route_htlcs<'a>(
-        self: Box<Self>,
-        task_group: &mut TaskGroup,
-    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError>;
-
-    async fn complete_htlc(
-        &self,
-        htlc: InterceptHtlcResponse,
-    ) -> Result<EmptyResponse, LightningRpcError>;
-}
 
 /// An `ILnRpcClient` that wraps around `GatewayLightningClient` for
 /// convenience, and makes real RPC requests over the wire to a remote lightning
@@ -219,33 +138,5 @@ impl ILnRpcClient for NetworkLnRpcClient {
             }
         })?;
         Ok(res.into_inner())
-    }
-}
-
-#[async_trait]
-pub trait LightningBuilder {
-    async fn build(&self) -> Box<dyn ILnRpcClient>;
-}
-
-#[derive(Clone)]
-pub struct GatewayLightningBuilder {
-    pub lightning_mode: LightningMode,
-}
-
-#[async_trait]
-impl LightningBuilder for GatewayLightningBuilder {
-    async fn build(&self) -> Box<dyn ILnRpcClient> {
-        match self.lightning_mode.clone() {
-            LightningMode::Cln { cln_extension_addr } => {
-                Box::new(NetworkLnRpcClient::new(cln_extension_addr).await)
-            }
-            LightningMode::Lnd {
-                lnd_rpc_addr,
-                lnd_tls_cert,
-                lnd_macaroon,
-            } => Box::new(
-                GatewayLndClient::new(lnd_rpc_addr, lnd_tls_cert, lnd_macaroon, None).await,
-            ),
-        }
     }
 }

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -24,14 +24,13 @@ use tonic_lnd::tonic::Code;
 use tonic_lnd::{connect, Client as LndClient};
 use tracing::{debug, error, info, trace, warn};
 
+use super::cln::RouteHtlcStream;
+use super::{ILnRpcClient, LightningRpcError, MAX_LIGHTNING_RETRIES};
 use crate::gateway_lnrpc::get_route_hints_response::{RouteHint, RouteHintHop};
 use crate::gateway_lnrpc::intercept_htlc_response::{Action, Cancel, Forward, Settle};
 use crate::gateway_lnrpc::{
     EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
     InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
-};
-use crate::lnrpc_client::{
-    ILnRpcClient, LightningRpcError, RouteHtlcStream, MAX_LIGHTNING_RETRIES,
 };
 
 type HtlcSubscriptionSender = mpsc::Sender<Result<InterceptHtlcRequest, Status>>;

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -1,0 +1,149 @@
+pub mod cln;
+pub mod lnd;
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use clap::Subcommand;
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::task::TaskGroup;
+use fedimint_core::util::SafeUrl;
+use fedimint_core::Amount;
+use fedimint_ln_common::PrunedInvoice;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use self::cln::{NetworkLnRpcClient, RouteHtlcStream};
+use self::lnd::GatewayLndClient;
+use crate::gateway_lnrpc::{
+    EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
+    PayInvoiceRequest, PayInvoiceResponse,
+};
+
+pub const MAX_LIGHTNING_RETRIES: u32 = 10;
+
+#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+pub enum LightningRpcError {
+    #[error("Failed to connect to Lightning node")]
+    FailedToConnect,
+    #[error("Failed to retrieve node info: {failure_reason}")]
+    FailedToGetNodeInfo { failure_reason: String },
+    #[error("Failed to retrieve route hints: {failure_reason}")]
+    FailedToGetRouteHints { failure_reason: String },
+    #[error("Payment failed: {failure_reason}")]
+    FailedPayment { failure_reason: String },
+    #[error("Failed to route HTLCs: {failure_reason}")]
+    FailedToRouteHtlcs { failure_reason: String },
+    #[error("Failed to complete HTLC: {failure_reason}")]
+    FailedToCompleteHtlc { failure_reason: String },
+    #[error("Failed to open channel: {failure_reason}")]
+    FailedToOpenChannel { failure_reason: String },
+    #[error("Failed to get Invoice: {failure_reason}")]
+    FailedToGetInvoice { failure_reason: String },
+}
+
+#[async_trait]
+pub trait ILnRpcClient: Debug + Send + Sync {
+    /// Get the public key and alias of the lightning node
+    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError>;
+
+    /// Get route hints to the lightning node
+    async fn routehints(
+        &self,
+        num_route_hints: usize,
+    ) -> Result<GetRouteHintsResponse, LightningRpcError>;
+
+    /// Attempt to pay an invoice using the lightning node
+    async fn pay(
+        &self,
+        invoice: PayInvoiceRequest,
+    ) -> Result<PayInvoiceResponse, LightningRpcError>;
+
+    /// Attempt to pay an invoice using the lightning node using a
+    /// [`PrunedInvoice`], increasing the user's privacy by not sending the
+    /// invoice description to the gateway.
+    async fn pay_private(
+        &self,
+        _invoice: PrunedInvoice,
+        _max_delay: u64,
+        _max_fee: Amount,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedPayment {
+            failure_reason: "Private payments not supported".to_string(),
+        })
+    }
+
+    /// Returns true if the lightning backend supports payments without full
+    /// invoices. If this returns true, then [`ILnRpcClient::pay_private`] has
+    /// to be implemented.
+    fn supports_private_payments(&self) -> bool {
+        false
+    }
+
+    // Consumes the current lightning client because `route_htlcs` should only be
+    // called once per client. A stream of intercepted HTLCs and a `Arc<dyn
+    // ILnRpcClient> are returned to the caller. The caller can use this new
+    // client to interact with the lightning node, but since it is an `Arc` is
+    // cannot call `route_htlcs` again.
+    async fn route_htlcs<'a>(
+        self: Box<Self>,
+        task_group: &mut TaskGroup,
+    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError>;
+
+    async fn complete_htlc(
+        &self,
+        htlc: InterceptHtlcResponse,
+    ) -> Result<EmptyResponse, LightningRpcError>;
+}
+
+#[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]
+pub enum LightningMode {
+    #[clap(name = "lnd")]
+    Lnd {
+        /// LND RPC address
+        #[arg(long = "lnd-rpc-host", env = "FM_LND_RPC_ADDR")]
+        lnd_rpc_addr: String,
+
+        /// LND TLS cert file path
+        #[arg(long = "lnd-tls-cert", env = "FM_LND_TLS_CERT")]
+        lnd_tls_cert: String,
+
+        /// LND macaroon file path
+        #[arg(long = "lnd-macaroon", env = "FM_LND_MACAROON")]
+        lnd_macaroon: String,
+    },
+    #[clap(name = "cln")]
+    Cln {
+        #[arg(long = "cln-extension-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
+        cln_extension_addr: SafeUrl,
+    },
+}
+
+#[async_trait]
+pub trait LightningBuilder {
+    async fn build(&self) -> Box<dyn ILnRpcClient>;
+}
+
+#[derive(Clone)]
+pub struct GatewayLightningBuilder {
+    pub lightning_mode: LightningMode,
+}
+
+#[async_trait]
+impl LightningBuilder for GatewayLightningBuilder {
+    async fn build(&self) -> Box<dyn ILnRpcClient> {
+        match self.lightning_mode.clone() {
+            LightningMode::Cln { cln_extension_addr } => {
+                Box::new(NetworkLnRpcClient::new(cln_extension_addr).await)
+            }
+            LightningMode::Lnd {
+                lnd_rpc_addr,
+                lnd_tls_cert,
+                lnd_macaroon,
+            } => Box::new(
+                GatewayLndClient::new(lnd_rpc_addr, lnd_tls_cert, lnd_macaroon, None).await,
+            ),
+        }
+    }
+}

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -1,5 +1,6 @@
 pub mod rpc_client;
 pub mod rpc_server;
+pub mod rpc_webhook_server;
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;

--- a/gateway/ln-gateway/src/rpc/rpc_webhook_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_webhook_server.rs
@@ -1,0 +1,164 @@
+use std::net::SocketAddr;
+
+use axum::routing::post;
+use axum::{Extension, Json, Router};
+use axum_macros::debug_handler;
+use fedimint_core::task::TaskGroup;
+use serde::{Deserialize, Deserializer, Serialize};
+use tracing::{error, instrument};
+
+use crate::gateway_lnrpc::intercept_htlc_response::Action;
+use crate::gateway_lnrpc::{InterceptHtlcRequest, InterceptHtlcResponse};
+use crate::lightning::alby::GatewayAlbyClient;
+use crate::lightning::LightningRpcError;
+use crate::GatewayError;
+
+pub async fn run_webhook_server(
+    bind_addr: SocketAddr,
+    task_group: &mut TaskGroup,
+    htlc_stream_sender: tokio::sync::mpsc::Sender<Result<InterceptHtlcRequest, tonic::Status>>,
+    client: GatewayAlbyClient,
+) -> axum::response::Result<()> {
+    let app = Router::new()
+        .route("/handle_htlc", post(handle_htlc))
+        .layer(Extension(htlc_stream_sender.clone()))
+        .layer(Extension(client));
+
+    let handle = task_group.make_handle();
+    let shutdown_rx = handle.make_shutdown_rx().await;
+    let server = axum::Server::bind(&bind_addr).serve(app.into_make_service());
+    task_group
+        .spawn("Gateway Webhook Server", move |_| async move {
+            let graceful = server.with_graceful_shutdown(async {
+                shutdown_rx.await;
+            });
+
+            if let Err(e) = graceful.await {
+                error!("Error shutting down gatewayd webhook server: {:?}", e);
+            }
+        })
+        .await;
+
+    Ok(())
+}
+
+/// `WebhookHandleHtlcParams` is a structure that holds an intercepted HTLC
+/// request.
+///
+/// Example JSON representation:
+/// ```json
+/// {
+///     "htlc": {
+///         "payment_hash": "a3f1e3b56a...",
+///         "incoming_amount_msat": 1000,
+///         "outgoing_amount_msat": 900,
+///         "incoming_expiry": 300,
+///         "short_channel_id": 2, // This is the short channel id of the federation mapping
+///         "incoming_chan_id": 987654321,
+///         "htlc_id": 12345
+///     }
+/// }
+/// ```
+struct WebhookHandleHtlcParams {
+    htlc: InterceptHtlcRequest,
+}
+
+use std::fmt;
+
+use serde::de::{MapAccess, Visitor};
+
+impl<'de> Deserialize<'de> for WebhookHandleHtlcParams {
+    fn deserialize<D>(deserializer: D) -> Result<WebhookHandleHtlcParams, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct WebhookHandleHtlcParamsVisitor;
+
+        impl<'de> Visitor<'de> for WebhookHandleHtlcParamsVisitor {
+            type Value = WebhookHandleHtlcParams;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct WebhookHandleHtlcParams")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<WebhookHandleHtlcParams, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut htlc = InterceptHtlcRequest::default();
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        "payment_hash" => htlc.payment_hash = map.next_value()?,
+                        "incoming_amount_msat" => htlc.incoming_amount_msat = map.next_value()?,
+                        "outgoing_amount_msat" => htlc.outgoing_amount_msat = map.next_value()?,
+                        "incoming_expiry" => htlc.incoming_expiry = map.next_value()?,
+                        "short_channel_id" => htlc.short_channel_id = map.next_value()?,
+                        "incoming_chan_id" => htlc.incoming_chan_id = map.next_value()?,
+                        "htlc_id" => htlc.htlc_id = map.next_value()?,
+                        _ => (),
+                    }
+                }
+
+                Ok(WebhookHandleHtlcParams { htlc })
+            }
+        }
+
+        deserializer.deserialize_struct(
+            "WebhookHandleHtlcParams",
+            &[
+                "payment_hash",
+                "incoming_amount_msat",
+                "outgoing_amount_msat",
+                "incoming_expiry",
+                "short_channel_id",
+                "incoming_chan_id",
+                "htlc_id",
+            ],
+            WebhookHandleHtlcParamsVisitor,
+        )
+    }
+}
+
+#[derive(Serialize)]
+struct WebhookHandleHtlcResponse {
+    preimage: Vec<u8>,
+}
+
+#[debug_handler]
+#[instrument(skip_all, err)]
+async fn handle_htlc(
+    Extension(htlc_stream_sender): Extension<
+        tokio::sync::mpsc::Sender<Result<InterceptHtlcRequest, tonic::Status>>,
+    >,
+    Extension(client): Extension<GatewayAlbyClient>,
+    params: Json<WebhookHandleHtlcParams>,
+) -> Result<Json<WebhookHandleHtlcResponse>, GatewayError> {
+    let htlc = params.htlc.clone();
+    let (sender, receiver) = tokio::sync::oneshot::channel::<InterceptHtlcResponse>();
+
+    client.outcomes.lock().await.insert(htlc.htlc_id, sender);
+
+    htlc_stream_sender.send(Ok(htlc)).await.map_err(|e| {
+        error!("Error sending htlc to stream: {:?}", e);
+        anyhow::anyhow!("Error sending htlc to stream: {:?}", e)
+    })?;
+
+    let response = receiver.await.map_err(|_| GatewayError::Disconnected)?;
+
+    match response.action {
+        Some(Action::Settle(preimage)) => Ok(Json(WebhookHandleHtlcResponse {
+            preimage: preimage.preimage,
+        })),
+        Some(Action::Cancel(cancel)) => Err(GatewayError::LightningRpcError(
+            LightningRpcError::FailedToCompleteHtlc {
+                failure_reason: cancel.reason,
+            },
+        )),
+        _ => Err(GatewayError::LightningRpcError(
+            LightningRpcError::FailedToCompleteHtlc {
+                failure_reason: "Invalid action specified for htlc {htlc_id}".to_string(),
+            },
+        )),
+    }
+}

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -24,7 +24,7 @@ use tracing::{debug, error, info, warn};
 use super::{GatewayClientContext, GatewayClientStateMachines, GatewayExtReceiveStates};
 use crate::db::PreimageAuthentication;
 use crate::gateway_lnrpc::{PayInvoiceRequest, PayInvoiceResponse};
-use crate::lnrpc_client::LightningRpcError;
+use crate::lightning::LightningRpcError;
 use crate::state_machine::GatewayClientModule;
 use crate::GatewayState;
 


### PR DESCRIPTION
Built this as a proof of concept for how we might be able to use a Lightning Service Provider API with the Gateway.

This fully implements the pay side of the gateway, receive side requires some changes on their end but working with @m1sterc001guy and @okjodom we think we found a pretty good solution:

Most custodial lightning APIs don't expose the htlc interceptor and it's a big ask to expose that, but they DO have the ability to register webhooks for updates. 

This impl adds a rpc_webhook_server that starts a webhook endpoint for the Alby API to forward htlcs marked for the gateway to. We use a btreemap of oneshot channels so that same endpoint can forward the htlc into the normal gateway htlc stream and listen for the response of Fail or Success(preimage), then return the preimage as a response to the webhook call.

So the entire ask for getting a lightning api provider to integrate with us turns into:

We need you to implement a single endpoint, where you POST an htlc that you would normally fail and the response will contain the preimage for that htlc or Error.

Which we were thinking is a way lighter lift than getting them to actually run gateways or our daemons/extensions themselves.

This is a WIP and was more of an exercise to see if it might work, would love to hear feedback/thoughts on the approach.