### PR TITLE
fix: remove leading and trailing newlines from password

### DIFF
--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -94,6 +94,12 @@ impl ConfigGenApi {
     // Sets the auth and decryption key derived from the password
     pub async fn set_password(&self, auth: ApiAuth) -> ApiResult<()> {
         let mut state = self.require_status(ServerStatus::AwaitingPassword).await?;
+        let auth_trimmed = auth.0.trim();
+        if auth_trimmed != auth.0 {
+            return Err(ApiError::bad_request(
+                "Password contains leading/trailing whitespace".to_string(),
+            ));
+        }
         state.auth = Some(auth);
         state.status = ServerStatus::SharingConfigGenParams;
         info!(

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -25,9 +25,9 @@ use fedimint_core::db::Database;
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::util::write_new;
-use fedimint_logging::LOG_CONSENSUS;
+use fedimint_logging::{LOG_CONSENSUS, LOG_CORE};
 use net::api::ApiSecrets;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::config::api::{ConfigGenApi, ConfigGenSettings};
 use crate::config::io::{write_server_config, SALT_FILE};
@@ -110,8 +110,22 @@ pub async fn run(
 
 pub fn get_config(data_dir: &Path) -> anyhow::Result<Option<ServerConfig>> {
     // Attempt get the config with local password, otherwise start config gen
-    if let Ok(password) = fs::read_to_string(data_dir.join(PLAINTEXT_PASSWORD)) {
-        return Ok(Some(read_server_config(&password, data_dir)?));
+    let path = data_dir.join(PLAINTEXT_PASSWORD);
+    if let Ok(password_untrimmed) = fs::read_to_string(&path) {
+        // We definitely don't want leading/trailing newlines, and user
+        // editing the file manually will probably get a free newline added
+        // by the text editor.
+        let password = password_untrimmed.trim_matches('\n');
+        // In the future we also don't want to support any leading/trailing newlines
+        let password_fully_trimmed = password.trim();
+        if password_fully_trimmed != password {
+            warn!(
+                target: LOG_CORE,
+                path = %path.display(),
+                "Password in the password file contains leading/trailing whitespaces. This will an error in the future."
+            );
+        }
+        return Ok(Some(read_server_config(password, data_dir)?));
     }
 
     Ok(None)


### PR DESCRIPTION
If the file was created/modified manually, the text editor will likely add an extra newline.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
