### PR TITLE
chore: introduce `cargo-sort` into our lives

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -223,6 +223,7 @@
                   pkgs.cargo-udeps
                   pkgs.cargo-audit
                   pkgs.cargo-deny
+                  pkgs.cargo-sort
                   pkgs.parallel
                   pkgs.just
                   pkgs.time
@@ -325,7 +326,11 @@
                 ];
               });
 
-              lint = flakeboxLib.mkLintShell { };
+              lint = flakeboxLib.mkLintShell {
+                nativeBuildInputs = [
+                  pkgs.cargo-sort
+                ];
+              };
 
               # Shell with extra stuff to support cross-compilation with `cargo build --target <target>`
               #

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -221,3 +221,14 @@ docs: build-docs
 
 release-bump-version VERSION="prerelease":
   cargo workspaces version --all --exact --no-git-commit --yes --force '*' --pre-id rc {{VERSION}}
+
+
+cargo_sort_defaults := "-w --order package,features,dependencies"
+
+# Fix sort order in `Cargo.toml` files
+cargo-sort-fix *ARGS="":
+  cargo sort {{cargo_sort_defaults}} {{ARGS}}
+
+# Check sort order in `Cargo.toml` files
+cargo-sort-check *ARGS="":
+  cargo sort {{cargo_sort_defaults}} --check {{ARGS}}


### PR DESCRIPTION
Currently not enforcing or modifing anything, as would be best to find a convenient time to minimize amount of merge conflicts.

After we get it in, we can run it, land the sorting PR, and then I'll add a check in the lint step or maybe right in the git check hook.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
