### PR TITLE
test: mock LNv2 interactions with gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ name = "fedimint-lnv2-tests"
 version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
+ "async-trait",
  "devimint",
  "fedimint-client",
  "fedimint-core",

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -554,7 +554,7 @@ impl FedimintCli {
             .with_module(MintClientInit)
             .with_module(WalletClientInit::default())
             .with_module(MetaClientInit)
-            .with_module(fedimint_lnv2_client::LightningClientInit)
+            .with_module(fedimint_lnv2_client::LightningClientInit::default())
     }
 
     pub async fn run(&mut self) {

--- a/fedimint-dbtool/src/lib.rs
+++ b/fedimint-dbtool/src/lib.rs
@@ -152,7 +152,7 @@ impl FedimintDBTool {
             .with_client_module_init(WalletClientInit::default())
             .with_client_module_init(MintClientInit)
             .with_client_module_init(LightningClientInit::default())
-            .with_client_module_init(fedimint_lnv2_client::LightningClientInit)
+            .with_client_module_init(fedimint_lnv2_client::LightningClientInit::default())
             .with_client_module_init(MetaClientInit)
     }
 

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -8,11 +8,11 @@ use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::OutPoint;
 use fedimint_lnv2_common::contracts::IncomingContract;
-use fedimint_lnv2_common::{LightningClientContext, LightningInput, LightningInputV0};
+use fedimint_lnv2_common::{LightningInput, LightningInputV0};
 use tpe::AggregateDecryptionKey;
 
 use crate::api::LnFederationApi;
-use crate::LightningClientStateMachines;
+use crate::{LightningClientContext, LightningClientStateMachines};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct ReceiveStateMachine {

--- a/modules/fedimint-lnv2-common/src/lib.rs
+++ b/modules/fedimint-lnv2-common/src/lib.rs
@@ -13,20 +13,16 @@ pub mod config;
 pub mod contracts;
 pub mod endpoint_constants;
 
-use std::collections::BTreeMap;
-
 use bitcoin_hashes::sha256;
 use config::LightningClientConfig;
-use fedimint_client::sm::Context;
-use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
-use fedimint_core::{extensible_associated_module_type, plugin_types_trait_impl_common, PeerId};
+use fedimint_core::{extensible_associated_module_type, plugin_types_trait_impl_common};
 use secp256k1::schnorr::Signature;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tpe::{AggregateDecryptionKey, AggregatePublicKey, DecryptionKeyShare, PublicKeyShare};
+use tpe::{AggregateDecryptionKey, DecryptionKeyShare};
 
 use crate::contracts::{IncomingContract, OutgoingContract};
 
@@ -160,13 +156,3 @@ plugin_types_trait_impl_common!(
     LightningInputError,
     LightningOutputError
 );
-
-#[derive(Debug, Clone)]
-pub struct LightningClientContext {
-    pub decoder: Decoder,
-    pub federation_id: FederationId,
-    pub tpe_agg_pk: AggregatePublicKey,
-    pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
-}
-
-impl Context for LightningClientContext {}

--- a/modules/fedimint-lnv2-tests/Cargo.toml
+++ b/modules/fedimint-lnv2-tests/Cargo.toml
@@ -13,6 +13,7 @@ path = "tests/tests.rs"
 
 [dependencies]
 anyhow = "1.0.86"
+async-trait = "0.1.80"
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-dummy-client = { path = "../fedimint-dummy-client" }

--- a/modules/fedimint-lnv2-tests/tests/mock.rs
+++ b/modules/fedimint-lnv2-tests/tests/mock.rs
@@ -1,0 +1,88 @@
+use std::time::Duration;
+
+use fedimint_core::config::FederationId;
+use fedimint_core::secp256k1::rand::rngs::OsRng;
+use fedimint_core::secp256k1::schnorr::Signature;
+use fedimint_core::secp256k1::{All, KeyPair, Secp256k1};
+use fedimint_core::util::SafeUrl;
+use fedimint_core::{apply, async_trait_maybe_send};
+use fedimint_ln_common::bitcoin;
+use fedimint_lnv2_client::api::GatewayConnection;
+use fedimint_lnv2_client::{
+    CreateBolt11InvoicePayload, GatewayError, LightningInvoice, PaymentFee, RoutingInfo,
+};
+use fedimint_lnv2_common::contracts::OutgoingContract;
+use fedimint_testing::ln::{INVALID_INVOICE_PAYMENT_SECRET, MOCK_INVOICE_PREIMAGE};
+use lightning_invoice::{Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret};
+
+#[derive(Debug)]
+pub struct MockGatewayConnection {
+    ctx: Secp256k1<All>,
+    keypair: KeyPair,
+}
+
+impl Default for MockGatewayConnection {
+    fn default() -> Self {
+        let ctx = bitcoin::secp256k1::Secp256k1::new();
+        let keypair = KeyPair::new_global(&mut OsRng);
+        MockGatewayConnection { ctx, keypair }
+    }
+}
+
+#[apply(async_trait_maybe_send!)]
+impl GatewayConnection for MockGatewayConnection {
+    async fn fetch_routing_info(
+        &self,
+        _gateway_api: SafeUrl,
+        _federation_id: &FederationId,
+    ) -> Result<Option<RoutingInfo>, GatewayError> {
+        Ok(Some(RoutingInfo {
+            public_key: self.keypair.public_key(),
+            send_fee_default: PaymentFee::one_percent(),
+            send_fee_minimum: PaymentFee::half_of_one_percent(),
+            receive_fee: PaymentFee::half_of_one_percent(),
+            expiration_delta_default: 500,
+            expiration_delta_minimum: 144,
+        }))
+    }
+
+    async fn fetch_invoice(
+        &self,
+        _gateway_api: SafeUrl,
+        payload: CreateBolt11InvoicePayload,
+    ) -> Result<Result<Bolt11Invoice, String>, GatewayError> {
+        Ok(Ok(InvoiceBuilder::new(Currency::Regtest)
+            .description(String::new())
+            .payment_hash(payload.contract.commitment.payment_hash)
+            .current_timestamp()
+            .min_final_cltv_expiry_delta(0)
+            .payment_secret(PaymentSecret([0; 32]))
+            .amount_milli_satoshis(payload.invoice_amount.msats)
+            .expiry_time(Duration::from_secs(payload.expiry_time as u64))
+            .build_signed(|m| {
+                self.ctx
+                    .sign_ecdsa_recoverable(m, &self.keypair.secret_key())
+            })
+            .unwrap()))
+    }
+
+    async fn try_gateway_send_payment(
+        &self,
+        _gateway_api: SafeUrl,
+        _federation_id: FederationId,
+        contract: OutgoingContract,
+        invoice: LightningInvoice,
+        _auth: Signature,
+    ) -> anyhow::Result<Result<Result<[u8; 32], Signature>, String>> {
+        match invoice {
+            LightningInvoice::Bolt11(invoice, _) => {
+                if *invoice.payment_secret() == PaymentSecret(INVALID_INVOICE_PAYMENT_SECRET) {
+                    let signature = self.keypair.sign_schnorr(contract.forfeit_message());
+                    return Ok(Ok(Err(signature)));
+                }
+
+                Ok(Ok(Ok(MOCK_INVOICE_PREIMAGE)))
+            }
+        }
+    }
+}

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -1,4 +1,5 @@
-use fedimint_core::config::FederationId;
+use std::sync::Arc;
+
 use fedimint_core::util::NextOrPending;
 use fedimint_core::{sats, Amount};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
@@ -13,6 +14,9 @@ use fedimint_testing::federation::FederationTest;
 use fedimint_testing::fixtures::Fixtures;
 use fedimint_testing::gateway::{GatewayTest, DEFAULT_GATEWAY_PASSWORD};
 use fedimint_testing::ln::FakeLightningTest;
+use mock::MockGatewayConnection;
+
+mod mock;
 
 fn fixtures() -> Fixtures {
     let fixtures = Fixtures::new_primary(DummyClientInit, DummyInit, DummyGenParams::default());
@@ -20,7 +24,9 @@ fn fixtures() -> Fixtures {
     let bitcoin_server = fixtures.bitcoin_server();
 
     let fixtures = fixtures.with_module(
-        LightningClientInit,
+        LightningClientInit {
+            gateway_conn: Arc::new(MockGatewayConnection::default()),
+        },
         LightningInit,
         LightningGenParams::regtest(bitcoin_server.clone()),
     );


### PR DESCRIPTION
As part of https://github.com/fedimint/fedimint/issues/5168, I would like to remove the gateway's webserver from our tests. It should not be necessary since everything is running in the same process, and in the past it has been the source of flakiness.

LNv2 still has a dependency on the webserver, this PR mocks the clients interactions with the gateway so that there is no dependency anymore. Necessary for https://github.com/fedimint/fedimint/pull/5545