### PR TITLE
chore(mint-client): deprecate redundant `get_notes_tier_counts` function

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -654,7 +654,7 @@ async fn get_note_summary(client: &ClientHandleArc) -> anyhow::Result<serde_json
     let mint_client = client.get_first_module::<MintClientModule>()?;
     let wallet_client = client.get_first_module::<WalletClientModule>()?;
     let summary = mint_client
-        .get_notes_tier_counts(
+        .get_note_counts_by_denomination(
             &mut client
                 .db()
                 .begin_transaction_nc()

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -339,7 +339,7 @@ pub fn parse_gateway_id(s: &str) -> Result<secp256k1_29::PublicKey, secp256k1_29
 pub async fn get_note_summary(client: &ClientHandleArc) -> anyhow::Result<TieredCounts> {
     let mint_client = client.get_first_module::<MintClientModule>()?;
     let summary = mint_client
-        .get_notes_tier_counts(
+        .get_note_counts_by_denomination(
             &mut client
                 .db()
                 .begin_transaction_nc()

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -810,7 +810,9 @@ impl ClientModule for MintClientModule {
     }
 
     async fn get_balance(&self, dbtx: &mut DatabaseTransaction<'_>) -> Amount {
-        self.get_notes_tier_counts(dbtx).await.total_amount()
+        self.get_note_counts_by_denomination(dbtx)
+            .await
+            .total_amount()
     }
 
     async fn subscribe_balance_changes(&self) -> BoxStream<'static, ()> {
@@ -1012,17 +1014,12 @@ impl MintClientModule {
     }
 
     /// Returns the number of held e-cash notes per denomination
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use `get_note_counts_by_denomination` instead"
+    )]
     pub async fn get_notes_tier_counts(&self, dbtx: &mut DatabaseTransaction<'_>) -> TieredCounts {
-        dbtx.find_by_prefix(&NoteKeyPrefix)
-            .await
-            .fold(
-                TieredCounts::default(),
-                |mut acc, (key, _note)| async move {
-                    acc.inc(key.amount, 1);
-                    acc
-                },
-            )
-            .await
+        self.get_note_counts_by_denomination(dbtx).await
     }
 
     /// Pick [`SpendableNote`]s by given counts, when available
@@ -1067,7 +1064,7 @@ impl MintClientModule {
 
         let denominations = represent_amount(
             exact_amount,
-            &self.get_notes_tier_counts(dbtx).await,
+            &self.get_note_counts_by_denomination(dbtx).await,
             &self.cfg.tbs_pks,
             notes_per_denomination,
             &self.cfg.fee_consensus,
@@ -1112,7 +1109,10 @@ impl MintClientModule {
     }
 
     /// Returns the number of held e-cash notes per denomination
-    pub async fn get_wallet_summary(&self, dbtx: &mut DatabaseTransaction<'_>) -> TieredCounts {
+    pub async fn get_note_counts_by_denomination(
+        &self,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) -> TieredCounts {
         dbtx.find_by_prefix(&NoteKeyPrefix)
             .await
             .fold(
@@ -1123,6 +1123,15 @@ impl MintClientModule {
                 },
             )
             .await
+    }
+
+    /// Returns the number of held e-cash notes per denomination
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use `get_note_counts_by_denomination` instead"
+    )]
+    pub async fn get_wallet_summary(&self, dbtx: &mut DatabaseTransaction<'_>) -> TieredCounts {
+        self.get_note_counts_by_denomination(dbtx).await
     }
 
     /// Wait for the e-cash notes to be retrieved. If this is not possible
@@ -1186,7 +1195,7 @@ impl MintClientModule {
             assert!(MIN_NOTES_PER_TIER <= MAX_NOTES_PER_TIER_TRIGGER);
         }
 
-        let counts = self.get_notes_tier_counts(dbtx).await;
+        let counts = self.get_note_counts_by_denomination(dbtx).await;
 
         let should_consolidate = counts
             .iter()


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
