### PR TITLE
chore: remove gateway balance command

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -14,9 +14,11 @@ just mprocs
 
 > [!NOTE]
 > In a memory-constrained environments you might want to [set the `CARGO_BUILD_JOBS` environment variable](https://doc.rust-lang.org/cargo/reference/config.html#buildjobs) to a lower number (defaults to number of logical CPU cores):
+>
 > ```shell
 > CARGO_BUILD_JOBS=2 just mprocs
 > ```
+>
 > As a rule of thumb expect each parallel job to require 2-2.5GB of memory. Running the build less parallel will lead to longer build times but can prevent the process from being [killed by the OOM killer](https://www.kernel.org/doc/gorman/html/understand/understand016.html), leading to hard to debug errors.
 
 This uses a tool called [mprocs](https://github.com/pvolok/mprocs) to spawn working local federation, displays logs for all daemons involved, as well as a shell with some convenient aliases and environment variables already setup so you can start tinkering. Click the tabs on the left nav to inspect the different processes. You can see available keyboard commands on the bottom -- for example, when you select text you'll see a `c` command that can be used to copy the text. To quit, type `ctrl-a` then `q` then `y`. If you're a tmux user, you can also use `just tmuxinator` to setup a tmux session with a running federation. But this is a little less user-friendly.
@@ -92,13 +94,20 @@ $ fedimint-cli reissue BgAAAAAAAAAgAAAAAAAAAAEAAAAAAAAAwdt...
 
 ### Using the Gateway
 
-The [lightning gateway](../gateway/ln-gateway) connects the federation to the lightning network. It contains a federation client that holds ecash notes just like `fedimint-cli`. The mprocs setup scripts also give it some ecash. To check its balance, we use the [`gateway-cli`](../gateway/cli) utility. In the mprocs environment there are 2 lightning gateways -- one for Core Lightning and one for LND -- so we add `gateway-cln` and `gateway-lnd` shell aliases which will run `gateway-cli` pointed at that gateway. To get the balance with the Core Lightinng gateway, run `gateway-cln info`, copy the federation id and then:
+The [lightning gateway](../gateway/ln-gateway) connects the federation to the lightning network. It contains a federation client that holds e-cash notes just like `fedimint-cli`. The mprocs setup scripts also give it some e-cash. To check its balance, we use the [`gateway-cli`](../gateway/cli) utility. In the mprocs environment there are 2 lightning gateways -- one for Core Lightning and one for LND -- so we add `gateway-cln` and `gateway-lnd` shell aliases which will run `gateway-cli` pointed at that gateway. To get the balance with the Core Lightinng gateway, run `gateway-cln info`, copy the federation id and then:
 
 ```shell
-$ gateway-cln balance --federation-id <FEDERATION-ID>
+$ gateway-cln balances
 
 {
-  30000000
+  "onchain_balance_sats": 89999846,
+  "lightning_balance_msats": 10000000000,
+  "ecash_balances": [
+    {
+      "federation_id": "922e768d81a1437439e8640c570edbec84ac0acca35fed2010b80fca38d642b8",
+      "ecash_balance_msats": 999000000
+    }
+  ]
 }
 ```
 
@@ -136,6 +145,7 @@ $ lncli lookupinvoice 1072fe19b3a53b3d778f6d5b0b...
 ```
 
 To receive a lightning payment inside use `fedimint-cli` to create an invoice:
+
 ```shell
 $ fedimint-cli ln-invoice --amount 1000
 

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -7,9 +7,9 @@ use fedimint_core::{fedimint_build_code_version_env, Amount, BitcoinAmountOrAll}
 use fedimint_mint_client::OOBNotes;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{
-    BackupPayload, BalancePayload, ConfigPayload, ConnectFedPayload, DepositAddressPayload,
-    FederationRoutingFees, LeaveFedPayload, ReceiveEcashPayload, SetConfigurationPayload,
-    SpendEcashPayload, WithdrawPayload,
+    BackupPayload, ConfigPayload, ConnectFedPayload, DepositAddressPayload, FederationRoutingFees,
+    LeaveFedPayload, ReceiveEcashPayload, SetConfigurationPayload, SpendEcashPayload,
+    WithdrawPayload,
 };
 
 use crate::print_response;
@@ -53,12 +53,8 @@ pub enum GeneralCommands {
         #[clap(long)]
         federation_id: Option<FederationId>,
     },
-    /// Check gateway's e-cash balance on the specified federation.
-    Balance {
-        #[clap(long)]
-        federation_id: FederationId,
-    },
-    /// Get the total on-chain, lightning, and eCash balances of the gateway.
+    /// Get the total on-chain, lightning, and per-federation e-cash balances of
+    /// the gateway.
     GetBalances,
     /// Generate a new peg-in address to a federation that the gateway can claim
     /// e-cash for later.
@@ -171,13 +167,6 @@ impl GeneralCommands {
             Self::Config { federation_id } => {
                 let response = create_client()
                     .get_config(ConfigPayload { federation_id })
-                    .await?;
-
-                print_response(response);
-            }
-            Self::Balance { federation_id } => {
-                let response = create_client()
-                    .get_balance(BalancePayload { federation_id })
                     .await?;
 
                 print_response(response);

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -115,7 +115,7 @@ use crate::gateway_module_v2::GatewayClientModuleV2;
 use crate::lightning::{GatewayLightningBuilder, LightningContext, RouteHtlcStream};
 use crate::rpc::rpc_server::{hash_password, run_webserver};
 use crate::rpc::{
-    BackupPayload, BalancePayload, ConnectFedPayload, DepositAddressPayload, FederationBalanceInfo,
+    BackupPayload, ConnectFedPayload, DepositAddressPayload, FederationBalanceInfo,
     GatewayBalances, WithdrawPayload,
 };
 use crate::types::PrettyInterceptHtlcRequest;
@@ -824,18 +824,6 @@ impl Gateway {
         };
 
         Ok(GatewayFedConfig { federations })
-    }
-
-    /// Returns the balance of the requested federation that the Gateway is
-    /// connected to.
-    pub async fn handle_balance_msg(&self, payload: BalancePayload) -> Result<Amount> {
-        // no need for instrument, it is done on api layer
-        Ok(self
-            .select_client(payload.federation_id)
-            .await?
-            .value()
-            .get_balance()
-            .await)
     }
 
     /// Returns a Bitcoin deposit on-chain address for pegging in Bitcoin for a

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -47,11 +47,6 @@ pub struct ConfigPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct BalancePayload {
-    pub federation_id: FederationId,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DepositAddressPayload {
     pub federation_id: FederationId,
 }

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -1,14 +1,13 @@
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Txid};
 use fedimint_core::util::SafeUrl;
-use fedimint_core::{Amount, TransactionId};
+use fedimint_core::TransactionId;
 use fedimint_ln_common::gateway_endpoint_constants::{
-    ADDRESS_ENDPOINT, BACKUP_ENDPOINT, BALANCE_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
-    CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, GATEWAY_INFO_ENDPOINT,
-    GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT,
-    LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT,
-    RECEIVE_ECASH_ENDPOINT, SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT,
-    SYNC_TO_CHAIN_ENDPOINT, WITHDRAW_ENDPOINT,
+    ADDRESS_ENDPOINT, BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
+    CONNECT_FED_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT,
+    GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
+    MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, RECEIVE_ECASH_ENDPOINT, SET_CONFIGURATION_ENDPOINT,
+    SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, SYNC_TO_CHAIN_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_common::endpoint_constants::{
     CREATE_BOLT11_INVOICE_FOR_SELF_ENDPOINT, PAY_INVOICE_SELF_ENDPOINT,
@@ -20,7 +19,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use super::{
-    BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConfigPayload, ConnectFedPayload,
+    BackupPayload, CloseChannelsWithPeerPayload, ConfigPayload, ConnectFedPayload,
     CreateInvoiceForSelfPayload, DepositAddressPayload, FederationInfo, GatewayBalances,
     GatewayFedConfig, GatewayInfo, GetLnOnchainAddressPayload, LeaveFedPayload, MnemonicResponse,
     OpenChannelPayload, PayInvoicePayload, ReceiveEcashPayload, ReceiveEcashResponse,
@@ -74,14 +73,6 @@ impl GatewayRpcClient {
         let url = self
             .base_url
             .join(CONFIGURATION_ENDPOINT)
-            .expect("invalid base url");
-        self.call_post(url, payload).await
-    }
-
-    pub async fn get_balance(&self, payload: BalancePayload) -> GatewayRpcResult<Amount> {
-        let url = self
-            .base_url
-            .join(BALANCE_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
     }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -11,13 +11,12 @@ use fedimint_core::config::FederationId;
 use fedimint_core::encoding::Encodable;
 use fedimint_core::task::TaskGroup;
 use fedimint_ln_common::gateway_endpoint_constants::{
-    ADDRESS_ENDPOINT, BACKUP_ENDPOINT, BALANCE_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
-    CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, GATEWAY_INFO_ENDPOINT,
-    GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_GATEWAY_ID_ENDPOINT,
-    GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_ENDPOINT, RECEIVE_ECASH_ENDPOINT,
-    SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, SYNC_TO_CHAIN_ENDPOINT,
-    WITHDRAW_ENDPOINT,
+    ADDRESS_ENDPOINT, BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
+    CONNECT_FED_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT,
+    GET_GATEWAY_ID_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT,
+    LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_ENDPOINT,
+    RECEIVE_ECASH_ENDPOINT, SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT,
+    SYNC_TO_CHAIN_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_client::{CreateBolt11InvoicePayload, SendPaymentPayload};
 use fedimint_lnv2_common::endpoint_constants::{
@@ -31,11 +30,10 @@ use tower_http::cors::CorsLayer;
 use tracing::{error, info, instrument};
 
 use super::{
-    BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConnectFedPayload,
-    CreateInvoiceForSelfPayload, DepositAddressPayload, GetLnOnchainAddressPayload, InfoPayload,
-    LeaveFedPayload, OpenChannelPayload, PayInvoicePayload, ReceiveEcashPayload,
-    SetConfigurationPayload, SpendEcashPayload, SyncToChainPayload, WithdrawPayload,
-    V1_API_ENDPOINT,
+    BackupPayload, CloseChannelsWithPeerPayload, ConnectFedPayload, CreateInvoiceForSelfPayload,
+    DepositAddressPayload, GetLnOnchainAddressPayload, InfoPayload, LeaveFedPayload,
+    OpenChannelPayload, PayInvoicePayload, ReceiveEcashPayload, SetConfigurationPayload,
+    SpendEcashPayload, SyncToChainPayload, WithdrawPayload, V1_API_ENDPOINT,
 };
 use crate::rpc::ConfigPayload;
 use crate::{Gateway, GatewayError};
@@ -169,7 +167,6 @@ fn v1_routes(gateway: Arc<Gateway>, task_group: TaskGroup) -> Router {
 
     // Authenticated, public routes used for gateway administration
     let always_authenticated_routes = Router::new()
-        .route(BALANCE_ENDPOINT, post(balance))
         .route(ADDRESS_ENDPOINT, post(address))
         .route(WITHDRAW_ENDPOINT, post(withdraw))
         .route(CONNECT_FED_ENDPOINT, post(connect_fed))
@@ -255,16 +252,6 @@ async fn configuration(
         .handle_get_federation_config(payload.federation_id)
         .await?;
     Ok(Json(json!(gateway_fed_config)))
-}
-
-/// Display gateway ecash note balance
-#[instrument(skip_all, err, fields(?payload))]
-async fn balance(
-    Extension(gateway): Extension<Arc<Gateway>>,
-    Json(payload): Json<BalancePayload>,
-) -> Result<impl IntoResponse, GatewayError> {
-    let amount = gateway.handle_balance_msg(payload).await?;
-    Ok(Json(json!(amount)))
 }
 
 /// Generate deposit address

--- a/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
+++ b/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
@@ -2,7 +2,6 @@
 
 pub const ADDRESS_ENDPOINT: &str = "/address";
 pub const BACKUP_ENDPOINT: &str = "/backup";
-pub const BALANCE_ENDPOINT: &str = "/balance";
 pub const CONFIGURATION_ENDPOINT: &str = "/config";
 pub const CONNECT_FED_ENDPOINT: &str = "/connect_fed";
 pub const GATEWAY_INFO_ENDPOINT: &str = "/info";


### PR DESCRIPTION
The `balance` command gets the e-cash balance for a given federation by its id. This is no longer needed since we added a more comprehensive `get-balances` command in #5823