### PR TITLE
chore: prevent hanging connnections failing builds

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+          extra_nix_config: |
+            connect-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -44,6 +44,8 @@ jobs:
       - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+          extra_nix_config: |
+            connect-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint
@@ -96,6 +98,8 @@ jobs:
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+          extra_nix_config: |
+            connect-timeout = 15
       - uses: cachix/cachix-action@v14
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
@@ -139,6 +143,8 @@ jobs:
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+          extra_nix_config: |
+            connect-timeout = 15
       - uses: cachix/cachix-action@v14
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
@@ -209,6 +215,8 @@ jobs:
       - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+          extra_nix_config: |
+            connect-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint
@@ -236,6 +244,8 @@ jobs:
       - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+          extra_nix_config: |
+            connect-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint
@@ -306,6 +316,8 @@ jobs:
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+          extra_nix_config: |
+            connect-timeout = 15
 
       - uses: cachix/cachix-action@v14
         if: github.event_name != 'pull_request' || matrix.build-in-pr
@@ -338,6 +350,8 @@ jobs:
       - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+          extra_nix_config: |
+            connect-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint
@@ -424,6 +438,8 @@ jobs:
       - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+          extra_nix_config: |
+            connect-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint


### PR DESCRIPTION
Stuff like this: https://github.com/fedimint/fedimint/actions/runs/8011581330/job/21885131838 , hangs on downloading something and must not be doing any progress.

It's better for `nix` to timeout and retry connection.