### PR TITLE
feat: Gateway Transaction Log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,6 +2564,7 @@ dependencies = [
  "clap_complete",
  "fedimint-build",
  "fedimint-core",
+ "fedimint-eventlog",
  "fedimint-ln-gateway",
  "fedimint-logging",
  "fedimint-mint-client",
@@ -2654,6 +2655,7 @@ dependencies = [
  "fedimint-dummy-client",
  "fedimint-dummy-common",
  "fedimint-dummy-server",
+ "fedimint-eventlog",
  "fedimint-ln-client",
  "fedimint-ln-common",
  "fedimint-ln-server",
@@ -2672,6 +2674,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "itertools 0.13.0",
  "jemallocator",
  "ldk-node",
  "lightning",
@@ -2681,6 +2684,7 @@ dependencies = [
  "reqwest 0.12.9",
  "serde",
  "serde_json",
+ "serde_millis",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "thiserror",
@@ -6852,6 +6856,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_millis"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e2dc780ca5ee2c369d1d01d100270203c4ff923d2a4264812d723766434d00"
+dependencies = [
  "serde",
 ]
 

--- a/fedimint-eventlog/src/lib.rs
+++ b/fedimint-eventlog/src/lib.rs
@@ -97,6 +97,14 @@ impl EventLogId {
     fn saturating_add(self, rhs: u64) -> EventLogId {
         Self(self.0.saturating_add(rhs))
     }
+
+    pub fn saturating_sub(self, rhs: u64) -> EventLogId {
+        Self(self.0.saturating_sub(rhs))
+    }
+
+    pub fn new(log: u64) -> Self {
+        Self(log)
+    }
 }
 
 impl FromStr for EventLogId {

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -24,6 +24,7 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.38"
 fedimint-core = { workspace = true }
+fedimint-eventlog = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-mint-client = { workspace = true }
 lightning-invoice = { workspace = true }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -45,6 +45,7 @@ fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.6.0-al
 fedimint-bip39 = { version = "=0.6.0-alpha", path = "../../fedimint-bip39" }
 fedimint-client = { path = "../../fedimint-client", version = "=0.6.0-alpha", default-features = false }
 fedimint-core = { workspace = true }
+fedimint-eventlog = { workspace = true }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
 fedimint-lnv2-client = { workspace = true }
@@ -64,6 +65,7 @@ rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_millis = "0.1.1"
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
@@ -86,6 +88,7 @@ fedimint-lnv2-server = { workspace = true }
 fedimint-testing = { workspace = true }
 fedimint-unknown-common = { workspace = true }
 fedimint-unknown-server = { workspace = true }
+itertools = { workspace = true }
 
 [build-dependencies]
 fedimint-build = { workspace = true }

--- a/gateway/ln-gateway/src/events.rs
+++ b/gateway/ln-gateway/src/events.rs
@@ -1,0 +1,112 @@
+use std::time::SystemTime;
+
+use fedimint_core::config::FederationId;
+use fedimint_core::core::ModuleKind;
+use fedimint_core::Amount;
+use fedimint_eventlog::{Event, EventKind};
+use fedimint_lnv2_common::contracts::{Commitment, OutgoingContract, PaymentImage};
+use serde::{Deserialize, Serialize};
+use serde_millis;
+
+/// All gateway events will be emitted using the same module kind.
+pub const GATEWAY_KIND: ModuleKind = ModuleKind::from_static_str("ln-gateway-core");
+
+pub const ALL_GATEWAY_EVENTS: [EventKind; 5] = [
+    OutgoingPaymentStarted::KIND,
+    OutgoingPaymentSucceeded::KIND,
+    IncomingPaymentStarted::KIND,
+    IncomingPaymentSucceeded::KIND,
+    CompleteLightningPaymentSucceeded::KIND,
+];
+
+/// Event that is emitted when an outgoing payment attempt is initiated.
+#[derive(Serialize, Deserialize)]
+pub struct OutgoingPaymentStarted {
+    /// The timestamp that the operation begins, including the API calls to the
+    /// federation to get the consensus block height.
+    #[serde(with = "serde_millis")]
+    pub operation_start: SystemTime,
+
+    /// The outgoing contract for this payment.
+    pub outgoing_contract: OutgoingContract,
+
+    /// The minimum amount that must be escrowed for the payment (includes the
+    /// gateway's fee)
+    pub min_contract_amount: Amount,
+
+    /// The amount requested in the invoice.
+    pub invoice_amount: Amount,
+
+    /// The max delay of the payment in blocks.
+    pub max_delay: u64,
+}
+
+impl Event for OutgoingPaymentStarted {
+    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
+
+    const KIND: EventKind = EventKind::from_static("outgoing-payment-started");
+}
+
+/// Event that is emitted when an outgoing payment attempt has succeeded.
+#[derive(Serialize, Deserialize)]
+pub struct OutgoingPaymentSucceeded {
+    /// The target federation ID if a swap was performed, otherwise `None`.
+    pub target_federation: Option<FederationId>,
+}
+
+impl Event for OutgoingPaymentSucceeded {
+    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
+
+    const KIND: EventKind = EventKind::from_static("outgoing-payment-succeeded");
+}
+
+/// Event that is emitted when an incoming payment attempt has started. Includes
+/// both internal swaps and outside LN payments.
+#[derive(Serialize, Deserialize)]
+pub struct IncomingPaymentStarted {
+    /// The timestamp that the operation begins, including any metadata checks
+    /// before the state machine has spawned.
+    #[serde(with = "serde_millis")]
+    pub operation_start: SystemTime,
+
+    /// The commitment for the incoming contract.
+    pub incoming_contract_commitment: Commitment,
+
+    /// The amount requested in the invoice.
+    pub invoice_amount: Amount,
+}
+
+impl Event for IncomingPaymentStarted {
+    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
+
+    const KIND: EventKind = EventKind::from_static("incoming-payment-started");
+}
+
+/// Event that is emitted when an incoming payment attempt has succeeded.
+/// Includes both internal swaps and outside LN payments.
+#[derive(Serialize, Deserialize)]
+pub struct IncomingPaymentSucceeded {
+    /// The payment hash of the invoice that was paid.
+    pub payment_hash: PaymentImage,
+}
+
+impl Event for IncomingPaymentSucceeded {
+    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
+
+    const KIND: EventKind = EventKind::from_static("incoming-payment-succeeded");
+}
+
+/// Event that is emitted when a preimage is revealed to the Lightning network.
+/// Only emitted for payments that are received from an external Lightning node,
+/// not internal swaps.
+#[derive(Serialize, Deserialize)]
+pub struct CompleteLightningPaymentSucceeded {
+    /// The payment hash of the invoice that was paid.
+    pub payment_hash: PaymentImage,
+}
+
+impl Event for CompleteLightningPaymentSucceeded {
+    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
+
+    const KIND: EventKind = EventKind::from_static("complete-lightning-payment-succeeded");
+}

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 mod db;
 pub mod envs;
 mod error;
+pub mod events;
 mod federation_manager;
 pub mod gateway_module_v2;
 pub mod lightning;
@@ -41,6 +42,7 @@ use config::GatewayOpts;
 pub use config::GatewayParameters;
 use db::{GatewayConfiguration, GatewayConfigurationKey, GatewayDbtxNcExt};
 use error::FederationNotConnected;
+use events::ALL_GATEWAY_EVENTS;
 use federation_manager::FederationManager;
 use fedimint_api_client::api::net::Connector;
 use fedimint_bip39::{Bip39RootSecretStrategy, Language, Mnemonic};
@@ -62,6 +64,7 @@ use fedimint_core::task::{sleep, TaskGroup, TaskHandle, TaskShutdownToken};
 use fedimint_core::time::duration_since_epoch;
 use fedimint_core::util::{SafeUrl, Spanned};
 use fedimint_core::{fedimint_build_code_version_env, Amount, BitcoinAmountOrAll};
+use fedimint_eventlog::{DBTransactionEventLogExt, EventLogId};
 use fedimint_ln_common::config::{GatewayFee, LightningClientConfig};
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::LightningCommonInit;
@@ -88,9 +91,9 @@ use rand::{thread_rng, Rng};
 use rpc::{
     CloseChannelsWithPeerPayload, CreateInvoiceForOperatorPayload, FederationInfo,
     GatewayFedConfig, GatewayInfo, LeaveFedPayload, MnemonicResponse, OpenChannelPayload,
-    PayInvoiceForOperatorPayload, ReceiveEcashPayload, ReceiveEcashResponse, SendOnchainPayload,
-    SetConfigurationPayload, SpendEcashPayload, SpendEcashResponse, WithdrawResponse,
-    V1_API_ENDPOINT,
+    PayInvoiceForOperatorPayload, PaymentLogPayload, PaymentLogResponse, ReceiveEcashPayload,
+    ReceiveEcashResponse, SendOnchainPayload, SetConfigurationPayload, SpendEcashPayload,
+    SpendEcashResponse, WithdrawResponse, V1_API_ENDPOINT,
 };
 use state_machine::{GatewayClientModule, GatewayExtPayStates};
 use tokio::sync::RwLock;
@@ -679,6 +682,7 @@ impl Gateway {
                 htlc_request.incoming_chan_id,
                 htlc_request.htlc_id,
                 contract,
+                htlc_request.amount_msat,
             )
             .await
         {
@@ -1610,6 +1614,66 @@ impl Gateway {
             }
         });
         Ok(())
+    }
+
+    /// Queries the client log for payment events and returns to the user.
+    pub async fn handle_payment_log_msg(
+        &self,
+        PaymentLogPayload {
+            end_position,
+            pagination_size,
+            federation_id,
+            event_kinds,
+        }: PaymentLogPayload,
+    ) -> AdminResult<PaymentLogResponse> {
+        const BATCH_SIZE: u64 = 10_000;
+        let federation_manager = self.federation_manager.read().await;
+        let client = federation_manager
+            .client(&federation_id)
+            .ok_or(FederationNotConnected {
+                federation_id_prefix: federation_id.to_prefix(),
+            })?
+            .value();
+
+        let event_kinds = if event_kinds.is_empty() {
+            ALL_GATEWAY_EVENTS.to_vec()
+        } else {
+            event_kinds
+        };
+
+        let end_position = if let Some(position) = end_position {
+            position
+        } else {
+            let mut dbtx = client.db().begin_transaction_nc().await;
+            dbtx.get_next_event_log_id().await
+        };
+
+        let mut start_position = end_position.saturating_sub(BATCH_SIZE);
+
+        let mut payment_log = Vec::new();
+
+        let log_start = EventLogId::new(0);
+        while payment_log.len() < pagination_size {
+            let batch = client.get_event_log(Some(start_position), BATCH_SIZE).await;
+            let mut filtered_batch = batch
+                .into_iter()
+                .filter(|e| e.0 <= end_position && event_kinds.contains(&e.1))
+                .collect::<Vec<_>>();
+            filtered_batch.reverse();
+            payment_log.extend(filtered_batch);
+
+            // Compute the start position for the next batch query
+            start_position = start_position.saturating_sub(BATCH_SIZE);
+
+            if start_position == log_start {
+                break;
+            }
+        }
+
+        // Truncate the payment log to the expected pagination size
+        payment_log.truncate(pagination_size);
+
+        Ok(PaymentLogResponse(payment_log))
     }
 
     /// Registers the gateway with each specified federation.

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -11,15 +11,15 @@ use super::{
     BackupPayload, CloseChannelsWithPeerPayload, ConfigPayload, ConnectFedPayload,
     CreateInvoiceForOperatorPayload, DepositAddressPayload, FederationInfo, GatewayBalances,
     GatewayFedConfig, GatewayInfo, LeaveFedPayload, MnemonicResponse, OpenChannelPayload,
-    PayInvoiceForOperatorPayload, ReceiveEcashPayload, ReceiveEcashResponse, SendOnchainPayload,
-    SetConfigurationPayload, SpendEcashPayload, SpendEcashResponse, WithdrawPayload,
-    WithdrawResponse, ADDRESS_ENDPOINT, BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
-    CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT,
-    GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT,
-    GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAY_INVOICE_FOR_OPERATOR_ENDPOINT,
-    RECEIVE_ECASH_ENDPOINT, SEND_ONCHAIN_ENDPOINT, SET_CONFIGURATION_ENDPOINT,
-    SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, WITHDRAW_ENDPOINT,
+    PayInvoiceForOperatorPayload, PaymentLogPayload, PaymentLogResponse, ReceiveEcashPayload,
+    ReceiveEcashResponse, SendOnchainPayload, SetConfigurationPayload, SpendEcashPayload,
+    SpendEcashResponse, WithdrawPayload, WithdrawResponse, ADDRESS_ENDPOINT, BACKUP_ENDPOINT,
+    CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT,
+    CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
+    GET_BALANCES_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT,
+    LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAYMENT_LOG_ENDPOINT,
+    PAY_INVOICE_FOR_OPERATOR_ENDPOINT, RECEIVE_ECASH_ENDPOINT, SEND_ONCHAIN_ENDPOINT,
+    SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use crate::lightning::{ChannelInfo, CloseChannelsWithPeerResponse};
 
@@ -237,6 +237,17 @@ impl GatewayRpcClient {
     pub async fn stop(&self) -> GatewayRpcResult<()> {
         let url = self.base_url.join(STOP_ENDPOINT).expect("invalid base url");
         self.call_get(url).await
+    }
+
+    pub async fn payment_log(
+        &self,
+        payload: PaymentLogPayload,
+    ) -> GatewayRpcResult<PaymentLogResponse> {
+        let url = self
+            .base_url
+            .join(PAYMENT_LOG_ENDPOINT)
+            .expect("Invalid base url");
+        self.call_post(url, payload).await
     }
 
     async fn call<P: Serialize, T: DeserializeOwned>(


### PR DESCRIPTION
Re-uses @dpc's client log for a "gateway transaction log".

Adds five LNv2 events `OutgoingPaymentStarted`, `OutgoingPaymentSucceeded`, `IncomingPaymentStarted`, `IncomingPaymentSucceeded`, and `CompleteLightningPaymentSucceeded`. Can tackle failure events in a follow up.

Also adds a `/payment_log` endpoint that allows querying for these events. The API contains very basic predicate filtering based on `FederationId` and `EventKind`, but I suspect the proper way to use this API will be to periodically query the data from an ETL task, insert it into a SQL database, and then execute more interesting queries there (e.g group by weekly, swaps vs LN, etc).

The added LNv2 events contain information required to compute fees, latency, and other payment information. Looking for feedback if there's other convenient data that we might want to include.