### PR TITLE
Remove usage of blockdata:: from bitcoin paths

### DIFF
--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -609,7 +609,7 @@ impl Feerate {
     }
 }
 
-const WITNESS_SCALE_FACTOR: u64 = bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR as u64;
+const WITNESS_SCALE_FACTOR: u64 = bitcoin::constants::WITNESS_SCALE_FACTOR as u64;
 
 /// Converts weight to virtual bytes, defined in [BIP-141] as weight / 4
 /// (rounded up to the next integer).

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -7,7 +7,7 @@ use anyhow::format_err;
 use async_trait::async_trait;
 use bitcoin::absolute::LockTime;
 use bitcoin::block::{Header as BlockHeader, Version};
-use bitcoin::blockdata::constants::genesis_block;
+use bitcoin::constants::genesis_block;
 use bitcoin::hash_types::Txid;
 use bitcoin::hashes::Hash;
 use bitcoin::merkle_tree::PartialMerkleTree;


### PR DESCRIPTION
In `rust-bitcoin` the `blockdata` module is a code organisation thing, it should never have been public. One day those guys would like to remove it, so as not to be a PITA for `fedimint` when they do lets remove all usage of `blockdata::` now.

Internal change only, no externally visible changes.


