### PR TITLE
feat: LNv2 allow user to verify payment parameters before paying

### DIFF
--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -260,9 +260,9 @@ pub struct RoutingInfo {
 impl RoutingInfo {
     pub fn send_parameters(&self, invoice: &Bolt11Invoice) -> (PaymentFee, u64) {
         if invoice.recover_payee_pub_key() == self.lightning_public_key {
-            (self.send_fee_minimum.clone(), self.expiration_delta_minimum)
+            (self.send_fee_minimum, self.expiration_delta_minimum)
         } else {
-            (self.send_fee_default.clone(), self.expiration_delta_default)
+            (self.send_fee_default, self.expiration_delta_default)
         }
     }
 }

--- a/modules/fedimint-lnv2-tests/src/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/src/bin/tests.rs
@@ -307,6 +307,7 @@ async fn test_send(
             "lnv2",
             "send",
             invoice.to_string(),
+            "--force",
             "--gateway",
             gateway
         )


### PR DESCRIPTION
Currently when paying an LNv2 invoice, there are a number of parameters that the user does not have a chance to verify, such as the CLTV delta and fees that are paid to the gateway. This PR refactors LNv2's API and allows the CLI (and other integrators) to display relevant details to the user before executing the payment.

![image](https://github.com/user-attachments/assets/bce0b295-c257-42ee-aca8-d11674f5c594)
