### PR TITLE
chore(fedimint-cli): increase wait-block-count to 60s

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -791,7 +791,7 @@ impl FedimintCli {
                 Ok(CliOutput::UntypedApiOutput { value: response })
             }
             Command::Dev(DevCmd::WaitBlockCount { count: target }) => {
-                task::timeout(Duration::from_secs(30), async move {
+                task::timeout(Duration::from_secs(60), async move {
                     let client = self.client_open(&cli).await?;
                     loop {
                         let wallet = client.get_first_module::<WalletClientModule>();


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/4636

Back-compat was flakey waiting for a block count. Let's bump to 60s.

```
00:00:09 Error: command: fedimint-cli --data-dir=/tmp/nix-shell.iv8sgM/latency_test_ln_send-m4EE/devimint-123920-936/clients/default-0 dev wait-block-count 122
```
https://github.com/fedimint/fedimint/actions/runs/8438702476/job/23111511369#step:6:1664

This may still be an issue when back-compat runs an old client version since this change is in `fedimint-cli`, but this will hopefully prevent flakiness in clients going forward.