### PR TITLE
cleanup: sane network encoding for lnv2

### DIFF
--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -10,7 +10,7 @@
 
 pub mod as_hex;
 mod bls12_381;
-mod btc;
+pub mod btc;
 mod secp256k1;
 mod threshold_crypto;
 

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1872,14 +1872,14 @@ impl Gateway {
             ))))?;
         let ln_cfg: &fedimint_lnv2_common::config::LightningClientConfig = cfg.cast()?;
 
-        if ln_cfg.network != network {
+        if ln_cfg.network.0 != network {
             error!(
                 "Federation {federation_id} runs on {} but this gateway supports {network}",
-                ln_cfg.network,
+                ln_cfg.network.0,
             );
             return Err(AdminGatewayError::ClientCreationError(anyhow!(format!(
                 "Unsupported network {}",
-                ln_cfg.network
+                ln_cfg.network.0
             ))));
         }
 

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -497,10 +497,10 @@ impl LightningClientModule {
             return Err(SendPaymentError::InvoiceExpired);
         }
 
-        if self.cfg.network != invoice.currency().into() {
+        if self.cfg.network.0 != invoice.currency().into() {
             return Err(SendPaymentError::WrongCurrency {
                 invoice_currency: invoice.currency(),
-                federation_currency: self.cfg.network.into(),
+                federation_currency: self.cfg.network.0.into(),
             });
         }
 

--- a/modules/fedimint-lnv2-common/src/config.rs
+++ b/modules/fedimint-lnv2-common/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 pub use bitcoin::Network;
 use fedimint_core::core::ModuleKind;
+use fedimint_core::encoding::btc::NetworkSaneEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::{plugin_types_trait_impl_config, Amount, PeerId};
@@ -58,7 +59,7 @@ pub struct LightningConfigConsensus {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
+    pub network: NetworkSaneEncodingWrapper,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -71,7 +72,7 @@ pub struct LightningClientConfig {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
+    pub network: NetworkSaneEncodingWrapper,
 }
 
 impl std::fmt::Display for LightningClientConfig {
@@ -188,7 +189,7 @@ fn migrate_config_consensus(
             })
             .collect(),
         fee_consensus: FeeConsensus::new(1000).expect("Relative fee is within range"),
-        network: config.network,
+        network: NetworkSaneEncodingWrapper(config.network),
     }
 }
 

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -16,6 +16,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::encoding::btc::NetworkSaneEncodingWrapper;
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiVersion, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
@@ -205,7 +206,7 @@ impl ServerModuleInit for LightningInit {
                             tpe_agg_pk,
                             tpe_pks: tpe_pks.clone(),
                             fee_consensus: params.consensus.fee_consensus.clone(),
-                            network: params.consensus.network,
+                            network: NetworkSaneEncodingWrapper(params.consensus.network),
                         },
                         private: LightningConfigPrivate {
                             sk: sks[peer.to_usize()],
@@ -247,7 +248,7 @@ impl ServerModuleInit for LightningInit {
                     })
                     .collect(),
                 fee_consensus: params.consensus.fee_consensus.clone(),
-                network: params.consensus.network,
+                network: NetworkSaneEncodingWrapper(params.consensus.network),
             },
             private: LightningConfigPrivate {
                 sk: SecretKeyShare(sk),


### PR DESCRIPTION
Encode magic bytes directly instead of as u32 which was a historical accident.

Will also be done with walletv2. We can then retire the old encoding eventually with lnv1 and walletv1.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
