### PR TITLE
chore(devimint): speed up start by jiting

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,7 +2,8 @@
 substituters = "substituters"
 # trips on some base64 string in the test
 wel = "wel"
-
+# common mistake that typos doesn't detect automatically
+reasponse= "response"
 
 [files]
 extend-exclude = [

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -14,7 +14,7 @@ use rand::Rng as _;
 use tokio::fs;
 use tokio::net::TcpStream;
 use tokio::time::Instant;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::federation::Fedimintd;
 use crate::util::{poll, ProcessManager};
@@ -211,6 +211,8 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
             task_group.make_handle().make_shutdown_rx().await.await;
         }
         Cmd::DevFed { exec } => {
+            trace!(target: LOG_DEVIMINT, "Starting dev fed");
+            let start_time = Instant::now();
             let (process_mgr, task_group) = setup(common_args).await?;
             let main = {
                 let task_group = task_group.clone();
@@ -266,6 +268,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                     let daemons = write_ready_file(&process_mgr.globals, Ok(dev_fed)).await?;
 
                     if let Some(exec) = exec {
+                        debug!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed().as_millis(), "Starting exec command");
                         exec_user_command(exec).await?;
                         task_group.shutdown();
                     }

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -683,21 +683,25 @@ async fn set_config_gen_params(
 }
 
 async fn wait_server_status(client: &DynGlobalApi, expected_status: ServerStatus) -> Result<()> {
-    poll("waiting-server-status", Duration::from_secs(30), || async {
-        let server_status = client
-            .status()
-            .await
-            .context("server status")
-            .map_err(ControlFlow::Continue)?
-            .server;
-        if server_status == expected_status {
-            Ok(())
-        } else {
-            Err(ControlFlow::Continue(anyhow!(
-                "expected status: {expected_status:?} current status: {server_status:?}"
-            )))
-        }
-    })
+    poll(
+        &format!("waiting-server-status: {expected_status:?}"),
+        Duration::from_secs(30),
+        || async {
+            let server_status = client
+                .status()
+                .await
+                .context("server status")
+                .map_err(ControlFlow::Continue)?
+                .server;
+            if server_status == expected_status {
+                Ok(())
+            } else {
+                Err(ControlFlow::Continue(anyhow!(
+                    "expected status: {expected_status:?} current status: {server_status:?}"
+                )))
+            }
+        },
+    )
     .await?;
     Ok(())
 }

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -6,7 +6,8 @@ use devimint::cli::CommonArgs;
 use fedimint_core::fedimint_build_code_version_env;
 use fedimint_core::util::{handle_version_hash_command, write_overwrite_async};
 use fedimint_logging::LOG_DEVIMINT;
-use tracing::warn;
+use tokio::time::Instant;
+use tracing::{debug, trace, warn};
 
 #[derive(Parser)]
 #[command(version)]
@@ -37,8 +38,10 @@ async fn handle_command() -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    trace!(target: LOG_DEVIMINT, "Started");
+    let start_time = Instant::now();
     handle_version_hash_command(fedimint_build_code_version_env!());
-    match handle_command().await {
+    let res = match handle_command().await {
         Ok(r) => Ok(r),
         Err(e) => {
             if let Ok(test_dir) = env::var("FM_TEST_DIR") {
@@ -49,5 +52,7 @@ async fn main() -> anyhow::Result<()> {
             }
             Err(e)
         }
-    }
+    };
+    debug!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed().as_millis(), "Finished");
+    res
 }

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1841,19 +1841,16 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
             .collect::<Vec<_>>(),
     ))?];
     info!("Getting wallet balances before import");
-    let balances_before = bitcoind.client().get_balances()?;
+    let bitcoin_client = bitcoind.wallet_client().await?;
+    let balances_before = bitcoin_client.get_balances()?;
     info!("Importing descriptors into bitcoin wallet");
-    let request = bitcoind
-        .client()
+    let request = bitcoin_client
         .get_jsonrpc_client()
         .build_request("importdescriptors", &descriptors_json);
-    let response = bitcoind
-        .client()
-        .get_jsonrpc_client()
-        .send_request(request)?;
+    let response = bitcoin_client.get_jsonrpc_client().send_request(request)?;
     response.check_error()?;
     info!("Getting wallet balances after import");
