### PR TITLE
chore(client): too chatty

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -293,7 +293,7 @@ pub async fn exec_user_command(exec: Vec<ffi::OsString>) -> Result<(), anyhow::E
         .join(ffi::OsStr::new(" "))
         .to_string_lossy()
         .to_string();
-    info!(cmd = %cmd_str, "Executing user command");
+    debug!(target: LOG_DEVIMINT, cmd = %cmd_str, "Executing user command");
     if !tokio::process::Command::new(&exec[0])
         .args(&exec[1..])
         .kill_on_drop(true)

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -104,11 +104,11 @@ impl Bitcoind {
         // mine blocks
         let blocks = 101;
         let address = client.get_new_address(None, None)?;
-        info!("Beginning to mine {blocks:?} blocks to address {address:?}");
+        debug!(target: LOG_DEVIMINT, blocks_num=blocks, %address, "Mining blocks to address");
         client
             .generate_to_address(blocks, &address)
             .context("Failed to generate blocks")?;
-        info!("Mined {blocks:?} blocks to address {address:?}");
+        trace!(target: LOG_DEVIMINT, blocks_num=blocks, %address, "Mining blocks to address complete");
 
         // wait bitciond is ready
         poll("bitcoind", None, || async {

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -569,7 +569,7 @@ pub async fn run_dkg(
         let name = followers_names
             .get(peer_id)
             .context("missing follower name")?;
-        info!("calling set_config_gen_connections for {peer_id} {name}");
+        debug!("calling set_config_gen_connections for {peer_id} {name}");
         client
             .set_config_gen_connections(
                 ConfigGenConnectionsRequest {

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -21,6 +21,7 @@ use fedimint_ln_client::{
 };
 use fedimint_ln_common::contracts::ContractId;
 use fedimint_ln_common::LightningGateway;
+use fedimint_logging::LOG_CLIENT;
 use fedimint_mint_client::{
     MintClientModule, OOBNotes, SelectNotesWithAtleastAmount, SelectNotesWithExactAmount,
 };
@@ -201,7 +202,7 @@ pub async fn handle_command(
                     bail!("Reissue failed: {e}");
                 }
 
-                info!("Update: {update:?}");
+                debug!(target: LOG_CLIENT, ?update, "Reissue external notes state update");
             }
 
             Ok(serde_json::to_value(amount).unwrap())
@@ -347,7 +348,7 @@ pub async fn handle_command(
                     _ => {}
                 }
 
-                info!("Update: {update:?}");
+                debug!(target: LOG_CLIENT, ?update, "Await invoice state update");
             }
 
             Err(anyhow::anyhow!(
@@ -449,7 +450,7 @@ pub async fn handle_command(
                 .into_stream();
 
             while let Some(update) = updates.next().await {
-                info!("Update: {update:?}");
+                debug!(target: LOG_CLIENT, ?update, "Await deposit state update");
             }
 
             Ok(serde_json::to_value(()).unwrap())
@@ -555,7 +556,7 @@ pub async fn handle_command(
                 .into_stream();
 
             while let Some(update) = updates.next().await {
-                info!("Update: {update:?}");
+                debug!(target: LOG_CLIENT, ?update, "Withdraw state update");
 
                 match update {
                     WithdrawState::Succeeded(txid) => {
@@ -692,7 +693,7 @@ async fn wait_for_ln_payment(
                         bail!("FundingFailed: {error}")
                     }
                 }
-                info!("Update: {update:?}");
+                debug!(target: LOG_CLIENT, ?update, "Wait for ln payment state update");
             }
         }
         PayType::Lightning(operation_id) => {
@@ -727,7 +728,7 @@ async fn wait_for_ln_payment(
                         bail!("UnexpectedError: {error_message}")
                     }
                 }
-                info!("Update: {update:?}");
+                debug!(target: LOG_CLIENT, ?update, "Wait for ln payment state update");
             }
         }
     };

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1808,7 +1808,7 @@ impl ClientBuilder {
             for (module_id, module_cfg) in client_config.modules {
                 let kind = module_cfg.kind.clone();
                 let Some(init) = self.module_inits.get(&kind) else {
-                    debug!("Detected configuration for unsupported module id: {module_id}, kind: {kind}");
+                    // normal, expected and already logged about when building the client
                     continue;
                 };
 
@@ -2377,7 +2377,7 @@ pub fn client_decoders<'a>(
     let mut modules = BTreeMap::new();
     for (id, kind) in module_kinds {
         let Some(init) = registry.get(kind) else {
-            info!("Detected configuration for unsupported module id: {id}, kind: {kind}");
+            debug!("Detected configuration for unsupported module id: {id}, kind: {kind}");
             continue;
         };
 

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -500,7 +500,7 @@ impl ExecutorInner {
                         ExecutorLoopEvent::Triggered(first_completed_result)
                     }));
 
-                    info!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), total = futures.len(), transitions_num, "Started new active state machine.");
+                    debug!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), total = futures.len(), transitions_num, "Started new active state machine.");
                 }
                 ExecutorLoopEvent::Triggered(TransitionForActiveState {
                     outcome,
@@ -530,12 +530,12 @@ impl ExecutorInner {
                         let global_context_gen = global_context_gen.clone();
                         Box::pin(
                             async move {
-                                info!(
+                                debug!(
                                     target: LOG_CLIENT_REACTOR,
                                     operation_id = %state.operation_id(),
                                     "Executing state transition",
                                 );
-                                debug!(
+                                trace!(
                                     target: LOG_CLIENT_REACTOR,
                                     operation_id = %state.operation_id(),
                                     ?state,

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -346,7 +346,7 @@ impl ExecutorInner {
         global_context_gen: ContextGen,
         sm_update_rx: tokio::sync::mpsc::UnboundedReceiver<DynState>,
     ) {
-        info!("Starting state machine executor task");
+        debug!(target: LOG_CLIENT_REACTOR, "Starting state machine executor task");
         if let Err(err) = self
             .run_state_machines_executor_inner(global_context_gen, sm_update_rx)
             .await

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -637,7 +637,7 @@ impl ExecutorInner {
                         currently_running_sms.remove(&state),
                         "State must have been recorded"
                     );
-                    info!(
+                    debug!(
                         target: LOG_CLIENT_REACTOR,
                         operation_id = %state.operation_id(),
                         outcome_active = outcome.is_active(),

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -1245,7 +1245,7 @@ impl Drop for CommitTracker {
     fn drop(&mut self) {
         if self.has_writes && !self.is_committed {
             if self.ignore_uncommitted {
-                debug!(
+                trace!(
                     target: LOG_DB,
                     "DatabaseTransaction has writes and has not called commit, but that's expected."
                 );

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 use tokio::sync::{oneshot, watch};
 #[cfg(not(target_family = "wasm"))]
 use tokio::task::{JoinError, JoinHandle};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 #[cfg(target_family = "wasm")]
 type JoinHandle<T> = future::Ready<anyhow::Result<T>>;
@@ -176,7 +176,7 @@ impl TaskGroup {
         Fut: Future<Output = R> + Send + 'static,
         R: Send + 'static,
     {
-        use tracing::{debug, info_span, Instrument, Span};
+        use tracing::{info_span, Instrument, Span};
 
         let name = name.into();
         // new child span of current span
@@ -296,12 +296,12 @@ impl TaskGroup {
             info!(target: LOG_TASK, "Subgroup finished");
         }
 
-        // drop lock earl
+        // drop lock early
         while let Some((name, join)) = {
             let mut lock = self.inner.join.lock().expect("lock poison");
             lock.pop_front()
         } {
-            info!(target: LOG_TASK, task=%name, "Waiting for task to finish");
+            debug!(target: LOG_TASK, task=%name, "Waiting for task to finish");
 
             let timeout = deadline.map(|deadline| {
                 deadline

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -326,7 +326,7 @@ impl TaskGroup {
 
             match join_future.await {
                 Ok(Ok(())) => {
-                    info!(target: LOG_TASK, task=%name, "Task finished");
+                    debug!(target: LOG_TASK, task=%name, "Task finished");
                 }
                 Ok(Err(e)) => {
                     error!(target: LOG_TASK, task=%name, error=%e, "Task panicked");

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -1025,7 +1025,7 @@ async fn wait_invoice_payment(
         .await?
         .into_stream();
     while let Some(update) = updates.next().await {
-        info!("{prefix} Update: {update:?}");
+        debug!(%prefix, ?update, "Invoice payment update");
         match update {
             LnReceiveState::Claimed => {
                 let elapsed: Duration = pay_invoice_time.elapsed()?;

--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -28,6 +28,7 @@ pub const LOG_CLIENT_BACKUP: &str = "client::backup";
 pub const LOG_CLIENT_RECOVERY: &str = "client::recovery";
 pub const LOG_CLIENT_RECOVERY_MINT: &str = "client::recovery::mint";
 pub const LOG_CLIENT_MODULE_META: &str = "client::module::meta";
+pub const LOG_CLIENT_MODULE_MINT: &str = "client::module::mint";
 
 /// Consolidates the setup of server tracing into a helper
 #[derive(Default)]

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -51,6 +51,7 @@ use fedimint_core::{
     TieredMulti, TieredSummary, TransactionId,
 };
 use fedimint_derive_secret::{ChildId, DerivableSecret};
+use fedimint_logging::LOG_CLIENT_MODULE_MINT;
 pub use fedimint_mint_common as common;
 use fedimint_mint_common::config::MintClientConfig;
 pub use fedimint_mint_common::*;
@@ -60,7 +61,7 @@ use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tbs::AggregatePublicKey;
 use thiserror::Error;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use crate::backup::EcashBackup;
 use crate::client_db::{
@@ -589,7 +590,7 @@ impl ClientModule for MintClientModule {
                         bail!("Reissue failed: {e}");
                     }
 
-                    info!("Update: {:?}", update);
+                    debug!(target: LOG_CLIENT_MODULE_MINT, ?update, "Reissue external notes update");
                 }
 
                 Ok(serde_json::to_value(amount).unwrap())


### PR DESCRIPTION
In a default (`info`) logging level `fedimint-cli` should only print most important and infrequent messages, and not be soo chatty.