### PR TITLE
chore: bump jsonrpsee and related dependencies from 0.22.5 to 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,16 +640,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
+ "digest",
 ]
 
 [[package]]
@@ -1176,20 +1167,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -2349,7 +2331,7 @@ dependencies = [
  "fedimint-threshold-crypto",
  "futures",
  "hex",
- "hyper 0.14.28",
+ "hyper 1.3.1",
  "itertools 0.12.1",
  "jsonrpsee",
  "lazy_static",
@@ -3518,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.22.5"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
+checksum = "67210bd846b2dca59dc73f34717d6e1589305d506cdd6f14c849115d08e40876"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-server",
@@ -3530,39 +3512,40 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.22.5"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
+checksum = "e4c171d64176ae8f57eec75bca9f9dda2b2f746314adef9160a5bbbb2a7c82cb"
 dependencies = [
+ "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 0.2.12",
+ "http 1.1.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls-pki-types",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls 0.25.0",
  "tokio-util",
  "tracing",
  "url",
- "webpki-roots 0.26.1",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.22.5"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257e1ec385e07b0255dde0b933f948b5c8b8c28d42afda9587c3a967b896d"
+checksum = "5e966c12c8b6c1790ce67683c792cea9dd250860df49f6b64f1b1ff6c6946850"
 dependencies = [
  "anyhow",
  "async-trait",
  "beef",
+ "bytes",
  "futures-timer",
  "futures-util",
- "hyper 0.14.28",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
@@ -3579,13 +3562,17 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.22.5"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d8b6a9674422a8572e0b0abb12feeb3f2aeda86528c80d0350c2bd0923ab41"
+checksum = "ba63ec742f5f9c4016ca4c443d04dc3ca56e240a26ebe6e56609a5109bd9d13f"
 dependencies = [
+ "anyhow",
  "futures-util",
- "http 0.2.12",
- "hyper 0.14.28",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "pin-project",
@@ -3603,12 +3590,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.22.5"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
+checksum = "328c33717b7bdc4f47cdf31c21d5449c5b713a800cb05cb767841ccf2944f9d9"
 dependencies = [
  "anyhow",
  "beef",
+ "http 1.1.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -3616,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.22.5"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f448d8eacd945cc17b6c0b42c361531ca36a962ee186342a97cdb8fca679cd77"
+checksum = "6c1c1b2f71c32f763d85c1b9836c1a522377b3972177a76b3e66ba42f2582929"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3627,11 +3615,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.22.5"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b9db2dfd5bb1194b0ce921504df9ceae210a345bc2f6c5a61432089bbab070"
+checksum = "aeb22661e1c018eb503d5a47be2d39a176de832b047d2757fa86b3d2b34fc84e"
 dependencies = [
- "http 0.2.12",
+ "http 1.1.0",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -3978,12 +3966,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opentelemetry"
@@ -4970,16 +4952,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.8"
+name = "sha1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -4988,7 +4968,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -5043,18 +5023,18 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "bytes",
  "futures",
- "http 0.2.12",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand",
- "sha-1",
+ "sha1",
 ]
 
 [[package]]

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-jsonrpsee-core = "0.22.5"
+jsonrpsee-core = "0.23.0"
 lru = "0.12.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -32,12 +32,12 @@ fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-jsonrpsee-ws-client = { version = "0.22.5", features = ["webpki-tls"], default-features = false }
+jsonrpsee-ws-client = { version = "0.23.0", default-features = false }
 tokio = { version = "1.38.0", features = ["full", "tracing"] }
 tokio-rustls = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-jsonrpsee-wasm-client = { version = "0.22.5", default-features = false }
+jsonrpsee-wasm-client = "0.23.0"
 async-lock = "3.4"
 # getrandom is transitive dependency of rand
 # on wasm, we need to enable the js backend

--- a/fedimint-api-client/src/api.rs
+++ b/fedimint-api-client/src/api.rs
@@ -97,8 +97,7 @@ impl PeerError {
             PeerError::Rpc(rpc_e) => match rpc_e {
                 // TODO: Does this cover all retryable cases?
                 JsonRpcClientError::Transport(_) | JsonRpcClientError::RequestTimeout => false,
-                JsonRpcClientError::MaxSlotsExceeded
-                | JsonRpcClientError::RestartNeeded(_)
+                JsonRpcClientError::RestartNeeded(_)
                 | JsonRpcClientError::Call(_)
                 | JsonRpcClientError::ParseError(_)
                 | JsonRpcClientError::InvalidSubscriptionId
@@ -1295,9 +1294,7 @@ impl JsonRpcClient for WsClient {
         api_secret: Option<String>,
     ) -> result::Result<Self, JsonRpcClientError> {
         #[cfg(not(target_family = "wasm"))]
-        let mut client = WsClientBuilder::default()
-            .use_webpki_rustls()
-            .max_concurrent_requests(u16::MAX as usize);
+        let mut client = WsClientBuilder::default().max_concurrent_requests(u16::MAX as usize);
 
         #[cfg(target_family = "wasm")]
         let client = WsClientBuilder::default().max_concurrent_requests(u16::MAX as usize);

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -25,7 +25,7 @@ bech32 = "0.11.0"
 bls12_381 = { workspace = true }
 serdect = { workspace = true }
 itertools = { workspace = true }
-jsonrpsee-core = { version = "0.22.5", features = ["client"] }
+jsonrpsee-core = { version = "0.23.0", features = ["client"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
@@ -58,7 +58,7 @@ tokio = { version = "1.38.0", features = ["full", "tracing"] }
 tokio-rustls = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-jsonrpsee-wasm-client = { version = "0.22.5", default-features = false }
+jsonrpsee-wasm-client = "0.23.0"
 async-lock = "3.4"
 tokio = "1.38.0"
 futures-util = { workspace = true }

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -27,8 +27,8 @@ fedimint-mint-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-m
 fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../fedimint-rocksdb" }
 fedimint-wallet-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-client" }
 futures = { workspace = true }
-jsonrpsee-core = { version = "0.22.5", features = [ "client" ] }
-jsonrpsee-types = { version = "0.22.5" }
+jsonrpsee-core = { version = "0.23.0", features = ["client"] }
+jsonrpsee-types = "0.23.0"
 lightning-invoice = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
@@ -38,7 +38,7 @@ tracing = { workspace = true }
 url = { version = "2.5.0", features = ["serde"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-jsonrpsee-ws-client = { version = "0.22.5", features = ["webpki-tls"], default-features = false }
+jsonrpsee-ws-client = { version = "0.23.0", default-features = false }
 
 [build-dependencies]
 fedimint-build = { version = "=0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -1138,7 +1138,6 @@ async fn test_connect_raw_client(
         .flat_map(|_| {
             let clients = cfg.global.api_endpoints.values().map(|url| async {
                 let ws_client = WsClientBuilder::default()
-                    .use_webpki_rustls()
                     .request_timeout(timeout)
                     .connection_timeout(timeout)
                     .build(url_to_string_with_default_port(&url.url))

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -30,7 +30,7 @@ bls12_381 = { workspace = true }
 bytes = "1.6.0"
 futures = { workspace = true }
 hex = { workspace = true }
-hyper = { version = "0.14" }
+hyper = "1"
 itertools = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-api-client = { workspace = true }
@@ -53,7 +53,7 @@ tower = { version = "0.4.13", default-features = false }
 tracing = { workspace = true }
 url = { version = "2.5.0", features = ["serde"] }
 threshold_crypto = { workspace = true }
-jsonrpsee = { version = "0.22.5", features = ["server"] }
+jsonrpsee = { version = "0.23.0", features = ["server"] }
 tokio = { version = "1.38.0", features = ["full", "tracing"] }
 tokio-stream = "0.1.15"
 tokio-rustls = { workspace = true }

--- a/fedimint-server/src/net/api.rs
+++ b/fedimint-server/src/net/api.rs
@@ -174,7 +174,7 @@ pub fn attach_endpoints<State, T>(
         let handler: &'static _ = Box::leak(endpoint.handler);
 
         rpc_module
-            .register_async_method(path, move |params, rpc_state| async move {
+            .register_async_method(path, move |params, rpc_state, _extensions| async move {
                 let params = params.one::<serde_json::Value>()?;
                 let rpc_context = &rpc_state.rpc_context;
 

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -36,7 +36,7 @@ bytes = "1.6.0"
 clap = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-jsonrpsee = { version = "0.22.5", features = ["server"] }
+jsonrpsee = { version = "0.23.0", features = ["server"] }
 fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../fedimint-bitcoind" }
 fedimint-core = { workspace = true }
 fedimint-ln-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-common" }


### PR DESCRIPTION
Replaces #5438, #5437, and #5436