### PR TITLE
chore: add DoS protection against infinite reader on decoding 

### DIFF
--- a/fedimint-core/src/encoding/btc.rs
+++ b/fedimint-core/src/encoding/btc.rs
@@ -20,11 +20,11 @@ macro_rules! impl_encode_decode_bridge {
         }
 
         impl crate::encoding::Decodable for $btc_type {
-            fn consensus_decode<D: std::io::Read>(
+            fn consensus_decode_from_finite_reader<D: std::io::Read>(
                 d: &mut D,
                 _modules: &$crate::module::registry::ModuleDecoderRegistry,
             ) -> Result<Self, crate::encoding::DecodeError> {
-                bitcoin::consensus::Decodable::consensus_decode(d)
+                bitcoin::consensus::Decodable::consensus_decode_from_finite_reader(d)
                     .map_err(crate::encoding::DecodeError::from_err)
             }
         }
@@ -56,11 +56,11 @@ where
     <Self as FromStr>::Err: ToString + std::error::Error + Send + Sync + 'static,
     K: MiniscriptKey,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let descriptor_str = String::consensus_decode(d, modules)?;
+        let descriptor_str = String::consensus_decode_from_finite_reader(d, modules)?;
         Descriptor::<K>::from_str(&descriptor_str).map_err(DecodeError::from_err)
     }
 }

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -113,13 +113,74 @@ pub trait Encodable {
     }
 }
 
