### PR TITLE
feat(audit): allow adding of AuditItem to Audit

### DIFF
--- a/fedimint-core/src/module/audit.rs
+++ b/fedimint-core/src/module/audit.rs
@@ -26,6 +26,10 @@ impl Audit {
         }
     }
 
+    pub fn add_item(&mut self, item: AuditItem) {
+        self.items.push(item);
+    }
+
     pub async fn add_items<KP, F>(
         &mut self,
         dbtx: &mut DatabaseTransaction<'_>,


### PR DESCRIPTION
New Audit::add_item to allow adding of AuditItem directly. 

I have a case in my module where Audit::add_items does not work because I need to read multiple DB keys to find my millisat i64. Thanks!
