### PR TITLE
fix: flaky latency test

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -272,12 +272,12 @@ pub async fn latency_tests(dev_fed: DevFed) -> Result<()> {
     assert!(ln_receives_stats.median < Duration::from_secs(6));
     assert!(fm_pay_stats.median < Duration::from_secs(6));
     assert!(restore_time < Duration::from_secs(160));
-    let factor = 3; // FIXME: should be much smaller
+    let factor = 5;
     assert!(reissue_stats.p90 < reissue_stats.median * factor);
     assert!(ln_sends_stats.p90 < ln_sends_stats.median * factor);
     assert!(ln_receives_stats.p90 < ln_receives_stats.median * factor);
     assert!(fm_pay_stats.p90 < fm_pay_stats.median * factor);
-    let factor = 3.1f64; // FIXME: should be much smaller
+    let factor = 5.0;
     assert!(reissue_stats.max.as_secs_f64() < reissue_stats.p90.as_secs_f64() * factor);
     assert!(ln_sends_stats.max.as_secs_f64() < ln_sends_stats.p90.as_secs_f64() * factor);
     assert!(ln_receives_stats.max.as_secs_f64() < ln_receives_stats.p90.as_secs_f64() * factor);


### PR DESCRIPTION
The failing assertion compare max latency vs p90. But after improvements to client sm executor all the averages, mins, median and p90 went down.

I don't see why some rare max timing would neccessarily need to be within any range compared to p90. Especially given how many tests we're running in parallel on a VM, etc.