### PR TITLE
chore: bump devimint channel open timeout

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -913,8 +913,7 @@ pub async fn open_channels_between_gateways(
             info!(target: LOG_DEVIMINT, "Opening channel between {gw_a_name} and {gw_b_name} gateway lightning nodes with {push_amount} on each side...");
             tokio::task::spawn(async move {
                 // Sometimes channel openings just after funding the lightning nodes don't work right away.
-                // This resolves itself after a few seconds, so we don't need to poll for very long.
-                poll_with_timeout("Open channel", Duration::from_secs(10), || async {
+                poll_with_timeout("Open channel", Duration::from_secs(30), || async {
                     gw_a.open_channel(&gw_b, 10_000_000, Some(push_amount)).await.map_err(ControlFlow::Continue)
                 })
                 .await


### PR DESCRIPTION
I've seen CI fail a few times due to this poll timing out, causing flakiness. Let's bump it.

For an example of this failure, see [this CI run](https://github.com/fedimint/fedimint/actions/runs/10926024375/job/30328929384) from #6035