### PR TITLE
feat: enable multi mint payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
  "fedimint-bitcoind",
  "fedimint-client",
  "fedimint-core",
+ "fedimint-ln-common",
  "fedimint-ln-gateway",
  "fedimint-logging",
  "fedimint-portalloc",

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-testing"
-version = {workspace = true}
+version = { workspace = true }
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-testing provides a library of shared objects and utilities for testing fedimint components"
@@ -23,21 +23,22 @@ async-stream = "0.3.5"
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 bitcoincore-rpc = "0.17.0"
-clap = { version = "4.5.7", features = ["derive", "std", "help", "usage", "error-context", "suggestions" ], default-features = false }
+clap = { version = "4.5.7", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 fedimint-core = { workspace = true }
 fedimint-api-client = { workspace = true }
-fedimint-client  = { version = "=0.4.0-alpha", path = "../fedimint-client" }
-fedimint-server  = { version = "=0.4.0-alpha", path = "../fedimint-server" }
+fedimint-client = { version = "=0.4.0-alpha", path = "../fedimint-client" }
+fedimint-server = { version = "=0.4.0-alpha", path = "../fedimint-server" }
 fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../fedimint-bitcoind" }
 fedimint-logging = { workspace = true }
 fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../fedimint-rocksdb" }
+fedimint-ln-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-common" }
 fs-lock = "0.1.3"
 lazy_static = "1.4.0"
 ln-gateway = { version = "=0.4.0-alpha", package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 futures = { workspace = true }
 lightning-invoice = { workspace = true }
 tempfile = "3.10.1"
-secp256k1-zkp = { version = "0.9.2", features = [ "global-context", "bitcoin_hashes" ] }
+secp256k1-zkp = { version = "0.9.2", features = ["global-context", "bitcoin_hashes"] }
 serde = { workspace = true }
 tracing = { workspace = true }
 rand = { workspace = true }

--- a/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
@@ -9,13 +9,11 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::secp256k1::KeyPair;
 use fedimint_core::{Amount, OutPoint};
 use fedimint_ln_common::PrunedInvoice;
-use fedimint_lnv2_client::LightningClientStateMachines;
+use fedimint_lnv2_client::{LightningClientStateMachines, LightningInvoice};
 use fedimint_lnv2_common::contracts::OutgoingContract;
 use fedimint_lnv2_common::{LightningInput, LightningInputV0, OutgoingWitness};
-use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 
-use crate::gateway_lnrpc::PayInvoiceRequest;
 use crate::gateway_module_v2::{GatewayClientContextV2, GatewayClientModuleV2};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
@@ -39,21 +37,8 @@ pub struct SendSMCommon {
     pub contract: OutgoingContract,
     pub max_delay: u64,
     pub min_contract_amount: Amount,
-    pub invoice: Invoice,
+    pub invoice: LightningInvoice,
     pub claim_keypair: KeyPair,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
-pub enum Invoice {
-    Bolt11(Bolt11Invoice),
-}
-
-impl Invoice {
-    pub fn bolt11(&self) -> &Bolt11Invoice {
-        match self {
-            Invoice::Bolt11(invoice) => invoice,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
@@ -105,7 +90,7 @@ impl State for SendStateMachine {
                         context.clone(),
                         self.common.max_delay,
                         self.common.min_contract_amount,
-                        self.common.invoice.bolt11().clone(),
+                        self.common.invoice.clone(),
                         self.common.contract.clone(),
                     ),
                     move |dbtx, result, old_state| {
@@ -134,10 +119,14 @@ impl SendStateMachine {
         context: GatewayClientContextV2,
         max_delay: u64,
         min_contract_amount: Amount,
-        invoice: Bolt11Invoice,
+        invoice: LightningInvoice,
         contract: OutgoingContract,
     ) -> Result<[u8; 32], Cancelled> {
-        // The following three checks may fail in edge cases since they have inherent
+        let (invoice, amount) = match invoice {
+            LightningInvoice::Bolt11(invoice, amount) => (invoice, amount),
+        };
+
+        // The following two checks may fail in edge cases since they have inherent
         // timing assumptions. Therefore, they may only be checked after we have created
         // the state machine such that we can cancel the contract.
         if invoice.is_expired() {
@@ -158,16 +147,12 @@ impl SendStateMachine {
             .await
             .map_err(|e| Cancelled::LightningRpcError(e.to_string()))?;
 
-        if lightning_context.lightning_public_key == invoice.recover_payee_pub_key() {
-            let invoice_msats = invoice
-                .amount_milli_satoshis()
-                .expect("We checked this previously");
-
+        if lightning_context.lightning_public_key == invoice.get_payee_pub_key() {
             let (contract, client) = context
                 .gateway
                 .get_registered_incoming_contract_and_client_v2(
                     invoice.payment_hash().to_byte_array(),
-                    invoice_msats,
+                    amount.msats,
                 )
                 .await
                 .map_err(|e| Cancelled::DirectSwapError(e.to_string()))?;
@@ -179,36 +164,22 @@ impl SendStateMachine {
                 .map_err(|e| Cancelled::DirectSwapError(e.to_string()));
         }
 
-        let max_fee = contract.amount - min_contract_amount;
-
-        if lightning_context.lnrpc.supports_private_payments() {
-            lightning_context
-                .lnrpc
-                .pay_private(
-                    PrunedInvoice::try_from(invoice).expect("Invoice has amount"),
-                    max_delay,
-                    max_fee,
-                )
-                .await
-        } else {
-            lightning_context
-                .lnrpc
-                .pay(PayInvoiceRequest {
-                    invoice: invoice.to_string(),
-                    max_delay,
-                    max_fee_msat: max_fee.msats,
-                    payment_hash: invoice.payment_hash().to_byte_array().to_vec(),
-                })
-                .await
-        }
-        .map(|response| {
-            response
-                .preimage
-                .as_slice()
-                .try_into()
-                .expect("Preimage is 32 bytes")
-        })
-        .map_err(|e| Cancelled::LightningRpcError(e.to_string()))
+        lightning_context
+            .lnrpc
+            .pay_private(
+                PrunedInvoice::new(&invoice, amount),
+                max_delay,
+                contract.amount - min_contract_amount,
+            )
+            .await
+            .map(|response| {
+                response
+                    .preimage
+                    .as_slice()
+                    .try_into()
+                    .expect("Preimage is 32 bytes")
+            })
+            .map_err(|e| Cancelled::LightningRpcError(e.to_string()))
     }
 
     async fn transition_send_payment(

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -79,8 +79,8 @@ use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::route_hints::RouteHint;
 use fedimint_ln_common::LightningCommonInit;
 use fedimint_lnv2_client::{
-    Bolt11InvoiceDescription, CreateBolt11InvoicePayload, PayBolt11InvoicePayload, PaymentFee,
-    RoutingInfo,
+    Bolt11InvoiceDescription, CreateBolt11InvoicePayload, PaymentFee, RoutingInfo,
+    SendPaymentPayload,
 };
 use fedimint_lnv2_common::contracts::IncomingContract;
 use fedimint_mint_client::{MintClientInit, MintCommonInit};
@@ -1712,9 +1712,9 @@ impl Gateway {
 
     /// Instructs this gateway to pay a Lightning network invoice via the LNv2
     /// protocol.
-    async fn pay_bolt11_invoice(
+    async fn send_payment_v2(
         &self,
-        payload: PayBolt11InvoicePayload,
+        payload: SendPaymentPayload,
     ) -> anyhow::Result<std::result::Result<[u8; 32], Signature>> {
         let clients = self.clients.read().await;
 

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -15,10 +15,10 @@ use fedimint_ln_common::gateway_endpoint_constants::{
     CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_V2_ENDPOINT,
     GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_FUNDING_ADDRESS_ENDPOINT,
     GET_GATEWAY_ID_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    OPEN_CHANNEL_ENDPOINT, PAY_BOLT11_INVOICE_V2_ENDPOINT, PAY_INVOICE_ENDPOINT, RESTORE_ENDPOINT,
-    ROUTING_INFO_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
+    OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_ENDPOINT, RESTORE_ENDPOINT, ROUTING_INFO_V2_ENDPOINT,
+    SEND_PAYMENT_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
 };
-use fedimint_lnv2_client::{CreateBolt11InvoicePayload, PayBolt11InvoicePayload};
+use fedimint_lnv2_client::{CreateBolt11InvoicePayload, SendPaymentPayload};
 use hex::ToHex;
 use serde_json::{json, Value};
 use tokio::net::TcpListener;
@@ -151,7 +151,7 @@ fn v1_routes(gateway: Gateway) -> Router {
         .route(GET_GATEWAY_ID_ENDPOINT, get(get_gateway_id))
         // These routes are for next generation lightning
         .route(ROUTING_INFO_V2_ENDPOINT, post(routing_info_v2))
-        .route(PAY_BOLT11_INVOICE_V2_ENDPOINT, post(pay_bolt11_invoice_v2))
+        .route(SEND_PAYMENT_V2_ENDPOINT, post(pay_bolt11_invoice_v2))
         .route(
             CREATE_BOLT11_INVOICE_V2_ENDPOINT,
             post(create_bolt11_invoice_v2),
@@ -381,10 +381,10 @@ async fn routing_info_v2(
 
 async fn pay_bolt11_invoice_v2(
     Extension(gateway): Extension<Gateway>,
-    Json(payload): Json<PayBolt11InvoicePayload>,
+    Json(payload): Json<SendPaymentPayload>,
 ) -> Json<Value> {
     Json(json!(gateway
-        .pay_bolt11_invoice(payload)
+        .send_payment_v2(payload)
         .await
         .map_err(|e| e.to_string())))
 }

--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -59,7 +59,7 @@ function check_check_forbidden_dependencies() {
       >&2 echo "fedimint-server/Cargo.toml must not depend on modules"
       return 1
     fi
-    if grep -E "(fedimint-mint|fedimint-wallet|fedimint-ln-(server|common|client))" fedimint-testing/Cargo.toml >&2 ; then
+    if grep -E "(fedimint-mint|fedimint-wallet|fedimint-ln-(server|client))" fedimint-testing/Cargo.toml >&2 ; then
       >&2 echo "fedimint-testing/Cargo.toml must not depend on modules"
       return 1
     fi

--- a/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
+++ b/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
@@ -17,6 +17,6 @@ pub const CLOSE_CHANNELS_WITH_PEER_ENDPOINT: &str = "/close_channels_with_peer";
 pub const ROUTING_INFO_V2_ENDPOINT: &str = "/routing_info";
 pub const PAY_INVOICE_ENDPOINT: &str = "/pay_invoice";
 pub const RESTORE_ENDPOINT: &str = "/restore";
-pub const PAY_BOLT11_INVOICE_V2_ENDPOINT: &str = "/pay_bolt11_invoice";
+pub const SEND_PAYMENT_V2_ENDPOINT: &str = "/send_payment";
 pub const SET_CONFIGURATION_ENDPOINT: &str = "/set_configuration";
 pub const WITHDRAW_ENDPOINT: &str = "/withdraw";

--- a/modules/fedimint-lnv2-client/Cargo.toml
+++ b/modules/fedimint-lnv2-client/Cargo.toml
@@ -17,7 +17,7 @@ name = "fedimint_lnv2_client"
 path = "src/lib.rs"
 
 [features]
-default =[]
+default = []
 cli = ["dep:clap", "dep:serde_json"]
 
 [dependencies]
@@ -34,8 +34,8 @@ lightning-invoice = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-api-client = { workspace = true }
-fedimint-lnv2-common ={ path = "../fedimint-lnv2-common" }
-secp256k1 = { version="0.27.0", default-features=false }
+fedimint-lnv2-common = { path = "../fedimint-lnv2-common" }
+secp256k1 = { version = "0.27.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = "1.0.61"


### PR DESCRIPTION
This pr allows a lnv2 client to specify a custom amount that should be payed instead of the invoices own amount. This allows to use lightning multi path payments to pay the same invoice from multiple mints and thereby simplifies liquidity management between mints and allows for a unified balance across mints. 

These so called multi mint payments where originally invented by the Cashu project.
