### PR TITLE
[Backport releases/v0.3] chore: disable txindex for bitcoind backends in tests

### DIFF
--- a/devimint/src/cfg/bitcoin.conf
+++ b/devimint/src/cfg/bitcoin.conf
@@ -1,6 +1,6 @@
 regtest=1
 fallbackfee=0.0004
-txindex=1
+txindex={tx_index}
 server=1
 rpcuser=bitcoin
 rpcpassword=bitcoin

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -23,6 +23,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::util::{poll, poll_with_timeout, ClnLightningCli, ProcessHandle, ProcessManager};
 use crate::vars::utf8;
+use crate::version_constants::VERSION_0_3_2;
 use crate::{cmd, poll_eq};
 
 #[derive(Clone)]
@@ -34,12 +35,24 @@ pub struct Bitcoind {
 impl Bitcoind {
     pub async fn new(processmgr: &ProcessManager) -> Result<Self> {
         let btc_dir = utf8(&processmgr.globals.FM_BTC_DIR);
+
+        // TODO(support:v0.3)
+        // we need to run with txindex for versions before 0.4.0-alpha to correctly
+        // process change outputs
+        let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
+        let tx_index = if fedimintd_version < *VERSION_0_3_2 {
+            "1"
+        } else {
+            "0"
+        };
+
         let conf = format!(
             include_str!("cfg/bitcoin.conf"),
             rpc_port = processmgr.globals.FM_PORT_BTC_RPC,
             p2p_port = processmgr.globals.FM_PORT_BTC_P2P,
             zmq_pub_raw_block = processmgr.globals.FM_PORT_BTC_ZMQ_PUB_RAW_BLOCK,
             zmq_pub_raw_tx = processmgr.globals.FM_PORT_BTC_ZMQ_PUB_RAW_TX,
+            tx_index = tx_index,
         );
         write_overwrite_async(processmgr.globals.FM_BTC_DIR.join("bitcoin.conf"), conf).await?;
         let process = processmgr

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -5,4 +5,5 @@ lazy_static! {
     pub static ref VERSION_0_3_0_ALPHA: Version =
         Version::parse("0.3.0-alpha").expect("version is parsable");
     pub static ref VERSION_0_3_0: Version = Version::parse("0.3.0").expect("version is parsable");
+    pub static ref VERSION_0_3_2: Version = Version::parse("0.3.2").expect("version is parsable");
 }

--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -99,6 +99,20 @@ impl IBitcoindRpc for BitcoinClient {
         Ok(height.map(|h| h as u64))
     }
 
+    async fn is_tx_in_block(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+        block_height: u64,
+    ) -> anyhow::Result<bool> {
+        let block_info = block_in_place(|| self.0.get_block_info(block_hash))?;
+        anyhow::ensure!(
+            block_info.height as u64 == block_height,
+            "Block height for block hash does not match expected height"
+        );
+        Ok(block_info.tx.contains(txid))
+    }
+
     async fn watch_script_history(&self, script: &Script) -> anyhow::Result<()> {
         // start watching for this script in our wallet to avoid the need to rescan the
         // blockchain, labeling it so we can reference it later

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -125,13 +125,25 @@ pub trait IBitcoindRpc: Debug {
     /// when it makes sense.
     async fn submit_transaction(&self, transaction: Transaction);
 
-    /// Check if a transaction is included in a block
+    /// If a transaction is included in a block, returns the block height.
+    /// Note: calling this method with bitcoind as a backend must first call
+    /// `watch_script_history` or run bitcoind with txindex enabled.
     async fn get_tx_block_height(&self, txid: &Txid) -> Result<Option<u64>>;
+
+    /// Check if a transaction is included in a block
+    async fn is_tx_in_block(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+        block_height: u64,
+    ) -> Result<bool>;
 
     /// Watches for a script and returns any transactions associated with it
     ///
     /// Should be called once prior to transactions being submitted or watching
     /// may not occur on backends that need it
+    /// TODO: bitcoind backend is broken
+    /// `<https://github.com/fedimint/fedimint/issues/5329>`
     async fn watch_script_history(&self, script: &Script) -> Result<()>;
 
     /// Get script transaction history
@@ -224,6 +236,20 @@ where
     async fn get_tx_block_height(&self, txid: &Txid) -> Result<Option<u64>> {
         self.retry_call(|| async { self.inner.get_tx_block_height(txid).await })
             .await
+    }
+
+    async fn is_tx_in_block(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+        block_height: u64,
+    ) -> Result<bool> {
+        self.retry_call(|| async {
+            self.inner
+                .is_tx_in_block(txid, block_hash, block_height)
+                .await
+        })
+        .await
     }
 
     async fn watch_script_history(&self, script: &Script) -> Result<()> {

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -72,6 +72,8 @@ pub struct FakeBitcoinTest {
     proofs: Arc<Mutex<BTreeMap<Txid, TxOutProof>>>,
     /// Simulates the script history
     scripts: Arc<Mutex<BTreeMap<Script, Vec<Transaction>>>>,
+    /// Tracks the block height a transaction was included
+    txid_to_block_height: Arc<Mutex<BTreeMap<Txid, usize>>>,
 }
 
 impl Default for FakeBitcoinTest {
@@ -88,6 +90,7 @@ impl FakeBitcoinTest {
             addresses: Arc::new(Mutex::new(Default::default())),
             proofs: Arc::new(Mutex::new(Default::default())),
             scripts: Arc::new(Mutex::new(Default::default())),
+            txid_to_block_height: Arc::new(Mutex::new(Default::default())),
         }
     }
 
@@ -110,15 +113,20 @@ impl FakeBitcoinTest {
         addresses: &mut BTreeMap<Txid, Amount>,
         blocks: &mut Vec<Block>,
         pending: &mut Vec<Transaction>,
-    ) {
+        txid_to_block_height: &mut BTreeMap<Txid, usize>,
+    ) -> bitcoin::BlockHash {
         debug!(
             "Mining block: {} transactions, {} blocks",
             pending.len(),
             blocks.len()
         );
         let root = BlockHash::hash(&[0]);
+        // block height is 0-based, so blocks.len() before appending the current block
+        // gives the correct height
+        let block_height = blocks.len();
         for tx in pending.iter() {
             addresses.insert(tx.txid(), Amount::from_sats(output_sum(tx)));
+            txid_to_block_height.insert(tx.txid(), block_height);
         }
         // all blocks need at least one transaction
         if pending.is_empty() {
@@ -139,7 +147,8 @@ impl FakeBitcoinTest {
             txdata: pending.clone(),
         };
         pending.clear();
-        blocks.push(block);
+        blocks.push(block.clone());
+        block.block_hash()
     }
 }
 
@@ -151,14 +160,22 @@ impl BitcoinTest for FakeBitcoinTest {
         Box::new(self.clone())
     }
 
-    async fn mine_blocks(&self, block_num: u64) {
+    async fn mine_blocks(&self, block_num: u64) -> Vec<bitcoin::BlockHash> {
         let mut blocks = self.blocks.lock().unwrap();
         let mut pending = self.pending.lock().unwrap();
         let mut addresses = self.addresses.lock().unwrap();
+        let mut txid_to_block_height = self.txid_to_block_height.lock().unwrap();
 
-        for _ in 1..=block_num {
-            FakeBitcoinTest::mine_block(&mut addresses, &mut blocks, &mut pending);
-        }
+        (1..=block_num)
+            .map(|_| {
+                FakeBitcoinTest::mine_block(
+                    &mut addresses,
+                    &mut blocks,
+                    &mut pending,
+                    &mut txid_to_block_height,
+                )
+            })
+            .collect()
     }
 
     async fn prepare_funding_wallet(&self) {
@@ -180,6 +197,7 @@ impl BitcoinTest for FakeBitcoinTest {
         let mut addresses = self.addresses.lock().unwrap();
         let mut scripts = self.scripts.lock().unwrap();
         let mut proofs = self.proofs.lock().unwrap();
+        let mut txid_to_block_height = self.txid_to_block_height.lock().unwrap();
 
         let transaction = FakeBitcoinTest::new_transaction(vec![TxOut {
             value: amount.to_sat(),
@@ -190,7 +208,12 @@ impl BitcoinTest for FakeBitcoinTest {
         pending.push(transaction.clone());
         let merkle_proof = FakeBitcoinTest::pending_merkle_tree(&pending);
 
-        FakeBitcoinTest::mine_block(&mut addresses, &mut blocks, &mut pending);
+        FakeBitcoinTest::mine_block(
+            &mut addresses,
+            &mut blocks,
+            &mut pending,
+            &mut txid_to_block_height,
+        );
         let block_header = blocks.last().unwrap().header;
         let proof = TxOutProof {
             block_header,
@@ -215,9 +238,8 @@ impl BitcoinTest for FakeBitcoinTest {
             .blocks
             .lock()
             .unwrap()
-            .clone()
-            .into_iter()
-            .flat_map(|block| block.txdata.into_iter().flat_map(|tx| tx.output))
+            .iter()
+            .flat_map(|block| block.txdata.iter().flat_map(|tx| tx.output.clone()))
             .find(|out| out.script_pubkey == address.payload.script_pubkey())
             .map(|tx| tx.value)
             .unwrap_or(0);
@@ -252,6 +274,14 @@ impl BitcoinTest for FakeBitcoinTest {
 
             return fee;
         }
+    }
+
+    async fn get_tx_block_height(&self, txid: &Txid) -> Option<u64> {
+        self.txid_to_block_height
+            .lock()
+            .expect("RwLock poisoned")
+            .get(txid)
+            .map(|height| height.to_owned() as u64)
     }
 }
 

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -333,6 +333,21 @@ impl IBitcoindRpc for FakeBitcoinTest {
         Ok(None)
     }
 
+    async fn is_tx_in_block(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+        block_height: u64,
+    ) -> BitcoinRpcResult<bool> {
+        let block = &self.blocks.lock().unwrap()[block_height as usize];
+        assert!(
+            block.block_hash() == *block_hash,
+            "Block height for hash does not match expected height"
+        );
+
+        Ok(block.txdata.iter().any(|tx| tx.txid() == *txid))
+    }
+
     async fn watch_script_history(&self, _: &Script) -> BitcoinRpcResult<()> {
         Ok(())
     }

--- a/fedimint-testing/src/btc/mod.rs
+++ b/fedimint-testing/src/btc/mod.rs
@@ -13,7 +13,7 @@ pub trait BitcoinTest {
     async fn lock_exclusive(&self) -> Box<dyn BitcoinTest + Send + Sync>;
 
     /// Mines a given number of blocks
-    async fn mine_blocks(&self, block_num: u64);
+    async fn mine_blocks(&self, block_num: u64) -> Vec<bitcoin::BlockHash>;
 
     /// Prepare funding wallet
     ///
@@ -41,4 +41,11 @@ pub trait BitcoinTest {
 
     /// Waits till tx is found in mempool and returns the fees
     async fn get_mempool_tx_fee(&self, txid: &Txid) -> Amount;
+
+    /// Returns the block height for the txid if found.
+    ///
+    /// Note: this exists since there's a bug for using bitcoind without txindex
+    /// for finding a tx block height.
+    /// see: `<https://github.com/fedimint/fedimint/issues/5329>`
+    async fn get_tx_block_height(&self, txid: &Txid) -> Option<u64>;
 }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -46,6 +46,7 @@ use fedimint_core::server::DynServerModule;
 #[cfg(not(target_family = "wasm"))]
 use fedimint_core::task::sleep;
 use fedimint_core::task::{TaskGroup, TaskHandle};
+use fedimint_core::util::{retry, FibonacciBackoff};
 use fedimint_core::{
     apply, async_trait_maybe_send, push_db_key_items, push_db_pair_items, Feerate, NumPeersExt,
     OutPoint, PeerId, ServerModule,
@@ -1003,11 +1004,19 @@ impl Wallet {
 
             // TODO: use batching for mainnet syncing
             trace!(block = height, "Fetching block hash");
-            let block_hash = self
-                .btc_rpc
-                .get_block_hash(height as u64)
+            let block_hash =
+                retry(
+                    "get_block_hash",
+                    FibonacciBackoff::default()
+                        .with_min_delay(Duration::from_secs(1))
+                        .with_max_delay(Duration::from_secs(10 * 60))
+                        .with_max_times(usize::MAX),
+                    || {
+                        self.btc_rpc.get_block_hash(height as u64) // TODO: use u64 for height everywhere
+                    },
+                )
                 .await
-                .expect("bitcoind rpc backend failed"); // TODO: use u64 for height everywhere
+                .expect("bitcoind rpc to get block hash");
 
             let pending_transactions = dbtx
                 .find_by_prefix(&PendingTransactionPrefixKey)
@@ -1023,12 +1032,21 @@ impl Wallet {
                 "Recognizing change UTXOs"
             );
             for (txid, tx) in &pending_transactions {
-                if self
-                    .btc_rpc
-                    .is_tx_in_block(txid, &block_hash, height as u64)
-                    .await
-                    .unwrap_or_else(|_| panic!("Failed checking if tx is in block height {height}"))
-                {
+                let is_tx_in_block = retry(
+                    "is_tx_in_block",
+                    FibonacciBackoff::default()
+                        .with_min_delay(Duration::from_secs(1))
+                        .with_max_delay(Duration::from_secs(10 * 60))
+                        .with_max_times(usize::MAX),
+                    || {
+                        self.btc_rpc
+                            .is_tx_in_block(txid, &block_hash, height as u64)
+                    },
+                )
+                .await
+                .unwrap_or_else(|_| panic!("Failed checking if tx is in block height {height}"));
+
+                if is_tx_in_block {
                     debug!(?txid, ?height, ?block_hash, "Recognizing change UTXO");
                     self.recognize_change_utxo(dbtx, tx).await;
                 } else {

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1023,25 +1023,21 @@ impl Wallet {
                 "Recognizing change UTXOs"
             );
             for (txid, tx) in &pending_transactions {
-                if let Ok(Some(tx_height)) = self
+                if self
                     .btc_rpc
-                    .get_tx_block_height(txid)
+                    .is_tx_in_block(txid, &block_hash, height as u64)
                     .await
-                    .map(|r| r.filter(|tx_height| *tx_height == height as u64))
+                    .unwrap_or_else(|_| panic!("Failed checking if tx is in block height {height}"))
                 {
-                    if tx_height == height as u64 {
-                        debug!(?txid, ?tx_height, "Recognizing change UTXO");
-                        self.recognize_change_utxo(dbtx, tx).await;
-                    } else {
-                        debug!(
-                            ?txid,
-                            ?tx_height,
-                            ?height,
-                            "Pending transaction not yet confirmed in this block"
-                        );
-                    }
+                    debug!(?txid, ?height, ?block_hash, "Recognizing change UTXO");
+                    self.recognize_change_utxo(dbtx, tx).await;
                 } else {
-                    debug!(?txid, ?height, "Pending transaction not yet confirmed");
+                    debug!(
+                        ?txid,
+                        ?height,
+                        ?block_hash,
+                        "Pending transaction not yet confirmed in this block"
+                    );
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/5344

Note that I changed the version check from < 0.4.0-alpha to < v0.3.2 and we're currently on v0.3.1-rc.1 for this branch. This means we're still running the test suite with txindex enabled.