### PR TITLE
chore: disable flaky test_gateway_configuration test

### DIFF
--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -1170,6 +1170,8 @@ async fn test_cannot_connect_same_federation() -> anyhow::Result<()> {
     Ok(())
 }
 
+// TODO: fix and re-enable https://github.com/fedimint/fedimint/issues/5001
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_configuration() -> anyhow::Result<()> {
     let fixtures = fixtures();


### PR DESCRIPTION
This is the only thing I see consistently flaking in the CI RN.

Re #5001 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
