### PR TITLE
feat: enable shutdown after certain session index for a coordinated consensus upgrade

### DIFF
--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -10,6 +10,7 @@ pub const SESSION_COUNT_ENDPOINT: &str = "session_count";
 pub const AWAIT_SESSION_OUTCOME_ENDPOINT: &str = "await_session_outcome";
 pub const AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT: &str = "await_signed_session_outcome";
 pub const SESSION_STATUS_ENDPOINT: &str = "session_status";
+pub const SHUTDOWN_ENDPOINT: &str = "shutdown";
 pub const CONFIG_GEN_PEERS_ENDPOINT: &str = "config_gen_peers";
 pub const CONSENSUS_CONFIG_GEN_PARAMS_ENDPOINT: &str = "consensus_config_gen_params";
 pub const DEFAULT_CONFIG_GEN_PARAMS_ENDPOINT: &str = "default_config_gen_params";

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -28,7 +28,8 @@ use fedimint_core::endpoint_constants::{
     CLIENT_CONFIG_ENDPOINT, FEDERATION_ID_ENDPOINT, GUARDIAN_CONFIG_BACKUP_ENDPOINT,
     INVITE_CODE_ENDPOINT, MODULES_CONFIG_JSON_ENDPOINT, RECOVER_ENDPOINT,
     SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT, SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT,
-    STATUS_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT, VERSION_ENDPOINT,
+    SHUTDOWN_ENDPOINT, STATUS_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT,
+    VERSION_ENDPOINT,
 };
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::audit::{Audit, AuditSummary};
@@ -45,7 +46,7 @@ use fedimint_logging::LOG_NET_API;
 use futures::StreamExt;
 use jsonrpsee::RpcModule;
 use secp256k1::SECP256K1;
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
 use tracing::{debug, info};
 
 use super::peers::PeerStatusChannels;
@@ -92,6 +93,7 @@ pub struct ConsensusApi {
     pub client_cfg: ClientConfig,
     /// For sending API events to consensus such as transactions
     pub submission_sender: async_channel::Sender<ConsensusItem>,
+    pub shutdown_sender: watch::Sender<Option<u64>>,
     pub peer_status_channels: PeerStatusChannels,
     pub latest_contribution_by_peer: Arc<RwLock<LatestContributionByPeer>>,
     pub consensus_status_cache: ExpiringCache<ApiResult<FederationStatus>>,
@@ -259,6 +261,10 @@ impl ConsensusApi {
             peers_flagged,
             status_by_peer,
         })
+    }
+
+    fn shutdown(&self, index: Option<u64>) {
+        self.shutdown_sender.send_replace(index);
     }
 
     async fn get_federation_audit(&self) -> ApiResult<AuditSummary> {
@@ -549,6 +555,15 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             ApiVersion::new(0, 1),
             async |fedimint: &ConsensusApi, _context, index: u64| -> SerdeModuleEncoding<SessionStatus> {
                 Ok((&fedimint.session_status(index).await).into())
+            }
+        },
+        api_endpoint! {
+            SHUTDOWN_ENDPOINT,
+            ApiVersion::new(0, 0),
+            async |fedimint: &ConsensusApi, context, index: Option<u64>| -> () {
+                check_auth(context)?;
+                fedimint.shutdown(index);
+                Ok(())
             }
         },
         api_endpoint! {


### PR DESCRIPTION
The intended shutdown procedure for this is that all guardians select a session to shutdown, let’s say via a group chat, that is sufficiently long in the future for all of them to set the index to shutdown at, so let’s say something like 15minutes. Then, when the guardians have shut down, every guardian needs to check that it has shut down at the at the intended index and confirm with each other via chat; this may not be the case of a guardian is lagging behind sufficiently. If not, retry. Only if successful for every guardian we can initialise the upgrade.