### PR TITLE
chore(ci): fix `--load` on `parallel` it doesn't mean percents

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -254,7 +254,7 @@ fi
 
 parallel_args+=(--timeout "${FM_TEST_CI_ALL_TIMEOUT:-600}")
 
-parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-1000}")
+parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-$(($(nproc) / 4 + 1))}")
 # --delay to let nix start extracting and bump the load
 parallel_args+=(--delay "${FM_TEST_CI_ALL_DELAY:-$((64 / $(nproc) + 1))}")
 

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -50,7 +50,7 @@ if [ -z "${CI:-}" ] && [[ -t 1 ]] && [ -z "${FM_TEST_CI_ALL_DISABLE_ETA:-}" ]; t
   parallel_args+=(--eta)
 fi
 parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS:-$(($(nproc) / 4 + 1))}")
-parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-1000}")
+parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-$(($(nproc) / 4 + 1))}")
 parallel_args+=(--delay "${FM_TEST_CI_ALL_DELAY:-$((64 / $(nproc) + 1))}")
 parallel_args+=(
   --halt-on-error 1


### PR DESCRIPTION
> Do not start new jobs on a given computer unless the number of running processes on the computer is less than max-load. max-load uses the same syntax as --jobs, so 100% for one per CPU is a valid setting. Only difference is 0 which is interpreted as 0.01.

https://www.gnu.org/software/parallel/parallel.html#synopsis

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
