### PR TITLE
chore: ignore uncommitted transaction during db migrations

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -337,6 +337,7 @@ pub async fn apply_migrations_client(
         }
 
         if current_db_version == target_db_version {
+            global_dbtx.ignore_uncommitted();
             return Ok(());
         }
 


### PR DESCRIPTION
Devimint is displaying some nasty stack traces, but its only because the db migrations did not need to do anything so the database transaction is not committed. It is safe to ignore.