### PR TITLE
Backport: fix: deposit `Claimed` state waits for e-cash to be in wallet

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -108,6 +108,11 @@ pub enum DepositStateV2 {
         btc_deposited: bitcoin::Amount,
         btc_out_point: bitcoin::OutPoint,
     },
+    Confirmed {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        btc_deposited: bitcoin::Amount,
+        btc_out_point: bitcoin::OutPoint,
+    },
     Claimed {
         #[serde(with = "bitcoin::amount::serde::as_sat")]
         btc_deposited: bitcoin::Amount,
@@ -864,7 +869,7 @@ impl WalletClientModule {
                         btc_out_point,
                     };
 
-                    stream_cient_ctx
+                    let claim_data =stream_cient_ctx
                         .module_db()
                         .wait_key_exists(&ClaimedPegInKey {
                             peg_in_index: tweak_idx,
@@ -872,10 +877,17 @@ impl WalletClientModule {
                         })
                         .await;
 
-                    yield DepositStateV2::Claimed {
+                    yield DepositStateV2::Confirmed {
+                    btc_deposited,
+                    btc_out_point
+                };
+
+                match stream_cient_ctx.await_primary_module_outputs(operation_id, claim_data.change).await {
+                    Ok(_) =>yield DepositStateV2::Claimed {
                         btc_deposited,
-                        btc_out_point,
-                    };
+                        btc_out_point},
+                    Err(e) => yield DepositStateV2::Failed(e.to_string())
+                    }
                 }
             }),
         )

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -878,15 +878,16 @@ impl WalletClientModule {
                         .await;
 
                     yield DepositStateV2::Confirmed {
-                    btc_deposited,
-                    btc_out_point
-                };
-
-                match stream_cient_ctx.await_primary_module_outputs(operation_id, claim_data.change).await {
-                    Ok(_) =>yield DepositStateV2::Claimed {
                         btc_deposited,
-                        btc_out_point},
-                    Err(e) => yield DepositStateV2::Failed(e.to_string())
+                        btc_out_point
+                    };
+
+                    match stream_cient_ctx.await_primary_module_outputs(operation_id, claim_data.change).await {
+                        Ok(_) => yield DepositStateV2::Claimed {
+                            btc_deposited,
+                            btc_out_point
+                        },
+                        Err(e) => yield DepositStateV2::Failed(e.to_string())
                     }
                 }
             }),

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -193,6 +193,10 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     ));
     assert!(matches!(
         deposit_updates.next().await.unwrap(),
+        DepositStateV2::Confirmed { .. }
+    ));
+    assert!(matches!(
+        deposit_updates.next().await.unwrap(),
         DepositStateV2::Claimed { .. }
     ));
     assert_eq!(deposit_updates.next().await, None);

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -26,6 +26,7 @@ use fedimint_wallet_common::txoproof::PegInProof;
 use fedimint_wallet_common::{PegOutFees, Rbf};
 use fedimint_wallet_server::WalletInit;
 use futures::stream::StreamExt;
+use tokio::select;
 use tracing::info;
 
 fn fixtures() -> Fixtures {
@@ -155,13 +156,21 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let mut balance_sub = initial_peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+    assert_eq!(client.get_balance().await, sats(0));
+    let (op, address, _) = wallet_module
+        .allocate_deposit_address_expert_only(())
+        .await?;
 
     // Test operation is created
     let operations = client.operation_log().list_operations(10, None).await;
     assert_eq!(operations.len(), 1, "Expecting only the peg-in operation");
+
     let deposit_operation_id = operations[0].0.operation_id;
     let deposit_operation = &operations[0].1;
+    assert_eq!(
+        deposit_operation_id, op,
+        "Operation ID should match the one returned by allocate_deposit_address"
+    );
 
     assert_eq!(
         deposit_operation.operation_module_kind(),
@@ -187,18 +196,57 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
         deposit_updates.next().await.unwrap(),
         DepositStateV2::WaitingForTransaction
     );
+
+    info!(?address, "Peg-in address generated");
+    let (_proof, tx) = bitcoin
+        .send_and_mine_block(
+            &address,
+            bsats(PEG_IN_AMOUNT_SATS)
+                + bsats(wallet_module.get_fee_consensus().peg_in_abs.msats / 1000),
+        )
+        .await;
+
+    info!("Waiting for confirmation");
     assert!(matches!(
         deposit_updates.next().await.unwrap(),
-        DepositStateV2::WaitingForConfirmation { .. }
+        DepositStateV2::WaitingForConfirmation { btc_out_point, .. } if btc_out_point.txid == tx.txid()
     ));
+
+    bitcoin.mine_blocks(finality_delay).await;
+
+    // Afaik technically not necessary, but useful to speed up test (should probably
+    // just poll more often in tests?)
+    let await_update_while_rechecking = async {
+        loop {
+            select! {
+                update = deposit_updates.next() => {
+                    break update;
+                },
+                _ = sleep_in_test("Waiting for address recheck", Duration::from_secs(1)) => {
+                    wallet_module.recheck_pegin_address_by_op_id(op).await
+                        .expect("Operation exists");
+                }
+            }
+        }
+    };
+
+    info!("Waiting for claim tx");
+    assert!(matches!(
+        await_update_while_rechecking.await.unwrap(),
+        DepositStateV2::Confirmed { btc_out_point, .. } if btc_out_point.txid == tx.txid()
+    ));
+
+    info!("Waiting for e-cash");
     assert!(matches!(
         deposit_updates.next().await.unwrap(),
-        DepositStateV2::Confirmed { .. }
+        DepositStateV2::Claimed { btc_out_point, .. } if btc_out_point.txid == tx.txid()
     ));
-    assert!(matches!(
-        deposit_updates.next().await.unwrap(),
-        DepositStateV2::Claimed { .. }
-    ));
+
+    info!("Checking balance after deposit");
+    let mut balance_sub = client.subscribe_balance_changes().await;
+    assert_eq!(client.get_balance().await, sats(PEG_IN_AMOUNT_SATS));
+    assert_eq!(balance_sub.ok().await?, sats(PEG_IN_AMOUNT_SATS));
+
     assert_eq!(deposit_updates.next().await, None);
 
     info!("Peg-in finished for test on_chain_peg_in_and_peg_out_happy_case");


### PR DESCRIPTION
Fixes  #5942

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
