### PR TITLE
chore: use a hardcoded regtest genesis block hash

### DIFF
--- a/fedimint-bitcoind/src/electrum.rs
+++ b/fedimint-bitcoind/src/electrum.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use anyhow::anyhow as format_err;
+use anyhow::{anyhow as format_err, bail};
 use bitcoin::{BlockHash, Network, ScriptBuf, Transaction, Txid};
 use electrum_client::ElectrumApi;
 use electrum_client::Error::Protocol;
@@ -11,7 +11,7 @@ use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Feerate};
 use hex::ToHex;
 use serde_json::{Map, Value};
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
 
@@ -50,9 +50,9 @@ impl IBitcoindRpc for ElectrumClient {
             crate::MAINNET_GENESIS_BLOCK_HASH => Network::Bitcoin,
             crate::TESTNET_GENESIS_BLOCK_HASH => Network::Testnet,
             crate::SIGNET_GENESIS_BLOCK_HASH => Network::Signet,
+            crate::REGTEST_GENESIS_BLOCK_HASH => Network::Regtest,
             hash => {
-                warn!("Unknown genesis hash {hash} - assuming regtest");
-                Network::Regtest
+                bail!("Unknown genesis hash {hash}");
             }
         })
     }

--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-use anyhow::format_err;
+use anyhow::{bail, format_err};
 use bitcoin::{BlockHash, Network, ScriptBuf, Transaction, Txid};
 use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Feerate};
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
 
@@ -47,9 +47,9 @@ impl IBitcoindRpc for EsploraClient {
             crate::MAINNET_GENESIS_BLOCK_HASH => Network::Bitcoin,
             crate::TESTNET_GENESIS_BLOCK_HASH => Network::Testnet,
             crate::SIGNET_GENESIS_BLOCK_HASH => Network::Signet,
+            crate::REGTEST_GENESIS_BLOCK_HASH => Network::Regtest,
             hash => {
-                warn!("Unknown genesis hash {hash} - assuming regtest");
-                Network::Regtest
+                bail!("Unknown genesis hash {hash}");
             }
         };
 

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -45,6 +45,10 @@ const TESTNET_GENESIS_BLOCK_HASH: &str =
 // <https://mempool.space/signet/api/block-height/0>
 const SIGNET_GENESIS_BLOCK_HASH: &str =
     "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6";
+// See <https://bitcoin.stackexchange.com/questions/122778/is-the-regtest-genesis-hash-always-the-same-or-not>
+// <https://github.com/bitcoin/bitcoin/blob/d82283950f5ff3b2116e705f931c6e89e5fdd0be/src/kernel/chainparams.cpp#L478>
+const REGTEST_GENESIS_BLOCK_HASH: &str =
+    "0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206";
 
 /// Global factories for creating bitcoin RPCs
 static BITCOIN_RPC_REGISTRY: LazyLock<Mutex<BTreeMap<String, DynBitcoindRpcFactory>>> =


### PR DESCRIPTION
Instead of assuming that any unknown gensis block hash is a regtest network, use the fact the regtest genesis block is hardcoded.

This should protect us from any bugs that lead to invalid block hashes, like in #5813.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
