### PR TITLE
chore: run one round of tests in hourly workflow

### DIFF
--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -78,9 +78,9 @@ jobs:
         run: |
           set -euo pipefail
           # first one might do nothing
-          nix build -L .#wasm32-unknown.ci.ciTestAll5Times --keep-failed
+          nix build -L .#wasm32-unknown.ci.ciTestAll --keep-failed
           # but this one will run
-          nix build -L .#wasm32-unknown.ci.ciTestAll5Times --rebuild --keep-failed
+          nix build -L .#wasm32-unknown.ci.ciTestAll --rebuild --keep-failed
 
       - name: Wasm Tests
         run: |


### PR DESCRIPTION
Seems like 5 takes more than 75 minutes (timeout), so let's start small and see how it goes.