### PR TITLE
refactor(consensus): some pass-by-ref tweaks

### DIFF
--- a/fedimint-core/src/core/server.rs
+++ b/fedimint-core/src/core/server.rs
@@ -42,10 +42,10 @@ pub trait IServerModule: Debug {
     /// This function is called once for every consensus item. The function
     /// returns an error if any only if the consensus item does not change
     /// our state and therefore may be safely discarded by the atomic broadcast.
-    async fn process_consensus_item<'a>(
+    async fn process_consensus_item<'a, 'b>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
-        consensus_item: DynModuleConsensusItem,
+        consensus_item: &'b DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()>;
 
@@ -140,10 +140,10 @@ where
     /// This function is called once for every consensus item. The function
     /// returns an error if any only if the consensus item does not change
     /// our state and therefore may be safely discarded by the atomic broadcast.
-    async fn process_consensus_item<'a>(
+    async fn process_consensus_item<'a, 'b>(
         &self,
         dbtx: &mut DatabaseTransaction<'a>,
-        consensus_item: DynModuleConsensusItem,
+        consensus_item: &'b DynModuleConsensusItem,
         peer_id: PeerId,
     ) -> anyhow::Result<()> {
         <Self as ServerModule>::process_consensus_item(

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -113,7 +113,7 @@ impl ConsensusApi {
         // We ignore any writes, as we only verify if the transaction is valid here
         dbtx.ignore_uncommitted();
 
-        process_transaction_with_dbtx(self.modules.clone(), &mut dbtx, transaction.clone()).await?;
+        process_transaction_with_dbtx(self.modules.clone(), &mut dbtx, &transaction).await?;
 
         self.submission_sender
             .send(ConsensusItem::Transaction(transaction))

--- a/fedimint-server/src/consensus/transaction.rs
+++ b/fedimint-server/src/consensus/transaction.rs
@@ -9,7 +9,7 @@ use crate::metrics::{CONSENSUS_TX_PROCESSED_INPUTS, CONSENSUS_TX_PROCESSED_OUTPU
 pub async fn process_transaction_with_dbtx(
     modules: ServerModuleRegistry,
     dbtx: &mut DatabaseTransaction<'_>,
-    transaction: Transaction,
+    transaction: &Transaction,
 ) -> Result<(), TransactionError> {
     let in_count = transaction.inputs.len();
     let out_count = transaction.outputs.len();


### PR DESCRIPTION
When working #5384 , which probably will get abandoned I needed/noticed some ways to avoid a clone and passed by reference stuff that didn't need to be moved.

The `&mut self` is not neccessary, but technically it does denote that the consensus code has an exclusive reference to `ConsensusEngine` which makese sense.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
