### PR TITLE
chore: default to 0s when unable to detect git hash version during build

### DIFF
--- a/fedimint-build/src/lib.rs
+++ b/fedimint-build/src/lib.rs
@@ -132,7 +132,8 @@ pub fn set_code_version() {
     match set_code_version_inner() {
         Ok(()) => {}
         Err(e) => {
-            panic!("Failed to detect git hash version: {e}. Set {FORCE_GIT_HASH_ENV} to skip this check")
+            eprintln!("Failed to detect git hash version: {e}. Set {FORCE_GIT_HASH_ENV} to enforce the version and skip auto-detection.");
+            println!("cargo:rustc-env={FEDIMINT_BUILD_CODE_VERSION_ENV}=0000000000000000000000000000000000000000");
         }
     }
 }


### PR DESCRIPTION
During 0.4 release process we've hit a case where we are unable to have auto-detection working, potentially forcing all downstream users to set env vars when building their projects.

Seems like having that git hash version always is not worth the troubles like this for the end users, so let's just default to 0s when all else failed.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
