### PR TITLE
feat(server): diagnostic consensus checksum

### DIFF
--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -42,10 +42,10 @@ pub trait IServerModule: Debug {
     /// This function is called once for every consensus item. The function
     /// returns an error if any only if the consensus item does not change
     /// our state and therefore may be safely discarded by the atomic broadcast.
-    async fn process_consensus_item<'a>(
+    async fn process_consensus_item<'a, 'b>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
-        consensus_item: DynModuleConsensusItem,
+        consensus_item: &'b DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()>;
 
@@ -140,10 +140,10 @@ where
     /// This function is called once for every consensus item. The function
     /// returns an error if any only if the consensus item does not change
     /// our state and therefore may be safely discarded by the atomic broadcast.
-    async fn process_consensus_item<'a>(
+    async fn process_consensus_item<'a, 'b>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
-        consensus_item: DynModuleConsensusItem,
+        consensus_item: &'b DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {
         <Self as ServerModule>::process_consensus_item(

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -293,6 +293,16 @@ impl DatabaseDump {
                         "Aleph Units"
                     );
                 }
+                ConsensusRange::DbKeyPrefix::ConsensusChecksum => {
+                    push_db_pair_items_no_serde!(
+                        dbtx,
+                        ConsensusRange::ConsensusChecksumPrefix,
+                        ConsensusRange::ConsensusChecksumKey,
+                        Vec<u8>,
+                        consensus,
+                        "Consensus Checksum"
+                    );
+                }
                 // Module is a global prefix for all module data
                 ConsensusRange::DbKeyPrefix::Module => {}
             }

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -113,7 +113,7 @@ impl ConsensusApi {
         // We ignore any writes, as we only verify if the transaction is valid here
         dbtx.ignore_uncommitted();
 
-        process_transaction_with_dbtx(self.modules.clone(), &mut dbtx, transaction.clone()).await?;
+        process_transaction_with_dbtx(self.modules.clone(), &mut dbtx, &transaction).await?;
 
         self.submission_sender
             .send(ConsensusItem::Transaction(transaction))

--- a/fedimint-server/src/consensus/consensus_checksum.rs
+++ b/fedimint-server/src/consensus/consensus_checksum.rs
@@ -1,0 +1,107 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
+
+use bitcoin_hashes::{sha256, Hash};
+use fedimint_core::core::{DynModuleConsensusItem, ModuleInstanceId};
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::encoding::Encodable;
+use fedimint_core::TransactionId;
+use fedimint_logging::LOG_CONSENSUS;
+use futures::StreamExt;
+use tracing::info;
+
+use super::db::{ConsensusChecksumKey, ConsensusChecksumPrefix};
+
+/// Simple helper object that tracks determinism of consensus item processing
+///
+/// Note that the implementation does not support any form of a rollback,
+/// and thus all `track_` methods must be called after last faliable step
+/// of consensus item processing.
+#[derive(Debug, Clone)]
+pub struct ConsensusChecksumTracker {
+    /// Currently
+    hashes: BTreeMap<ConsensusChecksumKey, [u8; 32]>,
+}
+
+impl ConsensusChecksumTracker {
+    /// Create [`Self`] by loading all checksum from the database
+    pub async fn new(dbtx: &mut DatabaseTransaction<'_>) -> Self {
+        Self {
+            hashes: dbtx
+                .find_by_prefix(&ConsensusChecksumPrefix)
+                .await
+                .collect()
+                .await,
+        }
+    }
+
+    /// Generalized logic calculating consensus checksum for a given key
+    /// and writing it back to database.
+    async fn track<F>(
+        &mut self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        key: ConsensusChecksumKey,
+        write_bytes: F,
+    ) where
+        F: FnOnce(&mut sha256::HashEngine),
+    {
+        let mut engine = sha256::HashEngine::default();
+        let hash = self.hashes.entry(key).or_default();
+
+        engine.write_all(hash.as_ref()).expect("can't fail");
+
+        write_bytes(&mut engine);
+
+        *hash = *sha256::Hash::from_engine(engine).as_byte_array();
+        dbtx.insert_entry(&key, hash).await;
+    }
+
+    /// Account for processing a module consensus item
+    pub async fn track_module_citem(
+        &mut self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        module_id: ModuleInstanceId,
+        module_item: &DynModuleConsensusItem,
+    ) {
+        self.track(dbtx, ConsensusChecksumKey::CItem(module_id), |w| {
+            module_item.consensus_encode(w).expect("can't fail");
+        })
+        .await;
+    }
+
+    /// Account for processing a consensus transaction
+    pub async fn track_tx(
+        &mut self,
+        dbtx: &mut DatabaseTransaction<'_>,
+        txid: &TransactionId,
+        input_module_id: &BTreeSet<ModuleInstanceId>,
+        output_module_id: &BTreeSet<ModuleInstanceId>,
+    ) {
+        for module_id in input_module_id {
+            self.track(dbtx, ConsensusChecksumKey::TxInput(*module_id), |w| {
+                w.write_all(txid.as_ref()).expect("can't fail");
+            })
+            .await;
+        }
+        for module_id in output_module_id {
+            self.track(dbtx, ConsensusChecksumKey::TxOutput(*module_id), |w| {
+                w.write_all(txid.as_ref()).expect("can't fail");
+            })
+            .await;
+        }
+    }
+
+    /// Report (log) current checksum(s)
+    pub fn report(&self, session_idx: u64) {
+        let mut sum = [0u8; 32];
+
+        for (key, checksum) in &self.hashes {
+            info!(target: LOG_CONSENSUS, k = ?key, v = hex::encode(checksum), session_idx, "Consensus checksum");
+
+            for (i, &b) in checksum.iter().enumerate() {
+                sum[i] ^= b;
+            }
+        }
+        info!(target: LOG_CONSENSUS, k = "Summary", v = hex::encode(sum), session_idx, "Consensus checksum");
+    }
+}

--- a/fedimint-server/src/consensus/db.rs
+++ b/fedimint-server/src/consensus/db.rs
@@ -18,6 +18,7 @@ pub enum DbKeyPrefix {
     AcceptedTransaction = 0x02,
     SignedSessionOutcome = 0x04,
     AlephUnits = 0x05,
+    ConsensusChecksum = 0x06,
     Module = MODULE_GLOBAL_PREFIX,
 }
 
@@ -88,6 +89,28 @@ impl_db_record!(
     notify_on_modify = false,
 );
 impl_db_lookup!(key = AlephUnitsKey, query_prefix = AlephUnitsPrefix);
+
+#[derive(Copy, Debug, Encodable, Decodable, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ConsensusChecksumKey {
+    TxInput(ModuleInstanceId),
+    TxOutput(ModuleInstanceId),
+    CItem(ModuleInstanceId),
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct ConsensusChecksumPrefix;
+
+impl_db_record!(
+    key = ConsensusChecksumKey,
+    value = [u8; 32],
+    db_prefix = DbKeyPrefix::ConsensusChecksum,
+    notify_on_modify = false,
+);
+
+impl_db_lookup!(
+    key = ConsensusChecksumKey,
+    query_prefix = ConsensusChecksumPrefix
+);
 
 pub fn get_global_database_migrations() -> BTreeMap<DatabaseVersion, ServerMigrationFn> {
     BTreeMap::new()
@@ -286,6 +309,8 @@ mod fedimint_migration_tests {
                             );
                             info!(target: LOG_DB, "Validated AlephUnits");
                         }
+                        // These are diagnostic caches ATM
+                        DbKeyPrefix::ConsensusChecksum => {}
                         // Module prefix is reserved for modules, no migration testing is needed
                         DbKeyPrefix::Module => {}
                     }

