### PR TITLE
chore: use begin_transaction_nc where possible

### DIFF
--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -63,7 +63,7 @@ impl OperationLog {
         limit: usize,
         start_after: Option<ChronologicalOperationLogKey>,
     ) -> Vec<(ChronologicalOperationLogKey, OperationLogEntry)> {
-        let mut dbtx = self.db.begin_transaction().await;
+        let mut dbtx = self.db.begin_transaction_nc().await;
         let operations: Vec<ChronologicalOperationLogKey> = dbtx
             .find_by_prefix_sorted_descending(&ChronologicalOperationLogKeyPrefix)
             .await
@@ -106,7 +106,7 @@ impl OperationLog {
 
     pub async fn get_operation(&self, operation_id: OperationId) -> Option<OperationLogEntry> {
         Self::get_operation_inner(
-            &mut self.db.begin_transaction().await.into_nc(),
+            &mut self.db.begin_transaction_nc().await.into_nc(),
             operation_id,
         )
         .await

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -687,7 +687,7 @@ impl ExecutorInner {
 
     async fn get_active_states(&self) -> Vec<(DynState, ActiveStateMeta)> {
         self.db
-            .begin_transaction()
+            .begin_transaction_nc()
             .await
             .find_by_prefix(&ActiveStateKeyPrefix)
             .await
@@ -712,7 +712,7 @@ impl ExecutorInner {
             return None;
         }
         self.db
-            .begin_transaction()
+            .begin_transaction_nc()
             .await
             .get_value(&ActiveStateKey::from_state(state.clone()))
             .await
@@ -720,7 +720,7 @@ impl ExecutorInner {
 
     async fn get_inactive_states(&self) -> Vec<(DynState, InactiveStateMeta)> {
         self.db
-            .begin_transaction()
+            .begin_transaction_nc()
             .await
             .find_by_prefix(&InactiveStateKeyPrefix)
             .await

--- a/fedimint-client/src/sm/notifier.rs
+++ b/fedimint-client/src/sm/notifier.rs
@@ -128,7 +128,7 @@ where
         let new_transitions = self.subscribe_all_operations();
 
         let db_states = {
-            let mut dbtx = self.db.begin_transaction().await;
+            let mut dbtx = self.db.begin_transaction_nc().await;
             let active_states = dbtx
                 .find_by_prefix(&ActiveModuleOperationStateKeyPrefix {
                     operation_id,

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -83,7 +83,7 @@ impl DatabaseDump {
                 }
             };
 
-            let mut dbtx = db.begin_transaction().await;
+            let mut dbtx = db.begin_transaction_nc().await;
             let client_cfg = dbtx
                 .find_by_prefix(&ClientConfigKeyPrefix)
                 .await
@@ -133,7 +133,7 @@ impl DatabaseDump {
         if !self.modules.is_empty() && !self.modules.contains(&kind.to_string()) {
             return Ok(());
         }
-        let mut dbtx = self.read_only.begin_transaction().await;
+        let mut dbtx = self.read_only.begin_transaction_nc().await;
         let db_version = dbtx.get_value(&DatabaseVersionKey(*module_id)).await;
         let mut isolated_dbtx = dbtx.to_ref_with_prefix_module_id(*module_id);
 
@@ -244,7 +244,7 @@ impl DatabaseDump {
     /// retrieves the corresponding data.
     async fn retrieve_consensus_data(&mut self) {
         let mut consensus: BTreeMap<String, Box<dyn Serialize>> = BTreeMap::new();
-        let mut dbtx = self.read_only.begin_transaction().await;
+        let mut dbtx = self.read_only.begin_transaction_nc().await;
         let dbtx = &mut dbtx;
         let prefix_names = &self.prefixes;
 

--- a/fedimint-recoverytool/src/main.rs
+++ b/fedimint-recoverytool/src/main.rs
@@ -163,7 +163,7 @@ async fn main() -> anyhow::Result<()> {
             };
 
             let utxos: Vec<ImportableWallet> = db
-                .begin_transaction()
+                .begin_transaction_nc()
                 .await
                 .find_by_prefix(&UTXOPrefixKey)
                 .await
@@ -192,7 +192,7 @@ async fn main() -> anyhow::Result<()> {
             .with_fallback();
 
             let db = get_db(opts.readonly, &db, decoders);
-            let mut dbtx = db.begin_transaction().await;
+            let mut dbtx = db.begin_transaction_nc().await;
 
             let mut change_tweak_idx: u64 = 0;
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -661,7 +661,7 @@ mod fedimint_rocksdb_tests {
         // Test readonly implementation
         let db_readonly = RocksDbReadOnly::open_read_only(path).unwrap();
         let db_readonly = Database::new(db_readonly, Default::default());
-        let mut dbtx = db_readonly.begin_transaction().await;
+        let mut dbtx = db_readonly.begin_transaction_nc().await;
         let query = dbtx
             .find_by_prefix_sorted_descending(&DbPrefixTestPrefix)
             .await

--- a/fedimint-server/src/consensus/aleph_bft/backup.rs
+++ b/fedimint-server/src/consensus/aleph_bft/backup.rs
@@ -19,7 +19,7 @@ impl BackupReader {
 #[async_trait]
 impl aleph_bft::BackupReader for BackupReader {
     async fn read(&mut self) -> std::io::Result<Vec<u8>> {
-        let mut dbtx = self.db.begin_transaction().await;
+        let mut dbtx = self.db.begin_transaction_nc().await;
 
         let units = dbtx
             .find_by_prefix(&AlephUnitsPrefix)

--- a/fedimint-server/src/consensus/db.rs
+++ b/fedimint-server/src/consensus/db.rs
@@ -230,7 +230,7 @@ mod fedimint_migration_tests {
 
         validate_migrations_global(
             |db| async move {
-                let mut dbtx = db.begin_transaction().await;
+                let mut dbtx = db.begin_transaction_nc().await;
 
                 for prefix in DbKeyPrefix::iter() {
                     match prefix {

--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -264,7 +264,7 @@ mod fedimint_migration_tests {
         let _ = TracingSetup::default().init();
         validate_migrations_global(
             |db| async move {
-                let mut dbtx = db.begin_transaction().await;
+                let mut dbtx = db.begin_transaction_nc().await;
 
                 for prefix in DbKeyPrefix::iter() {
                     match prefix {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1389,7 +1389,7 @@ impl Gateway {
         gateway_db: Database,
         gateway_parameters: &GatewayParameters,
     ) -> Option<GatewayConfiguration> {
-        let mut dbtx = gateway_db.begin_transaction().await;
+        let mut dbtx = gateway_db.begin_transaction_nc().await;
 
         // Always use the gateway configuration from the database if it exists.
         if let Some(gateway_config) = dbtx.get_value(&GatewayConfigurationKey).await {
@@ -1475,8 +1475,8 @@ impl Gateway {
     /// database and reconstructs the clients necessary for interacting with
     /// connection federations.
     async fn load_clients(&self) {
-        let dbtx = self.gateway_db.begin_transaction().await;
-        let configs = GatewayClientBuilder::load_configs(dbtx.into_nc()).await;
+        let dbtx = self.gateway_db.begin_transaction_nc().await;
+        let configs = GatewayClientBuilder::load_configs(dbtx).await;
 
         let _join_federation = self.client_joining_lock.lock().await;
 

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1338,7 +1338,7 @@ mod tests {
         };
 
         let db = Database::new(MemDatabase::new(), Default::default());
-        let mut dbtx = db.begin_transaction().await;
+        let mut dbtx = db.begin_transaction_nc().await;
 
         server
             .process_output(
@@ -1378,7 +1378,7 @@ mod tests {
     async fn process_input_for_valid_incoming_contracts() {
         let (server_cfg, client_cfg) = build_configs();
         let db = Database::new(MemDatabase::new(), Default::default());
-        let mut dbtx = db.begin_transaction().await;
+        let mut dbtx = db.begin_transaction_nc().await;
         let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42);
         let tg = TaskGroup::new();
         let server = Lightning::new(server_cfg[0].clone(), &tg, 0.into()).unwrap();
@@ -1439,7 +1439,7 @@ mod tests {
     async fn process_input_for_valid_outgoing_contracts() {
         let (server_cfg, _) = build_configs();
         let db = Database::new(MemDatabase::new(), Default::default());
-        let mut dbtx = db.begin_transaction().await;
+        let mut dbtx = db.begin_transaction_nc().await;
         let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42);
         let tg = TaskGroup::new();
         let server = Lightning::new(server_cfg[0].clone(), &tg, 0.into()).unwrap();

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -754,7 +754,7 @@ impl Lightning {
     }
 
     async fn gateways(db: Database) -> Vec<SafeUrl> {
-        db.begin_transaction()
+        db.begin_transaction_nc()
             .await
             .find_by_prefix(&GatewayPrefix)
             .await

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -788,7 +788,7 @@ mod test {
         let input = MintInput::new_v0(highest_denomination, note);
 
         // Double spend in same session is detected
-        let mut dbtx = db.begin_transaction().await;
+        let mut dbtx = db.begin_transaction_nc().await;
         mint.process_input(&mut dbtx.to_ref_with_prefix_module_id(42).into_nc(), &input)
             .await
             .expect("Spend of valid e-cash works");

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1289,7 +1289,7 @@ impl Wallet {
 #[instrument(level = "debug", skip_all)]
 pub async fn run_broadcast_pending_tx(db: Database, rpc: DynBitcoindRpc, tg_handle: &TaskHandle) {
     while !tg_handle.is_shutting_down() {
-        broadcast_pending_tx(db.begin_transaction().await.into_nc(), &rpc).await;
+        broadcast_pending_tx(db.begin_transaction_nc().await, &rpc).await;
         sleep(Duration::from_secs(1)).await;
     }
 }


### PR DESCRIPTION
This makes it easier to see at a glance whether a database interaction is writing or just reading