### PR TITLE
chore: Add bitcoin::Network to ServerConfigConsensus

### DIFF
--- a/devimint/src/federation/config.rs
+++ b/devimint/src/federation/config.rs
@@ -32,7 +32,7 @@ pub fn attach_default_module_init_params(
                 local: LightningGenParamsLocal {
                     bitcoin_rpc: bitcoin_rpc.clone(),
                 },
-                consensus: LightningGenParamsConsensus { network },
+                consensus: LightningGenParamsConsensus,
             },
         )
         .attach_config_gen_params(
@@ -49,7 +49,6 @@ pub fn attach_default_module_init_params(
                     bitcoin_rpc: bitcoin_rpc.clone(),
                 },
                 consensus: WalletGenParamsConsensus {
-                    network,
                     // TODO this is not very elegant, but I'm planning to get rid of it in a next
                     // commit anyway
                     finality_delay,
@@ -64,7 +63,7 @@ pub fn attach_default_module_init_params(
                 local: fedimint_lnv2_common::config::LightningGenParamsLocal {
                     bitcoin_rpc: bitcoin_rpc.clone(),
                 },
-                consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus { network },
+                consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus,
             },
         );
 

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2371,6 +2371,7 @@ impl ClientBuilder {
                             api.clone(),
                             self.admin_creds.as_ref().map(|cred| cred.auth.clone()),
                             task_group.clone(),
+                            config.global.network,
                         )
                         .await?;
 

--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -43,6 +43,7 @@ where
     module_api: DynModuleApi,
     context: ClientContext<<C as ClientModuleInit>::Module>,
     task_group: TaskGroup,
+    network: bitcoin::Network,
 }
 
 impl<C> ClientModuleInitArgs<C>
@@ -112,6 +113,10 @@ where
 
     pub fn task_group(&self) -> &TaskGroup {
         &self.task_group
+    }
+
+    pub fn network(&self) -> bitcoin::Network {
+        self.network
     }
 }
 
@@ -296,6 +301,7 @@ pub trait IClientModuleInit: IDynCommonModuleInit + Debug + MaybeSend + MaybeSyn
         api: DynGlobalApi,
         admin_auth: Option<ApiAuth>,
         task_group: TaskGroup,
+        network: bitcoin::Network,
     ) -> anyhow::Result<DynClientModule>;
 
     fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn>;
@@ -391,6 +397,7 @@ where
         api: DynGlobalApi,
         admin_auth: Option<ApiAuth>,
         task_group: TaskGroup,
