### PR TITLE
feat(devimint): add upgrade tests for all binaries

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -3,6 +3,7 @@ mod config;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::ControlFlow;
 use std::path::PathBuf;
+use std::time::Duration;
 use std::{env, fs};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -325,6 +326,77 @@ impl Federation {
             bail!("fedimintd-{peer_id} does not exist");
         };
         fedimintd.terminate().await?;
+        Ok(())
+    }
+
+    /// Starts all peers not currently running.
+    pub async fn start_all_servers(&mut self, process_mgr: &ProcessManager) -> Result<()> {
+        info!("starting all servers");
+        let fed_size = process_mgr.globals.FM_FED_SIZE;
+        for peer_id in 0..fed_size {
+            if self.members.contains_key(&peer_id) {
+                continue;
+            }
+            self.start_server(process_mgr, peer_id).await?
+        }
+        self.await_all_peers().await?;
+        Ok(())
+    }
+
+    /// Terminates all running peers.
+    pub async fn terminate_all_servers(&mut self) -> Result<()> {
+        info!("terminating all servers");
+        let running_peer_ids: Vec<_> = self.members.keys().cloned().collect();
+        for peer_id in running_peer_ids {
+            self.terminate_server(peer_id).await?
+        }
+        Ok(())
+    }
+
+    /// Coordinated shutdown of all peers that restart using the provided
+    /// `bin_path`. Returns `Ok()` once all peers are online.
+    ///
+    /// Staggering the restart more closely simulates upgrades in the wild.
+    pub async fn restart_all_staggered_with_bin(
+        &mut self,
+        process_mgr: &ProcessManager,
+        bin_path: &PathBuf,
+    ) -> Result<()> {
+        let fed_size = process_mgr.globals.FM_FED_SIZE;
+
+        // ensure all peers are online
+        self.start_all_servers(process_mgr).await?;
+
+        // staggered shutdown of peers
+        while self.num_members() > 0 {
+            self.terminate_server(self.num_members() - 1).await?;
+            if self.num_members() > 0 {
+                fedimint_core::task::sleep_in_test(
+                    "waiting to shutdown remaining peers",
+                    Duration::from_secs(10),
+                )
+                .await;
+            }
+        }
+
+        std::env::set_var("FM_FEDIMINTD_BASE_EXECUTABLE", bin_path);
+
+        // staggered restart
+        for peer_id in 0..fed_size {
+            self.start_server(process_mgr, peer_id).await?;
+            if peer_id < fed_size - 1 {
+                fedimint_core::task::sleep_in_test(
+                    "waiting to restart remaining peers",
+                    Duration::from_secs(10),
+                )
+                .await;
+            }
+        }
+
+        self.await_all_peers().await?;
+
+        let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
+        info!("upgraded fedimintd to version: {}", fedimintd_version);
         Ok(())
     }
 

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use std::ops::ControlFlow;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use ln_gateway::rpc::V1_API_ENDPOINT;
+use tracing::info;
 
 use crate::cmd;
 use crate::envs::{FM_GATEWAY_API_ADDR_ENV, FM_GATEWAY_DATA_DIR_ENV, FM_GATEWAY_LISTEN_ADDR_ENV};
@@ -63,7 +65,7 @@ impl Gatewayd {
     }
 
     pub async fn stop_lightning_node(&mut self) -> Result<()> {
-        tracing::info!("Stopping lightning node");
+        info!("Stopping lightning node");
         match self.ln.take() {
             Some(LightningNode::Lnd(lnd)) => lnd.terminate().await,
             Some(LightningNode::Cln(cln)) => cln.terminate().await,
@@ -71,6 +73,27 @@ impl Gatewayd {
                 "Cannot stop an already stopped Lightning Node"
             )),
         }
