### PR TITLE
chore: stop explicitly setting ldk gossip to p2p

### DIFF
--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -79,10 +79,9 @@ impl GatewayLdkClient {
             wallet_sync_interval_secs: 10,
             ..Default::default()
         });
-        node_builder.set_entropy_bip39_mnemonic(mnemonic, None);
         node_builder
-            .set_esplora_server(esplora_server_url.to_string())
-            .set_gossip_source_p2p();
+            .set_entropy_bip39_mnemonic(mnemonic, None)
+            .set_esplora_server(esplora_server_url.to_string());
         let Some(data_dir_str) = data_dir.to_str() else {
             return Err(anyhow::anyhow!("Invalid data dir path"));
         };


### PR DESCRIPTION
`ldk-node` already sets the gossip source to p2p [by default](https://docs.rs/ldk-node/0.3.0/ldk_node/struct.Builder.html#defaults), so this isn't needed