### PR TITLE
chore(ci): use same version for gateway-cli and gatewayd

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -145,15 +145,10 @@ function use_client_binaries_for_version() {
   version=$1
   if [[ "$version" == "current" ]]; then
     unset FM_FEDIMINT_CLI_BASE_EXECUTABLE
-    unset FM_GATEWAY_CLI_BASE_EXECUTABLE
   else
     var_name=$(nix_binary_version_var_name fedimint-cli "$version")
     FM_FEDIMINT_CLI_BASE_EXECUTABLE="${!var_name}"
     export FM_FEDIMINT_CLI_BASE_EXECUTABLE
-
-    var_name=$(nix_binary_version_var_name gateway-cli "$version")
-    FM_GATEWAY_CLI_BASE_EXECUTABLE="${!var_name}"
-    export FM_GATEWAY_CLI_BASE_EXECUTABLE
   fi
 }
 export -f use_client_binaries_for_version
@@ -162,10 +157,15 @@ function use_gateway_binaries_for_version() {
   version=$1
   if [[ "$version" == "current" ]]; then
     unset FM_GATEWAYD_BASE_EXECUTABLE
+    unset FM_GATEWAY_CLI_BASE_EXECUTABLE
   else
     var_name=$(nix_binary_version_var_name gatewayd "$version")
     FM_GATEWAYD_BASE_EXECUTABLE="${!var_name}"
     export FM_GATEWAYD_BASE_EXECUTABLE
+
+    var_name=$(nix_binary_version_var_name gateway-cli "$version")
+    FM_GATEWAY_CLI_BASE_EXECUTABLE="${!var_name}"
+    export FM_GATEWAY_CLI_BASE_EXECUTABLE
   fi
 }
 export -f use_gateway_binaries_for_version


### PR DESCRIPTION
This PR updates back-compat tests so `gateway-cli` and `gatewayd` are on the same version. We currently set `fedimint-cli` and `gateway-cli` to the same version.

@m1sterc001guy brought up some good points that there isn't much benefit in ensuring backwards-compatibility with `gateway-cli` since it's just a management tool for the gateway and doesn't hold funds or persist state like `fedimint-cli`. We should expect users to have the same version of `gatewayd` and `gateway-cli`. If there's a discrepancy, they can change the `gateway-cli` version to match, which doesn't require migrations.