### PR TITLE
chore(ci): reverse back-compat matrix loops

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -213,8 +213,8 @@ tests_to_run_in_parallel+=(
 done
 
 tests_with_versions=()
-for test in "${tests_to_run_in_parallel[@]}"; do
-  for version_combo in "${version_matrix[@]}"; do
+for version_combo in "${version_matrix[@]}"; do
+  for test in "${tests_to_run_in_parallel[@]}"; do
     tests_with_versions+=("run_test_for_versions $test $version_combo")
   done
 done


### PR DESCRIPTION
I originally reversed them, thinking "let's start all longest tests first, so the suite can complete fastest", but I think I inadvertently made it so that most heavy tests are running together at the same time creating heavy load, instead of spreading the load appart more.

Let's revert it.