### PR TITLE
feat: add session count to fedimint-cli

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -189,6 +189,8 @@ pub enum ClientCmd {
     },
     /// Returns the client config
     Config,
+    /// Gets the current fedimint AlephBFT session count
+    SessionCount,
 }
 
 pub async fn handle_command(
@@ -616,6 +618,10 @@ pub async fn handle_command(
         ClientCmd::Config => {
             let config = client.get_config_json().await;
             Ok(serde_json::to_value(config).expect("Client config is serializable"))
+        }
+        ClientCmd::SessionCount => {
+            let count = client.api().session_count().await?;
+            Ok(json!({ "count": count }))
         }
     }
 }


### PR DESCRIPTION
We only expose the session count using the dev commands. This adds session count to `fedimint-cli` so federations can easily get the current session count, which is useful for deciding on an upcoming session count to shutdown after for coordinated upgrades.

This requires backporting to `releases/v0.3` and `releases/v0.4`.

For improved UX, we should also surface the current session count in the admin ui. See: discord [thread](https://discord.com/channels/990354215060795454/990354215878688860/1263173477121130649).

---
```
bash-5.2$ fedimint-cli session-count
{
  "count": 1
}
```