### PR TITLE
cleanup: only check for mainnet

### DIFF
--- a/devimint/src/federation/config.rs
+++ b/devimint/src/federation/config.rs
@@ -90,7 +90,7 @@ pub fn attach_default_module_init_params(
                 consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus {
                     fee_consensus: fedimint_lnv2_common::config::FeeConsensus::new(1000)
                         .expect("Relative fee is within range"),
-                    network,
+                    mainnet: network == Network::Bitcoin,
                 },
             },
         );

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{bail, format_err, Context};
+use bitcoin::Network;
 use clap::{Parser, Subcommand};
 use fedimint_core::admin_client::ConfigGenParamsRequest;
 use fedimint_core::config::{
@@ -360,7 +361,7 @@ impl Fedimintd {
                         consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus {
                             // TODO: actually make the relative fee configurable
                             fee_consensus: fedimint_lnv2_common::config::FeeConsensus::new(1_000)?,
-                            network,
+                            mainnet: network == Network::Bitcoin,
                         },
                     },
                 )

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1872,14 +1872,11 @@ impl Gateway {
             ))))?;
         let ln_cfg: &fedimint_lnv2_common::config::LightningClientConfig = cfg.cast()?;
 
-        if ln_cfg.network != network {
-            error!(
-                "Federation {federation_id} runs on {} but this gateway supports {network}",
-                ln_cfg.network,
-            );
+        if ln_cfg.mainnet != (network == Network::Bitcoin) {
+            error!("Federation {federation_id} and gateway are on different networks");
+
             return Err(AdminGatewayError::ClientCreationError(anyhow!(format!(
-                "Unsupported network {}",
-                ln_cfg.network
+                "Federation {federation_id} and gateway are on different networks"
             ))));
         }
 

--- a/modules/fedimint-lnv2-common/src/config.rs
+++ b/modules/fedimint-lnv2-common/src/config.rs
@@ -24,7 +24,7 @@ impl LightningGenParams {
             local: LightningGenParamsLocal { bitcoin_rpc },
             consensus: LightningGenParamsConsensus {
                 fee_consensus: FeeConsensus::new(1000).expect("Relative fee is within range"),
-                network: Network::Regtest,
+                mainnet: false,
             },
         }
     }
@@ -33,7 +33,7 @@ impl LightningGenParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningGenParamsConsensus {
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
+    pub mainnet: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,7 +58,7 @@ pub struct LightningConfigConsensus {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
+    pub mainnet: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -71,7 +71,7 @@ pub struct LightningClientConfig {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
+    pub mainnet: bool,
 }
 
 impl std::fmt::Display for LightningClientConfig {
@@ -188,7 +188,7 @@ fn migrate_config_consensus(
             })
             .collect(),
         fee_consensus: FeeConsensus::new(1000).expect("Relative fee is within range"),
-        network: config.network,
+        mainnet: true,
     }
 }
 

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -205,7 +205,7 @@ impl ServerModuleInit for LightningInit {
                             tpe_agg_pk,
                             tpe_pks: tpe_pks.clone(),
                             fee_consensus: params.consensus.fee_consensus.clone(),
-                            network: params.consensus.network,
+                            mainnet: params.consensus.mainnet,
                         },
                         private: LightningConfigPrivate {
                             sk: sks[peer.to_usize()],
@@ -247,7 +247,7 @@ impl ServerModuleInit for LightningInit {
                     })
                     .collect(),
                 fee_consensus: params.consensus.fee_consensus.clone(),
-                network: params.consensus.network,
+                mainnet: params.consensus.mainnet,
             },
             private: LightningConfigPrivate {
                 sk: SecretKeyShare(sk),
@@ -282,7 +282,7 @@ impl ServerModuleInit for LightningInit {
             tpe_agg_pk: config.tpe_agg_pk,
             tpe_pks: config.tpe_pks,
             fee_consensus: config.fee_consensus,
-            network: config.network,
+            mainnet: config.mainnet,
         })
     }
 }

--- a/modules/fedimint-lnv2-tests/tests/mock.rs
+++ b/modules/fedimint-lnv2-tests/tests/mock.rs
@@ -66,8 +66,8 @@ fn bolt_11_invoice(payment_secret: [u8; 32], currency: Currency) -> Bolt11Invoic
         .expect("Invoice creation failed")
 }
 
-pub fn signet_bolt_11_invoice() -> Bolt11Invoice {
-    bolt_11_invoice(PAYABLE_PAYMENT_SECRET, Currency::Signet)
+pub fn mainnet_bolt_11_invoice() -> Bolt11Invoice {
+    bolt_11_invoice(PAYABLE_PAYMENT_SECRET, Currency::Bitcoin)
 }
 
 #[derive(Debug)]

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -271,16 +271,13 @@ async fn rejects_wrong_network_invoice() -> anyhow::Result<()> {
         client
             .get_first_module::<LightningClientModule>()?
             .send(
-                mock::signet_bolt_11_invoice(),
+                mock::mainnet_bolt_11_invoice(),
                 Some(mock::gateway()),
                 Value::Null
             )
             .await
             .expect_err("send did not fail due to incorrect Currency"),
-        SendPaymentError::WrongCurrency {
-            invoice_currency: lightning_invoice::Currency::Signet,
-            federation_currency: lightning_invoice::Currency::Regtest
-        }
+        SendPaymentError::WrongNetwork
     );
 
     Ok(())


### PR DESCRIPTION
I propose this since we had issues around distinguishing between the non-main net types. Especially in the consensus code this is highly problematic. 

I would do the same for the walletv2 modules, getting completely rid of the distinction in the future.

@elsirion @dpc thoughts?

I think this will break the upgrade tests, though it shouldn't. We had this issue the last time we made changes to the lnv2 client config.

Since lnv2 is about to be shipped, this is the last chance to remove it.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
