### PR TITLE
chore: cargo upgrade (backwards compatible)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -103,9 +103,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 dependencies = [
  "backtrace",
 ]
@@ -237,7 +237,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -270,7 +270,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -339,7 +339,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byte-slice-cast"
@@ -651,10 +651,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -696,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.11"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -706,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.11"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -718,30 +719,30 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.10"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb745187d7f4d76267b37485a65e0149edd0e91a4cfcdd3f27524ad86cee9f3"
+checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cln-plugin"
@@ -873,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2399,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "fs-lock"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a672b4ad40e0c0a40da1c96788d84312f7d28eedeeb49a9b1c2dcbb45824d23"
+checksum = "e4f2e18078ea3b2c89f718dd7dad6850e29d74330b37665bea259e5987be9301"
 dependencies = [
  "fs4",
 ]
@@ -2418,12 +2419,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
+checksum = "57b1e34e369d7f0151309821497440bd0266b86c77ccd69717c3b67e5eaeffe4"
 dependencies = [
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2488,7 +2489,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2668,7 +2669,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -2697,7 +2698,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.9",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -2722,9 +2723,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2988,9 +2989,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3061,6 +3062,15 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -3267,12 +3277,12 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3377,15 +3387,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lru"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
  "hashbrown 0.14.3",
 ]
@@ -3588,9 +3598,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opentelemetry"
@@ -3794,27 +3804,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3854,7 +3864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3893,9 +3903,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3952,7 +3962,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-types 0.12.3",
  "regex",
- "syn 2.0.50",
+ "syn 2.0.52",
  "tempfile",
  "which",
 ]
