### PR TITLE
fix: use federation id for database prefix

### DIFF
--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -523,6 +523,18 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
 
                 leave_federation(gw, fed_id, 1).await?;
                 leave_federation(gw, new_fed_id, 2).await?;
+
+                // Rejoin new federation, verify that the balance is the same
+                let output = cmd!(gw, "connect-fed", new_invite_code.clone())
+                    .out_json()
+                    .await?;
+                let rejoined_federation_info: FederationInfo =
+                    serde_json::from_value(output).expect("Could not parse FederationInfo");
+                info!(?rejoined_federation_info, "Rejoined Federation Info");
+                assert_eq!(
+                    second_fed_info.balance_msat,
+                    rejoined_federation_info.balance_msat
+                );
             }
 
             info!("Gateway configuration test successful");

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -13,6 +13,7 @@ use fedimint_client::{Client, ClientBuilder};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::encoding::Encodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 
 use crate::db::FederationConfig;
@@ -108,7 +109,7 @@ impl GatewayClientBuilder {
         let federation_id = config.invite_code.federation_id();
         let db = gateway
             .gateway_db
-            .with_prefix(config.federation_index.to_le_bytes().to_vec());
+            .with_prefix(federation_id.consensus_encode_to_vec());
         let client_builder = self
             .create_client_builder(db, &config, gateway.clone())
             .await?;
@@ -159,7 +160,7 @@ impl GatewayClientBuilder {
         } else {
             let db = gateway
                 .gateway_db
-                .with_prefix(config.federation_index.to_le_bytes().to_vec());
+                .with_prefix(federation_id.consensus_encode_to_vec());
             let secret = Self::derive_federation_secret(mnemonic, &federation_id);
             (db, secret)
         };


### PR DESCRIPTION
We have a bug in the DB implementation of the gateway. Previously, we used the `federation_index` as the prefix for the database. However, this has an issue because the `federation_index` changes when the user leaves and then rejoins the federation.

This PR changes it so that when building the client, we use the federation id instead (which should not change). It turns out that [RocksDB does delta encoding, so common prefixes will not be stored redundantly](https://docs.rockset.com/documentation/docs/storage-architecture#data-compaction-in-rocksdb). So storage size shouldn't be a concern.