### PR TITLE
chore(ci): start cross-compile jobs earlier

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -254,7 +254,7 @@ jobs:
 
   cross:
     name: "Cross-compile on ${{ matrix.host }} to ${{ matrix.toolchain }}"
-    needs: [lint, shell, build, ccov]
+    needs: [lint, shell]
 
     strategy:
       matrix:


### PR DESCRIPTION
This was introduced to limit amount of concurrency, and would be fine if not for the fact that in the merge queue we do need to run cross-compilation on MacOS which is slow, and our MQ is running serially. Because of that we want to start cross-compilation jobs sooner than later, so by the time other tests are done cross-compilation on MacOS is done as well.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
