### PR TITLE
chore: conditionally handle current binaries in upgrade tests

### DIFF
--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -28,7 +28,7 @@ test-compatibility *VERSIONS="v0.2.1":
 test-full-compatibility *VERSIONS="v0.2.1":
   env FM_FULL_VERSION_MATRIX=1 ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
-test-upgrades *VERSIONS="v0.2.1 v0.2.2":
+test-upgrades *VERSIONS="v0.2.2 v0.3.0 releases/v0.3":
   ./scripts/tests/upgrade-test.sh {{VERSIONS}}
 
 # `cargo udeps` check

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -21,15 +21,17 @@ fedimintd_paths=()
 fedimint_cli_paths=()
 gatewayd_paths=()
 for version in "${versions[@]}"; do
-  fedimintd_paths+=("$(nix_build_binary_for_version 'fedimintd' "$version")")
-  fedimint_cli_paths+=("$(nix_build_binary_for_version 'fedimint-cli' "$version")")
-  gatewayd_paths+=("$(nix_build_binary_for_version 'gatewayd' "$version")")
+  if [ "$version" == "current" ]; then
+    # Add current binaries from PATH
+    fedimintd_paths+=("fedimintd")
+    fedimint_cli_paths+=("fedimint-cli")
+    gatewayd_paths+=("gatewayd")
+  else
+    fedimintd_paths+=("$(nix_build_binary_for_version 'fedimintd' "$version")")
+    fedimint_cli_paths+=("$(nix_build_binary_for_version 'fedimint-cli' "$version")")
+    gatewayd_paths+=("$(nix_build_binary_for_version 'gatewayd' "$version")")
+  fi
 done
-
-# Add current binaries from PATH
-fedimintd_paths+=("fedimintd")
-fedimint_cli_paths+=("fedimint-cli")
-gatewayd_paths+=("gatewayd")
 
 upgrade_tests=(
   "devimint upgrade-tests fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"


### PR DESCRIPTION
Followup to https://github.com/fedimint/fedimint/pull/4762#issuecomment-2047483947

> Do we even need to backport this? It seems to me as if we could just run any upgrade tests off master, specifying the versions we want to test.

Previously upgrade tests would fail to discover a common api version against master. Instead, we can skip testing against the binaries in the target dir and use only the versions passed to `just test-upgrades`.