### PR TITLE
chore(consensus): ask for signed session outcomes without a delay

### DIFF
--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -797,11 +797,6 @@ impl ConsensusEngine {
         };
 
         loop {
-            // We only want to initiate the request if we have not ordered a unit in a
-            // while. This indicates that we have fallen behind and our peers
-            // have already switched sessions without us
-            sleep(Duration::from_secs(5)).await;
-
             let result = federation_api
                 .request_with_strategy(
                     FilterMap::new(filter_map.clone(), self.num_peers()),


### PR DESCRIPTION
I think this just leads to a huge slowdown of #6030 and in a normal operation the cost of this API call is neglible.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
