### PR TITLE
chore: re-enable discord alerts for backwards-compatibility

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -61,3 +61,21 @@ jobs:
           path: |
             /tmp/nix-build-*/
             !/tmp/nix-build-*/source/
+
+  notifications:
+    if: always() && github.repository == 'fedimint/fedimint'
+    name: "Notifications"
+    timeout-minutes: 1
+    runs-on: ubuntu-22.04
+    needs: [ tests ]
+
+    steps:
+    - name: Discord notifications on failure
+      # https://stackoverflow.com/a/74562058/134409
+      if: ${{ always() && contains(needs.*.result, 'failure') }}
+      # https://github.com/marketplace/actions/actions-status-discord
+      uses: sarisia/actions-status-discord@v1
+      with:
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        # current job is a success, but that's not what we're interested in
+        status: failure


### PR DESCRIPTION
Now that all backwards-compatibility issues have been resolved, we can re-enable the discord alerts.

See: https://github.com/fedimint/fedimint/pull/4139#issuecomment-1915905704