### PR TITLE
fix(ci): skip setting RUSTC_WRAPPER to sccache in ci

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -285,7 +285,10 @@
                     fi
                   fi
 
-                  export RUSTC_WRAPPER=${pkgs.sccache}/bin/sccache
+
+                  if [ "''${CARGO_PROFILE:-}" != "ci" ]; then
+                    export RUSTC_WRAPPER=${pkgs.sccache}/bin/sccache
+                  fi
                   export CARGO_BUILD_TARGET_DIR="''${CARGO_BUILD_TARGET_DIR:-''${REPO_ROOT}/target-nix}"
                   export FM_DISCOVER_API_VERSION_TIMEOUT=10
                   [ -f "$REPO_ROOT/.shrc.local" ] && source "$REPO_ROOT/.shrc.local"


### PR DESCRIPTION
The self hosted runner has permission issues due to `sccache`. The original intent of adding `sccache` was to make compilation faster on local dev environments when switching branches (see: https://github.com/fedimint/fedimint/pull/4360), so we can skip using in CI.

```
sccache: error: Failed to open file for hashing: "/var/lib/github-runner/runner-01-aa/.cache/fs-dir-cache/backward-compat-dbd8d46d51c79e46551ed37757b6f2894385816d10ab85bd32a4888003d03915/target/ci/deps/libaleph_bft_types-4504822894dd6e72.rmeta"
```

This is only an issue for back-compat in CI since the tests need to run with `nix develop -c`, which uses the `shellHook` unlike the rest of CI.