### PR TITLE
fix(justfile): don't use `cargo -p`

### DIFF
--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -114,7 +114,7 @@ mod fedimint_migration_tests {
     use fedimint_dummy_common::{DummyCommonInit, DummyInput, DummyOutput};
     use fedimint_dummy_server::Dummy;
     use fedimint_logging::TracingSetup;
-    use fedimint_testing::db::{prepare_db_migration_snapshot, validate_migrations, BYTE_32};
+    use fedimint_testing::db::{snapshot_db_migrations, validate_migrations, BYTE_32};
     use futures::StreamExt;
     use rand::rngs::OsRng;
     use secp256k1_zkp::Message;
@@ -198,8 +198,8 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn prepare_server_db_migration_snapshots() -> anyhow::Result<()> {
-        prepare_db_migration_snapshot(
+    async fn snapshot_server_db_migrations() -> anyhow::Result<()> {
+        snapshot_db_migrations(
             "fedimint-server-v0",
             |dbtx| {
                 Box::pin(async move {
@@ -216,7 +216,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_migrations() -> anyhow::Result<()> {
+    async fn test_server_db_migrations() -> anyhow::Result<()> {
         let _ = TracingSetup::default().init();
 
         validate_migrations(

--- a/fedimint-testing/src/db.rs
+++ b/fedimint-testing/src/db.rs
@@ -40,7 +40,7 @@ pub fn get_project_root() -> io::Result<PathBuf> {
 /// `prepare_fn` which is expected to populate the database with the appropriate
 /// data for testing a migration. If the snapshot directory already exists,
 /// this function will do nothing.
-pub async fn prepare_db_migration_snapshot<F>(
+pub async fn snapshot_db_migrations<F>(
     snapshot_name: &str,
     prepare_fn: F,
     decoders: ModuleDecoderRegistry,

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -44,6 +44,11 @@ check-wasm:
 # ex: `just prepare_server_db_migration_snapshots fedimint-dummy-tests`
 prepare_server_db_migration_snapshots package *extra_args:
   env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' prepare_server_db_migration_snapshots {{extra_args}}
+  just test_server_db_migrations {{package}} {{extra_args}}
+
+test_server_db_migrations package *extra_args:
+  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' test_migrations {{extra_args}}
+
 
 # regenerate client db migration snapshots
 # ex: `just prepare_client_db_migration_snapshots fedimint-dummy-tests`
@@ -52,6 +57,20 @@ prepare_server_db_migration_snapshots package *extra_args:
 # ex: `just prepare_client_db_migration_snapshots fedimint-wallet-tests`
 prepare_client_db_migration_snapshots package *extra_args:
   env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' prepare_client_db_migration_snapshots {{extra_args}}
+  just test_client_db_migrations {{package}} {{extra_args}}
+
+test_client_db_migrations package *extra_args:
+  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' test_client_migrations {{extra_args}}
+
+test_db_migrations:
+  just test_client_db_migrations fedimint-dummy-tests
+  just test_client_db_migrations fedimint-mint-tests
+  just test_client_db_migrations fedimint-ln-tests
+  just test_client_db_migrations fedimint-wallet-tests
+  just test_server_db_migrations fedimint-dummy-tests
+  just test_server_db_migrations fedimint-mint-tests
+  just test_server_db_migrations fedimint-ln-tests
+  just test_server_db_migrations fedimint-wallet-tests
 
 # start mprocs with a dev federation setup. Default: 4 nodes, add `-n 1` argument to start only 1 node
 mprocs *PARAMS:

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -42,16 +42,16 @@ check-wasm:
 # ex: `just prepare_server_db_migration_snapshots fedimint-ln-tests`
 # ex: `just prepare_server_db_migration_snapshots fedimint-wallet-tests`
 # ex: `just prepare_server_db_migration_snapshots fedimint-dummy-tests`
-prepare_server_db_migration_snapshots +extra_args:
-  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo test ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -p {{extra_args}} prepare_server_db_migration_snapshots
+prepare_server_db_migration_snapshots package *extra_args:
+  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' prepare_server_db_migration_snapshots {{extra_args}}
 
 # regenerate client db migration snapshots
 # ex: `just prepare_client_db_migration_snapshots fedimint-dummy-tests`
 # ex: `just prepare_client_db_migration_snapshots fedimint-mint-tests`
 # ex: `just prepare_client_db_migration_snapshots fedimint-ln-tests`
 # ex: `just prepare_client_db_migration_snapshots fedimint-wallet-tests`
-prepare_client_db_migration_snapshots +extra_args:
-  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo test ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -p {{extra_args}} prepare_client_db_migration_snapshots
+prepare_client_db_migration_snapshots package *extra_args:
+  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' prepare_client_db_migration_snapshots {{extra_args}}
 
 # start mprocs with a dev federation setup. Default: 4 nodes, add `-n 1` argument to start only 1 node
 mprocs *PARAMS:

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -37,17 +37,17 @@ check-wasm:
   nix develop .#crossWasm -c cargo check --target wasm32-unknown-unknown --package fedimint-client
 
 # regenerate server db migration snapshots
-# ex: `just prepare_server_db_migration_snapshots fedimint-server`
-# ex: `just prepare_server_db_migration_snapshots fedimint-mint-tests`
-# ex: `just prepare_server_db_migration_snapshots fedimint-ln-tests`
-# ex: `just prepare_server_db_migration_snapshots fedimint-wallet-tests`
-# ex: `just prepare_server_db_migration_snapshots fedimint-dummy-tests`
-prepare_server_db_migration_snapshots package *extra_args:
-  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' prepare_server_db_migration_snapshots {{extra_args}}
-  just test_server_db_migrations {{package}} {{extra_args}}
+# ex: `just prepare-server-db-migration-snapshots fedimint-server`
+# ex: `just prepare-server-db-migration-snapshots fedimint-mint-tests`
+# ex: `just prepare-server-db-migration-snapshots fedimint-ln-tests`
+# ex: `just prepare-server-db-migration-snapshots fedimint-wallet-tests`
+# ex: `just prepare-server-db-migration-snapshots fedimint-dummy-tests`
+snapshot-server-db-migrations PACKAGE *EXTRA_ARGS:
+  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{PACKAGE}})' snapshot_server_db_migrations {{EXTRA_ARGS}}
+  just test-server-db-migrations {{PACKAGE}} {{EXTRA_ARGS}}
 
-test_server_db_migrations package *extra_args:
-  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' test_migrations {{extra_args}}
+test-server-db-migrations PACKAGE *EXTRA_ARGS:
+  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{PACKAGE}})' test_server_db_migrations {{EXTRA_ARGS}}
 
 
 # regenerate client db migration snapshots
@@ -55,22 +55,35 @@ test_server_db_migrations package *extra_args:
 # ex: `just prepare_client_db_migration_snapshots fedimint-mint-tests`
 # ex: `just prepare_client_db_migration_snapshots fedimint-ln-tests`
 # ex: `just prepare_client_db_migration_snapshots fedimint-wallet-tests`
-prepare_client_db_migration_snapshots package *extra_args:
-  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' prepare_client_db_migration_snapshots {{extra_args}}
-  just test_client_db_migrations {{package}} {{extra_args}}
+snapshot-client-db-migrations PACKAGE *EXTRA_ARGS:
+  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{PACKAGE}})' prepare_client_db_migrations {{EXTRA_ARGS}}
+  just test-client-db-migrations {{PACKAGE}} {{EXTRA_ARGS}}
 
-test_client_db_migrations package *extra_args:
-  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{package}})' test_client_migrations {{extra_args}}
+test-client-db-migrations PACKAGE *EXTRA_ARGS:
+  env FM_PREPARE_DB_MIGRATION_SNAPSHOTS=force cargo nextest run --workspace --all-targets ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} -E 'package({{PACKAGE}})' test_client_db_migrations {{EXTRA_ARGS}}
 
-test_db_migrations:
-  just test_client_db_migrations fedimint-dummy-tests
-  just test_client_db_migrations fedimint-mint-tests
-  just test_client_db_migrations fedimint-ln-tests
-  just test_client_db_migrations fedimint-wallet-tests
-  just test_server_db_migrations fedimint-dummy-tests
-  just test_server_db_migrations fedimint-mint-tests
-  just test_server_db_migrations fedimint-ln-tests
-  just test_server_db_migrations fedimint-wallet-tests
+test-db-migrations:
+  just test-client-db-migrations fedimint-dummy-tests
+  just test-client-db-migrations fedimint-mint-tests
+  just test-client-db-migrations fedimint-ln-tests
+  just test-client-db-migrations fedimint-wallet-tests
+  just test-server-db-migrations fedimint-dummy-tests
+  just test-server-db-migrations fedimint-mint-tests
+  just test-server-db-migrations fedimint-ln-tests
+  just test-server-db-migrations fedimint-wallet-tests
+  just test-server-db-migrations fedimint-server
+
+snapshot-db-migrations:
+  just snapshot-client-db-migrations fedimint-dummy-tests
+  just snapshot-client-db-migrations fedimint-mint-tests
+  just snapshot-client-db-migrations fedimint-ln-tests
+  just snapshot-client-db-migrations fedimint-wallet-tests
+  just snapshot-server-db-migrations fedimint-dummy-tests
+  just snapshot-server-db-migrations fedimint-mint-tests
+  just snapshot-server-db-migrations fedimint-ln-tests
+  just snapshot-server-db-migrations fedimint-wallet-tests
+  just snapshot-server-db-migrations fedimint-server
+  just test-db-migrations
 
 # start mprocs with a dev federation setup. Default: 4 nodes, add `-n 1` argument to start only 1 node
 mprocs *PARAMS:

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -160,7 +160,7 @@ mod fedimint_migration_tests {
     };
     use fedimint_dummy_server::{Dummy, DummyInit};
     use fedimint_logging::TracingSetup;
-    use fedimint_testing::db::{prepare_db_migration_snapshot, validate_migrations, BYTE_32};
+    use fedimint_testing::db::{snapshot_db_migrations, validate_migrations, BYTE_32};
     use futures::StreamExt;
     use rand::rngs::OsRng;
     use strum::IntoEnumIterator;
@@ -200,8 +200,8 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn prepare_server_db_migration_snapshots() -> anyhow::Result<()> {
-        prepare_db_migration_snapshot(
+    async fn snapshot_server_db_migrations() -> anyhow::Result<()> {
+        snapshot_db_migrations(
             "dummy-server-v0",
             |dbtx| {
                 Box::pin(async move {
@@ -218,7 +218,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_migrations() -> anyhow::Result<()> {
+    async fn test_server_db_migrations() -> anyhow::Result<()> {
         let _ = TracingSetup::default().init();
 
         validate_migrations(
@@ -278,8 +278,8 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn prepare_client_db_migration_snapshots() -> anyhow::Result<()> {
-        prepare_db_migration_snapshot(
+    async fn snapshot_client_db_migrations() -> anyhow::Result<()> {
+        snapshot_db_migrations(
             "dummy-client-v0",
             |dbtx| Box::pin(async move { create_client_db_with_v0_data(dbtx).await }),
             ModuleDecoderRegistry::from_iter([(
@@ -292,7 +292,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_client_migrations() -> anyhow::Result<()> {
+    async fn test_client_db_migrations() -> anyhow::Result<()> {
         TracingSetup::default().init()?;
 
         validate_migrations(

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -527,7 +527,7 @@ mod fedimint_migration_tests {
     use fedimint_ln_server::Lightning;
     use fedimint_logging::TracingSetup;
     use fedimint_testing::db::{
-        prepare_db_migration_snapshot, validate_migrations, BYTE_32, BYTE_33, BYTE_8, STRING_64,
+        snapshot_db_migrations, validate_migrations, BYTE_32, BYTE_33, BYTE_8, STRING_64,
     };
     use futures::StreamExt;
     use lightning_invoice::RoutingFees;
@@ -736,8 +736,8 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn prepare_server_db_migration_snapshots() -> anyhow::Result<()> {
-        prepare_db_migration_snapshot(
+    async fn snapshot_server_db_migrations() -> anyhow::Result<()> {
+        snapshot_db_migrations(
             "lightning-server-v0",
             |dbtx| {
                 Box::pin(async move {
@@ -754,7 +754,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_migrations() -> anyhow::Result<()> {
+    async fn test_server_db_migrations() -> anyhow::Result<()> {
         let _ = TracingSetup::default().init();
 
         validate_migrations(
@@ -900,8 +900,8 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn prepare_client_db_migration_snapshots() -> anyhow::Result<()> {
-        prepare_db_migration_snapshot(
+    async fn snapshot_client_db_migrations() -> anyhow::Result<()> {
+        snapshot_db_migrations(
             "lightning-client-v0",
             |dbtx| Box::pin(async move { create_client_db_with_v0_data(dbtx).await }),
             ModuleDecoderRegistry::from_iter([(
@@ -914,7 +914,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_client_migrations() -> anyhow::Result<()> {
+    async fn test_client_db_migrations() -> anyhow::Result<()> {
         TracingSetup::default().init()?;
 
         validate_migrations(

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -185,9 +185,7 @@ mod fedimint_migration_tests {
     };
     use fedimint_mint_common::{MintCommonInit, MintOutputOutcome, Nonce};
     use fedimint_mint_server::Mint;
-    use fedimint_testing::db::{
-        prepare_db_migration_snapshot, validate_migrations, BYTE_32, BYTE_8,
-    };
+    use fedimint_testing::db::{snapshot_db_migrations, validate_migrations, BYTE_32, BYTE_8};
     use ff::Field;
     use futures::StreamExt;
     use rand::rngs::OsRng;
@@ -335,8 +333,8 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn prepare_server_db_migration_snapshots() -> anyhow::Result<()> {
-        prepare_db_migration_snapshot(
+    async fn snapshot_server_db_migrations() -> anyhow::Result<()> {
+        snapshot_db_migrations(
             "mint-server-v0",
             |dbtx| {
                 Box::pin(async move {
@@ -353,7 +351,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_migrations() -> anyhow::Result<()> {
+    async fn test_server_db_migrations() -> anyhow::Result<()> {
         let _ = TracingSetup::default().init();
 
         validate_migrations(
@@ -438,8 +436,8 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn prepare_client_db_migration_snapshots() -> anyhow::Result<()> {
-        prepare_db_migration_snapshot(
+    async fn snapshot_client_db_migrations() -> anyhow::Result<()> {
+        snapshot_db_migrations(
             "mint-client-v0",
             |dbtx| Box::pin(async move { create_client_db_with_v0_data(dbtx).await }),
             ModuleDecoderRegistry::from_iter([(
@@ -452,7 +450,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_client_migrations() -> anyhow::Result<()> {
+    async fn test_client_db_migrations() -> anyhow::Result<()> {
         TracingSetup::default().init()?;
 
         validate_migrations(

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -606,7 +606,7 @@ mod fedimint_migration_tests {
     use fedimint_core::{BitcoinHash, Feerate, OutPoint, PeerId, ServerModule, TransactionId};
     use fedimint_logging::TracingSetup;
     use fedimint_testing::db::{
-        prepare_db_migration_snapshot, validate_migrations, BYTE_20, BYTE_32, BYTE_33,
+        snapshot_db_migrations, validate_migrations, BYTE_20, BYTE_32, BYTE_33,
     };
     use fedimint_wallet_client::client_db::NextPegInTweakIndexKey;
     use fedimint_wallet_client::{WalletClientInit, WalletClientModule};
@@ -794,8 +794,8 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn prepare_server_db_migration_snapshots() -> anyhow::Result<()> {
-        prepare_db_migration_snapshot(
+    async fn snapshot_server_db_migrations() -> anyhow::Result<()> {
+        snapshot_db_migrations(
             "wallet-server-v0",
             |dbtx| {
                 Box::pin(async move {
@@ -812,7 +812,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_migrations() -> anyhow::Result<()> {
+    async fn test_server_db_migrations() -> anyhow::Result<()> {
         let _ = TracingSetup::default().init();
 
         validate_migrations(
@@ -951,8 +951,8 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn prepare_client_db_migration_snapshots() -> anyhow::Result<()> {
-        prepare_db_migration_snapshot(
+    async fn snapshot_client_db_migrations() -> anyhow::Result<()> {
+        snapshot_db_migrations(
             "wallet-client-v0",
             |dbtx| Box::pin(async move { create_client_db_with_v0_data(dbtx).await }),
             ModuleDecoderRegistry::from_iter([(
@@ -965,7 +965,7 @@ mod fedimint_migration_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_client_migrations() -> anyhow::Result<()> {
+    async fn test_client_db_migrations() -> anyhow::Result<()> {
         TracingSetup::default().init()?;
 
         validate_migrations(


### PR DESCRIPTION
It causes different features/deps being selected, which causes rebuilds of almost whole project, which can be painful.

Instead of `cargo test -p pkg` it's better to use
`cargo nextest run -E 'package(pkg)'`.