### PR TITLE
[Backport releases/v0.4] chore: always include invite code in oob ecash

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -87,10 +87,6 @@ pub enum ClientCmd {
         /// hasn't been redeemed by the recipient. Defaults to one week.
         #[clap(long, default_value_t = 60 * 60 * 24 * 7)]
         timeout: u64,
-        /// If the necessary information to join the federation the e-cash
-        /// belongs to should be included in the serialized notes
-        #[clap(long)]
-        include_invite: bool,
     },
     /// Verifies the signatures of e-cash notes, but *not* if they have been
     /// spent already
@@ -229,7 +225,6 @@ pub async fn handle_command(
             amount,
             allow_overpay,
             timeout,
-            include_invite: _,
         } => {
             warn!("The client will try to double-spend these notes after the duration specified by the --timeout option to recover any unclaimed e-cash.");
 

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -229,7 +229,7 @@ pub async fn handle_command(
             amount,
             allow_overpay,
             timeout,
-            include_invite,
+            include_invite: _,
         } => {
             warn!("The client will try to double-spend these notes after the duration specified by the --timeout option to recover any unclaimed e-cash.");
 
@@ -237,13 +237,7 @@ pub async fn handle_command(
             let timeout = Duration::from_secs(timeout);
             let (operation, notes) = if allow_overpay {
                 let (operation, notes) = mint_module
-                    .spend_notes_with_selector(
-                        &SelectNotesWithAtleastAmount,
-                        amount,
-                        timeout,
-                        include_invite,
-                        (),
-                    )
+                    .spend_notes_with_selector(&SelectNotesWithAtleastAmount, amount, timeout, ())
                     .await?;
 
                 let overspend_amount = notes.total_amount() - amount;
@@ -257,13 +251,7 @@ pub async fn handle_command(
                 (operation, notes)
             } else {
                 mint_module
-                    .spend_notes_with_selector(
-                        &SelectNotesWithExactAmount,
-                        amount,
-                        timeout,
-                        include_invite,
-                        (),
-                    )
+                    .spend_notes_with_selector(&SelectNotesWithExactAmount, amount, timeout, ())
                     .await?
             };
             info!("Spend e-cash operation: {}", operation.fmt_short());

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -90,7 +90,7 @@ pub async fn do_spend_notes(
 ) -> anyhow::Result<(OperationId, OOBNotes)> {
     let mint = &mint.get_first_module::<MintClientModule>();
     let (operation_id, oob_notes) = mint
-        .spend_notes(amount, Duration::from_secs(600), false, ())
+        .spend_notes(amount, Duration::from_secs(600), ())
         .await?;
     let mut updates = mint
         .subscribe_spend_notes(operation_id)

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -256,7 +256,7 @@ mod tests {
     ) -> Result<(), anyhow::Error> {
         let mint = client.get_first_module::<MintClientModule>();
         let (_, notes) = mint
-            .spend_notes(Amount::from_sats(11), Duration::from_secs(10000), false, ())
+            .spend_notes(Amount::from_sats(11), Duration::from_secs(10000), ())
             .await?;
         let operation_id = mint.reissue_external_notes(notes, ()).await?;
         let mut updates = mint
@@ -285,7 +285,7 @@ mod tests {
         let mint = client.get_first_module::<MintClientModule>();
         'retry: loop {
             let (operation_id, notes) = mint
-                .spend_notes(amount, Duration::from_secs(10000), false, ())
+                .spend_notes(amount, Duration::from_secs(10000), ())
                 .await?;
             if notes.total_amount() == amount {
                 return Ok(());

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -874,8 +874,6 @@ struct SubscribeReissueExternalNotesRequest {
 struct SpendNotesRequest {
     min_amount: Amount,
     try_cancel_after: Duration,
-    #[allow(dead_code)]
-    include_invite: bool,
     extra_meta: serde_json::Value,
 }
 

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -825,7 +825,7 @@ impl ClientModule for MintClientModule {
                 }
                 "spend_notes" => {
                     let req: SpendNotesRequest = serde_json::from_value(request)?;
-                    let result = self.spend_notes(req.min_amount, req.try_cancel_after, req.include_invite, req.extra_meta).await?;
+                    let result = self.spend_notes(req.min_amount, req.try_cancel_after, req.extra_meta).await?;
                     yield serde_json::to_value(result)?;
                 }
                 "validate_notes" => {
@@ -874,6 +874,7 @@ struct SubscribeReissueExternalNotesRequest {
 struct SpendNotesRequest {
     min_amount: Amount,
     try_cancel_after: Duration,
+    #[allow(dead_code)]
     include_invite: bool,
     extra_meta: serde_json::Value,
 }
@@ -1518,14 +1519,12 @@ impl MintClientModule {
         &self,
         min_amount: Amount,
         try_cancel_after: Duration,
-        include_invite: bool,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, OOBNotes)> {
         self.spend_notes_with_selector(
             &SelectNotesWithAtleastAmount,
             min_amount,
             try_cancel_after,
-            include_invite,
             extra_meta,
         )
         .await
@@ -1537,10 +1536,8 @@ impl MintClientModule {
         notes_selector: &impl NotesSelector,
         requested_amount: Amount,
         try_cancel_after: Duration,
-        include_invite: bool,
         extra_meta: M,
     ) -> anyhow::Result<(OperationId, OOBNotes)> {
-        let federation_id_prefix = self.federation_id.to_prefix();
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientModule::spend_notes extra_meta is serializable");
 
@@ -1558,14 +1555,10 @@ impl MintClientModule {
                             )
                             .await?;
 
-                        let oob_notes = if include_invite {
-                            OOBNotes::new_with_invite(
-                                notes,
-                                &self.client_ctx.get_invite_code().await,
-                            )
-                        } else {
-                            OOBNotes::new(federation_id_prefix, notes)
-                        };
+                        let oob_notes = OOBNotes::new_with_invite(
+                            notes,
+                            &self.client_ctx.get_invite_code().await,
+                        );
 
                         dbtx.add_state_machines(self.client_ctx.map_dyn(states).collect())
                             .await?;

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -59,9 +59,7 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     let client1_mint = client1.get_first_module::<MintClientModule>();
     let client2_mint = client2.get_first_module::<MintClientModule>();
     info!("### SPEND NOTES");
-    let (op, notes) = client1_mint
-        .spend_notes(sats(750), TIMEOUT, false, ())
-        .await?;
+    let (op, notes) = client1_mint.spend_notes(sats(750), TIMEOUT, ()).await?;
     let sub1 = &mut client1_mint.subscribe_spend_notes(op).await?.into_stream();
     assert_eq!(sub1.ok().await?, SpendOOBState::Created);
 
@@ -112,7 +110,7 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
                 info!("Starting spend {num_spend}");
                 let client1_mint = task_client1.get_first_module::<MintClientModule>();
                 let (op, notes) = client1_mint
-                    .spend_notes(sats(30), ECASH_TIMEOUT, false, ())
+                    .spend_notes(sats(30), ECASH_TIMEOUT, ())
                     .await
                     .unwrap();
                 let sub1 = &mut client1_mint
@@ -236,9 +234,7 @@ async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
 
     // Spend from client1 to client2
     let mint_module = client.get_first_module::<MintClientModule>();
-    let (op, _) = mint_module
-        .spend_notes(sats(750), TIMEOUT, false, ())
-        .await?;
+    let (op, _) = mint_module.spend_notes(sats(750), TIMEOUT, ()).await?;
     let sub1 = &mut mint_module.subscribe_spend_notes(op).await?.into_stream();
     assert_eq!(sub1.ok().await?, SpendOOBState::Created);
 
@@ -274,7 +270,7 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
     // Spend from client1 to client2
     let err_msg = client1
         .get_first_module::<MintClientModule>()
-        .spend_notes(Amount::ZERO, TIMEOUT, false, ())
+        .spend_notes(Amount::ZERO, TIMEOUT, ())
         .await
         .expect_err("Zero-amount spends should be forbidden")
         .to_string();


### PR DESCRIPTION
# Description
Backport of #5655 to `releases/v0.4`.