### PR TITLE
feat: accept whitespaces in oob notes str

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -314,10 +314,11 @@ impl FromStr for OOBNotes {
 
     /// Decode a set of out-of-band e-cash notes from a base64 string.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = if let Ok(bytes) = BASE64_URL_SAFE.decode(s) {
+        let s: String = s.chars().filter(|&c| !c.is_whitespace()).collect();
+        let bytes = if let Ok(bytes) = BASE64_URL_SAFE.decode(&s) {
             bytes
         } else {
-            base64::engine::general_purpose::STANDARD.decode(s)?
+            base64::engine::general_purpose::STANDARD.decode(&s)?
         };
         let oob_notes: OOBNotes = Decodable::consensus_decode(
             &mut std::io::Cursor::new(bytes),


### PR DESCRIPTION
Sometimes I need to copy&paste notes between terminals, logs, etc. and it is just a QoL if it could not complain about some random newline or space in there.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
