### PR TITLE
chore: remove instances of `tracing-chrome`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,6 @@ dependencies = [
  "console-subscriber",
  "opentelemetry 0.23.0",
  "opentelemetry-jaeger",
- "tracing-chrome",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -5758,17 +5757,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
-]
-
-[[package]]
-name = "tracing-chrome"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
-dependencies = [
- "serde_json",
- "tracing-core",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -14,13 +14,17 @@ name = "fedimint_logging"
 path = "src/lib.rs"
 
 [features]
-telemetry = ["tracing-opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "console-subscriber", "opentelemetry"]
+telemetry = [
+    "tracing-opentelemetry",
+    "opentelemetry-jaeger",
+    "console-subscriber",
+    "opentelemetry",
+]
 
 [dependencies]
 anyhow = { workspace = true }
 console-subscriber = { version = "0.3.0", optional = true }
 opentelemetry = { version = "0.23.0", optional = true }
 opentelemetry-jaeger = { version = "0.21.0", optional = true }
-tracing-chrome = { version = "0.7.2", optional = true }
 tracing-opentelemetry = { version = "0.23.0", optional = true }
-tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -167,26 +167,10 @@ impl TracingSetup {
             None
         };
 
-        let chrome_layer_opt = || -> Option<Box<dyn Layer<_> + Send + Sync + 'static>> {
-            #[cfg(feature = "telemetry")]
-            if self.with_chrome {
-                let (cr_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
-                    .include_args(true)
-                    .build();
-                // drop guard cause file to written and closed
-                // in this case file will closed after exit of program
-                std::mem::forget(guard);
-
-                return Some(cr_layer.boxed());
-            }
-            None
-        };
-
         tracing_subscriber::registry()
             .with(fmt_layer)
             .with(console_opt())
             .with(telemetry_layer_opt())
-            .with(chrome_layer_opt())
             .try_init()?;
         Ok(())
     }


### PR DESCRIPTION
Closes #5253 

Removed all the instance/reference of `tracing-chrome` from `fedimint-logging`