### PR TITLE
fix: add transaction fee

### DIFF
--- a/fedimint-core/src/amount.rs
+++ b/fedimint-core/src/amount.rs
@@ -71,6 +71,18 @@ impl Amount {
         Ok(Self::from(btc_amt))
     }
 
+    pub fn saturating_mul(self, multiplier: u64) -> Self {
+        Self {
+            msats: self.msats.saturating_mul(multiplier),
+        }
+    }
+
+    pub fn saturating_div(self, divisor: u64) -> Self {
+        Self {
+            msats: self.msats.saturating_div(divisor),
+        }
+    }
+
     pub fn saturating_sub(self, other: Self) -> Self {
         Self {
             msats: self.msats.saturating_sub(other.msats),

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -122,7 +122,13 @@ impl ConsensusApi {
         // We ignore any writes, as we only verify if the transaction is valid here
         dbtx.ignore_uncommitted();
 
-        process_transaction_with_dbtx(self.modules.clone(), &mut dbtx, &transaction).await?;
+        process_transaction_with_dbtx(
+            self.modules.clone(),
+            &mut dbtx,
+            &transaction,
+            &self.cfg.consensus.transaction_fee,
+        )
+        .await?;
 
         self.submission_sender
             .send(ConsensusItem::Transaction(transaction))

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -743,9 +743,14 @@ impl ConsensusEngine {
                     .map(DynOutput::module_instance_id)
                     .collect::<Vec<_>>();
 
-                process_transaction_with_dbtx(self.modules.clone(), dbtx, &transaction)
-                    .await
-                    .map_err(|error| anyhow!(error.to_string()))?;
+                process_transaction_with_dbtx(
+                    self.modules.clone(),
+                    dbtx,
+                    &transaction,
+                    &self.cfg.consensus.transaction_fee,
+                )
+                .await
+                .map_err(|error| anyhow!(error.to_string()))?;
 
                 debug!(target: LOG_CONSENSUS, %txid,  "Transaction accepted");
                 dbtx.insert_entry(&AcceptedTransactionKey(txid), &modules_ids)

--- a/fedimint-server/src/consensus/transaction.rs
+++ b/fedimint-server/src/consensus/transaction.rs
@@ -1,3 +1,4 @@
+use fedimint_core::config::TransactionFee;
 use fedimint_core::db::DatabaseTransaction;
 use fedimint_core::module::registry::ServerModuleRegistry;
 use fedimint_core::module::TransactionItemAmount;
@@ -11,6 +12,7 @@ pub async fn process_transaction_with_dbtx(
     modules: ServerModuleRegistry,
     dbtx: &mut DatabaseTransaction<'_>,
     transaction: &Transaction,
+    transaction_fee: &TransactionFee,
 ) -> Result<(), TransactionError> {
     let in_count = transaction.inputs.len();
     let out_count = transaction.outputs.len();
@@ -70,7 +72,7 @@ pub async fn process_transaction_with_dbtx(
         funding_verifier.add_output(amount);
     }
 
-    funding_verifier.verify_funding()?;
+    funding_verifier.verify_funding(transaction_fee)?;
 
     Ok(())
 }
@@ -92,14 +94,20 @@ impl FundingVerifier {
         self.fee_amount += output_amount.fee;
     }
 
-    pub fn verify_funding(self) -> Result<(), TransactionError> {
-        if self.input_amount == (self.output_amount + self.fee_amount) {
+    pub fn verify_funding(self, transaction_fee: &TransactionFee) -> Result<(), TransactionError> {
+        let transaction_fee = transaction_fee.base
+            + self
+                .input_amount
+                .saturating_mul(transaction_fee.parts_per_million)
+                .saturating_div(1_000_000);
+
+        if self.input_amount == self.output_amount + self.fee_amount + transaction_fee {
             Ok(())
         } else {
             Err(TransactionError::UnbalancedTransaction {
                 inputs: self.input_amount,
                 outputs: self.output_amount,
-                fee: self.fee_amount,
+                fee: self.fee_amount + transaction_fee,
             })
         }
     }


### PR DESCRIPTION
A transaction fee prevents the malicious use of 1 input ecash transactions to prevent parallelisation of ecash signature checks within a transaction making it cheaper to compute DOS the federation with valid transaction. Therefore, it is sufficient to parallelise signature checks within a transaction as a regular tx has enough mint inputs for effective use of multiple cores. 

This is the pr that parallelises signature checks within a transaction: https://github.com/fedimint/fedimint/pull/5836 

Since we cannot set the fee to a non-zero value as long as we run ln legacy I tested a tx fee of 1 sat manually with lnv2.  

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
