### PR TITLE
chore: anti-flakiness spring offensive

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -168,7 +168,7 @@ jobs:
           nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --option keep-failed true --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).ci.ciTestAll
 
       - name: Tests (5 times more)
-        if: github.event_name == 'merge_group'
+        if: github.event_name == 'merge_group' && matrix.run-tests
         run: |
           nix build -L .#ci.ciTestAll5Times --keep-failed
 

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -167,6 +167,11 @@ jobs:
         run: |
           nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --option keep-failed true --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).ci.ciTestAll
 
+      - name: Tests (5 times more)
+        if: github.event_name == 'merge_group'
+        run: |
+          nix build -L .#ci.ciTestAll5Times --keep-failed
+
       - name: Wasm Tests
         if: (github.event_name != 'pull_request' || matrix.build-in-pr) && matrix.run-tests && (matrix.host != 'macos')
         run: nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --option keep-failed true  --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).wasm32-unknown.ci.wasmTest
@@ -253,6 +258,10 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: result/lcov.info
+
+      - name: Build and run tests with Code Coverage (5 times more)
+        if: github.event_name == 'merge_group'
+        run: nix build -L .#ci.workspaceTest5TimesCov
 
   cross:
     name: "Cross-compile on ${{ matrix.host }} to ${{ matrix.toolchain }}"

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -118,7 +118,7 @@ jobs:
           - host: linux
             runs-on: buildjet-8vcpu-ubuntu-2004
             build-in-pr: true
-            timeout: 60
+            timeout: 75
             run-tests: true
           - host: macos
             runs-on: macos-14

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -577,6 +577,10 @@ impl ClientWeak {
     pub fn upgrade(&self) -> Option<ClientArc> {
         Weak::upgrade(&self.inner).map(ClientArc::new)
     }
+
+    pub fn strong_count(&self) -> usize {
+        self.inner.strong_count()
+    }
 }
 
 /// We need a separate drop implementation for `Client` that triggers

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -121,6 +121,8 @@ use rand::thread_rng;
 use secp256k1_zkp::{PublicKey, Secp256k1};
 use secret::{DeriveableSecretClientExt, PlainRootSecretStrategy, RootSecretStrategy as _};
 use thiserror::Error;
+#[cfg(not(target_family = "wasm"))]
+use tokio::runtime::{Handle as RuntimeHandle, RuntimeFlavor};
 use tokio::sync::watch;
 use tracing::{debug, error, info, warn};
 
@@ -524,7 +526,7 @@ fn states_add_instance(
 #[derive(Debug)]
 pub struct ClientArc {
     // Use [`ClientArc::new`] instead
-    inner: Arc<Client>,
+    inner: Option<Arc<Client>>,
 
     __use_constructor_to_create: (),
 }
@@ -536,32 +538,61 @@ impl ClientArc {
             .client_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Self {
-            inner,
+            inner: Some(inner),
             // this is the constructor
             __use_constructor_to_create: (),
+        }
+    }
+
+    fn as_inner(&self) -> &Arc<Client> {
+        self.inner.as_ref().expect("Inner always set")
+    }
+
+    pub async fn start_executor(&self) {
+        self.as_inner().start_executor().await
+    }
+
+    /// Block for the `client` to no longer contain any strong references.
+    ///
+    /// Some parts of the code can temporarily clone client to perform some
+    /// actions. No further strong references guarantees that the `client`
+    /// is no longer used inside the system.
+    pub async fn wait_until_fully_dropped(self) {
+        let weak = self.downgrade();
+        drop(self);
+
+        for attempt in 0u64.. {
+            if Weak::strong_count(&weak.inner) == 0 {
+                break;
+            }
+            // we want to retry fast, give feedback, but not spam
+            if attempt % 100 == 0 {
+                info!("Waiting for ArcClient to stop being used");
+            }
+            fedimint_core::task::sleep(Duration::from_millis(10)).await;
         }
     }
 }
 
 impl ops::Deref for ClientArc {
-    type Target = Arc<Client>;
+    type Target = Client;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner.as_ref().expect("Must have inner client set")
     }
 }
 
 impl ClientArc {
     pub fn downgrade(&self) -> ClientWeak {
         ClientWeak {
-            inner: Arc::downgrade(&self.inner),
+            inner: Arc::downgrade(self.inner.as_ref().expect("Inner always set")),
         }
     }
 }
 
 impl Clone for ClientArc {
     fn clone(&self) -> Self {
-        ClientArc::new(self.inner.clone())
+        ClientArc::new(self.inner.clone().expect("Must have inner client set"))
     }
 }
 
