### PR TITLE
chore(deps): bump bridge-encoded bitcoin structs to v0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e553c45ffed860aa7e0c6998c3a827fcdc039a2df76307563208ecfcae2f750"
 dependencies = [
  "bdk_core",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "miniscript 12.2.0",
  "serde",
 ]
@@ -628,7 +628,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c0b45300422611971b0bbe84b04d18e38e81a056a66860c9dd3434f6d0f5396"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "hashbrown 0.9.1",
  "serde",
 ]
@@ -653,7 +653,7 @@ checksum = "5aeb48cd8e0a15d0bf7351fc8c30e44c474be01f4f98eb29f20ab59b645bd29c"
 dependencies = [
  "bdk_chain",
  "bip39",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "miniscript 12.2.0",
  "rand_core",
  "serde",
@@ -707,7 +707,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe7a7f5928d264879d5b65eb18a72ea1890c57f22d62ee2eba93f207a6a020b"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "percent-encoding-rfc3986",
 ]
 
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.3"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0032b0e8ead7074cda7fc4f034409607e3f03a6f71d66ade8a307f79b4d99e73"
+checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
@@ -1688,6 +1688,7 @@ dependencies = [
  "anyhow",
  "axum 0.7.7",
  "bitcoin 0.30.2",
+ "bitcoin 0.32.4",
  "bitcoincore-rpc",
  "clap",
  "cln-rpc",
@@ -1964,7 +1965,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b546e91283ebfc56337de34e0cf814e3ad98083afde593b8e58495ee5355d0e"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "hex-conservative 0.2.1",
  "log",
  "reqwest 0.11.27",
@@ -2049,7 +2050,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "curve25519-dalek",
  "fedimint-arti-client",
  "fedimint-core",
@@ -2155,7 +2156,7 @@ version = "0.5.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "clap",
  "clap_complete",
  "fedimint-aead",
@@ -2193,7 +2194,7 @@ dependencies = [
  "aquamarine",
  "async-stream",
  "async-trait",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "fedimint-aead",
  "fedimint-api-client",
  "fedimint-build",
@@ -2254,7 +2255,8 @@ dependencies = [
  "bincode",
  "bitcoin 0.29.2",
  "bitcoin 0.30.2",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
+ "bitcoin-io",
  "bitcoin_hashes 0.12.0",
  "bitvec",
  "bls12_381",
@@ -2480,7 +2482,7 @@ name = "fedimint-gateway-cli"
 version = "0.5.0-alpha"
 dependencies = [
  "anyhow",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "clap",
  "clap_complete",
  "fedimint-build",
@@ -2539,7 +2541,7 @@ version = "0.5.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "bitcoin_hashes 0.12.0",
  "fedimint-client",
  "fedimint-core",
@@ -2566,7 +2568,7 @@ dependencies = [
  "axum 0.7.7",
  "axum-macros",
  "bitcoin 0.30.2",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "bitcoin_hashes 0.12.0",
  "clap",
  "cln-plugin",
@@ -2705,7 +2707,7 @@ version = "0.5.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "bitcoin_hashes 0.12.0",
  "fedimint-core",
  "fedimint-ln-common",
@@ -3005,7 +3007,7 @@ name = "fedimint-recoverytool"
 version = "0.5.0-alpha"
 dependencies = [
  "anyhow",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "clap",
  "fedimint-build",
  "fedimint-core",
@@ -3047,7 +3049,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bincode",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "bitcoin_hashes 0.12.0",
  "bitcoincore-rpc",
  "bls12_381",
@@ -3292,6 +3294,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bitcoin 0.30.2",
+ "bitcoin 0.32.4",
  "clap",
  "erased-serde",
  "fedimint-api-client",
@@ -3317,7 +3320,7 @@ version = "0.5.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "fedimint-core",
  "hex",
  "impl-tools",
@@ -3336,7 +3339,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitcoin 0.30.2",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "erased-serde",
  "fedimint-bitcoind",
  "fedimint-core",
@@ -3363,7 +3366,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bitcoin 0.30.2",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "bitcoincore-rpc",
  "devimint",
  "fedimint-client",
@@ -4645,7 +4648,7 @@ dependencies = [
  "bdk_wallet",
  "bip21",
  "bip39",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "chrono",
  "esplora-client 0.9.0",
  "libc",
@@ -4757,7 +4760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "lightning-invoice 0.32.0",
  "lightning-types",
 ]
@@ -4768,7 +4771,7 @@ version = "0.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4734caab73611a2c725f15392565150e4f5a531dd1f239365d01311f7de65d2d"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "lightning 0.0.125",
  "lightning-rapid-gossip-sync",
 ]
@@ -4779,7 +4782,7 @@ version = "0.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea041135bad736b075ad1123ef0a4793e78da8041386aa7887779fc5c540b94b"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "chunked_transfer",
  "lightning 0.0.125",
  "serde_json",
@@ -4806,7 +4809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "lightning-types",
  "serde",
 ]
@@ -4817,7 +4820,7 @@ version = "0.1.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175cff5d30b8d3f94ae9772b59f9ca576b1927a6ab60dd773e8c4e0593cd4e95"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "chrono",
  "lightning 0.0.125",
  "lightning-invoice 0.32.0",
@@ -4832,7 +4835,7 @@ version = "0.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af2847a19f892f32b9ab5075af25c70370b4cc5842b4f5b53c57092e52a49498"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "lightning 0.0.125",
  "tokio",
 ]
@@ -4843,7 +4846,7 @@ version = "0.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d06283d41eb8e6d4af883cd602d91ab0c5f9e0c9a6be1c944b10e6f47176f20"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "lightning 0.0.125",
  "windows-sys 0.48.0",
 ]
@@ -4854,7 +4857,7 @@ version = "0.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92185313db1075495e5efa3dd6a3b5d4dee63e1496059f58cf65074994718f05"
 dependencies = [
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "lightning 0.0.125",
 ]
 
@@ -4865,7 +4868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f023cb8dcd9c8b83b9b0c673ed6ca2e9afb57791119d3fa3224db2787b717e"
 dependencies = [
  "bdk-macros",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "esplora-client 0.9.0",
  "futures",
  "lightning 0.0.125",
@@ -4878,7 +4881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "hex-conservative 0.2.1",
 ]
 
@@ -4898,7 +4901,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bech32 0.11.0",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "cbc",
  "email_address",
  "reqwest 0.12.8",
@@ -5039,7 +5042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add2d4aee30e4291ce5cffa3a322e441ff4d4bc57b38c8d9bf0e94faa50ab626"
 dependencies = [
  "bech32 0.11.0",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "serde",
 ]
 
@@ -8489,7 +8492,7 @@ checksum = "d787f7640ceae8caef95434f1b14936402b73e18d34868b052a502a5d5085490"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
- "bitcoin 0.32.3",
+ "bitcoin 0.32.4",
  "bitcoin_hashes 0.14.0",
  "prost 0.11.9",
  "prost-build 0.11.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ axum = "0.7.7"
 base64 = "0.22.1"
 base64-url = "3.0.0"
 bincode = "1.3.3"
-bitcoin = { version = "0.32.3", features = ["serde"] }
+bitcoin = { version = "0.32.4", features = ["serde"] }
 bitcoin30 = { package = "bitcoin", version = "0.30.2" }
 bitcoincore-rpc = "0.17.0"
 bitcoin_hashes = "0.12.0"

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
 axum = { workspace = true, features = ["tracing"] }
+bitcoin = { workspace = true }
 bitcoin30 = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 clap = { workspace = true }

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -11,6 +11,7 @@ use bitcoincore_rpc::jsonrpc::error::RpcError;
 use bitcoincore_rpc::RpcApi;
 use cln_rpc::primitives::{Amount as ClnRpcAmount, AmountOrAny};
 use cln_rpc::ClnRpc;
+use fedimint_core::bitcoin_migration::bitcoin30_to_bitcoin32_tx;
 use fedimint_core::encoding::Encodable;
 use fedimint_core::task::jit::{JitTry, JitTryAnyhow};
 use fedimint_core::task::{block_in_place, block_on, sleep, timeout};
@@ -320,7 +321,7 @@ impl Bitcoind {
             ))) => return Ok(None),
             Err(err) => return Err(err.into()),
         };
