### PR TITLE
fix: make clang available in fuzz shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -309,6 +309,7 @@
                   libopcodes_2_38
                   libblocksruntime
                   lldb
+                  clang
                 ];
               });
 


### PR DESCRIPTION
I don't know how fuzzing worked for others, but I had to add `clang` to the dev env, otherwise `honggfuzz` would fail to compile with

```
  make: clang: No such file or directory
```

Follow-up to  #4494