### PR TITLE
feat: LNv2 Description Hashes and CLN Create Invoice

### DIFF
--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -114,7 +114,7 @@ message InterceptHtlcRequest {
 
   // The short channel id of the HTLC.
   // Use this value to confirm relevance of the intercepted HTLC
-  uint64 short_channel_id = 10;
+  optional uint64 short_channel_id = 10;
 
   // The id of the incoming channel
   uint64 incoming_chan_id = 12;
@@ -199,13 +199,21 @@ message GetRouteHintsResponse {
 }
 
 message CreateInvoiceRequest {
+  // The payment hash of the invoice being created.
   bytes payment_hash = 1;
 
+  // The amount in millisatoshis of the invoice.
   uint64 amount_msat = 2;
 
+  // The time in seconds this invoice is valid for.
   uint32 expiry = 3;
 
-  string description = 4;
+  // A description or a description hash must be provided.
+  oneof description {
+    string direct = 4;
+
+    bytes hash = 5;
+  }
 }
 
 message CreateInvoiceResponse {

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -888,18 +888,18 @@ impl ClnHtlcInterceptor {
                     tokio::time::timeout(MAX_HTLC_PROCESSING_DURATION, async {
                         receiver.await.unwrap_or_else(|e| {
                             error!("Failed to receive outcome of intercepted htlc: {e:?}");
-                            htlc_processing_failure()
+                            serde_json::json!({ "result": "continue" })
                         })
                     })
                     .await
                     .unwrap_or_else(|e| {
                         error!("await_htlc_processing error {e:?}");
-                        htlc_processing_failure()
+                        serde_json::json!({ "result": "continue" })
                     })
                 }
                 Err(e) => {
                     error!("Failed to send htlc to subscription: {e:?}");
-                    htlc_processing_failure()
+                    serde_json::json!({ "result": "continue" })
                 }
             };
 

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -704,7 +704,7 @@ impl State for GatewayClientStateMachines {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Htlc {
     /// The HTLC payment hash.
     pub payment_hash: sha256::Hash,
@@ -715,7 +715,7 @@ pub struct Htlc {
     /// The incoming HTLC expiry
     pub incoming_expiry: u32,
     /// The short channel id of the HTLC.
-    pub short_channel_id: u64,
+    pub short_channel_id: Option<u64>,
     /// The id of the incoming channel
     pub incoming_chan_id: u64,
     /// The index of the incoming htlc in the incoming channel

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -652,7 +652,7 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
             incoming_amount_msat: Amount::from_msats(invoice.amount_milli_satoshis().unwrap()),
             outgoing_amount_msat: Amount::from_msats(invoice.amount_milli_satoshis().unwrap()),
             incoming_expiry: u32::MAX,
-            short_channel_id: 1,
+            short_channel_id: Some(1),
             incoming_chan_id: 2,
             htlc_id: 1,
         };
@@ -697,7 +697,7 @@ async fn test_gateway_client_intercept_offer_does_not_exist() -> anyhow::Result<
             incoming_amount_msat: Amount::from_msats(100),
             outgoing_amount_msat: Amount::from_msats(100),
             incoming_expiry: u32::MAX,
-            short_channel_id: 1,
+            short_channel_id: Some(1),
             incoming_chan_id: 2,
             htlc_id: 1,
         };
@@ -743,7 +743,7 @@ async fn test_gateway_client_intercept_htlc_no_funds() -> anyhow::Result<()> {
             incoming_amount_msat: Amount::from_msats(invoice.amount_milli_satoshis().unwrap()),
             outgoing_amount_msat: Amount::from_msats(invoice.amount_milli_satoshis().unwrap()),
             incoming_expiry: u32::MAX,
-            short_channel_id: 1,
+            short_channel_id: Some(1),
             incoming_chan_id: 2,
             htlc_id: 1,
         };
@@ -839,7 +839,7 @@ async fn test_gateway_client_intercept_htlc_invalid_offer() -> anyhow::Result<()
                 incoming_amount_msat: Amount::from_msats(invoice.amount_milli_satoshis().unwrap()),
                 outgoing_amount_msat: Amount::from_msats(invoice.amount_milli_satoshis().unwrap()),
                 incoming_expiry: u32::MAX,
-                short_channel_id: 1,
+                short_channel_id: Some(1),
                 incoming_chan_id: 2,
                 htlc_id: 1,
             };

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -120,8 +120,14 @@ pub struct CreateInvoicePayload {
     pub federation_id: FederationId,
     pub contract: IncomingContract,
     pub invoice_amount: Amount,
-    pub description: String,
+    pub description: Bolt11InvoiceDescription,
     pub expiry_time: u32,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+pub enum Bolt11InvoiceDescription {
+    Direct(String),
+    Hash(sha256::Hash),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Decodable, Encodable)]
@@ -520,7 +526,7 @@ impl LightningClientModule {
             gateway_api,
             invoice_amount,
             INVOICE_EXPIRATION_SECONDS_DEFAULT,
-            String::new(),
+            Bolt11InvoiceDescription::Direct(String::new()),
             PaymentFee::one_percent(),
         )
         .await
@@ -531,7 +537,7 @@ impl LightningClientModule {
         gateway_api: SafeUrl,
         invoice_amount: Amount,
         expiry_time: u32,
-        description: String,
+        description: Bolt11InvoiceDescription,
         payment_fee_limit: PaymentFee,
     ) -> Result<(Bolt11Invoice, OperationId), FetchInvoiceError> {
         let (contract, .., invoice) = self
@@ -564,7 +570,7 @@ impl LightningClientModule {
             gateway_api,
             invoice_amount,
             INVOICE_EXPIRATION_SECONDS_DEFAULT,
-            String::new(),
+            Bolt11InvoiceDescription::Direct(String::new()),
             PaymentFee::one_percent(),
         )
         .await
@@ -576,7 +582,7 @@ impl LightningClientModule {
         gateway_api: SafeUrl,
         invoice_amount: Amount,
         expiry_time: u32,
-        description: String,
+        description: Bolt11InvoiceDescription,
         payment_fee_limit: PaymentFee,
     ) -> Result<(IncomingContract, [u8; 32], Bolt11Invoice), FetchInvoiceError> {
         let (ephemeral_tweak, ephemeral_pk) = generate_ephemeral_tweak(recipient_static_pk);


### PR DESCRIPTION
- Adds the ability to set a description or description hash for `create_invoice` which is used in LNv2
- Implements `create_invoice` for CLN

This PR is unfortunately difficult to test. That is because `create_invoice` is only used for LNv2 currently add there aren't currently tests that exercise paying into a Fedimint from an external Lightning node. Adding support for generating the invoice for LNv1 is a longer discussion, since we would need to figure out what backwards compatibility support we want (IMO we might want to do this in the future depending on when LNv2 ships). Adding testing support for paying fedimints from an external wallet using LNv2 requires adding CLI commands, which is out of scope for this PR.

Since this only affect LNv2 currently, I hope we can merge and iterate if any problems are found while we add tests. I think we need to overhaul and refactor a lot of the Lightning tests https://github.com/fedimint/fedimint/issues/5168
