### PR TITLE
fix(recoverytool): don't generate unused change descriptors

### DIFF
--- a/fedimint-recoverytool/src/main.rs
+++ b/fedimint-recoverytool/src/main.rs
@@ -240,7 +240,7 @@ async fn process_and_print_tweak_source(
                         let (mut peg_in_tweaks, peg_out_count) =
                             input_tweaks_and_peg_out_count(transaction_cis.into_iter());
 
-                        for _ in 0..=peg_out_count {
+                        for _ in 0..peg_out_count {
                             info!("Found change output, adding tweak {change_tweak_idx} to list");
                             peg_in_tweaks.insert(nonce_from_idx(change_tweak_idx));
                             change_tweak_idx += 1;


### PR DESCRIPTION
We were generating one descriptor per session, as if in each session we had one change output generated. We should only generate change descriptors when peg-outs happened.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
