### PR TITLE
chore: re-export bip39 types from fedimint-bip39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,7 +2107,6 @@ version = "0.5.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
- "bip39",
  "bitcoin 0.30.2",
  "clap",
  "clap_complete",
@@ -2512,7 +2511,6 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.7.7",
- "bip39",
  "bitcoin 0.30.2",
  "bitcoin_hashes 0.12.0",
  "clap",

--- a/fedimint-bip39/src/lib.rs
+++ b/fedimint-bip39/src/lib.rs
@@ -4,6 +4,7 @@
 
 use std::io::{Read, Write};
 
+pub use bip39::{Language, Mnemonic};
 use fedimint_client::derivable_secret::DerivableSecret;
 use fedimint_client::secret::RootSecretStrategy;
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
@@ -15,7 +16,7 @@ use rand::{CryptoRng, RngCore};
 pub struct Bip39RootSecretStrategy<const WORD_COUNT: usize = 12>;
 
 impl<const WORD_COUNT: usize> RootSecretStrategy for Bip39RootSecretStrategy<WORD_COUNT> {
-    type Encoding = bip39::Mnemonic;
+    type Encoding = Mnemonic;
 
     fn to_root_secret(secret: &Self::Encoding) -> DerivableSecret {
         const FEDIMINT_CLIENT_NONCE: &[u8] = b"Fedimint Client Salt";
@@ -38,14 +39,14 @@ impl<const WORD_COUNT: usize> RootSecretStrategy for Bip39RootSecretStrategy<WOR
         reader: &mut impl Read,
     ) -> Result<Self::Encoding, fedimint_core::encoding::DecodeError> {
         let bytes = Vec::<u8>::consensus_decode(reader, &ModuleRegistry::default())?;
-        bip39::Mnemonic::from_entropy(&bytes).map_err(DecodeError::from_err)
+        Mnemonic::from_entropy(&bytes).map_err(DecodeError::from_err)
     }
 
     fn random<R>(rng: &mut R) -> Self::Encoding
     where
         R: RngCore + CryptoRng,
     {
-        bip39::Mnemonic::generate_in_with(rng, bip39::Language::English, WORD_COUNT)
+        Mnemonic::generate_in_with(rng, Language::English, WORD_COUNT)
             .expect("Failed to generate mnemonic, bad word count")
     }
 }

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -26,7 +26,6 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-bip39 = { version = "2.0.0", features = ["rand"] }
 bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.29"

--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -4,10 +4,10 @@ use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context};
-use bip39::Mnemonic;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{secp256k1, Network};
 use clap::Subcommand;
+use fedimint_bip39::Mnemonic;
 use fedimint_client::backup::Metadata;
 use fedimint_client::ClientHandleArc;
 use fedimint_core::config::{ClientModuleConfig, FederationId};

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -24,7 +24,6 @@ use std::time::Duration;
 use std::{fs, result};
 
 use anyhow::{format_err, Context};
-use bip39::Mnemonic;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use db_locked::LockedBuilder;
 #[cfg(feature = "tor")]
@@ -35,7 +34,7 @@ use fedimint_api_client::api::net::Connector;
 use fedimint_api_client::api::{
     DynGlobalApi, FederationApiExt, FederationError, IRawFederationApi, WsFederationApi,
 };
-use fedimint_bip39::Bip39RootSecretStrategy;
+use fedimint_bip39::{Bip39RootSecretStrategy, Mnemonic};
 use fedimint_client::meta::{FetchKind, LegacyMetaSource, MetaSource};
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitRegistry};
 use fedimint_client::secret::{get_default_client_secret, RootSecretStrategy};

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -34,7 +34,6 @@ aquamarine = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
-bip39 = { version = "2.0.0", features = ["rand"] }
 bitcoin = { workspace = true }
 bitcoin_hashes = { workspace = true }
 clap = { workspace = true }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -3,8 +3,7 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use bip39::Mnemonic;
-use fedimint_bip39::Bip39RootSecretStrategy;
+use fedimint_bip39::{Bip39RootSecretStrategy, Mnemonic};
 use fedimint_client::db::ClientConfigKey;
 use fedimint_client::derivable_secret::{ChildId, DerivableSecret};
 use fedimint_client::module::init::ClientModuleInitRegistry;

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -38,7 +38,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::anyhow;
-use bip39::Mnemonic;
 use bitcoin::{Address, Network, Txid};
 use bitcoin_hashes::{sha256, Hash};
 use clap::Parser;
@@ -49,7 +48,7 @@ use db::{GatewayConfiguration, GatewayConfigurationKey, GatewayDbtxNcExt};
 use error::FederationNotConnected;
 use federation_manager::FederationManager;
 use fedimint_api_client::api::net::Connector;
-use fedimint_bip39::Bip39RootSecretStrategy;
+use fedimint_bip39::{Bip39RootSecretStrategy, Language, Mnemonic};
 use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::secret::RootSecretStrategy;
 use fedimint_client::{Client, ClientHandleArc};
@@ -1733,12 +1732,13 @@ impl Gateway {
             } else {
                 let mnemonic = if let Ok(words) = std::env::var(FM_GATEWAY_MNEMONIC_ENV) {
                     info!("Using provided mnemonic from environment variable");
-                    Mnemonic::parse_in_normalized(bip39::Language::English, words.as_str())
-                        .map_err(|e| {
+                    Mnemonic::parse_in_normalized(Language::English, words.as_str()).map_err(
+                        |e| {
                             AdminGatewayError::MnemonicError(anyhow!(format!(
                                 "Seed phrase provided in environment was invalid {e:?}"
                             )))
-                        })?
+                        },
+                    )?
                 } else {
                     info!("Generating mnemonic and writing entropy to client storage");
                     Bip39RootSecretStrategy::<12>::random(&mut thread_rng())

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use bip39::Mnemonic;
 use bitcoin::{secp256k1, Address, Network, OutPoint};
+use fedimint_bip39::Mnemonic;
 use fedimint_core::runtime::spawn;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{Amount, BitcoinAmountOrAll};

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -8,9 +8,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bip39::Mnemonic;
 use bitcoin::{Address, Network};
 use clap::Subcommand;
+use fedimint_bip39::Mnemonic;
 use fedimint_core::db::Database;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::secp256k1::PublicKey;


### PR DESCRIPTION
Both crates that rely on the `bip39` crate also rely on `fedimint-bip39`. Let's just re-export what we need from `bip39` from `fedimint-bip39`.