### PR TITLE
chore: gateway integration tests use select_client, not remove_client

### DIFF
--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -219,7 +219,7 @@ async fn test_gateway_can_pay_ldk_node() -> anyhow::Result<()> {
         )
         .await?;
 
-        let gateway = gateway.remove_client(&fed).await;
+        let gateway = gateway.select_client(fed.id()).await;
         // Print money for user_client
         let dummy_module = user_client.get_first_module::<DummyClientModule>();
         let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
@@ -242,7 +242,7 @@ async fn test_gateway_can_pay_ldk_node() -> anyhow::Result<()> {
 async fn test_gateway_client_pay_valid_invoice() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.select_client(fed.id()).await;
             // Print money for user_client
             let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
@@ -293,7 +293,7 @@ async fn test_can_change_routing_fees() -> anyhow::Result<()> {
             // Create test invoice
             let invoice = other_lightning_client.invoice(sats(250), None).await?;
 
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.select_client(fed.id()).await;
             pay_valid_invoice(invoice, &user_client, &gateway).await?;
 
             assert_eq!(
@@ -312,7 +312,7 @@ async fn test_can_change_routing_fees() -> anyhow::Result<()> {
 async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.select_client(fed.id()).await;
             // Print money for user_client
             let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
@@ -378,7 +378,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
 async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.select_client(fed.id()).await;
             // Print money for user client
             let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let lightning_module = user_client.get_first_module::<LightningClientModule>();
@@ -442,7 +442,7 @@ async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
     single_federation_test(|gateway, _, fed, user_client, _| async move {
-        let gateway = gateway.remove_client(&fed).await;
+        let gateway = gateway.select_client(fed.id()).await;
         // Print money for gateway client
         let initial_gateway_balance = sats(1000);
         let dummy_module = gateway.get_first_module::<DummyClientModule>();
@@ -499,7 +499,7 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_client_intercept_offer_does_not_exist() -> anyhow::Result<()> {
     single_federation_test(|gateway, _, fed, _, _| async move {
-        let gateway = gateway.remove_client(&fed).await;
+        let gateway = gateway.select_client(fed.id()).await;
         // Print money for gateway client
         let initial_gateway_balance = sats(1000);
         let dummy_module = gateway.get_first_module::<DummyClientModule>();
@@ -537,7 +537,7 @@ async fn test_gateway_client_intercept_offer_does_not_exist() -> anyhow::Result<
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_client_intercept_htlc_no_funds() -> anyhow::Result<()> {
     single_federation_test(|gateway, _, fed, user_client, _| async move {
-        let gateway = gateway.remove_client(&fed).await;
+        let gateway = gateway.select_client(fed.id()).await;
         // User client creates invoice in federation
         let (_invoice_op, invoice, _) = user_client
             .get_first_module::<LightningClientModule>()
@@ -579,7 +579,7 @@ async fn test_gateway_client_intercept_htlc_no_funds() -> anyhow::Result<()> {
 async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.select_client(fed.id()).await;
             // Print money for gateway client
             let initial_gateway_balance = sats(1000);
             let gateway_dummy_module = gateway.get_first_module::<DummyClientModule>();
@@ -740,7 +740,7 @@ async fn test_gateway_register_with_federation() -> anyhow::Result<()> {
 async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.select_client(fed.id()).await;
             let invoice = other_lightning_client
                 .invoice(sats(1000), 1.into())
                 .await


### PR DESCRIPTION
`remove_client()` is confusing. I spent a while wondering why cilents were being removed from the gateway. But I don't think we actually mean to remove this client from the gateway at all -- just to use it.