### PR TITLE
chore: claim_input returns result

### DIFF
--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -172,7 +172,7 @@ where
         &mut self,
         input: ClientInput<I, S>,
         operation_id: OperationId,
-    ) -> (TransactionId, Vec<OutPoint>)
+    ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)>
     where
         I: IInput + MaybeSend + MaybeSync + 'static,
         S: sm::IState + MaybeSend + MaybeSync + 'static,
@@ -193,7 +193,7 @@ where
         &mut self,
         input: InstancelessDynClientInput,
         operation_id: OperationId,
-    ) -> (TransactionId, Vec<OutPoint>) {
+    ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)> {
         let instance_input = ClientInput {
             input: DynInput::from_parts(self.client.module_instance_id, input.input),
             keys: input.keys,
@@ -213,7 +213,6 @@ where
                 TransactionBuilder::new().with_input(instance_input),
             )
             .await
-            .expect("Can only fail if additional funding is needed")
     }
 
     pub async fn add_state_machines_dbtx(

--- a/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
@@ -243,7 +243,11 @@ impl ReceiveStateMachine {
             state_machines: Arc::new(|_, _| vec![]),
         };
 
-        let outpoints = global_context.claim_input(dbtx, client_input).await.1;
+        let outpoints = global_context
+            .claim_input(dbtx, client_input)
+            .await
+            .expect("Cannot claim input, additional funding needed")
+            .1;
 
         old_state.update(ReceiveSMState::Refunding(outpoints))
     }

--- a/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
@@ -208,7 +208,11 @@ impl SendStateMachine {
                     state_machines: Arc::new(|_, _| vec![]),
                 };
 
-                let outpoints = global_context.claim_input(dbtx, client_input).await.1;
+                let outpoints = global_context
+                    .claim_input(dbtx, client_input)
+                    .await
+                    .expect("Cannot claim input, additional funding needed")
+                    .1;
 
                 old_state.update(SendSMState::Claiming(Claiming {
                     preimage,

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -694,7 +694,11 @@ impl GatewayPayClaimOutgoingContract {
             keys: vec![context.redeem_key],
         };
 
-        let out_points = global_context.claim_input(dbtx, client_input).await.1;
+        let out_points = global_context
+            .claim_input(dbtx, client_input)
+            .await
+            .expect("Cannot claim input, additional funding needed")
+            .1;
         debug!("Claimed outgoing contract {contract:?} with out points {out_points:?}");
         GatewayPayStateMachine {
             common,

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -333,7 +333,11 @@ impl DecryptingPreimageState {
             keys: vec![context.redeem_key],
         };
 
-        let out_points = global_context.claim_input(dbtx, client_input).await.1;
+        let out_points = global_context
+            .claim_input(dbtx, client_input)
+            .await
+            .expect("Cannot claim input, additional funding needed")
+            .1;
         debug!("Refunded incoming contract {contract:?} with {out_points:?}");
 
         IncomingStateMachine {

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -553,7 +553,10 @@ async fn try_refund_outgoing_contract(
         state_machines: Arc::new(|_, _| vec![]),
     };
 
-    let (txid, out_points) = global_context.claim_input(dbtx, refund_client_input).await;
+    let (txid, out_points) = global_context
+        .claim_input(dbtx, refund_client_input)
+        .await
+        .expect("Cannot claim input, additional funding needed");
 
     LightningPayStateMachine {
         common: old_state.common,

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -291,7 +291,10 @@ impl LightningReceiveConfirmedInvoice {
             state_machines: Arc::new(|_, _| vec![]),
         };
 
-        global_context.claim_input(dbtx, client_input).await
+        global_context
+            .claim_input(dbtx, client_input)
+            .await
+            .expect("Cannot claim input, additional funding needed")
     }
 }
 

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -120,7 +120,11 @@ impl ReceiveStateMachine {
             state_machines: Arc::new(|_, _| vec![]),
         };
 
-        let out_points = global_context.claim_input(dbtx, client_input).await.1;
+        let out_points = global_context
+            .claim_input(dbtx, client_input)
+            .await
+            .expect("Cannot claim input, additional funding needed")
+            .1;
 
         old_state.update(ReceiveSMState::Claiming(out_points))
     }

--- a/modules/fedimint-lnv2-client/src/send_sm.rs
+++ b/modules/fedimint-lnv2-client/src/send_sm.rs
@@ -234,7 +234,11 @@ impl SendStateMachine {
                     state_machines: Arc::new(|_, _| vec![]),
                 };
 
-                let outpoints = global_context.claim_input(dbtx, client_input).await.1;
+                let outpoints = global_context
+                    .claim_input(dbtx, client_input)
+                    .await
+                    .expect("Cannot claim input, additional funding needed")
+                    .1;
 
                 old_state.update(SendSMState::Refunding(outpoints))
             }
@@ -287,7 +291,11 @@ impl SendStateMachine {
             state_machines: Arc::new(|_, _| vec![]),
         };
 
-        let outpoints = global_context.claim_input(dbtx, client_input).await.1;
+        let outpoints = global_context
+            .claim_input(dbtx, client_input)
+            .await
+            .expect("Cannot claim input, additional funding needed")
+            .1;
 
         old_state.update(SendSMState::Refunding(outpoints))
     }

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -149,7 +149,10 @@ impl MintInputStateCreated {
             state_machines: Arc::new(|_, _| vec![]),
         };
 
-        let (refund_txid, _) = global_context.claim_input(dbtx, refund_input).await;
+        let (refund_txid, _) = global_context
+            .claim_input(dbtx, refund_input)
+            .await
+            .expect("Cannot claim input, additional funding needed");
 
         MintInputStateMachine {
             common: old_state.common,

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -192,5 +192,9 @@ async fn try_cancel_oob_spend(
         }),
     };
 
-    global_context.claim_input(dbtx, input).await.0
+    global_context
+        .claim_input(dbtx, input)
+        .await
+        .expect("Cannot claim input, additional funding needed")
+        .0
 }

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -284,7 +284,10 @@ pub(crate) async fn transition_btc_tx_confirmed(
         state_machines: Arc::new(|_, _| vec![]),
     };
 
-    let (fm_txid, change) = global_context.claim_input(dbtx, client_input).await;
+    let (fm_txid, change) = global_context
+        .claim_input(dbtx, client_input)
+        .await
+        .expect("Cannot claim input, additional funding needed");
 
     DepositStateMachine {
         operation_id: old_state.operation_id,

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -428,7 +428,10 @@ async fn claim_peg_in(
             state_machines: Arc::new(|_, _| vec![]),
         };
 
-        dbtx_context.claim_input(client_input, operation_id).await
+        dbtx_context
+            .claim_input(client_input, operation_id)
+            .await
+            .expect("Cannot claim input, additional funding needed")
     }
 
     let tx_out_proof = &tx_out_proof;


### PR DESCRIPTION
Partially Fixes: https://github.com/fedimint/fedimint/issues/5598

`claim_input` currently does not return a `Result`, but it can panic if there is not sufficient funds to claim the input. This is un-intuitive and a foot gun for module developers since it will crash if the client has no funds, which might be the default for newly initialized clients.

Instead, we should return a `Result` and force the module state machines to deal with this error. Currently, this PR just uses `expect` in each module state machine, so the behavior is the same, but in the future we could add looping to retrying claiming an input when funds are available.