### PR TITLE
chore: debug ci flake

### DIFF
--- a/scripts/tests/test-ci-all-backcompat.sh
+++ b/scripts/tests/test-ci-all-backcompat.sh
@@ -3,4 +3,7 @@
 # previous versions did not have unknown module so can't support it,
 # disable devimint enabling it in Federations
 export FM_USE_UNKNOWN_MODULE=0
+
+export RUST_LOG=${RUST_LOG:-debug}
+
 ./scripts/tests/test-ci-all.sh "$@"


### PR DESCRIPTION
When devimint initialization fails in back compat it's hard to say why.

For now we can land this. Since the logs are not printed out if the test succeeded, a lot of logs here should be OK.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
