### PR TITLE
fix: bitcoin network naming mismatch

### DIFF
--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -67,7 +67,7 @@ message GetNodeInfoResponse {
   // The alias of the lightning node
   string alias = 2;
 
-  // The network the node is on. Valid values are "main" | "test" | "signet" | "regtest"
+  // The network the node is on. Valid values are "bitcoin" | "testnet" | "signet" | "regtest"
   string network = 3;
 
   // The best block height that the associated lightning node is aware of

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -224,14 +224,7 @@ impl ILnRpcClient for GatewayLdkClient {
             pub_key: self.node.node_id().serialize().to_vec(),
             // TODO: This is a placeholder. We need to get the actual alias from the LDK node.
             alias: format!("LDK Fedimint Gateway Node {}", self.node.node_id()),
-            network: match self.node.config().network {
-                Network::Bitcoin => "main",
-                Network::Testnet => "test",
-                Network::Signet => "signet",
-                Network::Regtest => "regtest",
-                _ => panic!("Unsupported network"),
-            }
-            .to_string(),
+            network: self.node.config().network.to_string(),
             block_height,
             synced_to_chain,
         })


### PR DESCRIPTION
Fixes #5879

The [`Network`](https://docs.rs/bitcoin/0.30.2/bitcoin/network/constants/enum.Network.html) enum in the rust `bitcoin` crate is represented as the strings "bitcoin", "testnet", "regtest", and "signet" (see [here](https://docs.rs/bitcoin/0.30.2/src/bitcoin/network/constants.rs.html#569-578)). In `gateway_lnrpc.proto` we incorrectly documented `GetNodeInfoResponse.network` by saying that the acceptable values instead were "main", "test", "signet", and "regtest". Here we fix this documentation issue and change the LDK gateway implementation to stay true to that documentation change. No changes are needed for LND (we already convert "mainnet" to "bitcoin" [here](https://github.com/fedimint/fedimint/blob/df2073e53c496035fe37c999cb0821970f86dfcb/gateway/ln-gateway/src/lightning/lnd.rs#L671-L673)) and CLN (see the `network` field documentation [here](https://docs.corelightning.org/reference/lightning-getinfo)).