### PR TITLE
chore(devimint): bump poll lnd_startup from 15s to default 60s

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -429,7 +429,7 @@ impl Lnd {
             process,
         };
         // wait for lnd rpc to be active
-        poll_with_timeout("lnd_startup", Duration::from_secs(15), || async {
+        poll("lnd_startup", || async {
             this.pub_key().await.map_err(ControlFlow::Continue)
         })
         .await?;


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/4636

Polling `lnd_startup` for only 15s is causing flakiness in CI ([Build on linux](https://github.com/fedimint/fedimint/actions/runs/8682016495/job/23876043177?pr=4776) and [back-compat](https://github.com/fedimint/fedimint/actions/runs/8712142545/job/23897782551?pr=4983)). Let's try the default (60s) timeout.