### PR TITLE
refactor: rename mint_channel_id to federation_index

### DIFF
--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -417,7 +417,7 @@ async fn leave_federation(
     let fed_info: FederationInfo =
         serde_json::from_value(leave_fed).expect("Could not parse FederationInfo");
     assert_eq!(fed_info.federation_id.to_string(), fed_id);
-    assert_eq!(fed_info.channel_id, expected_scid);
+    assert_eq!(fed_info.federation_index, expected_scid);
     info!("Verified gateway left federation {fed_id}");
     Ok(fed_info)
 }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -52,7 +52,7 @@ impl GatewayClientBuilder {
         gateway: Arc<Gateway>,
     ) -> Result<ClientBuilder> {
         let FederationConfig {
-            mint_channel_id,
+            federation_index,
             timelock_delta,
             connector,
             ..
@@ -62,7 +62,7 @@ impl GatewayClientBuilder {
 
         registry.attach(GatewayClientInit {
             timelock_delta,
-            mint_channel_id,
+            federation_index,
             gateway: gateway.clone(),
         });
         registry.attach(GatewayClientInitV2 {
@@ -98,7 +98,7 @@ impl GatewayClientBuilder {
         } else {
             let db = gateway
                 .gateway_db
-                .with_prefix(config.mint_channel_id.to_le_bytes().to_vec());
+                .with_prefix(config.federation_index.to_le_bytes().to_vec());
             let secret = Self::derive_federation_secret(mnemonic, &federation_id);
             (db, secret)
         };

--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -267,7 +267,7 @@ struct FederationIdKeyV0 {
 #[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct FederationConfigV0 {
     pub invite_code: InviteCode,
-    pub mint_channel_id: u64,
+    pub federation_index: u64,
     pub timelock_delta: u64,
     #[serde(with = "serde_routing_fees")]
     pub fees: RoutingFees,
@@ -281,7 +281,10 @@ struct FederationIdKey {
 #[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable, Serialize, Deserialize)]
 pub struct FederationConfig {
     pub invite_code: InviteCode,
-    pub mint_channel_id: u64,
+    // Unique integer identifier per-federation that is assigned when the gateways joins a
+    // federation.
+    #[serde(alias = "mint_channel_id")]
+    pub federation_index: u64,
     pub timelock_delta: u64,
     #[serde(with = "serde_routing_fees")]
     pub fees: RoutingFees,
@@ -409,7 +412,7 @@ async fn migrate_to_v2(dbtx: &mut DatabaseTransaction<'_>) -> Result<(), anyhow:
         {
             let new_federation_config = FederationConfig {
                 invite_code: old_federation_config.invite_code,
-                mint_channel_id: old_federation_config.mint_channel_id,
+                federation_index: old_federation_config.federation_index,
                 timelock_delta: old_federation_config.timelock_delta,
                 fees: old_federation_config.fees,
                 connector: Connector::default(),
@@ -472,7 +475,7 @@ mod fedimint_migration_tests {
         );
         let federation_config = FederationConfigV0 {
             invite_code,
-            mint_channel_id: 2,
+            federation_index: 2,
             timelock_delta: 10,
             fees: DEFAULT_FEES,
         };

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -72,7 +72,7 @@ pub struct WithdrawPayload {
 pub struct FederationInfo {
     pub federation_id: FederationId,
     pub balance_msat: Amount, // TODO: Rename to `balance`, since `Amount` is already in msat.
-    pub channel_id: u64,
+    pub federation_index: u64,
     pub routing_fees: Option<FederationRoutingFees>,
 }
 

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -112,7 +112,7 @@ pub enum GatewayMeta {
 #[derive(Debug, Clone)]
 pub struct GatewayClientInit {
     pub timelock_delta: u64,
-    pub mint_channel_id: u64,
+    pub federation_index: u64,
     pub gateway: Arc<Gateway>,
 }
 
@@ -148,7 +148,7 @@ impl ClientModuleInit for GatewayClientInit {
                 .to_secp_key(&Secp256k1::new()),
             module_api: args.module_api().clone(),
             timelock_delta: self.timelock_delta,
-            mint_channel_id: self.mint_channel_id,
+            federation_index: self.federation_index,
             client_ctx: args.context(),
             gateway: self.gateway.clone(),
         })
@@ -189,7 +189,7 @@ pub struct GatewayClientModule {
     pub notifier: ModuleNotifier<GatewayClientStateMachines>,
     pub redeem_key: KeyPair,
     timelock_delta: u64,
-    mint_channel_id: u64,
+    federation_index: u64,
     module_api: DynModuleApi,
     client_ctx: ClientContext<Self>,
     gateway: Arc<Gateway>,
@@ -243,7 +243,7 @@ impl GatewayClientModule {
     ) -> LightningGatewayAnnouncement {
         LightningGatewayAnnouncement {
             info: LightningGateway {
-                mint_channel_id: self.mint_channel_id,
+                federation_index: self.federation_index,
                 gateway_redeem_key: self.redeem_key.public_key(),
                 node_pub_key: lightning_context.lightning_public_key,
                 lightning_alias: lightning_context.lightning_alias,

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -633,7 +633,7 @@ impl GatewayPayInvoice {
                         .federation_manager
                         .read()
                         .await
-                        .get_client_for_scid(hop.short_channel_id)
+                        .get_client_for_index(hop.short_channel_id)
                 }
                 _ => None,
             },

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -227,7 +227,7 @@ fn invoice_routes_back_to_federation(
             .first()
             .and_then(|rh| rh.0.last())
             .map(|hop| (hop.src_node_id, hop.short_channel_id))
-            == Some((gateway.node_pub_key, gateway.mint_channel_id))
+            == Some((gateway.node_pub_key, gateway.federation_index))
     })
 }
 
@@ -1490,7 +1490,7 @@ impl LightningClientModule {
         let (src_node_id, short_channel_id, route_hints) = if let Some(current_gateway) = gateway {
             (
                 current_gateway.node_pub_key,
-                current_gateway.mint_channel_id,
+                current_gateway.federation_index,
                 current_gateway.route_hints,
             )
         } else {

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -347,11 +347,12 @@ impl LightningGatewayAnnouncement {
 /// Information a gateway registers with a federation
 #[derive(Debug, Clone, Serialize, Deserialize, Encodable, Decodable, PartialEq, Eq, Hash)]
 pub struct LightningGateway {
-    /// Channel identifier assigned to the mint by the gateway.
+    /// Unique per-federation identifier assigned by the gateway.
     /// All clients in this federation should use this value as
     /// `short_channel_id` when creating invoices to be settled by this
     /// gateway.
-    pub mint_channel_id: u64,
+    #[serde(rename = "mint_channel_id")]
+    pub federation_index: u64,
     /// Key used to pay the gateway
     pub gateway_redeem_key: secp256k1::PublicKey,
     pub node_pub_key: secp256k1::PublicKey,

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -752,7 +752,7 @@ mod fedimint_migration_tests {
 
         let gateway = LightningGatewayRegistration {
             info: LightningGateway {
-                mint_channel_id: 100,
+                federation_index: 100,
                 gateway_redeem_key: pk,
                 node_pub_key: pk,
                 lightning_alias: "FakeLightningAlias".to_string(),
@@ -814,7 +814,7 @@ mod fedimint_migration_tests {
         let route_hints = vec![RouteHint(vec![hop])];
 
         let gateway_info = LightningGateway {
-            mint_channel_id: 3,
+            federation_index: 3,
             gateway_redeem_key: pk,
             node_pub_key: pk,
             lightning_alias: "MyLightningNode".to_string(),
@@ -990,7 +990,7 @@ mod fedimint_migration_tests {
         .consensus_encode(&mut funded_state)
         .expect("PayInvoicePayload is encodable");
         LightningGateway {
-            mint_channel_id: 3,
+            federation_index: 3,
             gateway_redeem_key: pk,
             node_pub_key: pk,
             lightning_alias: "MyLightningNode".to_string(),


### PR DESCRIPTION
The concept of a `mint_channel_id` is going away with LNv1, but as https://github.com/fedimint/fedimint/pull/5852 showed it is still useful to have a unique identifier for a federation that is not the federation id, since that is rather long (32 bytes), whereas this identifier is a `u64` and can be variable length encoded.

This PR just renames `mint_channel_id` to `federation_index` to reflect its new use. It will still be used as the short channel id for LNv1 until LNv1 is removed.