### PR TITLE
fix(client): current_consensus strategy should require threshold not all

### DIFF
--- a/fedimint-api-client/src/api.rs
+++ b/fedimint-api-client/src/api.rs
@@ -466,7 +466,7 @@ pub trait FederationApiExt: IRawFederationApi {
         Ret: serde::de::DeserializeOwned + Eq + Debug + Clone + MaybeSend,
     {
         self.request_with_strategy(
-            ThresholdConsensus::new(self.all_peers().total()),
+            ThresholdConsensus::new(self.all_peers().threshold()),
             method,
             params,
         )


### PR DESCRIPTION
Or am i just confused?

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
