### PR TITLE
chore: disable discord alerts for backwards-compatibility

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -61,23 +61,3 @@ jobs:
           path: |
             /tmp/nix-build-*/
             !/tmp/nix-build-*/source/
-
-  notifications:
-    if: always() && github.repository == 'fedimint/fedimint'
-    name: "Notifications"
-    timeout-minutes: 1
-    runs-on: ubuntu-22.04
-    # note: we don't depend on `audit` because it will
-    # be often broken, and we can't fix it immediately
-    needs: [ tests ]
-
-    steps:
-    - name: Discord notifications on failure
-      # https://stackoverflow.com/a/74562058/134409
-      if: ${{ always() && contains(needs.*.result, 'failure') }}
-      # https://github.com/marketplace/actions/actions-status-discord
-      uses: sarisia/actions-status-discord@v1
-      with:
-        webhook: ${{ secrets.DISCORD_WEBHOOK }}
-        # current job is a success, but that's not what we're interested in
-        status: failure


### PR DESCRIPTION
The discord `alerts` channel is too noisy with these alerts, especially while we know there are outstanding fixes.