### PR TITLE
chore(ci): print out only failed tests from the joblog

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -268,8 +268,8 @@ echo "$parsed_test_commands" | if parallel \
   "${parallel_args[@]}" ; then
   >&2 echo "All tests successful"
 else
-  >&2 echo "Some tests failed. Full job log:"
-  cat "$joblog"
+  >&2 echo "Some tests failed:"
+  awk '{ if($7 != "0") print $0 "\n" }' < "$joblog"
   >&2 echo "Search for '## FAIL' to find the end of the failing test"
   exit 1
 fi


### PR DESCRIPTION
Especially in the backward-compat, the list is long and hard to decipher.

Now:

![image](https://github.com/fedimint/fedimint/assets/9209/bd496826-21cb-445a-a53c-a520504ae8ce)

We could make the output more clear, but I'm just looking for a quick and easy improvement RN.
