### PR TITLE
chore: deativate LNv2 inter-federation test

### DIFF
--- a/modules/fedimint-lnv2-tests/src/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/src/bin/tests.rs
@@ -55,7 +55,9 @@ async fn main() -> anyhow::Result<()> {
 
                 test_self_payments_success(&dev_fed).await?;
                 test_lightning_payments(&dev_fed).await?;
-                test_inter_federation_payments(&dev_fed, &process_mgr).await?;
+
+                // TODO: Inter-federation tests have been deactivated from CI
+                // due to flakiness with CLN: https://github.com/fedimint/fedimint/issues/5944
             }
             TestOpts::GatewayRegistration => {
                 test_gateway_registration(&dev_fed).await?;


### PR DESCRIPTION
LNv2 inter federation test is flaky: https://github.com/fedimint/fedimint/issues/5944

Seems to be an issue with CLN crashing during the test for some reason. I have found it difficult to debug as I cannot reproduce locally and the CI runs have not had enough logs to debug properly.

To unblock CI, this PR deactivates the test from CI.