### PR TITLE
chore(mint-client): clarify the meaning and handling of one variable 

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1413,7 +1413,7 @@ pub async fn cli_tests_backup_and_restore(
 
     let pre_balance = pre_notes["total_amount_msat"].as_u64().unwrap();
 
-    debug!(%pre_notes, pre_balance, "State before backup");
+    debug!(target: LOG_DEVIMINT, %pre_notes, pre_balance, "State before backup");
 
     // we need to have some funds
     // TODO: right now we rely on previous tests to leave some balance
@@ -1444,7 +1444,7 @@ pub async fn cli_tests_backup_and_restore(
             let _ = cmd!(client, "dev", "wait-complete").out_json().await?;
             let post_notes = cmd!(client, "info").out_json().await?;
             let post_balance = post_notes["total_amount_msat"].as_u64().unwrap();
-            debug!(%post_notes, post_balance, "State after backup");
+            debug!(target: LOG_DEVIMINT, %post_notes, post_balance, "State after backup");
 
             post_balance
         } else {
@@ -1466,7 +1466,7 @@ pub async fn cli_tests_backup_and_restore(
                 .as_u64()
                 .unwrap();
             let post_notes = cmd!(client, "info").out_json().await?;
-            debug!(%post_notes, post_balance, "State after backup");
+            debug!(target: LOG_DEVIMINT, %post_notes, post_balance, "State after backup");
 
             post_balance
         };
@@ -1522,7 +1522,7 @@ pub async fn cli_tests_backup_and_restore(
                 let _ = cmd!(client, "dev", "wait-complete").out_json().await?;
                 let post_notes = cmd!(client, "info").out_json().await?;
                 let post_balance = post_notes["total_amount_msat"].as_u64().unwrap();
-                debug!(%post_notes, post_balance, "State after (subsequent) backup");
+                debug!(target: LOG_DEVIMINT, %post_notes, post_balance, "State after (subsequent) backup");
 
                 assert_eq!(pre_balance + EXTRA_PEGIN_SATS * 1000, post_balance);
             }
@@ -1539,7 +1539,7 @@ pub async fn cli_tests_backup_and_restore(
             let _ = cmd!(client, "restore", &secret,).out_json().await?;
             let post_notes = cmd!(client, "info").out_json().await?;
             let post_balance = post_notes["total_amount_msat"].as_u64().unwrap();
-            debug!(%post_notes, post_balance, "State after backup");
+            debug!(target: LOG_DEVIMINT, %post_notes, post_balance, "State after backup");
 
             assert_eq!(pre_balance, post_balance);
         }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -2114,6 +2114,10 @@ impl NoteIndex {
         Self(self.0 + 1)
     }
 
+    fn prev(self) -> Option<Self> {
+        self.0.checked_sub(0).map(Self)
+    }
+
     pub fn as_u64(self) -> u64 {
         self.0
     }


### PR DESCRIPTION
Draft. Let's land #5937 first.

Changes here are technically more correct, though in practice it
doesn't matter. I was debugging some other issue and had my doubts
about it, but after investigation it looks like overshooting here
only leads to mint client code skipping some nonce index, which
is harmless.

In https://github.com/fedimint/fedimint/pull/5937 I add a test that gives me more confidence everything is OK.