### PR TITLE
chore: bump version to 0.4.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.4",
@@ -1245,7 +1245,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1308,14 +1308,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.11.0",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "fedimint-core",
  "honggfuzz",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-cli"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1685,14 +1685,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.11.0",
 ]
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-gateway"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "base64 0.22.0",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.4",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.11.0",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin 0.29.2",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "aleph-bft-types",
  "anyhow",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.11.0",
  "bls12_381",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ resolver = "2"
 
 [workspace.metadata]
 name = "fedimint"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint is a prototype Federated Chaumian E-Cash Mint implementation, natively compatible with Bitcoin & the Lightning Network. This project is under heavy development, DO NOT USE WITH REAL FUNDS."

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-aead"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "aead utilities on top of ring"

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-derive-secret"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint derivable secret implementation"
@@ -19,8 +19,8 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.81"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-hkdf = { package = "fedimint-hkdf", version = "0.3.0-alpha", path = "../../crypto/hkdf" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+hkdf = { package = "fedimint-hkdf", version = "0.4.0-alpha", path = "../../crypto/hkdf" }
 ring = "0.17.8"
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.4.0-alpha", path = "../../crypto/tbs" }

--- a/crypto/hkdf/Cargo.toml
+++ b/crypto/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-hkdf"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "RFC5869 HKDF implementation on top of bitcoin_hashes"

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-tbs"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "tbs is a helper cryptography library for threshold blind signatures"

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devimint"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 publish = false
@@ -45,4 +45,4 @@ fedimint-portalloc = { path = "../utils/portalloc" }
 fs-lock = "0.1.3"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-bip39/Cargo.toml
+++ b/fedimint-bip39/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-bip39"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 readme = "../README.md"
@@ -18,6 +18,6 @@ path = "./src/lib.rs"
 
 [dependencies]
 bip39 = { version = "2.0.0", features = ["rand"] }
-fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
+fedimint-client = { version = "0.4.0-alpha", path = "../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
 rand = "0.8.5"

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-bitcoind"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Bitcoin Core connectivity used by Fedimint"
@@ -25,8 +25,8 @@ bitcoincore-rpc = { version = "0.16.0", optional = true }
 electrum-client = {version = "0.12.1", optional = true }
 esplora-client = { version = "0.5.0", default-features = false, features = ["async", "async-https-rustls"], optional = true }
 lazy_static = "1.4.0"
-fedimint-core  = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
+fedimint-core  = { version = "0.4.0-alpha", path = "../fedimint-core" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging" }
 rand = "0.8"
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"

--- a/fedimint-build/Cargo.toml
+++ b/fedimint-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-build"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint build script utilities for including git version information in builds"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-cli"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-cli is a command line interface wrapper for the client library."
@@ -32,20 +32,20 @@ clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error
 futures = "0.3.30"
 itertools = "0.12.1"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
-fedimint-bip39 = { version = "0.3.0-alpha", path = "../fedimint-bip39" }
-fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-mint-client = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-client" }
-fedimint-mint-common = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-common" }
-fedimint-ln-client = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-client" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-common" }
-fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-meta-client = { version = "0.3.0-alpha", path = "../modules/fedimint-meta-client", features = [ "cli" ] }
-fedimint-meta-common = { version = "0.3.0-alpha", path = "../modules/fedimint-meta-common" }
+fedimint-aead = { version = "0.4.0-alpha", path = "../crypto/aead" }
+fedimint-bip39 = { version = "0.4.0-alpha", path = "../fedimint-bip39" }
+fedimint-client = { version = "0.4.0-alpha", path = "../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
+fedimint-rocksdb = { version = "0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-mint-client = { version = "0.4.0-alpha", path = "../modules/fedimint-mint-client" }
+fedimint-mint-common = { version = "0.4.0-alpha", path = "../modules/fedimint-mint-common" }
+fedimint-ln-client = { version = "0.4.0-alpha", path = "../modules/fedimint-ln-client" }
+fedimint-ln-common = { version = "0.4.0-alpha", path = "../modules/fedimint-ln-common" }
+fedimint-wallet-client = { version = "0.4.0-alpha", path = "../modules/fedimint-wallet-client" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-server = { version = "0.4.0-alpha", path = "../fedimint-server" }
+fedimint-meta-client = { version = "0.4.0-alpha", path = "../modules/fedimint-meta-client", features = [ "cli" ] }
+fedimint-meta-common = { version = "0.4.0-alpha", path = "../modules/fedimint-meta-common" }
 fs-lock = "0.1.3"
 rand = "0.8"
 serde = { version = "1.0.197", features = [ "derive" ] }
@@ -60,4 +60,4 @@ lnurl-rs = { version = "0.4.1", features = ["async"], default-features = false }
 reqwest = { version = "0.11.26", features = [ "json", "rustls-tls" ], default-features = false }
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-client provides a library for sending transactions to the federation."
@@ -26,10 +26,10 @@ async-stream = "0.3.5"
 async-trait = "0.1.77"
 bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
-fedimint-core  = { version = "0.3.0-alpha", path = "../fedimint-core/" }
-fedimint-derive-secret = { version = "0.3.0-alpha", path = "../crypto/derive-secret" }
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
+fedimint-core  = { version = "0.4.0-alpha", path = "../fedimint-core/" }
+fedimint-derive-secret = { version = "0.4.0-alpha", path = "../crypto/derive-secret" }
+fedimint-aead = { version = "0.4.0-alpha", path = "../crypto/aead" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging" }
 futures = "0.3.30"
 itertools = "0.12.1"
 rand = "0.8.5"
@@ -50,4 +50,4 @@ ring = { version = "0.17.8", features = ["wasm32_unknown_unknown_js"] }
 tracing-test = "0.2.4"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-core"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-core provides common code used by both client and server."
@@ -32,7 +32,7 @@ strum = "0.26"
 strum_macros = "0.26"
 hex = { version = "0.4.3", features = [ "serde"] }
 sha3 = "0.10.8"
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.4.0-alpha", path = "../crypto/tbs" }
 tokio = { version = "1.36.0", features = ["sync", "io-util"] }
 thiserror = "1.0.58"
 tracing ="0.1.40"
@@ -44,8 +44,8 @@ bitcoin_hashes = { version = "0.11", features = ["serde"] }
 erased-serde = "0.4"
 lightning = "0.0.118"
 lightning-invoice = "0.26.0"
-fedimint-derive = { version = "0.3.0-alpha", path = "../fedimint-derive" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
+fedimint-derive = { version = "0.4.0-alpha", path = "../fedimint-derive" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging" }
 rand = "0.8.5"
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dbtool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
@@ -18,25 +18,25 @@ name = "fedimint-dbtool"
 
 [dependencies]
 anyhow = "1.0.81"
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
+fedimint-aead = { version = "0.4.0-alpha", path = "../crypto/aead" }
 bitcoin_hashes = "0.11.0"
 bytes = "1.5.0"
 clap = { version = "4.5.2", features = ["derive", "env"] }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-mint-server = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-server" }
-fedimint-mint-client = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-client" }
-fedimint-ln-server = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-server" }
-fedimint-ln-client = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-client" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-wallet-server = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-server" }
-fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
+fedimint-client = { version = "0.4.0-alpha", path = "../fedimint-client" }
+fedimint-server = { version = "0.4.0-alpha", path = "../fedimint-server" }
+fedimint-rocksdb = { version = "0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-mint-server = { version = "0.4.0-alpha", path = "../modules/fedimint-mint-server" }
+fedimint-mint-client = { version = "0.4.0-alpha", path = "../modules/fedimint-mint-client" }
+fedimint-ln-server = { version = "0.4.0-alpha", path = "../modules/fedimint-ln-server" }
+fedimint-ln-client = { version = "0.4.0-alpha", path = "../modules/fedimint-ln-client" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-wallet-server = { version = "0.4.0-alpha", path = "../modules/fedimint-wallet-server" }
+fedimint-wallet-client = { version = "0.4.0-alpha", path = "../modules/fedimint-wallet-client" }
 futures = "0.3.30"
 erased-serde = "0.4"
 hex = { version = "0.4.3", features = ["serde"] }
-ln-gateway = { package = "fedimint-ln-gateway", version = "0.3.0-alpha", path = "../gateway/ln-gateway" }
+ln-gateway = { package = "fedimint-ln-gateway", version = "0.4.0-alpha", path = "../gateway/ln-gateway" }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 strum = "0.26"
@@ -45,4 +45,4 @@ tokio = "1.36.0"
 tracing = "0.1.40"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-derive"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-derive provides helper macros for serialization."

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-load-test-tool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-load-test-tool is a tool to load test the fedimint server and gateway."
@@ -16,15 +16,15 @@ anyhow = "1"
 base64 = "0.22.0"
 bitcoin = "0.29.2"
 clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env" ], default-features = false }
-devimint = { version = "0.3.0-alpha", path = "../devimint" }
-fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-ln-client = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-client" }
+devimint = { version = "0.4.0-alpha", path = "../devimint" }
+fedimint-client = { version = "0.4.0-alpha", path = "../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
+fedimint-ln-client = { version = "0.4.0-alpha", path = "../modules/fedimint-ln-client" }
 fedimint-ln-common = { path = "../modules/fedimint-ln-common" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-mint-client = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-client" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-mint-client = { version = "0.4.0-alpha", path = "../modules/fedimint-mint-client" }
+fedimint-rocksdb = { version = "0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-wallet-client = { version = "0.4.0-alpha", path = "../modules/fedimint-wallet-client" }
 futures = "0.3"
 jsonrpsee-core = { version = "0.22.2", features = [ "client" ] }
 jsonrpsee-types = { version = "0.22.2" }
@@ -40,4 +40,4 @@ url = { version = "2.5.0", features = ["serde"] }
 jsonrpsee-ws-client = { version = "0.22.2", features = ["webpki-tls"], default-features = false }
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-logging"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "contains some utilities for logging and tracing"

--- a/fedimint-metrics/Cargo.toml
+++ b/fedimint-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-metrics"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
@@ -17,7 +17,7 @@ path = "./src/lib.rs"
 [dependencies]
 anyhow = { version = "1.0.81", features = ["backtrace"] }
 axum = "0.7.4"
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
 lazy_static = "1.4.0"
 prometheus = "0.13.3"
 tokio = "1"

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-rocksdb"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-rocksdb provides a rocksdb-backed database implementation for Fedimint."
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.81"
 async-trait = "0.1.77"
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
 futures = "0.3.30"
 rocksdb = { version = "0.22.0" }
 tracing = "0.1.40"

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-server' facilitates federated consensus with atomic broadcast and distributed configuration."
@@ -18,7 +18,7 @@ name = "fedimint_server"
 path = "src/lib.rs"
 
 [dependencies]
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
+fedimint-aead = { version = "0.4.0-alpha", path = "../crypto/aead" }
 anyhow = "1.0.81"
 async-channel = "2.2.0"
 async-trait = "0.1.77"
@@ -29,9 +29,9 @@ bytes = "1.5.0"
 futures = "0.3.30"
 hex = "0.4.3"
 itertools = "0.12.1"
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-metrics = { path = "../fedimint-metrics" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-metrics = { version = "0.4.0-alpha", path = "../fedimint-metrics" }
 lazy_static = "1.4.0"
 pin-project = "1.1.5"
 rand = "0.8"
@@ -44,7 +44,7 @@ sha3 = "0.10.8"
 strum = "0.26"
 strum_macros = "0.26"
 tar = "0.4.40"
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.4.0-alpha", path = "../crypto/tbs" }
 thiserror = "1.0.58"
 tower = { version = "0.4.13", default-features = false }
 tracing ="0.1.40"
@@ -72,4 +72,4 @@ fedimint-portalloc = { path = "../utils/portalloc" }
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-testing"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-testing provides a library of shared objects and utilities for testing fedimint components"
@@ -25,15 +25,15 @@ bitcoin = "0.29.2"
 bitcoincore-rpc = "0.16.0"
 clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions" ], default-features = false }
 cln-rpc = { workspace = true }
-fedimint-core  = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-client  = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-server  = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../fedimint-bitcoind" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-core  = { version = "0.4.0-alpha", path = "../fedimint-core" }
+fedimint-client  = { version = "0.4.0-alpha", path = "../fedimint-client" }
+fedimint-server  = { version = "0.4.0-alpha", path = "../fedimint-server" }
+fedimint-bitcoind = { version = "0.4.0-alpha", path = "../fedimint-bitcoind" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-rocksdb = { version = "0.4.0-alpha", path = "../fedimint-rocksdb" }
 fs-lock = "0.1.3"
 lazy_static = "1.4.0"
-ln-gateway = { version = "0.3.0-alpha", package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
+ln-gateway = { version = "0.4.0-alpha", package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 futures = "0.3"
 lightning-invoice = "0.26.0"
 tempfile = "3.10.1"
@@ -47,4 +47,4 @@ tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tokio-stream = "0.1.14"
 tonic_lnd = { workspace = true }
 url = "2.5.0"
-fedimint-portalloc = { version = "0.3.0-alpha", path = "../utils/portalloc" }
+fedimint-portalloc = { version = "0.4.0-alpha", path = "../utils/portalloc" }

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimintd"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimintd is the main consensus code for processing transactions and REST API"
@@ -24,7 +24,7 @@ name = "fedimintd"
 path = "src/lib.rs"
 
 [dependencies]
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
+fedimint-aead = { version = "0.4.0-alpha", path = "../crypto/aead" }
 ring = "0.17.8"
 anyhow = "1.0.81"
 async-trait = "0.1.77"
@@ -35,26 +35,26 @@ clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error
 futures = "0.3.30"
 itertools = "0.12.1"
 jsonrpsee = { version = "0.22.2", features = ["server"] }
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../fedimint-bitcoind" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-common" }
-fedimint-ln-server = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-server" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging", features = ["telemetry"] }
-fedimint-metrics = { version = "0.3.0-alpha", path = "../fedimint-metrics" }
-fedimint-mint-server = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-server" }
-fedimint-meta-server = { version = "0.3.0-alpha", path = "../modules/fedimint-meta-server" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-wallet-server = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-server" }
-fedimint-unknown-server = { version = "0.3.0-alpha", path = "../modules/fedimint-unknown-server" }
-fedimint-unknown-common = { version = "0.3.0-alpha", path = "../modules/fedimint-unknown-common" }
+fedimint-bitcoind = { version = "0.4.0-alpha", path = "../fedimint-bitcoind" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
+fedimint-ln-common = { version = "0.4.0-alpha", path = "../modules/fedimint-ln-common" }
+fedimint-ln-server = { version = "0.4.0-alpha", path = "../modules/fedimint-ln-server" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging", features = ["telemetry"] }
+fedimint-metrics = { version = "0.4.0-alpha", path = "../fedimint-metrics" }
+fedimint-mint-server = { version = "0.4.0-alpha", path = "../modules/fedimint-mint-server" }
+fedimint-meta-server = { version = "0.4.0-alpha", path = "../modules/fedimint-meta-server" }
+fedimint-rocksdb = { version = "0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-server = { version = "0.4.0-alpha", path = "../fedimint-server" }
+fedimint-wallet-server = { version = "0.4.0-alpha", path = "../modules/fedimint-wallet-server" }
+fedimint-unknown-server = { version = "0.4.0-alpha", path = "../modules/fedimint-unknown-server" }
+fedimint-unknown-common = { version = "0.4.0-alpha", path = "../modules/fedimint-unknown-common" }
 rand = "0.8"
 rcgen = "=0.12.1"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"
 sha3 = "0.10.8"
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.4.0-alpha", path = "../crypto/tbs" }
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tokio-rustls = "0.23.4"
@@ -72,4 +72,4 @@ tower = { version = "0.4", features = ["util"] }
 console-subscriber = "0.2.0"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "0.4.0-alpha", path = "../fedimint-build" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-fuzz"
 edition = "2021"
 authors = ["The Fedimint Developers"]
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 publish = false
 license = "MIT"
 readme = "../README.md"
@@ -13,7 +13,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
 
 # cargo-deny just needs at least one `bin` defined
 [lib]

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-gateway-cli"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 readme = "../../README.md"
@@ -23,9 +23,9 @@ axum = "0.7.4"
 axum-macros = "0.4.1"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
-ln-gateway = { version = "0.3.0-alpha", package = "fedimint-ln-gateway", path= "../ln-gateway" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
+ln-gateway = { version = "0.4.0-alpha", package = "fedimint-ln-gateway", path= "../ln-gateway" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../../fedimint-logging" }
 reqwest = { version = "0.11.26", features = [ "json", "rustls-tls" ], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.114"
@@ -35,4 +35,4 @@ url = { version = "2.5.0", features = ["serde"] }
 clap_complete = "4.5.1"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../../fedimint-build" }
+fedimint-build = { version = "0.4.0-alpha", path = "../../fedimint-build" }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-gateway"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln-gateway sends/receives Lightning Network payments on behalf of Fedimint clients"
@@ -39,15 +39,15 @@ clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error
 # cln-plugin made semver incompatible change
 cln-plugin = "=0.1.7"
 cln-rpc = { workspace = true }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../../fedimint-rocksdb" }
-fedimint-ln-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-ln-client" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../../modules/fedimint-ln-common" }
-fedimint-mint-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-mint-client" }
-fedimint-dummy-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-dummy-client" }
-fedimint-wallet-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-wallet-client" }
+fedimint-client = { version = "0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../../fedimint-logging" }
+fedimint-rocksdb = { version = "0.4.0-alpha", path = "../../fedimint-rocksdb" }
+fedimint-ln-client = { version = "0.4.0-alpha", path = "../../modules/fedimint-ln-client" }
+fedimint-ln-common = { version = "0.4.0-alpha", path = "../../modules/fedimint-ln-common" }
+fedimint-mint-client = { version = "0.4.0-alpha", path = "../../modules/fedimint-mint-client" }
+fedimint-dummy-client = { version = "0.4.0-alpha", path = "../../modules/fedimint-dummy-client" }
+fedimint-wallet-client = { version = "0.4.0-alpha", path = "../../modules/fedimint-wallet-client" }
 futures = "0.3.30"
 erased-serde = "0.4"
 lightning-invoice = "0.26.0"
@@ -85,5 +85,5 @@ threshold_crypto = { workspace = true }
 assert_matches = "1.5.0"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../../fedimint-build" }
+fedimint-build = { version = "0.4.0-alpha", path = "../../fedimint-build" }
 tonic-build = "0.11.0"

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
@@ -18,9 +18,9 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = "0.1.77"
 anyhow = "1.0.81"
-fedimint-dummy-common = { version = "0.3.0-alpha", path = "../fedimint-dummy-common" }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-dummy-common = { version = "0.4.0-alpha", path = "../fedimint-dummy-common" }
+fedimint-client = { version = "0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 futures = "0.3"
 erased-serde = "0.4"
 rand = "0.8.5"

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
@@ -21,7 +21,7 @@ async-trait = "0.1.77"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.4"
 futures = "0.3"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"
 serde = { version = "1.0.197", features = [ "derive" ] }
 secp256k1 = "0.24.3"

--- a/modules/fedimint-dummy-server/Cargo.toml
+++ b/modules/fedimint-dummy-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
@@ -21,8 +21,8 @@ async-trait = "0.1.77"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.4"
 futures = "0.3"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-dummy-common = { version = "0.3.0-alpha", path = "../fedimint-dummy-common" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-dummy-common = { version = "0.4.0-alpha", path = "../fedimint-dummy-common" }
 rand = "0.8"
 serde = { version = "1.0.197", features = [ "derive" ] }
 secp256k1 = "0.24.3"

--- a/modules/fedimint-dummy-tests/Cargo.toml
+++ b/modules/fedimint-dummy-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."

--- a/modules/fedimint-empty-client/Cargo.toml
+++ b/modules/fedimint-empty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-empty-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-empty is an empty fedimint module, good template for a new module."
@@ -18,9 +18,9 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = "0.1.77"
 anyhow = "1.0.81"
-fedimint-empty-common = { version = "0.3.0-alpha", path = "../fedimint-empty-common" }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-empty-common = { version = "0.4.0-alpha", path = "../fedimint-empty-common" }
+fedimint-client = { version = "0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 futures = "0.3"
 erased-serde = "0.4"
 serde = {version = "1.0.197", features = [ "derive" ] }

--- a/modules/fedimint-empty-common/Cargo.toml
+++ b/modules/fedimint-empty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-empty-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-empty is a empty fedimint module, good template for a new module."
@@ -20,7 +20,7 @@ anyhow = "1.0.81"
 async-trait = "0.1.77"
 erased-serde = "0.4"
 futures = "0.3"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.26"
 strum_macros = "0.26"

--- a/modules/fedimint-empty-server/Cargo.toml
+++ b/modules/fedimint-empty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-empty-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-empty is a empty fedimint module, good template for a new module."
@@ -20,8 +20,8 @@ anyhow = "1.0.81"
 async-trait = "0.1.77"
 erased-serde = "0.4"
 futures = "0.3"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-empty-common = { version = "0.3.0-alpha", path = "../fedimint-empty-common" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-empty-common = { version = "0.4.0-alpha", path = "../fedimint-empty-common" }
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.26"
 strum_macros = "0.26"

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
@@ -33,9 +33,9 @@ erased-serde = "0.4"
 futures = "0.3.30"
 itertools = "0.12.1"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../fedimint-ln-common" }
+fedimint-client = { version = "0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-ln-common = { version = "0.4.0-alpha", path = "../fedimint-ln-common" }
 secp256k1 = { version="0.24.3", default-features=false }
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
 serde = {version = "1.0.197", features = [ "derive" ] }

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
@@ -32,8 +32,8 @@ futures = "0.3.30"
 itertools = "0.12.1"
 lightning = { version = "0.0.118", default-features = false, features = ["no-std"] }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-client = { version = "0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 secp256k1 = { version="0.24.3", default-features=false }
 serde = {version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
@@ -27,10 +27,10 @@ futures = "0.3.30"
 itertools = "0.12.1"
 lightning = "0.0.118"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../fedimint-ln-common" }
-fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
+fedimint-bitcoind = { version = "0.4.0-alpha", path = "../../fedimint-bitcoind" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-ln-common = { version = "0.4.0-alpha", path = "../fedimint-ln-common" }
+fedimint-metrics = { version = "0.4.0-alpha", path = "../../fedimint-metrics" }
 secp256k1 = { version="0.24.3", default-features=false }
 serde = {version = "1.0.197", features = [ "derive" ] }
 serde_json = "1.0.114"
@@ -42,7 +42,7 @@ tokio = { version = "1.36", features = ["full"] }
 tracing = "0.1.40"
 rand = "0.8"
 url = { version = "2.5.0", features = ["serde"] }
-fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
+fedimint-server = { version = "0.4.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln-tests contains integration tests for the lightning module"

--- a/modules/fedimint-meta-client/Cargo.toml
+++ b/modules/fedimint-meta-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-meta-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-meta is a meta consensus fedimint module."
@@ -25,9 +25,9 @@ anyhow = "1.0.66"
 clap = { workspace = true, optional = true }
 hex = "0.4.3"
 serde_json = { workspace = true, optional = true }
-fedimint-meta-common = { version = "0.3.0-alpha", path = "../fedimint-meta-common" }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-meta-common = { version = "0.4.0-alpha", path = "../fedimint-meta-common" }
+fedimint-client = { version = "0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 futures = "0.3"
 erased-serde = "0.4"
 rand = "0.8.5"

--- a/modules/fedimint-meta-common/Cargo.toml
+++ b/modules/fedimint-meta-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-meta-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-meta is a meta-consensus fedimint module."
@@ -22,7 +22,7 @@ bitcoin_hashes = "0.11.0"
 erased-serde = "0.4"
 hex = "0.4.3"
 futures = "0.3"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"

--- a/modules/fedimint-meta-server/Cargo.toml
+++ b/modules/fedimint-meta-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-meta-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-meta is a meta consensus fedimint module."
@@ -21,9 +21,9 @@ async-trait = "0.1.73"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.4"
 futures = "0.3"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
-fedimint-meta-common = { version = "0.3.0-alpha", path = "../fedimint-meta-common" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../../fedimint-logging" }
+fedimint-meta-common = { version = "0.4.0-alpha", path = "../fedimint-meta-common" }
 rand = "0.8"
 serde = { version = "1.0.149", features = [ "derive" ] }
 secp256k1 = "0.24.2"

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
@@ -27,11 +27,11 @@ bitcoin_hashes = "0.11.0"
 erased-serde = "0.4"
 futures = "0.3"
 itertools = "0.12.1"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-derive-secret = { version = "0.3.0-alpha", path = "../../crypto/derive-secret"}
-fedimint-mint-common ={ version = "0.3.0-alpha", path = "../fedimint-mint-common" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-client = { version = "0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-derive-secret = { version = "0.4.0-alpha", path = "../../crypto/derive-secret"}
+fedimint-mint-common ={ version = "0.4.0-alpha", path = "../fedimint-mint-common" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../../fedimint-logging" }
 rand = "0.8"
 secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
@@ -40,7 +40,7 @@ serde-big-array = "0.5.1"
 serde_json = "1.0.114"
 strum = "0.26"
 strum_macros = "0.26"
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.4.0-alpha", path = "../../crypto/tbs" }
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
 tokio = { version = "1.36.0", features = [ "sync" ] }

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
@@ -23,14 +23,14 @@ bincode = "1.3.3"
 bitcoin_hashes = "0.11.0"
 futures = "0.3"
 itertools = "0.12.1"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"
 secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.26"
 strum_macros = "0.26"
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.4.0-alpha", path = "../../crypto/tbs" }
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
 tracing ="0.1.40"

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
@@ -25,20 +25,20 @@ bitcoin_hashes = "0.11.0"
 erased-serde = "0.4"
 futures = "0.3"
 itertools = "0.12.1"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
-fedimint-mint-common = { version = "0.3.0-alpha", path = "../fedimint-mint-common" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-metrics = { version = "0.4.0-alpha", path = "../../fedimint-metrics" }
+fedimint-mint-common = { version = "0.4.0-alpha", path = "../fedimint-mint-common" }
 rand = "0.8"
 secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.26"
 strum_macros = "0.26"
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.4.0-alpha", path = "../../crypto/tbs" }
 thiserror = "1.0.58"
 threshold_crypto = { workspace = true }
 tracing ="0.1.40"
-fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
+fedimint-server = { version = "0.4.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint-tests contains integration tests for the mint module"
@@ -31,7 +31,7 @@ tracing = "0.1.40"
 rand = "0.8"
 secp256k1 = "0.24.3"
 serde = { version = "1.0.197", features = [ "derive" ] }
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "0.4.0-alpha", path = "../../crypto/tbs" }
 threshold_crypto = { workspace = true }
 ff = "0.12.1"
 strum = "0.26"

--- a/modules/fedimint-unknown-common/Cargo.toml
+++ b/modules/fedimint-unknown-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-unknown-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-unknown is a fedimint module that doesn't have any client side implementation."
@@ -21,7 +21,7 @@ async-trait = "0.1.77"
 bitcoin_hashes = "0.11.0"
 erased-serde = "0.4"
 futures = "0.3"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 rand = "0.8"
 serde = { version = "1.0.197", features = [ "derive" ] }
 thiserror = "1.0.58"

--- a/modules/fedimint-unknown-server/Cargo.toml
+++ b/modules/fedimint-unknown-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-unknown-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-unknown-server is a test fedimint module that doesn't have any client side implementation."
@@ -20,8 +20,8 @@ anyhow = "1.0.81"
 async-trait = "0.1.77"
 erased-serde = "0.4"
 futures = "0.3"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-unknown-common = { version = "0.3.0-alpha", path = "../fedimint-unknown-common" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-unknown-common = { version = "0.4.0-alpha", path = "../fedimint-unknown-common" }
 rand = "0.8"
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = "0.26"

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
@@ -22,10 +22,10 @@ async-stream = "0.3.5"
 async-trait = "0.1.77"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.4"
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client", "bitcoincore-rpc"] }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-wallet-common = { version = "0.3.0-alpha", path = "../fedimint-wallet-common" }
+fedimint-bitcoind = { version = "0.4.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client", "bitcoincore-rpc"] }
+fedimint-client = { version = "0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-wallet-common = { version = "0.4.0-alpha", path = "../fedimint-wallet-common" }
 futures = "0.3"
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 impl-tools = "0.10.0"

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
@@ -20,7 +20,7 @@ anyhow = "1.0.81"
 async-trait = "0.1.77"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.4"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
 futures = "0.3"
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 miniscript9 = { package = "miniscript", version = "9.0.2" }

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
@@ -20,10 +20,10 @@ anyhow = "1.0.81"
 async-trait = "0.1"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = "0.4"
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
-fedimint-wallet-common = { version = "0.3.0-alpha", path = "../fedimint-wallet-common" }
+fedimint-bitcoind = { version = "0.4.0-alpha", path = "../../fedimint-bitcoind" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-metrics = { version = "0.4.0-alpha", path = "../../fedimint-metrics" }
+fedimint-wallet-common = { version = "0.4.0-alpha", path = "../fedimint-wallet-common" }
 futures = "0.3"
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 miniscript9 = { package = "miniscript", version = "9.0.2" }
@@ -38,7 +38,7 @@ tokio = { version = "1.36.0", features = ["sync"], optional = true }
 tracing ="0.1.40"
 url = "2.5.0"
 validator = { version = "0.17", features = ["derive"] }
-fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
+fedimint-server = { version = "0.4.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet-tests contains integration tests for the lightning module"

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -185,7 +185,7 @@ let
     (craneLib'.overrideArgs (commonEnvsBuild // commonArgs // {
       src = filterWorkspaceBuildFiles commonSrc;
       pname = "fedimint";
-      version = "0.1.0";
+      version = "0.4.0-alpha";
     })).overrideArgs'' (craneLib: args:
       pkgs.lib.optionalAttrs (!(builtins.elem (craneLib.toolchainName or null) [ null "default" "stable" "nightly" ])) commonEnvsShellRocksdbLinkCross
     );

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-recoverytool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 authors = ["The Fedimint Developers"]
 description = "recoverytool allows retrieving on-chain funds from a offline federation"
@@ -19,15 +19,15 @@ path = "src/main.rs"
 anyhow = "1.0.81"
 bitcoin = "0.29.2"
 clap = { version = "4.5.2", features = [ "derive", "env" ] }
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-wallet-server = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-server" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-common" }
-fedimint-ln-server = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-server" }
-fedimint-mint-server = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-server" }
+fedimint-aead = { version = "0.4.0-alpha", path = "../crypto/aead" }
+fedimint-core = { version = "0.4.0-alpha", path = "../fedimint-core" }
+fedimint-rocksdb = { version = "0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-server = { version = "0.4.0-alpha", path = "../fedimint-server" }
+fedimint-wallet-server = { version = "0.4.0-alpha", path = "../modules/fedimint-wallet-server" }
+fedimint-logging = { version = "0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-ln-common = { version = "0.4.0-alpha", path = "../modules/fedimint-ln-common" }
+fedimint-ln-server = { version = "0.4.0-alpha", path = "../modules/fedimint-ln-server" }
+fedimint-mint-server = { version = "0.4.0-alpha", path = "../modules/fedimint-mint-server" }
 futures = "0.3.30"
 miniscript = { version = "10.0.0" }
 secp256k1 = { version = "0.24.3", features = [ "serde", "global-context" ] }

--- a/utils/portalloc/Cargo.toml
+++ b/utils/portalloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-portalloc"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Port allocation utility for Fedimint"
@@ -23,4 +23,4 @@ serde_json = { version = "1.0.114", features = ["preserve_order"] }
 tracing = "0.1.40"
 rand = "0.8"
 dirs = "5.0.1"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "0.4.0-alpha", path = "../../fedimint-core" }


### PR DESCRIPTION
Also adds missing version to metrics dependency in fedimint-server.