+/// Maximum size, in bytes, of data we are allowed to ever decode
+/// for a single value.
+pub const MAX_DECODE_SIZE: usize = 16_000_000;
+
 /// Data which can be encoded in a consensus-consistent way
 pub trait Decodable: Sized {
-    /// Decode an object with a well-defined format
+    /// Decode `Self` from a size-limited reader.
+    ///
+    /// Like `consensus_decode` but relies on the reader being limited in the
+    /// amount of data it returns, e.g. by being wrapped in
+    /// [`std::io::Take`].
+    ///
+    /// Failing to abide to this requirement might lead to memory exhaustion
+    /// caused by malicious inputs.
+    ///
+    /// Users should default to `consensus_decode`, but when data to be decoded
+    /// is already in a byte vector of a limited size, calling this function
+    /// directly might be marginally faster (due to avoiding extra checks).
+    ///
+    /// ### Rules for trait implementations
+    ///
+    /// * Simple types that that have a fixed size (own and member fields),
+    ///   don't have to overwrite this method, or be concern with it, should
+    ///   only impl `consensus_decode`.
+    /// * Types that deserialize based on decoded untrusted length should
+    ///   implement `consensus_decode_from_finite_reader` only:
+    ///   * Default implementation of `consensus_decode` will forward to
+    ///     `consensus_decode_bytes_from_finite_reader` with the reader wrapped
+    ///     by `Take`, protecting from readers that keep returning data.
+    ///   * Implementation must make sure to put a cap on things like
+    ///     `Vec::with_capacity` and other allocations to avoid oversized
+    ///     allocations, and rely on the reader being finite and running out of
+    ///     data, and collections reallocating on a legitimately oversized input
+    ///     data, instead of trying to enforce arbitrary length limits.
+    /// * Types that contain other types that might be require limited reader
+    ///   (thus implementing `consensus_decode_from_finite_reader`), should also
+    ///   implement it applying same rules, and in addition make sure to call
+    ///   `consensus_decode_from_finite_reader` on all members, to avoid
+    ///   creating redundant `Take` wrappers (`Take<Take<...>>`). Failure to do
+    ///   so might result only in a tiny performance hit.
+    #[inline]
+    fn consensus_decode_from_finite_reader<R: std::io::Read>(
+        r: &mut R,
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        // This method is always strictly less general than, `consensus_decode`, so it's
+        // safe and make sense to default to just calling it. This way most
+        // types, that don't care about protecting against resource exhaustion
+        // due to malicious input, can just ignore it.
+        Self::consensus_decode(r, modules)
+    }
+
+    /// Decode an object with a well-defined format.
+    ///
+    /// This is the method that should be implemented for a typical, fixed sized
+    /// type implementing this trait. Default implementation is wrapping the
+    /// reader in [`std::io::Take`] to limit the input size to
+    /// [`MAX_DECODE_SIZE`], and forwards the call to
+    /// [`Self::consensus_decode_from_finite_reader`], which is convenient
+    /// for types that override [`Self::consensus_decode_from_finite_reader`]
+    /// instead.
+    #[inline]
     fn consensus_decode<R: std::io::Read>(
         r: &mut R,
-        _modules: &ModuleDecoderRegistry,
-    ) -> Result<Self, DecodeError>;
+        modules: &ModuleDecoderRegistry,
+    ) -> Result<Self, DecodeError> {
+        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_DECODE_SIZE as u64), modules)
+    }
 
     /// Decode an object from hex
     fn consensus_decode_hex(
@@ -149,11 +210,11 @@ impl Encodable for SafeUrl {
 }
 
 impl Decodable for SafeUrl {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        String::consensus_decode(d, modules)?
+        String::consensus_decode_from_finite_reader(d, modules)?
             .parse::<SafeUrl>()
             .map_err(DecodeError::from_err)
     }
@@ -311,7 +372,14 @@ fn read_bytes_from_finite_reader<D: Read + ?Sized>(
 
 /// Specialized version of Decodable for bytes
 pub fn consensus_decode_bytes<D: std::io::Read>(r: &mut D) -> Result<Vec<u8>, DecodeError> {
-    let len = u64::consensus_decode(r, &Default::default())?;
+    consensus_decode_bytes_from_finite_reader(&mut r.take(MAX_DECODE_SIZE as u64))
+}
+
+/// Specialized version of Decodable for bytes
+pub fn consensus_decode_bytes_from_finite_reader<D: std::io::Read>(
+    r: &mut D,
+) -> Result<Vec<u8>, DecodeError> {
+    let len = u64::consensus_decode_from_finite_reader(r, &Default::default())?;
 
     let len: usize =
         usize::try_from(len).map_err(|_| DecodeError::from_str("size exceeds memory"))?;
@@ -326,6 +394,12 @@ pub fn consensus_decode_bytes<D: std::io::Read>(r: &mut D) -> Result<Vec<u8>, De
 
 /// Specialized version of Decodable for fixed-size byte arrays
 pub fn consensus_decode_bytes_static<const N: usize, D: std::io::Read>(
+    r: &mut D,
+) -> Result<[u8; N], DecodeError> {
+    consensus_decode_bytes_static_from_finite_reader(&mut r.take(MAX_DECODE_SIZE as u64))
+}
+/// Specialized version of Decodable for fixed-size byte arrays
+pub fn consensus_decode_bytes_static_from_finite_reader<const N: usize, D: std::io::Read>(
     r: &mut D,
 ) -> Result<[u8; N], DecodeError> {
     let mut bytes = [0u8; N];
@@ -371,15 +445,17 @@ impl<T> Decodable for Vec<T>
 where
     T: Decodable + 'static,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         if TypeId::of::<T>() == TypeId::of::<u8>() {
             // unsafe: we've just checked that T is `u8` so the transmute here is a no-op
-            return Ok(unsafe { mem::transmute::<Vec<u8>, Vec<T>>(consensus_decode_bytes(d)?) });
+            return Ok(unsafe {
+                mem::transmute::<Vec<u8>, Vec<T>>(consensus_decode_bytes_from_finite_reader(d)?)
+            });
         }
-        let len = u64::consensus_decode(d, modules)?;
+        let len = u64::consensus_decode_from_finite_reader(d, modules)?;
 
         // `collect` under the hood uses `FromIter::from_iter`, which can potentially be
         // backed by code like:
@@ -392,12 +468,12 @@ where
         // Up to a cap, use the (potentially specialized for better perf in stdlib)
         // `from_iter`.
         let mut v: Vec<_> = (0..cap_len)
-            .map(|_| T::consensus_decode(d, modules))
+            .map(|_| T::consensus_decode_from_finite_reader(d, modules))
             .collect::<Result<Vec<_>, DecodeError>>()?;
 
         // Add any excess manually avoiding any surprises.
         while (v.len() as u64) < len {
-            v.push(T::consensus_decode(d, modules)?);
+            v.push(T::consensus_decode_from_finite_reader(d, modules)?);
         }
 
         assert_eq!(v.len() as u64, len);
@@ -452,21 +528,21 @@ impl<T, const SIZE: usize> Decodable for [T; SIZE]
 where
     T: Decodable + Debug + Default + Copy + 'static,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         if TypeId::of::<T>() == TypeId::of::<u8>() {
             // unsafe: we've just checked that T is `u8` so the transmute here is a no-op
             return Ok(unsafe {
-                let arr = consensus_decode_bytes_static(d)?;
+                let arr = consensus_decode_bytes_static_from_finite_reader(d)?;
                 horribe_array_transmute_workaround::<SIZE, u8, T>(arr)
             });
         }
         // todo: impl without copy
         let mut data = [T::default(); SIZE];
         for item in data.iter_mut() {
-            *item = T::consensus_decode(d, modules)?;
+            *item = T::consensus_decode_from_finite_reader(d, modules)?;
         }
         Ok(data)
     }
@@ -492,14 +568,14 @@ impl<T> Decodable for Option<T>
 where
     T: Decodable,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let flag = u8::consensus_decode(d, modules)?;
+        let flag = u8::consensus_decode_from_finite_reader(d, modules)?;
         match flag {
             0 => Ok(None),
-            1 => Ok(Some(T::consensus_decode(d, modules)?)),
+            1 => Ok(Some(T::consensus_decode_from_finite_reader(d, modules)?)),
             _ => Err(DecodeError::from_str(
                 "Invalid flag for option enum, expected 0 or 1",
             )),
@@ -535,14 +611,14 @@ where
     T: Decodable,
     E: Decodable,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let flag = u8::consensus_decode(d, modules)?;
+        let flag = u8::consensus_decode_from_finite_reader(d, modules)?;
         match flag {
-            0 => Ok(Err(E::consensus_decode(d, modules)?)),
-            1 => Ok(Ok(T::consensus_decode(d, modules)?)),
+            0 => Ok(Err(E::consensus_decode_from_finite_reader(d, modules)?)),
+            1 => Ok(Ok(T::consensus_decode_from_finite_reader(d, modules)?)),
             _ => Err(DecodeError::from_str(
                 "Invalid flag for option enum, expected 0 or 1",
             )),
@@ -563,11 +639,13 @@ impl<T> Decodable for Box<T>
 where
     T: Decodable,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Ok(Box::new(T::consensus_decode(d, modules)?))
+        Ok(Box::new(T::consensus_decode_from_finite_reader(
+            d, modules,
+        )?))
     }
 }
 
@@ -602,11 +680,12 @@ impl Encodable for String {
 }
 
 impl Decodable for String {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        String::from_utf8(Decodable::consensus_decode(d, modules)?).map_err(DecodeError::from_err)
+        String::from_utf8(Decodable::consensus_decode_from_finite_reader(d, modules)?)
+            .map_err(DecodeError::from_err)
     }
 }
 
