### PR TITLE
feat: Adds Ecash Send and Receive commands and RPCs to Gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-ln-gateway",
  "fedimint-logging",
+ "fedimint-mint-client",
  "reqwest 0.12.5",
  "serde",
  "serde_json",

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -19,16 +19,28 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = "0.7.5"
 bitcoin = { workspace = true }
-clap = { version = "4.5.15", features = ["derive", "std", "help", "usage", "error-context", "suggestions"], default-features = false }
+clap = { version = "4.5.15", features = [
+  "derive",
+  "std",
+  "help",
+  "usage",
+  "error-context",
+  "suggestions",
+], default-features = false }
 clap_complete = "4.5.14"
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
+fedimint-mint-client = { workspace = true }
 ln-gateway = { version = "=0.5.0-alpha", package = "fedimint-ln-gateway", path = "../ln-gateway" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1.39", features = ["full"] }
-tracing = { version = "0.1.40", default-features = false, features = ["log", "attributes", "std"] }
+tracing = { version = "0.1.40", default-features = false, features = [
+  "log",
+  "attributes",
+  "std",
+] }
 url = { version = "2.5.2", features = ["serde"] }
 
 [build-dependencies]

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -115,6 +115,15 @@ pub enum GeneralCommands {
         #[clap(long)]
         per_federation_routing_fees: Option<Vec<PerFederationRoutingFees>>,
     },
+    /// Spend e-cash
+    SpendEcash {
+        #[clap(long)]
+        amount: BitcoinAmountOrAll,
+        #[clap(long)]
+        timeout: u64,
+        #[clap(long)]
+        include_invite: bool,
+    },
 }
 
 impl GeneralCommands {
@@ -214,6 +223,19 @@ impl GeneralCommands {
                         routing_fees,
                         network,
                         per_federation_routing_fees,
+                    })
+                    .await?;
+            }
+            Self::SpendEcash {
+                amount,
+                timeout,
+                include_invite,
+            } => {
+                let response = create_client()
+                    .spend_ecash(SpendEcashPayload {
+                        amount,
+                        timeout,
+                        include_invite,
                     })
                     .await?;
             }

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -11,6 +11,7 @@ use ln_gateway::rpc::{
     FederationRoutingFees, LeaveFedPayload, ReceiveEcashPayload, RestorePayload,
     SetConfigurationPayload, SpendEcashPayload, WithdrawPayload,
 };
+use tracing::info;
 
 use crate::print_response;
 
