### PR TITLE
chore: pass ClientHandleArc to handle_cli_command

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -645,7 +645,7 @@ pub async fn handle_command(
                 client
                     .get_module_client_dyn(module_instance_id)
                     .context("Module not found")?
-                    .handle_cli_command(&args)
+                    .handle_cli_command(&args, client.clone())
                     .await
             }
             None => {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -30,7 +30,7 @@ use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
-use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
+use fedimint_client::{sm_enum_variant_translation, ClientHandleArc, DynGlobalClientContext};
 use fedimint_core::bitcoin_migration::{
     bitcoin30_to_bitcoin29_keypair, bitcoin30_to_bitcoin29_secp256k1_public_key,
 };
@@ -424,6 +424,7 @@ impl ClientModule for LightningClientModule {
     async fn handle_cli_command(
         &self,
         args: &[std::ffi::OsString],
+        _client: ClientHandleArc,
     ) -> anyhow::Result<serde_json::Value> {
         cli::handle_cli_command(self, args).await
     }

--- a/modules/fedimint-meta-client/src/lib.rs
+++ b/modules/fedimint-meta-client/src/lib.rs
@@ -15,6 +15,7 @@ use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client::module::recovery::NoModuleBackup;
 use fedimint_client::module::{ClientModule, IClientModule};
 use fedimint_client::sm::Context;
+use fedimint_client::ClientHandleArc;
 use fedimint_core::core::Decoder;
 use fedimint_core::db::{DatabaseTransaction, DatabaseVersion};
 use fedimint_core::module::{ApiAuth, ApiVersion, ModuleCommon, ModuleInit, MultiApiVersion};
@@ -128,6 +129,7 @@ impl ClientModule for MetaClientModule {
     async fn handle_cli_command(
         &self,
         args: &[std::ffi::OsString],
+        _client: ClientHandleArc,
     ) -> anyhow::Result<serde_json::Value> {
         cli::handle_cli_command(self, args).await
     }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -32,7 +32,7 @@ use fedimint_client::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
 use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
-use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
+use fedimint_client::{sm_enum_variant_translation, ClientHandleArc, DynGlobalClientContext};
 use fedimint_core::bitcoin_migration::bitcoin30_to_bitcoin29_keypair;
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
@@ -577,6 +577,7 @@ impl ClientModule for MintClientModule {
     async fn handle_cli_command(
         &self,
         args: &[ffi::OsString],
+        _client: ClientHandleArc,
     ) -> anyhow::Result<serde_json::Value> {
         if args.is_empty() {
             return Err(anyhow::format_err!(


### PR DESCRIPTION
When developing ROASTR I found myself needing to execute commands against other modules (for example: to get the Bitcoin network of the wallet module). There might be a more elegant way to do this, but one easy way to accomplish this is to pass `ClientHandlArc` into `handle_cli_command` so that the cli inside other modules can execute functions from other modules.
