### PR TITLE
chore(ci): add version params to manually triggered upgrade tests

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -13,6 +13,12 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions to test (if empty, uses same as daily run)'
+        required: false
+        default: ''
+        
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -40,6 +46,11 @@ jobs:
 
       - name: Upgrade tests
         run: |
+          # read versions from manually triggered workflows
+          # default needed for cron or manual workflow without params
+          VERSIONS="${{ github.event.inputs.versions }}"
+          VERSIONS=${VERSIONS:="v0.3.3 v0.4.0 current"}
+
           # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)
           # we need to use `nix develop -c` to be able to use `nix build` inside of backwards-compatibility-test
           # Disable `sccache`, it seems incompatible with self-hosted runner sandbox for some reason, and
@@ -51,7 +62,7 @@ jobs:
             nix shell github:rustshop/fs-dir-cache -c \
             scripts/ci/run-in-fs-dir-cache.sh upgrade-tests \
             env -u RUSTC_WRAPPER \
-            runLowPrio ./scripts/tests/upgrade-test.sh v0.3.3 v0.4.0 current
+            runLowPrio ./scripts/tests/upgrade-test.sh "$VERSIONS"
 
   notifications:
     if: always() && github.repository == 'fedimint/fedimint'

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -28,7 +28,7 @@ test-compatibility *VERSIONS="v0.2.1":
 test-full-compatibility *VERSIONS="v0.2.1":
   env FM_FULL_VERSION_MATRIX=1 ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
-test-upgrades *VERSIONS="v0.2.2 releases/v0.3":
+test-upgrades *VERSIONS="v0.3.3 v0.4.0 current":
   ./scripts/tests/upgrade-test.sh {{VERSIONS}}
 
 # `cargo udeps` check

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -9,7 +9,13 @@ if [ "$#" -eq 0 ]; then
   exit 1
 fi
 
-versions=("$@")
+# allows versions to be passed in as either a single string or multiple params
+# e.g. `"v0.3.0 v0.4.0"` is the same as `v0.3.0 v0.4.0`
+if [ "$#" -eq 1 ]; then
+  IFS=' ' read -r -a versions <<< "$1"
+else
+  versions=("$@")
+fi
 
 source scripts/_common.sh
 build_workspace


### PR DESCRIPTION
This should allow us to provide an upgrade path of versions when triggering a manual workflow (e.g. `"v0.3.3 v0.4.0 v0.4.1-rc.0"`). This seems like an improvement from needing to open a draft PR that includes the versions along with updating the workflow to trigger on PRs (see: https://github.com/fedimint/fedimint/pull/5821#issuecomment-2282259382).

I'll be able to verify once this is merged to `master`.

Resource to help review: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/