### PR TITLE
fix: add unicode 3.0 license to list of allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -110,7 +110,8 @@ allow = [
     "ISC",
     "CC0-1.0",
     "Unlicense",
-    "MITNFA"
+    "MITNFA",
+    "Unicode-3.0",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
@@ -148,7 +149,7 @@ exceptions = [
     ], name = "unicode-ident" },
     { allow = [
         "OpenSSL",
-    ], name = "ring" }
+    ], name = "ring" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,


### PR DESCRIPTION
This is causing our CI dependency audit to fail

For details, you can run `cargo-deny check licenses` locally. The following deps currently use the Unicode-3.0 license:

`icu_collections`
`icu_locid`
`icu_locid_transform`
`icu_locid_transform_data`
`icu_normalizer`
`icu_normalizer_data`
`icu_properties`
`icu_properties_data`
`icu_provider`
`icu_provider_macros`
`litemap`
`tinystr`
`writeable`
`yoke`
`yoke-derive`
`zerofrom`
`zerofrom-derive`
`zerovec`
`zerovec-derive`