### PR TITLE
Implement meta field fallback logic and caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,7 +1196,7 @@ checksum = "d3e11244e7fd8b0beee0a3c62137c4bd9f756fe2c492ccf93171f81467b59200"
 dependencies = [
  "bitcoin 0.29.2",
  "log",
- "reqwest",
+ "reqwest 0.11.26",
  "serde",
 ]
 
@@ -1351,7 +1351,7 @@ dependencies = [
  "lightning-invoice",
  "lnurl-rs",
  "rand",
- "reqwest",
+ "reqwest 0.11.26",
  "serde",
  "serde_json",
  "thiserror",
@@ -1681,7 +1681,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-ln-gateway",
  "fedimint-logging",
- "reqwest",
+ "reqwest 0.11.26",
  "serde",
  "serde_json",
  "tokio",
@@ -1716,7 +1716,7 @@ dependencies = [
  "itertools 0.12.1",
  "lightning-invoice",
  "rand",
- "reqwest",
+ "reqwest 0.11.26",
  "secp256k1 0.24.3",
  "secp256k1-zkp",
  "serde",
@@ -1801,7 +1801,7 @@ dependencies = [
  "lightning-invoice",
  "prost",
  "rand",
- "reqwest",
+ "reqwest 0.11.26",
  "secp256k1 0.24.3",
  "secp256k1-zkp",
  "serde",
@@ -1942,12 +1942,14 @@ dependencies = [
  "futures",
  "hex",
  "rand",
+ "reqwest 0.12.2",
  "secp256k1 0.24.3",
  "serde",
  "serde_json",
  "strum",
  "strum_macros",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 
@@ -2322,7 +2324,7 @@ dependencies = [
  "hex",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "prost",
  "rustls 0.21.10",
  "rustls-pemfile 1.0.4",
@@ -3149,6 +3151,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,6 +3186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -3174,6 +3194,9 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3627,7 +3650,7 @@ dependencies = [
  "bitcoin 0.30.2",
  "cbc",
  "email_address",
- "reqwest",
+ "reqwest 0.11.26",
  "serde",
  "serde_json",
  "url",
@@ -4366,7 +4389,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -4390,6 +4413,47 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.22.2",
+ "rustls-pemfile 1.0.4",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.1",
  "winreg",
 ]
 

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2235,6 +2235,7 @@ impl ClientBuilder {
                             notifier.clone(),
                             api.clone(),
                             self.admin_creds.as_ref().map(|cred| cred.auth.clone()),
+                            task_group.clone(),
                         )
                         .await?;
 

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2220,8 +2220,7 @@ impl ClientBuilder {
                     let module = module_init
                         .init(
                             final_client.clone(),
-                            fed_id,
-                            config.global.api_endpoints.len(),
+                            config.global.clone(),
                             module_config,
                             db.clone(),
                             module_instance_id,

--- a/modules/fedimint-meta-client/Cargo.toml
+++ b/modules/fedimint-meta-client/Cargo.toml
@@ -16,7 +16,7 @@ name = "fedimint_meta_client"
 path = "src/lib.rs"
 
 [features]
-default =[]
+default = []
 cli = ["dep:clap", "dep:serde_json"]
 
 [dependencies]
@@ -32,9 +32,11 @@ futures = { workspace = true }
 erased-serde = { workspace = true }
 rand = { workspace = true }
 secp256k1 = "0.24.2"
-serde = {version = "1.0.149", features = [ "derive" ] }
+serde = { version = "1.0.149", features = ["derive"] }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+tokio = { version = "1.36.0", features = ["sync"] }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 threshold_crypto = { workspace = true }
+reqwest = { version = "0.12.2", default-features = false, features = ["json", "rustls-tls", ] }

--- a/modules/fedimint-meta-client/src/db.rs
+++ b/modules/fedimint-meta-client/src/db.rs
@@ -1,11 +1,37 @@
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::impl_db_record;
+use serde::Serialize;
 use strum_macros::EnumIter;
 
-// #[repr(u8)]
+use crate::MetaFields;
+
+#[repr(u8)]
 #[derive(Clone, Debug, EnumIter)]
-pub enum DbKeyPrefix {}
+pub enum DbKeyPrefix {
+    LegacyMetaOverrideCache = 0x00,
+    MetaCache = 0x01,
+}
 
 impl std::fmt::Display for DbKeyPrefix {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{self:?}")
     }
 }
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct LegacyMetaOverrideCacheKey;
+
+impl_db_record!(
+    key = LegacyMetaOverrideCacheKey,
+    value = MetaFields,
+    db_prefix = DbKeyPrefix::LegacyMetaOverrideCache,
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct MetaCacheKey;
+
+impl_db_record!(
+    key = MetaCacheKey,
+    value = MetaFields,
+    db_prefix = DbKeyPrefix::MetaCache,
+);

--- a/modules/fedimint-meta-common/src/lib.rs
+++ b/modules/fedimint-meta-common/src/lib.rs
@@ -8,7 +8,7 @@ use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::plugin_types_trait_impl_common;
-use serde::de::{self, Visitor};
+use serde::de::{self, DeserializeOwned, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
@@ -43,7 +43,7 @@ pub const CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::ne
     Serialize,
     Deserialize,
 )]
-pub struct MetaKey(u8);
+pub struct MetaKey(pub u8);
 
 impl fmt::Display for MetaKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -94,7 +94,8 @@ impl MetaValue {
         &self.0
     }
 
-    pub fn to_json(&self) -> anyhow::Result<serde_json::Value> {
+    /// Parses the value as JSON into a given type `T`
+    pub fn json<T: DeserializeOwned>(&self) -> anyhow::Result<T> {
         Ok(serde_json::from_slice(&self.0)?)
     }
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -471,7 +471,7 @@ impl ClientModuleInit for MintClientInit {
 
     async fn init(&self, args: &ClientModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
         Ok(MintClientModule {
-            federation_id: *args.federation_id(),
+            federation_id: args.federation_id(),
             cfg: args.cfg().clone(),
             secret: args.module_root_secret().clone(),
             secp: Secp256k1::new(),


### PR DESCRIPTION
The new meta module (#4513) allows guardians to change meta fields by voting on them. But without providing an interface for actually fetching meta fields it's cumbersome to use. Furthermore, old federations still use a meta override file or the federation's static config. 

This PR implements background fetching and querying in order of precedence of all these sources.

TODO:
- [ ] Test: likely manual? Did we ever set up an override meta server in devimint?
- [ ] Expose via CLI for testing