### PR TITLE
[Backport releases/v0.2] fix: run real fedimint-ln-gateway tests

### DIFF
--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -193,6 +193,7 @@ async fn pay_valid_invoice(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore] // TODO: resolve in https://github.com/fedimint/fedimint/pull/4354
 async fn test_gateway_can_pay_ldk_node() -> anyhow::Result<()> {
     // Running LDK Node with the mock services doesnt provide any additional
     // coverage, since `FakeLightningTest` does not open any channels.

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -44,7 +44,8 @@ function run_tests() {
       -E 'package(fedimint-ln-tests)'
     cargo nextest run --locked --workspace --all-targets \
       ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
-      ${TEST_ARGS_SERIALIZED} 'package(ln-gateway)'
+      ${TEST_ARGS_SERIALIZED} \
+      -E 'package(fedimint-ln-gateway)'
     >&2 echo "### Testing against bitcoind - complete"
   fi
 


### PR DESCRIPTION
Backports https://github.com/fedimint/fedimint/pull/4388