### PR TITLE
chore: parallelize mprocs lightning channel opening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
  "fs-lock",
  "futures",
  "hex",
+ "itertools 0.13.0",
  "nix",
  "rand",
  "semver",

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -49,6 +49,7 @@ fedimintd = { path = "../fedimintd" }
 fs-lock = "0.1.3"
 futures = { workspace = true }
 hex = { workspace = true }
+itertools = { workspace = true }
 ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 nix = { version = "0.29.0", features = ["signal"] }
 rand = { workspace = true }

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -867,25 +867,25 @@ pub async fn open_channel_between_gateways(
     gw_a: &Gatewayd,
     gw_b: &Gatewayd,
 ) -> Result<()> {
-    // TODO: Find out why we need to wait for LDK here.
-    let funding_addr = loop {
-        if let Ok(address) = gw_a.get_funding_address().await {
-            break address;
-        }
-
-        fedimint_core::runtime::sleep(std::time::Duration::from_secs(1)).await;
-    };
-
-    bitcoind.send_to(funding_addr, 100_000_000).await?;
-    bitcoind.mine_blocks(10).await?;
-
-    debug!(target: LOG_DEVIMINT, "Await block ln nodes block processing");
+    debug!(target: LOG_DEVIMINT, "Syncing gateway lightning nodes to chain tip...");
     tokio::try_join!(
         gw_a.wait_for_chain_sync(bitcoind),
         gw_b.wait_for_chain_sync(bitcoind)
     )?;
 
-    debug!(target: LOG_DEVIMINT, "Opening LN channel between the nodes...");
+    debug!(target: LOG_DEVIMINT, "Performing peg-in...");
+    let funding_addr = gw_a.get_funding_address().await?;
+    bitcoind.send_to(funding_addr, 100_000_000).await?;
+
+    bitcoind.mine_blocks(10).await?;
+
+    debug!(target: LOG_DEVIMINT, "Syncing gateway lightning nodes to chain tip...");
+    tokio::try_join!(
+        gw_a.wait_for_chain_sync(bitcoind),
+        gw_b.wait_for_chain_sync(bitcoind)
+    )?;
+
+    debug!(target: LOG_DEVIMINT, "Opening lightning channel between gateway lightning nodes...");
     gw_a.open_channel(
         gw_b.lightning_pubkey().await?,
         gw_b.lightning_node_addr.clone(),
@@ -898,9 +898,9 @@ pub async fn open_channel_between_gateways(
     // so we need to wait for it to get to the mempool.
     // TODO: LDK is the culprit here. Find a way to ensure that
     // `GatewayLdkClient::open_channel` is fully done before it returns.
-    fedimint_core::runtime::sleep(Duration::from_secs(10)).await;
+    fedimint_core::runtime::sleep(Duration::from_secs(5)).await;
 
-    bitcoind.mine_blocks(20).await?;
+    bitcoind.mine_blocks(10).await?;
 
     let gw_a_node_pubkey = gw_a.lightning_pubkey().await?;
 

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -18,6 +18,7 @@ use fedimint_core::BitcoinHash;
 use fedimint_logging::LOG_DEVIMINT;
 use fedimint_testing::gateway::LightningNodeType;
 use hex::ToHex;
+use itertools::Itertools;
 use tokio::fs;
 use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
 use tokio::time::Instant;
@@ -862,37 +863,51 @@ pub async fn open_channel(
     Ok(())
 }
 
-pub async fn open_channel_between_gateways(
+#[allow(clippy::similar_names)]
+pub async fn open_channels_between_gateways(
     bitcoind: &Bitcoind,
-    gw_a: &Gatewayd,
-    gw_b: &Gatewayd,
+    gateways: &[(&Gatewayd, &str)],
 ) -> Result<()> {
     debug!(target: LOG_DEVIMINT, "Syncing gateway lightning nodes to chain tip...");
-    tokio::try_join!(
-        gw_a.wait_for_chain_sync(bitcoind),
-        gw_b.wait_for_chain_sync(bitcoind)
-    )?;
+    futures::future::try_join_all(
+        gateways
+            .iter()
+            .map(|(gw, _gw_name)| gw.wait_for_chain_sync(bitcoind)),
+    )
+    .await?;
 
-    debug!(target: LOG_DEVIMINT, "Performing peg-in...");
-    let funding_addr = gw_a.get_funding_address().await?;
-    bitcoind.send_to(funding_addr, 100_000_000).await?;
+    debug!(target: LOG_DEVIMINT, "Performing peg-in on all gateway lightning nodes...");
+    for (gw, _gw_name) in gateways {
+        let funding_addr = gw.get_funding_address().await?;
+        bitcoind.send_to(funding_addr, 100_000_000).await?;
+    }
 
     bitcoind.mine_blocks(10).await?;
 
     debug!(target: LOG_DEVIMINT, "Syncing gateway lightning nodes to chain tip...");
-    tokio::try_join!(
-        gw_a.wait_for_chain_sync(bitcoind),
-        gw_b.wait_for_chain_sync(bitcoind)
-    )?;
-
-    debug!(target: LOG_DEVIMINT, "Opening lightning channel between gateway lightning nodes...");
-    gw_a.open_channel(
-        gw_b.lightning_pubkey().await?,
-        gw_b.lightning_node_addr.clone(),
-        10_000_000,
-        Some(5_000_000),
+    futures::future::try_join_all(
+        gateways
+            .iter()
+            .map(|(gw, _gw_name)| gw.wait_for_chain_sync(bitcoind)),
     )
     .await?;
+
+    // All unique pairs of gateways.
+    // For a list of gateways [A, B, C], this will produce [(A, B), (B, C), (C, A)].
+    #[allow(clippy::type_complexity)]
+    let gateway_pairs: Vec<(&(&Gatewayd, &str), &(&Gatewayd, &str))> =
+        gateways.iter().circular_tuple_windows::<(_, _)>().collect();
+
+    for ((gw_a, gw_a_name), (gw_b, gw_b_name)) in &gateway_pairs {
+        debug!(target: LOG_DEVIMINT, "Opening channel between {gw_a_name} and {gw_b_name} gateway lightning nodes...");
+        gw_a.open_channel(
+            gw_b.lightning_pubkey().await?,
+            gw_b.lightning_node_addr.clone(),
+            10_000_000,
+            Some(5_000_000),
+        )
+        .await?;
+    }
 
     // `open_channel` may not send out the channel funding transaction immediately
     // so we need to wait for it to get to the mempool.
@@ -902,10 +917,23 @@ pub async fn open_channel_between_gateways(
 
     bitcoind.mine_blocks(10).await?;
 
-    let gw_a_node_pubkey = gw_a.lightning_pubkey().await?;
+    for ((gw_a, _gw_a_name), (gw_b, _gw_b_name)) in &gateway_pairs {
+        let gw_a_node_pubkey = gw_a.lightning_pubkey().await?;
+        let gw_b_node_pubkey = gw_b.lightning_pubkey().await?;
 
+        wait_for_ready_channel_on_gateway_with_counterparty(gw_b, gw_a_node_pubkey).await?;
+        wait_for_ready_channel_on_gateway_with_counterparty(gw_a, gw_b_node_pubkey).await?;
+    }
+
+    Ok(())
+}
+
+async fn wait_for_ready_channel_on_gateway_with_counterparty(
+    gw: &Gatewayd,
+    counterparty_lightning_node_pubkey: bitcoin::secp256k1::PublicKey,
+) -> anyhow::Result<()> {
     poll("Wait for channel update", || async {
-        let channels = gw_b
+        let channels = gw
             .list_active_channels()
             .await
             .context("list channels")
@@ -913,16 +941,14 @@ pub async fn open_channel_between_gateways(
 
         if channels
             .iter()
-            .any(|channel| channel.remote_pubkey == gw_a_node_pubkey)
+            .any(|channel| channel.remote_pubkey == counterparty_lightning_node_pubkey)
         {
             return Ok(());
         }
 
         Err(ControlFlow::Continue(anyhow!("channel not found")))
     })
-    .await?;
-
-    Ok(())
+    .await
 }
 
 #[derive(Clone)]

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -50,11 +50,11 @@ where
     let (process_mgr, task_group) = cli::setup(args).await?;
     log_binary_versions().await?;
     let dev_fed = devfed::DevJitFed::new(&process_mgr, false)?;
-    let res = cleanup_on_exit(f(dev_fed.clone(), process_mgr.clone()), task_group).await;
     // workaround https://github.com/tokio-rs/tokio/issues/6463
     // by waiting on all jits to complete, we make it less likely
     // that something is not finished yet and will block in `on_block`
     let _ = dev_fed.finalize(&process_mgr).await;
+    let res = cleanup_on_exit(f(dev_fed.clone(), process_mgr.clone()), task_group).await;
     dev_fed.fast_terminate().await;
     res?;
 


### PR DESCRIPTION
On my local machine (Apple M1 Pro, 32GB RAM) the mprocs startup times before/after are:

Before (master branch):
Attempt 1: 93.3s
Attempt 2: 95.5s
Attempt 3: 94.0s
Attempt 4: 93.8s
Attempt 5: 93.5s
Average: 94.0s

After (PR branch):
Attempt 1: 65.2s
Attempt 2: 64.0s
Attempt 3: 63.7s
Attempt 4: 65.7s
Attempt 5: 64.3s
Average: 64.6s

So this is roughly 30% faster and helps to undo some of the damage caused by merging the LDK gateway