### PR TITLE
cleanup: simplify verification hashes

### DIFF
--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(where_clauses_object_safety)] // https://github.com/dtolnay/async-trait/issues/228
 extern crate fedimint_core;
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::net::SocketAddr;
 use std::panic::AssertUnwindSafe;
@@ -10,17 +9,14 @@ use std::time::Duration;
 
 use anyhow::{anyhow as format_err, Context};
 use async_trait::async_trait;
-use bitcoin_hashes::sha256;
 use config::io::{read_server_config, PLAINTEXT_PASSWORD};
 use config::ServerConfig;
 use fedimint_core::config::ServerModuleInitRegistry;
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::Database;
-use fedimint_core::encoding::Encodable;
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::{ApiAuth, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased};
 use fedimint_core::task::TaskGroup;
-use fedimint_core::PeerId;
 use fedimint_logging::{LOG_CONSENSUS, LOG_CORE, LOG_NET_API};
 use futures::FutureExt;
 use jsonrpsee::server::{PingConfig, RpcServiceBuilder, ServerBuilder, ServerHandle};
@@ -345,15 +341,4 @@ pub fn check_auth(context: &mut ApiEndpointContext) -> ApiResult<()> {
     } else {
         Ok(())
     }
-}
-
-// The verification hashes are purposefully different for each peer such that
-// their manual verification by the guardians via the UI is more robust
-pub fn get_verification_hashes(config: &ServerConfig) -> BTreeMap<PeerId, sha256::Hash> {
-    config
-        .consensus
-        .api_endpoints
-        .keys()
-        .map(|peer| (*peer, (*peer, config.consensus.clone()).consensus_hash()))
-        .collect()
 }

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -27,8 +27,7 @@ use fedimint_core::endpoint_constants::{
     CLIENT_CONFIG_ENDPOINT, FEDERATION_ID_ENDPOINT, GUARDIAN_CONFIG_BACKUP_ENDPOINT,
     INVITE_CODE_ENDPOINT, MODULES_CONFIG_JSON_ENDPOINT, RECOVER_ENDPOINT,
     SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT, SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT,
-    SHUTDOWN_ENDPOINT, STATUS_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERIFY_CONFIG_HASH_ENDPOINT,
-    VERSION_ENDPOINT,
+    SHUTDOWN_ENDPOINT, STATUS_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
 };
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::audit::{Audit, AuditSummary};
@@ -58,7 +57,7 @@ use crate::consensus::server::{get_finished_session_count_static, LatestContribu
 use crate::db::{AcceptedItemPrefix, AcceptedTransactionKey, SignedSessionOutcomeKey};
 use crate::fedimint_core::encoding::Encodable;
 use crate::metrics::{BACKUP_WRITE_SIZE_BYTES, STORED_BACKUPS_COUNT};
-use crate::{check_auth, get_verification_hashes, ApiResult, HasApiContext};
+use crate::{check_auth, ApiResult, HasApiContext};
 
 /// A state that has context for the API, passed to each rpc handler callback
 #[derive(Clone)]
@@ -573,14 +572,6 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
                 check_auth(context)?;
                 let password = context.request_auth().expect("Auth was checked before").0;
                 Ok(fedimint.get_guardian_config_backup(password).await?)
-            }
-        },
-        api_endpoint! {
-            VERIFY_CONFIG_HASH_ENDPOINT,
-            ApiVersion::new(0, 0),
-            async |fedimint: &ConsensusApi, context, _v: ()| -> BTreeMap<PeerId, sha256::Hash> {
-                check_auth(context)?;
-                Ok(get_verification_hashes(&fedimint.cfg))
             }
         },
         api_endpoint! {


### PR DESCRIPTION
The verification hashes are used in the API to confirm the result of the DKG. Though all hashes are just derived from the config, and we could simply just compare the consensus config hash, the verification hashes are purposefully different for each peer such that their manual verification by the guardians via the UI is more robust.

After the dkg is done the verification hashes are not required anymore, the server checks config equality on startup via the SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT.