### PR TITLE
chore: build proc-macros and build deps in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ fedimint-wallet-common = { path = "./modules/fedimint-wallet-common" }
 #             https://github.com/ipetkov/crane/issues/370
 [profile.dev.build-override]
 debug = false
-opt-level = 1
+opt-level = 3
 
 [profile.ci.build-override]
 debug = false


### PR DESCRIPTION
It is actually slightly faster. (verified with `j bench-compilation`):

Before:

```
Full  check   debug:   38.38  447.02   44.17
Incr  check   debug:    3.31    4.79    3.42
Full  build   debug:   69.23 1166.67   97.05
Incr  build   debug:   14.32   24.23   14.01
```

After:

```
Full  check   debug:   38.23  447.73   44.11
Incr  check   debug:    3.29    4.81    3.36
Full  build   debug:   67.84 1165.78   93.52
Incr  build   debug:   13.34   24.01   12.85
```


Inspired by https://www.reddit.com/r/rust/comments/1dkzzn5/dioxus_labs_highlevel_rust/

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
