### PR TITLE
chore: update macos github runners to m1-based `macos-14`

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -81,7 +81,7 @@ jobs:
             timeout: 60
             run-tests: true
           - host: macos
-            runs-on: macos-12
+            runs-on: macos-14
             build-in-pr: false
             # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
             timeout: 60
@@ -231,7 +231,7 @@ jobs:
             build-in-pr: true
             timeout: 20
           - host: macos
-            runs-on: macos-12
+            runs-on: macos-14
             build-in-pr: false
             # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
             timeout: 60


### PR DESCRIPTION
All our MacOS developers using m1 or m2 now, so using that for MacOS CI jobs will be much better. Looks like GitHub just announced m1 runners that are free for open source projects: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/.

Inspired by https://github.com/fedimint/fedimint/pull/4234#issuecomment-1925958074

Closes https://github.com/fedimint/fedimint/issues/70