### PR TITLE
feat: add gateway rpc + cli command to get balances

### DIFF
--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -17,8 +17,8 @@ use lightning_invoice::{
 };
 use ln_gateway::gateway_lnrpc::{
     self, CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse,
-    EmptyResponse, GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse,
-    InterceptHtlcResponse, PayInvoiceResponse,
+    EmptyResponse, GetBalancesResponse, GetFundingAddressResponse, GetNodeInfoResponse,
+    GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceResponse,
 };
 use ln_gateway::lightning::{
     ChannelInfo, HtlcResult, ILnRpcClient, LightningRpcError, RouteHtlcStream,
@@ -257,5 +257,9 @@ impl ILnRpcClient for FakeLightningTest {
 
     async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError> {
         unimplemented!("FakeLightningTest does not support listing active channels")
+    }
+
+    async fn get_balances(&self) -> Result<GetBalancesResponse, LightningRpcError> {
+        unimplemented!("FakeLightningTest does not support getting balances")
     }
 }

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -59,6 +59,8 @@ pub enum GeneralCommands {
         #[clap(long)]
         federation_id: FederationId,
     },
+    /// Get the total on-chain, lightning, and eCash balances of the gateway.
+    GetBalances,
     /// Generate a new peg-in address to a federation that the gateway can claim
     /// e-cash for later.
     Address {
@@ -173,6 +175,10 @@ impl GeneralCommands {
                     .get_balance(BalancePayload { federation_id })
                     .await?;
 
+                print_response(response);
+            }
+            Self::GetBalances => {
+                let response = create_client().get_balances().await?;
                 print_response(response);
             }
             Self::Address { federation_id } => {

--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -47,6 +47,8 @@ service GatewayLightning {
 
   /* List all channels that are active and able to send and receive funds. */
   rpc ListActiveChannels(EmptyRequest) returns (ListActiveChannelsResponse) {}
+
+  rpc GetBalances(EmptyRequest) returns (GetBalancesResponse) {}
 }
 
 message EmptyRequest {}
@@ -311,4 +313,12 @@ message ListActiveChannelsResponse {
 
   // All channels on the node that are currently able to send and receive payments.
   repeated ChannelInfo channels = 1;
+}
+
+message GetBalancesResponse {
+    // The total balance of the node's on-chain wallet, in sats.
+    uint64 onchain_balance_sats = 1;
+
+    // The total balance of the node's lightning wallet, in millisats.
+    uint64 lightning_balance_msats = 2;
 }

--- a/gateway/ln-gateway/src/lightning/cln.rs
+++ b/gateway/ln-gateway/src/lightning/cln.rs
@@ -16,9 +16,9 @@ use super::{ChannelInfo, ILnRpcClient, LightningRpcError, RouteHtlcStream};
 use crate::gateway_lnrpc::gateway_lightning_client::GatewayLightningClient;
 use crate::gateway_lnrpc::{
     self, CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
-    CreateInvoiceResponse, EmptyRequest, EmptyResponse, GetFundingAddressResponse,
-    GetNodeInfoResponse, GetRouteHintsRequest, GetRouteHintsResponse, InterceptHtlcResponse,
-    OpenChannelRequest, PayInvoiceResponse, PayPrunedInvoiceRequest,
+    CreateInvoiceResponse, EmptyRequest, EmptyResponse, GetBalancesResponse,
+    GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsRequest, GetRouteHintsResponse,
+    InterceptHtlcResponse, OpenChannelRequest, PayInvoiceResponse, PayPrunedInvoiceRequest,
 };
 use crate::lightning::MAX_LIGHTNING_RETRIES;
 
@@ -240,5 +240,17 @@ impl ILnRpcClient for NetworkLnRpcClient {
                 short_channel_id: channel.short_channel_id,
             })
             .collect())
+    }
+
+    async fn get_balances(&self) -> Result<GetBalancesResponse, LightningRpcError> {
+        let mut client = self.connect().await?;
+
+        Ok(client
+            .get_balances(EmptyRequest {})
+            .await
+            .map_err(|status| LightningRpcError::FailedToGetBalances {
+                failure_reason: status.message().to_string(),
+            })?
+            .into_inner())
     }
 }

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -24,8 +24,8 @@ use crate::gateway_lnrpc::create_invoice_request::Description;
 use crate::gateway_lnrpc::intercept_htlc_response::{Action, Settle};
 use crate::gateway_lnrpc::{
     CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse,
-    GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
-    InterceptHtlcResponse, PayInvoiceResponse,
+    GetBalancesResponse, GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse,
+    InterceptHtlcRequest, InterceptHtlcResponse, PayInvoiceResponse,
 };
 
 pub struct GatewayLdkClient {
@@ -489,5 +489,13 @@ impl ILnRpcClient for GatewayLdkClient {
         }
 
         Ok(channels)
+    }
+
+    async fn get_balances(&self) -> Result<GetBalancesResponse, LightningRpcError> {
+        let balances = self.node.list_balances();
+        Ok(GetBalancesResponse {
+            onchain_balance_sats: balances.total_onchain_balance_sats,
+            lightning_balance_msats: balances.total_lightning_balance_sats * 1000,
+        })
     }
 }

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -31,8 +31,8 @@ use crate::envs::{
 };
 use crate::gateway_lnrpc::{
     CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse,
-    GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse, InterceptHtlcRequest,
-    InterceptHtlcResponse, PayInvoiceResponse,
+    GetBalancesResponse, GetFundingAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse,
+    InterceptHtlcRequest, InterceptHtlcResponse, PayInvoiceResponse,
 };
 use crate::GatewayError;
 
