### PR TITLE
feat: gateway safe stop

### DIFF
--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -124,6 +124,8 @@ pub enum GeneralCommands {
         #[clap(long)]
         per_federation_routing_fees: Option<Vec<PerFederationRoutingFees>>,
     },
+    /// Safely stop the gateway
+    Stop,
     /// Spend e-cash
     SpendEcash {
         #[clap(long)]
@@ -286,6 +288,9 @@ impl GeneralCommands {
             Self::Seed => {
                 let response = create_client().get_mnemonic().await?;
                 print_response(response);
+            }
+            Self::Stop => {
+                create_client().stop().await?;
             }
         }
 

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let tg = TaskGroup::new();
     tg.install_kill_handler();
     let gatewayd = Gateway::new_with_default_modules().await?;
-    let shutdown_receiver = gatewayd.clone().run(&tg).await?;
+    let shutdown_receiver = gatewayd.clone().run(tg).await?;
     shutdown_receiver.await;
     gatewayd.unannounce_from_all_federations().await;
     info!("Gatewayd exiting...");

--- a/gateway/ln-gateway/src/federation_manager.rs
+++ b/gateway/ln-gateway/src/federation_manager.rs
@@ -7,8 +7,10 @@ use fedimint_client::ClientHandleArc;
 use fedimint_core::config::{FederationId, FederationIdPrefix, JsonClientConfig};
 use fedimint_core::db::{DatabaseTransaction, NonCommittable};
 use fedimint_core::util::Spanned;
+use tracing::info;
 
 use crate::db::GatewayDbtxNcExt;
+use crate::gateway_module_v2::GatewayClientModuleV2;
 use crate::rpc::FederationInfo;
 use crate::state_machine::GatewayClientModule;
 use crate::{GatewayError, Result};
@@ -91,6 +93,35 @@ impl FederationManager {
                 "Federation client is not unique, failed to shutdown client".to_string(),
             ))
         }
+    }
+
+    /// Waits for ongoing incoming LNv1 and LNv2 payments to complete before
+    /// returning.
+    pub async fn wait_for_incoming_payments(&self) -> Result<()> {
+        for client in self.clients.values() {
+            let active_operations = client.value().get_active_operations().await;
+            let operation_log = client.value().operation_log();
+            for op_id in active_operations {
+                let log_entry = operation_log.get_operation(op_id).await;
+                if let Some(entry) = log_entry {
+                    match entry.operation_module_kind() {
+                        "lnv2" => {
+                            let lnv2 =
+                                client.value().get_first_module::<GatewayClientModuleV2>()?;
+                            lnv2.await_completion(op_id).await;
+                        }
+                        "ln" => {
+                            let lnv1 = client.value().get_first_module::<GatewayClientModule>()?;
+                            lnv1.await_completion(op_id).await;
+                        }
+                        _ => continue,
+                    }
+                }
+            }
+        }
+
+        info!("Finished waiting for incoming payments");
+        Ok(())
     }
 
     async fn unannounce_from_federation(

--- a/gateway/ln-gateway/src/gateway_module_v2/complete_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/complete_sm.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::time::Duration;
 
 use bitcoin_hashes::Hash;
@@ -41,6 +42,16 @@ impl CompleteStateMachine {
     }
 }
 
+impl fmt::Display for CompleteStateMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Complete State Machine Operation ID: {:?} State: {}",
+            self.common.operation_id, self.state
+        )
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct CompleteSMCommon {
     pub operation_id: OperationId,
@@ -54,6 +65,16 @@ pub enum CompleteSMState {
     Pending,
     Completing(FinalReceiveState),
     Completed,
+}
+
+impl fmt::Display for CompleteSMState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompleteSMState::Pending => write!(f, "Pending"),
+            CompleteSMState::Completing(_) => write!(f, "Completing"),
+            CompleteSMState::Completed => write!(f, "Completed"),
+        }
+    }
 }
 
 impl State for CompleteStateMachine {

--- a/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::collections::BTreeMap;
 use std::future::pending;
 use std::sync::Arc;
@@ -43,6 +44,16 @@ impl ReceiveStateMachine {
     }
 }
 
