### PR TITLE
chore: include binary name in test version string

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -53,7 +53,7 @@ function run_test_for_versions() {
     export FM_BACKWARDS_COMPATIBILITY_TEST=1
     # run back-compat tests with 4/4 setup
     export FM_OFFLINE_NODES=0
-    export FM_RUN_TEST_VERSIONS="$fed_version $client_version $gateway_version"
+    export FM_RUN_TEST_VERSIONS="FM: $fed_version, CLI: $client_version, GW: $gateway_version"
   else
     # default to run current tests in 3/4 setup
     export FM_OFFLINE_NODES=1


### PR DESCRIPTION
It's not obvious which versions map to which binaries when looking through the devimint logs.

```
## FAILED: latency_test_ln_send (current v0.2.1 current)
```

This will make it obvious at a glance what version each binary maps to.

```
## FAILED: latency_test_ln_send (FM: current, CLI: v0.2.1, GW: current)
```