@@ -120,11 +121,10 @@ pub enum GeneralCommands {
     SpendEcash {
         #[clap(long)]
         federation_id: FederationId,
-        #[clap(long)]
         amount: Amount,
         #[clap(long)]
         allow_overpay: bool,
-        #[clap(long)]
+        #[clap(long, default_value_t = 60 * 60 * 24 * 7)]
         timeout: u64,
         #[clap(long)]
         include_invite: bool,
@@ -133,7 +133,7 @@ pub enum GeneralCommands {
     ReceiveEcash {
         #[clap(long)]
         notes: OOBNotes,
-        #[clap(long)]
+        #[arg(long = "no-wait", action = clap::ArgAction::SetFalse)]
         wait: bool,
     },
 }
@@ -262,6 +262,8 @@ impl GeneralCommands {
                 let response = create_client()
                     .receive_ecash(ReceiveEcashPayload { notes, wait })
                     .await?;
+
+                info!("Response: {:?}", response);
 
                 print_response(response);
             }

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -263,8 +263,6 @@ impl GeneralCommands {
                     .receive_ecash(ReceiveEcashPayload { notes, wait })
                     .await?;
 
-                info!("Response: {:?}", response);
-
                 print_response(response);
             }
         }

--- a/gateway/ln-gateway/src/federation_manager.rs
+++ b/gateway/ln-gateway/src/federation_manager.rs
@@ -156,10 +156,10 @@ impl FederationManager {
 
     pub fn get_client_for_federation_id_prefix(
         &self,
-        federation_id_prefix: &FederationIdPrefix,
+        federation_id_prefix: FederationIdPrefix,
     ) -> Option<Spanned<ClientHandleArc>> {
         self.clients.iter().find_map(|(fid, client)| {
-            if &fid.to_prefix() == federation_id_prefix {
+            if fid.to_prefix() == federation_id_prefix {
                 Some(client.clone())
             } else {
                 None

--- a/gateway/ln-gateway/src/federation_manager.rs
+++ b/gateway/ln-gateway/src/federation_manager.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use bitcoin::secp256k1::KeyPair;
 use fedimint_client::ClientHandleArc;
-use fedimint_core::config::{FederationId, JsonClientConfig};
+use fedimint_core::config::{FederationId, FederationIdPrefix, JsonClientConfig};
 use fedimint_core::db::{DatabaseTransaction, NonCommittable};
 use fedimint_core::util::Spanned;
 
@@ -148,6 +148,19 @@ impl FederationManager {
         self.scid_to_federation.iter().find_map(|(scid, fid)| {
             if *fid == federation_id {
                 Some(*scid)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn get_client_for_federation_id_prefix(
+        &self,
+        federation_id_prefix: &FederationIdPrefix,
+    ) -> Option<Spanned<ClientHandleArc>> {
+        self.clients.iter().find_map(|(fid, client)| {
+            if &fid.to_prefix() == federation_id_prefix {
+                Some(client.clone())
             } else {
                 None
             }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1631,6 +1631,9 @@ impl Gateway {
                 .await?
         };
 
+        info!("Spend ecash operation id: {:?}", operation_id);
+        info!("Spend ecash notes: {:?}", notes);
+
         Ok(SpendEcashResponse {
             operation_id,
             notes,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -96,8 +96,8 @@ use lightning_invoice::{Bolt11Invoice, RoutingFees};
 use rand::Rng;
 use rpc::{
     CloseChannelsWithPeerPayload, FederationInfo, GatewayFedConfig, GatewayInfo, LeaveFedPayload,
-    OpenChannelPayload, SetConfigurationPayload, SpendEcashPayload, SpendEcashResponse,
-    V1_API_ENDPOINT,
+    OpenChannelPayload, ReceiveEcashPayload, ReceiveEcashResponse, SetConfigurationPayload,
+    SpendEcashPayload, SpendEcashResponse, V1_API_ENDPOINT,
 };
 use state_machine::pay::OutgoingPaymentError;
 use state_machine::GatewayClientModule;
@@ -1635,6 +1635,37 @@ impl Gateway {
             operation_id,
             notes,
         })
+    }
+
+    pub async fn receive_ecash(
+        &self,
+        payload: ReceiveEcashPayload,
+    ) -> anyhow::Result<ReceiveEcashResponse> {
+        let amount = payload.notes.total_amount();
+        let client = self
+            .federation_manager
+            .read()
+            .await
+            .get_client_for_federation_id_prefix(&payload.notes.federation_id_prefix())
+            .ok_or(anyhow!("Client not found"))?;
+        let mint = client.get_first_module::<MintClientModule>();
+
+        let operation_id = mint.reissue_external_notes(payload.notes, ()).await?;
+        if payload.wait {
+            let mut updates = mint
+                .subscribe_reissue_external_notes(operation_id)
+                .await
+                .unwrap()
+                .into_stream();
+
+            while let Some(update) = updates.next().await {
+                if let fedimint_mint_client::ReissueExternalNotesState::Failed(e) = update {
+                    bail!("Reissue failed: {e}");
+                }
+            }
+        }
+
+        Ok(ReceiveEcashResponse { amount })
     }
 }
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1646,9 +1646,9 @@ impl Gateway {
             .federation_manager
             .read()
             .await
-            .get_client_for_federation_id_prefix(&payload.notes.federation_id_prefix())
+            .get_client_for_federation_id_prefix(payload.notes.federation_id_prefix())
             .ok_or(anyhow!("Client not found"))?;
-        let mint = client.get_first_module::<MintClientModule>();
+        let mint = client.value().get_first_module::<MintClientModule>();
 
         let operation_id = mint.reissue_external_notes(payload.notes, ()).await?;
         if payload.wait {

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -7,9 +7,11 @@ use std::str::FromStr;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Network};
 use fedimint_core::config::{ClientConfig, FederationId, JsonClientConfig};
+use fedimint_core::core::OperationId;
 use fedimint_core::{secp256k1, Amount, BitcoinAmountOrAll};
 use fedimint_ln_common::config::parse_routing_fees;
 use fedimint_ln_common::{route_hints, serde_option_routing_fees};
+use fedimint_mint_client::OOBNotes;
 use lightning_invoice::RoutingFees;
 use serde::{Deserialize, Serialize};
 
@@ -160,4 +162,27 @@ pub struct OpenChannelPayload {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CloseChannelsWithPeerPayload {
     pub pubkey: secp256k1::PublicKey,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SpendEcashPayload {
+    /// Federation id of the e-cash to spend
+    pub federation_id: FederationId,
+    /// The amount of e-cash to spend
+    pub amount: Amount,
+    /// If the exact amount cannot be represented, return e-cash of a higher
+    /// value instead of failing
+    pub allow_overpay: bool,
+    /// After how many seconds we will try to reclaim the e-cash if it
+    /// hasn't been redeemed by the recipient. Defaults to one week.
+    pub timeout: u64,
+    /// If the necessary information to join the federation the e-cash
+    /// belongs to should be included in the serialized notes
+    pub include_invite: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SpendEcashResponse {
+    pub operation_id: OperationId,
+    pub notes: OOBNotes,
 }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -186,3 +186,14 @@ pub struct SpendEcashResponse {
     pub operation_id: OperationId,
     pub notes: OOBNotes,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReceiveEcashPayload {
+    pub notes: OOBNotes,
+    pub wait: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReceiveEcashResponse {
+    pub amount: Amount,
+}

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -184,8 +184,9 @@ pub struct SpendEcashPayload {
     pub include_invite: bool,
 }
 
+/// Default timeout for e-cash redemption of one week in seconds
 fn default_timeout() -> u64 {
-    604800
+    604_800
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -172,13 +172,20 @@ pub struct SpendEcashPayload {
     pub amount: Amount,
     /// If the exact amount cannot be represented, return e-cash of a higher
     /// value instead of failing
+    #[serde(default)]
     pub allow_overpay: bool,
     /// After how many seconds we will try to reclaim the e-cash if it
     /// hasn't been redeemed by the recipient. Defaults to one week.
+    #[serde(default = "default_timeout")]
     pub timeout: u64,
     /// If the necessary information to join the federation the e-cash
     /// belongs to should be included in the serialized notes
+    #[serde(default)]
     pub include_invite: bool,
+}
+
+fn default_timeout() -> u64 {
+    604800
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -190,6 +197,7 @@ pub struct SpendEcashResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReceiveEcashPayload {
     pub notes: OOBNotes,
+    #[serde(default)]
     pub wait: bool,
 }
 

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -223,7 +223,7 @@ impl GatewayRpcClient {
         let response = builder.send().await?;
 
         match response.status() {
-            StatusCode::OK => Ok(response.json().await?),
+            StatusCode::OK => Ok(response.json::<T>().await?),
             status => Err(GatewayRpcError::BadStatus(status)),
         }
     }

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -6,8 +6,8 @@ use fedimint_ln_common::gateway_endpoint_constants::{
     BACKUP_ENDPOINT, BALANCE_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
     CONNECT_FED_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
     GET_FUNDING_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    OPEN_CHANNEL_ENDPOINT, RESTORE_ENDPOINT, SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT,
-    WITHDRAW_ENDPOINT,
+    OPEN_CHANNEL_ENDPOINT, RECEIVE_ECASH_ENDPOINT, RESTORE_ENDPOINT, SET_CONFIGURATION_ENDPOINT,
+    SPEND_ECASH_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use reqwest::{Method, StatusCode};
 use serde::de::DeserializeOwned;
@@ -17,8 +17,8 @@ use thiserror::Error;
 use super::{
     BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConfigPayload, ConnectFedPayload,
     DepositAddressPayload, FederationInfo, GatewayFedConfig, GatewayInfo, GetFundingAddressPayload,
-    LeaveFedPayload, OpenChannelPayload, RestorePayload, SetConfigurationPayload,
-    SpendEcashPayload, SpendEcashResponse, WithdrawPayload,
+    LeaveFedPayload, OpenChannelPayload, ReceiveEcashPayload, ReceiveEcashResponse, RestorePayload,
+    SetConfigurationPayload, SpendEcashPayload, SpendEcashResponse, WithdrawPayload,
 };
 use crate::lightning::ChannelInfo;
 use crate::CloseChannelsWithPeerResponse;
@@ -189,6 +189,17 @@ impl GatewayRpcClient {
         let url = self
             .base_url
             .join(SPEND_ECASH_ENDPOINT)
+            .expect("invalid base url");
+        self.call_post(url, payload).await
+    }
+
+    pub async fn receive_ecash(
+        &self,
+        payload: ReceiveEcashPayload,
+    ) -> GatewayRpcResult<ReceiveEcashResponse> {
+        let url = self
+            .base_url
+            .join(RECEIVE_ECASH_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
     }

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -6,7 +6,8 @@ use fedimint_ln_common::gateway_endpoint_constants::{
     BACKUP_ENDPOINT, BALANCE_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
     CONNECT_FED_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
     GET_FUNDING_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    OPEN_CHANNEL_ENDPOINT, RESTORE_ENDPOINT, SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
+    OPEN_CHANNEL_ENDPOINT, RESTORE_ENDPOINT, SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT,
+    WITHDRAW_ENDPOINT,
 };
 use reqwest::{Method, StatusCode};
 use serde::de::DeserializeOwned;
@@ -16,7 +17,8 @@ use thiserror::Error;
 use super::{
     BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConfigPayload, ConnectFedPayload,
     DepositAddressPayload, FederationInfo, GatewayFedConfig, GatewayInfo, GetFundingAddressPayload,
-    LeaveFedPayload, OpenChannelPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload,
+    LeaveFedPayload, OpenChannelPayload, RestorePayload, SetConfigurationPayload,
+    SpendEcashPayload, SpendEcashResponse, WithdrawPayload,
 };
 use crate::lightning::ChannelInfo;
 use crate::CloseChannelsWithPeerResponse;
@@ -178,6 +180,17 @@ impl GatewayRpcClient {
             .join(LIST_ACTIVE_CHANNELS_ENDPOINT)
             .expect("invalid base url");
         self.call_get(url).await
+    }
+
+    pub async fn spend_ecash(
+        &self,
+        payload: SpendEcashPayload,
+    ) -> GatewayRpcResult<SpendEcashResponse> {
+        let url = self
+            .base_url
+            .join(SPEND_ECASH_ENDPOINT)
+            .expect("invalid base url");
+        self.call_post(url, payload).await
     }
 
     async fn call<P: Serialize, T: DeserializeOwned>(

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -13,6 +13,7 @@ use reqwest::{Method, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use thiserror::Error;
+use tracing::info;
 
 use super::{
     BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConfigPayload, ConnectFedPayload,
@@ -190,7 +191,9 @@ impl GatewayRpcClient {
             .base_url
             .join(SPEND_ECASH_ENDPOINT)
             .expect("invalid base url");
-        self.call_post(url, payload).await
+        let result = self.call_post(url, payload).await;
+        info!("Spend ecash result: {:?}", result);
+        result
     }
 
     pub async fn receive_ecash(
@@ -220,7 +223,6 @@ impl GatewayRpcClient {
                 .header(reqwest::header::CONTENT_TYPE, "application/json");
         }
         let response = builder.send().await?;
-
         match response.status() {
             StatusCode::OK => Ok(response.json().await?),
             status => Err(GatewayRpcError::BadStatus(status)),

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -401,19 +401,13 @@ async fn create_bolt11_invoice_v2(
 async fn spend_ecash(
     Extension(gateway): Extension<Arc<Gateway>>,
     Json(payload): Json<SpendEcashPayload>,
-) -> Json<Value> {
-    Json(json!(gateway
-        .spend_ecash(payload)
-        .await
-        .map_err(|e| e.to_string())))
+) -> Result<impl IntoResponse, GatewayError> {
+    Ok(Json(json!(gateway.spend_ecash(payload).await?)))
 }
 
 async fn receive_ecash(
     Extension(gateway): Extension<Arc<Gateway>>,
     Json(payload): Json<ReceiveEcashPayload>,
-) -> Json<Value> {
-    Json(json!(gateway
-        .receive_ecash(payload)
-        .await
-        .map_err(|e| e.to_string())))
+) -> Result<impl IntoResponse, GatewayError> {
+    Ok(Json(json!(gateway.receive_ecash(payload).await?)))
 }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -16,8 +16,9 @@ use fedimint_ln_common::gateway_endpoint_constants::{
     CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_V2_ENDPOINT,
     GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_FUNDING_ADDRESS_ENDPOINT,
     GET_GATEWAY_ID_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_ENDPOINT, RESTORE_ENDPOINT, ROUTING_INFO_V2_ENDPOINT,
-    SEND_PAYMENT_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, WITHDRAW_ENDPOINT,
+    OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_ENDPOINT, RECEIVE_ECASH_ENDPOINT, RESTORE_ENDPOINT,
+    ROUTING_INFO_V2_ENDPOINT, SEND_PAYMENT_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT,
+    SPEND_ECASH_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_client::{CreateBolt11InvoicePayload, SendPaymentPayload};
 use hex::ToHex;
@@ -29,8 +30,8 @@ use tracing::{error, info, instrument};
 use super::{
     BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConnectFedPayload,
     DepositAddressPayload, GetFundingAddressPayload, InfoPayload, LeaveFedPayload,
-    OpenChannelPayload, RestorePayload, SetConfigurationPayload, SpendEcashPayload,
-    WithdrawPayload, V1_API_ENDPOINT,
+    OpenChannelPayload, ReceiveEcashPayload, RestorePayload, SetConfigurationPayload,
+    SpendEcashPayload, WithdrawPayload, V1_API_ENDPOINT,
 };
 use crate::rpc::ConfigPayload;
 use crate::{Gateway, GatewayError};
@@ -156,7 +157,8 @@ fn v1_routes(gateway: Arc<Gateway>) -> Router {
             CREATE_BOLT11_INVOICE_V2_ENDPOINT,
             post(create_bolt11_invoice_v2),
         )
-        .route(SPEND_ECASH_ENDPOINT, post(spend_ecash));
+        .route(SPEND_ECASH_ENDPOINT, post(spend_ecash))
+        .route(RECEIVE_ECASH_ENDPOINT, post(receive_ecash));
 
     // Authenticated, public routes used for gateway administration
     let always_authenticated_routes = Router::new()
@@ -402,6 +404,16 @@ async fn spend_ecash(
 ) -> Json<Value> {
     Json(json!(gateway
         .spend_ecash(payload)
+        .await
+        .map_err(|e| e.to_string())))
+}
+
+async fn receive_ecash(
+    Extension(gateway): Extension<Arc<Gateway>>,
+    Json(payload): Json<ReceiveEcashPayload>,
+) -> Json<Value> {
+    Json(json!(gateway
+        .receive_ecash(payload)
         .await
         .map_err(|e| e.to_string())))
 }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -17,7 +17,7 @@ use fedimint_ln_common::gateway_endpoint_constants::{
     GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_FUNDING_ADDRESS_ENDPOINT,
     GET_GATEWAY_ID_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
     OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_ENDPOINT, RESTORE_ENDPOINT, ROUTING_INFO_V2_ENDPOINT,
-    SEND_PAYMENT_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT, WITHDRAW_ENDPOINT,
+    SEND_PAYMENT_V2_ENDPOINT, SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_client::{CreateBolt11InvoicePayload, SendPaymentPayload};
 use hex::ToHex;
@@ -29,7 +29,8 @@ use tracing::{error, info, instrument};
 use super::{
     BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConnectFedPayload,
     DepositAddressPayload, GetFundingAddressPayload, InfoPayload, LeaveFedPayload,
-    OpenChannelPayload, RestorePayload, SetConfigurationPayload, WithdrawPayload, V1_API_ENDPOINT,
+    OpenChannelPayload, RestorePayload, SetConfigurationPayload, SpendEcashPayload,
+    WithdrawPayload, V1_API_ENDPOINT,
 };
 use crate::rpc::ConfigPayload;
 use crate::{Gateway, GatewayError};
@@ -154,7 +155,8 @@ fn v1_routes(gateway: Arc<Gateway>) -> Router {
         .route(
             CREATE_BOLT11_INVOICE_V2_ENDPOINT,
             post(create_bolt11_invoice_v2),
-        );
+        )
+        .route(SPEND_ECASH_ENDPOINT, post(spend_ecash));
 
     // Authenticated, public routes used for gateway administration
     let always_authenticated_routes = Router::new()
@@ -390,6 +392,16 @@ async fn create_bolt11_invoice_v2(
 ) -> Json<Value> {
     Json(json!(gateway
         .create_bolt11_invoice_v2(payload)
+        .await
+        .map_err(|e| e.to_string())))
+}
+
+async fn spend_ecash(
+    Extension(gateway): Extension<Arc<Gateway>>,
+    Json(payload): Json<SpendEcashPayload>,
+) -> Json<Value> {
+    Json(json!(gateway
+        .spend_ecash(payload)
         .await
         .map_err(|e| e.to_string())))
 }

--- a/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
+++ b/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
@@ -19,4 +19,5 @@ pub const PAY_INVOICE_ENDPOINT: &str = "/pay_invoice";
 pub const RESTORE_ENDPOINT: &str = "/restore";
 pub const SEND_PAYMENT_V2_ENDPOINT: &str = "/send_payment";
 pub const SET_CONFIGURATION_ENDPOINT: &str = "/set_configuration";
+pub const SPEND_ECASH_ENDPOINT: &str = "/spend_ecash";
 pub const WITHDRAW_ENDPOINT: &str = "/withdraw";

--- a/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
+++ b/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
@@ -14,6 +14,7 @@ pub const LEAVE_FED_ENDPOINT: &str = "/leave-fed"; // uses `-` for backwards com
 pub const LIST_ACTIVE_CHANNELS_ENDPOINT: &str = "/list_active_channels";
 pub const OPEN_CHANNEL_ENDPOINT: &str = "/open_channel";
 pub const CLOSE_CHANNELS_WITH_PEER_ENDPOINT: &str = "/close_channels_with_peer";
+pub const RECEIVE_ECASH_ENDPOINT: &str = "/receive_ecash";
 pub const ROUTING_INFO_V2_ENDPOINT: &str = "/routing_info";
 pub const PAY_INVOICE_ENDPOINT: &str = "/pay_invoice";
 pub const RESTORE_ENDPOINT: &str = "/restore";


### PR DESCRIPTION
Adds functionality to directly send/receive ecash for a gateway operator. Part of the steps to make running a gateway more reasonable / manageable and exposing additional functionality for liquidity management through the new gateway UI.