### PR TITLE
fix: bump devimint dkg timeout

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -506,7 +506,7 @@ pub async fn run_dkg(
     for (peer_id, client) in &admin_clients {
         poll(
             "trying-to-connect-to-peers",
-            Duration::from_secs(15),
+            Duration::from_secs(30),
             || async {
                 client
                     .status()


### PR DESCRIPTION
Dkg isn't completing within the 15 second timeout, causing flakiness in back-compat tests. @elsirion flagged that this might be caused by the increased parallelism in https://github.com/fedimint/fedimint/issues/4636.

Let's see if giving a longer timeout resolves the flakiness.