### PR TITLE
feat(wallet): add wallet summary

### DIFF
--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -299,6 +299,19 @@ impl BitcoinTest for FakeBitcoinTest {
             .get(txid)
             .map(|height| height.to_owned() as u64)
     }
+
+    async fn get_block_count(&self) -> u64 {
+        self.inner.read().expect("RwLock poisoned").blocks.len() as u64
+    }
+
+    async fn get_mempool_tx(&self, txid: &Txid) -> Option<bitcoin::Transaction> {
+        let inner = self.inner.read().unwrap();
+        let mempool_transactions = inner.pending.clone();
+        mempool_transactions
+            .iter()
+            .find(|tx| tx.txid() == *txid)
+            .map(std::borrow::ToOwned::to_owned)
+    }
 }
 
 #[async_trait]

--- a/fedimint-testing/src/btc/mod.rs
+++ b/fedimint-testing/src/btc/mod.rs
@@ -48,4 +48,10 @@ pub trait BitcoinTest {
     /// for finding a tx block height.
     /// see: `<https://github.com/fedimint/fedimint/issues/5329>`
     async fn get_tx_block_height(&self, txid: &Txid) -> Option<u64>;
+
+    /// Returns the current block count
+    async fn get_block_count(&self) -> u64;
+
+    /// Returns a transaction with the provided txid if it exists in the mempool
+    async fn get_mempool_tx(&self, txid: &Txid) -> Option<bitcoin::Transaction>;
 }

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -172,6 +172,18 @@ impl BitcoinTest for RealBitcoinTestNoLock {
             })
             .map(|height| height as u64)
     }
+
+    async fn get_block_count(&self) -> u64 {
+        self.client
+            .get_block_count()
+            // The RPC function is confusingly named and actually returns the block height
+            .map(|count| count + 1)
+            .expect("failed to fetch block count")
+    }
+
+    async fn get_mempool_tx(&self, txid: &Txid) -> Option<bitcoin::Transaction> {
+        self.client.get_raw_transaction(txid, None).ok()
+    }
 }
 
 /// Fixture implementing bitcoin node under test by talking to a `bitcoind` -
@@ -265,6 +277,16 @@ impl BitcoinTest for RealBitcoinTest {
         let _lock = self.lock_exclusive().await;
         self.inner.get_tx_block_height(txid).await
     }
+
+    async fn get_block_count(&self) -> u64 {
+        let _lock = self.lock_exclusive().await;
+        self.inner.get_block_count().await
+    }
+
+    async fn get_mempool_tx(&self, txid: &Txid) -> Option<bitcoin::Transaction> {
+        let _lock = self.lock_exclusive().await;
+        self.inner.get_mempool_tx(txid).await
+    }
 }
 
 #[async_trait]
@@ -307,5 +329,13 @@ impl BitcoinTest for RealBitcoinTestLocked {
 
     async fn get_tx_block_height(&self, txid: &Txid) -> Option<u64> {
         self.inner.get_tx_block_height(txid).await
+    }
+
+    async fn get_block_count(&self) -> u64 {
+        self.inner.get_block_count().await
+    }
+
+    async fn get_mempool_tx(&self, txid: &Txid) -> Option<bitcoin::Transaction> {
+        self.inner.get_mempool_tx(txid).await
     }
 }

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -7,9 +7,10 @@ use fedimint_core::module::{ApiAuth, ApiRequestErased};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{apply, async_trait_maybe_send, PeerId};
 use fedimint_wallet_common::endpoint_constants::{
-    BITCOIN_KIND_ENDPOINT, BITCOIN_RPC_CONFIG_ENDPOINT, BLOCK_COUNT_ENDPOINT, PEG_OUT_FEES_ENDPOINT,
+    BITCOIN_KIND_ENDPOINT, BITCOIN_RPC_CONFIG_ENDPOINT, BLOCK_COUNT_ENDPOINT,
+    PEG_OUT_FEES_ENDPOINT, WALLET_SUMMARY_ENDPOINT,
 };
-use fedimint_wallet_common::PegOutFees;
+use fedimint_wallet_common::{PegOutFees, WalletSummary};
 
 #[apply(async_trait_maybe_send!)]
 pub trait WalletFederationApi {
@@ -24,6 +25,8 @@ pub trait WalletFederationApi {
     async fn fetch_bitcoin_rpc_kind(&self, peer_id: PeerId) -> FederationResult<String>;
 
     async fn fetch_bitcoin_rpc_config(&self, auth: ApiAuth) -> FederationResult<BitcoinRpcConfig>;
+
+    async fn fetch_wallet_summary(&self) -> FederationResult<WalletSummary>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -66,6 +69,14 @@ where
             BITCOIN_RPC_CONFIG_ENDPOINT,
             ApiRequestErased::default(),
             auth,
+        )
+        .await
+    }
+
+    async fn fetch_wallet_summary(&self) -> FederationResult<WalletSummary> {
+        self.request_current_consensus(
+            WALLET_SUMMARY_ENDPOINT.to_string(),
+            ApiRequestErased::default(),
         )
         .await
     }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -553,6 +553,11 @@ impl WalletClientModule {
             .context("Federation didn't return peg-out fees")
     }
 
