### PR TITLE
chore: improve gateway webserver logging

### DIFF
--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 use tower_http::validate_request::ValidateRequestHeaderLayer;
-use tracing::{error, instrument};
+use tracing::{error, info, instrument};
 
 use super::{
     BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, InfoPayload,
@@ -43,7 +43,9 @@ pub async fn run_webserver(
         });
 
         if let Err(e) = graceful.await {
-            error!("Error shutting down gatewayd webserver: {:?}", e);
+            error!("Error shutting down gateway webserver: {:?}", e);
+        } else {
+            info!("Successfully shutdown gateway webserver");
         }
     });
 


### PR DESCRIPTION
Spoke too soon on the flakiness with `test_gateway_configuration` :/ https://github.com/fedimint/fedimint/actions/runs/8350129601/job/22855854147

It's currently difficult to tell why the webserver is not coming back up after we change the gateway's password. This PR adds some logging to make it easier to tell what's happening.

I suspect there might be a race condition that is causing the webserver to still bind to the port, causing the restart to fail.