### PR TITLE
feat(gateway): Add admin session authentication manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "jemallocator",
+ "jsonwebtoken",
  "ldk-node",
  "lightning",
  "lightning-invoice",
@@ -2683,6 +2684,8 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
+ "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -4834,6 +4837,19 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "url",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "ring 0.17.8",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -8679,6 +8695,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8695,6 +8717,16 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+ "serde",
+]
 
 [[package]]
 name = "valuable"

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -27,6 +27,8 @@ struct Cli {
     /// WARNING: Passing in a password from the command line may be less secure!
     #[clap(long)]
     rpcpassword: Option<String>,
+    #[clap(long)]
+    rpcjwt: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -50,7 +52,13 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
     let versioned_api = cli.address.join(V1_API_ENDPOINT)?;
-    let create_client = || GatewayRpcClient::new(versioned_api.clone(), cli.rpcpassword.clone());
+    let create_client = || {
+        GatewayRpcClient::new(
+            versioned_api.clone(),
+            cli.rpcpassword.clone(),
+            cli.rpcjwt.clone(),
+        )
+    };
 
     match cli.command {
         Commands::General(general_command) => general_command.handle(create_client).await?,

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -50,6 +50,7 @@ fedimint-wallet-client = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
+jsonwebtoken = { version = "9.3.0", default-features = false }
 ldk-node = "0.4.2"
 lightning = { workspace = true }
 lightning-invoice = { workspace = true }
@@ -71,6 +72,8 @@ tower-http = { version = "0.6.1", features = ["cors", "auth"] }
 tpe = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 url = { workspace = true, features = ["serde"] }
+urlencoding = "2.1.3"
+uuid = { version = "1.11.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/gateway/ln-gateway/src/auth_manager.rs
+++ b/gateway/ln-gateway/src/auth_manager.rs
@@ -1,0 +1,201 @@
+use std::collections::BTreeSet;
+use std::str::FromStr;
+use std::time::UNIX_EPOCH;
+
+use bitcoin::hashes::{sha256, Hash as BitcoinHash};
+use bitcoin::secp256k1::schnorr::Signature;
+use bitcoin::secp256k1::{Keypair, Message, SecretKey};
+use fedimint_core::secp256k1::PublicKey;
+use fedimint_core::util::SafeUrl;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::rpc::AuthChallengePayload;
+
+const CHALLENGE_EXPIRY_SECONDS: u64 = 60; // 1 minute
+const SESSION_EXPIRY_SECONDS: u64 = 60 * 30; // 30 minute
+
+pub struct AuthManager {
+    /// The public key of the gateway
+    gateway_id: PublicKey,
+    /// The API endpoint of the gateway
+    gateway_api: SafeUrl,
+    /// Challenges with their expiry times
+    challenges: BTreeSet<AuthChallenge>,
+    /// A secret key to encode a JWT with
+    pub encoding_secret: [u8; 16],
+    /// A secret key for creating a Keypair
+    secret_key: SecretKey,
+}
+
+impl AuthManager {
+    /// Create a new auth manager
+    pub fn new(gateway_id: PublicKey, gateway_api: SafeUrl, encoding_secret: [u8; 16]) -> Self {
+        let secret_key = SecretKey::new(&mut rand::thread_rng());
+        Self {
+            gateway_id,
+            gateway_api,
+            challenges: BTreeSet::new(),
+            encoding_secret,
+            secret_key,
+        }
+    }
+
+    /// Create a new challenge
+    pub fn create_challenge(&mut self) -> anyhow::Result<String> {
+        let challenge = AuthChallenge::new(self.gateway_id.clone(), self.gateway_api.clone());
+        self.challenges.insert(challenge.clone());
+        let encode_challenge = urlencoding::encode(challenge.to_string().as_ref()).to_string();
+        Ok(encode_challenge)
+    }
+
+    /// sign the challenge
+    pub fn sign_challenge(
+        &self,
+        ctx: &bitcoin::secp256k1::global::GlobalContext,
+        challenge_payload: String,
+    ) -> anyhow::Result<Signature> {
+        let decode_challenge = urlencoding::decode(&challenge_payload)?;
+        let challenge = AuthChallenge::from_str(&decode_challenge)?;
+        if !self.challenges.contains(&challenge)
+            || challenge.gateway_id != self.gateway_id
+            || challenge.gateway_api != self.gateway_api
+        {
+            return Err(anyhow::anyhow!("Invalid challenge"));
+        }
+        if challenge.expiry
+            < fedimint_core::time::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_secs()
+        {
+            return Err(anyhow::anyhow!("Challenge expired"));
+        }
+        let sk = Keypair::from_secret_key(ctx, &self.secret_key);
+        let message = Message::from_digest(
+            sha256::Hash::hash(challenge.to_string().as_bytes()).to_byte_array(),
+        );
+        let signature = ctx.sign_schnorr(&message, &sk);
+        Ok(signature)
+    }
+
+    /// Verify the challenge
+    pub fn verify_challenge_response(
+        &mut self,
+        ctx: &bitcoin::secp256k1::global::GlobalContext,
+        challenge_response: &AuthChallengePayload,
+    ) -> anyhow::Result<Session> {
+        let decode_challenge = urlencoding::decode(&challenge_response.challenge)?;
+        let challenge = AuthChallenge::from_str(&decode_challenge)?;
+        if !self.challenges.contains(&challenge)
+            || challenge.gateway_id != self.gateway_id
+            || challenge.gateway_api != self.gateway_api
+        {
+            return Err(anyhow::anyhow!("Invalid challenge"));
+        }
+        if challenge.expiry
+            < fedimint_core::time::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_secs()
+        {
+            return Err(anyhow::anyhow!("Challenge expired"));
+        }
+
+        let sk = bitcoin::secp256k1::Keypair::from_secret_key(ctx, &self.secret_key);
+
+        // Verify the schnorr signature against the gateway's pubkey
+        let message = Message::from_digest(
+            sha256::Hash::hash(challenge.to_string().as_bytes()).to_byte_array(),
+        );
+        let signature = challenge_response.response;
+        ctx.verify_schnorr(&signature, &message, &sk.x_only_public_key().0)
+            .map_err(|_| anyhow::anyhow!("Invalid signature"))?;
+
+        // If valid, remove the challenge from the set
+        self.challenges.remove(&challenge);
+        let id = Uuid::new_v4();
+        let session = Session::new(id, SESSION_EXPIRY_SECONDS);
+        Ok(session)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AuthChallenge {
+    gateway_id: PublicKey,
+    gateway_api: SafeUrl,
+    /// The expiry time of the challenge
+    expiry: u64,
+}
+
+/// Structure to represent a challenge.
+/// gatewayid-gatewayapi-timestamp
+impl AuthChallenge {
+    /// Create a new challenge with a random string and an expiry time of 1
+    /// minute.
+    pub fn new(gateway_id: PublicKey, gateway_api: SafeUrl) -> Self {
+        let now = fedimint_core::time::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        let expiry = now + CHALLENGE_EXPIRY_SECONDS;
+        Self {
+            gateway_id,
+            gateway_api,
+            expiry,
+        }
+    }
+}
+
+impl FromStr for AuthChallenge {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split('-').collect::<Vec<&str>>();
+        let gateway_id = PublicKey::from_str(parts[0])?;
+        let gateway_api = SafeUrl::parse(parts[1])?;
+        let expiry = parts[2].parse::<u64>()?;
+        Ok(Self {
+            gateway_id,
+            gateway_api,
+            expiry,
+        })
+    }
+}
+
+impl ToString for AuthChallenge {
+    fn to_string(&self) -> String {
+        format!("{}-{}-{}", self.gateway_id, self.gateway_api, self.expiry)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Session {
+    /// the unique identifier of the session.
+    pub id: Uuid,
+    /// the expire time of the session
+    pub exp: u64,
+}
+
+impl Session {
+    pub fn new(id: Uuid, expiry: u64) -> Self {
+        let now = fedimint_core::time::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        Self {
+            id,
+            exp: now + expiry,
+        }
+    }
+
+    pub fn encode_jwt(self, encoding_secret: &[u8; 16]) -> anyhow::Result<String> {
+        let claim = self;
+        encode(
+            &Header::default(),
+            &claim,
+            &EncodingKey::from_secret(encoding_secret),
+        )
+        .map_err(|_| anyhow::anyhow!("Unable to generate jwt token session"))
+    }
+}

--- a/gateway/ln-gateway/src/error.rs
+++ b/gateway/ln-gateway/src/error.rs
@@ -92,6 +92,8 @@ pub enum AdminGatewayError {
     RegistrationError { federation_id: FederationId },
     #[error("Error withdrawing funds onchain: {failure_reason}")]
     WithdrawError { failure_reason: String },
+    #[error("Unauthorized: {failure_reason}")]
+    Unauthorized { failure_reason: String },
 }
 
 impl IntoResponse for AdminGatewayError {

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bitcoin::address::NetworkUnchecked;
+use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::{Address, Network};
 use fedimint_core::config::{FederationId, JsonClientConfig};
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
@@ -22,6 +23,11 @@ use crate::SafeUrl;
 pub const V1_API_ENDPOINT: &str = "v1";
 
 pub const ADDRESS_ENDPOINT: &str = "/address";
+pub const AUTH_CHALLENGE_ENDPOINT: &str = "/auth/challenge";
+// TODO: reserved for 2FA
+pub const AUTH_LOGIN_ENDPOINT: &str = "/auth/login";
+pub const AUTH_SESSION_ENDPOINT: &str = "/auth/session";
+pub const AUTH_SIGN_CHALLENGE_ENDPOINT: &str = "/auth/sign";
 pub const BACKUP_ENDPOINT: &str = "/backup";
 pub const CONFIGURATION_ENDPOINT: &str = "/config";
 pub const CONNECT_FED_ENDPOINT: &str = "/connect_fed";
@@ -287,7 +293,6 @@ pub struct PaymentLogPayload {
     // this `EventLogId`. If it is `None`, the last `EventLogId` is used.
     pub end_position: Option<EventLogId>,
 
-    // The number of events to return
     pub pagination_size: usize,
 
     pub federation_id: FederationId,
@@ -296,3 +301,16 @@ pub struct PaymentLogPayload {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PaymentLogResponse(pub Vec<GatewayTransactionEvent>);
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AuthChallengePayload {
+    /// The challenge string
+    pub challenge: String,
+    /// The response string
+    pub response: Signature,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct AuthChallengeResponse {
+    pub challenge: String,
+}


### PR DESCRIPTION
closes #4128 
# Motivation
Currently, authentication to the getaway admin endpoints is made through a password sent in clear text, which is a security concern.
This PR attempts to fix this issue by adding an Authentication Manager that distributes challenge codes that must be signed before users can request a JWT that allows them to authenticate to the gateway admin endpoints. 
Because of backward compatibility, the password check is not deleted but used as a fallback only if a JWT is absent in the request.
# This PR adds three additional endpoints:
- `/auth/challenge` generates a temporal challenge code
- `/auth/sign` once the challenge code is generated, this endpoint signs the challenge code
- `/auth/session` Once the challenge code is signed, it is possible to request a JWT token.
# How to test it:
- run `just mprocs`
- check which gateway address has to be used  running for example `gateway-lnd info`
- check which is the federation ID that has to be used with some commands such as `balance`
![image](https://github.com/user-attachments/assets/af451944-3857-4bd6-ab81-1b328d2aea23)
- Be aware that the process of requesting a challenge code, signing it, and requesting a JWT has to be done in less than one minute because of the expiration time.
- the JWT has an expiration time of 30 minutes
- `gateway-cli --address=http://127.0.0.1:13446/v1 get-challenge-auth`
- `gateway-cli --address=http://127.0.0.1:13446/v1 sign-challenge-auth --challenge-auth="02f0219bdc2ea9b4524a78f0a390863e16967940e9048171994b73d81305d76d7d-http://127.0.0.1:13446/v1-1728495691"`
- `gateway-cli --address=http://127.0.0.1:13446/v1 session-auth --challenge="02f0219bdc2ea9b4524a78f0a390863e16967940e9048171994b73d81305d76d7d-http://127.0.0.1:13446/v1-1728495691" --response="3acaa8ac174da093ff43eaab77e7ff916c202c8d744c2ec41df42f347b47ab03f162bb8c2a092008e804c90f9251d4553b95d8e2305d00e14012e19a25da6cb5"`
- `gateway-cli --address=http://127.0.0.1:13446/v1 --rpcjwt="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImlkLTY1MDQ5MDMxMDUzNzQxMzYzNTUiLCJleHAiOjE3Mjg0OTU2OTF9.mvBJcOLQqIZy5J8IDSr6SE9g9wSD0MiXbV9o6J9-30c" balance` 

