### PR TITLE
feat: Make claim_funded_incoming_contract public

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1396,7 +1396,7 @@ impl LightningClientModule {
 
     /// Claim the funded, unspent incoming contract by submitting a transaction
     /// to the federation and awaiting the primary module's outputs
-    async fn claim_funded_incoming_contract<M: Serialize + Send + Sync>(
+    pub async fn claim_funded_incoming_contract<M: Serialize + Send + Sync>(
         &self,
         key_pair: KeyPair,
         contract_id: ContractId,


### PR DESCRIPTION
Missed this in #3820 but it'd be nice to have this publicly available so we don't need to scan everytime we try to claim. We can instead give the user the `contract_id`s they need to claim