### PR TITLE
refactor: create_final_inputs_and_outputs

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -67,7 +67,6 @@
 //!
 //! For a hacky instantiation of a complete client see the [`ng` subcommand of `fedimint-cli`](https://github.com/fedimint/fedimint/blob/55f9d88e17d914b92a7018de677d16e57ed42bf6/fedimint-cli/src/ng.rs#L56-L73).
 
-use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::ops::{self, Range};
@@ -141,9 +140,8 @@ use crate::sm::{
     ClientSMDatabaseTransaction, DynState, Executor, IState, Notifier, OperationState, State,
 };
 use crate::transaction::{
-    tx_submission_sm_decoder, ClientInput, ClientOutput, TransactionBuilder,
-    TransactionBuilderBalance, TxSubmissionContext, TxSubmissionStates,
-    TRANSACTION_SUBMISSION_MODULE_INSTANCE,
+    tx_submission_sm_decoder, ClientInput, ClientOutput, TransactionBuilder, TxSubmissionContext,
+    TxSubmissionStates, TRANSACTION_SUBMISSION_MODULE_INSTANCE,
 };
 
 /// Client backup
@@ -907,15 +905,12 @@ impl Client {
         self.modules.get(instance).is_some()
     }
 
-    /// Determines if a transaction is underfunded, overfunded or balanced
+    /// Returns the input amount and output amount of a transaction
     ///
     /// # Panics
     /// If any of the input or output versions in the transaction builder are
     /// unknown by the respective module.
