### PR TITLE
fix(ci): self hosted runners don't need fs-dir-cache lock

### DIFF
--- a/scripts/ci/run-in-fs-dir-cache.sh
+++ b/scripts/ci/run-in-fs-dir-cache.sh
@@ -10,16 +10,23 @@ if [ -z "$job_name" ]; then
     exit 1
 fi
 
+export FS_DIR_CACHE_LOCK_TIMEOUT_SECS="$((60 * 30))" # unlock after timeout in case our job fails misereably
+
 USER_ROOT="$HOME"
 if [ -n "${RUNNER_ROOT:-}" ]; then
     # In self-hosted nixos module runner, the HOME is actually /run/... which is memory-quota-limited
     # so use the persisted root dir instead
     USER_ROOT="$RUNNER_ROOT"
+    # In our self-hosted runners the cache dir is actually local to instance and not shared,
+    # so there is not point in locking it. And if the run gets killed due to concurrency groups
+    # the lock might not get cleaned, and next job might need to wait for it to expire.
+    # We should really be using some kind of sockets that would disappear automatically, but
+    # for now making the timeout tiny is the easiest workaround.
+    FS_DIR_CACHE_LOCK_TIMEOUT_SECS=1
 fi
 export FS_DIR_CACHE_ROOT="$USER_ROOT/.cache/fs-dir-cache" # directory to hold all cache (sub)directories
 export FS_DIR_CACHE_LOCK_ID="pid-$$-rnd-$RANDOM"     # acquire lock based on the current pid and something random (just in case pid gets reused)
 export FS_DIR_CACHE_KEY_NAME="$job_name"             # the base name of our key
-export FS_DIR_CACHE_LOCK_TIMEOUT_SECS="$((60 * 30))" # unlock after timeout in case our job fails misereably
 
 log_file="$FS_DIR_CACHE_ROOT/log"
 


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
