### PR TITLE
chore: make fedimintd and devimint shutdown stuff fast

### DIFF
--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -153,7 +153,7 @@ impl FederationTest {
             .await
             .expect("Failed to init server");
 
-            let api_handle = FedimintServer::spawn_consensus_api(consensus_api, false).await;
+            let api_handle = FedimintServer::spawn_consensus_api(consensus_api).await;
 
             task_group.spawn("fedimintd", move |handle| async move {
                 consensus_server.run(handle).await.unwrap();

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -16,7 +16,7 @@ use fedimint_core::core::ModuleKind;
 use fedimint_core::db::Database;
 use fedimint_core::envs::{is_env_var_set, BitcoinRpcConfig, FM_USE_UNKNOWN_MODULE_ENV};
 use fedimint_core::module::{ServerApiVersionsSummary, ServerDbVersionsSummary, ServerModuleInit};
-use fedimint_core::task::{sleep, TaskGroup};
+use fedimint_core::task::TaskGroup;
 use fedimint_core::timing;
 use fedimint_core::util::{handle_version_hash_command, write_overwrite, SafeUrl};
 use fedimint_ln_common::config::{
@@ -355,9 +355,7 @@ impl Fedimintd {
                 .make_shutdown_rx()
                 .await
                 .then(|_| async {
-                    let shutdown_seconds = SHUTDOWN_TIMEOUT.as_secs();
-                    info!("Shutdown called, waiting {shutdown_seconds}s for main task to finish");
-                    sleep(SHUTDOWN_TIMEOUT).await;
+                    info!("Shutdown called");
                 });
 
         shutdown_future.await;


### PR DESCRIPTION
See commits.


### Testing

Start devimint with:

```
env RUST_LOG=fm=debug just devimint-env
```

`exit` in it, and observe the shutdown time. `tail -f target-nix/devimint/logs/fedimintd-0.log` if you want to see what's happening in `fedimintd`. Another way is to `killall fedimintd` from the outside with `tail -f`.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
