### PR TITLE
fix(ci): cachix commands failing in builds flows

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -500,6 +500,9 @@ jobs:
           fi
 
       - name: Build ${{ matrix.build.flake-output }}
+        env:
+          # seems like cachix needs this explicitly set in the env
+          CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         run: |
           nix build -L .#${{ matrix.build.flake-output }}
           mkdir -p bins


### PR DESCRIPTION
Tested in https://github.com/fedimint/fedimint/actions/runs/10116210016/job/27978568323 as a part of a 0.4 backport of #5753
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
