### PR TITLE
fix: don't split e-cash on refund

### DIFF
--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -27,7 +27,7 @@ use fedimint_core::{
 use self::init::ClientModuleInit;
 use crate::module::recovery::{DynModuleBackup, ModuleBackup};
 use crate::sm::{self, ActiveStateMeta, Context, DynContext, DynState, State};
-use crate::transaction::{ClientInput, ClientOutput, TransactionBuilder};
+use crate::transaction::{ChangeStrategy, ClientInput, ClientOutput, TransactionBuilder};
 use crate::{
     oplog, states_add_instance, states_to_instanceless_dyn, AddStateMachinesResult, Client,
     ClientStrong, ClientWeak, InstancelessDynClientInput, TransactionUpdates,
@@ -715,6 +715,7 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
         _operation_id: OperationId,
         _input_amount: Amount,
         _output_amount: Amount,
+        _change_strategy: ChangeStrategy,
     ) -> anyhow::Result<(
         Vec<ClientInput<<Self::Common as ModuleCommon>::Input, Self::States>>,
         Vec<ClientOutput<<Self::Common as ModuleCommon>::Output, Self::States>>,
@@ -844,6 +845,7 @@ pub trait IClientModule: Debug {
         operation_id: OperationId,
         input_amount: Amount,
         output_amount: Amount,
+        change_strategy: ChangeStrategy,
     ) -> anyhow::Result<(Vec<ClientInput>, Vec<ClientOutput>)>;
 
     async fn await_primary_module_output(
@@ -942,6 +944,7 @@ where
         operation_id: OperationId,
         input_amount: Amount,
         output_amount: Amount,
+        change_strategy: ChangeStrategy,
     ) -> anyhow::Result<(Vec<ClientInput>, Vec<ClientOutput>)> {
         let (inputs, outputs) = <T as ClientModule>::create_final_inputs_and_outputs(
             self,
@@ -949,6 +952,7 @@ where
             operation_id,
             input_amount,
             output_amount,
+            change_strategy,
         )
         .await?;
 

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -8,7 +8,7 @@ use bitcoin::secp256k1;
 use devimint::cmd;
 use devimint::util::{ClnLightningCli, FedimintCli, LnCli};
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
-use fedimint_client::transaction::TransactionBuilder;
+use fedimint_client::transaction::{ChangeStrategy, TransactionBuilder};
 use fedimint_client::{Client, ClientHandleArc};
 use fedimint_core::core::{IntoDynInstance, OperationId};
 use fedimint_core::db::Database;
@@ -360,6 +360,7 @@ pub async fn remint_denomination(
                 operation_id,
                 1,
                 denomination,
+                ChangeStrategy::default(),
             )
             .await
             .into_iter()

--- a/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, bail};
 use fedimint_api_client::api::{deserialize_outcome, FederationApiExt, SerdeOutputOutcome};
 use fedimint_api_client::query::FilterMapThreshold;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::{Decoder, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -246,7 +246,7 @@ impl ReceiveStateMachine {
         };
 
         let outpoints = global_context
-            .claim_input(dbtx, client_input)
+            .claim_input(dbtx, client_input, ChangeStrategy::default())
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bitcoin_hashes::Hash;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -209,7 +209,7 @@ impl SendStateMachine {
                 };
 
                 let outpoints = global_context
-                    .claim_input(dbtx, client_input)
+                    .claim_input(dbtx, client_input, ChangeStrategy::default())
                     .await
                     .expect("Cannot claim input, additional funding needed")
                     .1;

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use bitcoin_hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::{ClientInput, ClientOutput};
+use fedimint_client::transaction::{ChangeStrategy, ClientInput, ClientOutput};
 use fedimint_client::{ClientHandleArc, DynGlobalClientContext};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
@@ -695,7 +695,7 @@ impl GatewayPayClaimOutgoingContract {
         };
 
         let out_points = global_context
-            .claim_input(dbtx, client_input)
+            .claim_input(dbtx, client_input, ChangeStrategy::default())
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -17,7 +17,7 @@ use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client::module::recovery::NoModuleBackup;
 use fedimint_client::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client::sm::{Context, ModuleNotifier};
-use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
+use fedimint_client::transaction::{ChangeStrategy, ClientInput, ClientOutput, TransactionBuilder};
 use fedimint_core::core::{Decoder, ModuleKind, OperationId};
 use fedimint_core::db::{
     Database, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
@@ -94,6 +94,7 @@ impl ClientModule for DummyClientModule {
         operation_id: OperationId,
         input_amount: Amount,
         output_amount: Amount,
+        _change_strategy: ChangeStrategy,
     ) -> anyhow::Result<(
         Vec<ClientInput<DummyInput, DummyStateMachine>>,
         Vec<ClientOutput<DummyOutput, DummyStateMachine>>,

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use bitcoin::hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -334,7 +334,7 @@ impl DecryptingPreimageState {
         };
 
         let out_points = global_context
-            .claim_input(dbtx, client_input)
+            .claim_input(dbtx, client_input, ChangeStrategy::default())
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime};
 
 use bitcoin::hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, OperationId};
@@ -554,7 +554,7 @@ async fn try_refund_outgoing_contract(
     };
 
     let (txid, out_points) = global_context
-        .claim_input(dbtx, refund_client_input)
+        .claim_input(dbtx, refund_client_input, ChangeStrategy::default())
         .await
         .expect("Cannot claim input, additional funding needed");
 

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use bitcoin::key::KeyPair;
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, DynState, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -292,7 +292,7 @@ impl LightningReceiveConfirmedInvoice {
         };
 
         global_context
-            .claim_input(dbtx, client_input)
+            .claim_input(dbtx, client_input, ChangeStrategy::default())
             .await
             .expect("Cannot claim input, additional funding needed")
     }

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bitcoin::key::KeyPair;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -121,7 +121,7 @@ impl ReceiveStateMachine {
         };
 
         let out_points = global_context
-            .claim_input(dbtx, client_input)
+            .claim_input(dbtx, client_input, ChangeStrategy::default())
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/modules/fedimint-lnv2-client/src/send_sm.rs
+++ b/modules/fedimint-lnv2-client/src/send_sm.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use bitcoin::hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
@@ -223,7 +223,7 @@ impl SendStateMachine {
                 };
 
                 let outpoints = global_context
-                    .claim_input(dbtx, client_input)
+                    .claim_input(dbtx, client_input, ChangeStrategy::default())
                     .await
                     .expect("Cannot claim input, additional funding needed")
                     .1;
@@ -280,7 +280,7 @@ impl SendStateMachine {
         };
 
         let outpoints = global_context
-            .claim_input(dbtx, client_input)
+            .claim_input(dbtx, client_input, ChangeStrategy::default())
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -150,7 +150,7 @@ impl MintInputStateCreated {
         };
 
         let (refund_txid, _) = global_context
-            .claim_input(dbtx, refund_input)
+            .claim_input(dbtx, refund_input, ChangeStrategy::Minimize)
             .await
             .expect("Cannot claim input, additional funding needed");
 

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -193,7 +193,7 @@ async fn try_cancel_oob_spend(
     };
 
     global_context
-        .claim_input(dbtx, input)
+        .claim_input(dbtx, input, ChangeStrategy::Minimize)
         .await
         .expect("Cannot claim input, additional funding needed")
         .0

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ChangeStrategy, ClientInput};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -285,7 +285,7 @@ pub(crate) async fn transition_btc_tx_confirmed(
     };
 
     let (fm_txid, change) = global_context
-        .claim_input(dbtx, client_input)
+        .claim_input(dbtx, client_input, ChangeStrategy::default())
         .await
         .expect("Cannot claim input, additional funding needed");
 


### PR DESCRIPTION
One possible solution for #5069.

## Problem
The main problem is that if I have e-cash in an OOB spend or funding any other transaction and need to re-claim it because the user cancelled or the transaction failed then a bunch of e-cash notes will be re-issued *in parallel*. 

Let's assume 10 notes are being re-issued into an empty wallet. The reissuance state machine of each note will notice the empty wallet and generate at least two e-cash notes per denomination, starting from 1msat (to make sure the wallet has e-cash of every denomination for OOB spends). Unfortunately, all 10 do the same and we end up with at least 20 notes per denomination.

## Solution Approach
This PR introduces a strategy enum for change generation that is used to control change generation in this scenario. 

**Benefits:**
- No state machine migrations necessary
- Conceptually simple/small change

**Drawbacks:**
- API  changes to a bunch of interfaces
- The change strategy is only really relevant for e-cash primary modules, so it breaks modularization a bit

## Alternative
We want to eventually use one SM for multiple e-cash notes in cases where they all result from the same operation. This will allow to reissue multiple notes in a single transaction except in the case that there was an invalid note among them (then each still needs to go into a separate transaction). When reissued in a single transaction the parallelism problem doesn't occur anymore.

Thoughts @dpc @joschisan?

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
