### PR TITLE
chore: pipe payment hash from InterceptHtlcRequest to InterceptHtlcResponse

### DIFF
--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -91,7 +91,7 @@ message PayInvoiceResponse {
 
 message InterceptHtlcRequest {
   // The HTLC payment hash.
-  // Value is not guaranteed to be unique per intercepted HTLC
+  // HTLCs corresponding to the same payment will have the same payment hash.
   bytes payment_hash = 1;
 
   // The incoming HTLC amount in millisatoshi.
@@ -162,6 +162,10 @@ message InterceptHtlcResponse {
 
   // The index of the incoming htlc in the incoming channel
   uint64 htlc_id = 5;
+
+  // The HTLC payment hash.
+  // HTLCs corresponding to the same payment will have the same payment hash.
+  bytes payment_hash = 6;
 }
 
 message GetRouteHintsResponse {

--- a/gateway/ln-gateway/src/gateway_module_v2/mod.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/mod.rs
@@ -307,6 +307,7 @@ impl GatewayClientModuleV2 {
 
     pub async fn relay_incoming_htlc(
         &self,
+        payment_hash: bitcoin_hashes::sha256::Hash,
         incoming_chan_id: u64,
         htlc_id: u64,
         contract: IncomingContract,
@@ -336,6 +337,7 @@ impl GatewayClientModuleV2 {
                     GatewayClientStateMachinesV2::Complete(CompleteStateMachine {
                         common: CompleteSMCommon {
                             operation_id,
+                            payment_hash,
                             incoming_chan_id,
                             htlc_id,
                         },

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -578,6 +578,7 @@ impl ILnRpcClient for GatewayLndClient {
         if let Some(lnd_sender) = self.lnd_sender.clone() {
             let InterceptHtlcResponse {
                 action,
+                payment_hash: _,
                 incoming_chan_id,
                 htlc_id,
             } = htlc;

--- a/gateway/ln-gateway/src/state_machine/complete.rs
+++ b/gateway/ln-gateway/src/state_machine/complete.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use bitcoin_hashes::Hash;
 use fedimint_client::sm::{State, StateTransition};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
@@ -49,6 +50,7 @@ pub enum GatewayCompleteStates {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct GatewayCompleteCommon {
     pub operation_id: OperationId,
+    pub payment_hash: bitcoin_hashes::sha256::Hash,
     pub incoming_chan_id: u64,
     pub htlc_id: u64,
 }
@@ -190,11 +192,13 @@ impl CompleteHtlcState {
                             action: Some(Action::Settle(Settle {
                                 preimage: preimage.0.to_vec(),
                             })),
+                            payment_hash: common.payment_hash.to_byte_array().to_vec(),
                             incoming_chan_id: common.incoming_chan_id,
                             htlc_id: common.htlc_id,
                         },
                         HtlcOutcome::Failure(reason) => InterceptHtlcResponse {
                             action: Some(Action::Cancel(Cancel { reason })),
+                            payment_hash: common.payment_hash.to_byte_array().to_vec(),
                             incoming_chan_id: common.incoming_chan_id,
                             htlc_id: common.htlc_id,
                         },

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -290,6 +290,7 @@ impl GatewayClientModule {
                     GatewayClientStateMachines::Complete(GatewayCompleteStateMachine {
                         common: GatewayCompleteCommon {
                             operation_id,
+                            payment_hash: htlc.payment_hash,
                             incoming_chan_id: htlc.incoming_chan_id,
                             htlc_id: htlc.htlc_id,
                         },


### PR DESCRIPTION
# Background

On the lightning gateway, each incoming HTLC from the underlying lightning node fires out an `InterceptHtlcRequest` to the stream returned by `ILnRpcClient::route_htlcs()`. The gateway responds by calling `ILnRpcClient::complete_htlc()` and passing in an `InterceptHtlcResponse` which includes two pieces of data:

1. How the HTLC should be handled (`InterceptHtlcResponse.action`)
2. Data used to identify the HTLC (`InterceptHtlcResponse.incoming_chan_id` and `InterceptHtlcResponse.htlc_id`)

The `incoming_chan_id` and `htlc_id` fields combined act as a unique identifier for a given HTLC, essentially mapping an `InterceptHtlcResponse` to the `InterceptHtlcRequest` it is responding to. We use these two fields instead of simply using the payment hash because, while we don't currently support MPP, someone could attempt to pay using MPP, so the payment hash is not guaranteed to be unique to a single HTLC.

# What we're adding

In addition to `incoming_chan_id` and `htlc_id`, we're adding `payment_hash` as another field that can be used for uniquely mapping an `InterceptHtlcRequest` to an `InterceptHtlcResponse`.

# Why this is needed

This change will make it much easier to support an `ldk-node` lightning gateway. The folks who are working on `ldk-node` are planning on adding payment interception but _not_ HTLC interception. For intercepted payments, we will be given the payment hash but no HTLC IDs. However, the payment hash will be guaranteed to be unique since `ldk-node` will only trigger a `PaymentClaimable` event once the entire payment is received. Essentially we'll be pretending that incoming payments are single HTLCs even though they could be MPPs under the hood.