### PR TITLE
Remove json consensus config from server config only kept around for a UI

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1303,28 +1303,7 @@ impl Client {
     /// encoded this format cannot be cryptographically verified but is easier
     /// to consume and to some degree human-readable.
     pub fn get_config_json(&self) -> JsonClientConfig {
-        JsonClientConfig {
-            global: self.get_config().global.clone(),
-            modules: self
-                .get_config()
-                .modules
-                .iter()
-                .map(|(instance_id, ClientModuleConfig { kind, config, .. })| {
-                    (
-                        *instance_id,
-                        JsonWithKind::new(
-                            kind.clone(),
-                            config
-                                .clone()
-                                .decoded()
-                                .map_or(serde_json::Value::Null, |decoded| {
-                                    decoded.to_json().into()
-                                }),
-                        ),
-                    )
-                })
-                .collect(),
-        }
+        self.get_config().to_json()
     }
 
     /// Get the primary module

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -85,10 +85,7 @@ use db::{
 use fedimint_api_client::api::{
     ApiVersionSet, DynGlobalApi, DynModuleApi, FederationApiExt, IGlobalFederationApi,
 };
-use fedimint_core::config::{
-    ClientConfig, ClientModuleConfig, FederationId, JsonClientConfig, JsonWithKind,
-    ModuleInitRegistry,
-};
+use fedimint_core::config::{ClientConfig, FederationId, JsonClientConfig, ModuleInitRegistry};
 use fedimint_core::core::{
     DynInput, DynOutput, IInput, IOutput, ModuleInstanceId, ModuleKind, OperationId,
 };

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -721,7 +721,6 @@ pub struct ServerModuleConfig {
     pub local: JsonWithKind,
     pub private: JsonWithKind,
     pub consensus: ServerModuleConsensusConfig,
-    pub consensus_json: JsonWithKind,
 }
 
 impl ServerModuleConfig {
@@ -729,13 +728,11 @@ impl ServerModuleConfig {
         local: JsonWithKind,
         private: JsonWithKind,
         consensus: ServerModuleConsensusConfig,
-        consensus_json: JsonWithKind,
     ) -> Self {
         Self {
             local,
             private,
             consensus,
-            consensus_json,
         }
     }
 
@@ -801,10 +798,6 @@ pub trait TypedServerModuleConfig: DeserializeOwned + Serialize {
                 version: consensus.version(),
                 config: consensus.consensus_encode_to_vec(),
             },
-            consensus_json: JsonWithKind::new(
-                kind,
-                serde_json::to_value(consensus).expect("serialization can't fail"),
-            ),
         }
     }
 }

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -15,7 +15,6 @@ pub const CONFIG_GEN_PEERS_ENDPOINT: &str = "config_gen_peers";
 pub const CONSENSUS_CONFIG_GEN_PARAMS_ENDPOINT: &str = "consensus_config_gen_params";
 pub const DEFAULT_CONFIG_GEN_PARAMS_ENDPOINT: &str = "default_config_gen_params";
 pub const VERIFY_CONFIG_HASH_ENDPOINT: &str = "verify_config_hash";
-pub const MODULES_CONFIG_JSON_ENDPOINT: &str = "modules_config_json";
 pub const RECOVER_ENDPOINT: &str = "recover";
 pub const REGISTER_GATEWAY_ENDPOINT: &str = "register_gateway";
 pub const RUN_DKG_ENDPOINT: &str = "run_dkg";

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -5,6 +5,7 @@ pub const AUTH_ENDPOINT: &str = "auth";
 pub const AWAIT_OUTPUT_OUTCOME_ENDPOINT: &str = "await_output_outcome";
 pub const BACKUP_ENDPOINT: &str = "backup";
 pub const CLIENT_CONFIG_ENDPOINT: &str = "client_config";
+pub const CLIENT_CONFIG_JSON_ENDPOINT: &str = "client_config_json";
 pub const SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT: &str = "server_config_consensus_hash";
 pub const SESSION_COUNT_ENDPOINT: &str = "session_count";
 pub const AWAIT_SESSION_OUTCOME_ENDPOINT: &str = "await_session_outcome";

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -23,9 +23,9 @@ use fedimint_core::endpoint_constants::{
     AUDIT_ENDPOINT, AUTH_ENDPOINT, AWAIT_OUTPUT_OUTCOME_ENDPOINT, AWAIT_SESSION_OUTCOME_ENDPOINT,
     AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT, AWAIT_TRANSACTION_ENDPOINT, BACKUP_ENDPOINT,
     CLIENT_CONFIG_ENDPOINT, FEDERATION_ID_ENDPOINT, GUARDIAN_CONFIG_BACKUP_ENDPOINT,
-    INVITE_CODE_ENDPOINT, MODULES_CONFIG_JSON_ENDPOINT, RECOVER_ENDPOINT,
-    SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT, SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT,
-    SHUTDOWN_ENDPOINT, STATUS_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
+    INVITE_CODE_ENDPOINT, RECOVER_ENDPOINT, SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT,
+    SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT, SHUTDOWN_ENDPOINT, STATUS_ENDPOINT,
+    SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
 };
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::audit::{Audit, AuditSummary};
@@ -49,7 +49,7 @@ use tracing::{debug, info};
 use crate::config::io::{
     CONSENSUS_CONFIG, ENCRYPTED_EXT, JSON_EXT, LOCAL_CONFIG, PRIVATE_CONFIG, SALT_FILE,
 };
