### PR TITLE
Backport: remove redundant session counter from db

### DIFF
--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -18,7 +18,6 @@ use fedimint_rocksdb::RocksDbReadOnly;
 use fedimint_server::config::io::read_server_config;
 use fedimint_server::config::ServerConfig;
 use fedimint_server::db as ConsensusRange;
-use fedimint_server::db::DbKeyPrefix;
 use futures::StreamExt;
 use ln_gateway::Gateway;
 use strum::IntoEnumIterator;
@@ -293,16 +292,6 @@ impl DatabaseDump {
                         Vec<u8>,
                         consensus,
                         "Aleph Units"
-                    );
-                }
-                DbKeyPrefix::SignedSessionOutcomeCount => {
-                    push_db_pair_items_no_serde!(
-                        dbtx,
-                        ConsensusRange::SignedSessionOutcomeCountKey,
-                        ConsensusRange::SignedSessionOutcomeCountKey,
-                        u64,
-                        consensus,
-                        "Signed Session Count"
                     );
                 }
                 // Module is a global prefix for all module data

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -734,10 +734,12 @@ impl ConsensusServer {
 }
 
 pub(crate) async fn get_finished_session_count_static(dbtx: &mut DatabaseTransaction<'_>) -> u64 {
-    dbtx.find_by_prefix(&SignedSessionOutcomePrefix)
+    dbtx.find_by_prefix_sorted_descending(&SignedSessionOutcomePrefix)
         .await
-        .count()
-        .await as u64
+        .next()
+        .await
+        .map(|entry| (entry.0 .0) + 1)
+        .unwrap_or(0)
 }
 
 async fn submit_module_consensus_items(

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -40,8 +40,7 @@ use crate::config::ServerConfig;
 use crate::consensus::process_transaction_with_dbtx;
 use crate::db::{
     get_global_database_migrations, AcceptedItemKey, AcceptedItemPrefix, AcceptedTransactionKey,
-    AlephUnitsPrefix, SignedSessionOutcomeCountKey, SignedSessionOutcomeKey,
-    GLOBAL_DATABASE_VERSION,
+    AlephUnitsPrefix, SignedSessionOutcomeKey, SignedSessionOutcomePrefix, GLOBAL_DATABASE_VERSION,
 };
 use crate::fedimint_core::encoding::Encodable;
 use crate::net::api::{ConsensusApi, ExpiringCache};
@@ -547,15 +546,6 @@ impl ConsensusServer {
             panic!("We tried to overwrite a signed session outcome");
         }
 
-        // Update cached session count
-        let previous_session_count = self.get_finished_session_count().await;
-        assert_eq!(
-            previous_session_count, session_index,
-            "Session count and session index diverged"
-        );
-        dbtx.insert_entry(&SignedSessionOutcomeCountKey, &(previous_session_count + 1))
-            .await;
-
         dbtx.commit_tx_result()
             .await
             .expect("This is the only place where we write to this key");
@@ -744,9 +734,10 @@ impl ConsensusServer {
 }
 
 pub(crate) async fn get_finished_session_count_static(dbtx: &mut DatabaseTransaction<'_>) -> u64 {
-    dbtx.get_value(&SignedSessionOutcomeCountKey)
+    dbtx.find_by_prefix(&SignedSessionOutcomePrefix)
         .await
-        .unwrap_or(0)
+        .count()
+        .await as u64
 }
 
 async fn submit_module_consensus_items(

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,18 +1,14 @@
 use std::fmt::Debug;
 
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{
-    DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, MigrationMap,
-    MODULE_GLOBAL_PREFIX,
-};
+use fedimint_core::db::{DatabaseVersion, MigrationMap, MODULE_GLOBAL_PREFIX};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::session_outcome::{AcceptedItem, SignedSessionOutcome};
 use fedimint_core::{impl_db_lookup, impl_db_record, TransactionId};
-use futures::FutureExt;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
-pub const GLOBAL_DATABASE_VERSION: DatabaseVersion = DatabaseVersion(1);
+pub const GLOBAL_DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -21,7 +17,6 @@ pub enum DbKeyPrefix {
     AcceptedTransaction = 0x02,
     SignedSessionOutcome = 0x04,
     AlephUnits = 0x05,
-    SignedSessionOutcomeCount = 0x06,
     Module = MODULE_GLOBAL_PREFIX,
 }
 
@@ -79,17 +74,6 @@ impl_db_lookup!(
     query_prefix = SignedSessionOutcomePrefix
 );
 
-/// Database entry that caches the current number of [`SignedSessionOutcome`]s
-/// in the database.
-#[derive(Debug, Encodable, Decodable)]
-pub struct SignedSessionOutcomeCountKey;
-
-impl_db_record!(
-    key = SignedSessionOutcomeCountKey,
-    value = u64,
-    db_prefix = DbKeyPrefix::SignedSessionOutcomeCount,
-);
-
 #[derive(Debug, Encodable, Decodable)]
 pub struct AlephUnitsKey(pub u64);
 
@@ -105,25 +89,7 @@ impl_db_record!(
 impl_db_lookup!(key = AlephUnitsKey, query_prefix = AlephUnitsPrefix);
 
 pub fn get_global_database_migrations() -> MigrationMap {
-    let mut mm = MigrationMap::new();
-    mm.insert(DatabaseVersion(0), |dbtx| migrate_to_v1(dbtx).boxed());
-    mm
-}
-
-/// Adds a database key that contains the current session count so that we don't
-/// have to scan the entire session history every time just to count the
-/// entries.
-async fn migrate_to_v1(dbtx: &mut DatabaseTransaction<'_>) -> Result<(), anyhow::Error> {
-    use futures::StreamExt;
-
-    let session_count = dbtx
-        .find_by_prefix(&SignedSessionOutcomePrefix)
-        .await
-        .count()
-        .await as u64;
-    dbtx.insert_new_entry(&SignedSessionOutcomeCountKey, &session_count)
-        .await;
-    Ok(())
+    MigrationMap::new()
 }
 
 #[cfg(test)]
@@ -153,7 +119,7 @@ mod fedimint_migration_tests {
     use secp256k1_zkp::Message;
     use strum::IntoEnumIterator;
 
-    use super::{AcceptedTransactionKey, SignedSessionOutcomeCountKey};
+    use super::AcceptedTransactionKey;
     use crate::db::{
         get_global_database_migrations, AcceptedItem, AcceptedItemKey, AcceptedItemPrefix,
         AcceptedTransactionKeyPrefix, AlephUnitsKey, AlephUnitsPrefix, DbKeyPrefix,
@@ -312,23 +278,6 @@ mod fedimint_migration_tests {
                             ensure!(
                                 num_aleph_units > 0,
                                 "validate_migrations was not able to read any AlephUnits"
-                            );
-                        }
-                        DbKeyPrefix::SignedSessionOutcomeCount => {
-                            let session_outcome_count = dbtx
-                                .get_value(&SignedSessionOutcomeCountKey)
-                                .await
-                                .expect("Count key should have been created");
-
-                            let real_session_outcome_count =
-                                dbtx.find_by_prefix(&SignedSessionOutcomePrefix)
-                                    .await
-                                    .count()
-                                    .await as u64;
-
-                            assert_eq!(
-                                session_outcome_count, real_session_outcome_count,
-                                "Session outcome count cash is inconsistent"
                             );
                         }
                         // Module prefix is reserved for modules, no migration testing is needed


### PR DESCRIPTION
I `git revert`ed the corresponding cache session outcome count commit on 0.2 to avoid merge-conflicts from cherry-picking the revert commit, then cherry-picked @joschisan's actual changes. 

Backport #4159