### PR TITLE
[0.2] update macos github runners to m1-based `macos-14`

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -73,7 +73,7 @@ jobs:
             timeout: 60
             run-tests: true
           - host: macos
-            runs-on: macos-12
+            runs-on: macos-14
             build-in-pr: false
             # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
             timeout: 60
@@ -223,7 +223,7 @@ jobs:
             build-in-pr: true
             timeout: 20
           - host: macos
-            runs-on: macos-12
+            runs-on: macos-14
             build-in-pr: false
             # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
             timeout: 60


### PR DESCRIPTION
M1 MacOS dev shell broke on this branch recently ...