### PR TITLE
fix(ci): our runner can't use node16

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v1.4.1
+      - uses: rustsec/audit-check@fe0359b3e165e4d83e11ffab7715e56c43cc2d76
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
But so happens that this action was added node20 support few days ago:

https://github.com/rustsec/audit-check/commit/fe0359b3e165e4d83e11ffab7715e56c43cc2d76

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
