### PR TITLE
[repro, don't merge]: peer comms going crazy on random fake network error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
  "fedimint-derive-secret",
  "fedimint-logging",
  "futures",
+ "futures-util",
  "itertools 0.10.5",
  "rand",
  "ring 0.17.7",
@@ -2501,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2511,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
@@ -2528,15 +2529,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2545,15 +2546,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
@@ -2567,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -31,6 +31,7 @@ fedimint-derive-secret = { version = "0.3.0-alpha", path = "../crypto/derive-sec
 fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 futures = "0.3.26"
+futures-util = "0.3.30"
 itertools = "0.10.5"
 rand = "0.8.5"
 secp256k1-zkp = "0.7.0"

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -667,6 +667,7 @@ pub struct Client {
     modules: ClientModuleRegistry,
     module_inits: ClientModuleInitRegistry,
     executor: Executor,
+    sm_update_rx: tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<DynState>>>,
     api: DynGlobalApi,
     root_secret: DerivableSecret,
     operation_log: OperationLog,
@@ -778,7 +779,16 @@ impl Client {
             "Starting fedimint client executor (version: {})",
             env!("FEDIMINT_BUILD_CODE_VERSION")
         );
-        self.executor.start_executor(self.context_gen()).await;
+        self.executor
+            .start_executor(
+                self.context_gen(),
+                self.sm_update_rx
+                    .lock()
+                    .await
+                    .take()
+                    .expect("sm_update_rx missing. Trying to start executor twice?"),
+            )
+            .await;
     }
 
     pub fn federation_id(&self) -> FederationId {
@@ -2065,7 +2075,7 @@ impl ClientBuilder {
             dbtx.commit_tx().await;
         }
 
-        let executor = {
+        let (executor, sm_update_rx) = {
             let mut executor_builder = Executor::builder();
             executor_builder
                 .with_module(TRANSACTION_SUBMISSION_MODULE_INSTANCE, TxSubmissionContext);
@@ -2099,6 +2109,7 @@ impl ClientBuilder {
             modules,
             module_inits: self.module_inits.clone(),
             executor,
+            sm_update_rx: tokio::sync::Mutex::new(Some(sm_update_rx)),
             api,
             secp_ctx: Secp256k1::new(),
             root_secret,

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -1,8 +1,8 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::io::{Error, Read, Write};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use anyhow::anyhow;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
@@ -12,14 +12,15 @@ use fedimint_core::db::{
 };
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_core::fmt_utils::AbbreviateJson;
+use fedimint_core::maybe_add_send_sync;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::spawn;
 use fedimint_core::util::BoxFuture;
-use fedimint_core::{maybe_add_send_sync, task};
+use fedimint_logging::LOG_CLIENT_REACTOR;
 use futures::future::{self, select_all};
-use futures::stream::StreamExt;
+use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::select;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::{debug, error, info, trace, warn, Instrument};
 
 use super::state::StateTransitionFunction;
@@ -30,10 +31,6 @@ use crate::{AddStateMachinesError, AddStateMachinesResult, DynGlobalClientContex
 
 /// After how many attempts a DB transaction is aborted with an error
 const MAX_DB_ATTEMPTS: Option<usize> = Some(100);
-
-/// Wait time till checking the DB for new state machines when there are no
-/// active ones
-const EXECUTOR_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 pub type ContextGen =
     Arc<maybe_add_send_sync!(dyn Fn(ModuleInstanceId, OperationId) -> DynGlobalClientContext)>;
@@ -64,6 +61,9 @@ struct ExecutorInner {
     module_contexts: BTreeMap<ModuleInstanceId, DynContext>,
     valid_module_ids: BTreeSet<ModuleInstanceId>,
     notifier: Notifier,
+    /// Any time executor should notice state machine update (e.g. because it
+    /// was created), it's must be sent through this channel for it to notice.
+    sm_update_tx: mpsc::UnboundedSender<DynState>,
     shutdown_executor: Mutex<Option<oneshot::Sender<oneshot::Sender<()>>>>,
 }
 
@@ -174,7 +174,11 @@ impl Executor {
             )
             .await;
             let notify_sender = self.inner.notifier.sender();
-            dbtx.on_commit(move || notify_sender.notify(state));
+            let sm_updates_tx = self.inner.sm_update_tx.clone();
+            dbtx.on_commit(move || {
+                notify_sender.notify(state.clone());
+                let _ = sm_updates_tx.send(state);
+            });
         }
 
         Ok(())
@@ -237,7 +241,11 @@ impl Executor {
     ///
     /// ## Panics
     /// If called more than once.
-    pub async fn start_executor(&self, context_gen: ContextGen) {
+    pub async fn start_executor(
+        &self,
+        context_gen: ContextGen,
+        sm_update_rx: tokio::sync::mpsc::UnboundedReceiver<DynState>,
+    ) {
         let replaced_old_context_gen = self
             .inner
             .context
@@ -266,8 +274,8 @@ impl Executor {
         );
 
         let task_runner_inner = self.inner.clone();
-        let _handle = spawn("client state machine", async move {
-            let executor_runner = task_runner_inner.run(context_gen);
+        let _handle = spawn("state machine executor", async move {
+            let executor_runner = task_runner_inner.run(context_gen, sm_update_rx);
             select! {
                 shutdown_happened_sender = shutdown_receiver => {
                     match shutdown_happened_sender {
@@ -317,35 +325,37 @@ impl Drop for ExecutorInner {
     }
 }
 
-type TransitionForActiveState = (
-    serde_json::Value,
-    DynState,
-    StateTransitionFunction<DynState>,
-    ActiveState,
-);
+struct TransitionForActiveState {
+    outcome: serde_json::Value,
+    state: DynState,
+    meta: ActiveState,
+    transition_fn: StateTransitionFunction<DynState>,
+}
 
 impl ExecutorInner {
-    async fn run(&self, global_context_gen: ContextGen) {
+    async fn run(
+        &self,
+        global_context_gen: ContextGen,
+        sm_update_rx: tokio::sync::mpsc::UnboundedReceiver<DynState>,
+    ) {
         info!("Starting state machine executor task");
-        loop {
-            if let Err(err) = self
-                .execute_next_state_transitions(&global_context_gen)
-                .await
-            {
-                warn!(
-                    %err,
-                    "An unexpected error occurred during a state transition"
-                );
-            }
+        if let Err(err) = self
+            .run_state_machines_executor_inner(global_context_gen, sm_update_rx)
+            .await
+        {
+            warn!(
+                %err,
+                "An unexpected error occurred during a state transition"
+            );
         }
     }
 
     async fn get_transition_for(
         &self,
-        state: DynState,
+        state: &DynState,
         meta: ActiveState,
         global_context_gen: &ContextGen,
-    ) -> Option<BoxFuture<TransitionForActiveState>> {
+    ) -> Vec<BoxFuture<'static, TransitionForActiveState>> {
         let module_instance = state.module_instance_id();
         let context = &self
             .module_contexts
@@ -364,7 +374,12 @@ impl ExecutorInner {
                         trigger,
                         transition,
                     } = transition;
-                    (trigger.await, state, transition, meta)
+                    TransitionForActiveState {
+                        outcome: trigger.await,
+                        state,
+                        transition_fn: transition,
+                        meta,
+                    }
                 });
                 f
             })
@@ -390,181 +405,258 @@ impl ExecutorInner {
                 )
                 .await
                 .expect("Autocommit here can't fail");
-
-            None
-        } else {
-            Some(Box::pin(async move {
-                let (first_completed_result, _index, _unused_transitions) =
-                    select_all(transitions).await;
-                first_completed_result
-            }))
         }
+
+        transitions
     }
 
-    async fn execute_next_state_transitions(
+    async fn run_state_machines_executor_inner(
         &self,
-        global_context_gen: &ContextGen,
+        global_context_gen: ContextGen,
+        sm_update_rx: tokio::sync::mpsc::UnboundedReceiver<DynState>,
     ) -> anyhow::Result<()> {
+        // Re-add the same future  receiving on the channel.
+        // Not very elegant, but can't figure out how to make it a quine
+        // and don't know anything more clever.
+        fn re_add_sm_update_receiver(
+            futures: &mut FuturesUnordered<BoxFuture<'static, ExecutorLoopEvent>>,
+            mut sm_update_rx: mpsc::UnboundedReceiver<DynState>,
+        ) {
+            futures.push(Box::pin(async {
+                if let Some(new) = sm_update_rx.recv().await {
+                    ExecutorLoopEvent::New {
+                        state: new,
+                        sm_update_rx,
+                    }
+                } else {
+                    ExecutorLoopEvent::Disconnected
+                }
+            }));
+        }
+
         let active_states = self.get_active_states().await;
-        // TODO: use DB prefix subscription instead of polling
-        let mut active_state_count = active_states.len();
-        if active_states.is_empty() {
-            // FIXME: what to do in this case? Probably best to subscribe to DB eventually
-            trace!("No state transitions available, waiting before re-trying");
-            task::sleep(EXECUTOR_POLL_INTERVAL).await;
-            return Ok(());
-        }
-        trace!("Active states: {:?}", active_states);
-
-        let mut transitions = Vec::new();
-        for (state, meta) in active_states {
-            match self
-                .get_transition_for(state, meta, global_context_gen)
-                .await
-            {
-                None => {}
-                Some(t) => transitions.push(t),
-            }
+        trace!(target: LOG_CLIENT_REACTOR, "Starting active states: {:?}", active_states);
+        for (state, _meta) in active_states {
+            self.sm_update_tx
+                .send(state)
+                .expect("Must be able to send operation_id to own opened channel");
         }
 
-        loop {
-            if active_state_count == 0 {
-                debug!(
-                    "No state transitions remaining, exiting execute_next_state_transitions loops"
-                );
-                return Ok(());
-            }
-            let num_states = active_state_count;
-            let num_transitions = transitions.len();
-            debug!(
-                num_states,
-                num_transitions, "Awaiting any state transition to become ready"
-            );
-            let new_state_added = async move {
-                loop {
-                    // Prioritize existing active states over new states
-                    fedimint_core::task::sleep(EXECUTOR_POLL_INTERVAL).await;
-                    let new_active_states_count = self.get_active_states().await.len();
-                    if new_active_states_count > active_state_count {
-                        return;
+        /// All futures in the executor resolve to this type, so the handling
+        /// code can tell them apart.
+        enum ExecutorLoopEvent {
+            /// Notivication about `DynState` arrived and should be handled,
+            /// usually added to the list of pending futures.
+            New {
+                state: DynState,
+                sm_update_rx: mpsc::UnboundedReceiver<DynState>,
+            },
+            /// One of trigger functions of a state machine finished and
+            /// returned transition function to run
+            Triggered(TransitionForActiveState),
+            /// Transition function and all the accounting around it are done
+            Completed {
+                state: DynState,
+                outcome: ActiveOrInactiveState,
+            },
+            /// New job receiver disconnected, that can only mean termination
+            Disconnected,
+        }
+
+        // Keeps track of things already running, so we can deduplicate, just
+        // in case.
+        let mut currently_running_sms = HashSet::<DynState>::new();
+        // All things happening in parallel go into here
+        let mut futures: FuturesUnordered<BoxFuture<'_, ExecutorLoopEvent>> =
+            FuturesUnordered::new();
+
+        re_add_sm_update_receiver(&mut futures, sm_update_rx);
+
+        // main reactor loop: wait for next thing that completed, react (possibly adding
+        // more things to `futures`)
+        while let Some(event) = futures.next().await {
+            match event {
+                ExecutorLoopEvent::New {
+                    state,
+                    sm_update_rx,
+                } => {
+                    re_add_sm_update_receiver(&mut futures, sm_update_rx);
+
+                    if currently_running_sms.contains(&state) {
+                        warn!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), "Received a state machine that is already running. Ignoring");
+                        continue;
                     }
+                    let Some(meta) = self.get_active_state(&state).await else {
+                        warn!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), "Couldn't look up received state machine. Ignoring.");
+                        continue;
+                    };
+
+                    let transitions = self
+                        .get_transition_for(&state, meta, &global_context_gen)
+                        .await;
+                    if transitions.is_empty() {
+                        warn!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), "Received an active state that doesn't produce any transitions. Ignoring.");
+                        continue;
+                    }
+
+                    currently_running_sms.insert(state.clone());
+                    futures.push(Box::pin(async move {
+                        let (first_completed_result, _index, _unused_transitions) =
+                            select_all(transitions).await;
+                        ExecutorLoopEvent::Triggered(first_completed_result)
+                    }));
+
+                    info!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), total = futures.len(), "Started new active state machine.");
                 }
-            };
-            let (completed_result, _index, remaining_transitions) = select! {
-                res = select_all(transitions) => res,
-                () = new_state_added => {
-                    debug!("New state added, re-starting state transitions");
-                    return Ok(());
-                }
-            };
-            transitions = remaining_transitions;
-            let (transition_outcome, state, transition_fn, meta) = completed_result;
-            let operation_id = state.operation_id();
-            // info level because spans only log when any event happens within a span.
-            let span = tracing::info_span!("state_machine_transition", %operation_id);
-            async {
-                info!("Executing state transition");
-                debug!(
-                    ?state,
-                    transition_outcome = ?AbbreviateJson(&transition_outcome),
-                );
+                ExecutorLoopEvent::Triggered(TransitionForActiveState {
+                    outcome,
+                    state,
+                    meta,
+                    transition_fn,
+                }) => {
+                    let span = tracing::info_span!(
+                        "state_machine_transition",
+                        operation_id = %state.operation_id()
+                    );
+                    // Perform the transition as another future, so transitions can happen in
+                    // parallel.
+                    // Database write conflicts might be happening quite often here,
+                    // but transaction functions are supposed to be idempotent anyway,
+                    // so it seems like a good stress-test in the worst case.
+                    futures.push({
+                        let sm_update_tx = self.sm_update_tx.clone();
+                        let db = self.db.clone();
+                        let notifier = self.notifier.clone();
+                        let module_contexts = self
+                                                .module_contexts.clone();
+                        let global_context_gen = global_context_gen.clone();
+                        Box::pin(
+                        async move {
+                            debug!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id() , "Executing state transition");
+                            debug!(
+                                ?state,
+                                outcome = ?AbbreviateJson(&outcome),
+                            );
 
-                let active_or_inactive_state = self
-                    .db
-                    .autocommit(
-                        |dbtx, _| {
-                            let state = state.clone();
-                            let transition_fn = transition_fn.clone();
-                            let transition_outcome = transition_outcome.clone();
-                            Box::pin(async move {
-                                let new_state = transition_fn(
-                                    &mut ClientSMDatabaseTransaction::new(
-                                        &mut dbtx.to_ref(),
-                                        state.module_instance_id(),
-                                    ),
-                                    transition_outcome,
-                                    state.clone(),
+                            let module_contexts = &module_contexts;
+                            let global_context_gen = &global_context_gen;
+
+                            let outcome =
+                                db
+                                .autocommit(
+                                    |dbtx, _| {
+                                        let state = state.clone();
+                                        let transition_fn = transition_fn.clone();
+                                        let transition_outcome = outcome.clone();
+                                                let sm_update_tx = sm_update_tx.clone();
+                                        Box::pin(async move {
+                                            let new_state = transition_fn(
+                                                &mut ClientSMDatabaseTransaction::new(
+                                                    &mut dbtx.to_ref(),
+                                                    state.module_instance_id(),
+                                                ),
+                                                transition_outcome,
+                                                state.clone(),
+                                            )
+                                            .await;
+                                            dbtx.remove_entry(&ActiveStateKey::from_state(
+                                                state.clone(),
+                                            ))
+                                            .await;
+                                            dbtx.insert_entry(
+                                                &InactiveStateKey::from_state(state.clone()),
+                                                &meta.into_inactive(),
+                                            )
+                                            .await;
+
+                                            let context = &
+                                                module_contexts
+                                                .get(&state.module_instance_id())
+                                                .expect("Unknown module");
+
+                                            let global_context = global_context_gen(
+                                                state.module_instance_id(),
+                                                state.operation_id(),
+                                            );
+                                            if new_state.is_terminal(context, &global_context) {
+                                                // TODO: log state machine id or something
+                                                debug!("State machine reached terminal state");
+                                                let k =
+                                                    InactiveStateKey::from_state(new_state.clone());
+                                                let v = ActiveState::new().into_inactive();
+                                                dbtx.insert_entry(&k, &v).await;
+                                                Ok(ActiveOrInactiveState::Inactive {
+                                                    dyn_state: new_state,
+                                                })
+                                            } else {
+                                                let k =
+                                                    ActiveStateKey::from_state(new_state.clone());
+                                                let v = ActiveState::new();
+                                                dbtx.insert_entry(&k, &v).await;
+                                                dbtx.on_commit(move || {
+                                                    let _ = sm_update_tx.send(state);
+                                                });
+                                                Ok(ActiveOrInactiveState::Active {
+                                                    dyn_state: new_state,
+                                                    meta: v,
+                                                })
+                                            }
+                                        })
+                                    },
+                                    None,
                                 )
-                                .await;
-                                dbtx.remove_entry(&ActiveStateKey::from_state(state.clone()))
-                                    .await;
-                                dbtx.insert_entry(
-                                    &InactiveStateKey::from_state(state.clone()),
-                                    &meta.into_inactive(),
-                                )
-                                .await;
+                                .await
+                                .map_err(|e| match e {
+                                    AutocommitError::CommitFailed {
+                                        last_error,
+                                        attempts,
+                                    } => last_error.context(format!(
+                                        "Failed to commit after {attempts} attempts"
+                                    )),
+                                    AutocommitError::ClosureError { error, .. } => error,
+                                }).expect("autocommit of transition fn should never fail");
 
-                                let context = &self
-                                    .module_contexts
-                                    .get(&state.module_instance_id())
-                                    .expect("Unknown module");
 
-                                let global_context = global_context_gen(
-                                    state.module_instance_id(),
-                                    state.operation_id(),
-                                );
-                                if new_state.is_terminal(context, &global_context) {
-                                    // TODO: log state machine id or something
-                                    debug!("State machine reached terminal state");
-                                    let k = InactiveStateKey::from_state(new_state.clone());
-                                    let v = ActiveState::new().into_inactive();
-                                    dbtx.insert_entry(&k, &v).await;
-                                    Ok(ActiveOrInactiveState::Inactive {
-                                        dyn_state: new_state,
-                                    })
-                                } else {
-                                    let k = ActiveStateKey::from_state(new_state.clone());
-                                    let v = ActiveState::new();
-                                    dbtx.insert_entry(&k, &v).await;
-                                    Ok(ActiveOrInactiveState::Active {
-                                        dyn_state: new_state,
-                                        active_state: v,
-                                    })
+                            match &outcome {
+                                ActiveOrInactiveState::Active {
+                                    dyn_state,
+                                    meta: _,
+                                } => {
+                                    sm_update_tx.send(dyn_state.clone()).expect("can't fail: we are the receiving end");
+                                    notifier.notify(dyn_state.clone());
                                 }
-                            })
-                        },
-                        Some(100),
-                    )
-                    .await
-                    .map_err(|e| match e {
-                        AutocommitError::CommitFailed {
-                            last_error,
-                            attempts,
-                        } => last_error
-                            .context(format!("Failed to commit after {attempts} attempts")),
-                        AutocommitError::ClosureError { error, .. } => error,
-                    })?;
-
-                // TODO: add a INFO version without all the details
-                debug!(
-                    outcome = ?active_or_inactive_state,
-                    "Finished executing state transition"
-                );
-
-                active_state_count -= 1;
-                match active_or_inactive_state {
-                    ActiveOrInactiveState::Active {
-                        dyn_state,
-                        active_state,
-                    } => {
-                        if let Some(transition) = self
-                            .get_transition_for(dyn_state.clone(), active_state, global_context_gen)
-                            .await
-                        {
-                            active_state_count += 1;
-                            transitions.push(transition);
+                                ActiveOrInactiveState::Inactive { dyn_state } => {
+                                    notifier.notify(dyn_state.clone());
+                                }
+                            }
+                            ExecutorLoopEvent::Completed { state, outcome }
                         }
-                        self.notifier.notify(dyn_state);
-                    }
-                    ActiveOrInactiveState::Inactive { dyn_state } => {
-                        self.notifier.notify(dyn_state);
-                    }
+                        .instrument(span),
+                    )});
                 }
-                anyhow::Ok(())
+                ExecutorLoopEvent::Completed { state, outcome } => {
+                    currently_running_sms.remove(&state);
+                    info!(
+                        target: LOG_CLIENT_REACTOR,
+                        operation_id = %state.operation_id(),
+                        outcome_active = outcome.is_active(),
+                        total = futures.len(),
+                        "State transition complete");
+                    trace!(
+                        target: LOG_CLIENT_REACTOR,
+                        ?outcome,
+                        operation_id = %state.operation_id(), total = futures.len(),
+                        "State transition complete");
+                }
+                ExecutorLoopEvent::Disconnected => {
+                    info!(target: LOG_CLIENT_REACTOR, "Disconnected. Terminating.");
+                    break;
+                }
             }
-            .instrument(span)
-            .await?
         }
+
+        trace!(target: LOG_CLIENT_REACTOR, "Terminated");
+        Ok(())
     }
 
     async fn get_active_states(&self) -> Vec<(DynState, ActiveState)> {
@@ -582,6 +674,21 @@ impl ExecutorInner {
             })
             .map(|(state, meta)| (state.state, meta))
             .collect::<Vec<_>>()
+            .await
+    }
+
+    async fn get_active_state(&self, state: &DynState) -> Option<ActiveState> {
+        // ignore states from modules that are not initialized yet
+        if !self
+            .module_contexts
+            .contains_key(&state.module_instance_id())
+        {
+            return None;
+        }
+        self.db
+            .begin_transaction()
+            .await
+            .get_value(&ActiveStateKey::from_state(state.clone()))
             .await
     }
 
@@ -678,7 +785,13 @@ impl ExecutorBuilder {
     /// Build [`Executor`] and spawn background task in `tasks` executing active
     /// state machines. The supplied database `db` must support isolation, so
     /// cannot be an isolated DB instance itself.
-    pub async fn build(self, db: Database, notifier: Notifier) -> Executor {
+    pub async fn build(
+        self,
+        db: Database,
+        notifier: Notifier,
+    ) -> (Executor, mpsc::UnboundedReceiver<DynState>) {
+        let (sm_update_tx, sm_update_rx) = tokio::sync::mpsc::unbounded_channel();
+
         let inner = Arc::new(ExecutorInner {
             db,
             context: Mutex::new(None),
@@ -686,13 +799,14 @@ impl ExecutorBuilder {
             valid_module_ids: self.valid_module_ids,
             notifier,
             shutdown_executor: Default::default(),
+            sm_update_tx,
         });
 
         debug!(
             instances = ?inner.module_contexts.keys().copied().collect::<Vec<_>>(),
             "Initialized state machine executor with module instances"
         );
-        Executor { inner }
+        (Executor { inner }, sm_update_rx)
     }
 }
 
@@ -701,6 +815,7 @@ impl ExecutorBuilder {
 pub struct ActiveStateKey {
     // TODO: remove redundant operation id from state trait
     pub operation_id: OperationId,
+    // TODO: state being a key... seems ... risky?
     pub state: DynState,
 }
 
@@ -932,11 +1047,22 @@ impl ::fedimint_core::db::DatabaseLookup for InactiveStateKeyPrefix {
 enum ActiveOrInactiveState {
     Active {
         dyn_state: DynState,
-        active_state: ActiveState,
+        // TODO: remove?
+        #[allow(dead_code)]
+        meta: ActiveState,
     },
     Inactive {
         dyn_state: DynState,
     },
+}
+
+impl ActiveOrInactiveState {
+    fn is_active(&self) -> bool {
+        match self {
+            ActiveOrInactiveState::Active { .. } => true,
+            ActiveOrInactiveState::Inactive { .. } => false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -960,7 +1086,7 @@ mod tests {
     use crate::sm::{Executor, Notifier, State, StateTransition};
     use crate::DynGlobalClientContext;
 
-    #[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+    #[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Hash)]
     enum MockStateMachine {
         Start,
         ReceivedNonNull(u64),
@@ -1076,11 +1202,14 @@ mod tests {
                 broadcast: broadcast.clone(),
             },
         );
-        let executor = executor_builder
+        let (executor, sm_update_rx) = executor_builder
             .build(db.clone(), Notifier::new(db.clone()))
             .await;
         executor
-            .start_executor(Arc::new(|_, _| DynGlobalClientContext::new_fake()))
+            .start_executor(
+                Arc::new(|_, _| DynGlobalClientContext::new_fake()),
+                sm_update_rx,
+            )
             .await;
 
         info!("Initialized test executor");

--- a/fedimint-client/src/transaction/sm.rs
+++ b/fedimint-client/src/transaction/sm.rs
@@ -43,7 +43,7 @@ impl IntoDynInstance for TxSubmissionContext {
 ///     Created -- tx is accepted by consensus --> Accepted
 ///     Created -- tx is rejected on submission --> Rejected
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum TxSubmissionStates {
     /// The transaction has been created and potentially already been submitted,
     /// but no rejection or acceptance happened so far

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -55,7 +55,7 @@ pub mod backup;
 /// submitted the transaction's ID can be used as operation ID. If there is no
 /// transaction related to it, it should be generated randomly. Since it is a
 /// 256bit value collisions are impossible for all intents and purposes.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable, PartialOrd, Ord)]
 pub struct OperationId(pub [u8; 32]);
 
 impl OperationId {

--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -21,6 +21,7 @@ pub const LOG_TEST: &str = "test";
 pub const LOG_TIMING: &str = "timing";
 pub const LOG_WALLET: &str = "wallet";
 pub const LOG_CLIENT: &str = "client";
+pub const LOG_CLIENT_REACTOR: &str = "client::reactor";
 pub const LOG_CLIENT_NET_API: &str = "client::net::api";
 pub const LOG_CLIENT_BACKUP: &str = "client::backup";
 pub const LOG_CLIENT_RECOVERY: &str = "client::recovery";

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -416,8 +416,7 @@ where
                 match maybe_msg {
                     Ok(msg) => {
                         if self.our_id == PeerId::from(0) {
-
-                            debug!(target: LOG_NET_PEER, our_id = ?self.our_id, peer = ?self.peer_id, ?msg, "OUT");
+                            trace!(target: LOG_NET_PEER, our_id = ?self.our_id, peer = ?self.peer_id, ?msg, "OUT");
                         }
                         self.send_message_connected(connected, PeerMessage::Message(msg))
                             .await
@@ -451,7 +450,7 @@ where
             },
             Some(message_res) = connected.connection.next() => {
                 if self.peer_id == PeerId::from(0) {
-                    debug!(target: LOG_NET_PEER, our_id = ?self.our_id, peer = ?self.peer_id, "IN");
+                    trace!(target: LOG_NET_PEER, our_id = ?self.our_id, peer = ?self.peer_id, "IN");
                 }
                 match message_res {
                     Ok(peer_message) => {

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -415,6 +415,10 @@ where
             maybe_msg = self.outgoing.recv() => {
                 match maybe_msg {
                     Ok(msg) => {
+                        if self.our_id == PeerId::from(0) {
+
+                            debug!(target: LOG_NET_PEER, our_id = ?self.our_id, peer = ?self.peer_id, ?msg, "OUT");
+                        }
                         self.send_message_connected(connected, PeerMessage::Message(msg))
                             .await
                     },
@@ -446,6 +450,9 @@ where
                 PeerConnectionState::Connected(connected)
             },
             Some(message_res) = connected.connection.next() => {
+                if self.peer_id == PeerId::from(0) {
+                    debug!(target: LOG_NET_PEER, our_id = ?self.our_id, peer = ?self.peer_id, "IN");
+                }
                 match message_res {
                     Ok(peer_message) => {
                         if let PeerMessage::Message(msg) = peer_message {

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -562,6 +562,7 @@ where
             },
             () = tokio::time::sleep_until(disconnected.reconnect_at), if self.our_id < self.peer_id => {
                 // to prevent "reconnection ping-pongs", only the side with lower PeerId is responsible for reconnecting
+                debug!(target: LOG_NET_PEER, our_id = %self.our_id, peer_id = %self.peer_id, "Reconnecting to peer after timeout");
                 self.reconnect(disconnected).await
             },
             _ = task_handle.make_shutdown_rx().await => {

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -23,7 +23,9 @@ use crate::gateway_lnrpc::{
 
 pub const MAX_LIGHTNING_RETRIES: u32 = 10;
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,
+)]
 pub enum LightningRpcError {
     #[error("Failed to connect to Lightning node")]
     FailedToConnect,

--- a/gateway/ln-gateway/src/state_machine/complete.rs
+++ b/gateway/ln-gateway/src/state_machine/complete.rs
@@ -38,7 +38,7 @@ pub enum CompleteHtlcError {
 ///    CompleteHtlc -- successfully completed or canceled htlc --> HtlcFinished
 ///    CompleteHtlc -- failed to finish htlc --> Failure
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum GatewayCompleteStates {
     WaitForPreimage(WaitForPreimageState),
     CompleteHtlc(CompleteHtlcState),
@@ -46,14 +46,14 @@ pub enum GatewayCompleteStates {
     Failure,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct GatewayCompleteCommon {
     pub operation_id: OperationId,
     pub incoming_chan_id: u64,
     pub htlc_id: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct GatewayCompleteStateMachine {
     pub common: GatewayCompleteCommon,
     pub state: GatewayCompleteStates,
@@ -83,7 +83,7 @@ impl State for GatewayCompleteStateMachine {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct WaitForPreimageState;
 
 impl WaitForPreimageState {
@@ -148,13 +148,13 @@ impl WaitForPreimageState {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum HtlcOutcome {
     Success(Preimage),
     Failure(String),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct CompleteHtlcState {
     outcome: HtlcOutcome,
 }

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -624,7 +624,7 @@ impl GatewayClientModule {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum GatewayClientStateMachines {
     Pay(GatewayPayStateMachine),
     Receive(IncomingStateMachine),

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -48,7 +48,7 @@ use crate::GatewayState;
 ///    CancelContract -- cancel tx submission successful --> Canceled
 ///    CancelContract -- cancel tx submission unsuccessful --> Failed
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub enum GatewayPayStates {
     PayInvoice(GatewayPayInvoice),
     CancelContract(Box<GatewayPayCancelContract>),
@@ -67,12 +67,12 @@ pub enum GatewayPayStates {
     },
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayCommon {
     pub operation_id: OperationId,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayStateMachine {
     pub common: GatewayPayCommon,
     pub state: GatewayPayStates,
@@ -118,7 +118,9 @@ impl State for GatewayPayStateMachine {
     }
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,
+)]
 pub enum OutgoingContractError {
     #[error("Invalid OutgoingContract {contract_id}")]
     InvalidOutgoingContract { contract_id: ContractId },
@@ -138,7 +140,9 @@ pub enum OutgoingContractError {
     InvoiceExpired(u64),
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,
+)]
 pub enum OutgoingPaymentErrorType {
     #[error("OutgoingContract does not exist {contract_id}")]
     OutgoingContractDoesNotExist { contract_id: ContractId },
@@ -152,7 +156,9 @@ pub enum OutgoingPaymentErrorType {
     InvoiceAlreadyPaid,
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq, Hash,
+)]
 pub struct OutgoingPaymentError {
     error_type: OutgoingPaymentErrorType,
     contract_id: ContractId,
@@ -165,7 +171,7 @@ impl Display for OutgoingPaymentError {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayInvoice {
     pub pay_invoice_payload: PayInvoicePayload,
 }
@@ -634,7 +640,7 @@ pub struct PaymentParameters {
     payment_data: PaymentData,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayClaimOutgoingContract {
     contract: OutgoingContractAccount,
     preimage: Preimage,
@@ -689,7 +695,7 @@ impl GatewayPayClaimOutgoingContract {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayWaitForSwapPreimage {
     contract: OutgoingContractAccount,
     federation_id: FederationId,
@@ -817,7 +823,7 @@ impl GatewayPayWaitForSwapPreimage {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayCancelContract {
     contract: OutgoingContractAccount,
     error: OutgoingPaymentError,

--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -18,7 +18,7 @@ use crate::{get_funds, DummyClientContext};
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// Tracks a transaction
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum DummyStateMachine {
     Input(Amount, TransactionId, OperationId),
     Output(Amount, TransactionId, OperationId),

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -44,7 +44,7 @@ use crate::{set_payment_result, LightningClientContext, PayType};
 ///    DecryptingPreimage -- invalid preimage --> RefundSubmitted
 ///    DecryptingPreimage -- error decrypting preimage --> Failure
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum IncomingSmStates {
     FundingOffer(FundingOfferState),
     DecryptingPreimage(DecryptingPreimageState),
@@ -59,14 +59,14 @@ pub enum IncomingSmStates {
     Failure(String),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct IncomingSmCommon {
     pub operation_id: OperationId,
     pub contract_id: ContractId,
     pub payment_hash: sha256::Hash,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct IncomingStateMachine {
     pub common: IncomingSmCommon,
     pub state: IncomingSmStates,
@@ -96,7 +96,9 @@ impl State for IncomingStateMachine {
     }
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Serialize, Deserialize, Encodable, Decodable, Hash, Clone, Eq, PartialEq,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum IncomingSmError {
     #[error("Violated fee policy. Offer amount {offer_amount} Payment amount: {payment_amount}")]
@@ -126,7 +128,7 @@ pub enum IncomingSmError {
     AmountError { invoice: Bolt11Invoice },
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct FundingOfferState {
     pub txid: TransactionId,
 }
@@ -211,7 +213,7 @@ impl FundingOfferState {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct DecryptingPreimageState {
     txid: TransactionId,
 }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1402,7 +1402,7 @@ impl LightningClientModule {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum LightningClientStateMachines {
     InternalPay(IncomingStateMachine),
     LightningPay(LightningPayStateMachine),

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -46,7 +46,7 @@ const RETRY_DELAY: Duration = Duration::from_secs(1);
 ///  Refund -- await transaction rejected --> Failure
 /// ```
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum LightningPayStates {
     CreatedOutgoingLnContract(LightningPayCreatedOutgoingLnContract),
     Canceled,
@@ -58,7 +58,7 @@ pub enum LightningPayStates {
     Failure(String),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayCommon {
     pub operation_id: OperationId,
     pub federation_id: FederationId,
@@ -68,7 +68,7 @@ pub struct LightningPayCommon {
     pub invoice: lightning_invoice::Bolt11Invoice,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayStateMachine {
     pub common: LightningPayCommon,
     pub state: LightningPayStates,
@@ -111,7 +111,7 @@ impl State for LightningPayStateMachine {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayCreatedOutgoingLnContract {
     pub funding_txid: TransactionId,
     pub contract_id: ContractId,
@@ -239,14 +239,16 @@ impl LightningPayCreatedOutgoingLnContract {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayFunded {
     payload: PayInvoicePayload,
     gateway: LightningGateway,
     timelock: u32,
 }
 
-#[derive(Error, Debug, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq)]
+#[derive(
+    Error, Debug, Hash, Serialize, Deserialize, Encodable, Decodable, Clone, Eq, PartialEq,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum GatewayPayError {
     #[error("Lightning Gateway failed to pay invoice. ErrorCode: {error_code:?} ErrorMessage: {error_message}")]
@@ -385,7 +387,7 @@ impl LightningPayFunded {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayRefundable {
     contract_id: ContractId,
     pub block_timelock: u32,
@@ -499,7 +501,7 @@ impl LightningPayRefundable {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningPayRefund {
     txid: TransactionId,
     out_points: Vec<OutPoint>,
@@ -563,7 +565,7 @@ impl LightningPayRefund {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Decodable, Encodable)]
 pub struct PayInvoicePayload {
     pub federation_id: FederationId,
     pub contract_id: ContractId,
@@ -596,7 +598,7 @@ impl PayInvoicePayload {
 
 /// Data needed to pay an invoice, may be the whole invoice or only the required
 /// parts of it.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Decodable, Encodable)]
 #[serde(rename_all = "snake_case")]
 pub enum PaymentData {
     Invoice(Bolt11Invoice),

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -36,7 +36,7 @@ const RETRY_DELAY: Duration = Duration::from_secs(1);
 ///     Funded -- await claim tx acceptance --> Success
 ///     Funded -- await claim tx rejection --> Canceled
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum LightningReceiveStates {
     SubmittedOffer(LightningReceiveSubmittedOffer),
     Canceled(LightningReceiveError),
@@ -45,7 +45,7 @@ pub enum LightningReceiveStates {
     Success(Vec<OutPoint>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningReceiveStateMachine {
     pub operation_id: OperationId,
     pub state: LightningReceiveStates,
@@ -83,14 +83,16 @@ impl State for LightningReceiveStateMachine {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningReceiveSubmittedOffer {
     pub offer_txid: TransactionId,
     pub invoice: Bolt11Invoice,
     pub payment_keypair: KeyPair,
 }
 
-#[derive(Error, Clone, Debug, Serialize, Deserialize, Encodable, Decodable, Eq, PartialEq)]
+#[derive(
+    Error, Clone, Debug, Serialize, Deserialize, Encodable, Decodable, Eq, PartialEq, Hash,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum LightningReceiveError {
     #[error("Offer transaction was rejected")]
@@ -158,7 +160,7 @@ impl LightningReceiveSubmittedOffer {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningReceiveConfirmedInvoice {
     invoice: Bolt11Invoice,
     keypair: KeyPair,
@@ -308,7 +310,7 @@ async fn get_incoming_contract(
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningReceiveFunded {
     txid: TransactionId,
     out_points: Vec<OutPoint>,

--- a/modules/fedimint-ln-common/src/contracts/incoming.rs
+++ b/modules/fedimint-ln-common/src/contracts/incoming.rs
@@ -114,7 +114,7 @@ impl Decodable for OfferId {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub struct IncomingContractAccount {
     pub amount: Amount,
     pub contract: IncomingContract,

--- a/modules/fedimint-ln-common/src/contracts/outgoing.rs
+++ b/modules/fedimint-ln-common/src/contracts/outgoing.rs
@@ -53,13 +53,13 @@ impl OutgoingContract {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub struct OutgoingContractData {
     pub recovery_key: bitcoin::KeyPair,
     pub contract_account: OutgoingContractAccount,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Encodable, Decodable, Serialize, Deserialize)]
 pub struct OutgoingContractAccount {
     pub amount: Amount,
     pub contract: OutgoingContract,

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -647,7 +647,7 @@ pub async fn ln_operation(
 ///
 /// This is a subset of the data from a [`lightning_invoice::Bolt11Invoice`]
 /// that does not contain the description, which increases privacy for the user.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Decodable, Encodable)]
 pub struct PrunedInvoice {
     pub amount: Amount,
     pub destination: secp256k1::PublicKey,

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -23,7 +23,7 @@ use crate::{MintClientContext, MintClientStateMachines, SpendableNote};
 ///     Refund -- refund tx rejected --> Error
 ///     Refund -- refund tx accepted --> RS[Refund Success]
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum MintInputStates {
     Created(MintInputStateCreated),
     Refund(MintInputStateRefund),
@@ -32,14 +32,14 @@ pub enum MintInputStates {
     RefundSuccess(MintInputStateRefundSuccess),
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, Decodable, Encodable)]
 pub struct MintInputCommon {
     pub(crate) operation_id: OperationId,
     pub(crate) txid: TransactionId,
     pub(crate) input_idx: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateMachine {
     pub(crate) common: MintInputCommon,
     pub(crate) state: MintInputStates,
@@ -73,7 +73,7 @@ impl State for MintInputStateMachine {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateCreated {
     pub(crate) amount: Amount,
     pub(crate) spendable_note: SpendableNote,
@@ -158,7 +158,7 @@ impl MintInputStateCreated {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateRefund {
     refund_txid: TransactionId,
 }
@@ -218,15 +218,15 @@ impl MintInputStateRefund {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateSuccess {}
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateError {
     error: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateRefundSuccess {
     refund_txid: TransactionId,
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1496,7 +1496,7 @@ impl std::fmt::Display for InsufficientBalanceError {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum MintClientStateMachines {
     Output(MintOutputStateMachine),
     Input(MintInputStateMachine),

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -23,7 +23,7 @@ use crate::{MintClientContext, MintClientStateMachines, SpendableNote};
 ///     Created -- User triggered refund --> RefundU["User Refund"]
 ///     Created -- Timeout triggered refund --> RefundT["Timeout Refund"]
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum MintOOBStates {
     /// The e-cash has been taken out of the wallet and we are waiting for the
     /// recipient to reissue it or the user to trigger a refund.
@@ -36,25 +36,25 @@ pub enum MintOOBStates {
     TimeoutRefund(MintOOBStatesTimeoutRefund),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintOOBStateMachine {
     pub(crate) operation_id: OperationId,
     pub(crate) state: MintOOBStates,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintOOBStatesCreated {
     pub(crate) amount: Amount,
     pub(crate) spendable_note: SpendableNote,
     pub(crate) timeout: SystemTime,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintOOBStatesUserRefund {
     pub(crate) refund_txid: TransactionId,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintOOBStatesTimeoutRefund {
     pub(crate) refund_txid: TransactionId,
 }

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -33,7 +33,7 @@ const TRANSACTION_STATUS_FETCH_INTERVAL: Duration = Duration::from_secs(1);
 ///     AwaitingConfirmations -- "Retransmit seen tx (planned)" --> AwaitingConfirmations
 ///     Created -- "No transactions seen for [time]" --> Timeout["Timed out"]
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct DepositStateMachine {
     pub(crate) operation_id: OperationId,
     pub(crate) state: DepositStates,
@@ -303,7 +303,7 @@ async fn transition_btc_tx_confirmed(
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum DepositStates {
     Created(CreatedDepositState),
     WaitingForConfirmations(WaitingForConfirmationsDepositState),
@@ -311,13 +311,13 @@ pub enum DepositStates {
     TimedOut(TimedOutDepositState),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct CreatedDepositState {
     pub(crate) tweak_key: KeyPair,
     pub(crate) timeout_at: SystemTime,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct WaitingForConfirmationsDepositState {
     /// Key pair of which the public was used to tweak the federation's wallet
     /// descriptor. The secret key is later used to sign the fedimint claim
@@ -330,12 +330,12 @@ pub struct WaitingForConfirmationsDepositState {
     pub(crate) out_idx: u32,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct ClaimingDepositState {
     /// Fedimint transaction id in which the deposit is being claimed.
     pub(crate) transaction_id: TransactionId,
     pub(crate) change: Vec<OutPoint>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct TimedOutDepositState {}

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -682,7 +682,7 @@ async fn get_next_peg_in_tweak_child_id(dbtx: &mut DatabaseTransaction<'_>) -> C
     ChildId(index)
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum WalletClientStates {
     Deposit(DepositStateMachine),
     Withdraw(WithdrawStateMachine),

--- a/modules/fedimint-wallet-client/src/withdraw.rs
+++ b/modules/fedimint-wallet-client/src/withdraw.rs
@@ -19,7 +19,7 @@ const RETRY_DELAY: Duration = Duration::from_secs(1);
 /// graph LR
 ///     Created --> Success
 ///     Created --> Aborted
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct WithdrawStateMachine {
     pub(crate) operation_id: OperationId,
     pub(crate) state: WithdrawStates,
@@ -122,24 +122,24 @@ async fn transition_withdraw_processed(
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub enum WithdrawStates {
     Created(CreatedWithdrawState),
     Success(SuccessWithdrawState),
     Aborted(AbortedWithdrawState),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct CreatedWithdrawState {
     pub(crate) fm_outpoint: OutPoint,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct SuccessWithdrawState {
     pub(crate) txid: Txid,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct AbortedWithdrawState {
     pub(crate) error: String,
 }


### PR DESCRIPTION
repro esily with:

```
env RUST_LOG=debug TEST_ARGS="out_of_band_cancel --no-capture" ./scripts/tests/backend-test.sh
```

(might new few tries if you're lucky).

What will you see:

When things go OK, logs are relatively quiet.

When the randomized  error is introduced comms are going crazy. I added IN and OUT logs and seems like communidation between peers is working, just there's tons of traffic and things just getting stuck, in particular given that error has a higher chance of being introduced the more traffic is going through the connection, possibly re-introducing the reason for problems periodically.

Notably without [refactor: improve client executor loop](https://github.com/fedimint/fedimint/pull/4250/commits/0fdd33da0684c725e5bf7f56d7cc7dc409bf9a22), the problem seems gone. Which is weird - it should be strictly client-side chagne. It's unclear to me if there's a bug there introducing a problem, or could it be that more aggressive state machine execution is either overloading consensus or something else entirely.

**Edit**:

In [c82edbf](https://github.com/fedimint/fedimint/pull/4250/commits/c82edbf389bba06c68aca06e761450180378543e) I made sure that after initial failures the peers have time to recover any communication without further failures. But it doesn't help. The test fails like all other times anyway.

I wonder/suspect that either something about aleph item period/timeouts is wrong, or it has a bug.