### PR TITLE
fix: GatewayLdkClient::info() doesn't rely on esplora

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -30,7 +30,9 @@ use tonic_lnd::lnrpc::{ChanInfoRequest, GetInfoRequest, ListChannelsRequest};
 use tonic_lnd::Client as LndClient;
 use tracing::{debug, error, info, trace, warn};
 
-use crate::util::{poll, ClnLightningCli, GatewayClnExtension, ProcessHandle, ProcessManager};
+use crate::util::{
+    poll, poll_with_timeout, ClnLightningCli, GatewayClnExtension, ProcessHandle, ProcessManager,
+};
 use crate::vars::utf8;
 use crate::version_constants::VERSION_0_4_0_ALPHA;
 use crate::{cmd, poll_eq, Gatewayd};
@@ -956,12 +958,8 @@ pub async fn open_channels_between_gateways(
             info!(target: LOG_DEVIMINT, from=%gw_a_name, to=%gw_b_name, "Opening channel with {sats_per_side} sats on each side...");
             tokio::task::spawn(async move {
                 // Sometimes channel openings just after funding the lightning nodes don't work right away.
-                // This resolves itself after a few seconds, so we don't need to poll for very long.
-                let res = poll(&format!("Open channel from {gw_a_name} to {gw_b_name}"), || async {
-                    let gw_a_name = gw_a_name.clone();
-                    let gw_b_name = gw_b_name.clone();
-                    let txid = gw_a.open_channel(&gw_b, sats_per_side * 2, Some(sats_per_side)).await.map_err(ControlFlow::Continue)?;
-                    Ok((gw_a_name, gw_b_name, txid))
+                let res = poll_with_timeout(&format!("Open channel from {gw_a_name} to {gw_b_name}"), Duration::from_secs(30), || async {
+                    gw_a.open_channel(&gw_b, sats_per_side * 2, Some(sats_per_side)).await.map_err(ControlFlow::Continue)
                 })
                 .await;
 
@@ -995,7 +993,7 @@ pub async fn open_channels_between_gateways(
 
     // Wait for all channel funding transaction to be known by bitcoind.
     let mut is_missing_any_txids = false;
-    for (_gw_a_name, _gw_b_name, txid_or) in &channel_funding_txids {
+    for txid_or in &channel_funding_txids {
         if let Some(txid) = txid_or {
             loop {
                 if bitcoind.get_transaction(*txid).await.is_ok() {

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -995,7 +995,7 @@ pub async fn open_channels_between_gateways(
 
     // Wait for all channel funding transaction to be known by bitcoind.
     let mut is_missing_any_txids = false;
-    for (gw_a_name, gw_b_name, txid_or) in &channel_funding_txids {
+    for (_gw_a_name, _gw_b_name, txid_or) in &channel_funding_txids {
         if let Some(txid) = txid_or {
             loop {
                 if bitcoind.get_transaction(*txid).await.is_ok() {
@@ -1008,7 +1008,6 @@ pub async fn open_channels_between_gateways(
         } else {
             is_missing_any_txids = true;
         }
-        info!(target: LOG_DEVIMINT, "Channel funding transaction between {gw_a_name} and {gw_b_name} is known by bitcoind");
     }
 
     // `open_channel` may not have sent out the channel funding transaction
@@ -1028,13 +1027,12 @@ pub async fn open_channels_between_gateways(
     )
     .await?;
 
-    for ((gw_a, gw_a_name), (gw_b, gw_b_name)) in &gateway_pairs {
+    for ((gw_a, _gw_a_name), (gw_b, _gw_b_name)) in &gateway_pairs {
         let gw_a_node_pubkey = gw_a.lightning_pubkey().await?;
         let gw_b_node_pubkey = gw_b.lightning_pubkey().await?;
 
         wait_for_ready_channel_on_gateway_with_counterparty(gw_b, gw_a_node_pubkey).await?;
         wait_for_ready_channel_on_gateway_with_counterparty(gw_a, gw_b_node_pubkey).await?;
-        info!(target: LOG_DEVIMINT, "Channels between {gw_a_name} and {gw_b_name} are ready");
     }
 
     Ok(())

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1088,7 +1088,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     let tx_hex = poll("Waiting for transaction in mempool", || async {
         // TODO: distinguish errors from not found
         bitcoind
-            .get_raw_transaction(txid)
+            .get_transaction(txid)
             .await
             .context("getrawtransaction")
             .map_err(ControlFlow::Continue)
@@ -2035,7 +2035,7 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
             .expect("txid should be parsable");
         let tx_hex = poll("Waiting for transaction in mempool", || async {
             bitcoind
-                .get_raw_transaction(txid)
+                .get_transaction(txid)
                 .await
                 .context("getrawtransaction")
                 .map_err(ControlFlow::Continue)

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -453,22 +453,6 @@ impl ILnRpcClient for GatewayLdkClient {
         channel_size_sats: u64,
         push_amount_sats: u64,
     ) -> Result<OpenChannelResponse, LightningRpcError> {
-        let funding_txid_or = self
-            .node
-            .list_channels()
-            .iter()
-            .find(|channel| {
-                channel.counterparty_node_id == bitcoin30_to_bitcoin32_secp256k1_pubkey(&pubkey)
-            })
-            .and_then(|channel| channel.funding_txo)
-            .map(|funding_txo| funding_txo.txid);
-
-        if let Some(funding_txid) = funding_txid_or {
-            return Ok(OpenChannelResponse {
-                funding_txid: funding_txid.to_string(),
-            });
-        }
-
         let push_amount_msats_or = if push_amount_sats == 0 {
             None
         } else {

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -1178,7 +1178,7 @@ impl ILnRpcClient for GatewayLndClient {
         let mut client = self.connect().await?;
 
         // Connect to the peer first
-        let _ = client
+        client
             .lightning()
             .connect_peer(ConnectPeerRequest {
                 addr: Some(LightningAddress {
@@ -1188,7 +1188,10 @@ impl ILnRpcClient for GatewayLndClient {
                 perm: false,
                 timeout: 10,
             })
-            .await;
+            .await
+            .map_err(|e| LightningRpcError::FailedToConnectToPeer {
+                failure_reason: format!("Failed to connect to peer {e:?}"),
+            })?;
 
         // Open the channel
         match client

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -1178,7 +1178,7 @@ impl ILnRpcClient for GatewayLndClient {
         let mut client = self.connect().await?;
 
         // Connect to the peer first
-        client
+        let _ = client
             .lightning()
             .connect_peer(ConnectPeerRequest {
                 addr: Some(LightningAddress {
@@ -1188,10 +1188,7 @@ impl ILnRpcClient for GatewayLndClient {
                 perm: false,
                 timeout: 10,
             })
-            .await
-            .map_err(|e| LightningRpcError::FailedToConnectToPeer {
-                failure_reason: format!("Failed to connect to peer {e:?}"),
-            })?;
+            .await;
 
         // Open the channel
         match client

--- a/modules/fedimint-wallet-tests/src/bin/circular-deposit-test.rs
+++ b/modules/fedimint-wallet-tests/src/bin/circular-deposit-test.rs
@@ -43,7 +43,7 @@ async fn assert_withdrawal(
     let txid: Txid = withdraw_res["txid"].as_str().unwrap().parse().unwrap();
     let tx_hex = poll("Waiting for transaction in mempool", || async {
         bitcoind
-            .get_raw_transaction(txid)
+            .get_transaction(txid)
             .await
             .context("getrawtransaction")
             .map_err(ControlFlow::Continue)


### PR DESCRIPTION
Fixes #5965

Ever since adding the ldk gateway to mprocs, it's been significantly slower to fully initialize. To help speed it up, I made #5997 so that the `ldk-node::Node` instance would manually sync whenever we mined new blocks. This led to a ~8% improvement in `just mprocs` startup speed. Not bad, but less than I was hoping for. And strangely, even with that change, the startup time for `just mprocs` was heavily affected by the on-chain sync intervals:

https://github.com/fedimint/fedimint/blob/06717c0a480f619feadb9b411dd57267fbb03e98/gateway/ln-gateway/src/lightning/ldk.rs#L76-L77

It turns out the slowness was because the implementation of `ILnRpcClient::info()` for the LDK gateway set `synced_to_chain` to true only if the most recent sync time for the `ldk-node::Node` instance was more recent than the most recent esplora sync time. This led to `synced_to_chain` often staying false until _another_ sync was done, even if the node actually was fully synced. This effectively meant we had to wait for the background sync, which is why we couldn't remove the sync interval overrides above.

The solution is to simply use the block height provided by `ldk-node::Node::status()`. And with this change we can safely delete the sync overrides, preventing spam to the esplora server.

`just mprocs` startup speed tests on my M1 Pro machine:

Before:
51.7s, 47.2s, 50.5s, 50.1s, 49.7s, 55.1s, 41.7s, 41.9s, 52.2s, 50.5s
Average: 49.06s

After:
35.5s, 35.3s, 35.7s, 34.6s, 34.4s, 37.9s, 36.6s, 33.9s, 36.1s, 35.4s
Average: 35.54s

Average speed improvement of ~28%