### PR TITLE
chore(ci): upload release artifacts on tag builds

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -397,6 +397,12 @@ jobs:
           name: "${{ matrix.build.flake-output}}-linux-x86_64"
           path: "bins/**"
 
+      - name: Release Binaries
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "bins/**"
+
       - name: Build DEB package
         run: |
           nix bundle -L --bundler github:NixOS/bundlers#toDEB --accept-flake-config -o ${{ matrix.build.deb }}.deb .#${{ matrix.build.flake-output }}
@@ -417,11 +423,23 @@ jobs:
           name: "deb-bundle"
           path: "debs/**.deb"
 
+      - name: Release DEB packages
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "debs/**.deb"
+
       - name: Upload RPM packages
         uses: actions/upload-artifact@v3
         with:
           name: "rpm-bundle"
           path: "rpms/**.rpm"
+
+      - name: Release RPM packages
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "rpms/**.rpm"
 
   notifications:
     if: always() && github.repository == 'fedimint/fedimint'


### PR DESCRIPTION
Backport https://github.com/fedimint/fedimint/pull/4023

Fix https://github.com/fedimint/fedimint/pull/4163

"upload artifacts" we already have is not for release artifacts.