### PR TITLE
fix: check if in repl before running replit direnv check

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,7 @@
 # Replit requires this check to re-run direnv on reconnect
-if ! has nix_direnv_version || ! nix_direnv_version 3.0.4; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.4/direnvrc" "sha256-DzlYZ33mWF/Gs8DDeyjr8mnVmQGx7ASYqA5WlxwvBG4="
+if [ -n "$REPL_ID" ]; then
+  if ! has nix_direnv_version || ! nix_direnv_version 3.0.4; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.4/direnvrc" "sha256-DzlYZ33mWF/Gs8DDeyjr8mnVmQGx7ASYqA5WlxwvBG4="
+  fi
 fi
 use flake


### PR DESCRIPTION
Gets rid of this warning I introduced when running direnv on local from the replit support PR, sorry @dpc :

```
> cd fedimint
nix-direnv: error current version v2.3.0 is older than the desired version v3.0.4
:bulb: Run 'just' for a list of available 'just ...' helper recipes
```