### PR TITLE
fix: base64 url safe for display

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -320,11 +320,20 @@ impl FromStr for OOBNotes {
 }
 
 impl Display for OOBNotes {
-    /// Base64UrlSafe encode a set of e-cash notes for out-of-band spending.
+    /// Base64 encode a set of e-cash notes for out-of-band spending.
+    ///
+    /// Defaults to standard base64 for backwards compatibility.
+    /// For URL-safe base64 as alternative display use:
+    /// `format!("{:#}", oob_notes)`
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut bytes = Vec::new();
         Encodable::consensus_encode(self, &mut bytes).expect("encodes correctly");
-        f.write_str(&BASE64_URL_SAFE.encode(&bytes))
+
+        if f.alternate() {
+            f.write_str(&BASE64_URL_SAFE.encode(&bytes))
+        } else {
+            f.write_str(&base64::engine::general_purpose::STANDARD.encode(&bytes))
+        }
     }
 }
 

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -320,11 +320,11 @@ impl FromStr for OOBNotes {
 }
 
 impl Display for OOBNotes {
-    /// Base64 encode a set of e-cash notes for out-of-band spending.
+    /// Base64UrlSafe encode a set of e-cash notes for out-of-band spending.
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut bytes = Vec::new();
         Encodable::consensus_encode(self, &mut bytes).expect("encodes correctly");
-        f.write_str(&base64::engine::general_purpose::STANDARD.encode(&bytes))
+        f.write_str(&BASE64_URL_SAFE.encode(&bytes))
     }
 }
 


### PR DESCRIPTION
For decode we're handling both cases but for encode we're writing stand b64, should write as url safe