### PR TITLE
feat: enable migration of ln config to lnv2 config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,9 +2065,11 @@ dependencies = [
  "erased-serde",
  "fedimint-client",
  "fedimint-core",
+ "fedimint-ln-common",
  "fedimint-threshold-crypto",
  "fedimint-tpe",
  "futures",
+ "group",
  "itertools 0.12.1",
  "lightning-invoice",
  "rand",
@@ -2571,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "fedimint-threshold-crypto"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4f959c486005e123fc1658135119456540e0ab4193852d541004ed3edcfa8d"
+checksum = "3e5f0913eb5fb65f83e6b503794f2eba124b542b9bdbb5cf941bc12bc7b0ea67"
 dependencies = [
  "bls12_381",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
 [workspace.dependencies]
 criterion = { version = "0.5.1" }
-threshold_crypto = { version = "0.2", package = "fedimint-threshold-crypto" }
+threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tonic_lnd = { version = "0.2.0", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc"] }
 cln-rpc = "0.1.8"
 clap = { version = "4.5.4", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }

--- a/modules/fedimint-lnv2-common/Cargo.toml
+++ b/modules/fedimint-lnv2-common/Cargo.toml
@@ -29,6 +29,7 @@ itertools = "0.12.1"
 lightning-invoice = { version = "0.30.0", features = [ "serde" ] }
 fedimint-client = { path = "../../fedimint-client" }
 fedimint-core ={ path = "../../fedimint-core" }
+fedimint-ln-common ={ path = "../fedimint-ln-common" }
 secp256k1 = { version="0.27.0", default-features=false }
 serde = { workspace = true }
 serde_json = "1.0.116"
@@ -41,6 +42,7 @@ rand = { workspace = true }
 url = { version = "2.3.1", features = ["serde"] }
 # crypto deps
 bls12_381 = { workspace = true }
+group = { workspace = true }
 rand_chacha = { workspace = true }
 tpe = { package = "fedimint-tpe", version = "=0.4.0-alpha", path = "../../crypto/tpe" }
 


### PR DESCRIPTION
This is safe because encrypted preimage can only be decrypted in their respective module as the bls signatures internal to the ciphertext which authenticate the encryption commit to different messages hashes.