### PR TITLE
feat: federation_id guardian endpoint

### DIFF
--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -42,4 +42,5 @@ pub const AWAIT_PREIMAGE_DECRYPTION: &str = "await_preimage_decryption";
 pub const AWAIT_OFFER_ENDPOINT: &str = "await_offer";
 pub const AWAIT_TRANSACTION_ENDPOINT: &str = "await_transaction";
 pub const INVITE_CODE_ENDPOINT: &str = "invite_code";
+pub const FEDERATION_ID_ENDPOINT: &str = "federation_id";
 pub const RESTART_FEDERATION_SETUP_ENDPOINT: &str = "restart_federation_setup";

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -268,6 +268,10 @@ impl ServerConfig {
         )
     }
 
+    pub fn get_federation_id(&self) -> FederationId {
+        FederationId(self.consensus.api_endpoints.consensus_hash())
+    }
+
     pub fn add_modules(&mut self, modules: BTreeMap<ModuleInstanceId, ServerModuleConfig>) {
         for (name, config) in modules.into_iter() {
             let ServerModuleConfig {

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -486,11 +486,11 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
         },
         api_endpoint! {
             FEDERATION_ID_ENDPOINT,
-            ApiVersion::new(0, 0),
+            ApiVersion::new(0, 2),
             async |fedimint: &ConsensusApi, _context,  _v: ()| -> String {
                 Ok(fedimint.cfg.get_federation_id().to_string())
             }
-        }
+        },
         api_endpoint! {
             CLIENT_CONFIG_ENDPOINT,
             ApiVersion::new(0, 0),

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -24,10 +24,10 @@ use fedimint_core::db::{
 use fedimint_core::endpoint_constants::{
     AUDIT_ENDPOINT, AUTH_ENDPOINT, AWAIT_OUTPUT_OUTCOME_ENDPOINT, AWAIT_SESSION_OUTCOME_ENDPOINT,
     AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT, AWAIT_TRANSACTION_ENDPOINT, BACKUP_ENDPOINT,
-    CLIENT_CONFIG_ENDPOINT, GUARDIAN_CONFIG_BACKUP_ENDPOINT, INVITE_CODE_ENDPOINT,
-    MODULES_CONFIG_JSON_ENDPOINT, RECOVER_ENDPOINT, SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT,
-    SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT, STATUS_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT,
-    VERIFY_CONFIG_HASH_ENDPOINT, VERSION_ENDPOINT,
+    CLIENT_CONFIG_ENDPOINT, FEDERATION_ID_ENDPOINT, GUARDIAN_CONFIG_BACKUP_ENDPOINT,
+    INVITE_CODE_ENDPOINT, MODULES_CONFIG_JSON_ENDPOINT, RECOVER_ENDPOINT,
+    SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT, SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT,
+    STATUS_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT, VERSION_ENDPOINT,
 };
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::audit::{Audit, AuditSummary};
@@ -484,6 +484,13 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                 Ok(fedimint.cfg.get_invite_code().to_string())
             }
         },
+        api_endpoint! {
+            FEDERATION_ID_ENDPOINT,
+            ApiVersion::new(0, 0),
+            async |fedimint: &ConsensusApi, _context,  _v: ()| -> String {
+                Ok(fedimint.cfg.get_federation_id().to_string())
+            }
+        }
         api_endpoint! {
             CLIENT_CONFIG_ENDPOINT,
             ApiVersion::new(0, 0),


### PR DESCRIPTION
Closed https://github.com/fedimint/fedimint/pull/4559 in favor of this to clean force pushes / git history, just adds federation_id endpoint to not affect global client config backwards compat but still be able to get it from the guardian ui.