### PR TITLE
chore(ci): parameterize which upgrade tests to run

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -18,6 +18,10 @@ on:
         description: 'Versions to test (if empty, uses same as daily run)'
         required: false
         default: ''
+      test_kinds:
+        description: 'Comma-separated tests to run. Options: fedimintd,fedimint-cli,gateway'
+        required: false
+        default: ''
         
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -51,6 +55,9 @@ jobs:
           VERSIONS="${{ github.event.inputs.versions }}"
           VERSIONS=${VERSIONS:="v0.3.3 v0.4.0 current"}
 
+          # if empty, defaults to all test kinds within script
+          TEST_KINDS="${{ github.event.inputs.test_kinds }}"
+
           # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)
           # we need to use `nix develop -c` to be able to use `nix build` inside of backwards-compatibility-test
           # Disable `sccache`, it seems incompatible with self-hosted runner sandbox for some reason, and
@@ -62,6 +69,7 @@ jobs:
             nix shell github:rustshop/fs-dir-cache -c \
             scripts/ci/run-in-fs-dir-cache.sh upgrade-tests \
             env -u RUSTC_WRAPPER \
+            env TEST_KINDS="$TEST_KINDS" \
             runLowPrio ./scripts/tests/upgrade-test.sh "$VERSIONS"
 
   notifications:

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -287,3 +287,18 @@ function generate_partial_matrix() {
 function generate_current_only_matrix() {
   generate_matrix are_all_versions_current "$@"
 }
+
+# Returns true if the search string is contained in the array
+function contains() {
+  local search_str="$1"
+  shift
+  local array=("$@")
+
+  for item in "${array[@]}"; do
+    if [[ "$item" == "$search_str" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -3,6 +3,7 @@
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
+source scripts/_common.sh
 
 if [ "$#" -eq 0 ]; then
   echo "Must provide at least one version"
@@ -17,41 +18,88 @@ else
   versions=("$@")
 fi
 
-echo "## Running upgrade tests for versions: ${versions[*]}"
+default_test_kinds=("fedimintd" "fedimint-cli" "gateway")
 
-source scripts/_common.sh
+# runs a subset of tests if the user provides `TEST_KINDS`
+# ex: TEST_KINDS=fedimint-cli,gateway
+provided_test_kinds="${TEST_KINDS:-}"
+if [ -z "$provided_test_kinds" ]; then
+  test_kinds=("${default_test_kinds[@]}")
+  echo "no test kinds provided, running for all test kinds"
+else
+  IFS=',' read -r -a test_kinds<<< "$provided_test_kinds"
+  for test_kind in "${test_kinds[@]}"; do
+    if ! contains "$test_kind" "${default_test_kinds[@]}"; then
+      echo "not a valid test kind: $test_kind"
+      exit 1
+    fi
+  done
+fi
+
+echo "## Running upgrade tests
+versions: ${versions[*]}
+kinds: ${test_kinds[*]}"
+
 build_workspace
 add_target_dir_to_path
 
 export FM_BACKWARDS_COMPATIBILITY_TEST=1
 
-fedimintd_paths=()
-fedimint_cli_paths=()
-gatewayd_paths=()
-gateway_cli_paths=()
-gateway_cln_extension_paths=()
-for version in "${versions[@]}"; do
-  if [ "$version" == "current" ]; then
-    # Add current binaries from PATH
-    fedimintd_paths+=("fedimintd")
-    fedimint_cli_paths+=("fedimint-cli")
-    gatewayd_paths+=("gatewayd")
-    gateway_cli_paths+=("gateway-cli")
-    gateway_cln_extension_paths+=("gateway-cln-extension")
-  else
-    fedimintd_paths+=("$(nix_build_binary_for_version 'fedimintd' "$version")")
-    fedimint_cli_paths+=("$(nix_build_binary_for_version 'fedimint-cli' "$version")")
-    gatewayd_paths+=("$(nix_build_binary_for_version 'gatewayd' "$version")")
-    gateway_cli_paths+=("$(nix_build_binary_for_version 'gateway-cli' "$version")")
-    gateway_cln_extension_paths+=("$(nix_build_binary_for_version 'gateway-cln-extension' "$version")")
-  fi
-done
+upgrade_tests=()
 
-upgrade_tests=(
-  "devimint upgrade-tests fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
-  "devimint upgrade-tests fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
-  "devimint upgrade-tests gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}") --gateway-cln-extension-paths $(printf "%s " "${gateway_cln_extension_paths[@]}")"
-)
+if contains "fedimintd" "${test_kinds[@]}"; then
+  fedimintd_paths=()
+  for version in "${versions[@]}"; do
+    if [ "$version" == "current" ]; then
+      # Add current binaries from PATH
+      fedimintd_paths+=("fedimintd")
+    else
+      fedimintd_paths+=("$(nix_build_binary_for_version 'fedimintd' "$version")")
+    fi
+  done
+
+  upgrade_tests+=(
+    "devimint upgrade-tests fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
+  )
+fi
+
+if contains "fedimint-cli" "${test_kinds[@]}"; then
+  fedimint_cli_paths=()
+  for version in "${versions[@]}"; do
+    if [ "$version" == "current" ]; then
+      # Add current binaries from PATH
+      fedimint_cli_paths+=("fedimint-cli")
+    else
+      fedimint_cli_paths+=("$(nix_build_binary_for_version 'fedimint-cli' "$version")")
+    fi
+  done
+
+  upgrade_tests+=(
+    "devimint upgrade-tests fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
+  )
+fi
+
+if contains "gateway" "${test_kinds[@]}"; then
+  gatewayd_paths=()
+  gateway_cli_paths=()
+  gateway_cln_extension_paths=()
+  for version in "${versions[@]}"; do
+    if [ "$version" == "current" ]; then
+      # Add current binaries from PATH
+      gatewayd_paths+=("gatewayd")
+      gateway_cli_paths+=("gateway-cli")
+      gateway_cln_extension_paths+=("gateway-cln-extension")
+    else
+      gatewayd_paths+=("$(nix_build_binary_for_version 'gatewayd' "$version")")
+      gateway_cli_paths+=("$(nix_build_binary_for_version 'gateway-cli' "$version")")
+      gateway_cln_extension_paths+=("$(nix_build_binary_for_version 'gateway-cln-extension' "$version")")
+    fi
+  done
+
+  upgrade_tests+=(
+    "devimint upgrade-tests gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}") --gateway-cln-extension-paths $(printf "%s " "${gateway_cln_extension_paths[@]}")"
+  )
+fi
 
 parsed_test_commands=$(printf "%s\n" "${upgrade_tests[@]}")
 


### PR DESCRIPTION
Upgrade tests run all of the test kinds (`fedimint-cli`, `fedimintd`, and `gateway`) using the same upgrade paths. Now that `fedimintd` introduced coordinated upgrades, it's useful to trigger different upgrade paths for different test kinds. E.g. we know that `fedimintd` will fail upgrading from 0.2.1 -> 0.4.0, however it would be useful to test that upgrade path for `fedimint-cli` and `gateway`.

The changes to the GH workflow allows specifying the test kinds when manually triggering a run. If none are provided, all test kinds are run.