### PR TITLE
fix(wallet-client): ignores rpc env var settings

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -255,13 +255,7 @@ impl Context for WalletClientContext {}
 impl WalletClientModule {
     fn get_rpc_config(cfg: &WalletClientConfig) -> BitcoinRpcConfig {
         if let Ok(rpc_config) = BitcoinRpcConfig::get_defaults_from_env_vars() {
-            // TODO: Wallet client cannot support bitcoind RPC until the bitcoin dep is
-            // updated to 0.30
-            if rpc_config.kind != "bitcoind" {
-                rpc_config
-            } else {
-                cfg.default_bitcoin_rpc.clone()
-            }
+            rpc_config
         } else {
             cfg.default_bitcoin_rpc.clone()
         }


### PR DESCRIPTION
At least in devimint wallet-client will ignore env vars because it's `bitcoind`, only to switch to defaults from config ... which are also `bitcoind`.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
