### PR TITLE
chore: simplify dev fed startup

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -677,18 +677,12 @@ pub async fn open_channel_between_gateways(
     let gw_lnd = gw_lnd.get_try().await?.deref().clone();
     let gw_cln = gw_cln.get_try().await?.deref().clone();
 
-    debug!(target: LOG_DEVIMINT, "Await block ln nodes block processing");
-    tokio::try_join!(
-        gw_cln.wait_for_chain_sync(bitcoind),
-        gw_lnd.wait_for_chain_sync(bitcoind)
-    )?;
-
-    debug!(target: LOG_DEVIMINT, "Opening LN channel between the nodes...");
     let cln_addr = gw_cln.get_funding_address().await?;
 
     bitcoind.send_to(cln_addr, 100_000_000).await?;
     bitcoind.mine_blocks(10).await?;
 
+    debug!(target: LOG_DEVIMINT, "Await block ln nodes block processing");
     tokio::try_join!(
         gw_cln.wait_for_chain_sync(bitcoind),
         gw_lnd.wait_for_chain_sync(bitcoind)
@@ -697,6 +691,7 @@ pub async fn open_channel_between_gateways(
     let lnd_pubkey = gw_lnd.lightning_pubkey().await?;
     let cln_pubkey = gw_cln.lightning_pubkey().await?;
 
+    debug!(target: LOG_DEVIMINT, "Opening LN channel between the nodes...");
     gw_cln
         .open_channel(
             lnd_pubkey.clone(),

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -21,8 +21,8 @@ use ln_gateway::rpc::{
 };
 use serde::Serialize;
 
-const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES: u32 = 12;
-const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS: u64 = 10;
+const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES: u32 = 60;
+const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS: u64 = 2;
 
 #[derive(Parser)]
 #[command(version)]

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -346,7 +346,8 @@ async fn main() -> anyhow::Result<()> {
                             max_retries.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES) as usize
                         ),
                     || async {
-                        if client().get_info().await?.block_height.unwrap_or(0) >= block_height {
+                        let info = client().get_info().await?;
+                        if info.block_height.unwrap_or(0) >= block_height && info.synced_to_chain {
                             Ok(())
                         } else {
                             Err(anyhow::anyhow!("Not synced yet"))


### PR DESCRIPTION
Remove duplicate calls to `wait_for_chain_sync()` and stop polling the underlying command since the command itself already performs polling here:

https://github.com/fedimint/fedimint/blob/9e15104e126bb850e792d148aed14aa26d1dad6b/gateway/cli/src/main.rs#L338-L357

Also fix a race condition in `gateway-cli lightning wait-for-chain-sync` and raise the polling rate to get slightly faster & more consistent mprocs startup times