### PR TITLE
chore: Collect remaining env variables in envs.rs modules

### DIFF
--- a/crypto/aead/src/envs.rs
+++ b/crypto/aead/src/envs.rs
@@ -1,0 +1,2 @@
+// Env variable to make the creation Argon2 easier for testing
+pub const FM_TEST_FAST_WEAK_CRYPTO_ENV: &str = "FM_TEST_FAST_WEAK_CRYPTO";

--- a/crypto/aead/src/lib.rs
+++ b/crypto/aead/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod envs;
+
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
@@ -9,6 +11,8 @@ use rand::rngs::OsRng;
 use rand::Rng;
 use ring::aead::Nonce;
 pub use ring::aead::{Aad, LessSafeKey, UnboundKey, NONCE_LEN};
+
+use crate::envs::FM_TEST_FAST_WEAK_CRYPTO_ENV;
 
 /// Get a random nonce.
 pub fn get_random_nonce() -> ring::aead::Nonce {
@@ -107,7 +111,7 @@ pub fn random_salt() -> String {
 /// for testing
 fn argon2() -> Argon2<'static> {
     let mut params = argon2::ParamsBuilder::default();
-    if let Ok("1") = std::env::var("FM_TEST_FAST_WEAK_CRYPTO").as_deref() {
+    if let Ok("1") = std::env::var(FM_TEST_FAST_WEAK_CRYPTO_ENV).as_deref() {
         params.m_cost(Params::MIN_M_COST);
     }
     Argon2::from(params.build().expect("valid params"))

--- a/devimint/src/bin/faucet.rs
+++ b/devimint/src/bin/faucet.rs
@@ -9,6 +9,10 @@ use axum::Router;
 use clap::Parser;
 use cln_rpc::primitives::{Amount as ClnAmount, AmountOrAny};
 use cln_rpc::ClnRpc;
+use devimint::envs::{
+    FM_BITCOIN_RPC_URL_ENV, FM_CLIENT_DIR_ENV, FM_CLN_SOCKET_ENV, FM_FAUCET_BIND_ADDR_ENV,
+    FM_INVITE_CODE_ENV, FM_PORT_GW_LND_ENV,
+};
 use fedimint_logging::TracingSetup;
 use ln_gateway::rpc::V1_API_ENDPOINT;
 use tokio::net::TcpListener;
@@ -17,15 +21,15 @@ use tower_http::cors::CorsLayer;
 
 #[derive(clap::Parser)]
 struct Cmd {
-    #[clap(long, env = "FM_FAUCET_BIND_ADDR")]
+    #[clap(long, env = FM_FAUCET_BIND_ADDR_ENV)]
     bind_addr: String,
-    #[clap(long, env = "FM_BITCOIN_RPC_URL")]
+    #[clap(long, env = FM_BITCOIN_RPC_URL_ENV)]
     bitcoind_rpc: String,
-    #[clap(long, env = "FM_CLN_SOCKET")]
+    #[clap(long, env = FM_CLN_SOCKET_ENV)]
     cln_socket: String,
-    #[clap(long, env = "FM_PORT_GW_LND")]
+    #[clap(long, env = FM_PORT_GW_LND_ENV)]
     gw_lnd_port: u16,
-    #[clap(long, env = "FM_INVITE_CODE")]
+    #[clap(long, env = FM_INVITE_CODE_ENV)]
     invite_code: Option<String>,
 }
 
@@ -105,7 +109,7 @@ fn get_invite_code(invite_code: Option<String>) -> anyhow::Result<String> {
     match invite_code {
         Some(s) => Ok(s),
         None => {
-            let data_dir = std::env::var("FM_CLIENT_DIR")?;
+            let data_dir = std::env::var(FM_CLIENT_DIR_ENV)?;
             Ok(std::fs::read_to_string(
                 PathBuf::from(data_dir).join("invite-code"),
             )?)

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -6,6 +6,7 @@ use fedimint_core::task::jit::{JitTry, JitTryAnyhow};
 use fedimint_logging::LOG_DEVIMINT;
 use tracing::info;
 
+use crate::envs::{FM_GWID_CLN_ENV, FM_GWID_LND_ENV};
 use crate::external::{Bitcoind, Electrs, Esplora, Lightningd, Lnd};
 use crate::federation::{Client, Federation};
 use crate::gatewayd::Gatewayd;
@@ -261,8 +262,8 @@ impl DevJitFed {
             "too many offline nodes ({offline_nodes}) to reach consensus"
         );
 
-        std::env::set_var("FM_GWID_CLN", self.gw_cln().await?.gateway_id().await?);
-        std::env::set_var("FM_GWID_LND", self.gw_lnd().await?.gateway_id().await?);
+        std::env::set_var(FM_GWID_CLN_ENV, self.gw_cln().await?.gateway_id().await?);
+        std::env::set_var(FM_GWID_LND_ENV, self.gw_lnd().await?.gateway_id().await?);
         info!(target: LOG_DEVIMINT, "Setup gateway environment variables");
 
         let _ = self.client_gw_registered().await?;

--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -1,0 +1,139 @@
+// faucet.rs
+
+// Env variable to TODO
+pub const FM_FAUCET_BIND_ADDR_ENV: &str = "FM_FAUCET_BIND_ADDR";
+
+// Env variable to TODO
+pub const FM_BITCOIN_RPC_URL_ENV: &str = "FM_PASSWORD";
+
+// Env variable to TODO
+pub const FM_CLN_SOCKET_ENV: &str = "FM_CLN_SOCKET";
+
+// Env variable to TODO
+pub const FM_PORT_GW_LND_ENV: &str = "FM_PORT_GW_LND";
+
+// tests.rs
+
+// Env variable to TODO
+pub const FM_PASSWORD_ENV: &str = "FM_PASSWORD";
+
+// gatewayd.rs
+
+// Env variable to TODO
+pub const FM_GATEWAY_DATA_DIR_ENV: &str = "FM_GATEWAY_DATA_DIR";
+
+// Env variable to TODO
+pub const FM_GATEWAY_LISTEN_ADDR_ENV: &str = "FM_GATEWAY_LISTEN_ADDR";
+
+// Env variable to TODO
+pub const FM_GATEWAY_API_ADDR_ENV: &str = "FM_GATEWAY_API_ADDR";
+
+// federation.rs
+
+// Env variable to set client's data directory
+pub const FM_DATA_DIR_ENV: &str = "FM_DATA_DIR";
+
+// Env variable to set the working directory of the client containing the config
+// and db
+pub const FM_CLIENT_DIR_ENV: &str = "FM_CLIENT_DIR";
+
+// devfed.rs
+
+// Env variable to define the gateway_id of the CLN client
+pub const FM_GWID_CLN_ENV: &str = "FM_GWID_CLN";
+
+// Env variable to define the gateway_id of the LND client
+pub const FM_GWID_LND_ENV: &str = "FM_GWID_LND";
+
+// cli.rs
+
+// Env variable to set the testing directory of the client
+pub const FM_TEST_DIR_ENV: &str = "FM_TEST_DIR";
+
+// Env variable to set the size of the federation
+pub const FM_FED_SIZE_ENV: &str = "FM_FED_SIZE";
+
+// Env variable to create a link to the test dir under this path
+pub const FM_LINK_TEST_DIR_ENV: &str = "FM_LINK_TEST_DIR";
+
+// Env variable to run a degraded federation with FM_OFFLINE_NODES shutdown
+pub const FM_OFFLINE_NODES_ENV: &str = "FM_OFFLINE_NODES";
+
+// Env variable to set a federation's invite code
+pub const FM_INVITE_CODE_ENV: &str = "FM_INVITE_CODE";
+
+// util.rs
+
+// Env variable to override gatewayd binary set:
+pub const FM_GATEWAYD_BASE_EXECUTABLE_ENV: &str = "FM_GATEWAYD_BASE_EXECUTABLE";
+
+// Env variable to override override fedimintd binary set:
+pub const FM_FEDIMINTD_BASE_EXECUTABLE_ENV: &str = "FM_FEDIMINTD_BASE_EXECUTABLE";
+
+// Env variable to override fedimint-cli binary set:
+pub const FM_FEDIMINT_CLI_BASE_EXECUTABLE_ENV: &str = "FM_FEDIMINT_CLI_BASE_EXECUTABLE";
+
+// Env variable to override fedimint-cli default command
+// (like "$FM_FEDIMINT_CLI_BASE_EXECUTABLE --data-dir /tmp/xxx ....")
+// set:
+pub const FM_MINT_CLIENT_ENV: &str = "FM_MINT_CLIENT";
+
+// Env variable to override gateway-cli binary set:
+pub const FM_GATEWAY_CLI_BASE_EXECUTABLE_ENV: &str = "FM_GATEWAY_CLI_BASE_EXECUTABLE";
+
+// Env variable to override fedimint-load-test-tool binary set:
+pub const FM_LOAD_TEST_TOOL_BASE_EXECUTABLE_ENV: &str = "FM_LOAD_TEST_TOOL_BASE_EXECUTABLE";
+
+// Env variable to override lightning-cli binary set:
+pub const FM_LIGHTNING_CLI_BASE_EXECUTABLE_ENV: &str = "FM_LIGHTNING_CLI_BASE_EXECUTABLE";
+
+// Env variable to override lightning-cli default command set:
+pub const FM_LIGHTNING_CLI_ENV: &str = "FM_LIGHTNING_CLI";
+
+// Env variable to override lncli binary set:
+pub const FM_LNCLI_BASE_EXECUTABLE_ENV: &str = "FM_LNCLI_BASE_EXECUTABLE";
+
+// Env variable to override lncli default command set:
+pub const FM_LNCLI_ENV: &str = "FM_LNCLI";
+
+// Env variable to override bitcoin-cli binary set:
+pub const FM_BITCOIN_CLI_BASE_EXECUTABLE_ENV: &str = "FM_BITCOIN_CLI_BASE_EXECUTABLE";
+
+// Env variable to override bitcoin-cli default command set:
+pub const FM_BTC_CLIENT_ENV: &str = "FM_BTC_CLIENT";
+
+// Env variable to override bitcoind binary set:
+pub const FM_BITCOIND_BASE_EXECUTABLE_ENV: &str = "FM_BITCOIND_BASE_EXECUTABLE";
+
+// Env variable to override lightningd binary set:
+pub const FM_LIGHTNINGD_BASE_EXECUTABLE_ENV: &str = "FM_LIGHTNINGD_BASE_EXECUTABLE";
+
+// Env variable to override lnd binary set:
+pub const FM_LND_BASE_EXECUTABLE_ENV: &str = "FM_LND_BASE_EXECUTABLE";
+
+// Env variable to override electrs binary set:
+pub const FM_ELECTRS_BASE_EXECUTABLE_ENV: &str = "FM_ELECTRS_BASE_EXECUTABLE";
+
+// Env variable to override esplora binary set:
+pub const FM_ESPLORA_BASE_EXECUTABLE_ENV: &str = "FM_ESPLORA_BASE_EXECUTABLE";
+
+// Env variable to override esplora binary set:
+pub const FM_RECOVERYTOOL_BASE_EXECUTABLE_ENV: &str = "FM_RECOVERYTOOL_BASE_EXECUTABLE";
+
+// Env variable to override esplora binary set:
+pub const FM_FAUCET_BASE_EXECUTABLE_ENV: &str = "FM_FAUCET_BASE_EXECUTABLE";
+
+// Env variable to override esplora binary set:
+pub const FM_FEDIMINT_DBTOOL_BASE_EXECUTABLE_ENV: &str = "FM_FEDIMINT_DBTOOL_BASE_EXECUTABLE";
+
+// Env variable to set the logs directory
+pub const FM_LOGS_DIR_ENV: &str = "FM_LOGS_DIR";
+
+// Env variable to TODO
+pub const FM_BACKWARDS_COMPATIBILITY_TEST_ENV: &str = "FM_BACKWARDS_COMPATIBILITY_TEST";
+
+// Env variable to define command for the CLN client
+pub const FM_GWCLI_CLN_ENV: &str = "FM_GWCLI_CLN";
+
+// Env variable to define command for the LND client
+pub const FM_GWCLI_LND_ENV: &str = "FM_GWCLI_LND";

--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -4,7 +4,7 @@
 pub const FM_FAUCET_BIND_ADDR_ENV: &str = "FM_FAUCET_BIND_ADDR";
 
 // Env variable to TODO
-pub const FM_BITCOIN_RPC_URL_ENV: &str = "FM_PASSWORD";
+pub const FM_BITCOIN_RPC_URL_ENV: &str = "FM_BITCOIN_RPC_URL";
 
 // Env variable to TODO
 pub const FM_CLN_SOCKET_ENV: &str = "FM_CLN_SOCKET";

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -21,7 +21,7 @@ use fedimint_logging::LOG_DEVIMINT;
 use fedimint_server::config::ConfigGenParams;
 use fedimint_testing::federation::local_config_gen_params;
 use fedimint_wallet_client::config::WalletClientConfig;
-use fedimintd::envs::FM_EXTRA_DKG_META_VAR_ENV;
+use fedimintd::envs::FM_EXTRA_DKG_META_ENV;
 use fs_lock::FileLock;
 use futures::future::join_all;
 use rand::Rng;
@@ -667,11 +667,11 @@ async fn set_config_gen_params(
     // Since we are not actually calling `fedimintd` binary, parse and handle
     // `FM_EXTRA_META_DATA` like it would do.
     let mut extra_meta_data = parse_map(
-        &std::env::var(FM_EXTRA_DKG_META_VAR_ENV)
+        &std::env::var(FM_EXTRA_DKG_META_ENV)
             .ok()
             .unwrap_or_default(),
     )
-    .with_context(|| format!("Failed to parse {FM_EXTRA_DKG_META_VAR_ENV}"))
+    .with_context(|| format!("Failed to parse {FM_EXTRA_DKG_META_ENV}"))
     .expect("Failed");
     let mut meta = BTreeMap::from([("federation_name".to_string(), "testfed".to_string())]);
     meta.append(&mut extra_meta_data);

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -21,7 +21,7 @@ use fedimint_logging::LOG_DEVIMINT;
 use fedimint_server::config::ConfigGenParams;
 use fedimint_testing::federation::local_config_gen_params;
 use fedimint_wallet_client::config::WalletClientConfig;
-use fedimintd::FM_EXTRA_DKG_META_VAR;
+use fedimintd::envs::FM_EXTRA_DKG_META_VAR_ENV;
 use fs_lock::FileLock;
 use futures::future::join_all;
 use rand::Rng;
@@ -32,6 +32,7 @@ use tracing::{debug, info};
 use super::external::Bitcoind;
 use super::util::{cmd, parse_map, Command, ProcessHandle, ProcessManager};
 use super::vars::utf8;
+use crate::envs::{FM_CLIENT_DIR_ENV, FM_DATA_DIR_ENV};
 use crate::util::{poll, FedimintdCmd};
 use crate::{poll_eq, vars};
 
@@ -54,10 +55,10 @@ pub struct Client {
 
 impl Client {
     fn clients_dir() -> PathBuf {
-        let data_dir: PathBuf = env::var("FM_DATA_DIR")
-            .expect("FM_DATA_DIR not set")
+        let data_dir: PathBuf = env::var(FM_DATA_DIR_ENV)
+            .expect("FM_DATA_DIR_ENV not set")
             .parse()
-            .expect("FM_DATA_DIR invalid");
+            .expect("FM_DATA_DIR_ENV invalid");
         data_dir.join("clients")
     }
 
@@ -259,13 +260,13 @@ impl Federation {
 
     /// Read the invite code from the client data dir
     pub fn invite_code(&self) -> Result<String> {
-        let data_dir: PathBuf = env::var("FM_CLIENT_DIR")?.parse()?;
+        let data_dir: PathBuf = env::var(FM_CLIENT_DIR_ENV)?.parse()?;
         let invite_code = fs::read_to_string(data_dir.join("invite-code"))?;
         Ok(invite_code)
     }
 
     pub fn invite_code_for(peer_id: PeerId) -> Result<String> {
-        let data_dir: PathBuf = env::var("FM_CLIENT_DIR")?.parse()?;
+        let data_dir: PathBuf = env::var(FM_CLIENT_DIR_ENV)?.parse()?;
         let name = format!("invite-code-{}", peer_id);
         let invite_code = fs::read_to_string(data_dir.join(name))?;
         Ok(invite_code)
@@ -666,11 +667,11 @@ async fn set_config_gen_params(
     // Since we are not actually calling `fedimintd` binary, parse and handle
     // `FM_EXTRA_META_DATA` like it would do.
     let mut extra_meta_data = parse_map(
-        &std::env::var(FM_EXTRA_DKG_META_VAR)
+        &std::env::var(FM_EXTRA_DKG_META_VAR_ENV)
             .ok()
             .unwrap_or_default(),
     )
-    .with_context(|| format!("Failed to parse {FM_EXTRA_DKG_META_VAR}"))
+    .with_context(|| format!("Failed to parse {FM_EXTRA_DKG_META_VAR_ENV}"))
     .expect("Failed");
     let mut meta = BTreeMap::from([("federation_name".to_string(), "testfed".to_string())]);
     meta.append(&mut extra_meta_data);

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use ln_gateway::rpc::V1_API_ENDPOINT;
 
 use crate::cmd;
+use crate::envs::{FM_GATEWAY_API_ADDR_ENV, FM_GATEWAY_DATA_DIR_ENV, FM_GATEWAY_LISTEN_ADDR_ENV};
 use crate::external::LightningNode;
 use crate::federation::Federation;
 use crate::util::{poll, Command, ProcessHandle, ProcessManager};
@@ -29,14 +30,14 @@ impl Gatewayd {
         let addr = format!("http://127.0.0.1:{port}/{V1_API_ENDPOINT}");
         let gateway_env: HashMap<String, String> = HashMap::from_iter([
             (
-                "FM_GATEWAY_DATA_DIR".to_owned(),
+                FM_GATEWAY_DATA_DIR_ENV.to_owned(),
                 format!("{}/{ln_name}", utf8(test_dir)),
             ),
             (
-                "FM_GATEWAY_LISTEN_ADDR".to_owned(),
+                FM_GATEWAY_LISTEN_ADDR_ENV.to_owned(),
                 format!("127.0.0.1:{port}"),
             ),
-            ("FM_GATEWAY_API_ADDR".to_owned(), addr.clone()),
+            (FM_GATEWAY_API_ADDR_ENV.to_owned(), addr.clone()),
         ]);
         let process = process_mgr
             .spawn_daemon(

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -7,6 +7,7 @@ pub use gatewayd::Gatewayd;
 
 pub mod cli;
 pub mod devfed;
+pub mod envs;
 pub mod external;
 pub mod federation;
 pub mod gatewayd;

--- a/devimint/src/main.rs
+++ b/devimint/src/main.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use devimint::cli::CommonArgs;
+use devimint::envs::FM_TEST_DIR_ENV;
 use fedimint_core::fedimint_build_code_version_env;
 use fedimint_core::util::{handle_version_hash_command, write_overwrite_async};
 use fedimint_logging::LOG_DEVIMINT;
@@ -44,11 +45,11 @@ async fn main() -> anyhow::Result<()> {
     let res = match handle_command().await {
         Ok(r) => Ok(r),
         Err(e) => {
-            if let Ok(test_dir) = env::var("FM_TEST_DIR") {
+            if let Ok(test_dir) = env::var(FM_TEST_DIR_ENV) {
                 let ready_file = PathBuf::from(test_dir).join("ready");
                 write_overwrite_async(ready_file, "ERROR").await?;
             } else {
-                warn!(target: LOG_DEVIMINT, "FM_TEST_DIR was not set");
+                warn!(target: LOG_DEVIMINT, "{}", &format!("{} was not set", FM_TEST_DIR_ENV));
             }
             Err(e)
         }

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -24,6 +24,7 @@ use tokio::time::timeout;
 use tracing::{debug, info};
 
 use crate::cli::{cleanup_on_exit, exec_user_command, setup, write_ready_file, CommonArgs};
+use crate::envs::{FM_DATA_DIR_ENV, FM_PASSWORD_ENV};
 use crate::federation::{Client, Federation};
 use crate::util::{poll, LoadTestTool, ProcessManager};
 use crate::{cmd, dev_fed, poll_eq, DevFed, Gatewayd, LightningNode, Lightningd, Lnd};
@@ -352,7 +353,7 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
 
 pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     log_binary_versions().await?;
-    let data_dir = env::var("FM_DATA_DIR")?;
+    let data_dir = env::var(FM_DATA_DIR_ENV)?;
 
     #[allow(unused_variables)]
     let DevFed {
@@ -378,7 +379,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         "--in-file={data_dir}/fedimintd-0/private.encrypt",
         "--out-file={data_dir}/fedimintd-0/config-plaintext.json"
     )
-    .env("FM_PASSWORD", "pass")
+    .env(FM_PASSWORD_ENV, "pass")
     .run()
     .await?;
 
@@ -389,7 +390,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         "--in-file={data_dir}/fedimintd-0/config-plaintext.json",
         "--out-file={data_dir}/fedimintd-0/config-2"
     )
-    .env("FM_PASSWORD", "pass-foo")
+    .env(FM_PASSWORD_ENV, "pass-foo")
     .run()
     .await?;
 
@@ -400,7 +401,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         "--in-file={data_dir}/fedimintd-0/config-2",
         "--out-file={data_dir}/fedimintd-0/config-plaintext-2.json"
     )
-    .env("FM_PASSWORD", "pass-foo")
+    .env(FM_PASSWORD_ENV, "pass-foo")
     .run()
     .await?;
 
@@ -1053,7 +1054,7 @@ pub async fn finish_hold_invoice_payment(
 
 pub async fn cli_load_test_tool_test(dev_fed: DevFed) -> Result<()> {
     log_binary_versions().await?;
-    let data_dir = env::var("FM_DATA_DIR")?;
+    let data_dir = env::var(FM_DATA_DIR_ENV)?;
     let load_test_temp = PathBuf::from(data_dir).join("load-test-temp");
     dev_fed
         .fed
@@ -1760,7 +1761,7 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
         esplora,
     } = dev_fed;
 
-    let data_dir = env::var("FM_DATA_DIR")?;
+    let data_dir = env::var(FM_DATA_DIR_ENV)?;
     let client = fed.new_joined_client("recoverytool-test-client").await?;
 
     let mut fed_utxos_sats = HashSet::from([12_345_000, 23_456_000, 34_567_000]);
@@ -1829,7 +1830,7 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
         "--db",
         "{data_dir}/fedimintd-0/database"
     )
-    .env("FM_PASSWORD", "pass")
+    .env(FM_PASSWORD_ENV, "pass")
     .out_json()
     .await?;
     let outputs = output.as_array().context("expected an array")?;
@@ -1887,7 +1888,7 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
             "--db",
             "{data_dir}/fedimintd-0/database"
         )
-        .env("FM_PASSWORD", "pass")
+        .env(FM_PASSWORD_ENV, "pass")
         .out_json()
         .await?;
         let outputs = output.as_array().context("expected an array")?;

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -20,6 +20,19 @@ use tokio::process::Child;
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
+use crate::envs::{
+    FM_BACKWARDS_COMPATIBILITY_TEST_ENV, FM_BITCOIND_BASE_EXECUTABLE_ENV,
+    FM_BITCOIN_CLI_BASE_EXECUTABLE_ENV, FM_BTC_CLIENT_ENV, FM_ELECTRS_BASE_EXECUTABLE_ENV,
+    FM_ESPLORA_BASE_EXECUTABLE_ENV, FM_FAUCET_BASE_EXECUTABLE_ENV,
+    FM_FEDIMINTD_BASE_EXECUTABLE_ENV, FM_FEDIMINT_CLI_BASE_EXECUTABLE_ENV,
+    FM_FEDIMINT_DBTOOL_BASE_EXECUTABLE_ENV, FM_GATEWAYD_BASE_EXECUTABLE_ENV,
+    FM_GATEWAY_CLI_BASE_EXECUTABLE_ENV, FM_GWCLI_CLN_ENV, FM_GWCLI_LND_ENV,
+    FM_LIGHTNINGD_BASE_EXECUTABLE_ENV, FM_LIGHTNING_CLI_BASE_EXECUTABLE_ENV, FM_LIGHTNING_CLI_ENV,
+    FM_LNCLI_BASE_EXECUTABLE_ENV, FM_LNCLI_ENV, FM_LND_BASE_EXECUTABLE_ENV,
+    FM_LOAD_TEST_TOOL_BASE_EXECUTABLE_ENV, FM_LOGS_DIR_ENV, FM_MINT_CLIENT_ENV,
+    FM_RECOVERYTOOL_BASE_EXECUTABLE_ENV,
+};
+
 // If a binary doesn't provide a clap version, default to the first stable
 // release (v0.2.1)
 const DEFAULT_VERSION: Version = Version::new(0, 2, 1);
@@ -121,7 +134,7 @@ impl ProcessManager {
 
     /// Logs to $FM_LOGS_DIR/{name}.{out,err}
     pub async fn spawn_daemon(&self, name: &str, mut cmd: Command) -> Result<ProcessHandle> {
-        let logs_dir = env::var("FM_LOGS_DIR")?;
+        let logs_dir = env::var(FM_LOGS_DIR_ENV)?;
         let path = format!("{logs_dir}/{name}.log");
         let log = OpenOptions::new()
             .append(true)
@@ -273,7 +286,7 @@ impl Command {
 
     /// Run the command logging the output and error
     pub async fn run_with_logging(&mut self, name: String) -> Result<()> {
-        let logs_dir = env::var("FM_LOGS_DIR")?;
+        let logs_dir = env::var(FM_LOGS_DIR_ENV)?;
         let path = format!("{logs_dir}/{name}.log");
         let log = OpenOptions::new()
             .append(true)
@@ -446,114 +459,72 @@ impl JsonValueExt for serde_json::Value {
 }
 
 const GATEWAYD_FALLBACK: &str = "gatewayd";
-// To override gatewayd binary set:
-const ENV_FM_GATEWAYD_BASE_EXECUTABLE: &str = "FM_GATEWAYD_BASE_EXECUTABLE";
 
 const FEDIMINTD_FALLBACK: &str = "fedimintd";
-// To override fedimintd binary set:
-const ENV_FM_FEDIMINTD_BASE_EXECUTABLE: &str = "FM_FEDIMINTD_BASE_EXECUTABLE";
 
 const FEDIMINT_CLI_FALLBACK: &str = "fedimint-cli";
-// To override fedimint-cli binary set:
-const ENV_FM_FEDIMINT_CLI_BASE_EXECUTABLE: &str = "FM_FEDIMINT_CLI_BASE_EXECUTABLE";
-// To override fedimint-cli default command
-// (like "$FM_FEDIMINT_CLI_BASE_EXECUTABLE --data-dir /tmp/xxx ....")
-// set:
-const ENV_FM_MINT_CLIENT: &str = "FM_MINT_CLIENT";
 
 pub fn get_fedimint_cli_path() -> Vec<String> {
     get_command_str_for_alias(
-        &[ENV_FM_FEDIMINT_CLI_BASE_EXECUTABLE],
+        &[FM_FEDIMINT_CLI_BASE_EXECUTABLE_ENV],
         &[FEDIMINT_CLI_FALLBACK],
     )
 }
 
 const GATEWAY_CLI_FALLBACK: &str = "gateway-cli";
-// To override gateway-cli binary set:
-const ENV_FM_GATEWAY_CLI_BASE_EXECUTABLE: &str = "FM_GATEWAY_CLI_BASE_EXECUTABLE";
 
 pub fn get_gateway_cli_path() -> Vec<String> {
     get_command_str_for_alias(
-        &[ENV_FM_GATEWAY_CLI_BASE_EXECUTABLE],
+        &[FM_GATEWAY_CLI_BASE_EXECUTABLE_ENV],
         &[GATEWAY_CLI_FALLBACK],
     )
 }
 
 const LOAD_TEST_TOOL_FALLBACK: &str = "fedimint-load-test-tool";
-// To override fedimint-load-test-tool binary set:
-const ENV_FM_LOAD_TEST_TOOL_BASE_EXECUTABLE: &str = "FM_LOAD_TEST_TOOL_BASE_EXECUTABLE";
 
 const LIGHTNING_CLI_FALLBACK: &str = "lightning-cli";
-// To override lightning-cli binary set:
-const ENV_FM_LIGHTNING_CLI_BASE_EXECUTABLE: &str = "FM_LIGHTNING_CLI_BASE_EXECUTABLE";
-// to override lightning-cli default command set:
-const ENV_FM_LIGHTNING_CLI: &str = "FM_LIGHTNING_CLI";
 
 pub fn get_lightning_cli_path() -> Vec<String> {
     get_command_str_for_alias(
-        &[ENV_FM_LIGHTNING_CLI_BASE_EXECUTABLE],
+        &[FM_LIGHTNING_CLI_BASE_EXECUTABLE_ENV],
         &[LIGHTNING_CLI_FALLBACK],
     )
 }
 
 const LNCLI_FALLBACK: &str = "lncli";
-// To override lncli binary set:
-const ENV_FM_LNCLI_BASE_EXECUTABLE: &str = "FM_LNCLI_BASE_EXECUTABLE";
-// to override lncli default command set:
-const ENV_FM_LNCLI: &str = "FM_LNCLI";
 
 pub fn get_lncli_path() -> Vec<String> {
-    get_command_str_for_alias(&[ENV_FM_LNCLI_BASE_EXECUTABLE], &[LNCLI_FALLBACK])
+    get_command_str_for_alias(&[FM_LNCLI_BASE_EXECUTABLE_ENV], &[LNCLI_FALLBACK])
 }
 
 const BITCOIN_CLI_FALLBACK: &str = "bitcoin-cli";
-// To override bitcoin-cli binary set:
-const ENV_FM_BITCOIN_CLI_BASE_EXECUTABLE: &str = "FM_BITCOIN_CLI_BASE_EXECUTABLE";
-// to override bitcoin-cli default command set:
-const ENV_FM_BTC_CLIENT: &str = "FM_BTC_CLIENT";
 
 pub fn get_bitcoin_cli_path() -> Vec<String> {
     get_command_str_for_alias(
-        &[ENV_FM_BITCOIN_CLI_BASE_EXECUTABLE],
+        &[FM_BITCOIN_CLI_BASE_EXECUTABLE_ENV],
         &[BITCOIN_CLI_FALLBACK],
     )
 }
 
 const BITCOIND_FALLBACK: &str = "bitcoind";
-// To override bitcoind binary set:
-const ENV_FM_BITCOIND_BASE_EXECUTABLE: &str = "FM_BITCOIND_BASE_EXECUTABLE";
 
 const LIGHTNINGD_FALLBACK: &str = "lightningd";
-// To override lightningd binary set:
-const ENV_FM_LIGHTNINGD_BASE_EXECUTABLE: &str = "FM_LIGHTNINGD_BASE_EXECUTABLE";
 
 const LND_FALLBACK: &str = "lnd";
-// To override lnd binary set:
-const ENV_FM_LND_BASE_EXECUTABLE: &str = "FM_LND_BASE_EXECUTABLE";
 
 const ELECTRS_FALLBACK: &str = "electrs";
-// To override electrs binary set:
-const ENV_FM_ELECTRS_BASE_EXECUTABLE: &str = "FM_ELECTRS_BASE_EXECUTABLE";
 
 const ESPLORA_FALLBACK: &str = "esplora";
-// To override esplora binary set:
-const ENV_FM_ESPLORA_BASE_EXECUTABLE: &str = "FM_ESPLORA_BASE_EXECUTABLE";
 
 const RECOVERYTOOL_FALLBACK: &str = "recoverytool";
-// To override esplora binary set:
-const ENV_FM_RECOVERYTOOL_BASE_EXECUTABLE: &str = "FM_RECOVERYTOOL_BASE_EXECUTABLE";
 
 const FAUCET_FALLBACK: &str = "faucet";
-// To override esplora binary set:
-const ENV_FM_FAUCET_BASE_EXECUTABLE: &str = "FM_FAUCET_BASE_EXECUTABLE";
 
 const FEDIMINT_DBTOOL_FALLBACK: &str = "fedimint-dbtool";
-// To override esplora binary set:
-const ENV_FM_FEDIMINT_DBTOOL_BASE_EXECUTABLE: &str = "FM_FEDIMINT_DBTOOL_BASE_EXECUTABLE";
 
 pub fn get_fedimint_dbtool_cli_path() -> Vec<String> {
     get_command_str_for_alias(
-        &[ENV_FM_FEDIMINT_DBTOOL_BASE_EXECUTABLE],
+        &[FM_FEDIMINT_DBTOOL_BASE_EXECUTABLE_ENV],
         &[FEDIMINT_DBTOOL_FALLBACK],
     )
 }
@@ -571,7 +542,7 @@ pub struct FedimintdCmd;
 impl FedimintdCmd {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_FEDIMINTD_BASE_EXECUTABLE],
+            &[FM_FEDIMINTD_BASE_EXECUTABLE_ENV],
             &[FEDIMINTD_FALLBACK],
         ))
     }
@@ -593,7 +564,7 @@ pub struct Gatewayd;
 impl Gatewayd {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_GATEWAYD_BASE_EXECUTABLE],
+            &[FM_GATEWAYD_BASE_EXECUTABLE_ENV],
             &[GATEWAYD_FALLBACK],
         ))
     }
@@ -615,7 +586,7 @@ pub struct FedimintCli;
 impl FedimintCli {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_MINT_CLIENT],
+            &[FM_MINT_CLIENT_ENV],
             &get_fedimint_cli_path()
                 .iter()
                 .map(String::as_str)
@@ -636,7 +607,7 @@ pub struct LoadTestTool;
 impl LoadTestTool {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_LOAD_TEST_TOOL_BASE_EXECUTABLE],
+            &[FM_LOAD_TEST_TOOL_BASE_EXECUTABLE_ENV],
             &[LOAD_TEST_TOOL_FALLBACK],
         ))
     }
@@ -667,7 +638,7 @@ pub struct GatewayClnCli;
 impl GatewayClnCli {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &["FM_GWCLI_CLN"],
+            &[FM_GWCLI_CLN_ENV],
             &["gateway-cln"],
         ))
     }
@@ -677,7 +648,7 @@ pub struct GatewayLndCli;
 impl GatewayLndCli {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &["FM_GWCLI_LND"],
+            &[FM_GWCLI_LND_ENV],
             &["gateway-lnd"],
         ))
     }
@@ -687,7 +658,7 @@ pub struct LnCli;
 impl LnCli {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_LNCLI],
+            &[FM_LNCLI_ENV],
             &get_lncli_path()
                 .iter()
                 .map(String::as_str)
@@ -700,7 +671,7 @@ pub struct ClnLightningCli;
 impl ClnLightningCli {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_LIGHTNING_CLI],
+            &[FM_LIGHTNING_CLI_ENV],
             &get_lightning_cli_path()
                 .iter()
                 .map(String::as_str)
@@ -713,7 +684,7 @@ pub struct BitcoinCli;
 impl BitcoinCli {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_BTC_CLIENT],
+            &[FM_BTC_CLIENT_ENV],
             &get_bitcoin_cli_path()
                 .iter()
                 .map(String::as_str)
@@ -726,7 +697,7 @@ pub struct Bitcoind;
 impl Bitcoind {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_BITCOIND_BASE_EXECUTABLE],
+            &[FM_BITCOIND_BASE_EXECUTABLE_ENV],
             &[BITCOIND_FALLBACK],
         ))
     }
@@ -736,7 +707,7 @@ pub struct Lightningd;
 impl Lightningd {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_LIGHTNINGD_BASE_EXECUTABLE],
+            &[FM_LIGHTNINGD_BASE_EXECUTABLE_ENV],
             &[LIGHTNINGD_FALLBACK],
         ))
     }
