### PR TITLE
fix: always require serde_json dep in meta module client

### DIFF
--- a/modules/fedimint-meta-client/Cargo.toml
+++ b/modules/fedimint-meta-client/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-cli = ["dep:clap", "dep:serde_json"]
+cli = ["dep:clap"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -30,7 +30,7 @@ fedimint-core = { workspace = true }
 fedimint-meta-common = { version = "=0.4.2-rc.1", path = "../fedimint-meta-common" }
 futures = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true, optional = true }
+serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
`cargo workspaces publish --from-git` fails otherwise:

```
   Compiling fedimint-meta-client v0.4.2-rc.1 (/home/user/projects/elsirion/minimint/target-nix/package/fedimint-meta-client-0.4.2-rc.1)
error[E0433]: failed to resolve: use of undeclared crate or module `serde_json`
   --> src/lib.rs:230:29
    |
230 |                     values: serde_json::from_slice(meta.value.as_slice())?,
    |                             ^^^^^^^^^^ use of undeclared crate or module `serde_json`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `fedimint-meta-client` (lib) due to 1 previous error
error: failed to verify package tarball
error: unable to publish package fedimint-meta-client
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
