### PR TITLE
chore(port-alloc): lower port allocation time

### DIFF
--- a/utils/portalloc/src/lib.rs
+++ b/utils/portalloc/src/lib.rs
@@ -92,7 +92,7 @@ pub fn port_alloc(range_size: u16) -> anyhow::Result<u16> {
                 };
             }
 
-            const ALLOCATION_TIME_SECS: u64 = 600;
+            const ALLOCATION_TIME_SECS: u64 = 120;
             // The caller gets some time actually start using the port (`bind`),
             // to prevent other callers from re-using it. This could typically be
             // much shorter, as portalloc will not only respect the allocation,


### PR DESCRIPTION
10m is more than we allow our tests to run altogether, and as soon as a port is used, it no longer really needs to be reserved anyway.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
