### PR TITLE
chore(ci): use v0.3.3 -> v0.4.0 -> master in upgrade tests

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -51,7 +51,7 @@ jobs:
             nix shell github:rustshop/fs-dir-cache -c \
             scripts/ci/run-in-fs-dir-cache.sh upgrade-tests \
             env -u RUSTC_WRAPPER \
-            runLowPrio ./scripts/tests/upgrade-test.sh v0.2.1 v0.3.3 current
+            runLowPrio ./scripts/tests/upgrade-test.sh v0.3.3 v0.4.0 current
 
   notifications:
     if: always() && github.repository == 'fedimint/fedimint'


### PR DESCRIPTION
Using `v0.4.0` in the upgrade path vs master now that we've cut the release.

---

Verified CI passes for upgrade tests (doesn't run in PR workflow): https://github.com/fedimint/fedimint/actions/runs/10255509103/job/28372587992?pr=5802