### PR TITLE
 chore: claim oob refunds with a single state machine 

### DIFF
--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -228,18 +228,20 @@ impl Executor {
             if let Some(module_context) =
                 self.inner.module_contexts.get(&state.module_instance_id())
             {
-                let context = self
+                if let Some(context) = self
                     .inner
                     .state
                     .read()
-                    .unwrap()
+                    .expect("locking failed")
                     .gen_context(&state)
-                    .expect("executor should be running at this point");
-
-                if state.is_terminal(module_context, &context) {
-                    return Err(AddStateMachinesError::Other(anyhow!(
+                {
+                    if state.is_terminal(module_context, &context) {
+                        return Err(AddStateMachinesError::Other(anyhow!(
                         "State is already terminal, adding it to the executor doesn't make sense."
                     )));
+                    }
+                } else {
+                    warn!(target: LOG_CLIENT_REACTOR, "Executor should be running at this point");
                 }
             }
 

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -572,6 +572,7 @@ impl Database {
                         warn!(
                             target: LOG_DB,
                             curr_attempts,
+                            ?err,
                             "Database commit failed in an autocommit block - terminating"
                         );
                         return Err(AutocommitError::CommitFailed {
@@ -585,6 +586,7 @@ impl Database {
                     warn!(
                         target: LOG_DB,
                         curr_attempts,
+                        %err,
                         delay_ms = %delay,
                         "Database commit failed in an autocommit block - retrying"
                     );

--- a/modules/fedimint-dummy-client/src/db.rs
+++ b/modules/fedimint-dummy-client/src/db.rs
@@ -79,6 +79,8 @@ pub(crate) fn get_v1_migrated_state(
     let decoders = ModuleDecoderRegistry::default();
     let dummy_sm_variant = u16::consensus_decode(cursor, &decoders)?;
 
+    // We are only migrating the type of one of the variants, so we do nothing on
+    // other discriminants.
     if dummy_sm_variant != 5 {
         return Ok(None);
     }

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -163,7 +163,7 @@ impl MintInputStateCreated {
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintInputStateRefund {
-    refund_txid: TransactionId,
+    pub refund_txid: TransactionId,
 }
 
 impl MintInputStateRefund {

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -57,6 +57,12 @@ pub enum MintOOBStates {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct MintOOBStateMachineV1 {
+    pub(crate) operation_id: OperationId,
+    pub(crate) state: MintOOBStatesV1,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct MintOOBStateMachine {
     pub(crate) operation_id: OperationId,
     pub(crate) state: MintOOBStates,

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -9,10 +9,21 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{runtime, Amount, TransactionId};
 use fedimint_mint_common::MintInput;
 
-use crate::input::{
-    MintInputCommon, MintInputStateCreated, MintInputStateMachine, MintInputStates,
-};
+use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStateRefund, MintInputStates};
 use crate::{MintClientContext, MintClientStateMachines, SpendableNote};
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub enum MintOOBStatesV1 {
+    /// The e-cash has been taken out of the wallet and we are waiting for the
+    /// recipient to reissue it or the user to trigger a refund.
+    Created(MintOOBStatesCreated),
+    /// The user has triggered a refund.
+    UserRefund(MintOOBStatesUserRefund),
+    /// The timeout of this out-of-band transaction was hit and we attempted to
+    /// refund. This refund *failing* is the expected behavior since the
+    /// recipient is supposed to have already reissued it.
+    TimeoutRefund(MintOOBStatesTimeoutRefund),
+}
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// State machine managing e-cash that has been taken out of the wallet for
@@ -27,13 +38,22 @@ use crate::{MintClientContext, MintClientStateMachines, SpendableNote};
 pub enum MintOOBStates {
     /// The e-cash has been taken out of the wallet and we are waiting for the
     /// recipient to reissue it or the user to trigger a refund.
-    Created(MintOOBStatesCreated),
+    CreatedMulti(MintOOBStatesCreatedMulti),
     /// The user has triggered a refund.
-    UserRefund(MintOOBStatesUserRefund),
+    UserRefundMulti(MintOOBStatesUserRefundMulti),
     /// The timeout of this out-of-band transaction was hit and we attempted to
     /// refund. This refund *failing* is the expected behavior since the
     /// recipient is supposed to have already reissued it.
     TimeoutRefund(MintOOBStatesTimeoutRefund),
+
+    // States we want to drop eventually (that's why they are last)
+    // -
+    /// Obsoleted, legacy from [`MintOOBStatesV1`], like
+    /// [`MintOOBStates::CreatedMulti`] but for a single note only.
+    Created(MintOOBStatesCreated),
+    /// Obsoleted, legacy from [`MintOOBStatesV1`], like
+    /// [`MintOOBStates::UserRefundMulti`] but for single note only
+    UserRefund(MintOOBStatesUserRefund),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
@@ -47,6 +67,20 @@ pub struct MintOOBStatesCreated {
     pub(crate) amount: Amount,
     pub(crate) spendable_note: SpendableNote,
     pub(crate) timeout: SystemTime,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct MintOOBStatesCreatedMulti {
+    pub(crate) spendable_notes: Vec<(Amount, SpendableNote)>,
+    pub(crate) timeout: SystemTime,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
+pub struct MintOOBStatesUserRefundMulti {
+    /// The txid we are hoping succeeds refunding all notes in one go
+    pub(crate) refund_txid: TransactionId,
+    /// The notes we are going to refund individually if it doesn't
+    pub(crate) spendable_notes: Vec<(Amount, SpendableNote)>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
@@ -71,7 +105,12 @@ impl State for MintOOBStateMachine {
             MintOOBStates::Created(created) => {
                 created.transitions(self.operation_id, context, global_context)
             }
-            MintOOBStates::UserRefund(_) | MintOOBStates::TimeoutRefund(_) => {
+            MintOOBStates::CreatedMulti(created) => {
+                created.transitions(self.operation_id, context, global_context)
+            }
+            MintOOBStates::UserRefund(_)
+            | MintOOBStates::TimeoutRefund(_)
+            | MintOOBStates::UserRefundMulti(_) => {
                 vec![]
             }
         }
@@ -112,6 +151,40 @@ impl MintOOBStatesCreated {
     }
 }
 
+impl MintOOBStatesCreatedMulti {
+    fn transitions(
+        &self,
+        operation_id: OperationId,
+        context: &MintClientContext,
+        global_context: &DynGlobalClientContext,
+    ) -> Vec<StateTransition<MintOOBStateMachine>> {
+        let user_cancel_gc = global_context.clone();
+        let timeout_cancel_gc = global_context.clone();
+        vec![
+            StateTransition::new(
+                context.await_cancel_oob_payment(operation_id),
+                move |dbtx, (), state| {
+                    Box::pin(transition_user_cancel_multi(
+                        state,
+                        dbtx,
+                        user_cancel_gc.clone(),
+                    ))
+                },
+            ),
+            StateTransition::new(
+                await_timeout_cancel(self.timeout),
+                move |dbtx, (), state| {
+                    Box::pin(transition_timeout_cancel_multi(
+                        state,
+                        dbtx,
+                        timeout_cancel_gc.clone(),
+                    ))
+                },
+            ),
+        ]
+    }
+}
+
 async fn transition_user_cancel(
     prev_state: MintOOBStateMachine,
     dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
@@ -133,6 +206,32 @@ async fn transition_user_cancel(
     MintOOBStateMachine {
         operation_id: prev_state.operation_id,
         state: MintOOBStates::UserRefund(MintOOBStatesUserRefund { refund_txid }),
+    }
+}
+
+async fn transition_user_cancel_multi(
+    prev_state: MintOOBStateMachine,
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    global_context: DynGlobalClientContext,
+) -> MintOOBStateMachine {
+    let spendable_notes = match prev_state.state {
+        MintOOBStates::CreatedMulti(created) => created.spendable_notes,
+        _ => panic!("Invalid previous state: {prev_state:?}"),
+    };
+
+    let refund_txid = try_cancel_oob_spend_multi(
+        dbtx,
+        prev_state.operation_id,
+        spendable_notes.clone(),
+        global_context,
+    )
+    .await;
+    MintOOBStateMachine {
+        operation_id: prev_state.operation_id,
+        state: MintOOBStates::UserRefundMulti(MintOOBStatesUserRefundMulti {
+            refund_txid,
+            spendable_notes,
+        }),
     }
 }
 
@@ -166,6 +265,29 @@ async fn transition_timeout_cancel(
     }
 }
 
+async fn transition_timeout_cancel_multi(
+    prev_state: MintOOBStateMachine,
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    global_context: DynGlobalClientContext,
+) -> MintOOBStateMachine {
+    let spendable_notes = match prev_state.state {
+        MintOOBStates::CreatedMulti(created) => created.spendable_notes,
+        _ => panic!("Invalid previous state: {prev_state:?}"),
+    };
+
+    let refund_txid = try_cancel_oob_spend_multi(
+        dbtx,
+        prev_state.operation_id,
+        spendable_notes,
+        global_context,
+    )
+    .await;
+    MintOOBStateMachine {
+        operation_id: prev_state.operation_id,
+        state: MintOOBStates::TimeoutRefund(MintOOBStatesTimeoutRefund { refund_txid }),
+    }
+}
+
 async fn try_cancel_oob_spend(
     dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
     operation_id: OperationId,
@@ -173,9 +295,24 @@ async fn try_cancel_oob_spend(
     spendable_note: SpendableNote,
     global_context: DynGlobalClientContext,
 ) -> TransactionId {
-    let (inputs, input_sms) = vec![spendable_note]
+    try_cancel_oob_spend_multi(
+        dbtx,
+        operation_id,
+        vec![(amount, spendable_note)],
+        global_context,
+    )
+    .await
+}
+
+async fn try_cancel_oob_spend_multi(
+    dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
+    operation_id: OperationId,
+    spendable_notes: Vec<(Amount, SpendableNote)>,
+    global_context: DynGlobalClientContext,
+) -> TransactionId {
+    let (inputs, input_sms) = spendable_notes
         .into_iter()
-        .map(|spendable_note| {
+        .map(|(amount, spendable_note)| {
             (
                 ClientInput {
                     input: MintInput::new_v0(amount, spendable_note.note()),
@@ -190,9 +327,8 @@ async fn try_cancel_oob_spend(
                                 txid,
                                 input_idx,
                             },
-                            state: MintInputStates::Created(MintInputStateCreated {
-                                amount,
-                                spendable_note,
+                            state: MintInputStates::Refund(MintInputStateRefund {
+                                refund_txid: txid,
                             }),
                         })]
                     }),


### PR DESCRIPTION
Fix #5069

Alternative to #5833

Instead of trying to reclaim every spendable note from oob spend, reclaim them all in one tx.

This requires first a refactoring commit that breaks the 1:1 input to sm relationship. Now multiple inputs can generate a single state machine that will reclaim them all.

One behavior change is that the new tx will fail or succeed together. But if the destination user claimed one note, is it still a reasonable thing to do to reclaim other ones? I don't think so.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
