### PR TITLE
chore: reenable LNv2 inter federation tests in parallel

### DIFF
--- a/modules/fedimint-lnv2-tests/src/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/src/bin/tests.rs
@@ -55,9 +55,6 @@ async fn main() -> anyhow::Result<()> {
 
                 test_self_payments_success(&dev_fed).await?;
                 test_lightning_payments(&dev_fed).await?;
-
-                // TODO: Inter-federation tests have been deactivated from CI
-                // due to flakiness with CLN: https://github.com/fedimint/fedimint/issues/5944
             }
             TestOpts::GatewayRegistration => {
                 test_gateway_registration(&dev_fed).await?;

--- a/scripts/tests/lnv2-inter-federation.sh
+++ b/scripts/tests/lnv2-inter-federation.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Runs a test to determine the latency of certain user actions
+
+set -euo pipefail
+export RUST_LOG="${RUST_LOG:-info}"
+
+source scripts/_common.sh
+build_workspace
+add_target_dir_to_path
+
+tests inter-federation

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -114,6 +114,11 @@ function lnv2_module() {
 }
 export -f lnv2_module
 
+function lnv2_inter_federation() {
+  fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/lnv2-inter-federation.sh
+}
+export -f lnv2_inter_federation
+
 function mint_client_sanity() {
   fm-run-test "${FUNCNAME[0]}" env FM_OFFLINE_NODES=0 ./scripts/tests/mint-client-sanity.sh
 }
@@ -303,6 +308,7 @@ tests_to_run_in_parallel+=(
   "gateway_config_test_lnd"
   "gateway_restore_test"
   "lnv2_module"
+  "lnv2_inter_federation"
   "devimint_cli_test"
   "devimint_cli_test_single"
   "load_test_tool_test"


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/5944

Re-enables the LNv2 inter federation tests, but this time in parallel to the rest of the LNv2 tests. Should prevent any issues with the test timing out.