### PR TITLE
fix: make sure blinding key is not zero or one

### DIFF
--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -85,7 +85,12 @@ impl SecretKeyShare {
 impl BlindingKey {
     pub fn random() -> BlindingKey {
         // TODO: fix rand incompatibities
-        BlindingKey(Scalar::random(OsRng))
+        let scalar = Scalar::random(OsRng);
+        // make sure we don't return zero or one
+        if scalar == Scalar::zero() || scalar == Scalar::one() {
+            return BlindingKey::random();
+        }
+        BlindingKey(scalar)
     }
 }
 


### PR DESCRIPTION
This should be basically impossible but important to check. If the key is 0 it'll cause a panic during execution and if it is one it won't actually blind the message.

Maybe these checks should be done in `blind_message` as well