### PR TITLE
chore: liquidity api uses bytes for pubkey

### DIFF
--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -59,6 +59,7 @@ message GetRouteHintsRequest {
 
 message GetNodeInfoResponse {
   // The public key of the associated lightning node
+  // TODO: Rename this to `pubkey` to match the rest of the API.
   bytes pub_key = 1;
 
   // The alias of the lightning node
@@ -267,7 +268,7 @@ message GetFundingAddressResponse {
 
 message OpenChannelRequest {
   // The public key of the node we're opening a channel to.
-  string pubkey = 1;
+  bytes pubkey = 1;
 
   // The host address of the node we're connecting to.
   string host = 4;
@@ -293,7 +294,7 @@ message CloseChannelsWithPeerResponse {
 message ListActiveChannelsResponse {
   message ChannelInfo {
     // The pubkey of the lightning node that the channel is open with.
-    string remote_pubkey = 1;
+    bytes remote_pubkey = 1;
 
     // The total capacity of the channel, in sats.
     uint64 channel_size_sats = 2;

--- a/gateway/ln-gateway/src/lightning/cln.rs
+++ b/gateway/ln-gateway/src/lightning/cln.rs
@@ -191,7 +191,7 @@ impl ILnRpcClient for NetworkLnRpcClient {
 
         let res = client
             .open_channel(OpenChannelRequest {
-                pubkey: pubkey.to_string(),
+                pubkey: pubkey.serialize().to_vec(),
                 host,
                 channel_size_sats,
                 push_amount_sats,
@@ -232,7 +232,8 @@ impl ILnRpcClient for NetworkLnRpcClient {
             .channels
             .into_iter()
             .map(|channel| ChannelInfo {
-                remote_pubkey: channel.remote_pubkey,
+                remote_pubkey: secp256k1::PublicKey::from_slice(&channel.remote_pubkey)
+                    .expect("Lightning node returned invalid remote channel pubkey"),
                 channel_size_sats: channel.channel_size_sats,
                 outbound_liquidity_sats: channel.outbound_liquidity_sats,
                 inbound_liquidity_sats: channel.inbound_liquidity_sats,

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -477,7 +477,7 @@ impl ILnRpcClient for GatewayLdkClient {
             .filter(|channel| channel.is_channel_ready)
         {
             channels.push(ChannelInfo {
-                remote_pubkey: channel_details.counterparty_node_id.to_string(),
+                remote_pubkey: channel_details.counterparty_node_id,
                 channel_size_sats: channel_details.channel_value_sats,
                 outbound_liquidity_sats: channel_details.outbound_capacity_msat / 1000,
                 inbound_liquidity_sats: channel_details.inbound_capacity_msat / 1000,

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -1244,7 +1244,8 @@ impl ILnRpcClient for GatewayLndClient {
                         };
 
                     ChannelInfo {
-                        remote_pubkey: channel.remote_pubkey,
+                        remote_pubkey: PublicKey::from_str(&channel.remote_pubkey)
+                            .expect("Lightning node returned invalid remote channel pubkey"),
                         channel_size_sats,
                         outbound_liquidity_sats,
                         inbound_liquidity_sats,

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -218,7 +218,7 @@ impl dyn ILnRpcClient {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ChannelInfo {
-    pub remote_pubkey: String,
+    pub remote_pubkey: secp256k1::PublicKey,
     pub channel_size_sats: u64,
     pub outbound_liquidity_sats: u64,
     pub inbound_liquidity_sats: u64,


### PR DESCRIPTION
> Can we use bytes instead of string?

_Originally posted by @m1sterc001guy in https://github.com/fedimint/fedimint/pull/5218#discussion_r1600141463_

When adding `close_channels_with_peer` command to the gateway liquidity API, we decided to use bytes instead of a string for the pubkey. But this was after we already added a few other commands that used strings for the pubkey. Here we're going back and changing those to also use bytes for the pubkey.