### PR TITLE
fix: LNv1 add min_cltv_delta to timelock constant

### DIFF
--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -711,7 +711,12 @@ impl LightningClientModule {
             .fetch_consensus_block_count()
             .await?
             .ok_or(format_err!("Cannot get consensus block count"))?;
-        let absolute_timelock = consensus_count + OUTGOING_LN_CONTRACT_TIMELOCK - 1;
+
+        // Add the timelock to the current block count and the invoice's
+        // `min_cltv_delta`
+        let min_final_cltv = invoice.min_final_cltv_expiry_delta();
+        let absolute_timelock =
+            consensus_count + min_final_cltv + OUTGOING_LN_CONTRACT_TIMELOCK - 1;
 
         // Compute amount to lock in the outgoing contract
         let invoice_amount = Amount::from_msats(


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/6241

Adds LNv1's timelock constant to the invoice's `min_cltv_delta`. 

@joschisan should we do this for LNv2 as well? We would be able to decrease the total locktime that the user's ecash would be stuck if a gateway should disappear, which I think would be a UX improvement.