### PR TITLE
chore(deps): remove secp256k1-zkp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,7 +2228,6 @@ dependencies = [
  "parity-scale-codec",
  "rand",
  "secp256k1 0.27.0",
- "secp256k1-zkp",
  "serde",
  "serde_json",
  "serdect",
@@ -2298,7 +2297,6 @@ dependencies = [
  "fedimint-core",
  "fedimint-hkdf",
  "ring 0.17.8",
- "secp256k1-zkp",
 ]
 
 [[package]]
@@ -2851,7 +2849,6 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.13.0",
- "secp256k1-zkp",
  "serde",
  "serde-big-array",
  "serde_json",
@@ -2873,7 +2870,6 @@ dependencies = [
  "bitcoin_hashes 0.12.0",
  "fedimint-core",
  "fedimint-tbs",
- "secp256k1-zkp",
  "serde",
  "thiserror",
  "tracing",
@@ -2897,7 +2893,6 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "rand",
- "secp256k1-zkp",
  "serde",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -6420,29 +6415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "secp256k1-zkp"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026efcdacb95ee6aae5cc19144dc1549973eac36a4972700c28493de1ee5d69f"
-dependencies = [
- "bitcoin-private",
- "rand",
- "secp256k1 0.27.0",
- "secp256k1-zkp-sys",
- "serde",
-]
-
-[[package]]
-name = "secp256k1-zkp-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03ab1ca75a18e1899e8d9b8d28b5998ae1ddcb42fec5956769718543293c723"
-dependencies = [
- "cc",
- "secp256k1-sys 0.8.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,6 @@ rand = { opt-level = 3 }
 ring = { opt-level = 3 }
 secp256k1 = { opt-level = 3 }
 secp256k1-sys = { opt-level = 3 }
-secp256k1-zkp = { opt-level = 3 }
-secp256k1-zkp-sys = { opt-level = 3 }
 subtle = { opt-level = 3 }
 zeroize = { opt-level = 3 }
 

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -22,4 +22,3 @@ bls12_381 = { workspace = true }
 fedimint-core = { workspace = true }
 hkdf = { workspace = true }
 ring = { workspace = true }
-secp256k1-zkp = { version = "0.9.2", features = ["serde"] }

--- a/crypto/derive-secret/src/lib.rs
+++ b/crypto/derive-secret/src/lib.rs
@@ -18,11 +18,11 @@ use std::fmt::Formatter;
 use bls12_381::Scalar;
 use fedimint_core::config::FederationId;
 use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::secp256k1::{KeyPair, Secp256k1, Signing};
 use fedimint_core::BitcoinHash;
 use hkdf::hashes::Sha512;
 use hkdf::Hkdf;
 use ring::aead;
-use secp256k1_zkp::{KeyPair, Secp256k1, Signing};
 
 const CHILD_TAG: &[u8; 8] = b"childkey";
 const SECP256K1_TAG: &[u8; 8] = b"secp256k";

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -47,7 +47,6 @@ miniscript = { workspace = true, features = ["serde"] }
 parity-scale-codec = { version = "3.6.12", features = ["derive"] }
 rand = { workspace = true }
 secp256k1 = { workspace = true, features = ["global-context", "rand-std"] }
-secp256k1-zkp = { version = "0.9.2", features = ["serde", "global-context"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serdect = { workspace = true }

--- a/fedimint-core/src/backup.rs
+++ b/fedimint-core/src/backup.rs
@@ -12,7 +12,7 @@ use crate::db::DbKeyPrefix;
 
 /// Key used to store user's ecash backups
 #[derive(Debug, Clone, Copy, Encodable, Decodable, Serialize)]
-pub struct ClientBackupKey(pub secp256k1_zkp::PublicKey);
+pub struct ClientBackupKey(pub secp256k1::PublicKey);
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct ClientBackupKeyPrefix;

--- a/fedimint-core/src/core/backup.rs
+++ b/fedimint-core/src/core/backup.rs
@@ -2,8 +2,7 @@ use std::fmt::Debug;
 
 use bitcoin_hashes::{sha256, Hash};
 use fedimint_core::encoding::{Decodable, Encodable};
-use secp256k1::{Secp256k1, Signing, Verification};
-use secp256k1_zkp::{KeyPair, Message};
+use secp256k1::{KeyPair, Message, Secp256k1, Signing, Verification};
 use serde::{Deserialize, Serialize};
 
 /// Maximum payload size of a backup request

--- a/fedimint-core/src/encoding/secp256k1.rs
+++ b/fedimint-core/src/encoding/secp256k1.rs
@@ -3,7 +3,7 @@ use std::io::{Error, Read, Write};
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 
-impl Encodable for secp256k1_zkp::ecdsa::Signature {
+impl Encodable for secp256k1::ecdsa::Signature {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
         let bytes = self.serialize_compact();
         writer.write_all(&bytes)?;
@@ -11,7 +11,7 @@ impl Encodable for secp256k1_zkp::ecdsa::Signature {
     }
 }
 
-impl Decodable for secp256k1_zkp::ecdsa::Signature {
+impl Decodable for secp256k1::ecdsa::Signature {
     fn consensus_decode<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
@@ -21,13 +21,13 @@ impl Decodable for secp256k1_zkp::ecdsa::Signature {
     }
 }
 
-impl Encodable for secp256k1_zkp::PublicKey {
+impl Encodable for secp256k1::PublicKey {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
         self.serialize().consensus_encode(writer)
     }
 }
 
-impl Decodable for secp256k1_zkp::PublicKey {
+impl Decodable for secp256k1::PublicKey {
     fn consensus_decode<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
@@ -36,13 +36,13 @@ impl Decodable for secp256k1_zkp::PublicKey {
     }
 }
 
-impl Encodable for secp256k1_zkp::SecretKey {
+impl Encodable for secp256k1::SecretKey {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
         self.secret_bytes().consensus_encode(writer)
     }
 }
 
-impl Decodable for secp256k1_zkp::SecretKey {
+impl Decodable for secp256k1::SecretKey {
     fn consensus_decode<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
@@ -51,25 +51,22 @@ impl Decodable for secp256k1_zkp::SecretKey {
     }
 }
 
-impl Encodable for secp256k1_zkp::schnorr::Signature {
+impl Encodable for secp256k1::schnorr::Signature {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
         let bytes = &self[..];
-        assert_eq!(
-            bytes.len(),
-            secp256k1_zkp::constants::SCHNORR_SIGNATURE_SIZE
-        );
+        assert_eq!(bytes.len(), secp256k1::constants::SCHNORR_SIGNATURE_SIZE);
         writer.write_all(bytes)?;
-        Ok(secp256k1_zkp::constants::SCHNORR_SIGNATURE_SIZE)
+        Ok(secp256k1::constants::SCHNORR_SIGNATURE_SIZE)
     }
 }
 
-impl Decodable for secp256k1_zkp::schnorr::Signature {
+impl Decodable for secp256k1::schnorr::Signature {
     fn consensus_decode<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let bytes =
-            <[u8; secp256k1_zkp::constants::SCHNORR_SIGNATURE_SIZE]>::consensus_decode(d, modules)?;
+            <[u8; secp256k1::constants::SCHNORR_SIGNATURE_SIZE]>::consensus_decode(d, modules)?;
         Self::from_slice(&bytes).map_err(DecodeError::from_err)
     }
 }
@@ -86,24 +83,24 @@ impl Decodable for bitcoin::key::KeyPair {
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let sec_bytes = <[u8; 32]>::consensus_decode(d, modules)?;
-        Self::from_seckey_slice(secp256k1_zkp::global::SECP256K1, &sec_bytes) // FIXME: evaluate security risk of global ctx
+        Self::from_seckey_slice(secp256k1::global::SECP256K1, &sec_bytes) // FIXME: evaluate security risk of global ctx
             .map_err(DecodeError::from_err)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use secp256k1_zkp::hashes::Hash as BitcoinHash;
-    use secp256k1_zkp::Message;
+    use secp256k1::hashes::Hash as BitcoinHash;
+    use secp256k1::Message;
 
     use super::super::tests::test_roundtrip;
 
     #[test_log::test]
     fn test_ecdsa_sig() {
-        let ctx = secp256k1_zkp::Secp256k1::new();
+        let ctx = secp256k1::Secp256k1::new();
         let (sk, _pk) = ctx.generate_keypair(&mut rand::thread_rng());
         let sig = ctx.sign_ecdsa(
-            &Message::from_hashed_data::<secp256k1_zkp::hashes::sha256::Hash>(b"Hello World!"),
+            &Message::from_hashed_data::<secp256k1::hashes::sha256::Hash>(b"Hello World!"),
             &sk,
         );
 
@@ -112,14 +109,14 @@ mod tests {
 
     #[test_log::test]
     fn test_schnorr_pub_key() {
-        let ctx = secp256k1_zkp::global::SECP256K1;
+        let ctx = secp256k1::global::SECP256K1;
         let mut rng = rand::rngs::OsRng;
         let sec_key = bitcoin::key::KeyPair::new(ctx, &mut rng);
         let pub_key = sec_key.public_key();
         test_roundtrip(&pub_key);
 
         let sig = ctx.sign_schnorr(
-            &secp256k1_zkp::hashes::sha256::Hash::hash(b"Hello World!").into(),
+            &secp256k1::hashes::sha256::Hash::hash(b"Hello World!").into(),
             &sec_key,
         );
 

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -57,7 +57,7 @@ use crate::{
 #[derive(Debug, PartialEq, Eq)]
 pub struct InputMeta {
     pub amount: TransactionItemAmount,
-    pub pub_key: secp256k1_zkp::PublicKey,
+    pub pub_key: secp256k1::PublicKey,
 }
 
 /// Information about the amount represented by an input or output.

--- a/fedimint-core/src/transaction.rs
+++ b/fedimint-core/src/transaction.rs
@@ -3,7 +3,6 @@ use fedimint_core::core::{DynInput, DynOutput};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::SerdeModuleEncoding;
 use fedimint_core::{Amount, TransactionId};
-use secp256k1_zkp::schnorr;
 use thiserror::Error;
 
 use crate::config::ALEPH_BFT_UNIT_BYTE_LIMIT;
@@ -79,7 +78,7 @@ impl Transaction {
     /// Validate the schnorr signatures signed over the `tx_hash`
     pub fn validate_signatures(
         &self,
-        pub_keys: &[secp256k1_zkp::PublicKey],
+        pub_keys: &[secp256k1::PublicKey],
     ) -> Result<(), TransactionError> {
         let signatures = match &self.signatures {
             TransactionSignature::NaiveMultisig(sigs) => sigs,
@@ -93,10 +92,10 @@ impl Transaction {
         }
 
         let txid = self.tx_hash();
-        let msg = secp256k1_zkp::Message::from_slice(&txid[..]).expect("txid has right length");
+        let msg = secp256k1::Message::from_slice(&txid[..]).expect("txid has right length");
 
         for (pk, signature) in pub_keys.iter().zip(signatures) {
-            if secp256k1_zkp::global::SECP256K1
+            if secp256k1::global::SECP256K1
                 .verify_schnorr(signature, &msg, &pk.x_only_public_key().0)
                 .is_err()
             {
@@ -115,7 +114,7 @@ impl Transaction {
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
 pub enum TransactionSignature {
-    NaiveMultisig(Vec<schnorr::Signature>),
+    NaiveMultisig(Vec<secp256k1::schnorr::Signature>),
     #[encodable_default]
     Default {
         variant: u64,

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -43,7 +43,6 @@ fedimint-mint-common = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 itertools = { workspace = true }
-secp256k1-zkp = "0.9.2"
 serde = { workspace = true }
 serde-big-array = { workspace = true }
 serde_json = { workspace = true }

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -392,7 +392,7 @@ impl MintRecoveryStateV0 {
         let note_idx_ref = self.next_pending_note_idx.get_mut_or_default(amount);
 
         let (note_issuance_request, blind_nonce) = NoteIssuanceRequest::new(
-            secp256k1_zkp::SECP256K1,
+            fedimint_core::secp256k1::SECP256K1,
             &MintClientModule::new_note_secret_static(secret, amount, *note_idx_ref),
         );
         assert!(self

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -56,6 +56,7 @@ use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use fedimint_core::module::{
     ApiVersion, CommonModuleInit, ModuleCommon, ModuleInit, MultiApiVersion,
 };
+use fedimint_core::secp256k1::{All, KeyPair, Secp256k1};
 use fedimint_core::util::{BoxFuture, BoxStream, NextOrPending, SafeUrl};
 use fedimint_core::{
     apply, async_trait_maybe_send, push_db_pair_items, Amount, OutPoint, PeerId, Tiered,
@@ -68,7 +69,6 @@ use fedimint_mint_common::config::MintClientConfig;
 pub use fedimint_mint_common::*;
 use futures::{pin_mut, StreamExt};
 use hex::ToHex;
-use secp256k1_zkp::{All, KeyPair, Secp256k1};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tbs::{AggregatePublicKey, Signature};
@@ -2250,13 +2250,13 @@ mod tests {
     use fedimint_core::encoding::Decodable;
     use fedimint_core::invite_code::{InviteCode, InviteCodeV2};
     use fedimint_core::module::registry::ModuleRegistry;
-    use fedimint_core::secp256k1::rand::rngs::OsRng;
-    use fedimint_core::secp256k1::SecretKey;
     use fedimint_core::util::SafeUrl;
     use fedimint_core::{
         secp256k1, Amount, OutPoint, PeerId, Tiered, TieredCounts, TieredMulti, TransactionId,
     };
     use itertools::Itertools;
+    use secp256k1::rand::rngs::OsRng;
+    use secp256k1::{SecretKey, SECP256K1};
     use serde_json::json;
     use tbs::Signature;
 
@@ -2505,7 +2505,7 @@ mod tests {
             notes: iter::repeat(OOBNoteV2 {
                 amount: Amount::from_msats(1),
                 sig: Signature(bls12_381::G1Affine::generator()),
-                key: SecretKey::new(&mut OsRng).keypair(secp256k1::SECP256K1),
+                key: SecretKey::new(&mut OsRng).keypair(SECP256K1),
             })
             .take(NUMBER_OF_NOTES)
             .collect(),

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -11,14 +11,13 @@ use fedimint_core::core::{Decoder, OperationId};
 use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::ApiRequestErased;
-use fedimint_core::secp256k1::KeyPair;
+use fedimint_core::secp256k1::{KeyPair, Secp256k1, Signing};
 use fedimint_core::task::sleep;
 use fedimint_core::{Amount, NumPeersExt, OutPoint, PeerId, Tiered};
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_logging::LOG_CLIENT_MODULE_MINT;
 use fedimint_mint_common::endpoint_constants::AWAIT_OUTPUT_OUTCOME_ENDPOINT;
 use fedimint_mint_common::{BlindNonce, MintOutputOutcome, Nonce};
-use secp256k1_zkp::{Secp256k1, Signing};
 use serde::{Deserialize, Serialize};
 use tbs::{
     aggregate_signature_shares, blind_message, unblind_signature, AggregatePublicKey,

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -20,7 +20,6 @@ anyhow = { workspace = true }
 bincode = { workspace = true }
 bitcoin_hashes = { workspace = true }
 fedimint-core = { workspace = true }
-secp256k1-zkp = "0.9.2"
 serde = { workspace = true }
 tbs = { workspace = true }
 thiserror = { workspace = true }

--- a/modules/fedimint-mint-common/src/lib.rs
+++ b/modules/fedimint-mint-common/src/lib.rs
@@ -13,7 +13,9 @@ use config::MintClientConfig;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
-use fedimint_core::{extensible_associated_module_type, plugin_types_trait_impl_common, Amount};
+use fedimint_core::{
+    extensible_associated_module_type, plugin_types_trait_impl_common, secp256k1, Amount,
+};
 use serde::{Deserialize, Serialize};
 use tbs::BlindedSignatureShare;
 use thiserror::Error;
@@ -98,7 +100,7 @@ impl fmt::Display for Note {
     Encodable,
     Decodable,
 )]
-pub struct Nonce(pub secp256k1_zkp::PublicKey);
+pub struct Nonce(pub secp256k1::PublicKey);
 
 impl fmt::Display for Nonce {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -204,7 +206,7 @@ impl Note {
     }
 
     /// Access the nonce as the public key to the spend key
-    pub fn spend_key(&self) -> &secp256k1_zkp::PublicKey {
+    pub fn spend_key(&self) -> &secp256k1::PublicKey {
         &self.nonce.0
     }
 }

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -27,7 +27,6 @@ fedimint-server = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 rand = { workspace = true }
-secp256k1-zkp = "0.9.2"
 serde = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }

--- a/modules/fedimint-mint-server/src/db.rs
+++ b/modules/fedimint-mint-server/src/db.rs
@@ -76,7 +76,7 @@ impl_db_lookup!(
 
 /// Key used to store user's ecash backups
 #[derive(Debug, Clone, Copy, Encodable, Decodable, Serialize)]
-pub struct EcashBackupKey(pub secp256k1_zkp::PublicKey);
+pub struct EcashBackupKey(pub fedimint_core::secp256k1::PublicKey);
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct EcashBackupKeyPrefix;


### PR DESCRIPTION
We're not using any functionality from `secp256k1-zkp` that isn't simply re-exported from `secp256k1`.