### PR TITLE
fix: define nextest `dev` profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,6 +2,10 @@
 # no matter the profile, we want to kill tests that hanged on something
 slow-timeout = { period = "60s", terminate-after = 8 }
 
+# define `dev` to allow running cargo and nextest with the same profile name
+# inherits default profile config
+[profile.dev]
+
 [profile.ci]
 fail-fast = true
 failure-output = "immediate"


### PR DESCRIPTION
We recently introduced exporting `CARGO_PROFILE="dev"` when sourcing `scripts/_common.sh` (see: https://github.com/fedimint/fedimint/blob/f001570/scripts/_common.sh#L14). We need to define a `dev` profile for nextest or `just test-ci-all` fails locally with

```bash
nix@lenovo-m75q-ubuntu:~/fedimint$ just test-ci-all
./scripts/tests/test-ci-all.sh
Pre-building workspace...
    Finished dev [unoptimized + debuginfo] target(s) in 0.26s
Pre-building tests...
error: profile `dev not found (known profiles: ci, default, default-miri)`
error: Recipe `test-ci-all` failed on line 19 with exit code 96
```