### PR TITLE
Port replay protection test

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1952,6 +1952,86 @@ pub async fn guardian_backup_test(dev_fed: DevFed, process_mgr: &ProcessManager)
     Ok(())
 }
 
+pub async fn cannot_replay_tx_test(dev_fed: DevFed) -> Result<()> {
+    log_binary_versions().await?;
+
+    #[allow(unused_variables)]
+    let DevFed {
+        bitcoind,
+        cln,
+        lnd,
+        fed,
+        gw_cln,
+        gw_lnd,
+        electrs,
+        esplora,
+    } = dev_fed;
+
+    let client = fed.new_joined_client("cannot-replay-client").await?;
+
+    // Make the start and spend amount the same so we spend all ecash
+    const CLIENT_START_AMOUNT: u64 = 5_000_000_000;
+    const CLIENT_SPEND_AMOUNT: u64 = 5_000_000_000;
+
+    let initial_client_balance = client.balance().await?;
+    assert_eq!(initial_client_balance, 0);
+
+    fed.pegin_client(CLIENT_START_AMOUNT / 1000, &client)
+        .await?;
+
+    // Fork client before spending ecash so we can later attempt a double spend
+    let double_spend_client = client.new_forked("double-spender").await?;
+
+    // Spend and reissue all ecash from the client
+    let notes = cmd!(client, "spend", CLIENT_SPEND_AMOUNT)
+        .out_json()
+        .await?
+        .get("notes")
+        .expect("Output didn't contain e-cash notes")
+        .as_str()
+        .unwrap()
+        .to_owned();
+
+    let client_post_spend_balance = client.balance().await?;
+    assert_eq!(
+        client_post_spend_balance,
+        CLIENT_START_AMOUNT - CLIENT_SPEND_AMOUNT
+    );
+
+    cmd!(client, "reissue", notes).out_json().await?;
+    let client_post_reissue_balance = client.balance().await?;
+    assert_eq!(client_post_reissue_balance, CLIENT_START_AMOUNT);
+
+    // Attempt to spend the same ecash from the forked client
+    let double_spend_notes = cmd!(double_spend_client, "spend", CLIENT_SPEND_AMOUNT)
+        .out_json()
+        .await?
+        .get("notes")
+        .expect("Output didn't contain e-cash notes")
+        .as_str()
+        .unwrap()
+        .to_owned();
+
+    let double_spend_client_post_spend_balance = double_spend_client.balance().await?;
+    assert_eq!(
+        double_spend_client_post_spend_balance,
+        CLIENT_START_AMOUNT - CLIENT_SPEND_AMOUNT
+    );
+
+    cmd!(double_spend_client, "reissue", double_spend_notes)
+        .run()
+        .await
+        .expect_err("double spend must fail");
+
+    let double_spend_client_post_spend_balance = double_spend_client.balance().await?;
+    assert_eq!(
+        double_spend_client_post_spend_balance,
+        CLIENT_START_AMOUNT - CLIENT_SPEND_AMOUNT
+    );
+
+    Ok(())
+}
+
 #[derive(Subcommand)]
 pub enum LatencyTest {
     Reissue,
@@ -1992,6 +2072,8 @@ pub enum TestCmd {
     },
     /// Restore guardian from downloaded backup
     GuardianBackup,
+    /// `devfed` then tests that spent ecash cannot be double spent
+    CannotReplayTransaction,
 }
 
 pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()> {
@@ -2072,6 +2154,11 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
             let (process_mgr, _) = setup(common_args).await?;
             let dev_fed = dev_fed(&process_mgr).await?;
             guardian_backup_test(dev_fed, &process_mgr).await?;
+        }
+        TestCmd::CannotReplayTransaction => {
+            let (process_mgr, _) = setup(common_args).await?;
+            let dev_fed = dev_fed(&process_mgr).await?;
+            cannot_replay_tx_test(dev_fed).await?;
         }
     }
     Ok(())

--- a/scripts/tests/cannot-replay-tx.sh
+++ b/scripts/tests/cannot-replay-tx.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Runs a test to ensure an already spent input cannot be replayed
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+make_fm_test_marker
+
+devimint cannot-replay-transaction

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -95,6 +95,11 @@ function guardian_backup() {
 }
 export -f guardian_backup
 
+function cannot_replay_tx() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/cannot-replay-tx.sh
+}
+export -f cannot_replay_tx
+
 function devimint_cli_test() {
   fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-cli-test.sh
 }
@@ -201,6 +206,7 @@ tests_to_run_in_parallel=(
   "load_test_tool_test"
   "recoverytool_tests"
   "guardian_backup"
+  "cannot_replay_tx"
 )
 
 tests_with_versions=()


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/3234

Ports `cannot_replay_transactions` from the legacy integration tests.

https://github.com/fedimint/fedimint/blob/1132d742c2357fd70a0c3691636f80637edc0adb/integrationtests/tests/tests.rs#L348