### PR TITLE
Refactor/remove assume checked

### DIFF
--- a/fedimint-core/src/encoding/btc.rs
+++ b/fedimint-core/src/encoding/btc.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use anyhow::format_err;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash as BitcoinHash;
+use bitcoin::Network;
 use hex::{FromHex, ToHex};
 use miniscript::{Descriptor, MiniscriptKey};
 
@@ -198,7 +199,10 @@ impl Encodable for bitcoin::Address {
 
 impl Encodable for bitcoin::Address<NetworkUnchecked> {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        self.clone().assume_checked().consensus_encode(writer)
+        self.clone()
+            .require_network(Network::Bitcoin)
+            .unwrap()
+            .consensus_encode(writer)
     }
 }
 

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use bitcoin::{Address, Transaction, Txid};
+use bitcoin::{Address, Network, Transaction, Txid};
 use bitcoincore_rpc::{Client, RpcApi};
 use fedimint_bitcoind::DynBitcoindRpc;
 use fedimint_core::encoding::Decodable;
@@ -138,7 +138,8 @@ impl BitcoinTest for RealBitcoinTestNoLock {
         self.client
             .get_new_address(None, None)
             .expect(Self::ERROR)
-            .assume_checked()
+            .require_network(Network::Bitcoin)
+            .unwrap()
     }
 
     async fn get_mempool_tx_fee(&self, txid: &Txid) -> Amount {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1721383898,
-        "narHash": "sha256-oB7n3qZp0cVRiiFTSisg2eYfIbFXsbGWK/ZBD02Auq8=",
+        "lastModified": 1723729217,
+        "narHash": "sha256-wupzIoirfemelFTMIP6HAhEEIRRY5OCy+2/WHiqRUSk=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "eb081cbca8853b7481aec2f194627fa639bc5e62",
+        "rev": "3f19e3dd2810bc942d2d1aa25f09e98a344d348c",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1722320953,
-        "narHash": "sha256-DfGaJtgrzcwPQYLTvjL1KaVIjpvi85b2MpM6yEGvJzM=",
+        "lastModified": 1723703304,
+        "narHash": "sha256-7ehq0nfRHpU3oNAkRpklaDxQZUpuaUig2sR2LI+IL/U=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "483df76def3e5010d709aa3a0418ba2088503994",
+        "rev": "6e4233dc54850e8aff6eff401400e9a9343881eb",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1721226092,
-        "narHash": "sha256-UBvzVpo5sXSi2S/Av+t+Q+C2mhMIw/LBEZR+d6NMjws=",
+        "lastModified": 1723688146,
+        "narHash": "sha256-sqLwJcHYeWLOeP/XoLwAtYjr01TISlkOfz+NG82pbdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c716603a63aca44f39bef1986c13402167450e0a",
+        "rev": "c3d4ac725177c030b1e289015989da2ad9d56af0",
         "type": "github"
       },
       "original": {
@@ -355,11 +355,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1722262053,
-        "narHash": "sha256-KxjkPVn9rQqYam6DhiN/V2NcMXtYW25maxkJoiVMpmE=",
+        "lastModified": 1723648323,
+        "narHash": "sha256-AT6K9JREduWC1zcIJIx8JTZa4sYZD6VvyB/xRnjphqY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "a021b85be57d34b1eed687fcafd5d5ec64b2d853",
+        "rev": "64a140527b383e3a2fe95908881624fc5374c60c",
         "type": "github"
       },
       "original": {

--- a/gateway/cli/src/lightning_commands.rs
+++ b/gateway/cli/src/lightning_commands.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use bitcoin::Network;
 use clap::Subcommand;
 use fedimint_core::util::{backoff_util, retry};
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
@@ -69,7 +70,8 @@ impl LightningCommands {
                 let response = create_client()
                     .get_funding_address(GetFundingAddressPayload {})
                     .await?
-                    .assume_checked();
+                    .require_network(Network::Bitcoin)
+                    .unwrap();
                 println!("{response}");
             }
             Self::OpenChannel {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -41,7 +41,7 @@ use ::lightning::ln::PaymentHash;
 use anyhow::{anyhow, bail};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use bitcoin::{Address, Network, Txid};
+use bitcoin::{Address, Network, Network, Txid};
 use bitcoin_hashes::sha256;
 use clap::Parser;
 use client::GatewayClientBuilder;
@@ -904,7 +904,7 @@ impl Gateway {
                 WithdrawState::Succeeded(txid) => {
                     info!(
                         "Sent {amount} funds to address {}",
-                        address.assume_checked()
+                        address.require_network(Network::Bitcoin).unwrap()
                     );
                     return Ok(txid);
                 }
@@ -1233,7 +1233,7 @@ impl Gateway {
         let context = self.get_lightning_context().await?;
         let response = context.lnrpc.get_funding_address().await?;
         Address::from_str(&response.address)
-            .map(Address::assume_checked)
+            .map(Address::require_network(Network::Bitcoin).unwrap())
             .map_err(|e| GatewayError::LightningResponseParseError(e.into()))
     }
 

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -28,7 +28,7 @@ use anyhow::{anyhow, bail, ensure, Context as AnyhowContext};
 use async_stream::stream;
 use backup::WalletModuleBackup;
 use bitcoin::address::NetworkUnchecked;
-use bitcoin::{Address, Network, ScriptBuf};
+use bitcoin::{Address, Network, Network, ScriptBuf};
 use client_db::{DbKeyPrefix, PegInTweakIndexKey, TweakIdx};
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_bitcoind::{create_bitcoind, DynBitcoindRpc};
@@ -585,7 +585,7 @@ impl WalletClientModule {
         check_address(&address, self.cfg().network)?;
 
         self.module_api
-            .fetch_peg_out_fees(&address.assume_checked(), amount)
+            .fetch_peg_out_fees(&address.require_network(Network::Bitcoin).unwrap(), amount)
             .await?
             .context("Federation didn't return peg-out fees")
     }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -28,7 +28,7 @@ use anyhow::{anyhow, bail, ensure, Context as AnyhowContext};
 use async_stream::stream;
 use backup::WalletModuleBackup;
 use bitcoin::address::NetworkUnchecked;
-use bitcoin::{Address, Network, Network, ScriptBuf};
+use bitcoin::{Address, Network, ScriptBuf};
 use client_db::{DbKeyPrefix, PegInTweakIndexKey, TweakIdx};
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_bitcoind::{create_bitcoind, DynBitcoindRpc};

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -244,7 +244,11 @@ impl std::fmt::Display for WalletOutputV0 {
                     f,
                     "Wallet PegOut {} to {}",
                     pegout.amount,
-                    pegout.recipient.clone().assume_checked()
+                    pegout
+                        .recipient
+                        .clone()
+                        .require_network(Network::Bitcoin)
+                        .unwrap()
                 )
             }
             WalletOutputV0::Rbf(rbf) => write!(f, "Wallet RBF {:?} to {}", rbf.fees, rbf.txid),

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -702,7 +702,7 @@ impl ServerModule for Wallet {
 
                     let tx = module.offline_wallet().create_tx(
                         bitcoin::Amount::from_sat(sats),
-                        address.assume_checked().script_pubkey(),
+                        address.require_network(Network::Bitcoin).unwrap().script_pubkey(),
                         vec![],
                         module.available_utxos(&mut context.dbtx().into_nc()).await,
                         feerate,
@@ -1132,7 +1132,12 @@ impl Wallet {
         match output {
             WalletOutputV0::PegOut(peg_out) => self.offline_wallet().create_tx(
                 peg_out.amount,
-                peg_out.recipient.clone().assume_checked().script_pubkey(),
+                peg_out
+                    .recipient
+                    .clone()
+                    .require_network(Network::Bitcoin)
+                    .unwrap()
+                    .script_pubkey(),
                 vec![],
                 self.available_utxos(dbtx).await,
                 peg_out.fees.fee_rate,
@@ -1772,7 +1777,11 @@ mod tests {
         // spendable sats = 3000 - 219 - 330 = 2451
         let tx = wallet.create_tx(
             Amount::from_sat(2452),
-            recipient.clone().assume_checked().script_pubkey(),
+            recipient
+                .clone()
+                .require_network(Network::Bitcoin)
+                .unwrap()
+                .script_pubkey(),
             vec![],
             vec![(UTXOKey(OutPoint::null()), spendable.clone())],
             fee,
@@ -1785,7 +1794,11 @@ mod tests {
         let mut tx = wallet
             .create_tx(
                 Amount::from_sat(1000),
-                recipient.clone().assume_checked().script_pubkey(),
+                recipient
+                    .clone()
+                    .require_network(Network::Bitcoin)
+                    .unwrap()
+                    .script_pubkey(),
                 vec![],
                 vec![(UTXOKey(OutPoint::null()), spendable)],
                 fee,

--- a/modules/fedimint-wallet-tests/src/bin/circular-deposit-test.rs
+++ b/modules/fedimint-wallet-tests/src/bin/circular-deposit-test.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use bitcoincore_rpc::bitcoin::address::Address;
-use bitcoincore_rpc::bitcoin::{Transaction, Txid};
+use bitcoincore_rpc::bitcoin::{Network, Transaction, Txid};
 use devimint::cmd;
 use devimint::federation::Client;
 use devimint::util::poll;
@@ -53,7 +53,11 @@ async fn assert_withdrawal(
     let parsed_address = Address::from_str(&deposit_address)?;
     let tx = Transaction::consensus_decode_hex(&tx_hex, &Default::default()).unwrap();
     assert!(tx.output.iter().any(|o| o.script_pubkey
-        == parsed_address.clone().assume_checked().script_pubkey()
+        == parsed_address
+            .clone()
+            .require_network(Network::Bitcoin)
+            .unwrap()
+            .script_pubkey()
         && o.value == withdrawal_amount_sats));
 
     // Verify the receive client gets the deposit

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use anyhow::{bail, Context};
 use assert_matches::assert_matches;
-use bitcoin::secp256k1;
+use bitcoin::{secp256k1, Network};
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::ClientHandleArc;
 use fedimint_core::bitcoin_migration::checked_address_to_unchecked_address;
@@ -193,7 +193,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     assert_eq!(tx_fee, expected_tx_fee);
 
     let received = bitcoin
-        .mine_block_and_get_received(&address.clone().assume_checked())
+        .mine_block_and_get_received(&address.clone().require_network(Network::Bitcoin).unwrap())
         .await;
     assert_eq!(received, peg_out.into());
     Ok(())
@@ -384,7 +384,9 @@ async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
 
     assert_eq!(
         bitcoin
-            .mine_block_and_get_received(&address.clone().assume_checked())
+            .mine_block_and_get_received(
+                &address.clone().require_network(Network::Bitcoin).unwrap()
+            )
             .await,
         sats(PEG_OUT_AMOUNT_SATS)
     );


### PR DESCRIPTION
PR for issue: #5203 


This PR addresses the migration from Bitcoin v0.29 to v0.30 by replacing all instances of assume_checked() with require_network().

Background:
Bitcoin v30 introduced the concept of checked and unchecked addresses. During the migration from v0.29 to v0.30, assume_checked() was temporarily used to satisfy the compiler. Now that the migration is complete, it’s necessary to replace these temporary calls with the more appropriate require_network() to ensure the codebase adheres to the new standards introduced in v30.

Changes:

Replaced all instances of assume_checked() with require_network() throughout the codebase.
Verified that the changes align with the Bitcoin v30 standards and do not introduce any regressions.

Impact:
This change improves the safety and accuracy of address handling in the codebase, aligning it with the latest Bitcoin network standards.
