### PR TITLE
fix: break lockstep between peers in a round by adding jitter

### DIFF
--- a/fedimint-server/src/consensus/server.rs
+++ b/fedimint-server/src/consensus/server.rs
@@ -31,6 +31,7 @@ use fedimint_core::timing::TimeReporter;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{timing, NumPeers, PeerId};
 use futures::StreamExt;
+use rand::Rng;
 use tokio::sync::watch;
 use tracing::{debug, info, warn};
 
@@ -378,7 +379,9 @@ impl ConsensusServer {
             let delay = if round_index == 0 {
                 0.0
             } else {
-                round_delay * BASE.powf(round_index.saturating_sub(exp_slowdown_offset) as f64)
+                round_delay
+                    * BASE.powf(round_index.saturating_sub(exp_slowdown_offset) as f64)
+                    * rand::thread_rng().gen_range(0.5..=1.5)
             };
 
             Duration::from_millis(delay.round() as u64)


### PR DESCRIPTION
AlephBFT each round will basically take the first N responses from peers, and ignore other ones.

What can happen in a devimint run is that each `fedimintd` runs the exactly same loop but offseted by some tiny, tiny time, because we start peers in a `for _ in 0..N`.

So a last peer can get ignored consistently for a long while.

Adding any jitter breaks the lockstep immediately, but AFAIK in distributed systems it's a good practice to just use +/- 50% to immediately break any corelations, so we went with `0.5..=1.5`.