### PR TITLE
chore: migrate to miniscript v10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
  "getrandom",
  "js-sys",
  "log",
- "miniscript",
+ "miniscript 9.0.2",
  "rand",
  "rusqlite",
  "serde",
@@ -533,6 +533,7 @@ dependencies = [
  "bitcoin_hashes 0.12.0",
  "hex_lit",
  "secp256k1 0.27.0",
+ "serde",
 ]
 
 [[package]]
@@ -558,6 +559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+ "serde",
 ]
 
 [[package]]
@@ -1437,7 +1439,7 @@ dependencies = [
  "lightning-invoice 0.26.0",
  "lru",
  "macro_rules_attribute",
- "miniscript",
+ "miniscript 10.0.0",
  "once_cell",
  "parity-scale-codec",
  "rand",
@@ -2047,7 +2049,7 @@ dependencies = [
  "fedimint-server",
  "fedimint-wallet-server",
  "futures",
- "miniscript",
+ "miniscript 10.0.0",
  "rand",
  "secp256k1 0.24.3",
  "serde",
@@ -2231,7 +2233,7 @@ dependencies = [
  "fedimint-wallet-common",
  "futures",
  "impl-tools",
- "miniscript",
+ "miniscript 10.0.0",
  "rand",
  "secp256k1 0.24.3",
  "serde",
@@ -2257,7 +2259,8 @@ dependencies = [
  "fedimint-core",
  "futures",
  "impl-tools",
- "miniscript",
+ "miniscript 10.0.0",
+ "miniscript 9.0.2",
  "rand",
  "secp256k1 0.24.3",
  "serde",
@@ -2287,7 +2290,8 @@ dependencies = [
  "fedimint-wallet-common",
  "futures",
  "impl-tools",
- "miniscript",
+ "miniscript 10.0.0",
+ "miniscript 9.0.2",
  "rand",
  "secp256k1 0.24.3",
  "serde",
@@ -2323,7 +2327,7 @@ dependencies = [
  "fedimint-wallet-common",
  "fedimint-wallet-server",
  "futures",
- "miniscript",
+ "miniscript 10.0.0",
  "rand",
  "secp256k1 0.24.3",
  "strum",
@@ -3619,6 +3623,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniscript"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb102b66b2127a872dbcc73095b7b47aeb9d92f7b03c2b2298253ffc82c7594"
+dependencies = [
+ "bitcoin 0.30.2",
+ "bitcoin-private",
+ "serde",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4515,6 +4530,7 @@ checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes 0.12.0",
  "secp256k1-sys 0.8.1",
+ "serde",
 ]
 
 [[package]]

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -47,7 +47,7 @@ lightning-invoice = "0.26.0"
 fedimint-derive = { version = "0.3.0-alpha", path = "../fedimint-derive" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 rand = "0.8.5"
-miniscript = { version = "9.0.2", features = [ "compiler", "serde" ] }
+miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
 macro_rules_attribute = "0.1.3"
 bitvec = "1.0.1"

--- a/fedimint-core/src/bitcoin_migration.rs
+++ b/fedimint-core/src/bitcoin_migration.rs
@@ -1,0 +1,199 @@
+use std::str::FromStr;
+
+use bitcoin30::hashes::Hash as Bitcoin30Hash;
+use bitcoin_hashes::Hash as Bitcoin29Hash;
+
+pub fn bitcoin29_to_bitcoin30_public_key(pk: bitcoin::PublicKey) -> bitcoin30::PublicKey {
+    bitcoin30::PublicKey::from_slice(&pk.to_bytes())
+        .expect("Failed to convert bitcoin v29 public key to bitcoin v30 public key")
+}
+
+pub fn bitcoin29_to_bitcoin30_network(network: bitcoin::Network) -> bitcoin30::Network {
+    match network {
+        bitcoin::Network::Bitcoin => bitcoin30::Network::Bitcoin,
+        bitcoin::Network::Testnet => bitcoin30::Network::Testnet,
+        bitcoin::Network::Signet => bitcoin30::Network::Signet,
+        bitcoin::Network::Regtest => bitcoin30::Network::Regtest,
+    }
+}
+
+pub fn bitcoin30_to_bitcoin29_script(script: bitcoin30::ScriptBuf) -> bitcoin::Script {
+    script.to_bytes().into()
+}
+
+pub fn bitcoin30_to_bitcoin29_address(address: bitcoin30::Address) -> bitcoin::Address {
+    bitcoin::Address::from_str(&address.to_string())
+        .expect("Failed to convert bitcoin v30 address to bitcoin v29 address")
+}
+
+pub fn bitcoin29_to_bitcoin30_ripemd160_hash(
+    hash: bitcoin::hashes::ripemd160::Hash,
+) -> bitcoin30::hashes::ripemd160::Hash {
+    bitcoin30::hashes::ripemd160::Hash::from_byte_array(hash.into_inner())
+}
+
+pub fn bitcoin29_to_bitcoin30_hash160_hash(
+    hash: bitcoin::hashes::hash160::Hash,
+) -> bitcoin30::hashes::hash160::Hash {
+    bitcoin30::hashes::hash160::Hash::from_byte_array(hash.into_inner())
+}
+
+pub fn bitcoin29_to_bitcoin30_sha256_hash(
+    hash: bitcoin::hashes::sha256::Hash,
+) -> bitcoin30::hashes::sha256::Hash {
+    bitcoin30::hashes::sha256::Hash::from_byte_array(hash.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin_hashes::hex::FromHex;
+    use rand::thread_rng;
+
+    use super::*;
+
+    fn bitcoin30_to_bitcoin29_public_key(pk: bitcoin30::PublicKey) -> bitcoin::PublicKey {
+        bitcoin::PublicKey::from_slice(&pk.to_bytes())
+            .expect("Failed to convert bitcoin v30 public key to bitcoin v29 public key")
+    }
+
+    fn bitcoin29_to_bitcoin30_script(script: bitcoin::Script) -> bitcoin30::ScriptBuf {
+        bitcoin30::ScriptBuf::from_bytes(script.into_bytes())
+    }
+
+    #[test]
+    fn test_bitcoin29_to_bitcoin30_and_back_public_key() {
+        let bitcoin29_pk: bitcoin::PublicKey =
+            "037703ba67395870e5237787f380708f1b13751f7bdd97682e8f5af3f3a10a0a52"
+                .parse()
+                .expect("Failed to parse bitcoin v29 public key");
+
+        let bitcoin30_pk = bitcoin29_to_bitcoin30_public_key(bitcoin29_pk);
+        let bitcoin29_pk_back = bitcoin30_to_bitcoin29_public_key(bitcoin30_pk);
+
+        assert_eq!(bitcoin29_pk, bitcoin29_pk_back);
+    }
+
+    #[test]
+    fn test_bitcoin30_to_bitcoin29_and_back_public_key() {
+        let bitcoin30_pk: bitcoin30::PublicKey =
+            "0355aba9599a27e71eb515c813252f630c5914eb76b199b11db4265107619e8dcc"
+                .parse()
+                .expect("Failed to parse bitcoin v30 public key");
+
+        let bitcoin29_pk = bitcoin30_to_bitcoin29_public_key(bitcoin30_pk);
+        let bitcoin30_pk_back = bitcoin29_to_bitcoin30_public_key(bitcoin29_pk);
+
+        assert_eq!(bitcoin30_pk, bitcoin30_pk_back);
+    }
+
+    #[test]
+    fn test_network_conversions() {
+        assert_eq!(
+            bitcoin30::Network::Bitcoin,
+            bitcoin29_to_bitcoin30_network(bitcoin::Network::Bitcoin)
+        );
+    }
+
+    #[test]
+    fn test_script_conversions() {
+        let bitcoin29_public_key = bitcoin::PublicKey::new(
+            bitcoin::secp256k1::Secp256k1::new()
+                .generate_keypair(&mut thread_rng())
+                .1,
+        );
+        let bitcoin29_script: bitcoin::Script = bitcoin::Script::new_p2pk(&bitcoin29_public_key);
+
+        let bitcoin30_public_key = bitcoin29_to_bitcoin30_public_key(bitcoin29_public_key);
+        let bitcoin30_script: bitcoin30::ScriptBuf =
+            bitcoin30::ScriptBuf::new_p2pk(&bitcoin30_public_key);
+
+        // Assert that bitcoin30->bitcoin29 script is the same as native bitcoin29
+        // script.
+        assert_eq!(
+            bitcoin29_script,
+            bitcoin30_to_bitcoin29_script(bitcoin30_script.clone())
+        );
+        // Assert that bitcoin29->bitcoin30 script is the same as native bitcoin30
+        // script.
+        assert_eq!(
+            bitcoin30_script,
+            bitcoin29_to_bitcoin30_script(bitcoin29_script)
+        );
+    }
+
+    #[test]
+    fn test_bitcoin30_to_bitcoin29_address() {
+        let bitcoin29_public_key = bitcoin::PublicKey::new(
+            bitcoin::secp256k1::Secp256k1::new()
+                .generate_keypair(&mut thread_rng())
+                .1,
+        );
+        let bitcoin29_address: bitcoin::Address =
+            bitcoin::Address::p2pkh(&bitcoin29_public_key, bitcoin::Network::Bitcoin);
+
+        let bitcoin30_public_key = bitcoin29_to_bitcoin30_public_key(bitcoin29_public_key);
+        let bitcoin30_address: bitcoin30::Address =
+            bitcoin30::Address::p2pkh(&bitcoin30_public_key, bitcoin30::Network::Bitcoin);
+
+        // Assert that bitcoin30->bitcoin29 address is the same as native bitcoin29
+        // address.
+        assert_eq!(
+            bitcoin29_address,
+            bitcoin30_to_bitcoin29_address(bitcoin30_address)
+        );
+    }
+
+    #[test]
+    fn test_bitcoin29_to_bitcoin30_ripemd160_hash() {
+        let bitcoin29_hash =
+            bitcoin::hashes::ripemd160::Hash::from_hex("0123456789012345678901234567890123456789")
+                .expect("Failed to parse bitcoin v29 ripemd160 hash");
+        let bitcoin30_hash = bitcoin30::hashes::ripemd160::Hash::from_str(
+            "0123456789012345678901234567890123456789",
+        )
+        .expect("Failed to parse bitcoin v30 ripemd160 hash");
+
+        // Assert that bitcoin29->bitcoin30 ripemd160 hash is the same as native
+        // bitcoin30 ripemd160 hash.
+        assert_eq!(
+            bitcoin30_hash,
+            bitcoin29_to_bitcoin30_ripemd160_hash(bitcoin29_hash)
+        );
+    }
+
+    #[test]
+    fn test_bitcoin29_to_bitcoin30_hash160_hash() {
+        let bitcoin29_hash =
+            bitcoin::hashes::hash160::Hash::from_hex("0123456789012345678901234567890123456789")
+                .expect("Failed to parse bitcoin v29 hash160 hash");
+        let bitcoin30_hash =
+            bitcoin30::hashes::hash160::Hash::from_str("0123456789012345678901234567890123456789")
+                .expect("Failed to parse bitcoin v30 hash160 hash");
+
+        // Assert that bitcoin29->bitcoin30 hash160 hash is the same as native bitcoin30
+        // hash160 hash.
+        assert_eq!(
+            bitcoin30_hash,
+            bitcoin29_to_bitcoin30_hash160_hash(bitcoin29_hash)
+        );
+    }
+
+    #[test]
+    fn test_bitcoin29_to_bitcoin30_sha256_hash() {
+        let bitcoin29_hash = bitcoin::hashes::sha256::Hash::from_hex(
+            "0123456789012345678901234567890123456789012345678901234567890123",
+        )
+        .expect("Failed to parse bitcoin v29 sha256 hash");
+        let bitcoin30_hash = bitcoin30::hashes::sha256::Hash::from_str(
+            "0123456789012345678901234567890123456789012345678901234567890123",
+        )
+        .expect("Failed to parse bitcoin v30 sha256 hash");
+
+        // Assert that bitcoin29->bitcoin30 sha256 hash is the same as native bitcoin30
+        // sha256 hash.
+        assert_eq!(
+            bitcoin30_hash,
+            bitcoin29_to_bitcoin30_sha256_hash(bitcoin29_hash)
+        );
+    }
+}

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -28,6 +28,7 @@ use crate::module::registry::ModuleDecoderRegistry;
 pub mod admin_client;
 pub mod api;
 pub mod backup;
+pub mod bitcoin_migration;
 pub mod bitcoinrpc;
 pub mod cancellable;
 pub mod config;

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -27,7 +27,7 @@ fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-wallet-common = { version = "0.3.0-alpha", path = "../fedimint-wallet-common" }
 futures = "0.3"
-miniscript = { version = "9.0.2", features = [ "compiler", "serde" ] }
+miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 impl-tools = "0.8.0"
 rand = "0.8"
 secp256k1 = { version = "0.24.2", features = [ "serde" ] }

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, SystemTime};
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
+use fedimint_core::bitcoin_migration::bitcoin30_to_bitcoin29_script;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
@@ -101,10 +102,12 @@ async fn await_created_btc_transaction_submitted(
     context: WalletClientContext,
     tweak: KeyPair,
 ) -> (bitcoin::Transaction, u32) {
-    let script = context
-        .wallet_descriptor
-        .tweak(&tweak.public_key(), &context.secp)
-        .script_pubkey();
+    let script = bitcoin30_to_bitcoin29_script(
+        context
+            .wallet_descriptor
+            .tweak(&tweak.public_key(), &context.secp)
+            .script_pubkey(),
+    );
     loop {
         match context.rpc.watch_script_history(&script).await {
             Ok(_) => break,

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -22,7 +22,8 @@ bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 futures = "0.3"
-miniscript = { version = "9.0.2", features = [ "compiler", "serde" ] }
+miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
+miniscript9 = { package = "miniscript", version = "9.0.2" }
 impl-tools = "0.8.0"
 rand = "0.8"
 secp256k1 = { version = "0.24.2", features = [ "serde" ] }

--- a/modules/fedimint-wallet-common/src/keys.rs
+++ b/modules/fedimint-wallet-common/src/keys.rs
@@ -1,10 +1,11 @@
 use std::io::{Error, Write};
 use std::str::FromStr;
 
-use bitcoin::hashes::{hash160, ripemd160, sha256};
 use bitcoin::secp256k1::{Secp256k1, Verification};
 use bitcoin::PublicKey;
+use fedimint_core::bitcoin_migration::bitcoin29_to_bitcoin30_public_key;
 use fedimint_core::encoding::{Decodable, Encodable};
+use miniscript::bitcoin::hashes::{hash160, ripemd160, sha256};
 use miniscript::{hash256, MiniscriptKey, ToPublicKey};
 use secp256k1::Signing;
 use serde::{Deserialize, Serialize};
@@ -35,18 +36,22 @@ impl MiniscriptKey for CompressedPublicKey {
         false
     }
 
-    type Sha256 = bitcoin::hashes::sha256::Hash;
+    fn num_der_paths(&self) -> usize {
+        0
+    }
+
+    type Sha256 = miniscript::bitcoin::hashes::sha256::Hash;
     type Hash256 = miniscript::hash256::Hash;
-    type Ripemd160 = bitcoin::hashes::ripemd160::Hash;
-    type Hash160 = bitcoin::hashes::hash160::Hash;
+    type Ripemd160 = miniscript::bitcoin::hashes::ripemd160::Hash;
+    type Hash160 = miniscript::bitcoin::hashes::hash160::Hash;
 }
 
 impl ToPublicKey for CompressedPublicKey {
-    fn to_public_key(&self) -> PublicKey {
-        PublicKey {
+    fn to_public_key(&self) -> miniscript::bitcoin::PublicKey {
+        bitcoin29_to_bitcoin30_public_key(PublicKey {
             compressed: true,
             inner: self.key,
-        }
+        })
     }
 
     fn to_sha256(hash: &<Self as MiniscriptKey>::Sha256) -> sha256::Hash {

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -384,5 +384,5 @@ pub enum ProcessPegOutSigError {
     #[error("Missing change tweak")]
     MissingOrMalformedChangeTweak,
     #[error("Error finalizing PSBT {0:?}")]
-    ErrorFinalizingPsbt(Vec<miniscript::psbt::Error>),
+    ErrorFinalizingPsbt(Vec<miniscript9::psbt::Error>),
 }

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -25,7 +25,8 @@ fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
 fedimint-wallet-common = { version = "0.3.0-alpha", path = "../fedimint-wallet-common" }
 futures = "0.3"
-miniscript = { version = "9.0.2", features = [ "compiler", "serde" ] }
+miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
+miniscript9 = { package = "miniscript", version = "9.0.2" }
 impl-tools = "0.8.0"
 rand = "0.8"
 secp256k1 = { version = "0.24.2", features = [ "serde" ] }

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -30,7 +30,7 @@ fedimint-wallet-client = { path = "../fedimint-wallet-client" }
 fedimint-wallet-common = { path = "../fedimint-wallet-common" }
 fedimint-wallet-server = { path = "../fedimint-wallet-server" }
 futures = "0.3.28"
-miniscript = { version = "9.0.2" }
+miniscript = { version = "10.0.0" }
 tokio = { version = "1.26.0", features = ["sync"] }
 tracing = "0.1.37"
 secp256k1 = { version = "0.24.2", features = [ "serde" ] }

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -29,7 +29,7 @@ fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-c
 fedimint-ln-server = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-server" }
 fedimint-mint-server = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-server" }
 futures = "0.3.26"
-miniscript = { version = "9.0.2" }
+miniscript = { version = "10.0.0" }
 secp256k1 = { version = "0.24.3", features = [ "serde", "global-context" ] }
 serde = { version = "1.0.152", features = [ "derive" ] }
 serde_json = "1.0.93"

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -6,10 +6,13 @@ use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
 use bitcoin::hashes::hex::FromHex;
-use bitcoin::hashes::sha256::Hash;
 use bitcoin::network::constants::Network;
 use bitcoin::OutPoint;
 use clap::{ArgGroup, Parser, Subcommand};
+use fedimint_core::bitcoin_migration::{
+    bitcoin29_to_bitcoin30_hash160_hash, bitcoin29_to_bitcoin30_ripemd160_hash,
+    bitcoin29_to_bitcoin30_sha256_hash,
+};
 use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_LN, LEGACY_HARDCODED_INSTANCE_ID_MINT,
     LEGACY_HARDCODED_INSTANCE_ID_WALLET,
@@ -392,6 +395,10 @@ impl MiniscriptKey for Key {
         false
     }
 
+    fn num_der_paths(&self) -> usize {
+        0
+    }
+
     type Sha256 = bitcoin::hashes::sha256::Hash;
     type Hash256 = miniscript::hash256::Hash;
     type Ripemd160 = bitcoin::hashes::ripemd160::Hash;
@@ -399,24 +406,30 @@ impl MiniscriptKey for Key {
 }
 
 impl ToPublicKey for Key {
-    fn to_public_key(&self) -> bitcoin::PublicKey {
+    fn to_public_key(&self) -> miniscript::bitcoin::PublicKey {
         self.to_compressed_public_key().to_public_key()
     }
 
-    fn to_sha256(hash: &<Self as MiniscriptKey>::Sha256) -> Hash {
-        *hash
+    fn to_sha256(
+        hash: &<Self as MiniscriptKey>::Sha256,
+    ) -> miniscript::bitcoin::hashes::sha256::Hash {
+        bitcoin29_to_bitcoin30_sha256_hash(*hash)
     }
 
     fn to_hash256(hash: &<Self as MiniscriptKey>::Hash256) -> miniscript::hash256::Hash {
         *hash
     }
 
-    fn to_ripemd160(hash: &<Self as MiniscriptKey>::Ripemd160) -> bitcoin::hashes::ripemd160::Hash {
-        *hash
+    fn to_ripemd160(
+        hash: &<Self as MiniscriptKey>::Ripemd160,
+    ) -> miniscript::bitcoin::hashes::ripemd160::Hash {
+        bitcoin29_to_bitcoin30_ripemd160_hash(*hash)
     }
 
-    fn to_hash160(hash: &<Self as MiniscriptKey>::Hash160) -> bitcoin::hashes::hash160::Hash {
-        *hash
+    fn to_hash160(
+        hash: &<Self as MiniscriptKey>::Hash160,
+    ) -> miniscript::bitcoin::hashes::hash160::Hash {
+        bitcoin29_to_bitcoin30_hash160_hash(*hash)
     }
 }
 


### PR DESCRIPTION
Migrate from [miniscript v9.0.2](https://crates.io/crates/miniscript/9.0.2) to [miniscript v10.0.0](https://crates.io/crates/miniscript/10.0.0) everywhere except one callsite where bitcoin v0.29's `PartiallySignedTransaction` uses miniscript v9's `PsbtExt` trait and provided implementation.

Miniscript v9 relies on bitcoin v0.29, whereas miniscript v10 relies on bitcoin v0.30, which is why we're adding `fedimint-core/src/bitcoin_migration.rs` which contains functions that can convert necessary types between these two versions of the bitcoin crate.