### PR TITLE
debug: consensus issues [don't merge]

### DIFF
--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -732,7 +732,9 @@ impl ConsensusServer {
 
         loop {
             // we wait until we have stalled
+            info!(target: LOG_CONSENSUS, "### SLEEP START");
             sleep(Duration::from_secs(5)).await;
+            info!(target: LOG_CONSENSUS, "### SLEEP END");
 
             let result = federation_api
                 .request_with_strategy(


### PR DESCRIPTION
![image](https://github.com/fedimint/fedimint/assets/9209/674950f5-381b-472a-9c4d-d9864f3f8e21)


This sleep there never completes, as the alternative branch receives every second a batch of 0 bytes, even when no user does anything. Is this expected?


Anyway, when running:

```
env RUST_LOG=client::net::api=trace,consensus=debug,info just mprocs
```

and then `ps fax | grep fedimintd` and `kill <pid>` one of the peers, we no longer get new sessions, which seems to repro some consensus issue.