### PR TITLE
chore: bench SpendableNote decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,6 +2602,7 @@ name = "fedimint-tbs"
 version = "0.4.0-alpha"
 dependencies = [
  "bls12_381",
+ "criterion",
  "fedimint-core",
  "ff",
  "group",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +769,33 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "cipher"
@@ -958,10 +997,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2274,6 +2368,7 @@ dependencies = [
  "base64 0.22.0",
  "bincode",
  "bitcoin_hashes 0.11.0",
+ "criterion",
  "erased-serde",
  "fedimint-api-client",
  "fedimint-client",
@@ -3204,6 +3299,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -4148,6 +4253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4385,6 +4496,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4576,6 +4715,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -4912,6 +5071,15 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -5441,6 +5609,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5963,6 +6141,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ license-file = "LICENSE"
 keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
 [workspace.dependencies]
+criterion = { version = "0.5.1" }
 threshold_crypto = { version = "0.1", package = "fedimint-threshold-crypto" }
 tonic_lnd = { version = "0.2.0", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc"] }
 cln-rpc = { package = "fedimint-cln-rpc", version = "0.4.0" }

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -28,3 +28,10 @@ rand = { workspace = true }
 rand_chacha = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10.8"
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "tbs"
+harness = false

--- a/crypto/tbs/benches/tbs.rs
+++ b/crypto/tbs/benches/tbs.rs
@@ -1,78 +1,144 @@
-#![cfg_attr(feature = "unstable", feature(test))]
+use std::collections::BTreeMap;
+use std::io::Cursor;
 
-#[cfg(feature = "unstable")]
-mod bench {
-    extern crate test;
+use bls12_381::{G2Projective, Scalar};
+use criterion::{criterion_group, criterion_main, Criterion};
+use fedimint_core::encoding::{Decodable, Encodable};
+use ff::Field;
+use group::Curve;
+use rand::rngs::OsRng;
+use tbs::{
+    aggregate_signature_shares, blind_message, sign_blinded_msg, unblind_signature, verify,
+    AggregatePublicKey, BlindedSignatureShare, BlindingKey, Message, PublicKeyShare,
+    SecretKeyShare, Signature,
+};
 
-    use std::collections::BTreeMap;
+fn dealer_keygen(
+    threshold: usize,
+    keys: usize,
+) -> (AggregatePublicKey, Vec<PublicKeyShare>, Vec<SecretKeyShare>) {
+    let mut rng = OsRng;
+    let poly: Vec<Scalar> = (0..threshold).map(|_| Scalar::random(&mut rng)).collect();
 
-    use tbs::{
-        aggregate_signature_shares, blind_message, dealer_keygen, sign_blinded_msg,
-        unblind_signature, verify, BlindedSignatureShare, BlindingKey, Message,
-    };
-    use test::Bencher;
+    let apk = (G2Projective::generator() * eval_polynomial(&poly, &Scalar::zero())).to_affine();
 
-    #[bench]
-    fn bench_blinding(bencher: &mut Bencher) {
-        bencher.iter(|| {
+    let sks: Vec<SecretKeyShare> = (0..keys)
+        .map(|idx| SecretKeyShare(eval_polynomial(&poly, &Scalar::from(idx as u64 + 1))))
+        .collect();
+
+    let pks = sks
+        .iter()
+        .map(|sk| PublicKeyShare((G2Projective::generator() * sk.0).to_affine()))
+        .collect();
+
+    (AggregatePublicKey(apk), pks, sks)
+}
+
+fn eval_polynomial(coefficients: &[Scalar], x: &Scalar) -> Scalar {
+    coefficients
+        .iter()
+        .cloned()
+        .rev()
+        .reduce(|acc, coefficient| acc * x + coefficient)
+        .expect("We have at least one coefficient")
+}
+
+fn bench_blinding(c: &mut Criterion) {
+    c.bench_function("blinding", |b| {
+        b.iter(|| {
             let msg = Message::from_bytes(b"Hello World!");
             let bkey = BlindingKey::random();
             blind_message(msg, bkey)
-        });
-    }
-
-    #[bench]
-    fn bench_signing(bencher: &mut Bencher) {
-        let msg = Message::from_bytes(b"Hello World!");
-        let bkey = BlindingKey::random();
-        let bmsg = blind_message(msg, bkey);
-        let (_pk, _pks, sks) = dealer_keygen(4, 5);
-
-        bencher.iter(|| sign_blinded_msg(bmsg, sks[0]));
-    }
-
-    #[bench]
-    fn bench_aggregate(bencher: &mut Bencher) {
-        let msg = Message::from_bytes(b"Hello World!");
-        let bkey = BlindingKey::random();
-        let bmsg = blind_message(msg, bkey);
-        let (_pk, _pks, sks) = dealer_keygen(4, 5);
-        let shares: BTreeMap<u64, BlindedSignatureShare> = (1_u64..)
-            .zip(sks.iter().map(|sk| sign_blinded_msg(bmsg, *sk)))
-            .take(4)
-            .collect();
-
-        bencher.iter(move || aggregate_signature_shares(&shares));
-    }
-
-    #[bench]
-    fn bench_unblind(bencher: &mut Bencher) {
-        let msg = Message::from_bytes(b"Hello World!");
-        let bkey = BlindingKey::random();
-        let bmsg = blind_message(msg, bkey);
-        let (_pk, _pks, sks) = dealer_keygen(4, 5);
-        let shares = (1_u64..)
-            .zip(sks.iter().map(|sk| sign_blinded_msg(bmsg, *sk)))
-            .take(4)
-            .collect();
-        let bsig = aggregate_signature_shares(&shares);
-
-        bencher.iter(|| unblind_signature(bkey, bsig));
-    }
-
-    #[bench]
-    fn bench_verify(bencher: &mut Bencher) {
-        let msg = Message::from_bytes(b"Hello World!");
-        let bkey = BlindingKey::random();
-        let bmsg = blind_message(msg, bkey);
-        let (pk, _pks, sks) = dealer_keygen(4, 5);
-        let shares = (1_u64..)
-            .zip(sks.iter().map(|sk| sign_blinded_msg(bmsg, *sk)))
-            .take(4)
-            .collect();
-        let bsig = aggregate_signature_shares(&shares);
-        let sig = unblind_signature(bkey, bsig);
-
-        bencher.iter(|| verify(msg, sig, pk));
-    }
+        })
+    });
 }
+
+fn bench_signing(c: &mut Criterion) {
+    let msg = Message::from_bytes(b"Hello World!");
+    let bkey = BlindingKey::random();
+    let bmsg = blind_message(msg, bkey);
+    let (_pk, _pks, sks) = dealer_keygen(4, 5);
+
+    c.bench_function("signing", |b| b.iter(|| sign_blinded_msg(bmsg, sks[0])));
+}
+
+fn bench_aggregate(c: &mut Criterion) {
+    let msg = Message::from_bytes(b"Hello World!");
+    let bkey = BlindingKey::random();
+    let bmsg = blind_message(msg, bkey);
+    let (_pk, _pks, sks) = dealer_keygen(4, 5);
+    let shares: BTreeMap<u64, BlindedSignatureShare> = (1_u64..)
+        .zip(sks.iter().map(|sk| sign_blinded_msg(bmsg, *sk)))
+        .take(4)
+        .collect();
+
+    c.bench_function("signature aggregation", |b| {
+        b.iter(|| aggregate_signature_shares(&shares))
+    });
+}
+
+fn bench_unblind(c: &mut Criterion) {
+    let msg = Message::from_bytes(b"Hello World!");
+    let bkey = BlindingKey::random();
+    let bmsg = blind_message(msg, bkey);
+    let (_pk, _pks, sks) = dealer_keygen(4, 5);
+    let shares = (1_u64..)
+        .zip(sks.iter().map(|sk| sign_blinded_msg(bmsg, *sk)))
+        .take(4)
+        .collect();
+    let bsig = aggregate_signature_shares(&shares);
+
+    c.bench_function("signature unblinding", |b| {
+        b.iter(|| unblind_signature(bkey, bsig))
+    });
+}
+
+fn bench_verify(c: &mut Criterion) {
+    let msg = Message::from_bytes(b"Hello World!");
+    let bkey = BlindingKey::random();
+    let bmsg = blind_message(msg, bkey);
+    let (pk, _pks, sks) = dealer_keygen(4, 5);
+    let shares = (1_u64..)
+        .zip(sks.iter().map(|sk| sign_blinded_msg(bmsg, *sk)))
+        .take(4)
+        .collect();
+    let bsig = aggregate_signature_shares(&shares);
+    let sig = unblind_signature(bkey, bsig);
+
+    c.bench_function("signature verification", |b| {
+        b.iter(|| verify(msg, sig, pk))
+    });
+}
+
+fn bench_decode_signature(c: &mut Criterion) {
+    let msg = Message::from_bytes(b"Hello World!");
+    let bkey = BlindingKey::random();
+    let bmsg = blind_message(msg, bkey);
+    let (_pk, _pks, sks) = dealer_keygen(4, 5);
+    let shares = (1_u64..)
+        .zip(sks.iter().map(|sk| sign_blinded_msg(bmsg, *sk)))
+        .take(4)
+        .collect();
+    let bsig = aggregate_signature_shares(&shares);
+    let sig = unblind_signature(bkey, bsig);
+    let sig_bytes = sig.consensus_encode_to_vec();
+
+    c.bench_function("signature decoding", |b| {
+        b.iter(|| {
+            let mut sig_bytes_cursor = Cursor::new(&sig_bytes);
+            Signature::consensus_decode(&mut sig_bytes_cursor, &Default::default())
+                .expect("Decoding works")
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_blinding,
+    bench_signing,
+    bench_aggregate,
+    bench_unblind,
+    bench_verify,
+    bench_decode_signature
+);
+criterion_main!(benches);

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -35,6 +35,9 @@ test-upgrades *VERSIONS="v0.2.1 v0.2.2":
 udeps:
   nix build -L .#debug.workspaceCargoUdeps
 
+bench:
+  cargo bench
+
 # run all checks recommended before opening a PR
 final-check: lint
   # can't use nextest due to: https://github.com/nextest-rs/nextest/issues/16

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -16,6 +16,10 @@ rustc-args = ["--cfg", "tokio_unstable"]
 name = "fedimint_mint_client"
 path = "src/lib.rs"
 
+[[bench]]
+name = "notes"
+harness = false
+
 [dependencies]
 anyhow = { workspace = true }
 async-stream = "0.3.5"
@@ -49,6 +53,7 @@ tokio = { version = "1.36.0", features = [ "sync" ] }
 tracing = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 rand = { workspace = true }
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }

--- a/modules/fedimint-mint-client/benches/notes.rs
+++ b/modules/fedimint-mint-client/benches/notes.rs
@@ -1,0 +1,26 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use fedimint_core::encoding::Decodable;
+use fedimint_mint_client::{SpendableNote, SpendableNoteUndecoded};
+
+fn bench_note_decoding(c: &mut Criterion) {
+    pub const NOTE_HEX : &str = "a5dd3ebacad1bc48bd8718eed5a8da1d68f91323bef2848ac4fa2e6f8eed710f3178fd4aef047cc234e6b1127086f33cc408b39818781d9521475360de6b205f3328e490a6d99d5e2553a4553207c8bd";
+
+    let mut group = c.benchmark_group("SpendableNote decoding");
+
+    group.bench_function("SpendableNote", |b| {
+        b.iter(|| {
+            SpendableNote::consensus_decode_hex(black_box(NOTE_HEX), &Default::default()).unwrap()
+        })
+    });
+    group.bench_function("SpendableNoteUndecoded", |b| {
+        b.iter(|| {
+            SpendableNoteUndecoded::consensus_decode_hex(black_box(NOTE_HEX), &Default::default())
+                .unwrap()
+        })
+    });
+}
+
+criterion_group!(benches, bench_note_decoding);
+criterion_main!(benches);


### PR DESCRIPTION
As a part of #4923 I wanted to see if decoding `SpendableNote` is indeed slow, and how much could we save if we skipped decoding of the signature using an alternative parallel type.

```
     Running benches/divan.rs (target-nix/release/deps/divan-2d8a606864c20c66)
Timer precision: 20 ns
divan                               fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ spendable_note_decode            93.5 µs       │ 188 µs        │ 94.32 µs      │ 96.49 µs      │ 100     │ 100
╰─ spendable_note_undecoded_decode  14.79 µs      │ 24.49 µs      │ 14.88 µs      │ 15.11 µs      │ 100     │ 100
```

Seems like decoding seem to be orders of magnitude less than what was suspected, in the range of 100us, which even with hundreds of notes should not be a huge problem.

Using an alternative type is indeed significantly faster. It wouldn't be a lot of effort to use it tactically e.g. when reading all notes for the purposes of using `TieredCounts` instead of "streaming notes" in #4923.

But given how relatively small numbers we see here, and how infrequent note selection is in practice, I'm not sure if it's worthwile.


You can try it yourself by running `cargo bench`, let me know what you think.