### PR TITLE
docs: update release process to bump master *-alpha version

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -11,6 +11,7 @@ The release process evolves each cycle, so don't hesitate to make frequent edits
     - Push the release branch to `upstream`
     - Add branch protection rules to the release branch in GH
     - Push a signed tag to GH
+    - Create a PR that bumps master to a new `*-alpha` (e.g. `0.4.0-alpha -> 0.5.0-alpha`)
   - If there is already a `releases/v*` branch
     - Bump the cargo version to a new release candidate (e.g `0.4.3-rc.0`)
     - Open a PR targeting the `releases/v*` branch


### PR DESCRIPTION
Once we create a new `releases/v*` branch off of `master`, we can then bump the `*-alpha` version on `master`. This PR updates the release process docs to add a step to bump the version.