### PR TITLE
chore: use info tracing level for htlc stream open failure

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -576,7 +576,7 @@ impl Gateway {
                                 }
                             }
                             Err(e) => {
-                                debug!("Failed to open HTLC stream: {e:?}");
+                                warn!("Failed to open HTLC stream: {e:?}");
                             }
                         }
 


### PR DESCRIPTION
I had to enable debug logging just to see this message.