### PR TITLE
chore: disable very slow restore latency tests for all versions

### DIFF
--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -140,3 +140,6 @@ pub const FM_GWCLI_LND_ENV: &str = "FM_GWCLI_LND";
 
 /// Make `devimint` print stderr of called commands directly on its own stderr
 pub const FM_DEVIMINT_CMD_INHERIT_STDERR_ENV: &str = "FM_DEVIMINT_CMD_INHERIT_STDERR";
+
+/// Force devimint to run a test with a deprecated configuration
+pub const FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV: &str = "FM_DEVIMINT_RUN_DEPRECATED_TESTS";


### PR DESCRIPTION
We don't care about their latency anymore anyway.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
