### PR TITLE
chore: lnd gateway impl handles network naming mismatch

### DIFF
--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -194,14 +194,7 @@ impl dyn ILnRpcClient {
         } = self.info().await?;
         let node_pub_key = PublicKey::from_slice(&pub_key)
             .map_err(|e| GatewayError::InvalidMetadata(format!("Invalid node pubkey {e}")))?;
-        // TODO: create a fedimint Network that understands "mainnet"
-        let network = match network.as_str() {
-            // LND uses "mainnet", but rust-bitcoin uses "bitcoin".
-            // TODO(tvolk131): Push this detail down into the LND implementation of ILnRpcClient.
-            "mainnet" => "bitcoin",
-            other => other,
-        };
-        let network = Network::from_str(network).map_err(|e| {
+        let network = Network::from_str(&network).map_err(|e| {
             GatewayError::InvalidMetadata(format!("Invalid network {network}: {e}"))
         })?;
         Ok((node_pub_key, alias, network, block_height, synced_to_chain))


### PR DESCRIPTION
The `network` field of the `GetNodeInfoResponse` proto message states the following:

https://github.com/fedimint/fedimint/blob/0c7b40da7777311c95000fdac24fd77cfa730a21/gateway/ln-gateway/proto/gateway_lnrpc.proto#L67-L68

In this PR, we ensure that LND's implementation of `ILnRpcClient::info` adheres to the specified valid values constraint above.