### PR TITLE
chore: don't buil `cargo-workspace` on macos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -221,7 +221,6 @@
                   pkgs.cargo-udeps
                   pkgs.cargo-audit
                   pkgs.cargo-deny
-                  pkgs.cargo-workspaces
                   pkgs.parallel
                   pkgs.just
                   pkgs.time
@@ -257,6 +256,9 @@
                   pkgs.sccache
                 ] ++ lib.optionals (!stdenv.isAarch64 && !stdenv.isDarwin) [
                   pkgs.semgrep
+                ] ++ lib.optionals (!stdenv.isDarwin) [
+                  # broken on MacOS?
+                  pkgs.cargo-workspaces
                 ];
 
                 shellHook = ''


### PR DESCRIPTION
Seems broken:

https://github.com/fedimint/fedimint/actions/runs/8442492153/job/23124016592