### PR TITLE
chore: create admin federation client in fedimint-testing

### DIFF
--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -58,7 +58,9 @@ async fn client_ignores_unknown_module() {
     cfg.modules.insert(2142, extra_mod);
 
     // Test that building the client worked
-    let _client = fed.new_client_with(cfg, MemDatabase::new().into()).await;
+    let _client = fed
+        .new_client_with(cfg, MemDatabase::new().into(), None)
+        .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
As far as I can tell, it is not currently possible to make an admin client using `FederationTest` in `fedimint-testing`. For modules that are "admin-only" this is necessary for writing tests (I hit it while writing the ROASTR module).
