### PR TITLE
chore: devfed waits for channel funding txs before mining blocks

### DIFF
--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -18,7 +18,7 @@ use lightning_invoice::{
 use ln_gateway::gateway_lnrpc::{
     self, CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse,
     EmptyResponse, GetBalancesResponse, GetLnOnchainAddressResponse, GetNodeInfoResponse,
-    GetRouteHintsResponse, InterceptHtlcResponse, PayInvoiceResponse,
+    GetRouteHintsResponse, InterceptHtlcResponse, OpenChannelResponse, PayInvoiceResponse,
 };
 use ln_gateway::lightning::{
     ChannelInfo, HtlcResult, ILnRpcClient, LightningRpcError, RouteHtlcStream,
@@ -268,7 +268,7 @@ impl ILnRpcClient for FakeLightningTest {
         _host: String,
         _channel_size_sats: u64,
         _push_amount_sats: u64,
-    ) -> Result<EmptyResponse, LightningRpcError> {
+    ) -> Result<OpenChannelResponse, LightningRpcError> {
         Err(LightningRpcError::FailedToOpenChannel {
             failure_reason: "FakeLightningTest does not support opening channels".to_string(),
         })

--- a/gateway/cli/src/lightning_commands.rs
+++ b/gateway/cli/src/lightning_commands.rs
@@ -132,7 +132,7 @@ impl LightningCommands {
                 channel_size_sats,
                 push_amount_sats,
             } => {
-                create_client()
+                let funding_txid = create_client()
                     .open_channel(OpenChannelPayload {
                         pubkey,
                         host,
@@ -140,6 +140,7 @@ impl LightningCommands {
                         push_amount_sats: push_amount_sats.unwrap_or(0),
                     })
                     .await?;
+                println!("{funding_txid}");
             }
             Self::CloseChannelsWithPeer { pubkey } => {
                 let response = create_client()

--- a/gateway/ln-gateway/proto/gateway_lnrpc.proto
+++ b/gateway/ln-gateway/proto/gateway_lnrpc.proto
@@ -40,7 +40,7 @@ service GatewayLightning {
   rpc GetLnOnchainAddress(EmptyRequest) returns (GetLnOnchainAddressResponse) {}
 
   /* Open a channel on the underlying lightning node. */
-  rpc OpenChannel(OpenChannelRequest) returns (EmptyResponse) {}
+  rpc OpenChannel(OpenChannelRequest) returns (OpenChannelResponse) {}
 
   /* Close all channels with a given peer on the underlying lightning node. */
   rpc CloseChannelsWithPeer(CloseChannelsWithPeerRequest) returns (CloseChannelsWithPeerResponse) {}
@@ -292,6 +292,11 @@ message OpenChannelRequest {
   // The amount of sats that should be pushed to the
   // counterparty once the channel is opened.
   uint64 push_amount_sats = 3;
+}
+
+message OpenChannelResponse {
+    // The txid of the channel funding transaction.
+    string funding_txid = 1;
 }
 
 message CloseChannelsWithPeerRequest {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1335,13 +1335,17 @@ impl Gateway {
             channel_size_sats,
             push_amount_sats,
         }: OpenChannelPayload,
-    ) -> Result<()> {
+    ) -> Result<Txid> {
         let context = self.get_lightning_context().await?;
-        context
+        let res = context
             .lnrpc
             .open_channel(pubkey, host, channel_size_sats, push_amount_sats)
             .await?;
-        Ok(())
+        Txid::from_str(&res.funding_txid).map_err(|e| {
+            GatewayError::InvalidMetadata(format!(
+                "Received invalid channel funding txid string: {e}"
+            ))
+        })
     }
 
     /// Instructs the Gateway's Lightning node to close all channels with a peer

--- a/gateway/ln-gateway/src/lightning/cln.rs
+++ b/gateway/ln-gateway/src/lightning/cln.rs
@@ -18,7 +18,8 @@ use crate::gateway_lnrpc::{
     self, CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
     CreateInvoiceResponse, EmptyRequest, EmptyResponse, GetBalancesResponse,
     GetLnOnchainAddressResponse, GetNodeInfoResponse, GetRouteHintsRequest, GetRouteHintsResponse,
-    InterceptHtlcResponse, OpenChannelRequest, PayInvoiceResponse, PayPrunedInvoiceRequest,
+    InterceptHtlcResponse, OpenChannelRequest, OpenChannelResponse, PayInvoiceResponse,
+    PayPrunedInvoiceRequest,
 };
 use crate::lightning::MAX_LIGHTNING_RETRIES;
 
@@ -188,7 +189,7 @@ impl ILnRpcClient for NetworkLnRpcClient {
         host: String,
         channel_size_sats: u64,
         push_amount_sats: u64,
-    ) -> Result<EmptyResponse, LightningRpcError> {
+    ) -> Result<OpenChannelResponse, LightningRpcError> {
         let mut client = self.connect().await?;
 
         let res = client

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -33,7 +33,7 @@ use crate::envs::{
 use crate::gateway_lnrpc::{
     CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse, EmptyResponse,
     GetBalancesResponse, GetLnOnchainAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse,
-    InterceptHtlcRequest, InterceptHtlcResponse, PayInvoiceResponse,
+    InterceptHtlcRequest, InterceptHtlcResponse, OpenChannelResponse, PayInvoiceResponse,
 };
 use crate::GatewayError;
 
@@ -181,7 +181,7 @@ pub trait ILnRpcClient: Debug + Send + Sync {
         host: String,
         channel_size_sats: u64,
         push_amount_sats: u64,
-    ) -> Result<EmptyResponse, LightningRpcError>;
+    ) -> Result<OpenChannelResponse, LightningRpcError>;
 
     /// Close all channels with a peer lightning node from the gateway's
     /// lightning node.

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -1,5 +1,5 @@
 use bitcoin::address::NetworkUnchecked;
-use bitcoin::Address;
+use bitcoin::{Address, Txid};
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, TransactionId};
 use fedimint_ln_common::gateway_endpoint_constants::{
@@ -175,7 +175,7 @@ impl GatewayRpcClient {
         self.call_post(url, payload).await
     }
 
-    pub async fn open_channel(&self, payload: OpenChannelPayload) -> GatewayRpcResult<()> {
+    pub async fn open_channel(&self, payload: OpenChannelPayload) -> GatewayRpcResult<Txid> {
         let url = self
             .base_url
             .join(OPEN_CHANNEL_ENDPOINT)

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -364,8 +364,8 @@ async fn open_channel(
     Extension(gateway): Extension<Arc<Gateway>>,
     Json(payload): Json<OpenChannelPayload>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    gateway.handle_open_channel_msg(payload).await?;
-    Ok(Json(json!(())))
+    let funding_txid = gateway.handle_open_channel_msg(payload).await?;
+    Ok(Json(json!(funding_txid)))
 }
 
 #[instrument(skip_all, err, fields(?payload))]


### PR DESCRIPTION
Change `ILnRpcClient::open_channel()` to return the channel funding TXID, and set devfed to wait for those TXIDs to be present in the bitcoind mempool before mining blocks. Previously we were just blindly waiting, requiring that we waited significantly longer than needed in order to prevent flakiness.

`just mprocs` startup speed tests on my M1 Pro machine:

Before:
66.0s, 74.0s, 64.2s, 64.3s, 66.2s, 66.7s, 63.8s, 64.0s, 64.0s, 66.4s
Average: 65.96s

After:
55.8s, 54.5s, 56.0s, 54.3s, 56.4s, 54.8s, 54.5s, 56.5s, 63.8s, 54.1s
Average: 56.07s

Average speed improvement of ~15%