@@ -587,7 +618,7 @@ impl Drop for ClientArc {
         // Not sure if Ordering::SeqCst is strictly needed here, but better safe than
         // sorry.
         let client_count = self
-            .inner
+            .as_inner()
             .client_count
             .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
 
@@ -595,7 +626,42 @@ impl Drop for ClientArc {
         // client reference
         if client_count == 1 {
             info!("Last client reference dropped, shutting down client task group");
-            self.inner.executor.stop_executor();
+            let inner = self.inner.take().expect("Must have inner client set");
+            inner.executor.stop_executor();
+
+            #[cfg(not(target_family = "wasm"))]
+            {
+                if RuntimeHandle::current().runtime_flavor() == RuntimeFlavor::CurrentThread {
+                    // We can't use block_on in single-threaded mode
+                    return;
+                }
+
+                let db = inner.db.clone();
+                let federation_id = inner.federation_id();
+
+                drop(inner);
+
+                // wait until `self.inner.db` is the only strong reference
+                for attempt in 0u64.. {
+                    let strong_count = db.strong_count();
+                    if strong_count <= 1 {
+                        break;
+                    }
+                    tokio::task::block_in_place(|| {
+                        futures::executor::block_on(async {
+                            // we want to retry fast, give feedback, but not spam
+                            if attempt % 100 == 0 {
+                                info!(
+                                    %federation_id,
+                                    strong_count,
+                                    "Waiting for client database to stop being used"
+                                );
+                            }
+                            fedimint_core::task::sleep(Duration::from_millis(10)).await;
+                        });
+                    });
+                }
+            }
         }
     }
 }
@@ -1783,7 +1849,7 @@ impl ClientBuilder {
 
         let client = self.build_stopped(root_secret, config).await?;
         if !stopped {
-            client.start_executor().await;
+            client.as_inner().start_executor().await;
         }
         Ok(client)
     }