--- a/fedimint-server/src/consensus/transaction.rs
+++ b/fedimint-server/src/consensus/transaction.rs
@@ -9,7 +9,7 @@ use crate::metrics::{CONSENSUS_TX_PROCESSED_INPUTS, CONSENSUS_TX_PROCESSED_OUTPU
 pub async fn process_transaction_with_dbtx(
     modules: ServerModuleRegistry,
     dbtx: &mut DatabaseTransaction<'_>,
-    transaction: Transaction,
+    transaction: &Transaction,
 ) -> Result<(), TransactionError> {
     let in_count = transaction.inputs.len();
     let out_count = transaction.outputs.len();


### PR DESCRIPTION
Inspired by the discussion during last Deep Dive, about verifing determinism of consensus between peers and shuting down when incosistency was detected, it occured to me that we could get 90% there by simply tracking a rolling checksum of what happened and displaying it as diagnostics that guardians could sometimes simply compare.

So here is an initial implementation.

The checksum is maintained separately over txes and each of the modules, so in case total checksum does not match it's possible to compare each module specific one and hopefully figure out which module is to blame.

The whole thing is purely diagnostic, though in the future we could expose it in the Admin UI somehow.

No attempt is made to synchronize/correct the checksum between peers. It seems perfectly fine that Federations that were created before this was introduced will simply have a potential mismatched.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
