### PR TITLE
chore: devfed pegin setup only mines blocks once

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -250,9 +250,10 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                     let pegin_start_time = Instant::now();
                     debug!(target: LOG_DEVIMINT, "Peging in client and gateways");
 
-                    let gw_pegin_amount = 1_000_000;
-                    let client_pegin_amount = 1_000_000;
                     if !skip_setup {
+                        const GW_PEGIN_AMOUNT: u64 = 1_000_000;
+                        const CLIENT_PEGIN_AMOUNT: u64 = 1_000_000;
+
                         let (operation_id, (), (), ()) = tokio::try_join!(
                             async {
                                 let (address, operation_id) =
@@ -260,7 +261,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                                 dev_fed
                                     .bitcoind()
                                     .await?
-                                    .send_to(address, client_pegin_amount)
+                                    .send_to(address, CLIENT_PEGIN_AMOUNT)
                                     .await?;
                                 Ok(operation_id)
                             },
@@ -273,7 +274,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                                 dev_fed
                                     .bitcoind()
                                     .await?
-                                    .send_to(pegin_addr, gw_pegin_amount)
+                                    .send_to(pegin_addr, GW_PEGIN_AMOUNT)
                                     .await
                                     .map(|_| ())
                             },
@@ -286,7 +287,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                                 dev_fed
                                     .bitcoind()
                                     .await?
-                                    .send_to(pegin_addr, gw_pegin_amount)
+                                    .send_to(pegin_addr, GW_PEGIN_AMOUNT)
                                     .await
                                     .map(|_| ())
                             },
@@ -300,7 +301,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                                     dev_fed
                                         .bitcoind()
                                         .await?
-                                        .send_to(pegin_addr, gw_pegin_amount)
+                                        .send_to(pegin_addr, GW_PEGIN_AMOUNT)
                                         .await
                                         .map(|_| ())
                                 } else {


### PR DESCRIPTION
Rather than each pegin (to the global client, and to each of the 3 gateways) mining blocks, we wait for them all to finish and then mine blocks a single time. I made this change to see if it would uncover any flakiness (since, startup time aside, blocks should only need to be mined a single time), but it also appears to improve devimint startup time. My best guess as to why is that the gateways having fewer blocks to sync speeds up time-to-channel-readiness.

`just mprocs` startup speed tests on my M1 Pro machine:

Before:
51.3s, 48.6s, 49.5s, 55.3s, 52.5s, 45.4s, 56.3s, 52.2s, 50.1s, 52.6s
Average: 51.38s

After:
50.5s, 49.5s, 50.7s, 51.6s, 46.1s, 40.4s, 44.1s, 48.0s, 52.1s, 46.6s
Average: 47.96s

Average speed improvement of ~7%