### PR TITLE
chore: notify for back-compat failures in merge group

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -78,7 +78,7 @@ jobs:
             !/tmp/nix-build-*/source/
 
   notifications:
-    if: always() && github.repository == 'fedimint/fedimint' && github.event_name != 'merge_group'
+    if: always() && github.repository == 'fedimint/fedimint'
     name: "Notifications"
     timeout-minutes: 1
     runs-on: ubuntu-22.04


### PR DESCRIPTION
We recently started skipping notifications for failures in the merge queue in https://github.com/fedimint/fedimint/pull/4469. That makes sense for `ci-nix` since the workflows are required to pass, but back-compat isn't required and we may fail without notifications (e.g. [failed run](https://github.com/fedimint/fedimint/actions/runs/8445095915/job/23131758594)).

Alternatively, and perhaps preferably, we can make back-compat required in the merge queue.