+    /// Returns a summary of the wallet's coins
+    pub async fn get_wallet_summary(&self) -> anyhow::Result<WalletSummary> {
+        Ok(self.module_api.fetch_wallet_summary().await?)
+    }
+
     pub fn create_withdraw_output(
         &self,
         operation_id: OperationId,

--- a/modules/fedimint-wallet-common/src/endpoint_constants.rs
+++ b/modules/fedimint-wallet-common/src/endpoint_constants.rs
@@ -3,3 +3,4 @@ pub const PEG_OUT_FEES_ENDPOINT: &str = "peg_out_fees";
 pub const BLOCK_COUNT_LOCAL_ENDPOINT: &str = "block_count_local";
 pub const BITCOIN_KIND_ENDPOINT: &str = "bitcoin_kind";
 pub const BITCOIN_RPC_CONFIG_ENDPOINT: &str = "bitcoin_rpc_config";
+pub const WALLET_SUMMARY_ENDPOINT: &str = "wallet_summary";

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -103,6 +103,118 @@ pub struct SpendableUTXO {
     pub amount: bitcoin::Amount,
 }
 
+/// A transaction output, either unspent or consumed
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+pub struct TxOutputSummary {
+    pub outpoint: bitcoin::OutPoint,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub amount: bitcoin::Amount,
+}
+
+/// Summary of the coins within the wallet.
+///
+/// Coins within the wallet go from spendable, to consumed in a transaction that
+/// does not have threshold signatures (unsigned), to threshold signed and
+/// unconfirmed on-chain (unconfirmed).
+///
+/// This summary provides the most granular view possible of coins in the
+/// wallet.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+pub struct WalletSummary {
+    /// All UTXOs available as inputs for transactions
+    pub spendable_utxos: Vec<TxOutputSummary>,
+    /// Transaction outputs consumed in peg-out transactions that have not
+    /// reached threshold signatures
+    pub unsigned_peg_out_txos: Vec<TxOutputSummary>,
+    /// Change UTXOs created from peg-out transactions that have not reached
+    /// threshold signatures
+    pub unsigned_change_utxos: Vec<TxOutputSummary>,
+    /// Transaction outputs consumed in peg-out transactions that have reached
+    /// threshold signatures waiting for finality delay confirmations
+    pub unconfirmed_peg_out_txos: Vec<TxOutputSummary>,
+    /// Change UTXOs created from peg-out transactions that have reached
+    /// threshold signatures waiting for finality delay confirmations
+    pub unconfirmed_change_utxos: Vec<TxOutputSummary>,
+}
+
+impl WalletSummary {
+    fn sum<'a>(txos: impl Iterator<Item = &'a TxOutputSummary>) -> Amount {
+        txos.fold(Amount::ZERO, |acc, txo| txo.amount + acc)
+    }
+
+    /// Total amount of all spendable UTXOs
+    pub fn total_spendable_balance(&self) -> Amount {
+        WalletSummary::sum(self.spendable_utxos.iter())
+    }
+
+    /// Total amount of all transaction outputs from peg-out transactions that
+    /// have not reached threshold signatures
+    pub fn total_unsigned_peg_out_balance(&self) -> Amount {
+        WalletSummary::sum(self.unsigned_peg_out_txos.iter())
+    }
+
+    /// Total amount of all change UTXOs from peg-out transactions that have not
+    /// reached threshold signatures
+    pub fn total_unsigned_change_balance(&self) -> Amount {
+        WalletSummary::sum(self.unsigned_change_utxos.iter())
+    }
+
+    /// Total amount of all transaction outputs from peg-out transactions that
+    /// have reached threshold signatures waiting for finality delay
+    /// confirmations
+    pub fn total_unconfirmed_peg_out_balance(&self) -> Amount {
+        WalletSummary::sum(self.unconfirmed_peg_out_txos.iter())
+    }
+
+    /// Total amount of all change UTXOs from peg-out transactions that have
+    /// reached threshold signatures waiting for finality delay confirmations
+    pub fn total_unconfirmed_change_balance(&self) -> Amount {
+        WalletSummary::sum(self.unconfirmed_change_utxos.iter())
+    }
+
+    /// Total amount of all transaction outputs from peg-out transactions that
+    /// are either waiting for threshold signatures or confirmations. This is
+    /// the total in-flight amount leaving the wallet.
+    pub fn total_pending_peg_out_balance(&self) -> Amount {
+        self.total_unsigned_peg_out_balance() + self.total_unconfirmed_peg_out_balance()
+    }
+
+    /// Total amount of all change UTXOs from peg-out transactions that are
+    /// either waiting for threshold signatures or confirmations. This is the
+    /// total in-flight amount that will become spendable by the wallet.
+    pub fn total_pending_change_balance(&self) -> Amount {
+        self.total_unsigned_change_balance() + self.total_unconfirmed_change_balance()
+    }
+
+    /// Total amount of immediately spendable UTXOs and pending change UTXOs.
+    /// This is the spendable balance once all transactions confirm.
+    pub fn total_owned_balance(&self) -> Amount {
+        self.total_spendable_balance() + self.total_pending_change_balance()
+    }
+
+    /// All transaction outputs from peg-out transactions that are either
+    /// waiting for threshold signatures or confirmations. These are all the
+    /// in-flight coins leaving the wallet.
+    pub fn pending_peg_out_txos(&self) -> Vec<TxOutputSummary> {
+        self.unsigned_peg_out_txos
+            .clone()
+            .into_iter()
+            .chain(self.unconfirmed_peg_out_txos.clone())
+            .collect()
+    }
+
+    /// All change UTXOs from peg-out transactions that are either waiting for
+    /// threshold signatures or confirmations. These are all the in-flight coins
+    /// that will become spendable by the wallet.
+    pub fn pending_change_utxos(&self) -> Vec<TxOutputSummary> {
+        self.unsigned_change_utxos
+            .clone()
+            .into_iter()
+            .chain(self.unconfirmed_change_utxos.clone())
+            .collect()
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct PegOutFees {
     pub fee_rate: Feerate,

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
 use anyhow::{bail, Context};
@@ -23,7 +24,7 @@ use fedimint_wallet_client::{DepositStateV2, WalletClientInit, WalletClientModul
 use fedimint_wallet_common::config::{WalletConfig, WalletGenParams};
 use fedimint_wallet_common::tweakable::Tweakable;
 use fedimint_wallet_common::txoproof::PegInProof;
-use fedimint_wallet_common::{PegOutFees, Rbf};
+use fedimint_wallet_common::{PegOutFees, Rbf, TxOutputSummary};
 use fedimint_wallet_server::WalletInit;
 use futures::stream::StreamExt;
 use secp256k1::rand::rngs::OsRng;
@@ -44,13 +45,13 @@ fn bsats(satoshi: u64) -> bitcoin::Amount {
 const PEG_IN_AMOUNT_SATS: u64 = 10000;
 const PEG_OUT_AMOUNT_SATS: u64 = 1000;
 
-async fn initial_peg_in<'a>(
+async fn peg_in<'a>(
     client: &'a ClientHandleArc,
     bitcoin: &dyn BitcoinTest,
     finality_delay: u64,
-) -> anyhow::Result<BoxStream<'a, Amount>> {
+) -> anyhow::Result<(BoxStream<'a, Amount>, bitcoin::Transaction)> {
     let mut balance_sub = client.subscribe_balance_changes().await;
-    assert_eq!(balance_sub.ok().await?, sats(0));
+    let initial_balance = balance_sub.ok().await?;
 
     let wallet_module = &client.get_first_module::<WalletClientModule>()?;
     let (op, address, _) = wallet_module
@@ -68,16 +69,24 @@ async fn initial_peg_in<'a>(
         .get_tx_block_height(&tx.txid())
         .await
         .context("expected tx to be mined")?;
-    info!(?height, ?tx, txid = ?tx.txid(), "Peg-in transaction mined");
+    info!(?height, ?tx, "Peg-in transaction mined");
+
     bitcoin.mine_blocks(finality_delay).await;
+
     wallet_module
         .await_num_deposit_by_operation_id(op, 1)
         .await?;
-    assert_eq!(client.get_balance().await, sats(PEG_IN_AMOUNT_SATS));
-    assert_eq!(balance_sub.ok().await?, sats(PEG_IN_AMOUNT_SATS));
+    assert_eq!(
+        client.get_balance().await,
+        initial_balance + sats(PEG_IN_AMOUNT_SATS)
+    );
+    assert_eq!(
+        balance_sub.ok().await?,
+        initial_balance + sats(PEG_IN_AMOUNT_SATS)
+    );
     info!(?height, ?tx, "Peg-in transaction claimed");
 
-    Ok(balance_sub)
+    Ok((balance_sub, tx))
 }
 
 async fn await_consensus_to_catch_up(
@@ -382,7 +391,7 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let mut balance_sub = initial_peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+    let (mut balance_sub, _) = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
 
     info!("Peg-in finished for test peg_out_fail_refund");
     // Peg-out test, requires block to recognize change UTXOs
@@ -430,7 +439,7 @@ async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let mut balance_sub = initial_peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+    let (mut balance_sub, _) = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
 
     info!("Peg-in finished for test rbf_withdrawals_are_rejected");
     let address = checked_address_to_unchecked_address(&bitcoin.get_new_address().await);
@@ -511,7 +520,7 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let mut balance_sub = initial_peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+    let (mut balance_sub, _) = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
 
     info!("Peg-in finished for test peg_outs_must_wait_for_available_utxos");
     let address = checked_address_to_unchecked_address(&bitcoin.get_new_address().await);
@@ -695,6 +704,219 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         Ok(_)
     );
     dbtx.commit_tx().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn construct_wallet_summary() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_default_fed().await;
+    let client = fed.new_client().await;
+    let bitcoin = fixtures.bitcoin();
+    let bitcoin = bitcoin.lock_exclusive().await;
+    let wallet_module = client.get_first_module::<WalletClientModule>()?;
+    info!("Starting test construct_wallet_summary");
+
+    let finality_delay = 10;
+    bitcoin.mine_blocks(finality_delay).await;
+    await_consensus_to_catch_up(&client, 1).await?;
+
+    let mut expected_available_utxos: HashSet<TxOutputSummary> = HashSet::new();
+    fn sum_utxos<'a>(utxos: impl Iterator<Item = &'a TxOutputSummary>) -> bitcoin::Amount {
+        utxos.fold(bsats(0), |acc, utxo| bsats(utxo.amount.to_sat()) + acc)
+    }
+
+    // generate 3 peg-ins, verifying wallet summary after each
+    for _ in 0..3 {
+        let (_, tx) = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+        let expected_peg_in_amount =
+            PEG_IN_AMOUNT_SATS + (wallet_module.get_fee_consensus().peg_in_abs.msats / 1000);
+
+        let expected_available_utxo = tx
+            .output
+            .iter()
+            .enumerate()
+            .find_map(|(idx, output)| {
+                // bitcoin core randomizes the change output index so we can't assume the fed's
+                // utxo is always index 0
+                if output.value == expected_peg_in_amount {
+                    Some(TxOutputSummary {
+                        outpoint: bitcoin::OutPoint {
+                            txid: tx.txid(),
+                            vout: idx as u32,
+                        },
+                        amount: bitcoin::Amount::from_sat(output.value),
+                    })
+                } else {
+                    None
+                }
+            })
+            .expect("peg-in transaction must contain federation's UTXO");
+
+        assert!(expected_available_utxos.insert(expected_available_utxo));
+
+        let wallet_summary = wallet_module.get_wallet_summary().await?;
+        assert_eq!(
+            sum_utxos(expected_available_utxos.iter()),
+            wallet_summary.total_spendable_balance()
+        );
+        assert_eq!(bsats(0), wallet_summary.total_pending_change_balance());
+        assert_eq!(
+            expected_available_utxos,
+            wallet_summary
+                .spendable_utxos
+                .clone()
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+        assert_eq!(wallet_summary.pending_peg_out_txos(), vec![]);
+        assert_eq!(wallet_summary.pending_change_utxos(), vec![]);
+    }
+
+    // generate a peg-out, verifying the summary:
+    //   - while the tx is pending in the mempool
+    //   - after the tx is mined and finalized
+    let address = checked_address_to_unchecked_address(&bitcoin.get_new_address().await);
+    let peg_out = bsats(PEG_OUT_AMOUNT_SATS);
+    let fees = wallet_module
+        .get_withdraw_fees(address.clone(), peg_out)
+        .await?;
+    let op = wallet_module
+        .withdraw(address.clone(), peg_out, fees, ())
+        .await?;
+
+    let sub = wallet_module.subscribe_withdraw_updates(op).await?;
+    let mut sub = sub.into_stream();
+    assert_eq!(sub.ok().await?, WithdrawState::Created);
+
+    let txid = match sub.ok().await? {
+        WithdrawState::Succeeded(txid) => txid,
+        other => panic!("Unexpected state: {other:?}"),
+    };
+
+    let wallet_summary_before_mining = wallet_module.get_wallet_summary().await?;
+    info!(?wallet_summary_before_mining);
+
+    let mempool_tx = fedimint_core::util::retry(
+        "get peg-out mempool tx",
+        fedimint_core::util::backoff_util::custom_backoff(
+            Duration::from_millis(100),
+            Duration::from_millis(100),
+            Some(100),
+        ),
+        || async {
+            bitcoin
+                .get_mempool_tx(&txid)
+                .await
+                .ok_or(anyhow::anyhow!("No mempool tx found"))
+        },
+    )
+    .await
+    .expect("couldn't fetch mempool tx within 10s");
+    info!(?mempool_tx);
+
+    for input in mempool_tx.input {
+        // using `find` is clunky, however it's necessary since `getrawtransaction`
+        // doesn't include an amount with inputs so we cannot manually construct a
+        // TxOutputSummary
+        let consumed_utxo = expected_available_utxos
+            .iter()
+            .find(|utxo| utxo.outpoint == input.previous_output)
+            .expect("wallet should have consumed spendable UTXO")
+            .to_owned();
+
+        assert!(expected_available_utxos.remove(&consumed_utxo))
+    }
+
+    let expected_pending_peg_out_txo = TxOutputSummary {
+        outpoint: bitcoin::OutPoint { txid, vout: 0 },
+        amount: bitcoin::Amount::from_sat(
+            mempool_tx
+                .output
+                .first()
+                .expect("peg-out tx includes withdrawal output")
+                .value,
+        ),
+    };
+
+    let expected_pending_change_utxo = TxOutputSummary {
+        outpoint: bitcoin::OutPoint { txid, vout: 1 },
+        amount: bitcoin::Amount::from_sat(
+            mempool_tx
+                .output
+                .last()
+                .expect("peg-out tx includes change output")
+                .value,
+        ),
+    };
+
+    assert_eq!(
+        sum_utxos(expected_available_utxos.iter()),
+        wallet_summary_before_mining.total_spendable_balance()
+    );
+
+    assert_eq!(
+        bsats(
+            mempool_tx
+                .output
+                .last()
+                .expect("peg-out tx includes change output")
+                .value
+        ),
+        wallet_summary_before_mining.total_pending_change_balance()
+    );
+
+    assert_eq!(
+        wallet_summary_before_mining
+            .spendable_utxos
+            .clone()
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        expected_available_utxos
+    );
+
+    assert_eq!(
+        wallet_summary_before_mining.pending_peg_out_txos(),
+        vec![expected_pending_peg_out_txo]
+    );
+
+    assert_eq!(
+        wallet_summary_before_mining.pending_change_utxos(),
+        vec![expected_pending_change_utxo]
+    );
+
+    bitcoin.mine_blocks(finality_delay + 1).await;
+    let block_count = bitcoin.get_block_count().await;
+    await_consensus_to_catch_up(&client, block_count - finality_delay).await?;
+
+    let wallet_summary_after_mining = wallet_module.get_wallet_summary().await?;
+    info!(?wallet_summary_after_mining);
+
+    assert!(expected_available_utxos.insert(expected_pending_change_utxo));
+
+    assert_eq!(
+        sum_utxos(expected_available_utxos.iter()),
+        wallet_summary_after_mining.total_spendable_balance()
+    );
+
+    assert_eq!(
+        bsats(0),
+        wallet_summary_after_mining.total_pending_change_balance()
+    );
+
+    assert_eq!(
+        wallet_summary_after_mining
+            .spendable_utxos
+            .clone()
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        expected_available_utxos
+    );
+
+    assert_eq!(wallet_summary_after_mining.pending_peg_out_txos(), vec![]);
+
+    assert_eq!(wallet_summary_after_mining.pending_change_utxos(), vec![]);
+
     Ok(())
 }
 


### PR DESCRIPTION
This introduces a `WalletSummary`, which is a snapshot of the wallet's coins that are spendable and in-flight.

Consuming this new endpoint is interesting in a vacuum, however it becomes significantly more useful when consumed with a tool like `fedimint-observer`, since it allows us to have a view of the wallet's coins as reported from peer databases. We can compare the `WalletSummary` to the UTXO set constructed from scraping the session outcomes to detect inconsistencies. Historically this would have come in handy while investigating wallet bugs.

One approach we've discussed to solve https://github.com/fedimint/fedimint/issues/3802 is to compare the mint's reported coins against the UTXO set from a different bitcoin backend to detect spends constructed outside of the wallet.

Since we plan to hold off on 0.5 until after BTC++ Berlin, I propose we backport so we have this data available soon.