### PR TITLE
chore(devimint): increase default poll timeout from 30s to 60s

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -18,7 +18,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use crate::devfed::DevJitFed;
 use crate::federation::Fedimintd;
-use crate::util::{poll, ProcessManager};
+use crate::util::{poll, poll_with_timeout, ProcessManager};
 use crate::{external_daemons, vars, ExternalDaemons};
 
 fn random_test_dir_suffix() -> String {
@@ -337,7 +337,7 @@ pub async fn rpc_command(rpc: RpcCmd, common: CommonArgs) -> Result<()> {
     match rpc {
         RpcCmd::Env => {
             let env_file = common.test_dir().join("env");
-            poll("env file", None, || async {
+            poll("env file", || async {
                 if fs::try_exists(&env_file)
                     .await
                     .context("env file")
@@ -355,7 +355,7 @@ pub async fn rpc_command(rpc: RpcCmd, common: CommonArgs) -> Result<()> {
         }
         RpcCmd::Wait => {
             let ready_file = common.test_dir().join("ready");
-            poll("ready file", Duration::from_secs(60), || async {
+            poll_with_timeout("ready file", Duration::from_secs(60), || async {
                 if fs::try_exists(&ready_file)
                     .await
                     .context("ready file")
@@ -413,7 +413,7 @@ async fn run_ui(process_mgr: &ProcessManager) -> Result<(Vec<Fedimintd>, Externa
             let fm = Fedimintd::new(process_mgr, bitcoind.clone(), peer, &vars).await?;
             let server_addr = &vars.FM_BIND_API;
 
-            poll("waiting for api startup", None, || async {
+            poll("waiting for api startup", || async {
                 TcpStream::connect(server_addr)
                     .await
                     .context("connect to api")

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -2,7 +2,6 @@ use std::ffi;
 use std::fmt::Write;
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
@@ -18,7 +17,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use crate::devfed::DevJitFed;
 use crate::federation::Fedimintd;
-use crate::util::{poll, poll_with_timeout, ProcessManager};
+use crate::util::{poll, ProcessManager};
 use crate::{external_daemons, vars, ExternalDaemons};
 
 fn random_test_dir_suffix() -> String {
@@ -355,7 +354,7 @@ pub async fn rpc_command(rpc: RpcCmd, common: CommonArgs) -> Result<()> {
         }
         RpcCmd::Wait => {
             let ready_file = common.test_dir().join("ready");
-            poll_with_timeout("ready file", Duration::from_secs(60), || async {
+            poll("ready file", || async {
                 if fs::try_exists(&ready_file)
                     .await
                     .context("ready file")

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -456,7 +456,7 @@ impl Lnd {
         let lnd_rpc_addr = &process_mgr.globals.FM_LND_RPC_ADDR;
         let lnd_macaroon = &process_mgr.globals.FM_LND_MACAROON;
         let lnd_tls_cert = &process_mgr.globals.FM_LND_TLS_CERT;
-        poll_with_timeout("wait for lnd files", Duration::from_secs(60), || async {
+        poll("wait for lnd files", || async {
             if fs::try_exists(lnd_tls_cert)
                 .await
                 .context("lnd tls cert")

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -25,7 +25,7 @@ use tonic_lnd::lnrpc::{ChanInfoRequest, GetInfoRequest, ListChannelsRequest, Pol
 use tonic_lnd::Client as LndClient;
 use tracing::{debug, info, trace, warn};
 
-use crate::util::{poll, ClnLightningCli, ProcessHandle, ProcessManager};
+use crate::util::{poll, poll_with_timeout, ClnLightningCli, ProcessHandle, ProcessManager};
 use crate::vars::utf8;
 use crate::{cmd, poll_eq};
 
@@ -121,7 +121,7 @@ impl Bitcoind {
         trace!(target: LOG_DEVIMINT, blocks_num=blocks, %address, "Mining blocks to address complete");
 
         // wait bitciond is ready
-        poll("bitcoind", None, || async {
+        poll("bitcoind", || async {
             let info = client
                 .get_blockchain_info()
                 .context("bitcoind getblockchaininfo")
@@ -142,7 +142,7 @@ impl Bitcoind {
 
     /// Poll until bitcoind rpc responds for basic commands
     pub async fn poll_ready(&self) -> anyhow::Result<()> {
-        poll("btcoind rpc ready", Duration::from_secs(10), || async {
+        poll_with_timeout("btcoind rpc ready", Duration::from_secs(10), || async {
             self.get_block_count()
                 .await
                 .map_err(ControlFlow::Continue::<anyhow::Error, _>)?;
@@ -336,7 +336,7 @@ impl Lightningd {
         let process = Lightningd::start(process_mgr, cln_dir).await?;
 
         let socket_cln = cln_dir.join("regtest/lightning-rpc");
-        poll("lightningd", Duration::from_secs(15), || async {
+        poll_with_timeout("lightningd", Duration::from_secs(15), || async {
             ClnRpc::new(socket_cln.clone())
                 .await
                 .context("connect to lightningd")
@@ -378,7 +378,7 @@ impl Lightningd {
     }
 
     pub async fn await_block_processing(&self) -> Result<()> {
-        poll("lightningd block processing", None, || async {
+        poll("lightningd block processing", || async {
             let btc_height = self
                 .bitcoind
                 .get_blockchain_info()
@@ -429,7 +429,7 @@ impl Lnd {
             process,
         };
         // wait for lnd rpc to be active
-        poll("lnd_startup", Duration::from_secs(15), || async {
+        poll_with_timeout("lnd_startup", Duration::from_secs(15), || async {
             this.pub_key().await.map_err(ControlFlow::Continue)
         })
         .await?;
@@ -456,7 +456,7 @@ impl Lnd {
         let lnd_rpc_addr = &process_mgr.globals.FM_LND_RPC_ADDR;
         let lnd_macaroon = &process_mgr.globals.FM_LND_MACAROON;
         let lnd_tls_cert = &process_mgr.globals.FM_LND_TLS_CERT;
-        poll("wait for lnd files", Duration::from_secs(60), || async {
+        poll_with_timeout("wait for lnd files", Duration::from_secs(60), || async {
             if fs::try_exists(lnd_tls_cert)
                 .await
                 .context("lnd tls cert")
@@ -475,7 +475,7 @@ impl Lnd {
         })
         .await?;
 
-        let client = poll("lnd_connect", None, || async {
+        let client = poll("lnd_connect", || async {
             tonic_lnd::connect(
                 lnd_rpc_addr.clone(),
                 lnd_tls_cert.clone(),
@@ -515,7 +515,7 @@ impl Lnd {
     }
 
     pub async fn await_block_processing(&self) -> Result<()> {
-        poll("lnd block processing", None, || async {
+        poll("lnd block processing", || async {
             let synced = self
                 .lightning_client_lock()
                 .await
@@ -570,7 +570,7 @@ pub async fn open_channel(
     .await
     .context("connect request")?;
 
-    poll("fund channel", None, || async {
+    poll("fund channel", || async {
         cln.request(cln_rpc::model::requests::FundchannelRequest {
             id: lnd_pubkey
                 .parse()
@@ -595,7 +595,7 @@ pub async fn open_channel(
     })
     .await?;
 
-    poll("list peers", None, || async {
+    poll("list peers", || async {
         let num_peers = cln
             .request(cln_rpc::model::requests::ListpeersRequest {
                 id: Some(
@@ -615,7 +615,7 @@ pub async fn open_channel(
     .await?;
     bitcoind.mine_blocks(10).await?;
 
-    poll("Wait for channel update", None, || async {
+    poll("Wait for channel update", || async {
         let mut lnd_client = lnd.client.lock().await;
         let channels = lnd_client
             .lightning()

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -3,7 +3,6 @@ mod config;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::ControlFlow;
 use std::path::PathBuf;
-use std::time::Duration;
 use std::{env, fs};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -32,7 +31,7 @@ use tracing::{debug, info};
 use super::external::Bitcoind;
 use super::util::{cmd, parse_map, Command, ProcessHandle, ProcessManager};
 use super::vars::utf8;
-use crate::util::{poll, poll_with_timeout, FedimintdCmd};
+use crate::util::{poll, FedimintdCmd};
 use crate::{poll_eq, vars};
 
 #[derive(Clone)]
@@ -680,9 +679,8 @@ async fn set_config_gen_params(
 }
 
 async fn wait_server_status(client: &DynGlobalApi, expected_status: ServerStatus) -> Result<()> {
-    poll_with_timeout(
+    poll(
         &format!("waiting-server-status: {expected_status:?}"),
-        Duration::from_secs(60),
         || async {
             let server_status = client
                 .status()

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -32,7 +32,7 @@ use tracing::{debug, info};
 use super::external::Bitcoind;
 use super::util::{cmd, parse_map, Command, ProcessHandle, ProcessManager};
 use super::vars::utf8;
-use crate::util::{poll, FedimintdCmd};
+use crate::util::{poll, poll_with_timeout, FedimintdCmd};
 use crate::{poll_eq, vars};
 
 #[derive(Clone)]
@@ -345,7 +345,7 @@ impl Federation {
         let pegin_addr = gw.get_pegin_addr(&fed_id).await?;
         self.bitcoind.send_to(pegin_addr, amount).await?;
         self.bitcoind.mine_blocks(21).await?;
-        poll("gateway pegin", None, || async {
+        poll("gateway pegin", || async {
             let gateway_balance = cmd!(gw, "balance", "--federation-id={fed_id}")
                 .out_json()
                 .await
@@ -405,7 +405,7 @@ impl Federation {
             "update-gateway-cache"
         };
 
-        poll("gateways registered", None, || async {
+        poll("gateways registered", || async {
             let num_gateways = cmd!(self.client, command)
                 .out_json()
                 .await
@@ -424,7 +424,7 @@ impl Federation {
     }
 
     pub async fn await_all_peers(&self) -> Result<()> {
-        poll("Waiting for all peers to be online", None, || async {
+        poll("Waiting for all peers to be online", || async {
             cmd!(
                 self.client,
                 "dev",
@@ -505,17 +505,13 @@ pub async fn run_dkg(
 ) -> Result<()> {
     let auth_for = |peer: &PeerId| -> ApiAuth { params[peer].local.api_auth.clone() };
     for (peer_id, client) in &admin_clients {
-        poll(
-            "trying-to-connect-to-peers",
-            Duration::from_secs(30),
-            || async {
-                client
-                    .status()
-                    .await
-                    .context("dkg status")
-                    .map_err(ControlFlow::Continue)
-            },
-        )
+        poll("trying-to-connect-to-peers", || async {
+            client
+                .status()
+                .await
+                .context("dkg status")
+                .map_err(ControlFlow::Continue)
+        })
         .await?;
         debug!("Connected to {peer_id}")
     }
@@ -684,7 +680,7 @@ async fn set_config_gen_params(
 }
 
 async fn wait_server_status(client: &DynGlobalApi, expected_status: ServerStatus) -> Result<()> {
-    poll(
+    poll_with_timeout(
         &format!("waiting-server-status: {expected_status:?}"),
         Duration::from_secs(60),
         || async {

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::ops::ControlFlow;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 use ln_gateway::rpc::V1_API_ENDPOINT;
@@ -52,7 +51,6 @@ impl Gatewayd {
         };
         poll(
             "waiting for gateway to be ready to respond to rpc",
-            Duration::from_secs(30),
             || async { gatewayd.gateway_id().await.map_err(ControlFlow::Continue) },
         )
         .await?;
@@ -94,7 +92,7 @@ impl Gatewayd {
 
     pub async fn connect_fed(&self, fed: &Federation) -> Result<()> {
         let invite_code = fed.invite_code()?;
-        poll("gateway connect-fed", Duration::from_secs(30), || async {
+        poll("gateway connect-fed", || async {
             cmd!(self, "connect-fed", invite_code.clone())
                 .run()
                 .await

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info};
 
 use crate::cli::{cleanup_on_exit, exec_user_command, setup, write_ready_file, CommonArgs};
 use crate::federation::{Client, Federation};
-use crate::util::{poll, LoadTestTool, ProcessManager};
+use crate::util::{poll, poll_with_timeout, LoadTestTool, ProcessManager};
 use crate::{cmd, dev_fed, poll_eq, DevFed, Gatewayd, LightningNode, Lightningd, Lnd};
 
 pub struct Stats {
@@ -941,7 +941,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     let txid: Txid = withdraw_res["txid"].as_str().unwrap().parse().unwrap();
     let fees_sat = withdraw_res["fees_sat"].as_u64().unwrap();
 
-    let tx_hex = poll("Waiting for transaction in mempool", None, || async {
+    let tx_hex = poll("Waiting for transaction in mempool", || async {
         // TODO: distinguish errors from not found
         bitcoind
             .get_raw_transaction(&txid)
@@ -1485,7 +1485,7 @@ pub async fn gw_reboot_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
     )?;
 
     let cln_info: GatewayInfo = serde_json::from_value(cln_value)?;
-    poll(
+    poll_with_timeout(
         "Waiting for CLN Gateway Running state after reboot",
         Duration::from_secs(15),
         || async {
@@ -1505,7 +1505,7 @@ pub async fn gw_reboot_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
     .await?;
 
     let lnd_info: GatewayInfo = serde_json::from_value(lnd_value)?;
-    poll(
+    poll_with_timeout(
         "Waiting for LND Gateway Running state after reboot",
         Duration::from_secs(15),
         || async {
@@ -1537,18 +1537,14 @@ pub async fn do_try_create_and_pay_invoice(
     // Verify that after the lightning node has restarted, the gateway
     // automatically reconnects and can query the lightning node
     // info again.
-    poll(
-        "Waiting for info to succeed after restart",
-        None,
-        || async {
-            let mut info_cmd = cmd!(gw, "info");
-            let lightning_info = info_cmd.out_json().await.map_err(ControlFlow::Continue)?;
-            let gateway_info: GatewayInfo = serde_json::from_value(lightning_info)
-                .context("invalid json")
-                .map_err(ControlFlow::Break)?;
-            poll_eq!(gateway_info.lightning_pub_key.is_some(), true)
-        },
-    )
+    poll("Waiting for info to succeed after restart", || async {
+        let mut info_cmd = cmd!(gw, "info");
+        let lightning_info = info_cmd.out_json().await.map_err(ControlFlow::Continue)?;
+        let gateway_info: GatewayInfo = serde_json::from_value(lightning_info)
+            .context("invalid json")
+            .map_err(ControlFlow::Break)?;
+        poll_eq!(gateway_info.lightning_pub_key.is_some(), true)
+    })
     .await?;
 
     tracing::info!("Creating invoice....");
@@ -1789,7 +1785,7 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
         .expect("withdrawal should contain txid string")
         .parse()
         .expect("txid should be parsable");
-    let tx_hex = poll("Waiting for transaction in mempool", None, || async {
+    let tx_hex = poll("Waiting for transaction in mempool", || async {
         bitcoind
             .get_raw_transaction(&txid)
             .await
@@ -2024,7 +2020,7 @@ pub async fn guardian_backup_test(dev_fed: DevFed, process_mgr: &ProcessManager)
         .await
         .expect("could not restart fedimintd");
 
-    poll("Peer catches up again", Duration::from_secs(30), || async {
+    poll("Peer catches up again", || async {
         let block_count = cmd!(
             client,
             "dev",
@@ -2202,7 +2198,7 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                                 .spawn_daemon("faucet", cmd!(crate::util::Faucet))
                                 .await?;
 
-                            poll("waiting for faucet startup", None, || async {
+                            poll("waiting for faucet startup", || async {
                                 TcpStream::connect(format!(
                                     "127.0.0.1:{}",
                                     process_mgr.globals.FM_PORT_FAUCET

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -407,7 +407,7 @@ where
     unreachable!();
 }
 
-const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_secs(60);
 /// Retry until `f` succeeds or default timeout is reached
 ///
 /// - if `f` return Ok(val), this returns with Ok(val).

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -362,23 +362,21 @@ macro_rules! poll_eq {
 // Allow macro to be used within the crate. See https://stackoverflow.com/a/31749071.
 pub(crate) use cmd;
 
-const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_secs(30);
 /// Retry until `f` succeeds or timeout is reached
 ///
 /// - if `f` return Ok(val), this returns with Ok(val).
 /// - if `f` return Err(Control::Break(err)), this returns Err(err)
-/// - if `f` return Err(ControlFlow::Continue(err)), retries untile timeout
+/// - if `f` return Err(ControlFlow::Continue(err)), retries until timeout
 ///   reached
-pub async fn poll<Fut, R>(
+pub async fn poll_with_timeout<Fut, R>(
     name: &str,
-    timeout: impl Into<Option<Duration>>,
+    timeout: Duration,
     f: impl Fn() -> Fut,
 ) -> Result<R>
 where
     Fut: Future<Output = Result<R, ControlFlow<anyhow::Error, anyhow::Error>>>,
 {
     let start = now();
-    let timeout = timeout.into().unwrap_or(DEFAULT_POLL_TIMEOUT);
     for attempt in 0u64.. {
         let attempt_start = now();
         match f().await {
@@ -407,6 +405,20 @@ where
     }
 
     unreachable!();
+}
+
+const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_secs(30);
+/// Retry until `f` succeeds or default timeout is reached
+///
+/// - if `f` return Ok(val), this returns with Ok(val).
+/// - if `f` return Err(Control::Break(err)), this returns Err(err)
+/// - if `f` return Err(ControlFlow::Continue(err)), retries until timeout
+///   reached
+pub async fn poll<Fut, R>(name: &str, f: impl Fn() -> Fut) -> Result<R>
+where
+    Fut: Future<Output = Result<R, ControlFlow<anyhow::Error, anyhow::Error>>>,
+{
+    poll_with_timeout(name, DEFAULT_POLL_TIMEOUT, f).await
 }
 
 // used to add `cmd` method.


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/4636

30s caused a flake polling the gateway balance. Let's bump to 60s.

```
00:00:39 Error: Polling gateway pegin failed after 75 retries (timeout: 30s)
00:00:39 
00:00:39 Caused by:
00:00:39     assertion failed, left: 9999999999 right: 10000000000
## FAIL: devimint_cli_test_single (FM: current, CLI: v0.2.1, GW: current)
```
https://github.com/fedimint/fedimint/actions/runs/8445095915/job/23131758594#step:6:1737

I'm tempted to change the default for poll from 30s to 60s, but I think I'll wait for one more 30s threshold to cause a flake. If the reviewer(s) feels strongly, I can instead change the default in this PR.

Edit:
Changed the default