### PR TITLE
feat: add ldk gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -106,6 +117,21 @@ name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anes"
@@ -460,6 +486,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc1fc1a92e0943bfbcd6eb7d32c1b2a79f2f1357eb1e2eee9d7f36d6d7ca44a"
+dependencies = [
+ "ahash 0.7.8",
+ "async-trait",
+ "bdk-macros",
+ "bip39",
+ "bitcoin 0.30.2",
+ "esplora-client",
+ "futures",
+ "getrandom",
+ "js-sys",
+ "log",
+ "miniscript",
+ "rand",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "bdk-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81c1980e50ae23bb6efa9283ae8679d6ea2c6fa6a99fe62533f65f4a25a1a56c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +598,7 @@ version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
 dependencies = [
+ "base64 0.13.1",
  "bech32 0.9.1",
  "bitcoin-private",
  "bitcoin_hashes 0.12.0",
@@ -756,6 +818,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "ciborium"
@@ -1319,6 +1394,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +1930,7 @@ dependencies = [
  "cln-plugin",
  "cln-rpc",
  "erased-serde",
+ "esplora-client",
  "fedimint-api-client",
  "fedimint-build",
  "fedimint-client",
@@ -1868,6 +1956,7 @@ dependencies = [
  "fedimint-wallet-client",
  "futures",
  "hex",
+ "ldk-node",
  "lightning",
  "lightning-invoice",
  "prost 0.13.1",
@@ -3062,8 +3151,17 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -3338,6 +3436,29 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3689,6 +3810,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "ldk-node"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a5400043598f1da534abf81bb937739a680663d57a451bf8363d6113211424"
+dependencies = [
+ "bdk",
+ "bip39",
+ "bitcoin 0.30.2",
+ "chrono",
+ "esplora-client",
+ "libc",
+ "lightning",
+ "lightning-background-processor",
+ "lightning-invoice",
+ "lightning-liquidity",
+ "lightning-net-tokio",
+ "lightning-persister",
+ "lightning-rapid-gossip-sync",
+ "lightning-transaction-sync",
+ "prost 0.11.9",
+ "rand",
+ "reqwest 0.11.27",
+ "rusqlite",
+ "tokio",
+ "vss-client",
+ "winapi",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3738,6 +3888,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3763,6 +3924,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning-background-processor"
+version = "0.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1c2c64050e37cee7c3b6b022106523784055ac3ee572d360780a1d6fe8062c"
+dependencies = [
+ "bitcoin 0.30.2",
+ "lightning",
+ "lightning-rapid-gossip-sync",
+]
+
+[[package]]
 name = "lightning-invoice"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3773,6 +3945,65 @@ dependencies = [
  "lightning",
  "secp256k1 0.27.0",
  "serde",
+]
+
+[[package]]
+name = "lightning-liquidity"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa6284740f64672f42145de7b0a242beea3821dae1f0eac7949a8f48799c828"
+dependencies = [
+ "bitcoin 0.30.2",
+ "chrono",
+ "lightning",
+ "lightning-invoice",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lightning-net-tokio"
+version = "0.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e6a4d49c50a1344916d080dc8c012ce3a778cdd45de8def75350b2b40fe018"
+dependencies = [
+ "bitcoin 0.30.2",
+ "lightning",
+ "tokio",
+]
+
+[[package]]
+name = "lightning-persister"
+version = "0.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8dd33971815fa074b05678e09a6d4b15c78225ea34d66ed4f17c35a53467a9"
+dependencies = [
+ "bitcoin 0.30.2",
+ "lightning",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "lightning-rapid-gossip-sync"
+version = "0.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d861b0f0cd5f8fe8c63760023c4fd4fd32c384881b41780b62ced2a8a619f91"
+dependencies = [
+ "bitcoin 0.30.2",
+ "lightning",
+]
+
+[[package]]
+name = "lightning-transaction-sync"
+version = "0.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c1e88eece28f19b5834fb5aefceabc5d143cfda2dfa9a32f73e66f4d0c84ed"
+dependencies = [
+ "bdk-macros",
+ "bitcoin 0.30.2",
+ "esplora-client",
+ "futures",
+ "lightning",
 ]
 
 [[package]]
@@ -4304,6 +4535,16 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
@@ -4371,6 +4612,16 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
@@ -4391,6 +4642,28 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
@@ -4402,7 +4675,7 @@ dependencies = [
  "multimap",
  "once_cell",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.2.16",
  "prost 0.12.6",
  "prost-types 0.12.3",
  "regex",
@@ -4424,12 +4697,25 @@ dependencies = [
  "multimap",
  "once_cell",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.2.16",
  "prost 0.13.1",
  "prost-types 0.13.1",
  "regex",
  "syn 2.0.71",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4456,6 +4742,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.71",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -4797,6 +5092,20 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "rusqlite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+dependencies = [
+ "bitflags 1.3.2",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -5691,7 +6000,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.16",
  "proc-macro2",
  "prost-build 0.12.3",
  "quote",
@@ -5704,7 +6013,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.16",
  "proc-macro2",
  "prost-build 0.13.1",
  "quote",
@@ -5950,6 +6259,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "vss-client"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62cbd331368125aeb93b67dd4a80826a4ee29a810d4c76d2c9d265c1522a3f2"
+dependencies = [
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "rand",
+ "reqwest 0.11.27",
+ "tokio",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6161,6 +6483,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "windows-sys"

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -38,6 +38,7 @@ clap = { workspace = true }
 cln-plugin = "=0.1.7"
 cln-rpc = { workspace = true }
 erased-serde = { workspace = true }
+esplora-client = { version = "0.6.0", default-features = false, features = ["async", "async-https-rustls"] }
 fedimint-api-client = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
@@ -51,6 +52,7 @@ fedimint-rocksdb = { version = "=0.5.0-alpha", path = "../../fedimint-rocksdb" }
 fedimint-wallet-client = { version = "=0.5.0-alpha", path = "../../modules/fedimint-wallet-client" }
 futures = { workspace = true }
 hex = { workspace = true }
+ldk-node = "0.3.0"
 lightning = { workspace = true }
 lightning-invoice = { workspace = true }
 prost = "0.13.1"

--- a/gateway/ln-gateway/src/envs.rs
+++ b/gateway/ln-gateway/src/envs.rs
@@ -33,3 +33,12 @@ pub const FM_LND_MACAROON_ENV: &str = "FM_LND_MACAROON";
 
 // Env variable to TODO
 pub const FM_GATEWAY_LIGHTNING_ADDR_ENV: &str = "FM_GATEWAY_LIGHTNING_ADDR";
+
+// Env variable to TODO
+pub const FM_LDK_ESPLORA_SERVER_URL: &str = "FM_LDK_ESPLORA_SERVER_URL";
+
+// Env variable to TODO
+pub const FM_LDK_NETWORK: &str = "FM_LDK_NETWORK";
+
+// Env variable to TODO
+pub const FM_PORT_LDK: &str = "FM_PORT_LDK";

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -143,6 +143,10 @@ pub type Result<T> = std::result::Result<T, GatewayError>;
 /// storage.
 const DB_FILE: &str = "gatewayd.db";
 
+/// Name of the folder that the gateway uses to store its node database when
+/// running in LDK mode.
+const LDK_NODE_DB_FOLDER: &str = "ldk_node";
+
 /// The non-lightning default module types that the Gateway supports.
 const DEFAULT_MODULE_KINDS: [(ModuleInstanceId, &ModuleKind); 2] = [
     (LEGACY_HARDCODED_INSTANCE_ID_MINT, &MintCommonInit::KIND),
@@ -395,6 +399,7 @@ impl Gateway {
             Arc::new(GatewayLightningBuilder {
                 lightning_mode: opts.mode,
                 gateway_db: gateway_db.clone(),
+                ldk_data_dir: opts.data_dir.join(LDK_NODE_DB_FOLDER),
             }),
             gateway_parameters,
             gateway_db,

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -1,0 +1,493 @@
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bitcoin::{secp256k1, Network, OutPoint};
+use fedimint_core::runtime::spawn;
+use fedimint_core::task::TaskGroup;
+use fedimint_core::Amount;
+use ldk_node::lightning::ln::msgs::SocketAddress;
+use ldk_node::lightning::ln::PaymentHash;
+use ldk_node::lightning_invoice::Bolt11Invoice;
+use ldk_node::payment::{PaymentKind, PaymentStatus};
+use lightning::ln::PaymentPreimage;
+use lightning::util::scid_utils::scid_from_parts;
+use tokio::sync::mpsc::Sender;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::Status;
+use tracing::{error, info};
+
+use super::{ChannelInfo, ILnRpcClient, LightningRpcError, RouteHtlcStream};
+use crate::gateway_lnrpc::create_invoice_request::Description;
+use crate::gateway_lnrpc::intercept_htlc_response::{Action, Settle};
+use crate::gateway_lnrpc::{
+    CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse,
+    GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
+    InterceptHtlcResponse, PayInvoiceResponse,
+};
+
+pub struct GatewayLdkClient {
+    /// The underlying lightning node.
+    node: Arc<ldk_node::Node>,
+
+    /// The client for querying data about the blockchain.
+    esplora_client: esplora_client::AsyncClient,
+
+    /// A handle to the task that processes incoming events from the lightning
+    /// node. Responsible for sending incoming HTLCs to the caller of
+    /// `route_htlcs`.
+    /// TODO: This should be a shutdown sender instead, and we can discard the
+    /// handle.
+    event_handler_task_handle: tokio::task::JoinHandle<()>,
+
+    /// The HTLC stream, until it is taken by calling
+    /// `ILnRpcClient::route_htlcs`.
+    htlc_stream_receiver_or:
+        Option<tokio::sync::mpsc::Receiver<Result<InterceptHtlcRequest, Status>>>,
+}
+
+impl std::fmt::Debug for GatewayLdkClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GatewayLdkClient").finish_non_exhaustive()
+    }
+}
+
+impl GatewayLdkClient {
+    /// Creates a new `GatewayLdkClient` instance and starts the underlying
+    /// lightning node. All resources, including the lightning node, will be
+    /// cleaned up when the returned `GatewayLdkClient` instance is dropped.
+    /// There's no need to manually stop the node.
+    pub fn new(
+        data_dir: &Path,
+        esplora_server_url: &str,
+        network: Network,
+        lightning_port: u16,
+    ) -> anyhow::Result<Self> {
+        let mut node_builder = ldk_node::Builder::from_config(ldk_node::Config {
+            network,
+            listening_addresses: Some(vec![SocketAddress::TcpIpV4 {
+                addr: [0, 0, 0, 0],
+                port: lightning_port,
+            }]),
+            onchain_wallet_sync_interval_secs: 10,
+            wallet_sync_interval_secs: 10,
+            ..Default::default()
+        });
+        node_builder
+            .set_esplora_server(esplora_server_url.to_string())
+            .set_gossip_source_p2p();
+        let Some(data_dir_str) = data_dir.to_str() else {
+            return Err(anyhow::anyhow!("Invalid data dir path"));
+        };
+        node_builder.set_storage_dir_path(data_dir_str.to_string());
+
+        let node = Arc::new(node_builder.build()?);
+        node.start().map_err(|e| {
+            error!(?e, "Failed to start LDK Node");
+            LightningRpcError::FailedToConnect
+        })?;
+
+        let (htlc_stream_sender, htlc_stream_receiver) = tokio::sync::mpsc::channel(1024);
+
+        let node_clone = node.clone();
+        let event_handler_task_handle = spawn("ldk lightning node event handler", async move {
+            loop {
+                Self::handle_next_event(&node_clone, &htlc_stream_sender).await;
+            }
+        });
+
+        Ok(GatewayLdkClient {
+            node,
+            esplora_client: esplora_client::Builder::new(esplora_server_url).build_async()?,
+            event_handler_task_handle,
+            htlc_stream_receiver_or: Some(htlc_stream_receiver),
+        })
+    }
+
+    async fn handle_next_event(
+        node: &ldk_node::Node,
+        htlc_stream_sender: &Sender<Result<InterceptHtlcRequest, Status>>,
+    ) {
+        if let ldk_node::Event::PaymentClaimable {
+            payment_id: _,
+            payment_hash,
+            claimable_amount_msat,
+            claim_deadline,
+        } = node.next_event_async().await
+        {
+            if let Err(e) = htlc_stream_sender
+                .send(Ok(InterceptHtlcRequest {
+                    payment_hash: payment_hash.0.to_vec(),
+                    incoming_amount_msat: claimable_amount_msat,
+                    outgoing_amount_msat: 0,
+                    incoming_expiry: claim_deadline.unwrap_or_default(),
+                    short_channel_id: None,
+                    incoming_chan_id: 0,
+                    htlc_id: 0,
+                }))
+                .await
+            {
+                error!(?e, "Failed send InterceptHtlcRequest to stream");
+            }
+        }
+
+        // The `PaymentClaimable` event is the only event type that we are interested
+        // in. We can safely ignore all other events.
+        node.event_handled();
+    }
+
+    /// Converts a transaction outpoint to a short channel ID by querying the
+    /// blockchain.
+    async fn outpoint_to_scid(&self, funding_txo: OutPoint) -> anyhow::Result<u64> {
+        let block_height = self
+            .esplora_client
+            .get_merkle_proof(&funding_txo.txid)
+            .await?
+            .ok_or(anyhow::anyhow!("Failed to get merkle proof"))?
+            .block_height;
+
+        let block_hash = self.esplora_client.get_block_hash(block_height).await?;
+
+        let block = self
+            .esplora_client
+            .get_block_by_hash(&block_hash)
+            .await?
+            .ok_or(anyhow::anyhow!("Failed to get block"))?;
+
+        let tx_index = block
+            .txdata
+            .iter()
+            .enumerate()
+            .find(|(_, tx)| tx.txid() == funding_txo.txid)
+            .ok_or(anyhow::anyhow!("Failed to find transaction"))?
+            .0 as u32;
+
+        let output_index = funding_txo.vout;
+
+        scid_from_parts(
+            u64::from(block_height),
+            u64::from(tx_index),
+            u64::from(output_index),
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to convert to short channel ID: {e:?}"))
+    }
+}
+
+impl Drop for GatewayLdkClient {
+    fn drop(&mut self) {
+        self.event_handler_task_handle.abort();
+
+        info!("Stopping LDK Node...");
+        if let Err(e) = self.node.stop() {
+            error!(?e, "Failed to stop LDK Node");
+        } else {
+            info!("LDK Node stopped.");
+        }
+    }
+}
+
+#[async_trait]
+impl ILnRpcClient for GatewayLdkClient {
+    async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError> {
+        let node_status = self.node.status();
+
+        let Some(chain_tip_block_summary) = self
+            .esplora_client
+            .get_blocks(None)
+            .await
+            .map_err(|e| LightningRpcError::FailedToGetNodeInfo {
+                failure_reason: format!("Failed get chain tip block summary: {e:?}"),
+            })?
+            .into_iter()
+            .next()
+        else {
+            return Err(LightningRpcError::FailedToGetNodeInfo {
+                failure_reason:
+                    "Failed to get chain tip block summary (empty block list was returned)"
+                        .to_string(),
+            });
+        };
+
+        let esplora_chain_tip_timestamp = chain_tip_block_summary.time.timestamp;
+        let block_height: u32 = chain_tip_block_summary.time.height;
+
+        let synced_to_chain = node_status.latest_wallet_sync_timestamp.unwrap_or_default()
+            > esplora_chain_tip_timestamp
+            && node_status
+                .latest_onchain_wallet_sync_timestamp
+                .unwrap_or_default()
+                > esplora_chain_tip_timestamp;
+
+        Ok(GetNodeInfoResponse {
+            pub_key: self.node.node_id().serialize().to_vec(),
+            // TODO: This is a placeholder. We need to get the actual alias from the LDK node.
+            alias: format!("LDK Fedimint Gateway Node {}", self.node.node_id()),
+            network: match self.node.config().network {
+                Network::Bitcoin => "main",
+                Network::Testnet => "test",
+                Network::Signet => "signet",
+                Network::Regtest => "regtest",
+                _ => panic!("Unsupported network"),
+            }
+            .to_string(),
+            block_height,
+            synced_to_chain,
+        })
+    }
+
+    async fn routehints(
+        &self,
+        _num_route_hints: usize,
+    ) -> Result<GetRouteHintsResponse, LightningRpcError> {
+        // TODO: Return real route hints. Not strictly necessary but would be nice to
+        // have.
+        Ok(GetRouteHintsResponse {
+            route_hints: vec![],
+        })
+    }
+
+    // TODO: Respect `max_delay` and `max_fee` parameters.
+    async fn pay(
+        &self,
+        invoice: Bolt11Invoice,
+        _max_delay: u64,
+        _max_fee: Amount,
+    ) -> Result<PayInvoiceResponse, LightningRpcError> {
+        let payment_id = match self.node.bolt11_payment().send(&invoice) {
+            Ok(payment_id) => payment_id,
+            Err(e) => {
+                return Err(LightningRpcError::FailedPayment {
+                    failure_reason: format!("LDK payment failed to initialize: {e:?}"),
+                });
+            }
+        };
+
+        // TODO: Find a way to avoid looping/polling to know when a payment is
+        // completed. `ldk-node` provides `PaymentSuccessful` and `PaymentFailed`
+        // events, but interacting with the node event queue here isn't
+        // straightforward.
+        loop {
+            if let Some(payment_details) = self.node.payment(&payment_id) {
+                match payment_details.status {
+                    PaymentStatus::Pending => {}
+                    PaymentStatus::Succeeded => {
+                        if let PaymentKind::Bolt11 {
+                            preimage: Some(preimage),
+                            ..
+                        } = payment_details.kind
+                        {
+                            return Ok(PayInvoiceResponse {
+                                preimage: preimage.0.to_vec(),
+                            });
+                        }
+                    }
+                    PaymentStatus::Failed => {
+                        return Err(LightningRpcError::FailedPayment {
+                            failure_reason: "LDK payment failed".to_string(),
+                        });
+                    }
+                }
+            }
+            fedimint_core::runtime::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    async fn route_htlcs<'a>(
+        mut self: Box<Self>,
+        _task_group: &TaskGroup,
+    ) -> Result<(RouteHtlcStream<'a>, Arc<dyn ILnRpcClient>), LightningRpcError> {
+        let route_htlc_stream = match self.htlc_stream_receiver_or.take() {
+            Some(stream) => Ok(Box::pin(ReceiverStream::new(stream))),
+            None => Err(LightningRpcError::FailedToRouteHtlcs {
+                failure_reason:
+                    "Stream does not exist. Likely was already taken by calling `route_htlcs()`."
+                        .to_string(),
+            }),
+        }?;
+
+        Ok((route_htlc_stream, Arc::new(*self)))
+    }
+
+    async fn complete_htlc(
+        &self,
+        htlc: InterceptHtlcResponse,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        let InterceptHtlcResponse {
+            action,
+            payment_hash,
+            incoming_chan_id: _,
+            htlc_id: _,
+        } = htlc;
+
+        let ph = PaymentHash(payment_hash.clone().try_into().map_err(|_| {
+            LightningRpcError::FailedToCompleteHtlc {
+                failure_reason: "Failed to parse payment hash".to_string(),
+            }
+        })?);
+
+        // TODO: Get the actual amount from the LDK node. Probably makes the
+        // most sense to pipe it through the `InterceptHtlcResponse` struct.
+        // This value is only used by `ldk-node` to ensure that the amount
+        // claimed isn't less than the amount expected, but we've already
+        // verified that the amount is correct when we intercepted the payment.
+        let claimable_amount_msat = 999_999_999_999_999;
+
+        let ph_hex_str = hex::encode(payment_hash);
+
+        if let Some(Action::Settle(Settle { preimage })) = action {
+            self.node
+                .bolt11_payment()
+                .claim_for_hash(
+                    ph,
+                    claimable_amount_msat,
+                    PaymentPreimage(preimage.try_into().unwrap()),
+                )
+                .map_err(|_| LightningRpcError::FailedToCompleteHtlc {
+                    failure_reason: format!("Failed to claim LDK payment with hash {ph_hex_str}"),
+                })?;
+        } else {
+            error!("Unwinding payment with hash {ph_hex_str} because the action was not `Settle`");
+            self.node.bolt11_payment().fail_for_hash(ph).map_err(|_| {
+                LightningRpcError::FailedToCompleteHtlc {
+                    failure_reason: format!("Failed to unwind LDK payment with hash {ph_hex_str}"),
+                }
+            })?;
+        };
+
+        return Ok(EmptyResponse {});
+    }
+
+    async fn create_invoice(
+        &self,
+        create_invoice_request: CreateInvoiceRequest,
+    ) -> Result<CreateInvoiceResponse, LightningRpcError> {
+        let payment_hash = PaymentHash(create_invoice_request.payment_hash.try_into().map_err(
+            |_| LightningRpcError::FailedToGetInvoice {
+                failure_reason: "Failed to convert Vec<u8> to [u8; 32] (this probably means that LDK received an invalid payment hash)".to_string(),
+            },
+        )?);
+
+        let invoice = self
+            .node
+            .bolt11_payment()
+            .receive_for_hash(
+                create_invoice_request.amount_msat,
+                // Currently `ldk-node` only supports direct descriptions.
+                // See https://github.com/lightningdevkit/ldk-node/issues/325.
+                // TODO: Once the above issue is resolved, we should support
+                // description hashes as well.
+                if let Some(Description::Direct(description)) = &create_invoice_request.description
+                {
+                    description
+                } else {
+                    ""
+                },
+                create_invoice_request.expiry_secs,
+                payment_hash,
+            )
+            .map_err(|e| LightningRpcError::FailedToGetInvoice {
+                failure_reason: e.to_string(),
+            })?;
+
+        Ok(CreateInvoiceResponse {
+            invoice: invoice.to_string(),
+        })
+    }
+
+    async fn get_funding_address(&self) -> Result<GetFundingAddressResponse, LightningRpcError> {
+        self.node
+            .onchain_payment()
+            .new_address()
+            .map(|address| GetFundingAddressResponse {
+                address: address.to_string(),
+            })
+            .map_err(|e| LightningRpcError::FailedToGetFundingAddress {
+                failure_reason: e.to_string(),
+            })
+    }
+
+    async fn open_channel(
+        &self,
+        pubkey: secp256k1::PublicKey,
+        host: String,
+        channel_size_sats: u64,
+        push_amount_sats: u64,
+    ) -> Result<EmptyResponse, LightningRpcError> {
+        let push_amount_msats_or = if push_amount_sats == 0 {
+            None
+        } else {
+            Some(push_amount_sats * 1000)
+        };
+
+        self.node
+            .connect_open_channel(
+                pubkey,
+                SocketAddress::from_str(&host).map_err(|e| {
+                    LightningRpcError::FailedToConnectToPeer {
+                        failure_reason: e.to_string(),
+                    }
+                })?,
+                channel_size_sats,
+                push_amount_msats_or,
+                None,
+                true,
+            )
+            .map_err(|e| LightningRpcError::FailedToOpenChannel {
+                failure_reason: e.to_string(),
+            })?;
+
+        Ok(EmptyResponse {})
+    }
+
+    async fn close_channels_with_peer(
+        &self,
+        pubkey: secp256k1::PublicKey,
+    ) -> Result<CloseChannelsWithPeerResponse, LightningRpcError> {
+        let mut num_channels_closed = 0;
+
+        for channel_with_peer in self
+            .node
+            .list_channels()
+            .iter()
+            .filter(|channel| channel.counterparty_node_id == pubkey)
+        {
+            if self
+                .node
+                .close_channel(&channel_with_peer.user_channel_id, pubkey)
+                .is_ok()
+            {
+                num_channels_closed += 1;
+            }
+        }
+
+        Ok(CloseChannelsWithPeerResponse {
+            num_channels_closed,
+        })
+    }
+
+    async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError> {
+        let mut channels = Vec::new();
+
+        for channel_details in self
+            .node
+            .list_channels()
+            .iter()
+            .filter(|channel| channel.is_channel_ready)
+        {
+            channels.push(ChannelInfo {
+                remote_pubkey: channel_details.counterparty_node_id.to_string(),
+                channel_size_sats: channel_details.channel_value_sats,
+                outbound_liquidity_sats: channel_details.outbound_capacity_msat / 1000,
+                inbound_liquidity_sats: channel_details.inbound_capacity_msat / 1000,
+                short_channel_id: match channel_details.funding_txo {
+                    Some(funding_txo) => self.outpoint_to_scid(funding_txo).await.unwrap_or(0),
+                    None => 0,
+                },
+            });
+        }
+
+        Ok(channels)
+    }
+}


### PR DESCRIPTION
Add a third lightning node type to the gateway, a lightning node powered by [`ldk-node`](https://crates.io/crates/ldk-node) which runs in the same process as the gateway. The gateway can be run in ldk mode by setting the following environment variables:

`FM_LDK_ESPLORA_SERVER_URL`: Esplora server where blockchain data is accessed
`FM_LDK_NETWORK`: The bitcoin network being used (e.g. mainnet/testnet)
`FM_PORT_LDK`: The port that the lightning server is running on, where other lightning nodes can access it

The node's data is stored in a subdirectory of the gateway's data folder

This gateway mode should still be considered experimental!!! None of the behavior is tested or has locked-in backwards compatibility yet!