### PR TITLE
fix: remove non-fault tolerant query strategy

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -30,7 +30,6 @@ use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::OperationId;
 use fedimint_core::db::{Database, DatabaseValue};
 use fedimint_core::module::{ApiAuth, ApiRequestErased};
-use fedimint_core::query::ThresholdConsensus;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{task, PeerId, TieredMulti};
 use fedimint_ln_client::LightningClientInit;
@@ -720,11 +719,7 @@ impl FedimintCli {
                         .await
                         .map_err_cli_general()?,
                     None => ws_api
-                        .request_with_strategy(
-                            ThresholdConsensus::full_participation(ws_api.peers().len()),
-                            method,
-                            params,
-                        )
+                        .request_current_consensus(method, params)
                         .await
                         .map_err_cli_general()?,
                 };

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -368,7 +368,7 @@ pub trait FederationApiExt: IRawFederationApi {
         Ret: serde::de::DeserializeOwned + Eq + Debug + Clone + MaybeSend,
     {
         self.request_with_strategy(
-            ThresholdConsensus::overcome_evil(self.all_peers().total()),
+            ThresholdConsensus::new(self.all_peers().total()),
             method,
             params,
         )

--- a/fedimint-core/src/query.rs
+++ b/fedimint-core/src/query.rs
@@ -217,7 +217,7 @@ impl<R: Eq + Clone + Debug, T> QueryStrategy<R, BTreeMap<PeerId, T>> for FilterM
     }
 }
 
-/// Returns when a threshold of responses are equal
+/// Returns when we obtain a threshold of identical responses
 pub struct ThresholdConsensus<R> {
     error_strategy: ErrorStrategy,
     responses: BTreeMap<PeerId, R>,
@@ -226,9 +226,7 @@ pub struct ThresholdConsensus<R> {
 }
 
 impl<R> ThresholdConsensus<R> {
-    // Require that enough participants return the same message to ensure that we
-    // overcome the threshold for malicious nodes
-    pub fn overcome_evil(total_peers: usize) -> Self {
+    pub fn new(total_peers: usize) -> Self {
         let max_evil = (total_peers - 1) / 3;
         let threshold = total_peers - max_evil;
 
@@ -237,16 +235,6 @@ impl<R> ThresholdConsensus<R> {
             responses: BTreeMap::new(),
             retry: BTreeSet::new(),
             threshold,
-        }
-    }
-
-    // Require that all participants return the same message
-    pub fn full_participation(total_peers: usize) -> Self {
-        Self {
-            error_strategy: ErrorStrategy::new(1),
-            responses: BTreeMap::new(),
-            retry: BTreeSet::new(),
-            threshold: total_peers,
         }
     }
 }


### PR DESCRIPTION
Requiring full participation in this one place is unexpected behaviour in a bft system. All query strategies should be bft.