### PR TITLE
chore(wallet): shutdown fedimintd if bitcoin backend is stale

### DIFF
--- a/fedimint-core/src/util/backoff_util.rs
+++ b/fedimint-core/src/util/backoff_util.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-pub use backon::{Backoff, FibonacciBackoff};
-use backon::{BackoffBuilder, FibonacciBuilder};
+pub use backon::{Backoff, ConstantBackoff, FibonacciBackoff};
+use backon::{BackoffBuilder, ConstantBuilder, FibonacciBuilder};
 
 /// Backoff strategy for background tasks.
 ///
@@ -40,5 +40,12 @@ pub fn custom_backoff(
         .with_min_delay(min_delay)
         .with_max_delay(max_delay)
         .with_max_times(max_retries_or.unwrap_or(usize::MAX))
+        .build()
+}
+
+pub fn custom_constant_backoff(delay: Duration, max_times: Option<usize>) -> ConstantBackoff {
+    ConstantBuilder::default()
+        .with_delay(delay)
+        .with_max_times(max_times.unwrap_or(usize::MAX))
         .build()
 }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -802,6 +802,7 @@ pub struct Wallet {
     block_count_rx: watch::Receiver<Option<u32>>,
     /// Fee rate updated periodically by a background task
     fee_rate_rx: watch::Receiver<Feerate>,
+    task_group: TaskGroup,
 }
 
 impl Wallet {
@@ -847,6 +848,7 @@ impl Wallet {
             our_peer_id,
             block_count_rx,
             fee_rate_rx,
+            task_group: task_group.clone(),
         };
 
         Ok(wallet)
@@ -1023,6 +1025,10 @@ impl Wallet {
             blocks_to_go = new_count - old_count,
             "New consensus count, syncing up",
         );
+
+        // Before we can safely call our bitcoin backend to process the new consensus
+        // count, we need to ensure we observed enough confirmations
+        self.wait_for_finality_confs_or_shutdown(new_count).await;
 
         for height in old_count..new_count {
             if height % 100 == 0 {
@@ -1379,6 +1385,53 @@ impl Wallet {
             }
         });
         (block_count_rx, fee_rate_rx)
+    }
+
+    /// Shutdown the task group shared throughout fedimintd, giving 60 seconds
+    /// for other services to gracefully shutdown.
+    async fn graceful_shutdown(&self) {
+        if let Err(e) = self
+            .task_group
+            .clone()
+            .shutdown_join_all(Some(Duration::from_secs(60)))
+            .await
+        {
+            panic!("Error while shutting down fedimintd task group: {e}");
+        }
+    }
+
+    /// Returns once our bitcoin backend observes finality delay confirmations
+    /// of the consensus block count. If we don't observe enough confirmations
+    /// after one hour, we gracefully shutdown fedimintd. This is necessary
+    /// since we can no longer participate in consensus if our bitcoin backend
+    /// is unable to observe the same chain tip as our peers.
+    async fn wait_for_finality_confs_or_shutdown(&self, consensus_block_count: u32) {
+        let backoff = if is_running_in_test_env() {
+            // every 100ms for 60s
+            backoff_util::custom_constant_backoff(Duration::from_millis(100), Some(10 * 60))
+        } else {
+            // every 10s for 1 hour
+            backoff_util::custom_constant_backoff(Duration::from_secs(10), Some(6 * 60))
+        };
+
+        let wait_for_finality_confs = || async {
+            let our_chain_tip_block_count = self.get_block_count()?;
+            let consensus_chain_tip_block_count =
+                consensus_block_count + self.cfg.consensus.finality_delay;
+
+            if consensus_chain_tip_block_count <= our_chain_tip_block_count {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!("not enough confirmations"))
+            }
+        };
+
+        if retry("wait_for_finality_confs", backoff, wait_for_finality_confs)
+            .await
+            .is_err()
+        {
+            self.graceful_shutdown().await;
+        }
     }
 }
 

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -633,6 +633,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     let pk = bitcoin30_to_bitcoin32_secp256k1_pubkey(&tweak_key.public_key());
     let wallet_config: WalletConfig = wallet_server_cfg[0].to_typed()?;
     let peg_in_descriptor = wallet_config.consensus.peg_in_descriptor;
+    let finality_delay = wallet_config.consensus.finality_delay;
 
     let peg_in_address = peg_in_descriptor
         .tweak(&pk, secp256k1::SECP256K1)
@@ -650,18 +651,17 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     let mut dbtx = db.begin_transaction().await;
 
     // Generate a minimum number of blocks before sending transactions
-    bitcoin
-        .mine_blocks(wallet_config.consensus.finality_delay.into())
-        .await;
+    bitcoin.mine_blocks(finality_delay.into()).await;
 
-    let block_count = dyn_bitcoin_rpc.get_block_count().await?;
+    let block_count = dyn_bitcoin_rpc.get_block_count().await? as u32;
+    let consensus_block_count = block_count - finality_delay;
     sync_wallet_to_block(
         &mut dbtx
             .to_ref_with_prefix_module_id(module_instance_id)
             .0
             .into_nc(),
         &mut wallet,
-        block_count.try_into()?,
+        consensus_block_count,
     )
     .await?;
 
@@ -708,14 +708,15 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     bitcoin
         .mine_blocks((wallet_config.consensus.finality_delay).into())
         .await;
-    let block_count = dyn_bitcoin_rpc.get_block_count().await?;
+    let block_count = dyn_bitcoin_rpc.get_block_count().await? as u32;
+    let consensus_block_count = block_count - finality_delay;
     sync_wallet_to_block(
         &mut dbtx
             .to_ref_with_prefix_module_id(module_instance_id)
             .0
             .into_nc(),
         &mut wallet,
-        block_count.try_into()?,
+        consensus_block_count,
     )
     .await?;
 


### PR DESCRIPTION
We observed issues with a public federation that had peers with a bitcoin backend that was unable to stay at tip, with some that went two months without contributing a block count vote. Instead of allowing the peers to keep progressing and contributing other consensus items, this change introduces a graceful shutdown if we haven't observed a block that other peers have seen `finality_delay` confirmations.

I'm opening as a draft since I'm still chewing on the implications of these changes. Please flag any concerns with this approach cc: @elsirion @dpc @joschisan  