### PR TITLE
chore: never wait for fetch_lightning_route_hints

### DIFF
--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -1009,6 +1009,7 @@ async fn test_gateway_cannot_pay_expired_invoice() -> anyhow::Result<()> {
     .await
 }
 
+#[ignore] // TODO: This test should be refactored to a devimint test
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gateway_filters_route_hints_by_inbound() -> anyhow::Result<()> {
     if !Fixtures::is_real_test() {


### PR DESCRIPTION
Follow up to https://github.com/fedimint/fedimint/pull/5149

`fetch_lightning_route_hints` currently loops and waits for the route hints to exist. This is not necessary, the client is already adding a route hint for the gateway's lightning node. 