### PR TITLE
feat: parse-json for oobNotes and cli-command

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -59,6 +59,8 @@ pub enum ClientCmd {
     Info,
     /// Reissue notes received from a third party to avoid double spends
     Reissue { oob_notes: OOBNotes },
+    /// Parse notes from a string and return them as JSON
+    ParseJson { oob_notes: OOBNotes },
     /// Prepare notes to send to a third party as a payment
     Spend {
         /// The amount of e-cash to spend
@@ -184,6 +186,10 @@ pub async fn handle_command(
 ) -> anyhow::Result<serde_json::Value> {
     match command {
         ClientCmd::Info => get_note_summary(&client).await,
+        ClientCmd::ParseJson { oob_notes } => {
+            let notes = oob_notes.parse_json()?;
+            Ok(serde_json::to_value(notes)?)
+        }
         ClientCmd::Reissue { oob_notes } => {
             let amount = oob_notes.total_amount();
 


### PR DESCRIPTION
Adds a helper function to OOBNotes and a cli command to parse OOBNotes to JSON, been running into a bunch of situations where I'd like to parse a notes string and see what's in it.

Happy for any feedback on how to do it better, mostly want it for the fedimint-ts client so I don't have to try binary parsing notes in typescript.

```
$ fedimint-cli parse-json AgEEGhuHwAD1AgIBpf2ztoZ3YI9DX1iN06H+WqaQlgw1cG2s5plFzyTonpKQ6B9lANXwvD0H2TuH8vdANLzSLklv4WEPnNtknsStaY4DC4YUZp7tHsmKZ5uCHUoIArQxr5S/SzxUq5vsKXd1GKAAvMIAUXzbqMGUXgO61vUq0aOutjXDamJU+YJm0CxRBz7TW9CdTZwE/gax7DnA2XU5XuEzdBd7sJqr9LGY75lSjodKEWoYVBRy348b+YNufcLXXlAzVVOSw/CgcsFC2xAg7pMI+4IPbEuGc9i3nlFWgCParnCKCNXQGWMTTT+12h3ZiEcvmXkD0iwFSOTYvYU=

{
  "federation_id_prefix": [
    26,
    27,
    135,
    192
  ],
  "notes": {
    "2": [
      {
        "signature": "a5fdb3b68677608f435f588dd3a1fe5aa690960c35706dace69945cf24e89e9290e81f6500d5f0bc3d07d93b87f2f740",
        "spend_key": "34bcd22e496fe1610f9cdb649ec4ad698e030b8614669eed1ec98a679b821d4a"
      }
    ],
    "8": [
      {
        "signature": "b431af94bf4b3c54ab9bec29777518a000bcc200517cdba8c1945e03bad6f52ad1a3aeb635c36a6254f98266d02c5107",
        "spend_key": "3ed35bd09d4d9c04fe06b1ec39c0d975395ee13374177bb09aabf4b198ef9952"
      },
      {
        "signature": "8e874a116a18541472df8f1bf9836e7dc2d75e5033555392c3f0a072c142db1020ee9308fb820f6c4b8673d8b79e5156",
        "spend_key": "8023daae708a08d5d01963134d3fb5da1dd988472f997903d22c0548e4d8bd85"
      }
    ]
  }
}
Kodys-MacBook-Pro-2:fedimint kody$ 
```