### PR TITLE
fix(devimint): use Version instead of VersionReq for comparisons

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -24,7 +24,7 @@ use fedimintd::envs::FM_EXTRA_DKG_META_ENV;
 use fs_lock::FileLock;
 use futures::future::join_all;
 use rand::Rng;
-use semver::VersionReq;
+use semver::Version;
 use tokio::time::Instant;
 use tracing::{debug, info};
 
@@ -144,7 +144,7 @@ impl Client {
     // TODO(support:v0.2): remove
     pub async fn use_gateway(&self, gw: &super::gatewayd::Gatewayd) -> Result<()> {
         let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-        if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version) {
+        if fedimint_cli_version < Version::parse("0.3.0-alpha")? {
             let gateway_id = gw.gateway_id().await?;
             cmd!(self, "switch-gateway", gateway_id.clone())
                 .run()
@@ -399,7 +399,7 @@ impl Federation {
         let start_time = Instant::now();
         debug!(target: LOG_DEVIMINT, "Awaiting LN gateways registration");
         let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-        let command = if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version) {
+        let command = if fedimint_cli_version < Version::parse("0.3.0-alpha")? {
             "list-gateways"
         } else {
             "update-gateway-cache"

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -16,7 +16,7 @@ use fedimint_core::encoding::Decodable;
 use fedimint_core::Amount;
 use fedimint_logging::LOG_DEVIMINT;
 use ln_gateway::rpc::GatewayInfo;
-use semver::VersionReq;
+use semver::Version;
 use serde_json::json;
 use tokio::fs;
 use tokio::net::TcpStream;
@@ -308,7 +308,7 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
                 .unwrap();
             let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
             let start_time = Instant::now();
-            if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
+            if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
                 let restore_client = Client::create("restore").await?;
                 cmd!(
                     restore_client,
@@ -420,9 +420,9 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     let invite = fed.invite_code()?;
 
     let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let version_req = VersionReq::parse(">=0.3.0-alpha")?;
+    let version_req = Version::parse("0.3.0-alpha")?;
 
-    let invite_code = if version_req.matches(&fedimint_cli_version) {
+    let invite_code = if fedimint_cli_version >= version_req {
         cmd!(client, "dev", "decode", "invite-code", invite.clone())
     } else {
         cmd!(client, "dev", "decode-invite-code", invite.clone())
@@ -430,7 +430,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     .out_json()
     .await?;
 
-    let encode_invite_output = if version_req.matches(&fedimint_cli_version) {
+    let encode_invite_output = if fedimint_cli_version >= version_req {
         cmd!(
             client,
             "dev",
@@ -542,7 +542,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     // The code path is backwards-compatible, however this test will fail if we
     // check against earlier fedimintd versions.
     let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
-    if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimintd_version) {
+    if fedimintd_version >= Version::parse("0.3.0-alpha")? {
         // # Test the correct descriptor is used
         let config = cmd!(client, "config").out_json().await?;
         let guardian_count = config["global"]["api_endpoints"].as_object().unwrap().len();
@@ -647,23 +647,22 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .as_str()
         .map(|s| s.to_owned())
         .unwrap();
-    let client_reissue_amt =
-        if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
-            cmd!(client, "module", "mint", "reissue", reissue_notes)
-        } else {
-            cmd!(
-                client,
-                "module",
-                "--module",
-                "mint",
-                "reissue",
-                reissue_notes
-            )
-        }
-        .out_json()
-        .await?
-        .as_u64()
-        .unwrap();
+    let client_reissue_amt = if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
+        cmd!(client, "module", "mint", "reissue", reissue_notes)
+    } else {
+        cmd!(
+            client,
+            "module",
+            "--module",
+            "mint",
+            "reissue",
+            reissue_notes
+        )
+    }
+    .out_json()
+    .await?
+    .as_u64()
+    .unwrap();
     assert_eq!(client_reissue_amt, reissue_amount);
 
     // Before doing a normal payment, let's start with a HOLD invoice and only
@@ -1251,7 +1250,7 @@ pub async fn cli_tests_backup_and_restore(
     // Testing restore in different setups would require multiple clients,
     // which is a larger refactor.
     {
-        let post_balance = if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
+        let post_balance = if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
             let client = Client::create("restore-without-backup").await?;
             let _ = cmd!(
                 client,
@@ -1299,7 +1298,7 @@ pub async fn cli_tests_backup_and_restore(
 
     // with a backup
     {
-        let post_balance = if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
+        let post_balance = if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
             let _ = cmd!(reference_client, "backup",).out_json().await?;
             let client = Client::create("restore-with-backup").await?;
 
@@ -1629,7 +1628,7 @@ async fn ln_pay(
 
     // TODO(support:v0.2): 0.3 removed the active gateway concept and requires a
     // `gateway-id` parameter for lightning sends
-    let value = if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version) {
+    let value = if fedimint_cli_version < Version::parse("0.3.0-alpha")? {
         if finish_in_background {
             cmd!(client, "ln-pay", invoice, "--finish-in-background",)
                 .out_json()
@@ -1670,7 +1669,7 @@ async fn ln_invoice(
     let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
     // TODO(support:v0.2): 0.3 removed the active gateway concept and requires a
     // `gateway-id` parameter for lightning receives
-    let ln_response_val = if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version) {
+    let ln_response_val = if fedimint_cli_version < Version::parse("0.3.0-alpha")? {
         cmd!(
             client,
             "ln-invoice",
@@ -1917,8 +1916,8 @@ pub async fn guardian_backup_test(dev_fed: DevFed, process_mgr: &ProcessManager)
     let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
 
     // TODO(support:v0.2): remove
-    if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version)
-        || VersionReq::parse("<0.3.0-alpha")?.matches(&fedimintd_version)
+    if fedimint_cli_version < Version::parse("0.3.0-alpha")?
+        || fedimintd_version < Version::parse("0.3.0-alpha")?
     {
         info!("Guardian backups didn't exist pre-0.3.0, so can't be tested, exiting");
         return Ok(());
@@ -2118,7 +2117,7 @@ pub async fn cannot_replay_tx_test(dev_fed: DevFed) -> Result<()> {
     );
 
     // TODO(support:v0.2): remove
-    if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
+    if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
         cmd!(double_spend_client, "reissue", double_spend_notes)
             .assert_error_contains("The transaction had an invalid input")
             .await?;


### PR DESCRIPTION
`VersionReq` follows the semver range spec, which has unexpected behavior.

```rust
#[test]
fn version_req_behavior() -> Result<()> {
    use semver::{Version, VersionReq};
    let fedimint_cli_version = Version::parse("0.4.0-alpha")?;
    let req_version = VersionReq::parse(">=0.3.0-alpha")?;

    // 0.4.0-alpha is NOT >= 0.3.0-alpha since it contains a prerelease
    assert!(!req_version.matches(&fedimint_cli_version));

    // comparing using `Version`s gives us the desired behavior
    assert!(Version::parse("0.4.0-alpha")? >= Version::parse("0.3.0-alpha")?);
    Ok(())
}
```

This breaks multiple tests now that we're trying to bump to 0.4.0-alpha (noticed in https://github.com/fedimint/fedimint/pull/4623). We can instead compare using `Version`s.

For context why semver chose this, refer to section 5 from https://github.com/semver/semver/blob/efcff2c838c9945f79bfd21c1df0073271bcc29c/ranges.md. There's also additional context in this `semver` crate [issue](https://github.com/dtolnay/semver/issues/172).
