### PR TITLE
refactor: GlobalApi should make non-admin calls to all peers

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -214,8 +214,9 @@ impl Federation {
                 )
                 .await?,
             );
-            let admin_client =
-                DynGlobalApi::from_pre_peer_id_endpoint(SafeUrl::parse(&peer_env_vars.FM_API_URL)?);
+            let admin_client = DynGlobalApi::from_pre_peer_id_admin_endpoint(SafeUrl::parse(
+                &peer_env_vars.FM_API_URL,
+            )?);
             endpoints.insert(*peer, peer_env_vars.FM_API_URL.clone());
             admin_clients.insert(*peer, admin_client);
             peer_to_env_vars_map.insert(peer.to_usize(), peer_env_vars);

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -225,18 +225,7 @@ impl Opts {
 
     fn admin_client(&self, cfg: &ClientConfig) -> CliResult<DynGlobalApi> {
         let our_id = self.our_id.ok_or_cli_msg("Admin client needs our-id set")?;
-        Self::admin_client_from_id(our_id, cfg)
-    }
-
-    fn admin_client_from_id(id: PeerId, cfg: &ClientConfig) -> CliResult<DynGlobalApi> {
-        let url = cfg
-            .global
-            .api_endpoints
-            .get(&id)
-            .expect("Endpoint exists")
-            .url
-            .clone();
-        Ok(DynGlobalApi::from_single_endpoint(id, url))
+        Ok(DynGlobalApi::from_config_admin(cfg, our_id))
     }
 
     fn auth(&self) -> CliResult<ApiAuth> {
@@ -333,7 +322,7 @@ struct DkgAdminArgs {
 impl DkgAdminArgs {
     fn ws_admin_client(&self) -> CliResult<DynGlobalApi> {
         let ws = self.ws.clone();
-        Ok(DynGlobalApi::from_pre_peer_id_endpoint(ws))
+        Ok(DynGlobalApi::from_pre_peer_id_admin_endpoint(ws))
     }
 }
 

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2068,17 +2068,6 @@ impl ClientBuilder {
         Ok(client)
     }
 
-    fn admin_api_from_id(id: PeerId, cfg: &ClientConfig) -> anyhow::Result<DynGlobalApi> {
-        let url = cfg
-            .global
-            .api_endpoints
-            .get(&id)
-            .ok_or_else(|| anyhow::format_err!("Invalid admin peer_id: {id}"))?
-            .url
-            .clone();
-        Ok(DynGlobalApi::from_single_endpoint(id, url))
-    }
-
     /// Build a [`Client`] but do not start the executor
     async fn build(
         self,
@@ -2105,7 +2094,7 @@ impl ClientBuilder {
         let fed_id = config.calculate_federation_id();
         let db = self.db_no_decoders.with_decoders(decoders.clone());
         let api = if let Some(admin_creds) = self.admin_creds.as_ref() {
-            Self::admin_api_from_id(admin_creds.peer_id, &config)?
+            DynGlobalApi::from_config_admin(&config, admin_creds.peer_id)
         } else {
             DynGlobalApi::from_config(&config)
         };

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -133,7 +133,7 @@ impl ConfigGenApi {
         let local = state.local.clone();
 
         if let Some(url) = local.and_then(|local| local.leader_api_url) {
-            DynGlobalApi::from_pre_peer_id_endpoint(url)
+            DynGlobalApi::from_pre_peer_id_admin_endpoint(url)
                 .add_config_gen_peer(state.our_peer_info()?)
                 .await
                 .map_err(|_| ApiError::not_found("Unable to connect to the leader".to_string()))?;
@@ -193,7 +193,7 @@ impl ConfigGenApi {
 
         let consensus = match local.and_then(|local| local.leader_api_url) {
             Some(leader_url) => {
-                let client = DynGlobalApi::from_pre_peer_id_endpoint(leader_url.clone());
+                let client = DynGlobalApi::from_pre_peer_id_admin_endpoint(leader_url.clone());
                 let response = client.consensus_config_gen_params().await;
                 response
                     .map_err(|_| ApiError::not_found("Cannot get leader params".to_string()))?
@@ -233,7 +233,7 @@ impl ConfigGenApi {
             state.local.clone().and_then(|local| {
                 local
                     .leader_api_url
-                    .map(DynGlobalApi::from_pre_peer_id_endpoint)
+                    .map(DynGlobalApi::from_pre_peer_id_admin_endpoint)
             })
         };
 
@@ -458,7 +458,7 @@ impl ConfigGenApi {
             state.local.clone().and_then(|local| {
                 local
                     .leader_api_url
-                    .map(DynGlobalApi::from_pre_peer_id_endpoint)
+                    .map(DynGlobalApi::from_pre_peer_id_admin_endpoint)
             })
         };
 
@@ -993,7 +993,7 @@ mod tests {
 
             // our id doesn't really exist at this point
             let auth = ApiAuth(format!("password-{port}"));
-            let client = DynGlobalApi::from_pre_peer_id_endpoint(api_url);
+            let client = DynGlobalApi::from_pre_peer_id_admin_endpoint(api_url);
 
             (
                 TestConfigApi {


### PR DESCRIPTION
An-"admin-enabled" `GlobalApi` should behave for non-admin calls just like non-"admin-enabled" one. For this to happen self-peer-id needs to be tracked separately instead of just narrowing `all_peers` to one (self) peer_id.

In the future this should enable storing self-peer-id in the Client's db, and using such client for both admin and non-admin stuff all the same.

Re #4519

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
