### PR TITLE
fix(ci): use GITHUB_SHA for workflow_dispatch (manual) events

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -10,7 +10,7 @@ runs:
       run: |
         echo "LAST_COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> ${GITHUB_ENV}
     - name: Setup Environment (Push)
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
       shell: bash
       run: |
         echo "LAST_COMMIT_SHA=${GITHUB_SHA}" >> ${GITHUB_ENV}


### PR DESCRIPTION
Discord [thread](https://discord.com/channels/990354215060795454/1221951795576705127/1221960366053920818)

If we tigger a manual run on `master`, we'll fail tagging with docker since the environment doesn't have a commit sha. This change sets the commit sha to the last commit on the reference branch for manual workflows.

```
Error parsing reference: "fedimint/fedimintd:" is not a valid repository/tag: invalid reference format
```

https://github.com/fedimint/fedimint/actions/runs/8427922160/job/23079408272#step:13:19

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch