### PR TITLE
fix: use ancestor inputs first in RBF withdrawals

### DIFF
--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -33,7 +33,7 @@ pub mod tweakable;
 pub mod txoproof;
 
 pub const KIND: ModuleKind = ModuleKind::from_static_str("wallet");
-pub const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(2, 0);
+pub const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(3, 0);
 
 pub const CONFIRMATION_TARGET: u16 = 10;
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1423,7 +1423,7 @@ impl<'a> StatelessWallet<'a> {
         // Ensure deterministic ordering of UTXOs for all peers
         included_utxos.sort_by_key(|(_, utxo)| utxo.amount);
         remaining_utxos.sort_by_key(|(_, utxo)| utxo.amount);
-        included_utxos.extend(remaining_utxos);
+        remaining_utxos.extend(included_utxos);
 
         // Finally we initialize our accumulator for selected input amounts
         let mut total_selected_value = bitcoin::Amount::from_sat(0);
@@ -1431,7 +1431,7 @@ impl<'a> StatelessWallet<'a> {
         let mut fees = fee_rate.calculate_fee(total_weight);
 
         while total_selected_value < peg_out_amount + change_script.dust_value() + fees {
-            match included_utxos.pop() {
+            match remaining_utxos.pop() {
                 Some((utxo_key, utxo)) => {
                     total_selected_value += utxo.amount;
                     total_weight += max_input_weight;


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/5453

The implications of this bug are severe, so please review with caution. Fixing the implementation for RBF withdrawals is one approach, however it's worth considering if disabling RBF withdrawals is a better approach. If we do go with this fix, it requires all peers to shutdown and upgrade at the same time, which is already planned for 0.4. This is due to a change in the coin selection algorithm which will cause a consensus failure if peers are on different versions.

## Context

For RBF transactions we need to first spend the inputs used in the original transaction, then consider additional UTXOs if the original inputs are insufficient to cover the new feerate. Our coin selection algorithm has a bug that constructs the transaction using new UTXOs for RBF transactions. This creates two separate on-chain transactions that can be mined since we are not spending any of the same inputs as the ancestor transaction. Thankfully, the audit fails preventing the user from double spending the ecash, however this will halt any federation that has multiple UTXOs where a user initiates an RBF withdrawal.

The existing RBF withdrawal test succeeds since we initiated only a single deposit, which causes the coin selection algorithm to consider the same UTXO. The tests have been upgraded to consider multiple UTXOs.