### PR TITLE
fix(tests): use esplora and electrs backends

### DIFF
--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -48,7 +48,7 @@ const SIGNET_GENESIS_BLOCK_HASH: &str =
 // See <https://bitcoin.stackexchange.com/questions/122778/is-the-regtest-genesis-hash-always-the-same-or-not>
 // <https://github.com/bitcoin/bitcoin/blob/d82283950f5ff3b2116e705f931c6e89e5fdd0be/src/kernel/chainparams.cpp#L478>
 const REGTEST_GENESIS_BLOCK_HASH: &str =
-    "0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206";
+    "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206";
 
 /// Global factories for creating bitcoin RPCs
 static BITCOIN_RPC_REGISTRY: LazyLock<Mutex<BTreeMap<String, DynBitcoindRpcFactory>>> =

--- a/fedimint-testing-core/src/envs.rs
+++ b/fedimint-testing-core/src/envs.rs
@@ -30,3 +30,13 @@ pub const FM_LND_TLS_CERT_ENV: &str = "FM_LND_TLS_CERT";
 
 // Env variable to TODO
 pub const FM_TEST_BITCOIND_RPC_ENV: &str = "FM_TEST_BITCOIND_RPC";
+
+// Overrides the wallet server's Bitcoin RPC kind used in testing fixtures.
+// This is necessary instead of `FM_FORCE_BITCOIN_RPC_KIND_ENV` since that
+// overrides both the wallet client and server's Bitcoin RPC.
+pub const FM_TEST_BACKEND_BITCOIN_RPC_KIND_ENV: &str = "FM_TEST_BACKEND_BITCOIN_RPC_KIND";
+
+// Overrides the wallet server's Bitcoin RPC URL used in testing fixtures.
+// This is necessary instead of `FM_FORCE_BITCOIN_RPC_URL_ENV` since that
+// overrides both the wallet client and server's Bitcoin RPC.
+pub const FM_TEST_BACKEND_BITCOIN_RPC_URL_ENV: &str = "FM_TEST_BACKEND_BITCOIN_RPC_URL";

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -82,8 +82,8 @@ function run_tests() {
   fi
 
   # Switch to electrum and run wallet tests
-  export FM_BITCOIN_RPC_KIND="electrum"
-  export FM_BITCOIN_RPC_URL="tcp://127.0.0.1:$FM_PORT_ELECTRS"
+  export FM_TEST_BACKEND_BITCOIN_RPC_KIND="electrum"
+  export FM_TEST_BACKEND_BITCOIN_RPC_URL="tcp://127.0.0.1:$FM_PORT_ELECTRS"
 
   if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "electrs" ]; then
     >&2 echo "### Testing against electrs"
@@ -95,14 +95,14 @@ function run_tests() {
   fi
 
   # Switch to esplora and run wallet tests
-  export FM_BITCOIN_RPC_KIND="esplora"
-  export FM_BITCOIN_RPC_URL="http://127.0.0.1:$FM_PORT_ESPLORA"
+  export FM_TEST_BACKEND_BITCOIN_RPC_KIND="esplora"
+  export FM_TEST_BACKEND_BITCOIN_RPC_URL="http://127.0.0.1:$FM_PORT_ESPLORA"
 
   if [ -z "${FM_TEST_ONLY:-}" ] || [ "${FM_TEST_ONLY:-}" = "esplora" ]; then
     >&2 echo "### Testing against esplora"
     cargo nextest run --locked --workspace --all-targets \
       ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
-      ${TEST_ARGS_THREADED} \
+      ${TEST_ARGS_SERIALIZED} \
       -E 'package(fedimint-wallet-tests)'
     >&2 echo "### Testing against esplora - complete"
   fi


### PR DESCRIPTION
Noticed while testing https://github.com/fedimint/fedimint/pull/5900

Introduces new env vars to override only the wallet server's Bitcoin RPC for esplora and electrs backend tests. We can't use `FM_FORCE_*` env vars to override because that will also override the wallet client, which fails since electrum can't support `get_txout_proof`.