### PR TITLE
chore: ignore TracingSetup test in client db migration tests

### DIFF
--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -269,7 +269,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_client_db_migrations() -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
+        let _ = TracingSetup::default().init();
 
         let module = DynCommonModuleInit::from(DummyClientInit);
 

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -898,7 +898,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_client_db_migrations() -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
+        let _ = TracingSetup::default().init();
 
         let module = DynCommonModuleInit::from(LightningClientInit);
         validate_migrations_module(module, "lightning-client", |db| async move {

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -440,7 +440,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_client_db_migrations() -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
+        let _ = TracingSetup::default().init();
 
         let module = DynCommonModuleInit::from(MintClientInit);
         validate_migrations_module(module, "mint-client", |db| async move {

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -950,7 +950,7 @@ mod fedimint_migration_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_client_db_migrations() -> anyhow::Result<()> {
-        TracingSetup::default().init()?;
+        let _ = TracingSetup::default().init();
 
         let module = DynCommonModuleInit::from(WalletClientInit::default());
         validate_migrations_module(module, "wallet-client", |db| async move {


### PR DESCRIPTION
`cargo test` is broken again, the branch with the client db migrations wasn't update with the previous fix before merging.