### PR TITLE
fix: rm exact version in dev-dependency

### DIFF
--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -72,7 +72,7 @@ url = { version = "2.5.2", features = ["serde"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-fedimint-dummy-client = { version = "=0.4.0-alpha", path = "../../modules/fedimint-dummy-client" }
+fedimint-dummy-client = { path = "../../modules/fedimint-dummy-client" }
 fedimint-dummy-common = { path = "../../modules/fedimint-dummy-common" }
 fedimint-dummy-server = { path = "../../modules/fedimint-dummy-server" }
 fedimint-ln-client = { workspace = true }


### PR DESCRIPTION
This exact version in dev-dependencies causes issues when bumping the version. Removing since it's not necessary.