### PR TITLE
fix: make devimint backup & restore test backwards-compatible

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -97,7 +97,7 @@ impl Client {
 
     /// Create a [`Client`] that starts with a state that is a copy of
     /// of another one.
-    async fn new_forked(&self, name: &str) -> Result<Client> {
+    pub async fn new_forked(&self, name: &str) -> Result<Client> {
         let new = Client::create(name).await?;
 
         cmd!(

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -538,6 +538,15 @@ impl FedimintCli {
                 .collect::<Vec<_>>(),
         ))
     }
+
+    /// Returns the fedimintd version from clap or default min version if the
+    /// binary doesn't support a version flag
+    pub async fn version_or_default() -> Version {
+        match cmd!(FedimintCli, "--version").out_string().await {
+            Ok(version) => parse_clap_version(&version),
+            Err(_) => DEFAULT_VERSION,
+        }
+    }
 }
 
 pub struct LoadTestTool;

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -54,7 +54,10 @@ function gateway_reboot_test() {
 export -f gateway_reboot_test
 
 function latency_test() {
-  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh
+  # latency tests are not necessary for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh
+  fi
 }
 export -f latency_test
 


### PR DESCRIPTION
Fixes [#4106](https://github.com/fedimint/fedimint/issues/4016)

For visibility, resurfacing this comment from the associated issue:

> Should we adapt the test script instead here? At least in my mind we didn't commit to CLI stability (maybe we should? @justinmoon)

https://github.com/fedimint/fedimint/issues/4016#issuecomment-1893662992

This approach resolves by adapting the test script and doesn't change the CLI.