### PR TITLE
feature(wallet-client): client wallet module backup & recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bitcoin 0.30.2",
+ "clap",
  "erased-serde",
  "fedimint-api-client",
  "fedimint-bitcoind",

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -34,7 +34,7 @@ fedimint-portalloc = { path = "../utils/portalloc" }
 fedimint-server = { path = "../fedimint-server" }
 fedimint-testing = { workspace = true }
 fedimint-unknown-server = { path = "../modules/fedimint-unknown-server" }
-fedimint-wallet-client = { path = "../modules/fedimint-wallet-client" }
+fedimint-wallet-client = { path = "../modules/fedimint-wallet-client", features = [ "cli" ] }
 fedimint-wallet-server = { path = "../modules/fedimint-wallet-server" }
 fedimintd = { path = "../fedimintd" }
 fs-lock = "0.1.3"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -42,7 +42,7 @@ fedimint-mint-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-m
 fedimint-ln-client = { workspace = true, features = ["cli"] }
 fedimint-lnv2-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-lnv2-client", features = ["cli"] }
 fedimint-ln-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-common" }
-fedimint-wallet-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-client" }
+fedimint-wallet-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-client", features = [ "cli" ] }
 fedimint-logging = { workspace = true }
 fedimint-server = { version = "=0.4.0-alpha", path = "../fedimint-server" }
 fedimint-meta-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-meta-client", features = ["cli"] }

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -169,8 +169,7 @@ pub enum ClientCmd {
     /// federation
     #[clap(hide = true)]
     DiscoverVersion,
-    /// Restore the previously created backup of mint notes (with `backup`
-    /// command)
+    /// Join federation and restore modules that support it
     Restore {
         #[clap(long)]
         mnemonic: String,
@@ -480,7 +479,7 @@ pub async fn handle_command(
         ClientCmd::AwaitDeposit { operation_id } => {
             client
                 .get_first_module::<WalletClientModule>()
-                .await_deposit(operation_id)
+                .await_num_deposit_by_operation_id(operation_id, 1)
                 .await?;
 
             Ok(serde_json::to_value(()).unwrap())

--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -68,6 +68,7 @@ impl_db_record!(
     value = (MintRecoveryState, RecoveryFromHistoryCommon),
     db_prefix = DbKeyPrefix::RecoveryState,
 );
+
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct RecoveryFinalizedKey;
 
@@ -79,6 +80,7 @@ impl_db_record!(
     value = bool,
     db_prefix = DbKeyPrefix::RecoveryFinalized,
 );
+
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]
 pub struct CancelledOOBSpendKey(pub OperationId);
 

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -15,12 +15,17 @@ rustc-args = ["--cfg", "tokio_unstable"]
 name = "fedimint_wallet_client"
 path = "src/lib.rs"
 
+[features]
+default =[]
+cli = ["dep:clap" ]
+
 [dependencies]
 anyhow = { workspace = true }
 aquamarine = "0.5.0"
 async-stream = "0.3.5"
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
+clap = { workspace = true, optional = true }
 erased-serde = { workspace = true }
 fedimint-api-client = { workspace = true }
 fedimint-client = { workspace = true }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -39,14 +39,15 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-tokio = { version = "1.38.0", features = ["sync", "rt"] }
 tracing = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client", "bitcoincore-rpc"] }
+tokio = { version = "1.38.0", features = ["full", "tracing"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = ["esplora-client"] }
+tokio = { version = "1.38.0", features = [ "sync", "rt"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }

--- a/modules/fedimint-wallet-client/src/backup.rs
+++ b/modules/fedimint-wallet-client/src/backup.rs
@@ -1,0 +1,35 @@
+use fedimint_client::module::recovery::{DynModuleBackup, ModuleBackup};
+use fedimint_core::core::{IntoDynInstance, ModuleInstanceId};
+use fedimint_core::encoding::{Decodable, Encodable};
+
+use crate::client_db::TweakIdx;
+
+#[derive(Clone, PartialEq, Eq, Debug, Encodable, Decodable)]
+pub enum WalletModuleBackup {
+    V0(WalletModuleBackupV0),
+    #[encodable_default]
+    Default {
+        variant: u64,
+        bytes: Vec<u8>,
+    },
+}
+
+impl IntoDynInstance for WalletModuleBackup {
+    type DynType = DynModuleBackup;
+
+    fn into_dyn(self, instance_id: ModuleInstanceId) -> Self::DynType {
+        DynModuleBackup::from_typed(instance_id, self)
+    }
+}
+
+impl ModuleBackup for WalletModuleBackup {}
+
+impl WalletModuleBackup {
+    pub fn new_v0(next_tweak_idx: TweakIdx) -> WalletModuleBackup {
+        WalletModuleBackup::V0(WalletModuleBackupV0 { next_tweak_idx })
+    }
+}
+#[derive(Clone, PartialEq, Eq, Debug, Encodable, Decodable)]
+pub struct WalletModuleBackupV0 {
+    pub next_tweak_idx: TweakIdx,
+}

--- a/modules/fedimint-wallet-client/src/cli.rs
+++ b/modules/fedimint-wallet-client/src/cli.rs
@@ -1,0 +1,35 @@
+use std::{ffi, iter};
+
+use clap::Parser;
+use fedimint_core::core::OperationId;
+use serde::Serialize;
+
+use super::WalletClientModule;
+
+#[derive(Parser, Serialize)]
+enum Opts {
+    /// Await a deposit on a given deposit address
+    AwaitDeposit {
+        operation_id: OperationId,
+        #[arg(long, default_value = "1")]
+        num: usize,
+    },
+}
+
+pub(crate) async fn handle_cli_command(
+    module: &WalletClientModule,
+    args: &[ffi::OsString],
+) -> anyhow::Result<serde_json::Value> {
+    let opts = Opts::parse_from(iter::once(&ffi::OsString::from("wallet")).chain(args.iter()));
+
+    let res = match opts {
+        Opts::AwaitDeposit { operation_id, num } => {
+            module
+                .await_num_deposit_by_operation_id(operation_id, num)
+                .await?;
+            serde_json::Value::Null
+        }
+    };
+
+    Ok(res)
+}

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -38,9 +38,16 @@ impl fmt::Display for TweakIdx {
 }
 
 impl TweakIdx {
+    pub const ZERO: Self = TweakIdx(0);
+
     #[must_use]
     pub fn next(self) -> Self {
         Self(self.0 + 1)
+    }
+
+    #[must_use]
+    pub fn prev(self) -> Option<Self> {
+        self.0.checked_sub(1).map(Self)
     }
 
     #[must_use]

--- a/modules/fedimint-wallet-tests/src/bin/wallet-recovery-test.rs
+++ b/modules/fedimint-wallet-tests/src/bin/wallet-recovery-test.rs
@@ -1,0 +1,77 @@
+use devimint::cmd;
+use devimint::util::{FedimintCli, FedimintdCmd};
+use devimint::version_constants::VERSION_0_3_0_ALPHA;
+use futures::try_join;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    devimint::run_devfed_test(|dev_fed, _process_mgr| async move {
+        let fedimint_cli_version = FedimintCli::version_or_default().await;
+        let fedimintd_version = FedimintdCmd::version_or_default().await;
+        if fedimint_cli_version < *VERSION_0_3_0_ALPHA || fedimintd_version < *VERSION_0_3_0_ALPHA {
+            info!("Skipping whole test on old fedimint-cli/fedimintd that is missing some irrelevant bolts");
+            return Ok(());
+        }
+
+        let (fed, _bitcoind) = try_join!(dev_fed.fed(), dev_fed.bitcoind())?;
+
+        let peg_in_amount_sats = 100_000;
+
+        {
+            let client = fed
+                .new_joined_client("wallet-client-recovery-origin")
+                .await?;
+
+            info!("Join, but not claim");
+            let operation_id = fed
+                .pegin_client_no_wait(peg_in_amount_sats, &client)
+                .await?;
+
+            info!("Restore without backup");
+            let restored = client
+                .new_restored("restored-without-backup", fed.invite_code()?)
+                .await?;
+
+            cmd!(restored, "module", "wallet", "await-deposit", operation_id)
+                .run()
+                .await?;
+
+            info!("Check if claimed");
+            assert_eq!(peg_in_amount_sats * 1000, restored.balance().await?);
+        }
+
+        {
+            let client = fed
+                .new_joined_client("wallet-client-recovery-origin")
+                .await?;
+            assert_eq!(0, client.balance().await?);
+
+            info!("Join and claim");
+            fed.pegin_client(peg_in_amount_sats, &client).await?;
+
+            info!("Make a backup");
+            cmd!(client, "backup").run().await?;
+
+            info!("Join more, but not claim");
+            let operation_id = fed
+                .pegin_client_no_wait(peg_in_amount_sats, &client)
+                .await?;
+
+            info!("Restore with backup");
+            let restored = client
+                .new_restored("restored-with-backup", fed.invite_code()?)
+                .await?;
+
+            cmd!(restored, "module", "wallet", "await-deposit", operation_id)
+                .run()
+                .await?;
+
+            info!("Check if claimed");
+            assert_eq!(peg_in_amount_sats * 1000 * 2, restored.balance().await?);
+        }
+
+        Ok(())
+    })
+    .await
+}

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -65,7 +65,9 @@ async fn initial_peg_in<'a>(
         .context("expected tx to be mined")?;
     info!(?height, ?tx, txid = ?tx.txid(), "Peg-in transaction mined");
     bitcoin.mine_blocks(finality_delay).await;
-    wallet_module.await_deposit(op).await?;
+    wallet_module
+        .await_num_deposit_by_operation_id(op, 1)
+        .await?;
     assert_eq!(client.get_balance().await, sats(PEG_IN_AMOUNT_SATS));
     assert_eq!(balance_sub.ok().await?, sats(PEG_IN_AMOUNT_SATS));
     info!(?height, ?tx, "Peg-in transaction claimed");
@@ -231,7 +233,9 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
             .context("expected tx to be mined")?;
         info!(?height, ?tx, txid = ?tx.txid(), "First peg-in transaction mined");
         bitcoin.mine_blocks(finality_delay).await;
-        wallet_module.await_deposit(op).await?;
+        wallet_module
+            .await_num_deposit_by_operation_id(op, 1)
+            .await?;
         assert_eq!(
             client.get_balance().await,
             sats(PEG_IN_AMOUNT_SATS) + starting_balance
@@ -1037,6 +1041,7 @@ mod fedimint_migration_tests {
                         }
                         client_db::DbKeyPrefix::PegInTweakIndex => {}
                         client_db::DbKeyPrefix::ClaimedPegIn => {}
+                        client_db::DbKeyPrefix::RecoveryFinalized => {}
                     }
                 }
 

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -130,6 +130,11 @@ function circular_deposit() {
 }
 export -f circular_deposit
 
+function wallet_recovery() {
+  fm-run-test "${FUNCNAME[0]}" ./scripts/tests/wallet-recovery-test.sh
+}
+export -f wallet_recovery
+
 function devimint_cli_test() {
   fm-run-test "${FUNCNAME[0]}" ./scripts/tests/devimint-cli-test.sh
 }
@@ -299,6 +304,7 @@ tests_to_run_in_parallel+=(
   "mint_client_sanity"
   "cannot_replay_tx"
   "circular_deposit"
+  "wallet_recovery"
 )
 done
 

--- a/scripts/tests/wallet-recovery-test.sh
+++ b/scripts/tests/wallet-recovery-test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Runs a test to ensure on-chain withdrawals sent to same federation succeed
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+make_fm_test_marker
+
+wallet-recovery-test


### PR DESCRIPTION
During recovery scan the pegin addresses to find a best place to start deriving new
addresses.

Since we are already checking them and potentially leaking them to the node.

Notably adds module-cli `fedimint-cli module wallet ...` support.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
