### PR TITLE
fix: use default total send fee provided by the gateway

### DIFF
--- a/gateway/ln-gateway/src/gateway_module_v2/mod.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/mod.rs
@@ -19,7 +19,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion, TransactionItemAmount,
 };
-use fedimint_core::{apply, async_trait_maybe_send, OutPoint, PeerId};
+use fedimint_core::{apply, async_trait_maybe_send, Amount, OutPoint, PeerId};
 use fedimint_lnv2_common::config::LightningClientConfig;
 use fedimint_lnv2_common::contracts::{IncomingContract, OutgoingContract};
 use fedimint_lnv2_common::{LightningCommonInit, LightningModuleTypes, LightningOutput};
@@ -192,7 +192,7 @@ impl GatewayClientModuleV2 {
         &self,
         operation_id: OperationId,
         max_delay: u64,
-        max_fee_msat: u64,
+        min_contract_amount: Amount,
         invoice: Bolt11Invoice,
         contract: OutgoingContract,
     ) -> anyhow::Result<()> {
@@ -201,7 +201,7 @@ impl GatewayClientModuleV2 {
                 operation_id,
                 contract: contract.clone(),
                 max_delay,
-                max_fee_msat,
+                min_contract_amount,
                 invoice,
                 claim_keypair: self.keypair,
             },

--- a/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
@@ -140,15 +140,14 @@ impl SendStateMachine {
         let min_contract_amount = context
             .gateway
             .payment_fees_v2()
-            .send
+            .send_minimum
             .add_fee(invoice_msats);
 
         if contract_amount < min_contract_amount {
             return Err(Cancelled::Underfunded);
         }
 
-        let excess_fee = contract_amount - min_contract_amount;
-        let max_fee_msat = excess_fee.msats + (min_contract_amount.msats - invoice_msats) / 2;
+        let max_fee_msat = (contract_amount - min_contract_amount).msats;
 
         let lightning_context = context
             .gateway

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1584,10 +1584,9 @@ impl Gateway {
 
     pub fn payment_fees_v2(&self) -> PaymentFees {
         PaymentFees {
-            // we take a fee of one percent for outgoing contracts
-            send: PaymentFee::default(),
-            // we take a fee of one percent for incoming contracts
-            receive: PaymentFee::default(),
+            send_default: PaymentFee::one_percent(),
+            send_minimum: PaymentFee::half_of_one_percent(),
+            receive: PaymentFee::half_of_one_percent(),
         }
     }
 


### PR DESCRIPTION
The reasoning here is that the gateway is supposed to choose a fee for sending an outgoing payment that is sufficient for high lightning reliability; retrying with higher fees in case of cancellation is unnecessary. 

Furthermore, the fee behaviour is now identical to receiving an incoming payment.