### PR TITLE
[Backport releases/v0.4] fix(devimint): `devimint devfed` does not block

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -315,6 +315,9 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                         task_group.shutdown();
                     }
 
+                    debug!(target: LOG_DEVIMINT, "Waiting for group task shutdown");
+                    task_group.make_handle().make_shutdown_rx().await;
+
                     Ok::<_, anyhow::Error>(daemons)
                 }
             };


### PR DESCRIPTION
# Description
Backport of #5637 to `releases/v0.4`.