### PR TITLE
fix: decrease api discovery timeouts in dev shell and tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -282,6 +282,7 @@
 
                   export RUSTC_WRAPPER=${pkgs.sccache}/bin/sccache
                   export CARGO_BUILD_TARGET_DIR="''${CARGO_BUILD_TARGET_DIR:-''${root}/target-nix}"
+                  export FM_DISCOVER_API_VERSION_TIMEOUT=10
                 '';
               };
             in

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -223,6 +223,7 @@ rec {
     cargoArtifacts = workspaceBuild;
     cargoExtraArgs = "--workspace --all-targets --locked";
 
+    FM_DISCOVER_API_VERSION_TIMEOUT = "10";
     FM_CARGO_DENY_COMPILATION = "1";
   };
 
@@ -323,6 +324,9 @@ rec {
   workspaceTestCovBase = { times }: craneLib.buildPackage {
     pname = "fedimint-workspace-lcov";
     cargoArtifacts = workspaceCov;
+
+    FM_DISCOVER_API_VERSION_TIMEOUT = "10";
+
     buildPhaseCargoCommand = (''
       source <(cargo llvm-cov show-env --export-prefix)
     '' +
@@ -390,6 +394,8 @@ rec {
   ciTestAllBase = { times }: craneLibTests.mkCargoDerivation {
     pname = "${commonCliTestArgs.pname}-all";
     cargoArtifacts = workspaceBuild;
+
+    FM_DISCOVER_API_VERSION_TIMEOUT = "10";
 
     # One normal run, then if succeeded, modify the "always success test" to fail,
     # and make sure we detect it (happened too many times that we didn't).


### PR DESCRIPTION
We started getting slow test and timeouts in the CI:

https://github.com/fedimint/fedimint/actions/runs/8198894922/job/22423145415

caused by #4476.

Turns out there are other tests just degraded federation tests that run with degraded federations.

Generally in dev shell, tests and CI, we can just default to 10 seconds timeout, should be enough even under heavy load.