### PR TITLE
refactor: GuardianAuthToken

### DIFF
--- a/fedimint-server/src/net/api/mod.rs
+++ b/fedimint-server/src/net/api/mod.rs
@@ -113,11 +113,19 @@ pub trait HasApiContext<State> {
     ) -> (&State, ApiEndpointContext<'_>);
 }
 
+/// A token proving the the API call was authenticated
+///
+/// Api handlers are encouraged to take it as an argument to avoid sensitive
+/// guardian-only logic being accidentally unauthenticated.
+pub struct GuardianAuthToken {
+    _marker: (), // private field just to make creating it outside impossible
+}
+
 pub type ApiResult<T> = Result<T, ApiError>;
 
-pub fn check_auth(context: &mut ApiEndpointContext) -> ApiResult<()> {
+pub fn check_auth(context: &mut ApiEndpointContext) -> ApiResult<GuardianAuthToken> {
     if context.has_auth() {
-        Ok(())
+        Ok(GuardianAuthToken { _marker: () })
     } else {
         Err(ApiError::unauthorized())
     }


### PR DESCRIPTION
Currently not easy to ensure that a given piece of logic in a api endpoint handler is actually running after auth was performered.

By introducing a token returned only by `check_uath` and requiring it as an argument, we can make mistakes of this type near impossible.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
