### PR TITLE
fix(db): version field migration never completing

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -326,6 +326,12 @@ pub async fn apply_migrations_client(
 ) -> Result<(), anyhow::Error> {
     db.ensure_global()?;
 
+    // TODO(support:v0.3):
+    // https://github.com/fedimint/fedimint/issues/3481
+    // Somewhere after 0.3 is no longer supported,
+    // we should have no need to try to migrate the key, as all
+    // clients that ever ran the fixed version, should have it
+    // migrated or created in the new place from the start.
     {
         let mut global_dbtx = db.begin_transaction().await;
         migrate_database_version(

--- a/fedimint-testing/src/db.rs
+++ b/fedimint-testing/src/db.rs
@@ -25,6 +25,7 @@ use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt};
 use rand::rngs::OsRng;
 use rand::RngCore;
+use tempfile::TempDir;
 use tracing::{debug, trace};
 
 use crate::envs::FM_PREPARE_DB_MIGRATION_SNAPSHOTS_ENV;
@@ -237,7 +238,7 @@ pub const TEST_MODULE_INSTANCE_ID: u16 = 0;
 async fn get_temp_database(
     db_prefix: &str,
     decoders: ModuleDecoderRegistry,
-) -> anyhow::Result<Database> {
+) -> anyhow::Result<(Database, TempDir)> {
     let snapshot_dirs = get_project_root().unwrap().join("db/migrations");
     if snapshot_dirs.exists() {
         for file in fs::read_dir(&snapshot_dirs)
@@ -280,7 +281,7 @@ where
     F: Fn(Database) -> Fut,
     Fut: futures::Future<Output = anyhow::Result<()>>,
 {
-    let db = get_temp_database(db_prefix, decoders).await?;
+    let (db, _tmp_dir) = get_temp_database(db_prefix, decoders).await?;
     apply_migrations_server(&db, db_prefix.to_string(), target_db_version, migrations)
         .await
         .context("Error applying migrations to temp database")?;
@@ -308,7 +309,7 @@ where
         module.module_kind(),
         module.decoder(),
     )]);
-    let db = get_temp_database(db_prefix, decoders).await?;
+    let (db, _tmp_dir) = get_temp_database(db_prefix, decoders).await?;
     apply_migrations(
         &db,
         module.module_kind().to_string(),
@@ -347,7 +348,7 @@ where
         module.as_common().module_kind(),
         T::decoder(),
     )]);
-    let db = get_temp_database(db_prefix, decoders.clone()).await?;
+    let (db, _tmp_dir) = get_temp_database(db_prefix, decoders.clone()).await?;
     apply_migrations_client(
         &db,
         module.as_common().module_kind().to_string(),
@@ -392,16 +393,16 @@ fn open_temp_db_and_copy(
     temp_path: String,
     src_dir: &Path,
     decoders: ModuleDecoderRegistry,
-) -> anyhow::Result<Database> {
+) -> anyhow::Result<(Database, TempDir)> {
     // First copy the contents from src_dir to the path where the database will be
     // opened
-    let path = tempfile::Builder::new()
+    let tmp_dir = tempfile::Builder::new()
         .prefix(temp_path.as_str())
         .tempdir()?;
-    copy_directory(src_dir, path.path())
+    copy_directory(src_dir, tmp_dir.path())
         .context("Error copying database to temporary directory")?;
 
-    Ok(Database::new(RocksDb::open(path)?, decoders))
+    Ok((Database::new(RocksDb::open(&tmp_dir)?, decoders), tmp_dir))
 }
 
 /// Helper function that recursively copies all of the contents from


### PR DESCRIPTION
I've noticed the `fedimint-cli` keeps printing over and over:

```
2024-03-16T21:45:20.473825Z  INFO db: Migrating DatabaseVersionKeyV0 of ln to DatabaseVersionKey. Version: 1
2024-03-16T21:45:20.473877Z  INFO db: Migrating DatabaseVersionKeyV0 of mint to DatabaseVersionKey. Version: 0
2024-03-16T21:45:20.473899Z  INFO db: Migrating DatabaseVersionKeyV0 of wallet to DatabaseVersionKey. Version:
 0
2024-03-16T21:45:20.473917Z  INFO db: Migrating DatabaseVersionKeyV0 of meta to DatabaseVersionKey. Version: 0
2
```

and it seems it actually never completes it, because there is nothing else to migrate and transaction is terminated early, without completing this one migration. In other words - it does some modifications, than never calls the `commit`.