### PR TITLE
feat: ability to start devimint from existing state

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -4,7 +4,7 @@ use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use clap::{Parser, Subcommand};
 use fedimint_core::task::TaskGroup;
 use fedimint_core::util::write_overwrite_async;
@@ -38,6 +38,12 @@ fn random_test_dir_suffix() -> String {
 pub struct CommonArgs {
     #[clap(short = 'd', long, env = FM_TEST_DIR_ENV)]
     pub test_dir: Option<PathBuf>,
+
+    /// Don't set up new Federation, start from the state in existing
+    /// devimint data dir
+    #[arg(long, env = "FM_SKIP_SETUP")]
+    skip_setup: bool,
+
     #[clap(short = 'n', long, env = FM_FED_SIZE_ENV, default_value = "4")]
     pub fed_size: usize,
 
@@ -55,6 +61,12 @@ pub struct CommonArgs {
 
 impl CommonArgs {
     pub fn mk_test_dir(&self) -> Result<PathBuf> {
+        if self.skip_setup {
+            ensure!(
+                self.test_dir.is_some(),
+                "When using `--skip-setup`, `--test-dir` must be set"
+            );
+        }
         let path = self.test_dir();
 
         std::fs::create_dir_all(&path)
@@ -223,68 +235,71 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
         Cmd::DevFed { exec } => {
             trace!(target: LOG_DEVIMINT, "Starting dev fed");
             let start_time = Instant::now();
+            let skip_setup = common_args.skip_setup;
             let (process_mgr, task_group) = setup(common_args).await?;
             let main = {
                 let task_group = task_group.clone();
                 async move {
-                    let dev_fed = DevJitFed::new(&process_mgr)?;
+                    let dev_fed = DevJitFed::new(&process_mgr, skip_setup)?;
 
                     let pegin_start_time = Instant::now();
                     debug!(target: LOG_DEVIMINT, "Peging in client and gateways");
 
                     let gw_pegin_amount = 20_000;
                     let client_pegin_amount = 10_000;
-                    let (_, _, _) = tokio::try_join!(
-                        async {
-                            let (address, operation_id) =
-                                dev_fed.internal_client().await?.get_deposit_addr().await?;
-                            dev_fed
-                                .bitcoind()
-                                .await?
-                                .send_to(address, client_pegin_amount)
-                                .await?;
-                            dev_fed.bitcoind().await?.mine_blocks_no_wait(11).await?;
-                            dev_fed
-                                .internal_client()
-                                .await?
-                                .await_deposit(&operation_id)
-                                .await
-                        },
-                        async {
-                            let pegin_addr = dev_fed
-                                .gw_cln_registered()
-                                .await?
-                                .get_pegin_addr(
-                                    &dev_fed.fed().await?.calculate_federation_id().await,
-                                )
-                                .await?;
-                            dev_fed
-                                .bitcoind()
-                                .await?
-                                .send_to(pegin_addr, gw_pegin_amount)
-                                .await?;
-                            dev_fed.bitcoind().await?.mine_blocks_no_wait(11).await
-                        },
-                        async {
-                            let pegin_addr = dev_fed
-                                .gw_lnd_registered()
-                                .await?
-                                .get_pegin_addr(
-                                    &dev_fed.fed().await?.calculate_federation_id().await,
-                                )
-                                .await?;
-                            dev_fed
-                                .bitcoind()
-                                .await?
-                                .send_to(pegin_addr, gw_pegin_amount)
-                                .await?;
-                            dev_fed.bitcoind().await?.mine_blocks_no_wait(11).await
-                        },
-                    )?;
+                    if !skip_setup {
+                        let (_, _, _) = tokio::try_join!(
+                            async {
+                                let (address, operation_id) =
+                                    dev_fed.internal_client().await?.get_deposit_addr().await?;
+                                dev_fed
+                                    .bitcoind()
+                                    .await?
+                                    .send_to(address, client_pegin_amount)
+                                    .await?;
+                                dev_fed.bitcoind().await?.mine_blocks_no_wait(11).await?;
+                                dev_fed
+                                    .internal_client()
+                                    .await?
+                                    .await_deposit(&operation_id)
+                                    .await
+                            },
+                            async {
+                                let pegin_addr = dev_fed
+                                    .gw_cln_registered()
+                                    .await?
+                                    .get_pegin_addr(
+                                        &dev_fed.fed().await?.calculate_federation_id().await,
+                                    )
+                                    .await?;
+                                dev_fed
+                                    .bitcoind()
+                                    .await?
+                                    .send_to(pegin_addr, gw_pegin_amount)
+                                    .await?;
+                                dev_fed.bitcoind().await?.mine_blocks_no_wait(11).await
+                            },
+                            async {
+                                let pegin_addr = dev_fed
+                                    .gw_lnd_registered()
+                                    .await?
+                                    .get_pegin_addr(
+                                        &dev_fed.fed().await?.calculate_federation_id().await,
+                                    )
+                                    .await?;
+                                dev_fed
+                                    .bitcoind()
+                                    .await?
+                                    .send_to(pegin_addr, gw_pegin_amount)
+                                    .await?;
+                                dev_fed.bitcoind().await?.mine_blocks_no_wait(11).await
+                            },
+                        )?;
 
-                    info!(target: LOG_DEVIMINT,
+                        info!(target: LOG_DEVIMINT,
                         elapsed_ms = %pegin_start_time.elapsed().as_millis(),
                         "Pegins completed");
+                    }
 
                     std::env::set_var(FM_INVITE_CODE_ENV, dev_fed.fed().await?.invite_code()?);
 

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -928,7 +928,7 @@ async fn set_config_gen_params(
     mut server_gen_params: ServerModuleConfigGenParamsRegistry,
 ) -> Result<()> {
     self::config::attach_default_module_init_params(
-        BitcoinRpcConfig::from_env_vars()?,
+        BitcoinRpcConfig::get_defaults_from_env_vars()?,
         &mut server_gen_params,
         Network::Regtest,
         10,
@@ -959,7 +959,7 @@ async fn cli_set_config_gen_params(
     mut server_gen_params: ServerModuleConfigGenParamsRegistry,
 ) -> Result<()> {
     self::config::attach_default_module_init_params(
-        BitcoinRpcConfig::from_env_vars()?,
+        BitcoinRpcConfig::get_defaults_from_env_vars()?,
         &mut server_gen_params,
         Network::Regtest,
         10,

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -186,6 +186,7 @@ impl Federation {
         process_mgr: &ProcessManager,
         bitcoind: Bitcoind,
         servers: usize,
+        skip_setup: bool,
     ) -> Result<Self> {
         let mut members = BTreeMap::new();
         let mut peer_to_env_vars_map = BTreeMap::new();
@@ -219,49 +220,53 @@ impl Federation {
             peer_to_env_vars_map.insert(peer.to_usize(), peer_env_vars);
         }
 
-        let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-        if fedimint_cli_version >= *VERSION_0_3_0_ALPHA {
-            run_cli_dkg(params, endpoints).await?;
-        } else {
-            // TODO(support:v0.2): old fedimint-cli can't do DKG commands. keep this old DKG
-            // setup while fedimint-cli <= v0.2.x is supported
-            run_client_dkg(admin_clients, params).await?;
-        }
+        if !skip_setup {
+            let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
+            if fedimint_cli_version >= *VERSION_0_3_0_ALPHA {
+                run_cli_dkg(params, endpoints).await?;
+            } else {
+                // TODO(support:v0.2): old fedimint-cli can't do DKG commands. keep this old DKG
+                // setup while fedimint-cli <= v0.2.x is supported
+                run_client_dkg(admin_clients, params).await?;
+            }
 
-        // move configs to config directory
-        let client_dir = utf8(&process_mgr.globals.FM_CLIENT_DIR);
-        let invite_code_filename_original = "invite-code";
+            // move configs to config directory
+            let client_dir = utf8(&process_mgr.globals.FM_CLIENT_DIR);
+            let invite_code_filename_original = "invite-code";
 
-        // copy over invite-code file to client directory
-        let peer_data_dir = utf8(&peer_to_env_vars_map[&0].FM_DATA_DIR);
-        tokio::fs::copy(
-            format!("{peer_data_dir}/{invite_code_filename_original}"),
-            format!("{client_dir}/{invite_code_filename_original}"),
-        )
-        .await
-        .context("copying invite-code file")?;
-
-        // move each guardian's invite-code file to the client's directory
-        // appending the peer id to the end
-        for (index, peer_env_vars) in &peer_to_env_vars_map {
-            let peer_data_dir = utf8(&peer_env_vars.FM_DATA_DIR);
-
-            let invite_code_filename_indexed = format!("{invite_code_filename_original}-{}", index);
-            tokio::fs::rename(
-                format!("{peer_data_dir}/{}", invite_code_filename_original),
-                format!("{client_dir}/{}", invite_code_filename_indexed),
+            // copy over invite-code file to client directory
+            let peer_data_dir = utf8(&peer_to_env_vars_map[&0].FM_DATA_DIR);
+            tokio::fs::copy(
+                format!("{peer_data_dir}/{invite_code_filename_original}"),
+                format!("{client_dir}/{invite_code_filename_original}"),
             )
             .await
-            .context("moving invite-code file")?;
+            .context("copying invite-code file")?;
+
+            // move each guardian's invite-code file to the client's directory
+            // appending the peer id to the end
+            for (index, peer_env_vars) in &peer_to_env_vars_map {
+                let peer_data_dir = utf8(&peer_env_vars.FM_DATA_DIR);
+
+                let invite_code_filename_indexed =
+                    format!("{invite_code_filename_original}-{}", index);
+                tokio::fs::rename(
+                    format!("{peer_data_dir}/{}", invite_code_filename_original),
+                    format!("{client_dir}/{}", invite_code_filename_indexed),
+                )
+                .await
+                .context("moving invite-code file")?;
+            }
+            debug!("Moved invite-code files to client data directory");
         }
-        debug!(target: LOG_DEVIMINT, "Moved invite-code files to client data directory");
 
         let client = JitTryAnyhow::new_try({
             move || async move {
                 let client = Client::open_or_create("default").await?;
                 let invite_code = Self::invite_code_static()?;
-
-                cmd!(client, "join-federation", invite_code).run().await?;
+                if !skip_setup {
+                    cmd!(client, "join-federation", invite_code).run().await?;
+                }
                 Ok(client)
             }
         });

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -32,7 +32,7 @@ where
 
     let (process_mgr, task_group) = cli::setup(args).await?;
     log_binary_versions().await?;
-    let dev_fed = devfed::DevJitFed::new(&process_mgr)?;
+    let dev_fed = devfed::DevJitFed::new(&process_mgr, false)?;
     let res = cleanup_on_exit(f(dev_fed.clone()), task_group).await;
     // workaround https://github.com/tokio-rs/tokio/issues/6463
     // by waiting on all jits to complete, we make it less likely

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -163,10 +163,14 @@ declare_vars! {
             gateway_cli = crate::util::get_gateway_cli_path().join(" "),); env: "FM_GWCLI_LND";
         FM_DB_TOOL: String = f!("{fedimint_dbtool}", fedimint_dbtool = crate::util::get_fedimint_dbtool_cli_path().join(" ")); env: "FM_DB_TOOL";
 
-        // fedimint config variables env: "// ";
+        // fedimint config variables
         FM_TEST_BITCOIND_RPC: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_TEST_BITCOIND_RPC";
         FM_BITCOIN_RPC_URL: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_BITCOIN_RPC_URL";
         FM_BITCOIN_RPC_KIND: String = "bitcoind"; env: "FM_BITCOIN_RPC_KIND";
+        FM_DEFAULT_BITCOIN_RPC_URL: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_DEFAULT_BITCOIN_RPC_URL";
+        FM_DEFAULT_BITCOIN_RPC_KIND: String = "bitcoind"; env: "FM_DEFAULT_BITCOIN_RPC_KIND";
+        FM_FORCE_BITCOIN_RPC_URL: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_FORCE_BITCOIN_RPC_URL";
+        FM_FORCE_BITCOIN_RPC_KIND: String = "bitcoind"; env: "FM_FORCE_BITCOIN_RPC_KIND";
 
         FM_ROCKSDB_WRITE_BUFFER_SIZE : String = (1 << 20).to_string(); env: "FM_ROCKSDB_WRITE_BUFFER_SIZE ";
     }

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -172,7 +172,7 @@ declare_vars! {
         FM_FORCE_BITCOIN_RPC_URL: String = f!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_FORCE_BITCOIN_RPC_URL";
         FM_FORCE_BITCOIN_RPC_KIND: String = "bitcoind"; env: "FM_FORCE_BITCOIN_RPC_KIND";
 
-        FM_ROCKSDB_WRITE_BUFFER_SIZE : String = (1 << 20).to_string(); env: "FM_ROCKSDB_WRITE_BUFFER_SIZE ";
+        FM_ROCKSDB_WRITE_BUFFER_SIZE : String = (1 << 20).to_string(); env: "FM_ROCKSDB_WRITE_BUFFER_SIZE";
     }
 }
 

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -1,5 +1,6 @@
 use std::cmp::min;
 use std::collections::BTreeMap;
+use std::env;
 use std::fmt::Debug;
 use std::future::Future;
 use std::sync::{Arc, Mutex};
@@ -8,7 +9,9 @@ use std::time::Duration;
 use anyhow::Context;
 pub use anyhow::Result;
 use bitcoin::{BlockHash, Network, Script, Transaction, Txid};
-use fedimint_core::envs::BitcoinRpcConfig;
+use fedimint_core::envs::{
+    BitcoinRpcConfig, FM_FORCE_BITCOIN_RPC_KIND_ENV, FM_FORCE_BITCOIN_RPC_URL_ENV,
+};
 use fedimint_core::fmt_utils::OptStacktrace;
 use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
@@ -51,7 +54,16 @@ lazy_static! {
 /// Create a bitcoin RPC of a given kind
 pub fn create_bitcoind(config: &BitcoinRpcConfig, handle: TaskHandle) -> Result<DynBitcoindRpc> {
     let registry = BITCOIN_RPC_REGISTRY.lock().expect("lock poisoned");
-    let maybe_factory = registry.get(&config.kind);
+
+    let kind = env::var(FM_FORCE_BITCOIN_RPC_KIND_ENV)
+        .ok()
+        .unwrap_or_else(|| config.kind.clone());
+    let url = env::var(FM_FORCE_BITCOIN_RPC_URL_ENV)
+        .ok()
+        .map(|s| SafeUrl::parse(&s))
+        .transpose()?
+        .unwrap_or_else(|| config.url.clone());
+    let maybe_factory = registry.get(&kind);
     let factory = maybe_factory.with_context(|| {
         anyhow::anyhow!(
             "{} rpc not registered, available options: {:?}",
@@ -59,7 +71,7 @@ pub fn create_bitcoind(config: &BitcoinRpcConfig, handle: TaskHandle) -> Result<
             registry.keys()
         )
     })?;
-    factory.create_connection(&config.url, handle)
+    factory.create_connection(&url, handle)
 }
 
 /// Register a new factory for creating bitcoin RPCs

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -66,7 +66,7 @@ impl Fixtures {
             Arc<dyn BitcoinTest>,
             BitcoinRpcConfig,
         ) = if real_testing {
-            let rpc_config = BitcoinRpcConfig::from_env_vars().unwrap();
+            let rpc_config = BitcoinRpcConfig::get_defaults_from_env_vars().unwrap();
             let dyn_bitcoin_rpc = create_bitcoind(&rpc_config, task_group.make_handle()).unwrap();
             let bitcoincore_url = env::var(FM_TEST_BITCOIND_RPC_ENV)
                 .expect("Must have bitcoind RPC defined for real tests")

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -180,7 +180,7 @@ impl Fedimintd {
             .init()
             .unwrap();
 
-        let bitcoind_rpc = BitcoinRpcConfig::from_env_vars()?;
+        let bitcoind_rpc = BitcoinRpcConfig::get_defaults_from_env_vars()?;
 
         Ok(Self {
             opts,

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -269,7 +269,7 @@ impl Context for WalletClientContext {}
 
 impl WalletClientModule {
     fn get_rpc_config(cfg: &WalletClientConfig) -> BitcoinRpcConfig {
-        if let Ok(rpc_config) = BitcoinRpcConfig::from_env_vars() {
+        if let Ok(rpc_config) = BitcoinRpcConfig::get_defaults_from_env_vars() {
             // TODO: Wallet client cannot support bitcoind RPC until the bitcoin dep is
             // updated to 0.30
             if rpc_config.kind != "bitcoind" {


### PR DESCRIPTION
I need a way to verify certain behaviors manually between versions, etc. Similiar to upgrade tests etc.

It occurred to me that it should be possible to just start devimint skipping all the DKGs and other setups, and it should be relatively easy. So I implemeted it.

One blocker that I've hit was inability to tell fedimintd to use certain URL to connect to bitcoind, instead of whatever was added to the config. I made new env variables that can be used to force bitcoind kind&url. The way existing env vars are working is confusing (they are only used as a default for DKG, so I renamed them while at it (with backward-compat.  of course).

Another blocker was that on killing devimint, we send `kill -9` right away, which makes `bitcoind` not get any chance to flush database to disk, and thus lose block history. All other daemons get really upset about it. So I changed it to `kill`, 3s wait, `kill -9` sequence. A bit slower (`fedimimtd` takes some time to shutdown), but works, and seem better. We can fix & improve with time.


The implementation is a bit meh, but can be improved with time. I would also like to modularize the setup so e.g. test that doesn't need LND, or electrs, etc. does not need to start them, and can configure it via builder.

## Testing

Start devimint e.g. like this:

```
> just devimint-env
...
2024-04-13T04:29:23.013121Z  INFO fm::devimint: Devimint data dir path=/tmp/devimint-3321804-158
```

Stop it, and then start it again, but skip the setup.

```
env FM_TEST_DIR=/tmp/devimint-3321804-158 FM_SKIP_SETUP=true RUST_LOG=fm::devimint=debug just devimint-env
```

It takes it sweet time as LND Gateway blocks on LND starting to return route hints, but works.
 
