### PR TITLE
chore: Mock RPCs between Client -> Gateway

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -527,7 +527,7 @@ impl FedimintCli {
     }
 
     pub fn with_default_modules(self) -> Self {
-        self.with_module(LightningClientInit)
+        self.with_module(LightningClientInit::default())
             .with_module(MintClientInit)
             .with_module(WalletClientInit::default())
             .with_module(MetaClientInit)

--- a/fedimint-dbtool/src/main.rs
+++ b/fedimint-dbtool/src/main.rs
@@ -179,7 +179,7 @@ async fn main() -> Result<()> {
                 vec![
                     DynClientModuleInit::from(WalletClientInit::default()),
                     DynClientModuleInit::from(MintClientInit),
-                    DynClientModuleInit::from(LightningClientInit),
+                    DynClientModuleInit::from(LightningClientInit::default()),
                 ]
             });
 

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -144,7 +144,7 @@ pub async fn build_client(
     };
     let mut client_builder = Client::builder(db);
     client_builder.with_module(MintClientInit);
-    client_builder.with_module(LightningClientInit);
+    client_builder.with_module(LightningClientInit::default());
     client_builder.with_module(WalletClientInit::default());
     client_builder.with_primary_module(1);
     let client_secret =

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -55,27 +55,6 @@ impl GatewayTest {
         GatewayRpcClient::new(self.versioned_api.clone(), None)
     }
 
