### PR TITLE
chore: extend gateway dbtx ext trait

### DIFF
--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -187,9 +187,7 @@ impl DatabaseDump {
     async fn serialize_gateway(&mut self) -> anyhow::Result<()> {
         let mut dbtx = self.read_only.begin_transaction_nc().await;
         let mut dbtx = dbtx.to_ref();
-        let gateway_serialized = Gateway::dump_database(&mut dbtx, self.prefixes.clone())
-            .await
-            .collect::<BTreeMap<String, _>>();
+        let gateway_serialized = Gateway::dump_database(&mut dbtx, self.prefixes.clone()).await;
         self.serialized
             .insert("gateway".to_string(), Box::new(gateway_serialized));
         Ok(())

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -51,6 +51,7 @@ fedimint-rocksdb = { version = "=0.5.0-alpha", path = "../../fedimint-rocksdb" }
 fedimint-wallet-client = { version = "=0.5.0-alpha", path = "../../modules/fedimint-wallet-client" }
 futures = { workspace = true }
 hex = { workspace = true }
+lightning = { workspace = true }
 lightning-invoice = { workspace = true }
 prost = "0.12.6"
 rand = { workspace = true }
@@ -84,7 +85,6 @@ fedimint-testing = { workspace = true }
 fedimint-unknown-common = { path = "../../modules/fedimint-unknown-common" }
 fedimint-unknown-server = { path = "../../modules/fedimint-unknown-server" }
 fedimint-wallet-client = { path = "../../modules/fedimint-wallet-client" }
-lightning = { workspace = true }
 threshold_crypto = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
Follow-up to #5704

Move the rest of the gateway db code into the transaction extension trait. This makes usage of the db easier to understand at a glance, and allows us to make most of the gateway db keys private.