### PR TITLE
fix: devimint jit esplora waits for esplora server to be ready

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ dependencies = [
  "bitcoincore-rpc",
  "clap",
  "cln-rpc",
+ "esplora-client",
  "fedimint-aead",
  "fedimint-api-client",
  "fedimint-bitcoind",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,10 @@ threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tonic_lnd = { version = "0.2.0", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc"] }
 cln-rpc = "0.1.9"
 clap = { version = "4.5.7", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
+esplora-client = { version = "0.6.0", default-features = false, features = [
+    "async",
+    "async-https-rustls",
+] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde-big-array = "0.5.1"
 serde_json = "1.0.117"

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -17,10 +17,7 @@ axum = { version = "0.7.5", features = ["tracing"] }
 bitcoincore-rpc = { workspace = true }
 clap = { version = "4.5.7", features = ["derive", "env", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 cln-rpc = { workspace = true }
-esplora-client = { version = "0.6.0", default-features = false, features = [
-    "async",
-    "async-https-rustls",
-] }
+esplora-client = { workspace = true }
 fedimint-aead = { path = "../crypto/aead" }
 fedimintd = { path = "../fedimintd" }
 fedimint-core = { workspace = true }

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -17,6 +17,10 @@ axum = { version = "0.7.5", features = ["tracing"] }
 bitcoincore-rpc = { workspace = true }
 clap = { version = "4.5.7", features = ["derive", "env", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
 cln-rpc = { workspace = true }
+esplora-client = { version = "0.6.0", default-features = false, features = [
+    "async",
+    "async-https-rustls",
+] }
 fedimint-aead = { path = "../crypto/aead" }
 fedimintd = { path = "../fedimintd" }
 fedimint-core = { workspace = true }

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = { workspace = true }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { version = "0.17.0", optional = true }
 electrum-client = { version = "0.18.0", optional = true }
-esplora-client = { version = "0.6.0", default-features = false, features = ["async", "async-https-rustls"], optional = true }
+esplora-client = { workspace = true, optional = true }
 hex = "0.4.3"
 lazy_static = "1.4.0"
 fedimint-core  = { version = "=0.4.0-alpha", path = "../fedimint-core" }


### PR DESCRIPTION
Necessary for ldk lightning gateway, since `ldk-node` panics if the esplora server it relies on is not able to respond to requests when the node starts up