### PR TITLE
fix: slow client recovery in tests

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -312,7 +312,7 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
             let restore_time = start_time.elapsed();
 
             println!("### LATENCY RESTORE: {restore_time:?}");
-            assert!(restore_time < Duration::from_secs(160));
+            assert!(restore_time < Duration::from_secs(10));
         }
     }
 

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2004,6 +2004,7 @@ impl ClientBuilder {
                                             module_config.clone(),
                                             db.clone(),
                                             module_instance_id,
+                                            common_api_versions.core,
                                             api_version,
                                             root_secret.derive_module_secret(module_instance_id),
                                             notifier.clone(),
@@ -2071,6 +2072,7 @@ impl ClientBuilder {
                             module_config,
                             db.clone(),
                             module_instance_id,
+                            common_api_versions.core,
                             api_version,
                             // This is a divergence from the legacy client, where the child secret
                             // keys were derived using *module kind*-specific derivation paths.

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1415,7 +1415,10 @@ impl Client {
         let common_api_versions =
             Client::discover_common_api_version_static(config, module_inits, api).await?;
 
-        debug!("Updating the cached common api versions");
+        debug!(
+            value = ?common_api_versions,
+            "Updating the cached common api versions"
+        );
         let mut dbtx = db.begin_transaction().await;
         let _ = dbtx
             .insert_entry(
@@ -1947,6 +1950,8 @@ impl ClientBuilder {
             &db,
         )
         .await?;
+
+        debug!(?common_api_versions, "Completed api version negotiation");
 
         let mut module_recoveries: BTreeMap<
             ModuleInstanceId,

--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -33,7 +33,8 @@ where
     federation_id: FederationId,
     cfg: <<C as ModuleInit>::Common as CommonModuleInit>::ClientConfig,
     db: Database,
-    api_version: ApiVersion,
+    core_api_version: ApiVersion,
+    module_api_version: ApiVersion,
     module_root_secret: DerivableSecret,
     notifier: ModuleNotifier<<<C as ClientModuleInit>::Module as ClientModule>::States>,
     api: DynGlobalApi,
@@ -57,8 +58,17 @@ where
         &self.db
     }
 
+    pub fn core_api_version(&self) -> &ApiVersion {
+        &self.core_api_version
+    }
+
+    pub fn module_api_version(&self) -> &ApiVersion {
+        &self.module_api_version
+    }
+
+    // TODO: deprecate, use `module_api_version` instead
     pub fn api_version(&self) -> &ApiVersion {
-        &self.api_version
+        &self.module_api_version
     }
 
     pub fn module_root_secret(&self) -> &DerivableSecret {
@@ -99,7 +109,8 @@ where
     federation_id: FederationId,
     cfg: <<C as ModuleInit>::Common as CommonModuleInit>::ClientConfig,
     db: Database,
-    api_version: ApiVersion,
+    core_api_version: ApiVersion,
+    module_api_version: ApiVersion,
     module_root_secret: DerivableSecret,
     notifier: ModuleNotifier<<<C as ClientModuleInit>::Module as ClientModule>::States>,
     api: DynGlobalApi,
@@ -124,8 +135,17 @@ where
         &self.db
     }
 
+    pub fn core_api_version(&self) -> &ApiVersion {
+        &self.core_api_version
+    }
+
+    pub fn module_api_version(&self) -> &ApiVersion {
+        &self.module_api_version
+    }
+
+    // TODO: deprecate, use module_api_version instead
     pub fn api_version(&self) -> &ApiVersion {
-        &self.api_version
+        &self.module_api_version
     }
 
     pub fn module_root_secret(&self) -> &DerivableSecret {
@@ -224,7 +244,8 @@ pub trait IClientModuleInit: IDynCommonModuleInit + Debug + MaybeSend + MaybeSyn
         cfg: ClientModuleConfig,
         db: Database,
         instance_id: ModuleInstanceId,
-        api_version: ApiVersion,
+        core_api_version: ApiVersion,
+        module_api_version: ApiVersion,
         module_root_secret: DerivableSecret,
         notifier: Notifier,
         api: DynGlobalApi,
@@ -240,7 +261,8 @@ pub trait IClientModuleInit: IDynCommonModuleInit + Debug + MaybeSend + MaybeSyn
         cfg: ClientModuleConfig,
         db: Database,
         instance_id: ModuleInstanceId,
-        api_version: ApiVersion,
+        core_api_version: ApiVersion,
+        module_api_version: ApiVersion,
         module_root_secret: DerivableSecret,
         notifier: Notifier,
         api: DynGlobalApi,
@@ -277,7 +299,8 @@ where
         cfg: ClientModuleConfig,
         db: Database,
         instance_id: ModuleInstanceId,
-        api_version: ApiVersion,
+        core_api_version: ApiVersion,
+        module_api_version: ApiVersion,
         module_root_secret: DerivableSecret,
         // TODO: make dyn type for notifier
         notifier: Notifier,
@@ -299,7 +322,8 @@ where
                     federation_id,
                     cfg: typed_cfg.clone(),
                     db: db.with_prefix_module_id(instance_id),
-                    api_version,
+                    core_api_version,
+                    module_api_version,
                     module_root_secret,
                     notifier: notifier.module_notifier(instance_id),
                     api: api.clone(),
@@ -324,7 +348,8 @@ where
         cfg: ClientModuleConfig,
         db: Database,
         instance_id: ModuleInstanceId,
-        api_version: ApiVersion,
+        core_api_version: ApiVersion,
+        module_api_version: ApiVersion,
         module_root_secret: DerivableSecret,
         // TODO: make dyn type for notifier
         notifier: Notifier,
@@ -336,7 +361,8 @@ where
                 federation_id,
                 cfg: typed_cfg.clone(),
                 db: db.with_prefix_module_id(instance_id),
-                api_version,
+                core_api_version,
+                module_api_version,
                 module_root_secret,
                 notifier: notifier.module_notifier(instance_id),
                 api: api.clone(),

--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -265,7 +265,7 @@ where
                         let block = loop {
                             info!(target: LOG_CLIENT_RECOVERY, session_idx, "Awaiting signed block");
 
-                            let items_res = if core_api_version <= VERSION_THAT_INTRODUCED_GET_SESSION_STATUS {
+                            let items_res = if core_api_version < VERSION_THAT_INTRODUCED_GET_SESSION_STATUS {
                                 api.await_block(session_idx, &decoders).await.map(|s| s.items)
                             } else {
                                 api.get_session_status(session_idx, &decoders).await.map(|s| match s {

--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -245,7 +245,7 @@ where
         /// errors via `sender` itself.
         fn fetch_block_stream<'a>(
             api: DynGlobalApi,
-            api_version: ApiVersion,
+            core_api_version: ApiVersion,
             decoders: ModuleDecoderRegistry,
             epoch_range: ops::Range<u64>,
         ) -> impl futures::Stream<Item = (u64, Vec<AcceptedItem>)> + 'a {
@@ -265,7 +265,7 @@ where
                         let block = loop {
                             info!(target: LOG_CLIENT_RECOVERY, session_idx, "Awaiting signed block");
 
-                            let items_res = if api_version <= VERSION_THAT_INTRODUCED_GET_SESSION_STATUS {
+                            let items_res = if core_api_version <= VERSION_THAT_INTRODUCED_GET_SESSION_STATUS {
                                 api.await_block(session_idx, &decoders).await.map(|s| s.items)
                             } else {
                                 api.get_session_status(session_idx, &decoders).await.map(|s| match s {
@@ -403,7 +403,7 @@ where
 
         let mut block_stream = fetch_block_stream(
             self.api().clone(),
-            *self.api_version(),
+            *self.core_api_version(),
             client_ctx.decoders(),
             block_stream_session_range,
         );

--- a/fedimint-core/src/module/version.rs
+++ b/fedimint-core/src/module/version.rs
@@ -368,6 +368,24 @@ pub struct SupportedCoreApiVersions {
     pub api: MultiApiVersion,
 }
 
+impl SupportedCoreApiVersions {
+    /// Get minor supported version by consensus and major numbers
+    pub fn get_minor_api_version(
+        &self,
+        core_consensus: CoreConsensusVersion,
+        major: u32,
+    ) -> Option<u32> {
+        if self.core_consensus.major != core_consensus.major {
+            return None;
+        }
+
+        self.api.get_by_major(major).map(|v| {
+            debug_assert_eq!(v.major, major);
+            v.minor
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SupportedModuleApiVersions {
     pub core_consensus: CoreConsensusVersion,
@@ -395,6 +413,27 @@ impl SupportedModuleApiVersions {
                 "overlapping (conflicting) api versions when declaring SupportedModuleApiVersions",
             ),
         }
+    }
+
+    /// Get minor supported version by consensus and major numbers
+    pub fn get_minor_api_version(
+        &self,
+        core_consensus: CoreConsensusVersion,
+        module_consensus: ModuleConsensusVersion,
+        major: u32,
+    ) -> Option<u32> {
+        if self.core_consensus.major != core_consensus.major {
+            return None;
+        }
+
+        if self.module_consensus.major != module_consensus.major {
+            return None;
+        }
+
+        self.api.get_by_major(major).map(|v| {
+            debug_assert_eq!(v.major, major);
+            v.minor
+        })
     }
 }
 


### PR DESCRIPTION
I've noticed recovery tests are still super slow and investigating why that is, found bunch of bugs. This was the first time we are actually using api version discovery for anything, so it's unsurpring that I've found bunch of (my own) bugs. :D
