### PR TITLE
fix(docs): Search does not hide the static content

### DIFF
--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -210,6 +210,10 @@ fuzz-target-debug TARGET="" CRASH="" *ARGS="--exit_upon_crash":
 build-docs:
   ./scripts/dev/build-docs.sh
 
+# Build `cargo doc`-generated documentation just like on https://docs.fedimint.org
+build-docs-nix: build-docs
+  nix build -L .#nightly.ci.workspaceDocExport
+
 # Open `cargo doc`-generated documentation
 docs: build-docs
   #!/usr/bin/env bash

--- a/scripts/dev/build-docs.sh
+++ b/scripts/dev/build-docs.sh
@@ -34,7 +34,7 @@ if [ -e "${index_html}" ]; then
         close(insert_path);
       }
       {
-        sub(/<section id="main-content"/, content "&"); # Replace MARKER with insert.txt content + MARKER
+        sub(/<section id="main-content"[^>]*>/, "&" content); # Replace MARKER with insert.txt content + MARKER
         print;
       }' "$index_html" > "$index_html.tmp" && mv "$index_html.tmp" "$index_html"
   fi


### PR DESCRIPTION
If you go to https://docs.fedimint.org and type something in the search box, you'll see that the results are displayed under the index.html we added. It's annoying, so this PR fixes it.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
