### PR TITLE
chore: use fedimint.org perfit domain

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -3,7 +3,7 @@
 name: "Backwards-Compatibility"
 
 env:
-  PERFIT_SERVER: https://perfit-fedimint.dpc.pw
+  PERFIT_SERVER: https://perfit.dev.fedimint.org
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -3,7 +3,7 @@
 name: "CI (nix)"
 
 env:
-  PERFIT_SERVER: https://perfit-fedimint.dpc.pw
+  PERFIT_SERVER: https://perfit.dev.fedimint.org
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
I temporarily deployed a NGINX config that accepts both the old and the new domain, so we can merge this independently @dpc.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
