### PR TITLE
chore(ci): disable hourly workflow

### DIFF
--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -1,6 +1,7 @@
 on:
-  schedule:
-    - cron:  '30 * * * *' # every hour at `x:30`
+  # disable cron while debugging
+  # schedule:
+  #   - cron:  '30 * * * *' # every hour at `x:30`
   workflow_dispatch:
 
 name: Hourly check


### PR DESCRIPTION
We're spamming the alerts channel with false negatives. Lets disable the cron while I debug the failures. I suspect the issue has to do with a lower resource GH runner box taking longer to start services.