### PR TITLE
fix: persist xmpp message archives

### DIFF
--- a/docker/0.2.1/full-tls-mutinynet/docker-compose.yaml
+++ b/docker/0.2.1/full-tls-mutinynet/docker-compose.yaml
@@ -196,7 +196,7 @@ services:
           {levels = {min = "info"}, to = "console"};
         }
 
-        data_path = "/var/lib/prosody"
+        data_path = "/prosody_data"
         plugin_paths = {
         }
 


### PR DESCRIPTION
The data_path where xmpp archives messages in our prosody config writer is writing to /var/lib/prosody instead of the prosody_datadir volume that gets accessed by the xmpp service