### PR TITLE
chore(client): check peg-in addresses with no deposits more often

### DIFF
--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -279,7 +279,7 @@ impl CheckOutcome {
             }
             let now = time::now();
             let age = now.duration_since(creation_time).unwrap_or_default();
-            return Some(age / 2);
+            return Some(age / 10);
         }
 
         // The delays is the minimum retry delay.


### PR DESCRIPTION
Currently, if the user creates a deposit address, and then decides to make a peg-in after a week, they might wait 3.5 day for the client to notice.

Ultimately end-user apps needs to expose ability to check for deposits on demand (click a button or something), but irrespective of that, checking a 7 day old address arond once a day seems reasonable.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
