### PR TITLE
fix: ignore TracingSetup error in migration tests

### DIFF
--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -251,7 +251,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_migrations() -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
+        let _ = TracingSetup::default().init();
 
         validate_migrations(
             "fedimint-server",

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -207,7 +207,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_migrations() -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
+        let _ = TracingSetup::default().init();
 
         validate_migrations(
             "dummy-server",

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -673,7 +673,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_migrations() -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
+        let _ = TracingSetup::default().init();
 
         validate_migrations(
             "lightning-server",

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -255,7 +255,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_migrations() -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
+        let _ = TracingSetup::default().init();
 
         validate_migrations(
             "mint-server",

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -801,7 +801,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_migrations() -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
+        let _ = TracingSetup::default().init();
 
         validate_migrations(
             "wallet-server",


### PR DESCRIPTION
Running `cargo test` causes an error with the db migration tests since the tracing subscriber is already setup. Simple fix is just to ignore the error.