### PR TITLE
refactor: finish `NumPeers` refactoring

### DIFF
--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -327,8 +327,8 @@ pub enum ParseAmountError {
 }
 
 impl<T> NumPeersExt for BTreeMap<PeerId, T> {
-    fn total(&self) -> usize {
-        self.len()
+    fn to_num_peers(&self) -> NumPeers {
+        NumPeers(self.len())
     }
 }
 
@@ -386,67 +386,32 @@ impl NumPeers {
 }
 
 impl NumPeersExt for &[PeerId] {
-    fn total(&self) -> usize {
-        self.len()
+    fn to_num_peers(&self) -> NumPeers {
+        NumPeers(self.len())
     }
 }
 
 impl NumPeersExt for Vec<PeerId> {
-    fn total(&self) -> usize {
-        self.len()
+    fn to_num_peers(&self) -> NumPeers {
+        NumPeers(self.len())
     }
 }
 
 impl NumPeersExt for Vec<PeerUrl> {
-    fn total(&self) -> usize {
-        self.len()
+    fn to_num_peers(&self) -> NumPeers {
+        NumPeers(self.len())
     }
 }
 
 impl NumPeersExt for BTreeSet<PeerId> {
-    fn total(&self) -> usize {
-        self.len()
+    fn to_num_peers(&self) -> NumPeers {
+        NumPeers(self.len())
     }
 }
 
-/// for consensus-related calculations given the number of peers
+/// Types that can be easily converted to [`NumPeers`]
 pub trait NumPeersExt {
-    fn to_num_peers(&self) -> NumPeers {
-        #[allow(deprecated)]
-        NumPeers(self.total())
-    }
-
-    #[deprecated(note = "use `to_num_peers` instead")]
-    fn total(&self) -> usize;
-
-    /// number of peers that can be evil without disrupting the federation
-    #[deprecated(note = "use `to_num_peers` instead")]
-    #[allow(deprecated)]
-    fn max_evil(&self) -> usize {
-        (self.total() - 1) / 3
-    }
-
-    /// number of peers to select such that one is honest (under our
-    /// assumptions)
-    #[deprecated(note = "use `to_num_peers` instead")]
-    #[allow(deprecated)]
-    fn one_honest(&self) -> usize {
-        self.max_evil() + 1
-    }
-
-    /// Degree of a underlying polynomial to require `threshold` signatures
-    #[deprecated(note = "use `to_num_peers` instead")]
-    #[allow(deprecated)]
-    fn degree(&self) -> usize {
-        self.threshold() - 1
-    }
-
-    /// number of peers required for a signature
-    #[deprecated(note = "use `to_num_peers` instead")]
-    #[allow(deprecated)]
-    fn threshold(&self) -> usize {
-        self.total() - self.max_evil()
-    }
+    fn to_num_peers(&self) -> NumPeers;
 }
 
 impl PeerId {

--- a/fedimint-server/src/consensus/aleph_bft/keychain.rs
+++ b/fedimint-server/src/consensus/aleph_bft/keychain.rs
@@ -63,7 +63,7 @@ impl aleph_bft::Keychain for Keychain {
     type Signature = SchnorrSignature;
 
     fn node_count(&self) -> aleph_bft::NodeCount {
-        self.pks.total().into()
+        self.pks.len().into()
     }
 
     fn sign(&self, message: &[u8]) -> Self::Signature {
@@ -105,13 +105,13 @@ impl aleph_bft::MultiKeychain for Keychain {
         signature: &Self::Signature,
         index: aleph_bft::NodeIndex,
     ) -> Self::PartialMultisignature {
-        let mut partial = aleph_bft::NodeMap::with_size(self.pks.total().into());
+        let mut partial = aleph_bft::NodeMap::with_size(self.pks.len().into());
         partial.insert(index, signature.clone());
         partial
     }
 
     fn is_complete(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool {
-        if partial.iter().count() < self.pks.threshold() {
+        if partial.iter().count() < self.pks.to_num_peers().threshold() {
             return false;
         }
 

--- a/modules/fedimint-ln-client/src/api.rs
+++ b/modules/fedimint-ln-client/src/api.rs
@@ -8,7 +8,7 @@ use fedimint_api_client::api::{
 use fedimint_api_client::query::FilterMapThreshold;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::{apply, async_trait_maybe_send, NumPeers, NumPeersExt, PeerId};
+use fedimint_core::{apply, async_trait_maybe_send, NumPeersExt, PeerId};
 use fedimint_ln_common::contracts::incoming::{IncomingContractAccount, IncomingContractOffer};
 use fedimint_ln_common::contracts::outgoing::OutgoingContractAccount;
 use fedimint_ln_common::contracts::{
@@ -185,7 +185,7 @@ where
             .request_with_strategy(
                 FilterMapThreshold::new(
                     |_, gateways| Ok(gateways),
-                    NumPeers::from(self.all_peers().total()),
+                    self.all_peers().to_num_peers(),
                 ),
                 LIST_GATEWAYS_ENDPOINT.to_string(),
                 ApiRequestErased::default(),

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -232,7 +232,7 @@ impl ServerModuleInit for LightningInit {
         params: &ConfigGenModuleParams,
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let params = self.parse_params(params).unwrap();
-        let sks = threshold_crypto::SecretKeySet::random(peers.degree(), &mut OsRng);
+        let sks = threshold_crypto::SecretKeySet::random(peers.to_num_peers().degree(), &mut OsRng);
         let pks = sks.public_keys();
 
         let server_cfg = peers

--- a/modules/fedimint-lnv2-client/src/api.rs
+++ b/modules/fedimint-lnv2-client/src/api.rs
@@ -6,7 +6,7 @@ use fedimint_api_client::query::FilterMapThreshold;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{sleep, MaybeSend, MaybeSync};
 use fedimint_core::util::SafeUrl;
-use fedimint_core::{apply, async_trait_maybe_send, NumPeers, NumPeersExt, PeerId};
+use fedimint_core::{apply, async_trait_maybe_send, NumPeersExt, PeerId};
 use fedimint_lnv2_common::endpoint_constants::{
     AWAIT_INCOMING_CONTRACT_ENDPOINT, AWAIT_PREIMAGE_ENDPOINT, CONSENSUS_BLOCK_COUNT_ENDPOINT,
     GATEWAYS_ENDPOINT, OUTGOING_CONTRACT_EXPIRATION_ENDPOINT,
@@ -95,7 +95,7 @@ where
             .request_with_strategy(
                 FilterMapThreshold::new(
                     |_, gateways| Ok(gateways),
-                    NumPeers::from(self.all_peers().total()),
+                    self.all_peers().to_num_peers(),
                 ),
                 GATEWAYS_ENDPOINT.to_string(),
                 ApiRequestErased::default(),

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -191,7 +191,7 @@ impl ServerModuleInit for LightningInit {
     ) -> BTreeMap<PeerId, ServerModuleConfig> {
         let params = self.parse_params(params).unwrap();
 
-        let (tpe_agg_pk, pks, sks) = dealer_keygen(peers.threshold(), peers.len());
+        let (tpe_agg_pk, pks, sks) = dealer_keygen(peers.to_num_peers().threshold(), peers.len());
 
         let tpe_pks: BTreeMap<PeerId, PublicKeyShare> = peers.iter().copied().zip(pks).collect();
 

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -323,7 +323,7 @@ impl MintRecoveryState {
             pending_nonces: BTreeMap::default(),
             next_pending_note_idx: backup.next_note_idx.clone(),
             last_mined_nonce_idx: backup.next_note_idx,
-            threshold: pub_key_shares.threshold() as u64,
+            threshold: pub_key_shares.to_num_peers().threshold() as u64,
             gap_limit,
             tbs_pks,
             pub_key_shares,

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -13,7 +13,7 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::secp256k1::KeyPair;
 use fedimint_core::task::sleep;
-use fedimint_core::{Amount, NumPeers, NumPeersExt, OutPoint, PeerId, Tiered};
+use fedimint_core::{Amount, NumPeersExt, OutPoint, PeerId, Tiered};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_MINT;
 use fedimint_mint_common::endpoint_constants::AWAIT_OUTPUT_OUTCOME_ENDPOINT;
@@ -190,7 +190,7 @@ impl MintOutputStatesCreated {
                         move |peer, outcome| {
                             verify_blind_share(peer, &outcome, amount, message, &decoder, &pks)
                         },
-                        NumPeers::from(global_context.api().all_peers().total()),
+                        global_context.api().all_peers().to_num_peers(),
                     ),
                     AWAIT_OUTPUT_OUTCOME_ENDPOINT.to_owned(),
                     ApiRequestErased::new(common.out_point),

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -160,7 +160,8 @@ impl ServerModuleInit for MintInit {
             .gen_denominations()
             .iter()
             .map(|&amount| {
-                let (tbs_pk, tbs_pks, tbs_sks) = dealer_keygen(peers.threshold(), peers.len());
+                let (tbs_pk, tbs_pks, tbs_sks) =
+                    dealer_keygen(peers.to_num_peers().threshold(), peers.len());
                 (amount, (tbs_pk, tbs_pks, tbs_sks))
             })
             .collect::<HashMap<_, _>>();
@@ -298,7 +299,7 @@ impl ServerModuleInit for MintInit {
         .map(|(amt, keys)| {
             let keys = (1_u64..)
                 .zip(keys.into_iter().copied())
-                .take(config.peer_tbs_pks.threshold())
+                .take(config.peer_tbs_pks.to_num_peers().threshold())
                 .collect();
 
             (amt, aggregate_public_key_shares(&keys))
@@ -650,7 +651,7 @@ impl Mint {
         .map(|(amt, keys)| {
             let keys = (1_u64..)
                 .zip(keys.into_iter().copied())
-                .take(cfg.consensus.peer_tbs_pks.threshold())
+                .take(cfg.consensus.peer_tbs_pks.to_num_peers().threshold())
                 .collect();
 
             (amt, aggregate_public_key_shares(&keys))

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -268,7 +268,7 @@ impl ServerModuleInit for WalletInit {
                         .map(|(peer_id, (_, pk))| (*peer_id, CompressedPublicKey { key: *pk }))
                         .collect(),
                     *sk,
-                    peers.threshold(),
+                    peers.to_num_peers().threshold(),
                     params.consensus.network,
                     params.consensus.finality_delay,
                     params.local.bitcoin_rpc.clone(),
@@ -304,7 +304,7 @@ impl ServerModuleInit for WalletInit {
         let wallet_cfg = WalletConfig::new(
             peer_peg_in_keys,
             sk,
-            peers.peer_ids().threshold(),
+            peers.peer_ids().to_num_peers().threshold(),
             params.consensus.network,
             params.consensus.finality_delay,
             params.local.bitcoin_rpc.clone(),
@@ -917,7 +917,7 @@ impl Wallet {
     }
 
     pub async fn consensus_block_count(&self, dbtx: &mut DatabaseTransaction<'_>) -> u32 {
-        let peer_count = self.cfg.consensus.peer_peg_in_keys.total();
+        let peer_count = self.cfg.consensus.peer_peg_in_keys.to_num_peers().total();
 
         let mut counts = dbtx
             .find_by_prefix(&BlockCountVotePrefix)
@@ -938,7 +938,7 @@ impl Wallet {
     }
 
     pub async fn consensus_fee_rate(&self, dbtx: &mut DatabaseTransaction<'_>) -> Feerate {
-        let peer_count = self.cfg.consensus.peer_peg_in_keys.total();
+        let peer_count = self.cfg.consensus.peer_peg_in_keys.to_num_peers().total();
 
         let mut rates = dbtx
             .find_by_prefix(&FeeRateVotePrefix)


### PR DESCRIPTION
Follow-up to #5429

Actually it was smaller than I thought. But there might be further places where we e.g. want to take `NumPeers`.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
