### PR TITLE
test: basic gateway devimint config test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,6 +2871,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway-tests"
+version = "0.4.0-alpha"
+dependencies = [
+ "anyhow",
+ "clap",
+ "devimint",
+ "fedimint-core",
+ "fedimint-ln-gateway",
+ "fedimint-testing",
+ "semver",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "docs",
     "gateway/ln-gateway",
     "gateway/cli",
+    "gateway/integration_tests",
     "fedimintd",
     "fedimint-bip39",
     "fedimint-bitcoind",

--- a/fedimint-testing/src/gateway.rs
+++ b/fedimint-testing/src/gateway.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -219,6 +220,18 @@ impl Display for LightningNodeType {
         match self {
             LightningNodeType::Cln => write!(f, "cln"),
             LightningNodeType::Lnd => write!(f, "lnd"),
+        }
+    }
+}
+
+impl FromStr for LightningNodeType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "cln" => Ok(LightningNodeType::Cln),
+            "lnd" => Ok(LightningNodeType::Lnd),
+            _ => Err(format!("Invalid value for LightningNodeType: {}", s)),
         }
     }
 }

--- a/gateway/integration_tests/Cargo.toml
+++ b/gateway/integration_tests/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "gateway-tests"
+version = "0.4.0-alpha"
+authors = ["The Fedimint Developers"]
+edition = "2021"
+description = "gateway-tests contain integration tests for the gateway"
+license = "MIT"
+publish = false
+
+
+# workaround: cargo-deny in Nix needs to see at least one
+# artifact here
+[[bin]]
+name = "gateway-tests"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+devimint = { workspace = true }
+tokio = { workspace = true }
+fedimint-core = { workspace = true }
+fedimint-testing = { path = "../../fedimint-testing" }
+ln-gateway = { version = "=0.4.0-alpha", package = "fedimint-ln-gateway", path= "../ln-gateway" }
+tracing = { workspace = true }
+serde_json = { workspace = true }
+semver = { workspace = true }

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -1,0 +1,76 @@
+use clap::{Parser, Subcommand};
+use devimint::version_constants::VERSION_0_3_0;
+use devimint::{cmd, util};
+use fedimint_testing::gateway::LightningNodeType;
+use ln_gateway::rpc::FederationInfo;
+use tracing::info;
+
+#[derive(Parser)]
+struct GatewayTestOpts {
+    #[clap(subcommand)]
+    test: GatewayTest,
+
+    #[arg(long = "gw-type")]
+    gateway_type: LightningNodeType,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+enum GatewayTest {
+    ConfigTest,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let opts = GatewayTestOpts::parse();
+    match opts.test {
+        GatewayTest::ConfigTest => config_test(opts.gateway_type).await,
+    }
+}
+
+async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
+    devimint::run_devfed_test(|dev_fed| async move {
+        let gw = match gw_type {
+            LightningNodeType::Lnd => dev_fed.gw_lnd_registered().await?,
+            LightningNodeType::Cln => dev_fed.gw_cln_registered().await?,
+        };
+
+        // Try to connect to already connected federation
+        let gatewayd_version = util::Gatewayd::version_or_default().await;
+        if gatewayd_version >= *VERSION_0_3_0 {
+            let invite_code = dev_fed.fed().await?.invite_code()?;
+            let output = cmd!(gw, "connect-fed", invite_code.clone())
+                .out_json()
+                .await;
+            assert!(
+                output.is_err(),
+                "Connecting to the same federation succeeded"
+            );
+            info!("Verified that gateway couldn't connect to already connected federation");
+        }
+
+        // TODO: Add more configuration verification here
+
+        // Leave federation
+        let fed_id = dev_fed.fed().await?.calculate_federation_id().await;
+        let fedimint_cli_version = util::FedimintCli::version_or_default().await;
+        let gatewayd_version = util::Gatewayd::version_or_default().await;
+
+        // `leave-fed` did not return any output until 0.3.0
+        if fedimint_cli_version >= *VERSION_0_3_0 && gatewayd_version >= *VERSION_0_3_0 {
+            let leave_fed = cmd!(gw, "leave-fed", "--federation-id", fed_id.clone())
+                .out_json()
+                .await
+                .expect("Leaving the federation failed");
+
+            let fed_info: FederationInfo =
+                serde_json::from_value(leave_fed).expect("Could not parse FederationInfo");
+            assert_eq!(fed_info.federation_id.to_string(), fed_id);
+        }
+
+        info!("Verified gateway left federation {fed_id}");
+
+        info!("Gateway configuration test successful");
+        Ok(())
+    })
+    .await
+}

--- a/scripts/tests/gateway-module-test.sh
+++ b/scripts/tests/gateway-module-test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+
+# Check if both arguments are provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <test> <lnd|cln>"
+    exit 1
+fi
+
+test=$1
+gw_type=$2
+
+gateway-tests --gw-type $gw_type $test

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -64,6 +64,16 @@ function gateway_reboot_test() {
 }
 export -f gateway_reboot_test
 
+function gateway_config_test_lnd() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/gateway-module-test.sh config-test lnd
+}
+export -f gateway_config_test_lnd
+
+function gateway_config_test_cln() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/gateway-module-test.sh config-test cln
+}
+export -f gateway_config_test_cln
+
 function latency_test_reissue() {
   fm-run-test "${FUNCNAME[0]}" ./scripts/tests/latency-test.sh reissue
 }
@@ -272,6 +282,8 @@ tests_to_run_in_parallel+=(
   "reconnect_test"
   "lightning_reconnect_test"
   "gateway_reboot_test"
+  "gateway_config_test_cln"
+  "gateway_config_test_lnd"
   "devimint_cli_test"
   "devimint_cli_test_single"
   "load_test_tool_test"


### PR DESCRIPTION
Builds on https://github.com/fedimint/fedimint/pull/5233

Part of https://github.com/fedimint/fedimint/issues/5168

Removes two tests from `integration_tests.rs` in the gateway and re-writes them as devimint tests. LND and CLN can be run in parallel. More functionality will be added to these tests over time (to amortize the cost of setting up a all of the daemons).