### PR TITLE
feat: parallelise signature checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,6 +2430,7 @@ dependencies = [
  "pin-project",
  "rand",
  "rand_chacha",
+ "rayon",
  "rcgen",
  "serde",
  "serde_json",

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -851,6 +851,16 @@ pub trait ServerModule: Debug + Sized {
         peer_id: PeerId,
     ) -> anyhow::Result<()>;
 
+    // Use this function to parallelise stateless cryptographic verification of
+    // inputs across a transaction. All inputs of a transaction are verified
+    // before any input is processed.
+    fn verify_input(
+        &self,
+        _input: &<Self::Common as ModuleCommon>::Input,
+    ) -> Result<(), <Self::Common as ModuleCommon>::InputError> {
+        Ok(())
+    }
+
     /// Try to spend a transaction input. On success all necessary updates will
     /// be part of the database transaction. On failure (e.g. double spend)
     /// the database transaction is rolled back and the operation will take

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -41,6 +41,7 @@ parity-scale-codec = "3.6.12"
 pin-project = "1.1.5"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+rayon = "1.10.0"
 rcgen = "=0.13.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -625,7 +625,7 @@ pub struct MintClientModule {
     secret: DerivableSecret,
     secp: Secp256k1<All>,
     notifier: ModuleNotifier<MintClientStateMachines>,
-    client_ctx: ClientContext<Self>,
+    pub client_ctx: ClientContext<Self>,
 }
 
 // TODO: wrap in Arc


### PR DESCRIPTION
The verification of ecash note signatures is at the moment the biggest performance bottleneck of the system as we can only verify about 500 per second per core. Performance testing on my M2 MacBook Air with 8 cores showed a 5x speed up when parallelising the verification across 10 to 50 signatures.

This pr allows us to lower the input fee of one sat per ecash not to a more reasonable 100 msats for DOS protection.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
