### PR TITLE
fix: clippy warning lightning_context

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -568,7 +568,7 @@ impl Gateway {
                         }
                     };
 
-                    self.handle_htlc(payment_request, &lightning_context).await;
+                    self.handle_htlc(payment_request, lightning_context).await;
                 }
             })
             .await


### PR DESCRIPTION
gets rid of clippy warning, drops at end of scope so don't borrow