### PR TITLE
chore(wallet): bump api minor version

### DIFF
--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -219,7 +219,7 @@ impl ServerModuleInit for WalletInit {
                 MODULE_CONSENSUS_VERSION.major,
                 MODULE_CONSENSUS_VERSION.minor,
             ),
-            &[(0, 0)],
+            &[(0, 1)],
         )
     }
 


### PR DESCRIPTION
Followup to https://github.com/fedimint/fedimint/pull/5905

Two new endpoints were introduced to the wallet server without bumping the minor API version.