@@ -746,7 +717,7 @@ pub struct Lnd;
 impl Lnd {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_LND_BASE_EXECUTABLE],
+            &[FM_LND_BASE_EXECUTABLE_ENV],
             &[LND_FALLBACK],
         ))
     }
@@ -756,7 +727,7 @@ pub struct Electrs;
 impl Electrs {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_ELECTRS_BASE_EXECUTABLE],
+            &[FM_ELECTRS_BASE_EXECUTABLE_ENV],
             &[ELECTRS_FALLBACK],
         ))
     }
@@ -766,7 +737,7 @@ pub struct Esplora;
 impl Esplora {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_ESPLORA_BASE_EXECUTABLE],
+            &[FM_ESPLORA_BASE_EXECUTABLE_ENV],
             &[ESPLORA_FALLBACK],
         ))
     }
@@ -776,7 +747,7 @@ pub struct Recoverytool;
 impl Recoverytool {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_RECOVERYTOOL_BASE_EXECUTABLE],
+            &[FM_RECOVERYTOOL_BASE_EXECUTABLE_ENV],
             &[RECOVERYTOOL_FALLBACK],
         ))
     }
@@ -786,7 +757,7 @@ pub struct Faucet;
 impl Faucet {
     pub async fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
-            &[ENV_FM_FAUCET_BASE_EXECUTABLE],
+            &[FM_FAUCET_BASE_EXECUTABLE_ENV],
             &[FAUCET_FALLBACK],
         ))
     }
