### PR TITLE
chore: add clap version command to all binaries

### DIFF
--- a/fedimint-dbtool/src/main.rs
+++ b/fedimint-dbtool/src/main.rs
@@ -24,6 +24,7 @@ use crate::dump::DatabaseDump;
 mod dump;
 
 #[derive(Debug, Clone, Parser)]
+#[command(version)]
 struct Options {
     #[clap(long, env = "FM_DBTOOL_DATABASE")]
     database: String,

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -38,6 +38,7 @@ use tracing::{debug, error, info, warn};
 const MAX_HTLC_PROCESSING_DURATION: Duration = Duration::MAX;
 
 #[derive(Parser)]
+#[command(version)]
 struct ClnExtensionOpts {
     /// Gateway CLN extension service listen address
     #[arg(long = "fm-gateway-listen", env = FM_CLN_EXTENSION_LISTEN_ADDRESS_ENV)]

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -49,6 +49,7 @@ use tracing::info;
 
 /// Tool to recover the on-chain wallet of a Fedimint federation
 #[derive(Debug, Parser)]
+#[command(version)]
 #[command(group(
     ArgGroup::new("keysource")
         .required(true)


### PR DESCRIPTION
Followup: https://github.com/fedimint/fedimint/pull/4701#discussion_r1536676266

Find all binaries (`vec` isn't a clap cli binary)

```bash
nix@lenovo-m75q-ubuntu:~/fedimint$ rg -A 2 --type-add 'toml:*.toml' --type toml -F '[[bin]]' | rg name
fedimint-cli/Cargo.toml-name = "fedimint-cli"
fedimint-load-test-tool/Cargo.toml-name = "fedimint-load-test-tool"
fedimintd/Cargo.toml-name = "fedimintd"
devimint/Cargo.toml-name = "devimint"
recoverytool/Cargo.toml-name = "recoverytool"
fuzz/Cargo.toml-name = "vec"
gateway/cli/Cargo.toml-name = "gateway-cli"
fedimint-dbtool/Cargo.toml-name = "fedimint-dbtool"
gateway/ln-gateway/Cargo.toml-name = "gatewayd"
gateway/ln-gateway/Cargo.toml-name = "gateway-cln-extension"
```