### PR TITLE
fix: revert cln version bump

### DIFF
--- a/devimint/src/cfg/lightningd.conf
+++ b/devimint/src/cfg/lightningd.conf
@@ -3,4 +3,3 @@ bitcoin-rpcuser=bitcoin
 bitcoin-rpcpassword=bitcoin
 bitcoin-rpcport={bitcoin_rpcport}
 addr=127.0.0.1:{port}
-developer

--- a/gateway/ln-gateway/src/bin/cln_extension.rs
+++ b/gateway/ln-gateway/src/bin/cln_extension.rs
@@ -61,10 +61,6 @@ struct ClnExtensionOpts {
     /// Gateway CLN extension service listen address
     #[arg(long = "fm-gateway-listen", env = FM_CLN_EXTENSION_LISTEN_ADDRESS_ENV)]
     fm_gateway_listen: Option<SocketAddr>,
-
-    /// Developer mode flag
-    #[arg(long = "developer")]
-    developer: bool,
 }
 
 #[tokio::main]

--- a/nix/overlays/clightning.nix
+++ b/nix/overlays/clightning.nix
@@ -1,12 +1,15 @@
 final: prev: {
   clightning = prev.clightning.overrideAttrs (oldAttrs: rec {
-    version = "24.08.1";
+    version = "23.05.2";
     src = prev.fetchurl {
       url = "https://github.com/ElementsProject/lightning/releases/download/v${version}/clightning-v${version}.zip";
-      sha256 = "sha256-2ZKvhNuzGftKwSdmMkHOwE9UEI5Ewn5HHSyyZUcCwB4=";
+      sha256 = "sha256-Tj5ybVaxpk5wmOw85LkeU4pgM9NYl6SnmDG2gyXrTHw=";
     };
     makeFlags = [ "VERSION=v${version}" ];
-    configureFlags = [ "--disable-valgrind" ];
+    configureFlags = [
+        "--enable-developer"
+        "--disable-valgrind"
+    ];
     env = {
       NIX_CFLAGS_COMPILE = "-w";
     };


### PR DESCRIPTION
Bumping core lightning beyond v23.05.2 causes it to fail in devimint on MacOS due to this known issue:

Fixes #6193