### PR TITLE
fix(client): panic on executor lock

### DIFF
--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -699,8 +699,8 @@ impl ClientHandle {
         self.inner.as_ref().expect("Inner always set")
     }
 
-    pub async fn start_executor(&self) {
-        self.as_inner().start_executor().await;
+    pub fn start_executor(&self) {
+        self.as_inner().start_executor();
     }
 
     /// Shutdown the client.
@@ -1032,12 +1032,12 @@ impl Client {
         Self::get_config_from_db(db).await.is_some()
     }
 
-    pub async fn start_executor(self: &Arc<Self>) {
+    pub fn start_executor(self: &Arc<Self>) {
         debug!(
             "Starting fedimint client executor (version: {})",
             fedimint_build_code_version_env!()
         );
-        self.executor.start_executor(self.context_gen()).await;
+        self.executor.start_executor(self.context_gen());
     }
 
     pub fn federation_id(&self) -> FederationId {
@@ -2652,7 +2652,7 @@ impl ClientBuilder {
             )
             .await?;
         if !stopped {
-            client.as_inner().start_executor().await;
+            client.as_inner().start_executor();
         }
         Ok(client)
     }
@@ -2675,7 +2675,7 @@ impl ClientBuilder {
             )
             .await?;
         if !stopped {
-            client.as_inner().start_executor().await;
+            client.as_inner().start_executor();
         }
 
         Ok(client)

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -148,7 +148,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn receive() -> Result<()> {
         let client = client(&faucet::invite_code().await?.parse()?).await?;
-        client.start_executor().await;
+        client.start_executor();
         let ln_gateway = get_gateway(&client).await?;
         futures::future::try_join_all(
             (0..10)
@@ -243,7 +243,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn receive_and_pay() -> Result<()> {
         let client = client(&faucet::invite_code().await?.parse()?).await?;
-        client.start_executor().await;
+        client.start_executor();
         let ln_gateway = get_gateway(&client).await?;
 
         futures::future::try_join_all(
@@ -327,7 +327,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_ecash() -> Result<()> {
         let client = client(&faucet::invite_code().await?.parse()?).await?;
-        client.start_executor().await;
+        client.start_executor();
         let ln_gateway = get_gateway(&client).await?;
 
         futures::future::try_join_all(
@@ -343,7 +343,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_ecash_exact() -> Result<()> {
         let client = client(&faucet::invite_code().await?.parse()?).await?;
-        client.start_executor().await;
+        client.start_executor();
         let ln_gateway = get_gateway(&client).await?;
 
         receive_once(client.clone(), Amount::from_sats(100), ln_gateway).await?;


### PR DESCRIPTION
```
fedimint-test-all-wasm32-unknown-unknown-ci> 00:00:33 thread 'sends_ecash_out_of_band' panicked at fedimint-client/src/sm/executor.rs:814:14:
fedimint-test-all-wasm32-unknown-unknown-ci> 00:00:33 Only locked during startup, no collisions should be possible: TryLockError(())
fedimint-test-all-wasm32-unknown-unknown-ci> 00:00:33 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

https://github.com/fedimint/fedimint/actions/runs/11634629737/job/32402260832?pr=6264

There seem to be no reason to have an async lock there, all the locking is wrapping only non-blocking/non-async operations anyway.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
