### PR TITLE
demo: prove stuck change is recoverable using epochs method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,12 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bech32"
+version = "0.10.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+
+[[package]]
+name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
@@ -542,10 +548,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
+dependencies = [
+ "bech32 0.10.0-beta",
+ "bitcoin-internals 0.2.0",
+ "bitcoin_hashes 0.13.0",
+ "hex-conservative 0.1.1",
+ "hex_lit",
+ "secp256k1 0.28.2",
+ "serde",
+]
+
+[[package]]
 name = "bitcoin-internals"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f9997f8650dd818369931b5672a18dbef95324d0513aa99aae758de8ce86e5b"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-private"
@@ -570,6 +600,17 @@ checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
  "core2",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.1",
  "serde",
 ]
 
@@ -1297,7 +1338,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cb1f7f2489cce83bc3bd92784f9ba5271eeb6e729b975895fc541f78cbfcdca"
 dependencies = [
  "bitcoin 0.30.2",
- "bitcoin-internals",
+ "bitcoin-internals 0.1.0",
+ "log",
+ "reqwest 0.11.26",
+ "serde",
+]
+
+[[package]]
+name = "esplora-client"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a73e879128c5fcb38abaf0ec53e3310947c6e7b61ce0f1b4cd7a0b8ea1ab0389"
+dependencies = [
+ "bitcoin 0.31.2",
+ "hex-conservative 0.2.0",
  "log",
  "reqwest 0.11.26",
  "serde",
@@ -1433,7 +1487,7 @@ dependencies = [
  "bitcoin 0.30.2",
  "bitcoincore-rpc",
  "electrum-client",
- "esplora-client",
+ "esplora-client 0.6.0",
  "fedimint-core",
  "fedimint-logging",
  "hex",
@@ -2419,6 +2473,7 @@ dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
  "clap",
+ "esplora-client 0.7.0",
  "fedimint-aead",
  "fedimint-core",
  "fedimint-ln-common",
@@ -3257,6 +3312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3883,7 +3947,7 @@ dependencies = [
  "bitcoin 0.30.2",
  "core2",
  "hashbrown 0.8.2",
- "hex-conservative",
+ "hex-conservative 0.1.1",
  "libm",
 ]
 
@@ -4976,6 +5040,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+dependencies = [
+ "bitcoin_hashes 0.12.0",
+ "secp256k1-sys 0.9.2",
+ "serde",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4989,6 +5064,15 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]

--- a/recoverytool/Cargo.toml
+++ b/recoverytool/Cargo.toml
@@ -29,6 +29,7 @@ fedimint-ln-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-
 fedimint-ln-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-server" }
 fedimint-mint-server = { version = "=0.4.0-alpha", path = "../modules/fedimint-mint-server" }
 futures = { workspace = true }
+esplora-client = { version = "0.7.0", default-features = false, features = ["async", "async-https-rustls"] }
 hex = { workspace = true }
 miniscript = { version = "10.0.0" }
 secp256k1 = { version = "0.27.0", features = [ "serde", "global-context" ] }

--- a/scripts/tests/recoverytool-stuck-change-tests.sh
+++ b/scripts/tests/recoverytool-stuck-change-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Runs a simple recoverytool test
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+make_fm_test_marker
+
+devimint recoverytool-stuck-change-tests

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -48,6 +48,11 @@ function recoverytool_tests() {
 }
 export -f recoverytool_tests
 
+function recoverytool_stuck_change_tests() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/recoverytool-stuck-change-tests.sh
+}
+export -f recoverytool_stuck_change_tests
+
 function reconnect_test() {
   # reconnect-test runs a degraded federation, so we need to override FM_OFFLINE_NODES
   fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/reconnect-test.sh
@@ -250,37 +255,38 @@ for _ in $(seq "${FM_TEST_CI_ALL_TIMES:-1}"); do
 # as it's used for failure test
 tests_to_run_in_parallel+=(
   "always_success_test"
-  "rust_unit_tests"
+  # "rust_unit_tests"
   # TODO: unfortunately it seems like something about headless firefox is broken when
   # running in xarg -P or gnu parallel. Try re-enabling in the future and see if it works.
   # Other than this problem, everything about it is working.
   # "wasm_test"
-  "bckn_bitcoind_dummy"
-  "bckn_bitcoind_mint"
-  "bckn_bitcoind_wallet"
-  "bckn_bitcoind_ln"
-  "bckn_bitcoind_lnv2"
-  "bckn_gw_client"
-  "bckn_gw_not_client"
-  "bckn_electrs"
-  "bckn_esplora"
-  "latency_test_reissue"
-  "latency_test_ln_send"
-  "latency_test_ln_receive"
-  "latency_test_fm_pay"
-  "latency_test_restore"
-  "reconnect_test"
-  "lightning_reconnect_test"
-  "gateway_reboot_test"
-  "devimint_cli_test"
-  "devimint_cli_test_single"
-  "load_test_tool_test"
-  "recoverytool_tests"
-  "guardian_backup"
-  "meta_module"
-  "mint_client_sanity"
-  "cannot_replay_tx"
-  "circular_deposit"
+  # "bckn_bitcoind_dummy"
+  # "bckn_bitcoind_mint"
+  # "bckn_bitcoind_wallet"
+  # "bckn_bitcoind_ln"
+  # "bckn_bitcoind_lnv2"
+  # "bckn_gw_client"
+  # "bckn_gw_not_client"
+  # "bckn_electrs"
+  # "bckn_esplora"
+  # "latency_test_reissue"
+  # "latency_test_ln_send"
+  # "latency_test_ln_receive"
+  # "latency_test_fm_pay"
+  # "latency_test_restore"
+  # "reconnect_test"
+  # "lightning_reconnect_test"
+  # "gateway_reboot_test"
+  # "devimint_cli_test"
+  # "devimint_cli_test_single"
+  # "load_test_tool_test"
+  # "recoverytool_tests"
+  "recoverytool_stuck_change_tests"
+  # "guardian_backup"
+  # "meta_module"
+  # "mint_client_sanity"
+  # "cannot_replay_tx"
+  # "circular_deposit"
 )
 done
 


### PR DESCRIPTION
This PR demonstrates the epochs method will recover stuck change outputs.

A new devimint test reproduces the issue that causes the wallet to skip recognizing confirmed change outputs by running bitcoind without `txindex` and confirms a new method that won't be merged (`scan-pending`) along with the existing `epochs` method will recover the pending change outputs.

I'm closing this PR after opening since this is intended as a demonstration and not meant to be merged.

### Background

A mainnet federation experienced a bug that prevents the wallet from recognizing change outputs from withdrawal transactions (see: https://github.com/fedimint/fedimint/issues/5298). A fix has been merged that prevents this issue, but we still need to verify the ability to recover  funds for the impacted federation.

I've spoken out-of-band with some of the guardians of the impacted federation. They're planning on winding down this federation and already needed to use the recoverytool due to a previous bug related to the ln module, so using the epochs method for the recoverytool seems like good solution that doesn't introduce additional complexity to the codebase (e.g. creating a one-off binary that updates the wallet state and should only be run by the impacted federation).