### PR TITLE
chore: swap NetworkSaneEncodingWrapper for Legacy

### DIFF
--- a/fedimint-core/src/encoding/btc.rs
+++ b/fedimint-core/src/encoding/btc.rs
@@ -137,22 +137,35 @@ where
     }
 }
 
-impl Encodable for bitcoin::Network {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        u32::from_le_bytes(self.magic().to_bytes()).consensus_encode(writer)
+/// Wrapper around `bitcoin::Network` that encodes and decodes the network as a
+/// little-endian u32. This is here for backwards compatibility and is used by
+/// the LNv1 and WalletV1 modules.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct NetworkLegacyEncodingWrapper(pub bitcoin::Network);
+
+impl std::fmt::Display for NetworkLegacyEncodingWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 
-impl Decodable for bitcoin::Network {
+impl Encodable for NetworkLegacyEncodingWrapper {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+        u32::from_le_bytes(self.0.magic().to_bytes()).consensus_encode(writer)
+    }
+}
+
+impl Decodable for NetworkLegacyEncodingWrapper {
     fn consensus_decode<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let num = u32::consensus_decode(d, modules)?;
         let magic = bitcoin::p2p::Magic::from_bytes(num.to_le_bytes());
-        Self::from_magic(magic).ok_or_else(|| {
+        let network = bitcoin::Network::from_magic(magic).ok_or_else(|| {
             DecodeError::new_custom(format_err!("Unknown network magic: {:x}", magic))
-        })
+        })?;
+        Ok(Self(network))
     }
 }
 
