### PR TITLE
chore: task spawns should not inherit existing spans

### DIFF
--- a/fedimint-core/src/runtime.rs
+++ b/fedimint-core/src/runtime.rs
@@ -29,7 +29,7 @@ mod r#impl {
         F: Future<Output = T> + 'static + Send,
         T: Send + 'static,
     {
-        let span = tracing::debug_span!(target: LOG_RUNTIME, "spawn", task = name);
+        let span = tracing::debug_span!(target: LOG_RUNTIME, parent: None, "spawn", task = name);
         // nosemgrep: ban-tokio-spawn
         tokio::spawn(future.instrument(span))
     }
@@ -38,7 +38,8 @@ mod r#impl {
     where
         F: Future<Output = ()> + 'static,
     {
-        let span = tracing::debug_span!(target: LOG_RUNTIME, "spawn_local", task = name);
+        let span =
+            tracing::debug_span!(target: LOG_RUNTIME, parent: None, "spawn_local", task = name);
         // nosemgrep: ban-tokio-spawn
         tokio::task::spawn_local(future.instrument(span))
     }


### PR DESCRIPTION
It's just annoying, and they are conceptually top level things.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
