### PR TITLE
refactor(client): decouple inputs and their state machines

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -415,34 +415,6 @@ impl DynGlobalClientContext {
             .await
     }
 
-    /// Creates a transaction that with an output of the primary module,
-    /// claiming the given input and transferring its value into the client's
-    /// wallet.
-    ///
-    /// The transactions submission state machine as well as the state
-    /// machines responsible for the generated output are generated
-    /// automatically. The caller is responsible for the input's state machines,
-    /// should there be any required.
-    pub async fn claim_input<I, S>(
-        &self,
-        dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,
-        input: ClientInput<I>,
-        sm: ClientInputSM<S>,
-    ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)>
-    where
-        I: IInput + MaybeSend + MaybeSync + 'static,
-        S: IState + MaybeSend + MaybeSync + 'static,
-    {
-        self.claim_inputs(
-            dbtx,
-            ClientInputBundle {
-                inputs: vec![input],
-                sms: vec![sm],
-            },
-        )
-        .await
-    }
-
     pub async fn claim_inputs<I, S>(
         &self,
         dbtx: &mut ClientSMDatabaseTransaction<'_, '_>,

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -220,20 +220,13 @@ where
         self.make_dyn(output)
     }
 
-    /// Turn a typed [`ClientInput`] into a dyn version
-    pub fn make_client_input<I>(&self, input: ClientInput<I>) -> ClientInput
+    /// Turn a typed [`ClientInputBundle`] into a dyn version
+    pub fn make_client_inputs<I, S>(&self, inputs: ClientInputBundle<I, S>) -> ClientInputBundle
     where
         I: IntoDynInstance<DynType = DynInput> + 'static,
-    {
-        self.make_dyn(input)
-    }
-
-    /// Turn a typed [`ClientInputSM`] into a dyn version
-    pub fn make_client_input_sm<S>(&self, input: ClientInputSM<S>) -> ClientInputSM
-    where
         S: IntoDynInstance<DynType = DynState> + 'static,
     {
-        self.make_dyn(input)
+        self.make_dyn(inputs)
     }
 
     pub fn make_dyn_state<S>(&self, sm: S) -> DynState

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -31,10 +31,12 @@ use crate::db::event_log::Event;
 use crate::module::recovery::{DynModuleBackup, ModuleBackup};
 use crate::oplog::{OperationLogEntry, UpdateStreamOrOutcome};
 use crate::sm::{self, ActiveStateMeta, Context, DynContext, DynState, State};
-use crate::transaction::{ClientInput, ClientOutput, TransactionBuilder};
+use crate::transaction::{
+    ClientInput, ClientInputBundle, ClientInputSM, ClientOutput, TransactionBuilder,
+};
 use crate::{
-    oplog, states_add_instance, states_to_instanceless_dyn, AddStateMachinesResult, Client,
-    ClientStrong, ClientWeak, InstancelessDynClientInput, TransactionUpdates,
+    oplog, states_add_instance, AddStateMachinesResult, Client, ClientStrong, ClientWeak,
+    InstancelessDynClientInputBundle, TransactionUpdates,
 };
 
 pub mod init;
@@ -219,9 +221,16 @@ where
     }
 
     /// Turn a typed [`ClientInput`] into a dyn version
-    pub fn make_client_input<O, S>(&self, input: ClientInput<O, S>) -> ClientInput
+    pub fn make_client_input<I>(&self, input: ClientInput<I>) -> ClientInput
     where
-        O: IntoDynInstance<DynType = DynInput> + 'static,
+        I: IntoDynInstance<DynType = DynInput> + 'static,
+    {
+        self.make_dyn(input)
+    }
+
+    /// Turn a typed [`ClientInputSM`] into a dyn version
+    pub fn make_client_input_sm<S>(&self, input: ClientInputSM<S>) -> ClientInputSM
+    where
         S: IntoDynInstance<DynType = DynState> + 'static,
     {
         self.make_dyn(input)
@@ -466,48 +475,52 @@ where
         operation.outcome_or_updates(&self.global_db(), operation_id, stream_gen)
     }
 
