### PR TITLE
Simplify api version negotiation

### DIFF
--- a/fedimint-api-client/src/lib.rs
+++ b/fedimint-api-client/src/lib.rs
@@ -7,6 +7,7 @@ use fedimint_core::encoding::Encodable as _;
 use fedimint_core::endpoint_constants::CLIENT_CONFIG_ENDPOINT;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::ApiRequestErased;
+use fedimint_core::NumPeers;
 use query::FilterMap;
 use tracing::debug;
 
@@ -46,7 +47,7 @@ pub async fn try_download_client_config(invite_code: &InviteCode) -> anyhow::Res
 
             Ok(cfg.global.api_endpoints)
         },
-        1,
+        NumPeers::from(1),
     );
 
     let api_endpoints = DynGlobalApi::from_invite_code(invite_code)

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -613,7 +613,7 @@ pub async fn handle_command(
             unreachable!("Update stream ended without outcome");
         }
         ClientCmd::DiscoverVersion => {
-            Ok(json!({ "versions": client.discover_common_api_version(None).await? }))
+            Ok(json!({ "versions": client.discover_common_api_version().await? }))
         }
         ClientCmd::Module { module, args } => match module {
             Some(module) => {

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -82,7 +82,6 @@ use db::{
     ClientConfigKeyPrefix, ClientInitStateKey, ClientModuleRecovery, EncodedClientSecretKey,
     InitMode,
 };
-use envs::get_discover_api_version_timeout;
 use fedimint_api_client::api::{ApiVersionSet, DynGlobalApi, DynModuleApi, IGlobalFederationApi};
 use fedimint_core::config::{
     ClientConfig, ClientModuleConfig, FederationId, JsonClientConfig, JsonWithKind,
@@ -180,14 +179,6 @@ pub enum AddStateMachinesError {
     StateAlreadyExists,
     #[error("Got {0}")]
     Other(#[from] anyhow::Error),
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum DiscoverCommonApiVersionMode {
-    /// Get the response from only a few peers, or until a timeout
-    Fast,
-    /// Try to get a response from all peers, or until a timeout
-    Full,
 }
 
 pub type AddStateMachinesResult = Result<(), AddStateMachinesError>;
@@ -1358,19 +1349,13 @@ impl Client {
         })
     }
 
-    pub async fn discover_common_api_version(
-        &self,
-        threshold: Option<usize>,
-    ) -> anyhow::Result<ApiVersionSet> {
-        Ok(self
-            .api()
+    pub async fn discover_common_api_version(&self) -> anyhow::Result<ApiVersionSet> {
+        self.api()
             .discover_api_version_set(
                 &Self::supported_api_versions_summary_static(self.get_config(), &self.module_inits)
                     .await,
-                get_discover_api_version_timeout(),
-                threshold,
             )
-            .await?)
+            .await
     }
 
     /// Query the federation for API version support and then calculate
@@ -1379,27 +1364,17 @@ impl Client {
         config: &ClientConfig,
         client_module_init: &ClientModuleInitRegistry,
         api: &DynGlobalApi,
-        mode: DiscoverCommonApiVersionMode,
     ) -> anyhow::Result<ApiVersionSet> {
-        Ok(api
-            .discover_api_version_set(
-                &Self::supported_api_versions_summary_static(config, client_module_init).await,
-                get_discover_api_version_timeout(),
-                match mode {
-                    DiscoverCommonApiVersionMode::Fast => {
-                        Some((config.global.api_endpoints.len() / 2).min(1))
-                    }
-                    DiscoverCommonApiVersionMode::Full => None,
-                },
-            )
-            .await?)
+        api.discover_api_version_set(
+            &Self::supported_api_versions_summary_static(config, client_module_init).await,
+        )
+        .await
     }
 
     pub async fn discover_common_api_version_static(
         config: &ClientConfig,
         client_module_init: &ClientModuleInitRegistry,
         api: &DynGlobalApi,
-        mode: DiscoverCommonApiVersionMode,
     ) -> anyhow::Result<ApiVersionSet> {
         // We want to give it at least a good 30 second worth of trying, before we give
         // up.
@@ -1407,8 +1382,7 @@ impl Client {
 
         loop {
             let res =
-                Self::discover_common_api_version_static_try(config, client_module_init, api, mode)
-                    .await;
+                Self::discover_common_api_version_static_try(config, client_module_init, api).await;
 
             if res.is_ok() {
                 return res;
@@ -1480,14 +1454,8 @@ impl Client {
             // Separate task group, because we actually don't want to be waiting for this to
             // finish, and it's just best effort.
             task_group.spawn_cancellable("refresh_common_api_version_static", async move {
-                if let Err(error) = Self::refresh_common_api_version_static(
-                    &config,
-                    &module_inits,
-                    &api,
-                    &db,
-                    DiscoverCommonApiVersionMode::Full,
-                )
-                .await
+                if let Err(error) =
+                    Self::refresh_common_api_version_static(&config, &module_inits, &api, &db).await
                 {
                     warn!(%error, "Failed to discover common api versions");
                 }
@@ -1497,14 +1465,7 @@ impl Client {
         }
 
         debug!("No existing cached common api versions found, waiting for initial discovery");
-        Self::refresh_common_api_version_static(
-            config,
-            module_inits,
-            api,
-            db,
-            DiscoverCommonApiVersionMode::Fast,
-        )
-        .await
+        Self::refresh_common_api_version_static(config, module_inits, api, db).await
     }
 
     async fn refresh_common_api_version_static(
@@ -1512,12 +1473,11 @@ impl Client {
         module_inits: &ModuleInitRegistry<DynClientModuleInit>,
         api: &DynGlobalApi,
         db: &Database,
-        mode: DiscoverCommonApiVersionMode,
     ) -> anyhow::Result<ApiVersionSet> {
         debug!("Refreshing common api versions");
 
         let common_api_versions =
-            Client::discover_common_api_version_static(config, module_inits, api, mode).await?;
+            Client::discover_common_api_version_static(config, module_inits, api).await?;
 
         debug!(
             value = ?common_api_versions,

--- a/fedimint-core/src/module/version.rs
+++ b/fedimint-core/src/module/version.rs
@@ -192,8 +192,8 @@ impl cmp::Ord for ApiVersion {
 /// Each element must have a distinct major api number, and means
 /// either minimum required API version of this major number (for the client),
 /// or maximum supported version of this major number (for the server).
-#[derive(Debug, Clone, Serialize, Default)]
-pub struct MultiApiVersion(Vec<ApiVersion>);
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Default)]
+pub struct MultiApiVersion(pub Vec<ApiVersion>);
 
 impl MultiApiVersion {
     pub fn new() -> Self {
@@ -365,7 +365,7 @@ fn api_version_multi_from_iter_sanity() {
     .is_err());
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SupportedCoreApiVersions {
     pub core_consensus: CoreConsensusVersion,
     /// Supported Api versions for this core consensus versions
@@ -390,7 +390,7 @@ impl SupportedCoreApiVersions {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SupportedModuleApiVersions {
     pub core_consensus: CoreConsensusVersion,
     pub module_consensus: ModuleConsensusVersion,
@@ -441,7 +441,7 @@ impl SupportedModuleApiVersions {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SupportedApiVersionsSummary {
     pub core: SupportedCoreApiVersions,
     pub modules: BTreeMap<ModuleInstanceId, SupportedModuleApiVersions>,

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -23,7 +23,7 @@ use fedimint_core::session_outcome::{
 };
 use fedimint_core::task::{sleep, TaskGroup, TaskHandle};
 use fedimint_core::timing::TimeReporter;
-use fedimint_core::{timing, PeerId};
+use fedimint_core::{timing, NumPeers, PeerId};
 use futures::StreamExt;
 use rand::Rng;
 use tokio::sync::{watch, RwLock};
@@ -641,7 +641,7 @@ impl ConsensusEngine {
 
             let result = federation_api
                 .request_with_strategy(
-                    FilterMap::new(filter_map.clone(), total_peers),
+                    FilterMap::new(filter_map.clone(), NumPeers::from(total_peers)),
                     AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT.to_string(),
                     ApiRequestErased::new(index),
                 )

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -96,6 +96,9 @@ pub async fn run(
     let connection_status_channels = Default::default();
     let last_ci_by_peer = Default::default();
 
+    let supported_api_versions =
+        ServerConfig::supported_api_versions_summary(&cfg.consensus.modules, &module_init_registry);
+
     let consensus_api = ConsensusApi {
         cfg: cfg.clone(),
         db: db.clone(),
@@ -103,10 +106,7 @@ pub async fn run(
         client_cfg: client_cfg.clone(),
         submission_sender: submission_sender.clone(),
         shutdown_sender,
-        supported_api_versions: ServerConfig::supported_api_versions_summary(
-            &cfg.consensus.modules,
-            &module_init_registry,
-        ),
+        supported_api_versions: supported_api_versions.clone(),
         last_ci_by_peer: Arc::clone(&last_ci_by_peer),
         connection_status_channels: Arc::clone(&connection_status_channels),
     };
@@ -140,6 +140,7 @@ pub async fn run(
             .map(|x| x.to_string())
             .collect(),
         cfg: cfg.clone(),
+        supported_api_versions,
         connection_status_channels,
         submission_receiver,
         shutdown_receiver,

--- a/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
@@ -15,7 +15,7 @@ use fedimint_core::endpoint_constants::AWAIT_OUTPUT_OUTCOME_ENDPOINT;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::secp256k1::KeyPair;
 use fedimint_core::task::sleep;
-use fedimint_core::{NumPeersExt, OutPoint, PeerId, TransactionId};
+use fedimint_core::{NumPeers, NumPeersExt, OutPoint, PeerId, TransactionId};
 use fedimint_lnv2_client::LightningClientStateMachines;
 use fedimint_lnv2_common::contracts::IncomingContract;
 use fedimint_lnv2_common::{LightningInput, LightningInputV0, LightningOutputOutcome};
@@ -185,7 +185,7 @@ impl ReceiveStateMachine {
                 .request_with_strategy(
                     FilterMapThreshold::new(
                         verify_decryption_share.clone(),
-                        global_context.api().all_peers().total(),
+                        NumPeers::from(global_context.api().all_peers().total()),
                     ),
                     AWAIT_OUTPUT_OUTCOME_ENDPOINT.to_owned(),
                     ApiRequestErased::new(out_point),

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -387,7 +387,7 @@ impl GatewayClientModule {
         let challenges = self
             .module_api
             .get_remove_gateway_challenge(gateway_id)
-            .await?;
+            .await;
 
         let fed_public_key = self.cfg.threshold_pub_key;
         let signatures = challenges
@@ -404,9 +404,7 @@ impl GatewayClientModule {
             signatures,
         };
 
-        self.module_api
-            .remove_gateway(remove_gateway_request)
-            .await?;
+        self.module_api.remove_gateway(remove_gateway_request).await;
 
         Ok(())
     }

--- a/modules/fedimint-ln-client/src/api.rs
+++ b/modules/fedimint-ln-client/src/api.rs
@@ -8,7 +8,7 @@ use fedimint_api_client::api::{
 use fedimint_api_client::query::{ThresholdOrDeadline, UnionResponses};
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::{apply, async_trait_maybe_send, NumPeersExt, PeerId};
+use fedimint_core::{apply, async_trait_maybe_send, NumPeers, NumPeersExt, PeerId};
 use fedimint_ln_common::contracts::incoming::{IncomingContractAccount, IncomingContractOffer};
 use fedimint_ln_common::contracts::outgoing::OutgoingContractAccount;
 use fedimint_ln_common::contracts::{
@@ -186,7 +186,7 @@ where
     async fn fetch_gateways(&self) -> FederationResult<Vec<LightningGatewayAnnouncement>> {
         let gateway_announcements: Vec<LightningGatewayAnnouncement> = self
             .request_with_strategy(
-                UnionResponses::new(self.all_peers().total()),
+                UnionResponses::new(NumPeers::from(self.all_peers().total())),
                 LIST_GATEWAYS_ENDPOINT.to_string(),
                 ApiRequestErased::default(),
             )

--- a/modules/fedimint-ln-client/src/api.rs
+++ b/modules/fedimint-ln-client/src/api.rs
@@ -5,7 +5,7 @@ use bitcoin::hashes::sha256::{self, Hash as Sha256Hash};
 use fedimint_api_client::api::{
     FederationApiExt, FederationError, FederationResult, IModuleFederationApi,
 };
-use fedimint_api_client::query::{ThresholdOrDeadline, UnionResponses};
+use fedimint_api_client::query::UnionResponses;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{apply, async_trait_maybe_send, NumPeers, NumPeersExt, PeerId};
@@ -73,15 +73,12 @@ pub trait LnFederationApi {
     async fn get_remove_gateway_challenge(
         &self,
         gateway_id: PublicKey,
-    ) -> FederationResult<BTreeMap<PeerId, Option<sha256::Hash>>>;
+    ) -> BTreeMap<PeerId, Option<sha256::Hash>>;
 
     /// Removes the gateway's registration record. First checks the provided
     /// signature to verify the gateway authorized the removal of the
     /// registration.
-    async fn remove_gateway(
-        &self,
-        remove_gateway_request: RemoveGatewayRequest,
-    ) -> FederationResult<()>;
+    async fn remove_gateway(&self, remove_gateway_request: RemoveGatewayRequest);
 
     async fn offer_exists(&self, payment_hash: Sha256Hash) -> FederationResult<bool>;
 
@@ -211,46 +208,48 @@ where
     async fn get_remove_gateway_challenge(
         &self,
         gateway_id: PublicKey,
-    ) -> FederationResult<BTreeMap<PeerId, Option<sha256::Hash>>> {
-        // Only wait a second since removing a gateway is "best effort"
-        let deadline = fedimint_core::time::now() + Duration::from_secs(1);
-        let responses = self
-            .request_with_strategy(
-                ThresholdOrDeadline::<Option<sha256::Hash>>::new(
-                    self.all_peers().total(),
-                    deadline,
-                ),
-                REMOVE_GATEWAY_CHALLENGE_ENDPOINT.to_string(),
-                ApiRequestErased::new(gateway_id),
-            )
-            .await?;
-        Ok(responses)
-    }
+    ) -> BTreeMap<PeerId, Option<sha256::Hash>> {
+        let mut responses = BTreeMap::new();
 
-    async fn remove_gateway(
-        &self,
-        remove_gateway_request: RemoveGatewayRequest,
-    ) -> FederationResult<()> {
-        // Only wait a second since removing a gateway is "best effort"
-        let gateway_id = remove_gateway_request.gateway_id;
-        let deadline = fedimint_core::time::now() + Duration::from_secs(1);
-        let responses = self
-            .request_with_strategy(
-                ThresholdOrDeadline::<bool>::new(self.all_peers().total(), deadline),
-                REMOVE_GATEWAY_ENDPOINT.to_string(),
-                ApiRequestErased::new(remove_gateway_request),
-            )
-            .await?;
-
-        for (peer_id, response) in responses.into_iter() {
-            if response {
-                info!("Successfully removed {gateway_id} gateway from peer: {peer_id}",);
-            } else {
-                warn!("Unable to remove gateway {gateway_id} registration from peer: {peer_id}");
+        for peer in self.all_peers() {
+            if let Ok(response) = self
+                // Only wait a second since removing a gateway is "best effort"
+                .request_single_peer_federation::<Option<sha256::Hash>>(
+                    Some(Duration::from_secs(1)),
+                    REMOVE_GATEWAY_CHALLENGE_ENDPOINT.to_string(),
+                    ApiRequestErased::new(gateway_id),
+                    *peer,
+                )
+                .await
+            {
+                responses.insert(*peer, response);
             }
         }
 
-        Ok(())
+        responses
+    }
+
+    async fn remove_gateway(&self, remove_gateway_request: RemoveGatewayRequest) {
+        let gateway_id = remove_gateway_request.gateway_id;
+
+        for peer in self.all_peers() {
+            if let Ok(response) = self
+                .request_single_peer_federation::<bool>(
+                    // Only wait a second since removing a gateway is "best effort"
+                    Some(Duration::from_secs(1)),
+                    REMOVE_GATEWAY_ENDPOINT.to_string(),
+                    ApiRequestErased::new(remove_gateway_request.clone()),
+                    *peer,
+                )
+                .await
+            {
+                if response {
+                    info!("Successfully removed {gateway_id} gateway from peer: {peer}",);
+                } else {
+                    warn!("Unable to remove gateway {gateway_id} registration from peer: {peer}");
+                }
+            }
+        }
     }
 
     async fn offer_exists(&self, payment_hash: Sha256Hash) -> FederationResult<bool> {

--- a/modules/fedimint-lnv2-client/src/api.rs
+++ b/modules/fedimint-lnv2-client/src/api.rs
@@ -5,7 +5,7 @@ use fedimint_api_client::query::UnionResponses;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{sleep, MaybeSend, MaybeSync};
 use fedimint_core::util::SafeUrl;
-use fedimint_core::{apply, async_trait_maybe_send, NumPeersExt};
+use fedimint_core::{apply, async_trait_maybe_send, NumPeers, NumPeersExt};
 use fedimint_lnv2_common::endpoint_constants::{
     AWAIT_INCOMING_CONTRACT_ENDPOINT, AWAIT_PREIMAGE_ENDPOINT, CONSENSUS_BLOCK_COUNT_ENDPOINT,
     GATEWAYS_ENDPOINT, OUTGOING_CONTRACT_EXPIRATION_ENDPOINT,
@@ -90,7 +90,7 @@ where
 
     async fn fetch_gateways(&self) -> FederationResult<Vec<SafeUrl>> {
         self.request_with_strategy(
-            UnionResponses::new(self.all_peers().total()),
+            UnionResponses::new(NumPeers::from(self.all_peers().total())),
             GATEWAYS_ENDPOINT.to_string(),
             ApiRequestErased::default(),
         )

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -13,7 +13,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::secp256k1::KeyPair;
 use fedimint_core::task::sleep;
-use fedimint_core::{Amount, NumPeersExt, OutPoint, PeerId, Tiered};
+use fedimint_core::{Amount, NumPeers, NumPeersExt, OutPoint, PeerId, Tiered};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_MINT;
 use fedimint_mint_common::endpoint_constants::AWAIT_OUTPUT_OUTCOME_ENDPOINT;
@@ -196,7 +196,7 @@ impl MintOutputStatesCreated {
                         move |peer, outcome| {
                             verify_blind_share(peer, outcome, amount, message, &decoder, &pks)
                         },
-                        global_context.api().all_peers().total(),
+                        NumPeers::from(global_context.api().all_peers().total()),
                     ),
                     AWAIT_OUTPUT_OUTCOME_ENDPOINT.to_owned(),
                     ApiRequestErased::new(common.out_point),


### PR DESCRIPTION
We remove the requirement of peers being able to support different api versions. Allowing different api versions could lead to a situation where some client modules may be able to talk to some peers but not all, leading to different liveness guarantees for different modules.

Removing this requirement enables the removal of two query strategies as well as the ability for a query strategy to set custom timeouts per peer. Any operation should be explicitly timed out at the highest level possible, so either the test itself times out or the integrator sets a custom timeout by wrapping a call.