### PR TITLE
chore: remove backon upgrade warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,8 +527,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4fa97bb310c33c811334143cf64c5bb2b7b3c06e453db6b095d7061eff8f113"
 dependencies = [
  "fastrand",
- "gloo-timers 0.3.0",
- "tokio",
 ]
 
 [[package]]

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-recursion = "1.1.1"
 async-trait = { workspace = true }
-backon = "1.2.0"
+backon = { version = "1.2.0", default-features = false }
 backtrace = "0.3.74"
 base64-url = { workspace = true }
 bech32 = "0.11.0"

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-recursion = "1.1.1"
 async-trait = { workspace = true }
-backon = "=1.2.0" # don't upgrade unless really needed
+backon = "1.2.0"
 backtrace = "0.3.74"
 base64-url = { workspace = true }
 bech32 = "0.11.0"


### PR DESCRIPTION
We've bumped this dependency several times since adding this warning. I think we should just remove the warning.

@maan2003 