### PR TITLE
feat: add liquidity management API to ILnRpcClient

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -26,7 +26,8 @@ use tracing::{debug, info, trace, warn};
 
 use crate::util::{poll, ClnLightningCli, ProcessHandle, ProcessManager};
 use crate::vars::utf8;
-use crate::{cmd, poll_eq};
+use crate::version_constants::VERSION_0_4_0_ALPHA;
+use crate::{cmd, poll_eq, Gatewayd};
 
 #[derive(Clone)]
 pub struct Bitcoind {
@@ -377,6 +378,8 @@ impl Lightningd {
         Ok(rpc.call_typed(request).await?)
     }
 
+    // TODO(tvolk131): Remove this method and instead use
+    // `Gatewayd.wait_for_chain_sync()` once 0.4.0 is released
     pub async fn await_block_processing(&self) -> Result<()> {
         poll("lightningd block processing", || async {
             let btc_height = self
@@ -514,6 +517,8 @@ impl Lnd {
             .identity_pubkey)
     }
 
+    // TODO(tvolk131): Remove this method and instead use
+    // `Gatewayd.wait_for_chain_sync()` once 0.4.0 is released
     pub async fn await_block_processing(&self) -> Result<()> {
         poll("lnd block processing", || async {
             let synced = self
@@ -541,6 +546,8 @@ impl Lnd {
     }
 }
 
+// TODO(tvolk131): Remove this method and instead use
+// `open_channel_between_gateways()` below once 0.4.0 is released
 pub async fn open_channel(
     process_mgr: &ProcessManager,
     bitcoind: &Bitcoind,
@@ -610,6 +617,111 @@ pub async fn open_channel(
         .map_err(ControlFlow::Continue)
     })
     .await?;
+
+    bitcoind.mine_blocks(10).await?;
+
+    poll("Wait for channel update", || async {
+        let mut lnd_client = lnd.client.lock().await;
+        let channels = lnd_client
+            .lightning()
+            .list_channels(ListChannelsRequest {
+                active_only: true,
+                ..Default::default()
+            })
+            .await
+            .context("lnd list channels")
+            .map_err(ControlFlow::Break)?
+            .into_inner();
+
+        if let Some(channel) = channels
+            .channels
+            .iter()
+            .find(|channel| channel.remote_pubkey == cln_pubkey)
+        {
+            let chan_info = lnd_client
+                .lightning()
+                .get_chan_info(ChanInfoRequest {
+                    chan_id: channel.chan_id,
+                })
+                .await;
+
+            match chan_info {
+                Ok(info) => {
+                    let edge = info.into_inner();
+                    if edge.node1_policy.is_some() {
+                        return Ok(());
+                    } else {
+                        debug!(?edge, "Empty chan info");
+                    }
+                }
+                Err(e) => {
+                    debug!(%e, "Getting chan info failed")
+                }
+            }
+        }
+
+        Err(ControlFlow::Continue(anyhow!("channel not found")))
+    })
+    .await?;
+
+    Ok(())
+}
+
+// TODO(tvolk131): Remove the `cln` and `lnd` arguments and instead use `gw_cln`
+// and `gw_lnd` once version 0.4.0 is released
+pub async fn open_channel_between_gateways(
+    process_mgr: &ProcessManager,
+    bitcoind: &Bitcoind,
+    cln: &Lightningd,
+    gw_cln: &Gatewayd,
+    lnd: &Lnd,
+    gw_lnd: &Gatewayd,
+) -> Result<()> {
+    let gateway_cli_version = crate::util::GatewayCli::version_or_default().await;
+    let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
+    if gateway_cli_version < *VERSION_0_4_0_ALPHA || gatewayd_version < *VERSION_0_4_0_ALPHA {
+        return open_channel(process_mgr, bitcoind, cln, lnd).await;
+    }
+
+    lnd.client
+        .lock()
+        .await
+        .lightning()
+        .update_channel_policy(PolicyUpdateRequest {
+            min_htlc_msat: 1,
+            scope: Some(Scope::Global(true)),
+            time_lock_delta: 80,
+            base_fee_msat: 0,
+            fee_rate: 0.0,
+            fee_rate_ppm: 0,
+            max_htlc_msat: 10000000000,
+            min_htlc_msat_specified: true,
+        })
+        .await?;
+
+    tokio::try_join!(
+        gw_cln.wait_for_chain_sync(bitcoind),
+        gw_lnd.wait_for_chain_sync(bitcoind)
+    )?;
+    info!(target: LOG_DEVIMINT, "block sync done");
+    let cln_addr = gw_cln.get_funding_address().await?;
+
+    bitcoind.send_to(cln_addr, 100_000_000).await?;
+    bitcoind.mine_blocks(10).await?;
+
+    let lnd_pubkey = gw_lnd.lightning_pubkey().await?;
+    let cln_pubkey = gw_cln.lightning_pubkey().await?;
+
+    gw_cln
+        .connect_to_peer(
+            lnd_pubkey.parse()?,
+            format!("{}:{}", "127.0.0.1", process_mgr.globals.FM_PORT_LND_LISTEN),
+        )
+        .await?;
+
+    gw_cln
+        .open_channel(lnd_pubkey.clone(), 10_000_000, Some(5_000_000))
+        .await?;
 
     bitcoind.mine_blocks(10).await?;
 

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -548,7 +548,7 @@ impl Lnd {
 
 // TODO(tvolk131): Remove this method and instead use
 // `open_channel_between_gateways()` below once 0.4.0 is released
-pub async fn open_channel(
+async fn open_channel(
     process_mgr: &ProcessManager,
     bitcoind: &Bitcoind,
     cln: &Lightningd,

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -5,8 +5,7 @@ use cli::cleanup_on_exit;
 use devfed::DevJitFed;
 pub use devfed::{dev_fed, DevFed};
 pub use external::{
-    external_daemons, open_channel, ExternalDaemons, LightningNode, Lightningd,
-    LightningdProcessHandle, Lnd,
+    external_daemons, ExternalDaemons, LightningNode, Lightningd, LightningdProcessHandle, Lnd,
 };
 use futures::Future;
 pub use gatewayd::Gatewayd;

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -5,4 +5,6 @@ lazy_static! {
     pub static ref VERSION_0_3_0_ALPHA: Version =
         Version::parse("0.3.0-alpha").expect("version is parsable");
     pub static ref VERSION_0_3_0: Version = Version::parse("0.3.0").expect("version is parsable");
+    pub static ref VERSION_0_4_0_ALPHA: Version =
+        Version::parse("0.4.0-alpha").expect("version is parsable");
 }

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -56,14 +56,19 @@ $ gateway-cli help
 Usage: gateway-cli [OPTIONS] <COMMAND>
 
 Commands:
-  version-hash     Display CLI version hash
-  info             Display high-level information about the Gateway
-  balance          Check gateway balance
-  address          Generate a new peg-in address, funds sent to it can later be claimed
-  deposit          Deposit funds into a gateway federation
-  withdraw         Claim funds from a gateway federation
-  connect-fed      Connect federation with the gateway
-  help             Print this message or the help of the given subcommand(s)
+  version-hash          Display CLI version hash
+  info                  Display high-level information about the Gateway
+  balance               Check gateway balance
+  address               Generate a new peg-in address, funds sent to it can later be claimed
+  deposit               Deposit funds into a gateway federation
+  withdraw              Claim funds from a gateway federation
+  connect-fed           Connect federation with the gateway
+  help                  Print this message or the help of the given subcommand(s)
+  lightning
+    connect-to-peer     Connect to another lightning node from the gateway\'s underlying lightning node
+    get-funding-address Generate a new address belonging to the on-chain wallet of the gateway\'s underlying lightning node
+    open-channel        Open a lightning channel to another lighting node from the gateway\'s underlying lightning node
+    wait-for-chain-sync Wait for the gateway\'s underlying lightning node to sync to the blockchain at a given height
 
 Options:
   -a, --address <ADDRESS>          The address of the gateway webserver [default: http://127.0.0.1:8175]
@@ -97,7 +102,7 @@ As described in [Running Fedimint for dev testing](./tutorial.md#using-the-gatew
 ### Deploy a gateway-lnrpc-extension
 
 - [gateway-cln-extension](../gateway/ln-gateway/src/bin/cln_extension.rs): **TODO:** Add docs here
-- other _gateway-lnrpc-extension_:  **TODO:** Add docs here
+- other _gateway-lnrpc-extension_: **TODO:** Add docs here
 
 ### Configure and deploy gatewayd
 

--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -19,8 +19,9 @@ use lightning_invoice::{
     SignedRawBolt11Invoice, DEFAULT_EXPIRY_TIME,
 };
 use ln_gateway::gateway_lnrpc::{
-    self, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse, GetNodeInfoResponse,
-    GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
+    self, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse, GetFundingAddressResponse,
+    GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceRequest,
+    PayInvoiceResponse,
 };
 use ln_gateway::lightning::cln::{HtlcResult, RouteHtlcStream};
 use ln_gateway::lightning::{ILnRpcClient, LightningRpcError};
@@ -206,5 +207,26 @@ impl ILnRpcClient for FakeLightningTest {
         Ok(CreateInvoiceResponse {
             invoice: invoice.to_string(),
         })
+    }
+
+    async fn connect_to_peer(
+        &self,
+        _pubkey: bitcoin::secp256k1::PublicKey,
+        _host: String,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        unimplemented!("FakeLightningTest does not support connecting to peers")
+    }
+
+    async fn get_funding_address(&self) -> Result<GetFundingAddressResponse, LightningRpcError> {
+        unimplemented!("FakeLightningTest does not support getting a funding address")
+    }
+
+    async fn open_channel(
+        &self,
+        _pubkey: bitcoin::secp256k1::PublicKey,
+        _channel_size_sats: u64,
+        _push_amount_sats: u64,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        unimplemented!("FakeLightningTest does not support opening channels")
     }
 }

--- a/fedimint-testing/src/ln/real.rs
+++ b/fedimint-testing/src/ln/real.rs
@@ -12,8 +12,9 @@ use fedimint_core::Amount;
 use fedimint_logging::LOG_TEST;
 use lightning_invoice::Bolt11Invoice;
 use ln_gateway::gateway_lnrpc::{
-    CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse, GetNodeInfoResponse,
-    GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
+    CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse, GetFundingAddressResponse,
+    GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceRequest,
+    PayInvoiceResponse,
 };
 use ln_gateway::lightning::cln::{NetworkLnRpcClient, RouteHtlcStream};
 use ln_gateway::lightning::lnd::GatewayLndClient;
@@ -135,6 +136,29 @@ impl ILnRpcClient for ClnLightningTest {
         create_invoice_request: CreateInvoiceRequest,
     ) -> Result<CreateInvoiceResponse, LightningRpcError> {
         self.lnrpc.create_invoice(create_invoice_request).await
+    }
+
+    async fn connect_to_peer(
+        &self,
+        pubkey: bitcoin::secp256k1::PublicKey,
+        host: String,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        self.lnrpc.connect_to_peer(pubkey, host).await
+    }
+
+    async fn get_funding_address(&self) -> Result<GetFundingAddressResponse, LightningRpcError> {
+        self.lnrpc.get_funding_address().await
+    }
+
+    async fn open_channel(
+        &self,
+        pubkey: bitcoin::secp256k1::PublicKey,
+        channel_size_sats: u64,
+        push_amount_sats: u64,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        self.lnrpc
+            .open_channel(pubkey, channel_size_sats, push_amount_sats)
+            .await
     }
 }
 
@@ -300,6 +324,29 @@ impl ILnRpcClient for LndLightningTest {
         create_invoice_request: CreateInvoiceRequest,
     ) -> Result<CreateInvoiceResponse, LightningRpcError> {
         self.lnrpc.create_invoice(create_invoice_request).await
+    }
+
+    async fn connect_to_peer(
+        &self,
+        pubkey: bitcoin::secp256k1::PublicKey,
+        host: String,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        self.lnrpc.connect_to_peer(pubkey, host).await
+    }
+
+    async fn get_funding_address(&self) -> Result<GetFundingAddressResponse, LightningRpcError> {
+        self.lnrpc.get_funding_address().await
+    }
+
+    async fn open_channel(
+        &self,
+        pubkey: bitcoin::secp256k1::PublicKey,
+        channel_size_sats: u64,
+        push_amount_sats: u64,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        self.lnrpc
+            .open_channel(pubkey, channel_size_sats, push_amount_sats)
+            .await
     }
 }
 

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -305,7 +305,7 @@ async fn main() -> anyhow::Result<()> {
                 let response = client()
                     .get_funding_address(GetFundingAddressPayload {})
                     .await?;
-                print_response(response).await;
+                println!("{response}");
             }
             LightningCommands::OpenChannel {
                 pubkey,

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -1,21 +1,27 @@
+use std::time::Duration;
+
 use anyhow::bail;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::Address;
 use clap::{CommandFactory, Parser, Subcommand};
 use fedimint_core::bitcoin_migration::{
     bitcoin30_to_bitcoin29_address, bitcoin30_to_bitcoin29_network,
+    bitcoin30_to_bitcoin29_secp256k1_public_key,
 };
 use fedimint_core::config::FederationId;
-use fedimint_core::util::SafeUrl;
+use fedimint_core::util::{retry, ConstantBackoff, SafeUrl};
 use fedimint_core::{fedimint_build_code_version_env, BitcoinAmountOrAll};
 use fedimint_logging::TracingSetup;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{
-    BackupPayload, BalancePayload, ConfigPayload, ConnectFedPayload, DepositAddressPayload,
-    FederationRoutingFees, LeaveFedPayload, RestorePayload, SetConfigurationPayload,
-    WithdrawPayload, V1_API_ENDPOINT,
+    BackupPayload, BalancePayload, ConfigPayload, ConnectFedPayload, ConnectToPeerPayload,
+    DepositAddressPayload, FederationRoutingFees, GetFundingAddressPayload, LeaveFedPayload,
+    OpenChannelPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload, V1_API_ENDPOINT,
 };
 use serde::Serialize;
+
+const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES: u32 = 12;
+const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS: u64 = 10;
 
 #[derive(Parser)]
 #[command(version)]
@@ -104,6 +110,53 @@ pub enum Commands {
         /// other federations not given here will keep their current fees.
         #[clap(long)]
         per_federation_routing_fees: Option<Vec<PerFederationRoutingFees>>,
+    },
+    #[command(subcommand)]
+    Lightning(LightningCommands),
+}
+
+/// This API is intentionally kept very minimal, as its main purpose is to
+/// provide a simple and consistent way to establish liquidity between gateways
+/// in a test environment.
+#[derive(Subcommand)]
+pub enum LightningCommands {
+    /// Connect to another lightning node
+    ConnectToPeer {
+        #[clap(long)]
+        pubkey: bitcoin::secp256k1::PublicKey,
+
+        #[clap(long)]
+        host: String,
+    },
+    /// Get a Bitcoin address to fund the gateway
+    GetFundingAddress,
+    /// Open a channel with another lightning node
+    OpenChannel {
+        /// The public key of the node to open a channel with
+        #[clap(long)]
+        pubkey: bitcoin::secp256k1::PublicKey,
+
+        /// The amount to fund the channel with
+        #[clap(long)]
+        channel_size_sats: u64,
+
+        /// The amount to push to the other side of the channel
+        #[clap(long)]
+        push_amount_sats: Option<u64>,
+    },
+    /// Wait for the lightning node to be synced with the blockchain
+    WaitForChainSync {
+        /// The block height to wait for
+        #[clap(long)]
+        block_height: u32,
+
+        /// The maximum number of retries
+        #[clap(long)]
+        max_retries: Option<u32>,
+
+        /// The delay between retries
+        #[clap(long)]
+        retry_delay_seconds: Option<u64>,
     },
 }
 
@@ -238,6 +291,62 @@ async fn main() -> anyhow::Result<()> {
                 })
                 .await?;
         }
+
+        Commands::Lightning(lightning_command) => match lightning_command {
+            LightningCommands::ConnectToPeer { pubkey, host } => {
+                client()
+                    .connect_to_peer(ConnectToPeerPayload {
+                        pubkey: bitcoin30_to_bitcoin29_secp256k1_public_key(pubkey),
+                        host,
+                    })
+                    .await?;
+            }
+            LightningCommands::GetFundingAddress => {
+                let response = client()
+                    .get_funding_address(GetFundingAddressPayload {})
+                    .await?;
+                print_response(response).await;
+            }
+            LightningCommands::OpenChannel {
+                pubkey,
+                channel_size_sats,
+                push_amount_sats,
+            } => {
+                client()
+                    .open_channel(OpenChannelPayload {
+                        pubkey: bitcoin30_to_bitcoin29_secp256k1_public_key(pubkey),
+                        channel_size_sats,
+                        push_amount_sats: push_amount_sats.unwrap_or(0),
+                    })
+                    .await?;
+            }
+            LightningCommands::WaitForChainSync {
+                block_height,
+                max_retries,
+                retry_delay_seconds,
+            } => {
+                retry(
+                    "Wait for chain sync",
+                    ConstantBackoff::default()
+                        .with_delay(Duration::from_secs(
+                            retry_delay_seconds
+                                .unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS),
+                        ))
+                        .with_max_times(
+                            max_retries.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES) as usize
+                        ),
+                    || async {
+                        if client().get_info().await?.block_height.unwrap_or(0) >= block_height {
+                            Ok(())
+                        } else {
+                            Err(anyhow::anyhow!("Not synced yet"))
+                        }
+                    },
+                )
+                .await
+                .map_err(|_| anyhow::anyhow!("Timed out waiting for chain sync"))?;
+            }
+        },
     }
 
     Ok(())

--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -30,6 +30,15 @@ service GatewayLightning {
   rpc CompleteHtlc(InterceptHtlcResponse) returns (EmptyResponse) {}
 
   rpc CreateInvoice(CreateInvoiceRequest) returns (CreateInvoiceResponse) {}
+
+  /* Connect the underlying lightning node to another node. */
+  rpc ConnectToPeer(ConnectToPeerRequest) returns (EmptyResponse) {}
+
+  /* Get a Bitcoin address that belongs to the underlying lightning node's wallet. */
+  rpc GetFundingAddress(EmptyRequest) returns (GetFundingAddressResponse) {}
+
+  /* Open a channel on the underlying lightning node. */
+  rpc OpenChannel(OpenChannelRequest) returns (EmptyResponse) {}
 }
 
 message EmptyRequest {}
@@ -198,4 +207,29 @@ message CreateInvoiceRequest {
 
 message CreateInvoiceResponse {
   string invoice = 1;
+}
+
+message ConnectToPeerRequest {
+  // The public key of the node we're connecting to.
+  string pubkey = 1;
+
+  // The host address of the node we're connecting to.
+  string host = 2;
+}
+
+message GetFundingAddressResponse {
+  // An address belonging to the lightning node's on-chain wallet.
+  string address = 1;
+}
+
+message OpenChannelRequest {
+  // The public key of the node we're opening a channel to.
+  string pubkey = 1;
+
+  // The capacity of the channel, in sats.
+  uint64 channel_size_sats = 2;
+
+  // The amount of sats that should be pushed to the
+  // counterparty once the channel is opened.
+  uint64 push_amount_sats = 3;
 }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -82,6 +82,14 @@ pub struct GatewayInfo {
     pub gateway_id: secp256k1::PublicKey,
     pub gateway_state: String,
     pub network: Option<Network>,
+    // TODO: This is here to allow for backwards compatibility with old versions of this struct. We
+    // should be able to remove it once 0.4.0 is released.
+    #[serde(default)]
+    pub block_height: Option<u32>,
+    // TODO: This is here to allow for backwards compatibility with old versions of this struct. We
+    // should be able to remove it once 0.4.0 is released.
+    #[serde(default)]
+    pub synced_to_chain: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -132,4 +140,20 @@ pub struct SetConfigurationPayload {
     pub routing_fees: Option<FederationRoutingFees>,
     pub network: Option<Network>,
     pub per_federation_routing_fees: Option<Vec<(FederationId, FederationRoutingFees)>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ConnectToPeerPayload {
+    pub pubkey: secp256k1::PublicKey,
+    pub host: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GetFundingAddressPayload;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OpenChannelPayload {
+    pub pubkey: secp256k1::PublicKey,
+    pub channel_size_sats: u64,
+    pub push_amount_sats: u64,
 }

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -7,9 +7,9 @@ use serde::Serialize;
 use thiserror::Error;
 
 use super::{
-    BackupPayload, BalancePayload, ConfigPayload, ConnectFedPayload, DepositAddressPayload,
-    FederationInfo, GatewayFedConfig, GatewayInfo, LeaveFedPayload, RestorePayload,
-    SetConfigurationPayload, WithdrawPayload,
+    BackupPayload, BalancePayload, ConfigPayload, ConnectFedPayload, ConnectToPeerPayload,
+    DepositAddressPayload, FederationInfo, GatewayFedConfig, GatewayInfo, GetFundingAddressPayload,
+    LeaveFedPayload, OpenChannelPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload,
 };
 
 pub struct GatewayRpcClient {
@@ -105,6 +105,33 @@ impl GatewayRpcClient {
         let url = self
             .base_url
             .join("/set_configuration")
+            .expect("invalid base url");
+        self.call_post(url, payload).await
+    }
+
+    pub async fn connect_to_peer(&self, payload: ConnectToPeerPayload) -> GatewayRpcResult<()> {
+        let url = self
+            .base_url
+            .join("/connect_to_peer")
+            .expect("invalid base url");
+        self.call_post(url, payload).await
+    }
+
+    pub async fn get_funding_address(
+        &self,
+        payload: GetFundingAddressPayload,
+    ) -> GatewayRpcResult<Address> {
+        let url = self
+            .base_url
+            .join("/get_funding_address")
+            .expect("invalid base url");
+        self.call_post(url, payload).await
+    }
+
+    pub async fn open_channel(&self, payload: OpenChannelPayload) -> GatewayRpcResult<()> {
+        let url = self
+            .base_url
+            .join("/open_channel")
             .expect("invalid base url");
         self.call_post(url, payload).await
     }


### PR DESCRIPTION
Requires #4959

We can use this API to consolidate testing behavior which will help pave the way towards supporting an LDK-based gateway with a lightning node that lives in the gateway process