### PR TITLE
chore: disable flaky ecash_oob_highly_parallel

### DIFF
--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -78,6 +78,7 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore] // TODO: flaky https://github.com/fedimint/fedimint/issues/4508
 async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
     // Print notes for client1
     let fed = fixtures().new_fed().await;


### PR DESCRIPTION
We're observing a higher failure rate causing CI bottlenecks. Disabling for now.

https://github.com/fedimint/fedimint/issues/4508#issuecomment-2000407244