-    pub async fn claim_input<I, S>(
+    pub async fn claim_inputs<I, S>(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
-        input: ClientInput<I, S>,
+        inputs: ClientInputBundle<I, S>,
         operation_id: OperationId,
     ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)>
     where
         I: IInput + MaybeSend + MaybeSync + 'static,
         S: sm::IState + MaybeSend + MaybeSync + 'static,
     {
-        self.claim_input_dyn(
-            dbtx,
-            InstancelessDynClientInput {
-                input: Box::new(input.input),
-                keys: input.keys,
-                amount: input.amount,
-                state_machines: states_to_instanceless_dyn(input.state_machines),
-            },
-            operation_id,
-        )
-        .await
+        self.claim_inputs_dyn(dbtx, inputs.into_instanceless(), operation_id)
+            .await
     }
 
-    async fn claim_input_dyn(
+    async fn claim_inputs_dyn(
         &self,
         dbtx: &mut DatabaseTransaction<'_>,
-        input: InstancelessDynClientInput,
+        ClientInputBundle { inputs, sms }: InstancelessDynClientInputBundle,
         operation_id: OperationId,
     ) -> anyhow::Result<(TransactionId, Vec<OutPoint>)> {
-        let instance_input = ClientInput {
-            input: DynInput::from_parts(self.module_instance_id, input.input),
-            keys: input.keys,
-            amount: input.amount,
-            state_machines: states_add_instance(self.module_instance_id, input.state_machines),
-        };
+        let mut tx_builder = TransactionBuilder::new();
+
+        for input in inputs {
+            let instance_input = ClientInput {
+                input: DynInput::from_parts(self.module_instance_id, input.input),
+                keys: input.keys,
+                amount: input.amount,
+            };
+            tx_builder = tx_builder.with_input(instance_input);
+        }
+        for input_sm in sms {
+            let instance_input_sm = ClientInputSM {
+                state_machines: states_add_instance(
+                    self.module_instance_id,
+                    input_sm.state_machines,
+                ),
+            };
+            tx_builder = tx_builder.with_input_sm(instance_input_sm);
+        }
 
         self.client
             .get()
             .finalize_and_submit_transaction_inner(
                 &mut dbtx.global_dbtx(self.global_dbtx_access_token),
                 operation_id,
-                TransactionBuilder::new().with_input(instance_input),
+                tx_builder,
             )
             .await
     }
@@ -687,7 +700,7 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
         _input_amount: Amount,
         _output_amount: Amount,
     ) -> anyhow::Result<(
-        Vec<ClientInput<<Self::Common as ModuleCommon>::Input, Self::States>>,
+        ClientInputBundle<<Self::Common as ModuleCommon>::Input, Self::States>,
         Vec<ClientOutput<<Self::Common as ModuleCommon>::Output, Self::States>>,
     )> {
         unimplemented!()
@@ -815,7 +828,7 @@ pub trait IClientModule: Debug {
         operation_id: OperationId,
         input_amount: Amount,
         output_amount: Amount,
-    ) -> anyhow::Result<(Vec<ClientInput>, Vec<ClientOutput>)>;
+    ) -> anyhow::Result<(ClientInputBundle, Vec<ClientOutput>)>;
 
     async fn await_primary_module_output(
         &self,
@@ -914,7 +927,7 @@ where
         operation_id: OperationId,
         input_amount: Amount,
         output_amount: Amount,
-    ) -> anyhow::Result<(Vec<ClientInput>, Vec<ClientOutput>)> {
+    ) -> anyhow::Result<(ClientInputBundle, Vec<ClientOutput>)> {
         let (inputs, outputs) = <T as ClientModule>::create_final_inputs_and_outputs(
             self,
             &mut dbtx.to_ref_with_prefix_module_id(module_instance).0,
@@ -924,10 +937,7 @@ where
         )
         .await?;
 
-        let inputs = inputs
-            .into_iter()
-            .map(|input| input.into_dyn(module_instance))
-            .collect::<Vec<ClientInput>>();
+        let inputs = inputs.into_dyn(module_instance);
 
         let outputs = outputs
             .into_iter()

--- a/fedimint-client/src/sm/state.rs
+++ b/fedimint-client/src/sm/state.rs
@@ -252,6 +252,45 @@ pub struct DynState(
     ModuleInstanceId,
 );
 
+impl IState for DynState {
+    fn as_any(&self) -> &(maybe_add_send_sync!(dyn Any)) {
+        (**self).as_any()
+    }
+
+    fn transitions(
+        &self,
+        context: &DynContext,
+        global_context: &DynGlobalClientContext,
+    ) -> Vec<StateTransition<DynState>> {
+        (**self).transitions(context, global_context)
+    }
+
+    fn operation_id(&self) -> OperationId {
+        (**self).operation_id()
+    }
+
+    fn clone(&self, module_instance_id: ModuleInstanceId) -> DynState {
+        (**self).clone(module_instance_id)
+    }
+
+    fn erased_eq_no_instance_id(&self, other: &DynState) -> bool {
+        (**self).erased_eq_no_instance_id(other)
+    }
+
+    fn erased_hash_no_instance_id(&self, hasher: &mut dyn std::hash::Hasher) {
+        (**self).erased_hash_no_instance_id(hasher);
+    }
+}
+
+impl IntoDynInstance for DynState {
+    type DynType = DynState;
+
+    fn into_dyn(self, instance_id: ModuleInstanceId) -> Self::DynType {
+        assert_eq!(instance_id, self.1);
+        self
+    }
+}
+
 impl std::ops::Deref for DynState {
     type Target = maybe_add_send_sync!(dyn IState + 'static);
 

--- a/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
@@ -16,7 +16,6 @@ use fedimint_core::module::ApiRequestErased;
 use fedimint_core::secp256k1::KeyPair;
 use fedimint_core::task::sleep;
 use fedimint_core::{NumPeersExt, OutPoint, PeerId, TransactionId};
-use fedimint_lnv2_client::LightningClientStateMachines;
 use fedimint_lnv2_common::contracts::IncomingContract;
 use fedimint_lnv2_common::{
     LightningInput, LightningInputV0, LightningOutputOutcome, LightningOutputOutcomeV0,
@@ -268,11 +267,8 @@ impl ReceiveStateMachine {
         let outpoints = global_context
             .claim_inputs(
                 dbtx,
-                ClientInputBundle::<_, LightningClientStateMachines>::new(
-                    vec![client_input],
-                    // The input of the refund tx is managed by this state machine
-                    vec![],
-                ),
+                // The input of the refund tx is managed by this state machine
+                ClientInputBundle::new_no_sm(vec![client_input]),
             )
             .await
             .expect("Cannot claim input, additional funding needed")

--- a/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
@@ -7,7 +7,7 @@ use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::secp256k1::KeyPair;
 use fedimint_core::{Amount, OutPoint};
-use fedimint_lnv2_client::{LightningClientStateMachines, LightningInvoice};
+use fedimint_lnv2_client::LightningInvoice;
 use fedimint_lnv2_common::contracts::{OutgoingContract, PaymentImage};
 use fedimint_lnv2_common::{LightningInput, LightningInputV0, OutgoingWitness};
 use serde::{Deserialize, Serialize};
@@ -228,13 +228,7 @@ impl SendStateMachine {
                 };
 
                 let outpoints = global_context
-                    .claim_inputs(
-                        dbtx,
-                        ClientInputBundle::<_, LightningClientStateMachines>::new(
-                            vec![client_input],
-                            vec![],
-                        ),
-                    )
+                    .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
                     .await
                     .expect("Cannot claim input, additional funding needed")
                     .1;

--- a/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
@@ -1,8 +1,7 @@
 use std::fmt;
-use std::sync::Arc;
 
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ClientInput, ClientInputBundle};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -219,18 +218,23 @@ impl SendStateMachine {
     ) -> SendStateMachine {
         match result {
             Ok(preimage) => {
-                let client_input = ClientInput::<LightningInput, LightningClientStateMachines> {
+                let client_input = ClientInput::<LightningInput> {
                     input: LightningInput::V0(LightningInputV0::Outgoing(
                         old_state.common.contract.contract_id(),
                         OutgoingWitness::Claim(preimage),
                     )),
                     amount: old_state.common.contract.amount,
                     keys: vec![old_state.common.claim_keypair],
-                    state_machines: Arc::new(|_, _| vec![]),
                 };
 
                 let outpoints = global_context
-                    .claim_input(dbtx, client_input)
+                    .claim_inputs(
+                        dbtx,
+                        ClientInputBundle::<_, LightningClientStateMachines>::new(
+                            vec![client_input],
+                            vec![],
+                        ),
+                    )
                     .await
                     .expect("Cannot claim input, additional funding needed")
                     .1;

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use bitcoin_hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::{ClientInput, ClientOutput};
+use fedimint_client::transaction::{ClientInput, ClientInputBundle, ClientOutput};
 use fedimint_client::{ClientHandleArc, DynGlobalClientContext};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::OperationId;
@@ -714,15 +714,17 @@ impl GatewayPayClaimOutgoingContract {
     ) -> GatewayPayStateMachine {
         debug!("Claiming outgoing contract {contract:?}");
         let claim_input = contract.claim(preimage.clone());
-        let client_input = ClientInput::<LightningInput, GatewayClientStateMachines> {
+        let client_input = ClientInput::<LightningInput> {
             input: claim_input,
-            state_machines: Arc::new(|_, _| vec![]),
             amount: contract.amount,
             keys: vec![context.redeem_key],
         };
 
         let out_points = global_context
-            .claim_input(dbtx, client_input)
+            .claim_inputs(
+                dbtx,
+                ClientInputBundle::<_, GatewayClientStateMachines>::new(vec![client_input], vec![]),
+            )
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -721,10 +721,7 @@ impl GatewayPayClaimOutgoingContract {
         };
 
         let out_points = global_context
-            .claim_inputs(
-                dbtx,
-                ClientInputBundle::<_, GatewayClientStateMachines>::new(vec![client_input], vec![]),
-            )
+            .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/gateway/ln-gateway/tests/tests.rs
+++ b/gateway/ln-gateway/tests/tests.rs
@@ -51,8 +51,7 @@ use ln_gateway::state_machine::pay::{
     OutgoingContractError, OutgoingPaymentError, OutgoingPaymentErrorType,
 };
 use ln_gateway::state_machine::{
-    GatewayClientModule, GatewayClientStateMachines, GatewayExtPayStates, GatewayExtReceiveStates,
-    GatewayMeta, Htlc,
+    GatewayClientModule, GatewayExtPayStates, GatewayExtReceiveStates, GatewayMeta, Htlc,
 };
 use ln_gateway::Gateway;
 use tpe::G1Affine;
@@ -384,9 +383,8 @@ async fn test_gateway_cannot_claim_invalid_preimage() -> anyhow::Result<()> {
             // Bogus preimage
             let preimage = Preimage(rand::random());
             let claim_input = outgoing_contract.claim(preimage);
-            let client_input = ClientInput::<LightningInput, GatewayClientStateMachines> {
+            let client_input = ClientInput::<LightningInput> {
                 input: claim_input,
-                state_machines: Arc::new(|_, _| vec![]),
                 amount: outgoing_contract.amount,
                 keys: vec![gateway_module.redeem_key],
             };

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -234,7 +234,10 @@ impl DummyClientModule {
 
         // Build and send tx to the fed
         // Will output to our primary client module
-        let tx = TransactionBuilder::new().with_input(self.client_ctx.make_client_input(input));
+        let tx = TransactionBuilder::new().with_inputs(
+            self.client_ctx
+                .make_client_inputs(ClientInputBundle::new_no_sm(vec![input])),
+        );
         let outpoint = |txid, _| OutPoint { txid, out_idx: 0 };
         let (_, change) = self
             .client_ctx

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -93,7 +93,6 @@ async fn federation_should_abort_if_balance_sheet_is_negative() -> anyhow::Resul
         },
         amount: sats(1000),
         keys: vec![account_kp],
-        state_machines: Arc::new(|_, _| Vec::<DummyStateMachine>::new()),
     };
 
     let tx = TransactionBuilder::new().with_input(input.into_dyn(dummy.id));

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -356,10 +356,7 @@ impl DecryptingPreimageState {
         };
 
         let out_points = global_context
-            .claim_inputs(
-                dbtx,
-                ClientInputBundle::<_, IncomingStateMachine>::new(vec![client_input], vec![]),
-            )
+            .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -8,12 +8,11 @@
 //!   - `gateway` for receiving payments into the federation
 
 use core::fmt;
-use std::sync::Arc;
 use std::time::Duration;
 
 use bitcoin30::hashes::sha256;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ClientInput, ClientInputBundle};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -350,15 +349,17 @@ impl DecryptingPreimageState {
     ) -> IncomingStateMachine {
         debug!("Refunding incoming contract {contract:?}");
         let claim_input = contract.claim();
-        let client_input = ClientInput::<LightningInput, IncomingStateMachine> {
+        let client_input = ClientInput::<LightningInput> {
             input: claim_input,
             amount: contract.amount,
-            state_machines: Arc::new(|_, _| vec![]),
             keys: vec![context.redeem_key],
         };
 
         let out_points = global_context
-            .claim_input(dbtx, client_input)
+            .claim_inputs(
+                dbtx,
+                ClientInputBundle::<_, IncomingStateMachine>::new(vec![client_input], vec![]),
+            )
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1458,11 +1458,10 @@ impl LightningClientModule {
             .with_context(|| format!("No contract found for {contract_id:?}"))?;
 
         let input = incoming_contract_account.claim();
-        let client_input = ClientInput::<LightningInput, LightningClientStateMachines> {
+        let client_input = ClientInput::<LightningInput> {
             input,
             amount: incoming_contract_account.amount,
             keys: vec![key_pair],
-            state_machines: Arc::new(|_, _| vec![]),
         };
 
         let tx =

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -38,7 +38,9 @@ use fedimint_client::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{DynState, ModuleNotifier, State, StateTransition};
-use fedimint_client::transaction::{ClientInput, ClientOutput, TransactionBuilder};
+use fedimint_client::transaction::{
+    ClientInput, ClientInputBundle, ClientOutput, TransactionBuilder,
+};
 use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind, OperationId};
@@ -1464,8 +1466,10 @@ impl LightningClientModule {
             keys: vec![key_pair],
         };
 
-        let tx =
-            TransactionBuilder::new().with_input(self.client_ctx.make_client_input(client_input));
+        let tx = TransactionBuilder::new().with_inputs(
+            self.client_ctx
+                .make_client_inputs(ClientInputBundle::new_no_sm(vec![client_input])),
+        );
         let extra_meta = serde_json::to_value(extra_meta).expect("extra_meta is serializable");
         let operation_meta_gen = |_, out_points| LightningOperationMeta {
             variant: LightningOperationMetaVariant::Claim { out_points },

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, warn};
 
 pub use self::lightningpay::LightningPayStates;
 use crate::api::LnFederationApi;
-use crate::{set_payment_result, LightningClientContext, LightningClientStateMachines, PayType};
+use crate::{set_payment_result, LightningClientContext, PayType};
 
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
@@ -552,12 +552,9 @@ async fn try_refund_outgoing_contract(
     let (txid, out_points) = global_context
         .claim_inputs(
             dbtx,
-            ClientInputBundle::<_, LightningClientStateMachines>::new(
-                vec![refund_client_input],
-                // The input of the refund tx is managed by this state machine, so no new state
-                // machines need to be created
-                vec![],
-            ),
+            // The input of the refund tx is managed by this state machine, so no new state
+            // machines need to be created
+            ClientInputBundle::new_no_sm(vec![refund_client_input]),
         )
         .await
         .expect("Cannot claim input, additional funding needed");

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 use tracing::{debug, error, info};
 
 use crate::api::LnFederationApi;
-use crate::{LightningClientContext, LightningClientStateMachines, ReceivingKey};
+use crate::{LightningClientContext, ReceivingKey};
 
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
@@ -290,12 +290,9 @@ impl LightningReceiveConfirmedInvoice {
         global_context
             .claim_inputs(
                 dbtx,
-                ClientInputBundle::<_, LightningClientStateMachines>::new(
-                    vec![client_input],
-                    // The input of the refund tx is managed by this state machine, so no new state
-                    // machines need to be created
-                    vec![],
-                ),
+                // The input of the refund tx is managed by this state machine, so no new state
+                // machines need to be created
+                ClientInputBundle::new_no_sm(vec![client_input]),
             )
             .await
             .expect("Cannot claim input, additional funding needed")

--- a/modules/fedimint-ln-client/src/receive.rs
+++ b/modules/fedimint-ln-client/src/receive.rs
@@ -1,10 +1,9 @@
-use std::sync::Arc;
 use std::time::Duration;
 
 use bitcoin30::key::KeyPair;
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, DynState, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ClientInput, ClientInputBundle};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, OperationId};
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -282,17 +281,22 @@ impl LightningReceiveConfirmedInvoice {
         global_context: DynGlobalClientContext,
     ) -> (TransactionId, Vec<OutPoint>) {
         let input = contract.claim();
-        let client_input = ClientInput::<LightningInput, LightningClientStateMachines> {
+        let client_input = ClientInput::<LightningInput> {
             input,
             amount: contract.amount,
             keys: vec![keypair],
-            // The input of the refund tx is managed by this state machine, so no new state machines
-            // need to be created
-            state_machines: Arc::new(|_, _| vec![]),
         };
 
         global_context
-            .claim_input(dbtx, client_input)
+            .claim_inputs(
+                dbtx,
+                ClientInputBundle::<_, LightningClientStateMachines>::new(
+                    vec![client_input],
+                    // The input of the refund tx is managed by this state machine, so no new state
+                    // machines need to be created
+                    vec![],
+                ),
+            )
             .await
             .expect("Cannot claim input, additional funding needed")
     }

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -10,7 +10,7 @@ use fedimint_lnv2_common::{LightningInput, LightningInputV0};
 use tpe::AggregateDecryptionKey;
 
 use crate::api::LnFederationApi;
-use crate::{LightningClientContext, LightningClientStateMachines};
+use crate::LightningClientContext;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct ReceiveStateMachine {
@@ -118,13 +118,7 @@ impl ReceiveStateMachine {
         };
 
         let out_points = global_context
-            .claim_inputs(
-                dbtx,
-                ClientInputBundle::<_, LightningClientStateMachines>::new(
-                    vec![client_input],
-                    vec![],
-                ),
-            )
+            .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-
 use bitcoin30::key::KeyPair;
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ClientInput, ClientInputBundle};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -110,18 +108,23 @@ impl ReceiveStateMachine {
             return old_state.update(ReceiveSMState::Expired);
         }
 
-        let client_input = ClientInput::<LightningInput, LightningClientStateMachines> {
+        let client_input = ClientInput::<LightningInput> {
             input: LightningInput::V0(LightningInputV0::Incoming(
                 old_state.common.contract.contract_id(),
                 old_state.common.agg_decryption_key,
             )),
             amount: old_state.common.contract.commitment.amount,
             keys: vec![old_state.common.claim_keypair],
-            state_machines: Arc::new(|_, _| vec![]),
         };
 
         let out_points = global_context
-            .claim_input(dbtx, client_input)
+            .claim_inputs(
+                dbtx,
+                ClientInputBundle::<_, LightningClientStateMachines>::new(
+                    vec![client_input],
+                    vec![],
+                ),
+            )
             .await
             .expect("Cannot claim input, additional funding needed")
             .1;

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -2,7 +2,7 @@ mod mock;
 
 use std::sync::Arc;
 
-use fedimint_client::transaction::{ClientInput, TransactionBuilder};
+use fedimint_client::transaction::{ClientInput, ClientInputBundle, TransactionBuilder};
 use fedimint_core::core::OperationId;
 use fedimint_core::util::NextOrPending as _;
 use fedimint_core::{sats, Amount};
@@ -216,11 +216,11 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
             OperationId::new_random(),
             "Claiming Outgoing Contract",
             |_, _| (),
-            TransactionBuilder::new().with_input(
+            TransactionBuilder::new().with_inputs(
                 client
                     .get_first_module::<LightningClientModule>()?
                     .client_ctx
-                    .make_client_input(client_input),
+                    .make_client_inputs(ClientInputBundle::new_no_sm(vec![client_input])),
             ),
         )
         .await

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -4,15 +4,15 @@ use std::sync::Arc;
 
 use fedimint_client::transaction::{ClientInput, TransactionBuilder};
 use fedimint_core::core::OperationId;
-use fedimint_core::util::NextOrPending;
+use fedimint_core::util::NextOrPending as _;
 use fedimint_core::{sats, Amount};
 use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyInit;
 use fedimint_lnv2_client::{
-    Bolt11InvoiceDescription, LightningClientInit, LightningClientModule,
-    LightningClientStateMachines, LightningOperationMeta, ReceiveState, SendPaymentError,
-    SendState, CONTRACT_CONFIRMATION_BUFFER, EXPIRATION_DELTA_LIMIT_DEFAULT,
+    Bolt11InvoiceDescription, LightningClientInit, LightningClientModule, LightningOperationMeta,
+    ReceiveState, SendPaymentError, SendState, CONTRACT_CONFIRMATION_BUFFER,
+    EXPIRATION_DELTA_LIMIT_DEFAULT,
 };
 use fedimint_lnv2_common::config::LightningGenParams;
 use fedimint_lnv2_common::{LightningInput, LightningInputV0, OutgoingWitness};
@@ -202,14 +202,13 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
         LightningOperationMeta::Receive(..) => panic!("Operation Meta is a Receive variant"),
     };
 
-    let client_input = ClientInput::<LightningInput, LightningClientStateMachines> {
+    let client_input = ClientInput::<LightningInput> {
         input: LightningInput::V0(LightningInputV0::Outgoing(
             contract.contract_id(),
             OutgoingWitness::Claim(MOCK_INVOICE_PREIMAGE),
         )),
         amount: contract.amount,
         keys: vec![mock::gateway_keypair()],
-        state_machines: Arc::new(|_, _| vec![]),
     };
 
     client

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -8,7 +8,7 @@ use fedimint_logging::LOG_CLIENT_MODULE_MINT;
 use fedimint_mint_common::MintInput;
 use tracing::{debug, warn};
 
-use crate::{MintClientContext, MintClientStateMachines, SpendableNote};
+use crate::{MintClientContext, SpendableNote};
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 // TODO: add retry with valid subset of e-cash notes
@@ -147,12 +147,9 @@ impl MintInputStateCreated {
         let (refund_txid, _) = global_context
             .claim_inputs(
                 dbtx,
-                ClientInputBundle::<_, MintClientStateMachines>::new(
-                    vec![refund_input],
-                    // The input of the refund tx is managed by this state machine, so no new state
-                    // machines need to be created
-                    vec![],
-                ),
+                // The input of the refund tx is managed by this state machine, so no new state
+                // machines need to be created
+                ClientInputBundle::new_no_sm(vec![refund_input]),
             )
             .await
             .expect("Cannot claim input, additional funding needed");

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use bls12_381::G1Affine;
 use fedimint_client::backup::{ClientBackup, Metadata};
-use fedimint_client::transaction::{ClientInput, TransactionBuilder};
+use fedimint_client::transaction::{ClientInput, ClientInputBundle, TransactionBuilder};
 use fedimint_core::config::EmptyGenParams;
 use fedimint_core::core::OperationId;
 use fedimint_core::secp256k1::KeyPair;
@@ -78,11 +78,11 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
             operation_id,
             "Claiming Invalid Ecash Note",
             |_, _| (),
-            TransactionBuilder::new().with_input(
+            TransactionBuilder::new().with_inputs(
                 client
                     .get_first_module::<MintClientModule>()?
                     .client_ctx
-                    .make_client_input(client_input),
+                    .make_client_inputs(ClientInputBundle::new_no_sm(vec![client_input])),
             ),
         )
         .await

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -1,5 +1,4 @@
 use std::io::Cursor;
-use std::sync::Arc;
 use std::time::Duration;
 
 use bls12_381::G1Affine;
@@ -16,8 +15,7 @@ use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyInit;
 use fedimint_logging::LOG_TEST;
 use fedimint_mint_client::{
-    MintClientInit, MintClientModule, MintClientStateMachines, Note, OOBNotes,
-    ReissueExternalNotesState, SpendOOBState,
+    MintClientInit, MintClientModule, Note, OOBNotes, ReissueExternalNotesState, SpendOOBState,
 };
 use fedimint_mint_common::config::{FeeConsensus, MintGenParams, MintGenParamsConsensus};
 use fedimint_mint_common::{MintInput, MintInputV0, Nonce};
@@ -61,7 +59,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
 
     let keypair = KeyPair::new(secp256k1::SECP256K1, &mut rand::thread_rng());
 
-    let client_input = ClientInput::<MintInput, MintClientStateMachines> {
+    let client_input = ClientInput::<MintInput> {
         input: MintInput::V0(MintInputV0 {
             amount: Amount::from_msats(1024),
             note: Note {
@@ -71,7 +69,6 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
         }),
         amount: Amount::from_msats(1024),
         keys: vec![keypair],
-        state_machines: Arc::new(|_, _| vec![]),
     };
 
     let operation_id = OperationId::new_random();

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -17,7 +17,7 @@ use tracing::{debug, instrument, trace, warn};
 
 use crate::api::WalletFederationApi;
 use crate::pegin_monitor::filter_onchain_deposit_outputs;
-use crate::{WalletClientContext, WalletClientStates};
+use crate::WalletClientContext;
 
 const TRANSACTION_STATUS_FETCH_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -283,10 +283,7 @@ pub(crate) async fn transition_btc_tx_confirmed(
     };
 
     let (fm_txid, change) = global_context
-        .claim_inputs(
-            dbtx,
-            ClientInputBundle::<_, WalletClientStates>::new(vec![client_input], vec![]),
-        )
+        .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
         .await
         .expect("Cannot claim input, additional funding needed");
 

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -1,9 +1,8 @@
 use std::cmp;
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use fedimint_client::sm::{ClientSMDatabaseTransaction, State, StateTransition};
-use fedimint_client::transaction::ClientInput;
+use fedimint_client::transaction::{ClientInput, ClientInputBundle};
 use fedimint_client::DynGlobalClientContext;
 use fedimint_core::core::OperationId;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -277,15 +276,17 @@ pub(crate) async fn transition_btc_tx_confirmed(
 
     let wallet_input = WalletInput::new_v0(pegin_proof);
 
-    let client_input = ClientInput::<WalletInput, WalletClientStates> {
+    let client_input = ClientInput::<WalletInput> {
         input: wallet_input,
         keys: vec![awaiting_confirmation_state.tweak_key],
         amount,
-        state_machines: Arc::new(|_, _| vec![]),
     };
 
     let (fm_txid, change) = global_context
-        .claim_input(dbtx, client_input)
+        .claim_inputs(
+            dbtx,
+            ClientInputBundle::<_, WalletClientStates>::new(vec![client_input], vec![]),
+        )
         .await
         .expect("Cannot claim input, additional funding needed");
 

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -27,7 +27,7 @@ use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, PegInTweakIndexData, PegInTweakIndexKey,
     PegInTweakIndexPrefix, TweakIdx,
 };
-use crate::{WalletClientModule, WalletClientModuleData, WalletClientStates};
+use crate::{WalletClientModule, WalletClientModuleData};
 
 /// A helper struct meant to combined data from all addresses/records
 /// into a single struct with all actionable data.
@@ -432,7 +432,7 @@ async fn claim_peg_in(
         client_ctx
             .claim_inputs(
                 dbtx,
-                ClientInputBundle::<_, WalletClientStates>::new(vec![client_input], vec![]),
+                ClientInputBundle::new_no_sm(vec![client_input]),
                 operation_id,
             )
             .await


### PR DESCRIPTION
This will allow more efficient use of state machines in the client and enable e.g. #6176 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
