### PR TITLE
chore: disable all modules on lack of initial api version

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2120,7 +2120,15 @@ impl ClientBuilder {
             &db,
             &task_group,
         )
-        .await?;
+        .await
+        .inspect_err(|err| {
+            warn!(target: LOG_CLIENT, %err, "Failed to discover initial API version to use.");
+        })
+        .unwrap_or(ApiVersionSet {
+            core: ApiVersion::new(0, 0),
+            // This will cause all modules to skip initialization
+            modules: Default::default(),
+        });
 
         debug!(?common_api_versions, "Completed api version negotiation");
 


### PR DESCRIPTION
Instead of failing to initialize the Client, simply pretend it was impossible to initialize any module. This should be easier to gracefully handle downstream if the Federation is e.g. temporarily down.

Re #4887

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