@@ -69,6 +69,8 @@ pub enum LightningRpcError {
     FailedToConnectToPeer { failure_reason: String },
     #[error("Failed to list active channels: {failure_reason}")]
     FailedToListActiveChannels { failure_reason: String },
+    #[error("Failed to get balances: {failure_reason}")]
+    FailedToGetBalances { failure_reason: String },
     #[error("Failed to wait for chain sync: {failure_reason}")]
     FailedToWaitForChainSync { failure_reason: String },
     #[error("Failed to subscribe to invoice updates: {failure_reason}")]
@@ -177,6 +179,8 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     ) -> Result<CloseChannelsWithPeerResponse, LightningRpcError>;
 
     async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError>;
+
+    async fn get_balances(&self) -> Result<GetBalancesResponse, LightningRpcError>;
 }
 
 impl dyn ILnRpcClient {

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -66,7 +66,7 @@ pub struct WithdrawPayload {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FederationInfo {
     pub federation_id: FederationId,
-    pub balance_msat: Amount,
+    pub balance_msat: Amount, // TODO: Rename to `balance`, since `Amount` is already in msat.
     pub config: ClientConfig,
     pub channel_id: Option<u64>,
     pub routing_fees: Option<FederationRoutingFees>,

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -4,7 +4,7 @@ use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, TransactionId};
 use fedimint_ln_common::gateway_endpoint_constants::{
     BACKUP_ENDPOINT, BALANCE_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
-    CONNECT_FED_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
+    CONNECT_FED_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT,
     GET_FUNDING_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
     OPEN_CHANNEL_ENDPOINT, RECEIVE_ECASH_ENDPOINT, RESTORE_ENDPOINT, SET_CONFIGURATION_ENDPOINT,
     SPEND_ECASH_ENDPOINT, WITHDRAW_ENDPOINT,
@@ -21,7 +21,7 @@ use super::{
     SetConfigurationPayload, SpendEcashPayload, SpendEcashResponse, WithdrawPayload,
 };
 use crate::lightning::ChannelInfo;
-use crate::CloseChannelsWithPeerResponse;
+use crate::{CloseChannelsWithPeerResponse, GatewayBalances};
 
 pub struct GatewayRpcClient {
     /// Base URL to gateway web server
@@ -202,6 +202,14 @@ impl GatewayRpcClient {
             .join(RECEIVE_ECASH_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
+    }
+
+    pub async fn get_balances(&self) -> GatewayRpcResult<GatewayBalances> {
+        let url = self
+            .base_url
+            .join(GET_BALANCES_ENDPOINT)
+            .expect("invalid base url");
+        self.call_get(url).await
     }
 
     async fn call<P: Serialize, T: DeserializeOwned>(

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -14,11 +14,11 @@ use fedimint_ln_client::pay::PayInvoicePayload;
 use fedimint_ln_common::gateway_endpoint_constants::{
     ADDRESS_ENDPOINT, BACKUP_ENDPOINT, BALANCE_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
     CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_V2_ENDPOINT,
-    GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_FUNDING_ADDRESS_ENDPOINT,
-    GET_GATEWAY_ID_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_ENDPOINT, RECEIVE_ECASH_ENDPOINT, RESTORE_ENDPOINT,
-    ROUTING_INFO_V2_ENDPOINT, SEND_PAYMENT_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT,
-    SPEND_ECASH_ENDPOINT, WITHDRAW_ENDPOINT,
+    GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT,
+    GET_FUNDING_ADDRESS_ENDPOINT, GET_GATEWAY_ID_ENDPOINT, LEAVE_FED_ENDPOINT,
+    LIST_ACTIVE_CHANNELS_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_ENDPOINT,
+    RECEIVE_ECASH_ENDPOINT, RESTORE_ENDPOINT, ROUTING_INFO_V2_ENDPOINT, SEND_PAYMENT_V2_ENDPOINT,
+    SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_client::{CreateBolt11InvoicePayload, SendPaymentPayload};
 use hex::ToHex;
@@ -176,6 +176,7 @@ fn v1_routes(gateway: Arc<Gateway>) -> Router {
             post(close_channels_with_peer),
         )
         .route(LIST_ACTIVE_CHANNELS_ENDPOINT, get(list_active_channels))
+        .route(GET_BALANCES_ENDPOINT, get(get_balances))
         .layer(middleware::from_fn(auth_middleware));
 
     // Routes that are un-authenticated before gateway configuration, then become
@@ -362,6 +363,14 @@ async fn list_active_channels(
 ) -> Result<impl IntoResponse, GatewayError> {
     let channels = gateway.handle_list_active_channels_msg().await?;
     Ok(Json(json!(channels)))
+}
+
+#[instrument(skip_all, err)]
+async fn get_balances(
+    Extension(gateway): Extension<Arc<Gateway>>,
+) -> Result<impl IntoResponse, GatewayError> {
+    let balances = gateway.handle_get_balances_msg().await?;
+    Ok(Json(json!(balances)))
 }
 
 #[instrument(skip_all, err)]

--- a/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
+++ b/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
@@ -7,6 +7,7 @@ pub const CONFIGURATION_ENDPOINT: &str = "/config";
 pub const CONNECT_FED_ENDPOINT: &str = "/connect-fed"; // uses `-` for backwards compatibility
 pub const CREATE_BOLT11_INVOICE_V2_ENDPOINT: &str = "/create_bolt11_invoice";
 pub const GATEWAY_INFO_ENDPOINT: &str = "/info";
+pub const GET_BALANCES_ENDPOINT: &str = "/balances";
 pub const GET_GATEWAY_ID_ENDPOINT: &str = "/id";
 pub const GATEWAY_INFO_POST_ENDPOINT: &str = "/info";
 pub const GET_FUNDING_ADDRESS_ENDPOINT: &str = "/get_funding_address";


### PR DESCRIPTION
This command lists the following:

* Total amount of on-chain bitcoin
* Local lightning liquidity
* eCash across all federations

The primary purpose of this command is to provide a liquidity overview in the gateway UI