### PR TITLE
[Backport releases/v0.4] fix: `fedimint-cli invite-code` using deprecated API

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -716,14 +716,11 @@ impl FedimintCli {
     async fn handle_command(&mut self, cli: Opts) -> CliOutputResult {
         match cli.command.clone() {
             Command::InviteCode { peer } => {
-                let db = cli.load_rocks_db().await?;
-                let client_config = Client::get_config_from_db(&db)
-                    .await
-                    .ok_or_cli_msg("client config code not found")?;
-                let api_secret = Client::get_api_secret_from_db(&db).await;
+                let client = self.client_open(&cli).await?;
 
-                let invite_code = client_config
-                    .invite_code(&peer, &api_secret)
+                let invite_code = client
+                    .invite_code(peer)
+                    .await
                     .ok_or_cli_msg("peer not found")?;
 
                 Ok(CliOutput::InviteCode { invite_code })

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -30,7 +30,6 @@ use tracing::warn;
 
 use crate::core::DynClientConfig;
 use crate::encoding::Decodable;
-use crate::invite_code::InviteCode;
 use crate::module::{
     CoreConsensusVersion, DynCommonModuleInit, DynServerModuleInit, IDynCommonModuleInit,
     ModuleConsensusVersion,
@@ -278,23 +277,6 @@ impl ClientConfig {
         } else {
             res
         }
-    }
-
-    /// Create an invite code with the api endpoint of the given peer which can
-    /// be used to download this client config
-    #[deprecated(
-        since = "0.4.0",
-        note = "API endpoints included in the config may be outdated, use Client::invite_code instead"
-    )]
-    pub fn invite_code(&self, peer: &PeerId, api_secret: &Option<String>) -> Option<InviteCode> {
-        self.global.api_endpoints.get(peer).map(|peer_url| {
-            InviteCode::new(
-                peer_url.url.clone(),
-                *peer,
-                self.calculate_federation_id(),
-                api_secret.clone(),
-            )
-        })
     }
 
     /// Converts a consensus-encoded client config struct to a client config


### PR DESCRIPTION
# Description
Backport of #5607 to `releases/v0.4`.