### PR TITLE
Add semgrep rule for `.elapsed()`

### DIFF
--- a/.config/semgrep.yaml
+++ b/.config/semgrep.yaml
@@ -8,6 +8,21 @@ rules:
 
   severity: WARNING
 
+- id: ban-system-time-elapsed
+  languages:
+    - rust
+  message: Use fedimint_core::time::now and std::time::duration_since to compare an elapsed time for better wasm compatibility.
+  pattern: $SYSTEM_TIME.elapsed()
+  paths:
+    exclude:
+      # server only
+      - fedimint-server/
+      # doesn't run in wasm
+      - fedimint-load-test-tool/
+      # doesn't run in wasm
+      - devimint/
+  severity: WARNING
+
 - id: ban-instant-now
   languages:
     - rust

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -909,7 +909,7 @@ impl LightningClientModule {
             .get_value(&MetaOverridesKey {})
             .await
         {
-            let elapsed = now().duration_since(cache.fetched_at).unwrap();
+            let elapsed = now().duration_since(cache.fetched_at).unwrap_or_default();
             if elapsed < META_OVERRIDE_CACHE_DURATION {
                 debug!("Using cached meta overrides");
                 match serde_json::from_str(&cache.value) {


### PR DESCRIPTION
Followup to prevent further bugs similar to https://github.com/fedimint/fedimint/pull/4356

This rule catches usages of method calls to `.elapsed()`. I did an audit of all public functions for `std::time::SystemTime` and this is the only one that calls `std::time::SystemTime::now`.

Semgrep supports typed metavariables ([docs](https://semgrep.dev/docs/writing-rules/pattern-syntax/#using-typed-metavariables)), which would be much better than catching any usage of `.elapsed()`, however after testing locally it doesn't catch the usage in the associated PR. Rust support is beta and I believe it's limited in its ability to parse types from struct fields. We're currently using semgrep v1.37.0, so I installed the latest version and that doesn't work either.

Semgrep PR introducing typed metavariables for rust: https://github.com/semgrep/semgrep/pull/8201