### PR TITLE
fix(ci): add single quotes to PR titles

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -50,7 +50,7 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
           SHORT_PR_TITLE=$(
             echo '${{ github.event.pull_request.title }' \
-            | awk '{print (length($0) > 20) ? substr($0, 1, 20) "..." : $0}'
+            | awk '{print (length($0) > 40) ? substr($0, 1, 40) "..." : $0}'
           )
           echo "SHORT_PR_TITLE=$SHORT_PR_TITLE" >> "$GITHUB_ENV"
       - name: Create issue

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -48,7 +48,10 @@ jobs:
         run: |
           # logic to truncate titles needs to be run in a previous step
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-          SHORT_PR_TITLE=$(echo ${{ github.event.pull_request.title }} | awk '{print (length($0) > 20) ? substr($0, 1, 20) "..." : $0}')
+          SHORT_PR_TITLE=$(
+            echo '${{ github.event.pull_request.title }' \
+            | awk '{print (length($0) > 20) ? substr($0, 1, 20) "..." : $0}'
+          )
           echo "SHORT_PR_TITLE=$SHORT_PR_TITLE" >> "$GITHUB_ENV"
       - name: Create issue
         uses: JasonEtco/create-an-issue@v2


### PR DESCRIPTION
The backport bot had a few issues that are resolved by adding single quotes to the PR title when constructing the truncated PR title.

- Failed to open an issue
```
/home/runner/work/_temp/5a908921-0273-46b8-ada3-8b0b85137a8c.sh: command substitution: line 4: syntax error near unexpected token `('
```
https://github.com/fedimint/fedimint/actions/runs/8485661954/job/23250831899

- Attempted to execute command inside backticks

```
/home/runner/work/_temp/8b4842a9-3ce5-4a8f-a706-d08a03b64065.sh: line 3: just: command not found
```
https://github.com/fedimint/fedimint/actions/runs/8395853632/job/22996034143

@dpc thanks for highlighting that the issue bot created a funky short PR title in https://github.com/fedimint/fedimint/issues/4684.

Also increased the short PR title length (https://github.com/fedimint/fedimint/issues/4362#issuecomment-2012413386).

---
```bash
nix@lenovo-m75q-ubuntu:~/fedimint$
SHORT_PR_TITLE=$(
  echo 'chore: `just sign-release v0.3.0-rc.0` by dpc' \
  | awk '{print (length($0) > 40) ? substr($0, 1, 40) "..." : $0}'
)
nix@lenovo-m75q-ubuntu:~/fedimint$ echo "$SHORT_PR_TITLE"
chore: `just sign-release v0.3.0-rc.0` b...
```