### PR TITLE
chore: enable cranelift (switch to nightly)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["codegen-backend"]
+
 [workspace]
 members = [
     "crypto/aead",
@@ -104,31 +106,36 @@ opt-level = 1
 debug = false
 opt-level = 1
 
+[profile.dev]
+codegen-backend = "cranelift"
+
 [profile.dev.package."*"] # external dependencies
 opt-level = 1
 
 # in dev mode optimize crates that are perf-critical (usually just crypto crates)
 [profile.dev.package]
-secp256k1 = { opt-level = 3 }
-secp256k1-zkp = { opt-level = 3 }
-secp256k1-sys = { opt-level = 3 }
-secp256k1-zkp-sys = { opt-level = 3 }
-bitcoin_hashes = { opt-level = 3 }
-ff = { opt-level = 3 }
-group = { opt-level = 3 }
-pairing = { opt-level = 3 }
-rand_core = { opt-level = 3 }
-byteorder = { opt-level = 3 }
-zeroize = { opt-level = 3 }
-bls12_381 = { opt-level = 3 }
-subtle = { opt-level = 3 }
-ring = { opt-level = 3 }
-fedimint-threshold-crypto = { opt-level = 3 }
-aleph-bft-crypto = { opt-level = 3 }
-aleph-bft-rmc = { opt-level = 3 }
-aleph-bft-types = { opt-level = 3 }
+secp256k1 = { opt-level = 2, codegen-backend = "llvm" }
+secp256k1-zkp = { opt-level = 2, codegen-backend = "llvm" }
+secp256k1-sys = { opt-level = 2, codegen-backend = "llvm" }
+secp256k1-zkp-sys = { opt-level = 2, codegen-backend = "llvm" }
+bitcoin_hashes = { opt-level = 2, codegen-backend = "llvm" }
+ff = { opt-level = 2, codegen-backend = "llvm" }
+group = { opt-level = 2, codegen-backend = "llvm" }
+pairing = { opt-level = 2, codegen-backend = "llvm" }
+rand_core = { opt-level = 2, codegen-backend = "llvm" }
+byteorder = { opt-level = 2, codegen-backend = "llvm" }
+zeroize = { opt-level = 2, codegen-backend = "llvm" }
+bls12_381 = { opt-level = 2, codegen-backend = "llvm" }
+subtle = { opt-level = 2, codegen-backend = "llvm" }
+ring = { opt-level = 2, codegen-backend = "llvm" }
+aleph-bft-crypto = { opt-level = 2, codegen-backend = "llvm" }
+aleph-bft-rmc = { opt-level = 2, codegen-backend = "llvm" }
+aleph-bft-types = { opt-level = 2, codegen-backend = "llvm" }
 
 [profile.ci]
+# cranelift doesn't support xcompilation and doesn't generate as optimized code
+# so at least for now, we can not use it in the CI
+codegen-backend = "llvm"
 inherits = "dev"
 debug = "line-tables-only"
 incremental = false

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -47,7 +47,7 @@ pub struct Fixtures {
 
 impl Fixtures {
     pub fn new_primary(
-        client: impl IClientModuleInit + MaybeSend + MaybeSync + 'static,
+        client: impl IClientModuleInit + 'static,
         server: impl IServerModuleInit + MaybeSend + MaybeSync + 'static,
         params: impl ModuleInitParams,
     ) -> Self {
@@ -100,7 +100,7 @@ impl Fixtures {
     /// Add a module to the fed
     pub fn with_module(
         mut self,
-        client: impl IClientModuleInit + MaybeSend + MaybeSync + 'static,
+        client: impl IClientModuleInit + 'static,
         server: impl IServerModuleInit + MaybeSend + MaybeSync + 'static,
         params: impl ModuleInitParams,
     ) -> Self {

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,8 @@
                 "llvm-tools"
               ];
 
+              toolchain.channel = "latest";
+
               motd = {
                 enable = true;
                 command = ''

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
                 "rust-analyzer"
                 "rust-src"
                 "llvm-tools"
+                "rustc-codegen-cranelift-preview"
               ];
 
               toolchain.channel = "latest";


### PR DESCRIPTION
Not planning to land it right now.

On top of pending PRs, due to possibility of merge conflicts.

See https://blog.rust-lang.org/2023/11/09/parallel-rustc.html

On my machine I've noticed zero speedup. It might speed up someone's compilation time, but I guess it would require lots of cpu cores. (more than 20 I have?).

Use `just bench-compilation` to bench. If anyone sees a speedup and it seems beneficial, we could land. Otherwise I'm a bit dissapointed.