+    }
+
+    /// Restarts the gateway using the provided `bin_path`, which is useful for
+    /// testing upgrades.
+    pub async fn restart_with_bin(
+        &mut self,
+        process_mgr: &ProcessManager,
+        bin_path: &PathBuf,
+    ) -> Result<()> {
+        self._process.terminate().await?;
+        std::env::set_var("FM_GATEWAYD_BASE_EXECUTABLE", bin_path);
+        let ln = self
+            .ln
+            .as_ref()
+            .expect("gateway already had an associated ln node")
+            .clone();
+        let new_gw = Self::new(process_mgr, ln).await?;
+        self._process = new_gw._process;
+        let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
+        info!("upgraded gatewayd to version: {}", gatewayd_version);
+        Ok(())
     }
 
     pub async fn cmd(&self) -> Command {

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -17,9 +17,9 @@ use fedimint_logging::LOG_DEVIMINT;
 use hex::ToHex;
 use ln_gateway::rpc::GatewayInfo;
 use serde_json::json;
-use tokio::fs;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
+use tokio::{fs, try_join};
 use tracing::{debug, info};
 
 use crate::cli::{cleanup_on_exit, exec_user_command, setup, write_ready_file, CommonArgs};
@@ -98,7 +98,11 @@ pub async fn log_binary_versions() -> Result<()> {
     Ok(())
 }
 
-pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
+pub async fn latency_tests(
+    dev_fed: DevFed,
+    r#type: LatencyTest,
+    upgrade_clients: Option<&UpgradeClients>,
+) -> Result<()> {
     log_binary_versions().await?;
 
     #[allow(unused_variables)]
@@ -116,7 +120,17 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
     let max_p90_factor = 5.0;
     let p90_median_factor = 7;
 
-    let client = fed.new_joined_client("latency-tests-client").await?;
+    let client = match upgrade_clients {
+        Some(c) => match r#type {
+            LatencyTest::Reissue => c.reissue_client.clone(),
+            LatencyTest::LnSend => c.ln_send_client.clone(),
+            LatencyTest::LnReceive => c.ln_receive_client.clone(),
+            LatencyTest::FmPay => c.fm_pay_client.clone(),
+            LatencyTest::Restore => bail!("no reusable upgrade client for restore"),
+        },
+        None => fed.new_joined_client("latency-tests-client").await?,
+    };
+
     client.use_gateway(&gw_cln).await?;
     let initial_balance_sats = 100_000_000;
     fed.pegin_client(initial_balance_sats, &client).await?;
@@ -372,6 +386,164 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+/// Clients reused for upgrade tests
+pub struct UpgradeClients {
+    reissue_client: Client,
+    ln_send_client: Client,
+    ln_receive_client: Client,
+    fm_pay_client: Client,
+}
+
+async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> anyhow::Result<()> {
+    use futures::FutureExt;
+
+    // skip restore test for client upgrades, since restoring a client doesn't
+    // require a persistent data dir
+    let restore_test = if clients.is_some() {
+        futures::future::ok(()).right_future()
+    } else {
+        latency_tests(dev_fed.clone(), LatencyTest::Restore, clients).left_future()
+    };
+
+    try_join!(
+        latency_tests(dev_fed.clone(), LatencyTest::Reissue, clients),
+        latency_tests(dev_fed.clone(), LatencyTest::LnSend, clients),
+        latency_tests(dev_fed.clone(), LatencyTest::LnReceive, clients),
+        latency_tests(dev_fed.clone(), LatencyTest::FmPay, clients),
+        restore_test,
+    )?;
+    Ok(())
+}
+
+pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) -> Result<()> {
+    match binary {
+        UpgradeTest::Fedimintd { paths } => {
+            if let Some(oldest_fedimintd) = paths.first() {
+                std::env::set_var("FM_FEDIMINTD_BASE_EXECUTABLE", oldest_fedimintd);
+            } else {
+                bail!("Must provide at least 1 binary path");
+            }
+
+            let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
+            info!(
+                "running first stress test for fedimintd version: {}",
+                fedimintd_version
+            );
+
+            let mut dev_fed = dev_fed(process_mgr).await?;
+            let client = dev_fed.fed.new_joined_client("test-client").await?;
+            try_join!(stress_test_fed(&dev_fed, None), wait_session(&client))?;
+
+            for path in paths.iter().skip(1) {
+                dev_fed
+                    .fed
+                    .restart_all_staggered_with_bin(process_mgr, path)
+                    .await?;
+
+                // stress test with all peers online
+                try_join!(stress_test_fed(&dev_fed, None), wait_session(&client))?;
+
+                // ensure a degraded federation with the last peer online works, since the last
+                // peer is the last to restart
+                dev_fed.fed.terminate_server(1).await?;
+                try_join!(stress_test_fed(&dev_fed, None), wait_session(&client))?;
+
+                let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
+                info!(
+                    "### fedimintd passed stress test for version {}",
+                    fedimintd_version
+                );
+            }
+            info!("## fedimintd upgraded all binaries successfully")
+        }
+        UpgradeTest::FedimintCli { paths } => {
+            let set_fedimint_cli_path = |path: &PathBuf| {
+                std::env::set_var("FM_FEDIMINT_CLI_BASE_EXECUTABLE", path);
+                let fm_mint_client: String = format!(
+                    "{fedimint_cli} --data-dir {datadir}",
+                    fedimint_cli = crate::util::get_fedimint_cli_path().join(" "),
+                    datadir = crate::vars::utf8(&process_mgr.globals.FM_CLIENT_DIR)
+                );
+                std::env::set_var("FM_MINT_CLIENT", fm_mint_client);
+            };
+
+            if let Some(oldest_fedimint_cli) = paths.first() {
+                set_fedimint_cli_path(oldest_fedimint_cli);
+            } else {
+                bail!("Must provide at least 1 binary path");
+            }
+
+            let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
+            info!(
+                "running first stress test for fedimint-cli version: {}",
+                fedimint_cli_version
+            );
+
+            let dev_fed = dev_fed(process_mgr).await?;
+
+            let wait_session_client = dev_fed.fed.new_joined_client("wait-session-client").await?;
+            let reusable_upgrade_clients = UpgradeClients {
+                reissue_client: dev_fed.fed.new_joined_client("reissue-client").await?,
+                ln_send_client: dev_fed.fed.new_joined_client("ln-send-client").await?,
+                ln_receive_client: dev_fed.fed.new_joined_client("ln-receive-client").await?,
+                fm_pay_client: dev_fed.fed.new_joined_client("fm-pay-client").await?,
+            };
+
+            try_join!(
+                stress_test_fed(&dev_fed, Some(&reusable_upgrade_clients)),
+                wait_session(&wait_session_client)
+            )?;
+
+            for path in paths.iter().skip(1) {
+                set_fedimint_cli_path(path);
+                let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
+                info!("upgraded fedimint-cli to version: {}", fedimint_cli_version);
+                try_join!(
+                    stress_test_fed(&dev_fed, Some(&reusable_upgrade_clients)),
+                    wait_session(&wait_session_client)
+                )?;
+                info!(
+                    "### fedimint-cli passed stress test for version {}",
+                    fedimint_cli_version
+                );
+            }
+            info!("## fedimint-cli upgraded all binaries successfully")
+        }
+        UpgradeTest::Gatewayd { paths } => {
+            if let Some(oldest_gatewayd) = paths.first() {
+                std::env::set_var("FM_GATEWAYD_BASE_EXECUTABLE", oldest_gatewayd);
+            } else {
+                bail!("Must provide at least 1 binary path");
+            }
+
+            let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
+            info!(
+                "running first stress test for gatewayd version: {}",
+                gatewayd_version
+            );
+
+            let mut dev_fed = dev_fed(process_mgr).await?;
+            let client = dev_fed.fed.new_joined_client("test-client").await?;
+            try_join!(stress_test_fed(&dev_fed, None), wait_session(&client))?;
+
+            for path in paths.iter().skip(1) {
+                try_join!(
+                    dev_fed.gw_cln.restart_with_bin(process_mgr, path),
+                    dev_fed.gw_lnd.restart_with_bin(process_mgr, path),
+                )?;
+                try_join!(stress_test_fed(&dev_fed, None), wait_session(&client))?;
+                let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
+                info!(
+                    "### gatewayd passed stress test for version {}",
+                    gatewayd_version
+                );
+            }
+            info!("## gatewayd upgraded all binaries successfully")
+        }
+    }
     Ok(())
 }
 
