### PR TITLE
chore(ci): add label to backport issues

### DIFF
--- a/.github/templates/failed-backport-issue.md
+++ b/.github/templates/failed-backport-issue.md
@@ -1,5 +1,6 @@
 ---
 title: Backport PR `#{{ env.PR_NUMBER }}` {{ env.SHORT_PR_TITLE }}
+labels: backport
 ---
 PR: #{{ env.PR_NUMBER }}
 Title: {{ env.PR_TITLE }}


### PR DESCRIPTION
Filtering issues with a `backport` label helps us quickly see all outstanding failed backports.