### PR TITLE
chore: add ldk logs to mprocs

### DIFF
--- a/misc/mprocs.yaml
+++ b/misc/mprocs.yaml
@@ -20,6 +20,8 @@ procs:
     shell: tail -n +0 -F $FM_LOGS_DIR/lightningd.log
   lnd:
     shell: tail -n +0 -F $FM_LOGS_DIR/lnd.log
+  ldk:
+    shell: tail -n +0 -F $FM_DATA_DIR/ldk/ldk_node/logs/ldk_node_latest.log
   bitcoind:
     shell: tail -n +0 -F $FM_LOGS_DIR/bitcoind.log
   devimint:


### PR DESCRIPTION
LDK logs are emitted to a different directory than `ldk_gw`. It is useful for debugging to also have this pane in mprocs