### PR TITLE
feat: Rename federation_id() to calculate_federation_id()

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -326,7 +326,7 @@ impl Federation {
 
     pub async fn pegin_gateway(&self, amount: u64, gw: &super::gatewayd::Gatewayd) -> Result<()> {
         info!(amount, "Pegging-in gateway funds");
-        let fed_id = self.federation_id().await;
+        let fed_id = self.calculate_federation_id().await;
         let pegin_addr = cmd!(gw, "address", "--federation-id={fed_id}")
             .out_json()
             .await?
@@ -348,12 +348,12 @@ impl Federation {
         Ok(())
     }
 
-    pub async fn federation_id(&self) -> String {
+    pub async fn calculate_federation_id(&self) -> String {
         self.client_config()
             .await
             .unwrap()
             .global
-            .federation_id()
+            .calculate_federation_id()
             .to_string()
     }
 

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -408,7 +408,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
     fed.pegin_gateway(10_000_000, &gw_cln).await?;
 
-    let fed_id = fed.federation_id().await;
+    let fed_id = fed.calculate_federation_id().await;
     let invite = fed.invite_code()?;
     let invite_code = cmd!(client, "dev", "decode-invite-code", invite.clone())
         .out_json()
@@ -775,7 +775,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .bolt11;
     tokio::try_join!(cln.await_block_processing(), lnd.await_block_processing())?;
     cmd!(client, "ln-pay", invoice.clone()).run().await?;
-    let fed_id = fed.federation_id().await;
+    let fed_id = fed.calculate_federation_id().await;
 
     let invoice_status = cln
         .request(cln_rpc::model::requests::WaitanyinvoiceRequest {

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -536,7 +536,7 @@ impl FedimintCli {
             .join(
                 get_default_client_secret(
                     &Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
-                    &client_config.global.federation_id(),
+                    &client_config.global.calculate_federation_id(),
                 ),
                 client_config.clone(),
                 invite_code,
@@ -560,7 +560,7 @@ impl FedimintCli {
             .await
             .map_err_cli_general()?;
 
-        let federation_id = config.federation_id();
+        let federation_id = config.calculate_federation_id();
 
         client_builder
             .open(get_default_client_secret(
@@ -602,7 +602,7 @@ impl FedimintCli {
 
         let root_secret = get_default_client_secret(
             &Bip39RootSecretStrategy::<12>::to_root_secret(&mnemonic),
-            &client_config.federation_id(),
+            &client_config.calculate_federation_id(),
         );
         let backup = builder
             .download_backup_from_federation(&root_secret, &client_config)

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1781,7 +1781,7 @@ impl ClientBuilder {
             // Save config to DB
             dbtx.insert_new_entry(
                 &ClientConfigKey {
-                    id: config.federation_id(),
+                    id: config.calculate_federation_id(),
                 },
                 &config,
             )
@@ -1961,6 +1961,7 @@ impl ClientBuilder {
     ) -> anyhow::Result<ClientHandle> {
         let decoders = self.decoders(&config);
         let config = Self::config_decoded(config, &decoders)?;
+        let fed_id = config.calculate_federation_id();
         let db = self.db.with_decoders(decoders.clone());
         let api = DynGlobalApi::from_config(&config);
 
@@ -2018,7 +2019,6 @@ impl ClientBuilder {
                 // the recovery call is extracted here.
                 let start_module_recover_fn =
                     |snapshot: Option<ClientBackup>, progress: RecoveryProgress| {
-                        let config = config.clone();
                         let module_config = module_config.clone();
                         let db = db.clone();
                         let kind = kind.clone();
@@ -2033,7 +2033,7 @@ impl ClientBuilder {
                                 module_init
                                         .recover(
                                             final_client.clone(),
-                                            config.global.federation_id(),
+                                            fed_id,
                                             module_config.clone(),
                                             db.clone(),
                                             module_instance_id,
@@ -2101,7 +2101,7 @@ impl ClientBuilder {
                     let module = module_init
                         .init(
                             final_client.clone(),
-                            config.global.federation_id(),
+                            fed_id,
                             module_config,
                             db.clone(),
                             module_instance_id,
@@ -2167,7 +2167,7 @@ impl ClientBuilder {
             config: config.clone(),
             decoders,
             db: db.clone(),
-            federation_id: config.global.federation_id(),
+            federation_id: fed_id,
             federation_meta: config.global.meta,
             primary_module_instance,
             modules,
@@ -2242,7 +2242,7 @@ impl ClientBuilder {
         root_secret: &DerivableSecret,
         config: &ClientConfig,
     ) -> DerivableSecret {
-        root_secret.federation_key(&config.global.federation_id())
+        root_secret.federation_key(&config.global.calculate_federation_id())
     }
 }
 

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -445,7 +445,7 @@ where
         InviteCode::new(
             any_guardian_url.url.clone(),
             *any_guardian_id,
-            cfg.federation_id(),
+            cfg.calculate_federation_id(),
         )
     }
 

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -167,7 +167,7 @@ pub struct GlobalClientConfig {
 }
 
 impl GlobalClientConfig {
-    pub fn federation_id(&self) -> FederationId {
+    pub fn calculate_federation_id(&self) -> FederationId {
         FederationId(self.api_endpoints.consensus_hash())
     }
 
@@ -193,8 +193,8 @@ impl ClientConfig {
         })
     }
 
-    pub fn federation_id(&self) -> FederationId {
-        self.global.federation_id()
+    pub fn calculate_federation_id(&self) -> FederationId {
+        self.global.calculate_federation_id()
     }
 
     /// Get the value of a given meta field
@@ -227,10 +227,9 @@ impl ClientConfig {
     /// Create an invite code with the api endpoint of the given peer which can
     /// be used to download this client config
     pub fn invite_code(&self, peer: &PeerId) -> Option<InviteCode> {
-        self.global
-            .api_endpoints
-            .get(peer)
-            .map(|peer_url| InviteCode::new(peer_url.url.clone(), *peer, self.federation_id()))
+        self.global.api_endpoints.get(peer).map(|peer_url| {
+            InviteCode::new(peer_url.url.clone(), *peer, self.calculate_federation_id())
+        })
     }
 
     /// Tries to download the client config from the federation,
@@ -292,7 +291,7 @@ impl ClientConfig {
             )
             .await?;
 
-        if client_config.federation_id() != federation_id {
+        if client_config.calculate_federation_id() != federation_id {
             bail!("Obtained client config has different federation id");
         }
 

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -99,7 +99,7 @@ impl FederationTest {
             .to_client_config(&self.server_init)
             .unwrap()
             .global
-            .federation_id()
+            .calculate_federation_id()
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -356,7 +356,11 @@ impl GatewayClientModule {
             self.to_gateway_registration_info(route_hints, time_to_live, fees, lightning_context);
         let gateway_id = registration_info.info.gateway_id;
 
-        let federation_id = self.client_ctx.get_config().global.federation_id();
+        let federation_id = self
+            .client_ctx
+            .get_config()
+            .global
+            .calculate_federation_id();
         self.module_api.register_gateway(&registration_info).await?;
         debug!("Successfully registered gateway {gateway_id} with federation {federation_id}");
         Ok(())
@@ -371,7 +375,11 @@ impl GatewayClientModule {
         // fails
         if let Err(e) = self.remove_from_federation_inner(gateway_keypair).await {
             let gateway_id = gateway_keypair.public_key();
-            let federation_id = self.client_ctx.get_config().global.federation_id();
+            let federation_id = self
+                .client_ctx
+                .get_config()
+                .global
+                .calculate_federation_id();
             warn!("Failed to remove gateway {gateway_id} from federation {federation_id}: {e:?}");
         }
     }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1014,7 +1014,7 @@ impl LightningClientModule {
         if !gateways.is_empty() {
             let config = self.client_ctx.get_config().clone();
             let global_meta: BTreeMap<String, String> = config.global.meta.clone();
-            let federation_id = config.global.federation_id();
+            let federation_id = config.global.calculate_federation_id();
 
             let meta = match config.meta::<String>(META_OVERRIDE_URL_KEY)? {
                 Some(override_src) => {
@@ -1147,7 +1147,10 @@ impl LightningClientModule {
                     operation_id,
                     invoice.clone(),
                     gateway,
-                    self.client_ctx.get_config().global.federation_id(),
+                    self.client_ctx
+                        .get_config()
+                        .global
+                        .calculate_federation_id(),
                     rand::rngs::OsRng,
                 )
                 .await?;


### PR DESCRIPTION
The name federation_id() makes it sound like it is just retrieving the id, however it is actually calculating a hash and can take a mild amount of cpu power. Renaming this to calculate_federation_id() implies that there is some work being done and the user should instantiate it as a variable to not duplicate that work.

Found a place where this was happening in the codebase already. We did this in several places in Mutiny too.