### PR TITLE
chore(ci): add upgrade tests vs master

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -1,0 +1,72 @@
+# This is a basic workflow to help you get started with Actions
+
+name: "Upgrade Tests"
+
+env:
+  PERFIT_SERVER: https://perfit.dev.fedimint.org
+
+# Controls when the workflow will run
+on:
+  schedule:
+    # run daily during low usage hours
+    - cron:  '30 4 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  tests:
+    if: github.repository == 'fedimint/fedimint'
+    name: "Upgrade tests"
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - uses: cachix/install-nix-action@V27
+        with:
+          nix_path: nixpkgs=channel:nixos-23.11
+          extra_nix_config: |
+            connect-timeout = 15
+            stalled-download-timeout = 15
+      - uses: cachix/cachix-action@v15
+        with:
+          name: fedimint
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        continue-on-error: true
+
+      - name: Upgrade tests
+        run: |
+          # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)
+          # we need to use `nix develop -c` to be able to use `nix build` inside of backwards-compatibility-test
+          # Disable `sccache`, it seems incompatible with self-hosted runner sandbox for some reason, and
+          # it doesn't benefit us much here anyway.
+          env \
+            TMPDIR=/tmp \
+            CARGO_PROFILE=ci \
+            nix develop -c \
+            nix shell github:rustshop/fs-dir-cache -c \
+            scripts/ci/run-in-fs-dir-cache.sh upgrade-tests \
+            env -u RUSTC_WRAPPER \
+            runLowPrio ./scripts/tests/upgrade-test.sh v0.2.1 v0.3.3-rc.2 current
+
+  notifications:
+    if: always() && github.repository == 'fedimint/fedimint'
+    name: "Notifications"
+    timeout-minutes: 1
+    runs-on: [self-hosted, linux]
+    needs: [ tests ]
+
+    steps:
+    - name: Discord notifications on failure
+      # https://stackoverflow.com/a/74562058/134409
+      if: ${{ always() && contains(needs.*.result, 'failure') }}
+      # https://github.com/marketplace/actions/actions-status-discord
+      uses: sarisia/actions-status-discord@v1
+      with:
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        # current job is a success, but that's not what we're interested in
+        status: failure

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -871,6 +871,35 @@ impl FedimintCli {
         Ok(serde_json::from_value(result)?)
     }
 
+    pub async fn shutdown(self, auth: &ApiAuth, our_id: u64, session_count: u64) -> Result<()> {
+        cmd!(
+            self,
+            "--password",
+            &auth.0,
+            "--our-id",
+            our_id,
+            "admin",
+            "shutdown",
+            session_count,
+        )
+        .run()
+        .await
+    }
+
+    pub async fn status(self, auth: &ApiAuth, our_id: u64) -> Result<()> {
+        cmd!(
+            self,
+            "--password",
+            &auth.0,
+            "--our-id",
+            our_id,
+            "admin",
+            "status",
+        )
+        .run()
+        .await
+    }
+
     pub async fn start_consensus(self, auth: &ApiAuth, endpoint: &str) -> Result<()> {
         cmd!(
             self,


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/5604

- Adds new GH workflow that runs upgrade tests vs master once daily during off hours
- Adds coordinated shutdown logic to upgrade tests in devimint

Upgrade tests currently take a while to run, so this is triggered as a daily cron and not part of the PR jobs.