### PR TITLE
fix: upgrade test fixes

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -15,6 +15,7 @@ use crate::external::{Bitcoind, LightningNode};
 use crate::federation::Federation;
 use crate::util::{poll, Command, ProcessHandle, ProcessManager};
 use crate::vars::utf8;
+use crate::version_constants::VERSION_0_5_0_ALPHA;
 use crate::{cmd, Lightningd};
 
 #[derive(Clone)]
@@ -222,9 +223,17 @@ impl Gatewayd {
     }
 
     pub async fn get_ln_onchain_address(&self) -> Result<String> {
-        let address = cmd!(self, "lightning", "get-ln-onchain-address")
-            .out_string()
-            .await?;
+        let gateway_cli_version = crate::util::GatewayCli::version_or_default().await;
+        let address = if gateway_cli_version < *VERSION_0_5_0_ALPHA {
+            cmd!(self, "lightning", "get-funding-address")
+                .out_string()
+                .await?
+        } else {
+            cmd!(self, "lightning", "get-ln-onchain-address")
+                .out_string()
+                .await?
+        };
+
         Ok(address)
     }
 

--- a/gateway/ln-gateway/src/gateway_module_v2/mod.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/mod.rs
@@ -28,7 +28,7 @@ use fedimint_lnv2_client::{LightningInvoice, SendPaymentPayload};
 use fedimint_lnv2_common::config::LightningClientConfig;
 use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage};
 use fedimint_lnv2_common::{
-    LightningCommonInit, LightningInputV0, LightningModuleTypes, LightningOutput, LightningOutputV0,
+    LightningCommonInit, LightningModuleTypes, LightningOutput, LightningOutputV0,
 };
 use futures::StreamExt;
 use receive_sm::{ReceiveSMState, ReceiveStateMachine};
@@ -133,18 +133,12 @@ impl ClientModule for GatewayClientModuleV2 {
         }
     }
 