@@ -829,7 +1001,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         })
         .await?
         .bolt11;
-    tokio::try_join!(cln.await_block_processing(), lnd.await_block_processing())?;
+    try_join!(cln.await_block_processing(), lnd.await_block_processing())?;
     ln_pay(&client, invoice.clone(), lnd_gw_id.clone(), false).await?;
     let fed_id = fed.calculate_federation_id().await;
 
@@ -1476,7 +1648,7 @@ pub async fn gw_reboot_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
     // Query current gateway infos
     let mut cln_cmd = cmd!(gw_cln, "info");
     let mut lnd_cmd = cmd!(gw_lnd, "info");
-    let (cln_value, lnd_value) = tokio::try_join!(cln_cmd.out_json(), lnd_cmd.out_json())?;
+    let (cln_value, lnd_value) = try_join!(cln_cmd.out_json(), lnd_cmd.out_json())?;
 
     // Drop references to cln and lnd gateways so the test can kill them
     let cln_gateway_id = gw_cln.gateway_id().await?;
@@ -1505,7 +1677,7 @@ pub async fn gw_reboot_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
 
     // Reboot gateways with the same Lightning node instances
     info!("Rebooting gateways...");
-    let (new_gw_cln, new_gw_lnd) = tokio::try_join!(
+    let (new_gw_cln, new_gw_lnd) = try_join!(
         Gatewayd::new(process_mgr, LightningNode::Cln(cln.clone())),
         Gatewayd::new(process_mgr, LightningNode::Lnd(lnd.clone()))
     )?;
@@ -2172,6 +2344,22 @@ pub enum LatencyTest {
 }
 
 #[derive(Subcommand)]
+pub enum UpgradeTest {
+    Fedimintd {
+        #[arg(long, trailing_var_arg = true, num_args=1..)]
+        paths: Vec<PathBuf>,
+    },
+    FedimintCli {
+        #[arg(long, trailing_var_arg = true, num_args=1..)]
+        paths: Vec<PathBuf>,
+    },
+    Gatewayd {
+        #[arg(long, trailing_var_arg = true, num_args=1..)]
+        paths: Vec<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum TestCmd {
     /// `devfed` then checks the average latency of reissuing ecash, LN receive,
     /// and LN send
@@ -2204,8 +2392,10 @@ pub enum TestCmd {
     GuardianBackup,
     /// `devfed` then tests that spent ecash cannot be double spent
     CannotReplayTransaction,
-    UpgradeTest {
-        old_fedimintd: PathBuf,
+    /// Test upgrade paths for a given binary
+    UpgradeTests {
+        #[clap(subcommand)]
+        binary: UpgradeTest,
     },
 }
 
@@ -2238,17 +2428,6 @@ async fn wait_session(client: &federation::Client) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn stress_test_fed(dev_fed: &DevFed) -> anyhow::Result<()> {
-    tokio::try_join!(
-        latency_tests(dev_fed.clone(), LatencyTest::Reissue),
-        latency_tests(dev_fed.clone(), LatencyTest::LnSend),
-        latency_tests(dev_fed.clone(), LatencyTest::LnReceive),
-        latency_tests(dev_fed.clone(), LatencyTest::FmPay),
-        latency_tests(dev_fed.clone(), LatencyTest::Restore),
-    )?;
-    Ok(())
-}
-
 pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()> {
     match cmd {
         TestCmd::WasmTestSetup { exec } => {
@@ -2257,7 +2436,7 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                 let task_group = task_group.clone();
                 async move {
                     let dev_fed = dev_fed(&process_mgr).await?;
-                    let (_, _, faucet) = tokio::try_join!(
+                    let (_, _, faucet) = try_join!(
                         dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_cln),
                         dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_lnd),
                         async {
@@ -2291,7 +2470,7 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
         TestCmd::LatencyTests { r#type } => {
             let (process_mgr, _) = setup(common_args).await?;
             let dev_fed = dev_fed(&process_mgr).await?;
-            latency_tests(dev_fed, r#type).await?;
+            latency_tests(dev_fed, r#type, None).await?;
         }
         TestCmd::ReconnectTest => {
             let (process_mgr, _) = setup(common_args).await?;
@@ -2333,39 +2512,9 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
             let dev_fed = dev_fed(&process_mgr).await?;
             cannot_replay_tx_test(dev_fed).await?;
         }
-        TestCmd::UpgradeTest { old_fedimintd } => {
+        TestCmd::UpgradeTests { binary } => {
             let (process_mgr, _) = setup(common_args).await?;
-            std::env::set_var("FM_FEDIMINTD_BASE_EXECUTABLE", old_fedimintd);
-            let mut dev_fed = dev_fed(&process_mgr).await?;
-            let client = dev_fed.fed.new_joined_client("test-client").await?;
-
-            tokio::try_join!(stress_test_fed(&dev_fed), wait_session(&client))?;
-
-            info!("shutting down servers");
-            dev_fed.fed.terminate_server(3).await?;
-            // kill 3rd peer early
-            tokio::time::sleep(Duration::from_secs(30)).await;
-            dev_fed.fed.terminate_server(0).await?;
-            dev_fed.fed.terminate_server(1).await?;
-            dev_fed.fed.terminate_server(2).await?;
-            info!("restarting servers");
-            // upgrade to fedimintd from PATH
-            std::env::set_var("FM_FEDIMINTD_BASE_EXECUTABLE", "fedimintd");
-            dev_fed.fed.start_server(&process_mgr, 2).await?;
-            dev_fed.fed.start_server(&process_mgr, 1).await?;
-            dev_fed.fed.start_server(&process_mgr, 0).await?;
-            // restart 3rd peer later
-            tokio::time::sleep(Duration::from_secs(30)).await;
-            dev_fed.fed.start_server(&process_mgr, 3).await?;
-            info!("restarted waiting");
-            tokio::time::sleep(Duration::from_secs(10)).await;
-            info!("restarted waited");
-
-            stress_test_fed(&dev_fed).await?;
-            wait_session(&client).await?;
-            // kill 1 to check if 3 is working well
-            dev_fed.fed.terminate_server(1).await?;
-            tokio::try_join!(stress_test_fed(&dev_fed), wait_session(&client))?;
+            upgrade_tests(&process_mgr, binary).await?;
         }
     }
     Ok(())

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -24,7 +24,7 @@ use tracing::{debug, info};
 
 use crate::cli::{cleanup_on_exit, exec_user_command, setup, write_ready_file, CommonArgs};
 use crate::envs::{FM_DATA_DIR_ENV, FM_PASSWORD_ENV};
-use crate::federation::{Client, Federation};
+use crate::federation::{self, Client, Federation};
 use crate::util::{poll, poll_with_timeout, LoadTestTool, ProcessManager};
 use crate::version_constants::{VERSION_0_3_0, VERSION_0_3_0_ALPHA};
 use crate::{cmd, dev_fed, poll_eq, DevFed, Gatewayd, LightningNode, Lightningd, Lnd};
@@ -2204,6 +2204,49 @@ pub enum TestCmd {
     GuardianBackup,
     /// `devfed` then tests that spent ecash cannot be double spent
     CannotReplayTransaction,
+    UpgradeTest {
+        old_fedimintd: PathBuf,
+    },
+}
+
+async fn wait_session(client: &federation::Client) -> anyhow::Result<()> {
+    info!("Waiting for a new session");
+    let session_count = cmd!(client, "dev", "api", "session_count")
+        .out_json()
+        .await?["value"]
+        .as_u64()
+        .context("session count must be integer")?
+        .to_owned();
+    let start = Instant::now();
+    poll_with_timeout(
+        "Waiting for a new session",
+        Duration::from_secs(180),
+        || async {
+            info!("Awaiting session outcome {session_count}");
+            match cmd!(client, "dev", "api", "await_session_outcome", session_count)
+                .run()
+                .await
+            {
+                Err(e) => Err(ControlFlow::Continue(e)),
+                Ok(_) => Ok(()),
+            }
+        },
+    )
+    .await?;
+    let session_found_in = start.elapsed();
+    info!("session found in {session_found_in:?}");
+    Ok(())
+}
+
+async fn stress_test_fed(dev_fed: &DevFed) -> anyhow::Result<()> {
+    tokio::try_join!(
+        latency_tests(dev_fed.clone(), LatencyTest::Reissue),
+        latency_tests(dev_fed.clone(), LatencyTest::LnSend),
+        latency_tests(dev_fed.clone(), LatencyTest::LnReceive),
+        latency_tests(dev_fed.clone(), LatencyTest::FmPay),
+        latency_tests(dev_fed.clone(), LatencyTest::Restore),
+    )?;
+    Ok(())
 }
 
 pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()> {
@@ -2289,6 +2332,40 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
             let (process_mgr, _) = setup(common_args).await?;
             let dev_fed = dev_fed(&process_mgr).await?;
             cannot_replay_tx_test(dev_fed).await?;
+        }
+        TestCmd::UpgradeTest { old_fedimintd } => {
+            let (process_mgr, _) = setup(common_args).await?;
+            std::env::set_var("FM_FEDIMINTD_BASE_EXECUTABLE", old_fedimintd);
+            let mut dev_fed = dev_fed(&process_mgr).await?;
+            let client = dev_fed.fed.new_joined_client("test-client").await?;
+
+            tokio::try_join!(stress_test_fed(&dev_fed), wait_session(&client))?;
+
+            info!("shutting down servers");
+            dev_fed.fed.terminate_server(3).await?;
+            // kill 3rd peer early
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            dev_fed.fed.terminate_server(0).await?;
+            dev_fed.fed.terminate_server(1).await?;
+            dev_fed.fed.terminate_server(2).await?;
+            info!("restarting servers");
+            // upgrade to fedimintd from PATH
+            std::env::set_var("FM_FEDIMINTD_BASE_EXECUTABLE", "fedimintd");
+            dev_fed.fed.start_server(&process_mgr, 2).await?;
+            dev_fed.fed.start_server(&process_mgr, 1).await?;
+            dev_fed.fed.start_server(&process_mgr, 0).await?;
+            // restart 3rd peer later
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            dev_fed.fed.start_server(&process_mgr, 3).await?;
+            info!("restarted waiting");
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            info!("restarted waited");
+
+            stress_test_fed(&dev_fed).await?;
+            wait_session(&client).await?;
+            // kill 1 to check if 3 is working well
+            dev_fed.fed.terminate_server(1).await?;
+            tokio::try_join!(stress_test_fed(&dev_fed), wait_session(&client))?;
         }
     }
     Ok(())

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -28,6 +28,9 @@ test-compatibility *VERSIONS="v0.2.1":
 test-full-compatibility *VERSIONS="v0.2.1":
   env FM_FULL_VERSION_MATRIX=1 ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
+test-upgrades *VERSIONS="v0.2.1 v0.2.2":
+  ./scripts/tests/upgrade-test.sh {{VERSIONS}}
+
 # `cargo udeps` check
 udeps:
   nix build -L .#debug.workspaceCargoUdeps

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Runs a test to determine the latency of certain user actions
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+
+devimint upgrade-test "$@"

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -1,11 +1,70 @@
 #!/usr/bin/env bash
-# Runs a test to determine the latency of certain user actions
+# Runs a test to determine if upgrading binaries succeeds
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
+
+if [ "$#" -eq 0 ]; then
+  echo "Must provide at least one version"
+  exit 1
+fi
+
+versions=("$@")
 
 source scripts/_common.sh
 build_workspace
 add_target_dir_to_path
 
-devimint upgrade-test "$@"
+export FM_BACKWARDS_COMPATIBILITY_TEST=1
+
+fedimintd_paths=()
+fedimint_cli_paths=()
+gatewayd_paths=()
+for version in "${versions[@]}"; do
+  fedimintd_paths+=("$(nix_build_binary_for_version 'fedimintd' "$version")")
+  fedimint_cli_paths+=("$(nix_build_binary_for_version 'fedimint-cli' "$version")")
+  gatewayd_paths+=("$(nix_build_binary_for_version 'gatewayd' "$version")")
+done
+
+# Add current binaries from PATH
+fedimintd_paths+=("fedimintd")
+fedimint_cli_paths+=("fedimint-cli")
+gatewayd_paths+=("gatewayd")
+
+upgrade_tests=(
+  "devimint upgrade-tests fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
+  "devimint upgrade-tests fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
+  "devimint upgrade-tests gatewayd --paths $(printf "%s " "${gatewayd_paths[@]}")"
+)
+
+parsed_test_commands=$(printf "%s\n" "${upgrade_tests[@]}")
+
+tmpdir=$(mktemp --tmpdir -d XXXXX)
+trap 'rm -r $tmpdir' EXIT
+joblog="$tmpdir/joblog"
+
+parallel_args=()
+if [ -z "${CI:-}" ] && [[ -t 1 ]] && [ -z "${FM_TEST_CI_ALL_DISABLE_ETA:-}" ]; then
+  parallel_args+=(--eta)
+fi
+parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS:-$(($(nproc) / 4 + 1))}")
+parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-1000}")
+parallel_args+=(--delay "${FM_TEST_CI_ALL_DELAY:-$((64 / $(nproc) + 1))}")
+parallel_args+=(
+  --halt-on-error 1
+  --joblog "$joblog"
+  --noswap
+  --memfree 2G
+  --nice 15
+)
+
+>&2 echo "## Starting all tests in parallel..."
+>&2 echo "parallel ${parallel_args[*]}"
+
+echo "$parsed_test_commands" | if parallel "${parallel_args[@]}"; then
+  >&2 echo "All tests successful"
+else
+  >&2 echo "Some tests failed:"
+  awk '{ if($7 != "0") print $0 "\n" }' < "$joblog"
+  exit 1
+fi


### PR DESCRIPTION
Inspired by https://github.com/fedimint/fedimint/pull/4675 and closes https://github.com/fedimint/fedimint/issues/4486.

Use with `just test-upgrades` (defaults to linear upgrade paths for v0.2.1 -> v0.2.2 -> current).

`fedimintd` upgrades fail against `master` but work on `releases/v0.3`, so use the backport PR (https://github.com/fedimint/fedimint/pull/4763) if you verify locally.

Tests upgrades for `fedimintd`, `fedimint-cli`, and `gatewayd`:
- Runs latency tests
- Upgrades path for single binary
- Reruns latency tests
- Continues for all versions passed to script