### PR TITLE
chore(ci): introduce explicit status check

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -561,6 +561,20 @@ jobs:
         with:
           files: "rpms/**.rpm"
 
+  status:
+    name: Status
+    needs: [lint, shell, build, cross, ccov, containers, pkgs]
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check status of all jobs
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure') ||
+            contains(needs.*.result, 'cancelled')
+          }}
+        run: exit 1
+
   notifications:
     if: always() && github.repository == 'fedimint/fedimint' && github.event_name != 'merge_group'
     name: "Notifications"
@@ -568,7 +582,7 @@ jobs:
     runs-on: ubuntu-22.04
     # note: we don't depend on `audit` because it will
     # be often broken, and we can't fix it immediately
-    needs: [ build, shell, cross, ccov, containers, pkgs ]
+    needs: [ lint, build, shell, cross, ccov, containers, pkgs ]
 
     steps:
     - name: Discord notifications on failure


### PR DESCRIPTION
This is a workaround for matrix jobs "Required" being broken in Github Actions.

After it lands, we should make it "Required".