### PR TITLE
[Backport releases/v0.5] fix: outputs might be empoty due to fees

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1101,8 +1101,6 @@ impl MintClientModule {
             })]
         });
 
-        assert!(!outputs.is_empty());
-
         ClientOutputBundle::new(
             outputs,
             vec![ClientOutputSM {


### PR DESCRIPTION
# Description
Backport of #6377 to `releases/v0.5`.