### PR TITLE
chore: do not require identical git hash during DKG

### DIFF
--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -51,8 +51,8 @@ pub struct ConfigGenApi {
     config_generated_tx: Sender<ServerConfig>,
     /// Task group for running DKG
     task_group: TaskGroup,
-    /// Version hash
-    version_hash: String,
+    /// Code version str that will get encoded in consensus hash
+    code_version_str: String,
 }
 
 impl ConfigGenApi {
@@ -61,14 +61,14 @@ impl ConfigGenApi {
         db: Database,
         config_generated_tx: Sender<ServerConfig>,
         task_group: &mut TaskGroup,
-        version_hash: String,
+        code_version_str: String,
     ) -> Self {
         let config_gen_api = Self {
             state: Arc::new(Mutex::new(ConfigGenState::new(settings))),
             db,
             config_generated_tx,
             task_group: task_group.clone(),
-            version_hash,
+            code_version_str,
         };
         info!(target: fedimint_logging::LOG_NET_PEER_DKG, "Created new config gen Api");
         config_gen_api
@@ -271,7 +271,7 @@ impl ConfigGenApi {
                 registry,
                 DelayCalculator::PROD_DEFAULT,
                 &mut task_group,
-                self_clone.version_hash.clone(),
+                self_clone.code_version_str.clone(),
             )
             .await;
             task_group

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -226,7 +226,7 @@ impl ServerConfig {
         broadcast_public_keys: BTreeMap<PeerId, PublicKey>,
         broadcast_secret_key: SecretKey,
         modules: BTreeMap<ModuleInstanceId, ServerModuleConfig>,
-        version_hash: String,
+        code_version_str: String,
     ) -> Self {
         let private = ServerConfigPrivate {
             api_auth: params.local.api_auth.clone(),
@@ -248,7 +248,7 @@ impl ServerConfig {
             modules: Default::default(),
         };
         let consensus = ServerConfigConsensus {
-            code_version: version_hash,
+            code_version: code_version_str,
             version: CORE_CONSENSUS_VERSION,
             broadcast_public_keys,
             broadcast_expected_rounds_per_session: if is_running_in_test_env() {
@@ -409,7 +409,7 @@ impl ServerConfig {
     pub fn trusted_dealer_gen(
         params: &HashMap<PeerId, ConfigGenParams>,
         registry: ServerModuleInitRegistry,
-        version_hash: String,
+        code_version_str: String,
     ) -> BTreeMap<PeerId, Self> {
         let peer0 = &params[&PeerId::from(0)];
 
@@ -447,7 +447,7 @@ impl ServerConfig {
                         .iter()
                         .map(|(module_id, cfgs)| (*module_id, cfgs[&id].clone()))
                         .collect(),
-                    version_hash.clone(),
+                    code_version_str.clone(),
                 );
                 (id, config)
             })
@@ -462,7 +462,7 @@ impl ServerConfig {
         registry: ServerModuleInitRegistry,
         delay_calculator: DelayCalculator,
         task_group: &mut TaskGroup,
-        version_hash: String,
+        code_version_str: String,
     ) -> DkgResult<Self> {
         let _timing /* logs on drop */ = timing::TimeReporter::new("distributed-gen").info();
         let server_conn = connect(
@@ -495,7 +495,7 @@ impl ServerConfig {
             let server = Self::trusted_dealer_gen(
                 &HashMap::from([(*our_id, params.clone())]),
                 registry,
-                version_hash,
+                code_version_str,
             );
             return Ok(server[our_id].clone());
         }
@@ -582,7 +582,7 @@ impl ServerConfig {
             broadcast_public_keys,
             broadcast_sk,
             module_cfgs,
-            version_hash,
+            code_version_str,
         );
 
         info!(

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn run(
     data_dir: PathBuf,
     settings: ConfigGenSettings,
     db: Database,
-    version_hash: String,
+    code_version_str: String,
     module_init_registry: &ServerModuleInitRegistry,
     task_group: TaskGroup,
 ) -> anyhow::Result<()> {
@@ -53,7 +53,7 @@ pub async fn run(
                 data_dir,
                 settings,
                 db.clone(),
-                version_hash,
+                code_version_str,
                 task_group.make_subgroup(),
             )
             .await?
@@ -93,7 +93,7 @@ pub async fn run_config_gen(
     data_dir: PathBuf,
     settings: ConfigGenSettings,
     db: Database,
-    version_hash: String,
+    code_version_str: String,
     mut task_group: TaskGroup,
 ) -> anyhow::Result<ServerConfig> {
     info!(target: LOG_CONSENSUS, "Starting config gen");
@@ -107,7 +107,7 @@ pub async fn run_config_gen(
         db.clone(),
         cfg_sender,
         &mut task_group,
-        version_hash.clone(),
+        code_version_str.clone(),
     );
 
     let mut rpc_module = RpcHandlerCtx::new_module(config_gen);

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -3,7 +3,7 @@ use fedimintd::Fedimintd;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    Fedimintd::new(fedimint_build_code_version_env!())?
+    Fedimintd::new(fedimint_build_code_version_env!(), None)?
         .with_default_modules()
         .run()
         .await


### PR DESCRIPTION
That is waay to constraining. Different peers can't even include non-code fixes for their local deployement and other problems.

Since we're kind of good at the release and versioning and stability things, change the requirement to a `code_version_str`, which consists of the cargo release version of Fedimint code and optional vendor suffix.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
