### PR TITLE
fix: mark JsonRpcClientError:Call as retryable regardless of code

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -89,7 +89,7 @@ impl PeerError {
                 JsonRpcClientError::MaxSlotsExceeded => true,
                 JsonRpcClientError::RequestTimeout => true,
                 JsonRpcClientError::RestartNeeded(_) => true,
-                JsonRpcClientError::Call(e) => e.code() == 404,
+                JsonRpcClientError::Call(_) => true,
                 _ => false,
             },
             PeerError::InvalidResponse(_) => false,


### PR DESCRIPTION
Milder version of #4064 (and #4051) that solves the problem directly and can hopefully be merged and backported fast (while a more general solution is fleshed out).