### PR TITLE
 chore: standalone devimint tests PoC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-meta-tests"
+version = "0.3.0-alpha"
+dependencies = [
+ "anyhow",
+ "devimint",
+ "tokio",
+]
+
+[[package]]
 name = "fedimint-metrics"
 version = "0.4.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "modules/fedimint-meta-common",
     "modules/fedimint-meta-client",
     "modules/fedimint-meta-server",
+    "modules/fedimint-meta-tests",
     "modules/fedimint-unknown-common",
     "modules/fedimint-unknown-server",
     "modules/fedimint-dummy-tests",
@@ -86,6 +87,7 @@ strum = "0.26"
 strum_macros = "0.26"
 futures = "0.3.30"
 thiserror = "1.0.58"
+tokio = { version = "1.36.0", features = ["sync", "io-util"] }
 url = "2.5.0"
 erased-serde = "0.4"
 async-trait = "0.1.77"

--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -137,3 +137,6 @@ pub const FM_GWCLI_CLN_ENV: &str = "FM_GWCLI_CLN";
 
 // Env variable to define command for the LND client
 pub const FM_GWCLI_LND_ENV: &str = "FM_GWCLI_LND";
+
+/// Make `devimint` print stderr of called commands directly on its own stderr
+pub const FM_DEVIMINT_CMD_INHERIT_STDERR_ENV: &str = "FM_DEVIMINT_CMD_INHERIT_STDERR";

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -1,9 +1,15 @@
+use std::ffi;
+
+use clap::Parser as _;
+use cli::cleanup_on_exit;
 pub use devfed::{dev_fed, DevFed};
 pub use external::{
     external_daemons, open_channel, ExternalDaemons, LightningNode, Lightningd,
     LightningdProcessHandle, Lnd,
 };
+use futures::Future;
 pub use gatewayd::Gatewayd;
+use util::ProcessManager;
 
 pub mod cli;
 pub mod devfed;
@@ -14,3 +20,15 @@ pub mod gatewayd;
 pub mod tests;
 pub mod util;
 pub mod vars;
+
+pub async fn run_test<F, FF>(f: F) -> anyhow::Result<()>
+where
+    F: FnOnce(ProcessManager) -> FF,
+    FF: Future<Output = anyhow::Result<()>>,
+{
+    let args = cli::CommonArgs::parse_from::<_, ffi::OsString>(vec![]);
+
+    let (process_mgr, task_group) = cli::setup(args).await?;
+    cleanup_on_exit(f(process_mgr), task_group).await?;
+    Ok(())
+}

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -124,10 +124,10 @@ impl TaskGroup {
 
     pub async fn shutdown_join_all(
         self,
-        join_timeout: Option<Duration>,
+        join_timeout: impl Into<Option<Duration>>,
     ) -> Result<(), anyhow::Error> {
         self.shutdown();
-        self.join_all(join_timeout).await
+        self.join_all(join_timeout.into()).await
     }
 
     #[cfg(not(target_family = "wasm"))]

--- a/modules/fedimint-meta-tests/Cargo.toml
+++ b/modules/fedimint-meta-tests/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fedimint-meta-tests"
+version = "0.3.0-alpha"
+authors = ["The Fedimint Developers"]
+edition = "2021"
+description = "fedimint-mint-tests contains integration tests for the meta module"
+license = "MIT"
+publish = false
+
+
+[dependencies]
+anyhow = { workspace = true }
+devimint = { path = "../../devimint" }
+tokio = { workspace = true }

--- a/modules/fedimint-meta-tests/Cargo.toml
+++ b/modules/fedimint-meta-tests/Cargo.toml
@@ -8,6 +8,12 @@ license = "MIT"
 publish = false
 
 
+# workaround: cargo-deny in Nix needs to see at least one
+# artifact here
+[[bin]]
+name = "meta-dummy-test"
+path = "src/bin/meta-dummy-test.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 devimint = { path = "../../devimint" }

--- a/modules/fedimint-meta-tests/src/bin/meta-dummy-test.rs
+++ b/modules/fedimint-meta-tests/src/bin/meta-dummy-test.rs
@@ -1,0 +1,12 @@
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    devimint::run_test(|process_mgr| async move {
+        let dev_fed = devimint::devfed::DevJitFed::new(&process_mgr)?;
+
+        dev_fed.finalize(&process_mgr).await?;
+        let client = dev_fed.internal_client().await?;
+        client.balance().await?;
+        Ok(())
+    })
+    .await
+}


### PR DESCRIPTION
The fact that `devimint` binary carries all the tests with it is bothering me. I did some experiments how else could we achive it, and it seems to me that compiling devimint tests as standalone binaries is most reasonable.



Test with:

```
> just b && env PATH="$(pwd)/target-nix/debug:$PATH" ./target-nix/debug/meta-dummy-test
```

It's not an Rust integration  test (`./crate/src/tests`) or a unit-test (`#[test]`), as it can't really run without binaries in the `PATH` making it "something else" that requires setup `cargo` will never know about.


It has to be a separate crate, so it doesn't carry `devimint` as a dependency, as we can't use `dev-dependencies`.
