### PR TITLE
chore(empty-module): set db version to 0

### DIFF
--- a/modules/fedimint-empty-client/src/lib.rs
+++ b/modules/fedimint-empty-client/src/lib.rs
@@ -85,7 +85,7 @@ pub struct EmptyClientInit;
 #[apply(async_trait_maybe_send!)]
 impl ModuleInit for EmptyClientInit {
     type Common = EmptyCommonInit;
-    const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(2);
+    const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
     async fn dump_database(
         &self,

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -38,7 +38,7 @@ pub struct EmptyInit;
 #[async_trait]
 impl ModuleInit for EmptyInit {
     type Common = EmptyCommonInit;
-    const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(1);
+    const DATABASE_VERSION: DatabaseVersion = DatabaseVersion(0);
 
     /// Dumps all database items for debugging
     async fn dump_database(


### PR DESCRIPTION
Using the empty module as a reference makes it easy to accidentally start at a non-zero db version.