### PR TITLE
feat: add lightweight CLN container

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -414,6 +414,14 @@ jobs:
             nix build -L .#container.gatewayd
           fi
           echo "gatewayd_container_tag=$(docker load < result | awk '{ print $3 }')" >> $GITHUB_ENV
+      - name: Build cln-light-gateway container
+        run: |
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ] || [ "$GITHUB_EVENT_NAME" == "merge_group" ]; then
+            nix build -L .#ci.container.cln-light-gateway
+          else
+            nix build -L .#container.cln-light-gateway
+          fi
+          echo "cln_light_gateway_container_tag=$(docker load < result | awk '{ print $3 }')" >> $GITHUB_ENV
 
       - name: Build gateway-cli container
         run: |
@@ -446,6 +454,7 @@ jobs:
           nix_tag=${{ env.fedimintd_container_tag }} && hub_tag="fedimint/fedimintd:${LAST_COMMIT_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.fedimint_cli_container_tag }} && hub_tag="fedimint/fedimint-cli:${LAST_COMMIT_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.gatewayd_container_tag }} && hub_tag="fedimint/gatewayd:${LAST_COMMIT_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
+          nix_tag=${{ env.cln_light_gateway_container_tag }} && hub_tag="fedimint/cln-light-gateway:${LAST_COMMIT_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.gateway-cli_container_tag }} && hub_tag="fedimint/gateway-cli:${LAST_COMMIT_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.devtools_container_tag }} && hub_tag="fedimint/devtools:${LAST_COMMIT_SHA}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
 
@@ -455,6 +464,7 @@ jobs:
           nix_tag=${{ env.fedimintd_container_tag }} && hub_tag="fedimint/fedimintd:master" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.fedimint_cli_container_tag }} && hub_tag="fedimint/fedimint-cli:master" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.gatewayd_container_tag }} && hub_tag="fedimint/gatewayd:master" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
+          nix_tag=${{ env.cln_light_gateway_container_tag }} && hub_tag="fedimint/cln-light-gateway:master" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.gateway-cli_container_tag }} && hub_tag="fedimint/gateway-cli:master" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.devtools_container_tag }} && hub_tag="fedimint/devtools:master" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
 
@@ -464,6 +474,7 @@ jobs:
           nix_tag=${{ env.fedimintd_container_tag }} && hub_tag="fedimint/fedimintd:${GITHUB_REF_NAME}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.fedimint_cli_container_tag }} && hub_tag="fedimint/fedimint-cli:${GITHUB_REF_NAME}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.gatewayd_container_tag }} && hub_tag="fedimint/gatewayd:${GITHUB_REF_NAME}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
+          nix_tag=${{ env.cln_light_gateway_container_tag }} && hub_tag="fedimint/cln-light-gateway:${GITHUB_REF_NAME}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.gateway-cli_container_tag }} && hub_tag="fedimint/gateway-cli:${GITHUB_REF_NAME}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
           nix_tag=${{ env.devtools_container_tag }} && hub_tag="fedimint/devtools:${GITHUB_REF_NAME}" && docker tag "$nix_tag" "$hub_tag" && docker push "$hub_tag"
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             (import ./nix/overlays/clightning.nix)
             (import ./nix/overlays/darwin-compile-fixes.nix)
             (import ./nix/overlays/cargo-honggfuzz.nix)
