### PR TITLE
Add missing state machine migration

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -348,6 +348,14 @@ pub async fn apply_migrations_client(
         .get_value(&DatabaseVersionKey(module_instance_id))
         .await;
 
+    info!(
+        ?disk_version,
+        ?target_db_version,
+        module_instance_id,
+        kind,
+        "Migrating client module database"
+    );
+
     let db_version = if let Some(disk_version) = disk_version {
         let mut current_db_version = disk_version;
 
@@ -491,7 +499,8 @@ pub async fn remove_old_and_persist_new_active_states(
             module_instance_id,
             state: bytes,
         })
-        .await;
+        .await
+        .expect("Did not delete anything");
     }
 
     let new_active_states = new_active_states
@@ -526,7 +535,8 @@ pub async fn remove_old_and_persist_new_inactive_states(
             module_instance_id,
             state: bytes,
         })
-        .await;
+        .await
+        .expect("Did not delete anything");
     }
 
     let new_inactive_states = new_inactive_states

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -186,8 +186,8 @@ impl LightningReceiveSubmittedOffer {
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct LightningReceiveConfirmedInvoice {
-    invoice: Bolt11Invoice,
-    receiving_key: ReceivingKey,
+    pub(crate) invoice: Bolt11Invoice,
+    pub(crate) receiving_key: ReceivingKey,
 }
 
 impl LightningReceiveConfirmedInvoice {


### PR DESCRIPTION
I was considering to also rebuild the other, existing migration in the way I built the new one, eliminating the need for the `LightningReceiveStates::SubmittedOfferV0` variant, but that seems like too big of a change to backport and will follow in a separate PR to master only.

Fixes #4700 