### PR TITLE
refactor: move the FeeConsensus into fedimint-core

### DIFF
--- a/devimint/src/federation/config.rs
+++ b/devimint/src/federation/config.rs
@@ -72,7 +72,7 @@ pub fn attach_default_module_init_params(
                     bitcoin_rpc: bitcoin_rpc.clone(),
                 },
                 consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus {
-                    fee_consensus: fedimint_lnv2_common::config::FeeConsensus::default(),
+                    fee_consensus: fedimint_core::fee_consensus::FeeConsensus::default(),
                     network,
                 },
             },

--- a/fedimint-core/src/fee_consensus.rs
+++ b/fedimint-core/src/fee_consensus.rs
@@ -1,0 +1,79 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Amount, Decodable, Encodable};
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
+pub struct FeeConsensus {
+    base: Amount,
+    parts_per_million: u64,
+}
+
+impl FeeConsensus {
+    /// The lightning module will charge a non-configurable base fee of one
+    /// satoshi per transaction input and output too account for the costs
+    /// incurred by the federation for processing the transaction. On top of
+    /// that the federation may charge a additional relative fee per input and
+    /// output of up to one thousand parts per million which is equal to one
+    /// tenth of one percent.
+    ///
+    /// # Errors
+    /// - This constructor returns an error if the relative fee is in excess of
+    ///   one thousand parts per million.
+    pub fn new(parts_per_million: u64) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            parts_per_million <= 1_000,
+            "Relative fee over one thousand parts per million is excessive"
+        );
+
+        Ok(Self {
+            base: Amount::from_sats(1),
+            parts_per_million,
+        })
+    }
+
+    pub fn fee(&self, amount: Amount) -> Amount {
+        Amount::from_msats(self.fee_msats(amount.msats))
+    }
+
+    fn fee_msats(&self, msats: u64) -> u64 {
+        msats
+            .saturating_mul(self.parts_per_million)
+            .saturating_div(1_000_000)
+            .checked_add(self.base.msats)
+            .expect("The division creates sufficient headroom to add the base fee")
+    }
+}
+
+impl Default for FeeConsensus {
+    fn default() -> Self {
+        Self::new(1_000).expect("Relative fee is within the limit")
+    }
+}
+
+#[test]
+fn test_fee_consensus() {
+    assert_eq!(
+        FeeConsensus::default().fee(Amount::from_msats(999)),
+        Amount::from_sats(1)
+    );
+
+    assert_eq!(
+        FeeConsensus::default().fee(Amount::from_sats(1)),
+        Amount::from_msats(1001)
+    );
+
+    assert_eq!(
+        FeeConsensus::default().fee(Amount::from_sats(1000)),
+        Amount::from_sats(2)
+    );
+
+    assert_eq!(
+        FeeConsensus::default().fee(Amount::from_bitcoins(1)),
+        Amount::from_sats(100_001)
+    );
+
+    assert_eq!(
+        FeeConsensus::default().fee(Amount::from_bitcoins(100_000)),
+        Amount::from_bitcoins(100) + Amount::from_sats(1)
+    );
+}

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -82,6 +82,8 @@ pub mod endpoint_constants;
 /// Common environment variables
 pub mod envs;
 pub mod epoch;
+/// Fee structure shared across the v2 modules
+pub mod fee_consensus;
 /// Formatting helpers
 pub mod fmt_utils;
 /// Federation invite code

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -357,7 +357,7 @@ impl Fedimintd {
                         },
                         consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus {
                             // TODO: actually make the relative fee configurable
-                            fee_consensus: fedimint_lnv2_common::config::FeeConsensus::new(1_000)?,
+                            fee_consensus: fedimint_core::fee_consensus::FeeConsensus::new(1_000)?,
                             network,
                         },
                     },

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -297,10 +297,11 @@ impl PaymentFee {
     }
 
     fn absolute_fee(&self, msats: u64) -> u64 {
-        self.base.msats
-            + msats
-                .saturating_mul(self.parts_per_million)
-                .saturating_div(1_000_000)
+        msats
+            .saturating_mul(self.parts_per_million)
+            .saturating_div(1_000_000)
+            .checked_add(self.base.msats)
+            .expect("The division creates sufficient headroom to add the base fee")
     }
 }
 

--- a/modules/fedimint-lnv2-common/src/config.rs
+++ b/modules/fedimint-lnv2-common/src/config.rs
@@ -4,7 +4,8 @@ pub use bitcoin30::Network;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::BitcoinRpcConfig;
-use fedimint_core::{plugin_types_trait_impl_config, Amount, PeerId};
+use fedimint_core::fee_consensus::FeeConsensus;
+use fedimint_core::{plugin_types_trait_impl_config, PeerId};
 use group::Curve;
 use serde::{Deserialize, Serialize};
 use tpe::{AggregatePublicKey, PublicKeyShare, SecretKeyShare};
@@ -63,53 +64,6 @@ pub struct LightningConfigConsensus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningConfigPrivate {
     pub sk: SecretKeyShare,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
-pub struct FeeConsensus {
-    base: Amount,
-    parts_per_million: u64,
-}
-
-impl FeeConsensus {
-    /// The lightning module will charge a non-configurable base fee of one
-    /// satoshi per transaction input and output too account for the costs
-    /// incurred by the federation for processing the transaction. On top of
-    /// that the federation may charge a additional relative fee per input and
-    /// output of up to one thousand parts per million which is equal to one
-    /// tenth of one percent.
-    ///
-    /// # Errors
-    /// - This constructor returns an error if the relative fee is in excess of
-    ///   one thousand parts per million.
-    pub fn new(parts_per_million: u64) -> anyhow::Result<Self> {
-        anyhow::ensure!(
-            parts_per_million <= 1_000,
-            "Relative fee over one thousand parts per million is excessive"
-        );
-
-        Ok(Self {
-            base: Amount::from_sats(1),
-            parts_per_million,
-        })
-    }
-
-    pub fn fee(&self, amount: Amount) -> Amount {
-        Amount::from_msats(self.fee_msats(amount.msats))
-    }
-
-    fn fee_msats(&self, msats: u64) -> u64 {
-        self.base.msats
-            + msats
-                .saturating_mul(self.parts_per_million)
-                .saturating_div(1_000_000)
-    }
-}
-
-impl Default for FeeConsensus {
-    fn default() -> Self {
-        Self::new(1_000).expect("Relative fee is within the limit")
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Encodable, Decodable)]
@@ -182,32 +136,4 @@ fn migrate_config_local(
     LightningConfigLocal {
         bitcoin_rpc: config.bitcoin_rpc,
     }
-}
-
-#[test]
-fn test_fee_consensus() {
-    assert_eq!(
-        FeeConsensus::default().fee(Amount::from_msats(999)),
-        Amount::from_sats(1)
-    );
-
-    assert_eq!(
-        FeeConsensus::default().fee(Amount::from_sats(1)),
-        Amount::from_msats(1001)
-    );
-
-    assert_eq!(
-        FeeConsensus::default().fee(Amount::from_sats(1000)),
-        Amount::from_sats(2)
-    );
-
-    assert_eq!(
-        FeeConsensus::default().fee(Amount::from_bitcoins(1)),
-        Amount::from_sats(100_001)
-    );
-
-    assert_eq!(
-        FeeConsensus::default().fee(Amount::from_bitcoins(100_000)),
-        Amount::from_bitcoins(100) + Amount::from_sats(1)
-    );
 }


### PR DESCRIPTION
Move the FeeConsensus into fedimint-core such that it may be reused across all v2 modules.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
