### PR TITLE
docs: prepend 'v' for tags

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -41,5 +41,5 @@ To create a new signed tag, run
 ```
 git tag -a -s <tag> && git push <upstream> <tag>
 ex:
-git tag -a -s 0.5.0-rc.0 && git push upstream 0.5.0-rc.0
+git tag -a -s v0.5.0-rc.0 && git push upstream v0.5.0-rc.0
 ```


### PR DESCRIPTION
We've established a convention of prepending `v` to our version tags. Reflecting that in the release docs is more clear.