### PR TITLE
fix(client): always adding retry delay, even on first connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,7 @@ rand_chacha = { opt-level = 3 }
 rand_core = { opt-level = 3 }
 rand = { opt-level = 3 }
 ring = { opt-level = 3 }
+rustls = { opt-level = 3 }
 secp256k1 = { opt-level = 3 }
 secp256k1-sys = { opt-level = 3 }
 subtle = { opt-level = 3 }


### PR DESCRIPTION
While working on #6151 I've noticed that the duration of initial calls is suspiciously long.

Turns out we are always adding a delay on connecting, even the first time.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
