### PR TITLE
fix: recognize change outputs for bitcoind backends without txindex

### DIFF
--- a/devimint/src/cfg/bitcoin.conf
+++ b/devimint/src/cfg/bitcoin.conf
@@ -1,6 +1,6 @@
 regtest=1
 fallbackfee=0.0004
-txindex=1
+txindex={tx_index}
 server=1
 rpcuser=bitcoin
 rpcpassword=bitcoin

--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -100,6 +100,20 @@ impl IBitcoindRpc for BitcoinClient {
         Ok(height.map(|h| h as u64))
     }
 
+    async fn is_tx_in_block(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+        block_height: u64,
+    ) -> anyhow::Result<bool> {
+        let block_info = block_in_place(|| self.0.get_block_info(block_hash))?;
+        anyhow::ensure!(
+            block_info.height as u64 == block_height,
+            "Block height for block hash does not match expected height"
+        );
+        Ok(block_info.tx.contains(txid))
+    }
+
     async fn watch_script_history(&self, script: &ScriptBuf) -> anyhow::Result<()> {
         warn!(target: LOG_CORE, "Wallet operations are broken on bitcoind. Use different backend.");
         // start watching for this script in our wallet to avoid the need to rescan the

--- a/fedimint-bitcoind/src/electrum.rs
+++ b/fedimint-bitcoind/src/electrum.rs
@@ -108,6 +108,43 @@ impl IBitcoindRpc for ElectrumClient {
         }
     }
 
+    async fn is_tx_in_block(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+        block_height: u64,
+    ) -> anyhow::Result<bool> {
+        let tx = block_in_place(|| self.0.transaction_get(txid))
+            .map_err(|error| info!(?error, "Unable to get raw transaction"));
+
+        match tx.ok() {
+            None => Ok(false),
+            Some(tx) => {
+                let output = tx
+                    .output
+                    // use last since that's the change output we've constructed
+                    .last()
+                    .ok_or(format_err!("Transaction must contain at least one output"))?;
+
+                match block_in_place(|| self.0.script_get_history(&output.script_pubkey))?
+                    .iter()
+                    .find(|tx| tx.tx_hash == *txid && tx.height as u64 == block_height)
+                {
+                    Some(tx) => {
+                        let sanity_block_hash = self.get_block_hash(tx.height as u64).await?;
+                        anyhow::ensure!(
+                            *block_hash == sanity_block_hash,
+                            "Block height for block hash does not match expected height"
+                        );
+
+                        Ok(true)
+                    }
+                    None => Ok(false),
+                }
+            }
+        }
+    }
+
     async fn watch_script_history(&self, _: &ScriptBuf) -> anyhow::Result<()> {
         // no watching needed on electrs, has all the history already
         Ok(())

--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -101,6 +101,31 @@ impl IBitcoindRpc for EsploraClient {
             .map(|height| height as u64))
     }
 
