### PR TITLE
chore: split backend test for bitcoind

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -55,7 +55,7 @@ function ensure_in_dev_shell() {
 function make_fm_test_marker() {
   if [ -n "${FM_TEST_NAME:-}" ]; then
     # make it easy to identify which tmp dir belongs to which test
-    touch "${TMP:-/tmp}-$(echo "$FM_TEST_NAME" |tr -cd '[:alnum:]-_')" || true
+    touch "${TMP:-/tmp}/$(echo "$FM_TEST_NAME" |tr -cd '[:alnum:]-_')" || true
   fi
 }
 

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -25,27 +25,36 @@ function run_tests() {
   if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "bitcoind" ]; then
     >&2 echo "### Testing against bitcoind"
 
-    # Note: Ideally `-E` flags can be used together, but that seems to trigger lots of problems
-    cargo nextest run --locked --workspace --all-targets \
-      ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
-      ${TEST_ARGS_THREADED} \
-      -E 'package(fedimint-dummy-tests)'
-    cargo nextest run --locked --workspace --all-targets \
-      ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
-      ${TEST_ARGS_THREADED} \
-      -E 'package(fedimint-mint-tests)'
-    cargo nextest run --locked --workspace --all-targets \
-      ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
-      ${TEST_ARGS_THREADED} \
-      -E 'package(fedimint-wallet-tests)'
-    cargo nextest run --locked --workspace --all-targets \
-      ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
-      ${TEST_ARGS_SERIALIZED} \
-      -E 'package(fedimint-ln-tests)'
-    cargo nextest run --locked --workspace --all-targets \
-      ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
-      ${TEST_ARGS_SERIALIZED} \
-      -E 'package(fedimint-lnv2-tests)'
+    if [ -z "${FM_BITCOIND_TEST_ONLY:-}" ] || [ "${FM_BITCOIND_TEST_ONLY:-}" = "dummy" ]; then
+      cargo nextest run --locked --workspace --all-targets \
+        ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+        ${TEST_ARGS_THREADED} \
+        -E 'package(fedimint-dummy-tests)'
+    fi
+    if [ -z "${FM_BITCOIND_TEST_ONLY:-}" ] || [ "${FM_BITCOIND_TEST_ONLY:-}" = "mint" ]; then
+      cargo nextest run --locked --workspace --all-targets \
+        ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+        ${TEST_ARGS_THREADED} \
+        -E 'package(fedimint-mint-tests)'
+    fi
+    if [ -z "${FM_BITCOIND_TEST_ONLY:-}" ] || [ "${FM_BITCOIND_TEST_ONLY:-}" = "wallet" ]; then
+      cargo nextest run --locked --workspace --all-targets \
+        ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+        ${TEST_ARGS_THREADED} \
+        -E 'package(fedimint-wallet-tests)'
+    fi
+    if [ -z "${FM_BITCOIND_TEST_ONLY:-}" ] || [ "${FM_BITCOIND_TEST_ONLY:-}" = "ln" ]; then
+      cargo nextest run --locked --workspace --all-targets \
+        ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+        ${TEST_ARGS_SERIALIZED} \
+        -E 'package(fedimint-ln-tests)'
+    fi
+    if [ -z "${FM_BITCOIND_TEST_ONLY:-}" ] || [ "${FM_BITCOIND_TEST_ONLY:-}" = "lnv2" ]; then
+      cargo nextest run --locked --workspace --all-targets \
+        ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
+        ${TEST_ARGS_SERIALIZED} \
+        -E 'package(fedimint-lnv2-tests)'
+    fi
     >&2 echo "### Testing against bitcoind - complete"
   fi
 

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -165,13 +165,21 @@ function backend_test_bitcoind_lnv2() {
 }
 export -f backend_test_bitcoind_lnv2
 
-function backend_test_bitcoind_ln_gateway() {
+function backend_test_ln_gateway_client() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind-ln-gateway ./scripts/tests/backend-test.sh
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind-ln-gateway FM_BITCOIND_LN_GATEWAY_TEST_ONLY=gateway-client ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_bitcoind_ln_gateway
+export -f backend_test_ln_gateway_client
+
+function backend_test_ln_gateway_not_client() {
+  # backend tests don't support different versions, so we skip for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind-ln-gateway  FM_BITCOIND_LN_GATEWAY_TEST_ONLY=not-gateway-client ./scripts/tests/backend-test.sh
+  fi
+}
+export -f backend_test_ln_gateway_not_client
 
 function backend_test_electrs() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
@@ -247,7 +255,8 @@ tests_to_run_in_parallel+=(
   "backend_test_bitcoind_wallet"
   "backend_test_bitcoind_ln"
   "backend_test_bitcoind_lnv2"
-  "backend_test_bitcoind_ln_gateway"
+  "backend_test_ln_gateway_client"
+  "backend_test_ln_gateway_not_client"
   "backend_test_electrs"
   "backend_test_esplora"
   "latency_test_reissue"

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -125,77 +125,77 @@ function load_test_tool_test() {
 }
 export -f load_test_tool_test
 
-function backend_test_bitcoind_dummy() {
+function bckn_bitcoind_dummy() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
     fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=dummy ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_bitcoind_dummy
+export -f bckn_bitcoind_dummy
 
-function backend_test_bitcoind_mint() {
+function bckn_bitcoind_mint() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
     fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=mint ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_bitcoind_mint
+export -f bckn_bitcoind_mint
 
-function backend_test_bitcoind_wallet() {
+function bckn_bitcoind_wallet() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
     fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=wallet ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_bitcoind_wallet
+export -f bckn_bitcoind_wallet
 
-function backend_test_bitcoind_ln() {
+function bckn_bitcoind_ln() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
     fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=ln ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_bitcoind_ln
+export -f bckn_bitcoind_ln
 
-function backend_test_bitcoind_lnv2() {
+function bckn_bitcoind_lnv2() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
     fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=lnv2 ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_bitcoind_lnv2
+export -f bckn_bitcoind_lnv2
 
-function backend_test_ln_gateway_client() {
+function bckn_gw_client() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind-ln-gateway FM_BITCOIND_LN_GATEWAY_TEST_ONLY=gateway-client ./scripts/tests/backend-test.sh
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind-ln-gateway FM_BITCOIND_gw_TEST_ONLY=gateway-client ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_ln_gateway_client
+export -f bckn_gw_client
 
-function backend_test_ln_gateway_not_client() {
+function bckn_gw_not_client() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind-ln-gateway  FM_BITCOIND_LN_GATEWAY_TEST_ONLY=not-gateway-client ./scripts/tests/backend-test.sh
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind-ln-gateway  FM_BITCOIND_gw_TEST_ONLY=not-gateway-client ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_ln_gateway_not_client
+export -f bckn_gw_not_client
 
-function backend_test_electrs() {
+function bckn_electrs() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
     fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=electrs ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_electrs
+export -f bckn_electrs
 
-function backend_test_esplora() {
+function bckn_esplora() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
     fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=esplora ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_esplora
+export -f bckn_esplora
 
 function wasm_test() {
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
@@ -250,15 +250,15 @@ tests_to_run_in_parallel+=(
   # running in xarg -P or gnu parallel. Try re-enabling in the future and see if it works.
   # Other than this problem, everything about it is working.
   # "wasm_test"
-  "backend_test_bitcoind_dummy"
-  "backend_test_bitcoind_mint"
-  "backend_test_bitcoind_wallet"
-  "backend_test_bitcoind_ln"
-  "backend_test_bitcoind_lnv2"
-  "backend_test_ln_gateway_client"
-  "backend_test_ln_gateway_not_client"
-  "backend_test_electrs"
-  "backend_test_esplora"
+  "bckn_bitcoind_dummy"
+  "bckn_bitcoind_mint"
+  "bckn_bitcoind_wallet"
+  "bckn_bitcoind_ln"
+  "bckn_bitcoind_lnv2"
+  "bckn_gw_client"
+  "bckn_gw_not_client"
+  "bckn_electrs"
+  "bckn_esplora"
   "latency_test_reissue"
   "latency_test_ln_send"
   "latency_test_ln_receive"

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -125,13 +125,45 @@ function load_test_tool_test() {
 }
 export -f load_test_tool_test
 
-function backend_test_bitcoind() {
+function backend_test_bitcoind_dummy() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
   if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
-    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind ./scripts/tests/backend-test.sh
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=dummy ./scripts/tests/backend-test.sh
   fi
 }
-export -f backend_test_bitcoind
+export -f backend_test_bitcoind_dummy
+
+function backend_test_bitcoind_mint() {
+  # backend tests don't support different versions, so we skip for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=mint ./scripts/tests/backend-test.sh
+  fi
+}
+export -f backend_test_bitcoind_mint
+
+function backend_test_bitcoind_wallet() {
+  # backend tests don't support different versions, so we skip for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=wallet ./scripts/tests/backend-test.sh
+  fi
+}
+export -f backend_test_bitcoind_wallet
+
+function backend_test_bitcoind_ln() {
+  # backend tests don't support different versions, so we skip for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=ln ./scripts/tests/backend-test.sh
+  fi
+}
+export -f backend_test_bitcoind_ln
+
+function backend_test_bitcoind_lnv2() {
+  # backend tests don't support different versions, so we skip for backwards-compatibility tests
+  if [ -z "${FM_BACKWARDS_COMPATIBILITY_TEST:-}" ]; then
+    fm-run-test "${FUNCNAME[0]}" env FM_TEST_ONLY=bitcoind FM_BITCOIND_TEST_ONLY=lnv2 ./scripts/tests/backend-test.sh
+  fi
+}
+export -f backend_test_bitcoind_lnv2
 
 function backend_test_bitcoind_ln_gateway() {
   # backend tests don't support different versions, so we skip for backwards-compatibility tests
@@ -210,7 +242,11 @@ tests_to_run_in_parallel+=(
   # running in xarg -P or gnu parallel. Try re-enabling in the future and see if it works.
   # Other than this problem, everything about it is working.
   # "wasm_test"
-  "backend_test_bitcoind"
+  "backend_test_bitcoind_dummy"
+  "backend_test_bitcoind_mint"
+  "backend_test_bitcoind_wallet"
+  "backend_test_bitcoind_ln"
+  "backend_test_bitcoind_lnv2"
   "backend_test_bitcoind_ln_gateway"
   "backend_test_electrs"
   "backend_test_esplora"


### PR DESCRIPTION
It has a bit long runtime, and each module can just run in parallel to bring it down.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
