### PR TITLE
include wasm-test.sh in test-ci-all (almost)

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -181,6 +181,10 @@ jobs:
         run: |
           nix build -L .#wasm32-unknown.ci.ciTestAll5Times --keep-failed
 
+      - name: Wasm Tests
+        if: (github.event_name != 'pull_request' || matrix.build-in-pr) && matrix.run-tests && (matrix.host != 'macos')
+        run: nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --option keep-failed true --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).wasm32-unknown.ci.wasmTest
+
       - name: Prepare failed test build dirs
         if: always()
         run:  |

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -174,16 +174,12 @@ jobs:
       - name: Tests
         if: (github.event_name != 'pull_request' || matrix.build-in-pr) && matrix.run-tests
         run: |
-          nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --option keep-failed true --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).ci.ciTestAll
+          nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --option keep-failed true --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).wasm32-unknown.ci.ciTestAll
 
       - name: Tests (5 times more)
         if: github.event_name == 'merge_group' && matrix.run-tests
         run: |
-          nix build -L .#ci.ciTestAll5Times --keep-failed
-
-      - name: Wasm Tests
-        if: (github.event_name != 'pull_request' || matrix.build-in-pr) && matrix.run-tests && (matrix.host != 'macos')
-        run: nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --option keep-failed true  --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).wasm32-unknown.ci.wasmTest
+          nix build -L .#wasm32-unknown.ci.ciTestAll5Times --keep-failed
 
       - name: Prepare failed test build dirs
         if: always()

--- a/flake.lock
+++ b/flake.lock
@@ -213,17 +213,17 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1709090272,
-        "narHash": "sha256-hYzcnKPnH3+ecGEYwly0TGBECITV3eNINtDNwFCnUOk=",
+        "lastModified": 1709623646,
+        "narHash": "sha256-kqN+O/D+s2SKYfDdJUrmh1/tpc476gn+JU7JjjnkSik=",
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "49117df15209701f3e13ba2bcf514b550955e7b4",
+        "rev": "27ecbf8f2b252dd843d0f58d45658eb56bb5e223",
         "type": "github"
       },
       "original": {
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "49117df15209701f3e13ba2bcf514b550955e7b4",
+        "rev": "27ecbf8f2b252dd843d0f58d45658eb56bb5e223",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,7 @@
             targets = (pkgs.lib.getAttrs
               [
                 "default"
+                "wasm32-unknown"
               ]
               stdTargets
             );
@@ -122,6 +123,7 @@
           # toolchains for the native + wasm build
           toolchainWasm = flakeboxLib.mkFenixToolchain (toolchainArgs
           // {
+            defaultTarget = "wasm32-unknown-unknown";
             targets = (pkgs.lib.getAttrs
               [
                 "default"
@@ -129,6 +131,10 @@
               ]
               stdTargets
             );
+
+            args = {
+              nativeBuildInputs = [ pkgs.firefox pkgs.wasm-bindgen-cli pkgs.geckodriver pkgs.wasm-pack ];
+            };
           });
 
           # toolchains for the native + wasm build

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -219,6 +219,17 @@ rec {
     buildPhaseCargoCommand = "cargoWithProfile doc --locked ; cargoWithProfile check --all-targets --locked ; cargoWithProfile build --locked --all-targets";
   };
 
