### PR TITLE
chore: gateway list_active_channels command includes funding outpoint

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -230,12 +230,23 @@ impl Gatewayd {
                 let short_channel_id = channel["short_channel_id"]
                     .as_u64()
                     .context("short_channel_id must be a u64")?;
+                let channel_point_txid = channel["channel_point_txid"]
+                    .as_str()
+                    .context("channel_point_txid must be a string")?
+                    .to_owned();
+                let channel_point_output_index = channel["channel_point_output_index"]
+                    .as_u64()
+                    .context("channel_point_output_index must be a u32")?
+                    .try_into()
+                    .context("channel_point_output_index must be a u32")?;
                 Ok(ChannelInfo {
                     remote_pubkey,
                     channel_size_sats,
                     outbound_liquidity_sats,
                     inbound_liquidity_sats,
                     short_channel_id,
+                    channel_point_txid,
+                    channel_point_output_index,
                 })
             })
             .collect::<Result<Vec<ChannelInfo>>>()?;

--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -261,6 +261,12 @@ message ListActiveChannelsResponse {
 
     // The SCID of the channel.
     uint64 short_channel_id = 5;
+
+    // Hex-encoded string representing the byte-reversed hash of the funding transaction.
+    string channel_point_txid = 6;
+
+    // The output index of the funding transaction.
+    uint32 channel_point_output_index = 7;
   }
 
   // All channels on the node that are currently able to send and receive payments.

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -748,6 +748,10 @@ impl GatewayLightning for ClnRpcService {
                                         Some(scid) => scid_to_u64(scid),
                                         None => return None,
                                     },
+                                    channel_point_txid: channel.funding_txid.unwrap_or_default(),
+                                    channel_point_output_index: channel
+                                        .funding_outnum
+                                        .unwrap_or_default(),
                                 })
                             } else {
                                 None

--- a/gateway/ln-gateway/src/lightning/cln.rs
+++ b/gateway/ln-gateway/src/lightning/cln.rs
@@ -221,6 +221,8 @@ impl ILnRpcClient for NetworkLnRpcClient {
                 outbound_liquidity_sats: channel.outbound_liquidity_sats,
                 inbound_liquidity_sats: channel.inbound_liquidity_sats,
                 short_channel_id: channel.short_channel_id,
+                channel_point_txid: channel.channel_point_txid,
+                channel_point_output_index: channel.channel_point_output_index,
             })
             .collect())
     }

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -787,12 +787,25 @@ impl ILnRpcClient for GatewayLndClient {
                             0
                         };
 
+                    let (channel_point_txid, channel_point_output_index) = channel
+                        .channel_point
+                        .split_once(':')
+                        .map(|(txid, output_index)| {
+                            (
+                                txid.to_string(),
+                                output_index.parse::<u32>().unwrap_or_default(),
+                            )
+                        })
+                        .unwrap_or_default();
+
                     ChannelInfo {
                         remote_pubkey: channel.remote_pubkey,
                         channel_size_sats,
                         outbound_liquidity_sats,
                         inbound_liquidity_sats,
                         short_channel_id: channel.chan_id,
+                        channel_point_txid,
+                        channel_point_output_index,
                     }
                 })
                 .collect()),

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -156,6 +156,8 @@ pub struct ChannelInfo {
     pub outbound_liquidity_sats: u64,
     pub inbound_liquidity_sats: u64,
     pub short_channel_id: u64,
+    pub channel_point_txid: String,
+    pub channel_point_output_index: u32,
 }
 
 #[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]


### PR DESCRIPTION
To close a channel, both LDK and LND require the channel's funding TXID and output index, so we're adding them to the `gateway lightning list-active-channels` command output to ensure all necessary data is present to close channels