### PR TITLE
fix(tests): run electrum tests in sequence

### DIFF
--- a/scripts/tests/backend-test.sh
+++ b/scripts/tests/backend-test.sh
@@ -89,7 +89,7 @@ function run_tests() {
     >&2 echo "### Testing against electrs"
     cargo nextest run --locked --workspace --all-targets \
       ${CARGO_PROFILE:+--cargo-profile ${CARGO_PROFILE}} ${CARGO_PROFILE:+--profile ${CARGO_PROFILE}} \
-      ${TEST_ARGS_THREADED} \
+      ${TEST_ARGS_SERIALIZED} \
       -E 'package(fedimint-wallet-tests)'
     >&2 echo "### Testing against electrs - complete"
   fi


### PR DESCRIPTION
The hourly run is surfacing flakiness in the electrum tests. I noticed similar timeouts when enabling esplora tests in https://github.com/fedimint/fedimint/pull/5902 and needed to run in sequence, so applying the same fix here.