### PR TITLE
chore: print shortened version of OperationId when logging

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -971,7 +971,9 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     // Receive the ecash notes
     info!("Testing receiving e-cash notes");
     let operation_id = ln_invoice_response.operation_id;
-    cmd!(client, "await-invoice", operation_id).run().await?;
+    cmd!(client, "await-invoice", operation_id.fmt_full())
+        .run()
+        .await?;
 
     // Assert balances changed by 1100000 msat
     let final_cln_incoming_client_balance = client.balance().await?;
@@ -1093,7 +1095,9 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     // Receive the ecash notes
     info!("Testing receiving ecash notes");
     let operation_id = recv.operation_id;
-    cmd!(client, "await-invoice", operation_id).run().await?;
+    cmd!(client, "await-invoice", operation_id.fmt_full())
+        .run()
+        .await?;
 
     // Assert balances changed by 1_300_000 msat
     let final_lnd_incoming_client_balance = client.balance().await?;

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -273,7 +273,7 @@ pub async fn handle_command(
                     )
                     .await?
             };
-            info!("Spend e-cash operation: {operation}");
+            info!("Spend e-cash operation: {}", operation.fmt_short());
 
             Ok(json!({
                 "notes": notes,
@@ -418,7 +418,10 @@ pub async fn handle_command(
                 .pay_bolt11_invoice(ln_gateway, bolt11, ())
                 .await?;
             let operation_id = payment_type.operation_id();
-            info!("Gateway fee: {fee}, payment operation id: {operation_id}");
+            info!(
+                "Gateway fee: {fee}, payment operation id: {}",
+                operation_id.fmt_short()
+            );
             if finish_in_background {
                 client
                     .get_first_module::<LightningClientModule>()

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -471,7 +471,10 @@ where
         let mut dbtx = db.begin_transaction().await;
 
         if Client::operation_exists_dbtx(&mut dbtx.to_ref_nc(), operation_id).await {
-            bail!("Operation with id {operation_id} already exists");
+            bail!(
+                "Operation with id {} already exists",
+                operation_id.fmt_short()
+            );
         }
 
         self.client
@@ -487,9 +490,12 @@ where
             .await
             .expect("State machine is valid");
 
-        dbtx.commit_tx_result()
-            .await
-            .map_err(|_| anyhow!("Operation with id {operation_id} already exists"))?;
+        dbtx.commit_tx_result().await.map_err(|_| {
+            anyhow!(
+                "Operation with id {} already exists",
+                operation_id.fmt_short()
+            )
+        })?;
 
         Ok(())
     }

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -476,11 +476,11 @@ impl ExecutorInner {
             match event {
                 ExecutorLoopEvent::New { state } => {
                     if currently_running_sms.contains(&state) {
-                        warn!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), "Received a state machine that is already running. Ignoring");
+                        warn!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id().fmt_short(), "Received a state machine that is already running. Ignoring");
                         continue;
                     }
                     let Some(meta) = self.get_active_state(&state).await else {
-                        warn!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), "Couldn't look up received state machine. Ignoring.");
+                        warn!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id().fmt_short(), "Couldn't look up received state machine. Ignoring.");
                         continue;
                     };
 
@@ -488,7 +488,7 @@ impl ExecutorInner {
                         .get_transition_for(&state, meta, &global_context_gen)
                         .await;
                     if transitions.is_empty() {
-                        warn!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), "Received an active state that doesn't produce any transitions. Ignoring.");
+                        warn!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id().fmt_short(), "Received an active state that doesn't produce any transitions. Ignoring.");
                         continue;
                     }
 
@@ -500,7 +500,7 @@ impl ExecutorInner {
                         ExecutorLoopEvent::Triggered(first_completed_result)
                     }));
 
