### PR TITLE
chore(ci): disable `bckn_electrs` while investigating test timeouts

### DIFF
--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -282,7 +282,9 @@ tests_to_run_in_parallel+=(
   "bckn_bitcoind_lnv2"
   "bckn_gw_client"
   "bckn_gw_not_client"
-  "bckn_electrs"
+  # TODO: https://github.com/fedimint/fedimint/issues/5917
+  # disabling while we investigate 60s timeouts causing CI flakiness
+  # "bckn_electrs"
   "bckn_esplora"
   "latency_test_reissue"
   "latency_test_ln_send"


### PR DESCRIPTION
Associated with https://github.com/fedimint/fedimint/issues/5917

```
fedimint-test-all-wasm32-unknown-unknown-ci> 00:01:20      TIMEOUT [  60.059s] fedimint-wallet-tests::fedimint_wallet_tests on_chain_peg_in_and_peg_out_happy_case
```

I'd prefer to not increase the timeout just for this test using electrs. Disabling while investigating alternatives.