### PR TITLE
fix(ci): use `--start-load`, not `--load`

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -254,7 +254,7 @@ fi
 
 parallel_args+=(--timeout "${FM_TEST_CI_ALL_TIMEOUT:-600}")
 
-parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-1000}")
+parallel_args+=(--start-load "${FM_TEST_CI_ALL_MAX_LOAD:-1000}")
 # --delay to let nix start extracting and bump the load
 parallel_args+=(--delay "${FM_TEST_CI_ALL_DELAY:-$((64 / $(nproc) + 1))}")
 


### PR DESCRIPTION
`--load` means `--start-load` + `--run-load`, and `--run-load` actually slows down tests if the load of the system is too high, which is exactly what we want to avoid!

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
