### PR TITLE
chore: port in url handling improvements

### DIFF
--- a/fedimint-core/src/net/mod.rs
+++ b/fedimint-core/src/net/mod.rs
@@ -1,1 +1,3 @@
 pub mod peers;
+
+pub const STANDARD_FEDIMINT_P2P_PORT: u16 = 8173;

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -104,8 +104,26 @@ impl SafeUrl {
         self.0.port()
     }
     pub fn port_or_known_default(&self) -> Option<u16> {
-        self.0.port_or_known_default()
+        match self.0.scheme() {
+            // p2p port
+            "fedimint" => Some(8173),
+            _ => self.0.port_or_known_default(),
+        }
     }
+
+    /// `self` but with port explicitly set, if known from url
+    pub fn with_port_or_known_default(&self) -> SafeUrl {
+        if self.port().is_none() {
+            if let Some(default) = self.port_or_known_default() {
+                let mut url = self.clone();
+                url.0.set_port(Some(default)).expect("Can't fail");
+                return url;
+            }
+        }
+
+        self.clone()
+    }
+
     pub fn path(&self) -> &str {
         self.0.path()
     }

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -20,6 +20,7 @@ use tokio::io::AsyncWriteExt;
 use tracing::{debug, warn, Instrument, Span};
 use url::{Host, ParseError, Url};
 
+use crate::net::STANDARD_FEDIMINT_P2P_PORT;
 use crate::task::MaybeSend;
 use crate::{apply, async_trait_maybe_send, maybe_add_send, runtime};
 
@@ -114,7 +115,7 @@ impl SafeUrl {
         }
         match self.0.scheme() {
             // p2p port scheme
-            "fedimint" => Some(8173),
+            "fedimint" => Some(STANDARD_FEDIMINT_P2P_PORT),
             _ => self.0.port_or_known_default(),
         }
     }

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -590,8 +590,10 @@ where
 
     async fn try_reconnect(&self) -> Result<AnyFramedTransport<PeerMessage<M>>, anyhow::Error> {
         debug!(target: LOG_NET_PEER, our_id = ?self.our_id, peer = ?self.peer_id, "Trying to reconnect");
-        let addr = self.peer_address.clone();
-        let (connected_peer, conn) = self.connect.connect_framed(addr, self.peer_id).await?;
+        let (connected_peer, conn) = self
+            .connect
+            .connect_framed(self.peer_address.with_port_or_known_default(), self.peer_id)
+            .await?;
 
         if connected_peer == self.peer_id {
             Ok(conn)


### PR DESCRIPTION
Explicitly specifying port in p2p url should not be neccessary (just a room for mistakes).

Also - `SafeUrl` should reject any URLs for which we don't know which port to use as early as possible, to limit room for mistakes.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
