### PR TITLE
chore: update nix flake

### DIFF
--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -80,18 +80,16 @@ impl BitcoinRpcConfig {
     pub fn get_defaults_from_env_vars() -> anyhow::Result<Self> {
         Ok(Self {
             kind: env::var(FM_DEFAULT_BITCOIN_RPC_KIND_ENV)
-                .or_else(|_| env::var(FM_BITCOIN_RPC_KIND_ENV).map(|v| {
+                .or_else(|_| env::var(FM_BITCOIN_RPC_KIND_ENV).inspect(|_v| {
                     warn!(target: LOG_CORE, "{FM_BITCOIN_RPC_KIND_ENV} is obsolete, use {FM_DEFAULT_BITCOIN_RPC_KIND_ENV} instead");
-                    v
                 })
                 )
                 .with_context(|| {
                     anyhow::anyhow!("failure looking up env var {FM_DEFAULT_BITCOIN_RPC_KIND_ENV}")
                 })?,
             url: env::var(FM_DEFAULT_BITCOIN_RPC_URL_ENV)
-                .or_else(|_| env::var(FM_BITCOIN_RPC_URL_ENV).map(|v| {
+                .or_else(|_| env::var(FM_BITCOIN_RPC_URL_ENV).inspect(|_v| {
                     warn!(target: LOG_CORE, "{FM_BITCOIN_RPC_URL_ENV} is obsolete, use {FM_DEFAULT_BITCOIN_RPC_URL_ENV} instead");
-                    v
                 })
                 )
                 .with_context(|| {

--- a/fedimint-server/src/net/framed.rs
+++ b/fedimint-server/src/net/framed.rs
@@ -189,12 +189,11 @@ where
         assert_eq!(dst.len(), old_len + 8);
 
         // Then we serialize the message into the buffer
-        bincode::serialize_into(dst.writer(), &item).map_err(|e| {
+        bincode::serialize_into(dst.writer(), &item).inspect_err(|_e| {
             error!(
                 target: LOG_NET_PEER,
                 "Serializing message failed: {:?}", item
             );
-            e
         })?;
 
         // Lastly we update the length field by counting how many bytes have been

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -117,7 +117,7 @@ mod tests {
     use futures::StreamExt;
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    use super::*;
+    use super::{client, faucet, Result};
 
     #[wasm_bindgen_test]
     async fn build_client() -> Result<()> {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1723840407,
-        "narHash": "sha256-AZI593yLh4lcKJdAnnjyLMKUm5PMDpFy1APIYFURLyI=",
+        "lastModified": 1725883717,
+        "narHash": "sha256-QifFNLfu5bzKPO4iznCj1h+nHhqGZ8NR2Lo7tzh9FRc=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "201638b35a3e85b7794e84cc73f876d7a2b7ad51",
+        "rev": "7fbf1e630ae52b7b364791a107b5bee5ff929496",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1724049063,
-        "narHash": "sha256-aTnh9Ar40OaT2MTULeJMR9EIrylKeKUYWP61QEZBu0Q=",
+        "lastModified": 1725863722,
+        "narHash": "sha256-YBcCMVp9RrN2rgqhsMhpu/iw7L8z17N4fp4A129IZ3w=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "94c18bf5acb3966b07cc863bd00f4f959c0c5ec4",
+        "rev": "c30b094741641eef4a7200a5d52a8a16f0f345c6",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1723938990,
-        "narHash": "sha256-9tUadhnZQbWIiYVXH8ncfGXGvkNq3Hag4RCBEMUk7MI=",
+        "lastModified": 1725693463,
+        "narHash": "sha256-ZPzhebbWBOr0zRWW10FfqfbJlan3G96/h3uqhiFqmwg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c42fcfbdfeae23e68fc520f9182dde9f38ad1890",
+        "rev": "68e7dce0a6532e876980764167ad158174402c6f",
         "type": "github"
       },
       "original": {
@@ -355,11 +355,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1723915239,
-        "narHash": "sha256-x/RXN/ougJ1IEoBKrY0UijB530OfOfICK4KPa3Kj9Bk=",
+        "lastModified": 1725630423,
+        "narHash": "sha256-gNCLk3Zg7JlAwmWbVHTH6f3+iqdeQ4fheOotCZy8x5M=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "fa003262474185fd62168379500fe906b331824b",
+        "rev": "08c7bbc2dbe4dcc8968484f1a0e1e6fe7a1d4f6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
One of the flakes being updated bumps the rust version, which introduces some new clippy rules, hence a few rust diffs here