### PR TITLE
feat(client): save and verify root secret hash when creating the client

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -37,6 +37,7 @@ pub const CORE_CLIENT_DATABASE_VERSION: DatabaseVersion = DatabaseVersion(1);
 pub enum DbKeyPrefix {
     EncodedClientSecret = 0x28,
     ClientSecret = 0x29, // Unused
+    ClientPreRootSecretHash = 0x2a,
     OperationLog = 0x2c,
     ChronologicalOperationLog = 0x2d,
     CommonApiVersionCache = 0x2e,
@@ -104,6 +105,15 @@ impl_db_record!(
     key = OperationLogKey,
     value = OperationLogEntry,
     db_prefix = DbKeyPrefix::OperationLog
+);
+
+#[derive(Debug, Encodable, Decodable, Serialize)]
+pub struct ClientPreRootSecretHashKey;
+
+impl_db_record!(
+    key = ClientPreRootSecretHashKey,
+    value = [u8; 8],
+    db_prefix = DbKeyPrefix::ClientPreRootSecretHash
 );
 
 /// Key used to lookup operation log entries in chronological order

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -88,7 +88,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, bail, ensure, Context};
 use async_stream::stream;
 use backup::ClientBackup;
 use db::{
@@ -2069,7 +2069,7 @@ impl ClientBuilder {
 
     async fn init(
         self,
-        root_secret: DerivableSecret,
+        pre_root_secret: DerivableSecret,
         config: ClientConfig,
         api_secret: Option<String>,
         init_mode: InitMode,
@@ -2087,7 +2087,7 @@ impl ClientBuilder {
             dbtx.insert_new_entry(&ClientConfigKey, &config).await;
             dbtx.insert_entry(
                 &ClientPreRootSecretHashKey,
-                &root_secret.derive_pre_root_secret_hash(),
+                &pre_root_secret.derive_pre_root_secret_hash(),
             )
             .await;
 
@@ -2109,7 +2109,8 @@ impl ClientBuilder {
         }
 
         let stopped = self.stopped;
-        self.build(root_secret, config, api_secret, stopped).await
+        self.build(pre_root_secret, config, api_secret, stopped)
+            .await
     }
 
     /// Join a new Federation
@@ -2187,11 +2188,11 @@ impl ClientBuilder {
     /// ```
     pub async fn join(
         self,
-        root_secret: DerivableSecret,
+        pre_root_secret: DerivableSecret,
         config: ClientConfig,
         api_secret: Option<String>,
     ) -> anyhow::Result<ClientHandle> {
-        self.init(root_secret, config, api_secret, InitMode::Fresh)
+        self.init(pre_root_secret, config, api_secret, InitMode::Fresh)
             .await
     }
 
@@ -2250,7 +2251,7 @@ impl ClientBuilder {
         Ok(client)
     }
 
-    pub async fn open(self, root_secret: DerivableSecret) -> anyhow::Result<ClientHandle> {
+    pub async fn open(self, pre_root_secret: DerivableSecret) -> anyhow::Result<ClientHandle> {
         let Some(config) = Client::get_config_from_db(&self.db_no_decoders).await else {
             bail!("Client database not initialized")
         };
@@ -2262,14 +2263,17 @@ impl ClientBuilder {
             .get_value(&ClientPreRootSecretHashKey)
             .await
         {
-            if root_secret.derive_pre_root_secret_hash() != secret_hash {
-                bail!("Secret hash does not match. Incorrect secret")
-            }
-
+            ensure!(
+                pre_root_secret.derive_pre_root_secret_hash() == secret_hash,
+                "Secret hash does not match. Incorrect secret"
+            );
+        } else {
+            debug!(target: LOG_CLIENT, "Backfilling secret hash");
+            // Note: no need for dbtx autocommit, we are the only writer ATM
             let mut dbtx = self.db_no_decoders.begin_transaction().await;
             dbtx.insert_entry(
                 &ClientPreRootSecretHashKey,
-                &root_secret.derive_pre_root_secret_hash(),
+                &pre_root_secret.derive_pre_root_secret_hash(),
             )
             .await;
             dbtx.commit_tx().await;
@@ -2278,7 +2282,9 @@ impl ClientBuilder {
         let api_secret = Client::get_api_secret_from_db(&self.db_no_decoders).await;
         let stopped = self.stopped;
 
-        let client = self.build_stopped(root_secret, &config, api_secret).await?;
+        let client = self
+            .build_stopped(pre_root_secret, &config, api_secret)
+            .await?;
         if !stopped {
             client.as_inner().start_executor().await;
         }
@@ -2288,12 +2294,14 @@ impl ClientBuilder {
     /// Build a [`Client`] and start the executor
     async fn build(
         self,
-        root_secret: DerivableSecret,
+        pre_root_secret: DerivableSecret,
         config: ClientConfig,
         api_secret: Option<String>,
         stopped: bool,
     ) -> anyhow::Result<ClientHandle> {
-        let client = self.build_stopped(root_secret, &config, api_secret).await?;
+        let client = self
+            .build_stopped(pre_root_secret, &config, api_secret)
+            .await?;
         if !stopped {
             client.as_inner().start_executor().await;
         }

--- a/fedimint-client/src/secret.rs
+++ b/fedimint-client/src/secret.rs
@@ -7,12 +7,17 @@ use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use rand::{CryptoRng, Rng, RngCore};
 
+// Derived from pre-root-secret (pre-federation-derived)
+const TYPE_PRE_ROOT_SECRET_HASH: ChildId = ChildId(0);
+
+// Derived from federation-root-secret
 const TYPE_MODULE: ChildId = ChildId(0);
 const TYPE_BACKUP: ChildId = ChildId(1);
 
 pub trait DeriveableSecretClientExt {
     fn derive_module_secret(&self, module_instance_id: ModuleInstanceId) -> DerivableSecret;
     fn derive_backup_secret(&self) -> DerivableSecret;
+    fn derive_pre_root_secret_hash(&self) -> [u8; 8];
 }
 
 impl DeriveableSecretClientExt for DerivableSecret {
@@ -25,6 +30,14 @@ impl DeriveableSecretClientExt for DerivableSecret {
     fn derive_backup_secret(&self) -> DerivableSecret {
         assert_eq!(self.level(), 0);
         self.child_key(TYPE_BACKUP)
+    }
+
+    fn derive_pre_root_secret_hash(&self) -> [u8; 8] {
+        // Note: this hash is derived from a pre-root-secret: one passed from the
+        // outside, before the federation ID is used to derive the
+        // federation-specific-root-secret, which gets level reset to 0.
+        // Because of that we don't care about asserting the level.
+        self.child_key(TYPE_PRE_ROOT_SECRET_HASH).to_random_bytes()
     }
 }
 


### PR DESCRIPTION
Fix #3504

This prevent user/application from accidentally using a different secret, which could lead to ... who knows what. Not good things, that's for sure.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
