### PR TITLE
chore(deps): bump esplora-client from 0.5.0 to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9997f8650dd818369931b5672a18dbef95324d0513aa99aae758de8ce86e5b"
+
+[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,11 +1276,12 @@ dependencies = [
 
 [[package]]
 name = "esplora-client"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e11244e7fd8b0beee0a3c62137c4bd9f756fe2c492ccf93171f81467b59200"
+checksum = "0cb1f7f2489cce83bc3bd92784f9ba5271eeb6e729b975895fc541f78cbfcdca"
 dependencies = [
- "bitcoin 0.29.2",
+ "bitcoin 0.30.2",
+ "bitcoin-internals",
  "log",
  "reqwest 0.11.26",
  "serde",

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = { workspace = true }
 bitcoin = "0.29.2"
 bitcoincore-rpc = { version = "0.16.0", optional = true }
 electrum-client = { version = "0.18.0", optional = true }
-esplora-client = { version = "0.5.0", default-features = false, features = ["async", "async-https-rustls"], optional = true }
+esplora-client = { version = "0.6.0", default-features = false, features = ["async", "async-https-rustls"], optional = true }
 hex = "0.4.3"
 lazy_static = "1.4.0"
 fedimint-core  = { version = "=0.4.0-alpha", path = "../fedimint-core" }


### PR DESCRIPTION
Part of #2356 and #4561