### PR TITLE
feat: API for listing incoming unspent contract hashes

### DIFF
--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -1,4 +1,5 @@
 pub const ACCOUNT_ENDPOINT: &str = "account";
+pub const LIST_UNSPENT_INCOMING_CONTRACTS_ENDPOINT: &str = "list_unspent_incoming_contracts";
 pub const ADD_CONFIG_GEN_PEER_ENDPOINT: &str = "add_config_gen_peer";
 pub const AUDIT_ENDPOINT: &str = "audit";
 pub const GUARDIAN_CONFIG_BACKUP_ENDPOINT: &str = "download_guardian_backup";

--- a/modules/fedimint-ln-client/src/api.rs
+++ b/modules/fedimint-ln-client/src/api.rs
@@ -8,8 +8,9 @@ use fedimint_core::api::{
 use fedimint_core::endpoint_constants::{
     ACCOUNT_ENDPOINT, AWAIT_ACCOUNT_ENDPOINT, AWAIT_BLOCK_HEIGHT_ENDPOINT, AWAIT_OFFER_ENDPOINT,
     AWAIT_OUTGOING_CONTRACT_CANCELLED_ENDPOINT, AWAIT_PREIMAGE_DECRYPTION, BLOCK_COUNT_ENDPOINT,
-    GET_DECRYPTED_PREIMAGE_STATUS, LIST_GATEWAYS_ENDPOINT, OFFER_ENDPOINT,
-    REGISTER_GATEWAY_ENDPOINT, REMOVE_GATEWAY_CHALLENGE_ENDPOINT, REMOVE_GATEWAY_ENDPOINT,
+    GET_DECRYPTED_PREIMAGE_STATUS, LIST_GATEWAYS_ENDPOINT,
+    LIST_UNSPENT_INCOMING_CONTRACTS_ENDPOINT, OFFER_ENDPOINT, REGISTER_GATEWAY_ENDPOINT,
+    REMOVE_GATEWAY_CHALLENGE_ENDPOINT, REMOVE_GATEWAY_ENDPOINT,
 };
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::query::{ThresholdOrDeadline, UnionResponses};
@@ -35,6 +36,8 @@ pub trait LnFederationApi {
         &self,
         contract: ContractId,
     ) -> FederationResult<Option<ContractAccount>>;
+
+    async fn get_unspent_incoming_contracts(&self) -> FederationResult<Vec<sha256::Hash>>;
 
     async fn wait_contract(&self, contract: ContractId) -> FederationResult<ContractAccount>;
 
@@ -116,6 +119,14 @@ where
         self.request_current_consensus(
             ACCOUNT_ENDPOINT.to_string(),
             ApiRequestErased::new(contract),
+        )
+        .await
+    }
+
+    async fn get_unspent_incoming_contracts(&self) -> FederationResult<Vec<sha256::Hash>> {
+        self.request_current_consensus(
+            LIST_UNSPENT_INCOMING_CONTRACTS_ENDPOINT.to_string(),
+            ApiRequestErased::default(),
         )
         .await
     }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1457,6 +1457,10 @@ impl LightningClientModule {
             }
         }))
     }
+
+    pub async fn get_unspent_incoming_contract_hashes(&self) -> anyhow::Result<Vec<sha256::Hash>> {
+        Ok(self.module_api.get_unspent_incoming_contracts().await?)
+    }
 }
 
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
In order to support claiming ecash that is committed to a contract via an external pubkey, we need some additional functionality:

1. Federation API to list current incoming unspent contracts.
2. Logic on the client side to iterate through all hashes, apply any necessary tweaks to a private key, and check if the hash matches, then spawn a state machine to claim the ecash.

This PR implements #1. It adds a very simple test to verify that the API is working, this test can be iterated on and expanded as we add the claim functionality.

@Kodylow @benthecarman FYI