+        network: bitcoin::Network,
     ) -> anyhow::Result<DynClientModule> {
         let typed_cfg: &<<T as fedimint_core::module::ModuleInit>::Common as CommonModuleInit>::ClientConfig = cfg.cast()?;
         Ok(self
@@ -413,6 +420,7 @@ where
                     _marker: marker::PhantomData,
                 },
                 task_group,
+                network,
             })
             .await?
             .into())

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -160,6 +160,9 @@ pub struct GlobalClientConfig {
     // TODO: make it a String -> serde_json::Value map?
     /// Additional config the federation wants to transmit to the clients
     pub meta: BTreeMap<String, String>,
+    // TODO: Add database migration for this
+    /// The Bitcoin Network
+    pub network: bitcoin::Network,
 }
 
 impl GlobalClientConfig {
@@ -1036,6 +1039,7 @@ mod tests {
             global: GlobalClientConfig {
                 api_endpoints: Default::default(),
                 consensus_version: CoreConsensusVersion { major: 0, minor: 0 },
+                network: bitcoin::Network::Regtest,
                 meta: vec![
                     ("foo".to_string(), "bar".to_string()),
                     ("baz".to_string(), "\"bam\"".to_string()),

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -516,6 +516,7 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
         db: Database,
         task_group: &TaskGroup,
         our_peer_id: PeerId,
+        network: bitcoin::Network,
     ) -> anyhow::Result<DynServerModule>;
 
     fn validate_params(&self, params: &ConfigGenModuleParams) -> anyhow::Result<()>;
@@ -596,6 +597,7 @@ where
     task_group: TaskGroup,
     our_peer_id: PeerId,
     num_peers: NumPeers,
+    network: bitcoin::Network,
     // ClientModuleInitArgs needs a bound because sometimes we need
     // to pass associated-types data, so let's just put it here right away
     _marker: marker::PhantomData<S>,
@@ -623,6 +625,10 @@ where
 
     pub fn our_peer_id(&self) -> PeerId {
         self.our_peer_id
+    }
+
+    pub fn network(&self) -> bitcoin::Network {
+        self.network
     }
 }
 /// Module Generation trait with associated types
@@ -710,6 +716,7 @@ where
         db: Database,
         task_group: &TaskGroup,
         our_peer_id: PeerId,
+        network: bitcoin::Network,
     ) -> anyhow::Result<DynServerModule> {
         <Self as ServerModuleInit>::init(
             self,
@@ -719,6 +726,7 @@ where
                 db,
                 task_group: task_group.clone(),
                 our_peer_id,
+                network,
                 _marker: Default::default(),
             },
         )

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -184,6 +184,7 @@ impl ServerConfigConsensus {
                 api_endpoints: self.api_endpoints.clone(),
                 consensus_version: self.version,
                 meta: self.meta.clone(),
+                network: self.network,
             },
             modules: self
                 .modules

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -83,6 +83,7 @@ pub async fn run(
                         db.with_prefix_module_id(*module_id),
                         task_group,
                         cfg.local.identity,
+                        cfg.consensus.network,
                     )
                     .await?;
 

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -59,6 +59,7 @@ pub async fn run(
     code_version_str: String,
     module_init_registry: &ServerModuleInitRegistry,
     task_group: TaskGroup,
+    network: bitcoin::Network,
 ) -> anyhow::Result<()> {
     let cfg = match get_config(&data_dir)? {
         Some(cfg) => cfg,
@@ -70,6 +71,7 @@ pub async fn run(
                 code_version_str,
                 task_group.make_subgroup(),
                 force_api_secrets.clone(),
+                network,
             )
             .await?
         }
@@ -119,6 +121,7 @@ pub async fn run_config_gen(
     code_version_str: String,
     mut task_group: TaskGroup,
     force_api_secrets: ApiSecrets,
+    network: bitcoin::Network,
 ) -> anyhow::Result<ServerConfig> {
     info!(target: LOG_CONSENSUS, "Starting config gen");
 
@@ -133,6 +136,7 @@ pub async fn run_config_gen(
         &mut task_group,
         code_version_str.clone(),
         force_api_secrets.get_active(),
+        network,
     );
 
     let mut rpc_module = RpcHandlerCtx::new_module(config_gen);

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -51,6 +51,7 @@ pub mod config;
 /// Implementation of multiplexed peer connections
 pub mod multiplexed;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     data_dir: PathBuf,
     force_api_secrets: ApiSecrets,

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -196,8 +196,12 @@ impl FederationTestBuilder {
         let params = local_config_gen_params(&peers, self.base_port, &self.params)
             .expect("Generates local config");
 
-        let configs =
-            ServerConfig::trusted_dealer_gen(&params, &self.server_init, &self.version_hash);
+        let configs = ServerConfig::trusted_dealer_gen(
+            &params,
+            &self.server_init,
+            &self.version_hash,
+            bitcoin::Network::Regtest,
+        );
 
         let task_group = TaskGroup::new();
         for (peer_id, config) in configs.clone() {

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -291,7 +291,7 @@ impl Fedimintd {
                     local: LightningGenParamsLocal {
                         bitcoin_rpc: bitcoind_rpc.clone(),
                     },
-                    consensus: LightningGenParamsConsensus { network },
+                    consensus: LightningGenParamsConsensus,
                 },
             )
             .with_module_kind(MintInit)
@@ -313,7 +313,6 @@ impl Fedimintd {
                         bitcoin_rpc: bitcoind_rpc.clone(),
                     },
                     consensus: WalletGenParamsConsensus {
-                        network,
                         // TODO this is not very elegant, but I'm planning to get rid of it in a
                         // next commit anyway
                         finality_delay,
@@ -331,9 +330,7 @@ impl Fedimintd {
                         local: fedimint_lnv2_common::config::LightningGenParamsLocal {
                             bitcoin_rpc: bitcoind_rpc.clone(),
                         },
-                        consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus {
-                            network,
-                        },
+                        consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus,
                     },
                 )
         } else {

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -357,6 +357,7 @@ impl Fedimintd {
 
     /// Block thread and run a Fedimintd server
     pub async fn run(self) -> ! {
+        let network = self.opts.network;
         // handle optional subcommand
         if let Some(subcommand) = &self.opts.subcommand {
             match subcommand {
@@ -390,6 +391,7 @@ impl Fedimintd {
                 self.server_gens,
                 self.server_gen_params,
                 self.code_version_str,
+                network,
             )
             .await
             {
@@ -470,6 +472,7 @@ async fn run(
     module_inits: ServerModuleInitRegistry,
     module_inits_params: ServerModuleConfigGenParamsRegistry,
     code_version_str: String,
+    network: bitcoin::Network,
 ) -> anyhow::Result<()> {
     if let Some(socket_addr) = opts.bind_metrics_api.as_ref() {
         task_group.spawn_cancellable("metrics-server", {
@@ -516,6 +519,7 @@ async fn run(
         code_version_str,
         &module_inits,
         task_group.clone(),
+        network,
     )
     .await?;
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -74,10 +74,9 @@ use fedimint_core::{
     fedimint_build_code_version_env, push_db_pair_items, Amount, BitcoinAmountOrAll, BitcoinHash,
 };
 use fedimint_ln_client::pay::PayInvoicePayload;
-use fedimint_ln_common::config::{GatewayFee, LightningClientConfig};
+use fedimint_ln_common::config::GatewayFee;
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::route_hints::RouteHint;
-use fedimint_ln_common::LightningCommonInit;
 use fedimint_lnv2_client::{
     Bolt11InvoiceDescription, CreateBolt11InvoicePayload, PaymentFee, RoutingInfo,
     SendPaymentPayload,
@@ -1617,25 +1616,14 @@ impl Gateway {
     /// Verifies that the supplied `network` matches the Bitcoin network in the
     /// connected client's configuration.
     fn check_federation_network(info: &FederationInfo, network: Network) -> Result<()> {
-        let cfg = info
-            .config
-            .modules
-            .values()
-            .find(|m| LightningCommonInit::KIND == m.kind)
-            .ok_or_else(|| {
-                GatewayError::InvalidMetadata(format!(
-                    "Federation {} does not have a lightning module",
-                    info.federation_id
-                ))
-            })?;
-        let ln_cfg: &LightningClientConfig = cfg.cast()?;
+        let ln_network = info.config.global.network;
 
-        if ln_cfg.network != network {
+        if ln_network != network {
             error!(
                 "Federation {} runs on {} but this gateway supports {}",
-                info.federation_id, ln_cfg.network, network,
+                info.federation_id, ln_network, network,
             );
-            return Err(GatewayError::UnsupportedNetwork(ln_cfg.network));
+            return Err(GatewayError::UnsupportedNetwork(ln_network));
         }
 
         Ok(())

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -395,6 +395,7 @@ pub struct LightningClientModule {
     client_ctx: ClientContext<Self>,
     update_gateway_cache_merge: UpdateMerge,
     gateway_conn: Arc<dyn GatewayConnection + Send + Sync>,
+    network: bitcoin::Network,
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -467,6 +468,7 @@ impl LightningClientModule {
             client_ctx: args.context(),
             update_gateway_cache_merge: UpdateMerge::default(),
             gateway_conn: gateway_conn.clone(),
+            network: args.network(),
         };
 
         // Only initialize the gateway cache if it is empty
@@ -529,7 +531,7 @@ impl LightningClientModule {
         ClientOutput<LightningOutputV0, LightningClientStateMachines>,
         ContractId,
     )> {
-        let federation_currency: Currency = self.cfg.network.into();
+        let federation_currency: Currency = self.network.into();
         let invoice_currency = invoice.currency();
         ensure!(
             federation_currency == invoice_currency,
@@ -1420,7 +1422,7 @@ impl LightningClientModule {
             src_node_id,
             short_channel_id,
             &route_hints,
-            self.cfg.network,
+            self.network,
         )?;
 
         let tx = TransactionBuilder::new().with_output(self.client_ctx.make_client_output(output));

--- a/modules/fedimint-ln-common/src/config.rs
+++ b/modules/fedimint-ln-common/src/config.rs
@@ -22,17 +22,13 @@ impl LightningGenParams {
     pub fn regtest(bitcoin_rpc: BitcoinRpcConfig) -> Self {
         Self {
             local: LightningGenParamsLocal { bitcoin_rpc },
-            consensus: LightningGenParamsConsensus {
-                network: Network::Regtest,
-            },
+            consensus: LightningGenParamsConsensus,
         }
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LightningGenParamsConsensus {
-    pub network: Network,
-}
+pub struct LightningGenParamsConsensus;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningGenParamsLocal {
@@ -58,7 +54,6 @@ pub struct LightningConfigConsensus {
     pub threshold_pub_keys: threshold_crypto::PublicKeySet,
     /// Fees charged for LN transactions
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
 }
 
 impl LightningConfigConsensus {
@@ -79,7 +74,6 @@ pub struct LightningConfigPrivate {
 pub struct LightningClientConfig {
     pub threshold_pub_key: threshold_crypto::PublicKey,
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
 }
 
 impl std::fmt::Display for LightningClientConfig {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -249,7 +249,6 @@ impl ServerModuleInit for LightningInit {
                         consensus: LightningConfigConsensus {
                             threshold_pub_keys: pks.clone(),
                             fee_consensus: FeeConsensus::default(),
-                            network: params.consensus.network,
                         },
                         private: LightningConfigPrivate {
                             threshold_sec_key: threshold_crypto::serde_impl::SerdeSecret(sk),
@@ -280,7 +279,6 @@ impl ServerModuleInit for LightningInit {
             consensus: LightningConfigConsensus {
                 threshold_pub_keys: keys.public_key_set,
                 fee_consensus: Default::default(),
-                network: params.consensus.network,
             },
             private: LightningConfigPrivate {
                 threshold_sec_key: keys.secret_key_share,
@@ -311,7 +309,6 @@ impl ServerModuleInit for LightningInit {
         Ok(LightningClientConfig {
             threshold_pub_key: config.threshold_pub_keys.public_key(),
             fee_consensus: config.fee_consensus,
-            network: config.network,
         })
     }
 }
@@ -1255,7 +1252,7 @@ mod tests {
     use fedimint_core::{Amount, OutPoint, PeerId, ServerModule, TransactionId};
     use fedimint_ln_common::config::{
         LightningClientConfig, LightningConfig, LightningGenParams, LightningGenParamsConsensus,
-        LightningGenParamsLocal, Network,
+        LightningGenParamsLocal,
     };
     use fedimint_ln_common::contracts::incoming::{
         FundedIncomingContract, IncomingContract, IncomingContractOffer,
@@ -1286,9 +1283,7 @@ mod tests {
                         url: "http://localhost:18332".parse().unwrap(),
                     },
                 },
-                consensus: LightningGenParamsConsensus {
-                    network: Network::Regtest,
-                },
+                consensus: LightningGenParamsConsensus,
             })
             .expect("valid config params"),
         );

--- a/modules/fedimint-lnv2-common/src/config.rs
+++ b/modules/fedimint-lnv2-common/src/config.rs
@@ -21,17 +21,13 @@ impl LightningGenParams {
     pub fn regtest(bitcoin_rpc: BitcoinRpcConfig) -> Self {
         Self {
             local: LightningGenParamsLocal { bitcoin_rpc },
-            consensus: LightningGenParamsConsensus {
-                network: Network::Regtest,
-            },
+            consensus: LightningGenParamsConsensus,
         }
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LightningGenParamsConsensus {
-    pub network: Network,
-}
+pub struct LightningGenParamsConsensus;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningGenParamsLocal {
@@ -55,7 +51,6 @@ pub struct LightningConfigConsensus {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -68,7 +63,6 @@ pub struct LightningClientConfig {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
 }
 
 impl std::fmt::Display for LightningClientConfig {
@@ -135,7 +129,6 @@ fn migrate_config_consensus(
             input: config.fee_consensus.contract_input,
             output: config.fee_consensus.contract_output,
         },
-        network: config.network,
     }
 }
 

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -208,7 +208,6 @@ impl ServerModuleInit for LightningInit {
                             tpe_agg_pk,
                             tpe_pks: tpe_pks.clone(),
                             fee_consensus: FeeConsensus::default(),
-                            network: params.consensus.network,
                         },
                         private: LightningConfigPrivate {
                             sk: sks[peer.to_usize()],
@@ -250,7 +249,6 @@ impl ServerModuleInit for LightningInit {
                     })
                     .collect(),
                 fee_consensus: Default::default(),
-                network: params.consensus.network,
             },
             private: LightningConfigPrivate {
                 sk: SecretKeyShare(sk),
@@ -277,7 +275,6 @@ impl ServerModuleInit for LightningInit {
             tpe_agg_pk: config.tpe_agg_pk,
             tpe_pks: config.tpe_pks,
             fee_consensus: config.fee_consensus,
-            network: config.network,
         })
     }
 }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -186,6 +186,7 @@ impl ClientModuleInit for WalletClientInit {
         let data = WalletClientModuleData {
             cfg: args.cfg().clone(),
             module_root_secret: args.module_root_secret().clone(),
+            network: args.network(),
         };
 
         let rpc_config = self
@@ -249,6 +250,7 @@ pub enum WalletOperationMetaVariant {
 pub struct WalletClientModuleData {
     cfg: WalletClientConfig,
     module_root_secret: DerivableSecret,
+    network: bitcoin::Network,
 }
 
 impl WalletClientModuleData {
@@ -275,7 +277,7 @@ impl WalletClientModuleData {
             .cfg
             .peg_in_descriptor
             .tweak(&public_tweak_key, secp256k1::SECP256K1)
-            .address(self.cfg.network)
+            .address(self.network)
             .unwrap();
 
         // TODO: make hash?
@@ -396,7 +398,7 @@ impl WalletClientModule {
     }
 
     pub fn get_network(&self) -> Network {
-        self.cfg().network
+        self.data.network
     }
 
     pub fn get_fee_consensus(&self) -> FeeConsensus {
@@ -439,7 +441,7 @@ impl WalletClientModule {
         address: bitcoin::Address<NetworkUnchecked>,
         amount: bitcoin::Amount,
     ) -> anyhow::Result<PegOutFees> {
-        check_address(&address, self.cfg().network)?;
+        check_address(&address, self.data.network)?;
 
         self.module_api
             .fetch_peg_out_fees(&address.assume_checked(), amount)
@@ -454,7 +456,7 @@ impl WalletClientModule {
         amount: bitcoin::Amount,
         fees: PegOutFees,
     ) -> anyhow::Result<ClientOutput<WalletOutput, WalletClientStates>> {
-        check_address(&address, self.cfg().network)?;
+        check_address(&address, self.data.network)?;
 
         let output = WalletOutput::new_v0_peg_out(address, amount, fees);
 

--- a/modules/fedimint-wallet-common/src/config.rs
+++ b/modules/fedimint-wallet-common/src/config.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use bitcoin::Network;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::BitcoinRpcConfig;
@@ -30,7 +29,6 @@ impl WalletGenParams {
         WalletGenParams {
             local: WalletGenParamsLocal { bitcoin_rpc },
             consensus: WalletGenParamsConsensus {
-                network: Network::Regtest,
                 finality_delay: 10,
                 client_default_bitcoin_rpc: BitcoinRpcConfig {
                     kind: "esplora".to_string(),
@@ -53,7 +51,6 @@ pub struct WalletGenParamsLocal {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletGenParamsConsensus {
-    pub network: Network,
     pub finality_delay: u32,
     /// See [`WalletConfigConsensus::client_default_bitcoin_rpc`].
     pub client_default_bitcoin_rpc: BitcoinRpcConfig,
@@ -85,8 +82,6 @@ pub struct WalletConfigPrivate {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Encodable, Decodable)]
 pub struct WalletConfigConsensus {
-    /// Bitcoin network (e.g. testnet, bitcoin)
-    pub network: Network,
     /// The federations public peg-in-descriptor
     pub peg_in_descriptor: PegInDescriptor,
     /// The public keys for the bitcoin multisig
@@ -113,8 +108,6 @@ pub struct WalletConfigConsensus {
 pub struct WalletClientConfig {
     /// The federations public peg-in-descriptor
     pub peg_in_descriptor: PegInDescriptor,
-    /// The bitcoin network the client will use
-    pub network: Network,
     /// Confirmations required for a peg in to be accepted by federation
     pub finality_delay: u32,
     pub fee_consensus: FeeConsensus,
@@ -156,7 +149,6 @@ impl WalletConfig {
         pubkeys: BTreeMap<PeerId, CompressedPublicKey>,
         sk: SecretKey,
         threshold: usize,
-        network: Network,
         finality_delay: u32,
         bitcoin_rpc: BitcoinRpcConfig,
         client_default_bitcoin_rpc: BitcoinRpcConfig,
@@ -182,7 +174,6 @@ impl WalletConfig {
             local: WalletConfigLocal { bitcoin_rpc },
             private: WalletConfigPrivate { peg_in_key: sk },
             consensus: WalletConfigConsensus {
-                network,
                 peg_in_descriptor,
                 peer_peg_in_keys: pubkeys,
                 finality_delay,
@@ -197,13 +188,11 @@ impl WalletConfig {
 impl WalletClientConfig {
     pub fn new(
         peg_in_descriptor: PegInDescriptor,
-        network: bitcoin::network::constants::Network,
         finality_delay: u32,
         default_bitcoin_rpc: BitcoinRpcConfig,
     ) -> Self {
         Self {
             peg_in_descriptor,
-            network,
             finality_delay,
             fee_consensus: Default::default(),
             default_bitcoin_rpc,

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -567,6 +567,7 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     let fixtures = fixtures();
+    let network = bitcoin::Network::Regtest;
     let bitcoin = fixtures.bitcoin();
     let server_bitcoin_rpc_config = fixtures.bitcoin_server();
     let dyn_bitcoin_rpc = fixtures.dyn_bitcoin_rpc();
@@ -587,7 +588,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
 
     let peg_in_address = peg_in_descriptor
         .tweak(&pk, secp256k1::SECP256K1)
-        .address(wallet_config.consensus.network)?;
+        .address(network)?;
 
     let mut wallet = fedimint_wallet_server::Wallet::new_with_bitcoind(
         wallet_server_cfg[0].to_typed()?,
@@ -595,6 +596,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         dyn_bitcoin_rpc.clone(),
         &mut task_group,
         PeerId::from(0),
+        network,
     )
     .await?;
 
@@ -716,7 +718,6 @@ fn build_wallet_server_configs(
                 bitcoin_rpc: bitcoin_rpc.clone(),
             },
             consensus: fedimint_wallet_common::config::WalletGenParamsConsensus {
-                network: bitcoin::Network::Regtest,
                 finality_delay: 10,
                 client_default_bitcoin_rpc: bitcoin_rpc.clone(),
                 fee_consensus: Default::default(),

--- a/recoverytool/src/main.rs
+++ b/recoverytool/src/main.rs
@@ -143,7 +143,7 @@ async fn main() -> anyhow::Result<()> {
             .expect("Malformed wallet config");
         let base_descriptor = wallet_cfg.consensus.peg_in_descriptor;
         let base_key = wallet_cfg.private.peg_in_key;
-        let network = wallet_cfg.consensus.network;
+        let network = cfg.consensus.network;
 
         (base_descriptor, base_key, network)
     } else if let (Some(descriptor), Some(key)) = (opts.descriptor, opts.key) {


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/5121

I ended up keeping `network` in the individual module configs, but just passing the global value into it. To me this seemed like the easiest choice, but I'm open to other designs if there's suggestions.

Let me know if there's any backwards compatibility concerns.

I would like to get this in for 0.4 since I believe this is a consensus change.