### PR TITLE
refactor: get rid of ClientDbTxContext

### DIFF
--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -297,10 +297,18 @@ where
     ///
     /// Only intended for internal use (private).
     fn global_db(&self) -> fedimint_core::db::Database {
-        self.client.get().db().clone()
+        let db = self.client.get().db().clone();
+
+        db.ensure_global()
+            .expect("global_db must always return a global db");
+
+        db
     }
 
     pub fn module_db(&self) -> &Database {
+        self.module_db
+            .ensure_isolated()
+            .expect("module_db must always return isolated db");
         &self.module_db
     }
 

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -201,6 +201,7 @@ pub type PhantomBound<'big, 'small> = PhantomData<&'small &'big ()>;
 #[derive(Debug, Error)]
 pub enum AutocommitError<E> {
     /// Committing the transaction failed too many times, giving up
+    #[error("Commit Failed: {last_error}")]
     CommitFailed {
         /// Number of attempts
         attempts: usize,
@@ -209,6 +210,7 @@ pub enum AutocommitError<E> {
     },
     /// Error returned by the closure provided to `autocommit`. If returned no
     /// commit was attempted in that round
+    #[error("Closure error: {error}")]
     ClosureError {
         /// The attempt on which the closure returned an error
         ///

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -291,8 +291,9 @@ pub trait IDatabase: Debug + MaybeSend + MaybeSync + 'static {
     /// Notify about `key` update (creation, modification, deletion)
     async fn notify(&self, key: &[u8]);
 
-    /// The prefix len of this database instance
-    fn prefix_len(&self) -> usize;
+    /// The prefix len of this database refers to the global (as opposed to
+    /// module-isolated) key space
+    fn is_global(&self) -> bool;
 
     /// Checkpoints the database to a backup directory
     fn checkpoint(&self, backup_path: &Path) -> Result<()>;
@@ -313,8 +314,8 @@ where
         (**self).notify(key).await;
     }
 
-    fn prefix_len(&self) -> usize {
-        (**self).prefix_len()
+    fn is_global(&self) -> bool {
+        (**self).is_global()
     }
 
     fn checkpoint(&self, backup_path: &Path) -> Result<()> {
@@ -351,8 +352,8 @@ impl<RawDatabase: IRawDatabase + MaybeSend + 'static> IDatabase for BaseDatabase
         self.notifications.notify(key);
     }
 
-    fn prefix_len(&self) -> usize {
-        0
+    fn is_global(&self) -> bool {
+        true
     }
 
     fn checkpoint(&self, backup_path: &Path) -> Result<()> {
@@ -451,7 +452,7 @@ impl Database {
 
     /// Is this `Database` a global, unpartitioned `Database`
     pub fn is_global(&self) -> bool {
-        self.inner.prefix_len() == 0
+        self.inner.is_global()
     }
 
     /// `Err` if [`Self::is_global`] is not true
@@ -698,8 +699,12 @@ where
         self.inner.notify(&self.get_full_key(key)).await;
     }
 
-    fn prefix_len(&self) -> usize {
-        self.inner.prefix_len() + self.prefix.len()
+    fn is_global(&self) -> bool {
+        if self.global_dbtx_access_token.is_some() {
+            false
+        } else {
+            self.inner.is_global()
+        }
     }
 
     fn checkpoint(&self, backup_path: &Path) -> Result<()> {
@@ -749,8 +754,12 @@ where
         self.inner.commit_tx().await
     }
 
-    fn prefix_len(&self) -> usize {
-        self.inner.prefix_len() + self.prefix.len()
+    fn is_global(&self) -> bool {
+        if self.global_dbtx_access_token.is_some() {
+            false
+        } else {
+            self.inner.is_global()
+        }
     }
 
     fn global_dbtx(
@@ -1255,8 +1264,8 @@ pub trait IDatabaseTransaction: MaybeSend + IDatabaseTransactionOps + fmt::Debug
     /// Commit the transaction
     async fn commit_tx(&mut self) -> Result<()>;
 
-    /// The prefix len of this database instance
-    fn prefix_len(&self) -> usize;
+    /// Is global database
+    fn is_global(&self) -> bool;
 
     /// Get the global database tx from a module-prefixed database transaction
     ///
@@ -1276,8 +1285,8 @@ where
         (**self).commit_tx().await
     }
 
-    fn prefix_len(&self) -> usize {
-        (**self).prefix_len()
+    fn is_global(&self) -> bool {
+        (**self).is_global()
     }
 
     fn global_dbtx(
@@ -1296,8 +1305,9 @@ where
     async fn commit_tx(&mut self) -> Result<()> {
         (**self).commit_tx().await
     }
-    fn prefix_len(&self) -> usize {
-        (**self).prefix_len()
+
+    fn is_global(&self) -> bool {
+        (**self).is_global()
     }
 
     fn global_dbtx(&mut self, access_key: GlobalDBTxAccessToken) -> &mut dyn IDatabaseTransaction {
@@ -1450,8 +1460,8 @@ impl<Tx: IRawDatabaseTransaction + fmt::Debug> IDatabaseTransaction
         Ok(())
     }
 
-    fn prefix_len(&self) -> usize {
-        0
+    fn is_global(&self) -> bool {
+        true
     }
 
     fn global_dbtx(
@@ -1742,7 +1752,7 @@ impl<'tx, Cap> DatabaseTransaction<'tx, Cap> {
 
     /// Is this `Database` a global, unpartitioned `Database`
     pub fn is_global(&self) -> bool {
-        self.tx.prefix_len() == 0
+        self.tx.is_global()
     }
 
     /// `Err` if [`Self::is_global`] is not true

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -591,7 +591,7 @@ impl GatewayClientModule {
                             .map(|s| self.client_ctx.make_dyn(s))
                             .collect();
 
-                            match self.client_ctx.add_state_machines_dbtx( dbtx, dyn_states).await {
+                            match self.client_ctx.add_state_machines_dbtx(dbtx, dyn_states).await {
                                 Ok(()) => {
                                     self.client_ctx
                                         .add_operation_log_entry_dbtx(

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -572,8 +572,8 @@ impl GatewayClientModule {
             );
         }
 
-        self.client_ctx
-            .module_autocommit(
+        self.client_ctx.module_db()
+            .autocommit(
                 |dbtx, _| {
                     Box::pin(async {
                         let operation_id = OperationId(payload.contract_id.to_byte_array());
@@ -591,10 +591,11 @@ impl GatewayClientModule {
                             .map(|s| self.client_ctx.make_dyn(s))
                             .collect();
 
-                            match dbtx.add_state_machines( dyn_states).await {
+                            match self.client_ctx.add_state_machines_dbtx( dbtx, dyn_states).await {
                                 Ok(()) => {
-                                    dbtx
-                                        .add_operation_log_entry(
+                                    self.client_ctx
+                                        .add_operation_log_entry_dbtx(
+                                            dbtx,
                                             operation_id,
                                             KIND.as_str(),
                                             GatewayMeta::Pay,

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -480,7 +480,7 @@ impl GatewayClientModule {
         let mut stream = self.notifier.subscribe(operation_id).await;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, || {
             stream! {
 
                 yield GatewayExtReceiveStates::Funding;
@@ -630,7 +630,7 @@ impl GatewayClientModule {
         let operation = self.client_ctx.get_operation(operation_id).await?;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, || {
             stream! {
                 yield GatewayExtPayStates::Created;
 

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1209,7 +1209,7 @@ impl LightningClientModule {
         let mut stream = self.notifier.subscribe(operation_id).await;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, || {
             stream! {
                 yield InternalPayState::Funding;
 
@@ -1274,7 +1274,7 @@ impl LightningClientModule {
 
         let client_ctx = self.client_ctx.clone();
 
-        Ok(operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, || {
             stream! {
                 let self_ref = client_ctx.self_ref();
 
@@ -1593,7 +1593,7 @@ impl LightningClientModule {
 
         let client_ctx = self.client_ctx.clone();
 
-        Ok(operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, || {
             stream! {
                 yield LnReceiveState::AwaitingFunds;
 
@@ -1626,7 +1626,7 @@ impl LightningClientModule {
 
         let client_ctx = self.client_ctx.clone();
 
-        Ok(operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, || {
             stream! {
 
                 let self_ref = client_ctx.self_ref();

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -643,7 +643,7 @@ impl LightningClientModule {
         let client_ctx = self.client_ctx.clone();
         let module_api = self.module_api.clone();
 
-        Ok(operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, || {
             stream! {
                 loop {
                     if let Some(LightningClientStateMachines::Send(state)) = stream.next().await {
@@ -942,7 +942,7 @@ impl LightningClientModule {
         let mut stream = self.notifier.subscribe(operation_id).await;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, || {
             stream! {
                 loop {
                     if let Some(LightningClientStateMachines::Receive(state)) = stream.next().await {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -703,7 +703,8 @@ impl ClientModule for MintClientModule {
 
     async fn backup(&self) -> anyhow::Result<EcashBackup> {
         self.client_ctx
-            .module_autocommit(
+            .module_db()
+            .autocommit(
                 |dbtx_ctx, _| {
                     Box::pin(async { self.prepare_plaintext_ecash_backup(dbtx_ctx).await })
                 },
@@ -1548,13 +1549,14 @@ impl MintClientModule {
             .expect("MintClientModule::spend_notes extra_meta is serializable");
 
         self.client_ctx
-            .module_autocommit(
+            .module_db()
+            .autocommit(
                 |dbtx, _| {
                     let extra_meta = extra_meta.clone();
                     Box::pin(async {
                         let (operation_id, states, notes) = self
                             .spend_notes_oob(
-                                &mut dbtx.module_dbtx(),
+                                dbtx,
                                 notes_selector,
                                 requested_amount,
                                 try_cancel_after,
@@ -1570,21 +1572,27 @@ impl MintClientModule {
                             OOBNotes::new(federation_id_prefix, notes)
                         };
 
-                        dbtx.add_state_machines(self.client_ctx.map_dyn(states).collect())
+                        self.client_ctx
+                            .add_state_machines_dbtx(
+                                dbtx,
+                                self.client_ctx.map_dyn(states).collect(),
+                            )
                             .await?;
-                        dbtx.add_operation_log_entry(
-                            operation_id,
-                            MintCommonInit::KIND.as_str(),
-                            MintOperationMeta {
-                                variant: MintOperationMetaVariant::SpendOOB {
-                                    requested_amount,
-                                    oob_notes: oob_notes.clone(),
+                        self.client_ctx
+                            .add_operation_log_entry_dbtx(
+                                dbtx,
+                                operation_id,
+                                MintCommonInit::KIND.as_str(),
+                                MintOperationMeta {
+                                    variant: MintOperationMetaVariant::SpendOOB {
+                                        requested_amount,
+                                        oob_notes: oob_notes.clone(),
+                                    },
+                                    amount: oob_notes.total_amount(),
+                                    extra_meta,
                                 },
-                                amount: oob_notes.total_amount(),
-                                extra_meta,
-                            },
-                        )
-                        .await;
+                            )
+                            .await;
 
                         Ok((operation_id, oob_notes))
                     })

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -747,7 +747,7 @@ impl WalletClientModule {
             return Ok(UpdateStreamOrOutcome::Outcome(outcome_v2));
         };
 
-        Ok(operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self.client_ctx.outcome_or_updates(&operation, operation_id, || {
             let stream_rpc = self.rpc.clone();
             let stream_cient_ctx = self.client_ctx.clone();
             let stream_script_pub_key = address.assume_checked().script_pubkey();
@@ -1089,8 +1089,9 @@ impl WalletClientModule {
         let mut operation_stream = self.notifier.subscribe(operation_id).await;
         let client_ctx = self.client_ctx.clone();
 
-        Ok(
-            operation.outcome_or_updates(&self.client_ctx.global_db(), operation_id, || {
+        Ok(self
+            .client_ctx
+            .outcome_or_updates(&operation, operation_id, || {
                 stream! {
                     match next_withdraw_state(&mut operation_stream).await {
                         Some(WithdrawStates::Created(_)) => {
@@ -1124,8 +1125,7 @@ impl WalletClientModule {
                         None => {},
                     }
                 }
-            }),
-        )
+            }))
     }
 }
 

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -513,6 +513,8 @@ impl WalletClientModule {
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
     ) -> (OperationId, Address, TweakIdx) {
+        dbtx.ensure_isolated().expect("Must be isolated db");
+
         let tweak_idx = get_next_peg_in_tweak_child_id(dbtx).await;
         let (_secret_tweak_key, _, address, operation_id) =
             self.data.derive_deposit_address(tweak_idx);
@@ -645,7 +647,7 @@ impl WalletClientModule {
                     let extra_meta_value_inner = extra_meta_value.clone();
                     Box::pin(async move {
                         let (operation_id, address, tweak_idx) = self
-                            .allocate_deposit_address_inner( dbtx)
+                            .allocate_deposit_address_inner(dbtx)
                             .await;
 
                         self.client_ctx.manual_operation_start_dbtx(


### PR DESCRIPTION
It has been rendered redudndant, by the built-in DBTx global_tx.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
