### PR TITLE
chore: remove DynState in client db migrations

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -3,14 +3,12 @@ use std::time::SystemTime;
 
 use fedimint_api_client::api::ApiVersionSet;
 use fedimint_core::config::{ClientConfig, FederationId};
-use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
+use fedimint_core::core::{ModuleInstanceId, OperationId};
 use fedimint_core::db::{
-    create_database_version, Database, DatabaseTransaction, DatabaseValue, DatabaseVersion,
-    DatabaseVersionKey, IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped,
-    MODULE_GLOBAL_PREFIX,
+    create_database_version, Database, DatabaseTransaction, DatabaseVersion, DatabaseVersionKey,
+    IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped, MODULE_GLOBAL_PREFIX,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::util::BoxFuture;
 use fedimint_core::{impl_db_lookup, impl_db_record};
 use fedimint_logging::LOG_CLIENT_DB;
@@ -23,10 +21,10 @@ use crate::backup::{ClientBackup, Metadata};
 use crate::module::recovery::RecoveryProgress;
 use crate::oplog::OperationLogEntry;
 use crate::sm::executor::{
-    ActiveStateKey, ActiveStateKeyBytes, ActiveStateKeyPrefixBytes, InactiveStateKey,
-    InactiveStateKeyBytes, InactiveStateKeyPrefixBytes,
+    ActiveStateKeyBytes, ActiveStateKeyPrefixBytes, InactiveStateKeyBytes,
+    InactiveStateKeyPrefixBytes,
 };
-use crate::sm::{ActiveStateMeta, DynState, InactiveStateMeta, State};
+use crate::sm::{ActiveStateMeta, InactiveStateMeta};
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -334,14 +332,14 @@ impl_db_lookup!(key = MetaFieldKey, query_prefix = MetaFieldPrefix);
 
 /// `ClientMigrationFn` is a function that modules can implement to "migrate"
 /// the database to the next database version.
-pub type ClientMigrationFn =
-    for<'r, 'tx> fn(
-        &'r mut DatabaseTransaction<'tx>,
-        ModuleInstanceId,
-        Vec<(Vec<u8>, OperationId)>, // active states
-        Vec<(Vec<u8>, OperationId)>, // inactive states
-        ModuleDecoderRegistry,
-    ) -> BoxFuture<'r, anyhow::Result<Option<(Vec<DynState>, Vec<DynState>)>>>;
+pub type ClientMigrationFn = for<'r, 'tx> fn(
+    &'r mut DatabaseTransaction<'tx>,
+    Vec<(Vec<u8>, OperationId)>, // active states
+    Vec<(Vec<u8>, OperationId)>, // inactive states
+) -> BoxFuture<
+    'r,
+    anyhow::Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>>,
+>;
 
 /// `apply_migrations_client` iterates from the on disk database version for the
 /// client module up to `target_db_version` and executes all of the migrations
@@ -358,7 +356,6 @@ pub async fn apply_migrations_client(
     target_version: DatabaseVersion,
     migrations: BTreeMap<DatabaseVersion, ClientMigrationFn>,
     module_instance_id: ModuleInstanceId,
-    decoders: ModuleDecoderRegistry,
 ) -> Result<(), anyhow::Error> {
     // Newly created databases will not have any data underneath the
     // `MODULE_GLOBAL_PREFIX` since they have just been instantiated.
@@ -434,10 +431,8 @@ pub async fn apply_migrations_client(
                     &mut global_dbtx
                         .to_ref_with_prefix_module_id(module_instance_id)
                         .into_nc(),
-                    module_instance_id,
                     active_states.clone(),
                     inactive_states.clone(),
-                    decoders.clone(),
                 )
                 .await?
             } else {
@@ -466,14 +461,8 @@ pub async fn apply_migrations_client(
                 .await;
 
                 // the new states become the old states for the next migration
-                active_states = new_active_states
-                    .into_iter()
-                    .map(|state| (state.to_bytes(), state.operation_id()))
-                    .collect::<Vec<_>>();
-                inactive_states = new_inactive_states
-                    .into_iter()
-                    .map(|state| (state.to_bytes(), state.operation_id()))
-                    .collect::<Vec<_>>();
+                active_states = new_active_states;
+                inactive_states = new_inactive_states;
             }
 
             current_version.increment();
@@ -543,7 +532,7 @@ pub async fn get_inactive_states(
 /// expected to contain all active states, not just the newly created states.
 pub async fn remove_old_and_persist_new_active_states(
     dbtx: &mut DatabaseTransaction<'_>,
-    new_active_states: Vec<DynState>,
+    new_active_states: Vec<(Vec<u8>, OperationId)>,
     states_to_remove: Vec<(Vec<u8>, OperationId)>,
     module_instance_id: ModuleInstanceId,
 ) {
@@ -558,19 +547,17 @@ pub async fn remove_old_and_persist_new_active_states(
         .expect("Did not delete anything");
     }
 
-    let new_active_states = new_active_states
-        .into_iter()
-        .map(|state| {
-            (
-                ActiveStateKey::from_state(state),
-                ActiveStateMeta::default(),
-            )
-        })
-        .collect::<Vec<_>>();
-
     // Insert new "migrated" active states
-    for (state, active_state) in new_active_states {
-        dbtx.insert_new_entry(&state, &active_state).await;
+    for (bytes, operation_id) in new_active_states {
+        dbtx.insert_new_entry(
+            &ActiveStateKeyBytes {
+                operation_id,
+                module_instance_id,
+                state: bytes,
+            },
+            &ActiveStateMeta::default(),
+        )
+        .await;
     }
 }
 
@@ -579,7 +566,7 @@ pub async fn remove_old_and_persist_new_active_states(
 /// expected to contain all inactive states, not just the newly created states.
 pub async fn remove_old_and_persist_new_inactive_states(
     dbtx: &mut DatabaseTransaction<'_>,
-    new_inactive_states: Vec<DynState>,
+    new_inactive_states: Vec<(Vec<u8>, OperationId)>,
     states_to_remove: Vec<(Vec<u8>, OperationId)>,
     module_instance_id: ModuleInstanceId,
 ) {
@@ -594,72 +581,51 @@ pub async fn remove_old_and_persist_new_inactive_states(
         .expect("Did not delete anything");
     }
 
-    let new_inactive_states = new_inactive_states
-        .into_iter()
-        .map(|state| {
-            (
-                InactiveStateKey::from_state(state),
-                InactiveStateMeta {
-                    created_at: fedimint_core::time::now(),
-                    exited_at: fedimint_core::time::now(),
-                },
-            )
-        })
-        .collect::<Vec<_>>();
-
     // Insert new "migrated" inactive states
-    for (state, inactive_state) in new_inactive_states {
-        dbtx.insert_new_entry(&state, &inactive_state).await;
+    for (bytes, operation_id) in new_inactive_states {
+        dbtx.insert_new_entry(
+            &InactiveStateKeyBytes {
+                operation_id,
+                module_instance_id,
+                state: bytes,
+            },
+            &InactiveStateMeta {
+                created_at: fedimint_core::time::now(),
+                exited_at: fedimint_core::time::now(),
+            },
+        )
+        .await;
     }
 }
+
+/// Helper function definition for migrating a single state.
+type MigrateStateFn = fn(&[u8], OperationId) -> anyhow::Result<Option<(Vec<u8>, OperationId)>>;
 
 /// Migrates a particular state by looping over all active and inactive states.
 /// If the `migrate` closure returns `None`, this state was not migrated and
 /// should be added to the new state machine vectors.
-pub async fn migrate_state<S: State + IntoDynInstance<DynType = DynState>>(
-    module_instance_id: ModuleInstanceId,
+pub async fn migrate_state(
     active_states: Vec<(Vec<u8>, OperationId)>,
     inactive_states: Vec<(Vec<u8>, OperationId)>,
-    decoders: ModuleDecoderRegistry,
-    migrate: fn(
-        &[u8],
-        ModuleInstanceId,
-        &ModuleDecoderRegistry,
-    ) -> anyhow::Result<Option<DynState>>,
-) -> anyhow::Result<Option<(Vec<DynState>, Vec<DynState>)>> {
+    migrate: MigrateStateFn,
+) -> anyhow::Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>> {
     let mut new_active_states = Vec::with_capacity(active_states.len());
-    for (active_state, _) in active_states {
+    for (active_state, operation_id) in active_states {
         let bytes = active_state.as_slice();
-        let state = match migrate(bytes, module_instance_id, &decoders)? {
+        let state = match migrate(bytes, operation_id)? {
             Some(state) => state,
-            None => {
-                // Try to decode the bytes as a `DynState`
-                let dynstate = DynState::from_bytes(bytes, &decoders)?;
-                let state_machine = dynstate
-                    .as_any()
-                    .downcast_ref::<S>()
-                    .expect("Unexpected DynState supplied to migration function");
-                state_machine.clone().into_dyn(module_instance_id)
-            }
+            None => (active_state, operation_id),
         };
 
         new_active_states.push(state);
     }
 
     let mut new_inactive_states = Vec::with_capacity(inactive_states.len());
-    for (inactive_state, _) in inactive_states {
+    for (inactive_state, operation_id) in inactive_states {
         let bytes = inactive_state.as_slice();
-        let state = match migrate(bytes, module_instance_id, &decoders)? {
+        let state = match migrate(bytes, operation_id)? {
             Some(state) => state,
-            None => {
-                // Try to decode the bytes as a `DynState`
-                let dynstate = DynState::from_bytes(bytes, &decoders)?;
-                let state_machine = dynstate
-                    .as_any()
-                    .downcast_ref::<S>()
-                    .expect("Unexpected DynState supplied to migration function");
-                state_machine.clone().into_dyn(module_instance_id)
-            }
+            None => (inactive_state, operation_id),
         };
 
         new_inactive_states.push(state);

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1858,11 +1858,7 @@ impl ClientBuilder {
         self.meta_service = meta_service;
     }
 
-    async fn migrate_database(
-        &self,
-        db: &Database,
-        decoders: ModuleDecoderRegistry,
-    ) -> anyhow::Result<()> {
+    async fn migrate_database(&self, db: &Database) -> anyhow::Result<()> {
         // Only apply the client database migrations if the database has been
         // initialized.
         if let Ok(client_config) = self.load_existing_config().await {
@@ -1879,7 +1875,6 @@ impl ClientBuilder {
                     init.database_version(),
                     init.get_database_migrations(),
                     module_id,
-                    decoders.clone(),
                 )
                 .await?;
             }
@@ -2118,7 +2113,7 @@ impl ClientBuilder {
 
         // Migrate the database before interacting with it in case any on-disk data
         // structures have changed.
-        self.migrate_database(&db, decoders.clone()).await?;
+        self.migrate_database(&db).await?;
 
         let init_state = Self::load_init_state(&db).await;
 

--- a/fedimint-testing/src/db.rs
+++ b/fedimint-testing/src/db.rs
@@ -361,7 +361,6 @@ where
         module.database_version(),
         module.get_database_migrations(),
         TEST_MODULE_INSTANCE_ID,
-        decoders,
     )
     .await
     .context("Error applying migrations to temp database")?;

--- a/modules/fedimint-dummy-client/src/db.rs
+++ b/modules/fedimint-dummy-client/src/db.rs
@@ -1,6 +1,5 @@
-use fedimint_client::sm::DynState;
-use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
-use fedimint_core::db::{DatabaseTransaction, DatabaseValue, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::core::{ModuleInstanceId, OperationId};
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{impl_db_record, Amount};
@@ -56,7 +55,7 @@ impl_db_record!(
 /// The new key/value pair has an `Amount` as the value.
 pub async fn migrate_to_v1(
     dbtx: &mut DatabaseTransaction<'_>,
-) -> anyhow::Result<Option<(Vec<DynState>, Vec<DynState>)>> {
+) -> anyhow::Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>> {
     if dbtx.remove_entry(&DummyClientFundsKeyV0).await.is_some() {
         // Since this is a dummy migration, we can insert any value for the client
         // funds. Real modules should handle the funds properly.
@@ -70,69 +69,26 @@ pub async fn migrate_to_v1(
     Ok(None)
 }
 
-/// Migrates the database from version 1 to version 2. Maps all `Unreachable`
-/// states in the state machine to `InputDone`.
-pub async fn migrate_to_v2(
-    module_instance_id: ModuleInstanceId,
-    active_states: Vec<(Vec<u8>, OperationId)>,
-    inactive_states: Vec<(Vec<u8>, OperationId)>,
-    decoders: ModuleDecoderRegistry,
-) -> anyhow::Result<Option<(Vec<DynState>, Vec<DynState>)>> {
-    let mut new_active_states = Vec::new();
-    for (active_state, _) in active_states {
-        // Try to decode the bytes as a `DynState`
-        let dynstate = DynState::from_bytes(active_state.as_slice(), &decoders)?;
-        let typed_state = dynstate
-            .as_any()
-            .downcast_ref::<DummyStateMachine>()
-            .expect("Unexpected DynState suppilied to migration function");
+/// Maps all `Unreachable` states in the state machine to `OutputDone`
+pub(crate) fn get_v1_migrated_state(
+    bytes: &[u8],
+    operation_id: OperationId,
+) -> anyhow::Result<Option<(Vec<u8>, OperationId)>> {
+    let decoders = ModuleDecoderRegistry::default();
+    let mut cursor = std::io::Cursor::new(bytes);
+    let module_instance_id =
+        fedimint_core::core::ModuleInstanceId::consensus_decode(&mut cursor, &decoders)?;
+    let dummy_sm_variant = u16::consensus_decode(&mut cursor, &decoders)?;
 
-        match typed_state {
-            DummyStateMachine::Unreachable(_, _) => {
-                // Try to parse the bytes as the `Unreachable` struct to simulate a deleted
-                // state. In a real migration, `DynState::from_bytes` will
-                // fail since `DummyStateMachine::Unreachable` will not exist.
-                if let Ok(unreachable) =
-                    Unreachable::consensus_decode_vec(active_state.clone(), &decoders)
-                {
-                    new_active_states.push(
-                        DummyStateMachine::OutputDone(unreachable.amount, unreachable.operation_id)
-                            .into_dyn(module_instance_id),
-                    );
-                }
-            }
-            state => new_active_states.push(state.clone().into_dyn(module_instance_id)),
-        }
+    if dummy_sm_variant != 5 {
+        return Ok(None);
     }
 
-    let mut new_inactive_states = Vec::new();
-    for (inactive_state, _) in inactive_states {
-        // Try to decode the bytes as a `DynState`
-        let dynstate = DynState::from_bytes(inactive_state.as_slice(), &decoders)?;
-        let typed_state = dynstate
-            .as_any()
-            .downcast_ref::<DummyStateMachine>()
-            .expect("Unexpected DynState suppilied to migration function");
-
-        match typed_state {
-            DummyStateMachine::Unreachable(_, _) => {
-                // Try to parse the bytes as the `Unreachable` struct to simulate a deleted
-                // state. In a real migration, `DynState::from_bytes` will
-                // fail since `DummyStateMachine::Unreachable` will not exist.
-                if let Ok(unreachable) =
-                    Unreachable::consensus_decode_vec(inactive_state.clone(), &decoders)
-                {
-                    new_inactive_states.push(
-                        DummyStateMachine::OutputDone(unreachable.amount, unreachable.operation_id)
-                            .into_dyn(module_instance_id),
-                    );
-                }
-            }
-            state => new_inactive_states.push(state.clone().into_dyn(module_instance_id)),
-        }
-    }
-
-    Ok(Some((new_active_states, new_inactive_states)))
+    // Migrate `Unreachable` states to `OutputDone`
+    let unreachable = Unreachable::consensus_decode(&mut cursor, &decoders)?;
+    let new_state = DummyStateMachine::OutputDone(unreachable.amount, unreachable.operation_id);
+    let bytes = (module_instance_id, new_state).consensus_encode_to_vec();
+    Ok(Some((bytes, operation_id)))
 }
 
 #[derive(Debug)]

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -337,7 +337,7 @@ impl ClientModuleInit for LightningClientInit {
 
     fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn> {
         let mut migrations: BTreeMap<DatabaseVersion, ClientMigrationFn> = BTreeMap::new();
-        migrations.insert(DatabaseVersion(0), move |dbtx, _, _, _, _| {
+        migrations.insert(DatabaseVersion(0), move |dbtx, _, _| {
             Box::pin(async {
                 dbtx.remove_entry(&crate::db::ActiveGatewayKey).await;
                 Ok(None)
@@ -346,29 +346,15 @@ impl ClientModuleInit for LightningClientInit {
 
         migrations.insert(
             DatabaseVersion(1),
-            move |_, module_instance_id, active_states, inactive_states, decoders| {
-                migrate_state::<LightningClientStateMachines>(
-                    module_instance_id,
-                    active_states,
-                    inactive_states,
-                    decoders,
-                    db::get_v1_migrated_state,
-                )
-                .boxed()
+            move |_, active_states, inactive_states| {
+                migrate_state(active_states, inactive_states, db::get_v1_migrated_state).boxed()
             },
         );
 
         migrations.insert(
             DatabaseVersion(2),
-            move |_, module_instance_id, active_states, inactive_states, decoders| {
-                migrate_state::<LightningClientStateMachines>(
-                    module_instance_id,
-                    active_states,
-                    inactive_states,
-                    decoders,
-                    db::get_v2_migrated_state,
-                )
-                .boxed()
+            move |_, active_states, inactive_states| {
+                migrate_state(active_states, inactive_states, db::get_v2_migrated_state).boxed()
             },
         );
 


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/4823

Allows us to write "partial" migrations, that migrate states to another state, then migrate it again to the final state that can be parsed as a `DynState`.