### PR TITLE
[Backport releases/v0.3] feat(devimint): add upgrade tests for all binaries

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -3,6 +3,7 @@ mod config;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::ControlFlow;
 use std::path::PathBuf;
+use std::time::Duration;
 use std::{env, fs};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -305,6 +306,77 @@ impl Federation {
             bail!("fedimintd-{peer_id} does not exist");
         };
         fedimintd.terminate().await?;
+        Ok(())
+    }
+
+    /// Starts all peers not currently running.
+    pub async fn start_all_servers(&mut self, process_mgr: &ProcessManager) -> Result<()> {
+        info!("starting all servers");
+        let fed_size = process_mgr.globals.FM_FED_SIZE;
+        for peer_id in 0..fed_size {
+            if self.members.contains_key(&peer_id) {
+                continue;
+            }
+            self.start_server(process_mgr, peer_id).await?
+        }
+        self.await_all_peers().await?;
+        Ok(())
+    }
+
+    /// Terminates all running peers.
+    pub async fn terminate_all_servers(&mut self) -> Result<()> {
+        info!("terminating all servers");
+        let running_peer_ids: Vec<_> = self.members.keys().cloned().collect();
+        for peer_id in running_peer_ids {
+            self.terminate_server(peer_id).await?
+        }
+        Ok(())
+    }
+
+    /// Coordinated shutdown of all peers that restart using the provided
+    /// `bin_path`. Returns `Ok()` once all peers are online.
+    ///
+    /// Staggering the restart more closely simulates upgrades in the wild.
+    pub async fn restart_all_staggered_with_bin(
+        &mut self,
+        process_mgr: &ProcessManager,
+        bin_path: &PathBuf,
+    ) -> Result<()> {
+        let fed_size = process_mgr.globals.FM_FED_SIZE;
+
+        // ensure all peers are online
+        self.start_all_servers(process_mgr).await?;
+
+        // staggered shutdown of peers
+        while self.num_members() > 0 {
+            self.terminate_server(self.num_members() - 1).await?;
+            if self.num_members() > 0 {
+                fedimint_core::task::sleep_in_test(
+                    "waiting to shutdown remaining peers",
+                    Duration::from_secs(10),
+                )
+                .await;
+            }
+        }
+
+        std::env::set_var("FM_FEDIMINTD_BASE_EXECUTABLE", bin_path);
+
+        // staggered restart
+        for peer_id in 0..fed_size {
+            self.start_server(process_mgr, peer_id).await?;
+            if peer_id < fed_size - 1 {
+                fedimint_core::task::sleep_in_test(
+                    "waiting to restart remaining peers",
+                    Duration::from_secs(10),
+                )
+                .await;
+            }
+        }
+
+        self.await_all_peers().await?;
+
+        let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
+        info!("upgraded fedimintd to version: {}", fedimintd_version);
         Ok(())
     }
 

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -28,6 +28,9 @@ test-compatibility *VERSIONS="v0.2.1":
 test-full-compatibility *VERSIONS="v0.2.1":
   env FM_FULL_VERSION_MATRIX=1 ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
+test-upgrades *VERSIONS="v0.2.1 v0.2.2":
+  ./scripts/tests/upgrade-test.sh {{VERSIONS}}
+
 # `cargo udeps` check
 udeps:
   nix build -L .#debug.workspaceCargoUdeps

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Runs a test to determine the latency of certain user actions
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+
+devimint upgrade-test "$@"

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -1,11 +1,70 @@
 #!/usr/bin/env bash
-# Runs a test to determine the latency of certain user actions
+# Runs a test to determine if upgrading binaries succeeds
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
+
+if [ "$#" -eq 0 ]; then
+  echo "Must provide at least one version"
+  exit 1
+fi
+
+versions=("$@")
 
 source scripts/_common.sh
 build_workspace
 add_target_dir_to_path
 
-devimint upgrade-test "$@"
+export FM_BACKWARDS_COMPATIBILITY_TEST=1
+
+fedimintd_paths=()
+fedimint_cli_paths=()
+gatewayd_paths=()
+for version in "${versions[@]}"; do
+  fedimintd_paths+=("$(nix_build_binary_for_version 'fedimintd' "$version")")
+  fedimint_cli_paths+=("$(nix_build_binary_for_version 'fedimint-cli' "$version")")
+  gatewayd_paths+=("$(nix_build_binary_for_version 'gatewayd' "$version")")
+done
+
+# Add current binaries from PATH
+fedimintd_paths+=("fedimintd")
+fedimint_cli_paths+=("fedimint-cli")
+gatewayd_paths+=("gatewayd")
+
+upgrade_tests=(
+  "devimint upgrade-tests fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
+  "devimint upgrade-tests fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
+  "devimint upgrade-tests gatewayd --paths $(printf "%s " "${gatewayd_paths[@]}")"
+)
+
+parsed_test_commands=$(printf "%s\n" "${upgrade_tests[@]}")
+
+tmpdir=$(mktemp --tmpdir -d XXXXX)
+trap 'rm -r $tmpdir' EXIT
+joblog="$tmpdir/joblog"
+
+parallel_args=()
+if [ -z "${CI:-}" ] && [[ -t 1 ]] && [ -z "${FM_TEST_CI_ALL_DISABLE_ETA:-}" ]; then
+  parallel_args+=(--eta)
+fi
+parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS:-$(($(nproc) / 4 + 1))}")
+parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-1000}")
+parallel_args+=(--delay "${FM_TEST_CI_ALL_DELAY:-$((64 / $(nproc) + 1))}")
+parallel_args+=(
+  --halt-on-error 1
+  --joblog "$joblog"
+  --noswap
+  --memfree 2G
+  --nice 15
+)
+
+>&2 echo "## Starting all tests in parallel..."
+>&2 echo "parallel ${parallel_args[*]}"
+
+echo "$parsed_test_commands" | if parallel "${parallel_args[@]}"; then
+  >&2 echo "All tests successful"
+else
+  >&2 echo "Some tests failed:"
+  awk '{ if($7 != "0") print $0 "\n" }' < "$joblog"
+  exit 1
+fi


### PR DESCRIPTION
Backports https://github.com/fedimint/fedimint/pull/4762

Upgrade tests for `fedimintd` don't pass against `master` but pass on `releases/v0.3`, so I'm opening this before merging the associated PR so others can verify locally.