### PR TITLE
chore: consolidate usage of backoffs

### DIFF
--- a/fedimint-client/src/meta.rs
+++ b/fedimint-client/src/meta.rs
@@ -8,7 +8,7 @@ use async_stream::stream;
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::task::waiter::Waiter;
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::util::{backon, retry};
+use fedimint_core::util::{backoff_util, retry};
 use fedimint_core::{apply, async_trait_maybe_send};
 use serde::de::DeserializeOwned;
 use tokio::sync::Notify;
@@ -249,14 +249,8 @@ impl MetaSource for LegacyMetaSource {
             .map(|(key, value)| (MetaFieldKey(key.clone()), MetaFieldValue(value.clone())));
         let backoff = match fetch_kind {
             // need to be fast the first time.
-            FetchKind::Initial => backon::FibonacciBuilder::default()
-                .with_min_delay(Duration::from_millis(300))
-                .with_max_delay(Duration::from_secs(3))
-                .with_max_times(10),
-            FetchKind::Background => backon::FibonacciBuilder::default()
-                .with_min_delay(Duration::from_secs(10))
-                .with_max_delay(Duration::from_secs(10 * 60))
-                .with_max_times(usize::MAX),
+            FetchKind::Initial => backoff_util::aggressive_backoff(),
+            FetchKind::Background => backoff_util::background_backoff(),
         };
         let overrides = retry("fetch_meta_overrides", backoff, || {
             fetch_meta_overrides(&self.reqwest, client, "meta_override_url")

--- a/fedimint-core/src/util/backoff_util.rs
+++ b/fedimint-core/src/util/backoff_util.rs
@@ -1,0 +1,44 @@
+use std::time::Duration;
+
+pub use backon::{Backoff, FibonacciBackoff};
+use backon::{BackoffBuilder, FibonacciBuilder};
+
+/// Backoff strategy for background tasks.
+///
+/// Starts at 1s and increases to 60s, never giving up.
+pub fn background_backoff() -> FibonacciBackoff {
+    custom_backoff(Duration::from_secs(1), Duration::from_secs(60), None)
+}
+
+/// A backoff strategy for relatively quick foreground operations.
+///
+/// Starts at 200ms and increases to 5s. Will retry 10 times before giving up,
+/// with a maximum total delay between 20.8s and 22.8s depending on jitter.
+pub fn aggressive_backoff() -> FibonacciBackoff {
+    // Not accounting for jitter, the delays are:
+    // 0.2, 0.2, 0.4, 0.6, 1.0, 1.6, 2.6, 4.2, 5.0, 5.0.
+    //
+    // Jitter adds a random value between 0 and `min_delay` to each delay.
+    // Total jitter is between 0 and (10 * 0.2) = 2.0.
+    //
+    // Maximum possible delay including jitter is 22.8 seconds.
+    custom_backoff(Duration::from_millis(200), Duration::from_secs(5), Some(10))
+}
+
+#[cfg(test)]
+pub fn immediate_backoff(max_retries_or: Option<usize>) -> FibonacciBackoff {
+    custom_backoff(Duration::ZERO, Duration::ZERO, max_retries_or)
+}
+
+pub fn custom_backoff(
+    min_delay: Duration,
+    max_delay: Duration,
+    max_retries_or: Option<usize>,
+) -> FibonacciBackoff {
+    FibonacciBuilder::default()
+        .with_jitter()
+        .with_min_delay(min_delay)
+        .with_max_delay(max_delay)
+        .with_max_times(max_retries_or.unwrap_or(usize::MAX))
+        .build()
+}

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -698,12 +698,11 @@ where
 mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::sync::Arc;
-    use std::time::Duration;
 
     use anyhow::{ensure, Context as _};
     use fedimint_api_client::api::PeerConnectionStatus;
     use fedimint_core::task::TaskGroup;
-    use fedimint_core::util::{backon, retry};
+    use fedimint_core::util::{backoff_util, retry};
     use fedimint_core::PeerId;
     use tokio::sync::RwLock;
 
@@ -723,10 +722,7 @@ mod tests {
             ) {
                 retry(
                     format!("wait for client {name}"),
-                    backon::FibonacciBuilder::default()
-                        .with_min_delay(Duration::from_millis(200))
-                        .with_max_delay(Duration::from_secs(5))
-                        .with_max_times(10),
+                    backoff_util::aggressive_backoff(),
                     || async {
                         let status = status_channels.read().await;
                         ensure!(status.len() == 2);

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -10,7 +10,7 @@ use bitcoin::address::NetworkUnchecked;
 use bitcoin::Address;
 use clap::{CommandFactory, Parser, Subcommand};
 use fedimint_core::config::FederationId;
-use fedimint_core::util::{backon, retry, SafeUrl};
+use fedimint_core::util::{backoff_util, retry, SafeUrl};
 use fedimint_core::{fedimint_build_code_version_env, BitcoinAmountOrAll};
 use fedimint_logging::TracingSetup;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
@@ -335,16 +335,17 @@ async fn main() -> anyhow::Result<()> {
                 max_retries,
                 retry_delay_seconds,
             } => {
+                let retry_duration = Duration::from_secs(
+                    retry_delay_seconds.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS),
+                );
+
                 retry(
                     "Wait for chain sync",
-                    backon::ConstantBuilder::default()
-                        .with_delay(Duration::from_secs(
-                            retry_delay_seconds
-                                .unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS),
-                        ))
-                        .with_max_times(
-                            max_retries.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES) as usize
-                        ),
+                    backoff_util::custom_backoff(
+                        retry_duration,
+                        retry_duration,
+                        Some(max_retries.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES) as usize),
+                    ),
                     || async {
                         let info = client().get_info().await?;
                         if info.block_height.unwrap_or(0) >= block_height && info.synced_to_chain {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -58,7 +58,7 @@ use fedimint_core::module::{
 };
 use fedimint_core::task::{timeout, MaybeSend, MaybeSync};
 use fedimint_core::util::update_merge::UpdateMerge;
-use fedimint_core::util::{backon, retry, BoxStream};
+use fedimint_core::util::{backoff_util, retry, BoxStream};
 use fedimint_core::{
     apply, async_trait_maybe_send, push_db_pair_items, runtime, Amount, OutPoint, TransactionId,
 };
@@ -998,10 +998,7 @@ impl LightningClientModule {
             // should never fail with usize::MAX attempts.
             let _ = retry(
                 "update_gateway_cache",
-                backon::FibonacciBuilder::default()
-                    .with_min_delay(Duration::from_secs(1))
-                    .with_max_delay(Duration::from_secs(10 * 60))
-                    .with_max_times(usize::MAX),
+                backoff_util::background_backoff(),
                 || self.update_gateway_cache(),
             )
             .await;


### PR DESCRIPTION
Limit the `backon` types that are exported from `fedimint-core` and export a few standard backoff functions:

`background_backoff()`, `aggressive_backoff()`, `immediate_backoff()`, `custom_backoff()`