### PR TITLE
fix: LSP getting spooked

### DIFF
--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -307,7 +307,7 @@ where
     T: ClientModuleInit + 'static + MaybeSend + Sync,
 {
     fn decoder(&self) -> Decoder {
-        T::Module::decoder()
+        <<T as ClientModuleInit>::Module as ClientModule>::decoder()
     }
 
     fn module_kind(&self) -> ModuleKind {


### PR DESCRIPTION
I don't digged why, but without these extra annotations sometimes LSP thinks it's a recursive function and displays fake compilation errors.