### PR TITLE
chore: remove async from TaskGroup::spawn

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1432,31 +1432,29 @@ impl Client {
             let db = db.clone();
             // Separate task group, because we actually don't want to be waiting for this to
             // finish, and it's just best effort.
-            task_group
-                .spawn(
-                    "refresh_common_api_version_static",
-                    |task_handle| async move {
-                        let ok_or_canceled = task_handle
-                            .cancel_on_shutdown(async {
-                                if let Err(e) = Self::refresh_common_api_version_static(
-                                    &config,
-                                    &module_inits,
-                                    &api,
-                                    &db,
-                                    DiscoverCommonApiVersionMode::Full,
-                                )
-                                .await
-                                {
-                                    warn!("Failed to discover common api versions: {e}");
-                                }
-                            })
-                            .await;
-                        if ok_or_canceled.is_err() {
-                            debug!("Refreshing common api task version canceled");
-                        };
-                    },
-                )
-                .await;
+            task_group.spawn(
+                "refresh_common_api_version_static",
+                |task_handle| async move {
+                    let ok_or_canceled = task_handle
+                        .cancel_on_shutdown(async {
+                            if let Err(e) = Self::refresh_common_api_version_static(
+                                &config,
+                                &module_inits,
+                                &api,
+                                &db,
+                                DiscoverCommonApiVersionMode::Full,
+                            )
+                            .await
+                            {
+                                warn!("Failed to discover common api versions: {e}");
+                            }
+                        })
+                        .await;
+                    if ok_or_canceled.is_err() {
+                        debug!("Refreshing common api task version canceled");
+                    };
+                },
+            );
 
             return Ok(v.0);
         }
@@ -1627,8 +1625,7 @@ impl Client {
                     module_recovery_progress_receivers,
                 )
                 .await
-            })
-            .await;
+            });
     }
 
     async fn run_module_recoveries_task(

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -300,7 +300,7 @@ impl Executor {
                     error!("State machine executor runner exited unexpectedly!");
                 },
             };
-        }).await;
+        });
     }
 
     /// Stops the background task that runs the state machines.

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -10,7 +10,6 @@ use anyhow::bail;
 use fedimint_core::time::now;
 use fedimint_logging::{LOG_TASK, LOG_TEST};
 use futures::future::{self, Either};
-use futures::lock::Mutex;
 pub use imp::*;
 use thiserror::Error;
 use tokio::sync::{oneshot, watch};
