### PR TITLE
chore: add `fedimint-core` high-level docstrings

### DIFF
--- a/fedimint-core/src/backup.rs
+++ b/fedimint-core/src/backup.rs
@@ -1,3 +1,7 @@
+//! Federation-stored client backups
+//!
+//! Federations can store client-encrypted backups to help
+//! clients recover from a snapshot, instead of a blank slate.
 use std::time::SystemTime;
 
 use fedimint_core::encoding::{Decodable, Encodable};

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -1,6 +1,10 @@
 //! This module defines a binary encoding interface which is more suitable for
 //! consensus critical encoding than e.g. `bincode`. Over time all structs that
 //! need to be encoded to binary will be migrated to this interface.
+//!
+//! This code is based on corresponding `rust-bitcoin` types.
+//!
+//! See [`Encodable`] and [`Decodable`] for two main traits.
 
 pub mod as_hex;
 mod btc;

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -1,3 +1,21 @@
+//! Fedimint Core library
+//!
+//! `fedimint-core` contains are commonly used types, utilities and primitives,
+//! shared between both client and server code.
+//!
+//! Things that are server-side only typically live in `fedimint-server`, and
+//! client-side only in `fedimint-client`.
+//!
+//! ### Wasm support
+//!
+//! All code in `fedimint-core` needs to compile on Wasm, and `fedimint-core`
+//! includes helpers and wrappers around non-wasm-safe utitlies.
+//!
+//! In particular:
+//!
+//! * [`fedimint_core::task`] for task spawning and control
+//! * [`fedimint_core::time`] for time-related operations
+
 #![allow(where_clauses_object_safety)] // https://github.com/dtolnay/async-trait/issues/228
 extern crate self as fedimint_core;
 
@@ -24,33 +42,56 @@ pub use crate::core::server;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 
+/// Admin (guardian) client types
 pub mod admin_client;
+/// Client API request handling
 pub mod api;
+/// Federation-stored client backups
 pub mod backup;
+/// Gradual bitcoin dependency migration helpers
 pub mod bitcoin_migration;
 pub mod bitcoinrpc;
 pub mod cancellable;
+/// Federation configuration
 pub mod config;
+/// Fundamental types
 pub mod core;
+/// Database handling
 pub mod db;
+/// Consensus encoding
 pub mod encoding;
 pub mod endpoint_constants;
+/// Common environment variables
 pub mod envs;
 pub mod epoch;
+/// Formatting helpers
 pub mod fmt_utils;
+/// Hex encoding helpers
 pub mod hex;
+/// Common macros
 #[macro_use]
 pub mod macros;
+/// Extenable module sysystem
 pub mod module;
+/// Peer networking
 pub mod net;
+/// Client query system
 pub mod query;
+/// Task handling, including wasm safe logic
 pub mod task;
+/// Types handling per-denomination values
 pub mod tiered;
+/// Types handling multiple per-denomination values
 pub mod tiered_multi;
+/// Time handling, wasm safe functionality
 pub mod time;
+/// Timing helpers
 pub mod timing;
+/// Fedimint transaction (inpus + outputs + signature) types
 pub mod transaction;
+/// Peg-in txo proofs
 pub mod txoproof;
+/// General purpose utilities
 pub mod util;
 
 /// Atomic BFT unit containing consensus items

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -1,3 +1,16 @@
+//! Fedimint supports modules to allow extending it's functionality.
+//! Some of the standard functionality is implemented in form of modules as
+//! well.
+//!
+//! The top level server-side types are:
+//!
+//! * [`fedimint_core::module::ModuleInit`]
+//! * [`fedimint_core::module::ServerModule`]
+//!
+//! Top level client-side types are:
+//!
+//! * `ClientModuleInit` (in `fedimint_client`)
+//! * `ClientModule` (in `fedimint_client`)
 pub mod audit;
 pub mod registry;
 


### PR DESCRIPTION
Please don't be too nit-picky. It's better than nothing.