### PR TITLE
fix: use default port for p2p connections if none was specified

### DIFF
--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -237,7 +237,7 @@ pub fn parse_host_port(url: &SafeUrl) -> anyhow::Result<String> {
         .host_str()
         .ok_or_else(|| format_err!("Missing host in {url}"))?;
     let port = url
-        .port()
+        .port_or_known_default()
         .ok_or_else(|| format_err!("Missing port in {url}"))?;
 
     Ok(format!("{host}:{port}"))


### PR DESCRIPTION
Fixes  #6287

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