+    async fn is_tx_in_block(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+        block_height: u64,
+    ) -> anyhow::Result<bool> {
+        let tx_status = self.0.get_tx_status(txid).await?;
+
+        let is_in_block_height = tx_status
+            .block_height
+            .is_some_and(|height| height as u64 == block_height);
+
+        if is_in_block_height {
+            let tx_block_hash = tx_status.block_hash.ok_or(anyhow::format_err!(
+                "Tx has a block height without a block hash"
+            ))?;
+            anyhow::ensure!(
+                *block_hash == tx_block_hash,
+                "Block height for block hash does not match expected height"
+            );
+        }
+
+        Ok(is_in_block_height)
+    }
+
     async fn watch_script_history(&self, _: &ScriptBuf) -> anyhow::Result<()> {
         // no watching needed, has all the history already
         Ok(())

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -346,6 +346,21 @@ impl IBitcoindRpc for FakeBitcoinTest {
         Ok(None)
     }
 
+    async fn is_tx_in_block(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+        block_height: u64,
+    ) -> BitcoinRpcResult<bool> {
+        let block = &self.inner.read().unwrap().blocks[block_height as usize];
+        assert!(
+            block.block_hash() == *block_hash,
+            "Block height for hash does not match expected height"
+        );
+
+        Ok(block.txdata.iter().any(|tx| tx.txid() == *txid))
+    }
+
     async fn watch_script_history(&self, _: &ScriptBuf) -> BitcoinRpcResult<()> {
         Ok(())
     }

--- a/fedimint-testing/src/btc/mod.rs
+++ b/fedimint-testing/src/btc/mod.rs
@@ -13,7 +13,7 @@ pub trait BitcoinTest {
     async fn lock_exclusive(&self) -> Box<dyn BitcoinTest + Send + Sync>;
 
     /// Mines a given number of blocks
-    async fn mine_blocks(&self, block_num: u64);
+    async fn mine_blocks(&self, block_num: u64) -> Vec<bitcoin::BlockHash>;
 
     /// Prepare funding wallet
     ///
@@ -41,4 +41,11 @@ pub trait BitcoinTest {
 
     /// Waits till tx is found in mempool and returns the fees
     async fn get_mempool_tx_fee(&self, txid: &Txid) -> Amount;
+
+    /// Returns the block height for the txid if found.
+    ///
+    /// Note: this exists since there's a bug for using bitcoind without txindex
+    /// for finding a tx block height.
+    /// see: `<https://github.com/fedimint/fedimint/issues/5329>`
+    async fn get_tx_block_height(&self, txid: &Txid) -> Option<u64>;
 }

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -48,13 +48,13 @@ impl BitcoinTest for RealBitcoinTestNoLock {
         )
     }
 
-    async fn mine_blocks(&self, block_num: u64) {
-        if let Some(block_hash) = self
+    async fn mine_blocks(&self, block_num: u64) -> Vec<bitcoin::BlockHash> {
+        let mined_block_hashes = self
             .client
             .generate_to_address(block_num, &self.get_new_address().await)
-            .expect(Self::ERROR)
-            .last()
-        {
+            .expect(Self::ERROR);
+
+        if let Some(block_hash) = mined_block_hashes.last() {
             let last_mined_block = self
                 .client
                 .get_block_header_info(block_hash)
@@ -85,6 +85,8 @@ impl BitcoinTest for RealBitcoinTestNoLock {
                 }
             }
         };
+
+        mined_block_hashes
     }
 
     async fn prepare_funding_wallet(&self) {
@@ -103,11 +105,12 @@ impl BitcoinTest for RealBitcoinTestNoLock {
             .client
             .send_to_address(address, amount, None, None, None, None, None, None)
             .expect(Self::ERROR);
-        self.mine_blocks(1).await;
+        let mined_block_hashes = self.mine_blocks(1).await;
+        let mined_block_hash = mined_block_hashes.first().expect("mined a block");
 
         let tx = self
             .client
-            .get_raw_transaction(&id, None)
+            .get_raw_transaction(&id, Some(mined_block_hash))
             .expect(Self::ERROR);
         let proof = TxOutProof::consensus_decode(
             &mut Cursor::new(loop {
@@ -154,6 +157,28 @@ impl BitcoinTest for RealBitcoinTestNoLock {
                 }
             }
         }
+    }
+
+    async fn get_tx_block_height(&self, txid: &Txid) -> Option<u64> {
+        let current_block_count = self
+            .client
+            .get_block_count()
+            .expect("failed to fetch chain tip");
+        (0..=current_block_count)
+            .position(|height| {
+                let block_hash = self
+                    .client
+                    .get_block_hash(height)
+                    .expect("failed to fetch block hash");
+
+                self.client
+                    .get_block_info(&block_hash)
+                    .expect("failed to fetch block info")
+                    .tx
+                    .iter()
+                    .any(|id| id == txid)
+            })
+            .map(|height| height as u64)
     }
 }
 
@@ -210,9 +235,9 @@ impl BitcoinTest for RealBitcoinTest {
         })
     }
 
-    async fn mine_blocks(&self, block_num: u64) {
+    async fn mine_blocks(&self, block_num: u64) -> Vec<bitcoin::BlockHash> {
         let _lock = self.lock_exclusive().await;
-        self.inner.mine_blocks(block_num).await;
+        self.inner.mine_blocks(block_num).await
     }
 
     async fn prepare_funding_wallet(&self) {
@@ -242,6 +267,11 @@ impl BitcoinTest for RealBitcoinTest {
     async fn get_mempool_tx_fee(&self, txid: &Txid) -> Amount {
         let _lock = self.lock_exclusive().await;
         self.inner.get_mempool_tx_fee(txid).await
+    }
+
+    async fn get_tx_block_height(&self, txid: &Txid) -> Option<u64> {
+        let _lock = self.lock_exclusive().await;
+        self.inner.get_tx_block_height(txid).await
     }
 }
 
@@ -251,11 +281,12 @@ impl BitcoinTest for RealBitcoinTestLocked {
         panic!("Double-locking would lead to a hang");
     }
 
-    async fn mine_blocks(&self, block_num: u64) {
+    async fn mine_blocks(&self, block_num: u64) -> Vec<bitcoin::BlockHash> {
         let pre = self.inner.client.get_block_count().unwrap();
-        self.inner.mine_blocks(block_num).await;
+        let mined_block_hashes = self.inner.mine_blocks(block_num).await;
         let post = self.inner.client.get_block_count().unwrap();
         assert_eq!(post - pre, block_num);
+        mined_block_hashes
     }
 
     async fn prepare_funding_wallet(&self) {
@@ -280,5 +311,9 @@ impl BitcoinTest for RealBitcoinTestLocked {
 
     async fn get_mempool_tx_fee(&self, txid: &Txid) -> Amount {
         self.inner.get_mempool_tx_fee(txid).await
+    }
+
+    async fn get_tx_block_height(&self, txid: &Txid) -> Option<u64> {
+        self.inner.get_tx_block_height(txid).await
     }
 }

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use anyhow::{bail, Context};
 use assert_matches::assert_matches;
 use bitcoin::secp256k1::rand::rngs::OsRng;
-use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::ClientHandleArc;
 use fedimint_core::bitcoin_migration::checked_address_to_unchecked_address;
@@ -46,7 +45,6 @@ const PEG_IN_TIMEOUT: Duration = Duration::from_secs(60);
 async fn peg_in<'a>(
     client: &'a ClientHandleArc,
     bitcoin: &dyn BitcoinTest,
-    dyn_bitcoin_rpc: &DynBitcoindRpc,
     finality_delay: u64,
 ) -> anyhow::Result<BoxStream<'a, Amount>> {
     let valid_until = time::now() + PEG_IN_TIMEOUT;
@@ -64,9 +62,9 @@ async fn peg_in<'a>(
                 + bsats(wallet_module.get_fee_consensus().peg_in_abs.msats / 1000),
         )
         .await;
-    let height = dyn_bitcoin_rpc
+    let height = bitcoin
         .get_tx_block_height(&tx.txid())
-        .await?
+        .await
         .context("expected tx to be mined")?;
     info!(?height, ?tx, "Peg-in transaction mined");
     let sub = wallet_module.subscribe_deposit_updates(op).await?;
@@ -136,7 +134,7 @@ async fn sanity_check_bitcoin_blocks() -> anyhow::Result<()> {
     let expected_transaction_block_count = current_block_count;
     let expected_transaction_height = expected_transaction_block_count - 1;
     assert_eq!(
-        dyn_bitcoin_rpc.get_tx_block_height(&tx.txid()).await?,
+        bitcoin.get_tx_block_height(&tx.txid()).await,
         Some(expected_transaction_height),
     );
     let expected_transaction_block_hash = dyn_bitcoin_rpc
@@ -154,15 +152,13 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
-    let dyn_bitcoin_rpc = fixtures.dyn_bitcoin_rpc();
     info!("Starting test on_chain_peg_in_and_peg_out_happy_case");
 
     let finality_delay = 10;
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let mut balance_sub =
-        peg_in(&client, bitcoin.as_ref(), &dyn_bitcoin_rpc, finality_delay).await?;
+    let mut balance_sub = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
 
     info!("Peg-in finished for test on_chain_peg_in_and_peg_out_happy_case");
     // Peg-out test, requires block to recognize change UTXOs
@@ -216,15 +212,13 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
-    let dyn_bitcoin_rpc = fixtures.dyn_bitcoin_rpc();
     info!("Starting test peg_out_fail_refund");
 
     let finality_delay = 10;
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let mut balance_sub =
-        peg_in(&client, bitcoin.as_ref(), &dyn_bitcoin_rpc, finality_delay).await?;
+    let mut balance_sub = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
 
     info!("Peg-in finished for test peg_out_fail_refund");
     // Peg-out test, requires block to recognize change UTXOs
@@ -266,15 +260,13 @@ async fn peg_outs_support_rbf() -> anyhow::Result<()> {
     let bitcoin = fixtures.bitcoin();
     // Need lock to keep tx in mempool from getting mined
     let bitcoin = bitcoin.lock_exclusive().await;
-    let dyn_bitcoin_rpc = fixtures.dyn_bitcoin_rpc();
     info!("Starting test peg_outs_support_rbf");
 
     let finality_delay = 10;
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let mut balance_sub =
-        peg_in(&client, bitcoin.as_ref(), &dyn_bitcoin_rpc, finality_delay).await?;
+    let mut balance_sub = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
 
     info!("Peg-in finished for test peg_outs_support_rbf");
     let address = checked_address_to_unchecked_address(&bitcoin.get_new_address().await);
@@ -357,8 +349,7 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let mut balance_sub =
-        peg_in(&client, bitcoin.as_ref(), &dyn_bitcoin_rpc, finality_delay).await?;
+    let mut balance_sub = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
 
     info!("Peg-in finished for test peg_outs_must_wait_for_available_utxos");
     let address = checked_address_to_unchecked_address(&bitcoin.get_new_address().await);


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/5298

Peers using bitcoind without txindex will not recognize change outputs. This PR introduces `is_tx_in_block` to `IBitcoindRpc`, which uses [`getblock`](https://developer.bitcoin.org/reference/rpc/getblock.html) for bitcoind that doesn't require txindex.

For pruned nodes, calls to `getblock` will return an error if the block data has been pruned (see: https://github.com/bitcoin/bitcoin/blob/v0.11.0/doc/release-notes.md#block-file-pruning). The minimum allowed for pruned nodes is 550MB, which is ~2 days/288 blocks assuming average block size ~1.9MB. If a peer attempts to sync blocks that have been pruned while there are outstanding pending transactions, the underlying call to `getblock` will fail.

---
This change will prevent further issues but does not resolve bad state for federations that have not recognized pending change transactions. I'm still investigating a simple fix along with ensuring we can use the recoverytool for impacted federations.