### PR TITLE
Run devimint and rust tests with 1/4 guardians offline

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -367,6 +367,10 @@ impl Federation {
         self.await_block_sync().await?;
         Ok(())
     }
+
+    pub fn num_members(&self) -> usize {
+        self.members.len()
+    }
 }
 
 #[derive(Clone)]

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1781,11 +1781,11 @@ pub enum TestCmd {
 pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()> {
     match cmd {
         TestCmd::WasmTestSetup { exec } => {
-            let (process_mgr, task_group) = setup(common_args).await?;
+            let (process_mgr, task_group) = setup(&common_args).await?;
             let main = {
                 let task_group = task_group.clone();
                 async move {
-                    let dev_fed = dev_fed(&process_mgr).await?;
+                    let dev_fed = dev_fed(&process_mgr, common_args.degraded).await?;
                     let (_, _, faucet) = tokio::try_join!(
                         dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_cln),
                         dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_lnd),
@@ -1818,38 +1818,38 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
             cleanup_on_exit(main, task_group).await?;
         }
         TestCmd::LatencyTests => {
-            let (process_mgr, _) = setup(common_args).await?;
-            let dev_fed = dev_fed(&process_mgr).await?;
+            let (process_mgr, _) = setup(&common_args).await?;
+            let dev_fed = dev_fed(&process_mgr, common_args.degraded).await?;
             latency_tests(dev_fed).await?;
         }
         TestCmd::ReconnectTest => {
-            let (process_mgr, _) = setup(common_args).await?;
-            let dev_fed = dev_fed(&process_mgr).await?;
+            let (process_mgr, _) = setup(&common_args).await?;
+            let dev_fed = dev_fed(&process_mgr, common_args.degraded).await?;
             reconnect_test(dev_fed, &process_mgr).await?;
         }
         TestCmd::CliTests => {
-            let (process_mgr, _) = setup(common_args).await?;
-            let dev_fed = dev_fed(&process_mgr).await?;
+            let (process_mgr, _) = setup(&common_args).await?;
+            let dev_fed = dev_fed(&process_mgr, common_args.degraded).await?;
             cli_tests(dev_fed).await?;
         }
         TestCmd::LoadTestToolTest => {
-            let (process_mgr, _) = setup(common_args).await?;
-            let dev_fed = dev_fed(&process_mgr).await?;
+            let (process_mgr, _) = setup(&common_args).await?;
+            let dev_fed = dev_fed(&process_mgr, common_args.degraded).await?;
             cli_load_test_tool_test(dev_fed).await?;
         }
         TestCmd::LightningReconnectTest => {
-            let (process_mgr, _) = setup(common_args).await?;
-            let dev_fed = dev_fed(&process_mgr).await?;
+            let (process_mgr, _) = setup(&common_args).await?;
+            let dev_fed = dev_fed(&process_mgr, common_args.degraded).await?;
             lightning_gw_reconnect_test(dev_fed, &process_mgr).await?;
         }
         TestCmd::GatewayRebootTest => {
-            let (process_mgr, _) = setup(common_args).await?;
-            let dev_fed = dev_fed(&process_mgr).await?;
+            let (process_mgr, _) = setup(&common_args).await?;
+            let dev_fed = dev_fed(&process_mgr, common_args.degraded).await?;
             gw_reboot_test(dev_fed, &process_mgr).await?;
         }
         TestCmd::RecoverytoolTests => {
-            let (process_mgr, _) = setup(common_args).await?;
-            let dev_fed = dev_fed(&process_mgr).await?;
+            let (process_mgr, _) = setup(&common_args).await?;
+            let dev_fed = dev_fed(&process_mgr, common_args.degraded).await?;
             recoverytool_test(dev_fed).await?;
         }
     }

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -84,7 +84,9 @@ impl FederationTest {
             .federation_id()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
+        num_online: u16,
         num_peers: u16,
         base_port: u16,
         params: ServerModuleConfigGenParamsRegistry,
@@ -102,6 +104,9 @@ impl FederationTest {
 
         let mut task = TaskGroup::new();
         for (peer_id, config) in configs.clone() {
+            if (u16::from(peer_id)) >= num_online {
+                continue;
+            }
             let reliability = StreamReliability::INTEGRATION_TEST;
             let connections = network.connector(peer_id, reliability).into_dyn();
 

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -33,6 +33,7 @@ pub const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A tool for easily writing fedimint integration tests
 pub struct Fixtures {
+    num_online: u16,
     num_peers: u16,
     clients: Vec<DynClientModuleInit>,
     servers: Vec<DynServerModuleInit>,
@@ -53,6 +54,7 @@ impl Fixtures {
         // Ensure tracing has been set once
         let _ = TracingSetup::default().init();
         let real_testing = Fixtures::is_real_test();
+        let num_online = 3;
         let num_peers = 4;
         let task_group = TaskGroup::new();
         let (dyn_bitcoin_rpc, bitcoin, config): (
@@ -76,6 +78,7 @@ impl Fixtures {
         };
 
         Self {
+            num_online,
             num_peers,
             clients: vec![],
             servers: vec![],
@@ -112,13 +115,15 @@ impl Fixtures {
 
     /// Starts a new federation with default number of peers for testing
     pub async fn new_fed(&self) -> FederationTest {
-        self.new_fed_with_peers(self.num_peers).await
+        self.new_fed_with_peers(self.num_online, self.num_peers)
+            .await
     }
 
     /// Starts a new federation with number of peers
-    pub async fn new_fed_with_peers(&self, num_peers: u16) -> FederationTest {
+    pub async fn new_fed_with_peers(&self, num_online: u16, num_peers: u16) -> FederationTest {
         info!(target: LOG_TEST, num_peers, "Setting federation with peers");
         FederationTest::new(
+            num_online,
             num_peers,
             tokio::task::block_in_place(|| fedimint_portalloc::port_alloc(num_peers * 2))
                 .expect("Failed to allocate a port range"),

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -333,6 +333,12 @@ rec {
     buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/tests/latency-test.sh";
   };
 
+  latencyTestDegraded = craneLibTests.mkCargoDerivation {
+    pname = "${commonCliTestArgs.pname}-latency";
+    cargoArtifacts = workspaceBuild;
+    buildPhaseCargoCommand = "patchShebangs ./scripts ; env FM_DEVIMINT_DEGRADED=true ./scripts/tests/latency-test.sh";
+  };
+
   devimintCliTest = craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-cli";
     cargoArtifacts = workspaceBuild;

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 export LANG=C
 
 # run with 1 guardian offline
-export FM_DEVIMINT_DEGRADED=1
+export FM_DEVIMINT_DEGRADED=true
 
 if [ "$(ulimit -Sn)" -lt "10000" ]; then
   >&2 echo "⚠️  ulimit too small. Running 'ulimit -Sn 10000' to avoid problems running tests"

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # prevent locale settings messing with some setups
 export LANG=C
 
+# run with 1 guardian offline
+export FM_DEVIMINT_DEGRADED=1
+
 if [ "$(ulimit -Sn)" -lt "10000" ]; then
   >&2 echo "⚠️  ulimit too small. Running 'ulimit -Sn 10000' to avoid problems running tests"
   ulimit -Sn 10000

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -61,6 +61,11 @@ function latency_test() {
 }
 export -f latency_test
 
+function latency_test_degraded() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh --degraded
+}
+export -f latency_test_degraded
+
 function devimint_cli_test() {
   fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-cli-test.sh
 }
@@ -139,6 +144,7 @@ if parallel \
   backend_test_electrs \
   backend_test_esplora \
   latency_test \
+  latency_test_degraded \
   reconnect_test \
   lightning_reconnect_test \
   gateway_reboot_test \


### PR DESCRIPTION
* Extended https://github.com/fedimint/fedimint/pull/4181 allowing all devimint tests to run with with 1 guardian offline. This condition is now triggered by `FM_DEVIMINT_DEGRADED` environment variable.
* Modified the `FederationTest` fixture to start with 1 guardian offline
* In the future we should parameterize devimint and `FederationTests` so we can try any valid federation size and number of online / offline guardians. But I didn't attempt this here.