### PR TITLE
cleanup: remove operation id argument from await_tx_accepted

### DIFF
--- a/modules/fedimint-dummy-client/src/states.rs
+++ b/modules/fedimint-dummy-client/src/states.rs
@@ -37,7 +37,7 @@ impl State for DummyStateMachine {
     ) -> Vec<StateTransition<Self>> {
         match self.clone() {
             DummyStateMachine::Input(amount, txid, id) => vec![StateTransition::new(
-                await_tx_accepted(global_context.clone(), id, txid),
+                await_tx_accepted(global_context.clone(), txid),
                 move |dbtx, res, _state: Self| match res {
                     // accepted, we are done
                     Ok(_) => Box::pin(async move { DummyStateMachine::InputDone(id) }),
@@ -89,10 +89,9 @@ async fn add_funds(amount: Amount, mut dbtx: DatabaseTransaction<'_>) {
 // TODO: Boiler-plate, should return OutputOutcome
 async fn await_tx_accepted(
     context: DynGlobalClientContext,
-    id: OperationId,
     txid: TransactionId,
 ) -> Result<(), String> {
-    context.await_tx_accepted(id, txid).await
+    context.await_tx_accepted(txid).await
 }
 
 async fn await_dummy_output_outcome(

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -96,7 +96,7 @@ impl State for LightningPayStateMachine {
             LightningPayStates::Refundable(refundable) => {
                 refundable.transitions(self.common.clone(), global_context.clone())
             }
-            LightningPayStates::Refund(refund) => refund.transitions(&self.common, global_context),
+            LightningPayStates::Refund(refund) => refund.transitions(global_context),
             LightningPayStates::Refunded(_) => {
                 vec![]
             }
@@ -508,12 +508,11 @@ pub struct LightningPayRefund {
 impl LightningPayRefund {
     fn transitions(
         &self,
-        common: &LightningPayCommon,
         global_context: &DynGlobalClientContext,
     ) -> Vec<StateTransition<LightningPayStateMachine>> {
         let refund_out_points = self.out_points.clone();
         vec![StateTransition::new(
-            Self::await_refund_success(common.clone(), global_context.clone(), self.txid),
+            Self::await_refund_success(global_context.clone(), self.txid),
             move |_dbtx, result, old_state| {
                 let refund_out_points = refund_out_points.clone();
                 Box::pin(Self::transition_refund_success(
@@ -526,15 +525,12 @@ impl LightningPayRefund {
     }
 
     async fn await_refund_success(
-        common: LightningPayCommon,
         global_context: DynGlobalClientContext,
         refund_txid: TransactionId,
     ) -> Result<(), String> {
         // No network calls are done here, we just await other state machines, so no
         // retry logic is needed
-        global_context
-            .await_tx_accepted(common.operation_id, refund_txid)
-            .await
+        global_context.await_tx_accepted(refund_txid).await
     }
 
     async fn transition_refund_success(

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -152,7 +152,7 @@ impl MintOutputStatesCreated {
 
     async fn await_tx_rejected(global_context: DynGlobalClientContext, common: MintOutputCommon) {
         if global_context
-            .await_tx_accepted(common.operation_id, common.out_point.txid)
+            .await_tx_accepted(common.out_point.txid)
             .await
             .is_err()
         {

--- a/modules/fedimint-wallet-client/src/withdraw.rs
+++ b/modules/fedimint-wallet-client/src/withdraw.rs
@@ -66,7 +66,7 @@ async fn await_withdraw_processed(
     created: CreatedWithdrawState,
 ) -> Result<Txid, String> {
     global_context
-        .await_tx_accepted(operation_id, created.fm_outpoint.txid)
+        .await_tx_accepted(created.fm_outpoint.txid)
         .await?;
 
     loop {
@@ -95,6 +95,7 @@ async fn await_withdraw_processed(
                     "Awaiting output outcome failed, retrying in {}s",
                     RETRY_DELAY.as_secs_f64()
                 );
+
                 sleep(RETRY_DELAY).await;
             }
         }


### PR DESCRIPTION
This is another step in the direction of making client state machines unaware of their operation id.