### PR TITLE
chore: benchmark DB access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -1307,6 +1308,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -2979,6 +2981,7 @@ version = "0.5.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
+ "criterion",
  "fedimint-core",
  "futures",
  "rocksdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ bls12_381 = "0.8.0"
 bytes = "1.7.2"
 clap = { version = "4.5.18", features = ["derive", "env"] }
 cln-rpc = "0.1.9"
-criterion = "0.5.1"
+criterion = { version = "0.5.1", features = ["async_tokio"] }
 devimint = { path = "./devimint", version = "=0.5.0-alpha" }
 electrum-client = { version = "0.18.0", features = ["use-rustls"] }
 erased-serde = "0.4"

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -15,6 +15,10 @@ rustc-args = ["--cfg", "tokio_unstable"]
 name = "fedimint_rocksdb"
 path = "src/lib.rs"
 
+[[bench]]
+name = "db_access"
+harness = false
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -24,6 +28,7 @@ rocksdb = { version = "0.22.0" }
 tracing = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 tempfile = "3.12.0"
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]

--- a/fedimint-rocksdb/benches/db_access.rs
+++ b/fedimint-rocksdb/benches/db_access.rs
@@ -1,0 +1,151 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_core::secp256k1::rand::{thread_rng, Rng};
+use fedimint_core::{impl_db_lookup, impl_db_record};
+use fedimint_rocksdb::RocksDb;
+use futures::StreamExt;
+use tokio::runtime::Runtime;
+
+#[repr(u8)]
+#[derive(Clone)]
+enum TestDbKeyPrefix {
+    Test = 254,
+    MaxTest = 255,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+struct TestKey(pub Vec<u8>);
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+struct TestVal(pub Vec<u8>);
+
+#[derive(Debug, Encodable, Decodable)]
+struct DbPrefixTestPrefix;
+
+impl_db_record!(
+    key = TestKey,
+    value = TestVal,
+    db_prefix = TestDbKeyPrefix::Test,
+    notify_on_modify = true,
+);
+impl_db_lookup!(key = TestKey, query_prefix = DbPrefixTestPrefix);
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+struct TestKey2(pub Vec<u8>);
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+struct TestVal2(pub Vec<u8>);
+
+#[derive(Debug, Encodable, Decodable)]
+struct DbPrefixTestPrefixMax;
+
+impl_db_record!(
+    key = TestKey2,
+    value = TestVal2,
+    db_prefix = TestDbKeyPrefix::MaxTest, // max/last prefix
+    notify_on_modify = true,
+);
+impl_db_lookup!(key = TestKey2, query_prefix = DbPrefixTestPrefixMax);
+
+async fn new_db() -> Database {
+    let path = tempfile::Builder::new()
+        .prefix("rocksdb-bench")
+        .tempdir()
+        .expect("Failed to create temp dir");
+
+    Database::new(
+        RocksDb::open(&path).expect("Failed to open DB"),
+        ModuleDecoderRegistry::default(),
+    )
+}
+
+const ENTRIES: usize = 100000;
+
+async fn fill_db(dbtx: &mut DatabaseTransaction<'_>) {
+    let mut rng = thread_rng();
+    for i in 0..ENTRIES {
+        // Value is a vec with random bytes between 10 and 100 bytes long
+        let length = rng.gen_range(10..=100);
+        let mut value = vec![0; length];
+        rng.fill(&mut value[..]);
+
+        dbtx.insert_entry(&TestKey(i.to_be_bytes().to_vec()), &TestVal(value))
+            .await;
+    }
+
+    dbtx.insert_entry(&TestKey2(vec![0]), &TestVal2(vec![3]))
+        .await;
+    dbtx.insert_entry(&TestKey2(vec![254]), &TestVal2(vec![1]))
+        .await;
+    dbtx.insert_entry(&TestKey2(vec![255]), &TestVal2(vec![2]))
+        .await;
+}
+
+async fn reverse_prefix_search(db: &Database) {
+    let mut dbtx = db.begin_transaction().await;
+    let query = dbtx
+        .find_by_prefix_sorted_descending(&DbPrefixTestPrefix)
+        .await
+        .collect::<Vec<_>>()
+        .await;
+    assert_eq!(query.len(), ENTRIES);
+}
+
+async fn reverse_prefix_search_only_first(db: &Database) {
+    let mut dbtx = db.begin_transaction().await;
+    let query = dbtx
+        .find_by_prefix_sorted_descending(&DbPrefixTestPrefix)
+        .await
+        .next()
+        .await
+        .expect("No entries found");
+    assert_eq!(query.0 .0, (ENTRIES - 1).to_be_bytes().to_vec());
+}
+
+async fn increment_last(db: &Database) {
+    let mut dbtx = db.begin_transaction().await;
+    let query = dbtx
+        .find_by_prefix_sorted_descending(&DbPrefixTestPrefix)
+        .await
+        .next()
+        .await
+        .expect("No entries found");
+    let next = usize::from_be_bytes(query.0 .0.try_into().expect("Invalid DB entry")) + 1;
+
+    dbtx.insert_entry(&TestKey(next.to_be_bytes().to_vec()), &TestVal(vec![0; 50]))
+        .await;
+    dbtx.commit_tx().await;
+}
+
+fn benchmark_reverse_retrieval(c: &mut Criterion) {
+    let mut group = c.benchmark_group("async_group");
+
+    let rt = Runtime::new().expect("Failed to create runtime");
+    let db = rt.block_on(async {
+        let db = new_db().await;
+        let mut dbtx = db.begin_transaction().await;
+        fill_db(&mut dbtx.to_ref_nc()).await;
+        dbtx.commit_tx().await;
+        db
+    });
+
+    group.bench_function("reverse_prefix_search_only_first", |b| {
+        b.to_async(&rt)
+            .iter(|| reverse_prefix_search_only_first(&db));
+    });
+
+    group.bench_function("reverse_prefix_search", |b| {
+        b.to_async(&rt).iter(|| reverse_prefix_search(&db));
+    });
+
+    group.bench_function("increment_last", |b| {
+        b.to_async(&rt).iter(|| increment_last(&db));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_reverse_retrieval);
+criterion_main!(benches);


### PR DESCRIPTION
Fixes #6050, so we get some insight into RocksDB performance. I can't really see an obvious smoking gun here. While reverse iteration is about twice as slow as forward iteration, just getting the first element seems to be blazingly fast (less than 3us). If I combine it with an insert at the end it goes up to 462us, but that might just be the dbtx commit.

```
$ cargo bench -p fedimint-rocksdb

async_group/reverse_prefix_search_only_first
                        time:   [2.6789 µs 2.6957 µs 2.7144 µs]
                        change: [-0.6772% +1.1186% +3.1433%] (p = 0.28 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking async_group/reverse_prefix_search: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.0s, or reduce sample count to 80.
async_group/reverse_prefix_search
                        time:   [59.807 ms 60.265 ms 60.751 ms]
                        change: [-2.3671% -1.2342% -0.1487%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
async_group/prefix_search_only_first
                        time:   [1.5754 µs 1.5857 µs 1.5975 µs]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
async_group/prefix_search
                        time:   [28.188 ms 28.392 ms 28.631 ms]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
async_group/increment_last
                        time:   [457.40 µs 462.56 µs 468.48 µs]
                        change: [-4.2827% -2.5961% -0.8962%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe
```

TODO:
* Separate out write and commit in the `increment_last` test, so we only benchmark the reading (using [`iter_custom`](https://docs.rs/criterion/latest/criterion/struct.Bencher.html#method.iter_custom))
* Test with larger DB where most keys aren't queried

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
