### PR TITLE
fix: Client::has_pending_recoveries

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1470,7 +1470,7 @@ impl Client {
             .client_recovery_progress_receiver
             .borrow()
             .iter()
-            .any(|(_id, progress)| !progress.is_done())
+            .all(|(_id, progress)| progress.is_done())
     }
 
     /// Wait for all module recoveries to finish


### PR DESCRIPTION
earlier it returned true if client_recovery_progress_receiver returned empty btreemap