### PR TITLE
chore: replace consensus_encode() with consensus_encode_to_vec()

### DIFF
--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -648,11 +648,9 @@ impl Database {
 }
 
 fn module_instance_id_to_byte_prefix(module_instance_id: u16) -> Vec<u8> {
-    let mut prefix = vec![MODULE_GLOBAL_PREFIX];
-    module_instance_id
-        .consensus_encode(&mut prefix)
-        .expect("Error encoding module instance id as prefix");
-    prefix
+    let mut bytes = vec![MODULE_GLOBAL_PREFIX];
+    bytes.append(&mut module_instance_id.consensus_encode_to_vec());
+    bytes
 }
 
 /// A database that wraps an `inner` one and adds a prefix to all operations,
@@ -1932,8 +1930,7 @@ where
 {
     fn to_bytes(&self) -> Vec<u8> {
         let mut data = vec![<Self as DatabaseLookup>::Record::DB_PREFIX];
-        self.consensus_encode(&mut data)
-            .expect("Writing to vec is infallible");
+        data.append(&mut self.consensus_encode_to_vec());
         data
     }
 }
@@ -1973,10 +1970,7 @@ where
     }
 
     fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        self.consensus_encode(&mut bytes)
-            .expect("writing to vec can't fail");
-        bytes
+        self.consensus_encode_to_vec()
     }
 }
 

