### PR TITLE
 chore(metrics): labeled grouped promethus metrics for wallet module 

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -4,6 +4,8 @@ substituters = "substituters"
 wel = "wel"
 # common mistake that typos doesn't detect automatically
 reasponse= "response"
+# useful for "in/out" in the code
+inout="inout"
 
 [files]
 extend-exclude = [

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -21,8 +21,6 @@ use fedimint_core::{
     apply, async_trait_maybe_send, push_db_key_items, push_db_pair_items, Amount, NumPeersExt,
     OutPoint, PeerId, ServerModule, Tiered, TieredMultiZip,
 };
-use fedimint_metrics::prometheus::register_histogram_with_registry;
-use fedimint_metrics::{histogram_opts, lazy_static, Histogram, AMOUNTS_BUCKETS_SATS, REGISTRY};
 pub use fedimint_mint_common as common;
 use fedimint_mint_common::config::{
     MintClientConfig, MintConfig, MintConfigConsensus, MintConfigLocal, MintConfigPrivate,
@@ -36,6 +34,10 @@ use fedimint_mint_common::{
 use fedimint_server::config::distributedgen::{evaluate_polynomial_g2, scalar, PeerHandleOps};
 use futures::StreamExt;
 use itertools::Itertools;
+use metrics::{
+    MINT_ISSUED_ECASH_FEES_SATS, MINT_ISSUED_ECASH_SATS, MINT_REDEEMED_ECASH_FEES_SATS,
+    MINT_REDEEMED_ECASH_SATS,
+};
 use rand::rngs::OsRng;
 use secp256k1_zkp::SECP256K1;
 use strum::IntoEnumIterator;
@@ -54,44 +56,7 @@ use crate::db::{
     NonceKeyPrefix,
 };
 
-lazy_static! {
-    static ref MINT_REDEEMED_ECASH_SATS: Histogram = register_histogram_with_registry!(
-        histogram_opts!(
-            "mint_redeemed_ecash_sats",
-            "Value of redeemed e-cash notes in sats",
-            AMOUNTS_BUCKETS_SATS.clone()
-        ),
-        REGISTRY
-    )
-    .unwrap();
-    static ref MINT_REDEEMED_ECASH_FEES_SATS: Histogram = register_histogram_with_registry!(
-        histogram_opts!(
-            "mint_redeemed_ecash_fees_sats",
-            "Value of e-cash fees during reissue in sats",
-            AMOUNTS_BUCKETS_SATS.clone()
-        ),
-        REGISTRY
-    )
-    .unwrap();
-    static ref MINT_ISSUED_ECASH_SATS: Histogram = register_histogram_with_registry!(
-        histogram_opts!(
-            "mint_issued_ecash_sats",
-            "Value of issued e-cash notes in sats",
-            AMOUNTS_BUCKETS_SATS.clone()
-        ),
-        REGISTRY
-    )
-    .unwrap();
-    static ref MINT_ISSUED_ECASH_FEES_SATS: Histogram = register_histogram_with_registry!(
-        histogram_opts!(
-            "mint_issued_ecash_fees_sats",
-            "Value of e-cash fees during issue in sats",
-            AMOUNTS_BUCKETS_SATS.clone()
-        ),
-        REGISTRY
-    )
-    .unwrap();
-}
+mod metrics;
 
 #[derive(Debug, Clone)]
 pub struct MintInit;

--- a/modules/fedimint-mint-server/src/metrics.rs
+++ b/modules/fedimint-mint-server/src/metrics.rs
@@ -1,11 +1,36 @@
-use fedimint_metrics::prometheus::register_histogram_with_registry;
-use fedimint_metrics::{histogram_opts, lazy_static, Histogram, AMOUNTS_BUCKETS_SATS, REGISTRY};
+use fedimint_metrics::prometheus::{
+    register_histogram_vec_with_registry, register_histogram_with_registry,
+};
+use fedimint_metrics::{
+    histogram_opts, lazy_static, Histogram, HistogramVec, AMOUNTS_BUCKETS_SATS, REGISTRY,
+};
 
 lazy_static! {
+    pub(crate) static ref MINT_INOUT_SATS: HistogramVec = register_histogram_vec_with_registry!(
+        histogram_opts!(
+            "mint_inout_sats",
+            "Value of input/output e-cash notes in sats",
+            AMOUNTS_BUCKETS_SATS.clone()
+        ),
+        &["direction"],
+        REGISTRY
+    )
+    .unwrap();
+    pub(crate) static ref MINT_INOUT_FEES_SATS: HistogramVec =
+        register_histogram_vec_with_registry!(
+            histogram_opts!(
+                "mint_inout_fees_sats",
+                "Value of input/output e-cash fees in sats",
+                AMOUNTS_BUCKETS_SATS.clone()
+            ),
+            &["direction"],
+            REGISTRY
+        )
+        .unwrap();
     pub(crate) static ref MINT_REDEEMED_ECASH_SATS: Histogram = register_histogram_with_registry!(
         histogram_opts!(
             "mint_redeemed_ecash_sats",
-            "Value of redeemed e-cash notes in sats",
+            "Value of redeemed e-cash notes in sats (deprecated - prefer mint_inout_sats)",
             AMOUNTS_BUCKETS_SATS.clone()
         ),
         REGISTRY
@@ -15,7 +40,7 @@ lazy_static! {
         register_histogram_with_registry!(
             histogram_opts!(
                 "mint_redeemed_ecash_fees_sats",
-                "Value of e-cash fees during reissue in sats",
+                "Value of e-cash fees during reissue in sats (deprecated - prefer mint_inout_fees_sats)",
                 AMOUNTS_BUCKETS_SATS.clone()
             ),
             REGISTRY
@@ -24,7 +49,7 @@ lazy_static! {
     pub(crate) static ref MINT_ISSUED_ECASH_SATS: Histogram = register_histogram_with_registry!(
         histogram_opts!(
             "mint_issued_ecash_sats",
-            "Value of issued e-cash notes in sats",
+            "Value of issued e-cash notes in sats (deprecated - prefer mint_inout_sats)",
             AMOUNTS_BUCKETS_SATS.clone()
         ),
         REGISTRY
@@ -34,7 +59,7 @@ lazy_static! {
         register_histogram_with_registry!(
             histogram_opts!(
                 "mint_issued_ecash_fees_sats",
-                "Value of e-cash fees during issue in sats",
+                "Value of e-cash fees during issue in sats (deprecated - prefer mint_inout_fees_sats)",
                 AMOUNTS_BUCKETS_SATS.clone()
             ),
             REGISTRY

--- a/modules/fedimint-mint-server/src/metrics.rs
+++ b/modules/fedimint-mint-server/src/metrics.rs
@@ -1,0 +1,43 @@
+use fedimint_metrics::prometheus::register_histogram_with_registry;
+use fedimint_metrics::{histogram_opts, lazy_static, Histogram, AMOUNTS_BUCKETS_SATS, REGISTRY};
+
+lazy_static! {
+    pub(crate) static ref MINT_REDEEMED_ECASH_SATS: Histogram = register_histogram_with_registry!(
+        histogram_opts!(
+            "mint_redeemed_ecash_sats",
+            "Value of redeemed e-cash notes in sats",
+            AMOUNTS_BUCKETS_SATS.clone()
+        ),
+        REGISTRY
+    )
+    .unwrap();
+    pub(crate) static ref MINT_REDEEMED_ECASH_FEES_SATS: Histogram =
+        register_histogram_with_registry!(
+            histogram_opts!(
+                "mint_redeemed_ecash_fees_sats",
+                "Value of e-cash fees during reissue in sats",
+                AMOUNTS_BUCKETS_SATS.clone()
+            ),
+            REGISTRY
+        )
+        .unwrap();
+    pub(crate) static ref MINT_ISSUED_ECASH_SATS: Histogram = register_histogram_with_registry!(
+        histogram_opts!(
+            "mint_issued_ecash_sats",
+            "Value of issued e-cash notes in sats",
+            AMOUNTS_BUCKETS_SATS.clone()
+        ),
+        REGISTRY
+    )
+    .unwrap();
+    pub(crate) static ref MINT_ISSUED_ECASH_FEES_SATS: Histogram =
+        register_histogram_with_registry!(
+            histogram_opts!(
+                "mint_issued_ecash_fees_sats",
+                "Value of e-cash fees during issue in sats",
+                AMOUNTS_BUCKETS_SATS.clone()
+            ),
+            REGISTRY
+        )
+        .unwrap();
+}


### PR DESCRIPTION
It's often easier to chart things in Prometheus when similiar things
are grouped and use labels.

Keep the previous metrics for backward compat, it doesn't cost much
to keep them around.