### PR TITLE
feat: add close_channels_with_peer command to gateway liquidity API

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -56,20 +56,21 @@ $ gateway-cli help
 Usage: gateway-cli [OPTIONS] <COMMAND>
 
 Commands:
-  version-hash           Display CLI version hash
-  info                   Display high-level information about the Gateway
-  balance                Check gateway balance
-  address                Generate a new peg-in address, funds sent to it can later be claimed
-  deposit                Deposit funds into a gateway federation
-  withdraw               Claim funds from a gateway federation
-  connect-fed            Connect federation with the gateway
-  help                   Print this message or the help of the given subcommand(s)
+  version-hash               Display CLI version hash
+  info                       Display high-level information about the Gateway
+  balance                    Check gateway balance
+  address                    Generate a new peg-in address, funds sent to it can later be claimed
+  deposit                    Deposit funds into a gateway federation
+  withdraw                   Claim funds from a gateway federation
+  connect-fed                Connect federation with the gateway
+  help                       Print this message or the help of the given subcommand(s)
   lightning
-    connect-to-peer      Connect to another lightning node from the gateway\'s underlying lightning node
-    get-funding-address  Generate a new address belonging to the on-chain wallet of the gateway\'s underlying lightning node
-    open-channel         Open a lightning channel to another lighting node from the gateway\'s underlying lightning node
-    list-active-channels List all channels on the underlying lightning node that can send or receive payments
-    wait-for-chain-sync  Wait for the gateway\'s underlying lightning node to sync to the blockchain at a given height
+    connect-to-peer          Connect to another lightning node from the gateway\'s underlying lightning node
+    get-funding-address      Generate a new address belonging to the on-chain wallet of the gateway\'s underlying lightning node
+    open-channel             Open a lightning channel to another lighting node from the gateway\'s underlying lightning node
+    list-active-channels     List all channels on the underlying lightning node that can send or receive payments
+    close-channels-with-peer Close all lightning channels with a given peer, claiming the funds to the lightning node\'s on-chain wallet
+    wait-for-chain-sync      Wait for the gateway\'s underlying lightning node to sync to the blockchain at a given height
 
 Options:
   -a, --address <ADDRESS>          The address of the gateway webserver [default: http://127.0.0.1:8175]

--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -15,9 +15,9 @@ use lightning_invoice::{
     SignedRawBolt11Invoice, DEFAULT_EXPIRY_TIME,
 };
 use ln_gateway::gateway_lnrpc::{
-    self, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse, GetFundingAddressResponse,
-    GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceRequest,
-    PayInvoiceResponse,
+    self, CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse,
+    EmptyResponse, GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse,
+    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
 };
 use ln_gateway::lightning::cln::{HtlcResult, RouteHtlcStream};
 use ln_gateway::lightning::{ChannelInfo, ILnRpcClient, LightningRpcError};
@@ -229,7 +229,7 @@ impl ILnRpcClient for FakeLightningTest {
     async fn close_channels_with_peer(
         &self,
         _pubkey: bitcoin::secp256k1::PublicKey,
-    ) -> Result<u32, LightningRpcError> {
+    ) -> Result<CloseChannelsWithPeerResponse, LightningRpcError> {
         unimplemented!("FakeLightningTest does not support closing channels by peer")
     }
 

--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -226,6 +226,13 @@ impl ILnRpcClient for FakeLightningTest {
         unimplemented!("FakeLightningTest does not support opening channels")
     }
 
+    async fn close_channels_with_peer(
+        &self,
+        _pubkey: bitcoin::secp256k1::PublicKey,
+    ) -> Result<u32, LightningRpcError> {
+        unimplemented!("FakeLightningTest does not support closing channels by peer")
+    }
+
     async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError> {
         unimplemented!("FakeLightningTest does not support listing active channels")
     }

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -325,10 +325,10 @@ async fn main() -> anyhow::Result<()> {
                     .await?;
             }
             LightningCommands::CloseChannelsWithPeer { pubkey } => {
-                let num_channels_closed = client()
+                let response = client()
                     .close_channels_with_peer(CloseChannelsWithPeerPayload { pubkey })
                     .await?;
-                println!("Closed {num_channels_closed} channel(s)");
+                print_response(response);
             }
             LightningCommands::ListActiveChannels => {
                 let response = client().list_active_channels().await?;

--- a/gateway/ln-gateway/build.rs
+++ b/gateway/ln-gateway/build.rs
@@ -9,6 +9,7 @@ fn main() {
         .build_server(true)
         .build_client(true)
         .protoc_arg("--experimental_allow_proto3_optional")
+        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .compile(&[proto_path], &[include_path])
         .unwrap_or_else(|e| panic!("failed to compile gateway proto files: {e}"));
 

--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package gateway_lnrpc;
 
-/* 
+/*
  * GatewayLightning is a service that provides limited access and functionality
  * from a lightning node to Fedimint gateways
  */
@@ -13,12 +13,12 @@ service GatewayLightning {
   /* GetRouteHints returns the route hints to the associated lightning node */
   rpc GetRouteHints(GetRouteHintsRequest) returns (GetRouteHintsResponse) {}
 
-  /* 
+  /*
    * PayInvoice attempts to pay an invoice using the associated lightning node
    */
   rpc PayInvoice(PayInvoiceRequest) returns (PayInvoiceResponse) {}
 
-  /* 
+  /*
    * RouteHtlcs opens a bi-directional stream for the client to receive intercepted
    * HTLCs. `InterceptHtlcRequest` is sent from the server to alert the client that
    * an HTLC has been intercepted and needs to be processed. The client is expected
@@ -39,6 +39,9 @@ service GatewayLightning {
 
   /* Open a channel on the underlying lightning node. */
   rpc OpenChannel(OpenChannelRequest) returns (EmptyResponse) {}
+
+  /* Close all channels with a given peer on the underlying lightning node. */
+  rpc CloseChannelsWithPeer(CloseChannelsWithPeerRequest) returns (CloseChannelsWithPeerResponse) {}
 
   /* List all channels that are active and able to send and receive funds. */
   rpc ListActiveChannels(EmptyRequest) returns (ListActiveChannelsResponse) {}
@@ -243,6 +246,16 @@ message OpenChannelRequest {
   // The amount of sats that should be pushed to the
   // counterparty once the channel is opened.
   uint64 push_amount_sats = 3;
+}
+
+message CloseChannelsWithPeerRequest {
+  // The public key of the node we're closing channels with.
+  bytes pubkey = 1;
+}
+
+message CloseChannelsWithPeerResponse {
+    // The number of channels that were closed.
+    uint32 num_channels_closed = 1;
 }
 
 message ListActiveChannelsResponse {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -70,7 +70,10 @@ use fedimint_wallet_client::{
 };
 use futures::stream::StreamExt;
 use gateway_lnrpc::intercept_htlc_response::Action;
-use gateway_lnrpc::{GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse};
+use gateway_lnrpc::{
+    CloseChannelsWithPeerResponse, GetNodeInfoResponse, GetRouteHintsResponse,
+    InterceptHtlcResponse,
+};
 use hex::ToHex;
 use lightning::{ILnRpcClient, LightningBuilder, LightningMode, LightningRpcError};
 use lightning_invoice::{Bolt11Invoice, RoutingFees};
@@ -1301,14 +1304,14 @@ impl Gateway {
     }
 
     /// Instructs the Gateway's Lightning node to close all channels with a peer
-    /// specified by `pubkey`, and returns the number of channels closed.
+    /// specified by `pubkey`.
     pub async fn handle_close_channels_with_peer_msg(
         &self,
         CloseChannelsWithPeerPayload { pubkey }: CloseChannelsWithPeerPayload,
-    ) -> Result<u32> {
+    ) -> Result<CloseChannelsWithPeerResponse> {
         let context = self.get_lightning_context().await?;
-        let closed_channel_count = context.lnrpc.close_channels_with_peer(pubkey).await?;
-        Ok(closed_channel_count)
+        let response = context.lnrpc.close_channels_with_peer(pubkey).await?;
+        Ok(response)
     }
 
     /// Returns a list of Lightning network channels from the Gateway's

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -77,8 +77,8 @@ use lightning_invoice::{Bolt11Invoice, RoutingFees};
 use rand::rngs::OsRng;
 use rand::Rng;
 use rpc::{
-    ConnectToPeerPayload, FederationInfo, GatewayFedConfig, GatewayInfo, LeaveFedPayload,
-    OpenChannelPayload, SetConfigurationPayload, V1_API_ENDPOINT,
+    CloseChannelsWithPeerPayload, ConnectToPeerPayload, FederationInfo, GatewayFedConfig,
+    GatewayInfo, LeaveFedPayload, OpenChannelPayload, SetConfigurationPayload, V1_API_ENDPOINT,
 };
 use state_machine::pay::OutgoingPaymentError;
 use state_machine::GatewayClientModule;
@@ -1298,6 +1298,17 @@ impl Gateway {
             .open_channel(pubkey, channel_size_sats, push_amount_sats)
             .await?;
         Ok(())
+    }
+
+    /// Instructs the Gateway's Lightning node to close all channels with a peer
+    /// specified by `pubkey`, and returns the number of channels closed.
+    pub async fn handle_close_channels_with_peer_msg(
+        &self,
+        CloseChannelsWithPeerPayload { pubkey }: CloseChannelsWithPeerPayload,
+    ) -> Result<u32> {
+        let context = self.get_lightning_context().await?;
+        let closed_channel_count = context.lnrpc.close_channels_with_peer(pubkey).await?;
+        Ok(closed_channel_count)
     }
 
     /// Returns a list of Lightning network channels from the Gateway's

--- a/gateway/ln-gateway/src/lightning/cln.rs
+++ b/gateway/ln-gateway/src/lightning/cln.rs
@@ -14,10 +14,11 @@ use tracing::info;
 use super::{ChannelInfo, ILnRpcClient, LightningRpcError};
 use crate::gateway_lnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gateway_lnrpc::{
-    CloseChannelsWithPeerRequest, ConnectToPeerRequest, CreateInvoiceRequest,
-    CreateInvoiceResponse, EmptyRequest, EmptyResponse, GetFundingAddressResponse,
-    GetNodeInfoResponse, GetRouteHintsRequest, GetRouteHintsResponse, InterceptHtlcRequest,
-    InterceptHtlcResponse, OpenChannelRequest, PayInvoiceRequest, PayInvoiceResponse,
+    CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, ConnectToPeerRequest,
+    CreateInvoiceRequest, CreateInvoiceResponse, EmptyRequest, EmptyResponse,
+    GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsRequest, GetRouteHintsResponse,
+    InterceptHtlcRequest, InterceptHtlcResponse, OpenChannelRequest, PayInvoiceRequest,
+    PayInvoiceResponse,
 };
 use crate::lightning::MAX_LIGHTNING_RETRIES;
 pub type HtlcResult = std::result::Result<InterceptHtlcRequest, tonic::Status>;
@@ -207,7 +208,7 @@ impl ILnRpcClient for NetworkLnRpcClient {
     async fn close_channels_with_peer(
         &self,
         pubkey: secp256k1::PublicKey,
-    ) -> Result<u32, LightningRpcError> {
+    ) -> Result<CloseChannelsWithPeerResponse, LightningRpcError> {
         let mut client = self.connect().await?;
         let res = client
             .close_channels_with_peer(CloseChannelsWithPeerRequest {
@@ -217,7 +218,7 @@ impl ILnRpcClient for NetworkLnRpcClient {
             .map_err(|status| LightningRpcError::FailedToCloseChannelsWithPeer {
                 failure_reason: status.message().to_string(),
             })?;
-        Ok(res.into_inner().num_channels_closed)
+        Ok(res.into_inner())
     }
 
     async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError> {

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -36,9 +36,9 @@ use crate::gateway_lnrpc::create_invoice_request::Description;
 use crate::gateway_lnrpc::get_route_hints_response::{RouteHint, RouteHintHop};
 use crate::gateway_lnrpc::intercept_htlc_response::{Action, Cancel, Forward, Settle};
 use crate::gateway_lnrpc::{
-    CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse, GetFundingAddressResponse,
-    GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest, InterceptHtlcResponse,
-    PayInvoiceRequest, PayInvoiceResponse,
+    CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse,
+    GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
+    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
 };
 
 type HtlcSubscriptionSender = mpsc::Sender<Result<InterceptHtlcRequest, Status>>;
@@ -732,7 +732,10 @@ impl ILnRpcClient for GatewayLndClient {
         }
     }
 
-    async fn close_channels_with_peer(&self, pubkey: PublicKey) -> Result<u32, LightningRpcError> {
+    async fn close_channels_with_peer(
+        &self,
+        pubkey: PublicKey,
+    ) -> Result<CloseChannelsWithPeerResponse, LightningRpcError> {
         let mut client = self.connect().await?;
 
         let channels_with_peer = client
@@ -780,7 +783,9 @@ impl ILnRpcClient for GatewayLndClient {
                 })?;
         }
 
-        Ok(channels_with_peer.len() as u32)
+        Ok(CloseChannelsWithPeerResponse {
+            num_channels_closed: channels_with_peer.len() as u32,
+        })
     }
 
     async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError> {

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -20,9 +20,9 @@ use crate::envs::{
     FM_GATEWAY_LIGHTNING_ADDR_ENV, FM_LND_MACAROON_ENV, FM_LND_RPC_ADDR_ENV, FM_LND_TLS_CERT_ENV,
 };
 use crate::gateway_lnrpc::{
-    CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse, GetFundingAddressResponse,
-    GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceRequest,
-    PayInvoiceResponse,
+    CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse,
+    GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcResponse,
+    PayInvoiceRequest, PayInvoiceResponse,
 };
 
 pub const MAX_LIGHTNING_RETRIES: u32 = 10;
@@ -149,11 +149,11 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     ) -> Result<EmptyResponse, LightningRpcError>;
 
     /// Close all channels with a peer lightning node from the gateway's
-    /// lightning node, returning the number of channels closed.
+    /// lightning node.
     async fn close_channels_with_peer(
         &self,
         pubkey: secp256k1::PublicKey,
-    ) -> Result<u32, LightningRpcError>;
+    ) -> Result<CloseChannelsWithPeerResponse, LightningRpcError>;
 
     async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError>;
 }

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -45,6 +45,8 @@ pub enum LightningRpcError {
     FailedToCompleteHtlc { failure_reason: String },
     #[error("Failed to open channel: {failure_reason}")]
     FailedToOpenChannel { failure_reason: String },
+    #[error("Failed to close channel: {failure_reason}")]
+    FailedToCloseChannelsWithPeer { failure_reason: String },
     #[error("Failed to get Invoice: {failure_reason}")]
     FailedToGetInvoice { failure_reason: String },
     #[error("Failed to get funding address: {failure_reason}")]
@@ -145,6 +147,13 @@ pub trait ILnRpcClient: Debug + Send + Sync {
         channel_size_sats: u64,
         push_amount_sats: u64,
     ) -> Result<EmptyResponse, LightningRpcError>;
+
+    /// Close all channels with a peer lightning node from the gateway's
+    /// lightning node, returning the number of channels closed.
+    async fn close_channels_with_peer(
+        &self,
+        pubkey: secp256k1::PublicKey,
+    ) -> Result<u32, LightningRpcError>;
 
     async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError>;
 }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -158,3 +158,8 @@ pub struct OpenChannelPayload {
     pub channel_size_sats: u64,
     pub push_amount_sats: u64,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CloseChannelsWithPeerPayload {
+    pub pubkey: secp256k1::PublicKey,
+}

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -21,6 +21,7 @@ use super::{
     SetConfigurationPayload, WithdrawPayload,
 };
 use crate::lightning::ChannelInfo;
+use crate::CloseChannelsWithPeerResponse;
 
 pub struct GatewayRpcClient {
     /// Base URL to gateway web server
@@ -173,7 +174,7 @@ impl GatewayRpcClient {
     pub async fn close_channels_with_peer(
         &self,
         payload: CloseChannelsWithPeerPayload,
-    ) -> GatewayRpcResult<u32> {
+    ) -> GatewayRpcResult<CloseChannelsWithPeerResponse> {
         let url = self
             .base_url
             .join(CLOSE_CHANNELS_WITH_PEER_ENDPOINT)

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -3,10 +3,11 @@ use bitcoin::Address;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, TransactionId};
 use fedimint_ln_common::gateway_endpoint_constants::{
-    BACKUP_ENDPOINT, BALANCE_ENDPOINT, CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT,
-    CONNECT_TO_PEER_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
-    GET_FUNDING_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    OPEN_CHANNEL_ENDPOINT, RESTORE_ENDPOINT, SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
+    BACKUP_ENDPOINT, BALANCE_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
+    CONNECT_FED_ENDPOINT, CONNECT_TO_PEER_ENDPOINT, GATEWAY_INFO_ENDPOINT,
+    GATEWAY_INFO_POST_ENDPOINT, GET_FUNDING_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT,
+    LIST_ACTIVE_CHANNELS_ENDPOINT, OPEN_CHANNEL_ENDPOINT, RESTORE_ENDPOINT,
+    SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use reqwest::{Method, StatusCode};
 use serde::de::DeserializeOwned;
@@ -14,9 +15,10 @@ use serde::Serialize;
 use thiserror::Error;
 
 use super::{
-    BackupPayload, BalancePayload, ConfigPayload, ConnectFedPayload, ConnectToPeerPayload,
-    DepositAddressPayload, FederationInfo, GatewayFedConfig, GatewayInfo, GetFundingAddressPayload,
-    LeaveFedPayload, OpenChannelPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload,
+    BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConfigPayload, ConnectFedPayload,
+    ConnectToPeerPayload, DepositAddressPayload, FederationInfo, GatewayFedConfig, GatewayInfo,
+    GetFundingAddressPayload, LeaveFedPayload, OpenChannelPayload, RestorePayload,
+    SetConfigurationPayload, WithdrawPayload,
 };
 use crate::lightning::ChannelInfo;
 
@@ -164,6 +166,17 @@ impl GatewayRpcClient {
         let url = self
             .base_url
             .join(OPEN_CHANNEL_ENDPOINT)
+            .expect("invalid base url");
+        self.call_post(url, payload).await
+    }
+
+    pub async fn close_channels_with_peer(
+        &self,
+        payload: CloseChannelsWithPeerPayload,
+    ) -> GatewayRpcResult<u32> {
+        let url = self
+            .base_url
+            .join(CLOSE_CHANNELS_WITH_PEER_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
     }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -362,8 +362,8 @@ async fn close_channels_with_peer(
     Extension(gateway): Extension<Gateway>,
     Json(payload): Json<CloseChannelsWithPeerPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    let num_channels_closed = gateway.handle_close_channels_with_peer_msg(payload).await?;
-    Ok(Json(json!(num_channels_closed)))
+    let response = gateway.handle_close_channels_with_peer_msg(payload).await?;
+    Ok(Json(json!(response)))
 }
 
 #[instrument(skip_all, err)]

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -11,12 +11,13 @@ use fedimint_core::config::FederationId;
 use fedimint_core::task::TaskGroup;
 use fedimint_ln_client::pay::PayInvoicePayload;
 use fedimint_ln_common::gateway_endpoint_constants::{
-    ADDRESS_ENDPOINT, BACKUP_ENDPOINT, BALANCE_ENDPOINT, CONFIGURATION_ENDPOINT,
-    CONNECT_FED_ENDPOINT, CONNECT_TO_PEER_ENDPOINT, CREATE_INVOICE_V2_ENDPOINT,
-    GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_FUNDING_ADDRESS_ENDPOINT,
-    GET_GATEWAY_ID_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    OPEN_CHANNEL_ENDPOINT, PAYMENT_INFO_V2_ENDPOINT, PAY_INVOICE_ENDPOINT, RESTORE_ENDPOINT,
-    SEND_PAYMENT_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
+    ADDRESS_ENDPOINT, BACKUP_ENDPOINT, BALANCE_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
+    CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, CONNECT_TO_PEER_ENDPOINT,
+    CREATE_INVOICE_V2_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
+    GET_FUNDING_ADDRESS_ENDPOINT, GET_GATEWAY_ID_ENDPOINT, LEAVE_FED_ENDPOINT,
+    LIST_ACTIVE_CHANNELS_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAYMENT_INFO_V2_ENDPOINT,
+    PAY_INVOICE_ENDPOINT, RESTORE_ENDPOINT, SEND_PAYMENT_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT,
+    WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_client::{CreateInvoicePayload, SendPaymentPayload};
 use hex::ToHex;
@@ -26,9 +27,10 @@ use tower_http::cors::CorsLayer;
 use tracing::{error, info, instrument};
 
 use super::{
-    BackupPayload, BalancePayload, ConnectFedPayload, ConnectToPeerPayload, DepositAddressPayload,
-    GetFundingAddressPayload, InfoPayload, LeaveFedPayload, OpenChannelPayload, RestorePayload,
-    SetConfigurationPayload, WithdrawPayload, V1_API_ENDPOINT,
+    BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConnectFedPayload,
+    ConnectToPeerPayload, DepositAddressPayload, GetFundingAddressPayload, InfoPayload,
+    LeaveFedPayload, OpenChannelPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload,
+    V1_API_ENDPOINT,
 };
 use crate::rpc::ConfigPayload;
 use crate::{Gateway, GatewayError};
@@ -166,6 +168,10 @@ fn v1_routes(gateway: Gateway) -> Router {
         .route(CONNECT_TO_PEER_ENDPOINT, post(connect_to_peer))
         .route(GET_FUNDING_ADDRESS_ENDPOINT, post(get_funding_address))
         .route(OPEN_CHANNEL_ENDPOINT, post(open_channel))
+        .route(
+            CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
+            post(close_channels_with_peer),
+        )
         .route(LIST_ACTIVE_CHANNELS_ENDPOINT, get(list_active_channels))
         .layer(middleware::from_fn(auth_middleware));
 
@@ -349,6 +355,15 @@ async fn open_channel(
 ) -> Result<impl IntoResponse, GatewayError> {
     gateway.handle_open_channel_msg(payload).await?;
     Ok(Json(json!(())))
+}
+
+#[instrument(skip_all, err, fields(?payload))]
+async fn close_channels_with_peer(
+    Extension(gateway): Extension<Gateway>,
+    Json(payload): Json<CloseChannelsWithPeerPayload>,
+) -> Result<impl IntoResponse, GatewayError> {
+    let num_channels_closed = gateway.handle_close_channels_with_peer_msg(payload).await?;
+    Ok(Json(json!(num_channels_closed)))
 }
 
 #[instrument(skip_all, err)]

--- a/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
+++ b/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
@@ -14,6 +14,7 @@ pub const GET_FUNDING_ADDRESS_ENDPOINT: &str = "/get_funding_address";
 pub const LEAVE_FED_ENDPOINT: &str = "/leave-fed"; // uses `-` for backwards compatibility
 pub const LIST_ACTIVE_CHANNELS_ENDPOINT: &str = "/list_active_channels";
 pub const OPEN_CHANNEL_ENDPOINT: &str = "/open_channel";
+pub const CLOSE_CHANNELS_WITH_PEER_ENDPOINT: &str = "/close_channels_with_peer";
 pub const PAYMENT_INFO_V2_ENDPOINT: &str = "/payment_info";
 pub const PAY_INVOICE_ENDPOINT: &str = "/pay_invoice";
 pub const RESTORE_ENDPOINT: &str = "/restore";


### PR DESCRIPTION
This will be an important command to have once we ship an LDK-powered gateway since the liquidity API will be the only way to manage channels

~~Only implementing for LND for now since LND and LDK support closing channels by funding TXID + output index, while CLN instead requires funding tx block height + transaction index + output index~~

Changed from closing by TXID + output index to closing all channels with a specific peer