### PR TITLE
fix: remove ignored 'default-features = false'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,6 @@ dependencies = [
  "bech32 0.9.1",
  "bitcoin-private",
  "bitcoin_hashes 0.12.0",
- "core2",
  "hex_lit",
  "secp256k1 0.27.0",
  "serde",
@@ -731,7 +730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
- "core2",
  "serde",
 ]
 
@@ -1198,15 +1196,6 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "core2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -3841,12 +3830,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -4676,11 +4659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd92d4aa159374be430c7590e169b4a6c0fb79018f5bc4ea1bffde536384db3"
 dependencies = [
  "bitcoin 0.30.2",
- "core2",
- "hashbrown 0.13.2",
  "hex-conservative",
- "libm",
- "possiblyrandom",
 ]
 
 [[package]]
@@ -5470,15 +5449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "possiblyrandom"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -32,9 +32,9 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.24"
 fedimint-aead = { workspace = true }
-fedimint-api-client = { workspace = true, default-features = false }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.5.0-alpha", default-features = false }
 fedimint-bip39 = { workspace = true }
-fedimint-client = { workspace = true, default-features = false }
+fedimint-client = { path = "../fedimint-client", version = "=0.5.0-alpha", default-features = false }
 fedimint-core = { workspace = true }
 fedimint-ln-client = { workspace = true, features = ["cli"] }
 fedimint-ln-common = { workspace = true }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -30,7 +30,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-aead = { workspace = true }
-fedimint-api-client = { workspace = true, default-features = false }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.5.0-alpha", default-features = false }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-logging = { workspace = true }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -39,7 +39,7 @@ fedimint-testing-core = { workspace = true }
 fs-lock = { workspace = true }
 futures = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { workspace = true, default-features = false }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway", version = "=0.5.0-alpha", default-features = false }
 rand = { workspace = true }
 secp256k1-zkp = { version = "0.9.2", features = [
     "global-context",

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -28,10 +28,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 
 # setup dependencies
-axum = { workspace = true, default-features = false, features = [
-    "form",
-    "tokio",
-] }
+axum = { workspace = true }
 bincode = { workspace = true }
 bitcoin = { workspace = true }
 bytes = { workspace = true }

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -29,16 +29,12 @@ fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-mint-client = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { workspace = true, default-features = false }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../ln-gateway", version = "=0.5.0-alpha", default-features = false }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true, default-features = false, features = [
-    "log",
-    "attributes",
-    "std",
-] }
+tracing = { workspace = true, features = ["log"] }
 url = { workspace = true, features = ["serde"] }
 
 [build-dependencies]

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -43,9 +43,9 @@ cln-plugin = "=0.1.7"
 cln-rpc = { workspace = true }
 erased-serde = { workspace = true }
 esplora-client = { workspace = true }
-fedimint-api-client = { workspace = true, default-features = false }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.5.0-alpha", default-features = false }
 fedimint-bip39 = { version = "=0.5.0-alpha", path = "../../fedimint-bip39" }
-fedimint-client = { workspace = true, default-features = false }
+fedimint-client = { path = "../../fedimint-client", version = "=0.5.0-alpha", default-features = false }
 fedimint-core = { workspace = true }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
@@ -74,11 +74,7 @@ tonic = { version = "0.12.2", features = ["transport", "tls"] }
 tonic_lnd = { workspace = true }
 tower-http = { version = "0.5.2", features = ["cors", "auth"] }
 tpe = { workspace = true }
-tracing = { workspace = true, default-features = false, features = [
-    "log",
-    "attributes",
-    "std",
-] }
+tracing = { workspace = true, features = ["log"] }
 url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -25,9 +25,7 @@ bitcoin = { workspace = true }
 bitcoin_hashes = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
-lightning = { workspace = true, default-features = false, features = [
-    "no-std",
-] }
+lightning = { workspace = true }
 lightning-invoice = { workspace = true }
 secp256k1 = { workspace = true }
 serde = { workspace = true }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -45,10 +45,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-fedimint-bitcoind = { workspace = true, default-features = false, features = [
-    "esplora-client",
-    "bitcoincore-rpc",
-] }
+fedimint-bitcoind = { workspace = true }
 tokio = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]


### PR DESCRIPTION
On master, running `just check` produces the following errors:

```
warning: /Users/tommyvolk/Documents/GitHub/fedimint/fedimintd/Cargo.toml: `default-features` is ignored for axum, since `default-features` was not specified for `workspace.dependencies.axum`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/fedimint-testing/Cargo.toml: `default-features` is ignored for ln-gateway, since `default-features` was not specified for `workspace.dependencies.ln-gateway`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/fedimint-cli/Cargo.toml: `default-features` is ignored for fedimint-api-client, since `default-features` was not specified for `workspace.dependencies.fedimint-api-client`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/fedimint-cli/Cargo.toml: `default-features` is ignored for fedimint-client, since `default-features` was not specified for `workspace.dependencies.fedimint-client`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/fedimint-client/Cargo.toml: `default-features` is ignored for fedimint-api-client, since `default-features` was not specified for `workspace.dependencies.fedimint-api-client`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/modules/fedimint-wallet-client/Cargo.toml: `default-features` is ignored for fedimint-bitcoind, since `default-features` was not specified for `workspace.dependencies.fedimint-bitcoind`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/gateway/cli/Cargo.toml: `default-features` is ignored for ln-gateway, since `default-features` was not specified for `workspace.dependencies.ln-gateway`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/gateway/cli/Cargo.toml: `default-features` is ignored for tracing, since `default-features` was not specified for `workspace.dependencies.tracing`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/gateway/ln-gateway/Cargo.toml: `default-features` is ignored for fedimint-api-client, since `default-features` was not specified for `workspace.dependencies.fedimint-api-client`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/gateway/ln-gateway/Cargo.toml: `default-features` is ignored for fedimint-client, since `default-features` was not specified for `workspace.dependencies.fedimint-client`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/gateway/ln-gateway/Cargo.toml: `default-features` is ignored for tracing, since `default-features` was not specified for `workspace.dependencies.tracing`, this could become a hard error in the future
warning: /Users/tommyvolk/Documents/GitHub/fedimint/modules/fedimint-ln-common/Cargo.toml: `default-features` is ignored for lightning, since `default-features` was not specified for `workspace.dependencies.lightning`, this could become a hard error in the future
```

This pr fixes these. The issue is that features cannot be _removed_ by crates that use workspace dependencies, only _added_.

This makes it somewhat challenging to support features that are on-by-default and also need to be piped through from parent crates to child crates. The `tor` feature is the best example of this. In order to keep it on-by-default while still allowing it to be disabled by child crates, we are changing the child crates to import parent crates directly (instead of as a workspace dependency) so that we can disable default features.