### PR TITLE
chore: add blank .semgrepignore & fix findings

### DIFF
--- a/.config/semgrep.yaml
+++ b/.config/semgrep.yaml
@@ -105,13 +105,14 @@ rules:
   languages:
     - rust
   patterns:
-    - pattern: sleep($X)
+    - pattern-either:
+      - pattern: sleep(...)
+      - pattern: fedimint_core::task::sleep(...)
   paths:
     include:
       - fedimint-testing/
       - fedimint-wasm-testing/
       - fedimint-wasm-tests/
-      - fedimint-load-test-tool/
       - modules/fedimint-dummy-tests/
       - modules/fedimint-wallet-tests/
       - modules/fedimint-ln-tests/

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1389,7 +1389,11 @@ pub async fn lightning_gw_reconnect_test(
                             RETRY_INTERVAL.as_secs(),
                             i + 1,
                         );
-                        fedimint_core::task::sleep(RETRY_INTERVAL).await;
+                        fedimint_core::task::sleep_in_test(
+                            "paying invoice for gateway failed",
+                            RETRY_INTERVAL,
+                        )
+                        .await;
                     }
                 }
             }
@@ -1793,7 +1797,7 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
             // 3 minutes should be enough to finish one or two sessions
             bail!("recoverytool epochs method timed out");
         } else {
-            fedimint_core::task::sleep(Duration::from_secs(1)).await
+            fedimint_core::task::sleep_in_test("recovery failed", Duration::from_secs(1)).await
         }
     };
     let epochs_descriptors = outputs

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -116,7 +116,7 @@ impl BitcoinTest for RealBitcoinTestNoLock {
                     Err(e) => {
                         if e.to_string().contains("not yet in block") {
                             // mostly to yield, as we no other yield points
-                            task::sleep(Duration::from_millis(1)).await;
+                            task::sleep_in_test("not yet in block", Duration::from_millis(1)).await;
                             continue;
                         }
                         panic!("Could not get txoutproof: {e}");

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -456,9 +456,13 @@ impl LdkLightningTest {
                 break;
             }
 
-            fedimint_core::task::sleep(std::time::Duration::from_secs(1)).await;
+            fedimint_core::task::sleep_in_test(
+                "LDK Note didn't find onchain balance",
+                std::time::Duration::from_secs(1),
+            )
+            .await;
 
-            info!("LDK Node didn't find onchain balance, syncing wallet...");
+            info!("syncing wallet...");
             node.sync_wallets().map_err(|e| {
                 error!("Failed to sync LDK Node onchain wallet: {e:?}");
                 LightningRpcError::FailedToConnect

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -13,7 +13,7 @@ use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder
 use fedimint_client::ClientArc;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, OperationId};
-use fedimint_core::task::sleep;
+use fedimint_core::task::sleep_in_test;
 use fedimint_core::util::NextOrPending;
 use fedimint_core::{msats, sats, Amount, OutPoint, TransactionId};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
@@ -748,7 +748,7 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
             assert_eq!(invoice.expiry_time(), Duration::from_secs(1));
 
             // at seconds granularity, must wait `expiry + 1s` to make sure expired
-            sleep(Duration::from_secs(2)).await;
+            sleep_in_test("waiting for invoice to expire", Duration::from_secs(2)).await;
 
             // Print money for user_client
             let dummy_module = user_client.get_first_module::<DummyClientModule>();

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -481,7 +481,6 @@ async fn rejects_wrong_network_invoice() -> anyhow::Result<()> {
 #[cfg(test)]
 mod fedimint_migration_tests {
     use std::str::FromStr;
-    use std::time::SystemTime;
 
     use anyhow::ensure;
     use bitcoin_hashes::{sha256, Hash};
@@ -706,7 +705,7 @@ mod fedimint_migration_tests {
         let lightning_gateway_registration = LightningGatewayRegistration {
             info: gateway_info,
             vetted: false,
-            valid_until: SystemTime::now(),
+            valid_until: fedimint_core::time::now(),
         };
 
         dbtx.insert_new_entry(
@@ -734,7 +733,7 @@ mod fedimint_migration_tests {
             &MetaOverridesKey,
             &MetaOverrides {
                 value: "META OVERRIDE".to_string(),
-                fetched_at: SystemTime::now(),
+                fetched_at: fedimint_core::time::now(),
             },
         )
         .await;

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 use std::time::Duration;
 
 use fedimint_client::backup::{ClientBackup, Metadata};
-use fedimint_core::task::sleep;
+use fedimint_core::task::sleep_in_test;
 use fedimint_core::util::NextOrPending;
 use fedimint_core::{sats, Amount};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
@@ -108,7 +108,7 @@ async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
 
     // FIXME: UserCanceledSuccess should mean the money is in our wallet
     for _ in 0..200 {
-        sleep(Duration::from_millis(100)).await;
+        sleep_in_test("sats not in wallet yet", Duration::from_millis(100)).await;
         if client.get_balance().await == sats(1000) {
             return Ok(());
         }


### PR DESCRIPTION
If .semgrepignore is not present, semgrep uses a default .semgrepignore file. The defaults excluded some tests which is not the desired outcome.

Add a blank .semgrepignore file to indicate that nothing additional to .gitignore should be ignored by semgrep.

Also, add a second pattern to ban-direct-sleep-in-tests rule to find the sleep function when the fully qualified function name is present.