@@ -762,15 +841,15 @@ where
     K: Decodable + Ord,
     V: Decodable,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let mut res = BTreeMap::new();
-        let len = u64::consensus_decode(d, modules)?;
+        let len = u64::consensus_decode_from_finite_reader(d, modules)?;
         for _ in 0..len {
-            let amt = K::consensus_decode(d, modules)?;
-            let v = V::consensus_decode(d, modules)?;
+            let amt = K::consensus_decode_from_finite_reader(d, modules)?;
+            let v = V::consensus_decode_from_finite_reader(d, modules)?;
             if res.insert(amt, v).is_some() {
                 return Err(DecodeError(format_err!("Duplicate key")));
             }
@@ -797,14 +876,14 @@ impl<K> Decodable for BTreeSet<K>
 where
     K: Decodable + Ord,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let mut res = BTreeSet::new();
-        let len = u64::consensus_decode(d, modules)?;
+        let len = u64::consensus_decode_from_finite_reader(d, modules)?;
         for _ in 0..len {
-            let k = K::consensus_decode(d, modules)?;
+            let k = K::consensus_decode_from_finite_reader(d, modules)?;
             if !res.insert(k) {
                 return Err(DecodeError(format_err!("Duplicate key")));
             }
@@ -966,15 +1045,17 @@ impl<T> Decodable for DynRawFallback<T>
 where
     T: Decodable + 'static,
 {
-    fn consensus_decode<R: std::io::Read>(
+    fn consensus_decode_from_finite_reader<R: std::io::Read>(
         reader: &mut R,
         decoders: &ModuleDecoderRegistry,
     ) -> Result<Self, crate::encoding::DecodeError> {
         let module_instance_id =
-            fedimint_core::core::ModuleInstanceId::consensus_decode(reader, decoders)?;
+            fedimint_core::core::ModuleInstanceId::consensus_decode_from_finite_reader(
+                reader, decoders,
+            )?;
         Ok(match decoders.get(module_instance_id) {
             Some(decoder) => {
-                let total_len_u64 = u64::consensus_decode(reader, decoders)?;
+                let total_len_u64 = u64::consensus_decode_from_finite_reader(reader, decoders)?;
                 let mut reader = reader.take(total_len_u64);
                 let v: T = decoder.decode(&mut reader, module_instance_id, decoders)?;
 
@@ -990,7 +1071,7 @@ where
                 // since the decoder is not available, just read the raw data
                 Self::Raw {
                     module_instance_id,
-                    raw: Vec::consensus_decode(reader, decoders)?,
+                    raw: Vec::consensus_decode_from_finite_reader(reader, decoders)?,
                 }
             }
         })

--- a/fedimint-core/src/tiered_multi.rs
+++ b/fedimint-core/src/tiered_multi.rs
@@ -191,11 +191,13 @@ impl<C> Decodable for TieredMulti<C>
 where
     C: Decodable + 'static,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Ok(TieredMulti(BTreeMap::consensus_decode(d, modules)?))
+        Ok(TieredMulti(BTreeMap::consensus_decode_from_finite_reader(
+            d, modules,
+        )?))
     }
 }
 

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,10 +1,12 @@
-use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::encoding::{self, Decodable, Encodable};
 
 pub fn test_decodable<T>(data: &[u8])
 where
     T: Decodable + Encodable,
 {
     if let Ok(v) = T::consensus_decode(&mut &data[..], &Default::default()) {
+        assert!(data.len() <= encoding::MAX_DECODE_SIZE);
+
         let encoded_vec = v.consensus_encode_to_vec();
         // helps debugging to have it standalone
         let encoded = encoded_vec.as_slice();


### PR DESCRIPTION
This is based on the same API/traits from rust-bitcoin:

https://docs.rs/bitcoin/latest/bitcoin/consensus/encode/trait.Decodable.html#method.consensus_decode_from_finite_reader

Fix #4395

On top of #287 .

A problem was incidentally discovered when fuzzing the whole thing and the fix already has a merge conflict, so is tagging along.