### PR TITLE
test: assert that clients join degraded federations promptly

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -32,6 +32,7 @@ use super::vars::utf8;
 use crate::util::{poll, FedimintdCmd};
 use crate::{poll_eq, vars};
 
+#[derive(Clone)]
 pub struct Federation {
     // client is only for internal use, use cli commands instead
     members: BTreeMap<usize, Fedimintd>,
@@ -43,6 +44,7 @@ pub struct Federation {
 }
 
 /// `fedimint-cli` instance (basically path with client state: config + db)
+#[derive(Clone)]
 pub struct Client {
     name: String,
 }

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -12,6 +12,7 @@ macro_rules! declare_vars {
             $($env_name:ident : $env_ty:ty = $env_value:expr;)*
         }
     ) => {
+        #[derive(Clone)]
         pub struct $name {
             $(
                 #[allow(unused)]


### PR DESCRIPTION
This test currently fails because joining the federation takes ~60 seconds if 1/4 guardians is offline:

```
Error: client join took too long: 60.644507708s
```