### PR TITLE
feat(docs): improve documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,5 +26,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./result/
+          publish_dir: ./result/share/doc/
           cname: docs.fedimint.org

--- a/docs/rustdoc-index.md
+++ b/docs/rustdoc-index.md
@@ -1,0 +1,5 @@
+# Fedimint technical reference documentation
+
+<!-- this page is used a landing page for https://docs.fedimint.org/ -->
+
+This is documentation automatically generated from the Fedimint source code.

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -172,3 +172,29 @@ fuzz-target-debug TARGET="" CRASH="" *ARGS="--exit_upon_crash":
   # * TODO: make flakebox set RUSTFLAGS, as hfuzz seems to ignore CARGO_BUILD_<target>_RUSTFLAGS
   # * can't be run with sccache, so just disable here
   env -u RUSTC_WRAPPER CC=clang RUSTFLAGS="--cfg tokio_unstable" cargo hfuzz run-debug {{TARGET}} ${CRASH}
+
+# Build `cargo doc`-generated documentation
+build-docs:
+  ./scripts/dev/build-docs.sh
+
+# Open `cargo doc`-generated documentation
+docs: build-docs
+  #!/usr/bin/env bash
+  if command -v xdg-open 1>/dev/null 2>/dev/null ; then
+    open_cmd="xdg-open"
+  elif command -v open 1>/dev/null 2>/dev/null ; then
+    open_cmd="open"
+  else
+    >&2 echo "Install xdg-open. Falling back to one from nix"
+    open_cmd="nix shell nixpkgs#xdg-utils -c xdg-open"
+  fi
+  source "scripts/_common.sh"
+  main_index_path="${CARGO_BUILD_TARGET_DIR}/doc/index.html"
+  fallback_index_path="${CARGO_BUILD_TARGET_DIR}/doc/fedimint_core/index.html"
+  if [ -e "$main_index_path" ]; then
+    echo "http://$fallback_index_path"
+    $open_cmd "$main_index_path" || true
+  else
+    echo "http://$fallback_index_path"
+    $open_cmd "$fallback_index_path" || true
+  fi

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -20,6 +20,7 @@ else
   export CARGO_PROFILE_DIR="$CARGO_PROFILE"
 fi
 
+export CARGO_BUILD_TARGET_DIR="${CARGO_BUILD_TARGET_DIR:-"$REPO_ROOT/target"}"
 
 function add_target_dir_to_path() {
   export PATH="${CARGO_BUILD_TARGET_DIR:-$PWD/target}/${CARGO_PROFILE_DIR:-debug}:$PATH"

--- a/scripts/dev/build-docs.sh
+++ b/scripts/dev/build-docs.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "./scripts/_common.sh"
+
+fm_index_md=${FM_RUSTDOC_INDEX_MD:-./docs/rustdoc-index.md}
+index_html="${CARGO_BUILD_TARGET_DIR:-target}/doc/index.html"
+
+export RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links -D warnings'
+if cargo version | grep -q nightly ; then
+  RUSTDOCFLAGS="$RUSTDOCFLAGS -Z unstable-options --enable-index-page"
+  # broken: https://github.com/rust-lang/rust/issues/97881
+  # RUSTDOCFLAGS="$RUSTDOCFLAGS --index-page ${FM_RUSTDOC_INDEX_MD:-./docs/rustdoc-index.md}"
+fi
+echo RUSTDOCFLAGS: "$RUSTDOCFLAGS"
+
+cargo doc --profile "$CARGO_PROFILE" --locked --workspace --no-deps --document-private-items
+
+if [ -e "${index_html}" ]; then
+  if command -v pandoc >/dev/null 2>/dev/null ; then
+    # since `--index-page` is broken, improve our index page manually :/
+    pandoc "$fm_index_md" > "${fm_index_md}.html"
+    trap 'rm -f "${fm_index_md}.html"' EXIT
+
+    awk -v insert_path="${fm_index_md}.html" '
+      BEGIN {
+        RS = ORS = "\0"; # Treat the file as a single record
+        while ((getline line < insert_path) > 0) {
+          content = content line "\n";
+        }
+        close(insert_path);
+      }
+      {
+        sub(/<section id="main-content"/, content "&"); # Replace MARKER with insert.txt content + MARKER
+        print;
+      }' "$index_html" > "$index_html.tmp" && mv "$index_html.tmp" "$index_html"
+  fi
+fi


### PR DESCRIPTION

Re #4622


What we'll publish on docs.fedimint.org:

```
nix build .#nightly.ci.workspaceDocExport
xdg-open ./result/share/doc/index.html
```

Handy local version:

```
just docs
```
