### PR TITLE
chore(devimint): significantly improve shutdown time

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -183,7 +183,7 @@ pub async fn update_test_dir_link(
 pub async fn cleanup_on_exit<T>(
     main_process: impl futures::Future<Output = Result<T>>,
     task_group: TaskGroup,
-) -> Result<()> {
+) -> Result<Option<T>> {
     match task_group
         .make_handle()
         .cancel_on_shutdown(main_process)
@@ -191,7 +191,7 @@ pub async fn cleanup_on_exit<T>(
     {
         Err(_) => {
             info!("Received shutdown signal before finishing main process, exiting early");
-            Ok(())
+            Ok(None)
         }
         Ok(Ok(v)) => {
             debug!(target: LOG_DEVIMINT, "Main process finished successfully, shutting down task group");
@@ -199,9 +199,8 @@ pub async fn cleanup_on_exit<T>(
                 .shutdown_join_all(Duration::from_secs(30))
                 .await?;
 
-            // drop v here, not before the shutdown
-            drop(v);
-            Ok(())
+            // drop v faterthe shutdown
+            Ok(Some(v))
         }
         Ok(Err(err)) => {
             warn!(target: LOG_DEVIMINT, %err, "Main process failed, will shutdown");
@@ -317,7 +316,9 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                     Ok::<_, anyhow::Error>(daemons)
                 }
             };
-            cleanup_on_exit(main, task_group).await?;
+            if let Some(fed) = cleanup_on_exit(main, task_group).await? {
+                fed.fast_terminate().await
+            }
         }
         Cmd::Rpc(rpc_cmd) => rpc_command(rpc_cmd, common_args).await?,
         Cmd::RunUi => {

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -199,7 +199,7 @@ pub async fn cleanup_on_exit<T>(
                 .shutdown_join_all(Duration::from_secs(30))
                 .await?;
 
-            // drop v faterthe shutdown
+            // the caller can drop the v after shutdown
             Ok(Some(v))
         }
         Ok(Err(err)) => {

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -37,5 +37,8 @@ where
     // by waiting on all jits to complete, we make it less likely
     // that something is not finished yet and will block in `on_block`
     let _ = dev_fed.finalize(&process_mgr).await;
-    res
+    dev_fed.fast_terminate().await;
+    res?;
+
+    Ok(())
 }


### PR DESCRIPTION
We can just kill everything in parallel.


Requires manually calling a dropping function because of `fn drop` taking `&mut self`, and not `self`, but on the happy path (which matters in the CI), it is not a big deal.

#### Testing

`j devimint-env`, press `ctrl+D` and see how much faster it is.

Or `env RUST_LOG=fm=debug ./scripts/tests/meta-module-test.sh` and see termination going very fast.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
