### PR TITLE
[Backport releases/v0.4] docs: update lock-step upgrade docs for 0.4

### DIFF
--- a/docs/RELEASE_NOTES-v0.4.md
+++ b/docs/RELEASE_NOTES-v0.4.md
@@ -1,20 +1,47 @@
 ## Important Fedimint v0.4 Release Notes
 
 This document describes only critically important release notes.
-For all the non-critical release notes, see usual places (like github release pages).
+For all the non-critical release notes, see usual places (like github
+[release pages](https://github.com/fedimint/fedimint/releases)).
 
 ### Lock-step upgrade requirement
+
+**Must be on version >= v0.3.3 to coordinate shutdown**
 
 Upgrading existing Federations that were created using previous (pre v0.4.x)
 versions of `fedimintd` requires stopping all peers at the exact same session count
 (mint's internal consensus height), and switching to new v0.4.x release at the same time,
 before starting them again.
 
+All guardians should be available to coordinate upgrading using an out-of-band communicaitons
+channel, e.g. a group chat. Once all guardians are available, get the latest session count so
+a session in the future can be chosen to coordinate a shutdown.
 
-To schedule stopping your `fedimintd` at specific consensus height you can
-use `fedimin-cli` command:
+Get the current session count using `fedimint-cli`:
 
-**Details to be described in the near feature. Check newer version of this document.**
+```
+fedimint-cli session-count
+```
+
+The minimum time required to complete a session is 3 minutes, so choose a future session that
+will give all guardians enough time to schedule a shutdown after the session count (e.g. 15
+minutes implies 5 sessions after the current session count).
+
+To schedule stopping your `fedimintd` after a specific session count, use the
+`fedimint-cli` command:
+
+```
+fedimint-cli --password <password> --our-id <our_id> admin shutdown <session_count>
+```
+
+Alternatively, the current session count and scheduling a shutdown after session count is
+accessible through the guardian UI. At the bottom of the page are actions in a danger zone
+section. Click on "Schedule Shutdown" and fill in the form to schedule a shutdown after a
+future session count, referencing the current session count in the UI.
+
+Once all guardians have shutdown, every guardian needs to check in the logs that they
+shutdown at the expected session count. Once all guardians have verified, then you can proceed
+to upgrade to the latest version.
 
 ### Acknowledging
 


### PR DESCRIPTION
# Description
Backport of #5667 to `releases/v0.4`.