### PR TITLE
fix: esplora bitcoin backend returning reverse network hash / wrong network

### DIFF
--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -6,7 +6,6 @@ use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Feerate};
-use hex::ToHex;
 use tracing::{info, warn};
 
 use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
@@ -44,7 +43,7 @@ impl IBitcoindRpc for EsploraClient {
         let genesis_height: u32 = 0;
         let genesis_hash = self.0.get_block_hash(genesis_height).await?;
 
-        let network = match genesis_hash.encode_hex::<String>().as_str() {
+        let network = match genesis_hash.to_string().as_str() {
             crate::MAINNET_GENESIS_BLOCK_HASH => Network::Bitcoin,
             crate::TESTNET_GENESIS_BLOCK_HASH => Network::Testnet,
             crate::SIGNET_GENESIS_BLOCK_HASH => Network::Signet,


### PR DESCRIPTION
It seems to me that what happened is that during rust-bitcoin upgrade the internal representation of `BlockHash` was reversed and now naive `hex` crate encoding gives us wrong hash, that is interpreted as regtest network. Using `.to_string` on `BlockHash` does the right thing independent of underlying order of bytes.

This bug causes DKG to fail when esplora is used as a backend.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
