### PR TITLE
feat: handle gateway having funds when leaving fed

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -65,6 +65,8 @@ pub enum Commands {
     LeaveFed {
         #[clap(long)]
         federation_id: FederationId,
+        #[clap(long, help = "Leave the federation without requiring zero balance.")]
+        forced: Option<bool>,
     },
     /// Make a backup of snapshot of all ecash
     Backup {
@@ -159,9 +161,15 @@ async fn main() -> anyhow::Result<()> {
 
             print_response(response).await;
         }
-        Commands::LeaveFed { federation_id } => {
+        Commands::LeaveFed {
+            federation_id,
+            forced,
+        } => {
             let response = client()
-                .leave_federation(LeaveFedPayload { federation_id })
+                .leave_federation(LeaveFedPayload {
+                    federation_id,
+                    force_leave: forced,
+                })
                 .await?;
             print_response(response).await;
         }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -20,6 +20,7 @@ pub struct ConnectFedPayload {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LeaveFedPayload {
     pub federation_id: FederationId,
+    pub force_leave: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -83,7 +83,7 @@ impl GatewayRpcClient {
     pub async fn leave_federation(
         &self,
         payload: LeaveFedPayload,
-    ) -> GatewayRpcResult<FederationInfo> {
+    ) -> GatewayRpcResult<Option<FederationInfo>> {
         let url = self.base_url.join("/leave-fed").expect("invalid base url");
         self.call_post(url, payload).await
     }

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -1304,15 +1304,17 @@ async fn test_gateway_can_leave_connected_federations() -> anyhow::Result<()> {
                 .any(|info| info.federation_id == id2 && info.channel_id == Some(2)));
 
             // remove first connected federation
-            let fed_info = rpc
+            // The old gateway API didn't return the federation info, so we cannot check anything in that case
+            if let Some(fed_info) = rpc
                 .leave_federation(LeaveFedPayload {
                     federation_id: id1,
                     force_leave: Some(false),
                 })
                 .await
-                .unwrap_or_else(|_| panic!("Could not leave federation {id1}."));
-            assert_eq!(fed_info.federation_id, id1);
-            assert_eq!(fed_info.channel_id, Some(1));
+                .unwrap_or_else(|_| panic!("Could not leave federation {id1}.")) {
+                assert_eq!(fed_info.federation_id, id1);
+                assert_eq!(fed_info.channel_id, Some(1));
+            };
 
             // reconnect the first federation
             let fed_info = rpc
@@ -1325,15 +1327,16 @@ async fn test_gateway_can_leave_connected_federations() -> anyhow::Result<()> {
             assert_eq!(fed_info.channel_id, Some(3));
 
             // remove second connected federation
-            let fed_info = rpc
+            if let Some(fed_info) = rpc
                 .leave_federation(LeaveFedPayload {
                     federation_id: id2,
                     force_leave: Some(false),
                 })
                 .await
-                .unwrap_or_else(|_| panic!("Could not leave federation {id2}."));
-            assert_eq!(fed_info.federation_id, id2);
-            assert_eq!(fed_info.channel_id, Some(2));
+                .unwrap_or_else(|_| panic!("Could not leave federation {id2}.")) {
+                assert_eq!(fed_info.federation_id, id2);
+                assert_eq!(fed_info.channel_id, Some(2));
+            }
 
             // reconnect the second federation
             let fed_info = rpc

--- a/scripts/tests/gateway-leave-fed-test.sh
+++ b/scripts/tests/gateway-leave-fed-test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Runs a CLI-based integration test
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+make_fm_test_marker
+
+devimint gateway-leave-fed-test

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -64,6 +64,11 @@ function gateway_reboot_test() {
 }
 export -f gateway_reboot_test
 
+function gateway_leave_fed_test() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/gateway-leave-fed-test.sh
+}
+export -f gateway_leave_fed_test
+
 function latency_test_reissue() {
   fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh reissue
 }
@@ -203,6 +208,7 @@ tests_to_run_in_parallel+=(
   "reconnect_test"
   "lightning_reconnect_test"
   "gateway_reboot_test"
+  "gateway_leave_fed_test"
   "devimint_cli_test"
   "devimint_cli_test_single"
   "load_test_tool_test"


### PR DESCRIPTION
When a gateway sends the command to leave a federation without the
forced flag, it will receive an error `GatewayError::UnexpectedState`.
When a gateway sends the command to leave the federation with the forced
flag, it will be able to leave and no error will be returned.

Closes: https://github.com/fedimint/fedimint/issues/3935