### PR TITLE
chore: introduce `fedimint-docs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-docs"
+version = "0.3.0-alpha"
+
+[[package]]
 name = "fedimint-dummy-client"
 version = "0.4.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crypto/derive-secret",
     "crypto/hkdf",
     "crypto/tbs",
+    "docs",
     "gateway/ln-gateway",
     "gateway/cli",
     "fedimintd",

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fedimint-docs"
+edition = "2021"
+authors = ["The Fedimint Developers"]
+version = "0.3.0-alpha"
+publish = false
+license = "MIT"
+readme = "../README.md"
+repository = "https://github.com/fedimint/fedimint"
+
+[lib]
+name = "fedimint_docs"
+path = "lib.rs"

--- a/docs/lib.rs
+++ b/docs/lib.rs
@@ -1,0 +1,6 @@
+pub mod architecture {
+    #![doc = include_str!("./architecture.md")]
+}
+pub mod modular_architecture {
+    #![doc = include_str!("./modular-architecture.md")]
+}

--- a/docs/rustdoc-index.md
+++ b/docs/rustdoc-index.md
@@ -30,6 +30,8 @@ On a high-level Fedimint architecture consist of:
 communication with Fedimint peers. This library can be used to build Fedimint client applications that can run on
 desktop computers, mobile devices and in web browsers (WASM).
 
+More high level documentation is available as a part of [`fedimint-docs`](./fedimint_docs/indiex.html) crate.
+
 # Modules
 
 Fedimint architecture is extensible using a modular design. Fedimint modules can build on top of Fedimint consensus to implement additional functionality and applications.

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -51,10 +51,10 @@ let
   filterWorkspaceDepsBuildFiles = src: filterSrcWithRegexes filterWorkspaceDepsBuildFilesRegex src;
 
   # Filter only files relevant to building the workspace
-  filterWorkspaceBuildFiles = src: filterSrcWithRegexes (filterWorkspaceDepsBuildFilesRegex ++ [ ".*\.rs" ".*\.html" ".*/proto/.*" "db/migrations/.*" "devimint/src/cfg/.*" ]) src;
+  filterWorkspaceBuildFiles = src: filterSrcWithRegexes (filterWorkspaceDepsBuildFilesRegex ++ [ ".*\.rs" ".*\.html" ".*/proto/.*" "db/migrations/.*" "devimint/src/cfg/.*" "docs/.*\.md" ]) src;
 
   # Like `filterWorkspaceFiles` but with `./scripts/` included
-  filterWorkspaceTestFiles = src: filterSrcWithRegexes (filterWorkspaceDepsBuildFilesRegex ++ [ ".*\.rs" ".*\.html" ".*/proto/.*" "db/migrations/.*" "devimint/src/cfg/.*" "scripts/.*" ]) src;
+  filterWorkspaceTestFiles = src: filterSrcWithRegexes (filterWorkspaceDepsBuildFilesRegex ++ [ ".*\.rs" ".*\.html" ".*/proto/.*" "db/migrations/.*" "devimint/src/cfg/.*" "scripts/.*" "docs/.*\.md" ]) src;
 
   filterWorkspaceAuditFiles = src: filterSrcWithRegexes (filterWorkspaceDepsBuildFilesRegex ++ [ "deny.toml" ]) src;
 
@@ -295,8 +295,6 @@ rec {
 
   workspaceCargoUdeps = craneLib.mkCargoDerivation {
     pname = "fedimint-udeps";
-    # no need for inheriting any artifacts, as we are using it as a one-off, and only care
-    # about the docs
     cargoArtifacts = workspaceCargoUdepsDeps;
     nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-udeps ];
     buildPhaseCargoCommand = "cargo udeps --workspace --all-targets --profile $CARGO_PROFILE";


### PR DESCRIPTION
A crate to link our `./docs/` into cargo doc output.

Re #4847