### PR TITLE
chore: simplify FederationId and FederationIdPrefix string decoding

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -293,9 +293,7 @@ impl FromStr for FederationIdPrefix {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(Vec::from_hex(s)?.try_into().map_err(
-            |bytes: Vec<u8>| hex::Error::InvalidLength(4, bytes.len()),
-        )?))
+        Ok(Self(<[u8; 4]>::from_hex(s)?))
     }
 }
 
@@ -336,11 +334,7 @@ impl FromStr for FederationId {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::from_byte_array(
-            Vec::from_hex(s)?
-                .try_into()
-                .map_err(|bytes: Vec<u8>| hex::Error::InvalidLength(32, bytes.len()))?,
-        ))
+        Ok(Self::from_byte_array(<[u8; 32]>::from_hex(s)?))
     }
 }
 


### PR DESCRIPTION
Necessary when upgrading to bitcoin v0.31 since `Error::InvalidLength` is replaced with [`hex_conservative::error::InvalidLengthError`](https://docs.rs/hex-conservative/0.2.0/hex_conservative/error/struct.InvalidLengthError.html) which is marked as `#[non_exhaustive]` and therefore cannot be constructed directly outside of that crate.

This change shouldn't affect behavior, since the implementation we're switching to ([here](https://docs.rs/bitcoin_hashes/0.12.0/src/bitcoin_hashes/hex.rs.html#163-202)) essentially does what we were previously doing here.