-use crate::config::{JsonWithKind, ServerConfig};
+use crate::config::ServerConfig;
 use crate::consensus::db::{AcceptedItemPrefix, AcceptedTransactionKey, SignedSessionOutcomeKey};
 use crate::consensus::engine::get_finished_session_count_static;
 use crate::consensus::transaction::process_transaction_with_dbtx;
@@ -568,13 +568,6 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             async |_fedimint: &ConsensusApi, context, _v: ()| -> () {
                 check_auth(context)?;
                 Ok(())
-            }
-        },
-        api_endpoint! {
-            MODULES_CONFIG_JSON_ENDPOINT,
-            ApiVersion::new(0, 0),
-            async |fedimint: &ConsensusApi, _context, _v: ()| -> BTreeMap<ModuleInstanceId, JsonWithKind> {
-                Ok(fedimint.cfg.consensus.modules_json.clone())
             }
         },
     ]

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -13,7 +13,7 @@ use fedimint_api_client::api::{
 };
 use fedimint_core::admin_client::ServerStatus;
 use fedimint_core::backup::{ClientBackupKey, ClientBackupSnapshot};
-use fedimint_core::config::ClientConfig;
+use fedimint_core::config::{ClientConfig, JsonClientConfig};
 use fedimint_core::core::backup::{SignedBackupRequest, BACKUP_REQUEST_MAX_PAYLOAD_SIZE_BYTES};
 use fedimint_core::core::{DynOutputOutcome, ModuleInstanceId};
 use fedimint_core::db::{
@@ -22,10 +22,10 @@ use fedimint_core::db::{
 use fedimint_core::endpoint_constants::{
     AUDIT_ENDPOINT, AUTH_ENDPOINT, AWAIT_OUTPUT_OUTCOME_ENDPOINT, AWAIT_SESSION_OUTCOME_ENDPOINT,
     AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT, AWAIT_TRANSACTION_ENDPOINT, BACKUP_ENDPOINT,
-    CLIENT_CONFIG_ENDPOINT, FEDERATION_ID_ENDPOINT, GUARDIAN_CONFIG_BACKUP_ENDPOINT,
-    INVITE_CODE_ENDPOINT, RECOVER_ENDPOINT, SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT,
-    SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT, SHUTDOWN_ENDPOINT, STATUS_ENDPOINT,
-    SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
+    CLIENT_CONFIG_ENDPOINT, CLIENT_CONFIG_JSON_ENDPOINT, FEDERATION_ID_ENDPOINT,
+    GUARDIAN_CONFIG_BACKUP_ENDPOINT, INVITE_CODE_ENDPOINT, RECOVER_ENDPOINT,
+    SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT, SESSION_COUNT_ENDPOINT, SESSION_STATUS_ENDPOINT,
+    SHUTDOWN_ENDPOINT, STATUS_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
 };
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::audit::{Audit, AuditSummary};
@@ -471,6 +471,14 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context, _v: ()| -> ClientConfig {
                 Ok(fedimint.client_cfg.clone())
+            }
+        },
+        // Helper endpoint for Admin UI that can't parse consensus encoding
+        api_endpoint! {
+            CLIENT_CONFIG_JSON_ENDPOINT,
+            ApiVersion::new(0, 0),
+            async |fedimint: &ConsensusApi, _context, _v: ()| -> JsonClientConfig {
+                Ok(fedimint.client_cfg.to_json())
             }
         },
         api_endpoint! {


### PR DESCRIPTION
I split this PR into three commits:
1. Remove old, redundant `consensus_json` config field we drag around in the server config. This is a breaking change because that also requires removing a public API endpoint returning the JSON-encoded server consensus config. 
2. Add new API endpoint that returns the JSON-encoded client config, which is mostly identical to the server consensus config, just has a slightly different structure.
3. Lastly I noticed that this was the only use of the `#[encodable_ignore]` annotation, which can now be removed, simplifying our derive macros a bit (it always felt like a hack anyway).

Since the only consumer I'm aware of is the Admin UI I'd propose to merge the two commits together. If there is strong opposition we could also just add the new API and remove the old one in the future.

Fixes #3229

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
