### PR TITLE
chore: fix, improve, speedup recovery

### DIFF
--- a/fedimint-api-client/src/api.rs
+++ b/fedimint-api-client/src/api.rs
@@ -825,7 +825,7 @@ where
             ApiRequestErased::new(block_index),
         )
         .await?
-        .try_into_inner(decoders)
+        .try_into_inner(&decoders.clone().with_fallback())
         .map_err(|e| anyhow!(e))
     }
 }

--- a/fedimint-api-client/src/api.rs
+++ b/fedimint-api-client/src/api.rs
@@ -826,7 +826,7 @@ where
         )
         .await?
         .try_into_inner(decoders)
-        .map_err(|e| anyhow!(e.to_string()))
+        .map_err(|e| anyhow!(e))
     }
 }
 

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1671,6 +1671,7 @@ impl Client {
             watch::Receiver<RecoveryProgress>,
         >,
     ) {
+        debug!(target:LOG_CLIENT_RECOVERY, num_modules=%module_recovery_progress_receivers.len(), "Staring module recoveries");
         let mut completed_stream = Vec::new();
         let progress_stream = futures::stream::FuturesUnordered::new();
 

--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -278,7 +278,7 @@ where
                             match items_res {
                                 Ok(block) => break block,
                                 Err(e) => {
-                                    info!(e = %e, session_idx, "Error trying to fetch signed block");
+                                    info!(target: LOG_CLIENT_RECOVERY, e = %e, session_idx, "Error trying to fetch signed block");
                                     // We don't want PARALLISM_LEVEL tasks hammering Federation
                                     // with requests, so max sleep is significant
                                     const MAX_SLEEP: Duration = Duration::from_secs(120);

--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -238,7 +238,7 @@ where
             epoch_range: ops::Range<u64>,
         ) -> impl futures::Stream<Item = (u64, Vec<AcceptedItem>)> + 'a {
             // How many request for blocks to run in parallel (streaming).
-            const PARALLISM_LEVEL: usize = 8;
+            const PARALLISM_LEVEL: usize = 64;
             const VERSION_THAT_INTRODUCED_GET_SESSION_STATUS: ApiVersion =
                 ApiVersion { major: 0, minor: 1 };
 

--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -127,18 +127,6 @@ pub trait RecoveryFromHistory: std::fmt::Debug + MaybeSend + MaybeSync + Clone {
     ) -> anyhow::Result<()> {
         trace!(
             target: LOG_CLIENT_RECOVERY,
-            ?transaction,
-            "found consensus item"
-        );
-
-        trace!(
-            target: LOG_CLIENT_RECOVERY,
-            tx_hash = %transaction.tx_hash(),
-            "found transaction"
-        );
-
-        debug!(
-            target: LOG_CLIENT_RECOVERY,
             tx_hash = %transaction.tx_hash(),
             input_num = transaction.inputs.len(),
             output_num = transaction.outputs.len(),
@@ -146,7 +134,7 @@ pub trait RecoveryFromHistory: std::fmt::Debug + MaybeSend + MaybeSync + Clone {
         );
 
         for (idx, input) in transaction.inputs.iter().enumerate() {
-            debug!(
+            trace!(
                 target: LOG_CLIENT_RECOVERY,
                 tx_hash = %transaction.tx_hash(),
                 idx,
@@ -160,7 +148,7 @@ pub trait RecoveryFromHistory: std::fmt::Debug + MaybeSend + MaybeSync + Clone {
         }
 
         for (out_idx, output) in transaction.outputs.iter().enumerate() {
-            debug!(
+            trace!(
                 target: LOG_CLIENT_RECOVERY,
                 tx_hash = %transaction.tx_hash(),
                 idx = out_idx,
@@ -263,7 +251,7 @@ where
 
                         let mut retry_sleep = Duration::from_millis(10);
                         let block = loop {
-                            info!(target: LOG_CLIENT_RECOVERY, session_idx, "Awaiting signed block");
+                            trace!(target: LOG_CLIENT_RECOVERY, session_idx, "Awaiting signed block");
 
                             let items_res = if core_api_version < VERSION_THAT_INTRODUCED_GET_SESSION_STATUS {
                                 api.await_block(session_idx, &decoders).await.map(|s| s.items)
@@ -276,9 +264,12 @@ where
                             };
 
                             match items_res {
-                                Ok(block) => break block,
+                                Ok(block) => {
+                                    debug!(target: LOG_CLIENT_RECOVERY, session_idx, "Got signed session");
+                                    break block
+                                },
                                 Err(e) => {
-                                    info!(target: LOG_CLIENT_RECOVERY, e = %e, session_idx, "Error trying to fetch signed block");
+                                    warn!(target: LOG_CLIENT_RECOVERY, e = %e, session_idx, "Error trying to fetch signed block");
                                     // We don't want PARALLISM_LEVEL tasks hammering Federation
                                     // with requests, so max sleep is significant
                                     const MAX_SLEEP: Duration = Duration::from_secs(120);

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -335,7 +335,7 @@ impl MintRecoveryState {
 
     /// Fill each tier pool to the gap limit
     fn fill_initial_pending_nonces(&mut self, amount: Amount, secret: &DerivableSecret) {
-        info!(%amount, count=self.gap_limit, "Generating initial set of nonces for amount tier");
+        debug!(%amount, count=self.gap_limit, "Generating initial set of nonces for amount tier");
         for _ in 0..self.gap_limit {
             self.add_next_pending_nonce_in_pending_pool(amount, secret);
         }


### PR DESCRIPTION
I've got a report of slow recovery, so I investigated using `fedimint-cli` to recover in one of test (but otherwise real-like) Fedrations I have available.

I found a serious problem, improved some minor stuff and decided to increase parallism level for significant speedup.

Implementing fetching every session outcome from a single peer would be a significant improvement that could further reduce recovery time.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
