### PR TITLE
fix(test-ci-all): compile nix binaries of versions outside of test

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -116,17 +116,26 @@ export -f filter_count
 function nix_build_binary_for_version() {
   binary="$1"
   version="$2"
+  >&2 echo "Compiling ${binary} for version ${version} ..."
   echo "$(nix build 'github:fedimint/fedimint/'"$version"'#'"$binary" --no-link --print-out-paths)/bin/$binary"
 }
 export -f nix_build_binary_for_version
+
+# name of an an env variable to use for a path of a binary compiled by nix for given binary in a given version
+function nix_binary_version_var_name() {
+  binary="$1"
+  version="$2"
+  echo "fm_bin_${binary}_${version}" | tr '-' "_" | tr '.' '_'
+}
+export -f nix_binary_version_var_name
 
 function use_fed_binaries_for_version() {
   version=$1
   if [[ "$version" == "current" ]]; then
     unset FM_FEDIMINTD_BASE_EXECUTABLE
   else
-    >&2 echo "Compiling fed binaries for version $version..."
-    FM_FEDIMINTD_BASE_EXECUTABLE="$(nix_build_binary_for_version 'fedimintd' "$version")"
+    var_name=$(nix_binary_version_var_name fedimintd "$version")
+    FM_FEDIMINTD_BASE_EXECUTABLE="${!var_name}"
     export FM_FEDIMINTD_BASE_EXECUTABLE
   fi
 }
@@ -138,10 +147,12 @@ function use_client_binaries_for_version() {
     unset FM_FEDIMINT_CLI_BASE_EXECUTABLE
     unset FM_GATEWAY_CLI_BASE_EXECUTABLE
   else
-    >&2 echo "Compiling client binaries for version $version..."
-    FM_FEDIMINT_CLI_BASE_EXECUTABLE="$(nix_build_binary_for_version 'fedimint-cli' "$version")"
+    var_name=$(nix_binary_version_var_name fedimint-cli "$version")
+    FM_FEDIMINT_CLI_BASE_EXECUTABLE="${!var_name}"
     export FM_FEDIMINT_CLI_BASE_EXECUTABLE
-    FM_GATEWAY_CLI_BASE_EXECUTABLE="$(nix_build_binary_for_version 'gateway-cli' "$version")"
+
+    var_name=$(nix_binary_version_var_name gateway-cli "$version")
+    FM_GATEWAY_CLI_BASE_EXECUTABLE="${!var_name}"
     export FM_GATEWAY_CLI_BASE_EXECUTABLE
   fi
 }
@@ -152,8 +163,8 @@ function use_gateway_binaries_for_version() {
   if [[ "$version" == "current" ]]; then
     unset FM_GATEWAYD_BASE_EXECUTABLE
   else
-    >&2 echo "Compiling gateway binaries for version $version..."
-    FM_GATEWAYD_BASE_EXECUTABLE="$(nix_build_binary_for_version 'gatewayd' "$version")"
+    var_name=$(nix_binary_version_var_name gatewayd "$version")
+    FM_GATEWAYD_BASE_EXECUTABLE="${!var_name}"
     export FM_GATEWAYD_BASE_EXECUTABLE
   fi
 }

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -182,7 +182,16 @@ if [[ "$num_versions" == "0" ]]; then
 else
   # precompile binaries
   binaries=( "fedimintd" "fedimint-cli" "gateway-cli" "gatewayd" )
-  parallel nix_build_binary_for_version "{1}" "{2}" ::: "${binaries[@]}" ::: "${tagged_versions[@]}"
+  for version in "${versions[@]}" ; do
+    if [ "$version" == "current" ] ; then
+      continue
+    fi
+    for binary in "${binaries[@]}" ; do
+      var_name=$(nix_binary_version_var_name "$binary" "$version")
+      export "${var_name}=$(nix_build_binary_for_version "$binary" "$version")"
+    done
+  done
+
   if [ -n "${FM_FULL_VERSION_MATRIX:-}" ]; then
     mapfile -t version_matrix < <(generate_full_matrix "${versions[@]}")
   else


### PR DESCRIPTION
`nix build` can potentially hang for a long time, even if the binary was previous built, e.g. because Nix daemon is busy with other stuff and its database is locked.

This could previous potentially cause the test to spend a large part of it's time trying to build binaries.

Instead, prebuild all binaries once before `parallel` is started, and store the resulting path into matching env variable. During tests just take the path out of variable.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
