### PR TITLE
fix: opentelementry handling broken

### DIFF
--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -15,7 +15,7 @@ name = "fedimint_logging"
 path = "src/lib.rs"
 
 [features]
-telemetry = ["tracing-opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "console-subscriber"]
+telemetry = ["tracing-opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "console-subscriber", "opentelemetry" ]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -186,3 +186,8 @@ impl TracingSetup {
         Ok(())
     }
 }
+
+pub fn shutdown() {
+    #[cfg(feature = "telemetry")]
+    opentelemetry::global::shutdown_tracer_provider();
+}

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -14,6 +14,8 @@ rustc-args = ["--cfg", "tokio_unstable"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+telemetry = [ "fedimint-logging/telemetry" ]
+default = [ "telemetry" ]
 
 [[bin]]
 name = "fedimintd"
@@ -39,7 +41,7 @@ fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../fedimint-bitcoind" }
 fedimint-core = { version = "=0.4.0-alpha", path = "../fedimint-core" }
 fedimint-ln-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-common" }
 fedimint-ln-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-server" }
-fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging", features = ["telemetry"] }
+fedimint-logging = { version = "=0.4.0-alpha", path = "../fedimint-logging" }
 fedimint-metrics = { version = "=0.4.0-alpha", path = "../fedimint-metrics" }
 fedimint-mint-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-mint-server" }
 fedimint-meta-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-meta-server" }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -364,8 +364,7 @@ impl Fedimintd {
 
         info!("Shutdown complete");
 
-        #[cfg(feature = "telemetry")]
-        opentelemetry::global::shutdown_tracer_provider();
+        fedimint_logging::shutdown();
 
         drop(timing_total_runtime);
 


### PR DESCRIPTION
New rustc flagged a non-existant `cfg = feature` and it seems we had it generally messed-up.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
