### PR TITLE
feat: add scheduled_shutdown to FederationStatus

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1017,6 +1017,7 @@ pub struct FederationStatus {
     /// This should always be 0 if everything is okay, so a monitoring tool
     /// should generate an alert if this is not the case.
     pub peers_flagged: u64,
+    pub scheduled_shutdown: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -78,6 +78,7 @@ pub struct ConsensusApi {
     pub force_api_secret: Option<String>,
     /// For sending API events to consensus such as transactions
     pub submission_sender: async_channel::Sender<ConsensusItem>,
+    pub shutdown_receiver: watch::Receiver<Option<u64>>,
     pub shutdown_sender: watch::Sender<Option<u64>>,
     pub connection_status_channels: Arc<RwLock<BTreeMap<PeerId, PeerConnectionStatus>>>,
     pub last_ci_by_peer: Arc<RwLock<BTreeMap<PeerId, u64>>>,
@@ -200,6 +201,7 @@ impl ConsensusApi {
         let peers_connection_status = self.connection_status_channels.read().await.clone();
         let last_ci_by_peer = self.last_ci_by_peer.read().await.clone();
         let session_count = self.session_count().await;
+        let scheduled_shutdown = self.shutdown_receiver.borrow().to_owned();
 
         let status_by_peer = peers_connection_status
             .into_iter()
@@ -238,6 +240,7 @@ impl ConsensusApi {
             peers_online,
             peers_offline,
             peers_flagged,
+            scheduled_shutdown,
         })
     }
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -109,6 +109,7 @@ pub async fn run(
         client_cfg: client_cfg.clone(),
         submission_sender: submission_sender.clone(),
         shutdown_sender,
+        shutdown_receiver: shutdown_receiver.clone(),
         supported_api_versions: ServerConfig::supported_api_versions_summary(
             &cfg.consensus.modules,
             &module_init_registry,


### PR DESCRIPTION
Adds scheduled_shutdown to FederationStatus to surface in UI after someone schedules their shutdown