### PR TITLE
chore(ci): print versions in upgrade tests script

### DIFF
--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -17,6 +17,8 @@ else
   versions=("$@")
 fi
 
+echo "## Running upgrade tests for versions: ${versions[*]}"
+
 source scripts/_common.sh
 build_workspace
 add_target_dir_to_path


### PR DESCRIPTION
It's not obvious at a glance what versions are used in upgrade tests. This will help when looking through previous CI runs.