### PR TITLE
[Backport releases/v0.4] fix: use default port for p2p connections if none was specified

### DIFF
--- a/fedimint-server/src/net/connect.rs
+++ b/fedimint-server/src/net/connect.rs
@@ -237,7 +237,7 @@ pub fn parse_host_port(url: &SafeUrl) -> anyhow::Result<String> {
         .host_str()
         .ok_or_else(|| format_err!("Missing host in {url}"))?;
     let port = url
-        .port()
+        .port_or_known_default()
         .ok_or_else(|| format_err!("Missing port in {url}"))?;
 
     Ok(format!("{host}:{port}"))


### PR DESCRIPTION
# Description
Backport of #6292 to `releases/v0.4`.