### PR TITLE
fix: use random gateway on cli when gateway not specified

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -273,7 +273,8 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
                     client,
                     "ln-invoice",
                     "--amount=1000000msat",
-                    "--description=internal-swap-invoice"
+                    "--description=internal-swap-invoice",
+                    "--force-internal"
                 )
                 .out_json()
                 .await?;
@@ -287,7 +288,9 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
                     .to_owned();
 
                 let start_time = Instant::now();
-                cmd!(sender, "ln-pay", invoice).run().await?;
+                cmd!(sender, "ln-pay", invoice, "--force-internal")
+                    .run()
+                    .await?;
                 cmd!(client, "await-invoice", recv_op).run().await?;
                 fm_internal_pay.push(start_time.elapsed());
             }

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -26,7 +26,7 @@ use crate::cli::{cleanup_on_exit, exec_user_command, setup, write_ready_file, Co
 use crate::envs::{FM_DATA_DIR_ENV, FM_PASSWORD_ENV};
 use crate::federation::{Client, Federation};
 use crate::util::{poll, poll_with_timeout, LoadTestTool, ProcessManager};
-use crate::version_constants::VERSION_0_3_0_ALPHA;
+use crate::version_constants::{VERSION_0_3_0, VERSION_0_3_0_ALPHA};
 use crate::{cmd, dev_fed, poll_eq, DevFed, Gatewayd, LightningNode, Lightningd, Lnd};
 
 pub struct Stats {
@@ -268,16 +268,32 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
             let mut fm_internal_pay = Vec::with_capacity(iterations);
             let sender = fed.new_joined_client("internal-swap-sender").await?;
             fed.pegin_client(10_000_000, &sender).await?;
+            // TODO(support:v0.2): 0.3 removed the active gateway concept and requires an
+            // explicit gateway or `force-internal`
+            let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
+            let default_internal = fedimint_cli_version <= *VERSION_0_3_0;
             for _ in 0..iterations {
-                let recv = cmd!(
-                    client,
-                    "ln-invoice",
-                    "--amount=1000000msat",
-                    "--description=internal-swap-invoice",
-                    "--force-internal"
-                )
-                .out_json()
-                .await?;
+                let recv = if default_internal {
+                    cmd!(
+                        client,
+                        "ln-invoice",
+                        "--amount=1000000msat",
+                        "--description=internal-swap-invoice"
+                    )
+                    .out_json()
+                    .await?
+                } else {
+                    cmd!(
+                        client,
+                        "ln-invoice",
+                        "--amount=1000000msat",
+                        "--description=internal-swap-invoice",
+                        "--force-internal"
+                    )
+                    .out_json()
+                    .await?
+                };
+
                 let invoice = recv["invoice"]
                     .as_str()
                     .context("invoice must be string")?
@@ -288,9 +304,14 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
                     .to_owned();
 
                 let start_time = Instant::now();
-                cmd!(sender, "ln-pay", invoice, "--force-internal")
-                    .run()
-                    .await?;
+                if default_internal {
+                    cmd!(sender, "ln-pay", invoice).run().await?;
+                } else {
+                    cmd!(sender, "ln-pay", invoice, "--force-internal")
+                        .run()
+                        .await?;
+                }
+
                 cmd!(client, "await-invoice", recv_op).run().await?;
                 fm_internal_pay.push(start_time.elapsed());
             }

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -4,4 +4,5 @@ use semver::Version;
 lazy_static! {
     pub static ref VERSION_0_3_0_ALPHA: Version =
         Version::parse("0.3.0-alpha").expect("version is parsable");
+    pub static ref VERSION_0_3_0: Version = Version::parse("0.3.0").expect("version is parsable");
 }

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -808,8 +808,7 @@ async fn get_note_summary(client: &ClientHandleArc) -> anyhow::Result<serde_json
 }
 
 /// Returns a gateway to be used for a lightning operation. If `force_internal`
-/// is true and no `gateway_id` is specified, the function will assume an
-/// internal operation and return `None`.
+/// is true and no `gateway_id` is specified, no gateway will be selected.
 async fn get_gateway(
     client: &ClientHandleArc,
     gateway_id: Option<secp256k1::PublicKey>,
@@ -817,14 +816,21 @@ async fn get_gateway(
 ) -> anyhow::Result<Option<LightningGateway>> {
     let lightning_module = client.get_first_module::<LightningClientModule>();
     match gateway_id {
-        Some(gateway_id) => Ok(lightning_module.select_gateway(&gateway_id).await),
+        Some(gateway_id) => {
+            if let Some(gw) = lightning_module.select_gateway(&gateway_id).await {
+                Ok(Some(gw))
+            } else {
+                // Refresh the gateway cache in case the target gateway was registered since the
+                // last update.
+                lightning_module.update_gateway_cache().await?;
+                Ok(lightning_module.select_gateway(&gateway_id).await)
+            }
+        }
         None if !force_internal => {
-            let gw = lightning_module
-                .list_gateways()
-                .await
-                .into_iter()
-                .choose(&mut OsRng)
-                .map(|gw| gw.info);
+            // Refresh the gateway cache to find a random gateway to select from.
+            lightning_module.update_gateway_cache().await?;
+            let gateways = lightning_module.list_gateways().await;
+            let gw = gateways.into_iter().choose(&mut OsRng).map(|gw| gw.info);
             if let Some(gw) = gw {
                 let gw_id = gw.gateway_id;
                 info!(%gw_id, "Using random gateway");

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -3,7 +3,7 @@ use std::ffi;
 use std::str::FromStr;
 use std::time::{Duration, UNIX_EPOCH};
 
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
 use bip39::Mnemonic;
 use bitcoin::{secp256k1, Network};
 use clap::Subcommand;
@@ -28,6 +28,8 @@ use fedimint_wallet_client::{WalletClientModule, WithdrawState};
 use futures::StreamExt;
 use itertools::Itertools;
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
+use rand::rngs::OsRng;
+use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use time::format_description::well_known::iso8601;
@@ -111,6 +113,8 @@ pub enum ClientCmd {
         expiry_time: Option<u64>,
         #[clap(long)]
         gateway_id: Option<secp256k1::PublicKey>,
+        #[clap(long, default_value = "false")]
+        force_internal: bool,
     },
     /// Wait for incoming invoice to be paid
     AwaitInvoice { operation_id: OperationId },
@@ -129,6 +133,8 @@ pub enum ClientCmd {
         finish_in_background: bool,
         #[clap(long)]
         gateway_id: Option<secp256k1::PublicKey>,
+        #[clap(long, default_value = "false")]
+        force_internal: bool,
     },
     /// Wait for a lightning payment to complete
     AwaitLnPay { operation_id: OperationId },
@@ -330,8 +336,9 @@ pub async fn handle_command(
             description,
             expiry_time,
             gateway_id,
+            force_internal,
         } => {
-            let ln_gateway = get_gateway(&client, gateway_id).await;
+            let ln_gateway = get_gateway(&client, gateway_id, force_internal).await?;
 
             let lightning_module = client.get_first_module::<LightningClientModule>();
             let desc = Description::new(description)?;
@@ -380,10 +387,11 @@ pub async fn handle_command(
             finish_in_background,
             lnurl_comment,
             gateway_id,
+            force_internal,
         } => {
             let bolt11 = get_invoice(&payment_info, amount, lnurl_comment).await?;
             info!("Paying invoice: {bolt11}");
-            let ln_gateway = get_gateway(&client, gateway_id).await;
+            let ln_gateway = get_gateway(&client, gateway_id, force_internal).await?;
 
             let lightning_module = client.get_first_module::<LightningClientModule>();
             let OutgoingLightningPayment {
@@ -799,13 +807,36 @@ async fn get_note_summary(client: &ClientHandleArc) -> anyhow::Result<serde_json
     .unwrap())
 }
 
+/// Returns a gateway to be used for a lightning operation. If `force_internal`
+/// is true and no `gateway_id` is specified, the function will assume an
+/// internal operation and return `None`.
 async fn get_gateway(
     client: &ClientHandleArc,
     gateway_id: Option<secp256k1::PublicKey>,
-) -> Option<LightningGateway> {
+    force_internal: bool,
+) -> anyhow::Result<Option<LightningGateway>> {
     let lightning_module = client.get_first_module::<LightningClientModule>();
-    let gateway_id = gateway_id.or(None)?;
-    lightning_module.select_gateway(&gateway_id).await
+    match gateway_id {
+        Some(gateway_id) => Ok(lightning_module.select_gateway(&gateway_id).await),
+        None if !force_internal => {
+            let gw = lightning_module
+                .list_gateways()
+                .await
+                .into_iter()
+                .choose(&mut OsRng)
+                .map(|gw| gw.info);
+            if let Some(gw) = gw {
+                let gw_id = gw.gateway_id;
+                info!(%gw_id, "Using random gateway");
+                Ok(Some(gw))
+            } else {
+                Err(anyhow!(
+                    "No gateways exist in gateway cache and `force_internal` is false"
+                ))
+            }
+        }
+        None => Ok(None),
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/4797

Changes the default of the CLI to use a random gateway if no gateway is specified via `gateway-id` instead of defaulting to an internal invoice.