### PR TITLE
chore(deps): bump cln-rpc to internal version that uses bitcoin v0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,24 +1294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cln-rpc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3374857a63bde21f5cc54ed3884476f3118dd5e26d792d16dfa21d8a4acb23e8"
-dependencies = [
- "anyhow",
- "bitcoin 0.30.2",
- "bytes",
- "futures-util",
- "hex",
- "log",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "coarsetime"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,12 +1773,12 @@ dependencies = [
  "bitcoin 0.32.4",
  "bitcoincore-rpc",
  "clap",
- "cln-rpc",
  "esplora-client 0.10.0",
  "fedimint-api-client",
  "fedimint-bitcoind",
  "fedimint-build",
  "fedimint-client",
+ "fedimint-cln-rpc",
  "fedimint-core",
  "fedimint-ln-client",
  "fedimint-ln-gateway",
@@ -2346,6 +2328,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-cln-rpc"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b18ef5cb304805598eb57457da792d0ace660ec01f7fda82340511704420436"
+dependencies = [
+ "anyhow",
+ "bitcoin 0.32.4",
+ "bytes",
+ "futures-util",
+ "hex",
+ "log",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "fedimint-core"
 version = "0.5.0-alpha"
 dependencies = [
@@ -2669,13 +2669,13 @@ dependencies = [
  "bitcoin 0.32.4",
  "clap",
  "cln-plugin",
- "cln-rpc",
  "erased-serde",
  "esplora-client 0.10.0",
  "fedimint-api-client",
  "fedimint-bip39",
  "fedimint-build",
  "fedimint-client",
+ "fedimint-cln-rpc",
  "fedimint-core",
  "fedimint-dummy-client",
  "fedimint-dummy-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ bitcoin_hashes = "0.14.0"
 bls12_381 = "0.8.0"
 bytes = "1.7.2"
 clap = { version = "4.5.20", features = ["derive", "env"] }
-cln-rpc = "0.2.0"
+cln-rpc = { package = "fedimint-cln-rpc", version = "0.5.0" }
 criterion = "0.5.1"
 devimint = { path = "./devimint", version = "=0.5.0-alpha" }
 electrum-client = { version = "0.21.0", default-features = false, features = [

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -12,9 +12,6 @@ use bitcoincore_rpc::jsonrpc::error::RpcError;
 use bitcoincore_rpc::RpcApi;
 use cln_rpc::primitives::{Amount as ClnRpcAmount, AmountOrAny};
 use cln_rpc::ClnRpc;
-use fedimint_core::bitcoin_migration::{
-    bitcoin30_to_bitcoin32_sha256_hash, bitcoin32_to_bitcoin30_sha256_hash,
-};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::task::jit::{JitTry, JitTryAnyhow};
 use fedimint_core::task::{block_in_place, block_on, sleep, timeout};
@@ -797,11 +794,7 @@ impl Lnd {
             .await?
             .into_inner();
         let payment_request = hold_request.payment_request;
-        Ok((
-            preimage,
-            payment_request,
-            bitcoin32_to_bitcoin30_sha256_hash(&hash),
-        ))
+        Ok((preimage, payment_request, hash))
     }
 
     pub async fn settle_hold_invoice(
@@ -813,9 +806,7 @@ impl Lnd {
             .invoices_client_lock()
             .await?
             .subscribe_single_invoice(tonic_lnd::invoicesrpc::SubscribeSingleInvoiceRequest {
-                r_hash: bitcoin30_to_bitcoin32_sha256_hash(&payment_hash)
-                    .to_byte_array()
-                    .to_vec(),
+                r_hash: payment_hash.to_byte_array().to_vec(),
             })
             .await?
             .into_inner();

--- a/fedimint-core/src/bitcoin_migration.rs
+++ b/fedimint-core/src/bitcoin_migration.rs
@@ -1,7 +1,5 @@
 use std::str::FromStr;
 
-use bitcoin30::hashes::Hash;
-
 pub fn bitcoin29_to_bitcoin32_psbt(
     psbt: &bitcoin29::util::psbt::PartiallySignedTransaction,
 ) -> bitcoin::psbt::Psbt {
@@ -48,20 +46,6 @@ pub fn bitcoin32_checked_address_to_unchecked_address(
     address.as_unchecked().clone()
 }
 
-pub fn bitcoin30_to_bitcoin32_secp256k1_pubkey(
-    pubkey: &bitcoin30::secp256k1::PublicKey,
-) -> bitcoin::secp256k1::PublicKey {
-    bitcoin::secp256k1::PublicKey::from_slice(&pubkey.serialize())
-        .expect("Failed to convert bitcoin30 secp256k1 pubkey to bitcoin32 secp256k1 pubkey")
-}
-
-pub fn bitcoin32_to_bitcoin30_secp256k1_pubkey(
-    pubkey: &bitcoin::secp256k1::PublicKey,
-) -> bitcoin30::secp256k1::PublicKey {
-    bitcoin30::secp256k1::PublicKey::from_slice(&pubkey.serialize())
-        .expect("Failed to convert bitcoin32 secp256k1 pubkey to bitcoin30 secp256k1 pubkey")
-}
-
 pub fn bitcoin32_to_bitcoin30_address(address: &bitcoin::Address) -> bitcoin30::Address {
     // The bitcoin crate only allows for deserializing an address as unchecked.
     // However, we can safely call `assume_checked()` since the input address is
@@ -88,18 +72,6 @@ pub fn bitcoin30_to_bitcoin32_network(network: &bitcoin30::Network) -> bitcoin::
         bitcoin30::Network::Regtest => bitcoin::Network::Regtest,
         _ => panic!("There are no other enum cases, this should never be hit."),
     }
-}
-
-pub fn bitcoin30_to_bitcoin32_sha256_hash(
-    hash: &bitcoin30::hashes::sha256::Hash,
-) -> bitcoin::hashes::sha256::Hash {
-    *bitcoin::hashes::sha256::Hash::from_bytes_ref(hash.as_ref())
-}
-
-pub fn bitcoin32_to_bitcoin30_sha256_hash(
-    hash: &bitcoin::hashes::sha256::Hash,
-) -> bitcoin30::hashes::sha256::Hash {
-    bitcoin30::hashes::sha256::Hash::from_slice(hash.as_ref()).expect("Invalid hash length")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Part of #5200

Bumping `cln-rpc` to a fedimint release so that we can remove `bitcoin` v0.30