### PR TITLE
chore: lower scheduling prio of most heavy compilation items

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -162,7 +162,38 @@ let
       time
     ] ++ builtins.attrValues {
       inherit (pkgs) cargo-nextest;
-    };
+    } ++ [
+      # add a command that can be used to lower both CPU and IO priority
+      # of a command to help make it more friendly to other things
+      # potentially sharing the CI or dev machine
+      (if pkgs.stdenv.isLinux then [
+        pkgs.util-linux
+
+        (pkgs.writeShellScriptBin "runLowPrio" ''
+          set -euo pipefail
+
+          cmd=()
+          if ${pkgs.which}/bin/which chrt 1>/dev/null 2>/dev/null ; then
+            cmd+=(chrt -i 0)
+          fi
+          if ${pkgs.which}/bin/which ionice 1>/dev/null 2>/dev/null ; then
+            cmd+=(ionice -c 3)
+          fi
+
+          >&2 echo "Lowering IO priority with ''${cmd[@]}"
+          exec "''${cmd[@]}" "$@"
+        ''
+        )
+      ] else [
+
+        (pkgs.writeShellScriptBin "runLowPrio" ''
+          exec "$@"
+        ''
+        )
+      ])
+    ]
+
+    ;
 
     # we carefully optimize our debug symbols on cargo level,
     # and in case of errors and panics, would like to see the
@@ -188,6 +219,7 @@ let
       pkgs.lib.optionalAttrs (!(builtins.elem (craneLib.toolchainName or null) [ null "default" "stable" "nightly" ])) commonEnvsShellRocksdbLinkCross
     );
 
+
   craneLibTests = craneLib.overrideArgs (commonEnvsBuild // commonCliTestArgs // {
     src = filterWorkspaceTestFiles commonSrc;
     # there's no point saving the `./target/` dir
@@ -211,27 +243,28 @@ rec {
   commonArgsBase = commonArgs;
 
   workspaceDeps = craneLib.buildWorkspaceDepsOnly {
-    buildPhaseCargoCommand = "cargoWithProfile doc --locked ; cargoWithProfile check --all-targets --locked ; cargoWithProfile build --locked --all-targets";
+    buildPhaseCargoCommand = "runLowPrio cargo doc --profile $CARGO_PROFILE --locked ; runLowPrio cargo check --profile $CARGO_PROFILE --all-targets --locked ; runLowPrio cargo build --profile $CARGO_PROFILE --locked --all-targets";
   };
 
   # like `workspaceDeps` but don't run `cargo doc`
   workspaceDepsNoDocs = craneLib.buildWorkspaceDepsOnly {
-    buildPhaseCargoCommand = "cargoWithProfile check --all-targets --locked ; cargoWithProfile build --locked --all-targets";
+    buildPhaseCargoCommand = "runLowPrio cargo check --profile $CARGO_PROFILE --all-targets --locked ; runLowPrio cargo build --profile $CARGO_PROFILE --locked --all-targets";
   };
+
   workspaceBuild = craneLib.buildWorkspace {
     cargoArtifacts = workspaceDeps;
-    buildPhaseCargoCommand = "cargoWithProfile doc --locked ; cargoWithProfile check --all-targets --locked ; cargoWithProfile build --locked --all-targets";
+    buildPhaseCargoCommand = "runLowPrio cargo doc --profile $CARGO_PROFILE --locked ; runLowPrio cargo check --profile $CARGO_PROFILE --all-targets --locked ; runLowPrio cargo build --profile $CARGO_PROFILE --locked --all-targets";
   };
 
   workspaceDepsWasmTest = craneLib.buildWorkspaceDepsOnly {
     pname = "${commonArgs.pname}-wasm-test";
-    buildPhaseCargoCommand = "cargoWithProfile build --locked --tests -p fedimint-wasm-tests";
+    buildPhaseCargoCommand = "runLowPrio cargo build --profile $CARGO_PROFILE --locked --tests -p fedimint-wasm-tests";
   };
 
   workspaceBuildWasmTest = craneLib.buildWorkspace {
     pnameSuffix = "-workspace-wasm-test";
     cargoArtifacts = workspaceDepsWasmTest;
-    buildPhaseCargoCommand = "cargoWithProfile build --locked --tests -p fedimint-wasm-tests";
+    buildPhaseCargoCommand = "runLowPrio cargo build --profile $CARGO_PROFILE --locked --tests -p fedimint-wasm-tests";
   };
 
   workspaceTest = craneLib.cargoNextest {
@@ -314,7 +347,7 @@ rec {
   # Build only deps, but with llvm-cov so `workspaceCov` can reuse them cached
   workspaceDepsCov = craneLib.buildDepsOnly {
     pname = "fedimint-workspace-lcov";
-    buildPhaseCargoCommand = "source <(cargo llvm-cov show-env --export-prefix); cargo build --locked --workspace --all-targets --profile $CARGO_PROFILE";
+    buildPhaseCargoCommand = "source <(cargo llvm-cov show-env --export-prefix); runLowPrio cargo build --locked --workspace --all-targets --profile $CARGO_PROFILE";
     cargoBuildCommand = "dontuse";
     cargoCheckCommand = "dontuse";
     nativeBuildInputs = [ pkgs.cargo-llvm-cov ];
@@ -324,7 +357,7 @@ rec {
   workspaceCov = craneLib.buildWorkspace {
     pname = "fedimint-workspace-lcov";
     cargoArtifacts = workspaceDepsCov;
-    buildPhaseCargoCommand = "source <(cargo llvm-cov show-env --export-prefix); cargo build --locked --workspace --all-targets --profile $CARGO_PROFILE;";
+    buildPhaseCargoCommand = "source <(cargo llvm-cov show-env --export-prefix); runLowPrio cargo build --locked --workspace --all-targets --profile $CARGO_PROFILE;";
     nativeBuildInputs = [ pkgs.cargo-llvm-cov ];
     doCheck = false;
   };

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -23,10 +23,10 @@ fi
 # Avoid re-building workspace in parallel in all test derivations
 # Note: Respect 'CARGO_PROFILE' that crane uses
 >&2 echo "Pre-building workspace..."
-cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --workspace --all-targets
+runLowPrio cargo build ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --workspace --all-targets
 # Avoid re-building tests in parallel in all test derivations
 >&2 echo "Pre-building tests..."
-cargo nextest run --no-run ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --workspace --all-targets
+runLowPrio cargo nextest run --no-run ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} --workspace --all-targets
 
 # We've just built everything there is to built, so we should not have a
 # need to be build things again from now on, but since cargo does not


### PR DESCRIPTION
On Linux `chrt` and `iotop` can be used to set the scheduling priority for a process.

We can use it to tactically make all heavy compilation processes have "idle" priority which means they will only execute if nothing else is trying to. AFAIK, this is a global setting and should be respected between cgroups etc.

Since we can now schedule more jobs on a single CI box, such change makes it less likely for time sensitive tasks (tests) to miss some deadline, while still utilizing resources when possible.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
