### PR TITLE
chore: no need to cache `.cargo` anymore

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -44,13 +44,6 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 
-      # caching ~/.cargo to avoid downloading all (especially git) deps
-      - name: Cache ~/.cargo
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-
       - name: Backwards-compatibility tests
         run: |
           # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)


### PR DESCRIPTION
Workers will cache it around, and downloading from github is kind of slow anyway.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
