### PR TITLE
feat: reduce RAM usage by factor of three, simplify switching trigger logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-crypto"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de73b5bd99955d8728d2cce8199b02f938c2b44f2d2b738e6bea287a70500bad"
+checksum = "7fdf0c124883ef234a6262e43b9ed1d214e9f9c8744a88f1f2451c2b6efe4290"
 dependencies = [
  "async-trait",
  "bit-vec",
@@ -64,11 +64,12 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4470671c60202933de1945c7208125accd42f2cbd45fc8dcb5dd15d1d053ddd2"
+checksum = "5e9a4418a90817c8c4929d55019eeb2bdf1d4a6030d557f17b3f580723ab40f8"
 dependencies = [
  "aleph-bft-crypto",
+ "aleph-bft-types 0.12.0",
  "async-trait",
  "futures",
  "futures-timer",
@@ -78,14 +79,25 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-types"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d898329af9530cc10526b212eaa4365a4f199257e85ca712e959a24cb67fc"
+checksum = "7afbf87383e06ccfe9386cda59e57ac9d899267cc765fee654d921e4ba779f92"
 dependencies = [
  "aleph-bft-crypto",
  "async-trait",
  "futures",
- "log",
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "aleph-bft-types"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bca9d19f587215da2b6c50b5e71f9addbf2305153f850dad3f9496ed67e28bb"
+dependencies = [
+ "aleph-bft-crypto",
+ "async-trait",
+ "futures",
  "parity-scale-codec",
 ]
 
@@ -1359,18 +1371,18 @@ dependencies = [
 
 [[package]]
 name = "fedimint-aleph-bft"
-version = "0.30.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b6d7cad3a5af85956e9f1739fb8e27668652f523ccf3b8aeb20ed788a98c2a"
+checksum = "8b21015ab681cdddedd866fe4af9169901012e9a8bd4745da8423131cccae025"
 dependencies = [
  "aleph-bft-rmc",
- "aleph-bft-types",
+ "aleph-bft-types 0.13.0",
  "anyhow",
  "async-trait",
  "derivative",
  "futures",
  "futures-timer",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "log",
  "parity-scale-codec",
  "parking_lot",
@@ -2333,7 +2345,7 @@ dependencies = [
 name = "fedimint-server"
 version = "0.4.0-alpha"
 dependencies = [
- "aleph-bft-types",
+ "aleph-bft-types 0.13.0",
  "anyhow",
  "async-channel",
  "async-trait",

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-server"
-version = {workspace = true}
+version = { workspace = true }
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-server' facilitates federated consensus with atomic broadcast and distributed configuration."
@@ -57,10 +57,10 @@ jsonrpsee = { version = "0.22.5", features = ["server"] }
 tokio = { version = "1.38.0", features = ["full", "tracing"] }
 tokio-stream = "0.1.15"
 tokio-rustls = { workspace = true }
-tokio-util = { version = "0.7.11", features = [ "codec" ] }
-tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
-aleph-bft = { package = "fedimint-aleph-bft", version = "0.30.0", default-features = false }
-aleph-bft-types = "0.10.0"
+tokio-util = { version = "0.7.11", features = ["codec"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+aleph-bft = { package = "fedimint-aleph-bft", version = "0.36.0", default-features = false }
+aleph-bft-types = "0.13.0"
 parity-scale-codec = "3.6.12"
 
 

--- a/fedimint-server/src/consensus/aleph_bft/data_provider.rs
+++ b/fedimint-server/src/consensus/aleph_bft/data_provider.rs
@@ -92,10 +92,14 @@ impl aleph_bft::DataProvider<UnitData> for DataProvider {
             }
         }
 
+        if items.is_empty() {
+            return None;
+        }
+
         let bytes = items.consensus_encode_to_vec();
 
         assert!(bytes.len() <= ALEPH_BFT_UNIT_BYTE_LIMIT);
 
-        return Some(UnitData::Batch(bytes));
+        Some(UnitData::Batch(bytes))
     }
 }

--- a/fedimint-server/src/consensus/aleph_bft/finalization_handler.rs
+++ b/fedimint-server/src/consensus/aleph_bft/finalization_handler.rs
@@ -1,22 +1,37 @@
+use aleph_bft::{NodeIndex, Round};
 use fedimint_core::PeerId;
 
 use super::data_provider::UnitData;
 
+pub struct OrderedUnit {
+    pub creator: PeerId,
+    pub round: Round,
+    pub data: Option<UnitData>,
+}
+
 pub struct FinalizationHandler {
-    sender: async_channel::Sender<(UnitData, PeerId)>,
+    sender: async_channel::Sender<OrderedUnit>,
 }
 
 impl FinalizationHandler {
-    pub fn new(sender: async_channel::Sender<(UnitData, PeerId)>) -> Self {
+    pub fn new(sender: async_channel::Sender<OrderedUnit>) -> Self {
         Self { sender }
     }
 }
 
 impl aleph_bft::FinalizationHandler<UnitData> for FinalizationHandler {
-    fn data_finalized(&mut self, unit_data: UnitData, creator: aleph_bft::NodeIndex) {
+    fn data_finalized(&mut self, _data: UnitData) {
+        unreachable!("This method is not called")
+    }
+
+    fn unit_finalized(&mut self, creator: NodeIndex, round: Round, data: Option<UnitData>) {
         // the channel is unbounded
         self.sender
-            .try_send((unit_data, super::to_peer_id(creator)))
+            .try_send(OrderedUnit {
+                creator: super::to_peer_id(creator),
+                round,
+                data,
+            })
             .ok();
     }
 }


### PR DESCRIPTION
This change requires a coordinated shutdown of all guardians at the end of a session such that all of them can restart with the 0.4.0 binary.

With the new defaults the maximum RAM consumption of a peers aleph bft instance is 230mb per peer in case of an attack while it is at most 180mb per peer under the assumption that all peers are correct. In a 3/4 federation we would have 920mb and 720mb respectively.

The new minimum session time will be less variable with a minimum of 3 minutes, and will not increase when a peer goes offline.

This is the last change to core consensus I have planned.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
