### PR TITLE
chore: cleanup TaskGroupInner

### DIFF
--- a/fedimint-core/src/task/inner.rs
+++ b/fedimint-core/src/task/inner.rs
@@ -1,0 +1,131 @@
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::{Duration, SystemTime};
+
+use fedimint_core::time::now;
+use fedimint_logging::LOG_TASK;
+use tokio::sync::watch;
+use tracing::{debug, error, info, warn};
+
+use super::{TaskGroup, TaskShutdownToken};
+use crate::runtime::{JoinError, JoinHandle};
+
+#[derive(Debug)]
+pub struct TaskGroupInner {
+    on_shutdown_tx: watch::Sender<bool>,
+    // It is necessary to keep at least one `Receiver` around,
+    // otherwise shutdown writes are lost.
+    on_shutdown_rx: watch::Receiver<bool>,
+    // using blocking Mutex to avoid `async` in `add_join_handle`
+    // it's OK as we don't ever need to yield
+    join: std::sync::Mutex<VecDeque<(String, JoinHandle<()>)>>,
+    // using blocking Mutex to avoid `async` in `shutdown` and `add_subgroup`
+    // it's OK as we don't ever need to yield
+    subgroups: std::sync::Mutex<Vec<TaskGroup>>,
+}
+
+impl Default for TaskGroupInner {
+    fn default() -> Self {
+        let (on_shutdown_tx, on_shutdown_rx) = watch::channel(false);
+        Self {
+            on_shutdown_tx,
+            on_shutdown_rx,
+            join: std::sync::Mutex::new(Default::default()),
+            subgroups: std::sync::Mutex::new(vec![]),
+        }
+    }
+}
+
+impl TaskGroupInner {
+    pub fn shutdown(&self) {
+        // Note: set the flag before starting to call shutdown handlers
+        // to avoid confusion.
+        self.on_shutdown_tx
+            .send(true)
+            .expect("We must have on_shutdown_rx around so this never fails");
+
+        let subgroups = self.subgroups.lock().expect("locking failed").clone();
+        for subgroup in subgroups {
+            subgroup.inner.shutdown();
+        }
+    }
+
+    #[inline]
+    pub fn is_shutting_down(&self) -> bool {
+        *self.on_shutdown_tx.borrow()
+    }
+
+    #[inline]
+    pub fn make_shutdown_rx(&self) -> TaskShutdownToken {
+        TaskShutdownToken::new(self.on_shutdown_rx.clone())
+    }
+
+    #[inline]
+    pub fn add_subgroup(&self, tg: TaskGroup) {
+        self.subgroups.lock().expect("locking failed").push(tg);
+    }
+
+    #[inline]
+    pub async fn join_all(&self, deadline: Option<SystemTime>, errors: &mut Vec<JoinError>) {
+        let subgroups = self.subgroups.lock().expect("locking failed").clone();
+        for subgroup in subgroups {
+            info!(target: LOG_TASK, "Waiting for subgroup to finish");
+            subgroup.join_all_inner(deadline, errors).await;
+            info!(target: LOG_TASK, "Subgroup finished");
+        }
+
+        // drop lock early
+        while let Some((name, join)) = {
+            let mut lock = self.join.lock().expect("lock poison");
+            lock.pop_front()
+        } {
+            debug!(target: LOG_TASK, task=%name, "Waiting for task to finish");
+
+            let timeout = deadline.map(|deadline| {
+                deadline
+                    .duration_since(now())
+                    .unwrap_or(Duration::from_millis(10))
+            });
+
+            #[cfg(not(target_family = "wasm"))]
+            let join_future: Pin<Box<dyn Future<Output = _> + Send>> =
+                if let Some(timeout) = timeout {
+                    Box::pin(crate::runtime::timeout(timeout, join))
+                } else {
+                    Box::pin(async { Ok(join.await) })
+                };
+
+            #[cfg(target_family = "wasm")]
+            let join_future: Pin<Box<dyn Future<Output = _>>> = if let Some(timeout) = timeout {
+                Box::pin(crate::runtime::timeout(timeout, join))
+            } else {
+                Box::pin(async { Ok(join.await) })
+            };
+
+            match join_future.await {
+                Ok(Ok(())) => {
+                    debug!(target: LOG_TASK, task=%name, "Task finished");
+                }
+                Ok(Err(e)) => {
+                    error!(target: LOG_TASK, task=%name, error=%e, "Task panicked");
+                    errors.push(e);
+                }
+                Err(_) => {
+                    warn!(
+                        target: LOG_TASK, task=%name,
+                        "Timeout waiting for task to shut down"
+                    );
+                }
+            }
+        }
+    }
+
+    #[inline]
+    pub fn add_join_handle(&self, name: String, handle: JoinHandle<()>) {
+        self.join
+            .lock()
+            .expect("lock poison")
+            .push_back((name, handle));
+    }
+}


### PR DESCRIPTION
Part of #1576

`TaskGroupInner` contains a few locks, but its data and functionality are intermixed with `TaskGroup`.

In this PR we move `TaskGroupInner` into a separate file, isolating its functionality from `TaskGroup` and making its locking behavior easier to grok.

Then we replace `TaskGroupInner`'s `VecDeque` of task handles with an unbounded channel, which removes the need for any locking when adding a new task. We still need to lock when accessing the task handles, but this is already done in an `async` function so we can wrap the channel reader in an async mutex rather than a blocking one.