### PR TITLE
fix: remove tokio_unstable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["--cfg", "tokio_unstable"]
+# rustflags = ["--cfg", "tokio_unstable"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-# rustflags = ["--cfg", "tokio_unstable"]

--- a/.config/semgrep.yaml
+++ b/.config/semgrep.yaml
@@ -64,6 +64,9 @@ rules:
   message: "`tokio::spawn` won't set task name by default. use `fedimint_core::runtime::spawn` instead"
   pattern: tokio::spawn
   severity: WARNING
+  paths:
+    exclude:
+      - fedimint-core/src/runtime.rs
 
 - id: ban-tokio-sleep
   languages:

--- a/.config/semgrep.yaml
+++ b/.config/semgrep.yaml
@@ -64,9 +64,6 @@ rules:
   message: "`tokio::spawn` won't set task name by default. use `fedimint_core::runtime::spawn` instead"
   pattern: tokio::spawn
   severity: WARNING
-  paths:
-    exclude:
-      - fedimint-core/src/runtime.rs
 
 - id: ban-tokio-sleep
   languages:

--- a/fedimint-core/src/runtime.rs
+++ b/fedimint-core/src/runtime.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use thiserror::Error;
 use tokio::time::Instant;
+use tracing::Instrument;
 
 #[derive(Debug, Error)]
 #[error("deadline has elapsed")]
@@ -27,20 +28,16 @@ mod r#impl {
         F: Future<Output = T> + 'static + Send,
         T: Send + 'static,
     {
-        tokio::task::Builder::new()
-            .name(name)
-            .spawn(future)
-            .expect("spawn failed")
+        let span = tracing::span!(tracing::Level::INFO, "spawn", task_name = name);
+        tokio::spawn(future.instrument(span))
     }
 
     pub(crate) fn spawn_local<F>(name: &str, future: F) -> JoinHandle<()>
     where
         F: Future<Output = ()> + 'static,
     {
-        tokio::task::Builder::new()
-            .name(name)
-            .spawn_local(future)
-            .expect("spawn failed")
+        let span = tracing::span!(tracing::Level::INFO, "spawn_local", task_name = name);
+        tokio::task::spawn_local(future.instrument(span))
     }
 
     // note: this call does not exist on wasm and you need to handle it

--- a/fedimint-core/src/runtime.rs
+++ b/fedimint-core/src/runtime.rs
@@ -29,6 +29,7 @@ mod r#impl {
         T: Send + 'static,
     {
         let span = tracing::span!(tracing::Level::INFO, "spawn", task_name = name);
+        // nosemgrep: ban-tokio-spawn
         tokio::spawn(future.instrument(span))
     }
 
@@ -37,6 +38,7 @@ mod r#impl {
         F: Future<Output = ()> + 'static,
     {
         let span = tracing::span!(tracing::Level::INFO, "spawn_local", task_name = name);
+        // nosemgrep: ban-tokio-spawn
         tokio::task::spawn_local(future.instrument(span))
     }
 

--- a/flake.nix
+++ b/flake.nix
@@ -103,9 +103,7 @@
             };
           };
 
-          toolchainArgs = {
-            # extraRustFlags = "--cfg tokio_unstable";
-          } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+          toolchainArgs = { } // lib.optionalAttrs pkgs.stdenv.isDarwin {
             # on Darwin newest stdenv doesn't seem to work
             # linking rocksdb
             stdenv = pkgs.clang11Stdenv;

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
           };
 
           toolchainArgs = {
-            extraRustFlags = "--cfg tokio_unstable";
+            # extraRustFlags = "--cfg tokio_unstable";
           } // lib.optionalAttrs pkgs.stdenv.isDarwin {
             # on Darwin newest stdenv doesn't seem to work
             # linking rocksdb


### PR DESCRIPTION
Removes tokio_unstable `Builder`, turns the thread name into a tracing span, still enforces using fedimint_core's spawn and spawn_local.
