### PR TITLE
fix: default esplora address for signet network shouldn't be mutinynet

### DIFF
--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -27,7 +27,7 @@ pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
             std::env::var(FM_PORT_ESPLORA_ENV).unwrap_or(String::from("50002"))
         ))
         .expect("Failed to parse default esplora server"),
-        Network::Signet => SafeUrl::parse("https://mutinynet.com/api/")
+        Network::Signet => SafeUrl::parse("https://blockstream.info/signet/api/")
             .expect("Failed to parse default esplora server"),
         _ => panic!("Failed to parse default esplora server"),
     };


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
