### PR TITLE
fix(docs): exclude fedimint-fuzz from rustdoc

### DIFF
--- a/scripts/dev/build-docs.sh
+++ b/scripts/dev/build-docs.sh
@@ -15,7 +15,7 @@ if cargo version | grep -q nightly ; then
 fi
 echo RUSTDOCFLAGS: "$RUSTDOCFLAGS"
 
-cargo doc --profile "$CARGO_PROFILE" --locked --workspace --no-deps --document-private-items
+cargo doc --exclude fedimint-fuzz --profile "$CARGO_PROFILE" --locked --workspace --no-deps --document-private-items
 
 if [ -e "${index_html}" ]; then
   if command -v pandoc >/dev/null 2>/dev/null ; then


### PR DESCRIPTION
The binaries in it have short names and are just getting in a way.
![image](https://github.com/fedimint/fedimint/assets/9209/35c0192d-d1ed-4931-8df0-1f3772a0b4fb)
