### PR TITLE
fix: Handle http errors in wasm test

### DIFF
--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -52,7 +52,11 @@ mod faucet {
         let resp = gloo_net::http::Request::get("http://localhost:15243/connect-string")
             .send()
             .await?;
-        Ok(resp.text().await?)
+        if resp.ok() {
+            Ok(resp.text().await?)
+        } else {
+            anyhow::bail!(resp.text().await?);
+        }
     }
 
     pub async fn pay_invoice(invoice: &str) -> anyhow::Result<()> {
@@ -71,7 +75,11 @@ mod faucet {
         let resp = gloo_net::http::Request::get("http://localhost:15243/gateway-api")
             .send()
             .await?;
-        Ok(resp.text().await?)
+        if resp.ok() {
+            Ok(resp.text().await?)
+        } else {
+            anyhow::bail!(resp.text().await?);
+        }
     }
 
     pub async fn generate_invoice(amt: u64) -> anyhow::Result<String> {


### PR DESCRIPTION
Closes #4393

I suspect this happened because an http error was returned and it tried to parse the error string as an `InviteCode`