### PR TITLE
chore: poll longer in devimint

### DIFF
--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -315,7 +315,7 @@ macro_rules! poll_eq {
 // Allow macro to be used within the crate. See https://stackoverflow.com/a/31749071.
 pub(crate) use cmd;
 
-const DEFAULT_RETRIES: usize = 20;
+const DEFAULT_RETRIES: usize = 30;
 /// Will retry calling `f`.
 /// - if `f` return Ok(val), this returns with Ok(val).
 /// - if `f` return Err(Control::Break(err)), this returns Err(err)


### PR DESCRIPTION
Seems like LND was taking sweet time initializing, and it's better to wait 10 seconds more than flake out because of it.

https://github.com/fedimint/fedimint/actions/runs/7923824298/job/21634324405