### PR TITLE
Restore operation log entries for deposits

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -466,7 +466,7 @@ pub async fn handle_command(
         ClientCmd::DepositAddress => {
             let (operation_id, address, tweak_idx) = client
                 .get_first_module::<WalletClientModule>()
-                .allocate_deposit_address_expert_only()
+                .allocate_deposit_address_expert_only(())
                 .await?;
             Ok(serde_json::json! {
                 {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -841,7 +841,7 @@ impl Gateway {
             .await?
             .value()
             .get_first_module::<WalletClientModule>()
-            .allocate_deposit_address_expert_only()
+            .allocate_deposit_address_expert_only(())
             .await?;
         Ok(address)
     }

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -6,7 +6,7 @@ use fedimint_client::module::init::recovery::RecoveryFromHistoryCommon;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record, TransactionId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
 use crate::backup::WalletRecoveryState;
@@ -31,7 +31,18 @@ impl std::fmt::Display for DbKeyPrefix {
 /// Under the hood it's similar to `ChildId`, but in a wallet module
 /// it's used often enough to deserve own newtype.
 #[derive(
-    Copy, Clone, Debug, Encodable, Decodable, Serialize, Default, PartialEq, Eq, PartialOrd, Ord,
+    Copy,
+    Clone,
+    Debug,
+    Encodable,
+    Decodable,
+    Serialize,
+    Deserialize,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
 )]
 pub struct TweakIdx(pub u64);
 

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -140,6 +140,7 @@ impl_db_record!(
     key = ClaimedPegInKey,
     value = ClaimedPegInData,
     db_prefix = DbKeyPrefix::ClaimedPegIn,
+    notify_on_modify = true,
 );
 impl_db_lookup!(key = ClaimedPegInKey, query_prefix = ClaimedPegInPrefix);
 

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -19,7 +19,7 @@ use fedimint_dummy_server::DummyInit;
 use fedimint_testing::btc::BitcoinTest;
 use fedimint_testing::fixtures::Fixtures;
 use fedimint_wallet_client::api::WalletFederationApi;
-use fedimint_wallet_client::{WalletClientInit, WalletClientModule, WithdrawState};
+use fedimint_wallet_client::{DepositStateV2, WalletClientInit, WalletClientModule, WithdrawState};
 use fedimint_wallet_common::config::{WalletConfig, WalletGenParams};
 use fedimint_wallet_common::tweakable::Tweakable;
 use fedimint_wallet_common::txoproof::PegInProof;
@@ -147,6 +147,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     let fixtures = fixtures();
     let fed = fixtures.new_default_fed().await;
     let client = fed.new_client().await;
+    let wallet_module = client.get_first_module::<WalletClientModule>();
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
     info!("Starting test on_chain_peg_in_and_peg_out_happy_case");
@@ -157,16 +158,19 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
 
     let mut balance_sub = initial_peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
 
+    // Test operation is created
     let operations = client.operation_log().list_operations(10, None).await;
     assert_eq!(operations.len(), 1, "Expecting only the peg-in operation");
+    let deposit_operation_id = operations[0].0.operation_id;
+    let deposit_operation = &operations[0].1;
+
     assert_eq!(
-        operations[0].1.operation_module_kind(),
+        deposit_operation.operation_module_kind(),
         "wallet",
         "Peg-in operation should ke of kind wallet"
     );
     assert!(
-        operations[0]
-            .1
+        deposit_operation
             .meta::<serde_json::Value>()
             .get("variant")
             .and_then(|v| v.get("deposit"))
@@ -175,11 +179,29 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         "Peg-in operation meta data should contain address"
     );
 
+    // Test update stream returns expected updates
+    let mut deposit_updates = wallet_module
+        .subscribe_deposit(deposit_operation_id)
+        .await?
+        .into_stream();
+    assert_eq!(
+        deposit_updates.next().await.unwrap(),
+        DepositStateV2::WaitingForTransaction
+    );
+    assert!(matches!(
+        deposit_updates.next().await.unwrap(),
+        DepositStateV2::WaitingForConfirmation { .. }
+    ));
+    assert!(matches!(
+        deposit_updates.next().await.unwrap(),
+        DepositStateV2::Claimed { .. }
+    ));
+    assert_eq!(deposit_updates.next().await, None);
+
     info!("Peg-in finished for test on_chain_peg_in_and_peg_out_happy_case");
     // Peg-out test, requires block to recognize change UTXOs
     let address = checked_address_to_unchecked_address(&bitcoin.get_new_address().await);
     let peg_out = bsats(PEG_OUT_AMOUNT_SATS);
-    let wallet_module = client.get_first_module::<WalletClientModule>();
     let fees = wallet_module
         .get_withdraw_fees(address.clone(), peg_out)
         .await?;


### PR DESCRIPTION
The functionality to list and observe deposits was accidentally removed in #5473.

It's a bit tricky because technically a single generated address can now cause multiple operations. My plan is to create a first operation on address generation, this will correspond to the first deposit seen on-chain. 

## Possible extension
Any successive deposit could result in another operation log entry. Since this will be hard to do 100% consistently (we don't model the "transaction seen but unconfirmed" state anymore) and the previous behavior was to ignore this anyway I'm not including this here.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
