### PR TITLE
chore(devimint): polish `just devimint-env` output

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -122,10 +122,10 @@ pub async fn setup(arg: CommonArgs) -> Result<(ProcessManager, TaskGroup)> {
         .with_directive("jsonrpsee-client=off")
         .init()?;
 
-    info!(target: LOG_DEVIMINT, path=%globals.FM_DATA_DIR.display() , "Setting up test dir");
     if let Some(link_test_dir) = arg.link_test_dir.as_ref() {
         update_test_dir_link(link_test_dir, &arg.test_dir()).await?;
     }
+    info!(target: LOG_DEVIMINT, path=%globals.FM_DATA_DIR.display() , "Devimint data dir");
 
     let mut env_string = String::new();
     for (var, value) in globals.vars() {
@@ -230,7 +230,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                     let dev_fed = DevJitFed::new(&process_mgr)?;
 
                     let pegin_start_time = Instant::now();
-                    info!(target: LOG_DEVIMINT, "Peging in client and gateways");
+                    debug!(target: LOG_DEVIMINT, "Peging in client and gateways");
 
                     let gw_pegin_amount = 20_000;
                     let client_pegin_amount = 10_000;
@@ -292,8 +292,9 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
 
                     let daemons = write_ready_file(&process_mgr.globals, Ok(dev_fed)).await?;
 
+                    info!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed().as_millis(), "Devfed ready");
                     if let Some(exec) = exec {
-                        debug!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed().as_millis(), "Starting exec command");
+                        debug!(target: LOG_DEVIMINT, "Starting exec command");
                         exec_user_command(exec).await?;
                         task_group.shutdown();
                     }

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use fedimint_core::task::jit::{JitTry, JitTryAnyhow};
 use fedimint_logging::LOG_DEVIMINT;
-use tracing::info;
+use tracing::debug;
 
 use crate::envs::{FM_GWID_CLN_ENV, FM_GWID_LND_ENV};
 use crate::external::{Bitcoind, Electrs, Esplora, Lightningd, Lnd};
@@ -58,7 +58,7 @@ impl DevJitFed {
         );
         let start_time = fedimint_core::time::now();
 
-        info!("Starting dev federation");
+        debug!("Starting dev federation");
 
         let bitcoind = JitTry::new_try({
             let process_mgr = process_mgr.to_owned();
@@ -251,7 +251,6 @@ impl DevJitFed {
 
         std::env::set_var(FM_GWID_CLN_ENV, self.gw_cln().await?.gateway_id().await?);
         std::env::set_var(FM_GWID_LND_ENV, self.gw_lnd().await?.gateway_id().await?);
-        info!(target: LOG_DEVIMINT, "Setup gateway environment variables");
 
         let _ = self.internal_client_gw_registered().await?;
         let _ = self.channel_opened.get_try().await?;
@@ -263,7 +262,7 @@ impl DevJitFed {
         let _ = self.esplora().await?;
         let _ = self.fed_epoch_generated.get_try().await?;
 
-        info!(
+        debug!(
             target: LOG_DEVIMINT,
             fed_size,
             offline_nodes,

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -718,7 +718,7 @@ pub async fn run_dkg(
     let dkg_results = admin_clients
         .iter()
         .map(|(peer_id, client)| client.run_dkg(auth_for(peer_id)));
-    info!(target: LOG_DEVIMINT, "Running DKG");
+    debug!(target: LOG_DEVIMINT, "Running DKG");
     let (dkg_results, leader_wait_result) = tokio::join!(
         join_all(dkg_results),
         wait_server_status(leader, ServerStatus::VerifyingConfigs)
@@ -735,15 +735,15 @@ pub async fn run_dkg(
         hashes.insert(client.get_verify_config_hash(auth_for(peer_id)).await?);
     }
     assert_eq!(hashes.len(), 1);
-    debug!(target: LOG_DEVIMINT, "DKG ready");
-    info!(target: LOG_DEVIMINT, "Starting consensus");
+    info!(target: LOG_DEVIMINT, "DKG completed");
+    debug!(target: LOG_DEVIMINT, "Starting consensus");
     for (peer_id, client) in &admin_clients {
         if let Err(e) = client.start_consensus(auth_for(peer_id)).await {
             tracing::debug!("Error calling start_consensus: {e:?}, trying to continue...")
         }
         wait_server_status(client, ServerStatus::ConsensusRunning).await?;
     }
-    debug!("Consensus is running");
+    info!(target: LOG_DEVIMINT, "Consensus running");
     Ok(())
 }
 

--- a/scripts/dev/devimint-env.sh
+++ b/scripts/dev/devimint-env.sh
@@ -21,7 +21,7 @@ function devimint_env {
   # no confusion.
   export STARSHIP_CONFIG="${REPO_ROOT}/scripts/dev/devimint-env/starship.toml"
 
-  >&2 echo "Devimint Env Started"
+  >&2 echo "Devimint Env Shell Ready (exit to shutdown):"
   if [ "$SHELL" == "fish" ] || [[ "$SHELL" == */fish ]]; then
     "${SHELL}"
   else


### PR DESCRIPTION
![image](https://github.com/fedimint/fedimint/assets/9209/9b030ed7-e9de-4269-a0d3-794c7e91b1a4)

With `Jit` employed, printing when thing start is not as interesting, as they all tend to start at the same time.