### PR TITLE
chore: split gateway cli

### DIFF
--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -1,0 +1,224 @@
+use anyhow::bail;
+use bitcoin::address::NetworkUnchecked;
+use bitcoin::Address;
+use clap::Subcommand;
+use fedimint_core::config::FederationId;
+use fedimint_core::{fedimint_build_code_version_env, BitcoinAmountOrAll};
+use ln_gateway::rpc::rpc_client::GatewayRpcClient;
+use ln_gateway::rpc::{
+    BackupPayload, BalancePayload, ConfigPayload, ConnectFedPayload, DepositAddressPayload,
+    FederationRoutingFees, LeaveFedPayload, RestorePayload, SetConfigurationPayload,
+    WithdrawPayload,
+};
+
+use crate::print_response;
+
+#[derive(Clone)]
+pub struct PerFederationRoutingFees {
+    federation_id: FederationId,
+    routing_fees: FederationRoutingFees,
+}
+
+impl std::str::FromStr for PerFederationRoutingFees {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some((federation_id, routing_fees)) = s.split_once(',') {
+            Ok(Self {
+                federation_id: federation_id.parse()?,
+                routing_fees: routing_fees.parse()?,
+            })
+        } else {
+            bail!("Wrong format, please provide: <federation id>,<base msat>,<proportional to millionths part>");
+        }
+    }
+}
+
+impl From<PerFederationRoutingFees> for (FederationId, FederationRoutingFees) {
+    fn from(val: PerFederationRoutingFees) -> Self {
+        (val.federation_id, val.routing_fees)
+    }
+}
+
+#[derive(Subcommand)]
+pub enum GeneralCommands {
+    /// Display the version hash of the CLI.
+    VersionHash,
+    /// Display high-level information about the gateway.
+    Info,
+    /// Display config information about the federation(s) the gateway is
+    /// connected to.
+    Config {
+        #[clap(long)]
+        federation_id: Option<FederationId>,
+    },
+    /// Check gateway's e-cash balance on the specified federation.
+    Balance {
+        #[clap(long)]
+        federation_id: FederationId,
+    },
+    /// Generate a new peg-in address to a federation that the gateway can claim
+    /// e-cash for later.
+    Address {
+        #[clap(long)]
+        federation_id: FederationId,
+    },
+    /// Claim funds from a gateway federation to an on-chain address.
+    Withdraw {
+        #[clap(long)]
+        federation_id: FederationId,
+        /// The amount to withdraw
+        #[clap(long)]
+        amount: BitcoinAmountOrAll,
+        /// The address to send the funds to
+        #[clap(long)]
+        address: Address<NetworkUnchecked>,
+    },
+    /// Register the gateway with a federation.
+    ConnectFed {
+        /// Invite code to connect to the federation
+        invite_code: String,
+    },
+    /// Leave a federation.
+    LeaveFed {
+        #[clap(long)]
+        federation_id: FederationId,
+    },
+    /// Make a backup of snapshot of all e-cash.
+    Backup {
+        #[clap(long)]
+        federation_id: FederationId,
+    },
+    /// Restore e-cash from last available snapshot or from scratch.
+    Restore {
+        #[clap(long)]
+        federation_id: FederationId,
+    },
+    /// Set or update the gateway configuration.
+    SetConfiguration {
+        #[clap(long)]
+        password: Option<String>,
+
+        #[clap(long)]
+        num_route_hints: Option<u32>,
+
+        /// Default routing fee for all new federations. Setting it won't affect
+        /// existing federations
+        #[clap(long)]
+        routing_fees: Option<FederationRoutingFees>,
+
+        #[clap(long)]
+        network: Option<bitcoin::Network>,
+
+        /// Format federation id,base msat,proportional to millionths part. Any
+        /// other federations not given here will keep their current fees.
+        #[clap(long)]
+        per_federation_routing_fees: Option<Vec<PerFederationRoutingFees>>,
+    },
+}
+
+impl GeneralCommands {
+    pub async fn handle(
+        self,
+        create_client: impl Fn() -> GatewayRpcClient + Send + Sync,
+    ) -> anyhow::Result<()> {
+        match self {
+            Self::VersionHash => {
+                println!("{}", fedimint_build_code_version_env!());
+            }
+            Self::Info => {
+                // For backwards-compatibility, fallback to the original POST endpoint if the
+                // GET endpoint fails
+                // FIXME: deprecated >= 0.3.0
+                let client = create_client();
+                let response = match client.get_info().await {
+                    Ok(res) => res,
+                    Err(_) => client.get_info_legacy().await?,
+                };
+
+                print_response(response);
+            }
+
+            Self::Config { federation_id } => {
+                let response = create_client()
+                    .get_config(ConfigPayload { federation_id })
+                    .await?;
+
+                print_response(response);
+            }
+            Self::Balance { federation_id } => {
+                let response = create_client()
+                    .get_balance(BalancePayload { federation_id })
+                    .await?;
+
+                print_response(response);
+            }
+            Self::Address { federation_id } => {
+                let response = create_client()
+                    .get_deposit_address(DepositAddressPayload { federation_id })
+                    .await?;
+
+                print_response(response);
+            }
+            Self::Withdraw {
+                federation_id,
+                amount,
+                address,
+            } => {
+                let response = create_client()
+                    .withdraw(WithdrawPayload {
+                        federation_id,
+                        amount,
+                        address,
+                    })
+                    .await?;
+
+                print_response(response);
+            }
+            Self::ConnectFed { invite_code } => {
+                let response = create_client()
+                    .connect_federation(ConnectFedPayload { invite_code })
+                    .await?;
+
+                print_response(response);
+            }
+            Self::LeaveFed { federation_id } => {
+                let response = create_client()
+                    .leave_federation(LeaveFedPayload { federation_id })
+                    .await?;
+                print_response(response);
+            }
+            Self::Backup { federation_id } => {
+                create_client()
+                    .backup(BackupPayload { federation_id })
+                    .await?;
+            }
+            Self::Restore { federation_id } => {
+                create_client()
+                    .restore(RestorePayload { federation_id })
+                    .await?;
+            }
+            Self::SetConfiguration {
+                password,
+                num_route_hints,
+                routing_fees,
+                network,
+                per_federation_routing_fees,
+            } => {
+                let per_federation_routing_fees = per_federation_routing_fees
+                    .map(|input| input.into_iter().map(Into::into).collect());
+                create_client()
+                    .set_configuration(SetConfigurationPayload {
+                        password,
+                        num_route_hints,
+                        routing_fees,
+                        network,
+                        per_federation_routing_fees,
+                    })
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/gateway/cli/src/lightning_commands.rs
+++ b/gateway/cli/src/lightning_commands.rs
@@ -1,0 +1,132 @@
+use std::time::Duration;
+
+use clap::Subcommand;
+use fedimint_core::util::{backoff_util, retry};
+use ln_gateway::rpc::rpc_client::GatewayRpcClient;
+use ln_gateway::rpc::{CloseChannelsWithPeerPayload, GetFundingAddressPayload, OpenChannelPayload};
+
+use crate::print_response;
+
+const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES: u32 = 60;
+const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS: u64 = 2;
+
+/// This API is intentionally kept very minimal, as its main purpose is to
+/// provide a simple and consistent way to establish liquidity between gateways
+/// in a test environment.
+#[derive(Subcommand)]
+pub enum LightningCommands {
+    /// Get a Bitcoin address to fund the gateway.
+    GetFundingAddress,
+    /// Open a channel with another lightning node.
+    OpenChannel {
+        /// The public key of the node to open a channel with
+        #[clap(long)]
+        pubkey: bitcoin::secp256k1::PublicKey,
+
+        #[clap(long)]
+        host: String,
+
+        /// The amount to fund the channel with
+        #[clap(long)]
+        channel_size_sats: u64,
+
+        /// The amount to push to the other side of the channel
+        #[clap(long)]
+        push_amount_sats: Option<u64>,
+    },
+    /// Close all channels with a peer, claiming the funds to the lightning
+    /// node's on-chain wallet.
+    CloseChannelsWithPeer {
+        // The public key of the node to close channels with
+        #[clap(long)]
+        pubkey: bitcoin::secp256k1::PublicKey,
+    },
+    /// List active channels.
+    ListActiveChannels,
+    /// Wait for the lightning node to be synced with the blockchain.
+    WaitForChainSync {
+        /// The block height to wait for
+        #[clap(long)]
+        block_height: u32,
+
+        /// The maximum number of retries
+        #[clap(long)]
+        max_retries: Option<u32>,
+
+        /// The delay between retries
+        #[clap(long)]
+        retry_delay_seconds: Option<u64>,
+    },
+}
+
+impl LightningCommands {
+    pub async fn handle(
+        self,
+        create_client: impl Fn() -> GatewayRpcClient + Send + Sync,
+    ) -> anyhow::Result<()> {
+        match self {
+            Self::GetFundingAddress => {
+                let response = create_client()
+                    .get_funding_address(GetFundingAddressPayload {})
+                    .await?
+                    .assume_checked();
+                println!("{response}");
+            }
+            Self::OpenChannel {
+                pubkey,
+                host,
+                channel_size_sats,
+                push_amount_sats,
+            } => {
+                create_client()
+                    .open_channel(OpenChannelPayload {
+                        pubkey,
+                        host,
+                        channel_size_sats,
+                        push_amount_sats: push_amount_sats.unwrap_or(0),
+                    })
+                    .await?;
+            }
+            Self::CloseChannelsWithPeer { pubkey } => {
+                let response = create_client()
+                    .close_channels_with_peer(CloseChannelsWithPeerPayload { pubkey })
+                    .await?;
+                print_response(response);
+            }
+            Self::ListActiveChannels => {
+                let response = create_client().list_active_channels().await?;
+                print_response(response);
+            }
+            Self::WaitForChainSync {
+                block_height,
+                max_retries,
+                retry_delay_seconds,
+            } => {
+                let retry_duration = Duration::from_secs(
+                    retry_delay_seconds.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS),
+                );
+
+                retry(
+                    "Wait for chain sync",
+                    backoff_util::custom_backoff(
+                        retry_duration,
+                        retry_duration,
+                        Some(max_retries.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES) as usize),
+                    ),
+                    || async {
+                        let info = create_client().get_info().await?;
+                        if info.block_height.unwrap_or(0) >= block_height && info.synced_to_chain {
+                            Ok(())
+                        } else {
+                            Err(anyhow::anyhow!("Not synced yet"))
+                        }
+                    },
+                )
+                .await
+                .map_err(|_| anyhow::anyhow!("Timed out waiting for chain sync"))?;
+            }
+        };
+
+        Ok(())
+    }
+}

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -1,28 +1,16 @@
-#![warn(clippy::pedantic)]
-#![allow(clippy::doc_markdown)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::too_many_lines)]
+#![warn(clippy::pedantic, clippy::nursery)]
 
-use std::time::Duration;
+mod general_commands;
+mod lightning_commands;
 
-use anyhow::bail;
-use bitcoin::address::NetworkUnchecked;
-use bitcoin::Address;
 use clap::{CommandFactory, Parser, Subcommand};
-use fedimint_core::config::FederationId;
-use fedimint_core::util::{backoff_util, retry, SafeUrl};
-use fedimint_core::{fedimint_build_code_version_env, BitcoinAmountOrAll};
+use fedimint_core::util::SafeUrl;
 use fedimint_logging::TracingSetup;
+use general_commands::GeneralCommands;
+use lightning_commands::LightningCommands;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
-use ln_gateway::rpc::{
-    BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConfigPayload, ConnectFedPayload,
-    DepositAddressPayload, FederationRoutingFees, GetFundingAddressPayload, LeaveFedPayload,
-    OpenChannelPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload, V1_API_ENDPOINT,
-};
+use ln_gateway::rpc::V1_API_ENDPOINT;
 use serde::Serialize;
-
-const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES: u32 = 60;
-const DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS: u64 = 2;
 
 #[derive(Parser)]
 #[command(version)]
@@ -38,158 +26,14 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
-pub enum Commands {
-    /// Display CLI version hash
-    VersionHash,
-    /// Display high-level information about the Gateway
-    Info,
-    /// Display config information about the Gateways federation
-    Config {
-        #[clap(long)]
-        federation_id: Option<FederationId>,
-    },
-    /// Check gateway balance
-    Balance {
-        #[clap(long)]
-        federation_id: FederationId,
-    },
-    /// Generate a new peg-in address, funds sent to it can later be claimed
-    Address {
-        #[clap(long)]
-        federation_id: FederationId,
-    },
-    /// Claim funds from a gateway federation
-    Withdraw {
-        #[clap(long)]
-        federation_id: FederationId,
-        /// The amount to withdraw
-        #[clap(long)]
-        amount: BitcoinAmountOrAll,
-        /// The address to send the funds to
-        #[clap(long)]
-        address: Address<NetworkUnchecked>,
-    },
-    /// Register federation with the gateway
-    ConnectFed {
-        /// InviteCode code to connect to the federation
-        invite_code: String,
-    },
-    /// Leave a federation
-    LeaveFed {
-        #[clap(long)]
-        federation_id: FederationId,
-    },
-    /// Make a backup of snapshot of all ecash
-    Backup {
-        #[clap(long)]
-        federation_id: FederationId,
-    },
-    /// Restore ecash from last available snapshot or from scratch
-    Restore {
-        #[clap(long)]
-        federation_id: FederationId,
-    },
+enum Commands {
+    #[command(flatten)]
+    General(GeneralCommands),
+    #[command(subcommand)]
+    Lightning(LightningCommands),
     Completion {
         shell: clap_complete::Shell,
     },
-    SetConfiguration {
-        #[clap(long)]
-        password: Option<String>,
-
-        #[clap(long)]
-        num_route_hints: Option<u32>,
-
-        /// Default routing fee for all new federations. Setting it won't affect
-        /// existing federations
-        #[clap(long)]
-        routing_fees: Option<FederationRoutingFees>,
-
-        #[clap(long)]
-        network: Option<bitcoin::Network>,
-
-        /// Format federation id,base msat,proportional to millionths part. Any
-        /// other federations not given here will keep their current fees.
-        #[clap(long)]
-        per_federation_routing_fees: Option<Vec<PerFederationRoutingFees>>,
-    },
-    #[command(subcommand)]
-    Lightning(LightningCommands),
-}
-
-/// This API is intentionally kept very minimal, as its main purpose is to
-/// provide a simple and consistent way to establish liquidity between gateways
-/// in a test environment.
-#[derive(Subcommand)]
-pub enum LightningCommands {
-    /// Get a Bitcoin address to fund the gateway
-    GetFundingAddress,
-    /// Open a channel with another lightning node
-    OpenChannel {
-        /// The public key of the node to open a channel with
-        #[clap(long)]
-        pubkey: bitcoin::secp256k1::PublicKey,
-
-        #[clap(long)]
-        host: String,
-
-        /// The amount to fund the channel with
-        #[clap(long)]
-        channel_size_sats: u64,
-
-        /// The amount to push to the other side of the channel
-        #[clap(long)]
-        push_amount_sats: Option<u64>,
-    },
-    /// Close all channels with a peer, claiming the funds to the lightning
-    /// node's on-chain wallet
-    CloseChannelsWithPeer {
-        // The public key of the node to close channels with
-        #[clap(long)]
-        pubkey: bitcoin::secp256k1::PublicKey,
-    },
-    /// List active channels
-    ListActiveChannels,
-    /// Wait for the lightning node to be synced with the blockchain
-    WaitForChainSync {
-        /// The block height to wait for
-        #[clap(long)]
-        block_height: u32,
-
-        /// The maximum number of retries
-        #[clap(long)]
-        max_retries: Option<u32>,
-
-        /// The delay between retries
-        #[clap(long)]
-        retry_delay_seconds: Option<u64>,
-    },
-}
-
-#[derive(Clone)]
-pub struct PerFederationRoutingFees {
-    pub federation_id: FederationId,
-    pub routing_fees: FederationRoutingFees,
-}
-
-impl std::str::FromStr for PerFederationRoutingFees {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some((federation_id, rounting_fees)) = s.split_once(',') {
-            Ok(PerFederationRoutingFees {
-                federation_id: federation_id.parse()?,
-                routing_fees: rounting_fees.parse()?,
-            })
-        } else {
-            bail!("Wrong format, please provide: <federation id>,<base msat>,<proportional to millionths part>");
-        }
-    }
-}
-
-impl From<PerFederationRoutingFees> for (FederationId, FederationRoutingFees) {
-    fn from(val: PerFederationRoutingFees) -> Self {
-        (val.federation_id, val.routing_fees)
-    }
 }
 
 #[tokio::main]
@@ -198,77 +42,11 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
     let versioned_api = cli.address.join(V1_API_ENDPOINT)?;
-    let client = || GatewayRpcClient::new(versioned_api.clone(), cli.rpcpassword.clone());
+    let create_client = || GatewayRpcClient::new(versioned_api.clone(), cli.rpcpassword.clone());
 
     match cli.command {
-        Commands::VersionHash => {
-            println!("{}", fedimint_build_code_version_env!());
-        }
-        Commands::Info => {
-            // For backwards-compatibility, fallback to the original POST endpoint if the
-            // GET endpoint fails
-            // FIXME: deprecated >= 0.3.0
-            let response = match client().get_info().await {
-                Ok(res) => res,
-                Err(_) => client().get_info_legacy().await?,
-            };
-
-            print_response(response);
-        }
-
-        Commands::Config { federation_id } => {
-            let response = client().get_config(ConfigPayload { federation_id }).await?;
-
-            print_response(response);
-        }
-        Commands::Balance { federation_id } => {
-            let response = client()
-                .get_balance(BalancePayload { federation_id })
-                .await?;
-
-            print_response(response);
-        }
-        Commands::Address { federation_id } => {
-            let response = client()
-                .get_deposit_address(DepositAddressPayload { federation_id })
-                .await?;
-
-            print_response(response);
-        }
-        Commands::Withdraw {
-            federation_id,
-            amount,
-            address,
-        } => {
-            let response = client()
-                .withdraw(WithdrawPayload {
-                    federation_id,
-                    amount,
-                    address,
-                })
-                .await?;
-
-            print_response(response);
-        }
-        Commands::ConnectFed { invite_code } => {
-            let response = client()
-                .connect_federation(ConnectFedPayload { invite_code })
-                .await?;
-
-            print_response(response);
-        }
-        Commands::LeaveFed { federation_id } => {
-            let response = client()
-                .leave_federation(LeaveFedPayload { federation_id })
-                .await?;
-            print_response(response);
-        }
-        Commands::Backup { federation_id } => {
-            client().backup(BackupPayload { federation_id }).await?;
-        }
-        Commands::Restore { federation_id } => {
-            client().restore(RestorePayload { federation_id }).await?;
-        }
+        Commands::General(general_command) => general_command.handle(create_client).await?,
+        Commands::Lightning(lightning_command) => lightning_command.handle(create_client).await?,
         Commands::Completion { shell } => {
             clap_complete::generate(
                 shell,
@@ -277,94 +55,12 @@ async fn main() -> anyhow::Result<()> {
                 &mut std::io::stdout(),
             );
         }
-        Commands::SetConfiguration {
-            password,
-            num_route_hints,
-            routing_fees,
-            network,
-            per_federation_routing_fees,
-        } => {
-            let per_federation_routing_fees = per_federation_routing_fees
-                .map(|input| input.into_iter().map(Into::into).collect());
-            client()
-                .set_configuration(SetConfigurationPayload {
-                    password,
-                    num_route_hints,
-                    routing_fees,
-                    network,
-                    per_federation_routing_fees,
-                })
-                .await?;
-        }
-
-        Commands::Lightning(lightning_command) => match lightning_command {
-            LightningCommands::GetFundingAddress => {
-                let response = client()
-                    .get_funding_address(GetFundingAddressPayload {})
-                    .await?
-                    .assume_checked();
-                println!("{response}");
-            }
-            LightningCommands::OpenChannel {
-                pubkey,
-                host,
-                channel_size_sats,
-                push_amount_sats,
-            } => {
-                client()
-                    .open_channel(OpenChannelPayload {
-                        pubkey,
-                        host,
-                        channel_size_sats,
-                        push_amount_sats: push_amount_sats.unwrap_or(0),
-                    })
-                    .await?;
-            }
-            LightningCommands::CloseChannelsWithPeer { pubkey } => {
-                let response = client()
-                    .close_channels_with_peer(CloseChannelsWithPeerPayload { pubkey })
-                    .await?;
-                print_response(response);
-            }
-            LightningCommands::ListActiveChannels => {
-                let response = client().list_active_channels().await?;
-                print_response(response);
-            }
-            LightningCommands::WaitForChainSync {
-                block_height,
-                max_retries,
-                retry_delay_seconds,
-            } => {
-                let retry_duration = Duration::from_secs(
-                    retry_delay_seconds.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS),
-                );
-
-                retry(
-                    "Wait for chain sync",
-                    backoff_util::custom_backoff(
-                        retry_duration,
-                        retry_duration,
-                        Some(max_retries.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRIES) as usize),
-                    ),
-                    || async {
-                        let info = client().get_info().await?;
-                        if info.block_height.unwrap_or(0) >= block_height && info.synced_to_chain {
-                            Ok(())
-                        } else {
-                            Err(anyhow::anyhow!("Not synced yet"))
-                        }
-                    },
-                )
-                .await
-                .map_err(|_| anyhow::anyhow!("Timed out waiting for chain sync"))?;
-            }
-        },
     }
 
     Ok(())
 }
 
-pub fn print_response<T: Serialize>(val: T) {
+fn print_response<T: Serialize>(val: T) {
     println!(
         "{}",
         serde_json::to_string_pretty(&val).expect("Cannot serialize")


### PR DESCRIPTION
With the addition of the lightning liquidity API, the current structure of the gateway CLI is becoming a bit unwieldy. In this PR, we're splitting the CLI commands into two groups: lightning commands (i.e. the liquidity API) and general commands. Each lives in its own file, along with its handling logic. The `General(GeneralCommands)` enum variant of `Commands` is annotated with `#[command(flatten)]` which prevents any behavior change (so, for example, `gateway-cli info` is not changed to `gateway-cli general info`).