### PR TITLE
chore: better consensus item formatting

### DIFF
--- a/fedimint-server/src/consensus/debug.rs
+++ b/fedimint-server/src/consensus/debug.rs
@@ -1,30 +1,41 @@
-use std::fmt::Write;
-
-use fedimint_core::transaction::Transaction;
+use std::fmt;
 
 use crate::ConsensusItem;
 
-pub fn item_message(item: &ConsensusItem) -> String {
-    match item {
-        // TODO: make this nice again
-        ConsensusItem::Module(mci) => {
-            format!("Module CI: module={} ci={}", mci.module_instance_id(), mci)
-        }
-        ConsensusItem::Transaction(Transaction {
-            inputs, outputs, ..
-        }) => {
-            let mut tx_debug = "Transaction".to_string();
-            for input in inputs.iter() {
-                // TODO: add pretty print fn to interface
-                write!(tx_debug, "\n    Input: {input}").unwrap();
+/// A newtype for a nice [`fmt::Debug`] of a [`ConsensusItem`]
+pub struct FmtDbgConsensusItem<'ci>(pub &'ci ConsensusItem);
+
+impl<'ci> fmt::Debug for FmtDbgConsensusItem<'ci> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            ConsensusItem::Module(mci) => {
+                f.write_fmt(format_args!(
+                    "Module CI: module={} ci={}",
+                    mci.module_instance_id(),
+                    mci
+                ))?;
             }
-            for output in outputs.iter() {
-                write!(tx_debug, "\n    Output: {output}").unwrap();
+            ConsensusItem::Transaction(tx) => {
+                f.write_fmt(format_args!(
+                    "Transaction txid={}, inputs_num={}, outputs_num={}",
+                    tx.tx_hash(),
+                    tx.inputs.len(),
+                    tx.outputs.len(),
+                ))?;
+                // TODO: This is kind of lengthy, and maybe could be conditionally enabled
+                // via an env var or something.
+                for input in tx.inputs.iter() {
+                    // TODO: add pretty print fn to interface
+                    f.write_fmt(format_args!("\n    Input: {input}"))?;
+                }
+                for output in tx.outputs.iter() {
+                    f.write_fmt(format_args!("\n    Output: {output}")).unwrap();
+                }
             }
-            tx_debug
+            ConsensusItem::Default { variant, .. } => {
+                f.write_fmt(format_args!("Unknown CI variant: {variant}"))?;
+            }
         }
-        ConsensusItem::Default { variant, .. } => {
-            format!("Unknown CI variant: {variant}")
-        }
+        Ok(())
     }
 }

--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -38,6 +38,7 @@ use crate::atomic_broadcast::network::Network;
 use crate::atomic_broadcast::spawner::Spawner;
 use crate::atomic_broadcast::{to_node_index, Keychain, Message};
 use crate::config::ServerConfig;
+use crate::consensus::debug::FmtDbgConsensusItem;
 use crate::consensus::process_transaction_with_dbtx;
 use crate::db::{
     get_global_database_migrations, AcceptedItemKey, AcceptedItemPrefix, AcceptedTransactionKey,
@@ -577,7 +578,7 @@ impl ConsensusServer {
     ) -> anyhow::Result<()> {
         let _timing /* logs on drop */ = timing::TimeReporter::new("process_consensus_item");
 
-        debug!("Peer {peer}: {}", super::debug::item_message(&item));
+        debug!(%peer, item = ?FmtDbgConsensusItem(&item), "Processing consensus item");
 
         self.latest_contribution_by_peer
             .write()


### PR DESCRIPTION
Display txid, which is very useful for debuging.

Be lazy-evaluated which should give better perf when logging is not enabled and avoid extra allocation anyway.