### PR TITLE
feat(tor): put `tor` support behind a feature, use as default

### DIFF
--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/fedimint/fedimint"
 development = ["tokio-test"]
 
 [features]
+default = ["tor"]
 tor = ["dep:strum", "dep:curve25519-dalek", "arti-client/tokio", "arti-client/rustls", "arti-client/onion-service-client"]
 
 [lib]

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/fedimint/fedimint"
 development = ["tokio-test"]
 
 [features]
-tor = ["arti-client", "strum", "curve25519-dalek"]
+tor = ["dep:strum", "dep:curve25519-dalek", "arti-client/tokio", "arti-client/rustls", "arti-client/onion-service-client"]
 
 [lib]
 name = "fedimint_api_client"
@@ -51,7 +51,7 @@ tokio-rustls = { version = "0.26.0", default-features = false, features = [
 ] }
 webpki-roots = { version = "0.26.3" }
 rustls-pki-types = { version = "1.8.0" }
-arti-client = { version = "0.20.0", features = ["tokio", "rustls", "onion-service-client"], default-features = false, package = "fedimint-arti-client", optional = true }
+arti-client = { version = "0.20.0", default-features = false, package = "fedimint-arti-client", optional = true }
 strum = { version = "0.26.3", optional = true }
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/fedimint/fedimint"
 [package.metadata.cargo-udeps.ignore]
 development = ["tokio-test"]
 
+[features]
+tor = ["arti-client", "strum", "curve25519-dalek"]
+
 [lib]
 name = "fedimint_api_client"
 path = "src/lib.rs"
@@ -48,11 +51,11 @@ tokio-rustls = { version = "0.26.0", default-features = false, features = [
 ] }
 webpki-roots = { version = "0.26.3" }
 rustls-pki-types = { version = "1.8.0" }
-arti-client = { version = "0.20.0", features = ["tokio", "rustls", "onion-service-client"], default-features = false, package = "fedimint-arti-client" }
-strum = { version = "0.26.3" }
+arti-client = { version = "0.20.0", features = ["tokio", "rustls", "onion-service-client"], default-features = false, package = "fedimint-arti-client", optional = true }
+strum = { version = "0.26.3", optional = true }
 # We need to pin this arti's `curve25519-dalek` dependency, due to `https://rustsec.org/advisories/RUSTSEC-2024-0344` vulnerability
 # It's been updated by https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/2211, should be removed in next release.
