### PR TITLE
feat: latency tests on a degraded federation

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -333,6 +333,12 @@ rec {
     buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/tests/latency-test.sh";
   };
 
+  latencyTestDegraded = craneLibTests.mkCargoDerivation {
+    pname = "${commonCliTestArgs.pname}-latency";
+    cargoArtifacts = workspaceBuild;
+    buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/tests/latency-test.sh --degraded";
+  };
+
   devimintCliTest = craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-cli";
     cargoArtifacts = workspaceBuild;

--- a/scripts/tests/latency-test.sh
+++ b/scripts/tests/latency-test.sh
@@ -8,4 +8,4 @@ source scripts/_common.sh
 build_workspace
 add_target_dir_to_path
 
-devimint latency-tests
+devimint latency-tests "$@"

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -61,6 +61,11 @@ function latency_test() {
 }
 export -f latency_test
 
+function latency_test_degraded() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh --degraded
+}
+export -f latency_test_degraded
+
 function devimint_cli_test() {
   fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-cli-test.sh
 }
@@ -139,6 +144,7 @@ if parallel \
   backend_test_electrs \
   backend_test_esplora \
   latency_test \
+  latency_test_degraded \
   reconnect_test \
   lightning_reconnect_test \
   gateway_reboot_test \


### PR DESCRIPTION
not completely implmenting #4171

this increases latency significantly

related https://github.com/fedimint/fedimint/issues/4130

healthy federation:

```
================= RESULTS ==================
REISSUE: min: 1.8s, avg: 1.9s, median: 1.9s, p90: 2.0s, max: 2.0s, sum: 56.8s
LN SEND: min: 2.9s, avg: 3.1s, median: 3.0s, p90: 4.0s, max: 4.1s, sum: 62.3s
LN RECV: min: 1.9s, avg: 2.2s, median: 2.1s, p90: 2.6s, max: 3.1s, sum: 43.8s
FM PAY : min: 4.3s, avg: 4.4s, median: 4.4s, p90: 4.5s, max: 4.6s, sum: 87.7s
RESTORE: 60.401258381s
```

degraded federation: still running after 30 minutes, i gave up