### PR TITLE
chore: bump master to 0.6.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.7",
@@ -2059,7 +2059,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2191,14 +2191,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -2415,11 +2415,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-cli"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -2557,14 +2557,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-gateway"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.7",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "bls12_381",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-api-client",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 
 [workspace.metadata]
 name = "fedimint"
@@ -100,7 +100,7 @@ bytes = "1.7.2"
 clap = { version = "4.5.20", features = ["derive", "env"] }
 cln-rpc = { package = "fedimint-cln-rpc", version = "0.5.0" }
 criterion = "0.5.1"
-devimint = { path = "./devimint", version = "=0.5.0-alpha" }
+devimint = { path = "./devimint", version = "=0.6.0-alpha" }
 electrum-client = { version = "0.21.0", default-features = false, features = [
     "proxy",
     "use-rustls-ring",
@@ -109,55 +109,55 @@ erased-serde = "0.4"
 esplora-client = { version = "0.10.0", default-features = false, features = [
     "async-https-rustls",
 ] }
-fedimintd = { path = "./fedimintd", version = "=0.5.0-alpha" }
-fedimint-aead = { path = "./crypto/aead", version = "=0.5.0-alpha" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.5.0-alpha" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.5.0-alpha" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.5.0-alpha" }
-fedimint-build = { path = "./fedimint-build", version = "=0.5.0-alpha" }
-fedimint-client = { path = "./fedimint-client", version = "=0.5.0-alpha" }
-fedimint-core = { path = "./fedimint-core", version = "=0.5.0-alpha" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.5.0-alpha" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.5.0-alpha" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.5.0-alpha" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.5.0-alpha" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.5.0-alpha" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.5.0-alpha" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.5.0-alpha" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.5.0-alpha" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.5.0-alpha" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.5.0-alpha" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.5.0-alpha" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.5.0-alpha" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.5.0-alpha" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.5.0-alpha" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.5.0-alpha" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.5.0-alpha" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.5.0-alpha" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.5.0-alpha" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.5.0-alpha" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.5.0-alpha" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.5.0-alpha" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.5.0-alpha" }
-fedimint-server = { path = "./fedimint-server", version = "=0.5.0-alpha" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.5.0-alpha" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.5.0-alpha" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.5.0-alpha" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.5.0-alpha" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.5.0-alpha" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.5.0-alpha" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.5.0-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.6.0-alpha" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.6.0-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.6.0-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.6.0-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.6.0-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.6.0-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.6.0-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.6.0-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.6.0-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.6.0-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.6.0-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.6.0-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.6.0-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.6.0-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.6.0-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.6.0-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.6.0-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.6.0-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.6.0-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.6.0-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.6.0-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.6.0-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.6.0-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.6.0-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.6.0-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.6.0-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.6.0-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.6.0-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.6.0-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.6.0-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.6.0-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.6.0-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.6.0-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.6.0-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.6.0-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.6.0-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.6.0-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.6.0-alpha" }
 fs-lock = "0.1.6"
 futures = "0.3.31"
 futures-util = "0.3.30"
 group = "0.13.0"
 hex = "0.4.3"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.5.0-alpha" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.6.0-alpha" }
 hyper = "1.5"
 itertools = "0.13.0"
 lightning = "0.0.125"
 lightning-invoice = { version = "0.32.0", features = ["std"] }
-ln-gateway = { package = "fedimint-ln-gateway", path = "./gateway/ln-gateway", version = "=0.5.0-alpha" }
+ln-gateway = { package = "fedimint-ln-gateway", path = "./gateway/ln-gateway", version = "=0.6.0-alpha" }
 miniscript = "12.2.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
@@ -181,7 +181,7 @@ strum = "0.26"
 strum_macros = "0.26"
 subtle = "2.6.1"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.5.0-alpha" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.6.0-alpha" }
 thiserror = "1.0.68"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tokio = "1.41.1"
@@ -191,7 +191,7 @@ tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
     "lightningrpc",
     "routerrpc",
 ] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.5.0-alpha" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.6.0-alpha" }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = "2.5.3"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -30,9 +30,9 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.37"
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.5.0-alpha", default-features = false }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.6.0-alpha", default-features = false }
 fedimint-bip39 = { workspace = true }
-fedimint-client = { path = "../fedimint-client", version = "=0.5.0-alpha", default-features = false }
+fedimint-client = { path = "../fedimint-client", version = "=0.6.0-alpha", default-features = false }
 fedimint-core = { workspace = true }
 fedimint-ln-client = { workspace = true, features = ["cli"] }
 fedimint-lnv2-client = { workspace = true, features = ["cli"] }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -30,7 +30,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.5.0-alpha", default-features = false }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.6.0-alpha", default-features = false }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-logging = { workspace = true }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -37,7 +37,7 @@ fedimint-server = { workspace = true }
 fedimint-testing-core = { workspace = true }
 fs-lock = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway", version = "=0.5.0-alpha", default-features = false }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway", version = "=0.6.0-alpha", default-features = false }
 rand = { workspace = true }
 tempfile = "3.14.0"
 tokio = { workspace = true }

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -27,7 +27,7 @@ fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-mint-client = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { package = "fedimint-ln-gateway", path = "../ln-gateway", version = "=0.5.0-alpha", default-features = false }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../ln-gateway", version = "=0.6.0-alpha", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -41,9 +41,9 @@ cln-plugin = "0.2.0"
 cln-rpc = { workspace = true }
 erased-serde = { workspace = true }
 esplora-client = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.5.0-alpha", default-features = false }
-fedimint-bip39 = { version = "=0.5.0-alpha", path = "../../fedimint-bip39" }
-fedimint-client = { path = "../../fedimint-client", version = "=0.5.0-alpha", default-features = false }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.6.0-alpha", default-features = false }
+fedimint-bip39 = { version = "=0.6.0-alpha", path = "../../fedimint-bip39" }
+fedimint-client = { path = "../../fedimint-client", version = "=0.6.0-alpha", default-features = false }
 fedimint-core = { workspace = true }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -45,6 +45,6 @@ tracing = { workspace = true }
 fedimint-bitcoind = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-fedimint-bitcoind = { version = "=0.5.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = [
+fedimint-bitcoind = { version = "=0.6.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = [
     "esplora-client",
 ] }


### PR DESCRIPTION
As discussed on the deep dive call today, we can bump the version on master once we create the `releases/v*` branch. The release process docs are now updated to capture when we should do this step, see: https://github.com/fedimint/fedimint/pull/6356