### PR TITLE
chore: release devimint package

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -491,6 +491,9 @@ jobs:
           - flake-output: gateway-pkgs
             bins: gateway-cli,gatewayd,gateway-cln-extension
             deb: fedimint-gateway
+          - flake-output: devimint
+            bins: devimint,devimint-faucet
+            deb: devimint
 
     runs-on: [self-hosted, linux]
     timeout-minutes: 60

--- a/devimint/src/bin/devimint-faucet.rs
+++ b/devimint/src/bin/devimint-faucet.rs
@@ -13,6 +13,8 @@ use devimint::envs::{
     FM_BITCOIN_RPC_URL_ENV, FM_CLIENT_DIR_ENV, FM_CLN_SOCKET_ENV, FM_FAUCET_BIND_ADDR_ENV,
     FM_INVITE_CODE_ENV, FM_PORT_GW_LND_ENV,
 };
+use fedimint_core::fedimint_build_code_version_env;
+use fedimint_core::util::handle_version_hash_command;
 use fedimint_logging::TracingSetup;
 use ln_gateway::rpc::V1_API_ENDPOINT;
 use tokio::net::TcpListener;
@@ -122,6 +124,9 @@ fn get_invite_code(invite_code: Option<String>) -> anyhow::Result<String> {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     TracingSetup::default().init()?;
+
+    handle_version_hash_command(fedimint_build_code_version_env!());
+
     let cmd = Cmd::parse();
     let faucet = Faucet::new(&cmd).await?;
     let router = Router::new()

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -2535,7 +2535,7 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                         dev_fed.fed.pegin_gateway(20_000, &dev_fed.gw_lnd),
                         async {
                             let faucet = process_mgr
-                                .spawn_daemon("faucet", cmd!(crate::util::Faucet))
+                                .spawn_daemon("devimint-faucet", cmd!(crate::util::Faucet))
                                 .await?;
 
                             poll("waiting for faucet startup", || async {

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -626,7 +626,7 @@ const ESPLORA_FALLBACK: &str = "esplora";
 
 const RECOVERYTOOL_FALLBACK: &str = "fedimint-recoverytool";
 
-const FAUCET_FALLBACK: &str = "faucet";
+const FAUCET_FALLBACK: &str = "devimint-faucet";
 
 const FEDIMINT_DBTOOL_FALLBACK: &str = "fedimint-dbtool";
 


### PR DESCRIPTION
Rename `faucet` to `devimint-faucet`, as it is part of the `devimint` build itself so people installing it in dev shells will get it as well.

This should also pin all tagged releases of devimint (like all existing packages), as required in #6167.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
