### PR TITLE
fix: possible panic on server shutdown

### DIFF
--- a/fedimint-server/src/atomic_broadcast/spawner.rs
+++ b/fedimint-server/src/atomic_broadcast/spawner.rs
@@ -1,3 +1,6 @@
+use fedimint_logging::LOG_CONSENSUS;
+use tracing::warn;
+
 #[derive(Clone)]
 pub struct Spawner;
 
@@ -27,7 +30,9 @@ impl aleph_bft::SpawnHandle for Spawner {
 
         fedimint_core::task::spawn(name, async move {
             task.await;
-            res_tx.send(()).expect("We own the rx.");
+            if let Err(_err) = res_tx.send(()) {
+                warn!(target: LOG_CONSENSUS, "Unable to send essential spawned task completion. Are we shutting down?");
+            }
         });
 
         Box::pin(async move { res_rx.await.map_err(|_| ()) })


### PR DESCRIPTION
https://github.com/fedimint/fedimint/actions/runs/7860754434/job/21454090481?pr=4292

```
fedimint-test-all-ci> 00:08:10 2024-02-11T17:47:35.994448Z ERROR AlephBFT-backup-saver: receiver of alert data to save closed early
fedimint-test-all-ci> 00:08:10 thread 'tokio-runtime-worker' panicked at /build/source/fedimint-server/src/atomic_broadcast/spawner.rs:30:29:
fedimint-test-all-ci> 00:08:10 We own the rx.: ()
fedimint-test-all-ci> 00:08:10 stack backtrace:
fedimint-test-all-ci> 00:08:10    0: rust_begin_unwind
fedimint-test-all-ci> 00:08:10              at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/std/src/panicking.rs:595:5
fedimint-test-all-ci> 00:08:10    1: core::panicking::panic_fmt
fedimint-test-all-ci> 00:08:10              at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:67:14
fedimint-test-all-ci> 00:08:10    2: core::result::unwrap_failed
fedimint-test-all-ci> 00:08:10              at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/result.rs:1652:5
fedimint-test-all-ci> 00:08:10    3: core::result::Result<T,E>::expect
fedimint-test-all-ci> 00:08:10              at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/result.rs:1034:23
fedimint-test-all-ci> 00:08:10    4: {async_block#0}<fedimint_aleph_bft::runway::run::{async_fn#0}::{async_block_env#1}<fedimint_server::atomic_broadcast::network::Hasher, fedimint_server::atomic_broadcast::data_provider::UnitData, fedimint_server::atomic_broadcast::backup::UnitSaver, std::io::cursor::Cursor<alloc::vec::Vec<u8, alloc::alloc::Global>>, fedimint_server::atomic_broadcast::keychain::Keychain, fedimint_server::atomic_broadcast::data_provider::DataProvider, fedimint_server::atomic_broadcast::finalization_handler::FinalizationHandler, fedimint_server::atomic_broadcast::spawner::Spawner>>
fedimint-test-all-ci> 00:08:10              at /build/source/fedimint-server/src/atomic_broadcast/spawner.rs:30:13
fedimint-test-all-ci> 00:08:10    5: poll<fedimint_server::atomic_broadcast::spawner::{impl#2}::spawn_essential::{async_block_env#0}<fedimint_aleph_bft::runway::run::{async_fn#0}::{async_block_env#1}<fedimint_server::atomic_broadcast::network::Hasher, fedimint_server::atomic_broadcast::data_provider::UnitData, fedimint_server::atomic_broadcast::backup::UnitSaver, std::io::cursor::Cursor<alloc::vec::Vec<u8, alloc::alloc::Global>>, fedimint_server::atomic_broadcast::keychain::Keychain, fedimint_server::atomic_broadcast::data_provider::DataProvider, fedimint_server::atomic_broadcast::finalization_handler::FinalizationHandler, fedimint_server::atomic_broadcast::spawner::Spawner>>>
```

There's nothing guaranteeing that the handle wasn't dropped, e.g. because the whole thing is shutting down.