### PR TITLE
[Backport releases/v0.4] fix: esplora bitcoin backend returning reverse network hash / wrong network

### DIFF
--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -6,7 +6,6 @@ use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Feerate};
-use hex::ToHex;
 use tracing::{info, warn};
 
 use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
@@ -44,7 +43,7 @@ impl IBitcoindRpc for EsploraClient {
         let genesis_height: u32 = 0;
         let genesis_hash = self.0.get_block_hash(genesis_height).await?;
 
-        let network = match genesis_hash.encode_hex::<String>().as_str() {
+        let network = match genesis_hash.to_string().as_str() {
             crate::MAINNET_GENESIS_BLOCK_HASH => Network::Bitcoin,
             crate::TESTNET_GENESIS_BLOCK_HASH => Network::Testnet,
             crate::SIGNET_GENESIS_BLOCK_HASH => Network::Signet,


### PR DESCRIPTION
# Description
Backport of #5813 to `releases/v0.4`.