### PR TITLE
`fedimintd dev list-versions` subcommand

### DIFF
--- a/fedimint-core/src/module/version.rs
+++ b/fedimint-core/src/module/version.rs
@@ -58,7 +58,8 @@ use std::{cmp, result};
 
 use serde::{Deserialize, Serialize};
 
-use crate::core::ModuleInstanceId;
+use crate::core::{ModuleInstanceId, ModuleKind};
+use crate::db::DatabaseVersion;
 use crate::encoding::{Decodable, Encodable};
 
 /// Consensus version of a core server
@@ -441,4 +442,17 @@ impl SupportedModuleApiVersions {
 pub struct SupportedApiVersionsSummary {
     pub core: SupportedCoreApiVersions,
     pub modules: BTreeMap<ModuleInstanceId, SupportedModuleApiVersions>,
+}
+
+/// A summary of server API versions for core and all registered modules.
+#[derive(Serialize)]
+pub struct ServerApiVersionsSummary {
+    pub core: MultiApiVersion,
+    pub modules: BTreeMap<ModuleKind, MultiApiVersion>,
+}
+
+/// A summary of server database versions for all registered modules.
+#[derive(Serialize)]
+pub struct ServerDbVersionsSummary {
+    pub modules: BTreeMap<ModuleKind, DatabaseVersion>,
 }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -56,7 +56,7 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct ServerOpts {
     /// Path to folder containing federation config files
     #[arg(long = "data-dir", env = FM_DATA_DIR_ENV)]
-    pub data_dir: PathBuf,
+    pub data_dir: Option<PathBuf>,
     /// Password to encrypt sensitive config files
     // TODO: should probably never send password to the server directly, rather send the hash via
     // the API
@@ -441,6 +441,8 @@ async fn run(
         });
     }
 
+    let data_dir = opts.data_dir.context("data-dir option is not present")?;
+
     // TODO: Fedimintd should use the config gen API
     // on each run we want to pass the currently passed password, so we need to
     // overwrite
@@ -464,11 +466,11 @@ async fn run(
     };
 
     let db = Database::new(
-        fedimint_rocksdb::RocksDb::open(opts.data_dir.join(DB_FILE))?,
+        fedimint_rocksdb::RocksDb::open(data_dir.join(DB_FILE))?,
         Default::default(),
     );
 
-    FedimintServer::new(opts.data_dir, settings, db, version_hash)
+    FedimintServer::new(data_dir, settings, db, version_hash)
         .run(&module_inits, task_group.clone())
         .await?;
 


### PR DESCRIPTION
The server-side work for #4584.

Creates an optional subcommand `dev` for fedimintd, similar to fedimint-cli. 

~~Adds a single subcommand to `dev`: `list-versions`.This dumps all API and database versions and exits early.~~ 
Adds two subcommands to `dev`: `list-api-versions` and `list-db-versions`. These dump API and database versions respectively and exit early.

e.g.
```
FM_BITCOIN_RPC_KIND="bitcoind" FM_BITCOIN_RPC_URL="http://localhost:5002" fedimintd dev list-versions
```

<details>
<summary>And here's a sample of the output</summary>

```
{
  "core_api_versions": [
    {
      "major": 0,
      "minor": 2
    }
  ],
  "modules": [
    {
      "kind": "ln",
      "api_versions": [
        {
          "major": 0,
          "minor": 1
        }
      ],
      "database_version": 0
    },
    {
      "kind": "meta",
      "api_versions": [
        {
          "major": 0,
          "minor": 0
        }
      ],
      "database_version": 0
    },
    {
      "kind": "mint",
      "api_versions": [
        {
          "major": 0,
          "minor": 0
        }
      ],
      "database_version": 0
    },
    {
      "kind": "wallet",
      "api_versions": [
        {
          "major": 0,
          "minor": 0
        }
      ],
      "database_version": 0
    }
  ]
}
```

</details>

Unfortunately, the FM_BITCOIN_RPC_KIND and FM_BITCOIN_RPC_URL environment variables still need to be provided because otherwise fedimintd throws an error in `Fedimintd::new`.

It seems weird that they aren't part of the explicit CLI options but rather grabbed from the environment later:
https://github.com/fedimint/fedimint/blob/11c24a949840b317d52f85e282c1d43cabb2bafe/fedimintd/src/fedimintd.rs#L182

I did consider refactoring this into the `ServerOpts` struct (clap already supports reading from environment variables), but this doesn't resolve the issue that they are still required fields.

Basically I'd love to be able to do `fedimint dev list-versions` without any additional args (cli or env-vars), but wasn't sure how to get there. And I thought I'd rather get some feedback on what I've done before proceeding.