@@ -197,7 +210,8 @@ impl Decodable for bitcoin::Amount {
 impl Encodable for bitcoin::Address<NetworkUnchecked> {
     fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         let mut len = 0;
-        len += get_network_for_address(self.as_unchecked()).consensus_encode(writer)?;
+        len += NetworkLegacyEncodingWrapper(get_network_for_address(self.as_unchecked()))
+            .consensus_encode(writer)?;
         len += self
             .clone()
             .assume_checked()
@@ -212,7 +226,7 @@ impl Decodable for bitcoin::Address<NetworkUnchecked> {
         mut d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let network = bitcoin::Network::consensus_decode(&mut d, modules)?;
+        let network = NetworkLegacyEncodingWrapper::consensus_decode(&mut d, modules)?.0;
         let script_pk = bitcoin::ScriptBuf::consensus_decode(&mut d, modules)?;
 
         let address = bitcoin::Address::from_script(&script_pk, network)
@@ -246,7 +260,7 @@ mod tests {
 
     use bitcoin::hashes::Hash as BitcoinHash;
 
-    use crate::encoding::btc::NetworkSaneEncodingWrapper;
+    use crate::encoding::btc::{NetworkLegacyEncodingWrapper, NetworkSaneEncodingWrapper};
     use crate::encoding::tests::test_roundtrip_expected;
     use crate::encoding::{Decodable, Encodable};
     use crate::ModuleDecoderRegistry;
@@ -281,20 +295,23 @@ mod tests {
             ),
         ];
 
-        for (network, magic_bytes, magic_sane_bytes) in networks {
-            let mut network_encoded = Vec::new();
-            network.consensus_encode(&mut network_encoded).unwrap();
+        for (network, magic_legacy_bytes, magic_sane_bytes) in networks {
+            let mut network_legacy_encoded = Vec::new();
+            NetworkLegacyEncodingWrapper(network)
+                .consensus_encode(&mut network_legacy_encoded)
+                .unwrap();
 
             let mut network_sane_encoded = Vec::new();
             NetworkSaneEncodingWrapper(network)
                 .consensus_encode(&mut network_sane_encoded)
                 .unwrap();
 
-            let network_decoded = bitcoin::Network::consensus_decode(
-                &mut Cursor::new(network_encoded.clone()),
+            let network_legacy_decoded = NetworkLegacyEncodingWrapper::consensus_decode(
+                &mut Cursor::new(network_legacy_encoded.clone()),
                 &ModuleDecoderRegistry::default(),
             )
-            .unwrap();
+            .unwrap()
+            .0;
 
             let network_sane_decoded = NetworkSaneEncodingWrapper::consensus_decode(
                 &mut Cursor::new(network_sane_encoded.clone()),
@@ -302,9 +319,9 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(magic_bytes, *network_encoded);
+            assert_eq!(magic_legacy_bytes, *network_legacy_encoded);
             assert_eq!(magic_sane_bytes, *network_sane_encoded);
-            assert_eq!(network, network_decoded);
+            assert_eq!(network, network_legacy_decoded);
             assert_eq!(network, network_sane_decoded.0);
         }
     }

--- a/fedimint-recoverytool/src/main.rs
+++ b/fedimint-recoverytool/src/main.rs
@@ -125,7 +125,7 @@ async fn main() -> anyhow::Result<()> {
             .expect("Malformed wallet config");
         let base_descriptor = wallet_cfg.consensus.peg_in_descriptor;
         let base_key = wallet_cfg.private.peg_in_key;
-        let network = wallet_cfg.consensus.network;
+        let network = wallet_cfg.consensus.network.0;
 
         (base_descriptor, base_key, network)
     } else if let (Some(descriptor), Some(key)) = (opts.descriptor, opts.key) {

--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -1,13 +1,13 @@
 use std::collections::BTreeMap;
 
 use bitcoin::hashes::sha256;
-use bitcoin::Network;
 use fedimint_api_client::api::net::Connector;
 use fedimint_core::config::FederationId;
 use fedimint_core::db::{
     CoreMigrationFn, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
     MigrationContext,
 };
+use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::{impl_db_lookup, impl_db_record, push_db_pair_items, secp256k1, Amount};
@@ -326,7 +326,7 @@ struct GatewayConfigurationV0 {
     num_route_hints: u32,
     #[serde(with = "serde_routing_fees")]
     routing_fees: RoutingFees,
-    network: Network,
+    network: NetworkLegacyEncodingWrapper,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable)]
@@ -338,7 +338,7 @@ pub struct GatewayConfiguration {
     pub num_route_hints: u32,
     #[serde(with = "serde_routing_fees")]
     pub routing_fees: RoutingFees,
-    pub network: Network,
+    pub network: NetworkLegacyEncodingWrapper,
     pub password_salt: [u8; 16],
 }
 
@@ -494,7 +494,7 @@ mod fedimint_migration_tests {
             password: "EXAMPLE".to_string(),
             num_route_hints: 2,
             routing_fees: DEFAULT_FEES,
-            network: Network::Regtest,
+            network: NetworkLegacyEncodingWrapper(bitcoin::Network::Regtest),
         };
 
         dbtx.insert_new_entry(&GatewayConfigurationKeyV0, &gateway_configuration)

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1874,14 +1874,14 @@ impl Gateway {
             ))))?;
         let ln_cfg: &fedimint_lnv2_common::config::LightningClientConfig = cfg.cast()?;
 
-        if ln_cfg.network.0 != network {
+        if ln_cfg.network != network {
             error!(
                 "Federation {federation_id} runs on {} but this gateway supports {network}",
-                ln_cfg.network.0,
+                ln_cfg.network,
             );
             return Err(AdminGatewayError::ClientCreationError(anyhow!(format!(
                 "Unsupported network {}",
-                ln_cfg.network.0
+                ln_cfg.network
             ))));
         }
 

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -680,7 +680,7 @@ impl LightningClientModule {
         ClientOutputSM<LightningClientStateMachines>,
         ContractId,
     )> {
-        let federation_currency: Currency = self.cfg.network.into();
+        let federation_currency: Currency = self.cfg.network.0.into();
         let invoice_currency = invoice.currency();
         ensure!(
             federation_currency == invoice_currency,
@@ -1624,7 +1624,7 @@ impl LightningClientModule {
             src_node_id,
             short_channel_id,
             &route_hints,
-            self.cfg.network,
+            self.cfg.network.0,
         )?;
 
         let tx =

--- a/modules/fedimint-ln-common/src/config.rs
+++ b/modules/fedimint-ln-common/src/config.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use anyhow::Context;
 pub use bitcoin::Network;
 use fedimint_core::core::ModuleKind;
+use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::{msats, plugin_types_trait_impl_config, Amount};
@@ -58,7 +59,7 @@ pub struct LightningConfigConsensus {
     pub threshold_pub_keys: threshold_crypto::PublicKeySet,
     /// Fees charged for LN transactions
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
+    pub network: NetworkLegacyEncodingWrapper,
 }
 
 impl LightningConfigConsensus {
@@ -79,7 +80,7 @@ pub struct LightningConfigPrivate {
 pub struct LightningClientConfig {
     pub threshold_pub_key: threshold_crypto::PublicKey,
     pub fee_consensus: FeeConsensus,
-    pub network: Network,
+    pub network: NetworkLegacyEncodingWrapper,
 }
 
 impl std::fmt::Display for LightningClientConfig {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -17,6 +17,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{DatabaseTransaction, DatabaseValue, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -242,7 +243,7 @@ impl ServerModuleInit for LightningInit {
                         consensus: LightningConfigConsensus {
                             threshold_pub_keys: pks.clone(),
                             fee_consensus: FeeConsensus::default(),
-                            network: params.consensus.network,
+                            network: NetworkLegacyEncodingWrapper(params.consensus.network),
                         },
                         private: LightningConfigPrivate {
                             threshold_sec_key: threshold_crypto::serde_impl::SerdeSecret(sk),
@@ -273,7 +274,7 @@ impl ServerModuleInit for LightningInit {
             consensus: LightningConfigConsensus {
                 threshold_pub_keys: keys.public_key_set,
                 fee_consensus: FeeConsensus::default(),
-                network: params.consensus.network,
+                network: NetworkLegacyEncodingWrapper(params.consensus.network),
             },
             private: LightningConfigPrivate {
                 threshold_sec_key: keys.secret_key_share,

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -497,10 +497,10 @@ impl LightningClientModule {
             return Err(SendPaymentError::InvoiceExpired);
         }
 
-        if self.cfg.network.0 != invoice.currency().into() {
+        if self.cfg.network != invoice.currency().into() {
             return Err(SendPaymentError::WrongCurrency {
                 invoice_currency: invoice.currency(),
-                federation_currency: self.cfg.network.0.into(),
+                federation_currency: self.cfg.network.into(),
             });
         }
 

--- a/modules/fedimint-lnv2-common/src/config.rs
+++ b/modules/fedimint-lnv2-common/src/config.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 
 pub use bitcoin::Network;
 use fedimint_core::core::ModuleKind;
-use fedimint_core::encoding::btc::NetworkSaneEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::{plugin_types_trait_impl_config, Amount, PeerId};
@@ -59,7 +58,7 @@ pub struct LightningConfigConsensus {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
     pub fee_consensus: FeeConsensus,
-    pub network: NetworkSaneEncodingWrapper,
+    pub network: Network,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -72,7 +71,7 @@ pub struct LightningClientConfig {
     pub tpe_agg_pk: AggregatePublicKey,
     pub tpe_pks: BTreeMap<PeerId, PublicKeyShare>,
     pub fee_consensus: FeeConsensus,
-    pub network: NetworkSaneEncodingWrapper,
+    pub network: Network,
 }
 
 impl std::fmt::Display for LightningClientConfig {
@@ -189,7 +188,7 @@ fn migrate_config_consensus(
             })
             .collect(),
         fee_consensus: FeeConsensus::new(1000).expect("Relative fee is within range"),
-        network: NetworkSaneEncodingWrapper(config.network.0),
+        network: config.network.0,
     }
 }
 

--- a/modules/fedimint-lnv2-common/src/config.rs
+++ b/modules/fedimint-lnv2-common/src/config.rs
@@ -189,7 +189,7 @@ fn migrate_config_consensus(
             })
             .collect(),
         fee_consensus: FeeConsensus::new(1000).expect("Relative fee is within range"),
-        network: NetworkSaneEncodingWrapper(config.network),
+        network: NetworkSaneEncodingWrapper(config.network.0),
     }
 }
 

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -16,7 +16,6 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
-use fedimint_core::encoding::btc::NetworkSaneEncodingWrapper;
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiVersion, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
@@ -206,7 +205,7 @@ impl ServerModuleInit for LightningInit {
                             tpe_agg_pk,
                             tpe_pks: tpe_pks.clone(),
                             fee_consensus: params.consensus.fee_consensus.clone(),
-                            network: NetworkSaneEncodingWrapper(params.consensus.network),
+                            network: params.consensus.network,
                         },
                         private: LightningConfigPrivate {
                             sk: sks[peer.to_usize()],
@@ -248,7 +247,7 @@ impl ServerModuleInit for LightningInit {
                     })
                     .collect(),
                 fee_consensus: params.consensus.fee_consensus.clone(),
-                network: NetworkSaneEncodingWrapper(params.consensus.network),
+                network: params.consensus.network,
             },
             private: LightningConfigPrivate {
                 sk: SecretKeyShare(sk),

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -331,7 +331,7 @@ impl WalletClientModuleData {
             .cfg
             .peg_in_descriptor
             .tweak(&public_tweak_key, bitcoin::secp256k1::SECP256K1)
-            .address(self.cfg.network)
+            .address(self.cfg.network.0)
             .unwrap();
 
         // TODO: make hash?
@@ -503,7 +503,7 @@ impl WalletClientModule {
     }
 
     pub fn get_network(&self) -> Network {
-        self.cfg().network
+        self.cfg().network.0
     }
 
     pub fn get_fee_consensus(&self) -> FeeConsensus {
@@ -548,7 +548,7 @@ impl WalletClientModule {
         address: bitcoin::Address<NetworkUnchecked>,
         amount: bitcoin::Amount,
     ) -> anyhow::Result<PegOutFees> {
-        check_address(&address, self.cfg().network)?;
+        check_address(&address, self.cfg().network.0)?;
 
         self.module_api
             .fetch_peg_out_fees(&address.assume_checked(), amount)
@@ -568,7 +568,7 @@ impl WalletClientModule {
         amount: bitcoin::Amount,
         fees: PegOutFees,
     ) -> anyhow::Result<ClientOutputBundle<WalletOutput, WalletClientStates>> {
-        check_address(address, self.cfg().network)?;
+        check_address(address, self.cfg().network.0)?;
 
         let output = WalletOutput::new_v0_peg_out(address.clone(), amount, fees);
 

--- a/modules/fedimint-wallet-common/src/config.rs
+++ b/modules/fedimint-wallet-common/src/config.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use bitcoin::secp256k1::SecretKey;
 use bitcoin::Network;
 use fedimint_core::core::ModuleKind;
+use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::serde_json;
@@ -86,7 +87,7 @@ pub struct WalletConfigPrivate {
 #[derive(Clone, Debug, Serialize, Deserialize, Encodable, Decodable)]
 pub struct WalletConfigConsensus {
     /// Bitcoin network (e.g. testnet, bitcoin)
-    pub network: Network,
+    pub network: NetworkLegacyEncodingWrapper,
     /// The federations public peg-in-descriptor
     pub peg_in_descriptor: PegInDescriptor,
     /// The public keys for the bitcoin multisig
@@ -114,7 +115,7 @@ pub struct WalletClientConfig {
     /// The federations public peg-in-descriptor
     pub peg_in_descriptor: PegInDescriptor,
     /// The bitcoin network the client will use
-    pub network: Network,
+    pub network: NetworkLegacyEncodingWrapper,
     /// Confirmations required for a peg in to be accepted by federation
     pub finality_delay: u32,
     pub fee_consensus: FeeConsensus,
@@ -182,7 +183,7 @@ impl WalletConfig {
             local: WalletConfigLocal { bitcoin_rpc },
             private: WalletConfigPrivate { peg_in_key: sk },
             consensus: WalletConfigConsensus {
-                network,
+                network: NetworkLegacyEncodingWrapper(network),
                 peg_in_descriptor,
                 peer_peg_in_keys: pubkeys,
                 finality_delay,

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -9,9 +9,10 @@ use std::hash::Hasher;
 
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::psbt::raw::ProprietaryKey;
-use bitcoin::{secp256k1, Address, Amount, BlockHash, Network, Txid};
+use bitcoin::{secp256k1, Address, Amount, BlockHash, Txid};
 use config::WalletClientConfig;
 use fedimint_core::core::{Decoder, ModuleInstanceId, ModuleKind};
+use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{CommonModuleInit, ModuleCommon, ModuleConsensusVersion};
 use fedimint_core::{extensible_associated_module_type, plugin_types_trait_impl_common, Feerate};
@@ -406,7 +407,7 @@ plugin_types_trait_impl_common!(
 #[derive(Debug, Error, Encodable, Decodable, Hash, Clone, Eq, PartialEq)]
 pub enum WalletCreationError {
     #[error("Connected bitcoind is on wrong network, expected {0}, got {1}")]
-    WrongNetwork(Network, Network),
+    WrongNetwork(NetworkLegacyEncodingWrapper, NetworkLegacyEncodingWrapper),
     #[error("Error querying bitcoind: {0}")]
     RpcError(String),
 }
@@ -426,7 +427,7 @@ pub enum WalletInputError {
 #[derive(Debug, Error, Encodable, Decodable, Hash, Clone, Eq, PartialEq)]
 pub enum WalletOutputError {
     #[error("Connected bitcoind is on wrong network, expected {0}, got {1}")]
-    WrongNetwork(Network, Network),
+    WrongNetwork(NetworkLegacyEncodingWrapper, NetworkLegacyEncodingWrapper),
     #[error("Peg-out fee rate {0:?} is set below consensus {1:?}")]
     PegOutFeeBelowConsensus(Feerate, Feerate),
     #[error("Not enough SpendableUTXO")]

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -42,6 +42,7 @@ use fedimint_core::db::{
     CoreMigrationFn, Database, DatabaseTransaction, DatabaseVersion,
     IDatabaseTransactionOpsCoreTyped,
 };
+use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::envs::{is_rbf_withdrawal_enabled, is_running_in_test_env, BitcoinRpcConfig};
 use fedimint_core::module::audit::Audit;
@@ -593,7 +594,7 @@ impl ServerModule for Wallet {
 
         let fee_rate = self.consensus_fee_rate(dbtx).await;
 
-        StatelessWallet::validate_tx(&tx, output, fee_rate, self.cfg.consensus.network)?;
+        StatelessWallet::validate_tx(&tx, output, fee_rate, self.cfg.consensus.network.0)?;
 
         self.offline_wallet().sign_psbt(&mut tx.psbt);
 
@@ -849,10 +850,12 @@ impl Wallet {
 
         let bitcoind_rpc = bitcoind;
 
-        let bitcoind_net = bitcoind_rpc
-            .get_network()
-            .await
-            .map_err(|e| WalletCreationError::RpcError(e.to_string()))?;
+        let bitcoind_net = NetworkLegacyEncodingWrapper(
+            bitcoind_rpc
+                .get_network()
+                .await
+                .map_err(|e| WalletCreationError::RpcError(e.to_string()))?,
+        );
         if bitcoind_net != cfg.consensus.network {
             return Err(WalletCreationError::WrongNetwork(
                 cfg.consensus.network,
@@ -1511,8 +1514,8 @@ impl<'a> StatelessWallet<'a> {
         if let WalletOutputV0::PegOut(peg_out) = output {
             if !peg_out.recipient.is_valid_for_network(network) {
                 return Err(WalletOutputError::WrongNetwork(
-                    network,
-                    get_network_for_address(&peg_out.recipient),
+                    NetworkLegacyEncodingWrapper(network),
+                    NetworkLegacyEncodingWrapper(get_network_for_address(&peg_out.recipient)),
                 ));
             }
         }
@@ -1906,6 +1909,7 @@ mod tests {
     use bitcoin::hashes::Hash;
     use bitcoin::Network::{Bitcoin, Testnet};
     use bitcoin::{secp256k1, Address, Amount, OutPoint, Txid};
+    use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
     use fedimint_core::Feerate;
     use fedimint_wallet_common::{PegOut, PegOutFees, Rbf, WalletOutputV0};
     use miniscript::descriptor::Wsh;
@@ -2011,7 +2015,13 @@ mod tests {
             fees: PegOutFees::new(100, weight),
         });
         let res = StatelessWallet::validate_tx(&tx, &output, fee, Testnet);
-        assert_eq!(res, Err(WalletOutputError::WrongNetwork(Testnet, Bitcoin)));
+        assert_eq!(
+            res,
+            Err(WalletOutputError::WrongNetwork(
+                NetworkLegacyEncodingWrapper(Testnet),
+                NetworkLegacyEncodingWrapper(Bitcoin)
+            ))
+        );
     }
 
     fn rbf(sats_per_kvb: u64, total_weight: u64) -> WalletOutputV0 {

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -629,7 +629,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
 
     let peg_in_address = peg_in_descriptor
         .tweak(&pk, secp256k1::SECP256K1)
-        .address(wallet_config.consensus.network)?;
+        .address(wallet_config.consensus.network.0)?;
 
     let mut wallet = fedimint_wallet_server::Wallet::new_with_bitcoind(
         wallet_server_cfg[0].to_typed()?,


### PR DESCRIPTION
Follow-up to #6336

Makes the default encoding for `bitcoin::Network` byte-encoded instead of int-encoded to prevent accidental use of the old encoding

To ensure safe conversion, this PR is split into two commits. One commit removes `bitcoin::Network` en/decoding and replaces it with a `NetworkLegacyEncodingWrapper`, and a second commit removes `NetworkSaneEncodingWrapper` and replaces it with `bitcoin::Network` en/decoding.