### PR TITLE
chore: client shutdown on handle drop incorrect

### DIFF
--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -405,7 +405,7 @@ where
             self.api().clone(),
             *self.core_api_version(),
             client_ctx.decoders(),
-            common_state.next_session..common_state.end_session,
+            block_stream_session_range,
         );
         let client_ctx = self.context();
 


### PR DESCRIPTION
Fundamentally we can't rely on database count to detect when client executors (state machines and recoveries) finished, because external user might hold some references too.

Also, we must not be dropping `inner : Arc<Client>` before we ensure executors stopped, because something running in them might still require that `Arc<Client>` is alive and weak references to them can be upgraded.

Instead use the old and (somewhat) trusted TaskGroup to do the job.