### PR TITLE
test: get denomination from mint server config

### DIFF
--- a/fedimint-core/src/tiered.rs
+++ b/fedimint-core/src/tiered.rs
@@ -95,7 +95,7 @@ impl Tiered<SecretKeyShare> {
 }
 
 impl Tiered<()> {
-    /// Generates denominations of a give base up to and including `max`
+    /// Generates denominations of a given base up to and including `max`
     pub fn gen_denominations(denomination_base: u16, max: Amount) -> Tiered<()> {
         let mut amounts = vec![];
 

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -90,7 +90,7 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
     // We currently have a limit on DB retries, if this number is increased too much
     // we might hit it
     const NUM_PAR: u64 = 10;
-    // Tests are prety slow in CI, using the default 10s timeout worked locall but
+    // Tests are prety slow in CI, using the default 10s timeout worked locally but
     // failed in CI
     const ECASH_TIMEOUT: Duration = Duration::from_secs(60);
 


### PR DESCRIPTION
Resolves outstanding TODO in `test_detect_double_spends`.