-    /// Removes a client from the gateway and keeps it alive
-    ///
-    /// Note: this makes the database opened, which can lead to gateway
-    /// wanting to rejoin it. Better get your own client instead of being
-    /// lazy here.
-    // TODO: This stuff is horrible, why do we need it?
-    pub async fn remove_client_hack(&self, fed: &FederationTest) -> ClientHandleArc {
-        self.gateway
-            .remove_client_hack(fed.id())
-            .await
-            .unwrap()
-            .into_value()
-    }
-
-    // TODO: This stuff is horrible, why do we need it?
-    pub async fn add_client_hack(&self, fed: &FederationTest, client: ClientHandleArc) {
-        self.gateway
-            .add_client_hack(fed.id(), client)
-            .await
-            .unwrap()
-    }
     pub async fn select_client(&self, federation_id: FederationId) -> ClientHandleArc {
         self.gateway
             .select_client(federation_id)

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -26,7 +26,7 @@ async fn load_or_generate_mnemonic(db: &Database) -> anyhow::Result<[u8; 64]> {
 fn make_client_builder() -> fedimint_client::ClientBuilder {
     let mem_database = MemDatabase::default();
     let mut builder = fedimint_client::Client::builder(mem_database.into());
-    builder.with_module(LightningClientInit);
+    builder.with_module(LightningClientInit::default());
     builder.with_module(MintClientInit);
     builder.with_module(WalletClientInit::default());
     builder.with_primary_module(1);

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -33,12 +33,15 @@ use fedimint_ln_client::incoming::{
     FundingOfferState, IncomingSmCommon, IncomingSmError, IncomingSmStates, IncomingStateMachine,
 };
 use fedimint_ln_client::pay::{PayInvoicePayload, PaymentData};
-use fedimint_ln_client::{create_incoming_contract_output, LightningClientInit};
+use fedimint_ln_client::{
+    create_incoming_contract_output, LightningClientContext, LightningClientInit,
+    RealGatewayConnection,
+};
 use fedimint_ln_common::config::LightningClientConfig;
 use fedimint_ln_common::contracts::{ContractId, Preimage};
 use fedimint_ln_common::route_hints::RouteHint;
 use fedimint_ln_common::{
-    create_gateway_remove_message, LightningClientContext, LightningCommonInit, LightningGateway,
+    create_gateway_remove_message, LightningCommonInit, LightningGateway,
     LightningGatewayAnnouncement, LightningModuleTypes, LightningOutput, LightningOutputV0,
     RemoveGatewayRequest, KIND,
 };
@@ -173,6 +176,7 @@ impl From<&GatewayClientContext> for LightningClientContext {
         LightningClientContext {
             ln_decoder: ctx.ln_decoder.clone(),
             redeem_key: ctx.redeem_key,
+            gateway_conn: Arc::new(RealGatewayConnection),
         }
     }
 }

--- a/gateway/ln-gateway/tests/integration_tests.rs
+++ b/gateway/ln-gateway/tests/integration_tests.rs
@@ -28,7 +28,7 @@ use fedimint_ln_client::pay::{PayInvoicePayload, PaymentData};
 use fedimint_ln_client::{
     LightningClientInit, LightningClientModule, LightningClientStateMachines,
     LightningOperationMeta, LightningOperationMetaVariant, LnPayState, LnReceiveState,
-    OutgoingLightningPayment, PayType,
+    MockGatewayConnection, OutgoingLightningPayment, PayType,
 };
 use fedimint_ln_common::config::{FeeToAmount, GatewayFee, LightningGenParams};
 use fedimint_ln_common::contracts::incoming::IncomingContractOffer;
@@ -82,7 +82,13 @@ fn fixtures() -> Fixtures {
     let fixtures = Fixtures::new_primary(DummyClientInit, DummyInit, DummyGenParams::default())
         .with_server_only_module(UnknownInit, UnknownGenParams::default());
     let ln_params = LightningGenParams::regtest(fixtures.bitcoin_server());
-    fixtures.with_module(LightningClientInit, LightningInit, ln_params)
+    fixtures.with_module(
+        LightningClientInit {
+            gateway_conn: Arc::new(MockGatewayConnection),
+        },
+        LightningInit,
+        ln_params,
+    )
 }
 
 async fn single_federation_test<B>(

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -39,7 +39,7 @@ use fedimint_core::bitcoin_migration::{
     bitcoin30_to_bitcoin29_secp256k1_secret_key,
 };
 use fedimint_core::config::FederationId;
-use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
+use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, OperationId};
 use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{
@@ -62,9 +62,9 @@ use fedimint_ln_common::contracts::{
     PreimageKey,
 };
 use fedimint_ln_common::{
-    ContractOutput, LightningClientContext, LightningCommonInit, LightningGateway,
-    LightningGatewayAnnouncement, LightningGatewayRegistration, LightningInput,
-    LightningModuleTypes, LightningOutput, LightningOutputV0,
+    ContractOutput, LightningCommonInit, LightningGateway, LightningGatewayAnnouncement,
+    LightningGatewayRegistration, LightningInput, LightningModuleTypes, LightningOutput,
+    LightningOutputV0,
 };
 use fedimint_logging::LOG_CLIENT_MODULE_LN;
 use futures::{Future, FutureExt, StreamExt};
@@ -72,6 +72,7 @@ use incoming::IncomingSmError;
 use lightning_invoice::{
     Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, RouteHint, RouteHintHop, RoutingFees,
 };
+use pay::PayInvoicePayload;
 use rand::rngs::OsRng;
 use rand::seq::IteratorRandom as _;
 use rand::{CryptoRng, Rng, RngCore};
@@ -268,7 +269,17 @@ pub enum LightningOperationMetaVariant {
 }
 
 #[derive(Debug, Clone)]
-pub struct LightningClientInit;
+pub struct LightningClientInit {
+    pub gateway_conn: Arc<dyn GatewayConnection + Send + Sync>,
+}
+
+impl Default for LightningClientInit {
+    fn default() -> Self {
+        LightningClientInit {
+            gateway_conn: Arc::new(RealGatewayConnection),
+        }
+    }
+}
 
 impl ModuleInit for LightningClientInit {
     type Common = LightningCommonInit;
@@ -337,7 +348,7 @@ impl ClientModuleInit for LightningClientInit {
     }
 
     async fn init(&self, args: &ClientModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
-        Ok(LightningClientModule::new(args).await?)
+        Ok(LightningClientModule::new(args, self.gateway_conn.clone()).await?)
     }
 
     fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn> {
@@ -382,6 +393,7 @@ pub struct LightningClientModule {
     preimage_auth: KeyPair,
     client_ctx: ClientContext<Self>,
     update_gateway_cache_merge: UpdateMerge,
+    gateway_conn: Arc<dyn GatewayConnection + Send + Sync>,
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -396,6 +408,7 @@ impl ClientModule for LightningClientModule {
         LightningClientContext {
             ln_decoder: self.decoder(),
             redeem_key: bitcoin30_to_bitcoin29_keypair(self.redeem_key),
+            gateway_conn: self.gateway_conn.clone(),
         }
     }
 
@@ -437,6 +450,7 @@ enum PayError {
 impl LightningClientModule {
     async fn new(
         args: &ClientModuleInitArgs<LightningClientInit>,
+        gateway_conn: Arc<dyn GatewayConnection + Send + Sync>,
     ) -> anyhow::Result<LightningClientModule> {
         let secp24 = bitcoin29::secp256k1::Secp256k1::new();
         let secp = Secp256k1::new();
@@ -456,6 +470,7 @@ impl LightningClientModule {
             secp,
             client_ctx: args.context(),
             update_gateway_cache_merge: UpdateMerge::default(),
+            gateway_conn: gateway_conn.clone(),
         };
 
         // Only initialize the gateway cache if it is empty
@@ -491,36 +506,6 @@ impl LightningClientModule {
         bytes[32..34].copy_from_slice(&index.to_le_bytes());
         let hash: sha256::Hash = Hash::hash(&bytes);
         OperationId(hash.to_byte_array())
-    }
-
-    // Ping gateway endpoint to verify that it is available before locking funds in
-    // OutgoingContract
-    async fn verify_gateway_availability(&self, gateway: &LightningGateway) -> anyhow::Result<()> {
-        let response = reqwest::Client::new()
-            .get(
-                gateway
-                    .api
-                    .join("id")
-                    .expect("id contains no invalid characters for a URL")
-                    .as_str(),
-            )
-            .send()
-            .await
-            .context("Gateway is not available")?;
-        if !response.status().is_success() {
-            return Err(anyhow!(
-                "Gateway is not available. Returned error code: {}",
-                response.status()
-            ));
-        }
-
-        let text_gateway_id = response.text().await?;
-        let gateway_id = PublicKey::from_str(&text_gateway_id[1..text_gateway_id.len() - 1])?;
-        if gateway_id != bitcoin29_to_bitcoin30_secp256k1_public_key(gateway.gateway_id) {
-            return Err(anyhow!("Unexpected gateway id returned: {gateway_id}"));
-        }
-
-        Ok(())
     }
 
     /// Hashes the client's preimage authentication secret with the provided
@@ -559,7 +544,9 @@ impl LightningClientModule {
 
         // Do not create the funding transaction if the gateway is not currently
         // available
-        self.verify_gateway_availability(&gateway).await?;
+        self.gateway_conn
+            .verify_gateway_availability(&gateway)
+            .await?;
 
         let consensus_count = self
             .module_api
@@ -1935,5 +1922,123 @@ pub async fn get_invoice(
                 }
             }
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LightningClientContext {
+    pub ln_decoder: Decoder,
+    pub redeem_key: bitcoin29::KeyPair,
+    pub gateway_conn: Arc<dyn GatewayConnection + Send + Sync>,
+}
+
+impl fedimint_client::sm::Context for LightningClientContext {}
+
+#[apply(async_trait_maybe_send!)]
+pub trait GatewayConnection: std::fmt::Debug {
+    // Ping gateway endpoint to verify that it is available before locking funds in
+    // OutgoingContract
+    async fn verify_gateway_availability(&self, gateway: &LightningGateway) -> anyhow::Result<()>;
+
+    async fn pay_invoice(
+        &self,
+        gateway: LightningGateway,
+        payload: PayInvoicePayload,
+    ) -> Result<String, GatewayPayError>;
+}
+
+#[derive(Debug)]
+pub struct RealGatewayConnection;
+
+#[apply(async_trait_maybe_send!)]
+impl GatewayConnection for RealGatewayConnection {
+    async fn verify_gateway_availability(&self, gateway: &LightningGateway) -> anyhow::Result<()> {
+        let response = reqwest::Client::new()
+            .get(
+                gateway
+                    .api
+                    .join("id")
+                    .expect("id contains no invalid characters for a URL")
+                    .as_str(),
+            )
+            .send()
+            .await
+            .context("Gateway is not available")?;
+        if !response.status().is_success() {
+            return Err(anyhow!(
+                "Gateway is not available. Returned error code: {}",
+                response.status()
+            ));
+        }
+
+        let text_gateway_id = response.text().await?;
+        let gateway_id = PublicKey::from_str(&text_gateway_id[1..text_gateway_id.len() - 1])?;
+        if gateway_id != bitcoin29_to_bitcoin30_secp256k1_public_key(gateway.gateway_id) {
+            return Err(anyhow!("Unexpected gateway id returned: {gateway_id}"));
+        }
+
+        Ok(())
+    }
+
+    async fn pay_invoice(
+        &self,
+        gateway: LightningGateway,
+        payload: PayInvoicePayload,
+    ) -> Result<String, GatewayPayError> {
+        let response = reqwest::Client::new()
+            .post(
+                gateway
+                    .api
+                    .join("pay_invoice")
+                    .expect("'pay_invoice' contains no invalid characters for a URL")
+                    .as_str(),
+            )
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| GatewayPayError::GatewayInternalError {
+                error_code: None,
+                error_message: e.to_string(),
+            })?;
+
+        if !response.status().is_success() {
+            return Err(GatewayPayError::GatewayInternalError {
+                error_code: Some(response.status().as_u16()),
+                error_message: response
+                    .text()
+                    .await
+                    .expect("Could not retrieve text from response"),
+            });
+        }
+
+        let preimage =
+            response
+                .text()
+                .await
+                .map_err(|_| GatewayPayError::GatewayInternalError {
+                    error_code: None,
+                    error_message: "Error retrieving preimage from response".to_string(),
+                })?;
+        let length = preimage.len();
+        Ok(preimage[1..length - 1].to_string())
+    }
+}
+
+#[derive(Debug)]
+pub struct MockGatewayConnection;
+
+#[apply(async_trait_maybe_send!)]
+impl GatewayConnection for MockGatewayConnection {
+    async fn verify_gateway_availability(&self, _gateway: &LightningGateway) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn pay_invoice(
+        &self,
+        _gateway: LightningGateway,
+        _payload: PayInvoicePayload,
+    ) -> Result<String, GatewayPayError> {
+        // Just return a fake preimage to indicate success
+        Ok("00000000".to_string())
     }
 }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1940,6 +1940,7 @@ pub trait GatewayConnection: std::fmt::Debug {
     // OutgoingContract
     async fn verify_gateway_availability(&self, gateway: &LightningGateway) -> anyhow::Result<()>;
 
+    // Send a POST request to the gateway to request it to pay a BOLT11 invoice.
     async fn pay_invoice(
         &self,
         gateway: LightningGateway,

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -14,14 +14,14 @@ use fedimint_core::{OutPoint, TransactionId};
 use fedimint_ln_common::contracts::incoming::IncomingContractAccount;
 use fedimint_ln_common::contracts::{DecryptedPreimage, FundedContract};
 use fedimint_ln_common::endpoint_constants::ACCOUNT_ENDPOINT;
-use fedimint_ln_common::{LightningClientContext, LightningInput};
+use fedimint_ln_common::LightningInput;
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{debug, error, info};
 
 use crate::api::LnFederationApi;
-use crate::{LightningClientStateMachines, ReceivingKey};
+use crate::{LightningClientContext, LightningClientStateMachines, ReceivingKey};
 
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -21,7 +21,6 @@ use anyhow::{bail, Context as AnyhowContext};
 use bitcoin_hashes::sha256;
 use config::LightningClientConfig;
 use fedimint_client::oplog::OperationLogEntry;
-use fedimint_client::sm::Context;
 use fedimint_client::ClientHandleArc;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
@@ -416,14 +415,6 @@ plugin_types_trait_impl_common!(
     LightningInputError,
     LightningOutputError
 );
-
-#[derive(Debug, Clone)]
-pub struct LightningClientContext {
-    pub ln_decoder: Decoder,
-    pub redeem_key: bitcoin::KeyPair,
-}
-
-impl Context for LightningClientContext {}
 
 // TODO: upstream serde support to LDK
 /// Hack to get a route hint that implements `serde` traits.

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -32,7 +32,7 @@ fn fixtures() -> Fixtures {
     // gateway can connect to a federation. Remove this once connection to a
     // federation does not require lightning legacy anymore.
     fixtures.with_module(
-        fedimint_ln_client::LightningClientInit,
+        fedimint_ln_client::LightningClientInit::default(),
         fedimint_ln_server::LightningInit,
         fedimint_ln_common::config::LightningGenParams::regtest(bitcoin_server),
     )


### PR DESCRIPTION
Working towards: https://github.com/fedimint/fedimint/issues/5168

Gets rid of the ugly hack we used of removing the gateway's clients during the tests.