### PR TITLE
fix: backwards compatibility tests are started with too much parallel…

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -239,7 +239,7 @@ if [ -n "${FM_TEST_CI_ALL_JOBS:-}" ]; then
   parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS}")
 elif [ -n "${CI:-}" ] || [ "${CARGO_PROFILE:-}" == "ci" ]; then
   # in CI, we know number of cpus works OK
-  parallel_args+=(--jobs +0)
+  parallel_args+=(--jobs 4)
 else
   # on dev computers default to `num_cpus / 4 + 1` max parallel jobs
   parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS:-$(($(nproc) / 4 + 1))}")


### PR DESCRIPTION
…ism for our self-hosted CI

Since we don't use VMs and the CPU is a shared resource between all runners we shouldn't use all available cores for parallelism in one job.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
