### PR TITLE
chore(ci): bump v0.3.3-rc.2 -> v0.3.3 in upgrade tests

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -51,7 +51,7 @@ jobs:
             nix shell github:rustshop/fs-dir-cache -c \
             scripts/ci/run-in-fs-dir-cache.sh upgrade-tests \
             env -u RUSTC_WRAPPER \
-            runLowPrio ./scripts/tests/upgrade-test.sh v0.2.1 v0.3.3-rc.2 current
+            runLowPrio ./scripts/tests/upgrade-test.sh v0.2.1 v0.3.3 current
 
   notifications:
     if: always() && github.repository == 'fedimint/fedimint'


### PR DESCRIPTION
We cut v0.3.3 so we should use this version in the daily upgrade tests vs master.