### PR TITLE
[Backport releases/v0.4] fix(client): ignore user data in the new-db check

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -432,7 +432,15 @@ pub async fn apply_migrations_core_client(
     target_version: DatabaseVersion,
     migrations: BTreeMap<DatabaseVersion, CoreMigrationFn>,
 ) -> Result<(), anyhow::Error> {
-    apply_migrations(db, kind, target_version, migrations, None).await
+    apply_migrations(
+        db,
+        kind,
+        target_version,
+        migrations,
+        None,
+        Some(DbKeyPrefix::UserData as u8),
+    )
+    .await
 }
 
 /// `apply_migrations_client` iterates from the on disk database version for the

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -74,6 +74,7 @@ pub async fn run(
                     module_init.database_version(),
                     module_init.get_database_migrations(),
                     Some(*module_id),
+                    None,
                 )
                 .await?;
 

--- a/fedimint-testing/src/db.rs
+++ b/fedimint-testing/src/db.rs
@@ -324,6 +324,7 @@ where
         module.database_version(),
         module.get_database_migrations(),
         Some(TEST_MODULE_INSTANCE_ID),
+        None,
     )
     .await
     .context("Error applying migrations to temp database")?;


### PR DESCRIPTION
# Description
Backport of #5716 to `releases/v0.4`.