### PR TITLE
chore(client): during recovery detect burned ecash due to nonce reuse (backport to v0.4)

### DIFF
--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -84,7 +84,7 @@ impl RecoveryFromHistory for MintRecovery {
             .get_value(&RecoveryStateKey)
             .await
             .and_then(|(state, common)| {
-                if let MintRecoveryState::V0(state) = state {
+                if let MintRecoveryState::V1(state) = state {
                     Some((state, common))
                 } else {
                     warn!(target: LOG_CLIENT_RECOVERY, "Found unknown version recovery state. Ignoring");
@@ -109,7 +109,7 @@ impl RecoveryFromHistory for MintRecovery {
     ) {
         dbtx.insert_entry(
             &RecoveryStateKey,
-            &(MintRecoveryState::V0(self.state.clone()), common.clone()),
+            &(MintRecoveryState::V1(self.state.clone()), common.clone()),
         )
         .await;
     }
@@ -268,7 +268,7 @@ impl From<CompressedBlindedMessage> for BlindedMessage {
 
 #[derive(Debug, Clone, Decodable, Encodable)]
 pub enum MintRecoveryState {
-    V0(MintRecoveryStateV0),
+    V1(MintRecoveryStateV0),
     #[encodable_default]
     Default {
         variant: u64,

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -12,7 +12,7 @@ use fedimint_core::{
     apply, async_trait_maybe_send, Amount, NumPeersExt, OutPoint, PeerId, Tiered, TieredMulti,
 };
 use fedimint_derive_secret::DerivableSecret;
-use fedimint_logging::{LOG_CLIENT_MODULE_MINT, LOG_CLIENT_RECOVERY_MINT};
+use fedimint_logging::{LOG_CLIENT_MODULE_MINT, LOG_CLIENT_RECOVERY, LOG_CLIENT_RECOVERY_MINT};
 use fedimint_mint_common::{MintInput, MintOutput, Nonce};
 use serde::{Deserialize, Serialize};
 use tbs::{AggregatePublicKey, BlindedMessage, PublicKeyShare};
@@ -29,7 +29,7 @@ use crate::{MintClientInit, MintClientModule, MintClientStateMachines, NoteIndex
 
 #[derive(Clone, Debug)]
 pub struct MintRecovery {
-    state: MintRecoveryState,
+    state: MintRecoveryStateV0,
     secret: DerivableSecret,
 }
 
@@ -62,7 +62,7 @@ impl RecoveryFromHistory for MintRecovery {
 
         Ok((
             MintRecovery {
-                state: MintRecoveryState::from_backup(
+                state: MintRecoveryStateV0::from_backup(
                     snapshot,
                     30,
                     config.tbs_pks.clone(),
@@ -83,6 +83,14 @@ impl RecoveryFromHistory for MintRecovery {
         Ok(dbtx
             .get_value(&RecoveryStateKey)
             .await
+            .and_then(|(state, common)| {
+                if let MintRecoveryState::V0(state) = state {
+                    Some((state, common))
+                } else {
+                    warn!(target: LOG_CLIENT_RECOVERY, "Found unknown version recovery state. Ignoring");
+                    None
+                }
+            })
             .map(|(state, common)| {
                 (
                     MintRecovery {
@@ -99,8 +107,11 @@ impl RecoveryFromHistory for MintRecovery {
         dbtx: &mut DatabaseTransaction<'_>,
         common: &RecoveryFromHistoryCommon,
     ) {
-        dbtx.insert_entry(&RecoveryStateKey, &(self.state.clone(), common.clone()))
-            .await;
+        dbtx.insert_entry(
+            &RecoveryStateKey,
+            &(MintRecoveryState::V0(self.state.clone()), common.clone()),
+        )
+        .await;
     }
 
     async fn delete_dbtx(&self, dbtx: &mut DatabaseTransaction<'_>) {
@@ -151,7 +162,11 @@ impl RecoveryFromHistory for MintRecovery {
             .sum::<Amount>()
             + finalized.spendable_notes.total_amount();
 
-        info!(amount = %restored_amount, "Finalizing mint recovery");
+        info!(
+            amount = %restored_amount,
+            burned_total = %finalized.burned_total,
+            "Finalizing mint recovery"
+        );
 
         debug!(
             target: LOG_CLIENT_RECOVERY_MINT,
@@ -226,6 +241,8 @@ pub struct EcashRecoveryFinalState {
     pub unconfirmed_notes: Vec<(OutPoint, Amount, NoteIssuanceRequest)>,
     /// Note index to derive next note in a given amount tier
     pub next_note_idx: Tiered<NoteIndex>,
+    /// Total burned amount
+    pub burned_total: Amount,
 }
 
 /// Newtype over [`BlindedMessage`] to enable `Ord`
@@ -249,6 +266,16 @@ impl From<CompressedBlindedMessage> for BlindedMessage {
     }
 }
 
+#[derive(Debug, Clone, Decodable, Encodable)]
+pub enum MintRecoveryState {
+    V0(MintRecoveryStateV0),
+    #[encodable_default]
+    Default {
+        variant: u64,
+        bytes: Vec<u8>,
+    },
+}
+
 /// The state machine used for fast-forwarding backup from point when it was
 /// taken to the present time by following epoch history items from the time the
 /// snapshot was taken.
@@ -257,7 +284,7 @@ impl From<CompressedBlindedMessage> for BlindedMessage {
 /// valid consensus items from the epoch history between time taken (or even
 /// somewhat before it) and present time.
 #[derive(Clone, Eq, PartialEq, Decodable, Encodable, Serialize, Deserialize)]
-pub struct MintRecoveryState {
+pub struct MintRecoveryStateV0 {
     spendable_notes: BTreeMap<Nonce, (Amount, SpendableNote)>,
     /// Nonces that we track that are currently spendable.
     pending_outputs: BTreeMap<Nonce, (OutPoint, Amount, NoteIssuanceRequest)>,
@@ -268,6 +295,11 @@ pub struct MintRecoveryState {
     /// the pool is kept shared (so only one lookup is enough), and
     /// replenishment is done each time a note is consumed.
     pending_nonces: BTreeMap<CompressedBlindedMessage, (NoteIssuanceRequest, NoteIndex, Amount)>,
+    /// Nonces that we have already used. Used for detecting double-used nonces
+    /// (accidentally burning funds).
+    used_nonces: BTreeMap<CompressedBlindedMessage, (NoteIssuanceRequest, NoteIndex, Amount)>,
+    /// Total amount probably burned due to re-using nonces
+    burned_total: Amount,
     /// Tail of `pending`. `pending_notes` is filled by generating note with
     /// this index and incrementing it.
     next_pending_note_idx: Tiered<NoteIndex>,
@@ -290,17 +322,19 @@ pub struct MintRecoveryState {
     gap_limit: u64,
 }
 
-impl fmt::Debug for MintRecoveryState {
+impl fmt::Debug for MintRecoveryStateV0 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!(
-            "MintRestoreInProgressState(pending_outputs: {}, pending_nonces: {})",
+            "MintRestoreInProgressState(pending_outputs: {}, pending_nonces: {}, used_nonces: {}, burned_total: {})",
             self.pending_outputs.len(),
-            self.pending_nonces.len()
+            self.pending_nonces.len(),
+            self.used_nonces.len(),
+            self.burned_total,
         ))
     }
 }
 
-impl MintRecoveryState {
+impl MintRecoveryStateV0 {
     pub fn from_backup(
         backup: EcashBackupV0,
         gap_limit: u64,
@@ -326,6 +360,8 @@ impl MintRecoveryState {
                 })
                 .collect(),
             pending_nonces: BTreeMap::default(),
+            used_nonces: BTreeMap::default(),
+            burned_total: Amount::ZERO,
             next_pending_note_idx: backup.next_note_idx.clone(),
             last_mined_nonce_idx: backup.next_note_idx,
             threshold: pub_key_shares.to_num_peers().threshold() as u64,
@@ -395,6 +431,18 @@ impl MintRecoveryState {
             }
         };
 
+        if let Some((_issuance_request, note_idx, amount)) =
+            self.used_nonces.get(&output.blind_nonce.0.into())
+        {
+            self.burned_total += *amount;
+            warn!(
+                target: LOG_CLIENT_RECOVERY_MINT,
+                %note_idx,
+                %amount,
+                burned_total = %self.burned_total,
+                "Detected reused nonce during recovery. This means client probably burned funds in the past."
+            );
+        }
         // There is nothing preventing other users from creating valid
         // transactions mining notes to our own blind nonce, possibly
         // even racing with us. Including amount in blind nonce
@@ -409,10 +457,8 @@ impl MintRecoveryState {
         // greedy no matter what and take what we can, and just report
         // anything suspicious.
 
-        if let Some((issuance_request, note_idx, pending_amount)) = self
-            .pending_nonces
-            .get(&output.blind_nonce.0.into())
-            .copied()
+        if let Some((issuance_request, note_idx, pending_amount)) =
+            self.pending_nonces.remove(&output.blind_nonce.0.into())
         {
             // the moment we see our blind nonce in the epoch history, correctly or
             // incorrectly used, we know that we must have used
@@ -420,10 +466,10 @@ impl MintRecoveryState {
             self.observe_nonce_idx_being_used(pending_amount, note_idx, secret);
 
             if pending_amount == output.amount {
-                assert!(self
-                    .pending_nonces
-                    .remove(&output.blind_nonce.0.into())
-                    .is_some());
+                self.used_nonces.insert(
+                    output.blind_nonce.0.into(),
+                    (issuance_request, note_idx, pending_amount),
+                );
 
                 self.pending_outputs.insert(
                     issuance_request.nonce(),
@@ -435,8 +481,8 @@ impl MintRecoveryState {
                     output.blind_nonce.0.into(),
                     (issuance_request, note_idx, pending_amount),
                 );
-
                 warn!(
+                    target: LOG_CLIENT_RECOVERY_MINT,
                     output = ?out_point,
                     blind_nonce = ?output.blind_nonce.0,
                     expected_amount = %pending_amount,
@@ -489,6 +535,7 @@ impl MintRecoveryState {
                 .iter()
                 .map(|(amount, value)| (amount, value.next()))
                 .collect(),
+            burned_total: self.burned_total,
         }
     }
 }

--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -1,5 +1,6 @@
 use fedimint_client::module::init::recovery::RecoveryFromHistoryCommon;
 use fedimint_core::core::OperationId;
+use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record, Amount};
 use fedimint_mint_common::Nonce;
@@ -98,3 +99,14 @@ impl_db_lookup!(
     key = CancelledOOBSpendKey,
     query_prefix = CancelledOOBSpendKeyPrefix,
 );
+
+pub async fn migrate_to_v1(
+    dbtx: &mut DatabaseTransaction<'_>,
+) -> anyhow::Result<Option<(Vec<(Vec<u8>, OperationId)>, Vec<(Vec<u8>, OperationId)>)>> {
+    // between v0 and v1, we changed the format of `MintRecoveryState`, and instead
+    // of migrating it, we can just delete it, so the recovery will just start
+    // again, ignoring any existing state from before the migration
+    dbtx.remove_entry(&RecoveryStateKey).await;
+
+    Ok(None)
+}

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -331,7 +331,8 @@ mod fedimint_migration_tests {
     use fedimint_mint_client::backup::{EcashBackup, EcashBackupV0};
     use fedimint_mint_client::client_db::{
         CancelledOOBSpendKey, CancelledOOBSpendKeyPrefix, NextECashNoteIndexKey,
-        NextECashNoteIndexKeyPrefix, NoteKey, NoteKeyPrefix, RecoveryStateKey,
+        NextECashNoteIndexKeyPrefix, NoteKey, NoteKeyPrefix, RecoveryFinalizedKey,
+        RecoveryStateKey,
     };
     use fedimint_mint_client::output::NoteIssuanceRequest;
     use fedimint_mint_client::{MintClientInit, MintClientModule, NoteIndex, SpendableNote};
@@ -466,7 +467,7 @@ mod fedimint_migration_tests {
 
         let backup = create_ecash_backup_v0(spendable_note, secret.clone());
 
-        let mint_recovery_state = MintRecoveryState::V0(MintRecoveryStateV0::from_backup(
+        let mint_recovery_state = MintRecoveryState::V1(MintRecoveryStateV0::from_backup(
             backup,
             10,
             tbs_pks,
@@ -655,13 +656,13 @@ mod fedimint_migration_tests {
                         fedimint_mint_client::client_db::DbKeyPrefix::RecoveryState => {
                             let restore_state = dbtx.get_value(&RecoveryStateKey).await;
                             ensure!(
-                                restore_state.is_some(),
-                                "validate_migrations was not able to read any RecoveryState"
+                                restore_state.is_none(),
+                                "validate_migrations expect the restore state to get deleted"
                             );
                             info!("Validated RecoveryState");
                         }
                         fedimint_mint_client::client_db::DbKeyPrefix::RecoveryFinalized => {
-                            let recovery_finalized = dbtx.get_value(&RecoveryStateKey).await;
+                            let recovery_finalized = dbtx.get_value(&RecoveryFinalizedKey).await;
                             ensure!(
                                 recovery_finalized.is_some(),
                                 "validate_migrations was not able to read any RecoveryFinalized"

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -325,7 +325,9 @@ mod fedimint_migration_tests {
     use fedimint_core::time::now;
     use fedimint_core::{secp256k1, Amount, OutPoint, Tiered, TieredMulti, TransactionId};
     use fedimint_logging::TracingSetup;
-    use fedimint_mint_client::backup::recovery::{MintRecovery, MintRecoveryState};
+    use fedimint_mint_client::backup::recovery::{
+        MintRecovery, MintRecoveryState, MintRecoveryStateV0,
+    };
     use fedimint_mint_client::backup::{EcashBackup, EcashBackupV0};
     use fedimint_mint_client::client_db::{
         CancelledOOBSpendKey, CancelledOOBSpendKeyPrefix, NextECashNoteIndexKey,
@@ -464,8 +466,13 @@ mod fedimint_migration_tests {
 
         let backup = create_ecash_backup_v0(spendable_note, secret.clone());
 
-        let mint_recovery_state =
-            MintRecoveryState::from_backup(backup, 10, tbs_pks, pub_key_shares, &secret);
+        let mint_recovery_state = MintRecoveryState::V0(MintRecoveryStateV0::from_backup(
+            backup,
+            10,
+            tbs_pks,
+            pub_key_shares,
+            &secret,
+        ));
 
         MintRecovery::store_finalized(&mut dbtx.to_ref_nc(), true).await;
         dbtx.insert_new_entry(


### PR DESCRIPTION
Backport #6099

Fix #6114

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
