### PR TITLE
fix(consensus): cache unit count in `BackupWriter`

### DIFF
--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -302,7 +302,7 @@ impl ConsensusEngine {
                         timestamp_sender,
                     ),
                     FinalizationHandler::new(unit_data_sender),
-                    BackupWriter::new(self.db.clone()),
+                    BackupWriter::new(self.db.clone()).await,
                     BackupReader::new(self.db.clone()),
                 ),
                 Network::new(connections),


### PR DESCRIPTION
Partially reverting beb5892f0fb7ac485fe47b9b5091ecd9bda2dda8 .

This query performance is not as good as we would hope.

Re #6050

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
