### PR TITLE
chore(ci): run cross-compilation steps only core build passed

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -281,6 +281,7 @@ jobs:
 
   cross:
     name: "Cross-compile on ${{ matrix.host }} to ${{ matrix.toolchain }}"
+    needs: [lint, shell, build, ccov]
 
     strategy:
       matrix:


### PR DESCRIPTION
These are less important, and with current self-hosted runner, we have less parallelism ATM (we might add another one later).

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
