### PR TITLE
chore: bump remaining packages to 0.4.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.4",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "fedimint-core",
  "honggfuzz",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "base64 0.22.0",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.11.0",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.0.0"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ version = "0.4.0-alpha"
 
 [workspace.metadata]
 name = "fedimint"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint is a prototype Federated Chaumian E-Cash Mint implementation, natively compatible with Bitcoin & the Lightning Network. This project is under heavy development, DO NOT USE WITH REAL FUNDS."

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devimint"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-docs"
 edition = "2021"
 authors = ["The Fedimint Developers"]
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 publish = false
 license = "MIT"
 readme = "../README.md"

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-load-test-tool"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-load-test-tool is a tool to load test the fedimint server and gateway."
@@ -16,7 +16,7 @@ anyhow = { workspace = true }
 base64 = "0.22.0"
 bitcoin = "0.29.2"
 clap = { workspace = true }
-devimint = { version = "0.3.0-alpha", path = "../devimint" }
+devimint = { version = "=0.4.0-alpha", path = "../devimint" }
 fedimint-client = { version = "=0.4.0-alpha", path = "../fedimint-client" }
 fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
 fedimint-ln-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-client" }

--- a/fedimint-wasm-tests/Cargo.toml
+++ b/fedimint-wasm-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wasm-tests"
-version = "0.0.0"
+version = "0.4.0-alpha"
 edition = "2021"
 license = "MIT"
 description = "Wasm tests for the fedimint."

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fedimint-fuzz"
 edition = "2021"
 authors = ["The Fedimint Developers"]
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 publish = false
 license = "MIT"
 readme = "../README.md"

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -205,4 +205,4 @@ docs: build-docs
   fi
 
 release-bump-version VERSION="prerelease":
-  cargo workspaces version --exact --no-git-commit --yes --force '*' --pre-id rc {{VERSION}}
+  cargo workspaces version --all --exact --no-git-commit --yes --force '*' --pre-id rc {{VERSION}}

--- a/modules/fedimint-dummy-tests/Cargo.toml
+++ b/modules/fedimint-dummy-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-dummy-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-dummy is a dummy example fedimint module."

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-ln-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-ln-tests contains integration tests for the lightning module"

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-mint-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint-tests contains integration tests for the mint module"

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-wallet-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-wallet-tests contains integration tests for the lightning module"


### PR DESCRIPTION
We had a few packages that weren't updated in https://github.com/fedimint/fedimint/pull/4805. Adding the `--all` flag updates the remaining packages.

```
just release-bump-version "custom 0.4.0-alpha"
```