### PR TITLE
fix(wallet): prevent rbf withdrawals

### DIFF
--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -30,6 +30,11 @@ pub fn is_running_in_test_env() -> bool {
     unit_test || is_env_var_set("NEXTEST") || is_env_var_set(FM_IN_DEVIMINT_ENV)
 }
 
+/// Use to allow `process_output` to process RBF withdrawal outputs.
+pub fn is_rbf_withdrawal_enabled() -> bool {
+    is_env_var_set("FM_UNSAFE_ENABLE_RBF_WITHDRAWAL")
+}
+
 /// Get value of [`FEDIMINT_BUILD_CODE_VERSION_ENV`] at compile time
 #[macro_export]
 macro_rules! fedimint_build_code_version_env {

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -584,6 +584,10 @@ impl WalletClientModule {
     /// replace by fee (RBF).
     /// This can prevent transactions from getting stuck
     /// in the mempool
+    #[deprecated(
+        since = "0.4.0",
+        note = "RBF withdrawals are rejected by the federation"
+    )]
     pub async fn rbf_withdraw<M: Serialize + MaybeSync + MaybeSend>(
         &self,
         rbf: Rbf,

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -33,7 +33,7 @@ pub mod tweakable;
 pub mod txoproof;
 
 pub const KIND: ModuleKind = ModuleKind::from_static_str("wallet");
-pub const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(2, 0);
+pub const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVersion::new(2, 1);
 
 pub const CONFIRMATION_TARGET: u16 = 10;
 
@@ -317,6 +317,12 @@ pub enum WalletOutputError {
     #[error("The wallet output version is not supported by this federation")]
     UnknownOutputVariant(#[from] UnknownWalletOutputVariantError),
 }
+
+// For backwards-compatibility with old clients, we use an UnknownOutputVariant
+// error when a client attempts a deprecated RBF withdrawal.
+// see: https://github.com/fedimint/fedimint/issues/5453
+pub const DEPRECATED_RBF_ERROR: WalletOutputError =
+    WalletOutputError::UnknownOutputVariant(UnknownWalletOutputVariantError { variant: 1 });
 
 #[derive(Debug, Error)]
 pub enum ProcessPegOutSigError {

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -253,7 +253,8 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn peg_outs_support_rbf() -> anyhow::Result<()> {
+async fn peg_outs_support_rbf_with_env_var_enabled() -> anyhow::Result<()> {
+    std::env::set_var("FM_UNSAFE_ENABLE_RBF_WITHDRAWAL", "1");
     let fixtures = fixtures();
     let fed = fixtures.new_default_fed().await;
     let client = fed.new_client().await;
@@ -266,6 +267,9 @@ async fn peg_outs_support_rbf() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
+    // RBF withdrawals are deprecated due to a bug, however this test succeeds since
+    // there's a single peg-in/UTXO. The bug in the coin selection algorithm only
+    // impacts wallets > 1 UTXO.
     let mut balance_sub = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
 
     info!("Peg-in finished for test peg_outs_support_rbf");
@@ -301,6 +305,7 @@ async fn peg_outs_support_rbf() -> anyhow::Result<()> {
         txid,
     };
     let wallet_module = client.get_first_module::<WalletClientModule>();
+    #[allow(deprecated)]
     let op = wallet_module.rbf_withdraw(rbf.clone(), ()).await?;
     let sub = wallet_module.subscribe_withdraw_updates(op).await?;
     let mut sub = sub.into_stream();
@@ -330,6 +335,85 @@ async fn peg_outs_support_rbf() -> anyhow::Result<()> {
             "Balance is {current_balance}, expected {balance_after_rbf_peg_out} or {balance_after_normal_peg_out}"
         )
     }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_default_fed().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+    // Need lock to keep tx in mempool from getting mined
+    let bitcoin = bitcoin.lock_exclusive().await;
+    info!("Starting test rbf_withdrawals_are_rejected");
+
+    let finality_delay = 10;
+    bitcoin.mine_blocks(finality_delay).await;
+    await_consensus_to_catch_up(&client, 1).await?;
+
+    let mut balance_sub = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+
+    info!("Peg-in finished for test rbf_withdrawals_are_rejected");
+    let address = checked_address_to_unchecked_address(&bitcoin.get_new_address().await);
+    let peg_out = bsats(PEG_OUT_AMOUNT_SATS);
+    let wallet_module = client.get_first_module::<WalletClientModule>();
+    let fees = wallet_module
+        .get_withdraw_fees(address.clone(), peg_out)
+        .await?;
+    let op = wallet_module
+        .withdraw(address.clone(), peg_out, fees, ())
+        .await?;
+
+    let sub = wallet_module.subscribe_withdraw_updates(op).await?;
+    let mut sub = sub.into_stream();
+    assert_eq!(sub.ok().await?, WithdrawState::Created);
+    let state = sub.ok().await?;
+    let WithdrawState::Succeeded(txid) = state else {
+        bail!("Unexpected state: {state:?}")
+    };
+    assert_eq!(
+        bitcoin.get_mempool_tx_fee(&txid).await,
+        fees.amount().into()
+    );
+    let balance_after_normal_peg_out =
+        sats(PEG_IN_AMOUNT_SATS - PEG_OUT_AMOUNT_SATS - fees.amount().to_sat());
+    assert_eq!(client.get_balance().await, balance_after_normal_peg_out);
+    assert_eq!(balance_sub.ok().await?, balance_after_normal_peg_out);
+
+    // RBF by increasing sats per kvb by 1000
+    let rbf = Rbf {
+        fees: PegOutFees::new(1000, fees.total_weight),
+        txid,
+    };
+
+    let wallet_module = client.get_first_module::<WalletClientModule>();
+    #[allow(deprecated)]
+    let rbf_op = wallet_module.rbf_withdraw(rbf.clone(), ()).await?;
+    let rbf_sub = wallet_module.subscribe_withdraw_updates(rbf_op).await?;
+    let mut rbf_sub = rbf_sub.into_stream();
+
+    assert_eq!(rbf_sub.ok().await?, WithdrawState::Created);
+    match rbf_sub.ok().await? {
+        WithdrawState::Failed(err) => {
+            assert!(err.contains("The wallet output version is not supported by this federation"))
+        }
+        other => panic!("Unexpected state: {other:?}"),
+    }
+
+    assert_eq!(
+        bitcoin
+            .mine_block_and_get_received(&address.clone().assume_checked())
+            .await,
+        sats(PEG_OUT_AMOUNT_SATS)
+    );
+
+    let current_balance = client.get_balance().await;
+    assert_eq!(
+        current_balance, balance_after_normal_peg_out,
+        "Balance is {current_balance}, expected {balance_after_normal_peg_out}"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/5453

This approach prevents peers from processing RBF withdrawal outputs in `process_output`.

These changes are meant to be as minimal as possible to prevent RBF withdrawals, with the intent of removing all RBF withdrawal logic along with destructive client and server db migrations once this version reaches End of Life support. I'm not sure if we've reached consensus on how long we want to support versions (see: https://github.com/fedimint/fedimint/discussions/3950#discussioncomment-7862690), but the linked chart and several out-of-band discussions suggest the minimum supported version is two major versions in the past, i.e. if this lands in 0.4.0, we can safely remove the remaining RBF logic in 0.6.0. If this approach is accepted, I'll create an issue to track the removal for 0.6.0.

Taking a two step process (1. prevent, 2. remove logic/destructive migrations) is necessary to support any private federations that successfully processed an RBF withdrawal. Any federation that had a single UTXO and a user with an RBF withdrawal would have been able to successfully process the transaction, so if any peer needed to resync history and we removed all RBF withdrawal logic, the peer would be unable to sync to tip. I've scanned all public federations using `fedimint-observer` and none of them have RBF withdrawals, however it's still possible a private federation does. This PR introduces an environment variable `FM_UNSAFE_ENABLE_RBF_WITHDRAWAL` to support this edge case.

An alternative approach to fix the underlying bug was attempted in https://github.com/fedimint/fedimint/pull/5465, however after further discussion (see: [20240617 - Fedimint Dev Call](https://bitcointv.com/w/kfpAKiETfPTa69NVDLrKAb)) we decided the complexity of maintaining RBF withdrawals wasn't worth the risk, especially since we can set an aggressive confirmation target for estimating fees (I'll create a followup PR to reduce conf target from 10 to 1 if this lands https://github.com/fedimint/fedimint/issues/5498).

