### PR TITLE
wasm client: rpc stream updates

### DIFF
--- a/fedimint-client-wasm/src/lib.rs
+++ b/fedimint-client-wasm/src/lib.rs
@@ -133,7 +133,9 @@ impl WasmClient {
                     let _ = match item {
                         Ok(item) => cb.call1(
                             &this,
-                            &JsValue::from_str(&serde_json::to_string(&item).unwrap()),
+                            &JsValue::from_str(
+                                &serde_json::to_string(&json!({"data": item})).unwrap(),
+                            ),
                         ),
                         Err(err) => cb.call1(
                             &this,
@@ -143,6 +145,12 @@ impl WasmClient {
                         ),
                     };
                 }
+
+                // Send the end message
+                let _ = cb.call1(
+                    &JsValue::null(),
+                    &JsValue::from_str(&serde_json::to_string(&json!({"end": null})).unwrap()),
+                );
             };
 
             let abortable_future = Abortable::new(future, abort_registration);

--- a/fedimint-client-wasm/src/lib.rs
+++ b/fedimint-client-wasm/src/lib.rs
@@ -14,6 +14,7 @@ use fedimint_core::db::Database;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_ln_client::{LightningClientInit, LightningClientModule};
 use fedimint_mint_client::MintClientInit;
+use futures::future::{AbortHandle, Abortable};
 use futures::StreamExt;
 use serde_json::json;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -22,6 +23,19 @@ use wasm_bindgen::{JsError, JsValue};
 #[wasm_bindgen]
 pub struct WasmClient {
     client: ClientHandleArc,
+}
+
+#[wasm_bindgen]
+pub struct RpcHandle {
+    abort_handle: AbortHandle,
+}
+
+#[wasm_bindgen]
+impl RpcHandle {
+    #[wasm_bindgen]
+    pub fn cancel(&self) {
+        self.abort_handle.abort();
+    }
 }
 
 #[wasm_bindgen]
@@ -93,30 +107,52 @@ impl WasmClient {
     #[wasm_bindgen]
     /// Call a fedimint client rpc the responses are returned using `cb`
     /// callback. Each rpc call *can* return multiple responses by calling
-    /// `cb` multiple times. You should ignore the promise by this function
-    /// because it has no significance.
-    pub async fn rpc(&self, module: &str, method: &str, payload: String, cb: &js_sys::Function) {
-        let mut stream = pin!(self.rpc_inner(module, method, payload));
+    /// `cb` multiple times. The returned RpcHandle can be used to cancel the
+    /// operation.
+    pub fn rpc(
+        &self,
+        module: &str,
+        method: &str,
+        payload: String,
+        cb: &js_sys::Function,
+    ) -> RpcHandle {
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        let rpc_handle = RpcHandle { abort_handle };
 
-        while let Some(item) = stream.next().await {
-            let this = JsValue::null();
-            let _ = match item {
-                Ok(item) => cb.call1(
-                    &this,
-                    &JsValue::from_str(&serde_json::to_string(&item).unwrap()),
-                ),
-                Err(err) => cb.call1(
-                    &this,
-                    &JsValue::from_str(
-                        &serde_json::to_string(&json!({"error": err.to_string()})).unwrap(),
-                    ),
-                ),
+        let client = self.client.clone();
+        let module = module.to_string();
+        let method = method.to_string();
+        let cb = cb.clone();
+
+        wasm_bindgen_futures::spawn_local(async move {
+            let future = async {
+                let mut stream = pin!(Self::rpc_inner(&client, &module, &method, payload));
+
+                while let Some(item) = stream.next().await {
+                    let this = JsValue::null();
+                    let _ = match item {
+                        Ok(item) => cb.call1(
+                            &this,
+                            &JsValue::from_str(&serde_json::to_string(&item).unwrap()),
+                        ),
+                        Err(err) => cb.call1(
+                            &this,
+                            &JsValue::from_str(
+                                &serde_json::to_string(&json!({"error": err.to_string()})).unwrap(),
+                            ),
+                        ),
+                    };
+                }
             };
-        }
-    }
 
+            let abortable_future = Abortable::new(future, abort_registration);
+            let _ = abortable_future.await;
+        });
+
+        rpc_handle
+    }
     fn rpc_inner<'a>(
-        &'a self,
+        client: &'a ClientHandleArc,
         module: &'a str,
         method: &'a str,
         payload: String,
@@ -125,14 +161,13 @@ impl WasmClient {
             let payload: serde_json::Value = serde_json::from_str(&payload)?;
             match module {
                 "" => {
-                    let mut stream = self.client.handle_global_rpc(method.to_owned(), payload);
+                    let mut stream = client.handle_global_rpc(method.to_owned(), payload);
                     while let Some(item) = stream.next().await {
                         yield item?;
                     }
                 }
                 "ln" => {
-                    let ln = self
-                        .client
+                    let ln = client
                         .get_first_module::<LightningClientModule>()?
                         .inner();
                     let mut stream = ln.handle_rpc(method.to_owned(), payload).await;
@@ -141,8 +176,7 @@ impl WasmClient {
                     }
                 }
                 "mint" => {
-                    let mint = self
-                        .client
+                    let mint = client
                         .get_first_module::<fedimint_mint_client::MintClientModule>()?
                         .inner();
                     let mut stream = mint.handle_rpc(method.to_owned(), payload).await;


### PR DESCRIPTION
makes stream cancellable
sends end event for stream

based on requests from frontend. 

see commits
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