-curve25519-dalek = { version = ">=4.1.3" }
+curve25519-dalek = { version = ">=4.1.3", optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 jsonrpsee-wasm-client = "0.24.2"

--- a/fedimint-api-client/src/api/net.rs
+++ b/fedimint-api-client/src/api/net.rs
@@ -7,10 +7,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
 pub enum Connector {
     Tcp,
+    #[cfg(feature = "tor")]
     Tor,
 }
 
 impl Connector {
+    #[cfg(feature = "tor")]
     pub fn tor() -> Connector {
         Connector::Tor
     }
@@ -34,6 +36,7 @@ impl FromStr for Connector {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "tcp" => Ok(Connector::Tcp),
+            #[cfg(feature = "tor")]
             "tor" => Ok(Connector::Tor),
             _ => Err("invalid connector!"),
         }

--- a/fedimint-api-client/src/api/peer.rs
+++ b/fedimint-api-client/src/api/peer.rs
@@ -95,9 +95,9 @@ where
 
             let res = match connector {
                 Connector::Tcp => C::connect(&url, api_secret).await,
-                #[cfg(not(target_family = "wasm"))]
+                #[cfg(all(feature = "tor", not(target_family = "wasm")))]
                 Connector::Tor => C::connect_with_tor(&url, api_secret).await,
-                #[cfg(target_family = "wasm")]
+                #[cfg(all(feature = "tor", target_family = "wasm"))]
                 Connector::Tor => unimplemented!(),
             };
 

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/fedimint/fedimint"
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
+default = ["tor"]
 tor = ["fedimint-client/tor", "fedimint-api-client/tor"]
 
 [[bin]]

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/fedimint/fedimint"
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
+[features]
+tor = ["fedimint-client/tor", "fedimint-api-client/tor"]
+
 [[bin]]
 name = "fedimint-cli"
 path = "src/main.rs"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -31,9 +31,9 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.14"
 fedimint-aead = { version = "=0.5.0-alpha", path = "../crypto/aead" }
-fedimint-api-client = { workspace = true }
+fedimint-api-client = { workspace = true, default-features = false }
 fedimint-bip39 = { version = "=0.5.0-alpha", path = "../fedimint-bip39" }
-fedimint-client = { workspace = true }
+fedimint-client = { workspace = true, default-features = false }
 fedimint-core = { workspace = true }
 fedimint-ln-client = { workspace = true, features = ["cli"] }
 fedimint-ln-common = { version = "=0.5.0-alpha", path = "../modules/fedimint-ln-common" }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -29,7 +29,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-aead = { version = "=0.5.0-alpha", path = "../crypto/aead" }
-fedimint-api-client  = { workspace = true }
+fedimint-api-client  = { workspace = true, default-features = false }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { version = "=0.5.0-alpha", path = "../crypto/derive-secret" }
 fedimint-logging = { workspace = true }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -15,6 +15,9 @@ normal = ["aquamarine"]
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
+[features]
+tor = ["fedimint-api-client/tor"]
+
 [lib]
 name = "fedimint_client"
 path = "src/lib.rs"

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -16,6 +16,7 @@ normal = ["aquamarine"]
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
+default = ["tor"]
 tor = ["fedimint-api-client/tor"]
 
 [lib]

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2149,6 +2149,7 @@ impl ClientBuilder {
         self.connector = connector;
     }
 
+    #[cfg(feature = "tor")]
     pub fn with_tor_connector(&mut self) {
         self.with_connector(Connector::tor());
     }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/fedimint/fedimint"
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
+default = ["tor"]
 tor = ["ln-gateway/tor"]
 
 [lib]

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/fedimint/fedimint"
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
+[features]
+tor = ["ln-gateway/tor"]
+
 [lib]
 name = "fedimint_testing"
 path = "src/lib.rs"

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -38,7 +38,7 @@ fedimint-testing-core = { version = "=0.5.0-alpha", path = "../fedimint-testing-
 fs-lock = "0.1.4"
 futures = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { version = "=0.5.0-alpha", package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
+ln-gateway = { version = "=0.5.0-alpha", default-features = false, package = "fedimint-ln-gateway", path = "../gateway/ln-gateway" }
 rand = { workspace = true }
 secp256k1-zkp = { version = "0.9.2", features = ["global-context", "bitcoin_hashes"] }
 serde = { workspace = true }

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -134,6 +134,7 @@ impl FederationTest {
     pub async fn connect_gateway(&self, gw: &Gateway) {
         gw.handle_connect_federation(ConnectFedPayload {
             invite_code: self.invite_code().to_string(),
+            #[cfg(feature = "tor")]
             use_tor: Some(false), // TODO: (@leonardo) Should we get it from self.configs too ?
         })
         .await

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -34,7 +34,7 @@ clap_complete = "4.5.14"
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-mint-client = { workspace = true }
-ln-gateway = { version = "=0.5.0-alpha", package = "fedimint-ln-gateway", path = "../ln-gateway" }
+ln-gateway = { version = "=0.5.0-alpha", default-features = false, package = "fedimint-ln-gateway", path = "../ln-gateway" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/fedimint/fedimint"
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
+default = ["tor"]
 tor = ["ln-gateway/tor"]
 
 [[bin]]

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/fedimint/fedimint"
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]
 
+[features]
+tor = ["ln-gateway/tor"]
+
 [[bin]]
 name = "gateway-cli"
 path = "src/main.rs"

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -81,6 +81,7 @@ pub enum GeneralCommands {
     ConnectFed {
         /// Invite code to connect to the federation
         invite_code: String,
+        #[cfg(feature = "tor")]
         /// Activate usage of Tor (or not) as the connector for the federation
         /// client
         use_tor: Option<bool>,
@@ -207,11 +208,13 @@ impl GeneralCommands {
             }
             Self::ConnectFed {
                 invite_code,
+                #[cfg(feature = "tor")]
                 use_tor,
             } => {
                 let response = create_client()
                     .connect_federation(ConnectFedPayload {
                         invite_code,
+                        #[cfg(feature = "tor")]
                         use_tor,
                     })
                     .await?;

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -81,9 +81,9 @@ pub enum GeneralCommands {
     ConnectFed {
         /// Invite code to connect to the federation
         invite_code: String,
-        #[cfg(feature = "tor")]
         /// Activate usage of Tor (or not) as the connector for the federation
         /// client
+        #[cfg(feature = "tor")]
         use_tor: Option<bool>,
     },
     /// Leave a federation.

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT"
 readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
+[features]
+tor = ["fedimint-client/tor", "fedimint-api-client/tor"]
+
 [[bin]]
 name = "gatewayd"
 path = "src/bin/gatewayd.rs"

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [features]
+default = ["tor"]
 tor = ["fedimint-client/tor", "fedimint-api-client/tor"]
 
 [[bin]]

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -41,8 +41,8 @@ cln-plugin = "=0.1.7"
 cln-rpc = { workspace = true }
 erased-serde = { workspace = true }
 esplora-client = { version = "0.6.0", default-features = false, features = ["async", "async-https-rustls"] }
-fedimint-api-client = { workspace = true }
-fedimint-client = { workspace = true }
+fedimint-api-client = { workspace = true, default-features = false }
+fedimint-client = { workspace = true, default-features = false }
 fedimint-core = { workspace = true }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }

--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -401,7 +401,7 @@ async fn migrate_to_v1(dbtx: &mut DatabaseTransaction<'_>) -> Result<(), anyhow:
 
 async fn migrate_to_v2(dbtx: &mut DatabaseTransaction<'_>) -> Result<(), anyhow::Error> {
     // If there is no old federation configuration, there is nothing to do.
-    for (old_federation_id, old_federation_config) in dbtx.load_federation_configs_v0().await {
+    for (old_federation_id, _old_federation_config) in dbtx.load_federation_configs_v0().await {
         if let Some(old_federation_config) = dbtx
             .remove_entry(&FederationIdKeyV0 {
                 id: old_federation_id,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -983,6 +983,7 @@ impl Gateway {
         })?;
 
         // TODO: (@leonardo) Should we use default, or respond with an error ?
+        #[cfg(feature = "tor")]
         let connector = match &payload.use_tor {
             Some(use_tor) => match use_tor {
                 true => Connector::tor(),
@@ -993,6 +994,9 @@ impl Gateway {
                 Connector::default()
             }
         };
+
+        #[cfg(not(feature = "tor"))]
+        let connector = Connector::default();
 
         let federation_id = invite_code.federation_id();
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -982,7 +982,6 @@ impl Gateway {
             GatewayError::InvalidMetadata(format!("Invalid federation member string {e:?}"))
         })?;
 
-        // TODO: (@leonardo) Should we use default, or respond with an error ?
         #[cfg(feature = "tor")]
         let connector = match &payload.use_tor {
             Some(use_tor) => match use_tor {

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -23,6 +23,7 @@ pub const V1_API_ENDPOINT: &str = "v1";
 pub struct ConnectFedPayload {
     pub invite_code: String,
     #[serde(default)]
+    #[cfg(feature = "tor")]
     pub use_tor: Option<bool>,
 }
 


### PR DESCRIPTION
related to #4752 

## Description

The usage of `arti-client` for adding Tor support (#5443) recently landed on master, but `arti-client` relies on a bunch of other tor related crates, which can lead to an increase on the binary size.

In order to allow users to have the opt-in/opt-out of such feature and the leading binary increase, this PR adds a new feature where required for Tor support.

## Note for Reviewers

I'm wondering if we should have it by default, as its removal from default-features becomes a SemVer incompatible change.

Any other thoughts on it? 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
