### PR TITLE
 chore: cap maximum backup size at 128KiB, 32KiB per module

### DIFF
--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -75,9 +75,11 @@ pub struct ClientBackup {
 }
 
 impl ClientBackup {
+    pub const PADDING_ALIGNMENT: usize = 4 * 1024;
+
     /// Align an ecoded message size up for better privacy
     fn get_alignment_size(len: usize) -> usize {
-        let padding_alignment = 16 * 1024;
+        let padding_alignment = Self::PADDING_ALIGNMENT;
         ((len.saturating_sub(1) / padding_alignment) + 1) * padding_alignment
     }
 

--- a/fedimint-client/src/backup/tests.rs
+++ b/fedimint-client/src/backup/tests.rs
@@ -9,11 +9,17 @@ use crate::Client;
 
 #[test]
 fn sanity_ecash_backup_align() {
-    assert_eq!(ClientBackup::get_alignment_size(1), 16 * 1024);
-    assert_eq!(ClientBackup::get_alignment_size(16 * 1024), 16 * 1024);
     assert_eq!(
-        ClientBackup::get_alignment_size(16 * 1024 + 1),
-        16 * 1024 * 2
+        ClientBackup::get_alignment_size(1),
+        ClientBackup::PADDING_ALIGNMENT
+    );
+    assert_eq!(
+        ClientBackup::get_alignment_size(ClientBackup::PADDING_ALIGNMENT),
+        ClientBackup::PADDING_ALIGNMENT
+    );
+    assert_eq!(
+        ClientBackup::get_alignment_size(ClientBackup::PADDING_ALIGNMENT + 1),
+        ClientBackup::PADDING_ALIGNMENT * 2
     );
 }
 
@@ -26,7 +32,7 @@ fn sanity_ecash_backup_decode_encode() -> Result<()> {
     };
 
     let encoded = orig.consensus_encode_to_vec();
-    assert_eq!(encoded.len(), 16 * 1024);
+    assert_eq!(encoded.len(), ClientBackup::PADDING_ALIGNMENT);
     assert_eq!(
         orig,
         ClientBackup::consensus_decode(&mut Cursor::new(encoded), &Default::default())?

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -38,6 +38,7 @@ pub enum DbKeyPrefix {
     ClientInviteCode = 0x30,
     ClientInitState = 0x31,
     ClientMetadata = 0x32,
+    ClientLastBackup = 0x33,
     /// Arbitrary data of the applications integrating Fedimint client and
     /// wanting to store some Federation-specific data in Fedimint client
     /// database.
@@ -297,6 +298,19 @@ impl_db_record!(
 impl_db_lookup!(
     key = ClientModuleRecovery,
     query_prefix = ClientModuleRecoveryPrefix
+);
+
+/// Last valid backup the client attempted to make
+///
+/// Can be used to find previous valid versions of
+/// module backup.
+#[derive(Debug, Encodable, Decodable)]
+pub struct LastBackupKey;
+
+impl_db_record!(
+    key = LastBackupKey,
+    value = ClientBackup,
+    db_prefix = DbKeyPrefix::ClientLastBackup
 );
 
 /// `ClientMigrationFn` is a function that modules can implement to "migrate"

--- a/fedimint-core/src/core/backup.rs
+++ b/fedimint-core/src/core/backup.rs
@@ -6,6 +6,15 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use secp256k1_zkp::{KeyPair, Message, Secp256k1, Signing, Verification};
 use serde::{Deserialize, Serialize};
 
+/// Maximum payload size of a backup request
+///
+/// Note: this is just a current hard limit,
+/// that could be changed in the future versions.
+///
+/// For comparison - at the time of writing, ecash module
+/// backup with 52 notes is around 5.1K.
+pub const BACKUP_REQUEST_MAX_PAYLOAD_SIZE_BYTES: usize = 128 * 1024;
+
 #[derive(Debug, Serialize, Deserialize, Encodable, Decodable)]
 pub struct BackupRequest {
     pub id: secp256k1::PublicKey,

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -87,6 +87,11 @@ pub trait Encodable {
         bytes.to_hex()
     }
 
+    /// Encode without storing the encoding, return the size
+    fn consensus_encode_to_len(&self) -> usize {
+        self.consensus_encode(&mut io::sink())
+            .expect("encoding to bytes can't fail for io reasons")
+    }
     /// Generate a SHA256 hash of the consensus encoding using the default hash
     /// engine for `H`.
     ///

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -80,10 +80,14 @@ pub trait Encodable {
         bytes
     }
 
+    /// Encode and convert to hex string representation
     fn consensus_encode_to_hex(&self) -> String {
         let mut bytes = vec![];
         self.consensus_encode(&mut bytes)
             .expect("encoding to bytes can't fail for io reasons");
+        // TODO: This double allocation offends real Rustaceans. We should
+        // be able to go straight to String, but this use case seems under-served
+        // by hex encoding crates.
         bytes.to_hex()
     }
 


### PR DESCRIPTION
* Add server side limit per backup: 128KiB.
* Add client side limit per module-backup: 32KiB.
* Check the server limit on the client as well.
* Store and use old versions of each module backup if the current version is too large.