### PR TITLE
fix(ci): test-ci-all running `parallel` with `--eta`

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -428,6 +428,7 @@ rec {
       patchShebangs ./scripts
       export FM_CARGO_DENY_COMPILATION=1
       export FM_TEST_CI_ALL_TIMES=${builtins.toString times}
+      export FM_TEST_CI_ALL_DISABLE_ETA=1
       ./scripts/tests/test-ci-all.sh || exit 1
       cp scripts/tests/always-success-test.sh scripts/tests/always-success-test.sh.bck
       sed -i -e 's/exit 0/exit 1/g' scripts/tests/always-success-test.sh

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -224,7 +224,7 @@ parsed_test_commands=$(printf "%s\n" "${tests_with_versions[@]}")
 parallel_args=()
 export parallel_jobs='1'
 
-if [ -z "${CI:-}" ]; then
+if [ -z "${CI:-}" ] && [[ -t 1 ]] && [ -z "${FM_TEST_CI_ALL_DISABLE_ETA:-}" ]; then
   parallel_args+=(--eta)
 fi
 


### PR DESCRIPTION
`[ -t 1 ]` is true when running in terminal + a flag to disable it from Nix script.