### PR TITLE
chore: add default BTC RPC env vars in NixOS module

### DIFF
--- a/nix/modules/fedimintd.nix
+++ b/nix/modules/fedimintd.nix
@@ -235,9 +235,9 @@ in
                 (if cfg.bitcoin.rpc.secretFile != null then
                   ''
                     secret=$(${pkgs.coreutils}/bin/head -n 1 "${cfg.bitcoin.rpc.secretFile}")
-                    prefix="''${FM_BITCOIN_RPC_URL%*@*}"  # Everything before the last '@'
-                    suffix="''${FM_BITCOIN_RPC_URL##*@}"  # Everything after the last '@'
-                    FM_BITCOIN_RPC_URL="''${prefix}:''${secret}@''${suffix}"
+                    prefix="''${FM_DEFAULT_BITCOIN_RPC_URL%*@*}"  # Everything before the last '@'
+                    suffix="''${FM_DEFAULT_BITCOIN_RPC_URL##*@}"  # Everything after the last '@'
+                    FM_DEFAULT_BITCOIN_RPC_URL="''${prefix}:''${secret}@''${suffix}"
                   ''
                 else
                   "") +
@@ -258,6 +258,10 @@ in
                   FM_API_URL = cfg.api.address;
                   FM_DATA_DIR = cfg.dataDir;
                   FM_BITCOIN_NETWORK = cfg.bitcoin.network;
+                  FM_DEFAULT_BITCOIN_RPC_URL = cfg.bitcoin.rpc.address;
+                  FM_DEFAULT_BITCOIN_RPC_KIND = cfg.bitcoin.rpc.kind;
+
+                  # Deprecated envvars, for backward compatibility
                   FM_BITCOIN_RPC_URL = cfg.bitcoin.rpc.address;
                   FM_BITCOIN_RPC_KIND = cfg.bitcoin.rpc.kind;
                 }


### PR DESCRIPTION
This change is made to address deprecation warnings in the fedimint service logs. The environment variables `FM_BITCOIN_RPC_URL` and `FM_BITCOIN_RPC_KIND` are now considered obsolete, and having only these variables causes the following warnings:

```
2024-09-19T17:44:17.136580Z  WARN fm::core: FM_BITCOIN_RPC_KIND is obsolete, use FM_DEFAULT_BITCOIND_RPC_KIND instead
2024-09-19T17:44:17.136588Z  WARN fm::core: FM_BITCOIN_RPC_URL is obsolete, use FM_DEFAULT_BITCOIND_RPC_URL instead
```

To avoid these warnings, the corresponding environment variables with the `DEFAULT` prefix (`FM_DEFAULT_BITCOIND_RPC_URL` and `FM_DEFAULT_BITCOIND_RPC_KIND`) are added in the NixOS module, while keeping the deprecated ones for backward compatibility.

Ref: https://github.com/fedimint/fedimint/blob/master/fedimint-core/src/envs.rs#L80-L102

Related issue: https://github.com/fedimint/fedimint/issues/6047

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
