### PR TITLE
dbtool: add dump for operation log and client config

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -103,11 +103,16 @@ pub struct OperationLogKey {
     pub operation_id: OperationId,
 }
 
+#[derive(Debug, Encodable)]
+pub struct OperationLogKeyPrefix;
+
 impl_db_record!(
     key = OperationLogKey,
     value = OperationLogEntry,
     db_prefix = DbKeyPrefix::OperationLog
 );
+
+impl_db_lookup!(key = OperationLogKey, query_prefix = OperationLogKeyPrefix);
 
 #[derive(Debug, Encodable, Decodable, Serialize)]
 pub struct ClientPreRootSecretHashKey;

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -281,11 +281,11 @@ impl DecoderBuilder {
                 // pass empty `decoders`. But the client context uses nested `DynTypes` in
                 // `DynState`, so we special-case it with a flag.
                 let decoders = if is_transparent_decoder {
-                    Cow::Borrowed(decoders)
+                    decoders
                 } else {
-                    Cow::Owned(ModuleRegistry::default())
+                    &ModuleRegistry::default()
                 };
-                let typed_val = Type::consensus_decode(&mut reader, &decoders).map_err(|err| {
+                let typed_val = Type::consensus_decode(&mut reader, decoders).map_err(|err| {
                     let err: anyhow::Error = err.into();
                     DecodeError::new_custom(
                         err.context(format!("while decoding Dyn type module_id={instance}")),

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -106,6 +106,7 @@ impl DatabaseDump {
                     .available_decoders(kinds)
                     .unwrap()
                     .with_fallback();
+                let client_cfg = client_cfg.redecode_raw(&decoders)?;
                 (None, Some(client_cfg), decoders)
             } else {
                 (None, None, ModuleDecoderRegistry::default())
@@ -224,7 +225,7 @@ impl DatabaseDump {
 
         if let Some(cfg) = self.client_cfg.clone() {
             self.serialized
-                .insert("Client Config".into(), Box::new(cfg.clone()));
+                .insert("Client Config".into(), Box::new(cfg.to_json()));
 
             for (module_id, module_cfg) in &cfg.modules {
                 let kind = &module_cfg.kind;

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use erased_serde::Serialize;
-use fedimint_client::db::ClientConfigKey;
+use fedimint_client::db::{ClientConfigKey, OperationLogKeyPrefix};
 use fedimint_client::module::init::ClientModuleInitRegistry;
+use fedimint_client::oplog::OperationLogEntry;
 use fedimint_core::config::{ClientConfig, CommonModuleInitRegistry, ServerModuleInitRegistry};
 use fedimint_core::core::ModuleKind;
 use fedimint_core::db::{
@@ -13,6 +14,7 @@ use fedimint_core::db::{
 };
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
+use fedimint_core::push_db_pair_items;
 use fedimint_rocksdb::RocksDbReadOnly;
 use fedimint_server::config::io::read_server_config;
 use fedimint_server::config::ServerConfig;
@@ -221,6 +223,9 @@ impl DatabaseDump {
         }
 
         if let Some(cfg) = self.client_cfg.clone() {
+            self.serialized
+                .insert("Client Config".into(), Box::new(cfg.clone()));
+
             for (module_id, module_cfg) in &cfg.modules {
                 let kind = &module_cfg.kind;
                 let mut modules = Vec::new();
@@ -230,6 +235,11 @@ impl DatabaseDump {
 
                 let registry = CommonModuleInitRegistry::from(modules);
                 self.serialize_module(module_id, kind, registry).await?;
+            }
+
+            {
+                let mut dbtx = self.read_only_db.begin_transaction_nc().await;
+                Self::write_serialized_client_operation_log(&mut self.serialized, &mut dbtx).await;
             }
 
             self.print_database();
@@ -318,5 +328,18 @@ impl DatabaseDump {
                 );
             }
         }
+    }
+    async fn write_serialized_client_operation_log(
+        serialized: &mut BTreeMap<String, Box<dyn Serialize>>,
+        dbtx: &mut DatabaseTransaction<'_>,
+    ) {
+        push_db_pair_items!(
+            dbtx,
+            OperationLogKeyPrefix,
+            OperationLogKey,
+            OperationLogEntry,
+            serialized,
+            "Operations"
+        );
     }
 }


### PR DESCRIPTION
very helpful for debugging, hex is annoying

hit bunch of decoder issues when logging active and inactive state machines, for some other time 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
