### PR TITLE
Degraded federations for devimint and rust tests

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     name: "Backwards-compatibility tests"
     runs-on: buildjet-8vcpu-ubuntu-2004
-    timeout-minutes: 75
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     name: "Backwards-compatibility tests"
     runs-on: buildjet-8vcpu-ubuntu-2004
-    timeout-minutes: 60
+    timeout-minutes: 75
 
     steps:
       - uses: actions/checkout@v4

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -25,6 +25,10 @@ pub struct CommonArgs {
     #[clap(long, env = "FM_LINK_TEST_DIR")]
     /// Create a link to the test dir under this path
     pub link_test_dir: Option<PathBuf>,
+
+    /// Run degraded federation with FM_OFFLINE_NODES shutdown
+    #[clap(long, env = "FM_OFFLINE_NODES", default_value = "0")]
+    pub offline_nodes: usize,
 }
 
 impl CommonArgs {
@@ -75,7 +79,7 @@ pub enum RpcCmd {
 }
 
 pub async fn setup(arg: CommonArgs) -> Result<(ProcessManager, TaskGroup)> {
-    let globals = vars::Global::new(&arg.mk_test_dir()?, arg.fed_size).await?;
+    let globals = vars::Global::new(&arg.mk_test_dir()?, arg.fed_size, arg.offline_nodes).await?;
 
     let log_file = fs::OpenOptions::new()
         .write(true)

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -21,9 +21,16 @@ pub struct DevFed {
 }
 
 pub async fn dev_fed(process_mgr: &ProcessManager) -> Result<DevFed> {
+    let fed_size = process_mgr.globals.FM_FED_SIZE;
+    let offline_nodes = process_mgr.globals.FM_OFFLINE_NODES;
+    anyhow::ensure!(
+        fed_size > 3 * offline_nodes,
+        "too many offline nodes ({offline_nodes}) to reach consensus"
+    );
+
     let start_time = fedimint_core::time::now();
     let bitcoind = Bitcoind::new(process_mgr).await?;
-    let ((cln, lnd, gw_cln, gw_lnd), electrs, esplora, fed) = tokio::try_join!(
+    let ((cln, lnd, gw_cln, gw_lnd), electrs, esplora, mut fed) = tokio::try_join!(
         async {
             let (cln, lnd) = tokio::try_join!(
                 Lightningd::new(process_mgr, bitcoind.clone()),
@@ -40,10 +47,7 @@ pub async fn dev_fed(process_mgr: &ProcessManager) -> Result<DevFed> {
         },
         Electrs::new(process_mgr, bitcoind.clone()),
         Esplora::new(process_mgr, bitcoind.clone()),
-        async {
-            let fed_size = process_mgr.globals.FM_FED_SIZE;
-            Federation::new(process_mgr, bitcoind.clone(), fed_size).await
-        },
+        async { Federation::new(process_mgr, bitcoind.clone(), fed_size).await },
     )?;
 
     info!(target: LOG_DEVIMINT, "federation and gateways started");
@@ -62,11 +66,18 @@ pub async fn dev_fed(process_mgr: &ProcessManager) -> Result<DevFed> {
     info!(target: LOG_DEVIMINT, "await gateways registered");
     fed.await_gateways_registered().await?;
     info!(target: LOG_DEVIMINT, "gateways registered");
+
+    // Create a degraded federation if there are offline nodes
+    fed.degrade_federation(process_mgr).await?;
+
     info!(
         target: LOG_DEVIMINT,
-        "starting dev federation took {:?}",
+        fed_size,
+        offline_nodes,
+        "finished creating dev federation, took {:?}",
         start_time.elapsed()?
     );
+
     Ok(DevFed {
         bitcoind,
         cln,

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -47,7 +47,7 @@ pub async fn dev_fed(process_mgr: &ProcessManager) -> Result<DevFed> {
         },
         Electrs::new(process_mgr, bitcoind.clone()),
         Esplora::new(process_mgr, bitcoind.clone()),
-        async { Federation::new(process_mgr, bitcoind.clone(), fed_size).await },
+        Federation::new(process_mgr, bitcoind.clone(), fed_size),
     )?;
 
     info!(target: LOG_DEVIMINT, "federation and gateways started");

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -262,14 +262,6 @@ impl Federation {
         Ok(())
     }
 
-    pub async fn start_all_servers(&mut self, process_mgr: &ProcessManager) -> Result<()> {
-        let fed_size = process_mgr.globals.FM_FED_SIZE;
-        while self.num_members() < fed_size {
-            self.start_server(process_mgr, self.num_members()).await?
-        }
-        Ok(())
-    }
-
     pub async fn terminate_server(&mut self, peer_id: usize) -> Result<()> {
         let Some((_, fedimintd)) = self.members.remove_entry(&peer_id) else {
             bail!("fedimintd-{peer_id} does not exist");
@@ -290,7 +282,9 @@ impl Federation {
             self.terminate_server(self.num_members() - 1).await?;
         }
 
-        info!(fed_size, offline_nodes, "federation is degraded");
+        if offline_nodes > 0 {
+            info!(fed_size, offline_nodes, "federation is degraded");
+        }
         Ok(())
     }
 

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -112,11 +112,7 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
     } = dev_fed;
 
     let max_p90_factor = 5.0;
-    let p90_median_factor = if crate::util::is_backwards_compatibility_test() {
-        7
-    } else {
-        5
-    };
+    let p90_median_factor = 7;
 
     let client = fed.new_joined_client("latency-tests-client").await?;
     client.use_gateway(&gw_cln).await?;

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{env, unreachable};
 
-use anyhow::{bail, format_err, Context, Result};
+use anyhow::{anyhow, bail, format_err, Context, Result};
 use fedimint_core::task::{self, block_in_place};
 use fedimint_logging::LOG_DEVIMINT;
 use futures::executor::block_on;
@@ -505,6 +505,15 @@ pub fn get_fedimint_dbtool_cli_path() -> Vec<String> {
     )
 }
 
+/// Maps a version hash to a release version
+fn version_hash_to_version(version_hash: &str) -> Result<Version> {
+    match version_hash {
+        "a8422b84102ab5fc768307215d5b20d807143f27" => Ok(Version::new(0, 2, 1)),
+        "a849377f6466b26bf9b2747242ff01fd4d4a031b" => Ok(Version::new(0, 2, 2)),
+        _ => Err(anyhow!("no version known for version hash: {version_hash}")),
+    }
+}
+
 pub struct FedimintdCmd;
 impl FedimintdCmd {
     pub async fn cmd(self) -> Command {
@@ -514,12 +523,15 @@ impl FedimintdCmd {
         ))
     }
 
-    /// Returns the fedimintd version from clap or default min version if the
-    /// binary doesn't support a version flag
+    /// Returns the fedimintd version from clap or default min version
     pub async fn version_or_default() -> Version {
         match cmd!(FedimintdCmd, "--version").out_string().await {
             Ok(version) => parse_clap_version(&version),
-            Err(_) => DEFAULT_VERSION,
+            Err(_) => cmd!(FedimintdCmd, "version-hash")
+                .out_string()
+                .await
+                .map(|v| version_hash_to_version(&v).unwrap_or(DEFAULT_VERSION))
+                .unwrap_or(DEFAULT_VERSION),
         }
     }
 }
@@ -546,8 +558,7 @@ impl FedimintCli {
         ))
     }
 
-    /// Returns the fedimintd version from clap or default min version if the
-    /// binary doesn't support a version flag
+    /// Returns the fedimint-cli version from clap or default min version
     pub async fn version_or_default() -> Version {
         match cmd!(FedimintCli, "--version").out_string().await {
             Ok(version) => parse_clap_version(&version),

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -739,6 +739,11 @@ fn to_command(cli: Vec<String>) -> Command {
     }
 }
 
+/// Returns true if running backwards-compatibility tests
+pub fn is_backwards_compatibility_test() -> bool {
+    std::env::var("FM_BACKWARDS_COMPATIBILITY_TEST").is_ok_and(|x| x == "1")
+}
+
 /// Parses a version string returned from clap
 /// ex: fedimintd 0.3.0-alpha -> 0.3.0-alpha
 fn parse_clap_version(res: &str) -> Version {

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -86,9 +86,10 @@ pub fn utf8(path: &Path) -> &str {
 }
 
 declare_vars! {
-    Global = (test_dir: &Path, fed_size: usize) =>
+    Global = (test_dir: &Path, fed_size: usize, offline_nodes: usize) =>
     {
         FM_FED_SIZE: usize = fed_size;
+        FM_OFFLINE_NODES: usize = offline_nodes;
         FM_TMP_DIR: PathBuf = mkdir(test_dir.into()).await?;
         FM_TEST_DIR: PathBuf = FM_TMP_DIR.clone();
         FM_TEST_FAST_WEAK_CRYPTO: String = "1";
@@ -165,8 +166,12 @@ declare_vars! {
 }
 
 impl Global {
-    pub async fn new(test_dir: &Path, fed_size: usize) -> anyhow::Result<Self> {
-        let this = Self::init(test_dir, fed_size).await?;
+    pub async fn new(
+        test_dir: &Path,
+        fed_size: usize,
+        offline_nodes: usize,
+    ) -> anyhow::Result<Self> {
+        let this = Self::init(test_dir, fed_size, offline_nodes).await?;
         Ok(this)
     }
 }

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -791,7 +791,7 @@ where
         &self,
         client_versions: &SupportedApiVersionsSummary,
     ) -> FederationResult<ApiVersionSet> {
-        let timeout = Duration::from_secs(60);
+        let timeout = Duration::from_secs(5);
         self.request_with_strategy(
             DiscoverApiVersionSet::new(
                 self.all_peers().len(),

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -42,11 +42,17 @@ function run_tests() {
       ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
       ${TEST_ARGS_SERIALIZED} \
       -E 'package(fedimint-ln-tests)'
+    >&2 echo "### Testing against bitcoind - complete"
+  fi
+
+  if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "bitcoind-ln-gateway" ]; then
+    >&2 echo "### Testing against bitcoind for ln-gateway"
+
     cargo nextest run --locked --workspace --all-targets \
       ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
       ${TEST_ARGS_SERIALIZED} \
       -E 'package(fedimint-ln-gateway)'
-    >&2 echo "### Testing against bitcoind - complete"
+    >&2 echo "### Testing against bitcoind for ln-gateway - complete"
   fi
 
   # Switch to electrum and run wallet tests

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -5,9 +5,6 @@ set -euo pipefail
 # prevent locale settings messing with some setups
 export LANG=C
 
-# default to run all tests in a 3/4 setup
-export FM_OFFLINE_NODES=1
-
 if [ "$(ulimit -Sn)" -lt "10000" ]; then
   >&2 echo "⚠️  ulimit too small. Running 'ulimit -Sn 10000' to avoid problems running tests"
   ulimit -Sn 10000
@@ -35,6 +32,13 @@ cargo nextest run --no-run ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${
 # in the PATH.
 # If you really need to break this rule, ping dpc
 export FM_CARGO_DENY_COMPILATION=1
+
+# default to run all tests in a 3/4 setup and 4/4 in backwards-compatibility tests
+if [ -n "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+  export FM_OFFLINE_NODES=0
+else
+  export FM_OFFLINE_NODES=1
+fi
 
 function rust_unit_tests() {
   # unit tests don't use binaries from old versions, so there's no need to run for backwards-compatibility tests

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # prevent locale settings messing with some setups
 export LANG=C
 
+# default to run all tests in a 3/4 setup
+export FM_OFFLINE_NODES=1
+
 if [ "$(ulimit -Sn)" -lt "10000" ]; then
   >&2 echo "⚠️  ulimit too small. Running 'ulimit -Sn 10000' to avoid problems running tests"
   ulimit -Sn 10000
@@ -47,7 +50,8 @@ function recoverytool_tests() {
 export -f recoverytool_tests
 
 function reconnect_test() {
-  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/reconnect-test.sh
+  # reconnect-test runs a degraded federation, so we need to override FM_OFFLINE_NODES
+  fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/reconnect-test.sh
 }
 export -f reconnect_test
 
@@ -62,42 +66,27 @@ function gateway_reboot_test() {
 export -f gateway_reboot_test
 
 function latency_test_reissue() {
-  # latency tests are not necessary for backwards-compatibility tests
-  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh reissue
-  fi
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh reissue
 }
 export -f latency_test_reissue
 
 function latency_test_ln_send() {
-  # latency tests are not necessary for backwards-compatibility tests
-  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh ln-send
-  fi
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh ln-send
 }
 export -f latency_test_ln_send
 
 function latency_test_ln_receive() {
-  # latency tests are not necessary for backwards-compatibility tests
-  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh ln-receive
-  fi
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh ln-receive
 }
 export -f latency_test_ln_receive
 
 function latency_test_fm_pay() {
-  # latency tests are not necessary for backwards-compatibility tests
-  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh fm-pay
-  fi
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh fm-pay
 }
 export -f latency_test_fm_pay
 
 function latency_test_restore() {
-  # latency tests are not necessary for backwards-compatibility tests
-  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh restore
-  fi
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh restore
 }
 export -f latency_test_restore
 
@@ -107,7 +96,7 @@ function devimint_cli_test() {
 export -f devimint_cli_test
 
 function devimint_cli_test_single() {
-  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-cli-test-single.sh
+  fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/devimint-cli-test-single.sh
 }
 export -f devimint_cli_test_single
 

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -117,6 +117,14 @@ function backend_test_bitcoind() {
 }
 export -f backend_test_bitcoind
 
+function backend_test_bitcoind_ln_gateway() {
+  # backend tests don't support different versions, so we skip for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind-ln-gateway ./scripts/tests/backend-test.sh
+  fi
+}
+export -f backend_test_bitcoind_ln_gateway
+
 function backend_test_electrs() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
@@ -170,6 +178,7 @@ if parallel \
   always_success_test \
   rust_unit_tests \
   backend_test_bitcoind \
+  backend_test_bitcoind_ln_gateway \
   backend_test_electrs \
   backend_test_esplora \
   latency_test_reissue \


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/4171

Inspired by https://github.com/fedimint/fedimint/pull/4173 and https://github.com/fedimint/fedimint/pull/4198

Introduces the ability to run rust and devimint tests with a parameterized number of peers offline, defaulting to a 3/4 setup.

Running all tests with a degraded federation increases the time for CI to finish by a material amount, so we should consider if running all tests degraded is worth the additional overhead.

- Build on Linux tests step: before ~10 minutes ([CI](https://github.com/fedimint/fedimint/actions/runs/7895859707/job/21548890873?pr=4323#step:9:1)), degraded ~19 minutes ([CI](https://github.com/fedimint/fedimint/actions/runs/7909623387/job/21590963278?pr=4247#step:9:1))
- Back-compat: before ~45 minutes ([CI](https://github.com/fedimint/fedimint/actions/runs/7903266208)), degraded ~68 minutes ([CI](https://github.com/fedimint/fedimint/actions/runs/7906606111/job/21581827189?pr=4247#step:5:1))