-                    debug!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id(), total = futures.len(), transitions_num, "New active state machine.");
+                    debug!(target: LOG_CLIENT_REACTOR, operation_id = %state.operation_id().fmt_short(), total = futures.len(), transitions_num, "New active state machine.");
                 }
                 ExecutorLoopEvent::Triggered(TransitionForActiveState {
                     outcome,
@@ -510,13 +510,13 @@ impl ExecutorInner {
                 }) => {
                     debug!(
                         target: LOG_CLIENT_REACTOR,
-                        operation_id = %state.operation_id(),
+                        operation_id = %state.operation_id().fmt_short(),
                         "Triggered state transition",
                     );
                     let span = tracing::debug_span!(
                         target: LOG_CLIENT_REACTOR,
                         "sm_transition",
-                        operation_id = %state.operation_id()
+                        operation_id = %state.operation_id().fmt_short()
                     );
                     // Perform the transition as another future, so transitions can happen in
                     // parallel.
@@ -637,7 +637,7 @@ impl ExecutorInner {
                     );
                     debug!(
                         target: LOG_CLIENT_REACTOR,
-                        operation_id = %state.operation_id(),
+                        operation_id = %state.operation_id().fmt_short(),
                         outcome_active = outcome.is_active(),
                         total = futures.len(),
                         "State transition complete"
@@ -645,7 +645,7 @@ impl ExecutorInner {
                     trace!(
                         target: LOG_CLIENT_REACTOR,
                         ?outcome,
-                        operation_id = %state.operation_id(), total = futures.len(),
+                        operation_id = %state.operation_id().fmt_short(), total = futures.len(),
                         "State transition complete"
                     );
                 }

--- a/fedimint-client/src/sm/notifier.rs
+++ b/fedimint-client/src/sm/notifier.rs
@@ -161,9 +161,9 @@ where
                 .collect::<Vec<(S, _)>>();
             all_states_timed.sort_by(|(_, t1), (_, t2)| t1.cmp(t2));
             debug!(
-                %operation_id,
-                "Returning {} state transitions from DB for notifier subscription",
-                all_states_timed.len()
+                operation_id = %operation_id.fmt_short(),
+                num = all_states_timed.len(),
+                "Returning state transitions from DB for notifier subscription",
             );
             all_states_timed
                 .into_iter()
@@ -178,7 +178,7 @@ where
                 let db_states = db_states.clone();
                 async move {
                     if state.operation_id() == operation_id {
-                        trace!(%operation_id, ?state, "Received state transition notification");
+                        trace!(operation_id = %operation_id.fmt_short(), ?state, "Received state transition notification");
                         // Deduplicate events that might have both come from the DB and streamed,
                         // due to subscribing to notifier before querying the DB.
                         //
@@ -187,7 +187,7 @@ where
                         // so the overlap here should be minimal.
                         // And we'll rewrite the whole thing anyway and use only db as a reference.
                         if db_states.iter().any(|db_s| db_s == &state) {
-                            debug!(%operation_id, ?state, "Ignoring duplicated event");
+                            debug!(operation_id = %operation_id.fmt_short(), ?state, "Ignoring duplicated event");
                             return None;
                         }
                         Some(state)

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -85,7 +85,7 @@ impl OperationId {
 impl<'a> Display for OperationIdShortFmt<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         bitcoin29::hashes::hex::format_hex(&self.0 .0[0..4], f)?;
-        f.write_str("..")?;
+        f.write_str("_")?;
         bitcoin29::hashes::hex::format_hex(&self.0 .0[28..], f)?;
         Ok(())
     }

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -479,7 +479,7 @@ impl GatewayClientModule {
                 yield GatewayExtReceiveStates::Funding;
 
                 let state = loop {
-                    debug!("Getting next ln receive state for {operation_id}");
+                    debug!("Getting next ln receive state for {}", operation_id.fmt_short());
                     if let Some(GatewayClientStateMachines::Receive(state)) = stream.next().await {
                         match state.state {
                             IncomingSmStates::Preimage(preimage) =>{
@@ -504,7 +504,7 @@ impl GatewayClientModule {
                                 break GatewayExtReceiveStates::FundingFailed{ error }
                             },
                             other => {
-                                debug!("Got state {other:?} while awaiting for output of {operation_id}");
+                                debug!("Got state {other:?} while awaiting for output of {}", operation_id.fmt_short());
                             }
                         }
                     }
@@ -562,7 +562,7 @@ impl GatewayClientModule {
                                         .await;
                                 }
                                 Err(AddStateMachinesError::StateAlreadyExists) => {
-                                    info!("State machine for operation {operation_id} already exists, will not add a new one")
+                                    info!("State machine for operation {} already exists, will not add a new one", operation_id.fmt_short())
                                 }
                                 Err(other) => {
                                     anyhow::bail!("Failed to add state machines: {other:?}")
@@ -595,7 +595,7 @@ impl GatewayClientModule {
                 yield GatewayExtPayStates::Created;
 
                 loop {
-                    debug!("Getting next ln pay state for {operation_id}");
+                    debug!("Getting next ln pay state for {}", operation_id.fmt_short());
                     if let Some(GatewayClientStateMachines::Pay(state)) = stream.next().await {
                         match state.state {
                             GatewayPayStates::Preimage(out_points, preimage) => {
@@ -624,27 +624,27 @@ impl GatewayClientModule {
                                     }
                                     Err(e) => {
                                         warn!(?operation_id, "Got failure {e:?} while awaiting for transaction {txid} to be accepted for");
-                                        yield GatewayExtPayStates::Fail { error, error_message: format!("Refund transaction {txid} was not accepted by the federation. OperationId: {operation_id} Error: {e:?}") };
+                                        yield GatewayExtPayStates::Fail { error, error_message: format!("Refund transaction {txid} was not accepted by the federation. OperationId: {} Error: {e:?}", operation_id.fmt_short()) };
                                     }
                                 }
                             }
                             GatewayPayStates::OfferDoesNotExist(contract_id) => {
-                                warn!("Yielding OfferDoesNotExist state for {operation_id} and contract {contract_id}");
+                                warn!("Yielding OfferDoesNotExist state for {} and contract {contract_id}", operation_id.fmt_short());
                                 yield GatewayExtPayStates::OfferDoesNotExist { contract_id };
                             }
                             GatewayPayStates::Failed{ error, error_message } => {
-                                warn!("Yielding Fail state for {operation_id} due to {error:?} {error_message:?}");
+                                warn!("Yielding Fail state for {} due to {error:?} {error_message:?}", operation_id.fmt_short());
                                 yield GatewayExtPayStates::Fail{ error, error_message };
                             },
                             GatewayPayStates::PayInvoice(_) => {
-                                debug!("Got initial state PayInvoice while awaiting for output of {operation_id}");
+                                debug!("Got initial state PayInvoice while awaiting for output of {}", operation_id.fmt_short());
                             }
                             other => {
-                                info!("Got state {other:?} while awaiting for output of {operation_id}");
+                                info!("Got state {other:?} while awaiting for output of {}", operation_id.fmt_short());
                             }
                         }
                     } else {
-                        warn!("Got None while getting next ln pay state for {operation_id}");
+                        warn!("Got None while getting next ln pay state for {}", operation_id.fmt_short());
                     }
                 }
             }

--- a/modules/fedimint-ln-client/src/cli.rs
+++ b/modules/fedimint-ln-client/src/cli.rs
@@ -101,7 +101,10 @@ pub(crate) async fn handle_cli_command(
                 fee,
             } = module.pay_bolt11_invoice(ln_gateway, bolt11, ()).await?;
             let operation_id = payment_type.operation_id();
-            info!("Gateway fee: {fee}, payment operation id: {operation_id}");
+            info!(
+                "Gateway fee: {fee}, payment operation id: {}",
+                operation_id.fmt_short()
+            );
             if finish_in_background {
                 module
                     .wait_for_ln_payment(payment_type, contract_id, true)

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -425,7 +425,7 @@ impl ClientModule for LightningClientModule {
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum PayBolt11InvoiceError {
-    #[error("Previous payment attempt({}) still in progress", .operation_id)]
+    #[error("Previous payment attempt({}) still in progress", .operation_id.fmt_full())]
     PreviousPaymentAttemptStillInProgress { operation_id: OperationId },
     #[error("No LN gateway available")]
     NoLnGatewayAvailable,

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -807,9 +807,9 @@ pub enum SendPaymentError {
     InvoiceMissingAmount,
     #[error("The invoice has expired")]
     InvoiceExpired,
-    #[error("A previous payment for the same invoice is still pending: {0}")]
+    #[error("A previous payment for the same invoice is still pending: {}", .0.fmt_full())]
     PendingPreviousPayment(OperationId),
-    #[error("A previous payment for the same invoice was successful: {0}")]
+    #[error("A previous payment for the same invoice was successful: {}", .0.fmt_full())]
     SuccessfulPreviousPayment(OperationId),
     #[error("Gateway error: {0}")]
     GatewayError(GatewayError),

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -441,7 +441,7 @@ impl WalletClientModule {
             .client_ctx
             .get_operation(operation_id)
             .await
-            .with_context(|| anyhow!("Operation not found: {operation_id}"))?;
+            .with_context(|| anyhow!("Operation not found: {}", operation_id.fmt_short()))?;
 
         if operation_log_entry.operation_module_kind() != WalletCommonInit::KIND.as_str() {
             bail!("Operation is not a wallet operation");
@@ -602,7 +602,7 @@ impl WalletClientModule {
             .client_ctx
             .get_operation(operation_id)
             .await
-            .with_context(|| anyhow!("Operation not found: {operation_id}"))?;
+            .with_context(|| anyhow!("Operation not found: {}", operation_id.fmt_short()))?;
 
         if operation.operation_module_kind() != WalletCommonInit::KIND.as_str() {
             bail!("Operation is not a wallet operation");

--- a/modules/fedimint-wallet-client/src/withdraw.rs
+++ b/modules/fedimint-wallet-client/src/withdraw.rs
@@ -92,10 +92,10 @@ async fn await_withdraw_processed(
 
                 e.report_if_important();
                 debug!(
-                    error = e.to_string(),
-                    operation_id = operation_id.to_string(),
-                    "Retrying in {}s",
-                    RETRY_DELAY.as_secs_f64()
+                    error = %e,
+                    operation_id = %operation_id.fmt_short(),
+                    delay_secs =  RETRY_DELAY.as_secs_f64(),
+                    "Waiting before retry",
                 );
 
                 sleep(RETRY_DELAY).await;


### PR DESCRIPTION
`operation_id` is soo common and soo long in client side logging that it's just annoying.

Shorten it to `abcdefgh..abcdefgh` version.

To prevent unintentional mistakes, remove `Display` from `OperationId` and require going through `fmt_short` or `fmt_full` to declare intention.

Fix all the call-sites.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->

Before:

![image](https://github.com/fedimint/fedimint/assets/9209/6034ecf8-51df-4569-ad9d-dbf0bf5ae72a)


After:

![image](https://github.com/fedimint/fedimint/assets/9209/b2a3d48b-a120-4fb2-87b1-f4c8d9f585c0)
