### PR TITLE
chore: add documentation warning peg-ins are an expert only feature

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -466,7 +466,7 @@ pub async fn handle_command(
         ClientCmd::DepositAddress => {
             let (operation_id, address, tweak_idx) = client
                 .get_first_module::<WalletClientModule>()
-                .allocate_deposit_address()
+                .allocate_deposit_address_expert_only()
                 .await?;
             Ok(serde_json::json! {
                 {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -895,7 +895,7 @@ impl Gateway {
             .await?
             .value()
             .get_first_module::<WalletClientModule>()
-            .allocate_deposit_address()
+            .allocate_deposit_address_expert_only()
             .await?;
         Ok(address)
     }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -639,7 +639,24 @@ impl WalletClientModule {
         })
     }
 
-    pub async fn allocate_deposit_address(
+    /// Allocates a deposit address that is controlled by the federation.
+    ///
+    /// This is an EXPERT ONLY method intended for power users such as Lightning
+    /// gateways allocating liquidity, and we discourage exposing peg-in
+    /// functionality to everyday users of a Fedimint wallet due to the
+    /// following two limitations:
+    ///
+    /// The transaction sending to this address needs to be smaller than 40KB in
+    /// order for the peg-in to be claimable. If the transaction is too large,
+    /// funds will be lost.
+    ///
+    /// In the future, federations will also enforce a minimum peg-in amount to
+    /// prevent accumulation of dust UTXOs. Peg-ins under this minimum cannot be
+    /// claimed and funds will be lost.
+    ///
+    /// Everyday users should rely on Lightning to move funds into the
+    /// federation.
+    pub async fn allocate_deposit_address_expert_only(
         &self,
     ) -> anyhow::Result<(OperationId, Address, TweakIdx)> {
         let (operation_id, address, tweak_idx) = self

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -50,7 +50,7 @@ async fn initial_peg_in<'a>(
     assert_eq!(balance_sub.ok().await?, sats(0));
 
     let wallet_module = &client.get_first_module::<WalletClientModule>();
-    let (op, address, _) = wallet_module.allocate_deposit_address().await?;
+    let (op, address, _) = wallet_module.allocate_deposit_address_expert_only().await?;
     info!(?address, "Peg-in address generated");
     let (_proof, tx) = bitcoin
         .send_and_mine_block(
@@ -215,7 +215,7 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
     info!(?starting_balance, "Starting balance");
 
     let wallet_module = &client.get_first_module::<WalletClientModule>();
-    let (op, address, tweak_idx) = wallet_module.allocate_deposit_address().await?;
+    let (op, address, tweak_idx) = wallet_module.allocate_deposit_address_expert_only().await?;
 
     // First peg-in
     {


### PR DESCRIPTION
There are a few footguns that make peg-ins an expert only feature. This PR adds documentation highlighting these issues and strongly recommends clients to remove the functionality of generating peg-in addresses.