### PR TITLE
fix: poll in reconnect test

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -334,15 +334,19 @@ impl Federation {
     }
 
     pub async fn await_all_peers(&self) -> Result<()> {
-        cmd!(
-            self.client,
-            "dev",
-            "api",
-            "module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_block_count"
-        )
-        .run()
-        .await?;
-        Ok(())
+        poll("Waiting for all peers to be online", None, || async {
+            cmd!(
+                self.client,
+                "dev",
+                "api",
+                "module_{LEGACY_HARDCODED_INSTANCE_ID_WALLET}_block_count"
+            )
+            .run()
+            .await
+            .map_err(ControlFlow::Continue)?;
+            Ok(())
+        })
+        .await
     }
 
     /// Mines enough blocks to finalize mempool transactions, then waits for

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1572,11 +1572,7 @@ pub async fn reconnect_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
     fed.start_server(process_mgr, 2).await?;
     fed.start_server(process_mgr, 3).await?;
 
-    poll("federation back online", None, || async {
-        fed.await_all_peers().await.map_err(ControlFlow::Continue)?;
-        Ok(())
-    })
-    .await?;
+    fed.await_all_peers().await?;
 
     info!(target: LOG_DEVIMINT, "fm success: reconnect-test");
     Ok(())


### PR DESCRIPTION
`reconnect_test` is flakey, which can likely be resolved by polling.

https://github.com/fedimint/fedimint/actions/runs/7747755393/job/21128923550#step:5:1433

```
2024-02-01T21:34:35.3311143Z 00:00:30 Error: command: /nix/store/fdbrlr3n4n94gs5a1lgnzskhgmv8pimq-fedimint-cli/bin/fedimint-cli --data-dir=/tmp/nix-shell.qkvd7G/devimint-73588/cl
ients/default dev api module_2_block_count
2024-02-01T21:34:35.3312020Z 00:00:30
2024-02-01T21:34:35.3312197Z 00:00:30 Caused by:
2024-02-01T21:34:35.3312415Z 00:00:30     exit status: 1
2024-02-01T21:34:35.3312648Z 00:00:30     stdout:
2024-02-01T21:34:35.3312845Z 00:00:30
2024-02-01T21:34:35.3313047Z 00:00:30     stderr:
2024-02-01T21:34:35.3313661Z 00:00:30     2024-02-01T21:34:34.877575Z  INFO fedimint_cli::db_locked: Acquiring database lock
2024-02-01T21:34:35.3314777Z 00:00:30     2024-02-01T21:34:35.074923Z  INFO fedimint_client: Last client reference dropped, shutting down client task group
2024-02-01T21:34:35.3315862Z 00:00:30     2024-02-01T21:34:35.077403Z  INFO fedimint_client::sm::executor: Starting state machine executor task
2024-02-01T21:34:35.3317015Z 00:00:30     2024-02-01T21:34:35.081059Z  INFO fedimint_client::sm::executor: Shutting down state machine executor runner due to shutdown signal
2024-02-01T21:34:35.3317705Z 00:00:30     {
2024-02-01T21:34:35.3317921Z 00:00:30       "error": "CliError",
2024-02-01T21:34:35.3318208Z 00:00:30       "kind": "general_failure",
2024-02-01T21:34:35.3319757Z 00:00:30       "message": "Federation rpc error {general => Received errors from 1 peers: peer-0: Rpc error: Networking or low-level protocol error:
Error when opening the TCP socket: Connection refused (os error 111)), 0 => Rpc error: Networking or low-level protocol error: Error when opening the TCP socket: Connection refus
ed (os error 111)), }",
2024-02-01T21:34:35.3322451Z 00:00:30       "raw_error": "Federation rpc error {general => Received errors from 1 peers: peer-0: Rpc error: Networking or low-level protocol error
: Error when opening the TCP socket: Connection refused (os error 111)), 0 => Rpc error: Networking or low-level protocol error: Error when opening the TCP socket: Connection ref
used (os error 111)), }"
2024-02-01T21:34:35.3323774Z 00:00:30     }
2024-02-01T21:34:35.3323966Z 00:00:30
2024-02-01T21:34:35.3324168Z ## FAILED: reconnect_test
```