### PR TITLE
[Backport releases/v0.3] chore(gatewayd): add clap --version

### DIFF
--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -601,7 +601,11 @@ impl Gatewayd {
     pub async fn version_or_default() -> Version {
         match cmd!(Gatewayd, "--version").out_string().await {
             Ok(version) => parse_clap_version(&version),
-            Err(_) => DEFAULT_VERSION,
+            Err(_) => cmd!(Gatewayd, "version-hash")
+                .out_string()
+                .await
+                .map(|v| version_hash_to_version(&v).unwrap_or(DEFAULT_VERSION))
+                .unwrap_or(DEFAULT_VERSION),
         }
     }
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -118,6 +118,7 @@ const DEFAULT_MODULE_KINDS: [(ModuleInstanceId, &ModuleKind); 2] = [
 ];
 
 #[derive(Parser)]
+#[command(version)]
 struct GatewayOpts {
     #[clap(subcommand)]
     mode: LightningMode,


### PR DESCRIPTION
# Description
Backport of #4701 to `releases/v0.3`.