### PR TITLE
chore: reenable devimint gateway liquidity channel opening

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -584,9 +584,12 @@ async fn open_channel(
     let cln_pubkey = cln.pub_key().await?;
 
     cln.request(cln_rpc::model::requests::ConnectRequest {
-        id: lnd_pubkey.parse()?,
-        host: Some("127.0.0.1".to_owned()),
-        port: Some(process_mgr.globals.FM_PORT_LND_LISTEN),
+        id: format!(
+            "{}@127.0.0.1:{}",
+            lnd_pubkey, process_mgr.globals.FM_PORT_LND_LISTEN
+        ),
+        host: None,
+        port: None,
     })
     .await
     .context("connect request")?;

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -675,12 +675,7 @@ pub async fn open_channel_between_gateways(
 ) -> Result<()> {
     let gateway_cli_version = crate::util::GatewayCli::version_or_default().await;
     let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    #[allow(clippy::overly_complex_bool_expr)]
-    if gateway_cli_version < *VERSION_0_4_0_ALPHA || gatewayd_version < *VERSION_0_4_0_ALPHA
-        // FIXME: The new way is actually slower and require more things to initialize, and
-        // due to more dependency chains lead to flaky CI pipeline
-        || true
-    {
+    if gateway_cli_version < *VERSION_0_4_0_ALPHA || gatewayd_version < *VERSION_0_4_0_ALPHA {
         debug!(target: LOG_DEVIMINT, "Opening channel between gateways (the old way)");
         return open_channel(process_mgr, bitcoind, cln, lnd).await;
     }

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -640,7 +640,7 @@ impl GatewayLightning for ClnRpcService {
             .await
             .map_err(|e| Status::internal(e.to_string()))?
             .call(cln_rpc::Request::NewAddr(model::requests::NewaddrRequest {
-                addresstype: Some(cln_rpc::model::requests::NewaddrAddresstype::BECH32),
+                addresstype: None,
             }))
             .await
             .map(|response| match response {


### PR DESCRIPTION
I audited the code for [`open_channel()`](https://github.com/fedimint/fedimint/blob/5bd3555a5bf445def3f44f8b1a9049299e7f956b/devimint/src/external.rs#L552) to ensure that [`open_channel_between_gateways()`](https://github.com/fedimint/fedimint/blob/5bd3555a5bf445def3f44f8b1a9049299e7f956b/devimint/src/external.rs#L654) matches it 1-to-1. I then re-enabled `open_channel_between_gateways()` for devimint (which was disabled [here](https://github.com/fedimint/fedimint/pull/5149) due to being slow and flaky). I measured the startup time for `just mprocs` 10+ times on my local machine before and after the change and with the changes in this PR it never failed and the time difference was within margin of error.