### PR TITLE
fix: consensus panic

### DIFF
--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -344,7 +344,7 @@ impl ConsensusEngine {
         signature_sender: watch::Sender<Option<SchnorrSignature>>,
         timestamp_receiver: Receiver<(Instant, u64)>,
     ) -> anyhow::Result<SignedSessionOutcome> {
-        let mut item_index = 0;
+        let mut item_index = self.pending_accepted_items().await.len() as u64;
 
         let mut request_signed_session_outcome = Box::pin(async {
             self.request_signed_session_outcome(&self.federation_api, session_index)


### PR DESCRIPTION
Re #6155 

With this I'm no longer hitting panic in #6155 .

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
