### PR TITLE
chore: bump version to 0.4.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,7 +1268,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1331,14 +1331,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.11.0",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "bls12_381",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-cli"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1710,14 +1710,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.11.0",
 ]
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-gateway"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.4",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "aleph-bft-types",
  "anyhow",
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.11.0",
  "bls12_381",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ resolver = "2"
 
 [workspace.package]
 name = "fedimint"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 
 [workspace.metadata]
 name = "fedimint"

--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-aead"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "aead utilities on top of ring"

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-derive-secret"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint derivable secret implementation"
@@ -19,8 +19,8 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-hkdf = { package = "fedimint-hkdf", version = "0.3.0-alpha", path = "../../crypto/hkdf" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+hkdf = { package = "fedimint-hkdf", version = "=0.4.0-alpha", path = "../../crypto/hkdf" }
 ring = "0.17.8"
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
 bls12_381 = "0.7.1"

--- a/crypto/hkdf/Cargo.toml
+++ b/crypto/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-hkdf"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "RFC5869 HKDF implementation on top of bitcoin_hashes"

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-tbs"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "tbs is a helper cryptography library for threshold blind signatures"
@@ -19,7 +19,7 @@ name = "tbs"
 path = "src/lib.rs"
 
 [dependencies]
-fedimint-core  = { version = "0.3.0-alpha", path = "../../fedimint-core/" }
+fedimint-core  = { version = "=0.4.0-alpha", path = "../../fedimint-core/" }
 bls12_381 = "0.7.1"
 ff = "0.12.1"
 group = "0.12.1"

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -50,4 +50,4 @@ fedimint-portalloc = { path = "../utils/portalloc" }
 fs-lock = "0.1.3"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "=0.4.0-alpha", path = "../fedimint-build" }

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -24,7 +24,7 @@ use fedimintd::envs::FM_EXTRA_DKG_META_ENV;
 use fs_lock::FileLock;
 use futures::future::join_all;
 use rand::Rng;
-use semver::VersionReq;
+use semver::Version;
 use tokio::time::Instant;
 use tracing::{debug, info};
 
