### PR TITLE
chore(deps): bump jsonrpsee-* from 0.23.2 to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.68",
 ]
@@ -2064,7 +2064,7 @@ dependencies = [
  "fedimint-wallet-client",
  "futures",
  "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.23.2",
  "jsonrpsee-ws-client",
  "lightning-invoice",
  "rand",
@@ -3532,21 +3532,21 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
+checksum = "e419d6c39cb9632288c592a06d7d0a96740021b0bff812e211ace754b0fe8c9a"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-server",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.24.0",
  "tokio",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08163edd8bcc466c33d79e10f695cdc98c00d1e6ddfb95cec41b6b0279dd5432"
+checksum = "f8b6dc3b1e2da087969e69a095e7d6127966c8c194490b311017bb2053a7d5a1"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3565,24 +3565,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
+checksum = "d06b8be79a3bdd7d87c1d95c0e939052b7f64fffce7b9436986e43e92f20a978"
 dependencies = [
- "anyhow",
  "async-trait",
- "beef",
  "bytes",
  "futures-timer",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.24.0",
  "parking_lot",
  "pin-project",
  "rand",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -3594,11 +3592,10 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654afab2e92e5d88ebd8a39d6074483f3f2bfdf91c5ac57fe285e7127cdd4f51"
+checksum = "8c358788aa585f51a78b11bec5d4b16fbe26dda1cc149f21d95dc24836a0be83"
 dependencies = [
- "anyhow",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -3606,7 +3603,7 @@ dependencies = [
  "hyper 1.4.0",
  "hyper-util",
  "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.24.0",
  "pin-project",
  "route-recognizer",
  "serde",
@@ -3634,26 +3631,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-wasm-client"
-version = "0.23.2"
+name = "jsonrpsee-types"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4727ac037f834c6f04c0912cada7532dbddb54e92fbc64e33d6cb8c24af313c9"
+checksum = "0feba38a9878d70ccccd2f54b534b15e861d6caa7911d59abfd3e0d8b4de091f"
+dependencies = [
+ "http 1.1.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0da29b570ad645e72c6098716719d2ef58d51a8eb0f084ac5e43a5763839542"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.24.0",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c28759775f5cb2f1ea9667672d3fe2b0e701d1f4b7b67954e60afe7fd058b5e"
+checksum = "e82b1c7fc629c345581d89ad802d53dc11d18df11d4d94d2c95da6e70f8520d3"
 dependencies = [
  "http 1.1.0",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.24.0",
  "url",
 ]
 
@@ -4695,6 +4704,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-jsonrpsee-core = "0.23.2"
+jsonrpsee-core = "0.24.0"
 lru = "0.12.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -32,12 +32,12 @@ fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-jsonrpsee-ws-client = { version = "0.23.2", default-features = false }
+jsonrpsee-ws-client = { version = "0.24.0", default-features = false }
 tokio = { version = "1.38.0", features = ["full", "tracing"] }
 tokio-rustls = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-jsonrpsee-wasm-client = "0.23.2"
+jsonrpsee-wasm-client = "0.24.0"
 async-lock = "3.4"
 # getrandom is transitive dependency of rand
 # on wasm, we need to enable the js backend

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -849,10 +849,10 @@ impl JsonRpcClient for WsClient {
                 // `user:pass@...`
                 let mut url = url.clone();
                 url.set_username("fedimint").map_err(|_| {
-                    JsonRpcClientError::Transport(anyhow::format_err!("invalid username"))
+                    JsonRpcClientError::Transport(anyhow::format_err!("invalid username").into())
                 })?;
                 url.set_password(Some(&api_secret)).map_err(|_| {
-                    JsonRpcClientError::Transport(anyhow::format_err!("invalid secret"))
+                    JsonRpcClientError::Transport(anyhow::format_err!("invalid secret").into())
                 })?;
                 return client.build(url.as_str()).await;
             }
@@ -957,9 +957,9 @@ where
                 }
                 Ok(_client) => {
                     if 0 < attempts {
-                        return Err(JsonRpcClientError::Transport(anyhow::format_err!(
-                            "Disconnected"
-                        )));
+                        return Err(JsonRpcClientError::Transport(
+                            anyhow::format_err!("Disconnected").into(),
+                        ));
                     }
                     debug!(target: LOG_CLIENT_NET_API, "Triggering reconnection after disconnection");
                 }

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -26,7 +26,7 @@ base64-url = "3.0.0"
 bls12_381 = { workspace = true }
 serdect = { workspace = true }
 itertools = { workspace = true }
-jsonrpsee-core = { version = "0.23.2", features = ["client"] }
+jsonrpsee-core = { version = "0.24.0", features = ["client"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
@@ -59,7 +59,7 @@ tokio = { version = "1.38.0", features = ["full", "tracing"] }
 tokio-rustls = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-jsonrpsee-wasm-client = "0.23.2"
+jsonrpsee-wasm-client = "0.24.0"
 async-lock = "3.4"
 tokio = "1.38.0"
 futures-util = { workspace = true }

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -27,7 +27,7 @@ fedimint-mint-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-m
 fedimint-rocksdb = { version = "=0.4.0-alpha", path = "../fedimint-rocksdb" }
 fedimint-wallet-client = { version = "=0.4.0-alpha", path = "../modules/fedimint-wallet-client" }
 futures = { workspace = true }
-jsonrpsee-core = { version = "0.23.2", features = ["client"] }
+jsonrpsee-core = { version = "0.24.0", features = ["client"] }
 jsonrpsee-types = "0.23.0"
 lightning-invoice = { workspace = true }
 rand = { workspace = true }
@@ -38,7 +38,7 @@ tracing = { workspace = true }
 url = { version = "2.5.2", features = ["serde"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-jsonrpsee-ws-client = { version = "0.23.2", default-features = false }
+jsonrpsee-ws-client = { version = "0.24.0", default-features = false }
 
 [build-dependencies]
 fedimint-build = { version = "=0.4.0-alpha", path = "../fedimint-build" }

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -37,7 +37,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 hyper = "1"
 itertools = { workspace = true }
-jsonrpsee = { version = "0.23.2", features = ["server"] }
+jsonrpsee = { version = "0.24.0", features = ["server"] }
 once_cell = { workspace = true }
 parity-scale-codec = "3.6.12"
 pin-project = "1.1.5"

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -36,7 +36,7 @@ bytes = "1.6.0"
 clap = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-jsonrpsee = { version = "0.23.2", features = ["server"] }
+jsonrpsee = { version = "0.24.0", features = ["server"] }
 fedimint-bitcoind = { version = "=0.4.0-alpha", path = "../fedimint-bitcoind" }
 fedimint-core = { workspace = true }
 fedimint-ln-common = { version = "=0.4.0-alpha", path = "../modules/fedimint-ln-common" }


### PR DESCRIPTION
I'll keep #5544 just for the tls feature usage and fix, using this one for bumping jsonrpsee.
 
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
