### PR TITLE
chore(ci): `--keep-failed` won't work on self-hosted setup

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -167,36 +167,16 @@ jobs:
       - name: Tests
         if: (github.event_name != 'pull_request' || matrix.build-in-pr) && matrix.run-tests
         run: |
-          nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --option keep-failed true --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).wasm32-unknown.ci.ciTestAll
+          nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).wasm32-unknown.ci.ciTestAll
 
       - name: Tests (5 times more)
         if: github.event_name == 'merge_group' && matrix.run-tests
         run: |
-          nix build -L .#wasm32-unknown.ci.ciTestAll5Times --keep-failed
+          nix build -L .#wasm32-unknown.ci.ciTestAll5Times
 
       - name: Wasm Tests
         if: (github.event_name != 'pull_request' || matrix.build-in-pr) && matrix.run-tests && (matrix.host != 'macos')
-        run: nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --option keep-failed true --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).wasm32-unknown.ci.wasmTest
-
-      - name: Prepare failed test build dirs
-        if: always()
-        run:  |
-          set -x
-          # delete source and target artifacts as it is huge and rather useless now
-          rm -Rf /tmp/nix-build-*/source || true
-          # chown so actions/upload-artifact can access it
-          chown -R $USER /tmp/nix-build-* || true
-          # delete unix sockets, as actions/upload-artifact can't handle them
-          find /tmp/nix-build-* -type s -print0 | xargs -0 rm || true
-
-      - name: Upload failed test build dirs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: "fedimint-failed-test-logs-${{ github.run_number }}-${{ matrix.host}}"
-          path: |
-            /tmp/nix-build-*/
-            !/tmp/nix-build-*/source/
+        run: nix run "github:Mic92/nix-fast-build?rev=4376b8a33b217ee2f78ba3dcff01a3e464d13a46" -- --skip-cached --no-nom --flake .#legacyPackages.$(nix eval --raw --impure --expr builtins.currentSystem).wasm32-unknown.ci.wasmTest
 
   audit:
     if: github.repository == 'fedimint/fedimint'

--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -77,15 +77,15 @@ jobs:
         run: |
           set -euo pipefail
           # first one might do nothing
-          nix build -L .#wasm32-unknown.ci.ciTestAll --keep-failed
+          nix build -L .#wasm32-unknown.ci.ciTestAll
           # but this one will run
-          nix build -L .#wasm32-unknown.ci.ciTestAll --rebuild --keep-failed
+          nix build -L .#wasm32-unknown.ci.ciTestAll --rebuild
 
       - name: Wasm Tests
         run: |
           set -euo pipefail
-          nix build -L .#wasm32-unknown.ci.wasmTest --keep-failed
-          nix build -L .#wasm32-unknown.ci.wasmTest --rebuild --keep-failed
+          nix build -L .#wasm32-unknown.ci.wasmTest
+          nix build -L .#wasm32-unknown.ci.wasmTest --rebuild
 
       - name: Prepare failed test build dirs
         if: always()


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
