### PR TITLE
chore(deps): bump electrum-client from 0.14.1 to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,15 +1149,16 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "electrum-client"
-version = "0.14.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8debf63f96e20e6d9e94170227b4329806f5fbb87b1f0f10a597fd26f26902"
+checksum = "6bc133f1c8d829d254f013f946653cbeb2b08674b960146361d1e9b67733ad19"
 dependencies = [
- "bitcoin 0.29.2",
+ "bitcoin 0.30.2",
+ "bitcoin-private",
  "byteorder",
  "libc",
  "log",
- "rustls 0.20.9",
+ "rustls 0.21.10",
  "serde",
  "serde_json",
  "webpki",

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = "0.29.2"
 bitcoincore-rpc = { version = "0.16.0", optional = true }
-electrum-client = { version = "0.14.1", optional = true }
+electrum-client = { version = "0.18.0", optional = true }
 esplora-client = { version = "0.5.0", default-features = false, features = ["async", "async-https-rustls"], optional = true }
 hex = "0.4.3"
 lazy_static = "1.4.0"

--- a/fedimint-core/src/bitcoin_migration.rs
+++ b/fedimint-core/src/bitcoin_migration.rs
@@ -121,7 +121,7 @@ pub fn bitcoin30_to_bitcoin29_txid(txid: bitcoin30::Txid) -> bitcoin::Txid {
         .expect("Failed to convert bitcoin v30 txid to bitcoin v29 txid")
 }
 
-pub fn bitcoin30_to_bitcoin29_script(script: bitcoin30::ScriptBuf) -> bitcoin::Script {
+pub fn bitcoin30_to_bitcoin29_script(script: &bitcoin30::ScriptBuf) -> bitcoin::Script {
     script.to_bytes().into()
 }
 
@@ -403,7 +403,7 @@ mod tests {
         // script.
         assert_eq!(
             bitcoin29_script,
-            bitcoin30_to_bitcoin29_script(bitcoin30_script.clone())
+            bitcoin30_to_bitcoin29_script(&bitcoin30_script.clone())
         );
         // Assert that bitcoin29->bitcoin30 script is the same as native bitcoin30
         // script.

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -103,7 +103,7 @@ async fn await_created_btc_transaction_submitted(
     tweak: KeyPair,
 ) -> (bitcoin::Transaction, u32) {
     let script = bitcoin30_to_bitcoin29_script(
-        context
+        &context
             .wallet_descriptor
             .tweak(&tweak.public_key(), &context.secp)
             .script_pubkey(),

--- a/modules/fedimint-wallet-common/src/txoproof.rs
+++ b/modules/fedimint-wallet-common/src/txoproof.rs
@@ -67,7 +67,7 @@ impl PegInProof {
         untweaked_pegin_descriptor: &Descriptor<CompressedPublicKey>,
     ) -> Result<(), PegInProofError> {
         let script = bitcoin30_to_bitcoin29_script(
-            untweaked_pegin_descriptor
+            &untweaked_pegin_descriptor
                 .tweak(&self.tweak_contract_key, secp)
                 .script_pubkey(),
         );

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1075,7 +1075,8 @@ impl Wallet {
         self.remove_rbf_transactions(dbtx, pending_tx).await;
 
         let script_pk = bitcoin30_to_bitcoin29_script(
-            self.cfg
+            &self
+                .cfg
                 .consensus
                 .peg_in_descriptor
                 .tweak(&pending_tx.tweak, &self.secp)
@@ -1445,13 +1446,14 @@ impl<'a> StatelessWallet<'a> {
                         non_witness_utxo: None,
                         witness_utxo: Some(TxOut {
                             value: utxo.amount.to_sat(),
-                            script_pubkey: bitcoin30_to_bitcoin29_script(script_pubkey),
+                            script_pubkey: bitcoin30_to_bitcoin29_script(&script_pubkey),
                         }),
                         partial_sigs: Default::default(),
                         sighash_type: None,
                         redeem_script: None,
                         witness_script: Some(bitcoin30_to_bitcoin29_script(
-                            self.descriptor
+                            &self
+                                .descriptor
                                 .tweak(&utxo.tweak, self.secp)
                                 .script_code()
                                 .expect("Failed to tweak descriptor"),
@@ -1580,7 +1582,7 @@ impl<'a> StatelessWallet<'a> {
             })
             .expect("can't fail");
 
-        bitcoin30_to_bitcoin29_script(descriptor.script_pubkey())
+        bitcoin30_to_bitcoin29_script(&descriptor.script_pubkey())
     }
 }
 


### PR DESCRIPTION
v0.14.1 depends on bitcoin v0.29, whereas v0.18.0 depends on bitcoin v0.30 which requires extra changes