### PR TITLE
Allow downloading guardian config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
  "fedimintd",
  "fs-lock",
  "futures",
+ "hex",
  "nix",
  "rand",
  "semver",
@@ -2105,6 +2106,7 @@ dependencies = [
  "fedimint-testing",
  "fedimint-threshold-crypto",
  "futures",
+ "hex",
  "itertools 0.10.5",
  "jsonrpsee",
  "parity-scale-codec",
@@ -2117,6 +2119,7 @@ dependencies = [
  "sha3",
  "strum",
  "strum_macros",
+ "tar",
  "tempfile",
  "test-log",
  "thiserror",
@@ -2456,6 +2459,18 @@ dependencies = [
  "bitvec",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4907,6 +4922,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5917,6 +5943,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -28,6 +28,7 @@ fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
 fedimint-server = { path = "../fedimint-server" }
 fedimint-testing = { path = "../fedimint-testing" }
 futures = "0.3.24"
+hex = "0.4.3"
 ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 nix = { version = "0.26.2", features = ["signal"] }
 rand = "0.8.5"

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -354,6 +354,9 @@ enum AdminCmd {
 
     /// Show an audit across all modules
     Audit,
+
+    /// Download guardian config to back it up
+    GuardianConfigBackup,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -678,6 +681,18 @@ impl FedimintCli {
                 let status = cli.admin_client(client.get_config())?.status().await?;
                 Ok(CliOutput::Raw(
                     serde_json::to_value(status)
+                        .map_err_cli_msg(CliErrorKind::GeneralFailure, "invalid response")?,
+                ))
+            }
+            Command::Admin(AdminCmd::GuardianConfigBackup) => {
+                let client = self.client_open(&cli).await?;
+
+                let guardian_config_backup = cli
+                    .admin_client(client.get_config())?
+                    .guardian_config_backup(cli.auth()?)
+                    .await?;
+                Ok(CliOutput::Raw(
+                    serde_json::to_value(guardian_config_backup)
                         .map_err_cli_msg(CliErrorKind::GeneralFailure, "invalid response")?,
                 ))
             }

--- a/fedimint-core/src/admin_client.rs
+++ b/fedimint-core/src/admin_client.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use bitcoin_hashes::sha256;
+use fedimint_core::api::GuardianConfigBackup;
 use fedimint_core::module::audit::AuditSummary;
 use fedimint_core::task::MaybeSend;
 use fedimint_core::util::SafeUrl;
@@ -13,9 +14,10 @@ use crate::config::ServerModuleConfigGenParamsRegistry;
 use crate::endpoint_constants::{
     ADD_CONFIG_GEN_PEER_ENDPOINT, AUDIT_ENDPOINT, AUTH_ENDPOINT, CONFIG_GEN_PEERS_ENDPOINT,
     CONSENSUS_CONFIG_GEN_PARAMS_ENDPOINT, DEFAULT_CONFIG_GEN_PARAMS_ENDPOINT,
-    RESTART_FEDERATION_SETUP_ENDPOINT, RUN_DKG_ENDPOINT, SET_CONFIG_GEN_CONNECTIONS_ENDPOINT,
-    SET_CONFIG_GEN_PARAMS_ENDPOINT, SET_PASSWORD_ENDPOINT, START_CONSENSUS_ENDPOINT,
-    STATUS_ENDPOINT, VERIFIED_CONFIGS_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT,
+    GUARDIAN_CONFIG_BACKUP_ENDPOINT, RESTART_FEDERATION_SETUP_ENDPOINT, RUN_DKG_ENDPOINT,
+    SET_CONFIG_GEN_CONNECTIONS_ENDPOINT, SET_CONFIG_GEN_PARAMS_ENDPOINT, SET_PASSWORD_ENDPOINT,
+    START_CONSENSUS_ENDPOINT, STATUS_ENDPOINT, VERIFIED_CONFIGS_ENDPOINT,
+    VERIFY_CONFIG_HASH_ENDPOINT,
 };
 use crate::module::{ApiAuth, ApiRequestErased};
 use crate::PeerId;
@@ -185,6 +187,18 @@ impl WsAdminClient {
     pub async fn audit(&self, auth: ApiAuth) -> FederationResult<AuditSummary> {
         self.request(AUDIT_ENDPOINT, ApiRequestErased::default().with_auth(auth))
             .await
+    }
+
+    /// Download the guardian config to back it up
+    pub async fn guardian_config_backup(
+        &self,
+        auth: ApiAuth,
+    ) -> FederationResult<GuardianConfigBackup> {
+        self.request(
+            GUARDIAN_CONFIG_BACKUP_ENDPOINT,
+            ApiRequestErased::default().with_auth(auth),
+        )
+        .await
     }
 
     /// Check auth credentials

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -1223,6 +1223,14 @@ pub struct StatusResponse {
     pub federation: Option<FederationStatus>,
 }
 
+/// Archive of all the guardian config files that can be used to recover a lost
+/// guardian node.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GuardianConfigBackup {
+    #[serde(with = "fedimint_core::hex::serde")]
+    pub tar_archive_bytes: Vec<u8>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -1,6 +1,7 @@
 pub const ACCOUNT_ENDPOINT: &str = "account";
 pub const ADD_CONFIG_GEN_PEER_ENDPOINT: &str = "add_config_gen_peer";
 pub const AUDIT_ENDPOINT: &str = "audit";
+pub const GUARDIAN_CONFIG_BACKUP_ENDPOINT: &str = "download_guardian_backup";
 pub const AUTH_ENDPOINT: &str = "auth";
 pub const AWAIT_OUTPUT_OUTCOME_ENDPOINT: &str = "await_output_outcome";
 pub const BACKUP_ENDPOINT: &str = "backup";

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -27,6 +27,7 @@ bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 bytes = "1.4.0"
 futures = "0.3.24"
+hex = "0.4.3"
 itertools = "0.10.5"
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
@@ -39,6 +40,7 @@ serde_json = "1.0.91"
 sha3 = "0.10.5"
 strum = "0.24"
 strum_macros = "0.24"
+tar = "0.4.40"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
 thiserror = "1.0.39"
 tracing ="0.1.37"

--- a/fedimint-server/src/config/io.rs
+++ b/fedimint-server/src/config/io.rs
@@ -37,7 +37,7 @@ pub const DB_FILE: &str = "database";
 
 pub const JSON_EXT: &str = "json";
 
-const ENCRYPTED_EXT: &str = "encrypt";
+pub const ENCRYPTED_EXT: &str = "encrypt";
 
 /// Temporary directiry where server configs are stored / removed through the
 /// setup process On setup complete, the configs are moved to the server config

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -208,7 +208,7 @@ impl ServerConfig {
     pub fn supported_api_versions() -> SupportedCoreApiVersions {
         SupportedCoreApiVersions {
             core_consensus: CORE_CONSENSUS_VERSION,
-            api: MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 1 }])
+            api: MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 2 }])
                 .expect("not version conflicts"),
         }
     }

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -357,6 +357,12 @@ rec {
     buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/tests/latency-test.sh";
   };
 
