### PR TITLE
fix: allow lenient parsing of meta values if their encoding is broken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,6 +2839,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/modules/fedimint-meta-client/src/cli.rs
+++ b/modules/fedimint-meta-client/src/cli.rs
@@ -55,8 +55,9 @@ pub(crate) async fn handle_cli_command(
                 let value = if hex {
                     serde_json::to_value(value).expect("can't fail")
                 } else {
-                    serde_json::from_slice(value.as_slice())
-                        .context("deserializating consensus value as json")?
+                    value
+                        .to_json_lossy()
+                        .context("deserializing consensus value as json")?
                 };
                 json!({
                     "revision": revision,

--- a/modules/fedimint-meta-common/Cargo.toml
+++ b/modules/fedimint-meta-common/Cargo.toml
@@ -22,3 +22,4 @@ hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/modules/fedimint-meta-common/src/lib.rs
+++ b/modules/fedimint-meta-common/src/lib.rs
@@ -16,7 +16,7 @@ use fedimint_core::plugin_types_trait_impl_common;
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
-
+use tracing::warn;
 // Common contains types shared by both the client and server
 
 // The client and server configuration
@@ -105,6 +105,17 @@ impl MetaValue {
 
     pub fn to_json(&self) -> anyhow::Result<serde_json::Value> {
         Ok(serde_json::from_slice(&self.0)?)
+    }
+
+    /// Converts the value to a JSON value, ignoring invalid utf-8.
+    pub fn to_json_lossy(&self) -> anyhow::Result<serde_json::Value> {
+        let maybe_lossy_str = String::from_utf8_lossy(self.as_slice());
+
+        if maybe_lossy_str.as_bytes() != self.as_slice() {
+            warn!("Value contains invalid utf-8, converting to lossy string");
+        }
+
+        Ok(serde_json::from_str(&maybe_lossy_str)?)
     }
 }
 


### PR DESCRIPTION
@dpc did I miss any places where I should use the lenient decoding?

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