@@ -144,7 +144,7 @@ impl Client {
     // TODO(support:v0.2): remove
     pub async fn use_gateway(&self, gw: &super::gatewayd::Gatewayd) -> Result<()> {
         let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-        if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version) {
+        if fedimint_cli_version < Version::parse("0.3.0-alpha")? {
             let gateway_id = gw.gateway_id().await?;
             cmd!(self, "switch-gateway", gateway_id.clone())
                 .run()
@@ -399,7 +399,7 @@ impl Federation {
         let start_time = Instant::now();
         debug!(target: LOG_DEVIMINT, "Awaiting LN gateways registration");
         let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-        let command = if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version) {
+        let command = if fedimint_cli_version < Version::parse("0.3.0-alpha")? {
             "list-gateways"
         } else {
             "update-gateway-cache"

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -16,7 +16,7 @@ use fedimint_core::encoding::Decodable;
 use fedimint_core::Amount;
 use fedimint_logging::LOG_DEVIMINT;
 use ln_gateway::rpc::GatewayInfo;
-use semver::VersionReq;
+use semver::Version;
 use serde_json::json;
 use tokio::fs;
 use tokio::net::TcpStream;
@@ -308,7 +308,7 @@ pub async fn latency_tests(dev_fed: DevFed, r#type: LatencyTest) -> Result<()> {
                 .unwrap();
             let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
             let start_time = Instant::now();
-            if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
+            if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
                 let restore_client = Client::create("restore").await?;
                 cmd!(
                     restore_client,
@@ -420,9 +420,9 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     let invite = fed.invite_code()?;
 
     let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let version_req = VersionReq::parse(">=0.3.0-alpha")?;
+    let version_req = Version::parse("0.3.0-alpha")?;
 
-    let invite_code = if version_req.matches(&fedimint_cli_version) {
+    let invite_code = if fedimint_cli_version >= version_req {
         cmd!(client, "dev", "decode", "invite-code", invite.clone())
     } else {
         cmd!(client, "dev", "decode-invite-code", invite.clone())
@@ -430,7 +430,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     .out_json()
     .await?;
 
-    let encode_invite_output = if version_req.matches(&fedimint_cli_version) {
+    let encode_invite_output = if fedimint_cli_version >= version_req {
         cmd!(
             client,
             "dev",
@@ -542,7 +542,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     // The code path is backwards-compatible, however this test will fail if we
     // check against earlier fedimintd versions.
     let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
-    if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimintd_version) {
+    if fedimintd_version >= Version::parse("0.3.0-alpha")? {
         // # Test the correct descriptor is used
         let config = cmd!(client, "config").out_json().await?;
         let guardian_count = config["global"]["api_endpoints"].as_object().unwrap().len();
@@ -647,23 +647,22 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .as_str()
         .map(|s| s.to_owned())
         .unwrap();
-    let client_reissue_amt =
-        if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
-            cmd!(client, "module", "mint", "reissue", reissue_notes)
-        } else {
-            cmd!(
-                client,
-                "module",
-                "--module",
-                "mint",
-                "reissue",
-                reissue_notes
-            )
-        }
-        .out_json()
-        .await?
-        .as_u64()
-        .unwrap();
+    let client_reissue_amt = if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
+        cmd!(client, "module", "mint", "reissue", reissue_notes)
+    } else {
+        cmd!(
+            client,
+            "module",
+            "--module",
+            "mint",
+            "reissue",
+            reissue_notes
+        )
+    }
+    .out_json()
+    .await?
+    .as_u64()
+    .unwrap();
     assert_eq!(client_reissue_amt, reissue_amount);
 
     // Before doing a normal payment, let's start with a HOLD invoice and only
@@ -1251,7 +1250,7 @@ pub async fn cli_tests_backup_and_restore(
     // Testing restore in different setups would require multiple clients,
     // which is a larger refactor.
     {
-        let post_balance = if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
+        let post_balance = if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
             let client = Client::create("restore-without-backup").await?;
             let _ = cmd!(
                 client,
@@ -1299,7 +1298,7 @@ pub async fn cli_tests_backup_and_restore(
 
     // with a backup
     {
-        let post_balance = if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
+        let post_balance = if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
             let _ = cmd!(reference_client, "backup",).out_json().await?;
             let client = Client::create("restore-with-backup").await?;
 
@@ -1629,7 +1628,7 @@ async fn ln_pay(
 
     // TODO(support:v0.2): 0.3 removed the active gateway concept and requires a
     // `gateway-id` parameter for lightning sends
-    let value = if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version) {
+    let value = if fedimint_cli_version < Version::parse("0.3.0-alpha")? {
         if finish_in_background {
             cmd!(client, "ln-pay", invoice, "--finish-in-background",)
                 .out_json()
@@ -1670,7 +1669,7 @@ async fn ln_invoice(
     let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
     // TODO(support:v0.2): 0.3 removed the active gateway concept and requires a
     // `gateway-id` parameter for lightning receives
-    let ln_response_val = if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version) {
+    let ln_response_val = if fedimint_cli_version < Version::parse("0.3.0-alpha")? {
         cmd!(
             client,
             "ln-invoice",
@@ -1917,8 +1916,8 @@ pub async fn guardian_backup_test(dev_fed: DevFed, process_mgr: &ProcessManager)
     let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
 
     // TODO(support:v0.2): remove
-    if VersionReq::parse("<0.3.0-alpha")?.matches(&fedimint_cli_version)
-        || VersionReq::parse("<0.3.0-alpha")?.matches(&fedimintd_version)
+    if fedimint_cli_version < Version::parse("0.3.0-alpha")?
+        || fedimintd_version < Version::parse("0.3.0-alpha")?
     {
         info!("Guardian backups didn't exist pre-0.3.0, so can't be tested, exiting");
         return Ok(());
@@ -2118,7 +2117,7 @@ pub async fn cannot_replay_tx_test(dev_fed: DevFed) -> Result<()> {
     );
 
     // TODO(support:v0.2): remove
-    if VersionReq::parse(">=0.3.0-alpha")?.matches(&fedimint_cli_version) {
+    if fedimint_cli_version >= Version::parse("0.3.0-alpha")? {
         cmd!(double_spend_client, "reissue", double_spend_notes)
             .assert_error_contains("The transaction had an invalid input")
             .await?;

--- a/fedimint-bip39/Cargo.toml
+++ b/fedimint-bip39/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-bip39"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 readme = "../README.md"
@@ -18,6 +18,6 @@ path = "./src/lib.rs"
 
 [dependencies]
 bip39 = { version = "2.0.0", features = ["rand"] }
-fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
 rand = { workspace = true }

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-bitcoind"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Bitcoin Core connectivity used by Fedimint"
@@ -25,8 +25,8 @@ bitcoincore-rpc = { version = "0.16.0", optional = true }
 electrum-client = {version = "0.12.1", optional = true }
 esplora-client = { version = "0.5.0", default-features = false, features = ["async", "async-https-rustls"], optional = true }
 lazy_static = "1.4.0"
-fedimint-core  = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
+fedimint-core  = { version = "=0.4.0-alpha", path = "../fedimint-core" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
 rand = { workspace = true }
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = { workspace = true }

--- a/fedimint-build/Cargo.toml
+++ b/fedimint-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-build"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint build script utilities for including git version information in builds"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-cli"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-cli is a command line interface wrapper for the client library."
@@ -32,20 +32,20 @@ clap = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
-fedimint-bip39 = { version = "0.3.0-alpha", path = "../fedimint-bip39" }
-fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-mint-client = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-client" }
-fedimint-mint-common = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-common" }
-fedimint-ln-client = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-client" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-common" }
-fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-meta-client = { version = "0.3.0-alpha", path = "../modules/fedimint-meta-client", features = [ "cli" ] }
-fedimint-meta-common = { version = "0.3.0-alpha", path = "../modules/fedimint-meta-common" }
+fedimint-aead = { version = "=0.4.0-alpha", path = "../crypto/aead" }
+fedimint-bip39 = { version = "=0.4.0-alpha", path = "../fedimint-bip39" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
+fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-mint-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-mint-client" }
+fedimint-mint-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-mint-common" }
+fedimint-ln-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-client" }
+fedimint-ln-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-common" }
+fedimint-wallet-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-client" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-server = { version = "=0.4.0-alpha", path = "../fedimint-server" }
+fedimint-meta-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-meta-client", features = [ "cli" ] }
+fedimint-meta-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-meta-common" }
 fs-lock = "0.1.3"
 rand = { workspace = true }
 serde = { version = "1.0.197", features = [ "derive" ] }
@@ -60,4 +60,4 @@ lnurl-rs = { version = "0.4.1", features = ["async"], default-features = false }
 reqwest = { version = "0.11.26", features = [ "json", "rustls-tls" ], default-features = false }
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "=0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-client provides a library for sending transactions to the federation."
@@ -26,10 +26,10 @@ async-stream = "0.3.5"
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 bitcoin_hashes = { workspace = true }
-fedimint-core  = { version = "0.3.0-alpha", path = "../fedimint-core/" }
-fedimint-derive-secret = { version = "0.3.0-alpha", path = "../crypto/derive-secret" }
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
+fedimint-core  = { version = "=0.4.0-alpha", path = "../fedimint-core/" }
+fedimint-derive-secret = { version = "=0.4.0-alpha", path = "../crypto/derive-secret" }
+fedimint-aead = { version = "=0.4.0-alpha", path = "../crypto/aead" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
 futures = { workspace = true }
 itertools = { workspace = true }
 rand = { workspace = true }
@@ -50,4 +50,4 @@ ring = { version = "0.17.8", features = ["wasm32_unknown_unknown_js"] }
 tracing-test = "0.2.4"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "=0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-core"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-core provides common code used by both client and server."
@@ -44,8 +44,8 @@ bitcoin_hashes = { version = "0.11", features = ["serde"] }
 erased-serde = { workspace = true }
 lightning = "0.0.118"
 lightning-invoice = "0.26.0"
-fedimint-derive = { version = "0.3.0-alpha", path = "../fedimint-derive" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
+fedimint-derive = { version = "=0.4.0-alpha", path = "../fedimint-derive" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
 rand = { workspace = true }
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 secp256k1-zkp = { version = "0.7.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dbtool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
@@ -18,25 +18,25 @@ name = "fedimint-dbtool"
 
 [dependencies]
 anyhow = { workspace = true }
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
+fedimint-aead = { version = "=0.4.0-alpha", path = "../crypto/aead" }
 bitcoin_hashes = { workspace = true }
 bytes = "1.5.0"
 clap = { version = "4.5.2", features = ["derive", "env"] }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-mint-server = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-server" }
-fedimint-mint-client = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-client" }
-fedimint-ln-server = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-server" }
-fedimint-ln-client = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-client" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-wallet-server = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-server" }
-fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../fedimint-client" }
+fedimint-server = { version = "=0.4.0-alpha", path = "../fedimint-server" }
+fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-mint-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-mint-server" }
+fedimint-mint-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-mint-client" }
+fedimint-ln-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-server" }
+fedimint-ln-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-client" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-wallet-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-server" }
+fedimint-wallet-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-client" }
 futures = { workspace = true }
 erased-serde = { workspace = true }
 hex = { version = "0.4.3", features = ["serde"] }
-ln-gateway = { package = "fedimint-ln-gateway", version = "0.3.0-alpha", path = "../gateway/ln-gateway" }
+ln-gateway = { package = "fedimint-ln-gateway", version = "=0.4.0-alpha", path = "../gateway/ln-gateway" }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = { workspace = true }
 strum = { workspace = true }
@@ -45,4 +45,4 @@ tokio = "1.36.0"
 tracing = { workspace = true }
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "=0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-derive"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-derive provides helper macros for serialization."

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -17,14 +17,14 @@ base64 = "0.22.0"
 bitcoin = { workspace = true }
 clap = { workspace = true }
 devimint = { version = "0.3.0-alpha", path = "../devimint" }
-fedimint-client = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-ln-client = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-client" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
+fedimint-ln-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-client" }
 fedimint-ln-common = { path = "../modules/fedimint-ln-common" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-mint-client = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-client" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-wallet-client = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-client" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-mint-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-mint-client" }
+fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-wallet-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-client" }
 futures = { workspace = true }
 jsonrpsee-core = { version = "0.22.2", features = [ "client" ] }
 jsonrpsee-types = { version = "0.22.2" }
@@ -40,4 +40,4 @@ url = { version = "2.5.0", features = ["serde"] }
 jsonrpsee-ws-client = { version = "0.22.2", features = ["webpki-tls"], default-features = false }
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "=0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-logging"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "contains some utilities for logging and tracing"

--- a/fedimint-metrics/Cargo.toml
+++ b/fedimint-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-metrics"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
@@ -17,7 +17,7 @@ path = "./src/lib.rs"
 [dependencies]
 anyhow = { version = "1.0.81", features = ["backtrace"] }
 axum = "0.7.4"
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
 lazy_static = "1.4.0"
 prometheus = "0.13.3"
 tokio = "1"

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-rocksdb"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-rocksdb provides a rocksdb-backed database implementation for Fedimint."
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
 futures = { workspace = true }
 rocksdb = { version = "0.22.0" }
 tracing = { workspace = true }

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-server' facilitates federated consensus with atomic broadcast and distributed configuration."
@@ -18,7 +18,7 @@ name = "fedimint_server"
 path = "src/lib.rs"
 
 [dependencies]
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
+fedimint-aead = { version = "=0.4.0-alpha", path = "../crypto/aead" }
 anyhow = { workspace = true }
 async-channel = "2.2.0"
 async-trait = { workspace = true }
@@ -30,9 +30,9 @@ bytes = "1.5.0"
 futures = { workspace = true }
 hex = { workspace = true }
 itertools = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-metrics = { path = "../fedimint-metrics" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-metrics = { version = "=0.4.0-alpha", path = "../fedimint-metrics" }
 lazy_static = "1.4.0"
 pin-project = "1.1.5"
 rand = { workspace = true }
@@ -45,7 +45,7 @@ sha3 = "0.10.8"
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tar = "0.4.40"
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "=0.4.0-alpha", path = "../crypto/tbs" }
 thiserror = { workspace = true }
 tower = { version = "0.4.13", default-features = false }
 tracing = { workspace = true }
@@ -72,4 +72,4 @@ fedimint-portalloc = { path = "../utils/portalloc" }
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "=0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-testing"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-testing provides a library of shared objects and utilities for testing fedimint components"
@@ -25,15 +25,15 @@ bitcoin = { workspace = true }
 bitcoincore-rpc = "0.16.0"
 clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions" ], default-features = false }
 cln-rpc = { workspace = true }
-fedimint-core  = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-client  = { version = "0.3.0-alpha", path = "../fedimint-client" }
-fedimint-server  = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../fedimint-bitcoind" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-core  = { version = "=0.4.0-alpha", path = "../fedimint-core" }
+fedimint-client  = { version = "=0.4.0-alpha", path = "../fedimint-client" }
+fedimint-server  = { version = "=0.4.0-alpha", path = "../fedimint-server" }
+fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../fedimint-bitcoind" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../fedimint-rocksdb" }
 fs-lock = "0.1.3"
 lazy_static = "1.4.0"
-ln-gateway = { version = "0.3.0-alpha", package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
+ln-gateway = { version = "=0.4.0-alpha", package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 futures = { workspace = true }
 lightning-invoice = "0.26.0"
 tempfile = "3.10.1"
@@ -47,4 +47,4 @@ tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tokio-stream = "0.1.14"
 tonic_lnd = { workspace = true }
 url = { workspace = true }
-fedimint-portalloc = { version = "0.3.0-alpha", path = "../utils/portalloc" }
+fedimint-portalloc = { version = "=0.4.0-alpha", path = "../utils/portalloc" }

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimintd"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimintd is the main consensus code for processing transactions and REST API"
@@ -24,7 +24,7 @@ name = "fedimintd"
 path = "src/lib.rs"
 
 [dependencies]
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
+fedimint-aead = { version = "=0.4.0-alpha", path = "../crypto/aead" }
 ring = "0.17.8"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -35,26 +35,26 @@ clap = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 jsonrpsee = { version = "0.22.2", features = ["server"] }
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../fedimint-bitcoind" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-common" }
-fedimint-ln-server = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-server" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging", features = ["telemetry"] }
-fedimint-metrics = { version = "0.3.0-alpha", path = "../fedimint-metrics" }
-fedimint-mint-server = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-server" }
-fedimint-meta-server = { version = "0.3.0-alpha", path = "../modules/fedimint-meta-server" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-wallet-server = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-server" }
-fedimint-unknown-server = { version = "0.3.0-alpha", path = "../modules/fedimint-unknown-server" }
-fedimint-unknown-common = { version = "0.3.0-alpha", path = "../modules/fedimint-unknown-common" }
+fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../fedimint-bitcoind" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
+fedimint-ln-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-common" }
+fedimint-ln-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-server" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging", features = ["telemetry"] }
+fedimint-metrics = { version = "=0.4.0-alpha", path = "../fedimint-metrics" }
+fedimint-mint-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-mint-server" }
+fedimint-meta-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-meta-server" }
+fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-server = { version = "=0.4.0-alpha", path = "../fedimint-server" }
+fedimint-wallet-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-server" }
+fedimint-unknown-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-unknown-server" }
+fedimint-unknown-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-unknown-common" }
 rand = { workspace = true }
 rcgen = "=0.12.1"
 secp256k1-zkp = { version = "0.7.0", features = [ "global-context", "bitcoin_hashes" ] }
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = { workspace = true }
 sha3 = "0.10.8"
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "=0.4.0-alpha", path = "../crypto/tbs" }
 thiserror = { workspace = true }
 tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tokio-rustls = { workspace = true }
@@ -72,4 +72,4 @@ tower = { version = "0.4", features = ["util"] }
 console-subscriber = "0.2.0"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../fedimint-build" }
+fedimint-build = { version = "=0.4.0-alpha", path = "../fedimint-build" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
 
 # cargo-deny just needs at least one `bin` defined
 [lib]

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-gateway-cli"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 readme = "../../README.md"
@@ -23,9 +23,9 @@ axum = "0.7.4"
 axum-macros = "0.4.1"
 bitcoin = { version = "0.30.2", features = ["serde"] }
 clap = { version = "4.5.2", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
-ln-gateway = { version = "0.3.0-alpha", package = "fedimint-ln-gateway", path= "../ln-gateway" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
+ln-gateway = { version = "=0.4.0-alpha", package = "fedimint-ln-gateway", path= "../ln-gateway" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../../fedimint-logging" }
 reqwest = { version = "0.11.26", features = [ "json", "rustls-tls" ], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }
@@ -35,4 +35,4 @@ url = { version = "2.5.0", features = ["serde"] }
 clap_complete = "4.5.1"
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../../fedimint-build" }
+fedimint-build = { version = "=0.4.0-alpha", path = "../../fedimint-build" }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-gateway"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln-gateway sends/receives Lightning Network payments on behalf of Fedimint clients"
@@ -40,15 +40,15 @@ clap = { workspace = true }
 # cln-plugin made semver incompatible change
 cln-plugin = "=0.1.7"
 cln-rpc = { workspace = true }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../../fedimint-rocksdb" }
-fedimint-ln-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-ln-client" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../../modules/fedimint-ln-common" }
-fedimint-mint-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-mint-client" }
-fedimint-dummy-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-dummy-client" }
-fedimint-wallet-client = { version = "0.3.0-alpha", path = "../../modules/fedimint-wallet-client" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../../fedimint-logging" }
+fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../../fedimint-rocksdb" }
+fedimint-ln-client = { version = "=0.4.0-alpha", path = "../../modules/fedimint-ln-client" }
+fedimint-ln-common = { version = "=0.4.0-alpha", path = "../../modules/fedimint-ln-common" }
+fedimint-mint-client = { version = "=0.4.0-alpha", path = "../../modules/fedimint-mint-client" }
+fedimint-dummy-client = { version = "=0.4.0-alpha", path = "../../modules/fedimint-dummy-client" }
+fedimint-wallet-client = { version = "=0.4.0-alpha", path = "../../modules/fedimint-wallet-client" }
 futures = { workspace = true }
 erased-serde = { workspace = true }
 lightning-invoice = "0.26.0"
@@ -86,5 +86,5 @@ threshold_crypto = { workspace = true }
 assert_matches = { workspace = true }
 
 [build-dependencies]
-fedimint-build = { version = "0.3.0-alpha", path = "../../fedimint-build" }
+fedimint-build = { version = "=0.4.0-alpha", path = "../../fedimint-build" }
 tonic-build = "0.11.0"

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
@@ -18,9 +18,9 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = { workspace = true }
 anyhow = { workspace = true }
-fedimint-dummy-common = { version = "0.3.0-alpha", path = "../fedimint-dummy-common" }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-dummy-common = { version = "=0.4.0-alpha", path = "../fedimint-dummy-common" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 futures = { workspace = true }
 erased-serde = { workspace = true }
 rand = { workspace = true }

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
@@ -21,7 +21,7 @@ async-trait = { workspace = true }
 bitcoin_hashes = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 rand = { workspace = true }
 serde = { version = "1.0.197", features = [ "derive" ] }
 secp256k1 = "0.24.3"

--- a/modules/fedimint-dummy-server/Cargo.toml
+++ b/modules/fedimint-dummy-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."
@@ -21,8 +21,8 @@ async-trait = { workspace = true }
 bitcoin_hashes = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-dummy-common = { version = "0.3.0-alpha", path = "../fedimint-dummy-common" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-dummy-common = { version = "=0.4.0-alpha", path = "../fedimint-dummy-common" }
 rand = { workspace = true }
 serde = { version = "1.0.197", features = [ "derive" ] }
 secp256k1 = "0.24.3"

--- a/modules/fedimint-empty-client/Cargo.toml
+++ b/modules/fedimint-empty-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-empty-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-empty is an empty fedimint module, good template for a new module."
@@ -18,9 +18,9 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = { workspace = true }
 anyhow = { workspace = true }
-fedimint-empty-common = { version = "0.3.0-alpha", path = "../fedimint-empty-common" }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-empty-common = { version = "=0.4.0-alpha", path = "../fedimint-empty-common" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 futures = { workspace = true }
 erased-serde = { workspace = true }
 serde = {version = "1.0.197", features = [ "derive" ] }

--- a/modules/fedimint-empty-common/Cargo.toml
+++ b/modules/fedimint-empty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-empty-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-empty is a empty fedimint module, good template for a new module."
@@ -20,7 +20,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = { workspace = true }
 strum_macros = { workspace = true }

--- a/modules/fedimint-empty-server/Cargo.toml
+++ b/modules/fedimint-empty-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-empty-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-empty is a empty fedimint module, good template for a new module."
@@ -20,8 +20,8 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-empty-common = { version = "0.3.0-alpha", path = "../fedimint-empty-common" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-empty-common = { version = "=0.4.0-alpha", path = "../fedimint-empty-common" }
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = { workspace = true }
 strum_macros = { workspace = true }

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
@@ -33,9 +33,9 @@ erased-serde = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../fedimint-ln-common" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-ln-common = { version = "=0.4.0-alpha", path = "../fedimint-ln-common" }
 secp256k1 = { version="0.24.3", default-features=false }
 secp256k1-zkp = { version = "0.7.0", features = [ "serde", "bitcoin_hashes" ] }
 serde = {version = "1.0.197", features = [ "derive" ] }

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
@@ -32,8 +32,8 @@ futures = { workspace = true }
 itertools = { workspace = true }
 lightning = { version = "0.0.118", default-features = false, features = ["no-std"] }
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 secp256k1 = { version="0.24.3", default-features=false }
 serde = {version = "1.0.197", features = [ "derive" ] }
 serde_json = { workspace = true }

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln is a lightning payment service module."
@@ -27,10 +27,10 @@ futures = { workspace = true }
 itertools = { workspace = true }
 lightning = "0.0.118"
 lightning-invoice = { version = "0.26.0", features = [ "serde" ] }
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../fedimint-ln-common" }
-fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
+fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../../fedimint-bitcoind" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-ln-common = { version = "=0.4.0-alpha", path = "../fedimint-ln-common" }
+fedimint-metrics = { version = "=0.4.0-alpha", path = "../../fedimint-metrics" }
 secp256k1 = { version="0.24.3", default-features=false }
 serde = {version = "1.0.197", features = [ "derive" ] }
 serde_json = { workspace = true }
@@ -42,7 +42,7 @@ tokio = { version = "1.36", features = ["full"] }
 tracing = { workspace = true }
 rand = { workspace = true }
 url = { version = "2.5.0", features = ["serde"] }
-fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
+fedimint-server = { version = "=0.4.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/modules/fedimint-meta-client/Cargo.toml
+++ b/modules/fedimint-meta-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-meta-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-meta is a meta consensus fedimint module."
@@ -25,9 +25,9 @@ anyhow = { workspace = true }
 clap = { workspace = true, optional = true }
 hex = { workspace = true }
 serde_json = { workspace = true, optional = true }
-fedimint-meta-common = { version = "0.3.0-alpha", path = "../fedimint-meta-common" }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-meta-common = { version = "=0.4.0-alpha", path = "../fedimint-meta-common" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 futures = { workspace = true }
 erased-serde = { workspace = true }
 rand = { workspace = true }

--- a/modules/fedimint-meta-common/Cargo.toml
+++ b/modules/fedimint-meta-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-meta-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-meta is a meta-consensus fedimint module."
@@ -22,7 +22,7 @@ bitcoin_hashes = { workspace = true }
 erased-serde = { workspace = true }
 hex = { workspace = true }
 futures = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 rand = { workspace = true }
 serde = { version = "1.0.149", features = [ "derive" ] }
 serde_json = { workspace = true }

--- a/modules/fedimint-meta-server/Cargo.toml
+++ b/modules/fedimint-meta-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-meta-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-meta is a meta consensus fedimint module."
@@ -21,9 +21,9 @@ async-trait = "0.1.73"
 bitcoin_hashes = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
-fedimint-meta-common = { version = "0.3.0-alpha", path = "../fedimint-meta-common" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../../fedimint-logging" }
+fedimint-meta-common = { version = "=0.4.0-alpha", path = "../fedimint-meta-common" }
 rand = { workspace = true }
 serde = { version = "1.0.149", features = [ "derive" ] }
 secp256k1 = "0.24.2"

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
@@ -27,11 +27,11 @@ bitcoin_hashes = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-derive-secret = { version = "0.3.0-alpha", path = "../../crypto/derive-secret"}
-fedimint-mint-common ={ version = "0.3.0-alpha", path = "../fedimint-mint-common" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../../fedimint-logging" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-derive-secret = { version = "=0.4.0-alpha", path = "../../crypto/derive-secret"}
+fedimint-mint-common ={ version = "=0.4.0-alpha", path = "../fedimint-mint-common" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../../fedimint-logging" }
 rand = { workspace = true }
 secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
@@ -40,7 +40,7 @@ serde-big-array = "0.5.1"
 serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "=0.4.0-alpha", path = "../../crypto/tbs" }
 thiserror = { workspace = true }
 threshold_crypto = { workspace = true }
 tokio = { version = "1.36.0", features = [ "sync" ] }

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
@@ -23,14 +23,14 @@ bincode = { workspace = true }
 bitcoin_hashes = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 rand = { workspace = true }
 secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "=0.4.0-alpha", path = "../../crypto/tbs" }
 thiserror = { workspace = true }
 threshold_crypto = { workspace = true }
 tracing = { workspace = true }

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint is a chaumian ecash mint module."
@@ -25,20 +25,20 @@ bitcoin_hashes = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
-fedimint-mint-common = { version = "0.3.0-alpha", path = "../fedimint-mint-common" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-metrics = { version = "=0.4.0-alpha", path = "../../fedimint-metrics" }
+fedimint-mint-common = { version = "=0.4.0-alpha", path = "../fedimint-mint-common" }
 rand = { workspace = true }
 secp256k1 = "0.24.3"
 secp256k1-zkp = "0.7.0"
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "=0.4.0-alpha", path = "../../crypto/tbs" }
 thiserror = { workspace = true }
 threshold_crypto = { workspace = true }
 tracing = { workspace = true }
-fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
+fedimint-server = { version = "=0.4.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -32,7 +32,7 @@ tracing = { workspace = true }
 rand = { workspace = true }
 secp256k1 = "0.24.3"
 serde = { version = "1.0.197", features = [ "derive" ] }
-tbs = { package = "fedimint-tbs", version = "0.3.0-alpha", path = "../../crypto/tbs" }
+tbs = { package = "fedimint-tbs", version = "=0.4.0-alpha", path = "../../crypto/tbs" }
 threshold_crypto = { workspace = true }
 ff = "0.12.1"
 strum = { workspace = true }

--- a/modules/fedimint-unknown-common/Cargo.toml
+++ b/modules/fedimint-unknown-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-unknown-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-unknown is a fedimint module that doesn't have any client side implementation."
@@ -21,7 +21,7 @@ async-trait = { workspace = true }
 bitcoin_hashes = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 rand = { workspace = true }
 serde = { version = "1.0.197", features = [ "derive" ] }
 thiserror = { workspace = true }

--- a/modules/fedimint-unknown-server/Cargo.toml
+++ b/modules/fedimint-unknown-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-unknown-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-unknown-server is a test fedimint module that doesn't have any client side implementation."
@@ -20,8 +20,8 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-unknown-common = { version = "0.3.0-alpha", path = "../fedimint-unknown-common" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-unknown-common = { version = "=0.4.0-alpha", path = "../fedimint-unknown-common" }
 rand = { workspace = true }
 serde = { version = "1.0.197", features = [ "derive" ] }
 strum = { workspace = true }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
@@ -22,10 +22,10 @@ async-stream = "0.3.5"
 async-trait = { workspace = true }
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = { workspace = true }
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client", "bitcoincore-rpc"] }
-fedimint-client = { version = "0.3.0-alpha", path = "../../fedimint-client" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-wallet-common = { version = "0.3.0-alpha", path = "../fedimint-wallet-common" }
+fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client", "bitcoincore-rpc"] }
+fedimint-client = { version = "=0.4.0-alpha", path = "../../fedimint-client" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-wallet-common = { version = "=0.4.0-alpha", path = "../fedimint-wallet-common" }
 futures = { workspace = true }
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 impl-tools = "0.10.0"

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
@@ -20,7 +20,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = { workspace = true }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
 futures = { workspace = true }
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 miniscript9 = { package = "miniscript", version = "9.0.2" }

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-server"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
@@ -20,10 +20,10 @@ anyhow = { workspace = true }
 async-trait = "0.1"
 bitcoin = { version = "0.29.2", features = [ "rand", "serde"] }
 erased-serde = { workspace = true }
-fedimint-bitcoind = { version = "0.3.0-alpha", path = "../../fedimint-bitcoind" }
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
-fedimint-metrics = { version = "0.3.0-alpha", path = "../../fedimint-metrics" }
-fedimint-wallet-common = { version = "0.3.0-alpha", path = "../fedimint-wallet-common" }
+fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../../fedimint-bitcoind" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }
+fedimint-metrics = { version = "=0.4.0-alpha", path = "../../fedimint-metrics" }
+fedimint-wallet-common = { version = "=0.4.0-alpha", path = "../fedimint-wallet-common" }
 futures = { workspace = true }
 miniscript = { version = "10.0.0", features = [ "compiler", "serde" ] }
 miniscript9 = { package = "miniscript", version = "9.0.2" }
@@ -38,7 +38,7 @@ tokio = { version = "1.36.0", features = ["sync"], optional = true }
 tracing = { workspace = true }
 url = { workspace = true }
 validator = { version = "0.17", features = ["derive"] }
-fedimint-server = { version = "0.3.0-alpha", path = "../../fedimint-server" }
+fedimint-server = { version = "=0.4.0-alpha", path = "../../fedimint-server" }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-recoverytool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 authors = ["The Fedimint Developers"]
 description = "recoverytool allows retrieving on-chain funds from a offline federation"
@@ -19,15 +19,15 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 bitcoin = "0.30.2"
 clap = { version = "4.5.2", features = [ "derive", "env" ] }
-fedimint-aead = { version = "0.3.0-alpha", path = "../crypto/aead" }
-fedimint-core = { version = "0.3.0-alpha", path = "../fedimint-core" }
-fedimint-rocksdb = { version = "0.3.0-alpha", path = "../fedimint-rocksdb" }
-fedimint-server = { version = "0.3.0-alpha", path = "../fedimint-server" }
-fedimint-wallet-server = { version = "0.3.0-alpha", path = "../modules/fedimint-wallet-server" }
-fedimint-logging = { version = "0.3.0-alpha", path = "../fedimint-logging" }
-fedimint-ln-common = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-common" }
-fedimint-ln-server = { version = "0.3.0-alpha", path = "../modules/fedimint-ln-server" }
-fedimint-mint-server = { version = "0.3.0-alpha", path = "../modules/fedimint-mint-server" }
+fedimint-aead = { version = "=0.4.0-alpha", path = "../crypto/aead" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
+fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-server = { version = "=0.4.0-alpha", path = "../fedimint-server" }
+fedimint-wallet-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-server" }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
+fedimint-ln-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-common" }
+fedimint-ln-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-server" }
+fedimint-mint-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-mint-server" }
 futures = { workspace = true }
 hex = { workspace = true }
 miniscript = { version = "10.0.0" }

--- a/utils/portalloc/Cargo.toml
+++ b/utils/portalloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-portalloc"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Port allocation utility for Fedimint"
@@ -23,4 +23,4 @@ serde_json = { version = "1.0.114", features = ["preserve_order"] }
 tracing = { workspace = true }
 rand = { workspace = true }
 dirs = "5.0.1"
-fedimint-core = { version = "0.3.0-alpha", path = "../../fedimint-core" }
+fedimint-core = { version = "=0.4.0-alpha", path = "../../fedimint-core" }


### PR DESCRIPTION
A separate PR (https://github.com/fedimint/fedimint/pull/4623) bumping versions to 0.4.0-alpha uncovered issues with using `VersionReq`. This PR includes the fix (https://github.com/fedimint/fedimint/pull/4804), version bump, and adds the version to metrics dependency in fedimint-server.