### PR TITLE
Update tokio-rustls to v0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95446d919226d587817a7d21379e6eb099b97b45110a7f272a444ca5c54070"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ddc4a5b231dd6958b140ff3151b6412b3f4321fab354f399eec8f14b06df62"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,15 +807,18 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
+ "log",
+ "prettyplease 0.2.16",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.87",
+ "which",
 ]
 
 [[package]]
@@ -1085,13 +1115,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -1249,6 +1279,15 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1829,6 +1868,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,7 +2396,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.0",
  "tokio-test",
  "tracing",
  "url",
@@ -3159,7 +3204,7 @@ dependencies = [
  "tar",
  "test-log",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower 0.4.13",
  "tracing",
@@ -3205,7 +3250,7 @@ dependencies = [
  "rand",
  "tempfile",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.0",
  "tracing",
 ]
 
@@ -3625,6 +3670,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fslock"
@@ -5271,6 +5322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6086,7 +6143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -6604,6 +6661,7 @@ version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebbbdb961df0ad3f2652da8f3fdc4b36122f568f968f45ad3316f26c025c677b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.8",
@@ -6654,6 +6712,7 @@ version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.6.0-alpha
 thiserror = "1.0.68"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tokio = "1.41.1"
-tokio-rustls = "0.24.1"
+tokio-rustls = "0.26.0"
 tokio-stream = "0.1.16"
 tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
     "lightningrpc",
@@ -197,6 +197,7 @@ tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.6.0-alpha
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = "2.5.3"
+wasm-bindgen-test = "0.3.42"
 
 # Workaround: https://github.com/rust-lang/cargo/issues/12457 which causes
 #             https://github.com/ipetkov/crane/issues/370

--- a/deny.toml
+++ b/deny.toml
@@ -153,7 +153,7 @@ exceptions = [
     ], name = "unicode-ident" },
     { allow = [
         "OpenSSL",
-    ], name = "ring" },
+    ], name = [ "ring", "aws-lc-sys" ] },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -29,4 +29,4 @@ rexie = "0.6.2"
 serde_json = { workspace = true }
 wasm-bindgen = "=0.2.92"                                      # must match the nix provided wasm-bindgen-cli version
 wasm-bindgen-futures = "0.4.42"
-wasm-bindgen-test = "0.3.34"
+wasm-bindgen-test = { workspace = true }

--- a/fedimint-core/src/encoding/tls.rs
+++ b/fedimint-core/src/encoding/tls.rs
@@ -5,8 +5,8 @@ use tokio_rustls::rustls;
 
 use crate::encoding::Encodable;
 
-impl Encodable for rustls::Certificate {
+impl Encodable for rustls::pki_types::CertificateDer<'_> {
     fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        self.0.encode_hex::<String>().consensus_encode(writer)
+        self.encode_hex::<String>().consensus_encode(writer)
     }
 }

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -292,7 +292,13 @@ pub fn local_config_gen_params(
     server_config_gen: &ServerModuleConfigGenParamsRegistry,
 ) -> anyhow::Result<HashMap<PeerId, ConfigGenParams>> {
     // Generate TLS cert and private key
-    let tls_keys: HashMap<PeerId, (rustls::Certificate, rustls::PrivateKey)> = peers
+    let tls_keys: HashMap<
+        PeerId,
+        (
+            rustls::pki_types::CertificateDer,
+            rustls::pki_types::PrivateKeyDer,
+        ),
+    > = peers
         .iter()
         .map(|peer| {
             (
@@ -330,7 +336,9 @@ pub fn local_config_gen_params(
             let params = ConfigGenParams {
                 local: ConfigGenParamsLocal {
                     our_id: *peer,
-                    our_private_key: tls_keys[peer].1.clone(),
+                    our_private_key: fedimint_server::config::CloneablePrivateKey(
+                        tls_keys[peer].1.clone_key(),
+                    ),
                     api_auth: ApiAuth("pass".to_string()),
                     p2p_bind: p2p_bind.parse().expect("Valid address"),
                     api_bind: api_bind.parse().expect("Valid address"),

--- a/fedimint-wasm-tests/Cargo.toml
+++ b/fedimint-wasm-tests/Cargo.toml
@@ -23,4 +23,4 @@ fedimint-wallet-client = { workspace = true }
 futures = { workspace = true }
 gloo-net = "0.6.0"
 rand = { workspace = true }
-wasm-bindgen-test = "0.3.42"
+wasm-bindgen-test = { workspace = true }


### PR DESCRIPTION
This PR updates crate tokio-rustls from v0.24.1 to v0.26.0

Solves https://github.com/fedimint/fedimint/issues/5793
