### PR TITLE
chore: remove unused devfed env vars

### DIFF
--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -8,7 +8,6 @@ use fedimint_logging::LOG_DEVIMINT;
 use tokio::join;
 use tracing::debug;
 
-use crate::envs::{FM_GWID_CLN_ENV, FM_GWID_LDK_ENV, FM_GWID_LND_ENV};
 use crate::external::{
     open_channel, open_channels_between_gateways, Bitcoind, Electrs, Esplora, Lightningd, Lnd,
 };
@@ -375,12 +374,6 @@ impl DevJitFed {
             fed_size > 3 * offline_nodes,
             "too many offline nodes ({offline_nodes}) to reach consensus"
         );
-
-        std::env::set_var(FM_GWID_CLN_ENV, self.gw_cln().await?.gateway_id().await?);
-        std::env::set_var(FM_GWID_LND_ENV, self.gw_lnd().await?.gateway_id().await?);
-        if let Some(gw_ldk) = self.gw_ldk().await? {
-            std::env::set_var(FM_GWID_LDK_ENV, gw_ldk.gateway_id().await?);
-        }
 
         let _ = self.internal_client_gw_registered().await?;
         let _ = self.channel_opened.get_try().await?;

--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -37,17 +37,6 @@ pub const FM_DATA_DIR_ENV: &str = "FM_DATA_DIR";
 // and db
 pub const FM_CLIENT_DIR_ENV: &str = "FM_CLIENT_DIR";
 
-// devfed.rs
-
-// Env variable to define the gateway_id of the CLN client
-pub const FM_GWID_CLN_ENV: &str = "FM_GWID_CLN";
-
-// Env variable to define the gateway_id of the LND client
-pub const FM_GWID_LND_ENV: &str = "FM_GWID_LND";
-
-// Env variable to define the gateway_id of the LDK client
-pub const FM_GWID_LDK_ENV: &str = "FM_GWID_LDK";
-
 // cli.rs
 
 // Env variable to set the testing directory of the client


### PR DESCRIPTION
From this comment: https://github.com/fedimint/fedimint/pull/5852/files#r1723775088

> these are not used anywhere meaningful and they trigger a polling loop by contacting each gateway. Just not necessary.