### PR TITLE
chore(ci): bump upgrade tests timeout to 120 minutes

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     name: "Upgrade tests"
     runs-on: [self-hosted, linux]
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Timed out at 60 minutes. Since this isn't part of the CI flow, let's bump to 120.

https://discord.com/channels/990354215060795454/1092891381124579349/1273686857632186550