### PR TITLE
chore(devimint): fix most of flakiness in setting up LN gateways

### DIFF
--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -172,9 +172,7 @@ impl DevJitFed {
             move || async move {
                 let bitcoind = bitcoind.get_try().await?.deref().clone();
                 let lnd = lnd.get_try().await?.deref().clone();
-                let gw_lnd = gw_lnd.get_try().await?.deref().clone();
                 let cln = cln.get_try().await?.deref().clone();
-                let gw_cln = gw_cln.get_try().await?.deref().clone();
                 // Note: We open new channel even if starting from existing state
                 // as ports change on every start, and without this nodes will not find each
                 // other.

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -689,10 +689,17 @@ pub async fn open_channel_between_gateways(
 ) -> Result<()> {
     let gateway_cli_version = crate::util::GatewayCli::version_or_default().await;
     let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    if gateway_cli_version < *VERSION_0_4_0_ALPHA || gatewayd_version < *VERSION_0_4_0_ALPHA {
+    #[allow(clippy::overly_complex_bool_expr)]
+    if gateway_cli_version < *VERSION_0_4_0_ALPHA || gatewayd_version < *VERSION_0_4_0_ALPHA
+        // FIXME: The new way is actually slower and require more things to initialize, and
+        // due to more dependency chains lead to flaky CI pipeline
+        || true
+    {
+        debug!(target: LOG_DEVIMINT, "Opening channel between gateways (the old way)");
         return open_channel(process_mgr, bitcoind, cln, lnd).await;
     }
 
+    debug!(target: LOG_DEVIMINT, "Opening channel between gateways (the new way)");
     lnd.client
         .lock()
         .await

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1717,7 +1717,9 @@ pub async fn gw_reboot_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
             if reboot_info.gateway_state == "Running" {
                 info!(target: LOG_DEVIMINT, "CLN Gateway restarted, with auto-rejoin to federation");
                 // Assert that the gateway info is the same as before the reboot
-                assert_eq!(cln_info, reboot_info);
+                if cln_info != reboot_info {
+                    return Err(ControlFlow::Continue(anyhow!("cln_info != reboot_info")));
+                }
                 return Ok(());
             }
             Err(ControlFlow::Continue(anyhow!("gateway not running")))

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1670,9 +1670,7 @@ pub async fn gw_reboot_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
     fed.pegin_client(10_000, &client).await?;
 
     // Query current gateway infos
-    let mut cln_cmd = cmd!(gw_cln, "info");
-    let mut lnd_cmd = cmd!(gw_lnd, "info");
-    let (cln_value, lnd_value) = try_join!(cln_cmd.out_json(), lnd_cmd.out_json())?;
+    let (cln_value, lnd_value) = try_join!(gw_cln.get_info(), gw_lnd.get_info())?;
 
     // Drop references to cln and lnd gateways so the test can kill them
     let cln_gateway_id = gw_cln.gateway_id().await?;

--- a/fedimint-api-client/src/api.rs
+++ b/fedimint-api-client/src/api.rs
@@ -1181,7 +1181,7 @@ impl FederationPeerClientShared {
     /// Wait (if needed) + update reconnection stats
     async fn wait_and_inc_reconnect(&mut self) {
         self.wait().await;
-        self.connection_attempts += 1;
+        self.connection_attempts = self.connection_attempts.saturating_add(1);
         self.last_connection_attempt = now()
     }
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1812,7 +1812,7 @@ pub enum GatewayError {
     ClientStateMachineError(#[from] anyhow::Error),
     #[error("Failed to open the database: {}", OptStacktrace(.0))]
     DatabaseError(anyhow::Error),
-    #[error("Federation client error")]
+    #[error("Lightning rpc error: {}", .0)]
     LightningRpcError(#[from] LightningRpcError),
     #[error("Outgoing Payment Error {}", OptStacktrace(.0))]
     OutgoingPaymentError(#[from] Box<OutgoingPaymentError>),

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -713,8 +713,8 @@ impl Gateway {
                 .expect("Gateway configuration should be set");
             let mut federations = Vec::new();
             let federation_clients = self.clients.read().await.clone().into_iter();
-            let route_hints = Self::fetch_lightning_route_hints(
-                lightning_context.lnrpc.clone(),
+            let route_hints = Self::fetch_lightning_route_hints_try(
+                lightning_context.lnrpc.as_ref(),
                 gateway_config.num_route_hints,
             )
             .await?;

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -262,7 +262,8 @@ parallel_args+=(--timeout "${FM_TEST_CI_ALL_TIMEOUT:-600}")
 
 parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-$(($(nproc) / 4 + 1))}")
 # --delay to let nix start extracting and bump the load
-parallel_args+=(--delay "${FM_TEST_CI_ALL_DELAY:-$((64 / $(nproc) + 1))}")
+# usually not needed, as '--jobs' will keep a cap on the load anyway
+parallel_args+=(--delay "${FM_TEST_CI_ALL_DELAY:-0}")
 
 tmpdir=$(mktemp --tmpdir -d XXXXX)
 trap 'rm -r $tmpdir' EXIT

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -252,15 +252,15 @@ if [ -n "${FM_TEST_CI_ALL_JOBS:-}" ]; then
   # when specifically set, use the env var
   parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS}")
 elif [ -n "${CI:-}" ] || [ "${CARGO_PROFILE:-}" == "ci" ]; then
-  parallel_args+=(--jobs $(($(nproc) / 4 + 1)))
+  parallel_args+=(--jobs $(($(nproc) / 3 + 1)))
 else
-  # on dev computers default to `num_cpus / 4 + 1` max parallel jobs
-  parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS:-$(($(nproc) / 4 + 1))}")
+  # on dev computers default to `num_cpus / 3 + 1` max parallel jobs
+  parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS:-$(($(nproc) / 3 + 1))}")
 fi
 
 parallel_args+=(--timeout "${FM_TEST_CI_ALL_TIMEOUT:-600}")
 
-parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-$(($(nproc) / 4 + 1))}")
+parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-$(($(nproc) / 3 + 1))}")
 # --delay to let nix start extracting and bump the load
 # usually not needed, as '--jobs' will keep a cap on the load anyway
 parallel_args+=(--delay "${FM_TEST_CI_ALL_DELAY:-0}")

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -176,7 +176,7 @@ export -f always_success_test
 
 tagged_versions=("$@")
 num_versions="$#"
-versions=( "current" "${tagged_versions[@]}" )
+versions=( "${tagged_versions[@]}" "current" )
 if [[ "$num_versions" == "0" ]]; then
   mapfile -t version_matrix < <(generate_current_only_matrix "${versions[@]}")
 else
@@ -243,7 +243,6 @@ done
 parsed_test_commands=$(printf "%s\n" "${tests_with_versions[@]}")
 
 parallel_args=()
-export parallel_jobs='1'
 
 if [ -z "${CI:-}" ] && [[ -t 1 ]] && [ -z "${FM_TEST_CI_ALL_DISABLE_ETA:-}" ]; then
   parallel_args+=(--eta)


### PR DESCRIPTION
There's a complicated web of initialization dependencies in areas of LN that leads to flakes.

Most importantly `devimint` expects `gateway-cli info` to tell if gatewayd started. This doesn't currently work well, because it will hang for 60s or until gateway gets a channel opened. But then in a "new way" of opening channel doing so can't happen until gateway is ready to respond to API calls.

And then 60s of timeout is as much as other steps in `devimint` are actually polling some stuff. Some then sometimes it works, sometimes it doesn't.

Then `fedimint-cli connect-fed` also has the same behavior of waiting for a route hint from the channel. I don't change that, because it would probably spook many places in the tests that expect the hint to be there.

But generally currently it's all messed up to the point where it's hard to keep track of write a reliable code that would setup up devimint with gateways.


#4875 needs to get fixed, it's a significant architectural issue.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