+impl fmt::Display for ReceiveStateMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Receive State Machine Operation ID: {:?} State: {}",
+            self.common.operation_id, self.state
+        )
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct ReceiveSMCommon {
     pub operation_id: OperationId,
@@ -58,6 +69,18 @@ pub enum ReceiveSMState {
     Success([u8; 32]),
     Failure,
     Refunding(Vec<OutPoint>),
+}
+
+impl fmt::Display for ReceiveSMState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReceiveSMState::Funding => write!(f, "Funding"),
+            ReceiveSMState::Rejected(_) => write!(f, "Rejected"),
+            ReceiveSMState::Success(_) => write!(f, "Success"),
+            ReceiveSMState::Failure => write!(f, "Failure"),
+            ReceiveSMState::Refunding(_) => write!(f, "Refunding"),
+        }
+    }
 }
 
 #[cfg_attr(doc, aquamarine::aquamarine)]

--- a/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::Arc;
 
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
@@ -30,6 +31,16 @@ impl SendStateMachine {
     }
 }
 
+impl fmt::Display for SendStateMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Send State Machine Operation ID: {:?} State: {}",
+            self.common.operation_id, self.state
+        )
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct SendSMCommon {
     pub operation_id: OperationId,
@@ -45,6 +56,16 @@ pub enum SendSMState {
     Sending,
     Claiming(Claiming),
     Cancelled(Cancelled),
+}
+
+impl fmt::Display for SendSMState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SendSMState::Sending => write!(f, "Sending"),
+            SendSMState::Claiming(_) => write!(f, "Claiming"),
+            SendSMState::Cancelled(_) => write!(f, "Cancelled"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -178,6 +178,7 @@ pub enum GatewayState {
     Connected,
     Running { lightning_context: LightningContext },
     Disconnected,
+    ShuttingDown { lightning_context: LightningContext },
 }
 
 impl Display for GatewayState {
@@ -188,6 +189,7 @@ impl Display for GatewayState {
             GatewayState::Connected => write!(f, "Connected"),
             GatewayState::Running { .. } => write!(f, "Running"),
             GatewayState::Disconnected => write!(f, "Disconnected"),
+            GatewayState::ShuttingDown { .. } => write!(f, "ShuttingDown"),
         }
     }
 }
@@ -402,13 +404,13 @@ impl Gateway {
     /// timer, loads the federation clients from the persisted config,
     /// begins listening for intercepted HTLCs, and starts the webserver to
     /// service requests.
-    pub async fn run(self, tg: &TaskGroup) -> anyhow::Result<TaskShutdownToken> {
-        self.register_clients_timer(tg);
+    pub async fn run(self, tg: TaskGroup) -> anyhow::Result<TaskShutdownToken> {
+        self.register_clients_timer(&tg);
         self.load_clients().await?;
-        self.start_gateway(tg);
+        self.start_gateway(&tg);
         // start webserver last to avoid handling requests before fully initialized
-        run_webserver(Arc::new(self), tg).await?;
         let handle = tg.make_handle();
+        run_webserver(Arc::new(self), tg).await?;
         let shutdown_receiver = handle.make_shutdown_rx();
         Ok(shutdown_receiver)
     }
@@ -553,14 +555,19 @@ impl Gateway {
     /// complete the HTLC depending on if the gateway is able to acquire the
     /// preimage from the federation.
     pub async fn handle_htlc_stream(&self, mut stream: RouteHtlcStream<'_>, handle: TaskHandle) {
-        let GatewayState::Running { lightning_context } = self.get_state().await else {
-            panic!("Gateway isn't in a running state")
-        };
-
         loop {
             if handle.is_shutting_down() {
                 break;
             }
+
+            let state = self.get_state().await;
+            let GatewayState::Running { lightning_context } = state else {
+                warn!(
+                    ?state,
+                    "Gateway isn't in a running state, cannot handle incoming payments."
+                );
+                break;
+            };
 
             let htlc_request = match stream.next().await {
                 Some(Ok(htlc_request)) => htlc_request,
@@ -1456,6 +1463,26 @@ impl Gateway {
         Ok(ReceiveEcashResponse { amount })
     }
 
+    pub async fn handle_shutdown_msg(&self, task_group: TaskGroup) -> Result<()> {
+        if let GatewayState::Running { lightning_context } = self.get_state().await {
+            self.set_gateway_state(GatewayState::ShuttingDown { lightning_context })
+                .await;
+            self.federation_manager
+                .read()
+                .await
+                .wait_for_incoming_payments()
+                .await?;
+        }
+
+        let tg = task_group.clone();
+        tg.spawn("Kill Gateway", |_task_handle| async {
+            if let Err(e) = task_group.shutdown_join_all(Duration::from_secs(180)).await {
+                error!(?e, "Error shutting down gateway");
+            }
+        });
+        Ok(())
+    }
+
     /// Registers the gateway with each specified federation.
     async fn register_federations(
         &self,
@@ -1697,7 +1724,8 @@ impl Gateway {
     /// will not be connected and this will return an error.
     pub async fn get_lightning_context(&self) -> Result<LightningContext> {
         match self.get_state().await {
-            GatewayState::Running { lightning_context } => Ok(lightning_context),
+            GatewayState::Running { lightning_context }
+            | GatewayState::ShuttingDown { lightning_context } => Ok(lightning_context),
             _ => Err(GatewayError::LightningRpcError(
                 LightningRpcError::FailedToConnect,
             )),

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -8,7 +8,7 @@ use fedimint_ln_common::gateway_endpoint_constants::{
     GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT,
     LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT,
     RECEIVE_ECASH_ENDPOINT, RESTORE_ENDPOINT, SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT,
-    WITHDRAW_ENDPOINT,
+    STOP_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use fedimint_lnv2_common::endpoint_constants::{
     CREATE_BOLT11_INVOICE_FOR_SELF_ENDPOINT, PAY_INVOICE_SELF_ENDPOINT,
@@ -246,6 +246,11 @@ impl GatewayRpcClient {
             .base_url
             .join(MNEMONIC_ENDPOINT)
             .expect("invalid base url");
+        self.call_get(url).await
+    }
+
+    pub async fn stop(&self) -> GatewayRpcResult<()> {
+        let url = self.base_url.join(STOP_ENDPOINT).expect("invalid base url");
         self.call_get(url).await
     }
 

--- a/gateway/ln-gateway/src/state_machine/complete.rs
+++ b/gateway/ln-gateway/src/state_machine/complete.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::time::Duration;
 
 use bitcoin_hashes::Hash;
@@ -47,6 +48,17 @@ pub enum GatewayCompleteStates {
     Failure,
 }
 
+impl fmt::Display for GatewayCompleteStates {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GatewayCompleteStates::WaitForPreimage(_) => write!(f, "WaitForPreimage"),
+            GatewayCompleteStates::CompleteHtlc(_) => write!(f, "CompleteHtlc"),
+            GatewayCompleteStates::HtlcFinished => write!(f, "HtlcFinished"),
+            GatewayCompleteStates::Failure => write!(f, "Failure"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct GatewayCompleteCommon {
     pub operation_id: OperationId,
@@ -59,6 +71,16 @@ pub struct GatewayCompleteCommon {
 pub struct GatewayCompleteStateMachine {
     pub common: GatewayCompleteCommon,
     pub state: GatewayCompleteStates,
+}
+
+impl fmt::Display for GatewayCompleteStateMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Gateway Complete State Machine Operation ID: {:?} State: {}",
+            self.common.operation_id, self.state
+        )
+    }
 }
 
 impl State for GatewayCompleteStateMachine {

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{self, Display};
 use std::sync::Arc;
 
 use bitcoin_hashes::sha256;
@@ -67,6 +67,21 @@ pub enum GatewayPayStates {
     },
 }
 
+impl fmt::Display for GatewayPayStates {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GatewayPayStates::PayInvoice(_) => write!(f, "PayInvoice"),
+            GatewayPayStates::CancelContract(_) => write!(f, "CancelContract"),
+            GatewayPayStates::Preimage(..) => write!(f, "Preimage"),
+            GatewayPayStates::OfferDoesNotExist(_) => write!(f, "OfferDoesNotExist"),
+            GatewayPayStates::Canceled { .. } => write!(f, "Canceled"),
+            GatewayPayStates::WaitForSwapPreimage(_) => write!(f, "WaitForSwapPreimage"),
+            GatewayPayStates::ClaimOutgoingContract(_) => write!(f, "ClaimOutgoingContract"),
+            GatewayPayStates::Failed { .. } => write!(f, "Failed"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable, Serialize, Deserialize)]
 pub struct GatewayPayCommon {
     pub operation_id: OperationId,
@@ -76,6 +91,16 @@ pub struct GatewayPayCommon {
 pub struct GatewayPayStateMachine {
     pub common: GatewayPayCommon,
     pub state: GatewayPayStates,
+}
+
+impl fmt::Display for GatewayPayStateMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Gateway Pay State Machine Operation ID: {:?} State: {}",
+            self.common.operation_id, self.state
+        )
+    }
 }
 
 impl State for GatewayPayStateMachine {

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -7,6 +7,7 @@
 //!   - `fedimint-ln-client` for internal payments without involving the gateway
 //!   - `gateway` for receiving payments into the federation
 
+use core::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -59,6 +60,19 @@ pub enum IncomingSmStates {
     Failure(String),
 }
 
+impl fmt::Display for IncomingSmStates {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IncomingSmStates::FundingOffer(_) => write!(f, "FundingOffer"),
+            IncomingSmStates::DecryptingPreimage(_) => write!(f, "DecryptingPreimage"),
+            IncomingSmStates::Preimage(_) => write!(f, "Preimage"),
+            IncomingSmStates::RefundSubmitted { .. } => write!(f, "RefundSubmitted"),
+            IncomingSmStates::FundingFailed { .. } => write!(f, "FundingFailed"),
+            IncomingSmStates::Failure(_) => write!(f, "Failure"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct IncomingSmCommon {
     pub operation_id: OperationId,
@@ -70,6 +84,16 @@ pub struct IncomingSmCommon {
 pub struct IncomingStateMachine {
     pub common: IncomingSmCommon,
     pub state: IncomingSmStates,
+}
+
+impl fmt::Display for IncomingStateMachine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Incoming State Machine Operation ID: {:?} State: {}",
+            self.common.operation_id, self.state
+        )
+    }
 }
 
 impl State for IncomingStateMachine {

--- a/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
+++ b/modules/fedimint-ln-common/src/gateway_endpoint_constants.rs
@@ -19,5 +19,6 @@ pub const RECEIVE_ECASH_ENDPOINT: &str = "/receive_ecash";
 pub const PAY_INVOICE_ENDPOINT: &str = "/pay_invoice";
 pub const RESTORE_ENDPOINT: &str = "/restore";
 pub const SET_CONFIGURATION_ENDPOINT: &str = "/set_configuration";
+pub const STOP_ENDPOINT: &str = "/stop";
 pub const SPEND_ECASH_ENDPOINT: &str = "/spend_ecash";
 pub const WITHDRAW_ENDPOINT: &str = "/withdraw";


### PR DESCRIPTION
Keeping with the theme of gateway recovery, this PR adds a `stop` RPC that shuts down the gateway. Previously, to kill the gateway the gateway operator could just kill the process or use Ctrl-C. The issue with this though, is that if the gateway operator kills the gateway at an unfortunate time (after the incoming contract has been created, but before the gateway has revealed the preimage), AND the operator either deletes their database or restores their mnemonic into another gateway, then the gateway will lose money because it will never reveal the preimage for the incoming payment.

This "safe stop" mechanism will prevent new incoming payments, then wait for incoming payments to complete, then shutdown.