### PR TITLE
refactor: make conversion to num peers explicit

### DIFF
--- a/fedimint-api-client/src/query.rs
+++ b/fedimint-api-client/src/query.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 use anyhow::anyhow;
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::{maybe_add_send_sync, NumPeers, NumPeersExt, PeerId};
+use fedimint_core::{maybe_add_send_sync, NumPeers, PeerId};
 
 use crate::api::{self, PeerError, PeerResult};
 

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -117,7 +117,7 @@ use fedimint_core::transaction::Transaction;
 use fedimint_core::util::{BoxStream, NextOrPending};
 use fedimint_core::{
     apply, async_trait_maybe_send, dyn_newtype_define, fedimint_build_code_version_env,
-    maybe_add_send, maybe_add_send_sync, runtime, Amount, NumPeers, NumPeersExt, OutPoint, PeerId,
+    maybe_add_send, maybe_add_send_sync, runtime, Amount, NumPeers, OutPoint, PeerId,
     TransactionId,
 };
 pub use fedimint_derive_secret as derivable_secret;

--- a/fedimint-core/src/invite_code.rs
+++ b/fedimint-core/src/invite_code.rs
@@ -13,7 +13,7 @@ use crate::config::FederationId;
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 use crate::util::SafeUrl;
-use crate::{NumPeersExt as _, PeerId};
+use crate::{NumPeersExt, PeerId};
 
 /// Information required for client to join Federation
 ///
@@ -80,7 +80,7 @@ impl InviteCode {
         peer_to_url_map: &BTreeMap<PeerId, SafeUrl>,
         federation_id: FederationId,
     ) -> Self {
-        let max_size = peer_to_url_map.max_evil() + 1;
+        let max_size = peer_to_url_map.to_num_peers().max_evil() + 1;
         let mut code_vec: Vec<InviteCodePart> = peer_to_url_map
             .iter()
             .take(max_size)

--- a/fedimint-server/src/config/distributedgen.rs
+++ b/fedimint-server/src/config/distributedgen.rs
@@ -508,7 +508,12 @@ impl<'a> PeerHandleOps for PeerHandle<'a> {
     where
         T: Serialize + DeserializeOwned + Unpin + Send + Clone + Eq + Hash + Sync,
     {
-        let mut dkg = DkgRunner::new(v, self.peers.threshold(), &self.our_id, &self.peers);
+        let mut dkg = DkgRunner::new(
+            v,
+            self.peers.to_num_peers().threshold(),
+            &self.our_id,
+            &self.peers,
+        );
         dkg.run_g1(self.module_instance_id, self.connections).await
     }
 
@@ -516,7 +521,12 @@ impl<'a> PeerHandleOps for PeerHandle<'a> {
     where
         T: Serialize + DeserializeOwned + Unpin + Send + Clone + Eq + Hash + Sync,
     {
-        let mut dkg = DkgRunner::multi(v, self.peers.threshold(), &self.our_id, &self.peers);
+        let mut dkg = DkgRunner::multi(
+            v,
+            self.peers.to_num_peers().threshold(),
+            &self.our_id,
+            &self.peers,
+        );
 
         dkg.run_g2(self.module_instance_id, self.connections).await
     }

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -479,9 +479,14 @@ impl ServerConfig {
         );
 
         // BFT uses a lower threshold of signing keys (f+1)
-        let mut dkg = DkgRunner::new(KeyType::Bft, peers.one_honest(), our_id, peers);
-        dkg.add(KeyType::Auth, peers.threshold());
-        dkg.add(KeyType::Epoch, peers.threshold());
+        let mut dkg = DkgRunner::new(
+            KeyType::Bft,
+            peers.to_num_peers().one_honest(),
+            our_id,
+            peers,
+        );
+        dkg.add(KeyType::Auth, peers.to_num_peers().threshold());
+        dkg.add(KeyType::Epoch, peers.to_num_peers().threshold());
 
         let mut registered_modules = registry.kinds();
         let mut module_cfgs: BTreeMap<ModuleInstanceId, ServerModuleConfig> = Default::default();

--- a/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
@@ -15,7 +15,7 @@ use fedimint_core::endpoint_constants::AWAIT_OUTPUT_OUTCOME_ENDPOINT;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::secp256k1::KeyPair;
 use fedimint_core::task::sleep;
-use fedimint_core::{NumPeers, NumPeersExt, OutPoint, PeerId, TransactionId};
+use fedimint_core::{NumPeersExt, OutPoint, PeerId, TransactionId};
 use fedimint_lnv2_client::LightningClientStateMachines;
 use fedimint_lnv2_common::contracts::IncomingContract;
 use fedimint_lnv2_common::{LightningInput, LightningInputV0, LightningOutputOutcome};
@@ -180,7 +180,7 @@ impl ReceiveStateMachine {
                 .request_with_strategy(
                     FilterMapThreshold::new(
                         verify_decryption_share.clone(),
-                        NumPeers::from(global_context.api().all_peers().total()),
+                        global_context.api().all_peers().to_num_peers(),
                     ),
                     AWAIT_OUTPUT_OUTCOME_ENDPOINT.to_owned(),
                     ApiRequestErased::new(out_point),

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -27,9 +27,7 @@ use fedimint_core::module::{
     SupportedModuleApiVersions, TransactionItemAmount, CORE_CONSENSUS_VERSION,
 };
 use fedimint_core::server::DynServerModule;
-use fedimint_core::{
-    push_db_pair_items, NumPeers, NumPeersExt as _, OutPoint, PeerId, ServerModule,
-};
+use fedimint_core::{push_db_pair_items, NumPeers, OutPoint, PeerId, ServerModule};
 use fedimint_logging::LOG_MODULE_META;
 use fedimint_meta_common::config::{
     MetaClientConfig, MetaConfig, MetaConfigConsensus, MetaConfigLocal, MetaConfigPrivate,


### PR DESCRIPTION
It always bothered me that we have e.g. `peer_urls: BTreeMap<PeerId, String>` and we can write code like:

```
peer_urls.max_evil();
```

and while reading code like that I couldn't help but to think, "how do we go from a map to some consensus security calculations like that ...".

So at some point I added the `struct NumPeers` which is supposed to be an explicit newtype that carries the meaning of "how many peers we have", which seems like a decent place for methods like `max_evil` and `threshold`.

I recently attempted to remove the `NumPeersExt` where the methods like `max_evil` are implemented for collections, but it turned out that this was too much of a inconvenience. It is nice to be able to smoothly go from the data that carries number of peers implicitly (like a map of peer urls) to `NumPeers`. It just shouldn't be so implicit.

So in this PR I implement the final solution - going through an explicit `NumPeersExt::to_num_peers()`.

So a:

```
peer_urls.max_evil();
```

turns into:

```
peer_urls.to_num_peers().max_evil();
```

and in a lot of places `peer_urls.to_num_peers()` can replace existing `NumPeers::new(peer_urls.to_num_peers().total())`.

It's a little thing, but recently I've seen in the comments @joschisan and @elsirion talking about then need to clean up these num peer stuff, so here it is.

I didn't finish it (converting all the places that now complain with `deprecated` warning). I only converted a subset, just to give some sense how would it look like in practice. I first want to get some feedback if this seems OK, or maybe there are other opinions and ideas.
 
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
