### PR TITLE
fix(backport-ci): check label contains backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,8 +15,13 @@ jobs:
       pull-requests: write # so it can create pull requests
     name: Backport pull request
     runs-on: ubuntu-latest
-    # Don't run on closed unmerged pull requests
-    if: github.event.pull_request.merged
+    # Don't run on closed unmerged pull requests or if a non-backport label is added
+    if: |
+      github.event.pull_request.merged &&
+      (
+        github.event.action != 'labeled' ||
+        contains(github.event.label.name, 'backport')
+      )
     # Save the output from the create-pr step so it can be used in downstream jobs
     # https://github.com/korthout/backport-action/blob/e53c7b292aa9985d372c178a89d416ef2176c091/README.md#outputs
     outputs:


### PR DESCRIPTION
The backport bot successfully created a backport PR that was merged. We then added a new label (`flaky test` [event](https://github.com/fedimint/fedimint/pull/4641#event-12193358389)) that triggered another backport workflow run which failed. This PR checks the label contains "backport" if adding a label triggers the workflow.

References:
- [`github.event.action`](https://stackoverflow.com/questions/61886993/in-github-actions-how-to-get-the-type-of-a-trigger-event-as-a-variable)
- [`github.event.label.name`](https://stackoverflow.com/questions/62325286/run-github-actions-when-pull-requests-have-a-specific-label)
- [`contains`](https://docs.github.com/en/actions/learn-github-actions/expressions)