### PR TITLE
 refactor(metrics): combined and polish existing ln module metrics 

### DIFF
--- a/modules/fedimint-ln-server/src/metrics.rs
+++ b/modules/fedimint-ln-server/src/metrics.rs
@@ -1,58 +1,32 @@
-use fedimint_metrics::prometheus::register_int_counter_with_registry;
+use fedimint_metrics::prometheus::{
+    register_histogram_vec_with_registry, register_int_counter_with_registry,
+};
 use fedimint_metrics::{
-    histogram_opts, lazy_static, opts, register_histogram_with_registry, Histogram, IntCounter,
-    AMOUNTS_BUCKETS_SATS, REGISTRY,
+    histogram_opts, lazy_static, opts, HistogramVec, IntCounter, AMOUNTS_BUCKETS_SATS, REGISTRY,
 };
 
 lazy_static! {
     pub static ref LN_INCOMING_OFFER: IntCounter = register_int_counter_with_registry!(
-        opts!("ln_incoming_offer", "contracts::IncomingContractOffer"),
+        opts!("ln_incoming_offer_total", "Incoming payment offer"),
         REGISTRY
     )
     .unwrap();
-    pub static ref LN_OUTPUT_OUTCOME_CANCEL_OUTGOING_CONTRACT: IntCounter =
-        register_int_counter_with_registry!(
-            opts!(
-                "ln_output_outcome_cancel_outgoing_contract",
-                "LightningOutputOutcome::CancelOutgoingContract"
-            ),
-            REGISTRY
-        )
-        .unwrap();
-    pub static ref LN_FUNDED_CONTRACT_INCOMING: IntCounter = register_int_counter_with_registry!(
+    pub static ref LN_CANCEL_OUTGOING_CONTRACTS: IntCounter = register_int_counter_with_registry!(
         opts!(
-            "ln_funded_contract_incoming",
-            "contracts::FundedContract::Incoming"
+            "ln_canceled_outgoing_contract_total",
+            "Canceled outgoing contract"
         ),
         REGISTRY
     )
     .unwrap();
-    pub static ref LN_FUNDED_CONTRACT_OUTGOING: IntCounter = register_int_counter_with_registry!(
-        opts!(
-            "ln_funded_contract_outgoing",
-            "contracts::FundedContract::Outgoing"
+    pub static ref LN_FUNDED_CONTRACT_SATS: HistogramVec = register_histogram_vec_with_registry!(
+        histogram_opts!(
+            "ln_funded_contract_sats",
+            "Funded (with outgoing or incoming direction) contract amount in sats",
+            AMOUNTS_BUCKETS_SATS.clone()
         ),
+        &["direction"],
         REGISTRY
     )
     .unwrap();
-    pub static ref LN_FUNDED_CONTRACT_INCOMING_ACCOUNT_AMOUNTS_SATS: Histogram =
-        register_histogram_with_registry!(
-            histogram_opts!(
-                "ln_funded_contract_incoming_account_amounts_sats",
-                "contracts::FundedContract::Incoming account amount in sats",
-                AMOUNTS_BUCKETS_SATS.clone()
-            ),
-            REGISTRY
-        )
-        .unwrap();
-    pub static ref LN_FUNDED_CONTRACT_OUTGOING_ACCOUNT_AMOUNTS_SATS: Histogram =
-        register_histogram_with_registry!(
-            histogram_opts!(
-                "ln_funded_contract_outgoing_account_amounts_sats",
-                "contracts::FundedContract::Outgoing account amounts in sats",
-                AMOUNTS_BUCKETS_SATS.clone()
-            ),
-            REGISTRY
-        )
-        .unwrap();
 }

--- a/modules/fedimint-ln-server/src/metrics.rs
+++ b/modules/fedimint-ln-server/src/metrics.rs
@@ -1,0 +1,58 @@
+use fedimint_metrics::prometheus::register_int_counter_with_registry;
+use fedimint_metrics::{
+    histogram_opts, lazy_static, opts, register_histogram_with_registry, Histogram, IntCounter,
+    AMOUNTS_BUCKETS_SATS, REGISTRY,
+};
+
+lazy_static! {
+    pub static ref LN_INCOMING_OFFER: IntCounter = register_int_counter_with_registry!(
+        opts!("ln_incoming_offer", "contracts::IncomingContractOffer"),
+        REGISTRY
+    )
+    .unwrap();
+    pub static ref LN_OUTPUT_OUTCOME_CANCEL_OUTGOING_CONTRACT: IntCounter =
+        register_int_counter_with_registry!(
+            opts!(
+                "ln_output_outcome_cancel_outgoing_contract",
+                "LightningOutputOutcome::CancelOutgoingContract"
+            ),
+            REGISTRY
+        )
+        .unwrap();
+    pub static ref LN_FUNDED_CONTRACT_INCOMING: IntCounter = register_int_counter_with_registry!(
+        opts!(
+            "ln_funded_contract_incoming",
+            "contracts::FundedContract::Incoming"
+        ),
+        REGISTRY
+    )
+    .unwrap();
+    pub static ref LN_FUNDED_CONTRACT_OUTGOING: IntCounter = register_int_counter_with_registry!(
+        opts!(
+            "ln_funded_contract_outgoing",
+            "contracts::FundedContract::Outgoing"
+        ),
+        REGISTRY
+    )
+    .unwrap();
+    pub static ref LN_FUNDED_CONTRACT_INCOMING_ACCOUNT_AMOUNTS_SATS: Histogram =
+        register_histogram_with_registry!(
+            histogram_opts!(
+                "ln_funded_contract_incoming_account_amounts_sats",
+                "contracts::FundedContract::Incoming account amount in sats",
+                AMOUNTS_BUCKETS_SATS.clone()
+            ),
+            REGISTRY
+        )
+        .unwrap();
+    pub static ref LN_FUNDED_CONTRACT_OUTGOING_ACCOUNT_AMOUNTS_SATS: Histogram =
+        register_histogram_with_registry!(
+            histogram_opts!(
+                "ln_funded_contract_outgoing_account_amounts_sats",
+                "contracts::FundedContract::Outgoing account amounts in sats",
+                AMOUNTS_BUCKETS_SATS.clone()
+            ),
+            REGISTRY
+        )
+        .unwrap();
+}


### PR DESCRIPTION
Use `direction` label to combine contract funding metrics.

Drop the counters, histograms already track `<metric>_count`
anyway.

Shorten the names.

Add human-readable descriptions.