### PR TITLE
Remove multi mint payments from lnv2 to enable ldk gateways

### DIFF
--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -13,13 +13,12 @@ use fedimint_core::{secp256k1, Amount};
 use fedimint_ln_common::PrunedInvoice;
 use fedimint_logging::LOG_TEST;
 use lightning_invoice::{
-    Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, SignedRawBolt11Invoice,
-    DEFAULT_EXPIRY_TIME,
+    Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, DEFAULT_EXPIRY_TIME,
 };
 use ln_gateway::gateway_lnrpc::{
     self, CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse,
     EmptyResponse, GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse,
-    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
+    InterceptHtlcResponse, PayInvoiceResponse,
 };
 use ln_gateway::lightning::{
     ChannelInfo, HtlcResult, ILnRpcClient, LightningRpcError, RouteHtlcStream,
@@ -141,10 +140,10 @@ impl ILnRpcClient for FakeLightningTest {
 
     async fn pay(
         &self,
-        invoice: PayInvoiceRequest,
+        invoice: Bolt11Invoice,
+        _max_delay: u64,
+        _max_fee: Amount,
     ) -> Result<PayInvoiceResponse, LightningRpcError> {
-        let signed = invoice.invoice.parse::<SignedRawBolt11Invoice>().unwrap();
-        let invoice = Bolt11Invoice::from_signed(signed).unwrap();
         self.amount_sent
             .fetch_add(invoice.amount_milli_satoshis().unwrap(), Ordering::Relaxed);
 

--- a/gateway/ln-gateway/src/lightning/cln.rs
+++ b/gateway/ln-gateway/src/lightning/cln.rs
@@ -18,7 +18,7 @@ use crate::gateway_lnrpc::{
     self, CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
     CreateInvoiceResponse, EmptyRequest, EmptyResponse, GetFundingAddressResponse,
     GetNodeInfoResponse, GetRouteHintsRequest, GetRouteHintsResponse, InterceptHtlcResponse,
-    OpenChannelRequest, PayInvoiceRequest, PayInvoiceResponse, PayPrunedInvoiceRequest,
+    OpenChannelRequest, PayInvoiceResponse, PayPrunedInvoiceRequest,
 };
 use crate::lightning::MAX_LIGHTNING_RETRIES;
 
@@ -91,22 +91,6 @@ impl ILnRpcClient for NetworkLnRpcClient {
                 failure_reason: status.message().to_string(),
             }
         })?;
-        Ok(res.into_inner())
-    }
-
-    async fn pay(
-        &self,
-        invoice: PayInvoiceRequest,
-    ) -> Result<PayInvoiceResponse, LightningRpcError> {
-        let req = Request::new(invoice);
-        let mut client = self.connect().await?;
-        let res =
-            client
-                .pay_invoice(req)
-                .await
-                .map_err(|status| LightningRpcError::FailedPayment {
-                    failure_reason: status.message().to_string(),
-                })?;
         Ok(res.into_inner())
     }
 

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -46,7 +46,7 @@ use crate::gateway_lnrpc::intercept_htlc_response::{Action, Cancel, Forward, Set
 use crate::gateway_lnrpc::{
     CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse,
     GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
-    InterceptHtlcResponse, PayInvoiceRequest, PayInvoiceResponse,
+    InterceptHtlcResponse, PayInvoiceResponse,
 };
 type HtlcSubscriptionSender = mpsc::Sender<Result<InterceptHtlcRequest, Status>>;
 
@@ -742,20 +742,6 @@ impl ILnRpcClient for GatewayLndClient {
         }
 
         Ok(GetRouteHintsResponse { route_hints })
-    }
-
-    async fn pay(
-        &self,
-        request: PayInvoiceRequest,
-    ) -> Result<PayInvoiceResponse, LightningRpcError> {
-        error!(
-            "LND supports private payments, legacy `pay` should not be used. {}",
-            PrettyPaymentHash(&request.payment_hash)
-        );
-        Err(LightningRpcError::FailedPayment {
-            failure_reason: "LND supports private payments, legacy `pay` should not be used."
-                .to_string(),
-        })
     }
 
     async fn pay_private(

--- a/modules/fedimint-lnv2-tests/tests/mock.rs
+++ b/modules/fedimint-lnv2-tests/tests/mock.rs
@@ -123,7 +123,7 @@ impl GatewayConnection for MockGatewayConnection {
         _auth: Signature,
     ) -> anyhow::Result<Result<Result<[u8; 32], Signature>, String>> {
         match invoice {
-            LightningInvoice::Bolt11(invoice, _) => {
+            LightningInvoice::Bolt11(invoice) => {
                 if *invoice.payment_secret() == PaymentSecret(GATEWAY_CRASH_PAYMENT_SECRET) {
                     bail!("Failed to connect to gateway");
                 }


### PR DESCRIPTION
lnv2 multi mint payment support blocks the ldk gateway pr as discussed there: https://github.com/fedimint/fedimint/pull/5554

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
