### PR TITLE
chore: add stalled-download-timeout nix config in CI

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -37,6 +37,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-23.11
           extra_nix_config: |
             connect-timeout = 15
+            stalled-download-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -46,6 +46,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-23.11
           extra_nix_config: |
             connect-timeout = 15
+            stalled-download-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint
@@ -100,6 +101,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-23.11
           extra_nix_config: |
             connect-timeout = 15
+            stalled-download-timeout = 15
       - uses: cachix/cachix-action@v14
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
@@ -145,6 +147,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-23.11
           extra_nix_config: |
             connect-timeout = 15
+            stalled-download-timeout = 15
       - uses: cachix/cachix-action@v14
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
@@ -217,6 +220,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-23.11
           extra_nix_config: |
             connect-timeout = 15
+            stalled-download-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint
@@ -246,6 +250,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-23.11
           extra_nix_config: |
             connect-timeout = 15
+            stalled-download-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint
@@ -318,6 +323,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-23.11
           extra_nix_config: |
             connect-timeout = 15
+            stalled-download-timeout = 15
 
       - uses: cachix/cachix-action@v14
         if: github.event_name != 'pull_request' || matrix.build-in-pr
@@ -352,6 +358,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-23.11
           extra_nix_config: |
             connect-timeout = 15
+            stalled-download-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint
@@ -440,6 +447,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-23.11
           extra_nix_config: |
             connect-timeout = 15
+            stalled-download-timeout = 15
       - uses: cachix/cachix-action@v14
         with:
           name: fedimint


### PR DESCRIPTION
We'll occasionally see network issues with cachix in CI (again today - [run](https://github.com/fedimint/fedimint/actions/runs/8156982333/job/22295596321), [discord](https://discord.com/channels/990354215060795454/1075857804692295720/1214568693036744744)).

We've previously tried `connect-timeout` (see: https://github.com/fedimint/fedimint/pull/4401), but are still seeing issues. In my local env I've seen similar errors, which have been resolved by adding `stalled-download-timeout = 15` (default: 300s).

https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-stalled-download-timeout