### PR TITLE
 chore: test-ci-all can run more, otherwise it takes forever 

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -269,7 +269,6 @@ parallel_args+=(
   --joblog "$joblog"
   --noswap
   --memfree 2G
-  --nice 15
 )
 
 >&2 echo "## Starting all tests in parallel..."

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -245,8 +245,7 @@ if [ -n "${FM_TEST_CI_ALL_JOBS:-}" ]; then
   # when specifically set, use the env var
   parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS}")
 elif [ -n "${CI:-}" ] || [ "${CARGO_PROFILE:-}" == "ci" ]; then
-  # in CI, we know number of cpus works OK
-  parallel_args+=(--jobs 4)
+  parallel_args+=(--jobs $(($(nproc) / 4 + 1)))
 else
   # on dev computers default to `num_cpus / 4 + 1` max parallel jobs
   parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS:-$(($(nproc) / 4 + 1))}")


### PR DESCRIPTION
The load average limit there already protect from too much load on this particular workflow.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
