### PR TITLE
chore: add version to metrics workspace dep

### DIFF
--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -31,7 +31,7 @@ hex = "0.4.3"
 itertools = "0.12.1"
 fedimint-core = { version = "0.3.0-rc.1", path = "../fedimint-core" }
 fedimint-logging = { version = "0.3.0-rc.1", path = "../fedimint-logging" }
-fedimint-metrics = { path = "../fedimint-metrics" }
+fedimint-metrics = { version = "0.3.0-rc.1", path = "../fedimint-metrics" }
 lazy_static = "1.4.0"
 pin-project = "1.1.5"
 rand = "0.8"


### PR DESCRIPTION
Had to do this to finish the crates.io release, so the `v0.3.0-rc.0` tag is a bit of a lie :sweat_smile: first half of the creates was released from that commit, second one from this.