### PR TITLE
chore: cleanup fedimint-core code

### DIFF
--- a/fedimint-core/src/bitcoin_migration.rs
+++ b/fedimint-core/src/bitcoin_migration.rs
@@ -32,10 +32,10 @@ pub fn bitcoin30_to_bitcoin29_network_magic(magic: &bitcoin::network::Magic) -> 
     // See the following bitcoin v0.29 and v0.30 code:
     // https://docs.rs/bitcoin/0.29.2/src/bitcoin/network/constants.rs.html#81-84
     // https://docs.rs/bitcoin/0.30.2/src/bitcoin/network/constants.rs.html#251-258
-    ((bytes[3] as u32) << 24)
-        | ((bytes[2] as u32) << 16)
-        | ((bytes[1] as u32) << 8)
-        | (bytes[0] as u32)
+    (u32::from(bytes[3]) << 24)
+        | (u32::from(bytes[2]) << 16)
+        | (u32::from(bytes[1]) << 8)
+        | u32::from(bytes[0])
 }
 
 pub fn checked_address_to_unchecked_address(

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -67,7 +67,7 @@ impl OperationId {
         Self(bytes)
     }
 
-    pub fn from_encodable<E: Encodable>(encodable: E) -> OperationId {
+    pub fn from_encodable<E: Encodable>(encodable: &E) -> OperationId {
         Self(encodable.consensus_hash::<sha256::Hash>().to_byte_array())
     }
 }

--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -236,7 +236,7 @@ where
         audit: &mut Audit,
         module_instance_id: ModuleInstanceId,
     ) {
-        <Self as ServerModule>::audit(self, dbtx, audit, module_instance_id).await
+        <Self as ServerModule>::audit(self, dbtx, audit, module_instance_id).await;
     }
 
     fn api_endpoints(&self) -> Vec<ApiEndpoint<DynServerModule>> {

--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -214,7 +214,7 @@ impl<'a> IRawDatabaseTransaction for MemTransaction<'a> {
                     anyhow::ensure!(
                         data_copy.remove(&delete_op.key) == delete_op.old_value,
                         "write-write conflict"
-                    )
+                    );
                 }
             }
         }

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -226,10 +226,10 @@ where
         (**self).begin_transaction().await
     }
     async fn register(&self, key: &[u8]) {
-        (**self).register(key).await
+        (**self).register(key).await;
     }
     async fn notify(&self, key: &[u8]) {
-        (**self).notify(key).await
+        (**self).notify(key).await;
     }
 
     fn prefix_len(&self) -> usize {
@@ -260,10 +260,10 @@ impl<RawDatabase: IRawDatabase + MaybeSend + 'static> IDatabase for BaseDatabase
         ))
     }
     async fn register(&self, key: &[u8]) {
-        self.notifications.register(key).await
+        self.notifications.register(key).await;
     }
     async fn notify(&self, key: &[u8]) {
-        self.notifications.notify(key).await
+        self.notifications.notify(key).await;
     }
 
     fn prefix_len(&self) -> usize {
@@ -458,10 +458,7 @@ impl Database {
                     return Ok(val);
                 }
                 Err(err) => {
-                    if max_attempts
-                        .map(|max_att| max_att <= curr_attempts)
-                        .unwrap_or(false)
-                    {
+                    if max_attempts.is_some_and(|max_att| max_att <= curr_attempts) {
                         warn!(
                             target: LOG_DB,
                             curr_attempts,
@@ -583,11 +580,11 @@ where
         })
     }
     async fn register(&self, key: &[u8]) {
-        self.inner.register(&self.get_full_key(key)).await
+        self.inner.register(&self.get_full_key(key)).await;
     }
 
     async fn notify(&self, key: &[u8]) {
-        self.inner.notify(&self.get_full_key(key)).await
+        self.inner.notify(&self.get_full_key(key)).await;
     }
 
     fn prefix_len(&self) -> usize {
@@ -1035,7 +1032,7 @@ where
     {
         self.raw_remove_by_prefix(&key_prefix.to_bytes())
             .await
-            .expect("Unrecoverable error when removing entries from the database")
+            .expect("Unrecoverable error when removing entries from the database");
     }
 }
 
@@ -1219,7 +1216,8 @@ where
             .commit_tx()
             .await?;
         self.notifications.submit_queue(
-            self.notify_queue
+            &self
+                .notify_queue
                 .take()
                 .expect("commit must be called only once"),
         );
@@ -2385,7 +2383,7 @@ mod test_utils {
                     10
                 };
                 for _ in 0..times {
-                    tokio::task::yield_now().await
+                    tokio::task::yield_now().await;
                 }
             }
 
@@ -2429,8 +2427,8 @@ mod test_utils {
 
                     match (a, s) {
                         (None, None) | (Some(_), Some(_)) => {}
-                        (None, Some(_)) => panic!("none some?! {}", i),
-                        (Some(_), None) => panic!("some none?! {}", i),
+                        (None, Some(_)) => panic!("none some?! {i}"),
+                        (Some(_), None) => panic!("some none?! {i}"),
                     }
                 },
                 async {
@@ -2909,7 +2907,7 @@ mod test_utils {
                 attempts: failed_attempts,
                 ..
             } => {
-                assert_eq!(failed_attempts, 5)
+                assert_eq!(failed_attempts, 5);
             }
             AutocommitError::ClosureError { .. } => panic!("Closure did not return error"),
         }

--- a/fedimint-core/src/db/notifications.rs
+++ b/fedimint-core/src/db/notifications.rs
@@ -65,7 +65,7 @@ impl Notifications {
     }
 
     /// Notifies the waiters about the notifications recorded in NotifyQueue.
-    pub fn submit_queue(&self, queue: NotifyQueue) {
+    pub fn submit_queue(&self, queue: &NotifyQueue) {
         for bucket in queue.buckets.iter_ones() {
             self.buckets[bucket].notify_waiters();
         }
@@ -154,7 +154,7 @@ mod tests {
         let mut queue = NotifyQueue::new();
         queue.add(&key1);
         queue.add(&key2);
-        notifs.submit_queue(queue);
+        notifs.submit_queue(&queue);
         assert!(
             future_returns_shortly(sub1).await.is_some(),
             "should notify"

--- a/fedimint-core/src/encoding/secp256k1.rs
+++ b/fedimint-core/src/encoding/secp256k1.rs
@@ -111,7 +111,7 @@ mod tests {
             &sk,
         );
 
-        test_roundtrip(sig);
+        test_roundtrip(&sig);
     }
 
     #[test_log::test]
@@ -120,13 +120,13 @@ mod tests {
         let mut rng = rand::rngs::OsRng;
         let sec_key = bitcoin::key::KeyPair::new(ctx, &mut rng);
         let pub_key = sec_key.public_key();
-        test_roundtrip(pub_key);
+        test_roundtrip(&pub_key);
 
         let sig = ctx.sign_schnorr(
             &secp256k1_zkp::hashes::sha256::Hash::hash(b"Hello World!").into(),
             &sec_key,
         );
 
-        test_roundtrip(sig);
+        test_roundtrip(&sig);
     }
 }

--- a/fedimint-core/src/encoding/threshold_crypto.rs
+++ b/fedimint-core/src/encoding/threshold_crypto.rs
@@ -115,7 +115,7 @@ mod tests {
         let ciphertext = pk.encrypt(message);
         let decryption_share = sks.secret_key_share(0).decrypt_share(&ciphertext).unwrap();
 
-        test_roundtrip(ciphertext);
-        test_roundtrip(decryption_share);
+        test_roundtrip(&ciphertext);
+        test_roundtrip(&decryption_share);
     }
 }

--- a/fedimint-core/src/fmt_utils.rs
+++ b/fedimint-core/src/fmt_utils.rs
@@ -5,9 +5,7 @@ use serde_json::Value;
 pub fn rust_log_full_enabled() -> bool {
     // this will be called only once per-thread for best performance
     thread_local!(static RUST_LOG_FULL: bool = {
-        std::env::var_os("RUST_LOG_FULL")
-            .map(|val| !val.is_empty())
-            .unwrap_or(false)
+        std::env::var_os("RUST_LOG_FULL").is_some_and(|val| !val.is_empty())
     });
     RUST_LOG_FULL.with(|x| *x)
 }

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -442,7 +442,7 @@ impl std::ops::Div for Amount {
 
 impl std::ops::SubAssign for Amount {
     fn sub_assign(&mut self, rhs: Self) {
-        self.msats -= rhs.msats
+        self.msats -= rhs.msats;
     }
 }
 

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -241,12 +241,12 @@ impl<'a> ApiEndpointContext<'a> {
 
     /// Attempts to commit the dbtx or returns an ApiError
     pub async fn commit_tx_result(self, path: &'static str) -> Result<(), ApiError> {
-        self.dbtx.commit_tx_result().await.map_err(|_err| {
+        self.dbtx.commit_tx_result().await.map_err(|err| {
             tracing::warn!(
                 target: fedimint_logging::LOG_NET_API,
                 path,
                 "API server error when writing to database: {:?}",
-                _err
+                err
             );
             ApiError {
                 code: 500,

--- a/fedimint-core/src/module/registry.rs
+++ b/fedimint-core/src/module/registry.rs
@@ -143,7 +143,7 @@ impl<M: std::fmt::Debug, State> ModuleRegistry<M, State> {
         assert!(
             self.inner.insert(id, (kind, module)).is_none(),
             "Module was already registered!"
-        )
+        );
     }
 
     pub fn append_module(&mut self, kind: ModuleKind, module: M) {
@@ -155,7 +155,7 @@ impl<M: std::fmt::Debug, State> ModuleRegistry<M, State> {
         assert!(
             self.inner.insert(last_id, (kind, module)).is_none(),
             "Module was already registered?!"
-        )
+        );
     }
 }
 
@@ -166,11 +166,10 @@ impl ServerModuleRegistry {
     /// Generate a `ModuleDecoderRegistry` from this `ModuleRegistry`
     pub fn decoder_registry(&self) -> ModuleDecoderRegistry {
         // TODO: cache decoders
-        ModuleDecoderRegistry::from_iter(
-            self.inner
-                .iter()
-                .map(|(&id, (kind, module))| (id, kind.clone(), module.decoder())),
-        )
+        self.inner
+            .iter()
+            .map(|(&id, (kind, module))| (id, kind.clone(), module.decoder()))
+            .collect::<ModuleDecoderRegistry>()
     }
 }
 

--- a/fedimint-core/src/net/peers/fake.rs
+++ b/fedimint-core/src/net/peers/fake.rs
@@ -38,7 +38,7 @@ where
             if let Some(msg) = self.rx.recv().await {
                 return Ok((self.peer_id, msg));
             } else {
-                sleep(Duration::from_secs(10)).await
+                sleep(Duration::from_secs(10)).await;
             }
         }
         Err(Cancelled)

--- a/fedimint-core/src/runtime.rs
+++ b/fedimint-core/src/runtime.rs
@@ -22,7 +22,7 @@ pub use self::r#impl::*;
 mod r#impl {
     pub use tokio::task::{JoinError, JoinHandle};
 
-    use super::*;
+    use super::{Duration, Elapsed, Future, Instant, Instrument, LOG_RUNTIME};
 
     pub fn spawn<F, T>(name: &str, future: F) -> tokio::task::JoinHandle<T>
     where
@@ -63,11 +63,11 @@ mod r#impl {
 
     pub async fn sleep(duration: Duration) {
         // nosemgrep: ban-tokio-sleep
-        tokio::time::sleep(duration).await
+        tokio::time::sleep(duration).await;
     }
 
     pub async fn sleep_until(deadline: Instant) {
-        tokio::time::sleep_until(deadline).await
+        tokio::time::sleep_until(deadline).await;
     }
 
     pub async fn timeout<T>(duration: Duration, future: T) -> Result<T::Output, Elapsed>

--- a/fedimint-core/src/session_outcome.rs
+++ b/fedimint-core/src/session_outcome.rs
@@ -39,7 +39,7 @@ impl SessionOutcome {
         let leaf_hashes = self
             .items
             .iter()
-            .map(|item| item.consensus_hash::<sha256::Hash>());
+            .map(Encodable::consensus_hash::<sha256::Hash>);
 
         if let Some(root) = bitcoin::merkle_tree::calculate_root(leaf_hashes) {
             header[8..].copy_from_slice(&root.to_byte_array());

--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -112,7 +112,7 @@ impl TaskGroup {
     }
 
     pub fn shutdown(&self) {
-        self.inner.shutdown()
+        self.inner.shutdown();
     }
 
     pub async fn shutdown_join_all(
@@ -311,7 +311,7 @@ impl TaskGroup {
                     warn!(
                         target: LOG_TASK, task=%name,
                         "Timeout waiting for task to shut down"
-                    )
+                    );
                 }
             }
         }
@@ -543,7 +543,7 @@ mod tests {
     async fn shutdown_task_group_after() -> anyhow::Result<()> {
         let tg = TaskGroup::new();
         tg.spawn("shutdown waiter", |handle| async move {
-            handle.make_shutdown_rx().await.await
+            handle.make_shutdown_rx().await.await;
         });
         sleep(Duration::from_millis(10)).await;
         tg.shutdown_join_all(None).await?;
@@ -555,7 +555,7 @@ mod tests {
         let tg = TaskGroup::new();
         tg.spawn("shutdown waiter", |handle| async move {
             sleep(Duration::from_millis(10)).await;
-            handle.make_shutdown_rx().await.await
+            handle.make_shutdown_rx().await.await;
         });
         tg.shutdown_join_all(None).await?;
         Ok(())
@@ -566,7 +566,7 @@ mod tests {
         let tg = TaskGroup::new();
         tg.make_subgroup()
             .spawn("shutdown waiter", |handle| async move {
-                handle.make_shutdown_rx().await.await
+                handle.make_shutdown_rx().await.await;
             });
         sleep(Duration::from_millis(10)).await;
         tg.shutdown_join_all(None).await?;
@@ -579,7 +579,7 @@ mod tests {
         tg.make_subgroup()
             .spawn("shutdown waiter", |handle| async move {
                 sleep(Duration::from_millis(10)).await;
-                handle.make_shutdown_rx().await.await
+                handle.make_shutdown_rx().await.await;
             });
         tg.shutdown_join_all(None).await?;
         Ok(())

--- a/fedimint-core/src/tiered_multi.rs
+++ b/fedimint-core/src/tiered_multi.rs
@@ -36,7 +36,7 @@ impl<T> TieredMulti<T> {
 
     /// Returns the number of items in all vectors
     pub fn count_items(&self) -> usize {
-        self.0.values().map(|notes| notes.len()).sum()
+        self.0.values().map(Vec::len).sum()
     }
 
     /// Returns the number of tiers
@@ -51,9 +51,11 @@ impl<T> TieredMulti<T> {
 
     /// Returns the summary of number of items in each tier
     pub fn summary(&self) -> TieredCounts {
-        TieredCounts(Tiered::from_iter(
-            self.iter().map(|(amount, values)| (*amount, values.len())),
-        ))
+        TieredCounts(
+            self.iter()
+                .map(|(amount, values)| (*amount, values.len()))
+                .collect(),
+        )
     }
 
     /// Verifies whether all vectors in all tiers are empty
@@ -136,13 +138,13 @@ impl<T> TieredMulti<T> {
     }
 
     pub fn push(&mut self, amt: Amount, val: T) {
-        self.0.entry(amt).or_default().push(val)
+        self.0.entry(amt).or_default().push(val);
     }
 
     fn assert_invariants(&self) {
         // Just for compactness and determinism, we don't want entries with 0 items
         #[cfg(debug_assertions)]
-        self.iter().for_each(|(_, v)| debug_assert!(!v.is_empty()))
+        self.iter().for_each(|(_, v)| debug_assert!(!v.is_empty()));
     }
 }
 
@@ -180,7 +182,7 @@ impl<C> Default for TieredMulti<C> {
 impl<C> Extend<(Amount, C)> for TieredMulti<C> {
     fn extend<T: IntoIterator<Item = (Amount, C)>>(&mut self, iter: T) {
         for (amount, note) in iter {
-            self.0.entry(amount).or_default().push(note)
+            self.0.entry(amount).or_default().push(note);
         }
     }
 }
@@ -239,7 +241,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         let mut notes = Vec::with_capacity(self.iters.len());
         let mut amount = None;
-        for iter in self.iters.iter_mut() {
+        for iter in &mut self.iters {
             match iter.next() {
                 Some((amt, note)) => {
                     if let Some(amount) = amount {
@@ -317,7 +319,7 @@ impl TieredCounts {
     fn assert_invariants(&self) {
         // Just for compactness and determinism, we don't want entries with 0 count
         #[cfg(debug_assertions)]
-        self.iter().for_each(|(_, count)| debug_assert!(0 < count))
+        self.iter().for_each(|(_, count)| debug_assert!(0 < count));
     }
 }
 

--- a/fedimint-core/src/timing.rs
+++ b/fedimint-core/src/timing.rs
@@ -138,7 +138,7 @@ impl TimeReporter {
 impl Drop for TimeReporter {
     fn drop(&mut self) {
         if let Some(mut inner) = self.inner.take() {
-            inner.report()
+            inner.report();
         }
     }
 }

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -79,7 +79,7 @@ impl Transaction {
     /// Validate the schnorr signatures signed over the `tx_hash`
     pub fn validate_signatures(
         &self,
-        pub_keys: Vec<secp256k1_zkp::PublicKey>,
+        pub_keys: &[secp256k1_zkp::PublicKey],
     ) -> Result<(), TransactionError> {
         let signatures = match &self.signatures {
             TransactionSignature::NaiveMultisig(sigs) => sigs,

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -60,12 +60,11 @@ where
     /// where the future will be cancelled by shutdown logic anyway and handling
     /// each place where a stream may terminate would be too much trouble.
     async fn next_or_pending(&mut self) -> Self::Output {
-        match self.next().await {
-            Some(item) => item,
-            None => {
-                debug!("Stream ended in next_or_pending, pending forever to avoid throwing an error on shutdown");
-                std::future::pending().await
-            }
+        if let Some(item) = self.next().await {
+            item
+        } else {
+            debug!("Stream ended in next_or_pending, pending forever to avoid throwing an error on shutdown");
+            std::future::pending().await
         }
     }
 }
@@ -303,7 +302,7 @@ pub fn handle_version_hash_command(version_hash: &str) {
     let mut args = std::env::args();
     if let Some(ref arg) = args.nth(1) {
         if arg.as_str() == "version-hash" {
-            println!("{}", version_hash);
+            println!("{version_hash}");
             std::process::exit(0);
         }
     }

--- a/fedimint-server/src/consensus/transaction.rs
+++ b/fedimint-server/src/consensus/transaction.rs
@@ -37,7 +37,7 @@ pub async fn process_transaction_with_dbtx(
         public_keys.push(meta.pub_key);
     }
 
-    transaction.validate_signatures(public_keys)?;
+    transaction.validate_signatures(&public_keys)?;
 
     let txid = transaction.tx_hash();
 

--- a/gateway/ln-gateway/src/gateway_module_v2/mod.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/mod.rs
@@ -204,7 +204,7 @@ impl GatewayClientModuleV2 {
         // the gateways claim to a contract in case of cancellation. We only create a
         // forfeit signature after the we have started the send state machine to
         // prevent replay attacks with a previously cancelled outgoing contract
-        let operation_id = OperationId::from_encodable(payload.contract.clone());
+        let operation_id = OperationId::from_encodable(&payload.contract.clone());
 
         if self.client_ctx.operation_exists(operation_id).await {
             return Ok(self.subscribe_send(operation_id).await);
@@ -305,7 +305,7 @@ impl GatewayClientModuleV2 {
         htlc_id: u64,
         payload: CreateInvoicePayload,
     ) -> anyhow::Result<()> {
-        let operation_id = OperationId::from_encodable(payload.clone());
+        let operation_id = OperationId::from_encodable(&payload.clone());
 
         if self.client_ctx.operation_exists(operation_id).await {
             return Ok(());
@@ -358,7 +358,7 @@ impl GatewayClientModuleV2 {
         &self,
         payload: CreateInvoicePayload,
     ) -> anyhow::Result<[u8; 32]> {
-        let operation_id = OperationId::from_encodable(payload.clone());
+        let operation_id = OperationId::from_encodable(&payload.clone());
 
         if self.client_ctx.operation_exists(operation_id).await {
             return self

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -73,7 +73,7 @@ const INVOICE_EXPIRATION_SECONDS_DEFAULT: u32 = 3600;
 /// classDef virtual fill:#fff,stroke-dasharray: 5 5
 ///
 ///     Funding -- funding transaction is rejected --> Rejected
-///     Funding -- funding transaction is accepted --> Funded    
+///     Funding -- funding transaction is accepted --> Funded
 ///     Funded -- payment is confirmed  --> Success
 ///     Funded -- payment attempt expires --> Refunding
 ///     Funded -- gateway cancels payment attempt --> Refunding
@@ -428,7 +428,7 @@ impl LightningClientModule {
         invoice: &Bolt11Invoice,
     ) -> Result<OperationId, SendPaymentError> {
         for payment_attempt in 0..u64::MAX {
-            let operation_id = OperationId::from_encodable((invoice.clone(), payment_attempt));
+            let operation_id = OperationId::from_encodable(&(invoice.clone(), payment_attempt));
 
             if !self.client_ctx.operation_exists(operation_id).await {
                 return Ok(operation_id);
@@ -489,7 +489,7 @@ impl LightningClientModule {
                                     },
                                     Err(..) => {
                                         // The gateway may have incorrectly claimed the outgoing contract thereby causing
-                                        // our refund transaction to be rejected. Therefore, we check one last time if 
+                                        // our refund transaction to be rejected. Therefore, we check one last time if
                                         // the preimage is available before we enter the failure state.
                                         if let Some(preimage) = module_api.await_preimage(
                                             &state.common.contract.contract_id(),
@@ -687,7 +687,7 @@ impl LightningClientModule {
         &self,
         contract: IncomingContract,
     ) -> Option<OperationId> {
-        let operation_id = OperationId::from_encodable(contract.clone());
+        let operation_id = OperationId::from_encodable(&contract.clone());
 
         let (claim_keypair, agg_decryption_key) = self.recover_contract_keys(&contract).await?;
 


### PR DESCRIPTION
I temporarily enabled clippy pedantic rules and fixed the issues it caught (except the ones that sacrifice code readability)