### PR TITLE
fix: find_by_prefix should guarantee order

### DIFF
--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -797,7 +797,7 @@ pub trait IDatabaseTransactionOpsCore: MaybeSend {
     async fn raw_remove_entry(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
     /// Returns an stream of key-value pairs with keys that start with
-    /// `key_prefix`. No particular ordering is guaranteed.
+    /// `key_prefix`, sorted by key.
     async fn raw_find_by_prefix(&mut self, key_prefix: &[u8]) -> Result<PrefixStream<'_>>;
 
     /// Same as [`Self::raw_find_by_prefix`] but the order is descending by key.
@@ -2336,12 +2336,12 @@ mod test_utils {
         // Verify finding by prefix returns the correct set of key pairs
         let mut dbtx = db.begin_transaction().await;
 
-        let mut returned_keys = dbtx
+        let returned_keys = dbtx
             .find_by_prefix(&DbPrefixTestPrefix)
             .await
             .collect::<Vec<_>>()
             .await;
-        returned_keys.sort();
+
         let expected = vec![(TestKey(54), TestVal(8888)), (TestKey(55), TestVal(9999))];
         assert_eq!(returned_keys, expected);
 
@@ -2354,12 +2354,12 @@ mod test_utils {
         reversed_expected.reverse();
         assert_eq!(reversed, reversed_expected);
 
-        let mut returned_keys = dbtx
+        let returned_keys = dbtx
             .find_by_prefix(&AltDbPrefixTestPrefix)
             .await
             .collect::<Vec<_>>()
             .await;
-        returned_keys.sort();
+
         let expected = vec![
             (AltTestKey(54), TestVal(6666)),
             (AltTestKey(55), TestVal(7777)),


### PR DESCRIPTION
It's already the case, yet in the interface documentation we don't commit to it. I'm quite sure there are already parts of the code that depend on it anyway.

In a system like ours any form of non-determism is unwelcomed. I rather have the db impls have to do the sorting, than all users need to sort. Especially that for all kv stores, sorting should come naturally.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
