### PR TITLE
fix: docs.rs compilation error

### DIFF
--- a/fedimint-core/src/util/broadcaststream.rs
+++ b/fedimint-core/src/util/broadcaststream.rs
@@ -15,7 +15,6 @@ use crate::util::BoxFuture;
 ///
 /// [`tokio::sync::broadcast::Receiver`]: struct@tokio::sync::broadcast::Receiver
 /// [`Stream`]: trait@futures::Stream
-#[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
 pub struct BroadcastStream<T> {
     inner: BoxFuture<'static, (Result<T, RecvError>, Receiver<T>)>,
 }


### PR DESCRIPTION
Re #4841

AFAIK this line is not neccessary, and `fedimint-core` always enables `sync` on `tokio`, which this conditional seems to be related to.