### PR TITLE
fix(ci): client-pkgs doesn't contain any binaries (v0.2)

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -345,9 +345,6 @@ jobs:
     strategy:
       matrix:
         build:
-          - flake-output: client-pkgs
-            bins: ""
-            deb: fedimint
           - flake-output: fedimint-pkgs
             bins: fedimintd,fedimint-cli,fedimint-dbtool
             deb: fedimint


### PR DESCRIPTION
This is fixed already on `master`, and produces an empty deb&rpm release artifacts.