### PR TITLE
fix: make single guardian devimint cli test backwards-compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ name = "devimint"
 version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "axum",
  "bitcoincore-rpc",
  "clap",
@@ -1069,6 +1070,7 @@ dependencies = [
  "futures",
  "nix",
  "rand",
+ "regex",
  "serde",
  "serde_json",
  "tokio",
@@ -2622,7 +2624,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.4",
  "regex-syntax 0.8.2",
 ]
 
@@ -4209,13 +4211,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.4",
  "regex-syntax 0.8.2",
 ]
 
@@ -4230,9 +4232,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4551,9 +4553,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "send_wrapper"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,6 @@ name = "devimint"
 version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
- "assert_matches",
  "axum",
  "bitcoincore-rpc",
  "clap",
@@ -1070,7 +1069,7 @@ dependencies = [
  "futures",
  "nix",
  "rand",
- "regex",
+ "semver",
  "serde",
  "serde_json",
  "tokio",

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -31,7 +31,7 @@ futures = "0.3.24"
 ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 nix = { version = "0.26.2", features = ["signal"] }
 rand = "0.8.5"
-regex = "1.10.3"
+semver = "1.0.21"
 serde_json = "1.0.94"
 tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tonic_lnd = { workspace = true }
@@ -44,6 +44,3 @@ fedimint-portalloc = { path = "../utils/portalloc" }
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
-
-[dev-dependencies]
-assert_matches = "1.5.0"

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -31,6 +31,7 @@ futures = "0.3.24"
 ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 nix = { version = "0.26.2", features = ["signal"] }
 rand = "0.8.5"
+regex = "1.10.3"
 serde_json = "1.0.94"
 tokio = { version = "1.26.0", features = ["full", "tracing"] }
 tonic_lnd = { workspace = true }
@@ -43,3 +44,6 @@ fedimint-portalloc = { path = "../utils/portalloc" }
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+
+[dev-dependencies]
+assert_matches = "1.5.0"

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -21,6 +21,7 @@ use fedimint_core::task::{timeout, TaskGroup};
 use fedimint_core::util::write_overwrite_async;
 use fedimint_logging::LOG_DEVIMINT;
 use ln_gateway::rpc::GatewayInfo;
+use semver::VersionReq;
 use serde_json::json;
 use tokio::fs;
 use tokio::net::TcpStream;
@@ -419,10 +420,8 @@ async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     // fedimintd introduced wpkh for single guardian federations in v0.3.0 (9e35bdb)
     // The code path is backwards-compatible, however this test will fail if we
     // check against earlier fedimintd versions.
-    let fedimintd_version_res = cmd!(devimint::util::FedimintdCmd, "--version")
-        .out_string()
-        .await;
-    if devimint::util::is_min_version(0, 3, 0, fedimintd_version_res) {
+    let fedimintd_version = devimint::util::FedimintdCmd::version_or_default().await;
+    if VersionReq::parse(">=0.3.0")?.matches(&fedimintd_version) {
         // # Test the correct descriptor is used
         let config = cmd!(client, "config").out_json().await?;
         let guardian_count = config["global"]["api_endpoints"].as_object().unwrap().len();

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -6,16 +6,20 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{env, unreachable};
 
-use anyhow::{anyhow, bail, format_err, Context, Result};
+use anyhow::{bail, format_err, Context, Result};
 use fedimint_core::task::{self, block_in_place};
 use fedimint_logging::LOG_DEVIMINT;
 use futures::executor::block_on;
-use regex::Regex;
+use semver::Version;
 use serde::de::DeserializeOwned;
 use tokio::fs::OpenOptions;
 use tokio::process::Child;
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
+
+// If a binary doesn't provide a clap version, default to the first stable
+// release (v0.2.1)
+const DEFAULT_VERSION: Version = Version::new(0, 2, 1);
 
 pub fn parse_map(s: &str) -> Result<BTreeMap<String, String>> {
     let mut map = BTreeMap::new();
@@ -426,147 +430,43 @@ impl FedimintdCmd {
     pub async fn cmd(self) -> Command {
         get_command_for_alias("FM_FEDIMINTD_BASE_EXECUTABLE", "fedimintd")
     }
-}
 
-/// Representation of a cargo package version
-#[derive(Debug, PartialEq, Eq)]
-struct CrateVersion {
-    major: u32,
-    minor: u32,
-    patch: u32,
-}
-
-impl PartialOrd for CrateVersion {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for CrateVersion {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self.major != other.major {
-            self.major.cmp(&other.major)
-        } else if self.minor != other.minor {
-            self.minor.cmp(&other.minor)
-        } else {
-            self.patch.cmp(&other.patch)
+    /// Returns the fedimintd version from clap or default min version if the
+    /// binary doesn't support a version flag
+    pub async fn version_or_default() -> Version {
+        match cmd!(FedimintdCmd, "--version").out_string().await {
+            Ok(version) => parse_clap_version(&version),
+            Err(_) => DEFAULT_VERSION,
         }
     }
 }
 
-/// Parses a crate version string returned from clap
-/// ex: fedimintd 0.3.0-alpha -> 0.3.0
-fn parse_crate_version(version: &str) -> Result<CrateVersion> {
-    // from semver.org's recommended regex
-    // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-    let semver_pattern =
-        Regex::new(r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)")?;
-
-    let captured = semver_pattern
-        .captures(version)
-        .ok_or(anyhow!("Not a valid version string"))?;
-
-    Ok(CrateVersion {
-        major: captured["major"].parse()?,
-        minor: captured["minor"].parse()?,
-        patch: captured["patch"].parse()?,
-    })
-}
-
-/// Returns true if the provided version string is greater than or equal to the
-/// min version provided. If there's an error parsing the version, returns
-/// false.
-pub fn is_min_version(
-    min_major: u32,
-    min_minor: u32,
-    min_patch: u32,
-    version_res: Result<String, anyhow::Error>,
-) -> bool {
-    let min_crate_version = CrateVersion {
-        major: min_major,
-        minor: min_minor,
-        patch: min_patch,
-    };
-    version_res
-        .is_ok_and(|version| parse_crate_version(&version).is_ok_and(|v| min_crate_version <= v))
+/// Parses a version string returned from clap
+/// ex: fedimintd 0.3.0-alpha -> 0.3.0-alpha
+fn parse_clap_version(res: &str) -> Version {
+    match res.split(' ').collect::<Vec<&str>>().as_slice() {
+        [_binary, version] => Version::parse(version).unwrap_or(DEFAULT_VERSION),
+        _ => DEFAULT_VERSION,
+    }
 }
 
 #[test]
-fn test_parse_crate_versions() -> Result<()> {
+fn test_parse_clap_version() -> Result<()> {
     let version_str = "fedimintd 0.3.0-alpha";
-    let expected_version = CrateVersion {
-        major: 0,
-        minor: 3,
-        patch: 0,
-    };
-    assert_eq!(expected_version, parse_crate_version(version_str)?);
+    let expected_version = Version::parse("0.3.0-alpha")?;
+    assert_eq!(expected_version, parse_clap_version(version_str));
 
     let version_str = "fedimintd 0.3.12";
-    let expected_version = CrateVersion {
-        major: 0,
-        minor: 3,
-        patch: 12,
-    };
-    assert_eq!(expected_version, parse_crate_version(version_str)?);
+    let expected_version = Version::parse("0.3.12")?;
+    assert_eq!(expected_version, parse_clap_version(version_str));
 
     let version_str = "fedimint-cli 2.12.2-rc22";
-    let expected_version = CrateVersion {
-        major: 2,
-        minor: 12,
-        patch: 2,
-    };
-    assert_eq!(expected_version, parse_crate_version(version_str)?);
+    let expected_version = Version::parse("2.12.2-rc22")?;
+    assert_eq!(expected_version, parse_clap_version(version_str));
 
     let version_str = "bad version";
-    assert_matches::assert_matches!(parse_crate_version(version_str), Err(_));
-
-    Ok(())
-}
-
-#[test]
-fn test_is_min_version() -> Result<()> {
-    // patch equal
-    let version_res = Ok("fedimintd 0.3.1".to_string());
-    assert!(is_min_version(0, 3, 1, version_res));
-
-    // patch lower
-    let version_res = Ok("fedimintd 0.3.1".to_string());
-    assert!(is_min_version(0, 3, 0, version_res));
-
-    // patch greater
-    let version_res = Ok("fedimintd 0.3.1".to_string());
-    assert!(!is_min_version(0, 3, 2, version_res));
-
-    // minor equal
-    let version_res = Ok("gateway-cli 1.3.1".to_string());
-    assert!(is_min_version(1, 3, 0, version_res));
-
-    // minor lower
-    let version_res = Ok("gateway-cli 1.3.1".to_string());
-    assert!(is_min_version(1, 2, 0, version_res));
-
-    // minor greater
-    let version_res = Ok("gateway-cli 1.3.1".to_string());
-    assert!(!is_min_version(1, 4, 0, version_res));
-
-    // major equal
-    let version_res = Ok("gatewayd 3.2.1".to_string());
-    assert!(is_min_version(3, 0, 0, version_res));
-
-    // major lower
-    let version_res = Ok("gatewayd 3.2.1".to_string());
-    assert!(is_min_version(2, 0, 0, version_res));
-
-    // major greater
-    let version_res = Ok("gatewayd 3.2.1".to_string());
-    assert!(!is_min_version(4, 0, 0, version_res));
-
-    // error cases
-    let version_res = Err(anyhow!(""));
-    assert!(!is_min_version(0, 2, 3, version_res));
-
-    let version_res = Ok("bad version".to_string());
-    assert!(!is_min_version(0, 2, 3, version_res));
+    let expected_version = DEFAULT_VERSION;
+    assert_eq!(expected_version, parse_clap_version(version_str));
 
     Ok(())
 }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -35,6 +35,7 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 pub const FM_EXTRA_DKG_META_VAR: &str = "FM_EXTRA_DKG_META";
 
 #[derive(Parser)]
+#[command(version)]
 pub struct ServerOpts {
     /// Path to folder containing federation config files
     #[arg(long = "data-dir", env = "FM_DATA_DIR")]


### PR DESCRIPTION
Fixes #4017 

I verified locally against the full matrix of backwards-compatibility tests that `devimint_cli_test_single` succeeds (see: https://github.com/fedimint/fedimint/pull/4010).

```
Backwards-compatibility tests summary:
fed_version  client_version  gateway_version  exit_code
v0.2.1       v0.2.1          current          0
v0.2.1       current         v0.2.1           0
v0.2.1       current         current          0
current      v0.2.1          v0.2.1           0
current      v0.2.1          current          0
current      current         v0.2.1           0
```