### PR TITLE
chore: get_rpc_config no longer ignores bitcoind

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -484,17 +484,8 @@ impl WalletClientModule {
     }
 
     fn get_rpc_config(cfg: &WalletClientConfig) -> BitcoinRpcConfig {
-        if let Ok(rpc_config) = BitcoinRpcConfig::get_defaults_from_env_vars() {
-            // TODO: Wallet client cannot support bitcoind RPC until the bitcoin dep is
-            // updated to 0.30
-            if rpc_config.kind == "bitcoind" {
-                cfg.default_bitcoin_rpc.clone()
-            } else {
-                rpc_config
-            }
-        } else {
-            cfg.default_bitcoin_rpc.clone()
-        }
+        BitcoinRpcConfig::get_defaults_from_env_vars()
+            .unwrap_or_else(|_| cfg.default_bitcoin_rpc.clone())
     }
 
     pub fn get_network(&self) -> Network {


### PR DESCRIPTION
We added this ignoring behavior in #3301 because we needed to upgrade to bitcoin v0.30. That's now done, so we should be able to remove the ignoring behavior now.