### PR TITLE
[Backport releases/v0.2] chore(consensus): log items failing max size validation

### DIFF
--- a/fedimint-server/src/atomic_broadcast/data_provider.rs
+++ b/fedimint-server/src/atomic_broadcast/data_provider.rs
@@ -73,7 +73,7 @@ impl aleph_bft::DataProvider<UnitData> for DataProvider {
                 n_bytes += n_bytes_item;
                 items.push(item);
             } else {
-                tracing::warn!(target: LOG_CONSENSUS,"Consensus item length is over BYTE_LIMIT");
+                tracing::warn!(target: LOG_CONSENSUS, ?item, "Consensus item length is over BYTE_LIMIT");
             }
         }
 


### PR DESCRIPTION
# Description
Backport of #4898 to `releases/v0.2`.