+  guardianBackupTest = craneLibTests.mkCargoDerivation {
+    pname = "${commonCliTestArgs.pname}-guardian-backp";
+    cargoArtifacts = workspaceBuild;
+    buildPhaseCargoCommand = "patchShebangs ./scripts ; ./scripts/tests/guardian-backup.sh";
+  };
+
   devimintCliTest = craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-cli";
     cargoArtifacts = workspaceBuild;

--- a/scripts/tests/guardian-backup.sh
+++ b/scripts/tests/guardian-backup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Runs a test to see what happens if a server dies and rejoins
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+make_fm_test_marker
+
+devimint guardian-backup

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -89,6 +89,12 @@ function latency_test_restore() {
 }
 export -f latency_test_restore
 
+function guardian_backup() {
+  # guardian-backup-test runs a degraded federation, so we need to override FM_OFFLINE_NODES
+  fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/guardian-backup.sh
+}
+export -f guardian_backup
+
 function devimint_cli_test() {
   fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-cli-test.sh
 }
@@ -183,6 +189,7 @@ tests_to_run_in_parallel=(
   "devimint_cli_test_single"
   "load_test_tool_test"
   "recoverytool_tests"
+  "guardian_backup"
 )
 
 tests_with_versions=()


### PR DESCRIPTION
Fixes #4039 on the `fedimintd` side, also needs a UI feature. 

@EthnTuttle, @Kodylow how hard would that be to integrate on the frontend side? [It seems possible to download a file "from memory", although in the typical web tech hacky way :see_no_evil: ](https://stackoverflow.com/questions/3665115/how-to-create-a-file-in-memory-for-user-to-download-but-not-through-server)

For manual testing you can run

```bash
fedimint-cli --our-id 0 --password pass admin guardian-config-backup | jq -r .tar_archive_bytes | xxd -r -p  > backup.tar
```

it decodes the returned hex and writes it to `backup.tar`. Comparing the files they look reasonably similar (some differences due to non-pretty encoding):

```
$ ls -la target/devimint/fedimintd-0/
total 200
drwxr-xr-x  3 user users   4096 Feb 25 21:19 .
drwxr-xr-x 13 user users   4096 Feb 25 21:19 ..
-rw-r--r--  1 user users  59805 Feb 25 21:19 client.json
-rw-r--r--  1 user users 103889 Feb 25 21:19 consensus.json
drwxr-xr-x  2 user users   4096 Feb 25 21:42 database
-rw-r--r--  1 user users    898 Feb 25 21:19 local.json
-rw-r--r--  1 user users      4 Feb 25 21:19 password.private
-rw-r--r--  1 user users  10454 Feb 25 21:19 private.encrypt
-rw-r--r--  1 user users     22 Feb 25 21:19 private.salt

$ tar -tvf backup.tar 
---------- 0/0             628 1970-01-01 01:00 local.json
---------- 0/0          100143 1970-01-01 01:00 consensus.json
---------- 0/0              22 1970-01-01 01:00 private.salt
---------- 0/0           10454 1970-01-01 01:00 private.encrypt
```

TODO here: testing. I'm thinking of deleting the config of a guardian, replacing it with the tar archive versions and restarting it to see if it can start. I hope devimint supports such shenanigans.