### PR TITLE
fix: remove Database::ensure_global calls

### DIFF
--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -264,13 +264,11 @@ impl Client {
 
     async fn load_previous_backup(&self) -> Option<ClientBackup> {
         let mut dbtx = self.db.begin_transaction_nc().await;
-        dbtx.ensure_global().expect("global tx");
         dbtx.get_value(&LastBackupKey).await
     }
 
     async fn store_last_backup(&self, backup: &ClientBackup) {
         let mut dbtx = self.db.begin_transaction().await;
-        dbtx.ensure_global().expect("global tx");
         dbtx.insert_entry(&LastBackupKey, backup).await;
         dbtx.commit_tx().await;
     }

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -324,8 +324,6 @@ pub async fn apply_migrations_client(
     module_instance_id: ModuleInstanceId,
     decoders: ModuleDecoderRegistry,
 ) -> Result<(), anyhow::Error> {
-    db.ensure_global()?;
-
     // TODO(support:v0.3):
     // https://github.com/fedimint/fedimint/issues/3481
     // Somewhere after 0.3 is no longer supported,

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -1862,8 +1862,6 @@ pub async fn apply_migrations(
     migrations: BTreeMap<DatabaseVersion, ServerMigrationFn>,
     module_instance_id: Option<ModuleInstanceId>,
 ) -> Result<(), anyhow::Error> {
-    db.ensure_global()?;
-
     {
         let mut global_dbtx = db.begin_transaction().await;
         migrate_database_version(


### PR DESCRIPTION
> The client side migrations today assume that the global database is the db namespace where the states are stored. For any use case that needs multi-level nesting of isolated databases (e.g multiple clients within the gateway), this check doesn't make sense anymore and can be removed.

quote from https://github.com/fedimint/fedimint/issues/4616

fixes  https://github.com/fedimint/fedimint/issues/4616