### PR TITLE
test gateway fees and revise docker defaults

### DIFF
--- a/docker/0.2.1/full-tls-mutinynet/docker-compose.yaml
+++ b/docker/0.2.1/full-tls-mutinynet/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
       # Gateway webserver authentication password
       - FM_GATEWAY_PASSWORD=thereisnosecondbest
       # Configured gateway routing fees Format: <base_msat>,<proportional_millionths>
-      - FM_GATEWAY_FEES=0,0
+      - FM_GATEWAY_FEES=0,10000
       # LND RPC address
       - FM_LND_RPC_ADDR=https://lnd:10009
       # LND TLS cert file path

--- a/docker/0.2.1/gateway-mutinynet/docker-compose.yaml
+++ b/docker/0.2.1/gateway-mutinynet/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       # Gateway webserver authentication password
       - FM_GATEWAY_PASSWORD=thereisnosecondbest
       # Configured gateway routing fees Format: <base_msat>,<proportional_millionths>
-      - FM_GATEWAY_FEES=0,0
+      - FM_GATEWAY_FEES=0,10000
       # LND RPC address
       - FM_LND_RPC_ADDR=https://lnd:10009
       # LND TLS cert file path


### PR DESCRIPTION
- updates `v0.2.*` docker compose files to package gateway with **0 base msat, 10000 PPM** default fees
- updates tests to include assertions for variable part of globally configured gateway fees

partially addresses #4093 by updating fee defaults in docker packaged gatewayd