--- a/fedimint-core/src/encoding/btc.rs
+++ b/fedimint-core/src/encoding/btc.rs
@@ -73,9 +73,7 @@ impl crate::encoding::Encodable for bitcoin::Txid {
     }
 
     fn consensus_encode_to_hex(&self) -> String {
-        let mut bytes = vec![];
-        self.consensus_encode(&mut bytes)
-            .expect("encoding to bytes can't fail for io reasons");
+        let mut bytes = self.consensus_encode_to_vec();
 
         // Just Bitcoin things: transaction hashes are encoded reverse
         bytes.reverse();
@@ -290,13 +288,10 @@ mod tests {
         ];
 
         for (network, magic_legacy_bytes, magic_bytes) in networks {
-            let mut network_legacy_encoded = Vec::new();
-            NetworkLegacyEncodingWrapper(network)
-                .consensus_encode(&mut network_legacy_encoded)
-                .unwrap();
+            let network_legacy_encoded =
+                NetworkLegacyEncodingWrapper(network).consensus_encode_to_vec();
 
-            let mut network_encoded = Vec::new();
-            network.consensus_encode(&mut network_encoded).unwrap();
+            let network_encoded = network.consensus_encode_to_vec();
 
             let network_legacy_decoded = NetworkLegacyEncodingWrapper::consensus_decode(
                 &mut Cursor::new(network_legacy_encoded.clone()),
@@ -332,10 +327,7 @@ mod tests {
         for address_str in addresses {
             let address =
                 bitcoin::Address::from_str(address_str).expect("All tested addresses are valid");
-            let mut encoding = vec![];
-            address
-                .consensus_encode(&mut encoding)
-                .expect("Encoding to vec can't fail");
+            let encoding = address.consensus_encode_to_vec();
             let mut cursor = Cursor::new(encoding);
             let parsed_address =
                 bitcoin::Address::consensus_decode(&mut cursor, &ModuleDecoderRegistry::default())

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -98,13 +98,10 @@ pub trait Encodable {
 
     /// Encode and convert to hex string representation
     fn consensus_encode_to_hex(&self) -> String {
-        let mut bytes = vec![];
-        self.consensus_encode(&mut bytes)
-            .expect("encoding to bytes can't fail for io reasons");
         // TODO: This double allocation offends real Rustaceans. We should
         // be able to go straight to String, but this use case seems under-served
         // by hex encoding crates.
-        bytes.encode_hex()
+        self.consensus_encode_to_vec().encode_hex()
     }
 
     /// Encode without storing the encoding, return the size

--- a/fedimint-core/src/invite_code.rs
+++ b/fedimint-core/src/invite_code.rs
@@ -231,11 +231,7 @@ impl FromStr for InviteCode {
 /// Parses the invite code from a bech32 string
 impl Display for InviteCode {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        let mut data = vec![];
-
-        self.consensus_encode(&mut data)
-            .expect("Vec<u8> provides capacity");
-
+        let data = self.consensus_encode_to_vec();
         let encode = bech32::encode::<Bech32m>(BECH32_HRP, &data).map_err(|_| fmt::Error)?;
         formatter.write_str(&encode)
     }

--- a/fedimint-core/src/net/api_announcement.rs
+++ b/fedimint-core/src/net/api_announcement.rs
@@ -44,8 +44,7 @@ impl ApiAnnouncement {
 
     pub fn tagged_hash(&self) -> sha256::Hash {
         let mut msg = API_ANNOUNCEMENT_MESSAGE_TAG.to_vec();
-        self.consensus_encode(&mut msg)
-            .expect("writing to vec is infallible");
+        msg.append(&mut self.consensus_encode_to_vec());
         sha256::Hash::hash(&msg)
     }
 

--- a/fedimint-core/src/txoproof.rs
+++ b/fedimint-core/src/txoproof.rs
@@ -5,7 +5,7 @@ use std::io::Cursor;
 use bitcoin::block::Header as BlockHeader;
 use bitcoin::merkle_tree::PartialMerkleTree;
 use bitcoin::{BlockHash, Txid};
-use hex::{FromHex, ToHex};
+use hex::FromHex;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -80,13 +80,10 @@ impl Serialize for TxOutProof {
     where
         S: Serializer,
     {
-        let mut bytes = Vec::new();
-        self.consensus_encode(&mut bytes).unwrap();
-
         if serializer.is_human_readable() {
-            serializer.serialize_str(&bytes.encode_hex::<String>())
+            serializer.serialize_str(&self.consensus_encode_to_hex())
         } else {
-            serializer.serialize_bytes(&bytes)
+            serializer.serialize_bytes(&self.consensus_encode_to_vec())
         }
     }
 }
@@ -117,9 +114,7 @@ impl<'de> Deserialize<'de> for TxOutProof {
 // TODO: upstream
 impl Hash for TxOutProof {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let mut bytes = Vec::new();
-        self.consensus_encode(&mut bytes).unwrap();
-        state.write(&bytes);
+        state.write(&self.consensus_encode_to_vec());
     }
 }
 

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -44,10 +44,7 @@ struct SerdeWrapper(#[serde(with = "hex::serde")] Vec<u8>);
 
 impl SerdeWrapper {
     fn from_encodable<T: Encodable>(e: &T) -> SerdeWrapper {
-        let mut bytes = vec![];
-        e.consensus_encode(&mut bytes)
-            .expect("Write to vec can't fail");
-        SerdeWrapper(bytes)
+        SerdeWrapper(e.consensus_encode_to_vec())
     }
 }
 

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -230,12 +230,9 @@ fn v1_routes(gateway: Arc<Gateway>, task_group: TaskGroup) -> Router {
 /// Creates a password hash by appending a 4 byte salt to the plaintext
 /// password.
 pub fn hash_password(plaintext_password: &str, salt: [u8; 16]) -> sha256::Hash {
-    let mut bytes = Vec::<u8>::new();
-    plaintext_password
-        .consensus_encode(&mut bytes)
-        .expect("Password is encodable");
-    salt.consensus_encode(&mut bytes)
-        .expect("Salt is encodable");
+    let mut bytes = Vec::new();
+    bytes.append(&mut plaintext_password.consensus_encode_to_vec());
+    bytes.append(&mut salt.consensus_encode_to_vec());
     sha256::Hash::hash(&bytes)
 }
 

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -214,62 +214,42 @@ mod fedimint_migration_tests {
 
     fn create_client_states() -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
         // Create an active state and inactive state that will not be migrated.
-        let input_operation_id = OperationId::new_random();
-        let input_state = {
-            let mut input_state = Vec::<u8>::new();
-            Amount::from_sats(1000)
-                .consensus_encode(&mut input_state)
-                .expect("Amount is encodable");
-            TransactionId::from_slice(&BYTE_32)
-                .expect("Couldn't create TransactionId")
-                .consensus_encode(&mut input_state)
-                .expect("TransactionId is encodable");
-            input_operation_id
-                .consensus_encode(&mut input_state)
-                .expect("OperationId is encodable");
-            input_state
+        let input_state: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut Amount::from_sats(1000).consensus_encode_to_vec());
+            bytes.append(
+                &mut TransactionId::from_slice(&BYTE_32)
+                    .expect("Couldn't create TransactionId")
+                    .consensus_encode_to_vec(),
+            );
+            bytes.append(&mut OperationId::new_random().consensus_encode_to_vec());
+            bytes
         };
 
-        let input_variant = {
-            let mut input_variant = Vec::<u8>::new();
-            TEST_MODULE_INSTANCE_ID
-                .consensus_encode(&mut input_variant)
-                .expect("u16 is encodable");
-            0u64.consensus_encode(&mut input_variant)
-                .expect("u64 is encodable"); // Input variant
-            input_state
-                .consensus_encode(&mut input_variant)
-                .expect("input state is encodable");
-            input_variant
+        let input_variant: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut TEST_MODULE_INSTANCE_ID.consensus_encode_to_vec());
+            bytes.append(&mut 0u64.consensus_encode_to_vec()); // Input variant.
+            bytes.append(&mut input_state.consensus_encode_to_vec());
+            bytes
         };
 
         // Create and active state and inactive state that will be migrated.
         let unreachable_operation_id = OperationId::new_random();
-        let unreachable_state = {
-            let mut unreachable = Vec::<u8>::new();
-            unreachable_operation_id
-                .consensus_encode(&mut unreachable)
-                .expect("OperationId is encodable");
-            TransactionId::all_zeros()
-                .consensus_encode(&mut unreachable)
-                .expect("Amount is encodable");
-            Amount::from_sats(1000)
-                .consensus_encode(&mut unreachable)
-                .expect("Amount is encodable");
-            unreachable
+        let unreachable_state: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut unreachable_operation_id.consensus_encode_to_vec());
+            bytes.append(&mut TransactionId::all_zeros().consensus_encode_to_vec());
+            bytes.append(&mut Amount::from_sats(1000).consensus_encode_to_vec());
+            bytes
         };
 
-        let unreachable_variant = {
-            let mut unreachable = Vec::<u8>::new();
-            TEST_MODULE_INSTANCE_ID
-                .consensus_encode(&mut unreachable)
-                .expect("u16 is encodable");
-            5u64.consensus_encode(&mut unreachable)
-                .expect("u64 is encodable"); // Unreachable variant
-            unreachable_state
-                .consensus_encode(&mut unreachable)
-                .expect("unreachable state is encodable");
-            unreachable
+        let unreachable_variant: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut TEST_MODULE_INSTANCE_ID.consensus_encode_to_vec());
+            bytes.append(&mut 5u64.consensus_encode_to_vec()); // Unreachable variant
+            bytes.append(&mut unreachable_state.consensus_encode_to_vec());
+            bytes
         };
 
         (

--- a/modules/fedimint-ln-client/src/db.rs
+++ b/modules/fedimint-ln-client/src/db.rs
@@ -292,44 +292,28 @@ mod tests {
         let operation_id = OperationId::new_random();
         let txid = TransactionId::from_byte_array([42; 32]);
 
-        let submitted_offer_variant_old = {
-            let mut submitted_offer_variant = Vec::<u8>::new();
-            txid.consensus_encode(&mut submitted_offer_variant)
-                .expect("TransactionId is encodable");
-            dummy_invoice
-                .consensus_encode(&mut submitted_offer_variant)
-                .expect("Invoice is encodable");
-            claim_key
-                .consensus_encode(&mut submitted_offer_variant)
-                .expect("Keypair is encodable");
-
-            submitted_offer_variant
+        let submitted_offer_variant_old: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut txid.consensus_encode_to_vec());
+            bytes.append(&mut dummy_invoice.consensus_encode_to_vec());
+            bytes.append(&mut claim_key.consensus_encode_to_vec());
+            bytes
         };
 
-        let receive_variant = {
-            let mut receive_variant = Vec::<u8>::new();
-            operation_id
-                .consensus_encode(&mut receive_variant)
-                .expect("OperationId is encodable");
-            0u64.consensus_encode(&mut receive_variant)
-                .expect("u64 is encodable"); // Submitted Invoice variant
-            submitted_offer_variant_old
-                .consensus_encode(&mut receive_variant)
-                .expect("State is encodable");
-            receive_variant
+        let receive_variant: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut operation_id.consensus_encode_to_vec());
+            bytes.append(&mut 0u64.consensus_encode_to_vec()); // Submitted Invoice variant.
+            bytes.append(&mut submitted_offer_variant_old.consensus_encode_to_vec());
+            bytes
         };
 
-        let old_state = {
-            let mut sm_bytes = Vec::<u8>::new();
-            instance_id
-                .consensus_encode(&mut sm_bytes)
-                .expect("u16 is encodable");
-            2u64.consensus_encode(&mut sm_bytes)
-                .expect("u64 is encodable"); // Receive state machine variant
-            receive_variant
-                .consensus_encode(&mut sm_bytes)
-                .expect("receive variant is encodable");
-            sm_bytes
+        let old_state: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut instance_id.consensus_encode_to_vec());
+            bytes.append(&mut 2u64.consensus_encode_to_vec()); // Receive state machine variant.
+            bytes.append(&mut receive_variant.consensus_encode_to_vec());
+            bytes
         };
 
         let old_states = vec![(old_state, operation_id)];
@@ -373,27 +357,27 @@ mod tests {
         yysgqddrv0jqhyf3q6z75rt7nrwx0crxme87s8rx2rt8xr9slzu0p3xg3f3f0zmqavtmsnqaj5v0y5mdzszah7thrmg\
         2we42dvjggjkf44egqheymyw",).expect("Invalid invoice");
 
-        let confirmed_variant = {
-            let mut confirmed_variant = Vec::<u8>::new();
-            dummy_invoice.consensus_encode(&mut confirmed_variant)?;
-            claim_key.consensus_encode(&mut confirmed_variant)?;
-            confirmed_variant
+        let confirmed_variant: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut dummy_invoice.consensus_encode_to_vec());
+            bytes.append(&mut claim_key.consensus_encode_to_vec());
+            bytes
         };
 
-        let receive_variant = {
-            let mut receive_variant = Vec::<u8>::new();
-            operation_id.consensus_encode(&mut receive_variant)?;
-            2u64.consensus_encode(&mut receive_variant)?; // Enum variant confirmed invoice
-            confirmed_variant.consensus_encode(&mut receive_variant)?;
-            receive_variant
+        let receive_variant: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut operation_id.consensus_encode_to_vec());
+            bytes.append(&mut 2u64.consensus_encode_to_vec()); // Enum variant confirmed invoice.
+            bytes.append(&mut confirmed_variant.consensus_encode_to_vec());
+            bytes
         };
 
-        let old_sm_bytes = {
-            let mut sm_bytes_old = Vec::<u8>::new();
-            instance_id.consensus_encode(&mut sm_bytes_old)?;
-            2u64.consensus_encode(&mut sm_bytes_old)?; // Enum variant Receive
-            receive_variant.consensus_encode(&mut sm_bytes_old)?;
-            sm_bytes_old
+        let old_sm_bytes: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut instance_id.consensus_encode_to_vec());
+            bytes.append(&mut 2u64.consensus_encode_to_vec()); // Enum variant Receive.
+            bytes.append(&mut receive_variant.consensus_encode_to_vec());
+            bytes
         };
 
         let old_states = vec![(old_sm_bytes, operation_id)];
@@ -440,44 +424,28 @@ mod tests {
         let operation_id = OperationId::new_random();
         let txid = TransactionId::from_byte_array([42; 32]);
 
-        let submitted_offer_variant_deleted = {
-            let mut submitted_offer_variant = Vec::<u8>::new();
-            txid.consensus_encode(&mut submitted_offer_variant)
-                .expect("TransactionId is encodable");
-            dummy_invoice
-                .consensus_encode(&mut submitted_offer_variant)
-                .expect("Invoice is encodable");
-            ReceivingKey::Personal(claim_key)
-                .consensus_encode(&mut submitted_offer_variant)
-                .expect("Keypair is encodable");
-
-            submitted_offer_variant
+        let submitted_offer_variant_deleted: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut txid.consensus_encode_to_vec());
+            bytes.append(&mut dummy_invoice.consensus_encode_to_vec());
+            bytes.append(&mut ReceivingKey::Personal(claim_key).consensus_encode_to_vec());
+            bytes
         };
 
-        let receive_variant = {
-            let mut receive_variant = Vec::<u8>::new();
-            operation_id
-                .consensus_encode(&mut receive_variant)
-                .expect("OperationId is encodable");
-            5u64.consensus_encode(&mut receive_variant)
-                .expect("u64 is encodable"); // Deleted Submitted Invoice variant
-            submitted_offer_variant_deleted
-                .consensus_encode(&mut receive_variant)
-                .expect("State is encodable");
-            receive_variant
+        let receive_variant: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut operation_id.consensus_encode_to_vec());
+            bytes.append(&mut 5u64.consensus_encode_to_vec()); // Deleted Submitted Invoice variant.
+            bytes.append(&mut submitted_offer_variant_deleted.consensus_encode_to_vec());
+            bytes
         };
 
-        let old_state = {
-            let mut sm_bytes = Vec::<u8>::new();
-            instance_id
-                .consensus_encode(&mut sm_bytes)
-                .expect("u16 is encodable");
-            2u64.consensus_encode(&mut sm_bytes)
-                .expect("u64 is encodable"); // Receive state machine variant
-            receive_variant
-                .consensus_encode(&mut sm_bytes)
-                .expect("receive variant is encodable");
-            sm_bytes
+        let old_state: Vec<u8> = {
+            let mut bytes = Vec::new();
+            bytes.append(&mut instance_id.consensus_encode_to_vec());
+            bytes.append(&mut 2u64.consensus_encode_to_vec()); // Receive state machine variant.
+            bytes.append(&mut receive_variant.consensus_encode_to_vec());
+            bytes
         };
 
         let old_states = vec![(old_state, operation_id)];

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -355,8 +355,7 @@ impl Display for OOBNotes {
     /// For URL-safe base64 as alternative display use:
     /// `format!("{:#}", oob_notes)`
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut bytes = Vec::new();
-        Encodable::consensus_encode(self, &mut bytes).expect("encodes correctly");
+        let bytes = Encodable::consensus_encode_to_vec(self);
 
         if f.alternate() {
             f.write_str(&BASE64_URL_SAFE.encode(&bytes))

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -76,7 +76,6 @@ use fedimint_wallet_common::{
     Rbf, WalletInputError, WalletOutputError, WalletOutputV0, MODULE_CONSENSUS_VERSION,
 };
 use futures::{FutureExt, StreamExt};
-use hex::ToHex;
 use metrics::{
     WALLET_INOUT_FEES_SATS, WALLET_INOUT_SATS, WALLET_PEGIN_FEES_SATS, WALLET_PEGIN_SATS,
     WALLET_PEGOUT_FEES_SATS, WALLET_PEGOUT_SATS,
@@ -1860,13 +1859,10 @@ impl Serialize for PendingTransaction {
     where
         S: serde::Serializer,
     {
-        let mut bytes = Vec::new();
-        self.consensus_encode(&mut bytes).unwrap();
-
         if serializer.is_human_readable() {
-            serializer.serialize_str(&bytes.encode_hex::<String>())
+            serializer.serialize_str(&self.consensus_encode_to_hex())
         } else {
-            serializer.serialize_bytes(&bytes)
+            serializer.serialize_bytes(&self.consensus_encode_to_vec())
         }
     }
 }
@@ -1890,13 +1886,10 @@ impl Serialize for UnsignedTransaction {
     where
         S: serde::Serializer,
     {
-        let mut bytes = Vec::new();
-        self.consensus_encode(&mut bytes).unwrap();
-
         if serializer.is_human_readable() {
-            serializer.serialize_str(&bytes.encode_hex::<String>())
+            serializer.serialize_str(&self.consensus_encode_to_hex())
         } else {
-            serializer.serialize_bytes(&bytes)
+            serializer.serialize_bytes(&self.consensus_encode_to_vec())
         }
     }
 }


### PR DESCRIPTION
[`fedimint-core::Encodable::consensus_encode()`](https://github.com/fedimint/fedimint/blob/02bf690a8bb198d678b98e31112260185ea1b211/fedimint-core/src/encoding/mod.rs#L85-L89) returns a `Result<usize, std::io::Error>` because [`std::io::Write::write()`](https://doc.rust-lang.org/nightly/std/io/trait.Write.html#tymethod.write) returns the same type. However, since the implementation of `std::io::Write::write()` for `Vec<u8>` [never returns an error](https://doc.rust-lang.org/src/std/io/impls.rs.html#409-413), we have a helper function [`fedimint-core::Encodable::consensus_encode_to_vec()`](https://github.com/fedimint/fedimint/blob/02bf690a8bb198d678b98e31112260185ea1b211/fedimint-core/src/encoding/mod.rs#L91-L97) which safely unwraps the value. In this PR, we replace calls to `fedimint-core::Encodable::consensus_encode()` with `fedimint-core::Encodable::consensus_encode_to_vec()` in places where we're writing to a `Vec<u8>`. This makes code more concise and removes a lot of `.expect()`s and `?` operators that will never error.