### PR TITLE
chore: api calls with call error codes

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -30,7 +30,8 @@ use db_locked::LockedBuilder;
 use envs::FM_API_SECRET_ENV;
 use fedimint_aead::{encrypted_read, encrypted_write, get_encryption_key};
 use fedimint_api_client::api::{
-    DynGlobalApi, FederationApiExt, FederationError, IRawFederationApi, WsFederationApi,
+    CallResultExt, DynGlobalApi, FederationApiExt, FederationError, IRawFederationApi,
+    WsFederationApi,
 };
 use fedimint_bip39::Bip39RootSecretStrategy;
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitRegistry};
@@ -814,10 +815,12 @@ impl FedimintCli {
                     Some(peer_id) => ws_api
                         .request_raw(peer_id.into(), &method, &[params.to_json()])
                         .await
+                        .flatten()
                         .map_err_cli()?,
                     None => ws_api
                         .request_current_consensus(method, params)
                         .await
+                        .flatten()
                         .map_err_cli()?,
                 };
 

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -98,7 +98,8 @@ use db::{
     EncodedClientSecretKey, InitMode, PeerLastApiVersionsSummary, PeerLastApiVersionsSummaryKey,
 };
 use fedimint_api_client::api::{
-    ApiVersionSet, DynGlobalApi, DynModuleApi, FederationApiExt, IGlobalFederationApi,
+    ApiVersionSet, CallResultExt, DynGlobalApi, DynModuleApi, FederationApiExt,
+    IGlobalFederationApi,
 };
 use fedimint_core::config::{ClientConfig, FederationId, JsonClientConfig, ModuleInitRegistry};
 use fedimint_core::core::{
@@ -1389,11 +1390,12 @@ impl Client {
                 peer_id,
                 api.request_single_peer_typed::<SupportedApiVersionsSummary>(
                     None,
-                    VERSION_ENDPOINT.to_owned(),
-                    ApiRequestErased::default(),
+                    VERSION_ENDPOINT,
+                    &ApiRequestErased::default(),
                     peer_id,
                 )
-                .await,
+                .await
+                .flatten(),
             )
         }
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -64,7 +64,6 @@ use fedimint_core::core::{
 use fedimint_core::db::{
     apply_migrations_server, Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped,
 };
-use fedimint_core::endpoint_constants::REGISTER_GATEWAY_ENDPOINT;
 use fedimint_core::fmt_utils::OptStacktrace;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::CommonModuleInit;
@@ -1368,8 +1367,6 @@ impl Gateway {
                     .await
                     {
                         Err(GatewayError::FederationError(FederationError::general(
-                            REGISTER_GATEWAY_ENDPOINT,
-                            serde_json::Value::Null,
                             anyhow::anyhow!("Error registering federation {federation_id}: {e:?}"),
                         )))?;
                     }

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -12,7 +12,6 @@ use fedimint_core::task::sleep;
 use fedimint_core::{OutPoint, TransactionId};
 use fedimint_ln_common::contracts::incoming::IncomingContractAccount;
 use fedimint_ln_common::contracts::{DecryptedPreimage, FundedContract};
-use fedimint_ln_common::federation_endpoint_constants::ACCOUNT_ENDPOINT;
 use fedimint_ln_common::LightningInput;
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
@@ -320,8 +319,6 @@ pub async fn get_incoming_contract(
                 }))
             } else {
                 Err(fedimint_api_client::api::FederationError::general(
-                    ACCOUNT_ENDPOINT,
-                    contract_id,
                     anyhow::anyhow!("Contract {contract_id} is not an incoming contract"),
                 ))
             }

--- a/modules/fedimint-meta-client/src/api.rs
+++ b/modules/fedimint-meta-client/src/api.rs
@@ -1,4 +1,6 @@
-use fedimint_api_client::api::{FederationApiExt as _, FederationResult, IModuleFederationApi};
+use fedimint_api_client::api::{
+    CallResultExt as _, FederationApiExt as _, FederationResult, IModuleFederationApi,
+};
 use fedimint_core::module::{ApiAuth, ApiRequestErased};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{apply, async_trait_maybe_send};
@@ -36,6 +38,7 @@ where
             ApiRequestErased::new(GetConsensusRequest(key)),
         )
         .await
+        .flatten()
     }
     async fn get_consensus_rev(&self, key: MetaKey) -> FederationResult<Option<u64>> {
         self.request_current_consensus(
@@ -43,6 +46,7 @@ where
             ApiRequestErased::new(GetConsensusRequest(key)),
         )
         .await
+        .flatten()
     }
 
     async fn get_submissions(
@@ -56,6 +60,7 @@ where
             auth,
         )
         .await
