### PR TITLE
fix(ci): increase the poll time in sends_ecash_out_of_band_cancel

### DIFF
--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -249,14 +249,14 @@ async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
     info!("Refund tx accepted, waiting for refunded e-cash");
 
     // FIXME: UserCanceledSuccess should mean the money is in our wallet
-    for _ in 0..200 {
+    for _ in 0..120 {
         let balance = client.get_balance().await;
         let expected_min_balance = sats(1000) - EXPECTED_MAXIMUM_FEE;
         if expected_min_balance <= balance {
             return Ok(());
         }
         debug!(target: LOG_TEST, %balance, %expected_min_balance, "Wallet balance not updated yet");
-        sleep_in_test("waiting for wallet balance", Duration::from_millis(100)).await;
+        sleep_in_test("waiting for wallet balance", Duration::from_millis(500)).await;
     }
 
     panic!("Did not receive refund in time");


### PR DESCRIPTION
I've seen a weird fail that might, or might have not been a timeout here. Seems we standardize on 60s in other places, so lets increase it here as well.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