-        let bytes = tx.consensus_encode_to_vec();
+        let bytes = bitcoin30_to_bitcoin32_tx(&tx).consensus_encode_to_vec();
         Ok(Some(bytes.encode_hex()))
     }
 

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -8,6 +8,7 @@ use std::{env, ffi};
 use anyhow::{anyhow, bail, Context, Result};
 use bitcoin30::Txid;
 use clap::Subcommand;
+use fedimint_core::bitcoin_migration::bitcoin32_to_bitcoin30_tx;
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::encoding::Decodable;
 use fedimint_core::envs::is_env_var_set;
@@ -1076,8 +1077,10 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
     let tx_hex = bitcoind.poll_get_transaction(txid).await?;
 
-    let tx =
-        bitcoin30::Transaction::consensus_decode_hex(&tx_hex, &ModuleRegistry::default()).unwrap();
+    let tx = bitcoin32_to_bitcoin30_tx(&bitcoin::Transaction::consensus_decode_hex(
+        &tx_hex,
+        &ModuleRegistry::default(),
+    )?);
     assert!(tx
         .output
         .iter()
@@ -2020,7 +2023,10 @@ pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
             .expect("txid should be parsable");
         let tx_hex = bitcoind.poll_get_transaction(txid).await?;
 
-        let tx = bitcoin30::Transaction::consensus_decode_hex(&tx_hex, &ModuleRegistry::default())?;
+        let tx = bitcoin32_to_bitcoin30_tx(&bitcoin::Transaction::consensus_decode_hex(
+            &tx_hex,
+            &ModuleRegistry::default(),
+        )?);
         assert_eq!(tx.input.len(), 1);
         assert_eq!(tx.output.len(), 2);
 

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -25,6 +25,7 @@ base64-url = { workspace = true }
 bech32 = "0.11.0"
 bincode = { workspace = true }
 bitcoin = { workspace = true }
+bitcoin-io = "0.1.2"
 bitcoin29 = { package = "bitcoin", version = "0.29.2", features = [
     "rand",
     "serde",

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -1486,7 +1486,7 @@ mod tests {
             "02000000000101d35b66c54cf6c09b81a8d94cd5d179719cd7595c258449452a9305ab9b12df250200000000fdffffff020cd50a0000000000160014ae5d450b71c04218e6e81c86fcc225882d7b7caae695b22100000000160014f60834ef165253c571b11ce9fa74e46692fc5ec10248304502210092062c609f4c8dc74cd7d4596ecedc1093140d90b3fd94b4bdd9ad3e102ce3bc02206bb5a6afc68d583d77d5d9bcfb6252a364d11a307f3418be1af9f47f7b1b3d780121026e5628506ecd33242e5ceb5fdafe4d3066b5c0f159b3c05a621ef65f177ea28600000000"
         ).unwrap();
         let transaction =
-            bitcoin30::Transaction::from_bytes(&transaction, &ModuleDecoderRegistry::default())
+            bitcoin::Transaction::from_bytes(&transaction, &ModuleDecoderRegistry::default())
                 .unwrap();
         test_roundtrip_expected(
             &transaction,
@@ -1505,7 +1505,7 @@ mod tests {
                 89, 179, 192, 90, 98, 30, 246, 95, 23, 126, 162, 134, 0, 0, 0, 0,
             ],
         );
-        let blockhash = bitcoin30::BlockHash::from_str(
+        let blockhash = bitcoin::BlockHash::from_str(
             "0000000000000000000065bda8f8a88f2e1e00d9a6887a43d640e52a4c7660f2",
         )
         .unwrap();

--- a/fedimint-core/src/txoproof.rs
+++ b/fedimint-core/src/txoproof.rs
@@ -2,20 +2,27 @@ use std::borrow::Cow;
 use std::hash::Hash;
 use std::io::Cursor;
 
-use bitcoin30::block::Header as BlockHeader;
-use bitcoin30::merkle_tree::PartialMerkleTree;
+use bitcoin::block::Header as BlockHeader;
+use bitcoin::merkle_tree::PartialMerkleTree;
+use bitcoin30::block::Header as BlockHeader30;
+use bitcoin30::consensus::Encodable as Encodable30;
+use bitcoin30::merkle_tree::PartialMerkleTree as PartialMerkleTree30;
 use bitcoin30::{BlockHash, Txid};
 use hex::{FromHex, ToHex};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::bitcoin_migration::{
+    bitcoin30_to_bitcoin32_block_header, bitcoin32_to_bitcoin30_block_header,
+    bitcoin32_to_bitcoin30_partial_merkle_tree,
+};
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 
 #[derive(Clone, Debug)]
 pub struct TxOutProof {
-    pub block_header: BlockHeader,
-    pub merkle_proof: PartialMerkleTree,
+    pub block_header: BlockHeader30,
+    pub merkle_proof: PartialMerkleTree30,
 }
 
 impl TxOutProof {
@@ -42,8 +49,11 @@ impl Decodable for TxOutProof {
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let block_header = BlockHeader::consensus_decode(d, modules)?;
-        let merkle_proof = PartialMerkleTree::consensus_decode(d, modules)?;
+        let block_header =
+            bitcoin32_to_bitcoin30_block_header(&BlockHeader::consensus_decode(d, modules)?);
+        let merkle_proof = bitcoin32_to_bitcoin30_partial_merkle_tree(
+            &PartialMerkleTree::consensus_decode(d, modules)?,
+        );
 
         let mut transactions = Vec::new();
         let mut indices = Vec::new();
@@ -68,7 +78,8 @@ impl Encodable for TxOutProof {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
         let mut written = 0;
 
-        written += self.block_header.consensus_encode(writer)?;
+        written +=
+            bitcoin30_to_bitcoin32_block_header(&self.block_header).consensus_encode(writer)?;
         written += self.merkle_proof.consensus_encode(writer)?;
 
         Ok(written)

--- a/fedimint-recoverytool/src/main.rs
+++ b/fedimint-recoverytool/src/main.rs
@@ -10,9 +10,7 @@ use anyhow::anyhow;
 use bitcoin::network::Network;
 use bitcoin::OutPoint;
 use clap::{ArgGroup, Parser, Subcommand};
-use fedimint_core::bitcoin_migration::{
-    bitcoin30_to_bitcoin32_outpoint, bitcoin30_to_bitcoin32_secp256k1_secret_key,
-};
+use fedimint_core::bitcoin_migration::bitcoin30_to_bitcoin32_secp256k1_secret_key;
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::epoch::ConsensusItem;
@@ -175,7 +173,7 @@ async fn process_and_print_tweak_source(
                     let descriptor = tweak_descriptor(base_descriptor, base_key, &tweak, network);
 
                     ImportableWallet {
-                        outpoint: bitcoin30_to_bitcoin32_outpoint(&outpoint),
+                        outpoint,
                         descriptor,
                         amount_sat: amount,
                     }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -24,6 +24,7 @@ anyhow = { workspace = true }
 aquamarine = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
+bitcoin = { workspace = true }
 bitcoin30 = { workspace = true }
 clap = { workspace = true, optional = true }
 erased-serde = { workspace = true }

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -105,7 +105,7 @@ pub struct PegInTweakIndexData {
     pub creation_time: SystemTime,
     pub last_check_time: Option<SystemTime>,
     pub next_check_time: Option<SystemTime>,
-    pub claimed: Vec<bitcoin30::OutPoint>,
+    pub claimed: Vec<bitcoin::OutPoint>,
 }
 
 impl_db_record!(
@@ -122,7 +122,7 @@ impl_db_lookup!(
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]
 pub struct ClaimedPegInKey {
     pub peg_in_index: TweakIdx,
-    pub btc_out_point: bitcoin30::OutPoint,
+    pub btc_out_point: bitcoin::OutPoint,
 }
 
 #[derive(Clone, Debug, Encodable, Decodable, Serialize)]

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -7,10 +7,10 @@
 
 use std::hash::Hasher;
 
-use bitcoin::Network;
-use bitcoin30::address::NetworkUnchecked;
+use bitcoin::address::NetworkUnchecked;
+use bitcoin::{Address, BlockHash, Network};
 use bitcoin30::psbt::raw::ProprietaryKey;
-use bitcoin30::{Address, Amount, BlockHash, Txid};
+use bitcoin30::{Amount, Txid};
 use config::WalletClientConfig;
 use fedimint_core::bitcoin_migration::{
     bitcoin30_to_bitcoin32_amount, bitcoin32_to_bitcoin30_amount,
@@ -110,7 +110,7 @@ pub struct SpendableUTXO {
 /// A transaction output, either unspent or consumed
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct TxOutputSummary {
-    pub outpoint: bitcoin30::OutPoint,
+    pub outpoint: bitcoin::OutPoint,
     #[serde(with = "bitcoin::amount::serde::as_sat")]
     pub amount: bitcoin::Amount,
 }
@@ -242,7 +242,7 @@ impl PegOutFees {
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct PegOut {
-    pub recipient: bitcoin30::Address<NetworkUnchecked>,
+    pub recipient: Address<NetworkUnchecked>,
     #[serde(with = "bitcoin::amount::serde::as_sat")]
     pub amount: bitcoin::Amount,
     pub fees: PegOutFees,

--- a/modules/fedimint-wallet-server/src/db.rs
+++ b/modules/fedimint-wallet-server/src/db.rs
@@ -1,4 +1,5 @@
-use bitcoin30::{BlockHash, Txid};
+use bitcoin::BlockHash;
+use bitcoin30::Txid;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::{impl_db_lookup, impl_db_record, PeerId};
 use secp256k1::ecdsa::Signature;
@@ -41,7 +42,7 @@ impl_db_record!(
 impl_db_lookup!(key = BlockHashKey, query_prefix = BlockHashKeyPrefix);
 
 #[derive(Clone, Debug, Eq, PartialEq, Encodable, Decodable, Serialize)]
-pub struct UTXOKey(pub bitcoin30::OutPoint);
+pub struct UTXOKey(pub bitcoin::OutPoint);
 
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct UTXOPrefixKey;


### PR DESCRIPTION
Part of #5200

The primary changes are in `fedimint-core/src/encoding/btc.rs`. The rest of the diffs in this PR are downstream changes.