### PR TITLE
chore: future-proof api secrets in private federations

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -246,7 +246,7 @@ impl Federation {
             );
             let admin_client = DynGlobalApi::from_pre_peer_id_admin_endpoint(
                 SafeUrl::parse(&peer_env_vars.FM_API_URL)?,
-                process_mgr.globals.FM_API_SECRET.clone(),
+                process_mgr.globals.FM_FORCE_API_SECRETS.get_active(),
             );
             endpoints.insert(*peer, peer_env_vars.FM_API_URL.clone());
             admin_clients.insert(*peer, admin_client);

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -875,6 +875,7 @@ mod tests {
     use crate::config::io::{read_server_config, PLAINTEXT_PASSWORD};
     use crate::config::{DynServerModuleInit, ServerConfig, DEFAULT_MAX_CLIENT_CONNECTIONS};
     use crate::fedimint_core::module::ServerModuleInit;
+    use crate::net::api::ApiSecrets;
 
     /// Helper in config API tests for simulating a guardian's client and server
     struct TestConfigApi {
@@ -929,8 +930,7 @@ mod tests {
             spawn("fedimint server", async move {
                 crate::run(
                     dir_clone,
-                    None,
-                    vec![],
+                    ApiSecrets::none(),
                     settings_clone,
                     db,
                     "dummyversionhash".to_owned(),

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -68,7 +68,7 @@ pub struct ConsensusApi {
     /// Cached client config
     pub client_cfg: ClientConfig,
 
-    pub api_secret: Option<String>,
+    pub force_api_secret: Option<String>,
     /// For sending API events to consensus such as transactions
     pub submission_sender: async_channel::Sender<ConsensusItem>,
     pub shutdown_sender: watch::Sender<Option<u64>>,
@@ -80,6 +80,12 @@ pub struct ConsensusApi {
 impl ConsensusApi {
     pub fn api_versions_summary(&self) -> &SupportedApiVersionsSummary {
         &self.supported_api_versions
+    }
+
+    pub fn get_active_api_secret(&self) -> Option<String> {
+        // TODO: In the future, we might want to fetch it from the DB, so it's possible
+        // to customize from the UX
+        self.force_api_secret.clone()
     }
 
     // we want to return an error if and only if the submitted transaction is
@@ -453,7 +459,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             INVITE_CODE_ENDPOINT,
             ApiVersion::new(0, 0),
             async |fedimint: &ConsensusApi, _context,  _v: ()| -> String {
-                Ok(fedimint.cfg.get_invite_code(fedimint.api_secret.clone()).to_string())
+                Ok(fedimint.cfg.get_invite_code(fedimint.get_active_api_secret()).to_string())
             }
         },
         api_endpoint! {

--- a/fedimint-server/src/net/api/http_auth.rs
+++ b/fedimint-server/src/net/api/http_auth.rs
@@ -147,7 +147,7 @@ where
             }
         }
 
-        debug!(target: LOG_NET_AUTH, "Access denided to incoming api connection");
+        debug!(target: LOG_NET_AUTH, "Access denied to incoming api connection");
         let mut response = Response::new("Unauthorized".into());
         *response.status_mut() = http::StatusCode::UNAUTHORIZED;
         response.headers_mut().insert(

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -217,8 +217,7 @@ impl FederationTestBuilder {
                     db.clone(),
                     module_init_registry,
                     &subgroup,
-                    None,
-                    vec![],
+                    fedimint_server::net::api::ApiSecrets::default(),
                 )
                 .await
                 .expect("Could not initialise consensus");

--- a/fedimintd/src/envs.rs
+++ b/fedimintd/src/envs.rs
@@ -37,8 +37,8 @@ pub const FM_BIND_METRICS_API_ENV: &str = "FM_BIND_METRICS_API";
 // Env variable to TODO
 pub const FM_PORT_ESPLORA_ENV: &str = "FM_PORT_ESPLORA";
 
-// Api authentication primary secret
-pub const FM_API_SECRET_ENV: &str = "FM_API_SECRET";
+// Api authentication (pass,...)
+pub const FM_DEFAULT_API_SECRETS_ENV: &str = "FM_DEFAULT_API_SECRETS";
 
-// Api authentication (user=pass,...)
-pub const FM_API_EXTRA_SECRETS_ENV: &str = "FM_API_EXTRA_SECRETS";
+// Can be used to absolutely override the values stored in the db
+pub const FM_FORCE_API_SECRETS_ENV: &str = "FM_FORCE_API_SECRETS";

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -29,6 +29,7 @@ use fedimint_mint_server::MintInit;
 use fedimint_server::config::api::ConfigGenSettings;
 use fedimint_server::config::io::{DB_FILE, PLAINTEXT_PASSWORD};
 use fedimint_server::config::ServerConfig;
+use fedimint_server::net::api::ApiSecrets;
 use fedimint_unknown_common::config::UnknownGenParams;
 use fedimint_unknown_server::UnknownInit;
 use fedimint_wallet_server::common::config::{
@@ -40,10 +41,10 @@ use tracing::{debug, error, info};
 
 use crate::default_esplora_server;
 use crate::envs::{
-    FM_API_EXTRA_SECRETS_ENV, FM_API_SECRET_ENV, FM_API_URL_ENV, FM_BIND_API_ENV,
-    FM_BIND_METRICS_API_ENV, FM_BIND_P2P_ENV, FM_BITCOIN_NETWORK_ENV, FM_DATA_DIR_ENV,
-    FM_DISABLE_META_MODULE_ENV, FM_EXTRA_DKG_META_ENV, FM_FINALITY_DELAY_ENV, FM_P2P_URL_ENV,
-    FM_PASSWORD_ENV, FM_TOKIO_CONSOLE_BIND_ENV,
+    FM_API_URL_ENV, FM_BIND_API_ENV, FM_BIND_METRICS_API_ENV, FM_BIND_P2P_ENV,
+    FM_BITCOIN_NETWORK_ENV, FM_DATA_DIR_ENV, FM_DISABLE_META_MODULE_ENV, FM_EXTRA_DKG_META_ENV,
+    FM_FINALITY_DELAY_ENV, FM_FORCE_API_SECRETS_ENV, FM_P2P_URL_ENV, FM_PASSWORD_ENV,
+    FM_TOKIO_CONSOLE_BIND_ENV,
 };
 use crate::fedimintd::metrics::APP_START_TS;
 
@@ -95,23 +96,22 @@ pub struct ServerOpts {
     #[arg(long, env = FM_EXTRA_DKG_META_ENV, value_parser = parse_map, default_value="")]
     extra_dkg_meta: BTreeMap<String, String>,
 
-    /// Default Api secret that will be used to communicate with other peers
-    /// secret
+    /// Comma separated list of API secrets.
     ///
-    /// If Federation is public, it should have `api_secret` and
-    /// `api_extra_secrets` not set.
+    /// Setting it will enforce API authentication and make the Federation
+    /// "private".
     ///
-    /// Otherwise it will enforce authentication on the Api HTTP level.
-    #[arg(env = FM_API_SECRET_ENV)]
-    api_secret: Option<String>,
-
-    /// Comma separated list of additional secrets that can be used to access
-    /// the Api
+    /// The first secret in the list is the "active" one that the peer will use
+    /// itself to connect to other peers. Any further one is accepted by
+    /// this peer, e.g. for the purposes of smooth rotation of secret
+    /// between users.
     ///
-    /// Format: `secret1,secret2,...`
-    #[arg(env = FM_API_EXTRA_SECRETS_ENV, value_parser = parse_vec, default_value="")]
-    // Note: full path used due to https://github.com/clap-rs/clap/issues/4626#issuecomment-1593681582
-    api_extra_secrets: std::vec::Vec<String>,
+    /// Note that the value provided here will override any other settings
+    /// that the user might want to set via UI at runtime, etc.
+    /// In the future, managing secrets might be possible via Admin UI
+    /// and defaults will be provided via `FM_DEFAULT_API_SECRETS`.
+    #[arg(long, env = FM_FORCE_API_SECRETS_ENV, default_value = "")]
+    force_api_secrets: ApiSecrets,
 
     #[clap(subcommand)]
     subcommand: Option<ServerSubcommand>,
@@ -150,16 +150,6 @@ fn parse_map(s: &str) -> anyhow::Result<BTreeMap<String, String>> {
     Ok(map)
 }
 
-fn parse_vec(s: &str) -> anyhow::Result<Vec<String>> {
-    if s.is_empty() {
-        return Ok(vec![]);
-    }
-
-    Ok(s.split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect())
-}
 /// `fedimintd` builder
 ///
 /// Fedimint supports third party modules. Right now (and for forseable feature)
@@ -502,8 +492,7 @@ async fn run(
 
     fedimint_server::run(
         data_dir,
-        opts.api_secret,
-        opts.api_extra_secrets,
+        opts.force_api_secrets,
         settings,
         db,
         code_version_str,


### PR DESCRIPTION
Re #5366

In the future we might want to let guardians manage Api secrets of a Federation via UI, storing the Api Secrets configuration in the database.

This will make env var naming confusing, just like it was in the case of a `FM_BITCOIN_RPC_URL`, etc. which we've split into `FM_FORCE_` and `FM_DEFAULT_` recently.

Do the same split for `FM_FORCE_API_SECRETS`, so the meaning and behavior of it does not need to change in the future.

While at it merge existing two arguments into one, to avoid 2 * 2 env vars/flags, and unify everything in a newtype.


##### Testing

```
env RUST_LOG=fm=debug j devimint-env
```

Verify in the logs of fedimintd that it says near the top:

```
2024-05-24T21:50:36.733769Z  INFO spawn{task="main"}: fm::net::auth: Api available for public access
```

Then run:

```
env FM_FORCE_API_SECRETS=asdfadsf,asdfad,asdfadsfasdf RUST_LOG=fm=debug j devimint-env
```

Verify in the logs, that it now says:


```
2024-05-24T21:56:16.403660Z  INFO spawn{task="main"}: fm::net::auth: Api available for private access num_secrets=3
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
