### PR TITLE
refactor: get rid of last __reexports

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -275,10 +275,7 @@ pub trait TypedApiEndpoint {
         'dbtx: 'context;
 }
 
-#[doc(hidden)]
-pub mod __reexports {
-    pub use serde_json;
-}
+pub use serde_json;
 
 /// # Example
 ///

--- a/modules/fedimint-mint-common/src/config.rs
+++ b/modules/fedimint-mint-common/src/config.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use fedimint_core::config::EmptyGenParams;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::module::__reexports::serde_json;
+use fedimint_core::module::serde_json;
 use fedimint_core::{plugin_types_trait_impl_config, Amount, PeerId, Tiered};
 use serde::{Deserialize, Serialize};
 use tbs::{AggregatePublicKey, PublicKeyShare};

--- a/modules/fedimint-wallet-common/src/config.rs
+++ b/modules/fedimint-wallet-common/src/config.rs
@@ -4,7 +4,7 @@ use bitcoin::Network;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::BitcoinRpcConfig;
-use fedimint_core::module::__reexports::serde_json;
+use fedimint_core::module::serde_json;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{plugin_types_trait_impl_config, Feerate, PeerId};
 use miniscript::descriptor::{Wpkh, Wsh};


### PR DESCRIPTION
Fix #1346

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
