### PR TITLE
chore: add more context `api::FederationError`

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -48,6 +48,7 @@ use fedimint_core::db::{
     apply_migrations_server, Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::Encodable;
+use fedimint_core::endpoint_constants::REGISTER_GATEWAY_ENDPOINT;
 use fedimint_core::fmt_utils::OptStacktrace;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::CommonModuleInit;
@@ -1197,7 +1198,7 @@ impl Gateway {
                             .instrument(client.span())
                             .await
                             {
-                                Err(GatewayError::FederationError(FederationError::general(
+                                Err(GatewayError::FederationError(FederationError::general(REGISTER_GATEWAY_ENDPOINT, serde_json::Value::Null,
                                     anyhow::anyhow!(
                                         "Error registering federation {federation_id}: {e:?}"
                                     ),

--- a/modules/fedimint-ln-client/src/api.rs
+++ b/modules/fedimint-ln-client/src/api.rs
@@ -273,9 +273,11 @@ where
                 amount: account.amount,
                 contract: c.contract,
             }),
-            _ => Err(FederationError::general(anyhow::anyhow!(
-                "WrongAccountType"
-            ))),
+            _ => Err(FederationError::general(
+                AWAIT_ACCOUNT_ENDPOINT,
+                id,
+                anyhow::anyhow!("WrongAccountType"),
+            )),
         }
     }
 
@@ -289,9 +291,11 @@ where
                 amount: account.amount,
                 contract: c,
             }),
-            _ => Err(FederationError::general(anyhow::anyhow!(
-                "WrongAccountType"
-            ))),
+            _ => Err(FederationError::general(
+                AWAIT_ACCOUNT_ENDPOINT,
+                id,
+                anyhow::anyhow!("WrongAccountType"),
+            )),
         }
     }
 }

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -8,6 +8,7 @@ use fedimint_client::transaction::ClientInput;
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::endpoint_constants::ACCOUNT_ENDPOINT;
 use fedimint_core::task::sleep;
 use fedimint_core::{OutPoint, TransactionId};
 use fedimint_ln_common::contracts::incoming::IncomingContractAccount;
@@ -321,6 +322,8 @@ pub async fn get_incoming_contract(
                 }))
             } else {
                 Err(fedimint_api_client::api::FederationError::general(
+                    ACCOUNT_ENDPOINT,
+                    contract_id,
                     anyhow::anyhow!("Contract {contract_id} is not an incoming contract"),
                 ))
             }


### PR DESCRIPTION
When we log these errors I'd like to see why we made the failing API call. Alternatively we could also attach it as context to the anyhow error now that I think about it. But maybe having the data in a more structured form is also nice.