### PR TITLE
fix: switch back to `nix build` for release builds on master

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -412,7 +412,7 @@ jobs:
             deb: fedimint-gateway
 
     runs-on: buildjet-4vcpu-ubuntu-2004
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -424,13 +424,21 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 
+      - name: Set BUILD_ID to tag or commit hash
+        run: |
+          if [[ $GITHUB_REF_TYPE == "tag" ]]; then
+            echo "BUILD_ID=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          else
+            echo "BUILD_ID=${GITHUB_SHA}" >> $GITHUB_ENV
+          fi
+
       - name: Build ${{ matrix.build.flake-output }}
         run: |
           nix build -L .#${{ matrix.build.flake-output }}
           mkdir -p bins
           bins="${{ matrix.build.bins }}"
           for bin in ${bins//,/ } ; do
-            nix bundle .#$bin -o bins/$bin
+            nix bundle .#$bin -o "bins/$bin-$BUILD_ID" && sha256sum "bin/$bin-$BUILD_ID"
           done
 
       - name: Check version ${{ matrix.build.bins }}

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -426,7 +426,7 @@ jobs:
 
       - name: Build ${{ matrix.build.flake-output }}
         run: |
-          nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).${{ matrix.build.flake-output }}
+          nix build -L .#${{ matrix.build.flake-output }}
           mkdir -p bins
           bins="${{ matrix.build.bins }}"
           for bin in ${bins//,/ } ; do
@@ -444,7 +444,7 @@ jobs:
         run: |
           bins="${{ matrix.build.bins }}"
           for bin in ${bins//,/ } ; do
-            nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).$bin && sha256sum "./result/bin/$bin"
+            nix build .#$bin && sha256sum "./result/bin/$bin"
           done
 
       - name: Upload Binaries


### PR DESCRIPTION
For these we do want to produce the final binary every time, and their runtime is not as important.

Re #4258