### PR TITLE
fix: enable cli to fetch gateways without auth

### DIFF
--- a/modules/fedimint-lnv2-client/src/api.rs
+++ b/modules/fedimint-lnv2-client/src/api.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use fedimint_api_client::api::{FederationApiExt, FederationResult, IModuleFederationApi};
+use fedimint_api_client::api::{
+    FederationApiExt, FederationResult, IModuleFederationApi, PeerResult,
+};
 use fedimint_api_client::query::FilterMapThreshold;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::task::{sleep, MaybeSend, MaybeSync};
@@ -30,6 +32,8 @@ pub trait LnFederationApi {
     ) -> FederationResult<Option<u64>>;
 
     async fn fetch_gateways(&self) -> FederationResult<Vec<SafeUrl>>;
+
+    async fn fetch_gateways_from_peer(&self, peer: PeerId) -> PeerResult<Vec<SafeUrl>>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -117,5 +121,18 @@ where
         });
 
         Ok(union)
+    }
+
+    async fn fetch_gateways_from_peer(&self, peer: PeerId) -> PeerResult<Vec<SafeUrl>> {
+        let gateways = self
+            .request_single_peer_typed::<Vec<SafeUrl>>(
+                None,
+                GATEWAYS_ENDPOINT.to_string(),
+                ApiRequestErased::default(),
+                peer,
+            )
+            .await?;
+
+        Ok(gateways)
     }
 }

--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -5,9 +5,7 @@ use fedimint_api_client::api::FederationApiExt;
 use fedimint_core::module::ApiRequestErased;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::PeerId;
-use fedimint_lnv2_common::endpoint_constants::{
-    ADD_GATEWAY_ENDPOINT, GATEWAYS_ENDPOINT, REMOVE_GATEWAY_ENDPOINT,
-};
+use fedimint_lnv2_common::endpoint_constants::{ADD_GATEWAY_ENDPOINT, REMOVE_GATEWAY_ENDPOINT};
 use serde::Serialize;
 
 use crate::api::LnFederationApi;
@@ -32,17 +30,7 @@ pub(crate) async fn handle_cli_command(
     match opts {
         Opts::Gateways { peer } => {
             let gateways = match peer {
-                Some(peer) => {
-                    lightning
-                        .module_api
-                        .request_single_peer_typed::<Vec<SafeUrl>>(
-                            None,
-                            GATEWAYS_ENDPOINT.to_string(),
-                            ApiRequestErased::default(),
-                            peer,
-                        )
-                        .await?
-                }
+                Some(peer) => lightning.module_api.fetch_gateways_from_peer(peer).await?,
                 None => lightning.module_api.fetch_gateways().await?,
             };
 

--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -1,11 +1,8 @@
 use std::{ffi, iter};
 
 use clap::Parser;
-use fedimint_api_client::api::FederationApiExt;
-use fedimint_core::module::ApiRequestErased;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::PeerId;
-use fedimint_lnv2_common::endpoint_constants::{ADD_GATEWAY_ENDPOINT, REMOVE_GATEWAY_ENDPOINT};
 use serde::Serialize;
 
 use crate::api::LnFederationApi;
@@ -42,10 +39,7 @@ pub(crate) async fn handle_cli_command(
                 .clone()
                 .ok_or(anyhow::anyhow!("Admin auth not set"))?;
 
-            let is_new_entry: bool = lightning
-                .module_api
-                .request_admin(ADD_GATEWAY_ENDPOINT, ApiRequestErased::new(gateway), auth)
-                .await?;
+            let is_new_entry = lightning.module_api.add_gateway(auth, gateway).await?;
 
             Ok(serde_json::to_value(is_new_entry).expect("JSON serialization failed"))
         }
@@ -55,14 +49,7 @@ pub(crate) async fn handle_cli_command(
                 .clone()
                 .ok_or(anyhow::anyhow!("Admin auth not set"))?;
 
-            let entry_existed: bool = lightning
-                .module_api
-                .request_admin(
-                    REMOVE_GATEWAY_ENDPOINT,
-                    ApiRequestErased::new(gateway),
-                    auth,
-                )
-                .await?;
+            let entry_existed = lightning.module_api.remove_gateway(auth, gateway).await?;
 
             Ok(serde_json::to_value(entry_existed).expect("JSON serialization failed"))
         }

--- a/modules/fedimint-lnv2-tests/src/bin/gateway_registration_sanity.rs
+++ b/modules/fedimint-lnv2-tests/src/bin/gateway_registration_sanity.rs
@@ -42,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
                 "pass",
                 "module",
                 "lnv2",
-                "add",
+                "add-gateway",
                 gateway.clone().to_string(),
             )
             .out_json()
@@ -51,18 +51,9 @@ async fn main() -> anyhow::Result<()> {
         );
 
         assert_eq!(
-            cmd!(
-                client,
-                "--our-id",
-                "0",
-                "--password",
-                "pass",
-                "module",
-                "lnv2",
-                "list",
-            )
-            .out_json()
-            .await?,
+            cmd!(client, "module", "lnv2", "gateways", "0")
+                .out_json()
+                .await?,
             serde_json::to_value(vec![gateway.clone()]).expect("JSON serialization failed")
         );
 
@@ -75,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
                 "pass",
                 "module",
                 "lnv2",
-                "remove",
+                "remove-gateway",
                 gateway.to_string(),
             )
             .out_json()
@@ -84,18 +75,9 @@ async fn main() -> anyhow::Result<()> {
         );
 
         assert_eq!(
-            cmd!(
-                client,
-                "--our-id",
-                "0",
-                "--password",
-                "pass",
-                "module",
-                "lnv2",
-                "list",
-            )
-            .out_json()
-            .await?,
+            cmd!(client, "module", "lnv2", "gateways", "0",)
+                .out_json()
+                .await?,
             serde_json::to_value(Vec::<SafeUrl>::new()).expect("JSON serialization failed")
         );
 


### PR DESCRIPTION
The cli can now fetch the gateways from all peers or optionally supply a peer id to only fetch from one peer. The latter option is used by the guardian to check its own gateway set.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
