### PR TITLE
chore: gateway-cli info cleanup

### DIFF
--- a/gateway/ln-gateway/src/federation_manager.rs
+++ b/gateway/ln-gateway/src/federation_manager.rs
@@ -194,7 +194,6 @@ impl FederationManager {
             .borrow()
             .with(|client| async move {
                 let balance_msat = client.get_balance().await;
-                let config = client.config().await;
 
                 let routing_fees = dbtx
                     .load_federation_config(federation_id)
@@ -204,7 +203,6 @@ impl FederationManager {
                 Ok(FederationInfo {
                     federation_id,
                     balance_msat,
-                    config,
                     channel_id,
                     routing_fees,
                 })
@@ -221,7 +219,6 @@ impl FederationManager {
             let channel_id = self.get_scid_for_federation(*federation_id);
 
             let balance_msat = client.borrow().with(|client| client.get_balance()).await;
-            let config = client.borrow().with(|client| client.config()).await;
 
             let routing_fees = dbtx
                 .load_federation_config(*federation_id)
@@ -231,7 +228,6 @@ impl FederationManager {
             federation_infos.push(FederationInfo {
                 federation_id: *federation_id,
                 balance_msat,
-                config,
                 channel_id,
                 routing_fees,
             });

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -229,7 +229,7 @@ pub struct ChannelInfo {
     pub short_channel_id: u64,
 }
 
-#[derive(Debug, Clone, Subcommand, Serialize, Deserialize)]
+#[derive(Debug, Clone, Subcommand, Serialize, Deserialize, Eq, PartialEq)]
 pub enum LightningMode {
     #[clap(name = "lnd")]
     Lnd {
@@ -269,6 +269,9 @@ pub enum LightningMode {
 #[async_trait]
 pub trait LightningBuilder {
     async fn build(&self) -> Box<dyn ILnRpcClient>;
+    fn lightning_mode(&self) -> Option<LightningMode> {
+        None
+    }
 }
 
 #[derive(Clone)]
@@ -310,5 +313,9 @@ impl LightningBuilder for GatewayLightningBuilder {
                 .unwrap(),
             ),
         }
+    }
+
+    fn lightning_mode(&self) -> Option<LightningMode> {
+        Some(self.lightning_mode.clone())
     }
 }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -6,14 +6,16 @@ use std::str::FromStr;
 
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Network};
-use fedimint_core::config::{ClientConfig, FederationId, JsonClientConfig};
+use fedimint_core::config::{FederationId, JsonClientConfig};
 use fedimint_core::core::OperationId;
 use fedimint_core::{secp256k1, Amount, BitcoinAmountOrAll};
 use fedimint_ln_common::config::parse_routing_fees;
-use fedimint_ln_common::{route_hints, serde_option_routing_fees};
 use fedimint_mint_client::OOBNotes;
 use lightning_invoice::RoutingFees;
 use serde::{Deserialize, Serialize};
+
+use crate::lightning::LightningMode;
+use crate::SafeUrl;
 
 pub const V1_API_ENDPOINT: &str = "v1";
 
@@ -67,7 +69,6 @@ pub struct WithdrawPayload {
 pub struct FederationInfo {
     pub federation_id: FederationId,
     pub balance_msat: Amount, // TODO: Rename to `balance`, since `Amount` is already in msat.
-    pub config: ClientConfig,
     pub channel_id: Option<u64>,
     pub routing_fees: Option<FederationRoutingFees>,
 }
@@ -82,9 +83,6 @@ pub struct GatewayInfo {
     pub federation_fake_scids: Option<BTreeMap<u64, FederationId>>,
     pub lightning_pub_key: Option<String>,
     pub lightning_alias: Option<String>,
-    #[serde(with = "serde_option_routing_fees")]
-    pub fees: Option<RoutingFees>,
-    pub route_hints: Vec<route_hints::RouteHint>,
     pub gateway_id: secp256k1::PublicKey,
     pub gateway_state: String,
     pub network: Option<Network>,
@@ -96,6 +94,8 @@ pub struct GatewayInfo {
     // should be able to remove it once 0.4.0 is released.
     #[serde(default)]
     pub synced_to_chain: bool,
+    pub api: SafeUrl,
+    pub lightning_mode: Option<LightningMode>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -183,7 +183,7 @@ fn v1_routes(gateway: Arc<Gateway>) -> Router {
     // authenticated after a password has been set.
     let authenticated_after_config_routes = Router::new()
         .route(SET_CONFIGURATION_ENDPOINT, post(set_configuration))
-        .route(CONFIGURATION_ENDPOINT, get(configuration))
+        .route(CONFIGURATION_ENDPOINT, post(configuration))
         // FIXME: deprecated >= 0.3.0
         .route(GATEWAY_INFO_POST_ENDPOINT, post(handle_post_info))
         .route(GATEWAY_INFO_ENDPOINT, get(info))


### PR DESCRIPTION
Cleans up a bunch of stuff about `gateway-cli info` that has been bugging me for awhile.

 - Removes `ClientConfig` from the `info` command. `ClientConfig` can still be retrieved using `gateway-cli config` command.
 - Fixes `gateway-cli config` command
 - Removes route hints and routing fees from `info`. Routing fees are already included in each individual federation. Route hints can be acquired by generating an invoice.
 - Adds the gateway's API URL
 - Adds the gateway's Lightning Mode for determining what type of node it is. 