### PR TITLE
chore: consolidate cln create_invoice()

### DIFF
--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -11,7 +11,6 @@ use ln_gateway::rpc::{
     FederationRoutingFees, LeaveFedPayload, ReceiveEcashPayload, RestorePayload,
     SetConfigurationPayload, SpendEcashPayload, WithdrawPayload,
 };
-use tracing::info;
 
 use crate::print_response;
 


### PR DESCRIPTION
No functional change, just extracting duplicate code between two arms of a `match` statement