### PR TITLE
chore(nix-module): improvements

### DIFF
--- a/nix/modules/fedimintd.nix
+++ b/nix/modules/fedimintd.nix
@@ -240,17 +240,20 @@ in
                 User = cfg.user;
                 Group = cfg.group;
 
+                Restart = "always";
+                RestartSec = 10;
+                StartLimitBurst = 5;
+                UMask = "077";
+                LimitNOFILE = "100000";
+
                 LockPersonality = true;
-                MemoryDenyWriteExecute = true;
                 ProtectClock = true;
                 ProtectControlGroups = true;
                 ProtectHostname = true;
                 ProtectKernelLogs = true;
                 ProtectKernelModules = true;
                 ProtectKernelTunables = true;
-                PrivateDevices = true;
                 PrivateMounts = true;
-                PrivateUsers = true;
                 RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
                 RestrictNamespaces = true;
                 RestrictRealtime = true;
@@ -262,11 +265,14 @@ in
                 StateDirectory = "fedimintd";
                 StateDirectoryMode = "0700";
                 ExecStart = startScript;
-                Restart = "always";
-                RestartSec = 10;
-                StartLimitBurst = 5;
-                UMask = "077";
-                LimitNOFILE = "100000";
+
+
+                # Hardening measures
+                PrivateTmp = "true";
+                ProtectSystem = "full";
+                NoNewPrivileges = "true";
+                PrivateDevices = "true";
+                MemoryDenyWriteExecute = "true";
               };
             }
           )

--- a/nix/modules/fedimintd.nix
+++ b/nix/modules/fedimintd.nix
@@ -24,8 +24,13 @@ let
       extraEnvironment = mkOption {
         type = types.attrsOf types.str;
         description = lib.mdDoc "Extra Environment variables to pass to the fedimintd.";
-        default = { };
-        example = { RUST_BACKTRACE = "1"; };
+        default = {
+          RUST_BACKTRACE = "1";
+        };
+        example = {
+          RUST_LOG = "info,fm=debug";
+          RUST_BACKTRACE = "1";
+        };
       };
 
       package = mkOption {
@@ -136,11 +141,6 @@ let
           and is set to be read only.
         '';
       };
-      rustLogEnv = mkOption {
-        type = types.str;
-        default = "info,fedimint_server::request=debug,fedimint_client::request=debug";
-        description = "Value to set RUST_LOG to";
-      };
     };
   };
 in
@@ -225,7 +225,6 @@ in
               wantedBy = [ "multi-user.target" ];
               environment = lib.mkMerge ([
                 {
-                  RUST_LOG = cfg.rustLogEnv;
                   FM_BIND_P2P = "${cfg.p2p.bind}:${builtins.toString cfg.p2p.port}";
                   FM_BIND_API = "${cfg.api.bind}:${builtins.toString cfg.api.port}";
                   FM_P2P_URL = cfg.p2p.address;


### PR DESCRIPTION
* Ability to source the bitcoin rpc secret from a file (useful if you're using nix-bitcoin, or agenix, etc.)
* Ability to set user & group for the daemon.
* Cleanup.

Corresponding configuration.nix change (when using `nix-bitcoin`):

```
+  users.extraUsers.fedimintd-somefed.extraGroups = [ "bitcoinrpc-public" ];

   services.fedimintd."somefed" = {
     enable = true;
     package = pkgs.fedimintd;
+    extraEnvironment = {
+      "RUST_LOG" = "info";
+      "RUST_BACKTRACE" = "1";
+    };
     api = {
       address = "wss://${fmApiFqdn}/ws/";
       bind = "127.0.0.1";
@@ -133,7 +126,8 @@ in
     bitcoin = {
       network = "bitcoin";
       rpc = {
-        address = "http://bitcoin:${btcPass}@127.0.0.1:8332";
+        address = "http://bitcoin@127.0.0.1:8332";
+        secretFile = "/etc/nix-bitcoin-secrets/bitcoin-rpcpassword-public";
       };
     };
   };
```
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
