### PR TITLE
chore: bump fedimint-meta-tests to 0.4.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "devimint",

--- a/crypto/tpe/Cargo.toml
+++ b/crypto/tpe/Cargo.toml
@@ -17,7 +17,7 @@ name = "tpe"
 path = "src/lib.rs"
 
 [dependencies]
-fedimint-core  = { version = "0.4.0-alpha", path = "../../fedimint-core/" }
+fedimint-core  = { version = "=0.4.0-alpha", path = "../../fedimint-core/" }
 bls12_381 = { version = "0.7.1", features = [ "zeroize", "groups" ] }
 ff = "0.12.1"
 group = "0.12.1"

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -52,7 +52,7 @@ fedimint-dummy-client = { version = "=0.4.0-alpha", path = "../../modules/fedimi
 fedimint-wallet-client = { version = "=0.4.0-alpha", path = "../../modules/fedimint-wallet-client" }
 fedimint-lnv2-client = { path = "../../modules/fedimint-lnv2-client" }
 fedimint-lnv2-common = { path = "../../modules/fedimint-lnv2-common" }
-tpe = { package = "fedimint-tpe", version = "0.4.0-alpha", path = "../../crypto/tpe" }
+tpe = { package = "fedimint-tpe", version = "=0.4.0-alpha", path = "../../crypto/tpe" }
 futures = { workspace = true }
 hex = { workspace = true }
 erased-serde = { workspace = true }

--- a/modules/fedimint-lnv2-client/Cargo.toml
+++ b/modules/fedimint-lnv2-client/Cargo.toml
@@ -48,7 +48,7 @@ tokio = { version = "1.26.0", features = ["macros"] }
 tracing = "0.1.37"
 rand = "0.8"
 url = { version = "2.3.1", features = ["serde"] }
-tpe = { package = "fedimint-tpe", version = "0.4.0-alpha", path = "../../crypto/tpe" }
+tpe = { package = "fedimint-tpe", version = "=0.4.0-alpha", path = "../../crypto/tpe" }
 reqwest = { version = "0.11.14", features = [ "json", "rustls-tls" ], default-features = false }
 
 [dev-dependencies]

--- a/modules/fedimint-lnv2-common/Cargo.toml
+++ b/modules/fedimint-lnv2-common/Cargo.toml
@@ -44,7 +44,7 @@ bls12_381 = { version = "0.7.1", features = [ "zeroize", "groups" ] }
 ff = "0.12.1"
 group = "0.12.1"
 rand_chacha = "0.3.1"
-tpe = { package = "fedimint-tpe", version = "0.4.0-alpha", path = "../../crypto/tpe" }
+tpe = { package = "fedimint-tpe", version = "=0.4.0-alpha", path = "../../crypto/tpe" }
 
 [dev-dependencies]
 tokio = {version = "1.26.0", features = [ "full" ] }

--- a/modules/fedimint-lnv2-server/Cargo.toml
+++ b/modules/fedimint-lnv2-server/Cargo.toml
@@ -29,7 +29,7 @@ serde = {version = "1.0.149", features = [ "derive" ] }
 serde_json = "1.0.91"
 strum = "0.24"
 strum_macros = "0.24"
-tpe = { package = "fedimint-tpe", version = "0.4.0-alpha", path = "../../crypto/tpe" }
+tpe = { package = "fedimint-tpe", version = "=0.4.0-alpha", path = "../../crypto/tpe" }
 thiserror = "1.0.39"
 group = "0.12.1"
 threshold_crypto = { workspace = true }

--- a/modules/fedimint-meta-tests/Cargo.toml
+++ b/modules/fedimint-meta-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-meta-tests"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-mint-tests contains integration tests for the meta module"


### PR DESCRIPTION
The previous PR to bump remaining versions (https://github.com/fedimint/fedimint/pull/4877) was merged one day before `fedimint-meta-tests` was merged (https://github.com/fedimint/fedimint/pull/4772).

Verify locally with

```
just release-bump-version "custom 0.4.0-alpha"
```