### PR TITLE
chore: disable dependabot updates off lightning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     time: "05:30"
   ignore:
   - dependency-name: "bitcoin" # we can't "just update it"
+  - dependency-name: "lightning" # semver too hard :D
   open-pull-requests-limit: 5 # more than this would mean lot of rebasing
   groups:
     # put all patch version updates in one big PR, as


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
