### PR TITLE
fix: fix gateway endpoints

### DIFF
--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -4,8 +4,9 @@ use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, TransactionId};
 use fedimint_ln_common::gateway_endpoint_constants::{
     BACKUP_ENDPOINT, BALANCE_ENDPOINT, CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT,
-    GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, LEAVE_FED_ENDPOINT, RESTORE_ENDPOINT,
-    SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
+    CONNECT_TO_PEER_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
+    GET_FUNDING_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
+    OPEN_CHANNEL_ENDPOINT, RESTORE_ENDPOINT, SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use reqwest::{Method, StatusCode};
 use serde::de::DeserializeOwned;
@@ -143,7 +144,7 @@ impl GatewayRpcClient {
     pub async fn connect_to_peer(&self, payload: ConnectToPeerPayload) -> GatewayRpcResult<()> {
         let url = self
             .base_url
-            .join("/connect_to_peer")
+            .join(CONNECT_TO_PEER_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
     }
@@ -154,7 +155,7 @@ impl GatewayRpcClient {
     ) -> GatewayRpcResult<Address<NetworkUnchecked>> {
         let url = self
             .base_url
-            .join("/get_funding_address")
+            .join(GET_FUNDING_ADDRESS_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
     }
@@ -162,7 +163,7 @@ impl GatewayRpcClient {
     pub async fn open_channel(&self, payload: OpenChannelPayload) -> GatewayRpcResult<()> {
         let url = self
             .base_url
-            .join("/open_channel")
+            .join(OPEN_CHANNEL_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
     }
@@ -170,7 +171,7 @@ impl GatewayRpcClient {
     pub async fn list_active_channels(&self) -> GatewayRpcResult<Vec<ChannelInfo>> {
         let url = self
             .base_url
-            .join("/list_active_channels")
+            .join(LIST_ACTIVE_CHANNELS_ENDPOINT)
             .expect("invalid base url");
         self.call_get(url).await
     }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -12,10 +12,11 @@ use fedimint_core::task::TaskGroup;
 use fedimint_ln_client::pay::PayInvoicePayload;
 use fedimint_ln_common::gateway_endpoint_constants::{
     ADDRESS_ENDPOINT, BACKUP_ENDPOINT, BALANCE_ENDPOINT, CONFIGURATION_ENDPOINT,
-    CONNECT_FED_ENDPOINT, CREATE_INVOICE_V2_ENDPOINT, GATEWAY_INFO_ENDPOINT,
-    GATEWAY_INFO_POST_ENDPOINT, GET_GATEWAY_ID_ENDPOINT, LEAVE_FED_ENDPOINT,
-    PAYMENT_INFO_V2_ENDPOINT, PAY_INVOICE_ENDPOINT, RESTORE_ENDPOINT, SEND_PAYMENT_V2_ENDPOINT,
-    SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
+    CONNECT_FED_ENDPOINT, CONNECT_TO_PEER_ENDPOINT, CREATE_INVOICE_V2_ENDPOINT,
+    GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_FUNDING_ADDRESS_ENDPOINT,
+    GET_GATEWAY_ID_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
+    OPEN_CHANNEL_ENDPOINT, PAYMENT_INFO_V2_ENDPOINT, PAY_INVOICE_ENDPOINT, RESTORE_ENDPOINT,
+    SEND_PAYMENT_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_client::{CreateInvoicePayload, SendPaymentPayload};
 use hex::ToHex;
@@ -162,10 +163,10 @@ fn v1_routes(gateway: Gateway) -> Router {
         .route(LEAVE_FED_ENDPOINT, post(leave_fed))
         .route(BACKUP_ENDPOINT, post(backup))
         .route(RESTORE_ENDPOINT, post(restore))
-        .route("/connect_to_peer", post(connect_to_peer))
-        .route("/get_funding_address", post(get_funding_address))
-        .route("/open_channel", post(open_channel))
-        .route("/list_active_channels", get(list_active_channels))
+        .route(CONNECT_TO_PEER_ENDPOINT, post(connect_to_peer))
+        .route(GET_FUNDING_ADDRESS_ENDPOINT, post(get_funding_address))
+        .route(OPEN_CHANNEL_ENDPOINT, post(open_channel))
+        .route(LIST_ACTIVE_CHANNELS_ENDPOINT, get(list_active_channels))
         .layer(middleware::from_fn(auth_middleware));
 
     // Routes that are un-authenticated before gateway configuration, then become

--- a/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
+++ b/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
@@ -1,13 +1,19 @@
+/// Use `_` for word separator
+
 pub const ADDRESS_ENDPOINT: &str = "/address";
 pub const BACKUP_ENDPOINT: &str = "/backup";
 pub const BALANCE_ENDPOINT: &str = "/balance";
 pub const CONFIGURATION_ENDPOINT: &str = "/config";
-pub const CONNECT_FED_ENDPOINT: &str = "/connect-fed";
+pub const CONNECT_FED_ENDPOINT: &str = "/connect-fed"; // uses `-` for backwards compatibility
+pub const CONNECT_TO_PEER_ENDPOINT: &str = "/connect_to_peer";
 pub const CREATE_INVOICE_V2_ENDPOINT: &str = "/create_invoice";
 pub const GATEWAY_INFO_ENDPOINT: &str = "/info";
 pub const GET_GATEWAY_ID_ENDPOINT: &str = "/id";
 pub const GATEWAY_INFO_POST_ENDPOINT: &str = "/info";
-pub const LEAVE_FED_ENDPOINT: &str = "/leave_fed";
+pub const GET_FUNDING_ADDRESS_ENDPOINT: &str = "/get_funding_address";
+pub const LEAVE_FED_ENDPOINT: &str = "/leave-fed"; // uses `-` for backwards compatibility
+pub const LIST_ACTIVE_CHANNELS_ENDPOINT: &str = "/list_active_channels";
+pub const OPEN_CHANNEL_ENDPOINT: &str = "/open_channel";
 pub const PAYMENT_INFO_V2_ENDPOINT: &str = "/payment_info";
 pub const PAY_INVOICE_ENDPOINT: &str = "/pay_invoice";
 pub const RESTORE_ENDPOINT: &str = "/restore";


### PR DESCRIPTION
Fixes:

1. https://github.com/fedimint/fedimint/pull/4819 broke backwards compatibility since it changed the gateway's endpoint from `leave-fed` to `leave_fed`. We don't have tests to catch this. Adding in https://github.com/fedimint/fedimint/pull/5231
2. New endpoints for liquidity management didn't use constants.