### PR TITLE
fix: don't allow making new backups while recovery is running

### DIFF
--- a/fedimint-client/src/backup.rs
+++ b/fedimint-client/src/backup.rs
@@ -2,7 +2,7 @@ use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{Cursor, Error, Read, Write};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, SignOnly};
 use fedimint_api_client::api::DynGlobalApi;
 use fedimint_core::core::backup::{
@@ -279,6 +279,11 @@ impl Client {
 
     /// Prepare an encrypted backup and send it to federation for storing
     pub async fn backup_to_federation(&self, metadata: Metadata) -> Result<()> {
+        ensure!(
+            !self.has_pending_recoveries(),
+            "Cannot backup while there are pending recoveries"
+        );
+
         let last_backup = self.load_previous_backup().await;
         let new_backup = self.create_backup(metadata).await?;
 


### PR DESCRIPTION
That's a potential foot-gun for integrators imo.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
