### PR TITLE
fix: use same cln extension version as gatewayd

### DIFF
--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -84,6 +84,10 @@ pub const FM_MINT_CLIENT_ENV: &str = "FM_MINT_CLIENT";
 // Env variable to override gateway-cli binary set:
 pub const FM_GATEWAY_CLI_BASE_EXECUTABLE_ENV: &str = "FM_GATEWAY_CLI_BASE_EXECUTABLE";
 
+// Env variable to override gateway-cln-extension binary set:
+pub const FM_GATEWAY_CLN_EXTENSION_BASE_EXECUTABLE_ENV: &str =
+    "FM_GATEWAY_CLN_EXTENSION_BASE_EXECUTABLE";
+
 // Env variable to override fedimint-load-test-tool binary set:
 pub const FM_LOAD_TEST_TOOL_BASE_EXECUTABLE_ENV: &str = "FM_LOAD_TEST_TOOL_BASE_EXECUTABLE";
 

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -571,6 +571,10 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
             try_join!(stress_test_fed(&dev_fed, None), client.wait_session())?;
 
             for i in 1..gatewayd_paths.len() {
+                info!(
+                    "running stress test with gatewayd path {:?}",
+                    gatewayd_paths.get(i)
+                );
                 let new_gatewayd_path = gatewayd_paths.get(i).expect("Not enough gatewayd paths");
                 let new_gateway_cli_path = gateway_cli_paths
                     .get(i)
@@ -583,17 +587,22 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                         process_mgr,
                         new_gatewayd_path,
                         new_gateway_cli_path,
-                        new_gateway_extension_path
+                        new_gateway_extension_path,
+                        dev_fed.bitcoind.clone(),
                     ),
                     dev_fed.gw_lnd.restart_with_bin(
                         process_mgr,
                         new_gatewayd_path,
                         new_gateway_cli_path,
-                        new_gateway_extension_path
+                        new_gateway_extension_path,
+                        dev_fed.bitcoind.clone(),
                     ),
                 )?;
                 try_join!(stress_test_fed(&dev_fed, None), client.wait_session())?;
                 let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
