### PR TITLE
chore: remove version from workspace.metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ version = "0.4.0-alpha"
 
 [workspace.metadata]
 name = "fedimint"
-version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint is a prototype Federated Chaumian E-Cash Mint implementation, natively compatible with Bitcoin & the Lightning Network. This project is under heavy development, DO NOT USE WITH REAL FUNDS."


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/4892

This seems safe to remove after a quick glance at the cargo [docs](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-metadata-table) and CI is green.