### PR TITLE
feat: Checkpoint database when completing an AlephBFT session

### DIFF
--- a/fedimint-cli/src/db_locked.rs
+++ b/fedimint-cli/src/db_locked.rs
@@ -74,4 +74,8 @@ where
     ) -> <Locked<DB> as fedimint_core::db::IRawDatabase>::Transaction<'_> {
         self.inner.begin_transaction().await
     }
+
+    fn checkpoint(&self, backup_path: &Path) -> anyhow::Result<()> {
+        self.inner.checkpoint(backup_path)
+    }
 }

--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Debug};
+use std::path::Path;
 
 use anyhow::Result;
 use futures::{stream, StreamExt};
@@ -101,6 +102,10 @@ impl IRawDatabase for MemDatabase {
 
         memtx.set_tx_savepoint().await.expect("can't fail");
         memtx
+    }
+
+    fn checkpoint(&self, _backup_path: &Path) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use fedimint_core::db::{
     IDatabaseTransactionOps, IDatabaseTransactionOpsCore, IRawDatabase, IRawDatabaseTransaction,
@@ -172,8 +172,10 @@ impl IRawDatabase for RocksDbReadOnly {
         RocksDbReadOnlyTransaction(&self.0)
     }
 
-    fn checkpoint(&self, _backup_path: &Path) -> Result<()> {
-        Err(anyhow!("Cannot checkpoint a read only database"))
+    fn checkpoint(&self, backup_path: &Path) -> Result<()> {
+        let checkpoint = rocksdb::checkpoint::Checkpoint::new(&self.0)?;
+        checkpoint.create_checkpoint(backup_path)?;
+        Ok(())
     }
 }
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -8,6 +8,7 @@ pub mod engine;
 pub mod transaction;
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -45,6 +46,7 @@ pub async fn run(
     module_init_registry: ServerModuleInitRegistry,
     task_group: &TaskGroup,
     force_api_secrets: ApiSecrets,
+    data_dir: PathBuf,
 ) -> anyhow::Result<()> {
     cfg.validate_config(&cfg.local.identity, &module_init_registry)?;
 
@@ -147,6 +149,7 @@ pub async fn run(
         last_ci_by_peer,
         modules: module_registry,
         task_group: task_group.clone(),
+        data_dir,
     }
     .run()
     .await?;

--- a/fedimint-server/src/envs.rs
+++ b/fedimint-server/src/envs.rs
@@ -5,3 +5,7 @@ pub const FM_PEER_ID_SORT_BY_URL_ENV: &str = "FM_PEER_ID_SORT_BY_URL";
 /// Environment variable for the session count determining when to cleanup old
 /// checkpoints.
 pub const FM_DB_CHECKPOINT_RETENTION_ENV: &str = "FM_DB_CHECKPOINT_RETENTION";
+
+// Default number of checkpoints from the current session should be retained on
+// disk.
+pub const FM_DB_CHECKPOINT_RETENTION_DEFAULT: u64 = 1;

--- a/fedimint-server/src/envs.rs
+++ b/fedimint-server/src/envs.rs
@@ -4,7 +4,4 @@ pub const FM_PEER_ID_SORT_BY_URL_ENV: &str = "FM_PEER_ID_SORT_BY_URL";
 
 /// Environment variable for the session count determining when to cleanup old
 /// checkpoints.
-pub const FM_DB_CHECKPOINT_SESSION_DIFFERENCE_ENV: &str = "FM_DB_CHECKPOINT_SESSION_DIFFERENCE";
-/// Environment variable for how often (in # of sessions) to checkpoint the
-/// database.
-pub const FM_DB_CHECKPOINT_FREQ_ENV: &str = "FM_DB_CHECKPOINT_FREQ";
+pub const FM_DB_CHECKPOINT_RETENTION_ENV: &str = "FM_DB_CHECKPOINT_RETENTION";

--- a/fedimint-server/src/envs.rs
+++ b/fedimint-server/src/envs.rs
@@ -1,3 +1,10 @@
 /// The env var for maximum open connections the API can handle
 pub const FM_MAX_CLIENT_CONNECTIONS_ENV: &str = "FM_MAX_CLIENT_CONNECTIONS";
 pub const FM_PEER_ID_SORT_BY_URL_ENV: &str = "FM_PEER_ID_SORT_BY_URL";
+
+/// Environment variable for the session count determining when to cleanup old
+/// checkpoints.
+pub const FM_DB_CHECKPOINT_SESSION_DIFFERENCE_ENV: &str = "FM_DB_CHECKPOINT_SESSION_DIFFERENCE";
+/// Environment variable for how often (in # of sessions) to checkpoint the
+/// database.
+pub const FM_DB_CHECKPOINT_FREQ_ENV: &str = "FM_DB_CHECKPOINT_FREQ";

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -64,7 +64,7 @@ pub async fn run(
         Some(cfg) => cfg,
         None => {
             run_config_gen(
-                data_dir,
+                data_dir.clone(),
                 settings,
                 db.clone(),
                 code_version_str,
@@ -92,6 +92,7 @@ pub async fn run(
         module_init_registry.clone(),
         &task_group,
         force_api_secrets,
+        data_dir,
     )
     .await?;
 

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -210,6 +210,7 @@ impl FederationTestBuilder {
             let db = Database::new(MemDatabase::new(), decoders);
             let module_init_registry = self.server_init.clone();
             let subgroup = task_group.make_subgroup();
+            let checkpoint_dir = tempfile::Builder::new().tempdir().unwrap().into_path();
 
             task_group.spawn("fedimintd", |_| async move {
                 consensus::run(
@@ -218,6 +219,7 @@ impl FederationTestBuilder {
                     module_init_registry,
                     &subgroup,
                     fedimint_server::net::api::ApiSecrets::default(),
+                    checkpoint_dir,
                 )
                 .await
                 .expect("Could not initialise consensus");


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/5450

I think this might be useful for federations that potentially corrupt their database. The checkpoint retention  is configurable, so this feature can be turned off if guardian operators don't want the backups.
