### PR TITLE
chore(devimint): log descriptors in recoverytool tests

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -2082,6 +2082,8 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
         .map(|o| o["descriptor"].as_str().unwrap())
         .collect::<HashSet<_>>();
 
+    debug!(target: LOG_DEVIMINT, ?utxos_descriptors, "recoverytool descriptors using UTXOs method");
+
     let descriptors_json = [serde_json::value::to_raw_value(&serde_json::Value::Array(
         utxos_descriptors
             .iter()
@@ -2139,6 +2141,9 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
         .iter()
         .map(|o| o["descriptor"].as_str().unwrap())
         .collect::<HashSet<_>>();
+
+    debug!(target: LOG_DEVIMINT, ?epochs_descriptors, "recoverytool descriptors using epochs method");
+
     // Epochs method includes descriptors from spent outputs, so we only need to
     // verify the epochs method includes all available utxos
     for utxo_descriptor in utxos_descriptors.iter() {


### PR DESCRIPTION
Should help debug https://github.com/fedimint/fedimint/pull/5184

~After multiple attempts I couldn't reproduce the flake in the self-hosted runner, so let's add these logs for the next time it happens elsewhere in CI.~

Scratch that, right as I was throwing in the towel we have a flake!

---
Update: Investigating the flake showed that the epochs method returned only 3 descriptors with one descriptor different than the UTXOs method. On successful runs, the epochs method returns 4 descriptors. This is likely due to the looping approach that's removed in https://github.com/fedimint/fedimint/pull/5184 (see:  https://github.com/fedimint/fedimint/pull/5184#discussion_r1586305505), which suggests the different descriptor is a spent output instead of the change output.

Still a mystery how this happened in the merge queue with the updates from https://github.com/fedimint/fedimint/pull/5184 that waits for the session outcome instead of polling the epochs method. Hopefully we'll catch it again with more context with these logs.

https://github.com/fedimint/fedimint/actions/runs/8928703168/job/24524832587?pr=5192#step:5:1288

```
00:00:31 2024-05-02T18:32:14.428348Z  INFO devimint::tests: epochs_descriptors={"wsh(sortedmulti(3,cS1hQ2nLSjh3NBq84Gm8tdAs95xtgbfk7Chjs8RD3rmvRFA64TTo,0224c46a6a4d9ef97720e5e0f0606009ffb3277190c5845636b0fe913d62f0dc37,02df2b8eb59e33f801754d0abffdd458377529ca900ca5c8affb377f6011615244,038fab5711c464631b59753fbdfe0d2fb5f7cb2b527b066d3e85fc77ed26c3bb98))#dwkygtfg", "wsh(sortedmulti(3,cTCbHswxaqJWKeAqYeuGNduN1u5UxjoTmDhcqB288YinHWfRc3uP,03d4191c7fca9d1278763cecb668db3cbc0dac66418cd2def542b2664335c6928c,0224582d192de20d887f580489222c5800c20ab274a578a7f3f3fc4b062da3c24a,02334241f6d9c0b1e38e9f7025f252270f6086a388f4096b8e4e3c9ebaa12a099c))#fztzkckq", "wsh(sortedmulti(3,cNXNNRBmV8P6rG7rBrbVkgfwALz7SZUZSzKho5KKfqthv7jr1PQf,0266dbb3d10bde11ba94b41743e9db62525d220831e685cce22778d5abe6302174,021bd742b4d113e5723601126d07dc6d7892a4dc92b37b64b443803236affe5d9c,02b66e03c1bd0a36345dfc8bc7b0092e8e60add3a136285e716a45a072030f3e16))#rrdg74u2"}

00:00:31 2024-05-02T18:32:14.375721Z  INFO devimint::tests: utxos_descriptors={"wsh(sortedmulti(3,cNXNNRBmV8P6rG7rBrbVkgfwALz7SZUZSzKho5KKfqthv7jr1PQf,0266dbb3d10bde11ba94b41743e9db62525d220831e685cce22778d5abe6302174,021bd742b4d113e5723601126d07dc6d7892a4dc92b37b64b443803236affe5d9c,02b66e03c1bd0a36345dfc8bc7b0092e8e60add3a136285e716a45a072030f3e16))#rrdg74u2", "wsh(sortedmulti(3,cS1hQ2nLSjh3NBq84Gm8tdAs95xtgbfk7Chjs8RD3rmvRFA64TTo,0224c46a6a4d9ef97720e5e0f0606009ffb3277190c5845636b0fe913d62f0dc37,02df2b8eb59e33f801754d0abffdd458377529ca900ca5c8affb377f6011615244,038fab5711c464631b59753fbdfe0d2fb5f7cb2b527b066d3e85fc77ed26c3bb98))#dwkygtfg", "wsh(sortedmulti(3,cUbKgdchbDe9Dkn5T5kF3bLNgJuxb3EWMXZbZUfSMNB6yzaxe5GV,02a3704ee431272053f3d2fe3741b887847fed2a7d5b767744b1cfa81ce4fb3aa1,038f4d373053fe9f39b36533da3858fcc4667b51e418ef1fc7dac8ba78592e7c12,03fddc20aca953af2eef60808ef93d8a40c631178f2eb331a37f9afc4d336b1247))#k2hy4263"}
```

<img width="1406" alt="Screenshot 2024-05-02 at 5 58 44 PM" src="https://github.com/fedimint/fedimint/assets/11034691/b7a8d7d3-6d74-492b-94d9-ff931dc9c921">