### PR TITLE
fix: lower LND's max-commit-fee-rate-anchors in devimint

### DIFF
--- a/devimint/src/cfg/lnd.conf
+++ b/devimint/src/cfg/lnd.conf
@@ -6,6 +6,7 @@ restlisten=0.0.0.0:{rest_port}
 noseedbackup=1
 wtclient.active=false
 sync-freelist=true
+max-commit-fee-rate-anchors=5
 
 debuglevel=debug
 


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/6009

In our devimint environment, LND will by default use 10 sat/vbyte on commitment transactions. This causing payments from LND -> LDK to fail, because the HTLC commitments will create dust transactions that are larger than the amount LDK is configured to risk to dust. 

On regtest, 10 sat/vbyte is high and unnecessary. We want to set this value high enough that the channel opens are confirmed, but not so high that it causes payments to fail due to dust. In my testing, 5 sat/vbyte seems to work.