### PR TITLE
chore: add a WARNING for `process_consensus_items`

### DIFF
--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -199,6 +199,11 @@ impl ServerModule for Dummy {
         _consensus_item: DummyConsensusItem,
         _peer_id: PeerId,
     ) -> anyhow::Result<()> {
+        // WARNING: `process_consensus_item` should return an `Err` for items that do
+        // not change any internal consensus state. Failure to do so, will result in an
+        // (potentially significantly) increased consensus history size.
+        // If you are using this code as a template,
+        // make sure to read the [`ServerModule::process_consensus_item`] documentation,
         bail!("The dummy module does not use consensus items");
     }
 

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -175,6 +175,11 @@ impl ServerModule for Empty {
         _consensus_item: EmptyConsensusItem,
         _peer_id: PeerId,
     ) -> anyhow::Result<()> {
+        // WARNING: `process_consensus_item` should return an `Err` for items that do
+        // not change any internal consensus state. Failure to do so, will result in an
+        // (potentially significantly) increased consensus history size.
+        // If you are using this code as a template,
+        // make sure to read the [`ServerModule::process_consensus_item`] documentation,
         bail!("The empty module does not use consensus items");
     }
 

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -317,6 +317,10 @@ impl ServerModule for Meta {
         to_submit
     }
 
+    /// BUG: This implementation fails to return an `Err` on redundant consensus
+    /// items. If you are using this code as a template,
+    /// make sure to read the [`ServerModule::process_consensus_item`]
+    /// documentation,
     async fn process_consensus_item<'a, 'b>(
         &'a self,
         dbtx: &mut DatabaseTransaction<'b>,

--- a/modules/fedimint-unknown-server/src/lib.rs
+++ b/modules/fedimint-unknown-server/src/lib.rs
@@ -151,6 +151,11 @@ impl ServerModule for Unknown {
         _consensus_item: UnknownConsensusItem,
         _peer_id: PeerId,
     ) -> anyhow::Result<()> {
+        // WARNING: `process_consensus_item` should return an `Err` for items that do
+        // not change any internal consensus state. Failure to do so, will result in an
+        // (potentially significantly) increased consensus history size.
+        // If you are using this code as a template,
+        // make sure to read the [`ServerModule::process_consensus_item`] documentation,
         bail!("The unknown module does not use consensus items");
     }
 


### PR DESCRIPTION
In modules that are expected to commonly be used as a template for 3rd party modules.

I attempted to do it using return type changes, but indeeded without https://doc.rust-lang.org/core/ops/trait.Try.html stabilized, it leads to DX degradation and I have no better ideas.