### PR TITLE
wip: add releases/v0.2 branch to backwards-compatibility matrix

### DIFF
--- a/scripts/tests/backwards-compatibility-test.sh
+++ b/scripts/tests/backwards-compatibility-test.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # all versions to use for testing
-versions=("v0.2.1")
+versions=("v0.2.1" "releases/v0.2")
 >&2 echo "Running backwards-compatibility tests for versions: ${versions[*]}"
 
 # signal to downstream test scripts


### PR DESCRIPTION
_Do not merge_

Would close https://github.com/fedimint/fedimint/issues/4207

This will give us a matrix that will run
```
0.2.1 <> master
0.2.1 <> HEAD releases/v0.2
HEAD releases/v0.2 <> master
```

We shouldn't merge this PR since we don't need this full version matrix run on each PR. Instead, we can verify locally and using CI for just this PR.

I'm running locally and will upload the result logs when it finishes.