### PR TITLE
chore: timeouts on version discovery

### DIFF
--- a/fedimint-client/src/envs.rs
+++ b/fedimint-client/src/envs.rs
@@ -1,0 +1,26 @@
+use std::str::FromStr;
+use std::time::Duration;
+
+use tracing::warn;
+
+pub const FM_DISCOVER_API_VERSION_TIMEOUT_ENV: &str = "FM_DISCOVER_API_VERSION_TIMEOUT";
+
+#[cfg(not(target_family = "wasm"))]
+pub fn get_discover_api_version_timeout() -> Duration {
+    if let Ok(s) = std::env::var(FM_DISCOVER_API_VERSION_TIMEOUT_ENV) {
+        match FromStr::from_str(&s) {
+            Ok(secs) => return Duration::from_secs(secs),
+            Err(err) => warn!(
+                %err,
+                var = FM_DISCOVER_API_VERSION_TIMEOUT_ENV,
+                "Could not parse env variable"
+            ),
+        }
+    }
+    Duration::from_secs(60)
+}
+
+#[cfg(target_family = "wasm")]
+pub fn get_discover_api_version_timeout() -> Duration {
+    Duration::from_secs(60)
+}

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -84,6 +84,7 @@ use db::{
     ClientConfigKeyPrefix, ClientInitStateKey, ClientInviteCodeKey, ClientInviteCodeKeyPrefix,
     ClientModuleRecovery, EncodedClientSecretKey, InitMode,
 };
+use envs::get_discover_api_version_timeout;
 use fedimint_core::api::{
     ApiVersionSet, DynGlobalApi, DynModuleApi, IGlobalFederationApi, InviteCode,
 };
@@ -148,6 +149,8 @@ use crate::transaction::{
 pub mod backup;
 /// Database keys used by the client
 pub mod db;
+/// Environment variables
+pub mod envs;
 /// Module client interface definitions
 pub mod module;
 /// Operation log subsystem of the client
@@ -1316,6 +1319,7 @@ impl Client {
             .discover_api_version_set(
                 &Self::supported_api_versions_summary_static(self.get_config(), &self.module_inits)
                     .await,
+                get_discover_api_version_timeout(),
             )
             .await?)
     }
@@ -1330,6 +1334,7 @@ impl Client {
         Ok(api
             .discover_api_version_set(
                 &Self::supported_api_versions_summary_static(config, client_module_init).await,
+                get_discover_api_version_timeout(),
             )
             .await?)
     }

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -497,6 +497,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
     async fn discover_api_version_set(
         &self,
         client_versions: &SupportedApiVersionsSummary,
+        timeout: Duration,
     ) -> FederationResult<ApiVersionSet>;
 }
 
@@ -746,8 +747,8 @@ where
     async fn discover_api_version_set(
         &self,
         client_versions: &SupportedApiVersionsSummary,
+        timeout: Duration,
     ) -> FederationResult<ApiVersionSet> {
-        let timeout = Duration::from_secs(5);
         self.request_with_strategy(
             DiscoverApiVersionSet::new(
                 self.all_peers().len(),

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -57,6 +57,7 @@ function run_test_for_versions() {
   else
     # default to run current tests in 3/4 setup
     export FM_OFFLINE_NODES=1
+    export FM_DISCOVER_API_VERSION_TIMEOUT=5
     unset FM_RUN_TEST_VERSIONS
   fi
 


### PR DESCRIPTION

When working locally I've noticed test failing due to too short api discovery timeout.

Parametrize timeout of api version discovery using env variable. Set it to low value only when testing offline nodes.
