### PR TITLE
[Backport releases/v0.4] chore: default to 0s when unable to detect git hash version during build

### DIFF
--- a/fedimint-build/src/lib.rs
+++ b/fedimint-build/src/lib.rs
@@ -132,7 +132,8 @@ pub fn set_code_version() {
     match set_code_version_inner() {
         Ok(()) => {}
         Err(e) => {
-            panic!("Failed to detect git hash version: {e}. Set {FORCE_GIT_HASH_ENV} to skip this check")
+            eprintln!("Failed to detect git hash version: {e}. Set {FORCE_GIT_HASH_ENV} to enforce the version and skip auto-detection.");
+            println!("cargo:rustc-env={FEDIMINT_BUILD_CODE_VERSION_ENV}=0000000000000000000000000000000000000000");
         }
     }
 }


### PR DESCRIPTION
# Description
Backport of #5692 to `releases/v0.4`.