### PR TITLE
 refactor(client): remove manual client arc counting 

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -9,7 +9,7 @@ use bitcoin::{secp256k1, Network};
 use bitcoin_hashes::hex::ToHex;
 use clap::Subcommand;
 use fedimint_client::backup::Metadata;
-use fedimint_client::ClientArc;
+use fedimint_client::ClientHandle;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::encoding::Encodable;
@@ -180,7 +180,7 @@ pub fn parse_gateway_id(s: &str) -> Result<secp256k1::PublicKey, secp256k1::Erro
 
 pub async fn handle_command(
     command: ClientCmd,
-    client: ClientArc,
+    client: ClientHandle,
 ) -> anyhow::Result<serde_json::Value> {
     match command {
         ClientCmd::Info => get_note_summary(&client).await,
@@ -658,7 +658,7 @@ async fn get_invoice(
 }
 
 async fn wait_for_ln_payment(
-    client: &ClientArc,
+    client: &ClientHandle,
     payment_type: PayType,
     contract_id: ContractId,
     return_on_funding: bool,
@@ -747,7 +747,7 @@ async fn wait_for_ln_payment(
     bail!("Lightning Payment failed")
 }
 
-async fn get_note_summary(client: &ClientArc) -> anyhow::Result<serde_json::Value> {
+async fn get_note_summary(client: &ClientHandle) -> anyhow::Result<serde_json::Value> {
     let mint_client = client.get_first_module::<MintClientModule>();
     let wallet_client = client.get_first_module::<WalletClientModule>();
     let summary = mint_client

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -21,7 +21,7 @@ use fedimint_bip39::Bip39RootSecretStrategy;
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitRegistry};
 use fedimint_client::module::ClientModule as _;
 use fedimint_client::secret::{get_default_client_secret, RootSecretStrategy};
-use fedimint_client::{get_invite_code_from_db, Client, ClientArc, ClientBuilder};
+use fedimint_client::{get_invite_code_from_db, Client, ClientBuilder, ClientHandle};
 use fedimint_core::admin_client::WsAdminClient;
 use fedimint_core::api::{
     FederationApiExt, FederationError, IRawFederationApi, InviteCode, WsFederationApi,
@@ -519,7 +519,11 @@ impl FedimintCli {
         Ok(client_builder)
     }
 
-    async fn client_join(&mut self, cli: &Opts, invite_code: InviteCode) -> CliResult<ClientArc> {
+    async fn client_join(
+        &mut self,
+        cli: &Opts,
+        invite_code: InviteCode,
+    ) -> CliResult<ClientHandle> {
         let client_config = ClientConfig::download_from_invite_code(&invite_code)
             .await
             .map_err_cli_general()?;
@@ -541,7 +545,7 @@ impl FedimintCli {
             .map_err_cli_general()
     }
 
-    async fn client_open(&mut self, cli: &Opts) -> CliResult<ClientArc> {
+    async fn client_open(&mut self, cli: &Opts) -> CliResult<ClientHandle> {
         let client_builder = self.make_client_builder(cli).await?;
 
         let mnemonic = Mnemonic::from_entropy(
@@ -572,7 +576,7 @@ impl FedimintCli {
         cli: &Opts,
         mnemonic: Mnemonic,
         invite_code: InviteCode,
-    ) -> CliResult<ClientArc> {
+    ) -> CliResult<ClientHandle> {
         let builder = self.make_client_builder(cli).await?;
 
         let client_config = ClientConfig::download_from_invite_code(&invite_code)

--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -405,7 +405,7 @@ where
             self.api().clone(),
             *self.core_api_version(),
             client_ctx.decoders(),
-            block_stream_session_range,
+            common_state.next_session..common_state.end_session,
         );
         let client_ctx = self.context();
 

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -12,7 +12,7 @@ use common::{
 };
 use devimint::cmd;
 use devimint::util::{GatewayClnCli, GatewayLndCli};
-use fedimint_client::ClientArc;
+use fedimint_client::ClientHandle;
 use fedimint_core::api::InviteCode;
 use fedimint_core::config::ClientConfig;
 use fedimint_core::endpoint_constants::SESSION_COUNT_ENDPOINT;
@@ -487,7 +487,7 @@ async fn run_load_test(
 async fn get_notes_for_users(
     users: u16,
     notes_per_user: u16,
-    coordinator: ClientArc,
+    coordinator: ClientHandle,
     note_denomination: Amount,
 ) -> anyhow::Result<HashMap<u16, Vec<OOBNotes>>> {
     let mut users_notes = HashMap::new();
@@ -508,7 +508,7 @@ async fn get_users_clients(
     db_path: Option<PathBuf>,
     invite_code: Option<InviteCode>,
     gateway_id: Option<String>,
-) -> anyhow::Result<Vec<ClientArc>> {
+) -> anyhow::Result<Vec<ClientHandle>> {
     let mut users_clients = Vec::with_capacity(n.into());
     for u in 0..n {
         let (client, _) = get_user_client(u, &db_path, &invite_code, &gateway_id).await?;
@@ -522,7 +522,7 @@ async fn get_user_client(
     db_path: &Option<PathBuf>,
     invite_code: &Option<InviteCode>,
     gateway_id: &Option<String>,
-) -> anyhow::Result<(ClientArc, Option<InviteCode>)> {
+) -> anyhow::Result<(ClientHandle, Option<InviteCode>)> {
     let user_db = db_path
         .as_ref()
         .map(|db_path| db_path.join(format!("user_{user_index}.db")));
@@ -538,7 +538,7 @@ async fn get_user_client(
     Ok((client, invite_code))
 }
 
-async fn print_coordinator_notes(coordinator: &ClientArc) -> anyhow::Result<()> {
+async fn print_coordinator_notes(coordinator: &ClientHandle) -> anyhow::Result<()> {
     info!("Note summary:");
     let summary = get_note_summary(coordinator).await?;
     for (k, v) in summary.iter() {
@@ -548,7 +548,7 @@ async fn print_coordinator_notes(coordinator: &ClientArc) -> anyhow::Result<()> 
 }
 
 async fn get_required_notes(
-    coordinator: &ClientArc,
+    coordinator: &ClientHandle,
     minimum_amount_required: Amount,
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<()> {
@@ -572,7 +572,7 @@ async fn get_required_notes(
 
 async fn reissue_initial_notes(
     initial_notes: Option<OOBNotes>,
-    coordinator: &ClientArc,
+    coordinator: &ClientHandle,
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<()> {
     if let Some(notes) = initial_notes {
@@ -586,7 +586,7 @@ async fn reissue_initial_notes(
 async fn get_coordinator_client(
     db_path: &Option<PathBuf>,
     invite_code: &Option<InviteCode>,
-) -> anyhow::Result<(ClientArc, Option<InviteCode>)> {
+) -> anyhow::Result<(ClientHandle, Option<InviteCode>)> {
     let (client, invite_code) = if let Some(db_path) = db_path {
         let coordinator_db = db_path.join("coordinator.db");
         if coordinator_db.exists() {
@@ -622,7 +622,7 @@ fn get_db_path(archive_dir: Option<PathBuf>) -> Option<PathBuf> {
 #[allow(clippy::too_many_arguments)]
 async fn do_load_test_user_task(
     prefix: String,
-    client: ClientArc,
+    client: ClientHandle,
     oob_notes: Vec<OOBNotes>,
     generated_invoices_per_user: u16,
     ln_payment_sleep: Duration,
@@ -749,7 +749,7 @@ async fn run_ln_circular_load_test(
 #[allow(clippy::too_many_arguments)]
 async fn do_ln_circular_test_user_task(
     prefix: String,
-    client: ClientArc,
+    client: ClientHandle,
     invite_code: Option<InviteCode>,
     oob_notes: Vec<OOBNotes>,
     test_duration: Duration,
@@ -824,7 +824,7 @@ async fn run_two_gateways_strategy(
     invoice_generation: &mut LnInvoiceGeneration,
     invoice_amount: &Amount,
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
-    client: &ClientArc,
+    client: &ClientHandle,
 ) -> Result<(), anyhow::Error> {
     let create_invoice_time = fedimint_core::time::now();
     match *invoice_generation {
@@ -884,7 +884,7 @@ async fn run_two_gateways_strategy(
 
 async fn do_self_payment(
     prefix: &str,
-    client: &ClientArc,
+    client: &ClientHandle,
     invoice_amount: Amount,
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<()> {
@@ -910,8 +910,8 @@ async fn do_self_payment(
 
 async fn do_partner_ping_pong(
     prefix: &str,
-    client: &ClientArc,
-    partner: &ClientArc,
+    client: &ClientHandle,
+    partner: &ClientHandle,
     invoice_amount: Amount,
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<()> {
@@ -957,7 +957,7 @@ async fn do_partner_ping_pong(
 async fn wait_invoice_payment(
     prefix: &str,
     gateway_name: &str,
-    client: &ClientArc,
+    client: &ClientHandle,
     operation_id: fedimint_core::core::OperationId,
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
     pay_invoice_time: std::time::SystemTime,
@@ -1005,7 +1005,7 @@ async fn wait_invoice_payment(
 }
 
 async fn client_create_invoice(
-    client: &ClientArc,
+    client: &ClientHandle,
     invoice_amount: Amount,
     event_sender: &mpsc::UnboundedSender<MetricEvent>,
 ) -> anyhow::Result<(fedimint_core::core::OperationId, Bolt11Invoice)> {

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
-use fedimint_client::{Client, ClientArc};
+use fedimint_client::{Client, ClientHandle};
 use fedimint_core::admin_client::{ConfigGenParamsConsensus, PeerServerParams};
 use fedimint_core::api::InviteCode;
 use fedimint_core::config::{
@@ -38,12 +38,12 @@ pub struct FederationTest {
 
 impl FederationTest {
     /// Create two clients, useful for send/receive tests
-    pub async fn two_clients(&self) -> (ClientArc, ClientArc) {
+    pub async fn two_clients(&self) -> (ClientHandle, ClientHandle) {
         (self.new_client().await, self.new_client().await)
     }
 
     /// Create a client connected to this fed
-    pub async fn new_client(&self) -> ClientArc {
+    pub async fn new_client(&self) -> ClientHandle {
         let client_config = self.configs[&PeerId::from(0)]
             .consensus
             .to_client_config(&self.server_init)
@@ -54,7 +54,7 @@ impl FederationTest {
     }
 
     /// Create a client connected to this fed but using RocksDB instead of MemDB
-    pub async fn new_client_rocksdb(&self) -> ClientArc {
+    pub async fn new_client_rocksdb(&self) -> ClientHandle {
         let client_config = self.configs[&PeerId::from(0)]
             .consensus
             .to_client_config(&self.server_init)
@@ -69,7 +69,7 @@ impl FederationTest {
         .await
     }
 
-    pub async fn new_client_with(&self, client_config: ClientConfig, db: Database) -> ClientArc {
+    pub async fn new_client_with(&self, client_config: ClientConfig, db: Database) -> ClientHandle {
         info!(target: LOG_TEST, "Setting new client with config");
         let mut client_builder = Client::builder(db);
         client_builder.with_module_inits(self.client_init.clone());

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fedimint_client::module::init::ClientModuleInitRegistry;
-use fedimint_client::ClientArc;
+use fedimint_client::ClientHandle;
 use fedimint_core::config::FederationId;
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::Database;
@@ -60,7 +60,7 @@ impl GatewayTest {
     /// Note: this makes the database opened, which can lead to gateway
     /// wanting to rejoin it. Better get your own client instead of being
     /// lazy here.
-    pub async fn remove_client_hack(&self, fed: &FederationTest) -> ClientArc {
+    pub async fn remove_client_hack(&self, fed: &FederationTest) -> ClientHandle {
         self.gateway
             .remove_client_hack(fed.id())
             .await
@@ -68,7 +68,7 @@ impl GatewayTest {
             .into_value()
     }
 
-    pub async fn select_client(&self, federation_id: FederationId) -> ClientArc {
+    pub async fn select_client(&self, federation_id: FederationId) -> ClientHandle {
         self.gateway
             .select_client(federation_id)
             .await

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -33,7 +33,7 @@ fn make_client_builder() -> fedimint_client::ClientBuilder {
     builder
 }
 
-async fn client(invite_code: &InviteCode) -> Result<fedimint_client::ClientArc> {
+async fn client(invite_code: &InviteCode) -> Result<fedimint_client::ClientHandle> {
     let client_config = ClientConfig::download_from_invite_code(invite_code).await?;
     let mut builder = make_client_builder();
     let client_secret = load_or_generate_mnemonic(builder.db()).await?;
@@ -117,7 +117,7 @@ mod tests {
         Ok(())
     }
 
-    async fn set_gateway(client: &fedimint_client::ClientArc) -> anyhow::Result<()> {
+    async fn set_gateway(client: &fedimint_client::ClientHandle) -> anyhow::Result<()> {
         let lightning_module = client.get_first_module::<LightningClientModule>();
         let gws = lightning_module.fetch_registered_gateways().await?;
         let gw_api = faucet::gateway_api().await?;
@@ -144,7 +144,7 @@ mod tests {
         Ok(())
     }
 
-    async fn receive_once(client: fedimint_client::ClientArc, amount: Amount) -> Result<()> {
+    async fn receive_once(client: fedimint_client::ClientHandle, amount: Amount) -> Result<()> {
         let lightning_module = client.get_first_module::<LightningClientModule>();
         let (opid, invoice, _) = lightning_module
             .create_bolt11_invoice(amount, "test".to_string(), None, ())
@@ -179,7 +179,7 @@ mod tests {
         assert!(format!("key: {key:?}").len() > 8);
     }
 
-    async fn pay_once(client: fedimint_client::ClientArc) -> Result<(), anyhow::Error> {
+    async fn pay_once(client: fedimint_client::ClientHandle) -> Result<(), anyhow::Error> {
         let lightning_module = client.get_first_module::<LightningClientModule>();
         let bolt11 = faucet::generate_invoice(11).await?;
         let gateway = lightning_module.select_active_gateway_opt().await;
@@ -229,7 +229,7 @@ mod tests {
     }
 
     async fn send_and_recv_ecash_once(
-        client: fedimint_client::ClientArc,
+        client: fedimint_client::ClientHandle,
     ) -> Result<(), anyhow::Error> {
         let mint = client.get_first_module::<MintClientModule>();
         let (_, notes) = mint
@@ -256,7 +256,7 @@ mod tests {
     }
 
     async fn send_ecash_exact(
-        client: fedimint_client::ClientArc,
+        client: fedimint_client::ClientHandle,
         amount: Amount,
     ) -> Result<(), anyhow::Error> {
         let mint = client.get_first_module::<MintClientModule>();

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -45,7 +45,7 @@ impl GatewayClientBuilder {
         &self,
         config: FederationConfig,
         gateway: Gateway,
-    ) -> Result<fedimint_client::ClientArc> {
+    ) -> Result<fedimint_client::ClientHandle> {
         let FederationConfig {
             invite_code,
             mint_channel_id,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -33,7 +33,7 @@ use db::{
     GATEWAYD_DATABASE_VERSION,
 };
 use fedimint_client::module::init::ClientModuleInitRegistry;
-use fedimint_client::ClientArc;
+use fedimint_client::ClientHandle;
 use fedimint_core::api::{FederationError, InviteCode};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{
@@ -227,7 +227,7 @@ impl Display for GatewayState {
 
 type ScidToFederationMap = Arc<RwLock<BTreeMap<u64, FederationId>>>;
 type FederationToClientMap =
-    Arc<RwLock<BTreeMap<FederationId, Spanned<fedimint_client::ClientArc>>>>;
+    Arc<RwLock<BTreeMap<FederationId, Spanned<fedimint_client::ClientHandle>>>>;
 
 /// Represents an active connection to the lightning node.
 #[derive(Clone, Debug)]
@@ -1285,7 +1285,7 @@ impl Gateway {
     pub async fn remove_client_hack(
         &self,
         federation_id: FederationId,
-    ) -> Result<Spanned<fedimint_client::ClientArc>> {
+    ) -> Result<Spanned<fedimint_client::ClientHandle>> {
         let client = self.clients.write().await.remove(&federation_id).ok_or(
             GatewayError::InvalidMetadata(format!("No federation with id {federation_id}")),
         )?;
@@ -1295,7 +1295,7 @@ impl Gateway {
     pub async fn select_client(
         &self,
         federation_id: FederationId,
-    ) -> Result<Spanned<fedimint_client::ClientArc>> {
+    ) -> Result<Spanned<fedimint_client::ClientHandle>> {
         self.clients
             .read()
             .await
@@ -1445,7 +1445,7 @@ impl Gateway {
 
     async fn make_federation_info(
         &self,
-        client: &ClientArc,
+        client: &ClientHandle,
         federation_id: FederationId,
     ) -> FederationInfo {
         let balance_msat = client.get_balance().await;

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use bitcoin_hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
 use fedimint_client::transaction::{ClientInput, ClientOutput};
-use fedimint_client::{ClientArc, DynGlobalClientContext};
+use fedimint_client::{ClientHandle, DynGlobalClientContext};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
@@ -464,7 +464,7 @@ impl GatewayPayInvoice {
     }
 
     async fn buy_preimage_via_direct_swap(
-        client: ClientArc,
+        client: ClientHandle,
         payment_data: PaymentData,
         contract: OutgoingContractAccount,
         common: GatewayPayCommon,
@@ -628,7 +628,7 @@ impl GatewayPayInvoice {
     async fn check_swap_to_federation(
         context: GatewayClientContext,
         payment_data: PaymentData,
-    ) -> Option<Spanned<ClientArc>> {
+    ) -> Option<Spanned<ClientHandle>> {
         let rhints = payment_data.route_hints();
         match rhints.first().and_then(|rh| rh.0.last()) {
             None => None,

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -10,7 +10,7 @@ use assert_matches::assert_matches;
 use bitcoin::Network;
 use bitcoin_hashes::{sha256, Hash};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
-use fedimint_client::ClientArc;
+use fedimint_client::ClientHandle;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::task::sleep_in_test;
@@ -83,7 +83,7 @@ async fn single_federation_test<B>(
             GatewayTest,
             Box<dyn LightningTest>,
             FederationTest,
-            ClientArc, // User Client
+            ClientHandle, // User Client
             Arc<dyn BitcoinTest>,
         ) -> B
         + Copy,
@@ -156,8 +156,8 @@ fn sha256(data: &[u8]) -> sha256::Hash {
 /// specified by `gateway_id`.
 async fn pay_valid_invoice(
     invoice: Bolt11Invoice,
-    user_client: &ClientArc,
-    gateway_client: &ClientArc,
+    user_client: &ClientHandle,
+    gateway_client: &ClientHandle,
     gateway_id: &PublicKey,
 ) -> anyhow::Result<()> {
     let user_lightning_module = &user_client.get_first_module::<LightningClientModule>();

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -22,7 +22,7 @@ use bitcoin_hashes::sha256;
 use config::LightningClientConfig;
 use fedimint_client::oplog::OperationLogEntry;
 use fedimint_client::sm::Context;
-use fedimint_client::ClientArc;
+use fedimint_client::ClientHandle;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -631,7 +631,7 @@ pub enum LightningOutputError {
 }
 
 pub async fn ln_operation(
-    client: &ClientArc,
+    client: &ClientHandle,
     operation_id: OperationId,
 ) -> anyhow::Result<OperationLogEntry> {
     let operation = client

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -6,7 +6,7 @@ use bitcoin::secp256k1::rand::rngs::OsRng;
 use bitcoin::secp256k1::{self, Secp256k1};
 use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
-use fedimint_client::ClientArc;
+use fedimint_client::ClientHandle;
 use fedimint_core::bitcoin_migration::{
     bitcoin29_to_bitcoin30_network, bitcoin30_to_bitcoin29_address,
 };
@@ -47,7 +47,7 @@ const PEG_OUT_AMOUNT_SATS: u64 = 1000;
 const PEG_IN_TIMEOUT: Duration = Duration::from_secs(60);
 
 async fn peg_in<'a>(
-    client: &'a ClientArc,
+    client: &'a ClientHandle,
     bitcoin: &dyn BitcoinTest,
     dyn_bitcoin_rpc: &DynBitcoindRpc,
     finality_delay: u64,
@@ -83,7 +83,10 @@ async fn peg_in<'a>(
     Ok(balance_sub)
 }
 
-async fn await_consensus_to_catch_up(client: &ClientArc, block_count: u64) -> anyhow::Result<u64> {
+async fn await_consensus_to_catch_up(
+    client: &ClientHandle,
+    block_count: u64,
+) -> anyhow::Result<u64> {
     let wallet = client.get_first_module::<WalletClientModule>();
     loop {
         let current_consensus = client


### PR DESCRIPTION
On top of #4482 



Use two levels of `Arc` instead. While at it, rename and document things
better.

