### PR TITLE
chore: don't install rnix-lsp in our dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -249,7 +249,6 @@
                   # Nix
                   pkgs.nixpkgs-fmt
                   pkgs.shellcheck
-                  pkgs.rnix-lsp
                   pkgs.nil
                   pkgs.convco
                   pkgs.nodePackages.bash-language-server


### PR DESCRIPTION
`nil` seems to be the prefered option anyway.