### PR TITLE
 fix: api discovery task not being cancellable 

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -585,7 +585,7 @@ pub async fn handle_command(
             unreachable!("Update stream ended without outcome");
         }
         ClientCmd::DiscoverVersion => {
-            Ok(json!({ "versions": client.discover_common_api_version().await? }))
+            Ok(json!({ "versions": client.discover_common_api_version(None).await? }))
         }
         ClientCmd::Module { module, args } => {
             let module_instance_id = match module {

--- a/fedimint-core/src/api.rs
+++ b/fedimint-core/src/api.rs
@@ -498,6 +498,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
         &self,
         client_versions: &SupportedApiVersionsSummary,
         timeout: Duration,
+        num_responses_required: Option<usize>,
     ) -> FederationResult<ApiVersionSet>;
 }
 
@@ -748,10 +749,13 @@ where
         &self,
         client_versions: &SupportedApiVersionsSummary,
         timeout: Duration,
+        num_responses_required: Option<usize>,
     ) -> FederationResult<ApiVersionSet> {
         self.request_with_strategy(
             DiscoverApiVersionSet::new(
-                self.all_peers().len(),
+                num_responses_required
+                    .unwrap_or(self.all_peers().len())
+                    .min(self.all_peers().len()),
                 now().add(timeout),
                 client_versions.clone(),
             ),

--- a/modules/fedimint-ln-common/src/api.rs
+++ b/modules/fedimint-ln-common/src/api.rs
@@ -12,7 +12,7 @@ use fedimint_core::endpoint_constants::{
     REGISTER_GATEWAY_ENDPOINT, REMOVE_GATEWAY_CHALLENGE_ENDPOINT, REMOVE_GATEWAY_ENDPOINT,
 };
 use fedimint_core::module::ApiRequestErased;
-use fedimint_core::query::{AllOrDeadline, UnionResponses};
+use fedimint_core::query::{ThresholdOrDeadline, UnionResponses};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{apply, async_trait_maybe_send, NumPeers, PeerId};
 use itertools::Itertools;
@@ -215,7 +215,10 @@ where
         let deadline = fedimint_core::time::now() + Duration::from_secs(1);
         let responses = self
             .request_with_strategy(
-                AllOrDeadline::<Option<sha256::Hash>>::new(self.all_peers().total(), deadline),
+                ThresholdOrDeadline::<Option<sha256::Hash>>::new(
+                    self.all_peers().total(),
+                    deadline,
+                ),
                 REMOVE_GATEWAY_CHALLENGE_ENDPOINT.to_string(),
                 ApiRequestErased::new(gateway_id),
             )
@@ -232,7 +235,7 @@ where
         let deadline = fedimint_core::time::now() + Duration::from_secs(1);
         let responses = self
             .request_with_strategy(
-                AllOrDeadline::<bool>::new(self.all_peers().total(), deadline),
+                ThresholdOrDeadline::<bool>::new(self.all_peers().total(), deadline),
                 REMOVE_GATEWAY_ENDPOINT.to_string(),
                 ApiRequestErased::new(remove_gateway_request),
             )


### PR DESCRIPTION
Use a task_group.

On top of ... too many PRs, because merge conflicts and CI being stuck ATM. Can rebase when the dust clears.