-    fn transaction_builder_balance(
-        &self,
-        builder: &TransactionBuilder,
-    ) -> TransactionBuilderBalance {
+    fn transaction_builder_balance(&self, builder: &TransactionBuilder) -> (Amount, Amount) {
         // FIXME: prevent overflows, currently not suitable for untrusted input
         let mut in_amount = Amount::ZERO;
         let mut out_amount = Amount::ZERO;
@@ -943,15 +938,7 @@ impl Client {
             fee_amount += item_fee;
         }
 
-        let total_out_amount = out_amount + fee_amount;
-
-        match total_out_amount.cmp(&in_amount) {
-            Ordering::Equal => TransactionBuilderBalance::Balanced,
-            Ordering::Less => TransactionBuilderBalance::Overfunded(in_amount - total_out_amount),
-            Ordering::Greater => {
-                TransactionBuilderBalance::Underfunded(total_out_amount - in_amount)
-            }
-        }
+        (in_amount, out_amount + fee_amount)
     }
 
     pub fn get_internal_payment_markers(&self) -> anyhow::Result<(PublicKey, u64)> {
@@ -1013,54 +1000,33 @@ impl Client {
         operation_id: OperationId,
         mut partial_transaction: TransactionBuilder,
     ) -> anyhow::Result<(Transaction, Vec<DynState>, Range<u64>)> {
-        if let TransactionBuilderBalance::Underfunded(missing_amount) =
-            self.transaction_builder_balance(&partial_transaction)
-        {
-            let inputs = self
-                .primary_module()
-                .create_sufficient_input(
-                    self.primary_module_instance,
-                    dbtx,
-                    operation_id,
-                    missing_amount,
-                )
-                .await?;
-            partial_transaction.inputs.extend(inputs);
-        }
+        let (input_amount, output_amount) = self.transaction_builder_balance(&partial_transaction);
 
-        // This is the range of mint outputs that will be added to the transaction
+        let (added_inputs, change_outputs) = self
+            .primary_module()
+            .create_final_inputs_and_outputs(
+                self.primary_module_instance,
+                dbtx,
+                operation_id,
+                input_amount,
+                output_amount,
+            )
+            .await?;
+
+        // This is the range of  outputs that will be added to the transaction
         // in order to balance it. Notice that it may stay empty in case the transaction
         // is already balanced.
-        let mut change_range = Range {
+        let change_range = Range {
             start: partial_transaction.outputs.len() as u64,
-            end: partial_transaction.outputs.len() as u64,
+            end: (partial_transaction.outputs.len() + change_outputs.len()) as u64,
         };
 
-        if let TransactionBuilderBalance::Overfunded(excess_amount) =
-            self.transaction_builder_balance(&partial_transaction)
-        {
-            let change_outputs = self
-                .primary_module()
-                .create_exact_output(
-                    self.primary_module_instance,
-                    dbtx,
-                    operation_id,
-                    excess_amount,
-                )
-                .await;
+        partial_transaction.inputs.extend(added_inputs);
+        partial_transaction.outputs.extend(change_outputs);
 
-            // We add our new mint outputs to the change range
-            change_range.end += change_outputs.len() as u64;
-            partial_transaction.outputs.extend(change_outputs);
-        }
+        let (input_amount, output_amount) = self.transaction_builder_balance(&partial_transaction);
 
-        assert!(
-            matches!(
-                self.transaction_builder_balance(&partial_transaction),
-                TransactionBuilderBalance::Balanced
-            ),
-            "Transaction is balanced after the previous two operations"
-        );
+        assert_eq!(input_amount, output_amount, "Transaction is not balanced");
 
         let (tx, states) = partial_transaction.build(&self.secp_ctx, thread_rng());
 

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -569,8 +569,7 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
     ///
     /// If it does it must implement:
     ///
-    /// * [`Self::create_sufficient_input`]
-    /// * [`Self::create_exact_output`]
+    /// * [`Self::create_final_inputs_and_outputs`]
     /// * [`Self::await_primary_module_output`]
     /// * [`Self::get_balance`]
     /// * [`Self::subscribe_balance_changes`]
@@ -578,52 +577,40 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
         false
     }
 
-    /// Creates an input of **at least** a given `min_amount` from the holdings
-    /// managed by the module.
+    /// Creates all inputs and outputs necessary to balance the transaction.
+    /// The function returns an error if and only if the client's funds are not
+    /// sufficient to create the inputs necessary to fully fund the transaction.
     ///
-    /// If successful it returns:
+    /// A returned input also contains:
     /// * A set of private keys belonging to the input for signing the
     ///   transaction
-    /// * The input of **at least** `min_amount`, the actual amount might be
-    ///   larger, the caller has to handle this case and possibly generate
-    ///   change using `create_change_output`.
     /// * A closure that generates states belonging to the input. This closure
     ///   takes the transaction id of the transaction in which the input was
     ///   used and the input index as input since these cannot be known at time
     ///   of calling `create_funding_input` and have to be injected later.
     ///
-    /// The function returns an error if the client's funds are not sufficient
-    /// to create the requested input.
-    async fn create_sufficient_input(
-        &self,
-        _dbtx: &mut DatabaseTransaction<'_>,
-        _operation_id: OperationId,
-        _min_amount: Amount,
-    ) -> anyhow::Result<Vec<ClientInput<<Self::Common as ModuleCommon>::Input, Self::States>>> {
-        unimplemented!()
-    }
-
-    /// Creates an output of **exactly** `amount` that will pay into the
-    /// holdings managed by the module.
-    ///
-    /// It returns:
-    /// * The output of **exactly** `amount`.
+    /// A returned output also contains:
     /// * A closure that generates states belonging to the output. This closure
     ///   takes the transaction id of the transaction in which the output was
     ///   used and the output index as input since these cannot be known at time
     ///   of calling `create_change_output` and have to be injected later.
-    async fn create_exact_output(
+
+    async fn create_final_inputs_and_outputs(
         &self,
         _dbtx: &mut DatabaseTransaction<'_>,
         _operation_id: OperationId,
-        _amount: Amount,
-    ) -> Vec<ClientOutput<<Self::Common as ModuleCommon>::Output, Self::States>> {
+        _input_amount: Amount,
+        _output_amount: Amount,
+    ) -> anyhow::Result<(
+        Vec<ClientInput<<Self::Common as ModuleCommon>::Input, Self::States>>,
+        Vec<ClientOutput<<Self::Common as ModuleCommon>::Output, Self::States>>,
+    )> {
         unimplemented!()
     }
 
     /// Waits for the funds from an output created by
-    /// [`Self::create_exact_output`] to become available. This function
-    /// returning typically implies a change in the output of
+    /// [`Self::create_final_inputs_and_outputs`] to become available. This
+    /// function returning typically implies a change in the output of
     /// [`Self::get_balance`].
     async fn await_primary_module_output(
         &self,
@@ -728,21 +715,14 @@ pub trait IClientModule: Debug {
 
     fn supports_being_primary(&self) -> bool;
 
-    async fn create_sufficient_input(
+    async fn create_final_inputs_and_outputs(
         &self,
         module_instance: ModuleInstanceId,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
-        min_amount: Amount,
-    ) -> anyhow::Result<Vec<ClientInput>>;
-
-    async fn create_exact_output(
-        &self,
-        module_instance: ModuleInstanceId,
-        dbtx: &mut DatabaseTransaction<'_>,
-        operation_id: OperationId,
-        amount: Amount,
-    ) -> Vec<ClientOutput>;
+        input_amount: Amount,
+        output_amount: Amount,
+    ) -> anyhow::Result<(Vec<ClientInput>, Vec<ClientOutput>)>;
 
     async fn await_primary_module_output(
         &self,
@@ -821,42 +801,34 @@ where
         <T as ClientModule>::supports_being_primary(self)
     }
 
-    async fn create_sufficient_input(
+    async fn create_final_inputs_and_outputs(
         &self,
         module_instance: ModuleInstanceId,
         dbtx: &mut DatabaseTransaction<'_>,
         operation_id: OperationId,
-        min_amount: Amount,
-    ) -> anyhow::Result<Vec<ClientInput>> {
-        Ok(<T as ClientModule>::create_sufficient_input(
+        input_amount: Amount,
+        output_amount: Amount,
+    ) -> anyhow::Result<(Vec<ClientInput>, Vec<ClientOutput>)> {
+        let (inputs, outputs) = <T as ClientModule>::create_final_inputs_and_outputs(
             self,
             &mut dbtx.to_ref_with_prefix_module_id(module_instance),
             operation_id,
-            min_amount,
+            input_amount,
+            output_amount,
         )
-        .await?
-        .into_iter()
-        .map(|input| input.into_dyn(module_instance))
-        .collect())
-    }
+        .await?;
 
-    async fn create_exact_output(
-        &self,
-        module_instance: ModuleInstanceId,
-        dbtx: &mut DatabaseTransaction<'_>,
-        operation_id: OperationId,
-        amount: Amount,
-    ) -> Vec<ClientOutput> {
-        <T as ClientModule>::create_exact_output(
-            self,
-            &mut dbtx.to_ref_with_prefix_module_id(module_instance),
-            operation_id,
-            amount,
-        )
-        .await
-        .into_iter()
-        .map(|output| output.into_dyn(module_instance))
-        .collect()
+        let inputs = inputs
+            .into_iter()
+            .map(|input| input.into_dyn(module_instance))
+            .collect::<Vec<ClientInput>>();
+
+        let outputs = outputs
+            .into_iter()
+            .map(|output| output.into_dyn(module_instance))
+            .collect::<Vec<ClientOutput>>();
+
+        Ok((inputs, outputs))
     }
 
     async fn await_primary_module_output(

--- a/fedimint-client/src/transaction/builder.rs
+++ b/fedimint-client/src/transaction/builder.rs
@@ -151,13 +151,6 @@ impl TransactionBuilder {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
-pub(crate) enum TransactionBuilderBalance {
-    Underfunded(Amount),
-    Balanced,
-    Overfunded(Amount),
-}
-
 fn state_gen_to_dyn<S>(
     state_gen: StateGenerator<S>,
     module_instance: ModuleInstanceId,

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -183,6 +183,12 @@ impl Amount {
         }
     }
 
+    pub fn mul_u64(self, other: u64) -> Self {
+        Amount {
+            msats: self.msats * other,
+        }
+    }
+
     // Makes sure we're dealing with a precision of satoshi or higher
     pub fn ensure_sats_precision(&self) -> anyhow::Result<()> {
         if self.msats % 1000 != 0 {

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -355,7 +355,7 @@ pub async fn remint_denomination(
     let operation_id = OperationId::new_random();
     for _ in 0..quantity {
         let outputs = mint_client
-            .create_output(
+            .create_exact_output(
                 &mut module_transaction.to_ref_nc(),
                 operation_id,
                 1,


### PR DESCRIPTION
This refactor gives modules more freedom when finalising a transaction as inputs and outputs don't have to be created separately anymore. This change is in preparation for ecash-ng.