### PR TITLE
fix: hourly run

### DIFF
--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -32,12 +32,33 @@ jobs:
             runs-on: ubuntu-latest
             timeout: 75
             run-tests: true
+            free-disk-space-ubuntu: true
 
     name: "Test on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: ${{ matrix.timeout }}
 
     steps:
+      - name: Free Disk Space, Ubuntu, part 1
+        if: matrix.free-disk-space-ubuntu
+        run: |
+          docker rmi `docker images -q`
+          sudo rm -rf /usr/share/dotnet /etc/mysql /etc/php /etc/sudo apt/sources.list.d
+          sudo apt -y autoremove --purge
+          sudo apt -y autoclean
+          sudo apt clean
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df -h
+
+      - name: Free Disk Space, Ubuntu, part 2
+        if: matrix.free-disk-space-ubuntu
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          tool-cache: false
+          large-packages: true
+          swap-storage: true
+
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v26

--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -14,7 +14,10 @@ version_str="${FM_RUN_TEST_VERSIONS:+ ($FM_RUN_TEST_VERSIONS)}"
 test_out_path="$(mktemp --tmpdir fm-XXXXX)"
 time_out_path="$(mktemp --tmpdir fm-XXXXX)"
 time_fmt='%e\t%M\t%w\t%c'
+
 export FM_TEST_NAME="$test_name"
+TMPDIR="$(mktemp -d --tmpdir "${FM_TEST_NAME}-XXXX")"
+FM_RUN_TEST_TMPDIR="$TMPDIR"
 
 echo "## RUN:  $test_name$version_str"
 
@@ -25,9 +28,14 @@ on_error() {
 }
 
 on_exit() {
-    rm -Rf "$CARGO_BUILD_TARGET_DIR"
+    exit_status=$?
+    if [ $exit_status -eq 0 ]; then
+        # if successful, don't waste space keeping the test dir
+        rm -Rf "$FM_RUN_TEST_TMPDIR"
+    fi
 }
 trap on_error ERR
+trap on_exit EXIT
 
 command time -q --format="$time_fmt" -o "$time_out_path" "$@" 2>&1 | ts -s > "$test_out_path"
 


### PR DESCRIPTION
Fix for what caused #4657 

Tested in a different draft PRs (#4668).  We can land, then I should be able manually trigger some runs, see if they look OK, and then we can revert #4657