### PR TITLE
fix: LNv2 Lightning Fixes for Cancel Payment/HTLC

### DIFF
--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -743,9 +743,8 @@ impl GatewayLightning for ClnRpcService {
                     }
                 }
                 Some(Action::Cancel(Cancel { reason: _ })) => {
-                    // TODO: Translate the reason into a BOLT 4 failure message
-                    // See: https://github.com/lightning/bolts/blob/master/04-onion-routing.md#failure-messages
-                    htlc_processing_failure()
+                    // Simply forward the HTLC so that a "NoRoute" error response is returned.
+                    serde_json::json!({ "result": "continue" })
                 }
                 Some(Action::Forward(Forward {})) => {
                     serde_json::json!({ "result": "continue" })

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -608,14 +608,7 @@ impl GatewayLndClient {
 
         let state = invoice.state();
         if state != InvoiceState::Open {
-            error!(
-                ?state,
-                "HOLD invoice state is not accepted {}",
-                PrettyPaymentHash(&payment_hash)
-            );
-            return Err(LightningRpcError::FailedToCompleteHtlc {
-                failure_reason: "HOLD invoice state is not accepted".to_string(),
-            });
+            warn!(?state, "Trying to cancel HOLD invoice with {} that is not OPEN, gateway likely encountered an issue", PrettyPaymentHash(&payment_hash));
         }
 
         client


### PR DESCRIPTION
LNv2 exposed 2 separate problems with our lightning implementations when cancelling a HTLC (in v2 context, it is a "payment", not an HTLC).

CLN: Previously, we never canceled HTLCs, we only forwarded them when something would go wrong, which would cause the `FailureNoRoute` response to happen. Previously, if we canceled an HTLC, we actually returned an HTLC processing failure, which crashes the extension. This PR fixes this by just forwarding payments when `Cancel` is received, which will have the affect that we want (i.e failing the payment, but the extension will not crash). When V1 is removed, we can remove the forwarding option altogether and simply rely on `Cancel` now.

LND: There was a small bug in `cancel_hold_invoice`, where it refuses to cancel a invoice that is not in the open state. In some cases, like a liquidity issue with the gateway, we actually do want to cancel hold invoices, even if they're in the accepted state (since the gateway will not be able to acquire the preimage). This PR updates LND to just emit a warning.

A test has been added to cover both of these cases.