@@ -1855,7 +1921,7 @@ impl ClientBuilder {
 
         let client = self.build_stopped(root_secret, config).await?;
         if !stopped {
-            client.start_executor().await;
+            client.as_inner().start_executor().await;
         }
         Ok(client)
     }

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -282,6 +282,10 @@ pub struct Database {
 }
 
 impl Database {
+    pub fn strong_count(&self) -> usize {
+        Arc::strong_count(&self.inner)
+    }
+
     pub fn into_inner(self) -> Arc<dyn IDatabase + 'static> {
         self.inner
     }

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -282,6 +282,12 @@ pub struct Database {
 }
 
 impl Database {
+    pub fn into_inner(self) -> Arc<dyn IDatabase + 'static> {
+        self.inner
+    }
+}
+
+impl Database {
     /// Creates a new Fedimint database from any object implementing
     /// [`IDatabase`].
     ///

--- a/fedimint-server/src/atomic_broadcast/spawner.rs
+++ b/fedimint-server/src/atomic_broadcast/spawner.rs
@@ -1,3 +1,6 @@
+use fedimint_logging::LOG_CONSENSUS;
+use tracing::warn;
+
 #[derive(Clone)]
 pub struct Spawner;
 
@@ -27,7 +30,9 @@ impl aleph_bft::SpawnHandle for Spawner {
 
         fedimint_core::task::spawn(name, async move {
             task.await;
-            res_tx.send(()).expect("We own the rx.");
+            if let Err(_err) = res_tx.send(()) {
+                warn!(target: LOG_CONSENSUS, "Unable to send essential spawned task completion. Are we shutting down?");
+            }
         });
 
         Box::pin(async move { res_rx.await.map_err(|_| ()) })

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -1167,6 +1167,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[ignore] // TODO: flaky https://github.com/fedimint/fedimint/issues/4308
     async fn test_restart_setup() {
         const PEER_NUM: u16 = 4;
         const PORTS_PER_PEER: u16 = 2;

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -1166,9 +1166,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_restart_setup() {
+        const PEER_NUM: u16 = 4;
         let _ = TracingSetup::default().init();
         let (data_dir, _maybe_tmp_dir_guard) = test_dir("test-restart-setup");
-        let base_port = port_alloc(1).unwrap();
+        let base_port = port_alloc(PEER_NUM * 2).unwrap();
 
         // let mut join_handles = vec![];
         let mut apis = vec![];
@@ -1177,7 +1178,7 @@ mod tests {
 
         apis.push(api);
 
-        for i in 1..4 {
+        for i in 1..PEER_NUM {
             let port = base_port + (i * 2);
             let (follower, api) = TestConfigApi::new(port, i, data_dir.clone()).await;
             apis.push(api);

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -1117,9 +1117,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_config_api() {
+        const PEER_NUM: u16 = 4;
+        const PORTS_PER_PEER: u16 = 2;
         let _ = TracingSetup::default().init();
         let (data_dir, _maybe_tmp_dir_guard) = test_dir("test-config-api");
-        let base_port = port_alloc(1).unwrap();
+        let base_port = port_alloc(PEER_NUM * PORTS_PER_PEER).unwrap();
 
         // let mut join_handles = vec![];
         let mut apis = vec![];
@@ -1128,8 +1130,8 @@ mod tests {
 
         apis.push(api);
 
-        for i in 1..4 {
-            let port = base_port + (i * 2);
+        for i in 1..PEER_NUM {
+            let port = base_port + (i * PORTS_PER_PEER);
             let (follower, api) = TestConfigApi::new(port, i, data_dir.clone()).await;
             apis.push(api);
             followers.push(follower);
@@ -1167,9 +1169,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_restart_setup() {
         const PEER_NUM: u16 = 4;
+        const PORTS_PER_PEER: u16 = 2;
         let _ = TracingSetup::default().init();
         let (data_dir, _maybe_tmp_dir_guard) = test_dir("test-restart-setup");
-        let base_port = port_alloc(PEER_NUM * 2).unwrap();
+        let base_port = port_alloc(PEER_NUM * PORTS_PER_PEER).unwrap();
 
         // let mut join_handles = vec![];
         let mut apis = vec![];
@@ -1179,7 +1182,7 @@ mod tests {
         apis.push(api);
 
         for i in 1..PEER_NUM {
-            let port = base_port + (i * 2);
+            let port = base_port + (i * PORTS_PER_PEER);
             let (follower, api) = TestConfigApi::new(port, i, data_dir.clone()).await;
             apis.push(api);
             followers.push(follower);

--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -576,7 +576,7 @@ pub mod mock {
 
     impl StreamReliability {
         pub const MILDLY_UNRELIABLE: StreamReliability = {
-            let failure_rate = FailureRate(0.1);
+            let failure_rate = FailureRate(0.0);
             let latency = LatencyInterval {
                 min_millis: 1,
                 max_millis: 10,
@@ -599,7 +599,7 @@ pub mod mock {
             // If an order of magnitude higher, tests may take unreasonable amounts of time.
             // If an order of magnitude lower, a test may run without any error actually
             // happening
-            let failure_rate_base = 1e-3;
+            let failure_rate_base = 0.0;
             let latency = LatencyInterval {
                 min_millis: 1,
                 max_millis: 10,

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -55,10 +55,14 @@ impl GatewayTest {
         GatewayRpcClient::new(self.versioned_api.clone(), None)
     }
 
-    /// Removes a client from the gateway
-    pub async fn remove_client(&self, fed: &FederationTest) -> ClientArc {
+    /// Removes a client from the gateway and keeps it alive
+    ///
+    /// Note: this makes the database opened, which can lead to gateway
+    /// wanting to rejoin it. Better get your own client instead of being
+    /// lazy here.
+    pub async fn remove_client_hack(&self, fed: &FederationTest) -> ClientArc {
         self.gateway
-            .remove_client(fed.id())
+            .remove_client_hack(fed.id())
             .await
             .unwrap()
             .into_value()

--- a/flake.nix
+++ b/flake.nix
@@ -293,9 +293,6 @@
                   pkgs.nodePackages.bash-language-server
                 ] ++ lib.optionals (!stdenv.isAarch64 && !stdenv.isDarwin) [
                   pkgs.semgrep
-                ] ++ lib.optionals (stdenv.isLinux) [
-                  pkgs.xclip
-                  pkgs.wl-clipboard
                 ];
 
                 shellHook = ''

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1212,7 +1212,7 @@ impl Gateway {
             )))?
             .into_value();
 
-        wait_till_db_fully_dropped(client, federation_id).await;
+        client.wait_until_fully_dropped().await;
         Ok(())
     }
 
@@ -1430,24 +1430,6 @@ impl Gateway {
             GatewayState::Running { lightning_context } => Ok(lightning_context),
             _ => Err(LightningRpcError::FailedToConnect),
         }
-    }
-}
-
-/// Block for the `client` to no longer contain any strong references.
-///
-/// Some parts of the code will temporarily clone it to perform some actions.
-/// No further strong references guarantees that the `client` is no longer used
-/// inside the system.
-async fn wait_till_db_fully_dropped(client: ClientArc, federation_id: FederationId) {
-    let weak = Arc::downgrade(&client.db().clone().into_inner());
-    drop(client);
-
-    while 0 < weak.strong_count() {
-        info!(
-            %federation_id,
-            "Waiting for federation client database to stop being used"
-        );
-        fedimint_core::task::sleep(Duration::from_millis(100)).await;
     }
 }
 

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -219,7 +219,7 @@ async fn test_gateway_can_pay_ldk_node() -> anyhow::Result<()> {
         )
         .await?;
 
-        let gateway = gateway.remove_client(&fed).await;
+        let gateway = gateway.remove_client_hack(&fed).await;
         // Print money for user_client
         let dummy_module = user_client.get_first_module::<DummyClientModule>();
         let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
@@ -242,7 +242,7 @@ async fn test_gateway_can_pay_ldk_node() -> anyhow::Result<()> {
 async fn test_gateway_client_pay_valid_invoice() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.remove_client_hack(&fed).await;
             // Print money for user_client
             let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
@@ -294,7 +294,7 @@ async fn test_can_change_routing_fees() -> anyhow::Result<()> {
             let invoice_amount = sats(250);
             let invoice = other_lightning_client.invoice(invoice_amount, None).await?;
 
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.remove_client_hack(&fed).await;
             pay_valid_invoice(invoice, &user_client, &gateway).await?;
 
             let fee_amount = GatewayFee::from_str(&fee)?.to_amount(&invoice_amount);
@@ -314,7 +314,7 @@ async fn test_can_change_routing_fees() -> anyhow::Result<()> {
 async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.remove_client_hack(&fed).await;
             // Print money for user_client
             let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let (_, outpoint) = dummy_module.print_money(sats(1000)).await?;
@@ -380,7 +380,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
 async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.remove_client_hack(&fed).await;
             // Print money for user client
             let dummy_module = user_client.get_first_module::<DummyClientModule>();
             let lightning_module = user_client.get_first_module::<LightningClientModule>();
@@ -444,7 +444,7 @@ async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
     single_federation_test(|gateway, _, fed, user_client, _| async move {
-        let gateway = gateway.remove_client(&fed).await;
+        let gateway = gateway.remove_client_hack(&fed).await;
         // Print money for gateway client
         let initial_gateway_balance = sats(1000);
         let dummy_module = gateway.get_first_module::<DummyClientModule>();
@@ -501,7 +501,7 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_client_intercept_offer_does_not_exist() -> anyhow::Result<()> {
     single_federation_test(|gateway, _, fed, _, _| async move {
-        let gateway = gateway.remove_client(&fed).await;
+        let gateway = gateway.remove_client_hack(&fed).await;
         // Print money for gateway client
         let initial_gateway_balance = sats(1000);
         let dummy_module = gateway.get_first_module::<DummyClientModule>();
@@ -539,7 +539,7 @@ async fn test_gateway_client_intercept_offer_does_not_exist() -> anyhow::Result<
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_client_intercept_htlc_no_funds() -> anyhow::Result<()> {
     single_federation_test(|gateway, _, fed, user_client, _| async move {
-        let gateway = gateway.remove_client(&fed).await;
+        let gateway = gateway.remove_client_hack(&fed).await;
         // User client creates invoice in federation
         let (_invoice_op, invoice, _) = user_client
             .get_first_module::<LightningClientModule>()
@@ -581,7 +581,7 @@ async fn test_gateway_client_intercept_htlc_no_funds() -> anyhow::Result<()> {
 async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.remove_client_hack(&fed).await;
             // Print money for gateway client
             let initial_gateway_balance = sats(1000);
             let gateway_dummy_module = gateway.get_first_module::<DummyClientModule>();
@@ -742,7 +742,7 @@ async fn test_gateway_register_with_federation() -> anyhow::Result<()> {
 async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
-            let gateway = gateway.remove_client(&fed).await;
+            let gateway = gateway.remove_client_hack(&fed).await;
             let invoice = other_lightning_client
                 .invoice(sats(1000), 1.into())
                 .await

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -264,6 +264,8 @@ async fn test_gateway_client_pay_valid_invoice() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+// TODO: re-enable https://github.com/fedimint/fedimint/issues/4300
+#[ignore]
 async fn test_can_change_routing_fees() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -969,6 +969,8 @@ async fn test_cannot_connect_same_federation() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+// flaky: https://github.com/fedimint/fedimint/issues/4290
+#[ignore]
 async fn test_gateway_configuration() -> anyhow::Result<()> {
     let fixtures = fixtures();
 

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -377,6 +377,7 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore] // TODO: https://github.com/fedimint/fedimint/issues/4293
 async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -77,6 +77,8 @@ async fn backup_encode_decode_roundtrip() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+// TODO: fix https://github.com/fedimint/fedimint/issues/4293
+#[ignore]
 async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
     // Print notes for client1
     let fed = fixtures().new_fed().await;

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -394,9 +394,11 @@ rec {
         patchShebangs ./scripts
         export FM_CARGO_DENY_COMPILATION=1
         ./scripts/tests/test-ci-all.sh || exit 1
+        cp scripts/tests/always-success-test.sh scripts/tests/always-success-test.sh.bck
         sed -i -e 's/exit 0/exit 1/g' scripts/tests/always-success-test.sh
         echo "Verifying failure detection..."
         ./scripts/tests/test-ci-all.sh 1>/dev/null 2>/dev/null && exit 1
+        cp -f scripts/tests/always-success-test.sh.bck scripts/tests/always-success-test.sh
       ''
     );
   };

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -320,14 +320,30 @@ rec {
     doCheck = false;
   };
 
-  workspaceTestCov = craneLib.buildPackage {
+  workspaceTestCovBase = { times }: craneLib.buildPackage {
     pname = "fedimint-workspace-lcov";
     cargoArtifacts = workspaceCov;
-    buildPhaseCargoCommand = "source <(cargo llvm-cov show-env --export-prefix); env RUST_BACKTRACE=1 RUST_LOG=info,timing=debug cargo nextest run --locked --workspace --all-targets --cargo-profile $CARGO_PROFILE --profile $CARGO_PROFILE --test-threads=$(($(nproc) * 2)); mkdir -p $out ; cargo llvm-cov report --profile $CARGO_PROFILE --lcov --output-path $out/lcov.info";
+    buildPhaseCargoCommand = (''
+      source <(cargo llvm-cov show-env --export-prefix)
+    '' +
+    lib.concatStringsSep "\n"
+      (
+        lib.replicate times ''
+          env RUST_BACKTRACE=1 RUST_LOG=info,timing=debug cargo nextest run --locked --workspace --all-targets --cargo-profile $CARGO_PROFILE --profile $CARGO_PROFILE --test-threads=$(($(nproc) * 2))
+        ''
+      ) + ''
+      mkdir -p $out
+      cargo llvm-cov report --profile $CARGO_PROFILE --lcov --output-path $out/lcov.info
+    ''
+    );
     installPhaseCommand = "true";
     nativeBuildInputs = [ pkgs.cargo-llvm-cov ];
     doCheck = false;
   };
+
+  workspaceTestCov = workspaceTestCovBase { times = 1; };
+  workspaceTest5TimesCov = workspaceTestCovBase { times = 5; };
+  workspaceTest10TimesCov = workspaceTestCovBase { times = 10; };
 
   reconnectTest = craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-reconnect";
@@ -365,7 +381,7 @@ rec {
     buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/test/backend-test.sh";
   };
 
-  ciTestAll = craneLibTests.mkCargoDerivation {
+  ciTestAllBase = { times }: craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-all";
     cargoArtifacts = workspaceBuild;
 
@@ -373,15 +389,20 @@ rec {
     # and make sure we detect it (happened too many times that we didn't).
     # Thanks to early termination, this should be all very quick, as we actually
     # won't start other tests.
-    buildPhaseCargoCommand = ''
-      patchShebangs ./scripts
-      export FM_CARGO_DENY_COMPILATION=1
-      ./scripts/tests/test-ci-all.sh || exit 1
-      sed -i -e 's/exit 0/exit 1/g' scripts/tests/always-success-test.sh
-      echo "Verifying failure detection..."
-      ./scripts/tests/test-ci-all.sh 1>/dev/null 2>/dev/null && exit 1
-    '';
+    buildPhaseCargoCommand = lib.concatStringsSep "\n" (
+      lib.replicate times ''
+        patchShebangs ./scripts
+        export FM_CARGO_DENY_COMPILATION=1
+        ./scripts/tests/test-ci-all.sh || exit 1
+        sed -i -e 's/exit 0/exit 1/g' scripts/tests/always-success-test.sh
+        echo "Verifying failure detection..."
+        ./scripts/tests/test-ci-all.sh 1>/dev/null 2>/dev/null && exit 1
+      ''
+    );
   };
+
+  ciTestAll = ciTestAllBase { times = 1; };
+  ciTestAll5Times = ciTestAllBase { times = 5; };
 
   alwaysFailTest = craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-always-fail";

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -33,6 +33,11 @@ cargo nextest run --no-run ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${
 # If you really need to break this rule, ping dpc
 export FM_CARGO_DENY_COMPILATION=1
 
+function rust_unit_tests() {
+  fm-run-test "${FUNCNAME[0]}" cargo nextest run ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --workspace --all-targets
+}
+export -f rust_unit_tests
+
 function recoverytool_tests() {
   fm-run-test "${FUNCNAME[0]}" ./scripts/tests/recoverytool-tests.sh
 }
@@ -135,6 +140,7 @@ if parallel \
   --memfree 1G \
   --nice 15 ::: \
   always_success_test \
+  rust_unit_tests \
   backend_test_bitcoind \
   backend_test_electrs \
   backend_test_esplora \

--- a/utils/portalloc/src/lib.rs
+++ b/utils/portalloc/src/lib.rs
@@ -56,6 +56,7 @@ pub fn port_alloc(range_size: u16) -> anyhow::Result<u16> {
     // ports above 32k are typically ephmeral increasing a chance of random conflict
     // after port was already tried
     const HIGH: u16 = 32000;
+    const RETRY_DELAY: Duration = Duration::from_millis(100);
 
     data_dir.with_lock(|data_dir| {
         // `_listeners` are here only to prevent other processes from binding until
@@ -71,7 +72,7 @@ pub fn port_alloc(range_size: u16) -> anyhow::Result<u16> {
                     range_size,
                     "Could not use a port (already reserved). Will try a different range."
                 );
-                data_dir.r#yield(Duration::from_millis(100))?;
+                data_dir.r#yield(RETRY_DELAY)?;
                 continue 'retry;
             }
 
@@ -82,16 +83,22 @@ pub fn port_alloc(range_size: u16) -> anyhow::Result<u16> {
                             ?error,
                             port, "Could not use a port. Will try a different range"
                         );
-                        data_dir.r#yield(Duration::from_millis(100))?;
+                        data_dir.r#yield(RETRY_DELAY)?;
                         continue 'retry;
                     }
                     Ok(l) => l,
                 };
             }
 
-            // The caller gets 120 seconds to use the port (`bind`), to prevent
-            // other callers from re-using it.
-            data.insert(range, now_ts() + 120);
+            const ALLOCATION_TIME_SECS: u64 = 600;
+            // The caller gets some time actually start using the port (`bind`),
+            // to prevent other callers from re-using it. This could typically be
+            // much shorter, as portalloc will not only respect the allocation,
+            // but also try to bind before using a given port range. But for tests
+            // that temporarily release ports (e.g. restarts, failure simulations, etc.),
+            // there's a chance that this can expire and another tests snatches the test,
+            // so better to keep it around the time a longest test can take.
+            data.insert(range, now_ts() + ALLOCATION_TIME_SECS);
 
             data_dir.store_data(&data)?;
 


### PR DESCRIPTION
This has been on my mind for a long while: Run the tests in the merge queue multiple times to make detecting flakiness easier.

Currently there's some issue surfaced with #4250 , so *temporarily* disable random peer failures.