@@ -814,7 +785,7 @@ fn to_command(cli: Vec<String>) -> Command {
 
 /// Returns true if running backwards-compatibility tests
 pub fn is_backwards_compatibility_test() -> bool {
-    is_env_var_set("FM_BACKWARDS_COMPATIBILITY_TEST")
+    is_env_var_set(FM_BACKWARDS_COMPATIBILITY_TEST_ENV)
 }
 
 /// Parses a version string returned from clap

--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -7,7 +7,7 @@ use bitcoin::{BlockHash, Network, Script, Transaction, Txid};
 use bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
 use bitcoincore_rpc::{Auth, RpcApi};
 use fedimint_core::encoding::Decodable;
-use fedimint_core::envs::FM_BITCOIND_COOKIE_FILE_VAR_NAME;
+use fedimint_core::envs::FM_BITCOIND_COOKIE_FILE_ENV;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::task::{block_in_place, TaskHandle};
 use fedimint_core::txoproof::TxOutProof;
@@ -149,11 +149,11 @@ pub fn from_url_to_url_auth(url: &SafeUrl) -> anyhow::Result<(String, Auth)> {
         }),
         match (
             !url.username().is_empty(),
-            env::var(FM_BITCOIND_COOKIE_FILE_VAR_NAME),
+            env::var(FM_BITCOIND_COOKIE_FILE_ENV),
         ) {
-            (true, Ok(_)) => bail!(
-                "When {FM_BITCOIND_COOKIE_FILE_VAR_NAME} is set, the url auth part must be empty."
-            ),
+            (true, Ok(_)) => {
+                bail!("When {FM_BITCOIND_COOKIE_FILE_ENV} is set, the url auth part must be empty.")
+            }
             (true, Err(_)) => Auth::UserPass(
                 url.username().to_owned(),
                 url.password()

--- a/fedimint-cli/src/envs.rs
+++ b/fedimint-cli/src/envs.rs
@@ -1,0 +1,9 @@
+// Env variable to set the working directory of the client containing the config
+// and db
+pub const FM_CLIENT_DIR_ENV: &str = "FM_CLIENT_DIR";
+
+// Env variable to set the peer id of the guardian
+pub const FM_OUR_ID_ENV: &str = "FM_OUR_ID";
+
+// Env variable to set the guardian password for authentication
+pub const FM_PASSWORD_ENV: &str = "FM_PASSWORD";

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1,5 +1,6 @@
 mod client;
 mod db_locked;
+pub mod envs;
 mod utils;
 
 use core::fmt;
@@ -49,6 +50,7 @@ use tracing::{debug, error, info};
 use utils::parse_peer_id;
 
 use crate::client::ClientCmd;
+use crate::envs::{FM_CLIENT_DIR_ENV, FM_OUR_ID_ENV, FM_PASSWORD_ENV};
 
 /// Type of output the cli produces
 #[derive(Serialize)]
@@ -183,15 +185,15 @@ impl fmt::Display for CliError {
 #[command(version)]
 struct Opts {
     /// The working directory of the client containing the config and db
-    #[arg(long = "data-dir", env = "FM_CLIENT_DIR")]
+    #[arg(long = "data-dir", env = FM_CLIENT_DIR_ENV)]
     data_dir: Option<PathBuf>,
 
     /// Peer id of the guardian
-    #[arg(env = "FM_OUR_ID", long, value_parser = parse_peer_id)]
+    #[arg(env = FM_OUR_ID_ENV, long, value_parser = parse_peer_id)]
     our_id: Option<PeerId>,
 
     /// Guardian password for authentication
-    #[arg(long, env = "FM_PASSWORD")]
+    #[arg(long, env = FM_PASSWORD_ENV)]
     password: Option<String>,
 
     /// Activate more verbose logging, for full control use the RUST_LOG env
@@ -456,7 +458,7 @@ Examples:
         #[arg(long = "salt-file")]
         salt_file: Option<PathBuf>,
         /// The password that encrypts the configs
-        #[arg(env = "FM_PASSWORD")]
+        #[arg(env = FM_PASSWORD_ENV)]
         password: String,
     },
 
@@ -472,7 +474,7 @@ Examples:
         #[arg(long = "salt-file")]
         salt_file: Option<PathBuf>,
         /// The password that encrypts the configs
-        #[arg(env = "FM_PASSWORD")]
+        #[arg(env = FM_PASSWORD_ENV)]
         password: String,
     },
 

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -28,12 +28,12 @@ macro_rules! fedimint_build_code_version_env {
 }
 
 /// Env var for bitcoin RPC kind
-pub const FM_BITCOIN_RPC_KIND: &str = "FM_BITCOIN_RPC_KIND";
+pub const FM_BITCOIN_RPC_KIND_ENV: &str = "FM_BITCOIN_RPC_KIND";
 /// Env var for bitcoin URL
-pub const FM_BITCOIN_RPC_URL: &str = "FM_BITCOIN_RPC_URL";
+pub const FM_BITCOIN_RPC_URL_ENV: &str = "FM_BITCOIN_RPC_URL";
 /// Env var that can be set to point at the bitcoind's cookie file to use for
 /// auth
-pub const FM_BITCOIND_COOKIE_FILE_VAR_NAME: &str = "FM_BITCOIND_COOKIE_FILE";
+pub const FM_BITCOIND_COOKIE_FILE_ENV: &str = "FM_BITCOIND_COOKIE_FILE";
 
 /// Configuration for the bitcoin RPC
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
@@ -45,15 +45,17 @@ pub struct BitcoinRpcConfig {
 impl BitcoinRpcConfig {
     pub fn from_env_vars() -> anyhow::Result<Self> {
         Ok(Self {
-            kind: env::var(FM_BITCOIN_RPC_KIND).with_context(|| {
-                anyhow::anyhow!("failure looking up env var {FM_BITCOIN_RPC_KIND}")
+            kind: env::var(FM_BITCOIN_RPC_KIND_ENV).with_context(|| {
+                anyhow::anyhow!("failure looking up env var {FM_BITCOIN_RPC_KIND_ENV}")
             })?,
-            url: env::var(FM_BITCOIN_RPC_URL)
+            url: env::var(FM_BITCOIN_RPC_URL_ENV)
                 .with_context(|| {
-                    anyhow::anyhow!("failure looking up env var {FM_BITCOIN_RPC_URL}")
+                    anyhow::anyhow!("failure looking up env var {FM_BITCOIN_RPC_URL_ENV}")
                 })?
                 .parse()
-                .with_context(|| anyhow::anyhow!("failure parsing env var {FM_BITCOIN_RPC_URL}"))?,
+                .with_context(|| {
+                    anyhow::anyhow!("failure parsing env var {FM_BITCOIN_RPC_URL_ENV}")
+                })?,
         })
     }
 }

--- a/fedimint-dbtool/src/envs.rs
+++ b/fedimint-dbtool/src/envs.rs
@@ -1,0 +1,8 @@
+// Env variable to TODO
+pub const FM_DBTOOL_DATABASE_ENV: &str = "FM_DBTOOL_DATABASE";
+
+// Env variable to TODO
+pub const FM_DBTOOL_CONFIG_DIR_ENV: &str = "FM_DBTOOL_CONFIG_DIR";
+
+// Env variable to TODO
+pub const FM_PASSWORD_ENV: &str = "FM_PASSWORD";

--- a/fedimint-dbtool/src/main.rs
+++ b/fedimint-dbtool/src/main.rs
@@ -1,4 +1,6 @@
 #![allow(where_clauses_object_safety)] // https://github.com/dtolnay/async-trait/issues/228
+pub mod envs;
+
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -20,13 +22,14 @@ use fedimint_wallet_server::WalletInit;
 use futures::StreamExt;
 
 use crate::dump::DatabaseDump;
+use crate::envs::{FM_DBTOOL_CONFIG_DIR_ENV, FM_DBTOOL_DATABASE_ENV, FM_PASSWORD_ENV};
 
 mod dump;
 
 #[derive(Debug, Clone, Parser)]
 #[command(version)]
 struct Options {
-    #[clap(long, env = "FM_DBTOOL_DATABASE")]
+    #[clap(long, env = FM_DBTOOL_DATABASE_ENV)]
     database: String,
 
     #[clap(long, hide = true)]
@@ -71,9 +74,9 @@ enum DbCommand {
     /// configuration file. If dumping the client database, the password can
     /// be an arbitrary string.
     Dump {
-        #[clap(long, env = "FM_DBTOOL_CONFIG_DIR")]
+        #[clap(long, env = FM_DBTOOL_CONFIG_DIR_ENV)]
         cfg_dir: PathBuf,
-        #[arg(long, env = "FM_PASSWORD")]
+        #[arg(long, env = FM_PASSWORD_ENV)]
         password: String,
         #[arg(long, required = false)]
         modules: Option<String>,

--- a/fedimint-rocksdb/src/envs.rs
+++ b/fedimint-rocksdb/src/envs.rs
@@ -1,0 +1,2 @@
+// Env variable to TODO
+pub const FM_ROCKSDB_WRITE_BUFFER_SIZE_ENV: &str = "FM_ROCKSDB_WRITE_BUFFER_SIZE";

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -1,4 +1,7 @@
 #![allow(where_clauses_object_safety)] // https://github.com/dtolnay/async-trait/issues/228
+
+pub mod envs;
+
 use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
@@ -13,6 +16,8 @@ use futures::stream;
 pub use rocksdb;
 use rocksdb::{OptimisticTransactionDB, OptimisticTransactionOptions, WriteOptions};
 use tracing::debug;
+
+use crate::envs::FM_ROCKSDB_WRITE_BUFFER_SIZE_ENV;
 
 #[derive(Debug)]
 pub struct RocksDb(rocksdb::OptimisticTransactionDB);
@@ -62,13 +67,12 @@ fn is_power_of_two_sanity() {
 
 fn get_default_options() -> anyhow::Result<rocksdb::Options> {
     let mut opts = rocksdb::Options::default();
-    const VAR_NAME: &str = "FM_ROCKSDB_WRITE_BUFFER_SIZE";
-    if let Ok(var) = std::env::var(VAR_NAME) {
+    if let Ok(var) = std::env::var(FM_ROCKSDB_WRITE_BUFFER_SIZE_ENV) {
         debug!(var, "Using custom write buffer size");
-        let size: usize =
-            FromStr::from_str(&var).with_context(|| format!("Could not parse {VAR_NAME}"))?;
+        let size: usize = FromStr::from_str(&var)
+            .with_context(|| format!("Could not parse {FM_ROCKSDB_WRITE_BUFFER_SIZE_ENV}"))?;
         if !is_power_of_two(size) {
-            bail!("{} is not a power of 2", VAR_NAME);
+            bail!("{} is not a power of 2", FM_ROCKSDB_WRITE_BUFFER_SIZE_ENV);
         }
         opts.set_write_buffer_size(size);
     }

--- a/fedimint-testing/src/envs.rs
+++ b/fedimint-testing/src/envs.rs
@@ -1,1 +1,32 @@
+// Env variable to TODO
 pub const FM_PREPARE_DB_MIGRATION_SNAPSHOTS_ENV: &str = "FM_PREPARE_DB_MIGRATION_SNAPSHOTS";
+
+// Env variable to TODO
+pub const FM_TEST_USE_REAL_DAEMONS_ENV: &str = "FM_TEST_USE_REAL_DAEMONS";
+
+// Env variable to TODO
+pub const FM_PORT_ESPLORA_ENV: &str = "FM_PORT_ESPLORA";
+
+// Env variable to TODO
+pub const FM_TEST_DIR_ENV: &str = "FM_TEST_DIR";
+
+// Env variable to TODO
+pub const FM_PORT_CLN_ENV: &str = "FM_PORT_CLN";
+
+// Env variable to TODO
+pub const FM_GATEWAY_LIGHTNING_ADDR_ENV: &str = "FM_GATEWAY_LIGHTNING_ADDR";
+
+// Env variable to TODO
+pub const FM_PORT_LND_LISTEN_ENV: &str = "FM_PORT_LND_LISTEN";
+
+// Env variable to TODO
+pub const FM_LND_RPC_ADDR_ENV: &str = "FM_LND_RPC_ADDR";
+
+// Env variable to TODO
+pub const FM_LND_MACAROON_ENV: &str = "FM_LND_MACAROON";
+
+// Env variable to TODO
+pub const FM_LND_TLS_CERT_ENV: &str = "FM_LND_TLS_CERT";
+
+// Env variable to TODO
+pub const FM_TEST_BITCOIND_RPC_ENV: &str = "FM_TEST_BITCOIND_RPC";

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -22,6 +22,9 @@ use tracing::info;
 use crate::btc::mock::FakeBitcoinFactory;
 use crate::btc::real::RealBitcoinTest;
 use crate::btc::BitcoinTest;
+use crate::envs::{
+    FM_PORT_ESPLORA_ENV, FM_TEST_BITCOIND_RPC_ENV, FM_TEST_DIR_ENV, FM_TEST_USE_REAL_DAEMONS_ENV,
+};
 use crate::federation::FederationTest;
 use crate::gateway::GatewayTest;
 use crate::ln::mock::FakeLightningTest;
@@ -64,7 +67,7 @@ impl Fixtures {
         ) = if real_testing {
             let rpc_config = BitcoinRpcConfig::from_env_vars().unwrap();
             let dyn_bitcoin_rpc = create_bitcoind(&rpc_config, task_group.make_handle()).unwrap();
-            let bitcoincore_url = env::var("FM_TEST_BITCOIND_RPC")
+            let bitcoincore_url = env::var(FM_TEST_BITCOIND_RPC_ENV)
                 .expect("Must have bitcoind RPC defined for real tests")
                 .parse()
                 .expect("Invalid bitcoind RPC URL");
@@ -93,7 +96,7 @@ impl Fixtures {
     }
 
     pub fn is_real_test() -> bool {
-        env::var("FM_TEST_USE_REAL_DAEMONS") == Ok("1".to_string())
+        env::var(FM_TEST_USE_REAL_DAEMONS_ENV) == Ok("1".to_string())
     }
 
     // TODO: Auto-assign instance ids after removing legacy id order
@@ -207,7 +210,7 @@ impl Fixtures {
                 kind: "esplora".to_string(),
                 url: SafeUrl::parse(&format!(
                     "http://127.0.0.1:{}/",
-                    env::var("FM_PORT_ESPLORA").unwrap_or(String::from("50002"))
+                    env::var(FM_PORT_ESPLORA_ENV).unwrap_or(String::from("50002"))
                 ))
                 .expect("Failed to parse default esplora server"),
             },
@@ -229,7 +232,7 @@ impl Fixtures {
 ///
 /// Callers must hold onto the tempdir until it is no longer needed
 pub fn test_dir(pathname: &str) -> (PathBuf, Option<TempDir>) {
-    let (parent, maybe_tmp_dir_guard) = match env::var("FM_TEST_DIR") {
+    let (parent, maybe_tmp_dir_guard) = match env::var(FM_TEST_DIR_ENV) {
         Ok(directory) => (directory, None),
         Err(_) => {
             let random = format!("test-{}", rand::random::<u64>());

--- a/fedimintd/src/envs.rs
+++ b/fedimintd/src/envs.rs
@@ -2,7 +2,7 @@
 pub const FM_DISABLE_META_MODULE_ENV: &str = "FM_DISABLE_META_MODULE";
 
 // Env variable to TODO
-pub const FM_EXTRA_DKG_META_VAR_ENV: &str = "FM_EXTRA_DKG_META";
+pub const FM_EXTRA_DKG_META_ENV: &str = "FM_EXTRA_DKG_META";
 
 // Env variable to TODO
 pub const FM_DATA_DIR_ENV: &str = "FM_DATA_DIR";

--- a/fedimintd/src/envs.rs
+++ b/fedimintd/src/envs.rs
@@ -1,1 +1,38 @@
+// Env variable to TODO
 pub const FM_DISABLE_META_MODULE_ENV: &str = "FM_DISABLE_META_MODULE";
+
+// Env variable to TODO
+pub const FM_EXTRA_DKG_META_VAR_ENV: &str = "FM_EXTRA_DKG_META";
+
+// Env variable to TODO
+pub const FM_DATA_DIR_ENV: &str = "FM_DATA_DIR";
+
+// Env variable to TODO
+pub const FM_PASSWORD_ENV: &str = "FM_PASSWORD";
+
+// Env variable to TODO
+pub const FM_TOKIO_CONSOLE_BIND_ENV: &str = "FM_TOKIO_CONSOLE_BIND";
+
+// Env variable to TODO
+pub const FM_BIND_P2P_ENV: &str = "FM_BIND_P2P";
+
+// Env variable to TODO
+pub const FM_P2P_URL_ENV: &str = "FM_P2P_URL";
+
+// Env variable to TODO
+pub const FM_BIND_API_ENV: &str = "FM_BIND_API";
+
+// Env variable to TODO
+pub const FM_API_URL_ENV: &str = "FM_API_URL";
+
+// Env variable to TODO
+pub const FM_BITCOIN_NETWORK_ENV: &str = "FM_BITCOIN_NETWORK";
+
+// Env variable to TODO
+pub const FM_FINALITY_DELAY_ENV: &str = "FM_FINALITY_DELAY";
+
+// Env variable to TODO
+pub const FM_BIND_METRICS_API_ENV: &str = "FM_BIND_METRICS_API";
+
+// Env variable to TODO
+pub const FM_PORT_ESPLORA_ENV: &str = "FM_PORT_ESPLORA";

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -40,57 +40,59 @@ use tokio::select;
 use tracing::{debug, error, info, warn};
 
 use crate::default_esplora_server;
-use crate::envs::FM_DISABLE_META_MODULE_ENV;
+use crate::envs::{
+    FM_API_URL_ENV, FM_BIND_API_ENV, FM_BIND_METRICS_API_ENV, FM_BIND_P2P_ENV,
+    FM_BITCOIN_NETWORK_ENV, FM_DATA_DIR_ENV, FM_DISABLE_META_MODULE_ENV, FM_EXTRA_DKG_META_VAR_ENV,
+    FM_FINALITY_DELAY_ENV, FM_P2P_URL_ENV, FM_PASSWORD_ENV, FM_TOKIO_CONSOLE_BIND_ENV,
+};
 use crate::fedimintd::metrics::APP_START_TS;
 
 /// Time we will wait before forcefully shutting down tasks
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
-pub const FM_EXTRA_DKG_META_VAR: &str = "FM_EXTRA_DKG_META";
-
 #[derive(Parser)]
 #[command(version)]
 pub struct ServerOpts {
     /// Path to folder containing federation config files
-    #[arg(long = "data-dir", env = "FM_DATA_DIR")]
+    #[arg(long = "data-dir", env = FM_DATA_DIR_ENV)]
     pub data_dir: PathBuf,
     /// Password to encrypt sensitive config files
     // TODO: should probably never send password to the server directly, rather send the hash via
     // the API
-    #[arg(long, env = "FM_PASSWORD")]
+    #[arg(long, env = FM_PASSWORD_ENV)]
     pub password: Option<String>,
     /// Enable tokio console logging
-    #[arg(long, env = "FM_TOKIO_CONSOLE_BIND")]
+    #[arg(long, env = FM_TOKIO_CONSOLE_BIND_ENV)]
     pub tokio_console_bind: Option<SocketAddr>,
     /// Enable telemetry logging
     #[arg(long, default_value = "false")]
     pub with_telemetry: bool,
 
     /// Address we bind to for federation communication
-    #[arg(long, env = "FM_BIND_P2P", default_value = "127.0.0.1:8173")]
+    #[arg(long, env = FM_BIND_P2P_ENV, default_value = "127.0.0.1:8173")]
     bind_p2p: SocketAddr,
     /// Our external address for communicating with our peers
-    #[arg(long, env = "FM_P2P_URL", default_value = "fedimint://127.0.0.1:8173")]
+    #[arg(long, env = FM_P2P_URL_ENV, default_value = "fedimint://127.0.0.1:8173")]
     p2p_url: SafeUrl,
     /// Address we bind to for exposing the API
-    #[arg(long, env = "FM_BIND_API", default_value = "127.0.0.1:8174")]
+    #[arg(long, env = FM_BIND_API_ENV, default_value = "127.0.0.1:8174")]
     bind_api: SocketAddr,
     /// Our API address for clients to connect to us
-    #[arg(long, env = "FM_API_URL", default_value = "ws://127.0.0.1:8174")]
+    #[arg(long, env = FM_API_URL_ENV, default_value = "ws://127.0.0.1:8174")]
     api_url: SafeUrl,
     /// The bitcoin network that fedimint will be running on
-    #[arg(long, env = "FM_BITCOIN_NETWORK", default_value = "regtest")]
+    #[arg(long, env = FM_BITCOIN_NETWORK_ENV, default_value = "regtest")]
     network: bitcoin::network::constants::Network,
     /// The bitcoin network that fedimint will be running on
-    #[arg(long, env = "FM_FINALITY_DELAY", default_value = "10")]
+    #[arg(long, env = FM_FINALITY_DELAY_ENV, default_value = "10")]
     finality_delay: u32,
 
-    #[arg(long, env = "FM_BIND_METRICS_API")]
+    #[arg(long, env = FM_BIND_METRICS_API_ENV)]
     bind_metrics_api: Option<SocketAddr>,
 
     /// List of default meta values to use during config generation (format:
     /// `key1=value1,key2=value,...`)
-    #[arg(long, env = FM_EXTRA_DKG_META_VAR, value_parser = parse_map, default_value="")]
+    #[arg(long, env = FM_EXTRA_DKG_META_VAR_ENV, value_parser = parse_map, default_value="")]
     extra_dkg_meta: BTreeMap<String, String>,
 }
 

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -42,7 +42,7 @@ use tracing::{debug, error, info, warn};
 use crate::default_esplora_server;
 use crate::envs::{
     FM_API_URL_ENV, FM_BIND_API_ENV, FM_BIND_METRICS_API_ENV, FM_BIND_P2P_ENV,
-    FM_BITCOIN_NETWORK_ENV, FM_DATA_DIR_ENV, FM_DISABLE_META_MODULE_ENV, FM_EXTRA_DKG_META_VAR_ENV,
+    FM_BITCOIN_NETWORK_ENV, FM_DATA_DIR_ENV, FM_DISABLE_META_MODULE_ENV, FM_EXTRA_DKG_META_ENV,
     FM_FINALITY_DELAY_ENV, FM_P2P_URL_ENV, FM_PASSWORD_ENV, FM_TOKIO_CONSOLE_BIND_ENV,
 };
 use crate::fedimintd::metrics::APP_START_TS;
@@ -92,7 +92,7 @@ pub struct ServerOpts {
 
     /// List of default meta values to use during config generation (format:
     /// `key1=value1,key2=value,...`)
-    #[arg(long, env = FM_EXTRA_DKG_META_VAR_ENV, value_parser = parse_map, default_value="")]
+    #[arg(long, env = FM_EXTRA_DKG_META_ENV, value_parser = parse_map, default_value="")]
     extra_dkg_meta: BTreeMap<String, String>,
 }
 

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -1,3 +1,4 @@
+/// Module for creating `fedimintd` binary with custom modules
 use bitcoin::Network;
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::util::SafeUrl;
@@ -6,6 +7,7 @@ pub use fedimintd::*;
 mod fedimintd;
 
 pub mod envs;
+use crate::envs::FM_PORT_ESPLORA_ENV;
 
 pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
     let url = match network {
@@ -15,7 +17,7 @@ pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
             .expect("Failed to parse default esplora server"),
         Network::Regtest => SafeUrl::parse(&format!(
             "http://127.0.0.1:{}/",
-            std::env::var("FM_PORT_ESPLORA").unwrap_or(String::from("50002"))
+            std::env::var(FM_PORT_ESPLORA_ENV).unwrap_or(String::from("50002"))
         ))
         .expect("Failed to parse default esplora server"),
         Network::Signet => SafeUrl::parse("https://mutinynet.com/api/")

--- a/gateway/ln-gateway/src/envs.rs
+++ b/gateway/ln-gateway/src/envs.rs
@@ -1,9 +1,35 @@
+// Env variable to TODO
 pub const FM_CLN_EXTENSION_LISTEN_ADDRESS_ENV: &str = "FM_CLN_EXTENSION_LISTEN_ADDRESS";
 
+// Env variable to TODO
 pub const FM_GATEWAY_DATA_DIR_ENV: &str = "FM_GATEWAY_DATA_DIR";
+
+// Env variable to TODO
 pub const FM_GATEWAY_LISTEN_ADDR_ENV: &str = "FM_GATEWAY_LISTEN_ADDR";
+
+// Env variable to TODO
 pub const FM_GATEWAY_API_ADDR_ENV: &str = "FM_GATEWAY_API_ADDR";
+
+// Env variable to TODO
 pub const FM_GATEWAY_PASSWORD_ENV: &str = "FM_GATEWAY_PASSWORD";
+
+// Env variable to TODO
 pub const FM_GATEWAY_NETWORK_ENV: &str = "FM_GATEWAY_NETWORK";
+
+// Env variable to TODO
 pub const FM_GATEWAY_FEES_ENV: &str = "FM_GATEWAY_FEES";
+
+// Env variable to TODO
 pub const FM_NUMBER_OF_ROUTE_HINTS_ENV: &str = "FM_NUMBER_OF_ROUTE_HINTS";
+
+// Env variable to TODO
+pub const FM_LND_RPC_ADDR_ENV: &str = "FM_LND_RPC_ADDR";
+
+// Env variable to TODO
+pub const FM_LND_TLS_CERT_ENV: &str = "FM_LND_TLS_CERT";
+
+// Env variable to TODO
+pub const FM_LND_MACAROON_ENV: &str = "FM_LND_MACAROON";
+
+// Env variable to TODO
+pub const FM_GATEWAY_LIGHTNING_ADDR_ENV: &str = "FM_GATEWAY_LIGHTNING_ADDR";

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -16,6 +16,9 @@ use thiserror::Error;
 
 use self::cln::{NetworkLnRpcClient, RouteHtlcStream};
 use self::lnd::GatewayLndClient;
+use crate::envs::{
+    FM_GATEWAY_LIGHTNING_ADDR_ENV, FM_LND_MACAROON_ENV, FM_LND_RPC_ADDR_ENV, FM_LND_TLS_CERT_ENV,
+};
 use crate::gateway_lnrpc::{
     EmptyResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
     PayInvoiceRequest, PayInvoiceResponse,
@@ -115,20 +118,20 @@ pub enum LightningMode {
     #[clap(name = "lnd")]
     Lnd {
         /// LND RPC address
-        #[arg(long = "lnd-rpc-host", env = "FM_LND_RPC_ADDR")]
+        #[arg(long = "lnd-rpc-host", env = FM_LND_RPC_ADDR_ENV)]
         lnd_rpc_addr: String,
 
         /// LND TLS cert file path
-        #[arg(long = "lnd-tls-cert", env = "FM_LND_TLS_CERT")]
+        #[arg(long = "lnd-tls-cert", env = FM_LND_TLS_CERT_ENV)]
         lnd_tls_cert: String,
 
         /// LND macaroon file path
-        #[arg(long = "lnd-macaroon", env = "FM_LND_MACAROON")]
+        #[arg(long = "lnd-macaroon", env = FM_LND_MACAROON_ENV)]
         lnd_macaroon: String,
     },
     #[clap(name = "cln")]
     Cln {
-        #[arg(long = "cln-extension-addr", env = "FM_GATEWAY_LIGHTNING_ADDR")]
+        #[arg(long = "cln-extension-addr", env = FM_GATEWAY_LIGHTNING_ADDR_ENV)]
         cln_extension_addr: SafeUrl,
     },
 }

--- a/modules/fedimint-wallet-common/src/config.rs
+++ b/modules/fedimint-wallet-common/src/config.rs
@@ -11,6 +11,7 @@ use miniscript::descriptor::{Wpkh, Wsh};
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 
+use crate::envs::FM_PORT_ESPLORA_ENV;
 use crate::keys::CompressedPublicKey;
 use crate::{PegInDescriptor, WalletCommonInit};
 
@@ -31,7 +32,7 @@ impl WalletGenParams {
                     kind: "esplora".to_string(),
                     url: SafeUrl::parse(&format!(
                         "http://127.0.0.1:{}/",
-                        std::env::var("FM_PORT_ESPLORA").unwrap_or(String::from("50002"))
+                        std::env::var(FM_PORT_ESPLORA_ENV).unwrap_or(String::from("50002"))
                     ))
                     .expect("Failed to parse default esplora server"),
                 },

--- a/modules/fedimint-wallet-common/src/envs.rs
+++ b/modules/fedimint-wallet-common/src/envs.rs
@@ -1,0 +1,2 @@
+// Env variable to TODO
+pub const FM_PORT_ESPLORA_ENV: &str = "FM_PORT_ESPLORA";

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -17,6 +17,7 @@ use crate::keys::CompressedPublicKey;
 use crate::txoproof::{PegInProof, PegInProofError};
 
 pub mod config;
+pub mod envs;
 pub mod keys;
 pub mod tweakable;
 pub mod txoproof;

--- a/recoverytool/src/envs.rs
+++ b/recoverytool/src/envs.rs
@@ -1,0 +1,2 @@
+// Env variable to TODO
+pub const FM_PASSWORD_ENV: &str = "FM_PASSWORD";

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -1,3 +1,5 @@
+pub mod envs;
+
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter};
@@ -47,6 +49,8 @@ use secp256k1::SecretKey;
 use serde::Serialize;
 use tracing::info;
 
+use crate::envs::FM_PASSWORD_ENV;
+
 /// Tool to recover the on-chain wallet of a Fedimint federation
 #[derive(Debug, Parser)]
 #[command(version)]
@@ -60,7 +64,7 @@ struct RecoveryTool {
     #[arg(long = "cfg")]
     config: Option<PathBuf>,
     /// The password that encrypts the configs
-    #[arg(long, env = "FM_PASSWORD", requires = "config")]
+    #[arg(long, env = FM_PASSWORD_ENV, requires = "config")]
     password: String,
     /// Wallet descriptor, can be used instead of --cfg
     #[arg(long)]

--- a/utils/portalloc/src/envs.rs
+++ b/utils/portalloc/src/envs.rs
@@ -1,0 +1,2 @@
+// Env variable to TODO
+pub const FM_PORTALLOC_DATA_DIR_ENV: &str = "FM_PORTALLOC_DATA_DIR";

--- a/utils/portalloc/src/lib.rs
+++ b/utils/portalloc/src/lib.rs
@@ -16,6 +16,7 @@
 //! sure a given port is actually free
 
 pub mod data;
+pub mod envs;
 pub mod util;
 
 use std::net::TcpListener;
@@ -27,6 +28,7 @@ use rand::{thread_rng, Rng};
 use tracing::warn;
 
 use crate::data::DataDir;
+use crate::envs::FM_PORTALLOC_DATA_DIR_ENV;
 
 type UnixTimestamp = u64;
 
@@ -35,7 +37,7 @@ pub fn now_ts() -> UnixTimestamp {
 }
 
 pub fn data_dir() -> anyhow::Result<PathBuf> {
-    if let Some(env) = std::env::var_os("FM_PORTALLOC_DATA_DIR") {
+    if let Some(env) = std::env::var_os(FM_PORTALLOC_DATA_DIR_ENV) {
         Ok(PathBuf::from(env))
     } else if let Some(dir) = dirs::cache_dir() {
         Ok(dir.join("fm-portalloc"))


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/4191

It extracts all ENV variable names in the code to `envs.rs` files