### PR TITLE
feat: set mpp for generated invoices

### DIFF
--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -75,6 +75,7 @@ impl LightningTest for FakeLightningTest {
             .current_timestamp()
             .min_final_cltv_expiry_delta(0)
             .payment_secret(PaymentSecret([0; 32]))
+            .basic_mpp()
             .amount_milli_satoshis(amount.msats)
             .expiry_time(Duration::from_secs(
                 expiry_time.unwrap_or(DEFAULT_EXPIRY_TIME),

--- a/fedimint-testing/src/ln/mod.rs
+++ b/fedimint-testing/src/ln/mod.rs
@@ -48,6 +48,7 @@ pub trait LightningTest: ILnRpcClient {
             .current_timestamp()
             .min_final_cltv_expiry_delta(0)
             .payment_secret(PaymentSecret([0; 32]))
+            .basic_mpp()
             .amount_milli_satoshis(amount.msats)
             .expiry_time(Duration::from_secs(
                 expiry_time.unwrap_or(DEFAULT_EXPIRY_TIME),

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -770,6 +770,7 @@ impl LightningClientModule {
             .payment_hash(payment_hash)
             .payment_secret(PaymentSecret(rng.gen()))
             .duration_since_epoch(duration_since_epoch)
+            .basic_mpp()
             .min_final_cltv_expiry_delta(18)
             .payee_pub_key(node_public_key)
             .expiry_time(Duration::from_secs(

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -416,6 +416,7 @@ mod tests {
             .duration_since_epoch(now_epoch)
             .min_final_cltv_expiry_delta(0)
             .payment_secret(PaymentSecret([0; 32]))
+            .basic_mpp()
             .amount_milli_satoshis(1000)
             .expiry_time(expiry_time)
             .build_signed(|m| ctx.sign_ecdsa_recoverable(m, &secret_key))?)


### PR DESCRIPTION
Noticed this was missing from when building the invoice, MPP should be enabled so it can be paid with MPP. Should in general improve reliability with receives 