### PR TITLE
chore: better (hopefully) lock file handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lock merge=ours

--- a/flake.nix
+++ b/flake.nix
@@ -327,6 +327,10 @@
                   if [ "$(ulimit -Sn)" -lt "1024" ]; then
                       >&2 echo "⚠️  ulimit too small. Run 'ulimit -Sn 1024' to avoid problems running tests"
                   fi
+
+                  if [ -z "$(git config --global merge.ours.driver)" ]; then
+                      >&2 echo "⚠️  Recommended to run 'git config --global merge.ours.driver true' to enable better lock file handling. See https://blog.aspect.dev/easier-merges-on-lockfiles for more info"
+                  fi
                 '';
               };
             in


### PR DESCRIPTION
I've just read:

https://blog.aspect.dev/easier-merges-on-lockfiles

and it occured to me that it would be very easy to implement in a Nix shell.

Never tried it, so I'm not sure if it's a good idea, but I'm curious. I always resolve lock file conflicts this way anyway (just manually).