### PR TITLE
fix(devimint-env): `set -euo pipefail` missing

### DIFF
--- a/scripts/dev/devimint-env.sh
+++ b/scripts/dev/devimint-env.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 source scripts/_common.sh
 
 ensure_in_dev_shell


### PR DESCRIPTION
Trust me, you're going to have a great time if you use `just devimint-env` to test stuff, and sometimes you'll be running previous version because it ignored compilation error.

This change denies anyone that fun. Sorry.