### PR TITLE
chore: store Lightning Gateway Registrations by gateway id

### DIFF
--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1138,7 +1138,7 @@ impl Lightning {
         self.delete_expired_gateways(dbtx).await;
 
         dbtx.insert_entry(
-            &LightningGatewayKey(gateway.info.node_pub_key),
+            &LightningGatewayKey(gateway.info.gateway_id),
             &gateway.anchor(),
         )
         .await;


### PR DESCRIPTION
Replaces: https://github.com/fedimint/fedimint/pull/3389 @tvolk131 for visibility

Working towards https://github.com/fedimint/fedimint/issues/4027 I'd like to de-register the gateway when it receives SIGINT or it leaves the federation, but we can't do that until we store gateways by `gateway_id`, otherwise we risk deleting multiple gateways if they share the same `node_pub_key` (should only happen if using a custodial API)

I believe this is a rare care where a change to a database structure does not require a migration. The structure of the key stays the same (it is still a `PublicKey`), the value is just different. Additionally, on the next registration of the gateway, a new record in the db will be created, and the old one will just be cleaned up once it expires. Because of this, I do not believe a database migration is required.