-    let balances_after = bitcoind.client().get_balances()?;
+    let balances_after = bitcoin_client.get_balances()?;
     let diff = balances_after.mine.immature + balances_after.mine.trusted
         - balances_before.mine.immature
         - balances_before.mine.trusted;

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -181,7 +181,7 @@ pub enum AddStateMachinesError {
 pub enum DiscoverCommonApiVersionMode {
     /// Get the response from only a few peers, or until a timeout
     Fast,
-    /// Try to get a reasponse from all peers, or until a timeout
+    /// Try to get a response from all peers, or until a timeout
     Full,
 }
 

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_family = "wasm", allow(dead_code))]
 
+/// Just-in-time initialization
+pub mod jit;
+
 use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::{pin, Pin};

--- a/fedimint-core/src/task/jit.rs
+++ b/fedimint-core/src/task/jit.rs
@@ -1,0 +1,189 @@
+use std::convert::Infallible;
+use std::fmt;
+use std::sync::Arc;
+
+use fedimint_logging::LOG_TASK;
+use futures::Future;
+use tokio::select;
+use tokio::sync::{self, oneshot};
+use tracing::trace;
+
+use super::MaybeSend;
+
+pub type Jit<T> = JitCore<T, Infallible>;
+pub type JitTry<T, E> = JitCore<T, E>;
+pub type JitTryAnyhow<T> = JitCore<T, anyhow::Error>;
+
+/// Error that could have been returned before
+///
+/// Newtype over `Option<E>` that allows better user (error conversion mostly)
+/// experience
+#[derive(Debug)]
+pub struct OneTimeError<E>(Option<E>);
+
+impl<E> std::error::Error for OneTimeError<E>
+where
+    E: fmt::Debug,
+    E: fmt::Display,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+
+    fn cause(&self) -> Option<&dyn std::error::Error> {
+        self.source()
+    }
+}
+
+impl<E> fmt::Display for OneTimeError<E>
+where
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(e) = self.0.as_ref() {
+            fmt::Display::fmt(&e, f)
+        } else {
+            f.write_str("Error: (missing, it was returned before)")
+        }
+    }
+}
+
+/// A value that initializes eagerly in parallel in a falliable way
+#[derive(Debug, Clone)]
+pub struct JitCore<T, E> {
+    // on last drop it lets the inner task to know it should stop, because we don't care anymore
+    _cancel_tx: sync::mpsc::Sender<()>,
+    // since joinhandles, are not portable, we use this to wait for the value
+    // Note: the `std::sync::Mutex` is used intentionally, since contention never actually happens
+    // and we want to avoid cancelation because of it
+    #[allow(clippy::type_complexity)]
+    val_rx:
+        Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Receiver<std::result::Result<T, E>>>>>,
+    val: sync::OnceCell<T>,
+}
+
+impl<T, E> JitCore<T, E>
+where
+    T: MaybeSend + 'static,
+    E: MaybeSend + 'static,
+{
+    /// Create `JitTry` value, and spawn a future `f` that computes its value
+    ///
+    /// Unlike normal Rust futures, the `f` executes eagerly (is spawned as a
+    /// tokio task).
+    pub fn new_try<Fut>(f: impl FnOnce() -> Fut + 'static + MaybeSend) -> Self
+    where
+        Fut: Future<Output = std::result::Result<T, E>> + 'static + MaybeSend,
+    {
+        let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::channel(1);
+        let (val_tx, val_rx) = oneshot::channel();
+        let type_name = std::any::type_name::<T>();
+        super::imp::spawn(
+            &format!("JitTry {} value", std::any::type_name::<T>()),
+            async move {
+                select! {
+                    _ = cancel_rx.recv() => {
+                        trace!(target: LOG_TASK, r#type = %type_name, "JitTry value future canceled");
+                    },
+                    val = f() => {
+                        match val_tx.send(val) {
+                            Ok(_) => {
+                                trace!(target: LOG_TASK, r#type = %type_name, "JitTry value ready");
+                            },
+                            Err(_) => {
+                                trace!(target: LOG_TASK,  r#type = %type_name, "JitTry value ready, but ignored");
+                            },
+                        };
+                    },
+                }
+            },
+        )
+        .expect("spawn not fail");
+
+        Self {
+            _cancel_tx: cancel_tx,
+            val_rx: Arc::new(Some(val_rx).into()),
+            val: sync::OnceCell::new(),
+        }
+    }
+
+    /// Get the reference to the value, potentially blocking for the
+    /// initialization future to complete
+    pub async fn get_try(&self) -> std::result::Result<&T, OneTimeError<E>> {
+        #[allow(clippy::await_holding_lock)]
+        self.val
+            .get_or_try_init(|| async {
+                let val_res = self
+                    .val_rx
+                    // this lock gets locked only once so it's kind of useless other than making
+                    // Rust happy, but the overhead doesn't matter
+                    .try_lock()
+                    .expect("we can't ever have contention here")
+                    .as_mut()
+                    .ok_or_else(|| OneTimeError(None))?
+                    .await
+                    .unwrap_or_else(|_| {
+                        panic!("Jit value {} panicked", std::any::type_name::<T>())
+                    });
+                self.val_rx.lock().expect("locking can't fail").take();
+                val_res.map_err(|e| OneTimeError(Some(e)))
+            })
+            .await
+    }
+}
+impl<T> JitCore<T, Infallible>
+where
+    T: MaybeSend + 'static,
+{
+    pub fn new<Fut>(f: impl FnOnce() -> Fut + 'static + MaybeSend) -> Self
+    where
+        Fut: Future<Output = T> + 'static + MaybeSend,
+        T: 'static,
+    {
+        Self::new_try(|| async { Ok(f().await) })
+    }
+
+    pub async fn get(&self) -> &T {
+        self.get_try().await.expect("can't fail")
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use anyhow::bail;
+
+    use super::{Jit, JitTry, JitTryAnyhow};
+
+    #[test_log::test(tokio::test)]
+    async fn sanity_jit() {
+        let v = Jit::new(|| async {
+            fedimint_core::task::sleep(Duration::from_millis(0)).await;
+            3
+        });
+
+        assert_eq!(*v.get().await, 3);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn sanity_jit_try_ok() {
+        let v = JitTryAnyhow::new_try(|| async {
+            fedimint_core::task::sleep(Duration::from_millis(0)).await;
+            Ok(3)
+        });
+
+        assert_eq!(*v.get_try().await.expect("ok"), 3);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn sanity_jit_try_err() {
+        let v = JitTry::new_try(|| async {
+            fedimint_core::task::sleep(Duration::from_millis(0)).await;
+            bail!("BOOM");
+            #[allow(unreachable_code)]
+            Ok(3)
+        });
+
+        assert!(v.get_try().await.is_err());
+    }
+}


### PR DESCRIPTION
Is jitin' cheatin'?

At the beginning of setting up dev federation we start and initialize `bitcoind`, make it create a wallet and mine 101 blocks so it can start sending test on chain funds. This takes a couple of seconds, and we wait for it to complete.

I'm thinking - there's bunch of things we could be initializing while this is happening, we don't have to block *everything* on it. There's just no good way to easily and reliably express this ordering dependency.

That's how the idea of "just in time"-values was born. a `Jit` value is really ... an "eager future". `Jit<T>` will start a tokio task that starts executing immediately, but nothing has to block on it initially. Only calling `jit_val.get().await` will block the caller until the value is ready - which can be much, much later down the line, enabling more parallelism.

I'm hoping that by using `Jit` values, instead of trying to come up with with best combinations of steps and `select!`s we can speed up things significantly, and make code easier. We can just pass `Jit`-values around, and let synchronization happen on a per-need basic, in the most optimum way possible.


The first thing I parallelized is that `bitcoind` initialization.


Compare: two runs in each case, time elapsed since start to spawning the user shell.

## BEFORE

```
2024-03-17T23:56:32.579225Z DEBUG devimint: Starting exec command elapsed_ms=15249
2024-03-17T23:57:02.204861Z DEBUG devimint: Starting exec command elapsed_ms=15507
```

### AFTER

```
2024-03-18T00:53:26.750595Z DEBUG devimint: Starting exec command elapsed_ms=11502
2024-03-18T00:53:48.941331Z DEBUG devimint: Starting exec command elapsed_ms=10528
```

cutting the time to get the shell in `just devimint-env` by 25%-30%.

And that's just the start. 

By further refactoring I'd hope to get it to around 5-7s, which should significantly improve DX and our test times.
