### PR TITLE
chore: put tighther deadlines on test runtime

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,6 @@
 [profile.default]
 # no matter the profile, we want to kill tests that hanged on something
-slow-timeout = { period = "60s", terminate-after = 8 }
+slow-timeout = { period = "30s", terminate-after = 4 }
 
 # define `dev` to allow running cargo and nextest with the same profile name
 # inherits default profile config
@@ -9,4 +9,4 @@ slow-timeout = { period = "60s", terminate-after = 8 }
 [profile.ci]
 fail-fast = true
 failure-output = "immediate"
-slow-timeout = { period = "60s", terminate-after = 8 }
+slow-timeout = { period = "30s", terminate-after = 2 }

--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -37,7 +37,7 @@ on_exit() {
 trap on_error ERR
 trap on_exit EXIT
 
-command time -q --format="$time_fmt" -o "$time_out_path" timeout -k 450 500 "$@" 2>&1 | ts -s > "$test_out_path"
+command time -q --format="$time_fmt" -o "$time_out_path" timeout -k 230 245 "$@" 2>&1 | ts -s > "$test_out_path"
 
 awk 'BEGIN {FS="\t"} {printf "## STAT: %8.2fs %8dB %8dW %8dc\n", $1, $2, $3, $4}' < "$time_out_path"
 echo "## DONE: $test_name$version_str"

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -309,7 +309,7 @@ else
   parallel_args+=(--jobs "${FM_TEST_CI_ALL_JOBS:-$(($(nproc) / 2 + 1))}")
 fi
 
-parallel_args+=(--timeout "${FM_TEST_CI_ALL_TIMEOUT:-600}")
+parallel_args+=(--timeout "${FM_TEST_CI_ALL_TIMEOUT:-300}")
 
 parallel_args+=(--load "${FM_TEST_CI_ALL_MAX_LOAD:-$(($(nproc) / 3 + 1))}")
 # --delay to let nix start extracting and bump the load


### PR DESCRIPTION
Will rebase after #5176 lands

This is to prevent silent regressions.

I wish we could go lower. Most devimint-based tests are already below 40s, and unit-test like tests should be OK under 20s, IMO.

We'll get there.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
