### PR TITLE
cleanup: remove invite code from client db

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::pin::Pin;
 
-use fedimint_core::api::{ApiVersionSet, InviteCode};
+use fedimint_core::api::ApiVersionSet;
 use fedimint_core::config::{ClientConfig, FederationId};
 use fedimint_core::core::{ModuleInstanceId, OperationId};
 use fedimint_core::db::{
@@ -35,7 +35,7 @@ pub enum DbKeyPrefix {
     ChronologicalOperationLog = 0x2d,
     CommonApiVersionCache = 0x2e,
     ClientConfig = 0x2f,
-    ClientInviteCode = 0x30,
+    ClientInviteCode = 0x30, // Unused; clean out remnant data before re-using!
     ClientInitState = 0x31,
     ClientMetadata = 0x32,
     ClientLastBackup = 0x33,
@@ -142,23 +142,6 @@ impl_db_record!(
 );
 
 impl_db_lookup!(key = ClientConfigKey, query_prefix = ClientConfigKeyPrefix);
-
-#[derive(Debug, Encodable, Decodable)]
-pub struct ClientInviteCodeKey;
-
-#[derive(Debug, Encodable)]
-pub struct ClientInviteCodeKeyPrefix;
-
-impl_db_record!(
-    key = ClientInviteCodeKey,
-    value = InviteCode,
-    db_prefix = DbKeyPrefix::ClientInviteCode
-);
-
-impl_db_lookup!(
-    key = ClientInviteCodeKey,
-    query_prefix = ClientInviteCodeKeyPrefix
-);
 
 /// Client metadata that will be stored/restored on backup&recovery
 #[derive(Debug, Encodable, Decodable, Serialize)]

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -153,7 +153,7 @@ pub async fn build_client(
         if let Some(invite_code) = &invite_code {
             let client_config = ClientConfig::download_from_invite_code(invite_code).await?;
             client_builder
-                .join(root_secret, client_config.clone(), invite_code.clone())
+                .join(root_secret, client_config.clone())
                 .await
         } else {
             bail!("Database not initialize and invite code not provided");

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -81,7 +81,6 @@ impl FederationTest {
             .join(
                 PlainRootSecretStrategy::to_root_secret(&client_secret),
                 client_config,
-                self.invite_code(),
             )
             .await
             .expect("Failed to build client")

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -42,7 +42,6 @@ async fn client(invite_code: &InviteCode) -> Result<fedimint_client::ClientHandl
         .join(
             PlainRootSecretStrategy::to_root_secret(&client_secret),
             client_config.to_owned(),
-            invite_code.clone(),
         )
         .await
 }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -95,7 +95,7 @@ impl GatewayClientBuilder {
             let client_config = ClientConfig::download_from_invite_code(&invite_code).await?;
             client_builder
                 // TODO: make this configurable?
-                .join(root_secret, client_config.to_owned(), invite_code)
+                .join(root_secret, client_config.to_owned())
                 .await
         }
         .map_err(GatewayError::ClientStateMachineError)


### PR DESCRIPTION
We can generate invite codes from the client config, the separate invite code in the db is a remnant from a time when we had to request an invite code from the guardian.