### PR TITLE
fix: inefficient way to look for file

### DIFF
--- a/fedimint-testing/src/db.rs
+++ b/fedimint-testing/src/db.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::fs::read_dir;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::{env, fs, io};
@@ -41,10 +40,9 @@ pub fn get_project_root() -> io::Result<PathBuf> {
     let path = env::current_dir()?;
     let path_ancestors = path.as_path().ancestors();
 
-    for p in path_ancestors {
-        let has_cargo = read_dir(p)?.any(|p| p.unwrap().file_name() == *"Cargo.lock");
-        if has_cargo {
-            return Ok(PathBuf::from(p));
+    for path in path_ancestors {
+        if path.join("Cargo.lock").try_exists()? {
+            return Ok(PathBuf::from(path));
         }
     }
     Err(io::Error::new(


### PR DESCRIPTION
I was investigating something else and happened to need to rewrite it anyway.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
