### PR TITLE
refactor: improve client executor loop

### DIFF
--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -576,8 +576,6 @@ impl ExecutorInner {
                                                     state.operation_id(),
                                                 );
                                                 if new_state.is_terminal(context, &global_context) {
-                                                    // TODO: log state machine id or something
-                                                    debug!("State machine reached terminal state");
                                                     let k = InactiveStateKey::from_state(
                                                         new_state.clone(),
                                                     );
@@ -607,6 +605,7 @@ impl ExecutorInner {
                                 debug!(
                                     target: LOG_CLIENT_REACTOR,
                                     operation_id = %state.operation_id(),
+                                    terminal = !outcome.is_active(),
                                     ?outcome,
                                     "Finished executing state transition",
                                 );

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -43,7 +43,7 @@ impl IntoDynInstance for TxSubmissionContext {
 ///     Created -- tx is accepted by consensus --> Accepted
 ///     Created -- tx is rejected on submission --> Rejected
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum TxSubmissionStates {
     /// The transaction has been created and potentially already been submitted,
     /// but no rejection or acceptance happened so far

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -55,7 +55,7 @@ pub mod backup;
 /// submitted the transaction's ID can be used as operation ID. If there is no
 /// transaction related to it, it should be generated randomly. Since it is a
 /// 256bit value collisions are impossible for all intents and purposes.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable, PartialOrd, Ord)]
 pub struct OperationId(pub [u8; 32]);
 
 impl OperationId {

--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -21,6 +21,7 @@ pub const LOG_TEST: &str = "test";
 pub const LOG_TIMING: &str = "timing";
 pub const LOG_WALLET: &str = "wallet";
 pub const LOG_CLIENT: &str = "client";
+pub const LOG_CLIENT_REACTOR: &str = "client::reactor";
 pub const LOG_CLIENT_NET_API: &str = "client::net::api";
 pub const LOG_CLIENT_BACKUP: &str = "client::backup";
 pub const LOG_CLIENT_RECOVERY: &str = "client::recovery";

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -23,7 +23,9 @@ use crate::gateway_lnrpc::{
 
 pub const MAX_LIGHTNING_RETRIES: u32 = 10;
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,
+)]
 pub enum LightningRpcError {
     #[error("Failed to connect to Lightning node")]
     FailedToConnect,

--- a/gateway/ln-gateway/src/state_machine/complete.rs
+++ b/gateway/ln-gateway/src/state_machine/complete.rs
@@ -38,7 +38,7 @@ pub enum CompleteHtlcError {
 ///    CompleteHtlc -- successfully completed or canceled htlc --> HtlcFinished
 ///    CompleteHtlc -- failed to finish htlc --> Failure
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum GatewayCompleteStates {
     WaitForPreimage(WaitForPreimageState),
     CompleteHtlc(CompleteHtlcState),
@@ -46,14 +46,14 @@ pub enum GatewayCompleteStates {
     Failure,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct GatewayCompleteCommon {
     pub operation_id: OperationId,
     pub incoming_chan_id: u64,
     pub htlc_id: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct GatewayCompleteStateMachine {
     pub common: GatewayCompleteCommon,
     pub state: GatewayCompleteStates,
@@ -83,7 +83,7 @@ impl State for GatewayCompleteStateMachine {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct WaitForPreimageState;
 
 impl WaitForPreimageState {
@@ -148,13 +148,13 @@ impl WaitForPreimageState {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum HtlcOutcome {
     Success(Preimage),
     Failure(String),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct CompleteHtlcState {
     outcome: HtlcOutcome,
 }

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -621,7 +621,7 @@ impl GatewayClientModule {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum GatewayClientStateMachines {
     Pay(GatewayPayStateMachine),
     Receive(IncomingStateMachine),

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -48,7 +48,7 @@ use crate::GatewayState;
 ///    CancelContract -- cancel tx submission successful --> Canceled
 ///    CancelContract -- cancel tx submission unsuccessful --> Failed
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub enum GatewayPayStates {
     PayInvoice(GatewayPayInvoice),
     CancelContract(Box<GatewayPayCancelContract>),
@@ -67,12 +67,12 @@ pub enum GatewayPayStates {
     },
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayCommon {
     pub operation_id: OperationId,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayStateMachine {
     pub common: GatewayPayCommon,
     pub state: GatewayPayStates,
@@ -118,7 +118,9 @@ impl State for GatewayPayStateMachine {
     }
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,
+)]
 pub enum OutgoingContractError {
     #[error("Invalid OutgoingContract {contract_id}")]
     InvalidOutgoingContract { contract_id: ContractId },
@@ -138,7 +140,9 @@ pub enum OutgoingContractError {
     InvoiceExpired(u64),
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,
+)]
 pub enum OutgoingPaymentErrorType {
     #[error("OutgoingContract does not exist {contract_id}")]
     OutgoingContractDoesNotExist { contract_id: ContractId },
@@ -152,7 +156,9 @@ pub enum OutgoingPaymentErrorType {
     InvoiceAlreadyPaid,
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,
+)]
 pub struct OutgoingPaymentError {
     error_type: OutgoingPaymentErrorType,
     contract_id: ContractId,
@@ -165,7 +171,7 @@ impl Display for OutgoingPaymentError {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayInvoice {
     pub pay_invoice_payload: PayInvoicePayload,
 }
@@ -634,7 +640,7 @@ pub struct PaymentParameters {
     payment_data: PaymentData,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayClaimOutgoingContract {
     contract: OutgoingContractAccount,
     preimage: Preimage,
@@ -689,7 +695,7 @@ impl GatewayPayClaimOutgoingContract {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayWaitForSwapPreimage {
     contract: OutgoingContractAccount,
     federation_id: FederationId,
@@ -817,7 +823,7 @@ impl GatewayPayWaitForSwapPreimage {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayCancelContract {
     contract: OutgoingContractAccount,
     error: OutgoingPaymentError,

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -18,7 +18,7 @@ use crate::{get_funds, DummyClientContext};
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// Tracks a transaction
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum DummyStateMachine {
     Input(Amount, TransactionId, OperationId),
     Output(Amount, TransactionId, OperationId),

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -44,7 +44,7 @@ use crate::{set_payment_result, LightningClientContext, PayType};
 ///    DecryptingPreimage -- invalid preimage --> RefundSubmitted
 ///    DecryptingPreimage -- error decrypting preimage --> Failure
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum IncomingSmStates {
     FundingOffer(FundingOfferState),
     DecryptingPreimage(DecryptingPreimageState),
@@ -59,14 +59,14 @@ pub enum IncomingSmStates {
     Failure(String),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct IncomingSmCommon {
     pub operation_id: OperationId,
     pub contract_id: ContractId,
     pub payment_hash: sha256::Hash,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct IncomingStateMachine {
     pub common: IncomingSmCommon,
     pub state: IncomingSmStates,
@@ -96,7 +96,9 @@ impl State for IncomingStateMachine {
     }
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Hash, Clone, Eq, PartialEq,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum IncomingSmError {
     #[error("Violated fee policy. Offer amount {offer_amount} Payment amount: {payment_amount}")]
@@ -126,7 +128,7 @@ pub enum IncomingSmError {
     AmountError { invoice: Bolt11Invoice },
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct FundingOfferState {
     pub txid: TransactionId,
 }
@@ -211,7 +213,7 @@ impl FundingOfferState {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct DecryptingPreimageState {
     txid: TransactionId,
 }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1395,7 +1395,7 @@ impl LightningClientModule {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum LightningClientStateMachines {
     InternalPay(IncomingStateMachine),
     LightningPay(LightningPayStateMachine),

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -46,7 +46,7 @@ const RETRY_DELAY: Duration = Duration::from_secs(1);
 ///  Refund -- await transaction rejected --> Failure
 /// ```
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum LightningPayStates {
     CreatedOutgoingLnContract(LightningPayCreatedOutgoingLnContract),
     Canceled,
@@ -58,7 +58,7 @@ pub enum LightningPayStates {
     Failure(String),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayCommon {
     pub operation_id: OperationId,
     pub federation_id: FederationId,
@@ -68,7 +68,7 @@ pub struct LightningPayCommon {
     pub invoice: lightning_invoice::Bolt11Invoice,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayStateMachine {
     pub common: LightningPayCommon,
     pub state: LightningPayStates,
@@ -111,7 +111,7 @@ impl State for LightningPayStateMachine {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayCreatedOutgoingLnContract {
     pub funding_txid: TransactionId,
     pub contract_id: ContractId,
@@ -243,14 +243,16 @@ impl LightningPayCreatedOutgoingLnContract {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayFunded {
     payload: PayInvoicePayload,
     gateway: LightningGateway,
     timelock: u32,
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Hash, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum GatewayPayError {
     #[error("Lightning Gateway failed to pay invoice. ErrorCode: {error_code:?} ErrorMessage: {error_message}")]
@@ -389,7 +391,7 @@ impl LightningPayFunded {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayRefundable {
     contract_id: ContractId,
     pub block_timelock: u32,
@@ -503,7 +505,7 @@ impl LightningPayRefundable {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayRefund {
     txid: TransactionId,
     out_points: Vec<OutPoint>,
@@ -563,7 +565,7 @@ impl LightningPayRefund {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Decodable, Encodable)]
 pub struct PayInvoicePayload {
     pub federation_id: FederationId,
     pub contract_id: ContractId,
@@ -596,7 +598,7 @@ impl PayInvoicePayload {
 
 /// Data needed to pay an invoice, may be the whole invoice or only the required
 /// parts of it.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Decodable, Encodable)]
 #[serde(rename_all = "snake_case")]
 pub enum PaymentData {
     Invoice(Bolt11Invoice),

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -36,7 +36,7 @@ const RETRY_DELAY: Duration = Duration::from_secs(1);
 ///     Funded -- await claim tx acceptance --> Success
 ///     Funded -- await claim tx rejection --> Canceled
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum LightningReceiveStates {
     SubmittedOffer(LightningReceiveSubmittedOffer),
     Canceled(LightningReceiveError),
@@ -45,7 +45,7 @@ pub enum LightningReceiveStates {
     Success(Vec<OutPoint>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningReceiveStateMachine {
     pub operation_id: OperationId,
     pub state: LightningReceiveStates,
@@ -81,14 +81,16 @@ impl State for LightningReceiveStateMachine {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningReceiveSubmittedOffer {
     pub offer_txid: TransactionId,
     pub invoice: Bolt11Invoice,
     pub payment_keypair: KeyPair,
 }
 
-#[derive(Error, Clone, Debug, Serialize, Deserialize, Encodable, Decodable, Eq, PartialEq)]
+#[derive(
+    Error, Clone, Debug, Serialize, Deserialize, Encodable, Decodable, Eq, PartialEq, Hash,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum LightningReceiveError {
     #[error("Offer transaction was rejected")]
@@ -154,7 +156,7 @@ impl LightningReceiveSubmittedOffer {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningReceiveConfirmedInvoice {
     invoice: Bolt11Invoice,
     keypair: KeyPair,
@@ -304,7 +306,7 @@ async fn get_incoming_contract(
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningReceiveFunded {
     txid: TransactionId,
     out_points: Vec<OutPoint>,

--- a/modules/fedimint-ln-common/src/contracts/incoming.rs
+++ b/modules/fedimint-ln-common/src/contracts/incoming.rs
@@ -114,7 +114,7 @@ impl Decodable for OfferId {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub struct IncomingContractAccount {
     pub amount: Amount,
     pub contract: IncomingContract,

--- a/modules/fedimint-ln-common/src/contracts/outgoing.rs
+++ b/modules/fedimint-ln-common/src/contracts/outgoing.rs
@@ -53,13 +53,13 @@ impl OutgoingContract {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub struct OutgoingContractData {
     pub recovery_key: bitcoin::KeyPair,
     pub contract_account: OutgoingContractAccount,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub struct OutgoingContractAccount {
     pub amount: Amount,
     pub contract: OutgoingContract,

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -647,7 +647,7 @@ pub async fn ln_operation(
 ///
 /// This is a subset of the data from a [`lightning_invoice::Bolt11Invoice`]
 /// that does not contain the description, which increases privacy for the user.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Decodable, Encodable)]
 pub struct PrunedInvoice {
     pub amount: Amount,
     pub destination: secp256k1::PublicKey,

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -23,7 +23,7 @@ use crate::{MintClientContext, MintClientStateMachines, SpendableNote};
 ///     Refund -- refund tx rejected --> Error
 ///     Refund -- refund tx accepted --> RS[Refund Success]
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum MintInputStates {
     Created(MintInputStateCreated),
     Refund(MintInputStateRefund),
@@ -32,14 +32,14 @@ pub enum MintInputStates {
     RefundSuccess(MintInputStateRefundSuccess),
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, Decodable, Encodable)]
 pub struct MintInputCommon {
     pub(crate) operation_id: OperationId,
     pub(crate) txid: TransactionId,
     pub(crate) input_idx: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateMachine {
     pub(crate) common: MintInputCommon,
     pub(crate) state: MintInputStates,
@@ -73,7 +73,7 @@ impl State for MintInputStateMachine {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateCreated {
     pub(crate) amount: Amount,
     pub(crate) spendable_note: SpendableNote,
@@ -156,7 +156,7 @@ impl MintInputStateCreated {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateRefund {
     refund_txid: TransactionId,
 }
@@ -212,15 +212,15 @@ impl MintInputStateRefund {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateSuccess {}
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateError {
     error: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateRefundSuccess {
     refund_txid: TransactionId,
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1507,20 +1507,20 @@ impl std::fmt::Display for InsufficientBalanceError {
 }
 
 /// Old and no longer used, will be deleted in the future
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 enum MintRestoreStates {
     #[encodable_default]
     Default { variant: u64, bytes: Vec<u8> },
 }
 
 /// Old and no longer used, will be deleted in the future
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintRestoreStateMachine {
     operation_id: OperationId,
     state: MintRestoreStates,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum MintClientStateMachines {
     Output(MintOutputStateMachine),
     Input(MintInputStateMachine),

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -23,7 +23,7 @@ use crate::{MintClientContext, MintClientStateMachines, SpendableNote};
 ///     Created -- User triggered refund --> RefundU["User Refund"]
 ///     Created -- Timeout triggered refund --> RefundT["Timeout Refund"]
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum MintOOBStates {
     /// The e-cash has been taken out of the wallet and we are waiting for the
     /// recipient to reissue it or the user to trigger a refund.
@@ -36,25 +36,25 @@ pub enum MintOOBStates {
     TimeoutRefund(MintOOBStatesTimeoutRefund),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintOOBStateMachine {
     pub(crate) operation_id: OperationId,
     pub(crate) state: MintOOBStates,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintOOBStatesCreated {
     pub(crate) amount: Amount,
     pub(crate) spendable_note: SpendableNote,
     pub(crate) timeout: SystemTime,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintOOBStatesUserRefund {
     pub(crate) refund_txid: TransactionId,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintOOBStatesTimeoutRefund {
     pub(crate) refund_txid: TransactionId,
 }

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -33,7 +33,7 @@ const TRANSACTION_STATUS_FETCH_INTERVAL: Duration = Duration::from_secs(1);
 ///     AwaitingConfirmations -- "Retransmit seen tx (planned)" --> AwaitingConfirmations
 ///     Created -- "No transactions seen for [time]" --> Timeout["Timed out"]
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct DepositStateMachine {
     pub(crate) operation_id: OperationId,
     pub(crate) state: DepositStates,
@@ -303,7 +303,7 @@ async fn transition_btc_tx_confirmed(
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum DepositStates {
     Created(CreatedDepositState),
     WaitingForConfirmations(WaitingForConfirmationsDepositState),
@@ -311,13 +311,13 @@ pub enum DepositStates {
     TimedOut(TimedOutDepositState),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct CreatedDepositState {
     pub(crate) tweak_key: KeyPair,
     pub(crate) timeout_at: SystemTime,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct WaitingForConfirmationsDepositState {
     /// Key pair of which the public was used to tweak the federation's wallet
     /// descriptor. The secret key is later used to sign the fedimint claim
@@ -330,12 +330,12 @@ pub struct WaitingForConfirmationsDepositState {
     pub(crate) out_idx: u32,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct ClaimingDepositState {
     /// Fedimint transaction id in which the deposit is being claimed.
     pub(crate) transaction_id: TransactionId,
     pub(crate) change: Vec<OutPoint>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct TimedOutDepositState {}

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -682,7 +682,7 @@ async fn get_next_peg_in_tweak_child_id(dbtx: &mut DatabaseTransaction<'_>) -> C
     ChildId(index)
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum WalletClientStates {
     Deposit(DepositStateMachine),
     Withdraw(WithdrawStateMachine),

--- a/modules/fedimint-wallet-client/src/withdraw.rs
+++ b/modules/fedimint-wallet-client/src/withdraw.rs
@@ -19,7 +19,7 @@ const RETRY_DELAY: Duration = Duration::from_secs(1);
 /// graph LR
 ///     Created --> Success
 ///     Created --> Aborted
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct WithdrawStateMachine {
     pub(crate) operation_id: OperationId,
     pub(crate) state: WithdrawStates,
@@ -125,24 +125,24 @@ async fn transition_withdraw_processed(
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum WithdrawStates {
     Created(CreatedWithdrawState),
     Success(SuccessWithdrawState),
     Aborted(AbortedWithdrawState),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct CreatedWithdrawState {
     pub(crate) fm_outpoint: OutPoint,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct SuccessWithdrawState {
     pub(crate) txid: Txid,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct AbortedWithdrawState {
     pub(crate) error: String,
 }


### PR DESCRIPTION
On top of #4227 

Make client side state machines go brrrr:

* no busy looping/polling anything (good for phone bateries)
* no canceling anything
* parallel state transitions

 No state machine was harmed during the rewrite.