### PR TITLE
chore: delete incorrect argument

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -398,8 +398,6 @@ rec {
       "fedimint-cli"
       "fedimint-dbtool"
     ];
-
-    defaultBin = "fedimintd";
   };
 
   gateway-pkgs = fedimintBuildPackageGroup {


### PR DESCRIPTION
This wasn't doing anything, which OK, but might be confusing.