### PR TITLE
feat: `GetNodeInfoResponse` contains block height info

### DIFF
--- a/fedimint-testing/src/ln/mock.rs
+++ b/fedimint-testing/src/ln/mock.rs
@@ -116,6 +116,8 @@ impl ILnRpcClient for FakeLightningTest {
             pub_key: self.gateway_node_pub_key.serialize().to_vec(),
             alias: "FakeLightningNode".to_string(),
             network: "regtest".to_string(),
+            block_height: 0,
+            synced_to_chain: false,
         })
     }
 

--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -49,6 +49,13 @@ message GetNodeInfoResponse {
 
   // The network the node is on. Valid values are "main" | "test" | "signet" | "regtest"
   string network = 3;
+
+  // The best block height that the associated lightning node is aware of
+  // If `synced_to_chain` is true, then the node is also fully synced to this height
+  uint32 block_height = 4;
+
+  // Whether the associated lightning node is fully synced up to `block_height`
+  bool synced_to_chain = 5;
 }
 
 message PayInvoiceRequest {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1546,6 +1546,8 @@ pub(crate) async fn fetch_lightning_node_info(
         pub_key,
         alias,
         network,
+        block_height: _,
+        synced_to_chain: _,
     } = lnrpc.info().await?;
     let node_pub_key = PublicKey::from_slice(&pub_key)
         .map_err(|e| GatewayError::InvalidMetadata(format!("Invalid node pubkey {e}")))?;

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -314,6 +314,8 @@ impl ILnRpcClient for GatewayLndClient {
             pub_key: pub_key.serialize().to_vec(),
             alias: info.alias,
             network,
+            block_height: info.block_height,
+            synced_to_chain: info.synced_to_chain,
         });
     }
 


### PR DESCRIPTION
This will be used by #4514 to wait for the gateway's lightning node to be synced by polling [`ILnRpcClient::info()`](https://github.com/fedimint/fedimint/blob/f1a9c4927f8a351e4878a86e95861cabf35b59bb/gateway/ln-gateway/src/lightning/mod.rs#L57)