### PR TITLE
 chore: `SpendableNoteUndecoded` + bench SpendableNote decoding  (PoC)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim 0.11.0",
+ "terminal_size",
 ]
 
 [[package]]
@@ -860,6 +861,12 @@ checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console-api"
@@ -1140,6 +1147,31 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "divan"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d567df2c9c2870a43f3f2bd65aaeb18dbce1c18f217c3e564b4fbaeb3ee56c"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27540baf49be0d484d8f0130d7d8da3011c32a44d4fc873368154f1510e574a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2273,6 +2305,7 @@ dependencies = [
  "base64 0.22.0",
  "bincode",
  "bitcoin_hashes 0.11.0",
+ "divan",
  "erased-serde",
  "fedimint-api-client",
  "fedimint-client",
@@ -4642,6 +4675,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5324,6 +5363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ license-file = "LICENSE"
 keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
 [workspace.dependencies]
+divan = { version = "0.1.14" }
 threshold_crypto = { version = "0.1", package = "fedimint-threshold-crypto" }
 tonic_lnd = { version = "0.2.0", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc"] }
 cln-rpc = { package = "fedimint-cln-rpc", version = "0.4.0" }

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -16,6 +16,10 @@ rustc-args = ["--cfg", "tokio_unstable"]
 name = "fedimint_mint_client"
 path = "src/lib.rs"
 
+[[bench]]
+name = "divan"
+harness = false
+
 [dependencies]
 anyhow = { workspace = true }
 async-stream = "0.3.5"
@@ -53,3 +57,4 @@ rand = { workspace = true }
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 tokio = { version = "1.36.0", features = [ "macros", "rt" ] }
+divan = { workspace = true }

--- a/modules/fedimint-mint-client/benches/divan.rs
+++ b/modules/fedimint-mint-client/benches/divan.rs
@@ -1,0 +1,18 @@
+use divan::black_box;
+use fedimint_core::encoding::Decodable;
+use fedimint_mint_client::{SpendableNote, SpendableNoteUndecoded};
+
+fn main() {
+    // Run registered benchmarks.
+    divan::main();
+}
+
+#[divan::bench]
+fn spendable_note_decode() -> SpendableNote {
+    SpendableNote::consensus_decode_hex(black_box("a5dd3ebacad1bc48bd8718eed5a8da1d68f91323bef2848ac4fa2e6f8eed710f3178fd4aef047cc234e6b1127086f33cc408b39818781d9521475360de6b205f3328e490a6d99d5e2553a4553207c8bd"), &Default::default()).unwrap()
+}
+
+#[divan::bench]
+fn spendable_note_undecoded_decode() -> SpendableNoteUndecoded {
+    SpendableNoteUndecoded::consensus_decode_hex(black_box("a5dd3ebacad1bc48bd8718eed5a8da1d68f91323bef2848ac4fa2e6f8eed710f3178fd4aef047cc234e6b1127086f33cc408b39818781d9521475360de6b205f3328e490a6d99d5e2553a4553207c8bd"), &Default::default()).unwrap()
+}


### PR DESCRIPTION
As a part of #4923 I wanted to see if decoding `SpendableNote` is indeed slow, and how much could we save if we skipped decoding of the signature using an alternative parallel type.

```
     Running benches/divan.rs (target-nix/release/deps/divan-2d8a606864c20c66)
Timer precision: 20 ns
divan                               fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ spendable_note_decode            93.5 µs       │ 188 µs        │ 94.32 µs      │ 96.49 µs      │ 100     │ 100
╰─ spendable_note_undecoded_decode  14.79 µs      │ 24.49 µs      │ 14.88 µs      │ 15.11 µs      │ 100     │ 100
```

Seems like decoding seem to be orders of magnitude less than what was suspected, in the range of 100us, which even with hundreds of notes should not be a huge problem.

Using an alternative type is indeed significantly faster. It wouldn't be a lot of effort to use it tactically e.g. when reading all notes for the purposes of using `TieredCounts` instead of "streaming notes" in #4923.

But given how relatively small numbers we see here, and how infrequent note selection is in practice, I'm not sure if it's worthwile.


You can try it yourself by running `cargo bench`, let me know what you think.