+  workspaceDepsWasmTest = craneLib.buildWorkspaceDepsOnly {
+    pname = "${commonArgs.pname}-wasm-test";
+    buildPhaseCargoCommand = "cargoWithProfile build --locked --tests -p fedimint-wasm-tests";
+  };
+
+  workspaceBuildWasmTest = craneLib.buildWorkspace {
+    pnameSuffix = "-workspace-wasm-test";
+    cargoArtifacts = workspaceDepsWasmTest;
+    buildPhaseCargoCommand = "cargoWithProfile build --locked --tests -p fedimint-wasm-tests";
+  };
+
   workspaceTest = craneLib.cargoNextest {
     cargoArtifacts = workspaceBuild;
     cargoExtraArgs = "--workspace --all-targets --locked";
@@ -393,7 +404,7 @@ rec {
 
   ciTestAllBase = { times }: craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-all";
-    cargoArtifacts = workspaceBuild;
+    cargoArtifacts = craneMultiBuild.default.${craneLib.cargoProfile or "release"}.workspaceBuild;
 
     FM_DISCOVER_API_VERSION_TIMEOUT = "10";
 
@@ -401,18 +412,37 @@ rec {
     # and make sure we detect it (happened too many times that we didn't).
     # Thanks to early termination, this should be all very quick, as we actually
     # won't start other tests.
-    buildPhaseCargoCommand = lib.concatStringsSep "\n" (
-      lib.replicate times ''
-        patchShebangs ./scripts
-        export FM_CARGO_DENY_COMPILATION=1
-        ./scripts/tests/test-ci-all.sh || exit 1
-        cp scripts/tests/always-success-test.sh scripts/tests/always-success-test.sh.bck
-        sed -i -e 's/exit 0/exit 1/g' scripts/tests/always-success-test.sh
-        echo "Verifying failure detection..."
-        ./scripts/tests/test-ci-all.sh 1>/dev/null 2>/dev/null && exit 1
-        cp -f scripts/tests/always-success-test.sh.bck scripts/tests/always-success-test.sh
+    buildPhaseCargoCommand =
       ''
-    );
+        # when running on a wasm32-unknown toolchain...
+        if [ "$CARGO_BUILD_TARGET" == "wasm32-unknown-unknown" ]; then
+          # import pre-built wasm32-unknown wasm test artifacts
+          # notably, they are extracted to target's sub-directory, where wasm-test.sh expects them
+          inheritCargoArtifacts ${craneMultiBuild.wasm32-unknown.${craneLib.cargoProfile or "release"}.workspaceBuildWasmTest} "target/pkgs/fedimint-wasm-tests"
+        fi
+        # default to building for native; running test for cross-compilation targets
+        # here doesn't make any sense, and `wasm32-unknown-unknown` toolchain is used
+        # mostly to opt-in into wasm tests
+        unset CARGO_BUILD_TARGET
+
+        # TODO: hack, remove
+        echo "target"
+        ls ./target/pkgs
+        echo "target/wa..."
+        ls ./target/pkgs/fedimint-wasm-tests
+      '' +
+      lib.concatStringsSep "\n" (
+        lib.replicate times ''
+          patchShebangs ./scripts
+          export FM_CARGO_DENY_COMPILATION=1
+          ./scripts/tests/test-ci-all.sh || exit 1
+          cp scripts/tests/always-success-test.sh scripts/tests/always-success-test.sh.bck
+          sed -i -e 's/exit 0/exit 1/g' scripts/tests/always-success-test.sh
+          echo "Verifying failure detection..."
+          ./scripts/tests/test-ci-all.sh 1>/dev/null 2>/dev/null && exit 1
+          cp -f scripts/tests/always-success-test.sh.bck scripts/tests/always-success-test.sh
+        ''
+      );
   };
 
   ciTestAll = ciTestAllBase { times = 1; };
@@ -428,9 +458,11 @@ rec {
   wasmTest = craneLibTests.mkCargoDerivation {
     pname = "wasm-test";
     # TODO: https://github.com/ipetkov/crane/issues/416
-    cargoArtifacts = craneMultiBuild.${craneLib.cargoProfile or "release"}.workspaceBuild;
+    cargoArtifacts = craneMultiBuild.default.${craneLib.cargoProfile or "release"}.workspaceBuild;
     nativeBuildInputs = commonCliTestArgs.nativeBuildInputs ++ [ pkgs.firefox pkgs.wasm-bindgen-cli pkgs.geckodriver pkgs.wasm-pack ];
-    buildPhaseCargoCommand = "patchShebangs ./scripts; SKIP_CARGO_BUILD=1 ./scripts/tests/wasm-test.sh";
+    buildPhaseCargoCommand = ''
+      inheritCargoArtifacts ${craneMultiBuild.wasm32-unknown.${craneLib.cargoProfile or "release"}.workspaceBuildWasmTest}
+      patchShebangs ./scripts; SKIP_CARGO_BUILD=1 ./scripts/tests/wasm-test.sh'';
   };
 
   fedimint-pkgs = fedimintBuildPackageGroup {

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -424,12 +424,6 @@ rec {
         # here doesn't make any sense, and `wasm32-unknown-unknown` toolchain is used
         # mostly to opt-in into wasm tests
         unset CARGO_BUILD_TARGET
-
-        # TODO: hack, remove
-        echo "target"
-        ls ./target/pkgs
-        echo "target/wa..."
-        ls ./target/pkgs/fedimint-wasm-tests
       '' +
       lib.concatStringsSep "\n" (
         lib.replicate times ''
@@ -461,7 +455,7 @@ rec {
     cargoArtifacts = craneMultiBuild.default.${craneLib.cargoProfile or "release"}.workspaceBuild;
     nativeBuildInputs = commonCliTestArgs.nativeBuildInputs ++ [ pkgs.firefox pkgs.wasm-bindgen-cli pkgs.geckodriver pkgs.wasm-pack ];
     buildPhaseCargoCommand = ''
-      inheritCargoArtifacts ${craneMultiBuild.wasm32-unknown.${craneLib.cargoProfile or "release"}.workspaceBuildWasmTest}
+      inheritCargoArtifacts ${craneMultiBuild.wasm32-unknown.${craneLib.cargoProfile or "release"}.workspaceBuildWasmTest} "target/pkgs/fedimint-wasm-tests"
       patchShebangs ./scripts; SKIP_CARGO_BUILD=1 ./scripts/tests/wasm-test.sh'';
   };
 

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -180,7 +180,10 @@ fi
 tests_to_run_in_parallel=(
   "always_success_test"
   "rust_unit_tests"
-  "wasm_test"
+  # TODO: unfortunately it seems like something about headless firefox is broken when
+  # running in xarg -P or gnu parallel. Try re-enabling in the future and see if it works.
+  # Other than this problem, everything about it is working.
+  # "wasm_test"
   "backend_test_bitcoind"
   "backend_test_bitcoind_ln_gateway"
   "backend_test_electrs"

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -143,7 +143,14 @@ function backend_test_esplora() {
 export -f backend_test_esplora
 
 function wasm_test() {
-  fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=esplora ./scripts/tests/wasm-test.sh
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    # TODO: move this check to when forming the test list
+    if which wasm-pack 1>/dev/null 2>/dev/null ; then
+      fm-run-test "${FUNCNAME[0]}" ./scripts/tests/wasm-test.sh
+    else
+      echo >&2 "### SKIP: ${FUNCNAME[0]}"
+    fi
+  fi
 }
 export -f wasm_test
 
@@ -173,6 +180,7 @@ fi
 tests_to_run_in_parallel=(
   "always_success_test"
   "rust_unit_tests"
+  "wasm_test"
   "backend_test_bitcoind"
   "backend_test_bitcoind_ln_gateway"
   "backend_test_electrs"

--- a/scripts/tests/wasm-test.sh
+++ b/scripts/tests/wasm-test.sh
@@ -15,7 +15,12 @@ function run_tests() {
 
   echo Funding LND gateway e-cash wallet ...
 
-  WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --firefox --headless fedimint-wasm-tests
+  # Since this is going to effectively `cargo build -p ...` it needs to go
+  # to it's own directory. Otherwise it would invalidate existing ./target.
+  export CARGO_BUILD_TARGET_DIR
+  CARGO_BUILD_TARGET_DIR="${CARGO_BUILD_TARGET_DIR:-${PWD}/target}"
+  CARGO_BUILD_TARGET_DIR="${CARGO_BUILD_TARGET_DIR}/pkgs/fedimint-wasm-tests"
+  WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --firefox --headless fedimint-wasm-tests ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}}
 }
 export -f run_tests
 


### PR DESCRIPTION
This required:

* reachitecting flakebox target vs toolchain handling
* fixing wasm-test.sh to stop invalidating ./target
* bunch of nix glue to stich native vs wasm32-unknown ./targets together
* continuously ignoring the question is it even worth the time

Unfortunately after tackling all the scripts & Nix issues, it turned out that wasm-tests (headless firefox?) just doesn't work when being run in GNU `parallel` or `xargs -P`, and debugging it seems like lots of work.

So we'll still run wasm-test separately, but at least it will now re-use build artifacts with the main build, so it should still be faster. And in the future we can try again.