### PR TITLE
test: FederationTestBuilder for building federations in rust tests

### DIFF
--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -100,7 +100,7 @@ where
     let cln2 = fixtures.cln().await;
 
     for (gateway_ln, other_node) in [(lnd1, cln1), (cln2, lnd2)] {
-        let fed = fixtures.new_fed().await;
+        let fed = fixtures.new_default_fed().await;
         let mut gateway = fixtures
             .new_gateway(gateway_ln, 0, Some(DEFAULT_GATEWAY_PASSWORD.to_string()))
             .await;
@@ -127,8 +127,8 @@ where
     B: Future<Output = anyhow::Result<()>>,
 {
     let fixtures = fixtures();
-    let fed1 = fixtures.new_fed().await;
-    let fed2 = fixtures.new_fed().await;
+    let fed1 = fixtures.new_default_fed().await;
+    let fed2 = fixtures.new_default_fed().await;
 
     let lightning = match lightning_node_type {
         LightningNodeType::Lnd => fixtures.lnd().await,
@@ -882,7 +882,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
 async fn test_gateway_register_with_federation() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let node = fixtures.lnd().await;
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let user_client = fed.new_client().await;
     let mut gateway_test = fixtures
         .new_gateway(node, 0, Some(DEFAULT_GATEWAY_PASSWORD.to_string()))
@@ -1038,7 +1038,7 @@ async fn test_gateway_filters_route_hints_by_inbound() -> anyhow::Result<()> {
 
             tracing::info!("Creating federation with gateway type {gateway_type}. Number of route hints: {num_route_hints}");
 
-            let fed = fixtures.new_fed().await;
+            let fed = fixtures.new_default_fed().await;
             let mut gateway = fixtures
                 .new_gateway(
                     gateway_ln,
@@ -1138,7 +1138,7 @@ async fn test_gateway_filters_route_hints_by_inbound() -> anyhow::Result<()> {
 async fn test_cannot_connect_same_federation() -> anyhow::Result<()> {
     let fixtures = fixtures();
 
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let lnd = fixtures.lnd().await;
     let gateway = fixtures
         .new_gateway(lnd, 0, Some(DEFAULT_GATEWAY_PASSWORD.to_string()))
@@ -1174,7 +1174,7 @@ async fn test_cannot_connect_same_federation() -> anyhow::Result<()> {
 async fn test_gateway_configuration() -> anyhow::Result<()> {
     let fixtures = fixtures();
 
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let lnd = fixtures.lnd().await;
     let gateway = fixtures.new_gateway(lnd, 0, None).await;
     let initial_rpc_client = gateway.get_rpc().await;

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -22,7 +22,7 @@ fn fixtures() -> Fixtures {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_print_and_send_money() -> anyhow::Result<()> {
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let (client1, client2) = fed.two_clients().await;
 
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
@@ -42,7 +42,7 @@ async fn can_print_and_send_money() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn client_ignores_unknown_module() {
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let client = fed.new_client().await;
 
     let mut cfg = client.get_config().clone();
@@ -66,7 +66,7 @@ async fn client_ignores_unknown_module() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn federation_should_abort_if_balance_sheet_is_negative() -> anyhow::Result<()> {
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let client = fed.new_client().await;
 
     let (panic_sender, panic_receiver) = std::sync::mpsc::channel::<()>();
@@ -115,7 +115,7 @@ async fn federation_should_abort_if_balance_sheet_is_negative() -> anyhow::Resul
 /// the federation should reject because it's unbalanced.
 #[tokio::test(flavor = "multi_thread")]
 async fn unbalanced_transactions_get_rejected() -> anyhow::Result<()> {
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let client = fed.new_client().await;
 
     let dummy_module = client.get_first_module::<DummyClientModule>();

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -54,7 +54,7 @@ async fn pay_invoice(
 #[tokio::test(flavor = "multi_thread")]
 async fn test_can_attach_extra_meta_to_receive_operation() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>();
 
@@ -116,7 +116,7 @@ async fn test_can_attach_extra_meta_to_receive_operation() -> anyhow::Result<()>
 #[tokio::test(flavor = "multi_thread")]
 async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>();
 
@@ -195,7 +195,7 @@ async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn gateway_protects_preimage_for_payment() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let gw = gateway(&fixtures, &fed).await;
     let (client1, client2) = fed.two_clients().await;
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
@@ -263,7 +263,7 @@ async fn gateway_protects_preimage_for_payment() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let gw = gateway(&fixtures, &fed).await;
     let client = fed.new_client().await;
     let dummy_module = client.get_first_module::<DummyClientModule>();
@@ -331,7 +331,7 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>();
 
@@ -430,7 +430,7 @@ async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_receive_for_other_user() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>();
 
@@ -559,7 +559,7 @@ async fn can_receive_for_other_user() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_receive_for_other_user_tweaked() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let gw = gateway(&fixtures, &fed).await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>();
@@ -635,7 +635,7 @@ async fn can_receive_for_other_user_tweaked() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn rejects_wrong_network_invoice() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let gw = gateway(&fixtures, &fed).await;
     let client1 = fed.new_client().await;
 

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -68,7 +68,7 @@ async fn print_liquidity(gateway: &GatewayTest, federation_id: FederationId) {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let gateway_test = gateway(&fixtures, &fed).await;
     let gateway_api = gateway_test.gateway.versioned_api.clone();
 
@@ -126,7 +126,7 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn refund_unpayable_invoice() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let gateway_test = gateway(&fixtures, &fed).await;
     let gateway_api = gateway_test.gateway.versioned_api.clone();
 
@@ -165,7 +165,7 @@ async fn refund_unpayable_invoice() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_make_self_payment_exactly_once() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let gateway_test = gateway(&fixtures, &fed).await;
     let gateway_api = gateway_test.gateway.versioned_api.clone();
 
@@ -246,8 +246,8 @@ async fn can_make_self_payment_exactly_once() -> anyhow::Result<()> {
 async fn direct_swap() -> anyhow::Result<()> {
     let fixtures = fixtures();
 
-    let fed_send = fixtures.new_fed().await;
-    let fed_receive = fixtures.new_fed().await;
+    let fed_send = fixtures.new_default_fed().await;
+    let fed_receive = fixtures.new_default_fed().await;
 
     let mut gateway_test = gateway(&fixtures, &fed_send).await;
     let gateway_api = gateway_test.gateway.versioned_api.clone();

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -49,7 +49,7 @@ struct BackupTestMetadata {
 #[tokio::test(flavor = "multi_thread")]
 async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let (client1, client2) = fed.two_clients().await;
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
     let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
@@ -88,7 +88,7 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
 #[ignore] // TODO: flaky https://github.com/fedimint/fedimint/issues/4508
 async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let client1 = fed.new_client_rocksdb().await;
     let client2 = fed.new_client_rocksdb().await;
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
@@ -177,7 +177,7 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn backup_encode_decode_roundtrip() -> anyhow::Result<()> {
     // Print notes for client
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let client = fed.new_client().await;
     let client_dummy_module = client.get_first_module::<DummyClientModule>();
     let (op, outpoint) = client_dummy_module.print_money(sats(1000)).await?;
@@ -205,7 +205,7 @@ async fn backup_encode_decode_roundtrip() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn ecash_backup_can_recover_metadata() -> anyhow::Result<()> {
     // Print notes for client
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let client = fed.new_client().await;
     let client_dummy_module = client.get_first_module::<DummyClientModule>();
     let (op, outpoint) = client_dummy_module.print_money(sats(1000)).await?;
@@ -228,7 +228,7 @@ async fn ecash_backup_can_recover_metadata() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let client = fed.new_client().await;
     let dummy_module = client.get_first_module::<DummyClientModule>();
     let (op, outpoint) = dummy_module.print_money(sats(1000)).await?;
@@ -265,7 +265,7 @@ async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let (client1, _client2) = fed.two_clients().await;
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
     let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
@@ -286,7 +286,7 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn error_zero_value_oob_receive() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_fed().await;
+    let fed = fixtures().new_default_fed().await;
     let (client1, _client2) = fed.two_clients().await;
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>();
     let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -113,7 +113,7 @@ async fn await_consensus_to_catch_up(
 #[tokio::test(flavor = "multi_thread")]
 async fn sanity_check_bitcoin_blocks() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     // Avoid other tests from interfering here
@@ -157,7 +157,7 @@ async fn sanity_check_bitcoin_blocks() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
@@ -217,7 +217,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_out_fail_refund() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
@@ -266,7 +266,7 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_outs_support_rbf() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     // Need lock to keep tx in mempool from getting mined
@@ -347,7 +347,7 @@ async fn peg_outs_support_rbf() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_fed().await;
+    let fed = fixtures.new_default_fed().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     // This test has many assumptions about bitcoin L1 blocks


### PR DESCRIPTION
Adds `FederationTestBuilder` which allows us to customize how we build federations in our tests.
