### PR TITLE
fix(fedimintd): doesn't print version on start

### DIFF
--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -183,7 +183,6 @@ impl Fedimintd {
         handle_version_hash_command(version_hash);
 
         let version = env!("CARGO_PKG_VERSION");
-        info!("Starting fedimintd (version: {version} version_hash: {version_hash})");
 
         APP_START_TS
             .with_label_values(&[version, version_hash])
@@ -196,6 +195,8 @@ impl Fedimintd {
             .with_jaeger(opts.with_telemetry)
             .init()
             .unwrap();
+
+        info!("Starting fedimintd (version: {version} version_hash: {version_hash})");
 
         let bitcoind_rpc = BitcoinRpcConfig::get_defaults_from_env_vars()?;
 


### PR DESCRIPTION
Because it prints it before logging is initialized.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
