### PR TITLE
chore: backwards incompatible deps updates (1/n)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,16 +160,16 @@ dependencies = [
 
 [[package]]
 name = "aquamarine"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
+checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
 dependencies = [
  "include_dir",
  "itertools 0.10.5",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -207,15 +207,6 @@ dependencies = [
  "event-listener-strategy 0.5.0",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -368,6 +359,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64-compat"
@@ -675,6 +672,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,7 +717,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
 ]
 
 [[package]]
@@ -779,35 +782,36 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
+checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
 dependencies = [
- "prost 0.11.9",
- "prost-types 0.11.9",
- "tonic 0.9.2",
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
  "tracing-core",
 ]
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.10"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4cf42660ac07fcebed809cfe561dd8730bcd35b075215e6479c516bcd0d11cb"
+checksum = "7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e"
 dependencies = [
  "console-api",
  "crossbeam-channel",
  "crossbeam-utils",
- "futures",
+ "futures-task",
  "hdrhistogram",
  "humantime",
- "prost-types 0.11.9",
+ "prost-types",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -901,6 +905,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1078,9 +1117,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.31"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+checksum = "2b73807008a3c7f171cc40312f37d95ef0396e048b5848d775f54b1a4dd4a0d3"
 dependencies = [
  "serde",
 ]
@@ -1106,12 +1145,6 @@ dependencies = [
  "reqwest",
  "serde",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
@@ -1237,7 +1270,7 @@ version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bip39",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
@@ -1289,7 +1322,7 @@ dependencies = [
  "fedimint-derive-secret",
  "fedimint-logging",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "rand",
  "ring 0.17.8",
  "secp256k1-zkp",
@@ -1327,7 +1360,7 @@ name = "fedimint-core"
 version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
- "async-lock 2.8.0",
+ "async-lock",
  "async-recursion",
  "async-trait",
  "backtrace",
@@ -1344,13 +1377,13 @@ dependencies = [
  "fedimint-threshold-crypto",
  "futures",
  "getrandom",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "hex",
  "imbl",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "js-sys",
- "jsonrpsee-core 0.21.0",
- "jsonrpsee-types 0.22.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "lightning",
@@ -1414,10 +1447,10 @@ dependencies = [
 name = "fedimint-derive"
 version = "0.3.0-alpha"
 dependencies = [
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1623,7 +1656,7 @@ dependencies = [
  "fedimint-ln-common",
  "fedimint-threshold-crypto",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lightning-invoice",
  "rand",
  "reqwest",
@@ -1654,7 +1687,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-threshold-crypto",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lightning",
  "lightning-invoice",
  "rand",
@@ -1709,7 +1742,7 @@ dependencies = [
  "futures",
  "lightning",
  "lightning-invoice",
- "prost 0.12.3",
+ "prost",
  "rand",
  "reqwest",
  "secp256k1 0.24.3",
@@ -1721,7 +1754,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
+ "tonic",
  "tonic-build",
  "tower-http",
  "tracing",
@@ -1745,7 +1778,7 @@ dependencies = [
  "fedimint-server",
  "fedimint-threshold-crypto",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lightning",
  "lightning-invoice",
  "rand",
@@ -1799,7 +1832,7 @@ name = "fedimint-load-test-tool"
 version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bitcoin 0.29.2",
  "clap",
  "devimint",
@@ -1813,8 +1846,8 @@ dependencies = [
  "fedimint-rocksdb",
  "fedimint-wallet-client",
  "futures",
- "jsonrpsee-core 0.21.0",
- "jsonrpsee-types 0.22.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "jsonrpsee-ws-client",
  "lightning-invoice",
  "rand",
@@ -1859,7 +1892,7 @@ dependencies = [
  "aquamarine",
  "async-stream",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bincode",
  "bitcoin_hashes 0.11.0",
  "erased-serde",
@@ -1871,7 +1904,7 @@ dependencies = [
  "fedimint-tbs",
  "fedimint-threshold-crypto",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "rand",
  "secp256k1 0.24.3",
  "secp256k1-zkp",
@@ -1899,7 +1932,7 @@ dependencies = [
  "fedimint-tbs",
  "fedimint-threshold-crypto",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "rand",
  "secp256k1 0.24.3",
  "secp256k1-zkp",
@@ -1928,7 +1961,7 @@ dependencies = [
  "fedimint-tbs",
  "fedimint-threshold-crypto",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "rand",
  "secp256k1 0.24.3",
  "secp256k1-zkp",
@@ -2054,7 +2087,7 @@ dependencies = [
  "fedimint-threshold-crypto",
  "futures",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "jsonrpsee",
  "parity-scale-codec",
  "rand",
@@ -2161,12 +2194,12 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls",
- "prost 0.12.3",
+ "prost",
  "rustls 0.21.10",
  "rustls-pemfile",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
+ "tonic",
  "tonic-build",
  "tower",
 ]
@@ -2379,7 +2412,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "hyper 1.2.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "jsonrpsee",
  "rand",
  "rcgen",
@@ -2563,7 +2596,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "send_wrapper",
 ]
 
@@ -2666,6 +2699,18 @@ name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2979,14 +3024,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.4.0"
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2997,12 +3038,6 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "if_chain"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "imbl"
@@ -3028,26 +3063,26 @@ dependencies = [
 
 [[package]]
 name = "impl-tools"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bde75c0fa563af28932bd7317eaa58186d4d29043858f5f3a8c199076c06da7"
+checksum = "d82c305b1081f1a99fda262883c788e50ab57d36c00830bdd7e0a82894ad965c"
 dependencies = [
  "autocfg",
  "impl-tools-lib",
  "proc-macro-error",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "impl-tools-lib"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffdf3b0bdfaa18798f4df71bc965704f63fba521b24d425cd61fb2bc771a77b"
+checksum = "85d3946d886eaab0702fa0c6585adcced581513223fa9df7ccfabbd9fa331a88"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3202,23 +3237,23 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3ae45a64cfc0882934f963be9431b2a165d667f53140358181f262aca0702"
 dependencies = [
- "jsonrpsee-core 0.22.2",
+ "jsonrpsee-core",
  "jsonrpsee-server",
- "jsonrpsee-types 0.22.2",
+ "jsonrpsee-types",
  "tokio",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.21.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9f9ed46590a8d5681975f126e22531698211b926129a40a2db47cbca429220"
+checksum = "455fc882e56f58228df2aee36b88a1340eafd707c76af2fa68cf94b37d461131"
 dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net 0.5.0",
  "http 0.2.12",
- "jsonrpsee-core 0.21.0",
+ "jsonrpsee-core",
  "pin-project",
  "rustls-pki-types",
  "soketto",
@@ -3233,18 +3268,21 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.21.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776d009e2f591b78c038e0d053a796f94575d66ca4e77dd84bfc5e81419e436c"
+checksum = "b75568f4f9696e3a47426e1985b548e1a9fcb13372a5e320372acaf04aca30d1"
 dependencies = [
  "anyhow",
- "async-lock 3.3.0",
+ "async-lock",
  "async-trait",
  "beef",
  "futures-timer",
  "futures-util",
- "jsonrpsee-types 0.21.0",
+ "hyper 0.14.28",
+ "jsonrpsee-types",
+ "parking_lot",
  "pin-project",
+ "rand",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -3256,28 +3294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-core"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75568f4f9696e3a47426e1985b548e1a9fcb13372a5e320372acaf04aca30d1"
-dependencies = [
- "anyhow",
- "async-trait",
- "beef",
- "futures-util",
- "hyper 0.14.28",
- "jsonrpsee-types 0.22.2",
- "parking_lot",
- "rand",
- "rustc-hash",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "jsonrpsee-server"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,8 +3302,8 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
- "jsonrpsee-core 0.22.2",
- "jsonrpsee-types 0.22.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "route-recognizer",
  "serde",
@@ -3299,19 +3315,6 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3266dfb045c9174b24c77c2dfe0084914bb23a6b2597d70c9dc6018392e1cd1b"
-dependencies = [
- "anyhow",
- "beef",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -3329,25 +3332,25 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.21.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f36d27503d0efc0355c1630b74ecfb367050847bf7241a0ed75fab6dfa96c0"
+checksum = "ee61985930ef5b67bfcd0f21a881bae25e15fc982dfc943d73de39381d5e46bf"
 dependencies = [
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.21.0",
- "jsonrpsee-types 0.21.0",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.21.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073c077471e89c4b511fa88b3df9a0f0abdf4a0a2e6683dd2ab36893af87bb2d"
+checksum = "68ca71e74983f624c0cb67828e480a981586074da8ad3a2f214c6a3f884edab9"
 dependencies = [
  "http 0.2.12",
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.21.0",
- "jsonrpsee-types 0.21.0",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "url",
 ]
 
@@ -3460,16 +3463,15 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lnurl-rs"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3912d662eeb78043d92de3c36e3839ec831e4b224be194864a5f4057e34854e2"
+checksum = "29742339d2d88bd3ea1f4305e11b22d3efada9f86010ccbd7b6646837cc57e85"
 dependencies = [
  "aes",
  "anyhow",
  "base64 0.13.1",
  "bech32",
- "bitcoin 0.29.2",
- "bitcoin_hashes 0.12.0",
+ "bitcoin 0.30.2",
  "cbc",
  "email_address",
  "reqwest",
@@ -3515,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "macro_rules_attribute"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862"
+checksum = "8a82271f7bc033d84bbca59a3ce3e4159938cb08a9c3aebbe54d215131518a13"
 dependencies = [
  "macro_rules_attribute-proc_macro",
  "paste",
@@ -3525,9 +3527,9 @@ dependencies = [
 
 [[package]]
 name = "macro_rules_attribute-proc_macro"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+checksum = "b8dd856d451cc0da70e2ef2ce95a18e39a93b7558bedf10201ad28503f918568"
 
 [[package]]
 name = "matchers"
@@ -3557,15 +3559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -3628,15 +3621,14 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "cfg-if",
+ "cfg_aliases",
  "libc",
- "memoffset",
- "pin-utils",
 ]
 
 [[package]]
@@ -3707,46 +3699,12 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876958ba9084f390f913fcf04ddf7bbbb822898867bb0a51cc28f2b9e5c1b515"
-dependencies = [
- "async-trait",
  "futures-core",
- "futures-util",
- "opentelemetry",
- "opentelemetry-semantic-conventions",
- "thrift",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
+ "futures-sink",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -3755,22 +3713,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.20.0"
+name = "opentelemetry-jaeger"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+checksum = "fb7f5ef13427696ae8382c6f3bb7dcdadb5994223d6b983c7c50a46df7d19277"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "thrift",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
- "ordered-float 3.9.2",
+ "opentelemetry",
+ "ordered-float 4.2.0",
  "percent-encoding",
  "rand",
- "regex",
  "thiserror",
 ]
 
@@ -3791,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.9.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -4030,22 +4009,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
+ "prost-derive",
 ]
 
 [[package]]
@@ -4062,25 +4031,12 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.52",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4098,20 +4054,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost 0.11.9",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
- "prost 0.12.3",
+ "prost",
 ]
 
 [[package]]
@@ -4499,6 +4446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes 0.12.0",
+ "rand",
  "secp256k1-sys 0.8.1",
  "serde",
 ]
@@ -4720,27 +4668,33 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5095,34 +5049,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.24",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
@@ -5139,7 +5065,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.3",
+ "prost",
  "rustls 0.21.10",
  "rustls-pemfile",
  "tokio",
@@ -5262,17 +5188,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -5284,16 +5199,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc09e402904a5261e42cf27aea09ccb7d5318c6717a9eec3d8e2e65c56b18f19"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.4",
+ "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -5311,7 +5230,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5389,7 +5308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -5408,12 +5327,12 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "validator"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
+checksum = "da339118f018cc70ebf01fafc103360528aad53717e4bf311db929cb01cb9345"
 dependencies = [
- "idna 0.4.0",
- "lazy_static",
+ "idna",
+ "once_cell",
  "regex",
  "serde",
  "serde_derive",
@@ -5424,28 +5343,16 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
+checksum = "76e88ea23b8f5e59230bff8a2f03c0ee0054a61d5b8343a38946bcd406fe624c"
 dependencies = [
- "if_chain",
- "lazy_static",
+ "darling",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "regex",
- "syn 1.0.109",
- "validator_types",
-]
-
-[[package]]
-name = "validator_types"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5577,6 +5484,16 @@ name = "web-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,13 +277,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -318,14 +347,34 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
  "tracing",
 ]
 
 [[package]]
 name = "axum-macros"
-version = "0.3.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
+checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -789,7 +838,7 @@ dependencies = [
  "futures-core",
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.10.2",
  "tracing-core",
 ]
 
@@ -811,7 +860,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -980,7 +1029,7 @@ name = "devimint"
 version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.7.4",
  "bitcoincore-rpc",
  "clap",
  "fedimint-aead",
@@ -1615,7 +1664,7 @@ version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.7.4",
  "axum-macros",
  "bitcoin 0.29.2",
  "clap",
@@ -1713,7 +1762,7 @@ dependencies = [
  "assert_matches",
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.4",
  "axum-macros",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
@@ -1754,8 +1803,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
- "tonic-build",
+ "tonic 0.11.0",
+ "tonic-build 0.11.0",
  "tower-http",
  "tracing",
  "url",
@@ -1876,7 +1925,7 @@ name = "fedimint-metrics"
 version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.7.4",
  "fedimint-core",
  "lazy_static",
  "prometheus",
@@ -2196,11 +2245,11 @@ dependencies = [
  "hyper-rustls",
  "prost",
  "rustls 0.21.10",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-stream",
- "tonic",
- "tonic-build",
+ "tonic 0.10.2",
+ "tonic-build 0.10.2",
  "tower",
 ]
 
@@ -2386,7 +2435,7 @@ version = "0.3.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.7.4",
  "bincode",
  "bitcoin 0.29.2",
  "bytes",
@@ -2929,10 +2978,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
+name = "http-body-util"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "httparse"
@@ -3021,6 +3077,22 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
 ]
 
 [[package]]
@@ -4025,7 +4097,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -4046,7 +4118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -4221,7 +4293,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.10",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4364,6 +4436,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64 0.21.7",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5055,7 +5137,7 @@ checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "h2 0.3.24",
@@ -5067,9 +5149,39 @@ dependencies = [
  "pin-project",
  "prost",
  "rustls 0.21.10",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-rustls 0.24.1",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.6.20",
+ "base64 0.21.7",
+ "bytes",
+ "h2 0.3.24",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -5082,6 +5194,19 @@ name = "tonic-build"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5112,18 +5237,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "base64 0.21.7",
  "bitflags 2.4.2",
  "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "mime",
  "pin-project-lite",
  "tower-layer",

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { version = "1.0.81", features = ["backtrace"] }
-axum = { version = "0.6.20", features = ["tracing"] }
+axum = { version = "0.7.4", features = ["tracing"] }
 bitcoincore-rpc = "0.16.0"
 clap = { version = "4.5.2", features = ["derive", "env", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 cln-rpc = { workspace = true }
@@ -36,7 +36,7 @@ semver = "1.0.22"
 serde_json = "1.0.114"
 tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tonic_lnd = { workspace = true }
-tower-http = { version = "0.4.4", features = ["cors", "auth"] }
+tower-http = { version = "0.5.2", features = ["cors", "auth"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 serde = "1.0.197"

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -30,7 +30,7 @@ fedimint-testing = { path = "../fedimint-testing" }
 futures = "0.3.30"
 hex = "0.4.3"
 ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
-nix = { version = "0.26.4", features = ["signal"] }
+nix = { version = "0.28.0", features = ["signal"] }
 rand = "0.8.5"
 semver = "1.0.22"
 serde_json = "1.0.114"

--- a/devimint/src/bin/faucet.rs
+++ b/devimint/src/bin/faucet.rs
@@ -11,6 +11,7 @@ use cln_rpc::primitives::{Amount as ClnAmount, AmountOrAny};
 use cln_rpc::ClnRpc;
 use fedimint_logging::TracingSetup;
 use ln_gateway::rpc::V1_API_ENDPOINT;
+use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tower_http::cors::CorsLayer;
 
@@ -155,8 +156,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(CorsLayer::permissive())
         .with_state(faucet);
 
-    axum::Server::bind(&cmd.bind_addr.parse()?)
-        .serve(router.into_make_service())
-        .await?;
+    let listener = TcpListener::bind(&cmd.bind_addr).await?;
+    axum::serve(listener, router.into_make_service()).await?;
     Ok(())
 }

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.81"
 async-trait = "0.1.77"
-base64 = "0.21.7"
+base64 = "0.22.0"
 bip39 = { version = "2.0.0", features = ["rand"] }
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
@@ -54,7 +54,7 @@ tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
 serde_json = { version = "1.0.114", features = ["preserve_order"] }
 url = { version = "2.5.0", features = ["serde"] }
 clap_complete = "4.5.1"
-lnurl-rs = { version = "0.3.2", features = ["async"], default-features = false }
+lnurl-rs = { version = "0.4.1", features = ["async"], default-features = false }
 reqwest = { version = "0.11.26", features = [ "json", "rustls-tls" ], default-features = false }
 
 [build-dependencies]

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.81"
-aquamarine = "0.3.3"
+aquamarine = "0.5.0"
 async-stream = "0.3.5"
 async-trait = "0.1.77"
 bitcoin = "0.29.2"
@@ -31,13 +31,13 @@ fedimint-derive-secret = { version = "0.3.0-alpha", path = "../crypto/derive-sec
 fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 futures = "0.3.30"
-itertools = "0.10.5"
+itertools = "0.12.1"
 rand = "0.8.5"
 secp256k1-zkp = "0.7.0"
 serde = "1.0.197"
 serde_json = "1.0.114"
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.26.2"
+strum_macros = "0.26.2"
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = [ "time", "macros" ] }
 tokio-stream = { version = "0.1.14", features = [ "time", "sync" ] }

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -22,14 +22,14 @@ futures = "0.3.30"
 backtrace = "0.3.69"
 bincode = "1.3.3"
 bech32 = "0.9.1"
-itertools = "0.10.5"
+itertools = "0.12.1"
 jsonrpsee-types = { version = "0.22.2" }
-jsonrpsee-core = { version = "0.21.0", features = [ "client" ] }
+jsonrpsee-core = { version = "0.22.2", features = [ "client" ] }
 lru = "0.12.3"
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 hex = { version = "0.4.3", features = [ "serde"] }
 sha3 = "0.10.8"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
@@ -41,7 +41,7 @@ url = { version = "2.5.0", features = ["serde"] }
 bitcoin = { version = "0.29.2", features = [ "rand", "serde" ] }
 bitcoin30 = { package = "bitcoin", version = "0.30.2" }
 bitcoin_hashes = { version = "0.11", features = ["serde"] }
-erased-serde = "0.3"
+erased-serde = "0.4"
 lightning = "0.0.118"
 lightning-invoice = "0.26.0"
 fedimint-derive = { version = "0.3.0-alpha", path = "../fedimint-derive" }
@@ -49,24 +49,24 @@ fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 rand = "0.8.5"
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
-macro_rules_attribute = "0.1.3"
+macro_rules_attribute = "0.2.0"
 bitvec = "1.0.1"
 parity-scale-codec = { version = "3.6.9", features = ["derive"] }
 imbl = "2.0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-jsonrpsee-ws-client = { version = "0.21.0", features = ["webpki-tls"], default-features = false }
+jsonrpsee-ws-client = { version = "0.22.2", features = ["webpki-tls"], default-features = false }
 tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tokio-rustls = "0.23.4"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-jsonrpsee-wasm-client = { version = "0.21.0", default-features = false }
-async-lock = "2.8"
+jsonrpsee-wasm-client = { version = "0.22.2", default-features = false }
+async-lock = "3.3"
 # getrandom is transitive dependency of rand
 # on wasm, we need to enable the js backend
 # see https://docs.rs/getrandom/latest/getrandom/#indirect-dependencies and https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 getrandom = { version = "0.2.12", features = [ "js" ] }
-gloo-timers = { version = "0.2.6", features = ["futures"] }
+gloo-timers = { version = "0.3.0", features = ["futures"] }
 wasm-bindgen-futures = "0.4.42"
 js-sys = "0.3.69"
 

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -34,13 +34,13 @@ fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 fedimint-wallet-server = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-server" }
 fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
 futures = "0.3.30"
-erased-serde = "0.3"
+erased-serde = "0.4"
 hex = { version = "0.4.3", features = ["serde"] }
 ln-gateway = { package = "fedimint-ln-gateway", version = "0.3.0-alpha", path = "../gateway/ln-gateway" }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 tokio = "1.36.0"
 tracing = "0.1.40"
 

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 diagnostics = []
 
 [dependencies]
-itertools = "0.11.0"
+itertools = "0.12.1"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }

--- a/fedimint-derive/src/lib.rs
+++ b/fedimint-derive/src/lib.rs
@@ -14,7 +14,7 @@ fn do_not_ignore(field: &Field) -> bool {
     !field
         .attrs
         .iter()
-        .any(|attr| attr.path.is_ident("encodable_ignore"))
+        .any(|attr| attr.path().is_ident("encodable_ignore"))
 }
 
 fn panic_if_ignored(field: &Field) -> bool {
@@ -28,7 +28,7 @@ fn is_default_variant_enforce_valid(variant: &Variant) -> bool {
     let is_default = variant
         .attrs
         .iter()
-        .any(|attr| attr.path.is_ident("encodable_default"));
+        .any(|attr| attr.path().is_ident("encodable_default"));
 
     if is_default {
         assert_eq!(

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-base64 = "0.21.7"
+base64 = "0.22.0"
 bitcoin = "0.29.2"
 clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
 devimint = { version = "0.3.0-alpha", path = "../devimint" }
@@ -26,7 +26,7 @@ fedimint-mint-client = { version = "0.3.0-alpha", path = "../modules/fedimint-mi
 fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
 fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
 futures = "0.3"
-jsonrpsee-core = { version = "0.21.0", features = [ "client" ] }
+jsonrpsee-core = { version = "0.22.2", features = [ "client" ] }
 jsonrpsee-types = { version = "0.22.2" }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 rand = "0.8"
@@ -37,7 +37,7 @@ tracing = "0.1"
 url = { version = "2.5.0", features = ["serde"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-jsonrpsee-ws-client = { version = "0.21.0", features = ["webpki-tls"], default-features = false }
+jsonrpsee-ws-client = { version = "0.22.2", features = ["webpki-tls"], default-features = false }
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -20,8 +20,8 @@ telemetry = ["tracing-opentelemetry", "opentelemetry-jaeger", "tracing-chrome", 
 [dependencies]
 anyhow = "1.0.81"
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
-tracing-opentelemetry = { version = "0.20.0", optional = true}
-opentelemetry = { version = "0.20.0", optional = true }
-opentelemetry-jaeger = { version = "0.19.0", optional = true }
-console-subscriber = { version = "0.1.10", optional = true }
+tracing-opentelemetry = { version = "0.23.0", optional = true}
+opentelemetry = { version = "0.22.0", optional = true }
+opentelemetry-jaeger = { version = "0.21.0", optional = true }
+console-subscriber = { version = "0.2.0", optional = true }
 tracing-chrome = { version = "0.7.1", optional = true}

--- a/fedimint-metrics/Cargo.toml
+++ b/fedimint-metrics/Cargo.toml
@@ -16,7 +16,7 @@ path = "./src/lib.rs"
 
 [dependencies]
 anyhow = { version = "1.0.81", features = ["backtrace"] }
-axum = "0.6.20"
+axum = "0.7.4"
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
 lazy_static = "1.4.0"
 prometheus = "0.13.3"

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -28,7 +28,7 @@ bitcoin_hashes = "0.11.0"
 bytes = "1.5.0"
 futures = "0.3.30"
 hex = "0.4.3"
-itertools = "0.10.5"
+itertools = "0.12.1"
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
 fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
 rand = "0.8"
@@ -38,8 +38,8 @@ rand_chacha = "0.3.1"
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"
 sha3 = "0.10.8"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 tar = "0.4.40"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
 thiserror = "1.0.58"

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -63,7 +63,7 @@ url = { version = "2.5.0", features = ["serde"] }
 threshold_crypto = { workspace = true }
 
 # setup dependencies
-axum = { version = "0.6.20", default-features = false, features = [ "form", "tokio" ] }
+axum = { version = "0.7.4", default-features = false, features = [ "form", "tokio" ] }
 http = "1.1"
 http-body = "1.0"
 hyper = { version = "1.2", features = ["full"] }

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -33,7 +33,7 @@ bitcoin = "0.29.2"
 bytes = "1.5.0"
 clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
 futures = "0.3.30"
-itertools = "0.10.5"
+itertools = "0.12.1"
 jsonrpsee = { version = "0.22.2", features = ["server"] }
 fedimint-bitcoind = { version = "0.3.0-alpha", path = "../fedimint-bitcoind" }
 fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
@@ -68,7 +68,7 @@ http = "1.1"
 http-body = "1.0"
 hyper = { version = "1.2", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
-console-subscriber = "0.1.10"
+console-subscriber = "0.2.0"
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.81"
 async-trait = "0.1.77"
-axum = "0.6.20"
-axum-macros = "0.3.8"
+axum = "0.7.4"
+axum-macros = "0.4.1"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 ln-gateway = { version = "0.3.0-alpha", package = "fedimint-ln-gateway", path= "../ln-gateway" }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -32,7 +32,7 @@ async-stream = "0.3.5"
 async-trait = "0.1.77"
 axum = "0.6.20"
 axum-macros = "0.3.8"
-aquamarine = "0.3.3"
+aquamarine = "0.5.0"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 bitcoin_hashes = "0.11.0"
 clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
@@ -49,7 +49,7 @@ fedimint-mint-client = { version = "0.3.0-alpha", path = "../../modules/fedimint
 fedimint-dummy-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-dummy-client" }
 fedimint-wallet-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-wallet-client" }
 futures = "0.3.30"
-erased-serde = "0.3"
+erased-serde = "0.4"
 lightning-invoice = "0.26.0"
 prost = "0.12.3"
 rand = "0.8"
@@ -58,8 +58,8 @@ secp256k1 = "0.24.3"
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.114"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 tokio = { version = "1.36", features = ["full"] }
 tokio-stream = "0.1.14"

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -30,8 +30,8 @@ path = "tests/integration_tests.rs"
 anyhow = "1.0.81"
 async-stream = "0.3.5"
 async-trait = "0.1.77"
-axum = "0.6.20"
-axum-macros = "0.3.8"
+axum = "0.7.4"
+axum-macros = "0.4.1"
 aquamarine = "0.5.0"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 bitcoin_hashes = "0.11.0"
@@ -63,9 +63,9 @@ strum_macros = "0.26"
 thiserror = "1.0.58"
 tokio = { version = "1.36", features = ["full"] }
 tokio-stream = "0.1.14"
-tonic = { version = "0.10.2", features = ["transport", "tls"] }
+tonic = { version = "0.11.0", features = ["transport", "tls"] }
 tonic_lnd = { workspace = true }
-tower-http = { version = "0.4.4", features = ["cors", "auth"] }
+tower-http = { version = "0.5.2", features = ["cors", "auth"] }
 tracing = { version = "0.1.40", default-features = false, features= ["log", "attributes", "std"] }
 url = { version = "2.5.0", features = ["serde"] }
 
@@ -86,4 +86,4 @@ assert_matches = "1.5.0"
 
 [build-dependencies]
 fedimint-build = { version = "0.3.0-alpha", path = "../../fedimint-build" }
-tonic-build = "0.10.2"
+tonic-build = "0.11.0"

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -22,12 +22,12 @@ fedimint-dummy-common = { version = "0.3.0-alpha", path = "../fedimint-dummy-com
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 futures = "0.3"
-erased-serde = "0.3"
+erased-serde = "0.4"
 rand = "0.8.5"
 secp256k1 = "0.24.3"
 serde = {version = "1.0.197", features = [ "derive" ] }
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 tracing = "0.1.40"
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -19,14 +19,14 @@ path = "src/lib.rs"
 anyhow = "1.0.81"
 async-trait = "0.1.77"
 bitcoin_hashes = "0.11.0"
-erased-serde = "0.3"
+erased-serde = "0.4"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"
 serde = { version = "1.0.197", features = [ "derive" ] }
 secp256k1 = "0.24.3"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 tracing = "0.1.40"
 threshold_crypto = { workspace = true }

--- a/modules/fedimint-dummy-server/Cargo.toml
+++ b/modules/fedimint-dummy-server/Cargo.toml
@@ -19,15 +19,15 @@ path = "src/lib.rs"
 anyhow = "1.0.81"
 async-trait = "0.1.77"
 bitcoin_hashes = "0.11.0"
-erased-serde = "0.3"
+erased-serde = "0.4"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-dummy-common = { version = "0.3.0-alpha", path = "../fedimint-dummy-common" }
 rand = "0.8"
 serde = { version = "1.0.197", features = [ "derive" ] }
 secp256k1 = "0.24.3"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 tracing = "0.1.40"
 tokio = { version = "1.36.0", features = ["sync"] }

--- a/modules/fedimint-dummy-tests/Cargo.toml
+++ b/modules/fedimint-dummy-tests/Cargo.toml
@@ -24,8 +24,8 @@ fedimint-testing = { path = "../../fedimint-testing" }
 futures = "0.3.30"
 rand = "0.8"
 secp256k1 = "0.24.3"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 tokio = { version = "1.36.0", features = ["sync"] }
 tracing = "0.1.40"
 

--- a/modules/fedimint-empty-client/Cargo.toml
+++ b/modules/fedimint-empty-client/Cargo.toml
@@ -16,15 +16,15 @@ name = "fedimint_empty_client"
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1.73"
-anyhow = "1.0.66"
+async-trait = "0.1.77"
+anyhow = "1.0.81"
 fedimint-empty-common = { version = "0.3.0-alpha", path = "../fedimint-empty-common" }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 futures = "0.3"
-erased-serde = "0.3"
-serde = {version = "1.0.149", features = [ "derive" ] }
-strum = "0.24"
-strum_macros = "0.24"
-tracing = "0.1.37"
-thiserror = "1.0.39"
+erased-serde = "0.4"
+serde = {version = "1.0.197", features = [ "derive" ] }
+strum = "0.26"
+strum_macros = "0.26"
+tracing = "0.1.40"
+thiserror = "1.0.58"

--- a/modules/fedimint-empty-common/Cargo.toml
+++ b/modules/fedimint-empty-common/Cargo.toml
@@ -16,13 +16,13 @@ name = "fedimint_empty_common"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
-erased-serde = "0.3"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
+erased-serde = "0.4"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-serde = { version = "1.0.149", features = [ "derive" ] }
-strum = "0.24"
-strum_macros = "0.24"
-thiserror = "1.0.39"
-tracing = "0.1.37"
+serde = { version = "1.0.197", features = [ "derive" ] }
+strum = "0.26"
+strum_macros = "0.26"
+thiserror = "1.0.58"
+tracing = "0.1.40"

--- a/modules/fedimint-empty-server/Cargo.toml
+++ b/modules/fedimint-empty-server/Cargo.toml
@@ -16,14 +16,14 @@ name = "fedimint_empty_server"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.66"
-async-trait = "0.1.73"
-erased-serde = "0.3"
+anyhow = "1.0.81"
+async-trait = "0.1.77"
+erased-serde = "0.4"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-empty-common = { version = "0.3.0-alpha", path = "../fedimint-empty-common" }
-serde = { version = "1.0.149", features = [ "derive" ] }
-strum = "0.24"
-strum_macros = "0.24"
-thiserror = "1.0.39"
-tracing = "0.1.37"
+serde = { version = "1.0.197", features = [ "derive" ] }
+strum = "0.26"
+strum_macros = "0.26"
+thiserror = "1.0.58"
+tracing = "0.1.40"

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -25,13 +25,13 @@ path = "src/lib.rs"
 anyhow = "1.0.81"
 async-trait = "0.1.77"
 async-stream = "0.3.5"
-aquamarine = "0.3.3"
+aquamarine = "0.5.0"
 bincode = "1"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
-erased-serde = "0.3"
+erased-serde = "0.4"
 futures = "0.3.30"
-itertools = "0.10.5"
+itertools = "0.12.1"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
@@ -40,8 +40,8 @@ secp256k1 = { version="0.24.3", default-features=false }
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
 serde = {version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
 tokio = { version = "1.36.0", features = ["macros"] }

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -24,12 +24,12 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.81"
 async-trait = "0.1.77"
-aquamarine = "0.3.3"
+aquamarine = "0.5.0"
 bitcoin_hashes = "0.11.0"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
-erased-serde = "0.3"
+erased-serde = "0.4"
 futures = "0.3.30"
-itertools = "0.10.5"
+itertools = "0.12.1"
 lightning = { version = "0.0.118", default-features = false, features = ["no-std"] }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
@@ -37,8 +37,8 @@ fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 secp256k1 = { version="0.24.3", default-features=false }
 serde = {version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
 tracing = "0.1.40"

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -22,9 +22,9 @@ anyhow = "1.0.81"
 async-trait = "0.1.77"
 bincode = "1"
 bitcoin_hashes = "0.11.0"
-erased-serde = "0.3"
+erased-serde = "0.4"
 futures = "0.3.30"
-itertools = "0.10.5"
+itertools = "0.12.1"
 lightning = "0.0.118"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
 fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind" }
@@ -34,8 +34,8 @@ fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
 secp256k1 = { version="0.24.3", default-features=false }
 serde = {version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
 tokio = { version = "1.36", features = ["full"] }

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -36,5 +36,5 @@ tracing = "0.1.40"
 secp256k1 = { version="0.24.3", default-features=false }
 serde_json = "1.0.114"
 rand = "0.8"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -20,13 +20,13 @@ path = "src/lib.rs"
 anyhow = "1.0.81"
 async-stream = "0.3.5"
 async-trait = "0.1"
-aquamarine = "0.3.3"
-base64 = "0.21.7"
+aquamarine = "0.5.0"
+base64 = "0.22.0"
 bincode = "1.3.3"
 bitcoin_hashes = "0.11.0"
-erased-serde = "0.3"
+erased-serde = "0.4"
 futures = "0.3"
-itertools = "0.10.5"
+itertools = "0.12.1"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-derive-secret = { version = "0.3.0-alpha", path = "../../crypto/derive-secret"}
@@ -38,8 +38,8 @@ secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde-big-array = "0.5.1"
 serde_json = "1.0.114"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -22,14 +22,14 @@ async-trait = "0.1.77"
 bincode = "1.3.3"
 bitcoin_hashes = "0.11.0"
 futures = "0.3"
-itertools = "0.10.5"
+itertools = "0.12.1"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"
 secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.197", features = [ "derive" ] }
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -22,9 +22,9 @@ assert_matches = "1.5.0"
 async-trait = "0.1.77"
 bincode = "1.3.3"
 bitcoin_hashes = "0.11.0"
-erased-serde = "0.3"
+erased-serde = "0.4"
 futures = "0.3"
-itertools = "0.10.5"
+itertools = "0.12.1"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
 fedimint-mint-common = { version = "0.3.0-alpha", path = "../fedimint-mint-common" }
@@ -32,8 +32,8 @@ rand = "0.8"
 secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.197", features = [ "derive" ] }
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -33,5 +33,5 @@ secp256k1 = "0.24.3"
 tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
 threshold_crypto = { workspace = true }
 ff = "0.12.1"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"

--- a/modules/fedimint-unknown-common/Cargo.toml
+++ b/modules/fedimint-unknown-common/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 anyhow = "1.0.81"
 async-trait = "0.1.77"
 bitcoin_hashes = "0.11.0"
-erased-serde = "0.3"
+erased-serde = "0.4"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"

--- a/modules/fedimint-unknown-server/Cargo.toml
+++ b/modules/fedimint-unknown-server/Cargo.toml
@@ -18,14 +18,14 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.81"
 async-trait = "0.1.77"
-erased-serde = "0.3"
+erased-serde = "0.4"
 futures = "0.3"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-unknown-common = { version = "0.3.0-alpha", path = "../fedimint-unknown-common" }
 rand = "0.8"
 serde = { version = "1.0.197", features = [ "derive" ] }
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 tracing = "0.1.40"
 tokio = { version = "1.36.0", features = ["sync"] }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -17,29 +17,29 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.81"
-aquamarine = "0.3.3"
+aquamarine = "0.5.0"
 async-stream = "0.3.5"
 async-trait = "0.1.77"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
-erased-serde = "0.3"
+erased-serde = "0.4"
 fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client", "bitcoincore-rpc"] }
 fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-wallet-common = { version = "0.3.0-alpha", path = "../fedimint-wallet-common" }
 futures = "0.3"
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
-impl-tools = "0.8.0"
+impl-tools = "0.10.0"
 rand = "0.8"
 secp256k1 = { version = "0.24.3", features = [ "serde" ] }
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = ["sync", "rt"] }
 tracing ="0.1.40"
 url = "2.5.0"
-validator = { version = "0.16", features = ["derive"] }
+validator = { version = "0.17", features = ["derive"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -19,22 +19,22 @@ path = "src/lib.rs"
 anyhow = "1.0.81"
 async-trait = "0.1.77"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
-erased-serde = "0.3"
+erased-serde = "0.4"
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 futures = "0.3"
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 miniscript9 = { package = "miniscript", version = "9.0.2" }
-impl-tools = "0.8.0"
+impl-tools = "0.10.0"
 rand = "0.8"
 secp256k1 = { version = "0.24.3", features = [ "serde" ] }
 serde = { version = "1.0.197", features = [ "derive" ] }
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = ["sync"], optional = true }
 tracing ="0.1.40"
 url = "2.5.0"
-validator = { version = "0.16", features = ["derive"] }
+validator = { version = "0.17", features = ["derive"] }
 
 [dev-dependencies]
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 anyhow = "1.0.81"
 async-trait = "0.1"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
-erased-serde = "0.3"
+erased-serde = "0.4"
 fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind" }
 fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
 fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
@@ -27,17 +27,17 @@ fedimint-wallet-common = { version = "0.3.0-alpha", path = "../fedimint-wallet-c
 futures = "0.3"
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 miniscript9 = { package = "miniscript", version = "9.0.2" }
-impl-tools = "0.8.0"
+impl-tools = "0.10.0"
 rand = "0.8"
 secp256k1 = { version = "0.24.3", features = [ "serde" ] }
 serde = { version = "1.0.197", features = [ "derive" ] }
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = ["sync"], optional = true }
 tracing ="0.1.40"
 url = "2.5.0"
-validator = { version = "0.16", features = ["derive"] }
+validator = { version = "0.17", features = ["derive"] }
 fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.81"
 assert_matches = "1.5.0"
 async-trait = "0.1.77"
 bitcoin = "0.29.2"
-erased-serde = "0.3"
+erased-serde = "0.4"
 fedimint-bitcoind = { path = "../../fedimint-bitcoind" }
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-core ={ path = "../../fedimint-core" }
@@ -35,5 +35,5 @@ tokio = { version = "1.36.0", features = ["sync"] }
 tracing = "0.1.40"
 secp256k1 = { version = "0.24.3", features = [ "serde" ] }
 rand = "0.8"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.26"
+strum_macros = "0.26"


### PR DESCRIPTION
on top https://github.com/fedimint/fedimint/pull/4554

upgrade:

- itertools
- http-body
- hyper
- console-subscriber
- strum
- strum_macros
- validator
- impl-tools
- erased-serde
- aquamarine
- nix
- tracing-opentelemetry 
- macro_rules_attribute 
- opentelemetry-jaeger 
- opentelemetry
- syn
- gloo-timers
- async-lock
- axum 
- tonic 
- tonic-build 
- tower-http 
- axum-macros
- jsonrpsee-core
- jsonrpsee-ws-client
- jsonrpsee-wasm-client
- base64
- lnurl-rs
