### PR TITLE
chore(ci): increase containers workflow timeout

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -348,7 +348,7 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     name: "Containers"
     runs-on: buildjet-8vcpu-ubuntu-2004
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Seems like sometimes it might take a bit longer:

https://github.com/fedimint/fedimint/actions/runs/8424709083/job/23069227391