### PR TITLE
chore: rename CreateInvoiceRequest.expiry to expiry_secs

### DIFF
--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -217,7 +217,7 @@ impl ILnRpcClient for FakeLightningTest {
             .payment_secret(PaymentSecret([0; 32]))
             .amount_milli_satoshis(create_invoice_request.amount_msat)
             .expiry_time(Duration::from_secs(u64::from(
-                create_invoice_request.expiry,
+                create_invoice_request.expiry_secs,
             )))
             .build_signed(|m| ctx.sign_ecdsa_recoverable(m, &self.gateway_node_sec_key))
             .unwrap();

--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -246,7 +246,7 @@ message CreateInvoiceRequest {
   uint64 amount_msat = 2;
 
   // The time in seconds this invoice is valid for.
-  uint32 expiry = 3;
+  uint32 expiry_secs = 3;
 
   // A description or a description hash must be provided.
   oneof description {

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -713,7 +713,7 @@ impl GatewayLightning for ClnRpcService {
         let CreateInvoiceRequest {
             payment_hash,
             amount_msat,
-            expiry,
+            expiry_secs,
             description,
         } = create_invoice_request.into_inner();
 
@@ -742,7 +742,7 @@ impl GatewayLightning for ClnRpcService {
                 .payment_secret(PaymentSecret(OsRng.gen()))
                 .duration_since_epoch(duration_since_epoch)
                 .min_final_cltv_expiry_delta(18)
-                .expiry_time(Duration::from_secs(expiry.into()))
+                .expiry_time(Duration::from_secs(expiry_secs.into()))
                 // Temporarily sign with an ephemeral private key, we will request CLN to sign this
                 // invoice next.
                 .build_signed(|m| {
@@ -762,7 +762,7 @@ impl GatewayLightning for ClnRpcService {
                 .payment_secret(PaymentSecret(OsRng.gen()))
                 .duration_since_epoch(duration_since_epoch)
                 .min_final_cltv_expiry_delta(18)
-                .expiry_time(Duration::from_secs(expiry.into()))
+                .expiry_time(Duration::from_secs(expiry_secs.into()))
                 // Temporarily sign with an ephemeral private key, we will request CLN to sign this
                 // invoice next.
                 .build_signed(|m| {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1818,7 +1818,7 @@ impl Gateway {
                 .create_invoice(CreateInvoiceRequest {
                     payment_hash: payment_hash.to_byte_array().to_vec(),
                     amount_msat: amount.msats,
-                    expiry: expiry_time,
+                    expiry_secs: expiry_time,
                     description: Some(Description::Direct(description)),
                 })
                 .await
@@ -1827,7 +1827,7 @@ impl Gateway {
                 .create_invoice(CreateInvoiceRequest {
                     payment_hash: payment_hash.to_byte_array().to_vec(),
                     amount_msat: amount.msats,
-                    expiry: expiry_time,
+                    expiry_secs: expiry_time,
                     description: Some(Description::Hash(hash.to_byte_array().to_vec())),
                 })
                 .await

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -633,14 +633,14 @@ impl ILnRpcClient for GatewayLndClient {
                 memo: description,
                 hash: create_invoice_request.payment_hash,
                 value_msat: create_invoice_request.amount_msat as i64,
-                expiry: i64::from(create_invoice_request.expiry),
+                expiry: i64::from(create_invoice_request.expiry_secs),
                 ..Default::default()
             },
             Description::Hash(desc_hash) => AddHoldInvoiceRequest {
                 description_hash: desc_hash,
                 hash: create_invoice_request.payment_hash,
                 value_msat: create_invoice_request.amount_msat as i64,
-                expiry: i64::from(create_invoice_request.expiry),
+                expiry: i64::from(create_invoice_request.expiry_secs),
                 ..Default::default()
             },
         };


### PR DESCRIPTION
A bit of a nit, but the rest of the fields in our proto definitions have unit suffixes where appropriate (`_msats` or `_sats`). Should be a simple change since I don't believe we've locked in backwards-compatibility for this field yet since it's used for LNv2.