### PR TITLE
Surface Bitcoin RPC used by fedimintd

### DIFF
--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -7,7 +7,7 @@ use bitcoin::{BlockHash, Network, ScriptBuf, Transaction, Txid};
 use bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
 use bitcoincore_rpc::{Auth, RpcApi};
 use fedimint_core::encoding::Decodable;
-use fedimint_core::envs::FM_BITCOIND_COOKIE_FILE_ENV;
+use fedimint_core::envs::{BitcoinRpcConfig, FM_BITCOIND_COOKIE_FILE_ENV};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::runtime::block_in_place;
 use fedimint_core::task::TaskHandle;
@@ -33,19 +33,26 @@ impl IBitcoindRpcFactory for BitcoindFactory {
 }
 
 #[derive(Debug)]
-struct BitcoinClient(::bitcoincore_rpc::Client);
+struct BitcoinClient {
+    client: ::bitcoincore_rpc::Client,
+    url: SafeUrl,
+}
 
 impl BitcoinClient {
     fn new(url: &SafeUrl) -> anyhow::Result<Self> {
+        let safe_url = url.clone();
         let (url, auth) = from_url_to_url_auth(url)?;
-        Ok(Self(::bitcoincore_rpc::Client::new(&url, auth)?))
+        Ok(Self {
+            client: ::bitcoincore_rpc::Client::new(&url, auth)?,
+            url: safe_url,
+        })
     }
 }
 
 #[apply(async_trait_maybe_send!)]
 impl IBitcoindRpc for BitcoinClient {
     async fn get_network(&self) -> anyhow::Result<Network> {
-        let network = block_in_place(|| self.0.get_blockchain_info())?;
+        let network = block_in_place(|| self.client.get_blockchain_info())?;
         Ok(match network.chain.as_str() {
             "main" => Network::Bitcoin,
             "test" => Network::Testnet,
@@ -57,18 +64,18 @@ impl IBitcoindRpc for BitcoinClient {
 
     async fn get_block_count(&self) -> anyhow::Result<u64> {
         // The RPC function is confusingly named and actually returns the block height
-        block_in_place(|| self.0.get_block_count())
+        block_in_place(|| self.client.get_block_count())
             .map(|height| height + 1)
             .map_err(anyhow::Error::from)
     }
 
     async fn get_block_hash(&self, height: u64) -> anyhow::Result<BlockHash> {
-        block_in_place(|| self.0.get_block_hash(height)).map_err(anyhow::Error::from)
+        block_in_place(|| self.client.get_block_hash(height)).map_err(anyhow::Error::from)
     }
 
     async fn get_fee_rate(&self, confirmation_target: u16) -> anyhow::Result<Option<Feerate>> {
         let fee = block_in_place(|| {
-            self.0
+            self.client
                 .estimate_smart_fee(confirmation_target, Some(EstimateMode::Conservative))
         });
         Ok(fee?.fee_rate.map(|per_kb| Feerate {
@@ -79,7 +86,7 @@ impl IBitcoindRpc for BitcoinClient {
     async fn submit_transaction(&self, transaction: Transaction) {
         use bitcoincore_rpc::jsonrpc::Error::Rpc;
         use bitcoincore_rpc::Error::JsonRpc;
-        match block_in_place(|| self.0.send_raw_transaction(&transaction)) {
+        match block_in_place(|| self.client.send_raw_transaction(&transaction)) {
             // Bitcoin core's RPC will return error code -27 if a transaction is already in a block.
             // This is considered a success case, so we don't surface the error log.
             //
@@ -91,11 +98,11 @@ impl IBitcoindRpc for BitcoinClient {
     }
 
     async fn get_tx_block_height(&self, txid: &Txid) -> anyhow::Result<Option<u64>> {
-        let info = block_in_place(|| self.0.get_raw_transaction_info(txid, None))
+        let info = block_in_place(|| self.client.get_raw_transaction_info(txid, None))
             .map_err(|error| info!(?error, "Unable to get raw transaction"));
         let height = match info.ok().and_then(|info| info.blockhash) {
             None => None,
-            Some(hash) => Some(block_in_place(|| self.0.get_block_header_info(&hash))?.height),
+            Some(hash) => Some(block_in_place(|| self.client.get_block_header_info(&hash))?.height),
         };
         Ok(height.map(|h| h as u64))
     }
@@ -106,7 +113,7 @@ impl IBitcoindRpc for BitcoinClient {
         block_hash: &BlockHash,
         block_height: u64,
     ) -> anyhow::Result<bool> {
-        let block_info = block_in_place(|| self.0.get_block_info(block_hash))?;
+        let block_info = block_in_place(|| self.client.get_block_info(block_hash))?;
         anyhow::ensure!(
             block_info.height as u64 == block_height,
             "Block height for block hash does not match expected height"
@@ -119,7 +126,7 @@ impl IBitcoindRpc for BitcoinClient {
         // start watching for this script in our wallet to avoid the need to rescan the
         // blockchain, labeling it so we can reference it later
         block_in_place(|| {
-            self.0
+            self.client
                 .import_address_script(script, Some(&script.to_string()), Some(false), None)
         })?;
 
@@ -129,11 +136,11 @@ impl IBitcoindRpc for BitcoinClient {
     async fn get_script_history(&self, script: &ScriptBuf) -> anyhow::Result<Vec<Transaction>> {
         let mut results = vec![];
         let list = block_in_place(|| {
-            self.0
+            self.client
                 .list_transactions(Some(&script.to_string()), None, None, Some(true))
         })?;
         for tx in list {
-            let raw_tx = block_in_place(|| self.0.get_raw_transaction(&tx.info.txid, None))?;
+            let raw_tx = block_in_place(|| self.client.get_raw_transaction(&tx.info.txid, None))?;
             results.push(raw_tx);
         }
         Ok(results)
@@ -141,10 +148,19 @@ impl IBitcoindRpc for BitcoinClient {
 
     async fn get_txout_proof(&self, txid: Txid) -> anyhow::Result<TxOutProof> {
         TxOutProof::consensus_decode(
-            &mut Cursor::new(block_in_place(|| self.0.get_tx_out_proof(&[txid], None))?),
+            &mut Cursor::new(block_in_place(|| {
+                self.client.get_tx_out_proof(&[txid], None)
+            })?),
             &ModuleDecoderRegistry::default(),
         )
         .map_err(|error| format_err!("Could not decode tx: {}", error))
+    }
+
+    fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
+        BitcoinRpcConfig {
+            kind: "bitcoind".to_string(),
+            url: self.url.clone(),
+        }
     }
 }
 

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -179,6 +179,9 @@ pub trait IBitcoindRpc: Debug {
 
     /// Returns a proof that a tx is included in the bitcoin blockchain
     async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof>;
+
+    /// Returns the Bitcoin RPC config
+    fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig;
 }
 
 dyn_newtype_define! {
@@ -290,5 +293,9 @@ where
     async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof> {
         self.retry_call(|| async { self.inner.get_txout_proof(txid).await })
             .await
+    }
+
+    fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
+        self.inner.get_bitcoin_rpc_config()
     }
 }

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -385,6 +385,13 @@ impl IBitcoindRpc for FakeBitcoinTest {
         let proof = inner.proofs.get(&txid);
         Ok(proof.ok_or(format_err!("No proof stored"))?.clone())
     }
+
+    fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
+        BitcoinRpcConfig {
+            kind: "mock_kind".to_string(),
+            url: "http://mock".parse().unwrap(),
+        }
+    }
 }
 
 fn output_sum(tx: &Transaction) -> u64 {

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -1,19 +1,29 @@
+use std::time::Duration;
+
 use bitcoin::Address;
 use fedimint_api_client::api::{FederationApiExt, FederationResult, IModuleFederationApi};
-use fedimint_core::module::ApiRequestErased;
+use fedimint_core::envs::BitcoinRpcConfig;
+use fedimint_core::module::{ApiAuth, ApiRequestErased};
 use fedimint_core::task::{MaybeSend, MaybeSync};
-use fedimint_core::{apply, async_trait_maybe_send};
-use fedimint_wallet_common::endpoint_constants::{BLOCK_COUNT_ENDPOINT, PEG_OUT_FEES_ENDPOINT};
+use fedimint_core::{apply, async_trait_maybe_send, PeerId};
+use fedimint_wallet_common::endpoint_constants::{
+    BITCOIN_KIND_ENDPOINT, BITCOIN_RPC_CONFIG_ENDPOINT, BLOCK_COUNT_ENDPOINT, PEG_OUT_FEES_ENDPOINT,
+};
 use fedimint_wallet_common::PegOutFees;
 
 #[apply(async_trait_maybe_send!)]
 pub trait WalletFederationApi {
     async fn fetch_consensus_block_count(&self) -> FederationResult<u64>;
+
     async fn fetch_peg_out_fees(
         &self,
         address: &Address,
         amount: bitcoin::Amount,
     ) -> FederationResult<Option<PegOutFees>>;
+
+    async fn fetch_bitcoin_rpc_kind(&self, peer_id: PeerId) -> FederationResult<String>;
+
+    async fn fetch_bitcoin_rpc_config(&self, auth: ApiAuth) -> FederationResult<BitcoinRpcConfig>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -37,6 +47,25 @@ where
         self.request_current_consensus(
             PEG_OUT_FEES_ENDPOINT.to_string(),
             ApiRequestErased::new((address, amount.to_sat())),
+        )
+        .await
+    }
+
+    async fn fetch_bitcoin_rpc_kind(&self, peer_id: PeerId) -> FederationResult<String> {
+        self.request_single_peer_federation(
+            Some(Duration::from_secs(10)),
+            BITCOIN_KIND_ENDPOINT.to_string(),
+            ApiRequestErased::default(),
+            peer_id,
+        )
+        .await
+    }
+
+    async fn fetch_bitcoin_rpc_config(&self, auth: ApiAuth) -> FederationResult<BitcoinRpcConfig> {
+        self.request_admin(
+            BITCOIN_RPC_CONFIG_ENDPOINT,
+            ApiRequestErased::default(),
+            auth,
         )
         .await
     }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -50,7 +50,7 @@ use fedimint_core::db::{
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::{
-    ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion,
+    ApiAuth, ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion,
 };
 use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup};
 use fedimint_core::util::backoff_util::background_backoff;
@@ -248,6 +248,7 @@ impl ClientModuleInit for WalletClientInit {
             pegin_claimed_receiver,
             pegin_claimed_sender,
             task_group: args.task_group().clone(),
+            admin_auth: args.admin_auth().cloned(),
         })
     }
 
@@ -375,6 +376,7 @@ pub struct WalletClientModule {
     pegin_claimed_sender: watch::Sender<()>,
     pegin_claimed_receiver: watch::Receiver<()>,
     task_group: TaskGroup,
+    admin_auth: Option<ApiAuth>,
 }
 
 #[apply(async_trait_maybe_send!)]

--- a/modules/fedimint-wallet-common/src/endpoint_constants.rs
+++ b/modules/fedimint-wallet-common/src/endpoint_constants.rs
@@ -1,3 +1,5 @@
 pub const BLOCK_COUNT_ENDPOINT: &str = "block_count";
 pub const PEG_OUT_FEES_ENDPOINT: &str = "peg_out_fees";
 pub const BLOCK_COUNT_LOCAL_ENDPOINT: &str = "block_count_local";
+pub const BITCOIN_KIND_ENDPOINT: &str = "bitcoin_kind";
+pub const BITCOIN_RPC_CONFIG_ENDPOINT: &str = "bitcoin_rpc_config";

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -7,6 +7,11 @@ description = "fedimint-wallet-tests contains integration tests for the lightnin
 license = "MIT"
 publish = false
 
+[features]
+bitcoind = []
+electrum = []
+esplora = []
+
 [[bin]]
 name = "circular-deposit-test"
 path = "src/bin/circular-deposit-test.rs"

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1151,3 +1151,32 @@ mod fedimint_migration_tests {
         .await
     }
 }
+
+// Verify the correct Bitcoin RPC is used
+
+#[cfg(feature = "bitcoind")]
+#[test]
+fn verify_bitcoind_backend() {
+    let fixtures = fixtures();
+    let dyn_bitcoin_rpc = fixtures.dyn_bitcoin_rpc();
+    let bitcoin_rpc_kind = dyn_bitcoin_rpc.get_bitcoin_rpc_config().kind;
+    assert_eq!(bitcoin_rpc_kind, "bitcoind")
+}
+
+#[cfg(feature = "esplora")]
+#[test]
+fn verify_esplora_backend() {
+    let fixtures = fixtures();
+    let dyn_bitcoin_rpc = fixtures.dyn_bitcoin_rpc();
+    let bitcoin_rpc_kind = dyn_bitcoin_rpc.get_bitcoin_rpc_config().kind;
+    assert_eq!(bitcoin_rpc_kind, "esplora")
+}
+
+#[cfg(feature = "electrum")]
+#[test]
+fn verify_electrum_backend() {
+    let fixtures = fixtures();
+    let dyn_bitcoin_rpc = fixtures.dyn_bitcoin_rpc();
+    let bitcoin_rpc_kind = dyn_bitcoin_rpc.get_bitcoin_rpc_config().kind;
+    assert_eq!(bitcoin_rpc_kind, "electrum")
+}

--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -41,6 +41,7 @@ function run_tests() {
       cargo nextest run --locked --workspace --all-targets \
         ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
         ${TEST_ARGS_THREADED} \
+        --features bitcoind \
         -E 'package(fedimint-wallet-tests)'
     fi
     if [ -z "${FM_BITCOIND_TEST_ONLY:-}" ] || [ "${FM_BITCOIND_TEST_ONLY:-}" = "ln" ]; then
@@ -90,6 +91,7 @@ function run_tests() {
     cargo nextest run --locked --workspace --all-targets \
       ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
       ${TEST_ARGS_SERIALIZED} \
+      --features electrum \
       -E 'package(fedimint-wallet-tests)'
     >&2 echo "### Testing against electrs - complete"
   fi
@@ -103,6 +105,7 @@ function run_tests() {
     cargo nextest run --locked --workspace --all-targets \
       ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
       ${TEST_ARGS_SERIALIZED} \
+      --features esplora \
       -E 'package(fedimint-wallet-tests)'
     >&2 echo "### Testing against esplora - complete"
   fi


### PR DESCRIPTION
Followup addressing:

> Can we assert in a test that the correct blockchain API is used to avoid regressions? Do you think that would be useful?

https://github.com/fedimint/fedimint/pull/5902#pullrequestreview-2254638875

---

Adds two endpoints to wallet server:
- authed endpoint that returns bitcoin rpc kind and url
  - auth required since bitcoin url should not be leaked to public
  - useful for surfacing to guardians in UI
  - url is stripped of `user:pass` prior to sending over the wire
- no-auth endpoint that returns the bitcoin kind for a peer
  - useful for surfacing to clients (e.g. `fedimint-observer`)

```bash
bash-5.2$ fedimint-cli module wallet --help
Usage: wallet <COMMAND>

Commands:
  await-deposit           Await a deposit on a given deposit address
  get-bitcoin-rpc-kind    Returns the Bitcoin RPC kind
  get-bitcoin-rpc-config  Returns the Bitcoin RPC kind and URL, if authenticated
  help                    Print this message or the help of the given subcommand(s)

bash-5.2$ fedimint-cli module wallet get-bitcoin-rpc-kind 0
"bitcoind"

bash-5.2$ FM_OUR_ID=0 FM_PASSWORD=pass fedimint-cli module wallet get-bitcoin-rpc-config
{
  "kind": "bitcoind",
  "url": "http://127.0.0.1:11368/"
}
```
