### PR TITLE
chore: include federation name in `FederationInfo`

### DIFF
--- a/gateway/ln-gateway/src/federation_manager.rs
+++ b/gateway/ln-gateway/src/federation_manager.rs
@@ -234,12 +234,19 @@ impl FederationManager {
 
                 Ok(FederationInfo {
                     federation_id,
+                    federation_name: self.federation_name(client).await,
                     balance_msat,
                     federation_index,
                     routing_fees,
                 })
             })
             .await
+    }
+
+    pub async fn federation_name(&self, client: &ClientHandleArc) -> Option<String> {
+        let client_config = client.config().await;
+        let federation_name = client_config.global.federation_name();
+        federation_name.map(String::from)
     }
 
     pub async fn federation_info_all_federations(
@@ -259,6 +266,7 @@ impl FederationManager {
 
             federation_infos.push(FederationInfo {
                 federation_id: *federation_id,
+                federation_name: self.federation_name(client.value()).await,
                 balance_msat,
                 federation_index,
                 routing_fees,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1164,6 +1164,7 @@ impl Gateway {
         // federation info here because short channel id is not yet persisted.
         let federation_info = FederationInfo {
             federation_id,
+            federation_name: federation_manager.federation_name(&client).await,
             balance_msat: client.get_balance().await,
             federation_index,
             routing_fees: Some(gateway_config.routing_fees.into()),

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -91,6 +91,7 @@ pub struct WithdrawResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FederationInfo {
     pub federation_id: FederationId,
+    pub federation_name: Option<String>,
     pub balance_msat: Amount,
     pub federation_index: u64,
     pub routing_fees: Option<FederationRoutingFees>,


### PR DESCRIPTION
It is useful to have when managing multiple federations in a gateway.