-    fn input_fee(&self, input: &<Self::Common as ModuleCommon>::Input) -> Option<Amount> {
-        Some(match input.maybe_v0_ref()? {
-            LightningInputV0::Outgoing(..) => self.cfg.fees.spend_outgoing_contract,
-            LightningInputV0::Incoming(..) => self.cfg.fees.spend_incoming_contract,
-        })
+    fn input_fee(&self, _input: &<Self::Common as ModuleCommon>::Input) -> Option<Amount> {
+        Some(self.cfg.fee_consensus.input)
     }
 
-    fn output_fee(&self, output: &<Self::Common as ModuleCommon>::Output) -> Option<Amount> {
-        Some(match output.maybe_v0_ref()? {
-            LightningOutputV0::Outgoing(..) => self.cfg.fees.create_outgoing_contract,
-            LightningOutputV0::Incoming(..) => self.cfg.fees.create_incoming_contract,
-        })
+    fn output_fee(&self, _output: &<Self::Common as ModuleCommon>::Output) -> Option<Amount> {
+        Some(self.cfg.fee_consensus.output)
     }
 }
 

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -39,8 +39,8 @@ use fedimint_core::{apply, async_trait_maybe_send, Amount, OutPoint, PeerId, Tra
 use fedimint_lnv2_common::config::LightningClientConfig;
 use fedimint_lnv2_common::contracts::{IncomingContract, OutgoingContract, PaymentImage};
 use fedimint_lnv2_common::{
-    GatewayEndpoint, LightningCommonInit, LightningInputV0, LightningModuleTypes, LightningOutput,
-    LightningOutputV0, KIND,
+    GatewayEndpoint, LightningCommonInit, LightningModuleTypes, LightningOutput, LightningOutputV0,
+    KIND,
 };
 use futures::StreamExt;
 use lightning_invoice::{Bolt11Invoice, Currency};
@@ -362,18 +362,12 @@ impl ClientModule for LightningClientModule {
         }
     }
 
-    fn input_fee(&self, input: &<Self::Common as ModuleCommon>::Input) -> Option<Amount> {
-        Some(match input.maybe_v0_ref()? {
-            LightningInputV0::Outgoing(..) => self.cfg.fees.spend_outgoing_contract,
-            LightningInputV0::Incoming(..) => self.cfg.fees.spend_incoming_contract,
-        })
+    fn input_fee(&self, _input: &<Self::Common as ModuleCommon>::Input) -> Option<Amount> {
+        Some(self.cfg.fee_consensus.input)
     }
 
-    fn output_fee(&self, output: &<Self::Common as ModuleCommon>::Output) -> Option<Amount> {
-        Some(match output.maybe_v0_ref()? {
-            LightningOutputV0::Outgoing(..) => self.cfg.fees.create_outgoing_contract,
-            LightningOutputV0::Incoming(..) => self.cfg.fees.create_incoming_contract,
-        })
+    fn output_fee(&self, _output: &<Self::Common as ModuleCommon>::Output) -> Option<Amount> {
+        Some(self.cfg.fee_consensus.output)
     }
 
     #[cfg(feature = "cli")]

--- a/modules/fedimint-lnv2-common/src/config.rs
+++ b/modules/fedimint-lnv2-common/src/config.rs
@@ -54,7 +54,7 @@ pub struct LightningConfigLocal {
 pub struct LightningConfigConsensus {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
-    pub fees: LightningFees,
+    pub fee_consensus: FeeConsensus,
     pub network: Network,
 }
 
@@ -67,7 +67,7 @@ pub struct LightningConfigPrivate {
 pub struct LightningClientConfig {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
-    pub fees: LightningFees,
+    pub fee_consensus: FeeConsensus,
     pub network: Network,
 }
 
@@ -95,20 +95,16 @@ plugin_types_trait_impl_config!(
 );
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
-pub struct LightningFees {
-    pub spend_outgoing_contract: Amount,
-    pub spend_incoming_contract: Amount,
-    pub create_outgoing_contract: Amount,
-    pub create_incoming_contract: Amount,
+pub struct FeeConsensus {
+    pub input: Amount,
+    pub output: Amount,
 }
 
-impl Default for LightningFees {
+impl Default for FeeConsensus {
     fn default() -> Self {
         Self {
-            spend_outgoing_contract: Amount::from_sats(1),
-            spend_incoming_contract: Amount::from_sats(1),
-            create_outgoing_contract: Amount::from_sats(1),
-            create_incoming_contract: Amount::from_sats(1),
+            input: Amount::from_sats(1),
+            output: Amount::from_sats(1),
         }
     }
 }
@@ -135,7 +131,10 @@ fn migrate_config_consensus(
                 )
             })
             .collect(),
-        fees: LightningFees::default(),
+        fee_consensus: FeeConsensus {
+            input: config.fee_consensus.contract_input,
+            output: config.fee_consensus.contract_output,
+        },
         network: config.network,
     }
 }

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -31,8 +31,8 @@ use fedimint_core::{
     apply, async_trait_maybe_send, push_db_pair_items, NumPeersExt, OutPoint, PeerId, ServerModule,
 };
 use fedimint_lnv2_common::config::{
-    LightningClientConfig, LightningConfig, LightningConfigConsensus, LightningConfigLocal,
-    LightningConfigPrivate, LightningFees, LightningGenParams,
+    FeeConsensus, LightningClientConfig, LightningConfig, LightningConfigConsensus,
+    LightningConfigLocal, LightningConfigPrivate, LightningGenParams,
 };
 use fedimint_lnv2_common::contracts::{IncomingContract, OutgoingContract};
 use fedimint_lnv2_common::endpoint_constants::{
@@ -206,7 +206,7 @@ impl ServerModuleInit for LightningInit {
                         consensus: LightningConfigConsensus {
                             tpe_agg_pk,
                             tpe_pks: tpe_pks.clone(),
-                            fees: LightningFees::default(),
+                            fee_consensus: FeeConsensus::default(),
                             network: params.consensus.network,
                         },
                         private: LightningConfigPrivate {
@@ -248,7 +248,7 @@ impl ServerModuleInit for LightningInit {
                         (*peer, PublicKeyShare(pk))
                     })
                     .collect(),
-                fees: LightningFees::default(),
+                fee_consensus: FeeConsensus::default(),
                 network: params.consensus.network,
             },
             private: LightningConfigPrivate {
@@ -275,7 +275,7 @@ impl ServerModuleInit for LightningInit {
         Ok(LightningClientConfig {
             tpe_agg_pk: config.tpe_agg_pk,
             tpe_pks: config.tpe_pks,
-            fees: config.fees,
+            fee_consensus: config.fee_consensus,
             network: config.network,
         })
     }
@@ -377,7 +377,7 @@ impl ServerModule for Lightning {
     ) -> Result<InputMeta, LightningInputError> {
         let input = input.ensure_v0_ref()?;
 
-        match &input {
+        let (pub_key, amount) = match &input {
             LightningInputV0::Outgoing(contract_id, outgoing_witness) => {
                 let contract = dbtx
                     .remove_entry(&OutgoingContractKey(*contract_id))
@@ -415,13 +415,7 @@ impl ServerModule for Lightning {
                     }
                 };
 
-                Ok(InputMeta {
-                    amount: TransactionItemAmount {
-                        amount: contract.amount,
-                        fee: self.cfg.consensus.fees.spend_outgoing_contract,
-                    },
-                    pub_key,
-                })
+                (pub_key, contract.amount)
             }
             LightningInputV0::Incoming(contract_id, agg_decryption_key) => {
                 let contract = dbtx
@@ -440,15 +434,17 @@ impl ServerModule for Lightning {
                     None => contract.commitment.refund_pk,
                 };
 
-                Ok(InputMeta {
-                    amount: TransactionItemAmount {
-                        amount: contract.commitment.amount,
-                        fee: self.cfg.consensus.fees.spend_incoming_contract,
-                    },
-                    pub_key,
-                })
+                (pub_key, contract.commitment.amount)
             }
-        }
+        };
+
+        Ok(InputMeta {
+            amount: TransactionItemAmount {
+                amount,
+                fee: self.cfg.consensus.fee_consensus.input,
+            },
+            pub_key,
+        })
     }
 
     async fn process_output<'a, 'b>(
@@ -505,15 +501,12 @@ impl ServerModule for Lightning {
             panic!("Output Outcome for {out_point:?} already exists");
         }
 
-        Ok(match output {
-            LightningOutputV0::Outgoing(contract) => TransactionItemAmount {
-                amount: contract.amount,
-                fee: self.cfg.consensus.fees.create_outgoing_contract,
+        Ok(TransactionItemAmount {
+            amount: match output {
+                LightningOutputV0::Outgoing(contract) => contract.amount,
+                LightningOutputV0::Incoming(contract) => contract.commitment.amount,
             },
-            LightningOutputV0::Incoming(contract) => TransactionItemAmount {
-                amount: contract.commitment.amount,
-                fee: self.cfg.consensus.fees.create_incoming_contract,
-            },
+            fee: self.cfg.consensus.fee_consensus.output,
         })
     }
 


### PR DESCRIPTION
 - Reverts https://github.com/fedimint/fedimint/pull/5941
 - Adds logic for using `get-funding-address` vs `get-ln-onchain-address`

Debugging the same issue as https://github.com/fedimint/fedimint/pull/5952