### PR TITLE
chore(client): electrum-client to use rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc"] }
 cln-rpc = "0.1.9"
 clap = { version = "4.5.9", features = ["derive", "std", "help", "usage", "error-context", "suggestions", "env"], default-features = false }
+electrum-client = { version = "0.18.0", features = [ "use-rustls" ] }
 esplora-client = { version = "0.6.0", default-features = false, features = [
     "async",
     "async-https-rustls",

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { version = "0.17.0", optional = true }
-electrum-client = { version = "0.18.0", optional = true }
+electrum-client = { workspace = true, optional = true }
 esplora-client = { workspace = true, optional = true }
 fedimint-core  = { version = "=0.5.0-alpha", path = "../fedimint-core" }
 fedimint-logging = { workspace = true }


### PR DESCRIPTION
Re #3049,  but we need to update to electrum-client 0.19 (bitcoin 0.31)

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
