### PR TITLE
fix: add fedimint-dbtool version-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "clap",
  "erased-serde",
  "fedimint-aead",
+ "fedimint-build",
  "fedimint-client",
  "fedimint-core",
  "fedimint-ln-client",

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use devimint::cli::CommonArgs;
-use fedimint_core::util::write_overwrite_async;
+use fedimint_core::util::{handle_version_hash_command, write_overwrite_async};
 use fedimint_logging::LOG_DEVIMINT;
 use tracing::warn;
 
@@ -36,15 +36,7 @@ async fn handle_command() -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    pub const CODE_VERSION: &str = env!("FEDIMINT_BUILD_CODE_VERSION");
-
-    let mut args = std::env::args();
-    if let Some(ref arg) = args.nth(1) {
-        if arg.as_str() == "version-hash" {
-            println!("{CODE_VERSION}");
-            std::process::exit(0);
-        }
-    }
+    handle_version_hash_command(env!("FEDIMINT_BUILD_CODE_VERSION"));
     match handle_command().await {
         Ok(r) => Ok(r),
         Err(e) => {

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -30,7 +30,7 @@ use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::OperationId;
 use fedimint_core::db::{Database, DatabaseValue};
 use fedimint_core::module::{ApiAuth, ApiRequestErased};
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{handle_version_hash_command, SafeUrl};
 use fedimint_core::{task, PeerId, TieredMulti};
 use fedimint_ln_client::LightningClientInit;
 use fedimint_logging::{TracingSetup, LOG_CLIENT};
@@ -464,13 +464,7 @@ impl FedimintCli {
             "version_hash must have an expected length"
         );
 
-        let mut args = std::env::args();
-        if let Some(ref arg) = args.nth(1) {
-            if arg.as_str() == "version-hash" {
-                println!("{}", version_hash);
-                std::process::exit(0);
-            }
-        }
+        handle_version_hash_command(version_hash);
 
         let cli_args = Opts::parse();
         let base_level = if cli_args.verbose { "info" } else { "warn" };

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -293,6 +293,18 @@ impl<T> Spanned<T> {
     }
 }
 
+/// For CLIs, detects `version-hash` as a single argument, prints the provided
+/// version hash, then exits the process.
+pub fn handle_version_hash_command(version_hash: &str) {
+    let mut args = std::env::args();
+    if let Some(ref arg) = args.nth(1) {
+        if arg.as_str() == "version-hash" {
+            println!("{}", version_hash);
+            std::process::exit(0);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -43,3 +43,6 @@ strum = "0.24"
 strum_macros = "0.24"
 tokio = "1.26.0"
 tracing = "0.1.37"
+
+[build-dependencies]
+fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }

--- a/fedimint-dbtool/build.rs
+++ b/fedimint-dbtool/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    fedimint_build::set_code_version();
+}

--- a/fedimint-dbtool/src/main.rs
+++ b/fedimint-dbtool/src/main.rs
@@ -9,6 +9,7 @@ use fedimint_client::module::init::{ClientModuleInitRegistry, DynClientModuleIni
 use fedimint_core::config::ServerModuleInitRegistry;
 use fedimint_core::db::{IDatabaseTransactionOpsCore, IRawDatabaseExt};
 use fedimint_core::module::DynServerModuleInit;
+use fedimint_core::util::handle_version_hash_command;
 use fedimint_ln_client::LightningClientInit;
 use fedimint_ln_server::LightningInit;
 use fedimint_logging::TracingSetup;
@@ -89,20 +90,10 @@ fn print_kv(key: &[u8], value: &[u8]) {
     println!("{} {}", key.to_hex(), value.to_hex());
 }
 
-fn handle_version_hash_command() {
-    let mut args = std::env::args();
-    if let Some(ref arg) = args.nth(1) {
-        if arg.as_str() == "version-hash" {
-            println!("{}", env!("FEDIMINT_BUILD_CODE_VERSION"));
-            std::process::exit(0);
-        }
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
+    handle_version_hash_command(env!("FEDIMINT_BUILD_CODE_VERSION"));
     TracingSetup::default().init()?;
-    handle_version_hash_command();
 
     let options: Options = Options::parse();
 

--- a/fedimint-dbtool/src/main.rs
+++ b/fedimint-dbtool/src/main.rs
@@ -89,9 +89,21 @@ fn print_kv(key: &[u8], value: &[u8]) {
     println!("{} {}", key.to_hex(), value.to_hex());
 }
 
+fn handle_version_hash_command() {
+    let mut args = std::env::args();
+    if let Some(ref arg) = args.nth(1) {
+        if arg.as_str() == "version-hash" {
+            println!("{}", env!("FEDIMINT_BUILD_CODE_VERSION"));
+            std::process::exit(0);
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     TracingSetup::default().init()?;
+    handle_version_hash_command();
+
     let options: Options = Options::parse();
 
     match options.command {

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -15,7 +15,7 @@ use fedimint_core::db::Database;
 use fedimint_core::module::ServerModuleInit;
 use fedimint_core::task::{sleep, TaskGroup};
 use fedimint_core::timing;
-use fedimint_core::util::{write_overwrite, SafeUrl};
+use fedimint_core::util::{handle_version_hash_command, write_overwrite, SafeUrl};
 use fedimint_ln_server::LightningInit;
 use fedimint_logging::TracingSetup;
 use fedimint_mint_server::MintInit;
@@ -145,13 +145,7 @@ impl Fedimintd {
             "version_hash must have an expected length"
         );
 
-        let mut args = std::env::args();
-        if let Some(ref arg) = args.nth(1) {
-            if arg.as_str() == "version-hash" {
-                println!("{}", version_hash);
-                std::process::exit(0);
-            }
-        }
+        handle_version_hash_command(version_hash);
 
         info!("Starting fedimintd (version_hash: {})", version_hash);
 

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -13,6 +13,7 @@ use cln_plugin::{options, Builder, Plugin};
 use cln_rpc::model;
 use cln_rpc::primitives::ShortChannelId;
 use fedimint_core::task::TaskGroup;
+use fedimint_core::util::handle_version_hash_command;
 use fedimint_core::Amount;
 use ln_gateway::gateway_lnrpc::gateway_lightning_server::{
     GatewayLightning, GatewayLightningServer,
@@ -44,14 +45,7 @@ pub struct ClnExtensionOpts {
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let mut args = std::env::args();
-
-    if let Some(ref arg) = args.nth(1) {
-        if arg.as_str() == "version-hash" {
-            println!("{}", env!("FEDIMINT_BUILD_CODE_VERSION"));
-            return Ok(());
-        }
-    }
+    handle_version_hash_command(env!("FEDIMINT_BUILD_CODE_VERSION"));
 
     let (service, listen, plugin) = ClnRpcService::new()
         .await

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -1,4 +1,5 @@
 use fedimint_core::task::TaskGroup;
+use fedimint_core::util::handle_version_hash_command;
 use fedimint_logging::TracingSetup;
 use ln_gateway::Gateway;
 use tracing::info;
@@ -11,6 +12,7 @@ use tracing::info;
 /// remote Lightning node accessible through a `GatewayLightningServer`.
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    handle_version_hash_command(env!("FEDIMINT_BUILD_CODE_VERSION"));
     TracingSetup::default().init()?;
     let mut tg = TaskGroup::new();
     tg.install_kill_handler();

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -318,15 +318,6 @@ impl Gateway {
     }
 
     pub async fn new_with_default_modules() -> anyhow::Result<Gateway> {
-        let mut args = std::env::args();
-
-        if let Some(ref arg) = args.nth(1) {
-            if arg.as_str() == "version-hash" {
-                println!("{}", env!("FEDIMINT_BUILD_CODE_VERSION"));
-                std::process::exit(0);
-            }
-        }
-
         let opts = GatewayOpts::parse();
 
         // Gateway module will be attached when the federation clients are created


### PR DESCRIPTION
We added `fedimint-dbtool` as an output in https://github.com/fedimint/fedimint/pull/4075. This causes the release packages step in CI to fail since `fedimint-dbtool` doesn't have a version-hash command.

```
error: unrecognized subcommand 'version-hash'

Usage: fedimint-dbtool --database <DATABASE> <COMMAND>
```
https://github.com/fedimint/fedimint/actions/runs/7771368281/job/21192586123#step:6:47

Relevant CI step: https://github.com/fedimint/fedimint/blob/6d20243/.github/workflows/ci-nix.yml#L389

Verified locally with

```
nix@lenovo-m75q:~/fedimint$ ./target/debug/fedimint-dbtool version-hash
5a941b7339f332b3000000008d37e4f8e611f4
```