### PR TITLE
chore: move dev shell target to `./target-nix`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Cargo build directory.
 /target
+/target-nix
 
 # Nix build directory.
 /result

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target/
+/target-nix/
 # in case it's a symlink
 /target
+/target-nix
 
 /result
 .idea

--- a/flake.nix
+++ b/flake.nix
@@ -249,6 +249,8 @@
                 ];
 
                 shellHook = ''
+                  root="$(git rev-parse --show-toplevel)"
+
                   # workaround https://github.com/rust-lang/cargo/issues/11020
                   cargo_cmd_bins=( $(ls $HOME/.cargo/bin/cargo-{clippy,udeps,llvm-cov} 2>/dev/null) )
                   if (( ''${#cargo_cmd_bins[@]} != 0 )); then
@@ -279,6 +281,7 @@
                   fi
 
                   export RUSTC_WRAPPER=${pkgs.sccache}/bin/sccache
+                  export CARGO_BUILD_TARGET_DIR="''${CARGO_BUILD_TARGET_DIR:-''${root}/target-nix}"
                 '';
               };
             in

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 
 function add_target_dir_to_path() {
-  export PATH="$PWD/target/${CARGO_PROFILE:-debug}:$PATH"
+  export PATH="${CARGO_BUILD_TARGET_DIR:-$PWD/target}/${CARGO_PROFILE:-debug}:$PATH"
 }
 
 function build_workspace() {

--- a/scripts/dev/bootstrap.sh
+++ b/scripts/dev/bootstrap.sh
@@ -33,7 +33,7 @@ else
 fi
 
 
-if [ -e "./target/debug/fedimintd" ]; then
+if [ -e "${CARGO_BUILD_TARGET_DIR:-$PWD/target}/debug/fedimintd" ]; then
   >&2 echo "✅ fedimintd built already"
 else
   >&2 echo "✅ Use '$nix_cmd develop' to start the dev shell in another window, while the project is being pre-built below..."

--- a/scripts/dev/mprocs/run.sh
+++ b/scripts/dev/mprocs/run.sh
@@ -8,4 +8,4 @@ ensure_in_dev_shell
 build_workspace
 add_target_dir_to_path
 
-devimint --link-test-dir ./target/devimint "$@" dev-fed --exec bash -c 'mprocs -c misc/mprocs.yaml 2>$FM_LOGS_DIR/devimint-outer.log'
+devimint --link-test-dir "${CARGO_BUILD_TARGET_DIR:-$PWD/target}/devimint" "$@" dev-fed --exec bash -c 'mprocs -c misc/mprocs.yaml 2>$FM_LOGS_DIR/devimint-outer.log'

--- a/scripts/dev/tmuxinator/run.sh
+++ b/scripts/dev/tmuxinator/run.sh
@@ -22,4 +22,4 @@ function run_tmuxinator {
 }
 export -f run_tmuxinator
 
-SHELL=$(which bash) devimint  --link-test-dir ./target/devimint dev-fed --exec bash -c run_tmuxinator
+SHELL=$(which bash) devimint  --link-test-dir "${CARGO_BUILD_TARGET_DIR:-$PWD/target}/devimint" dev-fed --exec bash -c run_tmuxinator


### PR DESCRIPTION
People quite often report problems with constant rebuilds when using VSCode and other IDEs started outside of the dev shell.

These dev shells are using different rust-analyzer and Rust toolchain versions that mututally invalidate each other with dev shell setup.

While there are ways to configure such IDEs to co-exist with dev shell, they require customizing every text editor for every user.

We can't easily control IDEs of everyone, but we have a perfect control of the dev shell. It seems quite easy to just get out of the way, not use the default `./target` and problem mostly solved:

Dev shell users won't really notice the change, mostly.

Shell scripts need to use `CARGO_BUILD_TARGET_DIR`.

IDE users will have a separate ./target and ./target-nix, but it seems much better then suffering constant rebuilds of everything.