### PR TITLE
refactor: LNv2 pegin gateways before tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,7 @@ version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
+ "clap",
  "devimint",
  "fedimint-client",
  "fedimint-core",

--- a/modules/fedimint-lnv2-tests/Cargo.toml
+++ b/modules/fedimint-lnv2-tests/Cargo.toml
@@ -14,6 +14,7 @@ path = "tests/tests.rs"
 [dependencies]
 anyhow = "1.0.86"
 async-trait = "0.1.80"
+clap = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-dummy-client = { path = "../fedimint-dummy-client" }

--- a/scripts/tests/lnv2-module-test.sh
+++ b/scripts/tests/lnv2-module-test.sh
@@ -8,4 +8,4 @@ source scripts/_common.sh
 build_workspace
 add_target_dir_to_path
 
-tests
+tests all


### PR DESCRIPTION
Moves the pegin gateway commands above the tests since they are agnostic to each test. This allows us to run each test individually based on a CLI parameter.
