### PR TITLE
 chore: disable meh ln-gateway integration tests 

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,6 @@
 [profile.default]
 # no matter the profile, we want to kill tests that hanged on something
-slow-timeout = { period = "60s", terminate-after = 8 }
+slow-timeout = { period = "30s", terminate-after = 3 }
 
 # define `dev` to allow running cargo and nextest with the same profile name
 # inherits default profile config
@@ -9,4 +9,4 @@ slow-timeout = { period = "60s", terminate-after = 8 }
 [profile.ci]
 fail-fast = true
 failure-output = "immediate"
-slow-timeout = { period = "60s", terminate-after = 8 }
+slow-timeout = { period = "30s", terminate-after = 2 }

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -60,6 +60,7 @@ impl GatewayTest {
     /// Note: this makes the database opened, which can lead to gateway
     /// wanting to rejoin it. Better get your own client instead of being
     /// lazy here.
+    // TODO: This stuff is horrible, why do we need it?
     pub async fn remove_client_hack(&self, fed: &FederationTest) -> ClientHandleArc {
         self.gateway
             .remove_client_hack(fed.id())
@@ -68,6 +69,13 @@ impl GatewayTest {
             .into_value()
     }
 
+    // TODO: This stuff is horrible, why do we need it?
+    pub async fn add_client_hack(&self, fed: &FederationTest, client: ClientHandleArc) {
+        self.gateway
+            .add_client_hack(fed.id(), client)
+            .await
+            .unwrap()
+    }
     pub async fn select_client(&self, federation_id: FederationId) -> ClientHandleArc {
         self.gateway
             .select_client(federation_id)

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -552,6 +552,9 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
     .await
 }
 
+// disabled for being too slow and not even testing the right thing
+// see https://github.com/fedimint/fedimint/issues/4926
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_client_pay_unpayable_invoice() -> anyhow::Result<()> {
     single_federation_test(
@@ -928,6 +931,9 @@ async fn test_gateway_register_with_federation() -> anyhow::Result<()> {
     Ok(())
 }
 
+// disabled for being too slow and not even testing the right thing
+// see https://github.com/fedimint/fedimint/issues/4926
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
     single_federation_test(

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -933,7 +933,6 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
     single_federation_test(
         |gateway, other_lightning_client, fed, user_client, _| async move {
             let gateway_id = gateway.gateway.gateway_id;
-            let gateway_client = gateway.remove_client_hack(&fed).await;
             let invoice = other_lightning_client
                 .invoice(sats(1000), 1.into())
                 .await
@@ -951,7 +950,7 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
 
             // User client pays test invoice
             let lightning_module = user_client.get_first_module::<LightningClientModule>();
-            let gateway = lightning_module.select_gateway(&gateway_id).await;
+            let gateway_module = lightning_module.select_gateway(&gateway_id).await;
             let OutgoingLightningPayment {
                 payment_type,
                 contract_id,
@@ -970,10 +969,11 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
                     let payload = PayInvoicePayload {
                         federation_id: user_client.federation_id(),
                         contract_id,
-                        payment_data: get_payment_data(gateway, invoice),
+                        payment_data: get_payment_data(gateway_module, invoice),
                         preimage_auth: Hash::hash(&[0; 32]),
                     };
 
+                    let gateway_client = gateway.remove_client_hack(&fed).await;
                     let gw_pay_op = gateway_client
                         .get_first_module::<GatewayClientModule>()
                         .gateway_pay_bolt11_invoice(payload)
@@ -983,6 +983,9 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
                         .gateway_subscribe_ln_pay(gw_pay_op)
                         .await?
                         .into_stream();
+
+                    gateway.add_client_hack(&fed, gateway_client).await;
+
                     assert_eq!(gw_pay_sub.ok().await?, GatewayExtPayStates::Created);
                     assert_matches!(gw_pay_sub.ok().await?, GatewayExtPayStates::Canceled { .. });
 
@@ -995,6 +998,7 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
 
             // Balance should be unchanged
             assert_eq!(user_client.get_balance().await, sats(2000));
+            let gateway_client = gateway.remove_client_hack(&fed).await;
             assert_eq!(gateway_client.get_balance().await, sats(0));
 
             Ok(())


### PR DESCRIPTION
I just investigated #4926 a bit more, and discovered that two offending tests basically test expiration of the GW client state machine, and due to hacks they are using, they were not even succeeding (by failing) due to right error. They removed the internal client and then they were getting an error that the gateway did not joined the the corresponding federation.

Combined with the fact that they can't distinguish errors and need to wait for the full expiration time (30s), and we run it twice for each gw type, it makes them run the whole minute... to basically assert that they are broken.

There really has to be a more robust way to go about everything here.

Either we should make the error handling solid to detect the error and terminate state machine immediately after the irrecoverable condition is returned in the error, or we should maybe set up the gateway and mock responses to it, or just do something better. 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
