### PR TITLE
chore: add feerate multiplier

### DIFF
--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -45,6 +45,11 @@ pub const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVers
 /// wallet.
 pub const CONFIRMATION_TARGET: u16 = 1;
 
+/// To further mitigate the risk of a peg-out transaction getting stuck in the
+/// mempool, we multiply the feerate estimate returned from the backend by this
+/// value.
+pub const FEERATE_MULTIPLIER: u64 = 4;
+
 pub type PartialSig = Vec<u8>;
 
 pub type PegInDescriptor = Descriptor<CompressedPublicKey>;

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -31,6 +31,7 @@ use common::{
     proprietary_tweak_key, PegOutFees, PegOutSignatureItem, ProcessPegOutSigError, SpendableUTXO,
     WalletCommonInit, WalletConsensusItem, WalletCreationError, WalletInput, WalletModuleTypes,
     WalletOutput, WalletOutputOutcome, CONFIRMATION_TARGET, DEPRECATED_RBF_ERROR,
+    FEERATE_MULTIPLIER,
 };
 use fedimint_bitcoind::{create_bitcoind, DynBitcoindRpc};
 use fedimint_core::config::{
@@ -1256,7 +1257,8 @@ impl Wallet {
 
                     match res {
                         Ok(Some(r)) => {
-                            let _ = fee_rate_tx.send(r);
+                            let feerate_with_multiplier = Feerate { sats_per_kvb: r.sats_per_kvb * FEERATE_MULTIPLIER };
+                            let _ = fee_rate_tx.send(feerate_with_multiplier);
                         }
                         Ok(None) => {
                             debug!(target: LOG_MODULE_WALLET, "Bitcoin node did not return a fee rate");

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -38,7 +38,7 @@ fn bsats(satoshi: u64) -> bitcoin::Amount {
     bitcoin::Amount::from_sat(satoshi)
 }
 
-const PEG_IN_AMOUNT_SATS: u64 = 5000;
+const PEG_IN_AMOUNT_SATS: u64 = 10000;
 const PEG_OUT_AMOUNT_SATS: u64 = 1000;
 
 async fn initial_peg_in<'a>(


### PR DESCRIPTION
Peg-out transactions stuck in the mempool are incredibly risky. In addition to reducing the confirmation target used when estimating the feerate (see: https://github.com/fedimint/fedimint/issues/5498), we should multiply the estimated feerate.

The multiplier of 4 is hardcoded to be conservative. We've considered making this value configurable, either through the local config json or through environment variables, however making this multiplier easy to adjust downwards increases the risk of an operator optimizing peg-out fees then getting a peg-out stuck.