### PR TITLE
chore(devimint): bump lnd polling to 60s

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -456,7 +456,7 @@ impl Lnd {
         let lnd_rpc_addr = &process_mgr.globals.FM_LND_RPC_ADDR;
         let lnd_macaroon = &process_mgr.globals.FM_LND_MACAROON;
         let lnd_tls_cert = &process_mgr.globals.FM_LND_TLS_CERT;
-        poll("wait for lnd files", None, || async {
+        poll("wait for lnd files", Duration::from_secs(60), || async {
             if fs::try_exists(lnd_tls_cert)
                 .await
                 .context("lnd tls cert")


### PR DESCRIPTION
Hopefully improves https://github.com/fedimint/fedimint/issues/4636

Polling for lnd tls cert and macaroon is flakey in back-compat. Let's bump from 30s to 60s.

```
00:00:31 Error: Polling wait for lnd files failed after 76 retries (timeout: 30s)
00:00:31 
00:00:31 Caused by:
00:00:31     lnd tls cert or lnd macaroon not found
```
https://github.com/fedimint/fedimint/actions/runs/8412860972/job/23034240849#step:6:1741