### PR TITLE
fix: make gateway api backwards-compatible

### DIFF
--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -19,7 +19,7 @@ use lightning_invoice::RoutingFees;
 use ln_gateway::client::GatewayClientBuilder;
 use ln_gateway::lightning::{ILnRpcClient, LightningBuilder};
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
-use ln_gateway::rpc::{ConnectFedPayload, FederationConnectionInfo, V1_API_ENDPOINT};
+use ln_gateway::rpc::{ConnectFedPayload, FederationInfo, V1_API_ENDPOINT};
 use ln_gateway::{Gateway, GatewayState};
 use secp256k1::PublicKey;
 use tempfile::TempDir;
@@ -65,7 +65,7 @@ impl GatewayTest {
     }
 
     /// Connects to a new federation and stores the info
-    pub async fn connect_fed(&mut self, fed: &FederationTest) -> FederationConnectionInfo {
+    pub async fn connect_fed(&mut self, fed: &FederationTest) -> FederationInfo {
         info!(target: LOG_TEST, "Sending rpc to connect gateway to federation");
         let invite_code = fed.invite_code().to_string();
         let rpc = self

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -67,17 +67,12 @@ pub struct WithdrawPayload {
     pub address: Address,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct FederationConnectionInfo {
-    pub federation_id: FederationId,
-    pub config: ClientConfig,
-}
-
 /// Information about one of the feds we are connected to
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FederationInfo {
     pub federation_id: FederationId,
     pub balance_msat: Amount,
+    pub config: ClientConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -152,7 +147,7 @@ impl_gateway_request_trait!(InfoPayload, GatewayInfo, GatewayRequest::Info);
 impl_gateway_request_trait!(ConfigPayload, GatewayFedConfig, GatewayRequest::Config);
 impl_gateway_request_trait!(
     ConnectFedPayload,
-    FederationConnectionInfo,
+    FederationInfo,
     GatewayRequest::ConnectFederation
 );
 impl_gateway_request_trait!(PayInvoicePayload, Preimage, GatewayRequest::PayInvoice);

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use super::{
     BackupPayload, BalancePayload, ConfigPayload, ConnectFedPayload, DepositAddressPayload,
-    FederationConnectionInfo, GatewayFedConfig, GatewayInfo, LeaveFedPayload, RestorePayload,
+    FederationInfo, GatewayFedConfig, GatewayInfo, LeaveFedPayload, RestorePayload,
     SetConfigurationPayload, WithdrawPayload,
 };
 
@@ -43,6 +43,12 @@ impl GatewayRpcClient {
         self.call_get(url).await
     }
 
+    // FIXME: deprecated >= 0.3.0
+    pub async fn get_info_legacy(&self) -> GatewayRpcResult<GatewayInfo> {
+        let url = self.base_url.join("/info").expect("invalid base url");
+        self.call_post(url, ()).await
+    }
+
     pub async fn get_config(&self, payload: ConfigPayload) -> GatewayRpcResult<GatewayFedConfig> {
         let url = self.base_url.join("/config").expect("invalid base url");
         self.call_post(url, payload).await
@@ -69,7 +75,7 @@ impl GatewayRpcClient {
     pub async fn connect_federation(
         &self,
         payload: ConnectFedPayload,
-    ) -> GatewayRpcResult<FederationConnectionInfo> {
+    ) -> GatewayRpcResult<FederationInfo> {
         let url = self
             .base_url
             .join("/connect-fed")


### PR DESCRIPTION
Fixes #3977 

- Builds off of https://github.com/fedimint/fedimint/pull/4037
- Fixes backwards-incompatibility introduced in https://github.com/fedimint/fedimint/pull/3847 and  https://github.com/fedimint/fedimint/pull/3880