### PR TITLE
chore: modules to trigger `consensus_proposal` manualy, use in meta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,9 +5189,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 hex = { version = "0.4.3", features = ["serde"] }
-tokio = { version = "1.36.0", features = ["sync", "io-util"] }
+tokio = { version = "1.37.0", features = ["sync", "io-util"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 threshold_crypto = { workspace = true }

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -91,6 +91,8 @@ pub struct ConsensusApi {
     pub client_cfg: ClientConfig,
     /// For sending API events to consensus such as transactions
     pub submission_sender: async_channel::Sender<ConsensusItem>,
+    /// For triggering consensus proposal round
+    pub consensus_proposal_trigger_tx: tokio::sync::watch::Sender<u64>,
     pub peer_status_channels: PeerStatusChannels,
     pub latest_contribution_by_peer: Arc<RwLock<LatestContributionByPeer>>,
     pub consensus_status_cache: ExpiringCache<ApiResult<FederationStatus>>,

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -19,9 +19,9 @@ use fedimint_core::db::{
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
-    api_endpoint, ApiAuth, ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta,
-    ModuleConsensusVersion, ModuleInit, PeerHandle, ServerModuleInit, ServerModuleInitArgs,
-    SupportedModuleApiVersions, TransactionItemAmount,
+    api_endpoint, ApiAuth, ApiEndpoint, ApiError, ApiVersion, ConsensusProposalTrigger,
+    CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit, PeerHandle,
+    ServerModuleInit, ServerModuleInitArgs, SupportedModuleApiVersions, TransactionItemAmount,
 };
 use fedimint_core::server::DynServerModule;
 use fedimint_core::{
@@ -130,6 +130,7 @@ impl ServerModuleInit for MetaInit {
             cfg: args.cfg().to_typed()?,
             our_peer_id: args.our_peer_id(),
             num_peers: args.num_peers(),
+            consensus_proposal_trigger: args.consensus_proposal_trigger().clone(),
         }
         .into())
     }
@@ -200,6 +201,7 @@ pub struct Meta {
     pub cfg: MetaConfig,
     pub our_peer_id: PeerId,
     pub num_peers: NumPeers,
+    consensus_proposal_trigger: ConsensusProposalTrigger,
 }
 
 impl Meta {
@@ -467,6 +469,7 @@ impl Meta {
             },
         )
         .await;
+        self.consensus_proposal_trigger.send();
 
         Ok(())
     }


### PR DESCRIPTION
Re https://github.com/fedimint/fedimint/pull/4792#issuecomment-2035027975

Some modules will inevitably be bound in some places by the latency of `consensus_proposal` polling, and this is a clean and easy to use method to let them trigger consensus item processing.

This mimics how submitted transaction are being handled already - a side-channel. And saves module authors dealing with complicated calling conventions and wiring similar channels manually. The `consensus_proposal` can stay relatively dumb.