### PR TITLE
chore(core): `DatabaseTransaction::global_dbtx`

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -650,7 +650,8 @@ async fn get_note_summary(client: &ClientHandleArc) -> anyhow::Result<serde_json
                 .db()
                 .begin_transaction_nc()
                 .await
-                .to_ref_with_prefix_module_id(1),
+                .to_ref_with_prefix_module_id(1)
+                .0,
         )
         .await;
     Ok(serde_json::to_value(InfoResponse {

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -543,6 +543,7 @@ pub async fn apply_migrations_client(
                 migration(
                     &mut global_dbtx
                         .to_ref_with_prefix_module_id(module_instance_id)
+                        .0
                         .into_nc(),
                     active_states.clone(),
                     inactive_states.clone(),

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1268,9 +1268,10 @@ impl Client {
             .as_any()
             .downcast_ref::<M>()
             .ok_or_else(|| format_err!("Module is not of type {}", std::any::type_name::<M>()))?;
+        let (db, _) = self.db().with_prefix_module_id(id);
         Ok(ClientModuleInstance {
             id,
-            db: self.db().with_prefix_module_id(id),
+            db,
             api: self.api().with_module(id),
             module,
         })

--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -343,13 +343,14 @@ where
                     .expect("can't convert client module backup to desired type")
             });
 
+        let (module_db, global_dbtx_access_token) = db.with_prefix_module_id(instance_id);
         Ok(self
             .recover(
                 &ClientModuleRecoverArgs {
                     federation_id,
                     num_peers,
                     cfg: typed_cfg.clone(),
-                    db: db.with_prefix_module_id(instance_id),
+                    db: module_db.clone(),
                     core_api_version,
                     module_api_version,
                     module_root_secret,
@@ -360,7 +361,8 @@ where
                     context: ClientContext {
                         client: final_client,
                         module_instance_id: instance_id,
-                        module_db: db.with_prefix_module_id(instance_id),
+                        global_dbtx_access_token,
+                        module_db,
                         _marker: marker::PhantomData,
                     },
                     progress_tx,
@@ -389,12 +391,13 @@ where
         task_group: TaskGroup,
     ) -> anyhow::Result<DynClientModule> {
         let typed_cfg: &<<T as fedimint_core::module::ModuleInit>::Common as CommonModuleInit>::ClientConfig = cfg.cast()?;
+        let (module_db, global_dbtx_access_token) = db.with_prefix_module_id(instance_id);
         Ok(self
             .init(&ClientModuleInitArgs {
                 federation_id,
                 peer_num,
                 cfg: typed_cfg.clone(),
-                db: db.with_prefix_module_id(instance_id),
+                db: module_db.clone(),
                 core_api_version,
                 module_api_version,
                 module_root_secret,
@@ -405,7 +408,8 @@ where
                 context: ClientContext {
                     client: final_client,
                     module_instance_id: instance_id,
-                    module_db: db.with_prefix_module_id(instance_id),
+                    module_db,
+                    global_dbtx_access_token,
                     _marker: marker::PhantomData,
                 },
                 task_group,

--- a/fedimint-client/src/sm/dbtx.rs
+++ b/fedimint-client/src/sm/dbtx.rs
@@ -23,6 +23,7 @@ impl<'inner, 'parent> ClientSMDatabaseTransaction<'inner, 'parent> {
     pub fn module_tx(&mut self) -> DatabaseTransaction<'_> {
         self.dbtx
             .to_ref_with_prefix_module_id(self.module_instance)
+            .0
             .into_nc()
     }
 

--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -240,7 +240,7 @@ mod tests {
 
     fn module_database(module_instance_id: ModuleInstanceId) -> Database {
         let db = MemDatabase::new().into_database();
-        db.with_prefix_module_id(module_instance_id)
+        db.with_prefix_module_id(module_instance_id).0
     }
 
     #[test_log::test(tokio::test)]

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -407,19 +407,27 @@ impl Database {
     }
 
     /// Create [`Database`] isolated to a partition with a given `prefix`
-    pub fn with_prefix(&self, prefix: Vec<u8>) -> Self {
-        Self {
-            inner: Arc::new(PrefixDatabase {
-                inner: self.inner.clone(),
-                prefix,
-            }),
-            module_decoders: self.module_decoders.clone(),
-        }
+    pub fn with_prefix(&self, prefix: Vec<u8>) -> (Self, GlobalDBTxAccessToken) {
+        let global_dbtx_access_token = GlobalDBTxAccessToken::from_prefix(&prefix);
+        (
+            Self {
+                inner: Arc::new(PrefixDatabase {
+                    inner: self.inner.clone(),
+                    global_dbtx_access_token,
+                    prefix,
+                }),
+                module_decoders: self.module_decoders.clone(),
+            },
+            global_dbtx_access_token,
+        )
     }
 
     /// Create [`Database`] isolated to a partition with a prefix for a given
     /// `module_instance_id`
-    pub fn with_prefix_module_id(&self, module_instance_id: ModuleInstanceId) -> Self {
+    pub fn with_prefix_module_id(
+        &self,
+        module_instance_id: ModuleInstanceId,
+    ) -> (Self, GlobalDBTxAccessToken) {
         let prefix = module_instance_id_to_byte_prefix(module_instance_id);
         self.with_prefix(prefix)
     }
@@ -642,6 +650,7 @@ where
     Inner: Debug,
 {
     prefix: Vec<u8>,
+    global_dbtx_access_token: GlobalDBTxAccessToken,
     inner: Inner,
 }
 
@@ -667,6 +676,7 @@ where
     async fn begin_transaction<'a>(&'a self) -> Box<dyn IDatabaseTransaction + 'a> {
         Box::new(PrefixDatabaseTransaction {
             inner: self.inner.begin_transaction().await,
+            global_dbtx_access_token: self.global_dbtx_access_token,
             prefix: self.prefix.clone(),
         })
     }
@@ -694,6 +704,7 @@ where
 #[derive(Debug)]
 struct PrefixDatabaseTransaction<Inner> {
     inner: Inner,
+    global_dbtx_access_token: GlobalDBTxAccessToken,
     prefix: Vec<u8>,
 }
 
@@ -724,6 +735,17 @@ where
 
     fn prefix_len(&self) -> usize {
         self.inner.prefix_len() + self.prefix.len()
+    }
+
+    fn global_dbtx(
+        &mut self,
+        access_token: GlobalDBTxAccessToken,
+    ) -> &mut dyn IDatabaseTransaction {
+        assert_eq!(
+            access_token, self.global_dbtx_access_token,
+            "Invalid access key used to access global_dbtx"
+        );
+        &mut self.inner
     }
 }
 
@@ -1155,6 +1177,14 @@ pub trait IDatabaseTransaction: MaybeSend + IDatabaseTransactionOps + fmt::Debug
 
     /// The prefix len of this database instance
     fn prefix_len(&self) -> usize;
+
+    /// Get the global database tx from a module-prefixed database transaction
+    ///
+    /// Meant to be called only by core internals, and module developers should
+    /// not call it directly.
+    #[doc(hidden)]
+    fn global_dbtx(&mut self, access_token: GlobalDBTxAccessToken)
+        -> &mut dyn IDatabaseTransaction;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -1165,8 +1195,16 @@ where
     async fn commit_tx(&mut self) -> Result<()> {
         (**self).commit_tx().await
     }
+
     fn prefix_len(&self) -> usize {
         (**self).prefix_len()
+    }
+
+    fn global_dbtx(
+        &mut self,
+        access_token: GlobalDBTxAccessToken,
+    ) -> &mut dyn IDatabaseTransaction {
+        (**self).global_dbtx(access_token)
     }
 }
 
@@ -1180,6 +1218,10 @@ where
     }
     fn prefix_len(&self) -> usize {
         (**self).prefix_len()
+    }
+
+    fn global_dbtx(&mut self, access_key: GlobalDBTxAccessToken) -> &mut dyn IDatabaseTransaction {
+        (**self).global_dbtx(access_key)
     }
 }
 
@@ -1322,6 +1364,13 @@ impl<Tx: IRawDatabaseTransaction + fmt::Debug> IDatabaseTransaction
 
     fn prefix_len(&self) -> usize {
         0
+    }
+
+    fn global_dbtx(
+        &mut self,
+        _access_token: GlobalDBTxAccessToken,
+    ) -> &mut dyn IDatabaseTransaction {
+        panic!("Illegal to call global_dbtx on BaseDatabaseTransaction");
     }
 }
 
@@ -1481,20 +1530,28 @@ impl<'tx, Cap> DatabaseTransaction<'tx, Cap> {
     }
 
     /// Get [`DatabaseTransaction`] isolated to a `prefix`
-    pub fn with_prefix<'a: 'tx>(self, prefix: Vec<u8>) -> DatabaseTransaction<'a, Cap>
+    pub fn with_prefix<'a: 'tx>(
+        self,
+        prefix: Vec<u8>,
+    ) -> (DatabaseTransaction<'a, Cap>, GlobalDBTxAccessToken)
     where
         'tx: 'a,
     {
-        DatabaseTransaction {
-            tx: Box::new(PrefixDatabaseTransaction {
-                inner: self.tx,
-                prefix,
-            }),
-            decoders: self.decoders,
-            commit_tracker: self.commit_tracker,
-            on_commit_hooks: self.on_commit_hooks,
-            capability: self.capability,
-        }
+        let global_dbtx_access_token = GlobalDBTxAccessToken::from_prefix(&prefix);
+        (
+            DatabaseTransaction {
+                tx: Box::new(PrefixDatabaseTransaction {
+                    inner: self.tx,
+                    global_dbtx_access_token,
+                    prefix,
+                }),
+                decoders: self.decoders,
+                commit_tracker: self.commit_tracker,
+                on_commit_hooks: self.on_commit_hooks,
+                capability: self.capability,
+            },
+            global_dbtx_access_token,
+        )
     }
 
     /// Get [`DatabaseTransaction`] isolated to a prefix of a given
@@ -1502,7 +1559,7 @@ impl<'tx, Cap> DatabaseTransaction<'tx, Cap> {
     pub fn with_prefix_module_id<'a: 'tx>(
         self,
         module_instance_id: ModuleInstanceId,
-    ) -> DatabaseTransaction<'a, Cap>
+    ) -> (DatabaseTransaction<'a, Cap>, GlobalDBTxAccessToken)
     where
         'tx: 'a,
     {
@@ -1533,32 +1590,40 @@ impl<'tx, Cap> DatabaseTransaction<'tx, Cap> {
     }
 
     /// Get [`DatabaseTransaction`] isolated to a `prefix` of `self`
-    pub fn to_ref_with_prefix<'a>(&'a mut self, prefix: Vec<u8>) -> DatabaseTransaction<'a, Cap>
+    pub fn to_ref_with_prefix<'a>(
+        &'a mut self,
+        prefix: Vec<u8>,
+    ) -> (DatabaseTransaction<'a, Cap>, GlobalDBTxAccessToken)
     where
         'tx: 'a,
     {
-        DatabaseTransaction {
-            tx: Box::new(PrefixDatabaseTransaction {
-                inner: &mut self.tx,
-                prefix,
-            }),
-            decoders: self.decoders.clone(),
-            commit_tracker: match self.commit_tracker {
-                MaybeRef::Owned(ref mut o) => MaybeRef::Borrowed(o),
-                MaybeRef::Borrowed(ref mut b) => MaybeRef::Borrowed(b),
+        let global_dbtx_access_token = GlobalDBTxAccessToken::from_prefix(&prefix);
+        (
+            DatabaseTransaction {
+                tx: Box::new(PrefixDatabaseTransaction {
+                    inner: &mut self.tx,
+                    global_dbtx_access_token,
+                    prefix,
+                }),
+                decoders: self.decoders.clone(),
+                commit_tracker: match self.commit_tracker {
+                    MaybeRef::Owned(ref mut o) => MaybeRef::Borrowed(o),
+                    MaybeRef::Borrowed(ref mut b) => MaybeRef::Borrowed(b),
+                },
+                on_commit_hooks: match self.on_commit_hooks {
+                    MaybeRef::Owned(ref mut o) => MaybeRef::Borrowed(o),
+                    MaybeRef::Borrowed(ref mut b) => MaybeRef::Borrowed(b),
+                },
+                capability: self.capability,
             },
-            on_commit_hooks: match self.on_commit_hooks {
-                MaybeRef::Owned(ref mut o) => MaybeRef::Borrowed(o),
-                MaybeRef::Borrowed(ref mut b) => MaybeRef::Borrowed(b),
-            },
-            capability: self.capability,
-        }
+            global_dbtx_access_token,
+        )
     }
 
     pub fn to_ref_with_prefix_module_id<'a>(
         &'a mut self,
         module_instance_id: ModuleInstanceId,
-    ) -> DatabaseTransaction<'a, Cap>
+    ) -> (DatabaseTransaction<'a, Cap>, GlobalDBTxAccessToken)
     where
         'tx: 'a,
     {
@@ -1605,6 +1670,50 @@ impl<'tx, Cap> DatabaseTransaction<'tx, Cap> {
     #[instrument(level = "trace", skip_all)]
     pub fn on_commit(&mut self, f: maybe_add_send!(impl FnOnce() + 'static)) {
         self.on_commit_hooks.push(Box::new(f));
+    }
+
+    pub fn global_dbtx<'a>(
+        &'a mut self,
+        access_token: GlobalDBTxAccessToken,
+    ) -> DatabaseTransaction<'a, Cap>
+    where
+        'tx: 'a,
+    {
+        let decoders = self.decoders.clone();
+
+        DatabaseTransaction {
+            tx: Box::new(self.tx.global_dbtx(access_token)),
+            decoders,
+            commit_tracker: match self.commit_tracker {
+                MaybeRef::Owned(ref mut o) => MaybeRef::Borrowed(o),
+                MaybeRef::Borrowed(ref mut b) => MaybeRef::Borrowed(b),
+            },
+            on_commit_hooks: match self.on_commit_hooks {
+                MaybeRef::Owned(ref mut o) => MaybeRef::Borrowed(o),
+                MaybeRef::Borrowed(ref mut b) => MaybeRef::Borrowed(b),
+            },
+            capability: self.capability,
+        }
+    }
+}
+
+/// Code used to access `global_dbtx`
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GlobalDBTxAccessToken(u32);
+
+impl GlobalDBTxAccessToken {
+    /// Calculate an access code for accessing global_dbtx from a prefixed
+    /// database tx
+    ///
+    /// Since we need to do it at runtime, we want the user modules not to be
+    /// able to call `global_dbtx` too easily. But at the same time we don't
+    /// need to be paranoid.
+    ///
+    /// This must be deterministic during whole instance of the software running
+    /// (because it's being rederived independently in multiple codepahs) , but
+    /// it could be somewhat randomized between different runs and releases.
+    fn from_prefix(prefix: &[u8]) -> Self {
+        Self(prefix.iter().fold(0, |acc, b| acc + u32::from(*b)) + 513)
     }
 }
 
@@ -2030,6 +2139,7 @@ pub async fn apply_migrations(
                     migration(
                         &mut global_dbtx
                             .to_ref_with_prefix_module_id(module_instance_id)
+                            .0
                             .into_nc(),
                     )
                     .await?;
@@ -2092,6 +2202,7 @@ pub async fn create_database_version(
             remove_current_db_version_if_exists(
                 &mut global_dbtx
                     .to_ref_with_prefix_module_id(module_instance_id)
+                    .0
                     .into_nc(),
                 is_new_db,
                 target_db_version,
@@ -2756,7 +2867,7 @@ mod test_utils {
     pub async fn verify_module_prefix(db: Database) {
         let mut test_dbtx = db.begin_transaction().await;
         {
-            let mut test_module_dbtx = test_dbtx.to_ref_with_prefix_module_id(TEST_MODULE_PREFIX);
+            let mut test_module_dbtx = test_dbtx.to_ref_with_prefix_module_id(TEST_MODULE_PREFIX).0;
 
             test_module_dbtx
                 .insert_entry(&TestKey(100), &TestVal(101))
@@ -2771,7 +2882,7 @@ mod test_utils {
 
         let mut alt_dbtx = db.begin_transaction().await;
         {
-            let mut alt_module_dbtx = alt_dbtx.to_ref_with_prefix_module_id(ALT_MODULE_PREFIX);
+            let mut alt_module_dbtx = alt_dbtx.to_ref_with_prefix_module_id(ALT_MODULE_PREFIX).0;
 
             alt_module_dbtx
                 .insert_entry(&TestKey(100), &TestVal(103))
@@ -2786,7 +2897,7 @@ mod test_utils {
 
         // verify test_module_dbtx can only see key/value pairs from its own module
         let mut test_dbtx = db.begin_transaction().await;
-        let mut test_module_dbtx = test_dbtx.to_ref_with_prefix_module_id(TEST_MODULE_PREFIX);
+        let mut test_module_dbtx = test_dbtx.to_ref_with_prefix_module_id(TEST_MODULE_PREFIX).0;
         assert_eq!(
             test_module_dbtx.get_value(&TestKey(100)).await,
             Some(TestVal(101))
@@ -3138,7 +3249,7 @@ mod tests {
         let key = TestKey(1);
         let val = TestVal(2);
         let db = MemDatabase::new().into_database();
-        let db = db.with_prefix_module_id(module_instance_id);
+        let db = db.with_prefix_module_id(module_instance_id).0;
 
         let key_task = waiter(&db, TestKey(1)).await;
 
@@ -3160,10 +3271,10 @@ mod tests {
         let val = TestVal(2);
         let db = MemDatabase::new().into_database();
 
-        let key_task = waiter(&db.with_prefix_module_id(module_instance_id), TestKey(1)).await;
+        let key_task = waiter(&db.with_prefix_module_id(module_instance_id).0, TestKey(1)).await;
 
         let mut tx = db.begin_transaction().await;
-        let mut tx_mod = tx.to_ref_with_prefix_module_id(module_instance_id);
+        let mut tx_mod = tx.to_ref_with_prefix_module_id(module_instance_id).0;
         tx_mod.insert_new_entry(&key, &val).await;
         drop(tx_mod);
         tx.commit_tx().await;

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -141,7 +141,7 @@ impl DatabaseDump {
         }
         let mut dbtx = self.read_only_db.begin_transaction_nc().await;
         let db_version = dbtx.get_value(&DatabaseVersionKey(*module_id)).await;
-        let mut isolated_dbtx = dbtx.to_ref_with_prefix_module_id(*module_id);
+        let mut isolated_dbtx = dbtx.to_ref_with_prefix_module_id(*module_id).0;
 
         match inits.get(kind) {
             None => {

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -337,7 +337,8 @@ pub async fn get_note_summary(client: &ClientHandleArc) -> anyhow::Result<Tiered
                 .db()
                 .begin_transaction_nc()
                 .await
-                .to_ref_with_prefix_module_id(1),
+                .to_ref_with_prefix_module_id(1)
+                .0,
         )
         .await;
     Ok(summary)
@@ -350,7 +351,7 @@ pub async fn remint_denomination(
 ) -> anyhow::Result<()> {
     let mint_client = client.get_first_module::<MintClientModule>()?;
     let mut dbtx = client.db().begin_transaction().await;
-    let mut module_transaction = dbtx.to_ref_with_prefix_module_id(mint_client.id);
+    let mut module_transaction = dbtx.to_ref_with_prefix_module_id(mint_client.id).0;
     let mut tx = TransactionBuilder::new();
     let operation_id = OperationId::new_random();
     for _ in 0..quantity {

--- a/fedimint-recoverytool/src/main.rs
+++ b/fedimint-recoverytool/src/main.rs
@@ -179,6 +179,7 @@ async fn process_and_print_tweak_source(
                 db
             } else {
                 db.with_prefix_module_id(LEGACY_HARDCODED_INSTANCE_ID_WALLET)
+                    .0
             };
 
             let utxos: Vec<ImportableWallet> = db

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -543,7 +543,7 @@ mod fedimint_rocksdb_tests {
 
         fedimint_core::db::verify_module_db(
             open_temp_db("fcb-rocksdb-test-module-db"),
-            module_db.with_prefix_module_id(module_instance_id),
+            module_db.with_prefix_module_id(module_instance_id).0,
         )
         .await;
     }

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -705,8 +705,8 @@ impl HasApiContext<ConfigGenApi> for ConfigGenApi {
         let mut db = self.db.clone();
         let mut dbtx = self.db.begin_transaction().await;
         if let Some(id) = id {
-            db = self.db.with_prefix_module_id(id);
-            dbtx = dbtx.with_prefix_module_id(id);
+            db = self.db.with_prefix_module_id(id).0;
+            dbtx = dbtx.with_prefix_module_id(id).0;
         }
         let state = self.state.lock().await;
         let auth = request.auth.as_ref();

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -156,7 +156,7 @@ impl ConsensusApi {
             .modules
             .get_expect(module_id)
             .output_status(
-                &mut dbtx.to_ref_with_prefix_module_id(module_id).into_nc(),
+                &mut dbtx.to_ref_with_prefix_module_id(module_id).0.into_nc(),
                 outpoint,
                 module_id,
             )
@@ -262,7 +262,7 @@ impl ConsensusApi {
             module_instance_id_to_kind.insert(module_instance_id, kind.as_str().to_string());
             module
                 .audit(
-                    &mut dbtx.to_ref_with_prefix_module_id(module_instance_id),
+                    &mut dbtx.to_ref_with_prefix_module_id(module_instance_id).0,
                     &mut audit,
                     module_instance_id,
                 )
@@ -481,8 +481,8 @@ impl HasApiContext<ConsensusApi> for ConsensusApi {
         let mut db = self.db.clone();
         let mut dbtx = self.db.begin_transaction().await;
         if let Some(id) = id {
-            db = self.db.with_prefix_module_id(id);
-            dbtx = dbtx.with_prefix_module_id(id);
+            db = self.db.with_prefix_module_id(id).0;
+            dbtx = dbtx.with_prefix_module_id(id).0;
         }
         (
             self,

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -680,6 +680,7 @@ impl ConsensusEngine {
                 .audit(
                     &mut dbtx
                         .to_ref_with_prefix_module_id(module_instance_id)
+                        .0
                         .into_nc(),
                     &mut audit,
                     module_instance_id,
@@ -719,7 +720,7 @@ impl ConsensusEngine {
             ConsensusItem::Module(module_item) => {
                 let instance_id = module_item.module_instance_id();
 
-                let module_dbtx = &mut dbtx.to_ref_with_prefix_module_id(instance_id);
+                let module_dbtx = &mut dbtx.to_ref_with_prefix_module_id(instance_id).0;
 
                 self.modules
                     .get_expect(instance_id)

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -86,7 +86,7 @@ pub async fn run(
                     .init(
                         NumPeers::from(cfg.consensus.api_endpoints.len()),
                         cfg.get_module_config(*module_id)?,
-                        db.with_prefix_module_id(*module_id),
+                        db.with_prefix_module_id(*module_id).0,
                         task_group,
                         cfg.local.identity,
                     )
@@ -244,7 +244,7 @@ fn submit_module_ci_proposals(
                         &mut db
                             .begin_transaction_nc()
                             .await
-                            .to_ref_with_prefix_module_id(module_id)
+                            .to_ref_with_prefix_module_id(module_id).0
                             .into_nc(),
                         module_id,
                     ),

--- a/fedimint-server/src/consensus/transaction.rs
+++ b/fedimint-server/src/consensus/transaction.rs
@@ -42,7 +42,9 @@ pub async fn process_transaction_with_dbtx(
         let meta = modules
             .get_expect(input.module_instance_id())
             .process_input(
-                &mut dbtx.to_ref_with_prefix_module_id(input.module_instance_id()),
+                &mut dbtx
+                    .to_ref_with_prefix_module_id(input.module_instance_id())
+                    .0,
                 input,
             )
             .await
@@ -60,7 +62,9 @@ pub async fn process_transaction_with_dbtx(
         let amount = modules
             .get_expect(output.module_instance_id())
             .process_output(
-                &mut dbtx.to_ref_with_prefix_module_id(output.module_instance_id()),
+                &mut dbtx
+                    .to_ref_with_prefix_module_id(output.module_instance_id())
+                    .0,
                 output,
                 OutPoint { txid, out_idx },
             )

--- a/fedimint-testing-core/src/db.rs
+++ b/fedimint-testing-core/src/db.rs
@@ -68,7 +68,8 @@ fn open_snapshot_db(
                 .with_context(|| format!("Preparing snapshot in {}", snapshot_dir.display()))?,
             decoders,
         )
-        .with_prefix_module_id(TEST_MODULE_INSTANCE_ID))
+        .with_prefix_module_id(TEST_MODULE_INSTANCE_ID)
+        .0)
     } else {
         Ok(Database::new(
             RocksDb::open(snapshot_dir)
@@ -184,7 +185,7 @@ where
 
     let snapshot_fn = |db: Database| {
         async move {
-            let isolated_db = db.with_prefix_module_id(TEST_MODULE_INSTANCE_ID);
+            let isolated_db = db.with_prefix_module_id(TEST_MODULE_INSTANCE_ID).0;
             data_prepare(isolated_db).await;
 
             let (active_states, inactive_states) = state_machine_prepare();
@@ -329,7 +330,7 @@ where
     .await
     .context("Error applying migrations to temp database")?;
 
-    let module_db = db.with_prefix_module_id(TEST_MODULE_INSTANCE_ID);
+    let module_db = db.with_prefix_module_id(TEST_MODULE_INSTANCE_ID).0;
     validate(module_db)
         .await
         .with_context(|| format!("Validating {db_prefix}"))?;
@@ -416,7 +417,7 @@ where
         .collect::<Vec<_>>()
         .await;
 
-    let module_db = db.with_prefix_module_id(TEST_MODULE_INSTANCE_ID);
+    let module_db = db.with_prefix_module_id(TEST_MODULE_INSTANCE_ID).0;
     validate(module_db, active_states, inactive_states)
         .await
         .with_context(|| format!("Validating {db_prefix}"))?;

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -99,7 +99,8 @@ impl GatewayClientBuilder {
         let federation_id = config.invite_code.federation_id();
         let db = gateway
             .gateway_db
-            .with_prefix(config.federation_index.to_le_bytes().to_vec());
+            .with_prefix(config.federation_index.to_le_bytes().to_vec())
+            .0;
         let client_builder = self
             .create_client_builder(db, &config, gateway.clone())
             .await?;
@@ -147,7 +148,8 @@ impl GatewayClientBuilder {
         } else {
             let db = gateway
                 .gateway_db
-                .with_prefix(config.federation_index.to_le_bytes().to_vec());
+                .with_prefix(config.federation_index.to_le_bytes().to_vec())
+                .0;
             let secret = Self::derive_federation_secret(mnemonic, &federation_id);
             (db, secret)
         };

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -1339,7 +1339,7 @@ mod tests {
 
         server
             .process_output(
-                &mut dbtx.to_ref_with_prefix_module_id(42).into_nc(),
+                &mut dbtx.to_ref_with_prefix_module_id(42).0.into_nc(),
                 &output,
                 out_point,
             )
@@ -1362,7 +1362,7 @@ mod tests {
         assert_matches!(
             server
                 .process_output(
-                    &mut dbtx.to_ref_with_prefix_module_id(42).into_nc(),
+                    &mut dbtx.to_ref_with_prefix_module_id(42).0.into_nc(),
                     &output2,
                     out_point2
                 )
@@ -1376,7 +1376,7 @@ mod tests {
         let (server_cfg, client_cfg) = build_configs();
         let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
         let mut dbtx = db.begin_transaction_nc().await;
-        let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42);
+        let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42).0;
         let tg = TaskGroup::new();
         let server = Lightning::new(server_cfg[0].clone(), &tg, 0.into()).unwrap();
 
@@ -1437,7 +1437,7 @@ mod tests {
         let (server_cfg, _) = build_configs();
         let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
         let mut dbtx = db.begin_transaction_nc().await;
-        let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42);
+        let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42).0;
         let tg = TaskGroup::new();
         let server = Lightning::new(server_cfg[0].clone(), &tg, 0.into()).unwrap();
 

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -798,12 +798,18 @@ mod test {
 
         // Double spend in same session is detected
         let mut dbtx = db.begin_transaction_nc().await;
-        mint.process_input(&mut dbtx.to_ref_with_prefix_module_id(42).into_nc(), &input)
-            .await
-            .expect("Spend of valid e-cash works");
+        mint.process_input(
+            &mut dbtx.to_ref_with_prefix_module_id(42).0.into_nc(),
+            &input,
+        )
+        .await
+        .expect("Spend of valid e-cash works");
         assert_matches!(
-            mint.process_input(&mut dbtx.to_ref_with_prefix_module_id(42).into_nc(), &input,)
-                .await,
+            mint.process_input(
+                &mut dbtx.to_ref_with_prefix_module_id(42).0.into_nc(),
+                &input,
+            )
+            .await,
             Err(_)
         );
     }

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -625,6 +625,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     sync_wallet_to_block(
         &mut dbtx
             .to_ref_with_prefix_module_id(module_instance_id)
+            .0
             .into_nc(),
         &mut wallet,
         block_count.try_into()?,
@@ -658,6 +659,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         .process_input(
             &mut dbtx
                 .to_ref_with_prefix_module_id(module_instance_id)
+                .0
                 .into_nc(),
             &input,
         )
@@ -677,6 +679,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     sync_wallet_to_block(
         &mut dbtx
             .to_ref_with_prefix_module_id(module_instance_id)
+            .0
             .into_nc(),
         &mut wallet,
         block_count.try_into()?,
@@ -688,6 +691,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
             .process_input(
                 &mut dbtx
                     .to_ref_with_prefix_module_id(module_instance_id)
+                    .0
                     .into_nc(),
                 &input,
             )


### PR DESCRIPTION
This allows going back from prefixed dbtx, to global unprefixed dbtx, but only if one posseses the "access token" created during creation of the prefixed db.


In the future, this could help eliminate bunch of abstractions we introduced to juggle global vs module dbtx, though it might require long term effort and refactoring.

Currently  the goal is to unblock #5995 
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
