### PR TITLE
fix: remove random timeout from download of client config

### DIFF
--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -628,7 +628,7 @@ where
     ) -> FederationResult<ClientConfig> {
         // we have to download the api endpoints first
         let id = invite_code.federation_id();
-        let qs = FilterMap::new(
+        let query_strategy = FilterMap::new(
             move |cfg: ClientConfig| {
                 if id.0 != cfg.global.api_endpoints.consensus_hash() {
                     bail!("Guardian api endpoint map does not hash to FederationId")
@@ -637,13 +637,11 @@ where
                 Ok(cfg.global.api_endpoints)
             },
             self.all_peers().total(),
-        )
-        // downloading the endpoints shouldn't take too long
-        .with_request_timeout(Duration::from_secs(5));
+        );
 
         let api_endpoints = self
             .request_with_strategy(
-                qs,
+                query_strategy,
                 CLIENT_CONFIG_ENDPOINT.to_owned(),
                 ApiRequestErased::default(),
             )

--- a/fedimint-core/src/query.rs
+++ b/fedimint-core/src/query.rs
@@ -26,41 +26,6 @@ pub trait QueryStrategy<IR, OR = IR> {
         None
     }
     fn process(&mut self, peer_id: PeerId, response: api::PeerResult<IR>) -> QueryStep<OR>;
-
-    fn with_request_timeout(
-        self,
-        timeout: Duration,
-    ) -> QueryStrategyWithRequestTimeout<Self, IR, OR>
-    where
-        Self: Sized,
-    {
-        QueryStrategyWithRequestTimeout {
-            inner: self,
-            timeout,
-            _ir: std::marker::PhantomData,
-            _or: std::marker::PhantomData,
-        }
-    }
-}
-
-/// Wraps a strategy `S` and adds a timeout to each call
-pub struct QueryStrategyWithRequestTimeout<S, IR, OR> {
-    inner: S,
-    timeout: Duration,
-    _ir: std::marker::PhantomData<IR>,
-    _or: std::marker::PhantomData<OR>,
-}
-
-impl<IR, OR, S> QueryStrategy<IR, OR> for QueryStrategyWithRequestTimeout<S, IR, OR>
-where
-    S: QueryStrategy<IR, OR>,
-{
-    fn process(&mut self, peer_id: PeerId, response: api::PeerResult<IR>) -> QueryStep<OR> {
-        self.inner.process(peer_id, response)
-    }
-    fn request_timeout(&self) -> Option<Duration> {
-        Some(self.timeout)
-    }
 }
 
 /// Results from the strategy handling a response from a peer


### PR DESCRIPTION
We remove the timeout since this is the only place were we use such a timeout and therefore its unexpected behaviour, especially in a generally async system. If we want to timeout the download of the client config we should do so explicitly by wrapping either try_download_client_config or FederationInfo::from_invite_code with a timeout instead of somewhere in the middle.