### PR TITLE
chore: improve mprocs startup speed

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -946,6 +946,14 @@ pub async fn open_channels_between_gateways(
 
     bitcoind.mine_blocks(10).await?;
 
+    debug!(target: LOG_DEVIMINT, "Syncing gateway lightning nodes to chain tip...");
+    futures::future::try_join_all(
+        gateways
+            .iter()
+            .map(|(gw, _gw_name)| gw.wait_for_chain_sync(bitcoind)),
+    )
+    .await?;
+
     for ((gw_a, _gw_a_name), (gw_b, _gw_b_name)) in &gateway_pairs {
         let gw_a_node_pubkey = gw_a.lightning_pubkey().await?;
         let gw_b_node_pubkey = gw_b.lightning_pubkey().await?;

--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -296,4 +296,10 @@ impl ILnRpcClient for FakeLightningTest {
             failure_reason: "FakeLightningTest does not support getting balances".to_string(),
         })
     }
+
+    async fn sync_to_chain(&self, _block_height: u32) -> Result<EmptyResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedToSyncToChain {
+            failure_reason: "FakeLightningTest does not support getting balances".to_string(),
+        })
+    }
 }

--- a/gateway/cli/src/lightning_commands.rs
+++ b/gateway/cli/src/lightning_commands.rs
@@ -7,6 +7,7 @@ use lightning_invoice::Bolt11Invoice;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 use ln_gateway::rpc::{
     CloseChannelsWithPeerPayload, GetLnOnchainAddressPayload, OpenChannelPayload,
+    SyncToChainPayload,
 };
 
 use crate::print_response;
@@ -157,6 +158,10 @@ impl LightningCommands {
                 max_retries,
                 retry_delay_seconds,
             } => {
+                create_client()
+                    .sync_to_chain(SyncToChainPayload { block_height })
+                    .await?;
+
                 let retry_duration = Duration::from_secs(
                     retry_delay_seconds.unwrap_or(DEFAULT_WAIT_FOR_CHAIN_SYNC_RETRY_DELAY_SECONDS),
                 );

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -98,7 +98,7 @@ use rpc::{
     CloseChannelsWithPeerPayload, CreateInvoiceForSelfPayload, FederationInfo, GatewayFedConfig,
     GatewayInfo, LeaveFedPayload, MnemonicResponse, OpenChannelPayload, PayInvoicePayload,
     ReceiveEcashPayload, ReceiveEcashResponse, SetConfigurationPayload, SpendEcashPayload,
-    SpendEcashResponse, V1_API_ENDPOINT,
+    SpendEcashResponse, SyncToChainPayload, V1_API_ENDPOINT,
 };
 use state_machine::pay::OutgoingPaymentError;
 use state_machine::{GatewayClientModule, GatewayExtPayStates};
@@ -1396,6 +1396,16 @@ impl Gateway {
             lightning_balance_msats: lightning_node_balances.lightning_balance_msats,
             ecash_balances,
         })
+    }
+
+    pub async fn handle_sync_to_chain_msg(&self, payload: SyncToChainPayload) -> Result<()> {
+        self.get_lightning_context()
+            .await?
+            .lnrpc
+            .sync_to_chain(payload.block_height)
+            .await?;
+
+        Ok(())
     }
 
     // Handles a request the spend the gateway's ecash for a given federation.

--- a/gateway/ln-gateway/src/lightning/cln.rs
+++ b/gateway/ln-gateway/src/lightning/cln.rs
@@ -256,4 +256,9 @@ impl ILnRpcClient for NetworkLnRpcClient {
             })?
             .into_inner())
     }
+
+    async fn sync_to_chain(&self, _block_height: u32) -> Result<EmptyResponse, LightningRpcError> {
+        // We don't need to do anything here, as CLN automatically syncs to chain.
+        Ok(EmptyResponse {})
+    }
 }

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -13,6 +13,7 @@ use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_node::lightning::ln::PaymentHash;
 use ldk_node::lightning_invoice::Bolt11Invoice;
 use ldk_node::payment::{PaymentKind, PaymentStatus};
+use ldk_node::{Builder, Config, Event, Node};
 use lightning::ln::PaymentPreimage;
 use lightning::util::scid_utils::scid_from_parts;
 use tokio::sync::mpsc::Sender;
