### PR TITLE
fix(ci): timeout tests before parallel job times out

### DIFF
--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -37,7 +37,7 @@ on_exit() {
 trap on_error ERR
 trap on_exit EXIT
 
-command time -q --format="$time_fmt" -o "$time_out_path" "$@" 2>&1 | ts -s > "$test_out_path"
+command time -q --format="$time_fmt" -o "$time_out_path" timeout -k 450 500 "$@" 2>&1 | ts -s > "$test_out_path"
 
 awk 'BEGIN {FS="\t"} {printf "## STAT: %8.2fs %8dB %8dW %8dc\n", $1, $2, $3, $4}' < "$time_out_path"
 echo "## DONE: $test_name$version_str"


### PR DESCRIPTION
Otherwise we get no output on timeouts.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