@@ -33,7 +32,9 @@ struct TaskGroupInner {
     // It is necessary to keep at least one `Receiver` around,
     // otherwise shutdown writes are lost.
     on_shutdown_rx: watch::Receiver<bool>,
-    join: Mutex<VecDeque<(String, JoinHandle<()>)>>,
+    // using blocking Mutex to avoid `async` in `spawn`
+    // it's OK as we don't ever need to yield
+    join: std::sync::Mutex<VecDeque<(String, JoinHandle<()>)>>,
     // using blocking Mutex to avoid `async` in `shutdown`
     // it's OK as we don't ever need to yield
     subgroups: std::sync::Mutex<Vec<TaskGroup>>,
@@ -45,7 +46,7 @@ impl Default for TaskGroupInner {
         Self {
             on_shutdown_tx,
             on_shutdown_rx,
-            join: Mutex::new(Default::default()),
+            join: std::sync::Mutex::new(Default::default()),
             subgroups: std::sync::Mutex::new(vec![]),
         }
     }
@@ -166,7 +167,7 @@ impl TaskGroup {
     }
 
     #[cfg(not(target_family = "wasm"))]
-    pub async fn spawn<Fut, R>(
+    pub fn spawn<Fut, R>(
         &self,
         name: impl Into<String>,
         f: impl FnOnce(TaskHandle) -> Fut + Send + 'static,
@@ -199,7 +200,11 @@ impl TaskGroup {
             }
             .instrument(span)
         }) {
-            self.inner.join.lock().await.push_back((name, handle));
+            self.inner
+                .join
+                .lock()
+                .expect("lock poison")
+                .push_back((name, handle));
         }
         guard.completed = true;
 
@@ -225,13 +230,17 @@ impl TaskGroup {
         if let Some(handle) = self::imp::spawn_local(name.as_str(), async move {
             f(handle).await;
         }) {
-            self.inner.join.lock().await.push_back((name, handle));
+            self.inner
+                .join
+                .lock()
+                .expect("lock poison")
+                .push_back((name, handle));
         }
         guard.completed = true;
     }
     // TODO: Send vs lack of Send bound; do something about it
     #[cfg(target_family = "wasm")]
-    pub async fn spawn<Fut, R>(
+    pub fn spawn<Fut, R>(
         &self,
         name: impl Into<String>,
         f: impl FnOnce(TaskHandle) -> Fut + 'static,
@@ -252,7 +261,11 @@ impl TaskGroup {
         if let Some(handle) = self::imp::spawn(name.as_str(), async move {
             let _ = tx.send(f(handle).await);
         }) {
-            self.inner.join.lock().await.push_back((name, handle));
+            self.inner
+                .join
+                .lock()
+                .expect("lock poison")
+                .push_back((name, handle));
         }
         guard.completed = true;
 
@@ -283,7 +296,11 @@ impl TaskGroup {
             info!(target: LOG_TASK, "Subgroup finished");
         }
 
-        while let Some((name, join)) = self.inner.join.lock().await.pop_front() {
+        // drop lock earl
+        while let Some((name, join)) = {
+            let mut lock = self.inner.join.lock().expect("lock poison");
+            lock.pop_front()
+        } {
             info!(target: LOG_TASK, task=%name, "Waiting for task to finish");
 
             let timeout = deadline.map(|deadline| {
@@ -653,8 +670,7 @@ mod tests {
         let tg = TaskGroup::new();
         tg.spawn("shutdown waiter", |handle| async move {
             handle.make_shutdown_rx().await.await
-        })
-        .await;
+        });
         sleep(Duration::from_millis(10)).await;
         tg.shutdown_join_all(None).await?;
         Ok(())
@@ -666,8 +682,7 @@ mod tests {
         tg.spawn("shutdown waiter", |handle| async move {
             sleep(Duration::from_millis(10)).await;
             handle.make_shutdown_rx().await.await
-        })
-        .await;
+        });
         tg.shutdown_join_all(None).await?;
         Ok(())
     }
@@ -679,8 +694,7 @@ mod tests {
             .await
             .spawn("shutdown waiter", |handle| async move {
                 handle.make_shutdown_rx().await.await
-            })
-            .await;
+            });
         sleep(Duration::from_millis(10)).await;
         tg.shutdown_join_all(None).await?;
         Ok(())
@@ -694,8 +708,7 @@ mod tests {
             .spawn("shutdown waiter", |handle| async move {
                 sleep(Duration::from_millis(10)).await;
                 handle.make_shutdown_rx().await.await
-            })
-            .await;
+            });
         tg.shutdown_join_all(None).await?;
         Ok(())
     }

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -9,15 +9,11 @@ use std::time::{Duration, Instant, SystemTime};
 use anyhow::bail;
 use fedimint_core::time::now;
 use fedimint_logging::{LOG_TASK, LOG_TEST};
-#[cfg(target_family = "wasm")]
-use futures::channel::oneshot;
 use futures::future::{self, Either};
 use futures::lock::Mutex;
 pub use imp::*;
 use thiserror::Error;
-#[cfg(not(target_family = "wasm"))]
-use tokio::sync::oneshot;
-use tokio::sync::watch;
+use tokio::sync::{oneshot, watch};
 #[cfg(not(target_family = "wasm"))]
 use tokio::task::{JoinError, JoinHandle};
 use tracing::{error, info, warn};

--- a/fedimint-metrics/src/lib.rs
+++ b/fedimint-metrics/src/lib.rs
@@ -55,17 +55,15 @@ pub async fn run_api_server(
 
     let handle = task_group.make_handle();
     let shutdown_rx = handle.make_shutdown_rx().await;
-    task_group
-        .spawn("Metrics Api", move |_| async move {
-            let graceful = serve.with_graceful_shutdown(async {
-                shutdown_rx.await;
-            });
+    task_group.spawn("Metrics Api", move |_| async move {
+        let graceful = serve.with_graceful_shutdown(async {
+            shutdown_rx.await;
+        });
 
-            if let Err(e) = graceful.await {
-                error!("Error shutting down metrics api: {e:?}");
-            }
-        })
-        .await;
+        if let Err(e) = graceful.await {
+            error!("Error shutting down metrics api: {e:?}");
+        }
+    });
     let shutdown_receiver = handle.make_shutdown_rx().await;
 
     Ok(shutdown_receiver)

--- a/fedimint-server/src/multiplexed.rs
+++ b/fedimint-server/src/multiplexed.rs
@@ -235,39 +235,35 @@ pub mod test {
             for mux_key in modules.clone() {
                 let conn1 = conn1.clone();
                 let task_handle = task_handle.clone();
-                task_group
-                    .spawn(format!("sender-{mux_key}"), move |_| async move {
-                        for msg_i in 0..NUM_MSGS_PER_MODULE {
-                            // add some random jitter
-                            if OsRng.gen() {
-                                // Note that randomized sleep in sender is larger than
-                                // in receiver, to avoid just running with always full
-                                // queues.
-                                task::sleep(Duration::from_millis(2)).await;
-                            }
-                            if task_handle.is_shutting_down() {
-                                break;
-                            }
-                            conn1.send(&[peer2], mux_key, msg_i).await.unwrap();
+                task_group.spawn(format!("sender-{mux_key}"), move |_| async move {
+                    for msg_i in 0..NUM_MSGS_PER_MODULE {
+                        // add some random jitter
+                        if OsRng.gen() {
+                            // Note that randomized sleep in sender is larger than
+                            // in receiver, to avoid just running with always full
+                            // queues.
+                            task::sleep(Duration::from_millis(2)).await;
                         }
-                    })
-                    .await;
+                        if task_handle.is_shutting_down() {
+                            break;
+                        }
+                        conn1.send(&[peer2], mux_key, msg_i).await.unwrap();
+                    }
+                });
             }
 
             modules.shuffle(&mut thread_rng());
             for mux_key in modules.clone() {
                 let conn2 = conn2.clone();
-                task_group
-                    .spawn(format!("receiver-{mux_key}"), move |_| async move {
-                        for msg_i in 0..NUM_MSGS_PER_MODULE {
-                            // add some random jitter
-                            if OsRng.gen() {
-                                task::sleep(Duration::from_millis(1)).await;
-                            }
-                            assert_eq!(conn2.receive(mux_key).await.unwrap(), (peer1, msg_i));
+                task_group.spawn(format!("receiver-{mux_key}"), move |_| async move {
+                    for msg_i in 0..NUM_MSGS_PER_MODULE {
+                        // add some random jitter
+                        if OsRng.gen() {
+                            task::sleep(Duration::from_millis(1)).await;
                         }
-                    })
-                    .await;
+                        assert_eq!(conn2.receive(mux_key).await.unwrap(), (peer1, msg_i));
+                    }
+                });
             }
 
             task_group.join_all(None).await.expect("no failures");

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -249,11 +249,9 @@ where
             status_query_senders.insert(*peer, status_query_sender);
             connections.insert(*peer, connection);
         }
-        task_group
-            .spawn("listen task", move |handle| {
-                Self::run_listen_task(cfg, shared_connector, connection_senders, handle)
-            })
-            .await;
+        task_group.spawn("listen task", move |handle| {
+            Self::run_listen_task(cfg, shared_connector, connection_senders, handle)
+        });
         (
             ReconnectPeerConnections {
                 connections,
@@ -651,26 +649,24 @@ where
         let (outgoing_sender, outgoing_receiver) = async_channel::bounded(1024);
         let (incoming_sender, incoming_receiver) = async_channel::bounded(1024);
 
-        task_group
-            .spawn(
-                format!("io-thread-peer-{peer_id}"),
-                move |handle| async move {
-                    Self::run_io_thread(
-                        incoming_sender,
-                        outgoing_receiver,
-                        our_id,
-                        peer_id,
-                        peer_address,
-                        delay_calculator,
-                        connect,
-                        incoming_connections,
-                        status_query_receiver,
-                        &handle,
-                    )
-                    .await
-                },
-            )
-            .await;
+        task_group.spawn(
+            format!("io-thread-peer-{peer_id}"),
+            move |handle| async move {
+                Self::run_io_thread(
+                    incoming_sender,
+                    outgoing_receiver,
+                    our_id,
+                    peer_id,
+                    peer_address,
+                    delay_calculator,
+                    connect,
+                    incoming_connections,
+                    status_query_receiver,
+                    &handle,
+                )
+                .await
+            },
+        );
 
         PeerConnection {
             outgoing: outgoing_sender,

--- a/fedimint-server/src/net/peers_reliable.rs
+++ b/fedimint-server/src/net/peers_reliable.rs
@@ -180,11 +180,9 @@ where
             status_query_senders.insert(*peer, status_query_sender);
             connections.insert(*peer, connection);
         }
-        task_group
-            .spawn("listen task", move |handle| {
-                Self::run_listen_task(cfg, shared_connector, connection_senders, handle)
-            })
-            .await;
+        task_group.spawn("listen task", move |handle| {
+            Self::run_listen_task(cfg, shared_connector, connection_senders, handle)
+        });
         (
             ReconnectPeerConnectionsReliable { connections },
             PeerStatusChannels(status_query_senders),
@@ -657,26 +655,24 @@ where
         let (outgoing_sender, outgoing_receiver) = tokio::sync::mpsc::channel::<M>(1024);
         let (incoming_sender, incoming_receiver) = tokio::sync::mpsc::channel::<M>(1024);
 
-        task_group
-            .spawn(
-                format!("io-thread-peer-{peer_id}"),
-                move |handle| async move {
-                    Self::run_io_thread(
-                        incoming_sender,
-                        outgoing_receiver,
-                        our_id,
-                        peer_id,
-                        peer_address,
-                        delay_calculator,
-                        connect,
-                        incoming_connections,
-                        status_query_receiver,
-                        &handle,
-                    )
-                    .await
-                },
-            )
-            .await;
+        task_group.spawn(
+            format!("io-thread-peer-{peer_id}"),
+            move |handle| async move {
+                Self::run_io_thread(
+                    incoming_sender,
+                    outgoing_receiver,
+                    our_id,
+                    peer_id,
+                    peer_address,
+                    delay_calculator,
+                    connect,
+                    incoming_connections,
+                    status_query_receiver,
+                    &handle,
+                )
+                .await
+            },
+        );
 
         PeerConnection {
             outgoing: outgoing_sender,

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -158,8 +158,7 @@ impl FederationTest {
             task.spawn("fedimintd", move |handle| async move {
                 consensus_server.run(handle).await.unwrap();
                 api_handle.stop().await;
-            })
-            .await;
+            });
         }
 
         Self {

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -142,14 +142,12 @@ impl GatewayTest {
         let gateway_run = gateway.clone();
         let root_group = TaskGroup::new();
         let mut tg = root_group.clone();
-        root_group
-            .spawn("Gateway Run", |_handle| async move {
-                gateway_run
-                    .run(&mut tg)
-                    .await
-                    .expect("Failed to start gateway");
-            })
-            .await;
+        root_group.spawn("Gateway Run", |_handle| async move {
+            gateway_run
+                .run(&mut tg)
+                .await
+                .expect("Failed to start gateway");
+        });
 
         // Wait for the gateway web server to be available
         GatewayTest::wait_for_webserver(versioned_api.clone(), cli_password)

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -113,8 +113,7 @@ impl GatewayLndClient {
                 failure_reason: format!("Failed to get node info {status:?}"),
             })?;
 
-        task_group
-            .spawn("LND HTLC Subscription", move |handle| async move {
+        task_group.spawn("LND HTLC Subscription", move |handle| async move {
                 let future_stream = client
                     .router()
                     .htlc_interceptor(ReceiverStream::new(lnd_rx));
@@ -193,8 +192,7 @@ impl GatewayLndClient {
                         }
                     }
                 }
-            })
-            .await;
+            });
 
         Ok(())
     }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -37,17 +37,15 @@ pub async fn run_webserver(
     let shutdown_rx = handle.make_shutdown_rx().await;
     let listener = TcpListener::bind(&bind_addr).await?;
     let serve = axum::serve(listener, api_v1.into_make_service());
-    task_group
-        .spawn("Gateway Webserver", move |_| async move {
-            let graceful = serve.with_graceful_shutdown(async {
-                shutdown_rx.await;
-            });
+    task_group.spawn("Gateway Webserver", move |_| async move {
+        let graceful = serve.with_graceful_shutdown(async {
+            shutdown_rx.await;
+        });
 
-            if let Err(e) = graceful.await {
-                error!("Error shutting down gatewayd webserver: {:?}", e);
-            }
-        })
-        .await;
+        if let Err(e) = graceful.await {
+            error!("Error shutting down gatewayd webserver: {:?}", e);
+        }
+    });
 
     Ok(())
 }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -787,11 +787,9 @@ impl Wallet {
     ) -> Result<Wallet, WalletCreationError> {
         let broadcaster_bitcoind_rpc = bitcoind.clone();
         let broadcaster_db = db.clone();
-        task_group
-            .spawn("broadcast pending", |handle| async move {
-                run_broadcast_pending_tx(broadcaster_db, broadcaster_bitcoind_rpc, &handle).await;
-            })
-            .await;
+        task_group.spawn("broadcast pending", |handle| async move {
+            run_broadcast_pending_tx(broadcaster_db, broadcaster_bitcoind_rpc, &handle).await;
+        });
 
         let bitcoind_rpc = bitcoind;
 


### PR DESCRIPTION
fixes https://github.com/fedimint/fedimint/issues/4493

command used for replace:

	rust-analyzer ssr '$tg.spawn($n, $f).await ==>> $tg.spawn($n, $f)'