### PR TITLE
chore: enforce clippy nursery rules in fedimint-core

### DIFF
--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -382,20 +382,18 @@ impl ClientConfig {
     }
 
     pub fn get_module<T: Decodable + 'static>(&self, id: ModuleInstanceId) -> anyhow::Result<&T> {
-        if let Some(client_cfg) = self.modules.get(&id) {
-            client_cfg.cast()
-        } else {
-            Err(format_err!("Client config for module id {id} not found"))
-        }
+        self.modules.get(&id).map_or_else(
+            || Err(format_err!("Client config for module id {id} not found")),
+            |client_cfg| client_cfg.cast(),
+        )
     }
 
     // TODO: rename this and one above
     pub fn get_module_cfg(&self, id: ModuleInstanceId) -> anyhow::Result<ClientModuleConfig> {
-        if let Some(client_cfg) = self.modules.get(&id) {
-            Ok(client_cfg.clone())
-        } else {
-            Err(format_err!("Client config for module id {id} not found"))
-        }
+        self.modules.get(&id).map_or_else(
+            || Err(format_err!("Client config for module id {id} not found")),
+            |client_cfg| Ok(client_cfg.clone()),
+        )
     }
 
     /// (soft-deprecated): Get the first instance of a module of a given kind in
@@ -819,7 +817,7 @@ pub trait TypedServerModuleConfig: DeserializeOwned + Serialize {
                 serde_json::to_value(local).expect("serialization can't fail"),
             ),
             private: JsonWithKind::new(
-                kind.clone(),
+                kind,
                 serde_json::to_value(private).expect("serialization can't fail"),
             ),
             consensus: ServerModuleConsensusConfig {

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -204,7 +204,7 @@ impl From<&'static str> for ModuleKind {
 ///
 /// This allows parsing and handling of dyn-types of modules which
 /// are not available.
-#[derive(Debug, Hash, PartialEq, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct DynUnknown(pub Vec<u8>);
 
 impl fmt::Display for DynUnknown {

--- a/fedimint-core/src/encoding/bls12_381.rs
+++ b/fedimint-core/src/encoding/bls12_381.rs
@@ -17,7 +17,7 @@ impl Decodable for Scalar {
         let byte_array = <[u8; 32]>::consensus_decode(d, modules)?;
 
         Option::from(Scalar::from_bytes(&byte_array))
-            .ok_or(DecodeError::from_str("Error decoding Scalar"))
+            .ok_or_else(|| DecodeError::from_str("Error decoding Scalar"))
     }
 }
 
@@ -35,7 +35,7 @@ impl Decodable for G1Affine {
         let byte_array = <[u8; 48]>::consensus_decode(d, modules)?;
 
         Option::from(G1Affine::from_compressed(&byte_array))
-            .ok_or(DecodeError::from_str("Error decoding G1Affine"))
+            .ok_or_else(|| DecodeError::from_str("Error decoding G1Affine"))
     }
 }
 
@@ -53,6 +53,6 @@ impl Decodable for G2Affine {
         let byte_array = <[u8; 96]>::consensus_decode(d, modules)?;
 
         Option::from(G2Affine::from_compressed(&byte_array))
-            .ok_or(DecodeError::from_str("Error decoding G2Affine"))
+            .ok_or_else(|| DecodeError::from_str("Error decoding G2Affine"))
     }
 }

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -1,18 +1,24 @@
-#![warn(clippy::pedantic)]
+#![warn(clippy::pedantic, clippy::nursery)]
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_possible_wrap)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cognitive_complexity)]
 #![allow(clippy::default_trait_access)]
 #![allow(clippy::doc_markdown)]
+#![allow(clippy::future_not_send)]
+#![allow(clippy::missing_const_for_fn)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::must_use_candidate)]
+#![allow(clippy::redundant_pub_crate)]
 #![allow(clippy::return_self_not_must_use)]
+#![allow(clippy::significant_drop_tightening)]
 #![allow(clippy::similar_names)]
 #![allow(clippy::transmute_ptr_to_ptr)]
 #![allow(clippy::unsafe_derive_deserialize)]
+#![allow(clippy::use_self)]
 
 //! Fedimint Core library
 //!