+                let gateway_cli_version = crate::util::GatewayCli::version_or_default().await;
+                let gateway_cln_extension_version =
+                    crate::util::GatewayClnExtension::version_or_default().await;
                 info!(
                     ?gatewayd_version,
                     ?gateway_cli_version,

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -572,11 +572,20 @@ pub fn get_gateway_cli_path() -> Vec<String> {
 
 const GATEWAY_CLN_EXTENSION_FALLBACK: &str = "gateway-cln-extension";
 
-pub fn get_gateway_cln_extension_path(default_path: &str) -> Vec<String> {
-    get_command_str_for_alias(
+pub fn get_gateway_cln_extension_path(default_path: &str) -> String {
+    let paths = get_command_str_for_alias(
         &[FM_GATEWAY_CLN_EXTENSION_BASE_EXECUTABLE_ENV],
         &[default_path],
-    )
+    );
+    let path = paths
+        .first()
+        .expect("Gateway CLN extension should only have one alias")
+        .clone();
+    if path == GATEWAY_CLN_EXTENSION_FALLBACK {
+        return default_path.to_string();
+    }
+
+    path
 }
 
 const LOAD_TEST_TOOL_FALLBACK: &str = "fedimint-load-test-tool";
@@ -977,10 +986,7 @@ impl GatewayClnExtension {
     pub fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
             &[],
-            &get_gateway_cln_extension_path(self.default_path.as_str())
-                .iter()
-                .map(String::as_str)
-                .collect::<Vec<_>>(),
+            &[get_gateway_cln_extension_path(self.default_path.as_str()).as_str()],
         ))
     }
 

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -59,15 +59,14 @@ const FAILURE_ALONG_ROUTE: i32 = 204;
 struct ClnExtensionOpts {
     /// Gateway CLN extension service listen address
     #[arg(long = "fm-gateway-listen", env = FM_CLN_EXTENSION_LISTEN_ADDRESS_ENV)]
-    fm_gateway_listen: SocketAddr,
+    fm_gateway_listen: Option<SocketAddr>,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     handle_version_hash_command(fedimint_build_code_version_env!());
 
-    let extension_opts = ClnExtensionOpts::try_parse().ok();
-
+    let extension_opts = ClnExtensionOpts::parse();
     let (service, listen, plugin) = ClnRpcService::new(extension_opts)
         .await
         .expect("Failed to create cln rpc service");
@@ -131,7 +130,7 @@ struct ClnRpcService {
 
 impl ClnRpcService {
     async fn new(
-        extension_opts: Option<ClnExtensionOpts>,
+        extension_opts: ClnExtensionOpts,
     ) -> Result<(Self, SocketAddr, Plugin<Arc<ClnHtlcInterceptor>>), ClnExtensionError> {
         let interceptor = Arc::new(ClnHtlcInterceptor::new());
 
@@ -171,8 +170,8 @@ impl ClnRpcService {
             let socket = PathBuf::from(config.lightning_dir).join(config.rpc_file);
 
             // Parse configurations or read from
-            let fm_gateway_listen = match extension_opts {
-                Some(opts) => opts.fm_gateway_listen,
+            let fm_gateway_listen = match extension_opts.fm_gateway_listen {
+                Some(addr) => addr,
                 None => {
                     let listen_val = plugin.option("fm-gateway-listen")
                         .expect("Gateway CLN extension is missing a listen address configuration.

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -246,7 +246,7 @@ if [[ "$num_versions" == "0" ]]; then
   mapfile -t version_matrix < <(generate_current_only_matrix "${versions[@]}")
 else
   # precompile binaries
-  binaries=( "fedimintd" "fedimint-cli" "gateway-cli" "gatewayd" )
+  binaries=( "fedimintd" "fedimint-cli" "gateway-cli" "gatewayd" "gateway-cln-extension" )
   for version in "${versions[@]}" ; do
     if [ "$version" == "current" ] ; then
       continue

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -26,23 +26,29 @@ export FM_BACKWARDS_COMPATIBILITY_TEST=1
 fedimintd_paths=()
 fedimint_cli_paths=()
 gatewayd_paths=()
+gateway_cli_paths=()
+gateway_cln_extension_paths=()
 for version in "${versions[@]}"; do
   if [ "$version" == "current" ]; then
     # Add current binaries from PATH
     fedimintd_paths+=("fedimintd")
     fedimint_cli_paths+=("fedimint-cli")
     gatewayd_paths+=("gatewayd")
+    gateway_cli_paths+=("gateway-cli")
+    gateway_cln_extension_paths+=("gateway-cln-extension")
   else
     fedimintd_paths+=("$(nix_build_binary_for_version 'fedimintd' "$version")")
     fedimint_cli_paths+=("$(nix_build_binary_for_version 'fedimint-cli' "$version")")
     gatewayd_paths+=("$(nix_build_binary_for_version 'gatewayd' "$version")")
+    gateway_cli_paths+=("$(nix_build_binary_for_version 'gateway-cli' "$version")")
+    gateway_cln_extension_paths+=("$(nix_build_binary_for_version 'gateway-cln-extension' "$version")")
   fi
 done
 
 upgrade_tests=(
   "devimint upgrade-tests fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
   "devimint upgrade-tests fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
-  "devimint upgrade-tests gatewayd --paths $(printf "%s " "${gatewayd_paths[@]}")"
+  "devimint upgrade-tests gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}") --gateway-cln-extension-paths $(printf "%s " "${gateway_cln_extension_paths[@]}")"
 )
 
 parsed_test_commands=$(printf "%s\n" "${upgrade_tests[@]}")


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/5863

The culprit PR is https://github.com/fedimint/fedimint/pull/5663/files

This PR broke backwards compatibility between `gatewayd` and `gateway-cln-extension`. I do not think we need to maintain backwards compatibility between these binaries, but `devimint` does not enforce that all of these binaries run as the same version. This breaks the upgrade tests because the extension was expecting a different serialization of the public key when opening a channel than what v0.4.0 was providing.

This PR adds the necessary changes so that `gatewayd`, `gateway-cli`, and `gateway-cln-extension` all run as the same version.