### PR TITLE
chore: allocate client db prefix range for external use

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -38,6 +38,26 @@ pub enum DbKeyPrefix {
     ClientInviteCode = 0x30,
     ClientInitState = 0x31,
     ClientMetadata = 0x32,
+    /// Arbitrary data of the applications integrating Fedimint client and
+    /// wanting to store some Federation-specific data in Fedimint client
+    /// database.
+    ///
+    /// New users are encouraged to use this single prefix only.
+    //
+    // TODO: https://github.com/fedimint/fedimint/issues/4444
+    //       in the future, we should make all global access to the db private
+    //       and only expose a getter returning isolated database.
+    UserData = 0xb0,
+    /// Prefixes between 0xb1..=0xcf shall all be considered allocated for
+    /// historical and future external use
+    ExternalReservedStart = 0xb1,
+    /// Prefixes between 0xb1..=0xcf shall all be considered allocated for
+    /// historical and future external use
+    ExternalReservedEnd = 0xcf,
+    /// 0xd0.. reserved for Fedimint internal use
+    InternalReservedStart = 0xd0,
+    /// Per-module instance data
+    ModuleGlobalPrefix = 0xff,
 }
 
 impl std::fmt::Display for DbKeyPrefix {


### PR DESCRIPTION
Re #4444

I mentioned it before, but it was never followed through.

Sometimes applications using client will want to store some data, in client database. Potentially because it's already there and Fedimint provides all the infrastructure to use it, but also due to atomic transaction requirements.

We should wrap it up in a nicer interface in the future, but for now, just officially allocate it and document it in the code.

Not going to lie - while the exact range is somewhat arbitrary, and probably a smaller one would be enough, Fedi app has already started using this range, so it will make our life easier if we reserve it, and we will internally migrate to use only designated prefix when Fedimint has proper support for it, and we have some time to implement a migration.

While I think a single prefix would be enough for this exact use case, we (the Fedimint project) might come up with a need for other external use scenarios (you can't predict that stuff ahead of time), so might as well reserve a range.

New users (app integrators) are encouraged to just use the single designated user data prefix. If needs arise, we can discuss and allocate new ones in the reserved range.