### PR TITLE
feat: Support description hashes for invoices

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -27,7 +27,7 @@ use fedimint_mint_client::{
 use fedimint_wallet_client::{WalletClientModule, WithdrawState};
 use futures::StreamExt;
 use itertools::Itertools;
-use lightning_invoice::Bolt11Invoice;
+use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use time::format_description::well_known::iso8601;
@@ -321,8 +321,15 @@ pub async fn handle_command(
             let ln_gateway = get_gateway(&client, gateway_id).await;
 
             let lightning_module = client.get_first_module::<LightningClientModule>();
+            let desc = Description::new(description)?;
             let (operation_id, invoice, _) = lightning_module
-                .create_bolt11_invoice(amount, description, expiry_time, (), ln_gateway)
+                .create_bolt11_invoice(
+                    amount,
+                    Bolt11InvoiceDescription::Direct(&desc),
+                    expiry_time,
+                    (),
+                    ln_gateway,
+                )
                 .await?;
             Ok(serde_json::to_value(LnInvoiceResponse {
                 operation_id,

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -25,7 +25,7 @@ use fedimint_ln_client::{LightningClientModule, LnReceiveState};
 use fedimint_ln_common::LightningGateway;
 use fedimint_mint_client::OOBNotes;
 use futures::StreamExt;
-use lightning_invoice::Bolt11Invoice;
+use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
 use serde::{Deserialize, Serialize};
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufWriter};
@@ -1063,8 +1063,15 @@ async fn client_create_invoice(
 ) -> anyhow::Result<(fedimint_core::core::OperationId, Bolt11Invoice)> {
     let create_invoice_time = fedimint_core::time::now();
     let lightning_module = client.get_first_module::<LightningClientModule>();
+    let desc = Description::new("test".to_string())?;
     let (operation_id, invoice, _) = lightning_module
-        .create_bolt11_invoice(invoice_amount, "".into(), None, (), ln_gateway)
+        .create_bolt11_invoice(
+            invoice_amount,
+            Bolt11InvoiceDescription::Direct(&desc),
+            None,
+            (),
+            ln_gateway,
+        )
         .await?;
     let elapsed = create_invoice_time.elapsed()?;
     info!("Created invoice using gateway in {elapsed:?}");

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -107,6 +107,7 @@ mod tests {
     use fedimint_ln_client::{
         LightningClientModule, LnPayState, LnReceiveState, OutgoingLightningPayment, PayType,
     };
+    use fedimint_ln_common::lightning_invoice::{Bolt11InvoiceDescription, Description};
     use fedimint_ln_common::LightningGateway;
     use fedimint_mint_client::{MintClientModule, ReissueExternalNotesState, SpendOOBState};
     use futures::StreamExt;
@@ -153,8 +154,15 @@ mod tests {
         gateway: LightningGateway,
     ) -> Result<()> {
         let lightning_module = client.get_first_module::<LightningClientModule>();
+        let desc = Description::new("test".to_string())?;
         let (opid, invoice, _) = lightning_module
-            .create_bolt11_invoice(amount, "test".to_string(), None, (), Some(gateway))
+            .create_bolt11_invoice(
+                amount,
+                Bolt11InvoiceDescription::Direct(&desc),
+                None,
+                (),
+                Some(gateway),
+            )
             .await?;
         faucet::pay_invoice(&invoice.to_string()).await?;
 

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -42,7 +42,7 @@ use fedimint_testing::ln::LightningTest;
 use fedimint_unknown_common::config::UnknownGenParams;
 use fedimint_unknown_server::UnknownInit;
 use futures::Future;
-use lightning_invoice::{Bolt11Invoice, RoutingFees};
+use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description, RoutingFees};
 use ln_gateway::gateway_lnrpc::GetNodeInfoResponse;
 use ln_gateway::rpc::rpc_client::{GatewayRpcClient, GatewayRpcError, GatewayRpcResult};
 use ln_gateway::rpc::{
@@ -547,10 +547,11 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
         let invoice_amount = sats(100);
         let ln_module = user_client.get_first_module::<LightningClientModule>();
         let ln_gateway = ln_module.select_gateway(&gateway_id).await;
+        let desc = Description::new("description".to_string())?;
         let (_invoice_op, invoice, _) = ln_module
             .create_bolt11_invoice(
                 invoice_amount,
-                "description".into(),
+                Bolt11InvoiceDescription::Direct(&desc),
                 None,
                 "test intercept valid HTLC",
                 ln_gateway,
@@ -637,10 +638,11 @@ async fn test_gateway_client_intercept_htlc_no_funds() -> anyhow::Result<()> {
         // User client creates invoice in federation
         let ln_module = user_client.get_first_module::<LightningClientModule>();
         let ln_gateway = ln_module.select_gateway(&gateway_id).await;
+        let desc = Description::new("description".to_string())?;
         let (_invoice_op, invoice, _) = ln_module
             .create_bolt11_invoice(
                 sats(100),
-                "description".into(),
+                Bolt11InvoiceDescription::Direct(&desc),
                 None,
                 "test intercept htlc but with no funds",
                 ln_gateway,
@@ -956,11 +958,12 @@ async fn test_gateway_filters_route_hints_by_inbound() -> anyhow::Result<()> {
             let gateway_id = gateway.gateway.gateway_id;
             let ln_module = user_client.get_first_module::<LightningClientModule>();
             let ln_gateway = ln_module.select_gateway(&gateway_id).await;
+            let desc = Description::new("description".to_string())?;
             let (_invoice_op, invoice, _) = user_client
                 .get_first_module::<LightningClientModule>()
                 .create_bolt11_invoice(
                     invoice_amount,
-                    "description".into(),
+                    Bolt11InvoiceDescription::Direct(&desc),
                     None,
                     format!(
                         "gateway type: {gateway_type} number of route hints: {num_route_hints}"
@@ -1411,10 +1414,11 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
             let invoice_amt = msats(2_500);
             let ln_module = client2.get_first_module::<LightningClientModule>();
             let ln_gateway = ln_module.select_gateway(&gateway_id).await;
+            let desc = Description::new("description".to_string())?;
             let (receive_op, invoice, _) = ln_module
                 .create_bolt11_invoice(
                     invoice_amt,
-                    "description".into(),
+                    Bolt11InvoiceDescription::Direct(&desc),
                     None,
                     "test gw swap between federations",
                     ln_gateway,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -733,7 +733,7 @@ impl LightningClientModule {
     async fn create_lightning_receive_output<'a>(
         &'a self,
         amount: Amount,
-        description: String,
+        description: lightning_invoice::Bolt11InvoiceDescription<'a>,
         mut rng: impl RngCore + CryptoRng + 'a,
         expiry_time: Option<u64>,
         src_node_id: secp256k1::PublicKey,
@@ -788,7 +788,7 @@ impl LightningClientModule {
 
         let mut invoice_builder = InvoiceBuilder::new(network.into())
             .amount_milli_satoshis(amount.msats)
-            .description(description)
+            .invoice_description(description)
             .payment_hash(payment_hash)
             .payment_secret(PaymentSecret(rng.gen()))
             .duration_since_epoch(duration_since_epoch)
@@ -1324,7 +1324,7 @@ impl LightningClientModule {
     pub async fn create_bolt11_invoice<M: Serialize + Send + Sync>(
         &self,
         amount: Amount,
-        description: String,
+        description: lightning_invoice::Bolt11InvoiceDescription<'_>,
         expiry_time: Option<u64>,
         extra_meta: M,
         gateway: Option<LightningGateway>,


### PR DESCRIPTION
This is needed along with #3820 for the lightning address server. Without being able to set the description hash some clients will reject the invoice as invalid and will make all resulting zaps invalid as well.