### PR TITLE
cleanup: use ecdh::SharedSecret instead of manually hashing the share…

### DIFF
--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -338,13 +338,11 @@ impl ClientModule for LightningClientModule {
 }
 
 fn generate_ephemeral_tweak(static_pk: PublicKey) -> ([u8; 32], PublicKey) {
-    let ephemeral_keypair = KeyPair::new(secp256k1::SECP256K1, &mut rand::thread_rng());
+    let keypair = KeyPair::new(secp256k1::SECP256K1, &mut rand::thread_rng());
 
-    let ephemeral_tweak = ecdh::shared_secret_point(&static_pk, &ephemeral_keypair.secret_key())
-        .consensus_hash::<sha256::Hash>()
-        .to_byte_array();
+    let tweak = ecdh::SharedSecret::new(&static_pk, &keypair.secret_key());
 
-    (ephemeral_tweak, ephemeral_keypair.public_key())
+    (tweak.secret_bytes(), keypair.public_key())
 }
 
 impl LightningClientModule {
@@ -771,12 +769,11 @@ impl LightningClientModule {
         &self,
         contract: &IncomingContract,
     ) -> Option<(KeyPair, AggregateDecryptionKey)> {
-        let ephemeral_tweak = ecdh::shared_secret_point(
+        let ephemeral_tweak = ecdh::SharedSecret::new(
             &contract.commitment.ephemeral_pk,
             &self.keypair.secret_key(),
         )
-        .consensus_hash::<sha256::Hash>()
-        .to_byte_array();
+        .secret_bytes();
 
         let encryption_seed = ephemeral_tweak
             .consensus_hash::<sha256::Hash>()


### PR DESCRIPTION
…d point

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
