### PR TITLE
chore: devimint batch gateway pegins

### DIFF
--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -98,7 +98,7 @@ async fn backup_restore_test() -> anyhow::Result<()> {
             };
 
             let fed = dev_fed.fed().await?;
-            fed.pegin_gateway(10_000_000, gw).await?;
+            fed.pegin_gateways(10_000_000, vec![gw]).await?;
             let info = serde_json::from_value::<GatewayInfo>(gw.get_info().await?)?;
             let federation_info = info
                 .federations
@@ -488,7 +488,7 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
                 // Peg-in sats to gw for the new fed
                 let pegin_amount = Amount::from_msats(10_000_000);
                 new_fed
-                    .pegin_gateway(pegin_amount.sats_round_down(), gw)
+                    .pegin_gateways(pegin_amount.sats_round_down(), vec![gw])
                     .await?;
 
                 // Verify `info` returns multiple federations

--- a/modules/fedimint-lnv2-tests/src/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/src/bin/tests.rs
@@ -91,10 +91,9 @@ async fn pegin_gateways(dev_fed: &DevJitFed) -> anyhow::Result<()> {
         .as_ref()
         .expect("Gateways of version 0.5.0 or higher support LDK");
 
-    try_join!(
-        federation.pegin_gateway(1_000_000, gw_lnd),
-        federation.pegin_gateway(1_000_000, gw_ldk),
-    )?;
+    federation
+        .pegin_gateways(1_000_000, vec![gw_lnd, gw_ldk])
+        .await?;
 
     Ok(())
 }
@@ -378,11 +377,9 @@ async fn test_inter_federation_payments(
     gw_ldk.connect_fed(&receive_federation).await?;
 
     // pegin gateways for new federation
-    try_join!(
-        receive_federation.pegin_gateway(1_000_000, gw_cln),
-        receive_federation.pegin_gateway(1_000_000, gw_lnd),
-        receive_federation.pegin_gateway(1_000_000, gw_ldk),
-    )?;
+    receive_federation
+        .pegin_gateways(1_000_000, vec![gw_cln, gw_lnd, gw_ldk])
+        .await?;
 
     let receive_client = receive_federation
         .new_joined_client("lnv2-receive-client")


### PR DESCRIPTION
We often want to pegin to all gateways at the same time. Currently this leads to blocks being mined for each pegin. This isn't necessary, we can do all pegin transactions then mine the block and wait for the balance in parallel.