### PR TITLE
chore(rocksdb): lower memory footprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.12.1",
+ "jemallocator",
  "lightning-invoice",
  "rand",
  "reqwest 0.12.5",
@@ -1877,6 +1878,7 @@ dependencies = [
  "fedimint-wallet-client",
  "futures",
  "hex",
+ "jemallocator",
  "lightning",
  "lightning-invoice",
  "prost",
@@ -2683,6 +2685,7 @@ dependencies = [
  "http-body 1.0.0",
  "hyper 1.4.0",
  "itertools 0.12.1",
+ "jemallocator",
  "jsonrpsee",
  "once_cell",
  "rand",
@@ -3510,6 +3513,26 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ futures = "0.3.30"
 futures-util = "0.3.30"
 lightning = "0.0.123"
 lightning-invoice = "0.31.0"
+jemallocator = "0.5"
 once_cell = "1.19.0"
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["sync", "io-util"] }

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -62,3 +62,6 @@ reqwest = { workspace = true }
 
 [build-dependencies]
 fedimint-build = { version = "=0.4.4-rc.0", path = "../fedimint-build" }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { workspace = true }

--- a/fedimint-cli/src/main.rs
+++ b/fedimint-cli/src/main.rs
@@ -1,5 +1,12 @@
 use fedimint_cli::FedimintCli;
 use fedimint_core::fedimint_build_code_version_env;
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+// rocksdb suffers from memory fragmentation when using standard allocator
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -94,6 +94,14 @@ fn get_default_options() -> anyhow::Result<rocksdb::Options> {
         opts.set_db_write_buffer_size(16 * 1024 * 1024);
     }
     opts.create_if_missing(true);
+
+    let mut block_opts = rocksdb::BlockBasedOptions::default();
+    block_opts.set_optimize_filters_for_memory(true);
+    // counterintuitively, this limits amount of memory used as these will now be
+    // part of the block cache.
+    block_opts.set_cache_index_and_filter_blocks(true);
+    block_opts.set_ribbon_filter(10.0);
+    opts.set_block_based_table_factory(&block_opts);
     Ok(opts)
 }
 

--- a/fedimint-rocksdb/src/lib.rs
+++ b/fedimint-rocksdb/src/lib.rs
@@ -94,7 +94,8 @@ fn get_default_options() -> anyhow::Result<rocksdb::Options> {
         opts.set_db_write_buffer_size(16 * 1024 * 1024);
     }
     opts.create_if_missing(true);
-
+    // workaround https://github.com/facebook/rocksdb/pull/9020 (?)
+    opts.set_max_write_buffer_size_to_maintain(32 * 1024 * 1024);
     let mut block_opts = rocksdb::BlockBasedOptions::default();
     block_opts.set_optimize_filters_for_memory(true);
     // counterintuitively, this limits amount of memory used as these will now be

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -313,7 +313,9 @@ impl ConsensusEngine {
 
         // We can terminate the session instead of waiting for other peers to complete
         // it since they can always download the signed session outcome from us
-        terminator_sender.send(()).ok();
+        if terminator_sender.send(()).is_err() {
+            warn!(target: LOG_CONSENSUS, "Failed to send termination signal to aleph_bft session");
+        }
         aleph_handle.await.ok();
 
         // This method removes the backup of the current session from the database

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -77,3 +77,6 @@ console-subscriber = "0.3.0"
 
 [build-dependencies]
 fedimint-build = { version = "=0.4.4-rc.0", path = "../fedimint-build" }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { workspace = true }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,5 +1,12 @@
 use fedimint_core::fedimint_build_code_version_env;
 use fedimintd::Fedimintd;
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+// rocksdb suffers from memory fragmentation when using standard allocator
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -92,3 +92,6 @@ assert_matches = { workspace = true }
 [build-dependencies]
 fedimint-build = { version = "=0.4.4-rc.0", path = "../../fedimint-build" }
 tonic-build = "0.11.0"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { workspace = true }

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -12,8 +12,15 @@ use fedimint_core::fedimint_build_code_version_env;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::util::handle_version_hash_command;
 use fedimint_logging::TracingSetup;
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
 use ln_gateway::Gateway;
 use tracing::info;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+// rocksdb suffers from memory fragmentation when using standard allocator
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {


### PR DESCRIPTION
As per https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks:

> By default index, filter, and compression dictionary blocks (with the exception of the partitions of [partitioned indexes/filters](https://github.com/facebook/rocksdb/wiki/Partitioned-Index-Filters)) are cached outside of block cache, and users won't be able to control how much memory should be used to cache these blocks, other than setting max_open_files.


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
