### PR TITLE
feat: make gateway api optional

### DIFF
--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -13,21 +13,24 @@ use crate::LightningClientModule;
 
 #[derive(Parser, Serialize)]
 enum Opts {
-    /// Pay an invoice
+    /// Pay an invoice. For  testing  you can optionally specify a gateway to
+    /// route with, otherwise a gateway will be selected automatically.
     Send {
         invoice: Bolt11Invoice,
         #[arg(long)]
         gateway: Option<SafeUrl>,
     },
-    /// Await the final state of the send operation
+    /// Await the final state of the send operation.
     AwaitSend { operation_id: OperationId },
-    /// Request an invoice
+    /// Request an invoice. For testing you can optionally specify a gateway to
+    /// generate the invoice, otherwise a gateway will be selected
+    /// automatically.
     Receive {
         amount: Amount,
         #[arg(long)]
         gateway: Option<SafeUrl>,
     },
-    /// Await the final state of the receive operation
+    /// Await the final state of the receive operation.
     AwaitReceive { operation_id: OperationId },
     /// Gateway subcommands
     #[command(subcommand)]
@@ -36,16 +39,16 @@ enum Opts {
 
 #[derive(Clone, Subcommand, Serialize)]
 enum GatewayOpts {
-    /// Select an online vetted gateway
+    /// Select an online vetted gateway; this command is intended for testing.
     Select,
-    /// List all vetted gateways
+    /// List all vetted gateways.
     List {
         #[arg(long)]
         peer: Option<PeerId>,
     },
-    /// Add a vetted gateway
+    /// Add a vetted gateway.
     Add { gateway: SafeUrl },
-    /// Remove a vetted gateway
+    /// Remove a vetted gateway.
     Remove { gateway: SafeUrl },
 }
 

--- a/modules/fedimint-lnv2-client/src/cli.rs
+++ b/modules/fedimint-lnv2-client/src/cli.rs
@@ -36,7 +36,9 @@ enum Opts {
 
 #[derive(Clone, Subcommand, Serialize)]
 enum GatewayOpts {
-    /// List vetted gateways
+    /// Select an online vetted gateway
+    Select,
+    /// List all vetted gateways
     List {
         #[arg(long)]
         peer: Option<PeerId>,
@@ -59,6 +61,7 @@ pub(crate) async fn handle_cli_command(
         Opts::Receive { gateway, amount } => json(lightning.receive(amount, gateway).await?),
         Opts::AwaitReceive { operation_id } => json(lightning.await_receive(operation_id).await?),
         Opts::Gateway(gateway_opts) => match gateway_opts {
+            GatewayOpts::Select => json(lightning.select_gateway().await?.0),
             GatewayOpts::List { peer } => match peer {
                 Some(peer) => json(lightning.module_api.gateways_from_peer(peer).await?),
                 None => json(lightning.module_api.gateways().await?),

--- a/modules/fedimint-lnv2-client/src/send_sm.rs
+++ b/modules/fedimint-lnv2-client/src/send_sm.rs
@@ -10,9 +10,10 @@ use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::sleep;
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{OutPoint, TransactionId};
 use fedimint_lnv2_common::contracts::OutgoingContract;
-use fedimint_lnv2_common::{GatewayEndpoint, LightningInput, LightningInputV0, OutgoingWitness};
+use fedimint_lnv2_common::{LightningInput, LightningInputV0, OutgoingWitness};
 use secp256k1::schnorr::Signature;
 use secp256k1::KeyPair;
 use tracing::error;
@@ -41,7 +42,7 @@ impl SendStateMachine {
 pub struct SendSMCommon {
     pub operation_id: OperationId,
     pub funding_txid: TransactionId,
-    pub gateway_api: GatewayEndpoint,
+    pub gateway_api: SafeUrl,
     pub contract: OutgoingContract,
     pub invoice: LightningInvoice,
     pub refund_keypair: KeyPair,
@@ -154,7 +155,7 @@ impl SendStateMachine {
     }
 
     async fn gateway_send_payment(
-        gateway_api: GatewayEndpoint,
+        gateway_api: SafeUrl,
         federation_id: FederationId,
         contract: OutgoingContract,
         invoice: LightningInvoice,

--- a/modules/fedimint-lnv2-common/src/lib.rs
+++ b/modules/fedimint-lnv2-common/src/lib.rs
@@ -19,7 +19,6 @@ use config::LightningClientConfig;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
-use fedimint_core::util::SafeUrl;
 use fedimint_core::{extensible_associated_module_type, plugin_types_trait_impl_common};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -169,16 +168,3 @@ plugin_types_trait_impl_common!(
     LightningInputError,
     LightningOutputError
 );
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
-pub enum GatewayEndpoint {
-    Url(SafeUrl),
-}
-
-impl GatewayEndpoint {
-    pub fn into_url(self) -> SafeUrl {
-        match self {
-            GatewayEndpoint::Url(url) => url,
-        }
-    }
-}

--- a/modules/fedimint-lnv2-server/src/db.rs
+++ b/modules/fedimint-lnv2-server/src/db.rs
@@ -1,7 +1,8 @@
 use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::util::SafeUrl;
 use fedimint_core::{impl_db_lookup, impl_db_record, OutPoint, PeerId};
 use fedimint_lnv2_common::contracts::{IncomingContract, OutgoingContract};
-use fedimint_lnv2_common::{ContractId, GatewayEndpoint, LightningOutputOutcome};
+use fedimint_lnv2_common::{ContractId, LightningOutputOutcome};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
@@ -120,7 +121,7 @@ impl_db_record!(
 impl_db_lookup!(key = PreimageKey, query_prefix = PreimagePrefix);
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
-pub struct GatewayKey(pub GatewayEndpoint);
+pub struct GatewayKey(pub SafeUrl);
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct GatewayPrefix;

--- a/modules/fedimint-lnv2-tests/tests/mock.rs
+++ b/modules/fedimint-lnv2-tests/tests/mock.rs
@@ -14,7 +14,6 @@ use fedimint_lnv2_client::{
     Bolt11InvoiceDescription, GatewayError, LightningInvoice, PaymentFee, RoutingInfo,
 };
 use fedimint_lnv2_common::contracts::{IncomingContract, OutgoingContract, PaymentImage};
-use fedimint_lnv2_common::GatewayEndpoint;
 use lightning_invoice::{
     Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, DEFAULT_EXPIRY_TIME,
 };
@@ -88,7 +87,7 @@ impl Default for MockGatewayConnection {
 impl GatewayConnection for MockGatewayConnection {
     async fn routing_info(
         &self,
-        _gateway_api: GatewayEndpoint,
+        _gateway_api: SafeUrl,
         _federation_id: &FederationId,
     ) -> Result<Option<RoutingInfo>, GatewayError> {
         Ok(Some(RoutingInfo {
@@ -104,7 +103,7 @@ impl GatewayConnection for MockGatewayConnection {
 
     async fn bolt11_invoice(
         &self,
-        _gateway_api: GatewayEndpoint,
+        _gateway_api: SafeUrl,
         _federation_id: FederationId,
         contract: IncomingContract,
         invoice_amount: Amount,
@@ -130,7 +129,7 @@ impl GatewayConnection for MockGatewayConnection {
 
     async fn send_payment(
         &self,
-        _gateway_api: GatewayEndpoint,
+        _gateway_api: SafeUrl,
         _federation_id: FederationId,
         contract: OutgoingContract,
         invoice: LightningInvoice,

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -235,12 +235,12 @@ async fn receive_operation_expires() -> anyhow::Result<()> {
 
     let op = client
         .get_first_module::<LightningClientModule>()?
-        .receive_internal(
+        .receive_custom(
             Amount::from_sats(1000),
-            Some(mock::gateway_api()),
             5, // receive operation expires in 5 seconds
             Bolt11InvoiceDescription::Direct(String::new()),
             PaymentFee::RECEIVE_FEE_LIMIT_DEFAULT,
+            Some(mock::gateway_api()),
         )
         .await?
         .1;

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -54,13 +54,13 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
 
     let operation_id = client
         .get_first_module::<LightningClientModule>()?
-        .send(gateway_api.clone(), invoice.clone())
+        .send(invoice.clone(), Some(gateway_api.clone()))
         .await?;
 
     assert_eq!(
         client
             .get_first_module::<LightningClientModule>()?
-            .send(gateway_api.clone(), invoice.clone())
+            .send(invoice.clone(), Some(gateway_api.clone()))
             .await,
         Err(SendPaymentError::PendingPreviousPayment(operation_id)),
     );
@@ -78,7 +78,7 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<LightningClientModule>()?
-            .send(gateway_api, invoice)
+            .send(invoice, Some(gateway_api))
             .await,
         Err(SendPaymentError::SuccessfulPreviousPayment(operation_id)),
     );
@@ -102,7 +102,7 @@ async fn refund_failed_payment() -> anyhow::Result<()> {
 
     let op = client
         .get_first_module::<LightningClientModule>()?
-        .send(mock::gateway_api(), mock::unpayable_invoice())
+        .send(mock::unpayable_invoice(), Some(mock::gateway_api()))
         .await?;
 
     let mut sub = client
@@ -135,7 +135,7 @@ async fn unilateral_refund_of_outgoing_contracts() -> anyhow::Result<()> {
 
     let op = client
         .get_first_module::<LightningClientModule>()?
-        .send(mock::gateway_api(), mock::crash_invoice())
+        .send(mock::crash_invoice(), Some(mock::gateway_api()))
         .await?;
 
     let mut sub = client
@@ -174,7 +174,7 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
 
     let op = client
         .get_first_module::<LightningClientModule>()?
-        .send(mock::gateway_api(), mock::crash_invoice())
+        .send(mock::crash_invoice(), Some(mock::gateway_api()))
         .await?;
 
     let mut sub = client
@@ -236,8 +236,8 @@ async fn receive_operation_expires() -> anyhow::Result<()> {
     let op = client
         .get_first_module::<LightningClientModule>()?
         .receive_internal(
-            mock::gateway_api(),
             Amount::from_sats(1000),
+            Some(mock::gateway_api()),
             5, // receive operation expires in 5 seconds
             Bolt11InvoiceDescription::Direct(String::new()),
             PaymentFee::RECEIVE_FEE_LIMIT_DEFAULT,
@@ -266,7 +266,7 @@ async fn rejects_wrong_network_invoice() -> anyhow::Result<()> {
     assert_eq!(
         client
             .get_first_module::<LightningClientModule>()?
-            .send(mock::gateway_api(), mock::signet_bolt_11_invoice())
+            .send(mock::signet_bolt_11_invoice(), Some(mock::gateway_api()))
             .await
             .expect_err("send did not fail due to incorrect Currency"),
         SendPaymentError::WrongCurrency {


### PR DESCRIPTION
Currently LNV2 api requires you to specify the gateway api by url, makes it optional. Only really used in testing. In practice you would set this to none and module will choose the gateway for you.

Philosophy of LNv2: guardians set list of vetted gateways and module handles selection logic. All gatways are equal but some are more equal than others.