### PR TITLE
fix: wait longer for lnd startup in reconnection test

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -327,7 +327,7 @@ impl Lnd {
             process,
         };
         // wait for lnd rpc to be active
-        poll("lnd_startup", None, || async {
+        poll("lnd_startup", 60, || async {
             this.pub_key().await.map_err(ControlFlow::Continue)
         })
         .await?;

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -323,6 +323,7 @@ const DEFAULT_RETRIES: usize = 30;
 ///   `retries` times.
 pub async fn poll<Fut, R>(
     name: &str,
+    // TODO: this should be `Duration`, not number of retries --dpc
     retries: impl Into<Option<usize>>,
     f: impl Fn() -> Fut,
 ) -> Result<R>


### PR DESCRIPTION
https://github.com/fedimint/fedimint/actions/runs/7933984731/job/21663951534

suggests that lnd needs even more time.