### PR TITLE
fix: bump retry count for test_gateway_configuration

### DIFF
--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -1049,7 +1049,7 @@ async fn test_gateway_configuration() -> anyhow::Result<()> {
             Ok(info)
         },
         Duration::from_secs(1),
-        5,
+        30,
     )
     .await?;
 


### PR DESCRIPTION
The web server is restarting so we may need to wait a bit longer. Multiple code coverage CI failures due to this.

```
Error: error sending request for url (http://127.0.0.1:20037/info): error trying to connect: tcp connect error: Connection refused (os error 111)
```
https://github.com/fedimint/fedimint/actions/runs/7704054812/job/20995614440?pr=4169#step:6:1719