### PR TITLE
chore(ci): increase timeout on code coverage run in CI

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -242,7 +242,7 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     name: "Code coverage"
     runs-on: buildjet-8vcpu-ubuntu-2004
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25

--- a/flake.nix
+++ b/flake.nix
@@ -282,6 +282,7 @@
 
                   export RUSTC_WRAPPER=${pkgs.sccache}/bin/sccache
                   export CARGO_BUILD_TARGET_DIR="''${CARGO_BUILD_TARGET_DIR:-''${root}/target-nix}"
+                  export FM_DISCOVER_API_VERSION_TIMEOUT=10
                 '';
               };
             in

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -223,6 +223,7 @@ rec {
     cargoArtifacts = workspaceBuild;
     cargoExtraArgs = "--workspace --all-targets --locked";
 
+    FM_DISCOVER_API_VERSION_TIMEOUT = "10";
     FM_CARGO_DENY_COMPILATION = "1";
   };
 
@@ -323,6 +324,9 @@ rec {
   workspaceTestCovBase = { times }: craneLib.buildPackage {
     pname = "fedimint-workspace-lcov";
     cargoArtifacts = workspaceCov;
+
+    FM_DISCOVER_API_VERSION_TIMEOUT = "10";
+
     buildPhaseCargoCommand = (''
       source <(cargo llvm-cov show-env --export-prefix)
     '' +
@@ -390,6 +394,8 @@ rec {
   ciTestAllBase = { times }: craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-all";
     cargoArtifacts = workspaceBuild;
+
+    FM_DISCOVER_API_VERSION_TIMEOUT = "10";
 
     # One normal run, then if succeeded, modify the "always success test" to fail,
     # and make sure we detect it (happened too many times that we didn't).


### PR DESCRIPTION
We're seeing failures due to these being slow, like:

https://github.com/fedimint/fedimint/actions/runs/8198894922/job/22423145415

Not sure if got slower recently, or something else is wrong, but it's blocking the CI.