### PR TITLE
fix(ci): dependabot still not grouping patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,8 @@ updates:
       applies-to: version-updates
       patterns:
       - "*"
-      update-types: patch
+      update-types:
+      - patch
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Looking at

https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml

I think this part is off.

Would be nice to have a validator for this stuff...

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
