### PR TITLE
Faster devimint startup using `Jit<T>`

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -220,8 +220,6 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                 async move {
                     let dev_fed = DevJitFed::new(&process_mgr)?;
 
-                    let fed_id = dev_fed.fed().await?.calculate_federation_id().await;
-
                     let pegin_start_time = Instant::now();
                     info!(target: LOG_DEVIMINT, "Peging in client and gateways");
 
@@ -250,7 +248,9 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                             let pegin_addr = dev_fed
                                 .gw_cln_registered()
                                 .await?
-                                .get_pegin_addr(&fed_id)
+                                .get_pegin_addr(
+                                    &dev_fed.fed().await?.calculate_federation_id().await,
+                                )
                                 .await?;
                             dev_fed
                                 .bitcoind()
@@ -263,7 +263,9 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                             let pegin_addr = dev_fed
                                 .gw_lnd_registered()
                                 .await?
-                                .get_pegin_addr(&fed_id)
+                                .get_pegin_addr(
+                                    &dev_fed.fed().await?.calculate_federation_id().await,
+                                )
                                 .await?;
                             dev_fed
                                 .bitcoind()

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -16,9 +16,10 @@ use tokio::net::TcpStream;
 use tokio::time::Instant;
 use tracing::{debug, error, info, trace, warn};
 
+use crate::devfed::DevJitFed;
 use crate::federation::Fedimintd;
 use crate::util::{poll, ProcessManager};
-use crate::{dev_fed, external_daemons, vars, ExternalDaemons};
+use crate::{external_daemons, vars, ExternalDaemons};
 
 fn random_test_dir_suffix() -> String {
     rand::thread_rng()
@@ -217,8 +218,9 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
             let main = {
                 let task_group = task_group.clone();
                 async move {
-                    let dev_fed = dev_fed(&process_mgr).await?;
-                    let fed_id = dev_fed.fed.calculate_federation_id().await;
+                    let dev_fed = DevJitFed::new(&process_mgr)?;
+
+                    let fed_id = dev_fed.fed().await?.calculate_federation_id().await;
 
                     let pegin_start_time = Instant::now();
                     info!(target: LOG_DEVIMINT, "Peging in client and gateways");
@@ -227,44 +229,57 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                     let client_pegin_amount = 10_000;
                     let (deposit_op_id, _, _) = tokio::try_join!(
                         async {
-                            let (address, operation_id) =
-                                dev_fed.fed.internal_client().get_deposit_addr().await?;
+                            let (address, operation_id) = dev_fed
+                                .client_registered()
+                                .await?
+                                .get_deposit_addr()
+                                .await?;
                             dev_fed
-                                .fed
-                                .bitcoind
+                                .bitcoind()
+                                .await?
                                 .send_to(address, client_pegin_amount)
                                 .await?;
                             Ok(operation_id)
                         },
                         async {
-                            let pegin_addr = dev_fed.gw_cln.get_pegin_addr(&fed_id).await?;
+                            let pegin_addr = dev_fed
+                                .gw_cln_registered()
+                                .await?
+                                .get_pegin_addr(&fed_id)
+                                .await?;
                             dev_fed
-                                .fed
-                                .bitcoind
+                                .bitcoind()
+                                .await?
                                 .send_to(pegin_addr, gw_pegin_amount)
                                 .await
                         },
                         async {
-                            let pegin_addr = dev_fed.gw_lnd.get_pegin_addr(&fed_id).await?;
+                            let pegin_addr = dev_fed
+                                .gw_lnd_registered()
+                                .await?
+                                .get_pegin_addr(&fed_id)
+                                .await?;
                             dev_fed
-                                .fed
-                                .bitcoind
+                                .bitcoind()
+                                .await?
                                 .send_to(pegin_addr, gw_pegin_amount)
                                 .await?;
                             Ok(())
                         },
                     )?;
-                    dev_fed.fed.bitcoind.mine_blocks(11).await?;
-                    dev_fed
-                        .fed
-                        .internal_client()
-                        .await_deposit(&deposit_op_id)
-                        .await?;
+                    let client = dev_fed.client_registered().await?;
+                    tokio::try_join!(
+                        dev_fed.bitcoind().await?.mine_blocks(11),
+                        client.await_deposit(&deposit_op_id),
+                    )?;
 
                     info!(target: LOG_DEVIMINT,
                         elapsed_ms = %pegin_start_time.elapsed().as_millis(),
                         "Pegins completed");
-                    std::env::set_var("FM_INVITE_CODE", dev_fed.fed.invite_code()?);
+                    std::env::set_var("FM_INVITE_CODE", dev_fed.fed().await?.invite_code()?);
+
+                    dev_fed.finalize(&process_mgr).await?;
+
                     let daemons = write_ready_file(&process_mgr.globals, Ok(dev_fed)).await?;
 
                     if let Some(exec) = exec {
@@ -272,6 +287,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                         exec_user_command(exec).await?;
                         task_group.shutdown();
                     }
+
                     Ok::<_, anyhow::Error>(daemons)
                 }
             };

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -1,9 +1,13 @@
+use std::ops::Deref as _;
+use std::sync::Arc;
+
 use anyhow::Result;
+use fedimint_core::task::jit::{JitTry, JitTryAnyhow};
 use fedimint_logging::LOG_DEVIMINT;
 use tracing::{debug, info};
 
 use crate::external::{Bitcoind, Electrs, Esplora, Lightningd, Lnd};
-use crate::federation::Federation;
+use crate::federation::{Client, Federation};
 use crate::gatewayd::Gatewayd;
 use crate::util::ProcessManager;
 use crate::{cmd, open_channel, LightningNode};
@@ -92,4 +96,262 @@ pub async fn dev_fed(process_mgr: &ProcessManager) -> Result<DevFed> {
         electrs,
         esplora,
     })
+}
+
+type JitArc<T> = JitTryAnyhow<Arc<T>>;
+
+#[derive(Clone)]
+pub struct DevJitFed {
+    bitcoind: JitArc<Bitcoind>,
+    cln: JitArc<Lightningd>,
+    lnd: JitArc<Lnd>,
+    fed: JitArc<Federation>,
+    gw_cln: JitArc<Gatewayd>,
+    gw_lnd: JitArc<Gatewayd>,
+    electrs: JitArc<Electrs>,
+    esplora: JitArc<Esplora>,
+    start_time: std::time::SystemTime,
+    gw_cln_registered: JitArc<()>,
+    gw_lnd_registered: JitArc<()>,
+    fed_client_joined: JitArc<()>,
+    fed_epoch_generated: JitArc<()>,
+    channel_opened: JitArc<()>,
+}
+
+impl DevJitFed {
+    pub fn new(process_mgr: &ProcessManager) -> Result<DevJitFed> {
+        let fed_size = process_mgr.globals.FM_FED_SIZE;
+        let offline_nodes = process_mgr.globals.FM_OFFLINE_NODES;
+        anyhow::ensure!(
+            fed_size > 3 * offline_nodes,
+            "too many offline nodes ({offline_nodes}) to reach consensus"
+        );
+        let start_time = fedimint_core::time::now();
+
+        info!("Starting dev federation");
+
+        let bitcoind = JitTry::new_try({
+            let process_mgr = process_mgr.to_owned();
+            move || async move { Ok(Arc::new(Bitcoind::new(&process_mgr).await?)) }
+        });
+        let cln = JitTry::new_try({
+            let process_mgr = process_mgr.to_owned();
+            let bitcoind = bitcoind.clone();
+            move || async move {
+                Ok(Arc::new(
+                    Lightningd::new(&process_mgr, bitcoind.get_try().await?.deref().clone())
+                        .await?,
+                ))
+            }
+        });
+        let lnd = JitTry::new_try({
+            let process_mgr = process_mgr.to_owned();
+            let bitcoind = bitcoind.clone();
+            move || async move {
+                Ok(Arc::new(
+                    Lnd::new(&process_mgr, bitcoind.get_try().await?.deref().clone()).await?,
+                ))
+            }
+        });
+        let electrs = JitTryAnyhow::new_try({
+            let process_mgr = process_mgr.to_owned();
+            let bitcoind = bitcoind.clone();
+            move || async move {
+                let bitcoind = bitcoind.get_try().await?.deref().clone();
+                Ok(Arc::new(Electrs::new(&process_mgr, bitcoind).await?))
+            }
+        });
+        let esplora = JitTryAnyhow::new_try({
+            let process_mgr = process_mgr.to_owned();
+            let bitcoind = bitcoind.clone();
+            move || async move {
+                let bitcoind = bitcoind.get_try().await?.deref().clone();
+                Ok(Arc::new(Esplora::new(&process_mgr, bitcoind).await?))
+            }
+        });
+
+        let fed = JitTryAnyhow::new_try({
+            let process_mgr = process_mgr.to_owned();
+            let bitcoind = bitcoind.clone();
+            move || async move {
+                let bitcoind = bitcoind.get_try().await?.deref().clone();
+                let mut fed = Federation::new(&process_mgr, bitcoind, fed_size).await?;
+
+                // Create a degraded federation if there are offline nodes
+                fed.degrade_federation(&process_mgr).await?;
+
+                Ok(Arc::new(fed))
+            }
+        });
+
+        let gw_cln = JitTryAnyhow::new_try({
+            let process_mgr = process_mgr.to_owned();
+            let cln = cln.clone();
+            move || async move {
+                let cln = cln.get_try().await?.deref().clone();
+                Ok(Arc::new(
+                    Gatewayd::new(&process_mgr, LightningNode::Cln(cln)).await?,
+                ))
+            }
+        });
+        let gw_cln_registered = JitTryAnyhow::new_try({
+            let gw_cln = gw_cln.clone();
+            let fed = fed.clone();
+            move || async move {
+                let gw_cln = gw_cln.get_try().await?.deref();
+                let fed = fed.get_try().await?.deref();
+
+                gw_cln.connect_fed(fed).await?;
+                Ok(Arc::new(()))
+            }
+        });
+        let gw_lnd = JitTryAnyhow::new_try({
+            let process_mgr = process_mgr.to_owned();
+            let lnd = lnd.clone();
+            move || async move {
+                let lnd = lnd.get_try().await?.deref().clone();
+                Ok(Arc::new(
+                    Gatewayd::new(&process_mgr, LightningNode::Lnd(lnd)).await?,
+                ))
+            }
+        });
+        let gw_lnd_registered = JitTryAnyhow::new_try({
+            let gw_lnd = gw_lnd.clone();
+            let fed = fed.clone();
+            move || async move {
+                let gw_lnd = gw_lnd.get_try().await?.deref();
+                let fed = fed.get_try().await?.deref();
+
+                gw_lnd.connect_fed(fed).await?;
+                Ok(Arc::new(()))
+            }
+        });
+
+        let channel_opened = JitTryAnyhow::new_try({
+            let process_mgr = process_mgr.to_owned();
+            let lnd = lnd.clone();
+            let cln = cln.clone();
+            let bitcoind = bitcoind.clone();
+            move || async move {
+                let bitcoind = bitcoind.get_try().await?.deref().clone();
+                let lnd = lnd.get_try().await?.deref().clone();
+                let cln = cln.get_try().await?.deref().clone();
+                open_channel(&process_mgr, &bitcoind, &cln, &lnd).await?;
+                Ok(Arc::new(()))
+            }
+        });
+
+        let fed_epoch_generated = JitTryAnyhow::new_try({
+            let fed = fed.clone();
+            move || async move {
+                let fed = fed.get_try().await?.deref().clone();
+                fed.mine_then_wait_blocks_sync(10).await?;
+                Ok(Arc::new(()))
+            }
+        });
+        let fed_client_joined = JitTryAnyhow::new_try({
+            let fed = fed.clone();
+            move || async move {
+                let fed = fed.get_try().await?.deref();
+                cmd!(fed.internal_client(), "join-federation", fed.invite_code()?)
+                    .run()
+                    .await?;
+                Ok(Arc::new(()))
+            }
+        });
+
+        Ok(DevJitFed {
+            bitcoind,
+            cln,
+            lnd,
+            fed,
+            gw_cln,
+            gw_cln_registered,
+            gw_lnd,
+            gw_lnd_registered,
+            electrs,
+            esplora,
+            channel_opened,
+            fed_client_joined,
+            fed_epoch_generated,
+            start_time,
+        })
+    }
+
+    pub async fn electrs(&self) -> anyhow::Result<&Electrs> {
+        Ok(self.electrs.get_try().await?.deref())
+    }
+    pub async fn esplora(&self) -> anyhow::Result<&Esplora> {
+        Ok(self.esplora.get_try().await?.deref())
+    }
+    pub async fn cln(&self) -> anyhow::Result<&Lightningd> {
+        Ok(self.cln.get_try().await?.deref())
+    }
+    pub async fn lnd(&self) -> anyhow::Result<&Lnd> {
+        Ok(self.lnd.get_try().await?.deref())
+    }
+    pub async fn gw_cln(&self) -> anyhow::Result<&Gatewayd> {
+        Ok(self.gw_cln.get_try().await?.deref())
+    }
+    pub async fn gw_cln_registered(&self) -> anyhow::Result<&Gatewayd> {
+        self.gw_cln_registered.get_try().await?;
+        Ok(self.gw_cln.get_try().await?.deref())
+    }
+    pub async fn gw_lnd(&self) -> anyhow::Result<&Gatewayd> {
+        Ok(self.gw_lnd.get_try().await?.deref())
+    }
+    pub async fn gw_lnd_registered(&self) -> anyhow::Result<&Gatewayd> {
+        self.gw_lnd_registered.get_try().await?;
+        Ok(self.gw_lnd.get_try().await?.deref())
+    }
+    pub async fn fed(&self) -> anyhow::Result<&Federation> {
+        Ok(self.fed.get_try().await?.deref())
+    }
+    pub async fn bitcoind(&self) -> anyhow::Result<&Bitcoind> {
+        Ok(self.bitcoind.get_try().await?.deref())
+    }
+
+    pub async fn client_registered(&self) -> anyhow::Result<Client> {
+        self.fed_client_joined.get_try().await?;
+        Ok(self.fed().await?.internal_client().clone())
+    }
+
+    pub async fn client_gw_registered(&self) -> anyhow::Result<Client> {
+        self.fed_client_joined.get_try().await?;
+        // Initialize fedimint-cli
+        self.fed().await?.await_gateways_registered().await?;
+        Ok(self.fed().await?.internal_client().clone())
+    }
+
+    pub async fn finalize(&self, process_mgr: &ProcessManager) -> anyhow::Result<()> {
+        let fed_size = process_mgr.globals.FM_FED_SIZE;
+        let offline_nodes = process_mgr.globals.FM_OFFLINE_NODES;
+        anyhow::ensure!(
+            fed_size > 3 * offline_nodes,
+            "too many offline nodes ({offline_nodes}) to reach consensus"
+        );
+
+        std::env::set_var("FM_GWID_CLN", self.gw_cln().await?.gateway_id().await?);
+        std::env::set_var("FM_GWID_LND", self.gw_lnd().await?.gateway_id().await?);
+        info!(target: LOG_DEVIMINT, "Setup gateway environment variables");
+
+        let _ = self.client_gw_registered().await?;
+        let _ = self.channel_opened.get_try().await?;
+        let _ = self.gw_cln_registered().await?;
+        let _ = self.gw_lnd_registered().await?;
+        let _ = self.cln().await?;
+        let _ = self.lnd().await?;
+        let _ = self.electrs().await?;
+        let _ = self.esplora().await?;
+        let _ = self.fed_epoch_generated.get_try().await?;
+
+        info!(
+            target: LOG_DEVIMINT,
+            fed_size,
+            offline_nodes,
+            elapsed_ms = %self.start_time.elapsed()?.as_millis(),
+            "Dev federation ready",
+        );
+        Ok(())
+    }
 }

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -167,6 +167,19 @@ impl Bitcoind {
         Ok(tokio::task::block_in_place(|| self.client.get_block_count())? + 1)
     }
 