+        .flatten()
     }
     async fn submit(
         &self,
@@ -69,5 +74,6 @@ where
             auth,
         )
         .await
+        .flatten()
     }
 }

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -190,7 +190,7 @@ impl MintOutputStatesCreated {
                     // this query collects a threshold of 2f + 1 valid blind signature shares
                     FilterMapThreshold::new(
                         move |peer, outcome| {
-                            verify_blind_share(peer, &outcome, amount, message, &decoder, &pks)
+                            verify_blind_share(peer, &outcome?, amount, message, &decoder, &pks)
                         },
                         NumPeers::from(global_context.api().all_peers().total()),
                     ),

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -1,5 +1,7 @@
 use bitcoin::Address;
-use fedimint_api_client::api::{FederationApiExt, FederationResult, IModuleFederationApi};
+use fedimint_api_client::api::{
+    CallResultExt as _, FederationApiExt, FederationResult, IModuleFederationApi,
+};
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{apply, async_trait_maybe_send};
@@ -27,6 +29,7 @@ where
             ApiRequestErased::default(),
         )
         .await
+        .flatten()
     }
 
     async fn fetch_peg_out_fees(
@@ -39,5 +42,6 @@ where
             ApiRequestErased::new((address, amount.to_sat())),
         )
         .await
+        .flatten()
     }
 }


### PR DESCRIPTION
This is a follow-up of the discussion in #5244 , though only the client side.

The motivation here is to allow API calls to return well defined "errors", that the client side can act on, possibly conditionally. We don't have many calls like this currently, because we were avoiding the matter altogether. The `submit_transaction` is the only call like that we have, though the approach taken there turned out to be too constraining, and frustrated by not being able to add a single field for better diagnostics, I created #5238 which started this whole effort.

#### Some rationale of the design

For the client logic to remain secure in the presence of potentially malicious peers, any application-level api errors need to be a subject of client side consensus (query strategies). Changing api response (including errors) is an API breaking change. This goes against the need to return rich data-structures and/or diagnostic information. Therefor error conditions should preferably be simple enumerations (error codes), with any diagnostics specifically not being part of client api result consensus logic.

JsonRpc already allows returning both application level error codes with extra information: https://www.jsonrpc.org/specification#error_object . It makes sense to just use it in an jsonrpc idiomatic way, as it fits our needs and and avoids inventing new serialization schemes for distinguishing successful responses from error conditions.

##### About the changes

The root change is elevating application level errors from being the same as any other errors (connection error, timeouts, server side jsonrpc error, etc.). This is so it can be used to return application level server side errors to the client as first class values.

In a nutshell, where before client api code (especially query strategies) worked on `T` as a server side api response, now it's a `Result<T, CallError>`. Query strategies consider the whole `Result<T, CallError>` as a succesful "response" and might collect the whole thing, gather a threshold of them and return as a consensus on the result to the call, etc.

`CallError` is a bit special. The `impl Eq for CallError` compares only the `code`. All other fields: `message` and `data` are considered diagnostics only. The reason for this is that if the client needs to agree on a consensus, anything it compares becomes effectively set in stone and immutable. If we are to compare `message`, it means it's no longer possible to fix a typo in it without breaking the client side. That's why server side api application errors need to be as small and precise as possible. Adding a new error code is effectively a API breaking change.

If client side ever needs more broader information about the details of error (e.g. submitted tx being rejected), it needs to facilitate it using separate follow-up api code. There are many reason for it. E.g. `submit_transaction` fail on a first input/output with a problem, and can't return all processing errors; or the fact that `submit_transaaction` can't start returning new error codes/data just because new module is available because it's a core-API endpoint. By introducing another call, it's possible to evolve per-case handling, without having to break the wholerror e core API to accommodate it.


As currently all except `submit_transaction` api calls don't use application-side level errors, and in the future most probably will not, a simple `.flatten()` method is provided for the call to turn `Result<Result<T, CallError>, PeerError>` into just `Result<T, PeerError>` like what was returned before. Logic that does want to handle specific error cases of an Api, will just not call `.flatten` and handle `CallError` directly.

Query strategy logic stays mostly intact. A `CallError` is just a part of `T`. Filter/map strategies might just want to call `?` to throw away `CallErrors`.


#####  Follow-up

If this is accepted, I'd like to rotate `submit_transaction` to a new API call, that uses call error codes for rejected transactions, somehow like in #5244, but with re-considered error codes.

Afterwards, we might considered changing `InputError`, `OutputError` and even `OutputOutcome` in the module system, as these might not require consensus encoding anymore.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