@@ -31,7 +32,7 @@ use crate::gateway_lnrpc::{
 
 pub struct GatewayLdkClient {
     /// The underlying lightning node.
-    node: Arc<ldk_node::Node>,
+    node: Arc<Node>,
 
     /// The client for querying data about the blockchain.
     esplora_client: esplora_client::AsyncClient,
@@ -67,7 +68,7 @@ impl GatewayLdkClient {
         lightning_port: u16,
         mnemonic: Mnemonic,
     ) -> anyhow::Result<Self> {
-        let mut node_builder = ldk_node::Builder::from_config(ldk_node::Config {
+        let mut node_builder = Builder::from_config(Config {
             network,
             listening_addresses: Some(vec![SocketAddress::TcpIpV4 {
                 addr: [0, 0, 0, 0],
@@ -110,10 +111,10 @@ impl GatewayLdkClient {
     }
 
     async fn handle_next_event(
-        node: &ldk_node::Node,
+        node: &Node,
         htlc_stream_sender: &Sender<Result<InterceptHtlcRequest, Status>>,
     ) {
-        if let ldk_node::Event::PaymentClaimable {
+        if let Event::PaymentClaimable {
             payment_id: _,
             payment_hash,
             claimable_amount_msat,

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -74,6 +74,8 @@ impl GatewayLdkClient {
                 addr: [0, 0, 0, 0],
                 port: lightning_port,
             }]),
+            // TODO: Remove these and rely on the default values.
+            // See here for details: https://github.com/lightningdevkit/ldk-node/issues/339#issuecomment-2344230472
             onchain_wallet_sync_interval_secs: 10,
             wallet_sync_interval_secs: 10,
             ..Default::default()
@@ -529,5 +531,23 @@ impl ILnRpcClient for GatewayLdkClient {
             onchain_balance_sats: balances.total_onchain_balance_sats,
             lightning_balance_msats: balances.total_lightning_balance_sats * 1000,
         })
+    }
+
+    async fn sync_to_chain(&self, block_height: u32) -> Result<EmptyResponse, LightningRpcError> {
+        loop {
+            self.node
+                .sync_wallets()
+                .map_err(|e| LightningRpcError::FailedToSyncToChain {
+                    failure_reason: e.to_string(),
+                })?;
+
+            if self.node.status().current_best_block.height < block_height {
+                fedimint_core::runtime::sleep(Duration::from_millis(100)).await;
+            } else {
+                break;
+            }
+        }
+
+        Ok(EmptyResponse {})
     }
 }

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -1333,6 +1333,11 @@ impl ILnRpcClient for GatewayLndClient {
                 .msat,
         })
     }
+
+    async fn sync_to_chain(&self, _block_height: u32) -> Result<EmptyResponse, LightningRpcError> {
+        // We don't need to do anything here, as LND automatically syncs to chain.
+        Ok(EmptyResponse {})
+    }
 }
 
 fn route_hints_to_lnd(

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -72,10 +72,10 @@ pub enum LightningRpcError {
     FailedToListActiveChannels { failure_reason: String },
     #[error("Failed to get balances: {failure_reason}")]
     FailedToGetBalances { failure_reason: String },
-    #[error("Failed to wait for chain sync: {failure_reason}")]
-    FailedToWaitForChainSync { failure_reason: String },
     #[error("Failed to subscribe to invoice updates: {failure_reason}")]
     FailedToSubscribeToInvoiceUpdates { failure_reason: String },
+    #[error("Failed to sync to chain: {failure_reason}")]
+    FailedToSyncToChain { failure_reason: String },
 }
 
 /// Represents an active connection to the lightning node.
@@ -193,6 +193,8 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError>;
 
     async fn get_balances(&self) -> Result<GetBalancesResponse, LightningRpcError>;
+
+    async fn sync_to_chain(&self, block_height: u32) -> Result<EmptyResponse, LightningRpcError>;
 }
 
 impl dyn ILnRpcClient {

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -233,6 +233,11 @@ pub struct FederationBalanceInfo {
     pub ecash_balance_msats: Amount,
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SyncToChainPayload {
+    pub block_height: u32,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MnemonicResponse {
     pub mnemonic: Vec<String>,

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -8,7 +8,7 @@ use fedimint_ln_common::gateway_endpoint_constants::{
     GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT,
     LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT,
     RECEIVE_ECASH_ENDPOINT, SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT,
-    WITHDRAW_ENDPOINT,
+    SYNC_TO_CHAIN_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_common::endpoint_constants::{
     CREATE_BOLT11_INVOICE_FOR_SELF_ENDPOINT, PAY_INVOICE_SELF_ENDPOINT,
@@ -24,7 +24,8 @@ use super::{
     CreateInvoiceForSelfPayload, DepositAddressPayload, FederationInfo, GatewayBalances,
     GatewayFedConfig, GatewayInfo, GetLnOnchainAddressPayload, LeaveFedPayload, MnemonicResponse,
     OpenChannelPayload, PayInvoicePayload, ReceiveEcashPayload, ReceiveEcashResponse,
-    SetConfigurationPayload, SpendEcashPayload, SpendEcashResponse, WithdrawPayload,
+    SetConfigurationPayload, SpendEcashPayload, SpendEcashResponse, SyncToChainPayload,
+    WithdrawPayload,
 };
 use crate::lightning::ChannelInfo;
 use crate::CloseChannelsWithPeerResponse;
@@ -230,6 +231,14 @@ impl GatewayRpcClient {
             .join(GET_BALANCES_ENDPOINT)
             .expect("invalid base url");
         self.call_get(url).await
+    }
+
+    pub async fn sync_to_chain(&self, payload: SyncToChainPayload) -> GatewayRpcResult<()> {
+        let url = self
+            .base_url
+            .join(SYNC_TO_CHAIN_ENDPOINT)
+            .expect("invalid base url");
+        self.call_post(url, payload).await
     }
 
     pub async fn get_mnemonic(&self) -> GatewayRpcResult<MnemonicResponse> {

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -16,7 +16,8 @@ use fedimint_ln_common::gateway_endpoint_constants::{
     GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_GATEWAY_ID_ENDPOINT,
     GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
     MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_ENDPOINT, RECEIVE_ECASH_ENDPOINT,
-    SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, WITHDRAW_ENDPOINT,
+    SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, SYNC_TO_CHAIN_ENDPOINT,
+    WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_client::{CreateBolt11InvoicePayload, SendPaymentPayload};
 use fedimint_lnv2_common::endpoint_constants::{
@@ -33,7 +34,8 @@ use super::{
     BackupPayload, BalancePayload, CloseChannelsWithPeerPayload, ConnectFedPayload,
     CreateInvoiceForSelfPayload, DepositAddressPayload, GetLnOnchainAddressPayload, InfoPayload,
     LeaveFedPayload, OpenChannelPayload, PayInvoicePayload, ReceiveEcashPayload,
-    SetConfigurationPayload, SpendEcashPayload, WithdrawPayload, V1_API_ENDPOINT,
+    SetConfigurationPayload, SpendEcashPayload, SyncToChainPayload, WithdrawPayload,
+    V1_API_ENDPOINT,
 };
 use crate::rpc::ConfigPayload;
 use crate::{Gateway, GatewayError};
@@ -163,7 +165,8 @@ fn v1_routes(gateway: Arc<Gateway>, task_group: TaskGroup) -> Router {
             CREATE_BOLT11_INVOICE_ENDPOINT,
             post(create_bolt11_invoice_v2),
         )
-        .route(RECEIVE_ECASH_ENDPOINT, post(receive_ecash));
+        .route(RECEIVE_ECASH_ENDPOINT, post(receive_ecash))
+        .route(SYNC_TO_CHAIN_ENDPOINT, post(sync_to_chain));
 
     // Authenticated, public routes used for gateway administration
     let always_authenticated_routes = Router::new()
@@ -391,6 +394,15 @@ async fn get_balances(
 ) -> Result<impl IntoResponse, GatewayError> {
     let balances = gateway.handle_get_balances_msg().await?;
     Ok(Json(json!(balances)))
+}
+
+#[instrument(skip_all, err)]
+async fn sync_to_chain(
+    Extension(gateway): Extension<Arc<Gateway>>,
+    Json(payload): Json<SyncToChainPayload>,
+) -> Result<impl IntoResponse, GatewayError> {
+    gateway.handle_sync_to_chain_msg(payload).await?;
+    Ok(Json(json!(())))
 }
 
 #[instrument(skip_all, err)]

--- a/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
+++ b/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
@@ -20,4 +20,5 @@ pub const PAY_INVOICE_ENDPOINT: &str = "/pay_invoice";
 pub const SET_CONFIGURATION_ENDPOINT: &str = "/set_configuration";
 pub const STOP_ENDPOINT: &str = "/stop";
 pub const SPEND_ECASH_ENDPOINT: &str = "/spend_ecash";
+pub const SYNC_TO_CHAIN_ENDPOINT: &str = "/sync_to_chain";
 pub const WITHDRAW_ENDPOINT: &str = "/withdraw";


### PR DESCRIPTION
Startup Time Before:
66.0s, 66.1s, 74.0s, 65.7s, 66.2s, 74.4s, 73.9s, 64.0s, 74.4s, 63.6s
Average: 68.83s

Startup Time After:
56.4s, 53.9s, 56.2s, 54.2s, 53.9s, 54.4s, 54.5s, 66.3s, 56.0s, 72.1s
Average: 57.79s

Speedup of ~16%

This speedup comes primarily from two things:
* Gateway wait-for-chain-sync command now also triggers a chain sync for LDK (which otherwise syncs every 10 seconds)
* Devimint now collects the TXIDs of channel funding transactions and waits for them all to appear in bitcoind's mempool before mining blocks (whereas before, we just blindly waited a few seconds)

As a minor improvement, we're also opening channels in parallel