+    pub async fn mine_blocks_no_wait(&self, block_num: u64) -> Result<u64> {
+        let start_time = Instant::now();
+        debug!(target: LOG_DEVIMINT, ?block_num, "Mining bitcoin blocks");
+        let addr = self.get_new_address().await?;
+        let initial_block_count = self.get_block_count().await?;
+        self.generate_to_address(block_num, &addr).await?;
+        debug!(target: LOG_DEVIMINT,
+            elapsed_ms = %start_time.elapsed().as_millis(),
+            ?block_num, "Mined blocks (no wait)");
+
+        Ok(initial_block_count)
+    }
+
     pub async fn mine_blocks(&self, block_num: u64) -> Result<()> {
         let start_time = Instant::now();
         debug!(target: LOG_DEVIMINT, ?block_num, "Mining bitcoin blocks");

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -6,6 +6,8 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use bitcoincore_rpc::bitcoin::hashes::hex::ToHex;
+use bitcoincore_rpc::bitcoin::{Address, BlockHash};
+use bitcoincore_rpc::bitcoincore_rpc_json::{GetBalancesResult, GetBlockchainInfoResult};
 use bitcoincore_rpc::{bitcoin, RpcApi};
 use cln_rpc::ClnRpc;
 use fedimint_core::encoding::Encodable;
@@ -29,7 +31,7 @@ use crate::{cmd, poll_eq};
 
 #[derive(Clone)]
 pub struct Bitcoind {
-    pub(crate) client: Arc<bitcoincore_rpc::Client>,
+    pub client: Arc<bitcoincore_rpc::Client>,
     pub(crate) wallet_client: Arc<JitTryAnyhow<Arc<bitcoincore_rpc::Client>>>,
     pub(crate) _process: ProcessHandle,
 }
@@ -141,42 +143,37 @@ impl Bitcoind {
     /// Poll until bitcoind rpc responds for basic commands
     pub async fn poll_ready(&self) -> anyhow::Result<()> {
         poll("btcoind rpc ready", Duration::from_secs(10), || async {
-            tokio::task::block_in_place(|| self.client().get_block_count())
-                .map_err(|e| ControlFlow::Continue::<anyhow::Error, _>(e.into()))?;
+            self.get_block_count()
+                .await
+                .map_err(ControlFlow::Continue::<anyhow::Error, _>)?;
             Ok(())
         })
         .await
     }
 
-    /// Client
-    pub fn client(&self) -> &Arc<bitcoincore_rpc::Client> {
-        &self.client
-    }
-
     /// Client that can has wallet initialized, can generate internal addresses
     /// and send funds
-    pub async fn wallet_client(&self) -> anyhow::Result<&Arc<bitcoincore_rpc::Client>> {
-        Ok(self.wallet_client.get_try().await?)
+    pub async fn wallet_client(&self) -> anyhow::Result<&Self> {
+        self.wallet_client.get_try().await?;
+        Ok(self)
     }
+
     /// Returns the total number of blocks in the chain.
     ///
     /// Fedimint's IBitcoindRpc considers block count the total number of
     /// blocks, where bitcoind's rpc returns the height. Since the genesis
     /// block has height 0, we need to add 1 to get the total block count.
-    pub fn get_block_count(&self) -> Result<u64> {
-        Ok(self.client().get_block_count()? + 1)
+    pub async fn get_block_count(&self) -> Result<u64> {
+        Ok(tokio::task::block_in_place(|| self.client.get_block_count())? + 1)
     }
 
     pub async fn mine_blocks(&self, block_num: u64) -> Result<()> {
         let start_time = Instant::now();
         debug!(target: LOG_DEVIMINT, ?block_num, "Mining bitcoin blocks");
-        let client = self.wallet_client().await?;
-        let addr = client.get_new_address(None, None)?;
-        let initial_block_count = client.get_block_count()?;
-        tokio::task::block_in_place(|| client.generate_to_address(block_num, &addr))?;
-        while tokio::task::block_in_place(|| client.get_block_count())?
-            < initial_block_count + block_num
-        {
+        let addr = self.get_new_address().await?;
+        let initial_block_count = self.get_block_count().await?;
+        self.generate_to_address(block_num, &addr).await?;
+        while self.get_block_count().await? < initial_block_count + block_num {
             trace!(target: LOG_DEVIMINT, ?block_num, "Waiting for blocks to be mined");
             sleep(Duration::from_millis(100)).await;
         }
@@ -191,33 +188,81 @@ impl Bitcoind {
     pub async fn send_to(&self, addr: String, amount: u64) -> Result<bitcoin::Txid> {
         debug!(target: LOG_DEVIMINT, amount, addr, "Sending funds from bitcoind");
         let amount = bitcoin::Amount::from_sat(amount);
-        let tx = self.wallet_client().await?.send_to_address(
-            &bitcoin::Address::from_str(&addr)?,
-            amount,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        )?;
+        let tx = self
+            .wallet_client()
+            .await?
+            .send_to_address(&bitcoin::Address::from_str(&addr)?, amount)
+            .await?;
         Ok(tx)
     }
 
     pub async fn get_txout_proof(&self, txid: &bitcoin::Txid) -> Result<String> {
-        let proof = self.client().get_tx_out_proof(&[*txid], None)?;
+        let proof = self.get_tx_out_proof(&[*txid], None).await?;
         Ok(proof.to_hex())
     }
 
     pub async fn get_raw_transaction(&self, txid: &bitcoin::Txid) -> Result<String> {
-        let tx = self.client().get_raw_transaction(txid, None)?;
+        let tx = self.client.get_raw_transaction(txid, None)?;
         let bytes = tx.consensus_encode_to_vec();
         Ok(bytes.to_hex())
     }
 
-    pub async fn get_new_address(&self) -> Result<String> {
-        let addr = self.wallet_client().await?.get_new_address(None, None)?;
-        Ok(addr.to_string())
+    pub async fn get_new_address(&self) -> Result<Address> {
+        let client = &self.wallet_client().await?;
+        let addr = tokio::task::block_in_place(|| client.client.get_new_address(None, None))?;
+        Ok(addr)
+    }
+
+    pub async fn generate_to_address(
+        &self,
+        block_num: u64,
+        address: &Address,
+    ) -> Result<Vec<BlockHash>> {
+        let client = &self.wallet_client().await?;
+        Ok(tokio::task::block_in_place(|| {
+            client.client.generate_to_address(block_num, address)
+        })?)
+    }
+
+    pub async fn get_tx_out_proof(
+        &self,
+        txid: &[bitcoin::Txid],
+        block_hash: Option<&BlockHash>,
+    ) -> anyhow::Result<Vec<u8>> {
+        let client = &self.wallet_client().await?;
+        Ok(tokio::task::block_in_place(|| {
+            client.client.get_tx_out_proof(txid, block_hash)
+        })?)
+    }
+
+    pub async fn get_blockchain_info(&self) -> anyhow::Result<GetBlockchainInfoResult> {
+        Ok(tokio::task::block_in_place(|| {
+            self.client.get_blockchain_info()
+        })?)
+    }
+
+    pub async fn send_to_address(
+        &self,
+        addr: &Address,
+        amount: bitcoin::Amount,
+    ) -> anyhow::Result<bitcoin::Txid> {
+        let client = self.wallet_client().await?;
+        Ok(tokio::task::block_in_place(|| {
+            client
+                .client
+                .send_to_address(addr, amount, None, None, None, None, None, None)
+        })?)
+    }
+
+    pub(crate) async fn get_balances(&self) -> anyhow::Result<GetBalancesResult> {
+        let client = self.wallet_client().await?;
+        Ok(tokio::task::block_in_place(|| {
+            client.client.get_balances()
+        })?)
+    }
+
+    pub(crate) fn get_jsonrpc_client(&self) -> &bitcoincore_rpc::jsonrpc::Client {
+        self.client.get_jsonrpc_client()
     }
 }
 
@@ -323,8 +368,8 @@ impl Lightningd {
         poll("lightningd block processing", None, || async {
             let btc_height = self
                 .bitcoind
-                .client()
                 .get_blockchain_info()
+                .await
                 .context("bitcoind getblockchaininfo")
                 .map_err(ControlFlow::Continue)?
                 .blocks;

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -368,7 +368,7 @@ impl Federation {
 
     pub async fn await_block_sync(&self) -> Result<u64> {
         let finality_delay = self.get_finality_delay().await?;
-        let block_count = self.bitcoind.get_block_count()?;
+        let block_count = self.bitcoind.get_block_count().await?;
         let expected = block_count.saturating_sub(finality_delay.into());
         cmd!(self.client, "dev", "wait-block-count", expected)
             .run()

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -45,11 +45,18 @@ impl Gatewayd {
             )
             .await?;
 
-        Ok(Self {
+        let gatewayd = Self {
             ln: Some(ln),
             _process: process,
             addr,
-        })
+        };
+        poll(
+            "waiting for gateway to be ready to respond to rpc",
+            Duration::from_secs(30),
+            || async { gatewayd.gateway_id().await.map_err(ControlFlow::Continue) },
+        )
+        .await?;
+        Ok(gatewayd)
     }
 
     pub fn set_lightning_node(&mut self, ln_node: LightningNode) {

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -109,6 +109,7 @@ impl Drop for ProcessHandleInner {
     }
 }
 
+#[derive(Clone)]
 pub struct ProcessManager {
     pub globals: super::vars::Global,
 }


### PR DESCRIPTION
Decided to try `Jit<T>` all the way.

Discovered limitations (`JitCore::get` not being `Send`), and a bug (incorrect handling of `Clone` on `JitCore`).

Implemented `JitFed` which is `DevFed` where every major step is `Jit<T>`, potentially waiting for previous `Jit<T>`s.

Improved some minor other things I've found along the way.

I test everything with `env RUST_LOG=devimint=debug CARGO_PROFILE=ci j devimint-env` (multiple runs). Not exactly scientific, but will have to do for now.

Before:

```
2024-03-22T05:54:08.245424Z DEBUG devimint: Starting exec command elapsed_ms=14992
2024-03-22T05:54:30.448997Z DEBUG devimint: Starting exec command elapsed_ms=13799
2024-03-22T05:54:50.507175Z DEBUG devimint: Starting exec command elapsed_ms=14319
2024-03-22T05:55:10.860077Z DEBUG devimint: Starting exec command elapsed_ms=13667
```

After:

```
2024-03-22T06:43:32.096970Z DEBUG devimint: Starting exec command elapsed_ms=10874
2024-03-22T06:43:56.014684Z DEBUG devimint: Starting exec command elapsed_ms=9933
2024-03-22T06:44:16.107255Z DEBUG devimint: Starting exec command elapsed_ms=9931
2024-03-22T06:44:49.697992Z DEBUG devimint: Starting exec command elapsed_ms=10002
```