### PR TITLE
feat: url safe json encoded invite codes and ecash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-url"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2b6c78c06f7288d5e3c3d683bde35a79531127c83b087e5d0d77c974b4b28"
+dependencies = [
+ "base64 0.22.1",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1534,7 @@ dependencies = [
  "async-trait",
  "backon",
  "backtrace",
+ "base64-url",
  "bech32 0.11.0",
  "bincode",
  "bitcoin 0.29.2",
@@ -2164,8 +2174,10 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.22.1",
+ "base64-url",
  "bincode",
  "bitcoin_hashes 0.12.0",
+ "bls12_381",
  "criterion",
  "erased-serde",
  "fedimint-api-client",

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-core"
-version = {workspace = true}
+version = { workspace = true }
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "fedimint-core provides common code used by both client and server."
@@ -22,6 +22,7 @@ futures = { workspace = true }
 backtrace = "0.3.72"
 bincode = { workspace = true }
 bech32 = "0.11.0"
+base64-url = "3.0.0"
 bls12_381 = { workspace = true }
 serdect = { workspace = true }
 itertools = { workspace = true }

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -30,7 +30,9 @@ async-stream = "0.3.5"
 async-trait = "0.1"
 aquamarine = "0.5.0"
 base64 = "0.22.1"
+base64-url = "3.0.0"
 bincode = { workspace = true }
+bls12_381 = { workspace = true }
 bitcoin_hashes = { workspace = true }
 erased-serde = { workspace = true }
 futures = { workspace = true }
@@ -39,8 +41,8 @@ itertools = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-api-client = { workspace = true }
 fedimint-client = { workspace = true }
-fedimint-derive-secret = { version = "=0.4.0-alpha", path = "../../crypto/derive-secret"}
-fedimint-mint-common ={ version = "=0.4.0-alpha", path = "../fedimint-mint-common" }
+fedimint-derive-secret = { version = "=0.4.0-alpha", path = "../../crypto/derive-secret" }
+fedimint-mint-common = { version = "=0.4.0-alpha", path = "../fedimint-mint-common" }
 fedimint-logging = { workspace = true }
 secp256k1-zkp = "0.9.2"
 serde = { workspace = true }
@@ -52,9 +54,9 @@ strum_macros = { workspace = true }
 tbs = { package = "fedimint-tbs", version = "=0.4.0-alpha", path = "../../crypto/tbs" }
 thiserror = { workspace = true }
 threshold_crypto = { workspace = true }
-tokio = { version = "1.38.0", features = [ "sync" ] }
+tokio = { version = "1.38.0", features = ["sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-test-log = { version = "0.2", features = [ "trace" ], default-features = false }
+test-log = { version = "0.2", features = ["trace"], default-features = false }


### PR DESCRIPTION
The encoding unifies our cash with Cashu. Furthermore the url safe base64 encoding makes it easy to copy and paste a token from and into chats, email etc. Using json makes it extendable and human readable given any standard url safe decoder.

Furthermore, this will save us just short of 500 lines when we remove the old encoding and also allow us to rid ourselves of TieredMulti.