### PR TITLE
feat(flake): use `sccache` in the dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -297,6 +297,7 @@
                   pkgs.nil
                   pkgs.convco
                   pkgs.nodePackages.bash-language-server
+                  pkgs.sccache
                 ] ++ lib.optionals (!stdenv.isAarch64 && !stdenv.isDarwin) [
                   pkgs.semgrep
                 ];
@@ -330,6 +331,8 @@
                   if [ -z "$(git config --global merge.ours.driver)" ]; then
                       >&2 echo "⚠️  Recommended to run 'git config --global merge.ours.driver true' to enable better lock file handling. See https://blog.aspect.dev/easier-merges-on-lockfiles for more info"
                   fi
+
+                  export RUSTC_WRAPPER=${pkgs.sccache}/bin/sccache
                 '';
               };
             in


### PR DESCRIPTION
This should improve compilation times when switching between branches etc.

You can view the sccache with `sccache --show-stats`:


```
> sccache --show-stats
Compile requests                   2093
Compile requests executed          1501
Cache hits                         1150
Cache hits (Rust)                  1150
Cache misses                        339
Cache misses (Rust)                 339
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Compilation failures                 11
Cache errors                          0
Non-cacheable compilations            0
Non-cacheable calls                 592
Non-compilation calls                 0
Unsupported compiler calls            0
Average cache write               0.008 s
Average compiler                  0.564 s
Average cache read hit            0.004 s
Failed distributed compilations       0

Non-cacheable reasons:
crate-type                          456
incremental                         125
-                                    11

Cache location                  Local disk: "/home/dpc/.cache/sccache"
Use direct/preprocessor mode?   yes
Version (client)                0.7.4
Cache size                          937 MiB
Max cache size                       10 GiB
```
