### PR TITLE
chore: remove Gateway.client_joining_lock

### DIFF
--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -35,9 +35,7 @@ impl GatewayClientBuilder {
             primary_module,
         }
     }
-}
 
-impl GatewayClientBuilder {
     pub async fn build(
         &self,
         config: FederationConfig,


### PR DESCRIPTION
Rather than having a lock for joining & leaving federations that carries only semantic meaning, we can grab the write lock for `Gateway.federation_manager`. Locking on the data we're modifying makes it more clear what's going on.