### PR TITLE
refactor(server): remove bind addr's from local config

### DIFF
--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -170,8 +170,7 @@ impl ConsensusEngine {
 
         // Build P2P connections for the atomic broadcast
         let connections = ReconnectPeerConnections::new(
-            p2p_bind_addr,
-            self.cfg.network_config(),
+            self.cfg.network_config(p2p_bind_addr),
             DelayCalculator::PROD_DEFAULT,
             TlsTcpConnector::new(self.cfg.tls_config(), self.identity()).into_dyn(),
             &self.task_group,

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs;
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -74,6 +75,7 @@ pub struct ConsensusEngine {
     pub task_group: TaskGroup,
     pub data_dir: PathBuf,
     pub checkpoint_retention: u64,
+    pub p2p_bind_addr: SocketAddr,
 }
 
 impl ConsensusEngine {
@@ -91,7 +93,8 @@ impl ConsensusEngine {
             self.run_single_guardian(self.task_group.make_handle())
                 .await
         } else {
-            self.run_consensus(self.task_group.make_handle()).await
+            self.run_consensus(self.p2p_bind_addr, self.task_group.make_handle())
+                .await
         }
     }
 
@@ -155,7 +158,11 @@ impl ConsensusEngine {
         Ok(())
     }
 
-    pub async fn run_consensus(&self, task_handle: TaskHandle) -> anyhow::Result<()> {
+    pub async fn run_consensus(
+        &self,
+        p2p_bind_addr: SocketAddr,
+        task_handle: TaskHandle,
+    ) -> anyhow::Result<()> {
         // We need four peers to run the atomic broadcast
         assert!(self.num_peers().total() >= 4);
 
@@ -163,6 +170,7 @@ impl ConsensusEngine {
 
         // Build P2P connections for the atomic broadcast
         let connections = ReconnectPeerConnections::new(
+            p2p_bind_addr,
             self.cfg.network_config(),
             DelayCalculator::PROD_DEFAULT,
             TlsTcpConnector::new(self.cfg.tls_config(), self.identity()).into_dyn(),

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -44,6 +44,7 @@ use crate::net::api::{ApiSecrets, RpcHandlerCtx};
 /// How many txs can be stored in memory before blocking the API
 const TRANSACTION_BUFFER: usize = 1000;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     p2p_bind_addr: SocketAddr,
     api_bind_addr: SocketAddr,

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -66,7 +66,7 @@ pub async fn run(
         None => {
             run_config_gen(
                 data_dir.clone(),
-                settings,
+                settings.clone(),
                 db.clone(),
                 code_version_str,
                 task_group.make_subgroup(),
@@ -90,6 +90,8 @@ pub async fn run(
     start_api_announcement_service(&db, &task_group, &cfg, force_api_secrets.get_active()).await;
 
     consensus::run(
+        settings.p2p_bind,
+        settings.api_bind,
         cfg,
         db,
         module_init_registry.clone(),
@@ -130,6 +132,7 @@ pub async fn run_config_gen(
     let (cfg_sender, mut cfg_receiver) = tokio::sync::mpsc::channel(1);
 
     let config_gen = ConfigGenApi::new(
+        settings.p2p_bind,
         settings.clone(),
         db.clone(),
         cfg_sender,
@@ -144,7 +147,7 @@ pub async fn run_config_gen(
 
     let api_handler = net::api::spawn(
         "config-gen",
-        &settings.api_bind,
+        settings.api_bind,
         rpc_module,
         10,
         force_api_secrets.clone(),

--- a/fedimint-server/src/net/api/mod.rs
+++ b/fedimint-server/src/net/api/mod.rs
@@ -133,12 +133,12 @@ pub fn check_auth(context: &mut ApiEndpointContext) -> ApiResult<GuardianAuthTok
 
 pub async fn spawn<T>(
     name: &'static str,
-    api_bind: &SocketAddr,
+    api_bind_addr: SocketAddr,
     module: RpcModule<RpcHandlerCtx<T>>,
     max_connections: u32,
     force_api_secrets: ApiSecrets,
 ) -> ServerHandle {
-    info!(target: LOG_NET_API, "Starting api on ws://{api_bind}");
+    info!(target: LOG_NET_API, "Starting api on ws://{api_bind_addr}");
 
     let builder =
         tower::ServiceBuilder::new().layer(HttpAuthLayer::new(force_api_secrets.get_all()));
@@ -148,9 +148,9 @@ pub async fn spawn<T>(
         .enable_ws_ping(PingConfig::new().ping_interval(Duration::from_secs(10)))
         .set_rpc_middleware(RpcServiceBuilder::new().layer(metrics::jsonrpsee::MetricsLayer))
         .set_http_middleware(builder)
-        .build(&api_bind.to_string())
+        .build(&api_bind_addr.to_string())
         .await
-        .context(format!("Bind address: {api_bind}"))
+        .context(format!("Bind address: {api_bind_addr}"))
         .context(format!("API name: {name}"))
         .expect("Could not build API server")
         .start(module)

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -70,9 +70,6 @@ struct PeerConnection<T> {
 pub struct NetworkConfig {
     /// Our federation member's identity
     pub identity: PeerId,
-    /// Our listen address for incoming connections from other federation
-    /// members
-    pub bind_addr: SocketAddr,
     /// Map of all peers' connection information we want to be connected to
     pub peers: HashMap<PeerId, SafeUrl>,
 }
@@ -177,6 +174,7 @@ where
     /// `Connector`.
     #[instrument(skip_all)]
     pub(crate) async fn new(
+        p2p_bind_addr: SocketAddr,
         cfg: NetworkConfig,
         delay_calculator: DelayCalculator,
         connect: PeerConnector<T>,
@@ -212,8 +210,14 @@ where
                 .insert(*peer, PeerConnectionStatus::Disconnected);
         }
 
-        task_group.spawn("listen task", |handle| {
-            Self::run_listen_task(cfg, shared_connector, connection_senders, handle)
+        task_group.spawn("listen task", move |handle| {
+            Self::run_listen_task(
+                p2p_bind_addr,
+                cfg,
+                shared_connector,
+                connection_senders,
+                handle,
+            )
         });
 
         ReconnectPeerConnections {
@@ -223,15 +227,16 @@ where
     }
 
     async fn run_listen_task(
+        p2p_bind_addr: SocketAddr,
         cfg: NetworkConfig,
         connect: SharedAnyConnector<PeerMessage<T>>,
         mut connection_senders: HashMap<PeerId, Sender<AnyFramedTransport<PeerMessage<T>>>>,
         task_handle: TaskHandle,
     ) {
         let mut listener = connect
-            .listen(cfg.bind_addr)
+            .listen(p2p_bind_addr)
             .await
-            .with_context(|| anyhow::anyhow!("Failed to listen on {}", cfg.bind_addr))
+            .with_context(|| anyhow::anyhow!("Failed to listen on {}", p2p_bind_addr))
             .expect("Could not bind port");
 
         let mut shutdown_rx = task_handle.make_shutdown_rx();
@@ -754,7 +759,6 @@ mod tests {
             let build_peers = |bind: &'static str, id: u16, task_group: TaskGroup| async move {
                 let cfg = NetworkConfig {
                     identity: PeerId::from(id),
-                    bind_addr: bind.parse().unwrap(),
                     peers: peers_ref.clone(),
                 };
                 let connect = net_ref
@@ -762,6 +766,7 @@ mod tests {
                     .into_dyn();
                 let status_channels = Default::default();
                 let connection = ReconnectPeerConnections::<u64>::new(
+                    bind.parse().unwrap(),
                     cfg,
                     DelayCalculator::TEST_DEFAULT,
                     connect,

--- a/fedimint-server/src/net/peers.rs
+++ b/fedimint-server/src/net/peers.rs
@@ -66,10 +66,13 @@ struct PeerConnection<T> {
 }
 
 /// Specifies the network configuration for federation-internal communication
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct NetworkConfig {
     /// Our federation member's identity
     pub identity: PeerId,
+    /// Our listen address for incoming connections from other federation
+    /// members
+    pub p2p_bind_addr: SocketAddr,
     /// Map of all peers' connection information we want to be connected to
     pub peers: HashMap<PeerId, SafeUrl>,
 }
@@ -174,7 +177,6 @@ where
     /// `Connector`.
     #[instrument(skip_all)]
     pub(crate) async fn new(
-        p2p_bind_addr: SocketAddr,
         cfg: NetworkConfig,
         delay_calculator: DelayCalculator,
         connect: PeerConnector<T>,
@@ -211,13 +213,7 @@ where
         }
 
         task_group.spawn("listen task", move |handle| {
-            Self::run_listen_task(
-                p2p_bind_addr,
-                cfg,
-                shared_connector,
-                connection_senders,
-                handle,
-            )
+            Self::run_listen_task(cfg, shared_connector, connection_senders, handle)
         });
 
         ReconnectPeerConnections {
@@ -227,16 +223,15 @@ where
     }
 
     async fn run_listen_task(
-        p2p_bind_addr: SocketAddr,
         cfg: NetworkConfig,
         connect: SharedAnyConnector<PeerMessage<T>>,
         mut connection_senders: HashMap<PeerId, Sender<AnyFramedTransport<PeerMessage<T>>>>,
         task_handle: TaskHandle,
     ) {
         let mut listener = connect
-            .listen(p2p_bind_addr)
+            .listen(cfg.p2p_bind_addr)
             .await
-            .with_context(|| anyhow::anyhow!("Failed to listen on {}", p2p_bind_addr))
+            .with_context(|| anyhow::anyhow!("Failed to listen on {}", cfg.p2p_bind_addr))
             .expect("Could not bind port");
 
         let mut shutdown_rx = task_handle.make_shutdown_rx();
@@ -759,6 +754,7 @@ mod tests {
             let build_peers = |bind: &'static str, id: u16, task_group: TaskGroup| async move {
                 let cfg = NetworkConfig {
                     identity: PeerId::from(id),
+                    p2p_bind_addr: bind.parse().unwrap(),
                     peers: peers_ref.clone(),
                 };
                 let connect = net_ref
@@ -766,7 +762,6 @@ mod tests {
                     .into_dyn();
                 let status_channels = Default::default();
                 let connection = ReconnectPeerConnections::<u64>::new(
-                    bind.parse().unwrap(),
                     cfg,
                     DelayCalculator::TEST_DEFAULT,
                     connect,

--- a/fedimint-server/src/net/peers_reliable.rs
+++ b/fedimint-server/src/net/peers_reliable.rs
@@ -7,7 +7,6 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::net::SocketAddr;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -148,7 +147,6 @@ where
     /// `Connector`.
     #[instrument(skip_all)]
     pub(crate) async fn new(
-        p2p_bind_addr: SocketAddr,
         cfg: NetworkConfig,
         delay_calculator: DelayCalculator,
         connect: PeerConnector<T>,
@@ -181,13 +179,7 @@ where
             connections.insert(*peer, connection);
         }
         task_group.spawn("listen task", move |handle| {
-            Self::run_listen_task(
-                p2p_bind_addr,
-                cfg,
-                shared_connector,
-                connection_senders,
-                handle,
-            )
+            Self::run_listen_task(cfg, shared_connector, connection_senders, handle)
         });
         (
             ReconnectPeerConnectionsReliable { connections },
@@ -196,16 +188,15 @@ where
     }
 
     async fn run_listen_task(
-        p2p_bind_addr: SocketAddr,
         cfg: NetworkConfig,
         connect: SharedAnyConnector<PeerMessage<T>>,
         mut connection_senders: HashMap<PeerId, Sender<AnyFramedTransport<PeerMessage<T>>>>,
         task_handle: TaskHandle,
     ) {
         let mut listener = connect
-            .listen(p2p_bind_addr)
+            .listen(cfg.p2p_bind_addr)
             .await
-            .with_context(|| anyhow::anyhow!("Failed to listen on {}", p2p_bind_addr))
+            .with_context(|| anyhow::anyhow!("Failed to listen on {}", cfg.p2p_bind_addr))
             .expect("Could not bind port");
 
         let mut shutdown_rx = task_handle.make_shutdown_rx();
@@ -777,13 +768,13 @@ mod tests {
             let build_peers = |bind: &'static str, id: u16, task_group: TaskGroup| async move {
                 let cfg = NetworkConfig {
                     identity: PeerId::from(id),
+                    p2p_bind_addr: bind.parse().unwrap(),
                     peers: peers_ref.clone(),
                 };
                 let connect = net_ref
                     .connector(cfg.identity, StreamReliability::MILDLY_UNRELIABLE)
                     .into_dyn();
                 ReconnectPeerConnectionsReliable::<u64>::new(
-                    bind.parse().unwrap(),
                     cfg,
                     DelayCalculator::TEST_DEFAULT,
                     connect,

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -212,6 +212,8 @@ impl FederationTestBuilder {
 
         let task_group = TaskGroup::new();
         for (peer_id, config) in configs.clone() {
+            let p2p_bind_addr = params.get(&peer_id).expect("Must exist").local.p2p_bind;
+            let api_bind_addr = params.get(&peer_id).expect("Must exist").local.api_bind;
             if u16::from(peer_id) >= self.num_peers - self.num_offline {
                 continue;
             }
@@ -223,8 +225,10 @@ impl FederationTestBuilder {
             let subgroup = task_group.make_subgroup();
             let checkpoint_dir = tempfile::Builder::new().tempdir().unwrap().into_path();
 
-            task_group.spawn("fedimintd", |_| async move {
+            task_group.spawn("fedimintd", move |_| async move {
                 consensus::run(
+                    p2p_bind_addr,
+                    api_bind_addr,
                     config.clone(),
                     db.clone(),
                     module_init_registry,


### PR DESCRIPTION
They can be controlled by command line args / env vars directly, and having them redundantly in the config is just confusing.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