+            (import ./nix/overlays/trustedcoin.nix)
           ];
     in
     {

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -608,19 +608,12 @@ rec {
         pkgs.writeShellScriptBin "entrypoint" ''
           exec bash "${../misc/fedimintd-container-entrypoint.sh}" "$@"
         '';
+      defaultPackages = [ pkgs.bash pkgs.coreutils pkgs.fakeNss pkgs.busybox pkgs.curl pkgs.rsync ];
     in
     {
       fedimintd = pkgs.dockerTools.buildLayeredImage {
         name = "fedimintd";
-        contents = [
-          fedimint-pkgs
-          pkgs.bash
-          pkgs.coreutils
-          pkgs.fakeNss
-          pkgs.busybox
-          pkgs.curl
-          pkgs.rsync
-        ];
+        contents = [ fedimint-pkgs ] ++ defaultPackages;
         config = {
           Cmd = [ ]; # entrypoint will handle empty vs non-empty cmd
           Env = [
@@ -642,7 +635,7 @@ rec {
 
       fedimint-cli = pkgs.dockerTools.buildLayeredImage {
         name = "fedimint-cli";
-        contents = [ fedimint-pkgs pkgs.bash pkgs.coreutils pkgs.sqlite pkgs.fakeNss pkgs.busybox pkgs.curl pkgs.rsync ];
+        contents = [ fedimint-pkgs ] ++ defaultPackages;
         config = {
           Cmd = [
             "${fedimint-pkgs}/bin/fedimint-cli"
@@ -652,7 +645,7 @@ rec {
 
       gatewayd = pkgs.dockerTools.buildLayeredImage {
         name = "gatewayd";
-        contents = [ gateway-pkgs pkgs.bash pkgs.coreutils pkgs.sqlite pkgs.fakeNss pkgs.busybox pkgs.curl pkgs.rsync ];
+        contents = [ gateway-pkgs ] ++ defaultPackages;
         config = {
           Cmd = [
             "${gateway-pkgs}/bin/gatewayd"
@@ -660,9 +653,40 @@ rec {
         };
       };
 
+      cln-light-gateway = let
+        entrypoint = pkgs.writeShellScriptBin "entrypoint.sh" ''
+          ${pkgs.clightning}/bin/lightningd \
+            --lightning-dir=/lightning \
+            --disable-plugin=bcli \
+            --network=$NETWORK \
+            --plugin=${pkgs.trustedcoin}/bin/trustedcoin \
+            --plugin=${gateway-pkgs}/bin/gateway-cln-extension \
+            --fm-gateway-listen=127.0.0.1:3301 \
+            $@
+        '';
+      in pkgs.dockerTools.buildLayeredImage {
+        name = "cln-light-gateway";
+        contents = [ gateway-pkgs pkgs.clightning pkgs.trustedcoin pkgs.cacert ] ++ defaultPackages;
+        config = {
+          Cmd = [
+            "${entrypoint}/bin/entrypoint.sh"
+          ];
+          Volumes = {
+            "/lightning" = {};
+          };
+          ExposedPorts = {
+            "9735/tcp" = {};
+            "3301/tcp" = {};
+          };
+          Env = [
+            "NETWORK=bitcoin"
+          ];
+        };
+      };
+
       gateway-cli = pkgs.dockerTools.buildLayeredImage {
         name = "gateway-cli";
-        contents = [ gateway-pkgs pkgs.bash pkgs.coreutils pkgs.sqlite pkgs.fakeNss pkgs.busybox pkgs.curl pkgs.rsync ];
+        contents = [ gateway-pkgs ] ++ defaultPackages;
         config = {
           Cmd = [
             "${gateway-pkgs}/bin/gateway-cli"
@@ -679,13 +703,7 @@ rec {
               fedimint-dbtool
               fedimint-load-test-tool
               fedimint-recoverytool
-              pkgs.bash
-              pkgs.coreutils
-              pkgs.sqlite
-              pkgs.busybox
-              pkgs.curl
-              pkgs.rsync
-            ];
+            ] ++ defaultPackages;
             config = {
               Cmd = [
                 "${pkgs.bash}/bin/bash"

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -661,7 +661,7 @@ rec {
             --network=$NETWORK \
             --plugin=${pkgs.trustedcoin}/bin/trustedcoin \
             --plugin=${gateway-pkgs}/bin/gateway-cln-extension \
-            --fm-gateway-listen=127.0.0.1:3301 \
+            --fm-gateway-listen=0.0.0.0:3301 \
             $@
         '';
       in pkgs.dockerTools.buildLayeredImage {

--- a/nix/overlays/trustedcoin.nix
+++ b/nix/overlays/trustedcoin.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  trustedcoin = prev.callPackage ../pkgs/trustedcoin.nix { };
+}

--- a/nix/pkgs/trustedcoin.nix
+++ b/nix/pkgs/trustedcoin.nix
@@ -1,0 +1,25 @@
+# Copied from: https://github.com/fort-nix/nix-bitcoin/blob/548f17d8680c26b429c086d68c98184bc6f6e840/pkgs/trustedcoin/default.nix#L4
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "trustedcoin";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "nbd-wtf";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-M1z5Vn3UGLJHdCZxud8jM2ewiW90zzC7Vaidv3yGNAE=";
+  };
+
+  vendorHash = "sha256-hKaSB8/pymA7o2LuUpLjLZYn37JzEBn3a/3vkGbhLdM=";
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Light bitcoin node implementation";
+    homepage = "https://github.com/nbd-wtf/trustedcoin";
+    maintainers = with maintainers; [ seberm fort-nix ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
* Uses trustedcoin as its BTC backend
* Ships with the gateway plugin

Makes setting up gateways easier since there's no need to wait for chain sync. Caveats: 
* Depends on 3rd party APIs that might become malicious or go offline.
* Only expose the CLN gateway plugin port (`3301`) to the gateway container and **never publicly**, it's unauthenticated and gives node access.

Fixes #6088.

Try it this way:

```
$ nix build .#container.cln-light-gateway
$ docker load < result 
006b2621cc78: Loading layer [==================================================>]  325.8MB/325.8MB
…
62a910d016c0: Loading layer [==================================================>]  440.3kB/440.3kB
Loaded image: cln-light-gateway:0ryra1zr5hl111xvg4hca9n1ii65w40b
$ docker run -it --rm -p 9735:9735 -p 3301:3301 -e NETWORK=testnet -v $(pwd)/cfg/cln-gateway-data:/lightning cln-light-gateway:0ryra1zr5hl111xvg4hca9n1ii65w40b
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
