### PR TITLE
cleanup: cleanup lnv2 module client api

### DIFF
--- a/crypto/tpe/src/lib.rs
+++ b/crypto/tpe/src/lib.rs
@@ -42,6 +42,10 @@ pub struct CipherText {
     pub signature: EphemeralSignature,
 }
 
+pub fn derive_public_key_share(sk: &SecretKeyShare) -> PublicKeyShare {
+    PublicKeyShare(G1Projective::generator().mul(sk.0).to_affine())
+}
+
 pub fn encrypt_preimage(
     agg_pk: &AggregatePublicKey,
     encryption_seed: &[u8; 32],

--- a/gateway/ln-gateway/src/gateway_module_v2/mod.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/mod.rs
@@ -295,7 +295,7 @@ impl GatewayClientModuleV2 {
             .await?
             .ok_or(anyhow!("Routing Info not available"))?
             .send_fee_minimum
-            .add_fee(amount);
+            .add_to(amount);
 
         let send_sm = GatewayClientStateMachinesV2::Send(SendStateMachine {
             common: SendSMCommon {

--- a/modules/fedimint-lnv2-client/Cargo.toml
+++ b/modules/fedimint-lnv2-client/Cargo.toml
@@ -12,7 +12,7 @@ normal = ["aquamarine"]
 
 [features]
 default = []
-cli = ["dep:clap", "dep:serde_json"]
+cli = ["dep:clap"]
 
 [lib]
 name = "fedimint_lnv2_client"
@@ -36,7 +36,7 @@ lightning-invoice = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true, optional = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tpe = { workspace = true }
 tracing = { workspace = true }

--- a/modules/fedimint-lnv2-client/src/api.rs
+++ b/modules/fedimint-lnv2-client/src/api.rs
@@ -186,9 +186,9 @@ pub trait GatewayConnection: std::fmt::Debug {
         gateway_api: SafeUrl,
         federation_id: FederationId,
         contract: IncomingContract,
-        invoice_amount: Amount,
+        amount: Amount,
         description: Bolt11InvoiceDescription,
-        expiry_time: u32,
+        expiry_secs: u32,
     ) -> Result<Bolt11Invoice, GatewayConnectionError>;
 
     async fn send_payment(
@@ -232,9 +232,9 @@ impl GatewayConnection for RealGatewayConnection {
         gateway_api: SafeUrl,
         federation_id: FederationId,
         contract: IncomingContract,
-        invoice_amount: Amount,
+        amount: Amount,
         description: Bolt11InvoiceDescription,
-        expiry_time: u32,
+        expiry_secs: u32,
     ) -> Result<Bolt11Invoice, GatewayConnectionError> {
         reqwest::Client::new()
             .post(
@@ -246,9 +246,9 @@ impl GatewayConnection for RealGatewayConnection {
             .json(&CreateBolt11InvoicePayload {
                 federation_id,
                 contract,
-                invoice_amount,
+                amount,
                 description,
-                expiry_time,
+                expiry_secs,
             })
             .send()
             .await

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -46,6 +46,7 @@ use lightning_invoice::{Bolt11Invoice, Currency};
 use secp256k1::schnorr::Signature;
 use secp256k1::{ecdh, KeyPair, PublicKey, Scalar, SecretKey};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use thiserror::Error;
 use tpe::{derive_agg_decryption_key, AggregateDecryptionKey, AggregatePublicKey, PublicKeyShare};
 
@@ -66,11 +67,37 @@ pub struct SendOperationMeta {
     pub gateway_api: SafeUrl,
     pub contract: OutgoingContract,
     pub invoice: Bolt11Invoice,
+    pub custom_meta: Value,
+}
+
+impl SendOperationMeta {
+    /// Calculate the absolute fee paid to the gateway on success.
+    pub fn gateway_fee(&self) -> Amount {
+        self.contract.amount
+            - Amount::from_msats(
+                self.invoice
+                    .amount_milli_satoshis()
+                    .expect("Invoice has amount"),
+            )
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReceiveOperationMeta {
     pub contract: IncomingContract,
+    pub invoice: Bolt11Invoice,
+    pub custom_meta: Value,
+}
+
+impl ReceiveOperationMeta {
+    /// Calculate the absolute fee paid to the gateway on success.
+    pub fn gateway_fee(&self) -> Amount {
+        Amount::from_msats(
+            self.invoice
+                .amount_milli_satoshis()
+                .expect("Invoice has amount"),
+        ) - self.contract.commitment.amount
+    }
 }
 
 /// Number of blocks until outgoing lightning contracts times out and user
@@ -103,18 +130,27 @@ pub const INVOICE_EXPIRATION_SECONDS_DEFAULT: u32 = 24 * 60 * 60;
 /// misbehaves.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SendState {
+    /// We are funding the outgoing contract.
     Funding,
+    /// We are waiting for the gateway to complete the payment.
     Funded,
+    /// The payment was successful.
     Success,
+    /// The payment has failed. We are refunding the outgoing contract.
     Refunding,
+    /// The outgoing contract has been refunded.
     Refunded,
+    /// Either a programming error has occurred or the federation is malicious.
     Failure,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum FinalSendState {
+    /// The payment was successful.
     Success,
+    /// The outgoing contract has been refunded.
     Refunded,
+    /// Either a programming error has occurred or the federation is malicious.
     Failure,
 }
 
@@ -134,38 +170,46 @@ pub type SendResult = Result<OperationId, SendPaymentError>;
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ReceiveState {
+    /// We are waititng for the gateway to fund the incoming contract.
     Pending,
+    /// The incoming contract has expired.
     Expired,
+    /// The gateway has funded the incoming contract.
     Claiming,
+    /// The payment was successful.
     Claimed,
+    /// Either a programming error has occurred or the federation is malicious.
     Failure,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum FinalReceiveState {
+    /// The incoming contract has expired.
     Expired,
+    /// The payment was successful.
     Claimed,
+    /// Either a programming error has occurred or the federation is malicious.
     Failure,
 }
 
-pub type ReceiveResult = Result<(Bolt11Invoice, OperationId), FetchInvoiceError>;
+pub type ReceiveResult = Result<(Bolt11Invoice, OperationId), ReceiveError>;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CreateBolt11InvoicePayload {
     pub federation_id: FederationId,
     pub contract: IncomingContract,
-    pub invoice_amount: Amount,
+    pub amount: Amount,
     pub description: Bolt11InvoiceDescription,
-    pub expiry_time: u32,
+    pub expiry_secs: u32,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Bolt11InvoiceDescription {
     Direct(String),
     Hash(sha256::Hash),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct SendPaymentPayload {
     pub federation_id: FederationId,
     pub contract: OutgoingContract,
@@ -178,7 +222,7 @@ pub enum LightningInvoice {
     Bolt11(Bolt11Invoice),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Decodable, Encodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct RoutingInfo {
     /// The public key of the gateways lightning node. Since this key signs the
     /// gateways invoices the senders client uses it to differentiate between a
@@ -192,10 +236,8 @@ pub struct RoutingInfo {
     pub send_fee_minimum: PaymentFee,
     /// This is the default total fee the gateway recommends for an outgoing
     /// payment in case of a lightning swap. It accounts for the additional fee
-    /// required to successfully route this payment over lightning.
+    /// required to reliably route this payment over lightning.
     pub send_fee_default: PaymentFee,
-    /// This is the fee the gateway charges for an incoming payment.
-    pub receive_fee: PaymentFee,
     /// This is the minimum expiration delta in block the gateway requires for
     /// an outgoing payment. The senders client will use this expiration delta
     /// in case of a direct swap.
@@ -205,6 +247,8 @@ pub struct RoutingInfo {
     /// additional expiration delta required to successfully route this payment
     /// over lightning.
     pub expiration_delta_default: u64,
+    /// This is the fee the gateway charges for an incoming payment.
+    pub receive_fee: PaymentFee,
 }
 
 impl RoutingInfo {
@@ -217,44 +261,37 @@ impl RoutingInfo {
     }
 }
 
-#[derive(
-    Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize, Decodable, Encodable,
-)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct PaymentFee {
     pub base: Amount,
     pub parts_per_million: u64,
 }
 
-const DUST_LIMIT: Amount = Amount::from_sats(50);
-
 impl PaymentFee {
-    pub const SEND_FEE_MINIMUM: PaymentFee = PaymentFee {
-        base: DUST_LIMIT,
-        parts_per_million: 5_000,
-    };
-
-    // The difference between the SEND_FEE_LIMIT_DEFAULT and the SEND_FEE_MINIMUM
-    // leaves the gateway with a limit of one percent + 50 sats for lightning
-    // routing fees which is the LDK default
+    /// This is the maximum send fee of one and a half percent plus one hundred
+    /// satoshis a correct gateway may recommend as a default. It accounts for
+    /// the fee required to reliably route this payment over lightning.
     pub const SEND_FEE_LIMIT_DEFAULT: PaymentFee = PaymentFee {
         base: Amount::from_sats(100),
         parts_per_million: 15_000,
     };
 
+    /// This is the maximum receive fee of half of one percent plus fifty
+    /// satoshis a correct gateway may recommend as a default.
     pub const RECEIVE_FEE_LIMIT_DEFAULT: PaymentFee = PaymentFee {
-        base: DUST_LIMIT,
+        base: Amount::from_sats(50),
         parts_per_million: 5_000,
     };
 
-    pub fn add_fee(&self, msats: u64) -> Amount {
-        Amount::from_msats(msats.saturating_add(self.fee(msats)))
+    pub fn add_to(&self, msats: u64) -> Amount {
+        Amount::from_msats(msats.saturating_add(self.absolute_fee(msats)))
     }
 
-    pub fn subtract_fee(&self, msats: u64) -> Amount {
-        Amount::from_msats(msats.saturating_sub(self.fee(msats)))
+    pub fn subtract_from(&self, msats: u64) -> Amount {
+        Amount::from_msats(msats.saturating_sub(self.absolute_fee(msats)))
     }
 
-    fn fee(&self, msats: u64) -> u64 {
+    fn absolute_fee(&self, msats: u64) -> u64 {
         self.base.msats
             + msats
                 .saturating_mul(self.parts_per_million)
@@ -284,7 +321,7 @@ impl ModuleInit for LightningClientInit {
         _dbtx: &mut DatabaseTransaction<'_>,
         _prefix_names: Vec<String>,
     ) -> Box<dyn Iterator<Item = (String, Box<dyn erased_serde::Serialize + Send>)> + '_> {
-        todo!()
+        Box::new(BTreeMap::new().into_iter())
     }
 }
 
@@ -437,6 +474,7 @@ impl LightningClientModule {
             PaymentFee::SEND_FEE_LIMIT_DEFAULT,
             EXPIRATION_DELTA_LIMIT_DEFAULT,
             gateway_api,
+            Value::Null,
         )
         .await
     }
@@ -449,6 +487,7 @@ impl LightningClientModule {
         payment_fee_limit: PaymentFee,
         expiration_delta_limit: u64,
         gateway_api: Option<SafeUrl>,
+        custom_meta: Value,
     ) -> Result<OperationId, SendPaymentError> {
         let amount = invoice
             .amount_milli_satoshis()
@@ -507,7 +546,7 @@ impl LightningClientModule {
 
         let contract = OutgoingContract {
             payment_image: PaymentImage::Hash(*invoice.payment_hash()),
-            amount: send_fee.add_fee(amount),
+            amount: send_fee.add_to(amount),
             expiration: consensus_block_count + expiration_delta + CONTRACT_CONFIRMATION_BUFFER,
             claim_pk: routing_info.module_public_key,
             refund_pk: refund_keypair.public_key(),
@@ -550,6 +589,7 @@ impl LightningClientModule {
                         gateway_api: gateway_api.clone(),
                         contract: contract.clone(),
                         invoice: invoice.clone(),
+                        custom_meta: custom_meta.clone(),
                     })
                 },
                 transaction,
@@ -593,8 +633,7 @@ impl LightningClientModule {
         panic!("We could not find an unused operation id for sending a lightning payment");
     }
 
-    /// Subscribe to all updates of the send operation. No specific order is not
-    /// guaranteed.
+    /// Subscribe to all updates of the send operation.
     pub async fn subscribe_send(
         &self,
         operation_id: OperationId,
@@ -677,17 +716,14 @@ impl LightningClientModule {
     /// Request an invoice. For testing you can optionally specify a gateway to
     /// generate the invoice, otherwise a gateway will be selected
     /// automatically.
-    pub async fn receive(
-        &self,
-        invoice_amount: Amount,
-        gateway_api: Option<SafeUrl>,
-    ) -> ReceiveResult {
+    pub async fn receive(&self, amount: Amount, gateway_api: Option<SafeUrl>) -> ReceiveResult {
         self.receive_custom(
-            invoice_amount,
+            amount,
             INVOICE_EXPIRATION_SECONDS_DEFAULT,
             Bolt11InvoiceDescription::Direct(String::new()),
             PaymentFee::RECEIVE_FEE_LIMIT_DEFAULT,
             gateway_api,
+            Value::Null,
         )
         .await
     }
@@ -697,17 +733,18 @@ impl LightningClientModule {
     /// automatically.
     pub async fn receive_custom(
         &self,
-        invoice_amount: Amount,
-        expiry_time: u32,
+        amount: Amount,
+        expiry_secs: u32,
         description: Bolt11InvoiceDescription,
         payment_fee_limit: PaymentFee,
         gateway_api: Option<SafeUrl>,
-    ) -> Result<(Bolt11Invoice, OperationId), FetchInvoiceError> {
-        let (contract, .., invoice) = self
-            .create_contract_and_fetch_invoice_custom(
+        custom_meta: Value,
+    ) -> Result<(Bolt11Invoice, OperationId), ReceiveError> {
+        let (contract, invoice) = self
+            .create_contract_and_fetch_invoice(
                 self.keypair.public_key(),
-                invoice_amount,
-                expiry_time,
+                amount,
+                expiry_secs,
                 description,
                 payment_fee_limit,
                 gateway_api,
@@ -715,7 +752,7 @@ impl LightningClientModule {
             .await?;
 
         let operation_id = self
-            .receive_incoming_contract(contract)
+            .receive_incoming_contract(contract, invoice.clone(), custom_meta)
             .await
             .expect("The contract has been generated with our public key");
 
@@ -724,42 +761,16 @@ impl LightningClientModule {
 
     /// Create an incoming contract locked to a public key derived from the
     /// recipient's static module public key and fetches the corresponding
-    /// invoice. To receive the payment the recipient needs to call
-    /// [`Self::receive_incoming_contract`] on the returned contract. For
-    /// testing you can optionally specify a gateway to generate the
-    /// invoice, otherwise a gateway will be selected automatically.
-    pub async fn create_contract_and_fetch_invoice(
+    /// invoice.
+    async fn create_contract_and_fetch_invoice(
         &self,
         recipient_static_pk: PublicKey,
-        invoice_amount: Amount,
-        gateway_api: Option<SafeUrl>,
-    ) -> Result<(IncomingContract, [u8; 32], Bolt11Invoice), FetchInvoiceError> {
-        self.create_contract_and_fetch_invoice_custom(
-            recipient_static_pk,
-            invoice_amount,
-            INVOICE_EXPIRATION_SECONDS_DEFAULT,
-            Bolt11InvoiceDescription::Direct(String::new()),
-            PaymentFee::RECEIVE_FEE_LIMIT_DEFAULT,
-            gateway_api,
-        )
-        .await
-    }
-
-    /// Create an incoming contract locked to a public key derived from the
-    /// recipient's static module public key and fetches the corresponding
-    /// invoice. To receive the payment the recipient needs to call
-    /// [`Self::receive_incoming_contract`] on the returned contract. For
-    /// testing you can optionally specify a gateway to generate the
-    /// invoice, otherwise a gateway will be selected automatically.
-    pub async fn create_contract_and_fetch_invoice_custom(
-        &self,
-        recipient_static_pk: PublicKey,
-        invoice_amount: Amount,
-        expiry_time: u32,
+        amount: Amount,
+        expiry_secs: u32,
         description: Bolt11InvoiceDescription,
         payment_fee_limit: PaymentFee,
         gateway_api: Option<SafeUrl>,
-    ) -> Result<(IncomingContract, [u8; 32], Bolt11Invoice), FetchInvoiceError> {
+    ) -> Result<(IncomingContract, Bolt11Invoice), ReceiveError> {
         let (ephemeral_tweak, ephemeral_pk) = generate_ephemeral_tweak(recipient_static_pk);
 
         let encryption_seed = ephemeral_tweak
@@ -775,32 +786,32 @@ impl LightningClientModule {
                 gateway_api.clone(),
                 self.routing_info(&gateway_api)
                     .await
-                    .map_err(FetchInvoiceError::GatewayConnectionError)?
-                    .ok_or(FetchInvoiceError::UnknownFederation)?,
+                    .map_err(ReceiveError::GatewayConnectionError)?
+                    .ok_or(ReceiveError::UnknownFederation)?,
             ),
             None => self
                 .select_gateway()
                 .await
-                .map_err(FetchInvoiceError::FailedToSelectGateway)?,
+                .map_err(ReceiveError::FailedToSelectGateway)?,
         };
 
         if !routing_info.receive_fee.le(&payment_fee_limit) {
-            return Err(FetchInvoiceError::PaymentFeeExceedsLimit(
+            return Err(ReceiveError::PaymentFeeExceedsLimit(
                 routing_info.receive_fee,
             ));
         }
 
-        let contract_amount = routing_info.receive_fee.subtract_fee(invoice_amount.msats);
+        let contract_amount = routing_info.receive_fee.subtract_from(amount.msats);
 
         // The dust limit ensures that the incoming contract can be claimed without
         // additional funds as the contracts amount is sufficient to cover the fees
-        if contract_amount < DUST_LIMIT {
-            return Err(FetchInvoiceError::DustAmount);
+        if contract_amount < Amount::from_sats(50) {
+            return Err(ReceiveError::DustAmount);
         }
 
         let expiration = duration_since_epoch()
             .as_secs()
-            .saturating_add(u64::from(expiry_time));
+            .saturating_add(u64::from(expiry_secs));
 
         let claim_pk = recipient_static_pk
             .mul_tweak(
@@ -827,38 +838,31 @@ impl LightningClientModule {
                 gateway_api,
                 self.federation_id,
                 contract.clone(),
-                invoice_amount,
+                amount,
                 description,
-                expiry_time,
+                expiry_secs,
             )
             .await
-            .map_err(FetchInvoiceError::GatewayConnectionError)?;
+            .map_err(ReceiveError::GatewayConnectionError)?;
 
         if invoice.payment_hash() != &preimage.consensus_hash() {
-            return Err(FetchInvoiceError::InvalidInvoicePaymentHash);
+            return Err(ReceiveError::InvalidInvoicePaymentHash);
         }
 
-        if invoice.amount_milli_satoshis() != Some(invoice_amount.msats) {
-            return Err(FetchInvoiceError::InvalidInvoiceAmount);
+        if invoice.amount_milli_satoshis() != Some(amount.msats) {
+            return Err(ReceiveError::InvalidInvoiceAmount);
         }
 
-        Ok((contract, preimage, invoice))
+        Ok((contract, invoice))
     }
 
-    /// Await an incoming contract to be confirmed or to expire. The return
-    /// value indicates whether the contract was confirmed in time.
-    pub async fn await_incoming_contract(&self, contract: IncomingContract) -> bool {
-        self.module_api
-            .await_incoming_contract(&contract.contract_id(), contract.commitment.expiration)
-            .await
-    }
-
-    /// Receive an incoming contract locked to a public key derived from our
-    /// static module public key such as a contract generated by a lightning
-    /// address provider.
-    pub async fn receive_incoming_contract(
+    // Receive an incoming contract locked to a public key derived from our
+    // static module public key.
+    async fn receive_incoming_contract(
         &self,
         contract: IncomingContract,
+        invoice: Bolt11Invoice,
+        custom_meta: Value,
     ) -> Option<OperationId> {
         let operation_id = OperationId::from_encodable(&contract.clone());
 
@@ -880,7 +884,11 @@ impl LightningClientModule {
             .manual_operation_start(
                 operation_id,
                 LightningCommonInit::KIND.as_str(),
-                LightningOperationMeta::Receive(ReceiveOperationMeta { contract }),
+                LightningOperationMeta::Receive(ReceiveOperationMeta {
+                    contract,
+                    invoice,
+                    custom_meta,
+                }),
                 vec![self.client_ctx.make_dyn_state(receive_sm)],
             )
             .await
@@ -925,8 +933,7 @@ impl LightningClientModule {
         Some((claim_keypair, agg_decryption_key))
     }
 
-    /// Subscribe to all updates of the receive operation. No specific order is
-    /// not guaranteed.
+    /// Subscribe to all updates of the receive operation.
     pub async fn subscribe_receive(
         &self,
         operation_id: OperationId,
@@ -1037,7 +1044,7 @@ pub enum SendPaymentError {
 }
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
-pub enum FetchInvoiceError {
+pub enum ReceiveError {
     #[error("Failed to select gateway: {0}")]
     FailedToSelectGateway(SelectGatewayError),
     #[error("Gateway connection error: {0}")]

--- a/modules/fedimint-lnv2-common/src/config.rs
+++ b/modules/fedimint-lnv2-common/src/config.rs
@@ -60,7 +60,7 @@ pub struct LightningConfigConsensus {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningConfigPrivate {
-    pub sk: SecretKeyShare,
+    pub tpe_sk: SecretKeyShare,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
@@ -154,7 +154,7 @@ fn migrate_config_private(
     config: &fedimint_ln_common::config::LightningConfigPrivate,
 ) -> LightningConfigPrivate {
     LightningConfigPrivate {
-        sk: SecretKeyShare(config.threshold_sec_key.0 .0 .0),
+        tpe_sk: SecretKeyShare(config.threshold_sec_key.0 .0 .0),
     }
 }
 
@@ -187,5 +187,10 @@ fn test_fee_consensus() {
     assert_eq!(
         FeeConsensus::default().fee(Amount::from_bitcoins(1)),
         Amount::from_sats(100_001)
+    );
+
+    assert_eq!(
+        FeeConsensus::default().fee(Amount::from_bitcoins(100_000)),
+        Amount::from_bitcoins(100) + Amount::from_sats(1)
     );
 }

--- a/modules/fedimint-lnv2-server/src/db.rs
+++ b/modules/fedimint-lnv2-server/src/db.rs
@@ -9,13 +9,13 @@ use strum_macros::EnumIter;
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
 pub enum DbKeyPrefix {
-    BlockCountVote = 0x45,
-    UnixTimeVote = 0x46,
-    IncomingContract = 0x47,
-    OutgoingContract = 0x48,
-    OutputOutcome = 0x49,
-    Preimage = 0x50,
-    Gateway = 0x51,
+    BlockCountVote = 0x41,
+    UnixTimeVote = 0x42,
+    IncomingContract = 0x43,
+    OutgoingContract = 0x44,
+    OutputOutcome = 0x45,
+    Preimage = 0x46,
+    Gateway = 0x47,
 }
 
 impl std::fmt::Display for DbKeyPrefix {

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -7,7 +7,7 @@ mod db;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use anyhow::{anyhow, ensure};
+use anyhow::{anyhow, ensure, Context};
 use bls12_381::{G1Projective, Scalar};
 use fedimint_bitcoind::{create_bitcoind, DynBitcoindRpc};
 use fedimint_core::config::{
@@ -211,7 +211,7 @@ impl ServerModuleInit for LightningInit {
                             network: params.consensus.network,
                         },
                         private: LightningConfigPrivate {
-                            sk: sks[peer.to_usize()],
+                            tpe_sk: sks[peer.to_usize()],
                         },
                     }
                     .to_erased(),
@@ -253,18 +253,26 @@ impl ServerModuleInit for LightningInit {
                 network: params.consensus.network,
             },
             private: LightningConfigPrivate {
-                sk: SecretKeyShare(sk),
+                tpe_sk: SecretKeyShare(sk),
             },
         };
 
         Ok(server.to_erased())
     }
 
-    fn validate_config(
-        &self,
-        _identity: &PeerId,
-        _config: ServerModuleConfig,
-    ) -> anyhow::Result<()> {
+    fn validate_config(&self, identity: &PeerId, config: ServerModuleConfig) -> anyhow::Result<()> {
+        let config = config.to_typed::<LightningConfig>()?;
+
+        ensure!(
+            tpe::derive_public_key_share(&config.private.tpe_sk)
+                == *config
+                    .consensus
+                    .tpe_pks
+                    .get(identity)
+                    .context("Public key set has no key for our identity")?,
+            "Preimge encryption secret key share does not match our public key share"
+        );
+
         Ok(())
     }
 
@@ -485,7 +493,7 @@ impl ServerModule for Lightning {
                     return Err(LightningOutputError::ContractAlreadyExists);
                 }
 
-                let dk_share = contract.create_decryption_key_share(&self.cfg.private.sk);
+                let dk_share = contract.create_decryption_key_share(&self.cfg.private.tpe_sk);
 
                 LightningOutputOutcomeV0::Incoming(dk_share)
             }

--- a/modules/fedimint-lnv2-tests/tests/mock.rs
+++ b/modules/fedimint-lnv2-tests/tests/mock.rs
@@ -94,10 +94,13 @@ impl GatewayConnection for MockGatewayConnection {
             lightning_public_key: self.keypair.public_key(),
             module_public_key: self.keypair.public_key(),
             send_fee_default: PaymentFee::SEND_FEE_LIMIT_DEFAULT,
-            send_fee_minimum: PaymentFee::SEND_FEE_MINIMUM,
-            receive_fee: PaymentFee::RECEIVE_FEE_LIMIT_DEFAULT,
+            send_fee_minimum: PaymentFee {
+                base: Amount::from_sats(50),
+                parts_per_million: 5_000,
+            },
             expiration_delta_default: 500,
             expiration_delta_minimum: 144,
+            receive_fee: PaymentFee::RECEIVE_FEE_LIMIT_DEFAULT,
         }))
     }
 

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -18,6 +18,7 @@ use fedimint_lnv2_common::config::LightningGenParams;
 use fedimint_lnv2_common::{LightningInput, LightningInputV0, OutgoingWitness};
 use fedimint_lnv2_server::LightningInit;
 use fedimint_testing::fixtures::Fixtures;
+use serde_json::Value;
 
 use crate::mock::{MockGatewayConnection, MOCK_INVOICE_PREIMAGE};
 
@@ -241,6 +242,7 @@ async fn receive_operation_expires() -> anyhow::Result<()> {
             Bolt11InvoiceDescription::Direct(String::new()),
             PaymentFee::RECEIVE_FEE_LIMIT_DEFAULT,
             Some(mock::gateway_api()),
+            Value::Null,
         )
         .await?
         .1;


### PR DESCRIPTION
A bunch of API cleanup, methods not used yet become private for now. Most importantly I added the invoice to the receive operation meta and provided a method to calculate the fees paid to the gateway from the meta. 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
