### PR TITLE
chore: improve documentation of fees

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1957,7 +1957,7 @@ impl Gateway {
             .map(|module_public_key| RoutingInfo {
                 lightning_public_key: context.lightning_public_key,
                 module_public_key,
-                send_fee_default: PaymentFee::SEND_FEE_LIMIT_DEFAULT,
+                send_fee_default: PaymentFee::SEND_FEE_LIMIT,
                 // The base fee ensures that the gateway does not loose sats sending the payment due
                 // to fees paid on the transaction claiming the outgoing contract or
                 // subsequent transactions spending the newly issued ecash
@@ -1969,7 +1969,7 @@ impl Gateway {
                 expiration_delta_minimum: EXPIRATION_DELTA_MINIMUM_V2,
                 // The base fee ensures that the gateway does not loose sats receiving the payment
                 // due to fees paid on the transaction funding the incoming contract
-                receive_fee: PaymentFee::RECEIVE_FEE_LIMIT_DEFAULT,
+                receive_fee: PaymentFee::RECEIVE_FEE_LIMIT,
             }))
     }
 

--- a/modules/fedimint-lnv2-tests/tests/mock.rs
+++ b/modules/fedimint-lnv2-tests/tests/mock.rs
@@ -93,14 +93,14 @@ impl GatewayConnection for MockGatewayConnection {
         Ok(Some(RoutingInfo {
             lightning_public_key: self.keypair.public_key(),
             module_public_key: self.keypair.public_key(),
-            send_fee_default: PaymentFee::SEND_FEE_LIMIT_DEFAULT,
+            send_fee_default: PaymentFee::SEND_FEE_LIMIT,
             send_fee_minimum: PaymentFee {
                 base: Amount::from_sats(50),
                 parts_per_million: 5_000,
             },
             expiration_delta_default: 500,
             expiration_delta_minimum: 144,
-            receive_fee: PaymentFee::RECEIVE_FEE_LIMIT_DEFAULT,
+            receive_fee: PaymentFee::RECEIVE_FEE_LIMIT,
         }))
     }
 


### PR DESCRIPTION
We remove the parameters from PaymentFeeExceedsLimit, ExpirationDeltaExceedsLimit and PaymentFeeExceedsLimit as they are not actionable, with the current implementation that is just considered invalid by the client and three no mechanism to accept them anyway.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
