### PR TITLE
refactor(client): decouple outputs and their state machines

### DIFF
--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -370,9 +370,7 @@ pub async fn remint_denomination(
                 denomination,
             )
             .await
-            .into_iter()
-            .map(|output| output.into_dyn(mint_client.id))
-            .collect();
+            .into_dyn(mint_client.id);
 
         tx = tx.with_outputs(outputs);
     }

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -27,7 +27,9 @@ use fedimint_client::module::{ClientContext, ClientModule, IClientModule};
 use fedimint_client::oplog::UpdateStreamOrOutcome;
 use fedimint_client::sm::util::MapStateTransitions;
 use fedimint_client::sm::{Context, DynState, ModuleNotifier, State, StateTransition};
-use fedimint_client::transaction::{ClientOutput, TransactionBuilder};
+use fedimint_client::transaction::{
+    ClientOutput, ClientOutputBundle, ClientOutputSM, TransactionBuilder,
+};
 use fedimint_client::{sm_enum_variant_translation, DynGlobalClientContext};
 use fedimint_core::bitcoin_migration::{
     bitcoin30_to_bitcoin32_keypair, bitcoin32_to_bitcoin30_network,
@@ -591,9 +593,11 @@ impl LightningClientModule {
         let gateway_api_clone = gateway_api.clone();
         let invoice_clone = invoice.clone();
 
-        let client_output = ClientOutput::<LightningOutput, LightningClientStateMachines> {
+        let client_output = ClientOutput::<LightningOutput> {
             output: LightningOutput::V0(LightningOutputV0::Outgoing(contract.clone())),
             amount: contract.amount,
+        };
+        let client_output_sm = ClientOutputSM::<LightningClientStateMachines> {
             state_machines: Arc::new(move |funding_txid, _| {
                 vec![LightningClientStateMachines::Send(SendStateMachine {
                     common: SendSMCommon {
@@ -609,8 +613,11 @@ impl LightningClientModule {
             }),
         };
 
-        let client_output = self.client_ctx.make_client_output(client_output);
-        let transaction = TransactionBuilder::new().with_output(client_output);
+        let client_output = self.client_ctx.make_client_outputs(ClientOutputBundle::new(
+            vec![client_output],
+            vec![client_output_sm],
+        ));
+        let transaction = TransactionBuilder::new().with_outputs(client_output);
 
         self.client_ctx
             .finalize_and_submit_transaction(


### PR DESCRIPTION
This is like https://github.com/fedimint/fedimint/pull/6207, but for outputs.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
