### PR TITLE
fix: typos

### DIFF
--- a/fedimint-core/src/timing.rs
+++ b/fedimint-core/src/timing.rs
@@ -72,7 +72,7 @@ impl TimeReporterInner {
                     name = %self.name,
                     duration_ms = duration.as_millis(),
                     threshold_ms = threshold.as_millis(),
-                    "Operation time exeeded threshold"
+                    "Operation time exceeded threshold"
                 );
             }
         }
@@ -107,7 +107,7 @@ impl TimeReporter {
         }
     }
 
-    /// Add a threshold, which will log a warning if exeeded
+    /// Add a threshold, which will log a warning if exceeded
     pub fn threshold(mut self, threshold: time::Duration) -> Self {
         Self {
             inner: self.inner.take().map(|inner| TimeReporterInner {

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -399,7 +399,7 @@ impl ConfigGenApi {
             state.status = ServerStatus::VerifiedConfigs;
             info!(
                 target: fedimint_logging::LOG_NET_PEER_DKG,
-                "Update config gen status to 'Verfied configs'"
+                "Update config gen status to 'Verified configs'"
             );
         }
 


### PR DESCRIPTION
Typos wasn't catching these inside nix develop, when I run `typos` in normal shell it catches these.