### PR TITLE
fix: mint client state machine migration

### DIFF
--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -117,7 +117,7 @@ pub async fn migrate_to_v1(
     Ok(None)
 }
 
-/// Maps all `Unreachable` states in the state machine to `OutputDone`
+/// Migrates `MintClientStateMachinesV1`
 pub(crate) fn migrate_state_to_v2(
     operation_id: OperationId,
     cursor: &mut Cursor<&[u8]>,
@@ -128,7 +128,9 @@ pub(crate) fn migrate_state_to_v2(
 
     let new_mint_state_machine = match mint_client_state_machine_variant {
         0 => {
+            let _output_sm_len = u16::consensus_decode(cursor, &decoders)?;
             let old_state = MintOutputStateMachineV1::consensus_decode(cursor, &decoders)?;
+
             MintClientStateMachines::Output(MintOutputStateMachine {
                 common: MintOutputCommon {
                     operation_id: old_state.common.operation_id,
@@ -140,6 +142,7 @@ pub(crate) fn migrate_state_to_v2(
             })
         }
         1 => {
+            let _input_sm_len = u16::consensus_decode(cursor, &decoders)?;
             let old_state = MintInputStateMachineV1::consensus_decode(cursor, &decoders)?;
 
             MintClientStateMachines::Input(MintInputStateMachine {
@@ -152,6 +155,7 @@ pub(crate) fn migrate_state_to_v2(
             })
         }
         2 => {
+            let _oob_sm_len = u16::consensus_decode(cursor, &decoders)?;
             let old_state = MintOOBStateMachineV1::consensus_decode(cursor, &decoders)?;
 
             let new_state = match old_state.state {

--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -11,9 +11,9 @@ use serde::Serialize;
 use strum_macros::EnumIter;
 
 use crate::backup::recovery::MintRecoveryState;
-use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStateMachineV1};
-use crate::oob::{MintOOBStateMachine, MintOOBStateMachineV1, MintOOBStates, MintOOBStatesV1};
-use crate::output::{MintOutputCommon, MintOutputStateMachine, MintOutputStateMachineV1};
+use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStateMachineV0};
+use crate::oob::{MintOOBStateMachine, MintOOBStateMachineV0, MintOOBStates, MintOOBStatesV0};
+use crate::output::{MintOutputCommon, MintOutputStateMachine, MintOutputStateMachineV0};
 use crate::{MintClientStateMachines, SpendableNoteUndecoded};
 
 #[repr(u8)]
@@ -117,7 +117,7 @@ pub async fn migrate_to_v1(
     Ok(None)
 }
 
-/// Migrates `MintClientStateMachinesV1`
+/// Migrates `MintClientStateMachinesV0`
 pub(crate) fn migrate_state_to_v2(
     operation_id: OperationId,
     cursor: &mut Cursor<&[u8]>,
@@ -129,7 +129,7 @@ pub(crate) fn migrate_state_to_v2(
     let new_mint_state_machine = match mint_client_state_machine_variant {
         0 => {
             let _output_sm_len = u16::consensus_decode(cursor, &decoders)?;
-            let old_state = MintOutputStateMachineV1::consensus_decode(cursor, &decoders)?;
+            let old_state = MintOutputStateMachineV0::consensus_decode(cursor, &decoders)?;
 
             MintClientStateMachines::Output(MintOutputStateMachine {
                 common: MintOutputCommon {
@@ -143,7 +143,7 @@ pub(crate) fn migrate_state_to_v2(
         }
         1 => {
             let _input_sm_len = u16::consensus_decode(cursor, &decoders)?;
-            let old_state = MintInputStateMachineV1::consensus_decode(cursor, &decoders)?;
+            let old_state = MintInputStateMachineV0::consensus_decode(cursor, &decoders)?;
 
             MintClientStateMachines::Input(MintInputStateMachine {
                 common: MintInputCommon {
@@ -156,12 +156,12 @@ pub(crate) fn migrate_state_to_v2(
         }
         2 => {
             let _oob_sm_len = u16::consensus_decode(cursor, &decoders)?;
-            let old_state = MintOOBStateMachineV1::consensus_decode(cursor, &decoders)?;
+            let old_state = MintOOBStateMachineV0::consensus_decode(cursor, &decoders)?;
 
             let new_state = match old_state.state {
-                MintOOBStatesV1::Created(created) => MintOOBStates::Created(created),
-                MintOOBStatesV1::UserRefund(refund) => MintOOBStates::UserRefund(refund),
-                MintOOBStatesV1::TimeoutRefund(refund) => MintOOBStates::TimeoutRefund(refund),
+                MintOOBStatesV0::Created(created) => MintOOBStates::Created(created),
+                MintOOBStatesV0::UserRefund(refund) => MintOOBStates::UserRefund(refund),
+                MintOOBStatesV0::TimeoutRefund(refund) => MintOOBStates::TimeoutRefund(refund),
             };
             MintClientStateMachines::OOB(MintOOBStateMachine {
                 operation_id: old_state.operation_id,

--- a/modules/fedimint-mint-client/src/input.rs
+++ b/modules/fedimint-mint-client/src/input.rs
@@ -45,7 +45,7 @@ pub enum MintInputStates {
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Decodable, Encodable)]
-pub struct MintInputCommonV1 {
+pub struct MintInputCommonV0 {
     pub(crate) operation_id: OperationId,
     pub(crate) txid: TransactionId,
     pub(crate) input_idx: u64,
@@ -59,8 +59,8 @@ pub struct MintInputCommon {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
-pub struct MintInputStateMachineV1 {
-    pub(crate) common: MintInputCommonV1,
+pub struct MintInputStateMachineV0 {
+    pub(crate) common: MintInputCommonV0,
     pub(crate) state: MintInputStates,
 }
 

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -15,7 +15,7 @@ use crate::input::{
 use crate::{MintClientContext, MintClientStateMachines, SpendableNote};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
-pub enum MintOOBStatesV1 {
+pub enum MintOOBStatesV0 {
     /// The e-cash has been taken out of the wallet and we are waiting for the
     /// recipient to reissue it or the user to trigger a refund.
     Created(MintOOBStatesCreated),
@@ -50,18 +50,18 @@ pub enum MintOOBStates {
 
     // States we want to drop eventually (that's why they are last)
     // -
-    /// Obsoleted, legacy from [`MintOOBStatesV1`], like
+    /// Obsoleted, legacy from [`MintOOBStatesV0`], like
     /// [`MintOOBStates::CreatedMulti`] but for a single note only.
     Created(MintOOBStatesCreated),
-    /// Obsoleted, legacy from [`MintOOBStatesV1`], like
+    /// Obsoleted, legacy from [`MintOOBStatesV0`], like
     /// [`MintOOBStates::UserRefundMulti`] but for single note only
     UserRefund(MintOOBStatesUserRefund),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
-pub struct MintOOBStateMachineV1 {
+pub struct MintOOBStateMachineV0 {
     pub(crate) operation_id: OperationId,
-    pub(crate) state: MintOOBStatesV1,
+    pub(crate) state: MintOOBStatesV0,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -74,7 +74,7 @@ pub enum MintOutputStates {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
-pub struct MintOutputCommonV1 {
+pub struct MintOutputCommonV0 {
     pub(crate) operation_id: OperationId,
     pub(crate) out_point: OutPoint,
 }
@@ -87,8 +87,8 @@ pub struct MintOutputCommon {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
-pub struct MintOutputStateMachineV1 {
-    pub(crate) common: MintOutputCommonV1,
+pub struct MintOutputStateMachineV0 {
+    pub(crate) common: MintOutputCommonV0,
     pub(crate) state: MintOutputStates,
 }
 


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/6338

This only fixes one failure of upgrade tests. Since `master` and `releases/v0.5` are still broken after including this fix, I haven't kicked off a run in CI, only local tests. To verify locally against these changes, first checkout the commit that introduced this failure and run upgrade tests for `fedimint-cli`

```
git checkout 8d156fd39049203fc134c2debe99e1182c3a6d60
TEST_KINDS=fedimint-cli just test-upgrades v0.4.0 current &> results.log
```

Expected failure message

```
Error: command: fedimint-cli --data-dir=/tmp/nix-shell.lh5Zqz/devimint-2050963-520/clients/reissue-client-0 deposit-address

Caused by:
    exit status: 1
    stdout:
    {
      "error": "Decoding named block MintOOBStateMachineV1 {} state"
    }
```

After applying the changes in this PR, `fedimint-cli` upgrade tests pass.

It's worth noting that I verified each variant of `MintClientStateMachines` that's included in this migration (`Output`, `Input`, and `OOB`) failed individually prior to adding the logic to parse the struct length, so I'm confident all paths are tested in the upgrade tests.