### PR TITLE
fix: use private payments rpc when available

### DIFF
--- a/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
@@ -7,6 +7,7 @@ use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::{KeyPair, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{Amount, OutPoint};
+use fedimint_ln_common::PrunedInvoice;
 use fedimint_lnv2_client::LightningClientStateMachines;
 use fedimint_lnv2_common::contracts::OutgoingContract;
 use fedimint_lnv2_common::{LightningInput, OutgoingWitness, Witness};
@@ -141,7 +142,7 @@ impl SendStateMachine {
             return Err(Cancelled::Underfunded);
         }
 
-        let max_fee_msat = (contract.amount - min_contract_amount).msats;
+        let max_fee = contract.amount - min_contract_amount;
 
         let lightning_context = context
             .gateway
@@ -164,23 +165,34 @@ impl SendStateMachine {
                 .map_err(|e| Cancelled::ReceiveError(e.to_string()));
         }
 
-        lightning_context
-            .lnrpc
-            .pay(PayInvoiceRequest {
-                invoice: invoice.to_string(),
-                max_delay,
-                max_fee_msat,
-                payment_hash: invoice.payment_hash().to_vec(),
-            })
-            .await
-            .map(|response| {
-                response
-                    .preimage
-                    .as_slice()
-                    .try_into()
-                    .expect("Preimage is 32 bytes")
-            })
-            .map_err(|e| Cancelled::LightningRpcError(e.to_string()))
+        if lightning_context.lnrpc.supports_private_payments() {
+            lightning_context
+                .lnrpc
+                .pay_private(
+                    PrunedInvoice::try_from(invoice).expect("Invoice has amount"),
+                    max_delay,
+                    max_fee,
+                )
+                .await
+        } else {
+            lightning_context
+                .lnrpc
+                .pay(PayInvoiceRequest {
+                    invoice: invoice.to_string(),
+                    max_delay,
+                    max_fee_msat: max_fee.msats,
+                    payment_hash: invoice.payment_hash().to_vec(),
+                })
+                .await
+        }
+        .map(|response| {
+            response
+                .preimage
+                .as_slice()
+                .try_into()
+                .expect("Preimage is 32 bytes")
+        })
+        .map_err(|e| Cancelled::LightningRpcError(e.to_string()))
     }
 
     async fn transition_send_payment(

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -66,11 +66,6 @@ async fn print_liquidity(gateway: &GatewayTest, federation_id: FederationId) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
-    // TODO: remove this
-    if Fixtures::is_real_test() {
-        return Ok(());
-    }
-
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
     let gw = gateway(&fixtures, &fed).await;
@@ -136,11 +131,6 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn refund_unpayable_invoice() -> anyhow::Result<()> {
-    // TODO: remove this
-    if Fixtures::is_real_test() {
-        return Ok(());
-    }
-
     let fixtures = fixtures();
     let fed = fixtures.new_fed().await;
     let gw = gateway(&fixtures, &fed).await;


### PR DESCRIPTION
This fixes two lnv2 tests that had to be deactivated in CI before.