### PR TITLE
test: gateway short channel id assignments

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -160,9 +160,10 @@ async fn main() -> anyhow::Result<()> {
             print_response(response).await;
         }
         Commands::LeaveFed { federation_id } => {
-            client()
+            let response = client()
                 .leave_federation(LeaveFedPayload { federation_id })
                 .await?;
+            print_response(response).await;
         }
         Commands::Backup { federation_id } => {
             client().backup(BackupPayload { federation_id }).await?;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1229,6 +1229,12 @@ impl Gateway {
             .into_value();
 
         client.wait_until_fully_dropped().await;
+
+        // Remove previously assigned scid from `scid_to_federation` map
+        self.scid_to_federation
+            .write()
+            .await
+            .retain(|_, fid| *fid != federation_id);
         Ok(())
     }
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -689,6 +689,7 @@ impl Gateway {
 
             return Ok(GatewayInfo {
                 federations,
+                channels: Some(self.scid_to_federation.read().await.clone()),
                 version_hash: fedimint_build_code_version_env!().to_string(),
                 lightning_pub_key: Some(lightning_context.lightning_public_key.to_hex()),
                 lightning_alias: Some(lightning_context.lightning_alias.clone()),
@@ -702,6 +703,7 @@ impl Gateway {
 
         Ok(GatewayInfo {
             federations: vec![],
+            channels: None,
             version_hash: fedimint_build_code_version_env!().to_string(),
             lightning_pub_key: None,
             lightning_alias: None,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -86,8 +86,9 @@ use crate::rpc::{
 };
 use crate::state_machine::GatewayExtPayStates;
 
-/// LND HTLC interceptor can't handle SCID of 0, so start from 1
-pub const INITIAL_SCID: u64 = 1;
+/// This initial SCID is considered invalid by LND HTLC interceptor,
+/// So we should always increment the value before assigning a new SCID.
+pub const INITIAL_SCID: u64 = 0;
 
 /// How long a gateway announcement stays valid
 pub const GW_ANNOUNCEMENT_TTL: Duration = Duration::from_secs(600);
@@ -873,17 +874,12 @@ impl Gateway {
             let invite_code = InviteCode::from_str(&payload.invite_code).map_err(|e| {
                 GatewayError::InvalidMetadata(format!("Invalid federation member string {e:?}"))
             })?;
+            let federation_id = invite_code.federation_id();
 
             let _join_federation = self.client_joining_lock.lock().await;
 
             // Check if this federation has already been registered
-            if self
-                .clients
-                .read()
-                .await
-                .get(&invite_code.federation_id())
-                .is_some()
-            {
+            if self.clients.read().await.get(&federation_id).is_some() {
                 return Err(GatewayError::FederationAlreadyConnected);
             }
 
@@ -905,7 +901,6 @@ impl Gateway {
                     ))?;
             *max_used_scid = mint_channel_id;
 
-            let federation_id = invite_code.federation_id();
             let gw_client_cfg = FederationConfig {
                 invite_code,
                 mint_channel_id,
@@ -926,7 +921,14 @@ impl Gateway {
                 .build(gw_client_cfg.clone(), self.clone())
                 .await?;
 
-            let federation_info = self.make_federation_info(&client, federation_id).await;
+            // Instead of using `make_federation_info`, we manually create federation info
+            // here because short channel id is not yet persisted
+            let federation_info = FederationInfo {
+                federation_id,
+                balance_msat: client.get_balance().await,
+                config: client.get_config().clone(),
+                channel_id: Some(mint_channel_id),
+            };
 
             self.check_federation_network(&federation_info, gateway_config.network)
                 .await?;
@@ -958,6 +960,7 @@ impl Gateway {
             self.client_builder
                 .save_config(gw_client_cfg.clone(), dbtx)
                 .await?;
+            debug!("Federation with ID: {federation_id} connected and assigned channel id: {mint_channel_id}");
 
             return Ok(federation_info);
         }
@@ -1391,11 +1394,24 @@ impl Gateway {
     ) -> FederationInfo {
         let balance_msat = client.get_balance().await;
         let config = client.get_config().clone();
+        let channel_id = self
+            .scid_to_federation
+            .read()
+            .await
+            .iter()
+            .find_map(|(scid, fid)| {
+                if *fid == federation_id {
+                    Some(*scid)
+                } else {
+                    None
+                }
+            });
 
         FederationInfo {
             federation_id,
             balance_msat,
             config,
+            channel_id,
         }
     }
 

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -70,6 +70,7 @@ pub struct FederationInfo {
 pub struct GatewayInfo {
     pub version_hash: String,
     pub federations: Vec<FederationInfo>,
+    pub channels: Option<BTreeMap<u64, FederationId>>,
     pub lightning_pub_key: Option<String>,
     pub lightning_alias: Option<String>,
     #[serde(with = "serde_option_routing_fees")]

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -63,6 +63,7 @@ pub struct FederationInfo {
     pub federation_id: FederationId,
     pub balance_msat: Amount,
     pub config: ClientConfig,
+    pub channel_id: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -83,7 +83,10 @@ impl GatewayRpcClient {
         self.call_post(url, payload).await
     }
 
-    pub async fn leave_federation(&self, payload: LeaveFedPayload) -> GatewayRpcResult<()> {
+    pub async fn leave_federation(
+        &self,
+        payload: LeaveFedPayload,
+    ) -> GatewayRpcResult<FederationInfo> {
         let url = self.base_url.join("/leave-fed").expect("invalid base url");
         self.call_post(url, payload).await
     }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -183,8 +183,8 @@ async fn leave_fed(
     Extension(mut gateway): Extension<Gateway>,
     Json(payload): Json<LeaveFedPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    gateway.handle_leave_federation(payload).await?;
-    Ok(Json(json!(())))
+    let fed = gateway.handle_leave_federation(payload).await?;
+    Ok(Json(json!(fed)))
 }
 
 /// Backup a gateway actor state

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -1234,7 +1234,7 @@ async fn test_gateway_can_leave_connected_federations() -> anyhow::Result<()> {
             assert_eq!(info.federations.len(), 2);
             assert_eq!(
                 info.channels.unwrap().keys().cloned().collect::<Vec<u64>>(),
-                vec![1, 2, 3, 4]
+                vec![3, 4]
             );
 
             drop(gateway); // keep until the end to avoid the gateway shutting down too early

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -1232,6 +1232,10 @@ async fn test_gateway_can_leave_connected_federations() -> anyhow::Result<()> {
 
             let info = rpc.get_info().await.unwrap();
             assert_eq!(info.federations.len(), 2);
+            assert_eq!(
+                info.channels.unwrap().keys().cloned().collect::<Vec<u64>>(),
+                vec![1, 2, 3, 4]
+            );
 
             drop(gateway); // keep until the end to avoid the gateway shutting down too early
             Ok(())

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -1175,8 +1175,11 @@ async fn test_gateway_can_leave_connected_federations() -> anyhow::Result<()> {
         |gateway, rpc, fed1, fed2, _| async move {
             assert_eq!(rpc.get_info().await.unwrap().federations.len(), 0);
 
-            let id1 = fed1.invite_code().federation_id();
-            let id2 = fed2.invite_code().federation_id();
+            let invite1 = fed1.invite_code();
+            let invite2 = fed2.invite_code();
+
+            let id1 = invite1.federation_id();
+            let id2 = invite2.federation_id();
 
             connect_federations(&rpc, &[fed1, fed2]).await.unwrap();
 
@@ -1185,11 +1188,11 @@ async fn test_gateway_can_leave_connected_federations() -> anyhow::Result<()> {
             assert!(info
                 .federations
                 .iter()
-                .any(|info| info.federation_id == id1 && info.balance_msat == Amount::ZERO));
+                .any(|info| info.federation_id == id1 && info.channel_id == Some(1)));
             assert!(info
                 .federations
                 .iter()
-                .any(|info| info.federation_id == id2 && info.balance_msat == Amount::ZERO));
+                .any(|info| info.federation_id == id2 && info.channel_id == Some(2)));
 
             // remove first connected federation
             let fed_info = rpc
@@ -1197,6 +1200,17 @@ async fn test_gateway_can_leave_connected_federations() -> anyhow::Result<()> {
                 .await
                 .unwrap();
             assert_eq!(fed_info.federation_id, id1);
+            assert_eq!(fed_info.channel_id, Some(1));
+
+            // reconnect the first federation
+            let fed_info = rpc
+                .connect_federation(ConnectFedPayload {
+                    invite_code: invite1.to_string(),
+                })
+                .await
+                .unwrap();
+            assert_eq!(fed_info.federation_id, id1);
+            assert_eq!(fed_info.channel_id, Some(3));
 
             // remove second connected federation
             let fed_info = rpc
@@ -1204,9 +1218,20 @@ async fn test_gateway_can_leave_connected_federations() -> anyhow::Result<()> {
                 .await
                 .unwrap();
             assert_eq!(fed_info.federation_id, id2);
+            assert_eq!(fed_info.channel_id, Some(2));
+
+            // reconnect the second federation
+            let fed_info = rpc
+                .connect_federation(ConnectFedPayload {
+                    invite_code: invite2.to_string(),
+                })
+                .await
+                .unwrap();
+            assert_eq!(fed_info.federation_id, id2);
+            assert_eq!(fed_info.channel_id, Some(4));
 
             let info = rpc.get_info().await.unwrap();
-            assert_eq!(info.federations.len(), 0);
+            assert_eq!(info.federations.len(), 2);
 
             drop(gateway); // keep until the end to avoid the gateway shutting down too early
             Ok(())


### PR DESCRIPTION
- adds coverage for short channel id assignments when federations are connected to gateway
- shows  each scid assignment info for each connected federation
- shows all scid assignments in gateway info. This includes scids assigned to federations that have since been removed
- sets const `INITIAL_SCID = 0` because we always increment the scid value before assignment.