### PR TITLE
chore(ci): limit fuzz-ci-quick to 2 threads

### DIFF
--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -171,7 +171,7 @@ fuzz-target TARGET="" *ARGS="--exit_upon_crash":
   env -u RUSTC_WRAPPER CC=clang RUSTFLAGS="--cfg tokio_unstable" cargo hfuzz run {{TARGET}}
 
 # A quick round of fuzzing for every defined target
-fuzz-ci-quick *ARGS="--exit_upon_crash --run_time 30 -q -v":
+fuzz-ci-quick *ARGS="--exit_upon_crash --run_time 30 -q -v --threads 2":
   #!/usr/bin/env bash
   set -euo pipefail
 


### PR DESCRIPTION
It's just a quick check, no need to fire up all 96 CPUs of our CI workers.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
