### PR TITLE
chore(ci): run a round of fuzzing for every fuzz target

### DIFF
--- a/.github/workflows/ci-fuzz.yml
+++ b/.github/workflows/ci-fuzz.yml
@@ -1,0 +1,85 @@
+name: "Fuzzing"
+
+env:
+  PERFIT_SERVER: https://perfit.dev.fedimint.org
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch and release tags
+  push:
+    branches: [ "main", "master", "devel", "releases/v*" ]
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches: [ "main", "master", "devel", "releases/v*" ]
+  merge_group:
+    branches: [ "main", "master", "devel", "releases/v*" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  tests:
+    if: github.repository == 'fedimint/fedimint'
+    name: "Quick fuzzing"
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - uses: cachix/install-nix-action@V27
+        with:
+          nix_path: nixpkgs=channel:nixos-23.11
+          extra_nix_config: |
+            connect-timeout = 15
+            stalled-download-timeout = 15
+      - uses: cachix/cachix-action@v14
+        with:
+          name: fedimint
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        continue-on-error: true
+
+      - name: Quick fuzzing
+        run: |
+          # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)
+          # we need to use `nix develop -c` to be able to use `nix build` inside of backwards-compatibility-test
+          # Disable `sccache`, it seems incompatible with self-hosted runner sandbox for some reason, and
+          # it doesn't benefit us much here anyway.
+          env \
+            TMPDIR=/tmp \
+            CARGO_PROFILE=ci \
+            PERFIT_ACCESS_TOKEN="${{ secrets.PERFIT_ACCESS_TOKEN }}" \
+            nix develop .#fuzz -c \
+            nix shell github:rustshop/fs-dir-cache -c \
+            nix run 'github:rustshop/perfit?rev=a2ea3bae86b0e70d2ebdbca1fd16a843b7f0a3bd#perfit' -- \
+              run \
+                --metric G7nbgg0NS_mR5377weP5gg \
+                --metadata "commit=${LAST_COMMIT_SHA}" \
+                -- \
+            runLowPrio just fuzz-ci-quick
+
+  notifications:
+    if: always() && github.repository == 'fedimint/fedimint' && github.event_name != 'merge_group'
+    name: "Notifications"
+    timeout-minutes: 1
+    runs-on: [self-hosted, linux]
+    needs: [ tests ]
+
+    steps:
+    - name: Discord notifications on failure
+      # https://stackoverflow.com/a/74562058/134409
+      if: ${{ always() && contains(needs.*.result, 'failure') }}
+      # https://github.com/marketplace/actions/actions-status-discord
+      uses: sarisia/actions-status-discord@v1
+      with:
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        # current job is a success, but that's not what we're interested in
+        status: failure

--- a/flake.nix
+++ b/flake.nix
@@ -314,7 +314,7 @@
               default = flakeboxLib.mkDevShell (commonShellArgs // { });
 
               fuzz = flakeboxLib.mkDevShell (commonShellArgs // {
-                nativeBuildInputs = with pkgs; [
+                nativeBuildInputs = with pkgs; commonShellArgs.nativeBuildInputs ++ [
                   cargo-hongfuzz
                   libbfd_2_38
                   libunwind.dev

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -169,6 +169,18 @@ fuzz-target TARGET="" *ARGS="--exit_upon_crash":
   # * can't be run with sccache, so just disable here
   env -u RUSTC_WRAPPER CC=clang RUSTFLAGS="--cfg tokio_unstable" cargo hfuzz run {{TARGET}}
 
+# A quick round of fuzzing for every defined target
+fuzz-ci-quick *ARGS="--exit_upon_crash --run_time 30 -q -v":
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  export HFUZZ_RUN_ARGS="{{ARGS}}"
+  for target in $(ls fuzz/src/bin/ | sed -e 's/.rs$//g') ; do
+    >&2 echo "Fuzzing ${target}"
+    env -u RUSTC_WRAPPER CC=clang RUSTFLAGS="--cfg tokio_unstable" \
+      cargo hfuzz run "${target}"
+  done
+
 fuzz-target-debug TARGET="" CRASH="" *ARGS="--exit_upon_crash":
   #!/usr/bin/env bash
   set -euo pipefail


### PR DESCRIPTION


Now that we self-hosted runners, that we don't pay for cycles used, it makes sense to run some fuzzing all the time, just to avoid accidental breakages and maybe even randomly discover something over time.

It will be running with the same `runLowPrio` we use for other CPU-heavy things, so it should not cause tests running in parallel to be affected too much.

Re #287 
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
