### PR TITLE
fix(ci): set release to prerelease if tag contains 'rc'

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -543,6 +543,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: "bins/**"
+          prerelease: ${{ contains(github.ref, 'rc') }}
 
       - name: Build DEB package
         run: |
@@ -573,6 +574,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: "debs/**.deb"
+          prerelease: ${{ contains(github.ref, 'rc') }}
 
       - name: Upload RPM packages
         uses: actions/upload-artifact@v4
@@ -585,6 +587,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: "rpms/**.rpm"
+          prerelease: ${{ contains(github.ref, 'rc') }}
 
   status:
     name: Status


### PR DESCRIPTION
Related to https://github.com/fedimint/fedimint/issues/5896

Keeping the issue open after merging so we can verify the `Pre-release` tag is correctly set the next time we push a `*-rc.*` tag.

Resources to help with review
- Custom inputs available in [action-gh-release](https://github.com/softprops/action-gh-release#-customizing)
- `contains()` expression [docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#contains)