### PR TITLE
fix: fix gateway protoc warning

### DIFF
--- a/gateway/ln-gateway/build.rs
+++ b/gateway/ln-gateway/build.rs
@@ -10,7 +10,7 @@ fn main() {
         .build_client(true)
         .protoc_arg("--experimental_allow_proto3_optional")
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .compile(&[proto_path], &[include_path])
+        .compile_protos(&[proto_path], &[include_path])
         .unwrap_or_else(|e| panic!("failed to compile gateway proto files: {e}"));
 
     fedimint_build::set_code_version();


### PR DESCRIPTION
Fixes a warning that must have been introduced with a recent version bump.