### PR TITLE
chore: validate routing fees format in the gateway cli

### DIFF
--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -95,7 +95,7 @@ pub enum Commands {
         /// Default routing fee for all new federations. Setting it won't affect
         /// existing federations
         #[clap(long)]
-        routing_fees: Option<String>,
+        routing_fees: Option<FederationRoutingFees>,
 
         #[clap(long)]
         network: Option<bitcoin::Network>,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1102,8 +1102,8 @@ impl Gateway {
 
             // Using this routing fee config as a default for all federation that has none
             // routing fees specified.
-            if let Some(fees_str) = routing_fees.clone() {
-                let routing_fees = GatewayFee::from_str(fees_str.as_str())?.0;
+            if let Some(fees) = routing_fees.clone() {
+                let routing_fees = GatewayFee(fees.into()).0;
                 prev_config.routing_fees = routing_fees;
             }
 

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -129,7 +129,7 @@ impl FromStr for FederationRoutingFees {
 pub struct SetConfigurationPayload {
     pub password: Option<String>,
     pub num_route_hints: Option<u32>,
-    pub routing_fees: Option<String>,
+    pub routing_fees: Option<FederationRoutingFees>,
     pub network: Option<Network>,
     pub per_federation_routing_fees: Option<Vec<(FederationId, FederationRoutingFees)>>,
 }

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -274,7 +274,7 @@ async fn test_can_change_default_routing_fees() -> anyhow::Result<()> {
             let set_configuration_payload = SetConfigurationPayload {
                 password: None,
                 num_route_hints: None,
-                routing_fees: Some(fee.clone()),
+                routing_fees: Some(federation_fee.clone()),
                 network: None,
                 per_federation_routing_fees: None,
             };
@@ -392,10 +392,11 @@ async fn test_gateway_enforces_fees() -> anyhow::Result<()> {
 
             // Change the fees of the gateway
             let fee = "10,10000".to_string();
+            let federation_fee = FederationRoutingFees::from_str(&fee)?;
             let set_configuration_payload = SetConfigurationPayload {
                 password: None,
                 num_route_hints: None,
-                routing_fees: Some(fee.clone()),
+                routing_fees: Some(federation_fee),
                 network: None,
                 per_federation_routing_fees: None,
             };
@@ -1243,11 +1244,12 @@ async fn test_gateway_configuration() -> anyhow::Result<()> {
 
     // Verify we can change configurations when the gateway is running
     let new_password = "new_password".to_string();
-    let fee = "1000,2000".to_string();
+    let fee = "10,10000".to_string();
+    let federation_fee = FederationRoutingFees::from_str(&fee)?;
     let set_configuration_payload = SetConfigurationPayload {
         password: Some(new_password.clone()),
         num_route_hints: Some(1),
-        routing_fees: Some(fee.clone()),
+        routing_fees: Some(federation_fee.clone()),
         network: None,
         per_federation_routing_fees: None,
     };
@@ -1262,7 +1264,7 @@ async fn test_gateway_configuration() -> anyhow::Result<()> {
         verify_gateway_rpc_success("get_info", || new_password_rpc_client.get_info()).await;
 
     assert_eq!(gw_info.gateway_state, "Running".to_string());
-    assert_eq!(gw_info.fees, Some(GatewayFee::from_str(&fee)?.0));
+    assert_eq!(gw_info.fees, Some(GatewayFee(federation_fee.into()).0));
     assert_eq!(
         gw_info.network,
         Some(bitcoin30_to_bitcoin29_network(DEFAULT_NETWORK))


### PR DESCRIPTION
This commit adds validation for the routing-fees parameter in the gateway-cli set-configuration command, ensuring it follows the correct format before sending the request to the gateway API.

Previously, setting an invalid routing-fees value could lead to a 500 Internal Server Error on the Gateway side. With this validation, such errors are prevented, and users are informed of the correct format for routing-fees.

Before:
```
bash-5.2$ $FM_GWCLI_LND set-configuration --routing-fees 10
Error: Bad status returned 500 Internal Server Error

bash-5.2$ $FM_GWCLI_LND set-configuration --routing-fees
error: a value is required for '--routing-fees <ROUTING_FEES>' but none was supplied

bash-5.2$ $FM_GWCLI_LND set-configuration --routing-fees 10,100
bash-5.2$ echo $?
0
```

After:
```
bash-5.2$ $FM_GWCLI_LND set-configuration --routing-fees 10000
error: invalid value '10000' for '--routing-fees <ROUTING_FEES>': missing liquidity based fee as proportional millionths of routed amount

bash-5.2$ $FM_GWCLI_LND set-configuration --routing-fees
error: a value is required for '--routing-fees <ROUTING_FEES>' but none was supplied

bash-5.2$ $FM_GWCLI_LND set-configuration --routing-fees 10,10000
bash-5.2$ echo $?
0
````

Closes: fedimint/fedimint#4914