### PR TITLE
fix: fix broken nix link

### DIFF
--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -76,7 +76,7 @@ for `nix develop`.
 
 Fedimint uses a [Cachix](https://www.cachix.org/) binary cache to cache builds.
 To benefit from this cache and avoid building everything from scratch, you must
-ensure that your user is a [trusted user](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users).
+ensure that your user is a [trusted user](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users).
 You can do this by modifying `/etc/nix/nix.conf`, adding the following line.
 
 ```


### PR DESCRIPTION
The existing link was broken here: https://github.com/NixOS/nixos-homepage/pull/1446

It used to redirect to `https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users` but now redirects to `https://nix.dev/manual/nix/stable/stable/command-ref/conf-file.html#conf-trusted-users` (`stable/stable` instead of just `stable`). This PR simply updates the link to where the old link used to redirect to.