### PR TITLE
chore: use sleep_in_test over sleep in tests

### DIFF
--- a/.config/semgrep.yaml
+++ b/.config/semgrep.yaml
@@ -85,3 +85,35 @@ rules:
   message: "Wildcard imports make it unclear which items are being used. Avoid using `use ...::*;` except in sub-modules of a file such as `use super::*;` in a test module."
   pattern-regex: '^use .*::\*;$'
   severity: WARNING
+
+- id: ban-direct-sleep-in-tests
+  languages:
+    - rust
+  patterns:
+    - pattern: sleep($X)
+  paths:
+    include:
+      - fedimint-testing/
+      - fedimint-wasm-testing/
+      - fedimint-wasm-tests/
+      - fedimint-load-test-tool/
+      - modules/fedimint-dummy-tests/
+      - modules/fedimint-wallet-tests/
+      - modules/fedimint-ln-tests/
+      - modules/fedimint-mint-tests/
+      - gateway/ln-gateway/tests/
+      - fedimint-client/src/backup/tests.rs
+      - devimint/src/tests.rs
+  message: "Direct use of fedimint_core::task::sleep in tests is discouraged. Use fedimint_core::task::sleep_in_test instead."
+  severity: WARNING
+
+- id: ban-sleep-in-test-scripts
+  languages:
+     - bash
+  patterns:
+    - pattern: sleep $X
+  paths:
+    include:
+      - scripts/tests/
+  message: "Sleeping in test scripts is discouraged. Sleep in rust using fedimint_core::task::sleep_in_test instead."
+  severity: WARNING

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::bail;
 use fedimint_core::time::now;
-use fedimint_logging::LOG_TASK;
+use fedimint_logging::{LOG_TASK, LOG_TEST};
 #[cfg(target_family = "wasm")]
 use futures::channel::oneshot;
 use futures::lock::Mutex;
@@ -616,6 +616,19 @@ impl<T: Sync> MaybeSync for T {}
 
 #[cfg(target_family = "wasm")]
 impl<T> MaybeSync for T {}
+
+// Used in tests when sleep functionality is desired so it can be logged.
+// Must include comment describing the reason for sleeping.
+pub async fn sleep_in_test(comment: impl AsRef<str>, duration: Duration) {
+    info!(
+        target: LOG_TEST,
+        "Sleeping for {}.{:03} seconds because: {}",
+        duration.as_secs(),
+        duration.subsec_millis(),
+        comment.as_ref()
+    );
+    sleep(duration).await;
+}
 
 #[cfg(test)]
 mod tests {

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -18,7 +18,7 @@ use fedimint_bitcoind::{
     Result as BitcoinRpcResult,
 };
 use fedimint_core::bitcoinrpc::BitcoinRpcConfig;
-use fedimint_core::task::{sleep, TaskHandle};
+use fedimint_core::task::{sleep_in_test, TaskHandle};
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, Feerate};
@@ -234,7 +234,7 @@ impl BitcoinTest for FakeBitcoinTest {
 
             let tx = match maybe_tx {
                 None => {
-                    sleep(Duration::from_millis(100)).await;
+                    sleep_in_test("no transaction found", Duration::from_millis(100)).await;
                     continue;
                 }
                 Some(tx) => tx,

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -9,7 +9,7 @@ use bitcoincore_rpc::{Client, RpcApi};
 use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_core::encoding::Decodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::task::sleep;
+use fedimint_core::task::sleep_in_test;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{task, Amount};
@@ -71,7 +71,8 @@ impl BitcoinTest for RealBitcoinTestNoLock {
                         ?current_block_count,
                         "Waiting for blocks to be mined"
                     );
-                    sleep(Duration::from_millis(200)).await;
+                    sleep_in_test("waiting for blocks to be mined", Duration::from_millis(200))
+                        .await;
                 } else {
                     debug!(
                         target: LOG_TEST,
@@ -145,7 +146,7 @@ impl BitcoinTest for RealBitcoinTestNoLock {
             match self.client.get_mempool_entry(txid) {
                 Ok(tx) => return tx.fees.base.into(),
                 Err(_) => {
-                    sleep(Duration::from_millis(100)).await;
+                    sleep_in_test("could not get mempool tx fee", Duration::from_millis(100)).await;
                     continue;
                 }
             }

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -11,7 +11,7 @@ use fedimint_core::config::FederationId;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::Database;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
-use fedimint_core::task::{block_in_place, sleep, TaskGroup};
+use fedimint_core::task::{block_in_place, sleep_in_test, TaskGroup};
 use fedimint_core::util::SafeUrl;
 use fedimint_logging::LOG_TEST;
 use futures::executor::block_on;
@@ -194,7 +194,7 @@ impl GatewayTest {
                 return Ok(());
             }
 
-            sleep(Duration::from_secs(1)).await;
+            sleep_in_test("waiting for webserver to be ready", Duration::from_secs(1)).await;
         }
 
         Err(anyhow!(
@@ -212,7 +212,7 @@ impl GatewayTest {
                 return Ok(());
             }
 
-            sleep(Duration::from_secs(1)).await;
+            sleep_in_test("waiting for gateway state", Duration::from_secs(1)).await;
         }
 
         Err(anyhow!(


### PR DESCRIPTION
The function fedimint_core::task::sleep_in_test should be used over fedimint_core::task::sleep in tests so the duration of the sleep and a comment describing the reason for sleeping can be logged.

Closes: https://github.com/fedimint/fedimint/issues/1792