### PR TITLE
fix(ln-gateway): don't hang on `info` if there's no channels

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -715,8 +715,8 @@ impl Gateway {
                 .expect("Gateway configuration should be set");
             let mut federations = Vec::new();
             let federation_clients = self.clients.read().await.clone().into_iter();
-            let route_hints = Self::fetch_lightning_route_hints(
-                lightning_context.lnrpc.clone(),
+            let route_hints = Self::fetch_lightning_route_hints_try(
+                lightning_context.lnrpc.as_ref(),
                 gateway_config.num_route_hints,
             )
             .await?;


### PR DESCRIPTION
`info` is used in `devimint` to check if the gateway is ready to respond to API calls, at which point there's absolutely no chance the channel was created yet.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
