### PR TITLE
chore: allow download backup manually for recovery

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -596,15 +596,16 @@ impl FedimintCli {
             }
         }
 
+        let root_secret = get_default_client_secret(
+            &Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
+            &client_config.federation_id(),
+        );
+        let backup = builder
+            .download_backup_from_federation(&root_secret, &client_config)
+            .await
+            .map_err_cli_general()?;
         builder
-            .recover(
-                get_default_client_secret(
-                    &Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
-                    &client_config.federation_id(),
-                ),
-                client_config.to_owned(),
-                invite_code,
-            )
+            .recover(root_secret, client_config.to_owned(), invite_code, backup)
             .await
             .map_err_cli_general()
     }


### PR DESCRIPTION
allows client to decide whether they want to support recover without backup snapshot or not