### PR TITLE
chore: dump citems dump on consensus mismatch

### DIFF
--- a/fedimint-server/src/consensus/debug.rs
+++ b/fedimint-server/src/consensus/debug.rs
@@ -1,5 +1,9 @@
 use std::fmt;
 
+use bitcoin_hashes::{sha256, Hash as _};
+use fedimint_core::encoding::Encodable as _;
+use fedimint_core::session_outcome::AcceptedItem;
+
 use crate::ConsensusItem;
 
 /// A newtype for a nice [`fmt::Debug`] of a [`ConsensusItem`]
@@ -36,6 +40,60 @@ impl<'ci> fmt::Debug for DebugConsensusItem<'ci> {
                 f.write_fmt(format_args!("Unknown CI variant: {variant}"))?;
             }
         }
+        Ok(())
+    }
+}
+
+/// A compact citem formatter, useful for debugging in case of consensus failure
+///
+/// Unlike [`DebugConsensusItem`], this one is used when a (potentially) long
+/// list of citems are dumped, so it needs to be very compact.
+pub struct DebugConsensusItemCompact<'a>(pub &'a AcceptedItem);
+
+impl<'a> fmt::Display for DebugConsensusItemCompact<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut engine = sha256::HashEngine::default();
+        let len = self
+            .0
+            .consensus_encode(&mut engine)
+            .map_err(|_| fmt::Error)?;
+        let hash = *sha256::Hash::from_engine(engine).as_byte_array();
+        f.write_fmt(format_args!(
+            "{}; peer={}; len={}; ",
+            hex::encode(&hash[0..12]),
+            self.0.peer,
+            len
+        ))?;
+
+        match &self.0.item {
+            ConsensusItem::Transaction(ref tx) => {
+                f.write_fmt(format_args!("txid={}; ", tx.tx_hash()))?;
+                f.write_str("inputs_module_ids=")?;
+                for (i, input) in tx.inputs.iter().enumerate() {
+                    if i != 0 {
+                        f.write_str(",")?;
+                    }
+                    f.write_fmt(format_args!("{}", input.module_instance_id()))?;
+                }
+                f.write_str("; outputs_module_ids=")?;
+                for (i, output) in tx.outputs.iter().enumerate() {
+                    if i != 0 {
+                        f.write_str(",")?;
+                    }
+                    f.write_fmt(format_args!("{}", output.module_instance_id()))?;
+                }
+            }
+            ConsensusItem::Module(module_citem) => {
+                f.write_fmt(format_args!(
+                    "citem={}; ",
+                    module_citem.module_instance_id()
+                ))?;
+            }
+            ConsensusItem::Default { variant, .. } => {
+                f.write_fmt(format_args!("unknown variant={variant}"))?;
+            }
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/fedimint/fedimint/pull/5386/files#r1619463731

The goal here is to be able to do binary search using logs of peer nodes that have a mismatch and find the element(s) that are mismatched and at very least known which modules might have been involved, before attempting a full scale debugging with dbtool etc.

That's why the index and short-hash are printed first, and then it's some compact general info about txid, modules and/or total length.



If I'm reading it right, there is no guarantee that any peer with a majority-correct checksum/signature will notice invalid signature of another peer, but over 3 peers, the chance is high, and it's better than nothing.

Looks like this:

![image](https://github.com/fedimint/fedimint/assets/9209/612d0a78-1ccb-4781-a6b5-3c7dc636d84e)

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