@@ -3980,7 +3990,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4101,7 +4111,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -4116,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4139,9 +4149,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -4308,9 +4318,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-webpki"
@@ -4468,7 +4478,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4477,7 +4487,7 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -4485,9 +4495,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
@@ -4607,9 +4617,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
@@ -4649,9 +4659,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4725,9 +4735,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
+checksum = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6"
 dependencies = [
  "test-log-macros",
  "tracing-subscriber",
@@ -4735,33 +4745,33 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
+checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4889,7 +4899,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4975,7 +4985,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -5048,7 +5058,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5123,7 +5133,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5389,7 +5399,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -5423,7 +5433,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5456,7 +5466,7 @@ checksum = "794645f5408c9a039fd09f4d113cdfb2e7eba5ff1956b07bcf701cf4b394fe89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5561,7 +5571,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -5581,17 +5591,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.3",
- "windows_aarch64_msvc 0.52.3",
- "windows_i686_gnu 0.52.3",
- "windows_i686_msvc 0.52.3",
- "windows_x86_64_gnu 0.52.3",
- "windows_x86_64_gnullvm 0.52.3",
- "windows_x86_64_msvc 0.52.3",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -5602,9 +5612,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5614,9 +5624,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5626,9 +5636,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5638,9 +5648,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5650,9 +5660,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5662,9 +5672,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5674,9 +5684,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
@@ -5743,7 +5753,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,9 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -5380,9 +5380,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5390,9 +5390,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -5405,9 +5405,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5417,9 +5417,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5427,9 +5427,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5440,15 +5440,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.39"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9242c0d27999b831eae4767b2a146feb0b27d332d553e605864acd2afd403"
+checksum = "d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -5460,9 +5460,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.39"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794645f5408c9a039fd09f4d113cdfb2e7eba5ff1956b07bcf701cf4b394fe89"
+checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -16,8 +16,8 @@ name = "fedimint_aead"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.65"
-argon2 = { version = "0.5.0", features = ["password-hash", "alloc"] }
-ring = "0.17.5"
+anyhow = "1.0.81"
+argon2 = { version = "0.5.3", features = ["password-hash", "alloc"] }
+ring = "0.17.8"
 hex = "0.4.3"
 rand = "0.8"

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/lib.rs"
 
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 hkdf = { package = "fedimint-hkdf", version = "0.3.0-alpha", path = "../../crypto/hkdf" }
-ring = "0.17.5"
+ring = "0.17.8"
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -26,4 +26,4 @@ rand = "0.8"
 rand_chacha = "0.3.1"
 bitcoin_hashes = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
-sha3 = "0.10.5"
+sha3 = "0.10.8"

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -12,10 +12,10 @@ name = "devimint"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = { version = "1.0.69", features = ["backtrace"] }
-axum = { version = "0.6.4", features = ["tracing"] }
+anyhow = { version = "1.0.81", features = ["backtrace"] }
+axum = { version = "0.6.20", features = ["tracing"] }
 bitcoincore-rpc = "0.16.0"
-clap = { version = "4.1.6", features = ["derive", "env", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
+clap = { version = "4.5.2", features = ["derive", "env", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 cln-rpc = { workspace = true }
 fedimint-aead = { path = "../crypto/aead" }
 fedimintd = { path = "../fedimintd" }
@@ -27,22 +27,22 @@ fedimint-logging = { path = "../fedimint-logging" }
 fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
 fedimint-server = { path = "../fedimint-server" }
 fedimint-testing = { path = "../fedimint-testing" }
-futures = "0.3.24"
+futures = "0.3.30"
 hex = "0.4.3"
 ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
-nix = { version = "0.26.2", features = ["signal"] }
+nix = { version = "0.26.4", features = ["signal"] }
 rand = "0.8.5"
-semver = "1.0.21"
-serde_json = "1.0.94"
-tokio = { version = "1.26.0", features = ["full", "tracing"] }
+semver = "1.0.22"
+serde_json = "1.0.114"
+tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tonic_lnd = { workspace = true }
-tower-http = { version = "0.4.3", features = ["cors", "auth"] }
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
-serde = "1.0.159"
-url = "2.3.1"
+tower-http = { version = "0.4.4", features = ["cors", "auth"] }
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
+serde = "1.0.197"
+url = "2.5.0"
 fedimint-portalloc = { path = "../utils/portalloc" }
-fs-lock = "0.1.2"
+fs-lock = "0.1.3"
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -17,21 +17,21 @@ name = "fedimint_bitcoind"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 bitcoincore-rpc = { version = "0.16.0", optional = true }
-electrum-client = {version = "0.12.0", optional = true }
+electrum-client = {version = "0.12.1", optional = true }
 esplora-client = { version = "0.5.0", default-features = false, features = ["async", "async-https-rustls"], optional = true }
 lazy_static = "1.4.0"
 fedimint-core  = { version = "0.3.0-alpha", path = "../fedimint-core" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 rand = "0.8"
-serde = { version = "1.0.149", features = [ "derive" ] }
-serde_json = "1.0.91"
-tracing = "0.1.37"
-url = "2.3.1"
+serde = { version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
+tracing = "0.1.40"
+url = "2.5.0"
 
 [features]
 default = ["bitcoincore-rpc", "electrum-client", "esplora-client"]

--- a/fedimint-build/Cargo.toml
+++ b/fedimint-build/Cargo.toml
@@ -13,4 +13,4 @@ name = "fedimint_build"
 path = "src/lib.rs"
 
 [dependencies]
-serde_json = "1.0.108"
+serde_json = "1.0.114"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -21,16 +21,16 @@ name = "fedimint_cli"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 base64 = "0.21.7"
 bip39 = { version = "2.0.0", features = ["rand"] }
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
-time = { version = "0.3.25", features = [ "formatting" ] }
-clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
-futures = "0.3.28"
-itertools = "0.12.0"
+time = { version = "0.3.34", features = [ "formatting" ] }
+clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
+futures = "0.3.30"
+itertools = "0.12.1"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
 fedimint-bip39 = { version = "0.3.0-alpha", path = "../fedimint-bip39" }
@@ -44,18 +44,18 @@ fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-c
 fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fs-lock = "0.1.0"
+fs-lock = "0.1.3"
 rand = "0.8"
-serde = { version = "1.0.149", features = [ "derive" ] }
-thiserror = "1.0.39"
-tokio = { version = "1.26.0", features = ["full", "tracing"] }
-tracing ="0.1.37"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
-serde_json = { version = "1.0.91", features = ["preserve_order"] }
-url = { version = "2.3.1", features = ["serde"] }
-clap_complete = "4.3.1"
-lnurl-rs = { version = "0.3.1", features = ["async"], default-features = false }
-reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }
+serde = { version = "1.0.197", features = [ "derive" ] }
+thiserror = "1.0.58"
+tokio = { version = "1.36.0", features = ["full", "tracing"] }
+tracing ="0.1.40"
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
+serde_json = { version = "1.0.114", features = ["preserve_order"] }
+url = { version = "2.5.0", features = ["serde"] }
+clap_complete = "4.5.1"
+lnurl-rs = { version = "0.3.2", features = ["async"], default-features = false }
+reqwest = { version = "0.11.26", features = [ "json", "rustls-tls" ], default-features = false }
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -20,31 +20,31 @@ name = "fedimint_client"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.69"
-aquamarine = "0.3.1"
+anyhow = "1.0.81"
+aquamarine = "0.3.3"
 async-stream = "0.3.5"
-async-trait = "0.1.73"
+async-trait = "0.1.77"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 fedimint-core  = { version = "0.3.0-alpha", path = "../fedimint-core/" }
 fedimint-derive-secret = { version = "0.3.0-alpha", path = "../crypto/derive-secret" }
 fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-futures = "0.3.26"
+futures = "0.3.30"
 itertools = "0.10.5"
 rand = "0.8.5"
 secp256k1-zkp = "0.7.0"
-serde = "1.0.152"
-serde_json = "1.0.91"
+serde = "1.0.197"
+serde_json = "1.0.114"
 strum = "0.24.1"
-strum_macros = "0.24.1"
-thiserror = "1.0.39"
-tokio = { version = "1.26.0", features = [ "time", "macros" ] }
+strum_macros = "0.24.3"
+thiserror = "1.0.58"
+tokio = { version = "1.36.0", features = [ "time", "macros" ] }
 tokio-stream = { version = "0.1.14", features = [ "time", "sync" ] }
-tracing = "0.1.37"
+tracing = "0.1.40"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-ring = { version = "0.17.5", features = ["wasm32_unknown_unknown_js"] }
+ring = { version = "0.17.8", features = ["wasm32_unknown_unknown_js"] }
 
 [dev-dependencies]
 tracing-test = "0.2.4"

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -15,31 +15,31 @@ name = "fedimint_core"
 path = "src/lib.rs"
 
 [dependencies]
-async-recursion = "1.0.4"
-anyhow = "1.0.65"
-async-trait = "0.1.73"
-futures = "0.3.24"
-backtrace = "0.3.67"
-bincode = "1.3.1"
+async-recursion = "1.0.5"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
+futures = "0.3.30"
+backtrace = "0.3.69"
+bincode = "1.3.3"
 bech32 = "0.9.1"
 itertools = "0.10.5"
 jsonrpsee-types = { version = "0.22.2" }
 jsonrpsee-core = { version = "0.21.0", features = [ "client" ] }
-lru = "0.12.1"
-serde = { version = "1.0.149", features = [ "derive" ] }
-serde_json = "1.0.91"
+lru = "0.12.3"
+serde = { version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
 strum = "0.24"
 strum_macros = "0.24"
 hex = { version = "0.4.3", features = [ "serde"] }
-sha3 = "0.10.5"
+sha3 = "0.10.8"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
-tokio = { version = "1.26.0", features = ["sync", "io-util"] }
-thiserror = "1.0.39"
-tracing ="0.1.37"
+tokio = { version = "1.36.0", features = ["sync", "io-util"] }
+thiserror = "1.0.58"
+tracing ="0.1.40"
 threshold_crypto = { workspace = true }
-url = { version = "2.3.1", features = ["serde"] }
+url = { version = "2.5.0", features = ["serde"] }
 bitcoin = { version = "0.29.2", features = [ "rand", "serde" ] }
-bitcoin30 = { package = "bitcoin", version = "0.30.0" }
+bitcoin30 = { package = "bitcoin", version = "0.30.2" }
 bitcoin_hashes = { version = "0.11", features = ["serde"] }
 erased-serde = "0.3"
 lightning = "0.0.118"
@@ -51,26 +51,26 @@ miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
 macro_rules_attribute = "0.1.3"
 bitvec = "1.0.1"
-parity-scale-codec = { version = "3.5.0", features = ["derive"] }
+parity-scale-codec = { version = "3.6.9", features = ["derive"] }
 imbl = "2.0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 jsonrpsee-ws-client = { version = "0.21.0", features = ["webpki-tls"], default-features = false }
-tokio = { version = "1.25.0", features = ["full", "tracing"] }
+tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tokio-rustls = "0.23.4"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 jsonrpsee-wasm-client = { version = "0.21.0", default-features = false }
-async-lock = "2.7"
+async-lock = "2.8"
 # getrandom is transitive dependency of rand
 # on wasm, we need to enable the js backend
 # see https://docs.rs/getrandom/latest/getrandom/#indirect-dependencies and https://docs.rs/getrandom/latest/getrandom/#webassembly-support
-getrandom = { version = "0.2.8", features = [ "js" ] }
+getrandom = { version = "0.2.12", features = [ "js" ] }
 gloo-timers = { version = "0.2.6", features = ["futures"] }
-wasm-bindgen-futures = "0.4.33"
-js-sys = "0.3.61"
+wasm-bindgen-futures = "0.4.42"
+js-sys = "0.3.69"
 
 [dev-dependencies]
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
-once_cell = "1.16.0"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+once_cell = "1.19.0"
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -17,11 +17,11 @@ path = "src/main.rs"
 name = "fedimint-dbtool"
 
 [dependencies]
-anyhow = "1.0.68"
+anyhow = "1.0.81"
 fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
 bitcoin_hashes = "0.11.0"
-bytes = "1.4.0"
-clap = { version = "4.1.6", features = ["derive", "env"] }
+bytes = "1.5.0"
+clap = { version = "4.5.2", features = ["derive", "env"] }
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
 fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
 fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
@@ -33,16 +33,16 @@ fedimint-ln-client = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-c
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 fedimint-wallet-server = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-server" }
 fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
-futures = "0.3.24"
+futures = "0.3.30"
 erased-serde = "0.3"
 hex = { version = "0.4.3", features = ["serde"] }
 ln-gateway = { package = "fedimint-ln-gateway", version = "0.3.0-alpha", path = "../gateway/ln-gateway" }
-serde = { version = "1.0.149", features = ["derive"] }
-serde_json = "1.0.91"
+serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.114"
 strum = "0.24"
 strum_macros = "0.24"
-tokio = "1.26.0"
-tracing = "0.1.37"
+tokio = "1.36.0"
+tracing = "0.1.40"
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 anyhow = "1"
 base64 = "0.21.7"
 bitcoin = "0.29.2"
-clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
+clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
 devimint = { version = "0.3.0-alpha", path = "../devimint" }
 fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
@@ -29,11 +29,11 @@ jsonrpsee-core = { version = "0.21.0", features = [ "client" ] }
 jsonrpsee-types = { version = "0.22.2" }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 rand = "0.8"
-serde = { version = "1.0.149", features = [ "derive" ] }
-serde_json = "1.0.91"
+serde = { version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
 tokio = { version = "1", features = ["full", "tracing"] }
 tracing = "0.1"
-url = { version = "2.3.1", features = ["serde"] }
+url = { version = "2.5.0", features = ["serde"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 jsonrpsee-ws-client = { version = "0.21.0", features = ["webpki-tls"], default-features = false }

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/lib.rs"
 telemetry = ["tracing-opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "console-subscriber"]
 
 [dependencies]
-anyhow = "1.0.66"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+anyhow = "1.0.81"
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
 tracing-opentelemetry = { version = "0.20.0", optional = true}
 opentelemetry = { version = "0.20.0", optional = true }
 opentelemetry-jaeger = { version = "0.19.0", optional = true }
-console-subscriber = { version = "0.1.8", optional = true }
-tracing-chrome = { version = "0.7.0", optional = true}
+console-subscriber = { version = "0.1.10", optional = true }
+tracing-chrome = { version = "0.7.1", optional = true}

--- a/fedimint-metrics/Cargo.toml
+++ b/fedimint-metrics/Cargo.toml
@@ -15,10 +15,10 @@ name = "fedimint_metrics"
 path = "./src/lib.rs"
 
 [dependencies]
-anyhow = { version = "1.0.71", features = ["backtrace"] }
-axum = "0.6.18"
+anyhow = { version = "1.0.81", features = ["backtrace"] }
+axum = "0.6.20"
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
 lazy_static = "1.4.0"
 prometheus = "0.13.3"
 tokio = "1"
-tracing = "0.1.37"
+tracing = "0.1.40"

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -18,16 +18,16 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-futures = "0.3.24"
+futures = "0.3.30"
 rocksdb = { version = "0.22.0" }
-tracing = "0.1.37"
+tracing = "0.1.40"
 
 [dev-dependencies]
 tempfile = "3.10.1"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-tokio = { version = "1.26.0", features = ["rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.36.0", features = ["rt", "rt-multi-thread", "sync", "time"] }

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -19,14 +19,14 @@ path = "src/lib.rs"
 
 [dependencies]
 fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 async-channel = "2.2.0"
-async-trait = "0.1.73"
-bincode = "1.3.1"
+async-trait = "0.1.77"
+bincode = "1.3.3"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
-bytes = "1.4.0"
-futures = "0.3.24"
+bytes = "1.5.0"
+futures = "0.3.30"
 hex = "0.4.3"
 itertools = "0.10.5"
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
@@ -35,28 +35,28 @@ rand = "0.8"
 rcgen = "=0.10.0"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
 rand_chacha = "0.3.1"
-serde = { version = "1.0.149", features = [ "derive" ] }
-serde_json = "1.0.91"
-sha3 = "0.10.5"
+serde = { version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
+sha3 = "0.10.8"
 strum = "0.24"
 strum_macros = "0.24"
 tar = "0.4.40"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
-thiserror = "1.0.39"
-tracing ="0.1.37"
-url = { version = "2.3.1", features = ["serde"] }
+thiserror = "1.0.58"
+tracing ="0.1.40"
+url = { version = "2.5.0", features = ["serde"] }
 threshold_crypto = { workspace = true }
 jsonrpsee = { version = "0.22.2", features = ["server"] }
-tokio = { version = "1.26.0", features = ["full", "tracing"] }
-tokio-stream = "0.1.11"
+tokio = { version = "1.36.0", features = ["full", "tracing"] }
+tokio-stream = "0.1.14"
 tokio-rustls = "0.23.4"
-tokio-util = { version = "0.7.4", features = [ "codec" ] }
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tokio-util = { version = "0.7.10", features = [ "codec" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
 aleph-bft = { package = "fedimint-aleph-bft", version = "0.30.0", default-features = false }
 aleph-bft-types = "0.10.0"
-bitcoin_30 = { package = "bitcoin", version = "0.30.0" }
+bitcoin_30 = { package = "bitcoin", version = "0.30.2" }
 bitcoin_hashes_12 = { package = "bitcoin_hashes", version = "0.12.0" }
-parity-scale-codec = "3.5.0"
+parity-scale-codec = "3.6.9"
 
 
 [dev-dependencies]

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -18,12 +18,12 @@ path = "src/lib.rs"
 
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.81"
 async-stream = "0.3.5"
-async-trait = "0.1.73"
+async-trait = "0.1.77"
 bitcoin = "0.29.2"
 bitcoincore-rpc = "0.16.0"
-clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions" ], default-features = false }
+clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions" ], default-features = false }
 cln-rpc = { workspace = true }
 fedimint-core  = { version = "0.3.0-alpha", path = "../fedimint-core" }
 fedimint-client  = { version = "0.3.0-alpha", path = "../fedimint-client" }
@@ -31,20 +31,20 @@ fedimint-server  = { version = "0.3.0-alpha", path = "../fedimint-server" }
 fedimint-bitcoind = { version = "0.3.0-alpha", path = "../fedimint-bitcoind" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fs-lock = "0.1.0"
+fs-lock = "0.1.3"
 lazy_static = "1.4.0"
 ln-gateway = { version = "0.3.0-alpha", package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 futures = "0.3"
 lightning-invoice = "0.26.0"
 tempfile = "3.10.1"
-secp256k1 = "0.24.2"
+secp256k1 = "0.24.3"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
-serde = { version = "1.0.149", features = [ "derive" ] }
-tracing ="0.1.37"
+serde = { version = "1.0.197", features = [ "derive" ] }
+tracing ="0.1.40"
 rand = "0.8"
 tokio-rustls = "0.23.4"
-tokio = { version = "1.26.0", features = ["full", "tracing"] }
-tokio-stream = "0.1.11"
+tokio = { version = "1.36.0", features = ["full", "tracing"] }
+tokio-stream = "0.1.14"
 tonic_lnd = { workspace = true }
-url = "2.3.1"
+url = "2.5.0"
 fedimint-portalloc = { version = "0.3.0-alpha", path = "../utils/portalloc" }

--- a/fedimint-wasm-tests/Cargo.toml
+++ b/fedimint-wasm-tests/Cargo.toml
@@ -12,18 +12,18 @@ name = "fedimint_wasm_tests"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.69"
-futures = "0.3.26"
-ring = { version = "0.17.5", features = ["wasm32_unknown_unknown_js"] }
+anyhow = "1.0.81"
+futures = "0.3.30"
+ring = { version = "0.17.8", features = ["wasm32_unknown_unknown_js"] }
 fedimint-client = { path = "../fedimint-client" }
 fedimint-core = { path = "../fedimint-core" }
 fedimint-mint-client = { path = "../modules/fedimint-mint-client" }
 fedimint-mint-common = { path = "../modules/fedimint-mint-common" }
 fedimint-ln-client = { path = "../modules/fedimint-ln-client" }
 fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
-js-sys = "0.3.61"
-wasm-bindgen = "=0.2.89" # must match the nix provided wasm-bindgen-cli version
-wasm-bindgen-futures = "0.4.34"
-wasm-bindgen-test = "0.3.34"
+js-sys = "0.3.69"
+wasm-bindgen = "=0.2.92" # must match the nix provided wasm-bindgen-cli version
+wasm-bindgen-futures = "0.4.42"
+wasm-bindgen-test = "0.3.42"
 gloo-net = "0.2.6"
 rand = "0.8.5"

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -25,16 +25,16 @@ path = "src/lib.rs"
 
 [dependencies]
 fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
-ring = "0.17.5"
-anyhow = "1.0.66"
-async-trait = "0.1.73"
-bincode = "1.3.1"
+ring = "0.17.8"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
+bincode = "1.3.3"
 bitcoin = "0.29.2"
-bytes = "1.4.0"
-clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
-futures = "0.3.24"
+bytes = "1.5.0"
+clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
+futures = "0.3.30"
 itertools = "0.10.5"
-jsonrpsee = { version = "0.22.1", features = ["server"] }
+jsonrpsee = { version = "0.22.2", features = ["server"] }
 fedimint-bitcoind = { version = "0.3.0-alpha", path = "../fedimint-bitcoind" }
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
 fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-common" }
@@ -50,25 +50,25 @@ fedimint-unknown-common = { version = "0.3.0-alpha", path = "../modules/fedimint
 rand = "0.8"
 rcgen = "=0.10.0"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
-serde = { version = "1.0.149", features = [ "derive" ] }
-serde_json = "1.0.91"
-sha3 = "0.10.5"
+serde = { version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
+sha3 = "0.10.8"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
-thiserror = "1.0.39"
-tokio = { version = "1.26.0", features = ["full", "tracing"] }
+thiserror = "1.0.58"
+tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tokio-rustls = "0.23.4"
-tokio-util = { version = "0.7.4", features = [ "codec" ] }
-tracing ="0.1.37"
-url = { version = "2.3.1", features = ["serde"] }
+tokio-util = { version = "0.7.10", features = [ "codec" ] }
+tracing ="0.1.40"
+url = { version = "2.5.0", features = ["serde"] }
 threshold_crypto = { workspace = true }
 
 # setup dependencies
-axum = { version = "0.6.4", default-features = false, features = [ "form", "tokio" ] }
+axum = { version = "0.6.20", default-features = false, features = [ "form", "tokio" ] }
 http = "1.1"
 http-body = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
-console-subscriber = "0.1.8"
+console-subscriber = "0.1.10"
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -17,22 +17,22 @@ name = "gateway-cli"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.64"
-axum = "0.6.4"
-axum-macros = "0.3.1"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
+axum = "0.6.20"
+axum-macros = "0.3.8"
 bitcoin = { version = "0.29.2", features = ["serde"] }
-clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
+clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 ln-gateway = { version = "0.3.0-alpha", package = "fedimint-ln-gateway", path= "../ln-gateway" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
-reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }
+reqwest = { version = "0.11.26", features = [ "json", "rustls-tls" ], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.91"
-tokio = {version = "1.26", features = ["full"]}
-tracing = { version = "0.1.37", default-features = false, features= ["log", "attributes", "std"] }
-url = { version = "2.3.1", features = ["serde"] }
-clap_complete = "4.3.1"
+serde_json = "1.0.114"
+tokio = {version = "1.36", features = ["full"]}
+tracing = { version = "0.1.40", default-features = false, features= ["log", "attributes", "std"] }
+url = { version = "2.5.0", features = ["serde"] }
+clap_complete = "4.5.1"
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../../fedimint-build" }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -27,15 +27,15 @@ name = "gatewayd-integration-tests"
 path = "tests/integration_tests.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 async-stream = "0.3.5"
-async-trait = "0.1.64"
-axum = "0.6.4"
-axum-macros = "0.3.1"
-aquamarine = "0.3.0"
+async-trait = "0.1.77"
+axum = "0.6.20"
+axum-macros = "0.3.8"
+aquamarine = "0.3.3"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 bitcoin_hashes = "0.11.0"
-clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
+clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
 # cln-plugin made semver incompatible change
 cln-plugin = "=0.1.7"
 cln-rpc = { workspace = true }
@@ -48,26 +48,26 @@ fedimint-ln-common = { version = "0.3.0-alpha", path = "../../modules/fedimint-l
 fedimint-mint-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-mint-client" }
 fedimint-dummy-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-dummy-client" }
 fedimint-wallet-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-wallet-client" }
-futures = "0.3.24"
+futures = "0.3.30"
 erased-serde = "0.3"
 lightning-invoice = "0.26.0"
-prost = "0.12.1"
+prost = "0.12.3"
 rand = "0.8"
-reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }
-secp256k1 = "0.24.2"
+reqwest = { version = "0.11.26", features = [ "json", "rustls-tls" ], default-features = false }
+secp256k1 = "0.24.3"
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.91"
+serde_json = "1.0.114"
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
-tokio = { version = "1.26", features = ["full"] }
-tokio-stream = "0.1.11"
+thiserror = "1.0.58"
+tokio = { version = "1.36", features = ["full"] }
+tokio-stream = "0.1.14"
 tonic = { version = "0.10.2", features = ["transport", "tls"] }
 tonic_lnd = { workspace = true }
-tower-http = { version = "0.4.3", features = ["cors", "auth"] }
-tracing = { version = "0.1.37", default-features = false, features= ["log", "attributes", "std"] }
-url = { version = "2.3.1", features = ["serde"] }
+tower-http = { version = "0.4.4", features = ["cors", "auth"] }
+tracing = { version = "0.1.40", default-features = false, features= ["log", "attributes", "std"] }
+url = { version = "2.5.0", features = ["serde"] }
 
 [dev-dependencies]
 fedimint-dummy-server = { path = "../../modules/fedimint-dummy-server" }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -36,7 +36,8 @@ aquamarine = "0.3.0"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 bitcoin_hashes = "0.11.0"
 clap = { version = "4.1.6", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
-cln-plugin = "0.1.5"
+# cln-plugin made semver incompatible change
+cln-plugin = "=0.1.7"
 cln-rpc = { workspace = true }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -16,18 +16,18 @@ name = "fedimint_dummy_client"
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1.73"
-anyhow = "1.0.66"
+async-trait = "0.1.77"
+anyhow = "1.0.81"
 fedimint-dummy-common = { version = "0.3.0-alpha", path = "../fedimint-dummy-common" }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 futures = "0.3"
 erased-serde = "0.3"
 rand = "0.8.5"
-secp256k1 = "0.24.2"
-serde = {version = "1.0.149", features = [ "derive" ] }
+secp256k1 = "0.24.3"
+serde = {version = "1.0.197", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
-tracing = "0.1.37"
-thiserror = "1.0.39"
+tracing = "0.1.40"
+thiserror = "1.0.58"
 threshold_crypto = { workspace = true }

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -16,17 +16,17 @@ name = "fedimint_dummy_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"
-serde = { version = "1.0.149", features = [ "derive" ] }
-secp256k1 = "0.24.2"
+serde = { version = "1.0.197", features = [ "derive" ] }
+secp256k1 = "0.24.3"
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
-tracing = "0.1.37"
+thiserror = "1.0.58"
+tracing = "0.1.40"
 threshold_crypto = { workspace = true }

--- a/modules/fedimint-dummy-server/Cargo.toml
+++ b/modules/fedimint-dummy-server/Cargo.toml
@@ -16,18 +16,18 @@ name = "fedimint_dummy_server"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-dummy-common = { version = "0.3.0-alpha", path = "../fedimint-dummy-common" }
 rand = "0.8"
-serde = { version = "1.0.149", features = [ "derive" ] }
-secp256k1 = "0.24.2"
+serde = { version = "1.0.197", features = [ "derive" ] }
+secp256k1 = "0.24.3"
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
-tracing = "0.1.37"
-tokio = { version = "1.26.0", features = ["sync"] }
+thiserror = "1.0.58"
+tracing = "0.1.40"
+tokio = { version = "1.36.0", features = ["sync"] }

--- a/modules/fedimint-dummy-tests/Cargo.toml
+++ b/modules/fedimint-dummy-tests/Cargo.toml
@@ -12,7 +12,7 @@ name = "fedimint_dummy_tests"
 path = "tests/tests.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-core ={ path = "../../fedimint-core" }
 fedimint-dummy-client = { path = "../fedimint-dummy-client" }
@@ -21,13 +21,13 @@ fedimint-dummy-server = { path = "../fedimint-dummy-server" }
 fedimint-logging = { path = "../../fedimint-logging" }
 fedimint-server = { path = "../../fedimint-server" }
 fedimint-testing = { path = "../../fedimint-testing" }
-futures = "0.3.24"
+futures = "0.3.30"
 rand = "0.8"
-secp256k1 = "0.24.2"
+secp256k1 = "0.24.3"
 strum = "0.24"
 strum_macros = "0.24"
-tokio = { version = "1.26.0", features = ["sync"] }
-tracing = "0.1.37"
+tokio = { version = "1.36.0", features = ["sync"] }
+tracing = "0.1.40"
 
 [dev-dependencies]
 threshold_crypto = { workspace = true }

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -22,34 +22,34 @@ name = "fedimint_ln_client"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 async-stream = "0.3.5"
-aquamarine = "0.3.0"
+aquamarine = "0.3.3"
 bincode = "1"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
-futures = "0.3.24"
+futures = "0.3.30"
 itertools = "0.10.5"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-ln-common = { version = "0.3.0-alpha", path = "../fedimint-ln-common" }
-secp256k1 = { version="0.24.2", default-features=false }
+secp256k1 = { version="0.24.3", default-features=false }
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
-serde = {version = "1.0.149", features = [ "derive" ] }
-serde_json = "1.0.91"
+serde = {version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
+thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
-tokio = { version = "1.26.0", features = ["macros"] }
-tracing = "0.1.37"
+tokio = { version = "1.36.0", features = ["macros"] }
+tracing = "0.1.40"
 rand = "0.8"
-reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }
-url = { version = "2.3.1", features = ["serde"] }
+reqwest = { version = "0.11.26", features = [ "json", "rustls-tls" ], default-features = false }
+url = { version = "2.5.0", features = ["serde"] }
 
 [dev-dependencies]
-tokio = {version = "1.26.0", features = [ "full" ] }
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tokio = {version = "1.36.0", features = [ "full" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -22,30 +22,30 @@ name = "fedimint_ln_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
-aquamarine = "0.3.0"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
+aquamarine = "0.3.3"
 bitcoin_hashes = "0.11.0"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
-futures = "0.3.24"
+futures = "0.3.30"
 itertools = "0.10.5"
 lightning = { version = "0.0.118", default-features = false, features = ["no-std"] }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-secp256k1 = { version="0.24.2", default-features=false }
-serde = {version = "1.0.149", features = [ "derive" ] }
-serde_json = "1.0.91"
+secp256k1 = { version="0.24.3", default-features=false }
+serde = {version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
+thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
-tracing = "0.1.37"
+tracing = "0.1.40"
 rand = "0.8"
-url = { version = "2.3.1", features = ["serde"] }
+url = { version = "2.5.0", features = ["serde"] }
 serde-big-array = "0.5.1"
 
 [dev-dependencies]
-tokio = {version = "1.26.0", features = [ "full" ] }
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tokio = {version = "1.36.0", features = [ "full" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -18,12 +18,12 @@ name = "fedimint_ln_server"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 bincode = "1"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
-futures = "0.3.24"
+futures = "0.3.30"
 itertools = "0.10.5"
 lightning = "0.0.118"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
@@ -31,21 +31,21 @@ fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind" 
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-ln-common = { version = "0.3.0-alpha", path = "../fedimint-ln-common" }
 fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
-secp256k1 = { version="0.24.2", default-features=false }
-serde = {version = "1.0.149", features = [ "derive" ] }
-serde_json = "1.0.91"
+secp256k1 = { version="0.24.3", default-features=false }
+serde = {version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
+thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
-tokio = { version = "1.26", features = ["full"] }
-tracing = "0.1.37"
+tokio = { version = "1.36", features = ["full"] }
+tracing = "0.1.40"
 rand = "0.8"
-url = { version = "2.3.1", features = ["serde"] }
+url = { version = "2.5.0", features = ["serde"] }
 fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
-tokio = {version = "1.26.0", features = [ "full" ] }
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tokio = {version = "1.36.0", features = [ "full" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -12,7 +12,7 @@ name = "fedimint_ln_tests"
 path = "tests/tests.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 assert_matches = "1.5.0"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 bitcoin_hashes = "0.11.0"
@@ -28,13 +28,13 @@ fedimint-client = { path = "../../fedimint-client" }
 fedimint-core ={ path = "../../fedimint-core" }
 fedimint-server = { path = "../../fedimint-server" }
 fedimint-logging = { path = "../../fedimint-logging" }
-futures = "0.3.24"
+futures = "0.3.30"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 threshold_crypto = { workspace = true }
-tokio = { version = "1.26.0", features = ["sync"] }
-tracing = "0.1.37"
-secp256k1 = { version="0.24.2", default-features=false }
-serde_json = "1.0.91"
+tokio = { version = "1.36.0", features = ["sync"] }
+tracing = "0.1.40"
+secp256k1 = { version="0.24.3", default-features=false }
+serde_json = "1.0.114"
 rand = "0.8"
 strum = "0.24"
 strum_macros = "0.24"

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -17,12 +17,12 @@ name = "fedimint_mint_client"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 async-stream = "0.3.5"
 async-trait = "0.1"
-aquamarine = "0.3.1"
+aquamarine = "0.3.3"
 base64 = "0.21.7"
-bincode = "1.3.1"
+bincode = "1.3.3"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3"
@@ -33,21 +33,21 @@ fedimint-derive-secret = { version = "0.3.0-alpha", path = "../../crypto/derive-
 fedimint-mint-common ={ version = "0.3.0-alpha", path = "../fedimint-mint-common" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
 rand = "0.8"
-secp256k1 = "0.24.2"
+secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
-serde = { version = "1.0.149", features = [ "derive" ] }
+serde = { version = "1.0.197", features = [ "derive" ] }
 serde-big-array = "0.5.1"
-serde_json = "1.0.96"
+serde_json = "1.0.114"
 strum = "0.24"
 strum_macros = "0.24"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
-thiserror = "1.0.39"
+thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
-tokio = { version = "1.27.0", features = [ "sync" ] }
-tracing ="0.1.37"
+tokio = { version = "1.36.0", features = [ "sync" ] }
+tracing ="0.1.40"
 
 [dev-dependencies]
 rand = "0.8"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
-tokio = { version = "1.27.0", features = [ "macros", "rt" ] }
+tokio = { version = "1.36.0", features = [ "macros", "rt" ] }

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -17,24 +17,24 @@ name = "fedimint_mint_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
-bincode = "1.3.1"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
+bincode = "1.3.3"
 bitcoin_hashes = "0.11.0"
 futures = "0.3"
 itertools = "0.10.5"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"
-secp256k1 = "0.24.2"
+secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
-serde = { version = "1.0.149", features = [ "derive" ] }
+serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
-thiserror = "1.0.39"
+thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
-tracing ="0.1.37"
+tracing ="0.1.40"
 
 [dev-dependencies]
 rand = "0.8"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -17,10 +17,10 @@ name = "fedimint_mint_server"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 assert_matches = "1.5.0"
-async-trait = "0.1.73"
-bincode = "1.3.1"
+async-trait = "0.1.77"
+bincode = "1.3.3"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3"
@@ -29,19 +29,19 @@ fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
 fedimint-mint-common = { version = "0.3.0-alpha", path = "../fedimint-mint-common" }
 rand = "0.8"
-secp256k1 = "0.24.2"
+secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
-serde = { version = "1.0.149", features = [ "derive" ] }
+serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
-thiserror = "1.0.39"
+thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
-tracing ="0.1.37"
+tracing ="0.1.40"
 fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]
 rand = "0.8"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
-tokio = {version = "1.26.0", features = [ "full" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
+tokio = {version = "1.36.0", features = [ "full" ] }
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -12,7 +12,7 @@ name = "fedimint_mint_tests"
 path = "tests/tests.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 bitcoin_hashes = "0.11.0"
 fedimint-dummy-common = { path = "../fedimint-dummy-common" }
 fedimint-dummy-client = { path = "../fedimint-dummy-client" }
@@ -26,10 +26,10 @@ fedimint-core ={ path = "../../fedimint-core" }
 fedimint-server = { path = "../../fedimint-server" }
 fedimint-logging = { path = "../../fedimint-logging" }
 futures = "0.3"
-tokio = { version = "1.26.0", features = ["sync"] }
-tracing = "0.1.37"
+tokio = { version = "1.36.0", features = ["sync"] }
+tracing = "0.1.40"
 rand = "0.8"
-secp256k1 = "0.24.2"
+secp256k1 = "0.24.3"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
 threshold_crypto = { workspace = true }
 ff = "0.12.1"

--- a/modules/fedimint-unknown-common/Cargo.toml
+++ b/modules/fedimint-unknown-common/Cargo.toml
@@ -16,13 +16,13 @@ name = "fedimint_unknown_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.3"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"
-serde = { version = "1.0.149", features = [ "derive" ] }
-thiserror = "1.0.39"
-tracing = "0.1.37"
+serde = { version = "1.0.197", features = [ "derive" ] }
+thiserror = "1.0.58"
+tracing = "0.1.40"

--- a/modules/fedimint-unknown-server/Cargo.toml
+++ b/modules/fedimint-unknown-server/Cargo.toml
@@ -16,16 +16,16 @@ name = "fedimint_unknown_server"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 erased-serde = "0.3"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-unknown-common = { version = "0.3.0-alpha", path = "../fedimint-unknown-common" }
 rand = "0.8"
-serde = { version = "1.0.149", features = [ "derive" ] }
+serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
-tracing = "0.1.37"
-tokio = { version = "1.26.0", features = ["sync"] }
+thiserror = "1.0.58"
+tracing = "0.1.40"
+tokio = { version = "1.36.0", features = ["sync"] }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -16,10 +16,10 @@ name = "fedimint_wallet_client"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-aquamarine = "0.3.1"
+anyhow = "1.0.81"
+aquamarine = "0.3.3"
 async-stream = "0.3.5"
-async-trait = "0.1.73"
+async-trait = "0.1.77"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
 fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client", "bitcoincore-rpc"] }
@@ -30,16 +30,16 @@ futures = "0.3"
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 impl-tools = "0.8.0"
 rand = "0.8"
-secp256k1 = { version = "0.24.2", features = [ "serde" ] }
-serde = { version = "1.0.149", features = [ "derive" ] }
-serde_json = "1.0.108"
+secp256k1 = { version = "0.24.3", features = [ "serde" ] }
+serde = { version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
-tokio = { version = "1.26.0", features = ["sync", "rt"] }
-tracing ="0.1.37"
-url = "2.3.1"
+thiserror = "1.0.58"
+tokio = { version = "1.36.0", features = ["sync", "rt"] }
+tracing ="0.1.40"
+url = "2.5.0"
 validator = { version = "0.16", features = ["derive"] }
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -16,8 +16,8 @@ name = "fedimint_wallet_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
@@ -26,16 +26,16 @@ miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 miniscript9 = { package = "miniscript", version = "9.0.2" }
 impl-tools = "0.8.0"
 rand = "0.8"
-secp256k1 = { version = "0.24.2", features = [ "serde" ] }
-serde = { version = "1.0.149", features = [ "derive" ] }
+secp256k1 = { version = "0.24.3", features = [ "serde" ] }
+serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
-tokio = { version = "1.26.0", features = ["sync"], optional = true }
-tracing ="0.1.37"
-url = "2.3.1"
+thiserror = "1.0.58"
+tokio = { version = "1.36.0", features = ["sync"], optional = true }
+tracing ="0.1.40"
+url = "2.5.0"
 validator = { version = "0.16", features = ["derive"] }
 
 [dev-dependencies]
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -16,7 +16,7 @@ name = "fedimint_wallet_server"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 async-trait = "0.1"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.3"
@@ -29,17 +29,17 @@ miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 miniscript9 = { package = "miniscript", version = "9.0.2" }
 impl-tools = "0.8.0"
 rand = "0.8"
-secp256k1 = { version = "0.24.2", features = [ "serde" ] }
-serde = { version = "1.0.149", features = [ "derive" ] }
+secp256k1 = { version = "0.24.3", features = [ "serde" ] }
+serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.39"
-tokio = { version = "1.26.0", features = ["sync"], optional = true }
-tracing ="0.1.37"
-url = "2.3.1"
+thiserror = "1.0.58"
+tokio = { version = "1.36.0", features = ["sync"], optional = true }
+tracing ="0.1.40"
+url = "2.5.0"
 validator = { version = "0.16", features = ["derive"] }
 fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
-tokio = { version = "1.26.0", features = ["full"] }
+tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
+tokio = { version = "1.36.0", features = ["full"] }

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -12,9 +12,9 @@ name = "fedimint_wallet_tests"
 path = "tests/tests.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.81"
 assert_matches = "1.5.0"
-async-trait = "0.1.73"
+async-trait = "0.1.77"
 bitcoin = "0.29.2"
 erased-serde = "0.3"
 fedimint-bitcoind = { path = "../../fedimint-bitcoind" }
@@ -29,11 +29,11 @@ fedimint-testing ={ path = "../../fedimint-testing" }
 fedimint-wallet-client = { path = "../fedimint-wallet-client" }
 fedimint-wallet-common = { path = "../fedimint-wallet-common" }
 fedimint-wallet-server = { path = "../fedimint-wallet-server" }
-futures = "0.3.28"
+futures = "0.3.30"
 miniscript = { version = "10.0.0" }
-tokio = { version = "1.26.0", features = ["sync"] }
-tracing = "0.1.37"
-secp256k1 = { version = "0.24.2", features = [ "serde" ] }
+tokio = { version = "1.36.0", features = ["sync"] }
+tracing = "0.1.40"
+secp256k1 = { version = "0.24.3", features = [ "serde" ] }
 rand = "0.8"
 strum = "0.24"
 strum_macros = "0.24"

--- a/nix/overlays/wasm-bindgen.nix
+++ b/nix/overlays/wasm-bindgen.nix
@@ -2,9 +2,9 @@
 final: prev: {
   wasm-bindgen-cli = final.rustPlatform.buildRustPackage rec {
     pname = "wasm-bindgen-cli";
-    version = "0.2.89";
-    hash = "sha256-IPxP68xtNSpwJjV2yNMeepAS0anzGl02hYlSTvPocz8=";
-    cargoHash = "sha256-pBeQaG6i65uJrJptZQLuIaCb/WCQMhba1Z1OhYqA8Zc=";
+    version = "0.2.92";
+    hash = "sha256-1VwY8vQy7soKEgbki4LD+v259751kKxSxmo/gqE6yV0=";
+    cargoHash = "sha256-aACJ+lYNEU8FFBs158G1/JG8sc6Rq080PeKCMnwdpH0=";
 
     src = final.fetchCrate {
       inherit pname version hash;

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -16,9 +16,9 @@ name = "recoverytool"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1.0.69"
+anyhow = "1.0.81"
 bitcoin = "0.29.2"
-clap = { version = "4.4.7", features = [ "derive", "env" ] }
+clap = { version = "4.5.2", features = [ "derive", "env" ] }
 fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
 fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
@@ -28,14 +28,14 @@ fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-common" }
 fedimint-ln-server = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-server" }
 fedimint-mint-server = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-server" }
-futures = "0.3.26"
+futures = "0.3.30"
 miniscript = { version = "10.0.0" }
 secp256k1 = { version = "0.24.3", features = [ "serde", "global-context" ] }
-serde = { version = "1.0.152", features = [ "derive" ] }
-serde_json = "1.0.93"
-tokio = { version = "1.26.0", features = [ "rt-multi-thread", "macros" ] }
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+serde = { version = "1.0.197", features = [ "derive" ] }
+serde_json = "1.0.114"
+tokio = { version = "1.36.0", features = [ "rt-multi-thread", "macros" ] }
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/utils/portalloc/Cargo.toml
+++ b/utils/portalloc/Cargo.toml
@@ -16,11 +16,11 @@ name = "fedimint_portalloc"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.81"
 fs2 = "0.4.3"
-serde = { version = "1.0.149", features = [ "derive" ] }
-serde_json = { version = "1.0.91", features = ["preserve_order"] }
-tracing = "0.1.37"
+serde = { version = "1.0.197", features = [ "derive" ] }
+serde_json = { version = "1.0.114", features = ["preserve_order"] }
+tracing = "0.1.40"
 rand = "0.8"
 dirs = "5.0.1"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }


### PR DESCRIPTION
on top of #4553

contains backwards compatible crate updates in Cargo.tomls
