### PR TITLE
chore(ci): publish fedimint-recoverytool as a part of the release

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -469,7 +469,7 @@ jobs:
       matrix:
         build:
           - flake-output: fedimint-pkgs
-            bins: fedimintd,fedimint-cli,fedimint-dbtool
+            bins: fedimintd,fedimint-cli,fedimint-dbtool,fedimint-recoverytool
             deb: fedimint
           - flake-output: gateway-pkgs
             bins: gateway-cli,gatewayd,gateway-cln-extension


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
