### PR TITLE
Revert "fix: GatewayLdkClient::info() doesn't rely on timestamps"

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -234,14 +234,9 @@ impl Gatewayd {
         let federation_id = fed.calculate_federation_id();
         let invite_code = fed.invite_code()?;
         info!("Recovering {federation_id}...");
-        poll("gateway connect-fed", || async {
-            cmd!(self, "connect-fed", invite_code.clone(), "--recover=true")
-                .run()
-                .await
-                .map_err(ControlFlow::Continue)?;
-            Ok(())
-        })
-        .await?;
+        cmd!(self, "connect-fed", invite_code.clone(), "--recover=true")
+            .run()
+            .await?;
         Ok(())
     }
 

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -14,6 +14,7 @@ use fedimint_core::bitcoin_migration::{
 use fedimint_core::runtime::spawn;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{Amount, BitcoinAmountOrAll};
+use ldk_node::config::EsploraSyncConfig;
 use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_node::lightning::ln::PaymentHash;
 use ldk_node::lightning::routing::gossip::NodeAlias;
@@ -98,7 +99,16 @@ impl GatewayLdkClient {
         });
         node_builder
             .set_entropy_bip39_mnemonic(mnemonic, None)
-            .set_chain_source_esplora(esplora_server_url.to_string(), None);
+            .set_chain_source_esplora(
+                esplora_server_url.to_string(),
+                Some(EsploraSyncConfig {
+                    // TODO: Remove these and rely on the default values.
+                    // See here for details: https://github.com/lightningdevkit/ldk-node/issues/339#issuecomment-2344230472
+                    onchain_wallet_sync_interval_secs: 10,
+                    lightning_wallet_sync_interval_secs: 10,
+                    ..Default::default()
+                }),
+            );
         let Some(data_dir_str) = data_dir.to_str() else {
             return Err(anyhow::anyhow!("Invalid data dir path"));
         };
@@ -214,13 +224,9 @@ impl Drop for GatewayLdkClient {
 #[async_trait]
 impl ILnRpcClient for GatewayLdkClient {
     async fn info(&self) -> Result<GetNodeInfoResponse, LightningRpcError> {
-        // It's important that this is called before getting esplora chain tip data
-        // since we assume that the node is _never_ ahead of esplora. But if we called
-        // this after esplora, a block could be mined and processed in between the two
-        // calls.
         let node_status = self.node.status();
 
-        let Some(esplora_chain_tip_block_summary) = self
+        let Some(chain_tip_block_summary) = self
             .esplora_client
             .get_blocks(None)
             .await
@@ -237,13 +243,17 @@ impl ILnRpcClient for GatewayLdkClient {
             });
         };
 
-        let esplora_chain_tip_block_height = esplora_chain_tip_block_summary.time.height;
-        let ldk_node_chain_tip_block_height = node_status.current_best_block.height;
+        let esplora_chain_tip_timestamp = chain_tip_block_summary.time.timestamp;
+        let block_height: u32 = chain_tip_block_summary.time.height;
 
-        // The LDK node should never be ahead of the Esplora chain tip block height.
-        assert!(esplora_chain_tip_block_height >= ldk_node_chain_tip_block_height);
-
-        let synced_to_chain = esplora_chain_tip_block_height == ldk_node_chain_tip_block_height;
+        let synced_to_chain = node_status
+            .latest_lightning_wallet_sync_timestamp
+            .unwrap_or_default()
+            > esplora_chain_tip_timestamp
+            && node_status
+                .latest_onchain_wallet_sync_timestamp
+                .unwrap_or_default()
+                > esplora_chain_tip_timestamp;
 
         Ok(GetNodeInfoResponse {
             pub_key: self.node.node_id().serialize().to_vec(),
@@ -252,7 +262,7 @@ impl ILnRpcClient for GatewayLdkClient {
                 None => format!("LDK Fedimint Gateway Node {}", self.node.node_id()),
             },
             network: self.node.config().network.to_string(),
-            block_height: ldk_node_chain_tip_block_height,
+            block_height,
             synced_to_chain,
         })
     }


### PR DESCRIPTION
This reverts commit 1cfa530153837397cfc9cee003d2fa03cb6d0898.

I have a suspicion this is what is causing CI flakiness.