@@ -185,7 +191,7 @@ impl Amount {
     }
 
     pub fn from_str_in(s: &str, denom: Denomination) -> Result<Amount, ParseAmountError> {
-        if let Denomination::MilliSatoshi = denom {
+        if denom == Denomination::MilliSatoshi {
             return Ok(Self::from_msats(s.parse()?));
         }
         let btc_amt = bitcoin::amount::Amount::from_str_in(s, denom)?;

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -53,7 +53,7 @@ use crate::{
     PeerId,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct InputMeta {
     pub amount: TransactionItemAmount,
     pub pub_key: secp256k1_zkp::PublicKey,

--- a/fedimint-core/src/task/jit.rs
+++ b/fedimint-core/src/task/jit.rs
@@ -26,8 +26,7 @@ pub enum OneTimeError<E> {
 
 impl<E> std::error::Error for OneTimeError<E>
 where
-    E: fmt::Debug,
-    E: fmt::Display,
+    E: fmt::Debug + fmt::Display,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None

--- a/fedimint-core/src/tiered.rs
+++ b/fedimint-core/src/tiered.rs
@@ -137,7 +137,7 @@ mod tests {
         let denominations = Tiered::gen_denominations(2, max_amount);
 
         // should produce [1, 2, 4, 8, 16]
-        assert_eq!(denominations.tiers().collect::<Vec<&Amount>>().len(), 5);
+        assert_eq!(denominations.tiers().count(), 5);
     }
 
     #[test]
@@ -146,6 +146,6 @@ mod tests {
         let denominations = Tiered::gen_denominations(10, max_amount);
 
         // should produce [1, 10, 100, 1000, 10_000]
-        assert_eq!(denominations.tiers().collect::<Vec<&Amount>>().len(), 5);
+        assert_eq!(denominations.tiers().count(), 5);
     }
 }

--- a/fedimint-core/src/tiered_multi.rs
+++ b/fedimint-core/src/tiered_multi.rs
@@ -125,10 +125,10 @@ impl<T> TieredMulti<T> {
     /// Verifies that all keys in `self` are present in the keys of the given
     /// parameter `Tiered`
     pub fn all_tiers_exist_in<K>(&self, keys: &Tiered<K>) -> Result<(), InvalidAmountTierError> {
-        match self.0.keys().find(|&amt| keys.get(*amt).is_none()) {
-            Some(amt) => Err(InvalidAmountTierError(*amt)),
-            None => Ok(()),
-        }
+        self.0
+            .keys()
+            .find(|&amt| keys.get(*amt).is_none())
+            .map_or(Ok(()), |amt| Err(InvalidAmountTierError(*amt)))
     }
 
     /// Returns an `Option` with a reference to the vector of the given `Amount`
@@ -266,7 +266,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, Clone)]
 pub struct TieredCounts(Tiered<usize>);
 
 impl TieredCounts {

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -50,10 +50,9 @@ where
     /// Waits for the next item in a stream. If the stream is closed while
     /// waiting, returns an error.  Useful when expecting a stream to progress.
     async fn ok(&mut self) -> anyhow::Result<Self::Output> {
-        match self.next().await {
-            Some(item) => Ok(item),
-            None => Err(format_err!("Stream was unexpectedly closed")),
-        }
+        self.next()
+            .await
+            .map_or_else(|| Err(format_err!("Stream was unexpectedly closed")), Ok)
     }
 
     /// Waits for the next item in a stream. If the stream is closed while
@@ -317,7 +316,7 @@ impl<T> Spanned<T> {
     pub fn map<U>(self, map: impl Fn(T) -> U) -> Spanned<U> {
         Spanned {
             value: map(self.value),
-            span: self.span.clone(),
+            span: self.span,
         }
     }
 


### PR DESCRIPTION
Enforce most clippy nursery rules in fedimint-core. I disabled a few that seemed annoying. One rule that I'm on the fence about (that's currently enabled in this PR) is [missing_const_for_fn](https://rust-lang.github.io/rust-clippy/master/index.html#/missing_const_for_fn) since removing `const` from a function later would break API compatibility. Lmk if anyone has thoughts on that. If people like the restrictions in this PR, I'll do a sweep across the rest of the rust codebase and enable it everywhere.