### PR TITLE
Revert "[Backport releases/v0.4] chore: always include invite code in oob ecash"

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -87,6 +87,10 @@ pub enum ClientCmd {
         /// hasn't been redeemed by the recipient. Defaults to one week.
         #[clap(long, default_value_t = 60 * 60 * 24 * 7)]
         timeout: u64,
+        /// If the necessary information to join the federation the e-cash
+        /// belongs to should be included in the serialized notes
+        #[clap(long)]
+        include_invite: bool,
     },
     /// Verifies the signatures of e-cash notes, but *not* if they have been
     /// spent already
@@ -227,6 +231,7 @@ pub async fn handle_command(
             amount,
             allow_overpay,
             timeout,
+            include_invite,
         } => {
             warn!("The client will try to double-spend these notes after the duration specified by the --timeout option to recover any unclaimed e-cash.");
 
@@ -234,7 +239,13 @@ pub async fn handle_command(
             let timeout = Duration::from_secs(timeout);
             let (operation, notes) = if allow_overpay {
                 let (operation, notes) = mint_module
-                    .spend_notes_with_selector(&SelectNotesWithAtleastAmount, amount, timeout, ())
+                    .spend_notes_with_selector(
+                        &SelectNotesWithAtleastAmount,
+                        amount,
+                        timeout,
+                        include_invite,
+                        (),
+                    )
                     .await?;
 
                 let overspend_amount = notes.total_amount() - amount;
@@ -248,7 +259,13 @@ pub async fn handle_command(
                 (operation, notes)
             } else {
                 mint_module
-                    .spend_notes_with_selector(&SelectNotesWithExactAmount, amount, timeout, ())
+                    .spend_notes_with_selector(
+                        &SelectNotesWithExactAmount,
+                        amount,
+                        timeout,
+                        include_invite,
+                        (),
+                    )
                     .await?
             };
             info!("Spend e-cash operation: {}", operation.fmt_short());

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -90,7 +90,7 @@ pub async fn do_spend_notes(
 ) -> anyhow::Result<(OperationId, OOBNotes)> {
     let mint = &mint.get_first_module::<MintClientModule>();
     let (operation_id, oob_notes) = mint
-        .spend_notes(amount, Duration::from_secs(600), ())
+        .spend_notes(amount, Duration::from_secs(600), false, ())
         .await?;
     let mut updates = mint
         .subscribe_spend_notes(operation_id)

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -256,7 +256,7 @@ mod tests {
     ) -> Result<(), anyhow::Error> {
         let mint = client.get_first_module::<MintClientModule>();
         let (_, notes) = mint
-            .spend_notes(Amount::from_sats(11), Duration::from_secs(10000), ())
+            .spend_notes(Amount::from_sats(11), Duration::from_secs(10000), false, ())
             .await?;
         let operation_id = mint.reissue_external_notes(notes, ()).await?;
         let mut updates = mint
@@ -285,7 +285,7 @@ mod tests {
         let mint = client.get_first_module::<MintClientModule>();
         'retry: loop {
             let (operation_id, notes) = mint
-                .spend_notes(amount, Duration::from_secs(10000), ())
+                .spend_notes(amount, Duration::from_secs(10000), false, ())
                 .await?;
             if notes.total_amount() == amount {
                 return Ok(());

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -59,7 +59,9 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     let client1_mint = client1.get_first_module::<MintClientModule>();
     let client2_mint = client2.get_first_module::<MintClientModule>();
     info!("### SPEND NOTES");
-    let (op, notes) = client1_mint.spend_notes(sats(750), TIMEOUT, ()).await?;
+    let (op, notes) = client1_mint
+        .spend_notes(sats(750), TIMEOUT, false, ())
+        .await?;
     let sub1 = &mut client1_mint.subscribe_spend_notes(op).await?.into_stream();
     assert_eq!(sub1.ok().await?, SpendOOBState::Created);
 
@@ -110,7 +112,7 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
                 info!("Starting spend {num_spend}");
                 let client1_mint = task_client1.get_first_module::<MintClientModule>();
                 let (op, notes) = client1_mint
-                    .spend_notes(sats(30), ECASH_TIMEOUT, ())
+                    .spend_notes(sats(30), ECASH_TIMEOUT, false, ())
                     .await
                     .unwrap();
                 let sub1 = &mut client1_mint
@@ -234,7 +236,9 @@ async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
 
     // Spend from client1 to client2
     let mint_module = client.get_first_module::<MintClientModule>();
-    let (op, _) = mint_module.spend_notes(sats(750), TIMEOUT, ()).await?;
+    let (op, _) = mint_module
+        .spend_notes(sats(750), TIMEOUT, false, ())
+        .await?;
     let sub1 = &mut mint_module.subscribe_spend_notes(op).await?.into_stream();
     assert_eq!(sub1.ok().await?, SpendOOBState::Created);
 
@@ -270,7 +274,7 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
     // Spend from client1 to client2
     let err_msg = client1
         .get_first_module::<MintClientModule>()
-        .spend_notes(Amount::ZERO, TIMEOUT, ())
+        .spend_notes(Amount::ZERO, TIMEOUT, false, ())
         .await
         .expect_err("Zero-amount spends should be forbidden")
         .to_string();


### PR DESCRIPTION
I talked to @joschisan, not every federation will want users to leak the invite code. `OOBNotesV2` will need to have an optional invite code too instead of the other way around.