### PR TITLE
chore(ci): re-enable hourly runs

### DIFF
--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -1,7 +1,6 @@
 on:
-  # disable cron while debugging
-  # schedule:
-  #   - cron:  '30 * * * *' # every hour at `x:30`
+  schedule:
+    - cron:  '30 * * * *' # every hour at `x:30`
   workflow_dispatch:
 
 name: Hourly check


### PR DESCRIPTION
https://github.com/fedimint/fedimint/actions/runs/8392962219
https://github.com/fedimint/fedimint/actions/runs/8392961815
https://github.com/fedimint/fedimint/actions/runs/8392961211

Seems to be working fine when running manually, let's give it another go.