### PR TITLE
feat: track ordering latency

### DIFF
--- a/fedimint-server/src/consensus/aleph_bft/data_provider.rs
+++ b/fedimint-server/src/consensus/aleph_bft/data_provider.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::time::Instant;
 
+use bitcoin_hashes::Hash;
 use fedimint_core::config::ALEPH_BFT_UNIT_BYTE_LIMIT;
 use fedimint_core::encoding::Encodable;
 use fedimint_core::epoch::ConsensusItem;
@@ -117,11 +118,8 @@ impl aleph_bft::DataProvider<UnitData> for DataProvider {
     }
 }
 
-/// Calculate a cheap chesum of an encoded citem, as a
-/// XOR of its len and first 8 bytes.
+/// Calculate a cheap chesum of an encoded citem
 pub(crate) fn get_citem_bytes_chsum(bytes: &[u8]) -> u64 {
-    let mut chsum = [0u8; 8];
-    let len = std::cmp::min(bytes.len(), 8);
-    chsum[..len].copy_from_slice(&bytes[..len]);
-    u64::from_le_bytes(chsum) ^ u64::try_from(bytes.len()).expect("Can't fail")
+    let chsum = bitcoin_hashes::sha256::Hash::hash(bytes);
+    u64::from_le_bytes(chsum[..8].try_into().expect("Can't fail"))
 }

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use aleph_bft::Keychain as KeychainTrait;
 use anyhow::{anyhow, bail};
@@ -48,7 +48,7 @@ use crate::consensus::transaction::process_transaction_with_dbtx;
 use crate::fedimint_core::encoding::Encodable;
 use crate::metrics::{
     CONSENSUS_ITEMS_PROCESSED_TOTAL, CONSENSUS_ITEM_PROCESSING_DURATION_SECONDS,
-    CONSENSUS_ITEM_PROCESSING_MODULE_AUDIT_DURATION_SECONDS,
+    CONSENSUS_ITEM_PROCESSING_MODULE_AUDIT_DURATION_SECONDS, CONSENSUS_ORDERING_LATENCY_SECONDS,
     CONSENSUS_PEER_CONTRIBUTION_SESSION_IDX, CONSENSUS_SESSION_COUNT,
 };
 use crate::net::connect::{Connector, TlsTcpConnector};
@@ -288,6 +288,7 @@ impl ConsensusEngine {
         // ordered in a single aleph session is bounded as described above
         let (unit_data_sender, unit_data_receiver) = async_channel::unbounded();
         let (signature_sender, signature_receiver) = watch::channel(None);
+        let (timestamp_sender, timestamp_receiver) = async_channel::unbounded();
         let (terminator_sender, terminator_receiver) = futures::channel::oneshot::channel();
 
         let aleph_handle = spawn(
@@ -295,7 +296,11 @@ impl ConsensusEngine {
             aleph_bft::run_session(
                 config,
                 aleph_bft::LocalIO::new(
-                    DataProvider::new(self.submission_receiver.clone(), signature_receiver),
+                    DataProvider::new(
+                        self.submission_receiver.clone(),
+                        signature_receiver,
+                        timestamp_sender,
+                    ),
                     FinalizationHandler::new(unit_data_sender),
                     BackupWriter::new(self.db.clone()),
                     BackupReader::new(self.db.clone()),
@@ -308,7 +313,12 @@ impl ConsensusEngine {
         );
 
         let signed_session_outcome = self
-            .complete_signed_session_outcome(session_index, unit_data_receiver, signature_sender)
+            .complete_signed_session_outcome(
+                session_index,
+                unit_data_receiver,
+                signature_sender,
+                timestamp_receiver,
+            )
             .await?;
 
         // We can terminate the session instead of waiting for other peers to complete
@@ -332,6 +342,7 @@ impl ConsensusEngine {
         session_index: u64,
         ordered_unit_receiver: Receiver<OrderedUnit>,
         signature_sender: watch::Sender<Option<SchnorrSignature>>,
+        timestamp_receiver: Receiver<(Instant, usize)>,
     ) -> anyhow::Result<SignedSessionOutcome> {
         let mut item_index = 0;
 
@@ -348,6 +359,24 @@ impl ConsensusEngine {
                     }
 
                     if let Some(UnitData::Batch(bytes)) = ordered_unit.data {
+                        if ordered_unit.creator == self.identity() {
+                            loop {
+                                 match timestamp_receiver.try_recv() {
+                                    Ok((timestamp, bytes_len)) => {
+                                        if bytes.len() == bytes_len {
+                                            CONSENSUS_ORDERING_LATENCY_SECONDS.observe(timestamp.elapsed().as_secs_f64());
+                                            break;
+                                        }
+                                        warn!(target: LOG_CONSENSUS, "Not reporting ordering latency on possibly out of sync item");
+                                    }
+                                    Err(e) => {
+                                        warn!(target: LOG_CONSENSUS, "Missing submission timestamp: {e}");
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
                         if let Ok(items) = Vec::<ConsensusItem>::consensus_decode(&mut bytes.as_slice(), &self.decoders()){
                             for item in items {
                                 if self.process_consensus_item(

--- a/fedimint-server/src/metrics.rs
+++ b/fedimint-server/src/metrics.rs
@@ -75,6 +75,18 @@ pub(crate) static CONSENSUS_ITEM_PROCESSING_MODULE_AUDIT_DURATION_SECONDS: Lazy<
         )
         .unwrap()
     });
+
+pub(crate) static CONSENSUS_ORDERING_LATENCY_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram_with_registry!(
+        histogram_opts!(
+            "consensus_ordering_latency_seconds",
+            "Duration of ordering a batch of consensus items",
+        ),
+        REGISTRY
+    )
+    .unwrap()
+});
+
 pub(crate) static JSONRPC_API_REQUEST_DURATION_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec_with_registry!(
         histogram_opts!(


### PR DESCRIPTION
This is resurrecting @joschisan 's #5432 with a fix I proposed for self-synchronization.

Fix #3759 - which I spotted during going through old issues and it reminded me about #5432.

This PR was&is a great idea, it has minimal implementation and I believe the fix I proposed is absolutely practical and will work just fine. There is really no point sitting on it: We could have been already gathering information from real deployments had it been a part of 0.4.

If you figure out a better way to do it, we can just replace it. It's not a consensus or any backward compat-encumbered code. Let's not let perfect be an enemy of good enough. Even if this metric would return wrong results 50% of the time, it still would be very useful.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
