### PR TITLE
fix: Gateway Enforce Routing Fees

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -896,6 +896,19 @@ impl LightningClientModule {
         Ok(())
     }
 
+    /// Overrides the active gateway with an explicit `announcement`. This
+    /// should only be used for testing.
+    pub async fn override_active_gateway(
+        &self,
+        announcement: LightningGatewayAnnouncement,
+    ) -> anyhow::Result<()> {
+        let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
+        dbtx.insert_entry(&LightningGatewayKey, &announcement.anchor())
+            .await;
+        dbtx.commit_tx_result().await?;
+        Ok(())
+    }
+
     /// Fetches the metadata overrides for a given federation
     ///
     /// # Arguments


### PR DESCRIPTION
In debugging https://github.com/fedimint/fedimint/issues/4350 I realized that the gateway is not independently verifying that the client attached routing fees to the contract. We check if the contract is underfunded, but only against the invoice amount, not invoice amount + gateway fee. 

This PR adds gateway enforcement of fees and adds a test that verifies clients cannot cheat and not pay fees.