### PR TITLE
Add transasction fees

### DIFF
--- a/fedimint-client/src/extra_config.rs
+++ b/fedimint-client/src/extra_config.rs
@@ -1,0 +1,270 @@
+//! Helper module for handling syncing of dynamically updated config between
+//! client and server. See [`ExtraConfigService`] for more information.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::time::Duration;
+
+use fedimint_api_client::api::{DynGlobalApi, FederationApiExt};
+use fedimint_core::config::ExtraConfig;
+use fedimint_core::core::ModuleInstanceId;
+use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::module::ApiRequestErased;
+use fedimint_core::runtime::sleep;
+use fedimint_core::task::TaskGroup;
+use fedimint_core::time::now;
+use futures::future::join_all;
+use tracing::warn;
+
+use crate::db::{ExtraConfigKey, ExtraConfigValue};
+
+#[derive(Debug, Default)]
+pub struct ExtraConfigServiceBuilder {
+    tracked_values: HashMap<ExtraConfigKey, (Duration, ValidationFn)>,
+    db: Option<Database>,
+    api: Option<DynGlobalApi>,
+}
+
+impl ExtraConfigServiceBuilder {
+    /// Registers an extra config field not belonging to any module to be
+    /// tracked by the service
+    pub fn with_tracked_core_config(
+        &mut self,
+        tracked_values: impl IntoIterator<Item = TrackedExtraConfig>,
+    ) {
+        self.tracked_values
+            .extend(tracked_values.into_iter().map(|tv| {
+                (
+                    ExtraConfigKey {
+                        module_instance_id: None,
+                        tracked_value: tv.fetch_method.to_owned(),
+                    },
+                    (tv.update_interval, tv.validation_fn),
+                )
+            }));
+    }
+
+    /// Registers an extra config field belonging to a module to be tracked by
+    /// the service
+    pub fn with_tracked_module_config(
+        &mut self,
+        module_instance_id: ModuleInstanceId,
+        tracked_values: impl IntoIterator<Item = TrackedExtraConfig>,
+    ) {
+        self.tracked_values
+            .extend(tracked_values.into_iter().map(|tv| {
+                (
+                    ExtraConfigKey {
+                        module_instance_id: Some(module_instance_id),
+                        tracked_value: tv.fetch_method.to_owned(),
+                    },
+                    (tv.update_interval, tv.validation_fn),
+                )
+            }));
+    }
+
+    /// Sets the database to use for storing the fetched values, mandatory.
+    pub fn with_db(&mut self, db: Database) {
+        self.db = Some(db);
+    }
+
+    /// Sets the API to use for fetching the values, mandatory.
+    pub fn with_api(&mut self, api: DynGlobalApi) {
+        self.api = Some(api);
+    }
+
+    /// Starts the service with the provided configuration and spawns a
+    /// background task continuously updating the registered config fields. The
+    /// task will shut down when the supplied task manager shuts down.
+    pub fn start(self, task_group: &TaskGroup) -> ExtraConfigService {
+        let db = self
+            .db
+            .expect("Database must be set before starting the service");
+        let api = self
+            .api
+            .expect("API must be set before starting the service");
+
+        let update_loops = self
+            .tracked_values
+            .iter()
+            .map(|(extra_config_key, &(update_interval, validation_fn))| {
+                let db = db.clone();
+                let api = api.clone();
+                let module_instance_id = extra_config_key.module_instance_id;
+                let tracked_value = extra_config_key.tracked_value.clone();
+
+                async move {
+                    loop {
+                        if let Err(e) = update_config_value(
+                            &db,
+                            &api,
+                            module_instance_id,
+                            &tracked_value,
+                            validation_fn,
+                        )
+                        .await
+                        {
+                            warn!(%tracked_value, ?e, "Updating extra config field failed");
+                        };
+                        sleep(update_interval).await;
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        task_group.spawn_cancellable("dyn_cfg_sync", async move {
+            join_all(update_loops).await;
+        });
+
+        ExtraConfigService {
+            tracked_values: Arc::new(self.tracked_values.into_keys().collect()),
+        }
+    }
+}
+
+async fn update_config_value(
+    db: &Database,
+    api: &DynGlobalApi,
+    module_instance_id: Option<ModuleInstanceId>,
+    fetch_method: &str,
+    validation_fn: ValidationFn,
+) -> anyhow::Result<()> {
+    let fetched_value = api
+        .request_current_consensus::<serde_json::Value>(
+            fetch_method.to_owned(),
+            ApiRequestErased::default(),
+        )
+        .await?;
+
+    validation_fn(fetched_value.clone())?;
+
+    let db_key = ExtraConfigKey {
+        module_instance_id,
+        tracked_value: fetch_method.to_owned(),
+    };
+    let db_value = ExtraConfigValue {
+        value: fetched_value,
+        last_update: now(),
+    };
+
+    db.autocommit(
+        |dbtx, _pd| {
+            let db_key_inner = db_key.clone();
+            let db_value_inner = db_value.clone();
+            Box::pin(async move {
+                dbtx.insert_entry(&db_key_inner, &db_value_inner).await;
+                Result::<(), ()>::Ok(())
+            })
+        },
+        None,
+    )
+    .await
+    .expect("DB operation cannot fail");
+
+    Ok(())
+}
+
+/// Service that keeps track of a fixed list of dynamic config fields. These are
+/// regularly re-fetched from the server and saved in the DB. Use
+/// `[DynConfigService::get_config_value]` to retrieve the latest value.
+#[derive(Debug, Clone)]
+pub struct ExtraConfigService {
+    tracked_values: Arc<HashSet<ExtraConfigKey>>,
+}
+
+impl ExtraConfigService {
+    // TODO: add example
+    pub fn builder() -> ExtraConfigServiceBuilder {
+        ExtraConfigServiceBuilder::default()
+    }
+
+    /// Returns the last fetched config value from the database. If the value
+    /// wasn't fetched yet successfully returns `None`.
+    pub async fn get_config_value<T: ExtraConfig>(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> Option<T> {
+        get_config_value(&self.tracked_values, dbtx, None).await
+    }
+
+    pub fn module_service(&self, module_instance_id: ModuleInstanceId) -> ModuleExtraConfigService {
+        ModuleExtraConfigService {
+            module_instance_id,
+            tracked_values: self.tracked_values.clone(),
+        }
+    }
+}
+
+/// Reference to the [`ExtraConfigService`] that only allows accessing a
+/// specific module's tracked extra config values.
+#[derive(Debug, Clone)]
+pub struct ModuleExtraConfigService {
+    module_instance_id: ModuleInstanceId,
+    tracked_values: Arc<HashSet<ExtraConfigKey>>,
+}
+
+impl ModuleExtraConfigService {
+    /// Returns the last valid fetched config value from the database. If the
+    /// value wan't fetched yet successfully returns `None`.
+    pub async fn get_config_value<T: ExtraConfig>(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> Option<T> {
+        get_config_value(&self.tracked_values, dbtx, Some(self.module_instance_id)).await
+    }
+}
+
+async fn get_config_value<T: ExtraConfig>(
+    tracked_values: &HashSet<ExtraConfigKey>,
+    dbtx: &mut DatabaseTransaction<'_>,
+    module_instance_id: Option<ModuleInstanceId>,
+) -> Option<T> {
+    assert!(
+        tracked_values.contains(&ExtraConfigKey {
+            module_instance_id,
+            tracked_value: T::FETCH_METHOD.to_owned(),
+        }),
+        "You need to register the dynamic config value first before reading it: {}",
+        T::FETCH_METHOD
+    );
+
+    let db_key = ExtraConfigKey {
+        module_instance_id,
+        tracked_value: T::FETCH_METHOD.to_owned(),
+    };
+
+    let db_value = dbtx.get_value(&db_key).await.map(|db_val| db_val.value)?;
+
+    serde_json::from_value(db_value).expect("Decodability was checked at fetch time")
+}
+
+type ValidationFn = fn(value: serde_json::Value) -> Result<(), anyhow::Error>;
+
+#[derive(Debug, Clone)]
+pub struct TrackedExtraConfig {
+    fetch_method: &'static str,
+    update_interval: Duration,
+    validation_fn: ValidationFn,
+}
+
+pub trait ExtraConfigTacking {
+    fn tracking_info() -> TrackedExtraConfig;
+}
+
+impl<T> ExtraConfigTacking for T
+where
+    T: ExtraConfig,
+{
+    /// Returns the tracking information for the extra config value that will be
+    /// used to dynamically fetch it in the background.
+    fn tracking_info() -> TrackedExtraConfig {
+        TrackedExtraConfig {
+            fetch_method: T::FETCH_METHOD,
+            update_interval: T::UPDATE_INTERVAL,
+            validation_fn: |value| {
+                serde_json::from_value::<T>(value)?;
+                Ok(())
+            },
+        }
+    }
+}

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -4,6 +4,7 @@ use std::hash::Hash;
 use std::ops::Mul;
 use std::path::Path;
 use std::str::FromStr;
+use std::time::Duration;
 
 use anyhow::{bail, format_err, Context};
 use bitcoin29::hashes::hex::format_hex;
@@ -1035,6 +1036,19 @@ pub const META_OVERRIDE_URL_KEY: &str = "meta_override_url";
 pub fn load_from_file<T: DeserializeOwned>(path: &Path) -> Result<T, anyhow::Error> {
     let file = std::fs::File::open(path)?;
     Ok(serde_json::from_reader(file)?)
+}
+
+/// Some config values that the client and its modules use are dynamic in
+/// nature. This trait is implemented for structs representing such config
+/// values that can be fetched from the federation regularly to keep them up to
+/// date.
+pub trait ExtraConfig: DeserializeOwned {
+    /// Server method that returns the latest value
+    const FETCH_METHOD: &'static str;
+    /// The interval at which the value is being fetched. This is only a rough
+    /// guideline, fetching may be more or less frequent depending on network
+    /// conditions and restarts of the update service.
+    const UPDATE_INTERVAL: Duration;
 }
 
 pub mod serde_binary_human_readable {

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -34,3 +34,4 @@ pub const RESTART_FEDERATION_SETUP_ENDPOINT: &str = "restart_federation_setup";
 pub const API_ANNOUNCEMENTS_ENDPOINT: &str = "api_announcements";
 pub const SUBMIT_API_ANNOUNCEMENT_ENDPOINT: &str = "submit_api_announcement";
 pub const SIGN_API_ANNOUNCEMENT_ENDPOINT: &str = "sign_api_announcement";
+pub const TRANSACTION_FEE_ENDPOINT: &str = "transaction_fee";

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -1,13 +1,19 @@
+use std::time::Duration;
+
 use bitcoin::hashes::Hash as BitcoinHash;
 use fedimint_core::core::{DynInput, DynOutput};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::SerdeModuleEncoding;
 use fedimint_core::{Amount, TransactionId};
 use secp256k1_zkp::schnorr;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::config::ALEPH_BFT_UNIT_BYTE_LIMIT;
+use crate::config::{ExtraConfig, ALEPH_BFT_UNIT_BYTE_LIMIT};
 use crate::core::{DynInputError, DynOutputError};
+use crate::endpoint_constants::TRANSACTION_FEE_ENDPOINT;
+
+pub const DEFAULT_TRANSACTION_FEE: Amount = Amount::ZERO;
 
 /// An atomic value transfer operation within the Fedimint system and consensus
 ///
@@ -121,6 +127,16 @@ pub enum TransactionSignature {
         variant: u64,
         bytes: Vec<u8>,
     },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]
+pub struct TransactionFee {
+    pub fee_per_transaction: Amount,
+}
+
+impl ExtraConfig for TransactionFee {
+    const FETCH_METHOD: &'static str = TRANSACTION_FEE_ENDPOINT;
+    const UPDATE_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24);
 }
 
 #[derive(Debug, Error, Encodable, Decodable, Clone, Eq, PartialEq)]


### PR DESCRIPTION
Reimplementation of #5837 using #5914.

The idea is to phase in new config we may need using new API endpoints the content of which gets synced by the client regularly. That way we can evolve the config structure and values over time.

To activate transaction fees we need to do two things:
1. **Allow over-paying fees**: this is necessary to have a smooth transition where some clients aren't aware of transaction fees while others aren't. We'd be allowing transactions without fees for a transition period after the change kicks in.
2. **A way to activate transaction fees on the federation.**
    * This could be done using a consensus version upgrade as a static value, 
    * or preferably by implementing the server side of dynamic config, which would mean voting on values by peers. The voting would likely happen automatically in this case, but for other values we might want user input.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
