### PR TITLE
chore(dev-env): `just devimint-env`

### DIFF
--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -106,6 +106,15 @@ exit-mprocs:
 tmuxinator:
   ./scripts/dev/tmuxinator/run.sh
 
+devimint-env *PARAMS:
+  ./scripts/dev/devimint-env.sh {{PARAMS}}
+
+devimint-env-tmux *PARAMS:
+  ./scripts/dev/tmuxinator/run.sh {{PARAMS}}
+
+devimint-env-mprocs *PARAMS:
+  ./scripts/dev/mprocs/run.sh {{PARAMS}}
+
 # exit tmuxinator session
 exit-tmuxinator:
   tmux kill-session -t fedimint-dev

--- a/scripts/dev/devimint-env.sh
+++ b/scripts/dev/devimint-env.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+source scripts/_common.sh
+
+ensure_in_dev_shell
+build_workspace
+add_target_dir_to_path
+
+export DEVIMINT_DIR="${CARGO_BUILD_TARGET_DIR:-target}/devimint"
+rm -f "$DEVIMINT_DIR/devimint"
+
+function devimint_env {
+  set -euo pipefail
+
+  export RUST_LOG=info
+  export RUST_BACKTRACE=1
+
+  if [ -n "${PS1:-}" ]; then
+    PS1="[devimint] $PS1"
+  else
+    PS1="[devimint]"
+  fi
+
+  >&2 echo "Devimint Env Shell"
+  "${SHELL}"
+}
+export -f devimint_env
+
+env RUST_LOG=warn,jsonrpsee-client=off \
+  devimint --link-test-dir "${CARGO_BUILD_TARGET_DIR:-$PWD/target}/devimint" "$@" dev-fed \
+    --exec bash -c devimint_env


### PR DESCRIPTION
Copy&paste in `mprocs` is always annoying. I started improving tmux working in nested tmux, but then it occured to me, that I actually don't want devimint starting either.

All I really want is a shell inside devimint environment. I can `tail` logs myself if I need to (I usually don't). And that's what `just devimint-env` is.

Please give it a try locally before approving. High chance there are some details that can fail on different shells/systems, even if I tried to keep it *really* simple.