### PR TITLE
fix: make `spend_ecash` not overspend by default

### DIFF
--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -20,7 +20,9 @@ use fedimint_ln_client::{
     LightningClientInit, LightningClientModule, LnPayState, OutgoingLightningPayment,
 };
 use fedimint_ln_common::LightningGateway;
-use fedimint_mint_client::{MintClientInit, MintClientModule, MintCommonInit, OOBNotes};
+use fedimint_mint_client::{
+    MintClientInit, MintClientModule, MintCommonInit, OOBNotes, SelectNotesWithAtleastAmount,
+};
 use fedimint_wallet_client::WalletClientInit;
 use futures::StreamExt;
 use lightning_invoice::Bolt11Invoice;
@@ -91,7 +93,13 @@ pub async fn do_spend_notes(
 ) -> anyhow::Result<(OperationId, OOBNotes)> {
     let mint = &mint.get_first_module::<MintClientModule>()?;
     let (operation_id, oob_notes) = mint
-        .spend_notes(amount, Duration::from_secs(600), false, ())
+        .spend_notes_with_selector(
+            &SelectNotesWithAtleastAmount,
+            amount,
+            Duration::from_secs(600),
+            false,
+            (),
+        )
         .await?;
     let mut updates = mint
         .subscribe_spend_notes(operation_id)

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -117,7 +117,9 @@ mod tests {
     };
     use fedimint_ln_common::lightning_invoice::{Bolt11InvoiceDescription, Description};
     use fedimint_ln_common::LightningGateway;
-    use fedimint_mint_client::{MintClientModule, ReissueExternalNotesState, SpendOOBState};
+    use fedimint_mint_client::{
+        MintClientModule, ReissueExternalNotesState, SelectNotesWithAtleastAmount, SpendOOBState,
+    };
     use futures::StreamExt;
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -262,7 +264,13 @@ mod tests {
     ) -> Result<(), anyhow::Error> {
         let mint = client.get_first_module::<MintClientModule>()?;
         let (_, notes) = mint
-            .spend_notes(Amount::from_sats(11), Duration::from_secs(10000), false, ())
+            .spend_notes_with_selector(
+                &SelectNotesWithAtleastAmount,
+                Amount::from_sats(11),
+                Duration::from_secs(10000),
+                false,
+                (),
+            )
             .await?;
         let operation_id = mint.reissue_external_notes(notes, ()).await?;
         let mut updates = mint
@@ -291,7 +299,13 @@ mod tests {
         let mint = client.get_first_module::<MintClientModule>()?;
         'retry: loop {
             let (operation_id, notes) = mint
-                .spend_notes(amount, Duration::from_secs(10000), false, ())
+                .spend_notes_with_selector(
+                    &SelectNotesWithAtleastAmount,
+                    amount,
+                    Duration::from_secs(10000),
+                    false,
+                    (),
+                )
                 .await?;
             if notes.total_amount() == amount {
                 return Ok(());

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -856,6 +856,17 @@ impl ClientModule for MintClientModule {
                         yield serde_json::to_value(state)?;
                     }
                 }
+                "spend_notes" => {
+                    let req: SpendNotesRequest = serde_json::from_value(request)?;
+                    let result = self.spend_notes_with_selector(
+                        &SelectNotesWithExactAmount,
+                        req.amount,
+                        req.try_cancel_after,
+                        req.include_invite,
+                        req.extra_meta
+                    ).await?;
+                    yield serde_json::to_value(result)?;
+                }
                 "spend_notes_expert" => {
                     let req: SpendNotesExpertRequest = serde_json::from_value(request)?;
                     let result = self.spend_notes(req.min_amount, req.try_cancel_after, req.include_invite, req.extra_meta).await?;
@@ -904,10 +915,18 @@ struct SubscribeReissueExternalNotesRequest {
 }
 
 /// Caution: if no notes of the correct denomination are available the next
-/// bigger note will be selected
+/// bigger note will be selected. You might want to use `spend_notes` instead.
 #[derive(Deserialize)]
 struct SpendNotesExpertRequest {
     min_amount: Amount,
+    try_cancel_after: Duration,
+    include_invite: bool,
+    extra_meta: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct SpendNotesRequest {
+    amount: Amount,
     try_cancel_after: Duration,
     include_invite: bool,
     extra_meta: serde_json::Value,

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -856,8 +856,8 @@ impl ClientModule for MintClientModule {
                         yield serde_json::to_value(state)?;
                     }
                 }
-                "spend_notes" => {
-                    let req: SpendNotesRequest = serde_json::from_value(request)?;
+                "spend_notes_expert" => {
+                    let req: SpendNotesExpertRequest = serde_json::from_value(request)?;
                     let result = self.spend_notes(req.min_amount, req.try_cancel_after, req.include_invite, req.extra_meta).await?;
                     yield serde_json::to_value(result)?;
                 }
@@ -903,8 +903,10 @@ struct SubscribeReissueExternalNotesRequest {
     operation_id: OperationId,
 }
 
+/// Caution: if no notes of the correct denomination are available the next
+/// bigger note will be selected
 #[derive(Deserialize)]
-struct SpendNotesRequest {
+struct SpendNotesExpertRequest {
     min_amount: Amount,
     try_cancel_after: Duration,
     include_invite: bool,

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -15,7 +15,8 @@ use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyInit;
 use fedimint_logging::LOG_TEST;
 use fedimint_mint_client::{
-    MintClientInit, MintClientModule, Note, OOBNotes, ReissueExternalNotesState, SpendOOBState,
+    MintClientInit, MintClientModule, Note, OOBNotes, ReissueExternalNotesState,
+    SelectNotesWithAtleastAmount, SpendOOBState,
 };
 use fedimint_mint_common::config::{FeeConsensus, MintGenParams, MintGenParamsConsensus};
 use fedimint_mint_common::{MintInput, MintInputV0, Nonce};
@@ -113,7 +114,7 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     let client2_mint = client2.get_first_module::<MintClientModule>()?;
     info!("### SPEND NOTES");
     let (op, notes) = client1_mint
-        .spend_notes(sats(750), TIMEOUT, false, ())
+        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, sats(750), TIMEOUT, false, ())
         .await?;
     let sub1 = &mut client1_mint.subscribe_spend_notes(op).await?.into_stream();
     assert_eq!(sub1.ok().await?, SpendOOBState::Created);
@@ -165,7 +166,13 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
                 info!("Starting spend {num_spend}");
                 let client1_mint = task_client1.get_first_module::<MintClientModule>().unwrap();
                 let (op, notes) = client1_mint
-                    .spend_notes(sats(30), ECASH_TIMEOUT, false, ())
+                    .spend_notes_with_selector(
+                        &SelectNotesWithAtleastAmount,
+                        sats(30),
+                        ECASH_TIMEOUT,
+                        false,
+                        (),
+                    )
                     .await
                     .unwrap();
                 let sub1 = &mut client1_mint
@@ -290,7 +297,7 @@ async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
     // Spend from client1 to client2
     let mint_module = client.get_first_module::<MintClientModule>()?;
     let (op, _) = mint_module
-        .spend_notes(sats(750), TIMEOUT, false, ())
+        .spend_notes_with_selector(&SelectNotesWithAtleastAmount, sats(750), TIMEOUT, false, ())
         .await?;
     let sub1 = &mut mint_module.subscribe_spend_notes(op).await?.into_stream();
     assert_eq!(sub1.ok().await?, SpendOOBState::Created);
@@ -327,7 +334,13 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
     // Spend from client1 to client2
     let err_msg = client1
         .get_first_module::<MintClientModule>()?
-        .spend_notes(Amount::ZERO, TIMEOUT, false, ())
+        .spend_notes_with_selector(
+            &SelectNotesWithAtleastAmount,
+            Amount::ZERO,
+            TIMEOUT,
+            false,
+            (),
+        )
         .await
         .expect_err("Zero-amount spends should be forbidden")
         .to_string();


### PR DESCRIPTION
The default behavior of `spend_ecash` is a foot-gun: if no notes of the correct denominatons are available it will return the next bigger note without regard for the amount over-spent. This was ok for expert integrators, but is a massive foot-gun for people less familiar with the code base.

This PR makes `spend_ecash` fail if the exact amount cannot be provided and introduces a new `spend_ecash_expert` function that can be used by people relying on the old behavior.

This is mostly relevant to the Web SDK, but also the CLI. cc @maan2003 @alexlwn123

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
