### PR TITLE
chore: update log level for mprocs

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1714,7 +1714,7 @@ impl ClientBuilder {
             for (module_id, module_cfg) in client_config.modules {
                 let kind = module_cfg.kind.clone();
                 let Some(init) = self.module_inits.get(&kind) else {
-                    warn!("Detected configuration for unsupported module id: {module_id}, kind: {kind}");
+                    debug!("Detected configuration for unsupported module id: {module_id}, kind: {kind}");
                     continue;
                 };
 
@@ -1979,7 +1979,7 @@ impl ClientBuilder {
             for (module_instance_id, module_config) in config.modules.clone() {
                 let kind = module_config.kind().clone();
                 let Some(module_init) = self.module_inits.get(&kind).cloned() else {
-                    warn!("Module kind {kind} of instance {module_instance_id} not found in module gens, skipping");
+                    debug!("Module kind {kind} of instance {module_instance_id} not found in module gens, skipping");
                     continue;
                 };
 


### PR DESCRIPTION
Using the unknown module in mprocs will cause warning logs which can be unsettling for users. This change updates to a `debug!` log, which suppresses these warning.

See: [discord](https://discord.com/channels/990354215060795454/990354215878688860/1213174844275826728)

```
bash-5.2$ fedimint-cli info
2024-03-01T20:31:51.184211Z  WARN fedimint_client: Detected configuration for unsupported module id: 3, kind: unknown
2024-03-01T20:31:51.186137Z  WARN fedimint_client: Module kind unknown of instance 3 not found in module gens, skipping
{
...
```