### PR TITLE
chore: give macos-14 runner some time to cross-compile everything

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -285,7 +285,7 @@ jobs:
             runs-on: macos-14
             build-in-pr: false
             # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
-            timeout: 60
+            timeout: 120
         exclude:
             # there's not enough macos runners available for our CI, so test only the more important cross-compilation toolchains
             # if they work, rest probably works as well


### PR DESCRIPTION
Seems like it consistently times out in the CI:

https://github.com/fedimint/fedimint/actions/runs/7881787581/job/21505971243

It will probably pass if given enough time, and caching will take care of it afterwards.