### PR TITLE
feat: add expert-user script for activating the meta module

### DIFF
--- a/scripts/ops/add_meta_module.sh
+++ b/scripts/ops/add_meta_module.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REQUIRED_BINS=(jq fedimint-cli)
+for REQUIRED_BIN in "${REQUIRED_BINS[@]}"; do
+    if ! which "$REQUIRED_BIN" &> /dev/null; then
+        echo "$REQUIRED_BIN is not installed."
+        exit 1
+    fi
+done
+
+if [ -z "${1:-}" ]; then
+    echo "Error: No directory specified."
+    echo "Usage: $0 <data_directory>"
+    exit 1
+fi
+DATA_DIR=$1
+
+echo "This script will add the meta module to federation config, which is technically"
+echo "a consensus-breaking change. Make sure that:"
+echo "  * All fedimintd instances are shut down"
+echo "  * You run this script on all of them"
+echo "  * Only restart once all are patched"
+echo "  * Let them run for a bit after restarting before voting on meta module"
+echo "    consensus proposals"
+echo ""
+echo -e "\e[1mIt's like open heart surgery on a federation, please only continue if you know\e[0m"
+echo -e "\e[1mwhat you are doing and can debug Fedimint problems yourself.\e[0m"
+echo ""
+echo -n "Do you wish to continue? (yes/no): "
+read response
+
+if [[ "$response" != "yes" ]]; then
+    echo "Operation aborted by the user."
+    exit 1
+fi
+
+exists=$(jq '.modules | to_entries | any(.value.kind == "meta")' "$DATA_DIR/consensus.json")
+if [ "$exists" == "true" ]; then
+    echo "A module of kind 'meta' already exists."
+    exit 1
+fi
+
+NEXT_MOD_ID="$(jq '[.modules | keys[] | tonumber] | max + 1' "$DATA_DIR/consensus.json")"
+
+mv "$DATA_DIR/consensus.json" "$DATA_DIR/consensus.json.bak"
+mv "$DATA_DIR/local.json" "$DATA_DIR/local.json.bak"
+mv "$DATA_DIR/private.encrypt" "$DATA_DIR/private.encrypt.bak"
+
+PASSWORD="$(cat "$DATA_DIR/password.private")"
+fedimint-cli dev config-decrypt --in-file "$DATA_DIR/private.encrypt.bak" --out-file "$DATA_DIR/private.json.old" "$PASSWORD" > /dev/null
+
+jq --arg next_mod_id "$NEXT_MOD_ID" '.modules_json += {($next_mod_id): {"kind": "meta"}} | .modules += {($next_mod_id): {"kind": "meta", "version": {"major": 0, "minor": 0}, "config": ""}}' "$DATA_DIR/consensus.json.bak" > "$DATA_DIR/consensus.json"
+jq --arg next_mod_id "$NEXT_MOD_ID" '.modules += {($next_mod_id): {"kind": "meta"}}' "$DATA_DIR/local.json.bak" > "$DATA_DIR/local.json"
+jq --arg next_mod_id "$NEXT_MOD_ID" '.modules += {($next_mod_id): {"kind": "meta"}}' "$DATA_DIR/private.json.old" > "$DATA_DIR/private.json.new"
+
+fedimint-cli dev config-encrypt --in-file "$DATA_DIR/private.json.new" --out-file "$DATA_DIR/private.encrypt" "$PASSWORD" > /dev/null
+
+rm "$DATA_DIR/private.json.old" "$DATA_DIR/private.json.new"
+
+echo "Config files in $DATA_DIR have been patched, you can start fedimintd again."
+echo -e "\e[1mONLY VOTE ON META VALUES ONCE ALL GUARDIANS ARE UPGRADED\e[0m"


### PR DESCRIPTION
Federations deployed prior to 0.3.0 do not have the meta module in their config, meaning it doesn't get deactivated even though >=0.3.0 fedimintds support it. We currently don't support adding modules after the fact, but in case of the meta module we can kinda hack it in since it doesn't need any config, which is what the added script does.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
