### PR TITLE
Allow overpayment of fees

### DIFF
--- a/fedimint-core/src/module/version.rs
+++ b/fedimint-core/src/module/version.rs
@@ -68,7 +68,9 @@ use crate::encoding::{Decodable, Encodable};
 ///
 /// See [`ModuleConsensusVersion`] for more details on how it interacts with
 /// module's consensus.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Encodable, Decodable, PartialEq, Eq)]
+#[derive(
+    Debug, Copy, Clone, PartialOrd, Ord, Serialize, Deserialize, Encodable, Decodable, PartialEq, Eq,
+)]
 pub struct CoreConsensusVersion {
     pub major: u32,
     pub minor: u32,
@@ -81,7 +83,7 @@ impl CoreConsensusVersion {
 }
 
 /// Globally declared core consensus version
-pub const CORE_CONSENSUS_VERSION: CoreConsensusVersion = CoreConsensusVersion::new(2, 0);
+pub const CORE_CONSENSUS_VERSION: CoreConsensusVersion = CoreConsensusVersion::new(2, 1);
 
 /// Consensus version of a specific module instance
 ///

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -122,7 +122,13 @@ impl ConsensusApi {
         // We ignore any writes, as we only verify if the transaction is valid here
         dbtx.ignore_uncommitted();
 
-        process_transaction_with_dbtx(self.modules.clone(), &mut dbtx, &transaction).await?;
+        process_transaction_with_dbtx(
+            self.modules.clone(),
+            &mut dbtx,
+            &transaction,
+            self.cfg.consensus.version,
+        )
+        .await?;
 
         self.submission_sender
             .send(ConsensusItem::Transaction(transaction))

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -757,9 +757,14 @@ impl ConsensusEngine {
                     .map(DynOutput::module_instance_id)
                     .collect::<Vec<_>>();
 
-                process_transaction_with_dbtx(self.modules.clone(), dbtx, &transaction)
-                    .await
-                    .map_err(|error| anyhow!(error.to_string()))?;
+                process_transaction_with_dbtx(
+                    self.modules.clone(),
+                    dbtx,
+                    &transaction,
+                    self.cfg.consensus.version,
+                )
+                .await
+                .map_err(|error| anyhow!(error.to_string()))?;
 
                 debug!(target: LOG_CONSENSUS, %txid,  "Transaction accepted");
                 dbtx.insert_entry(&AcceptedTransactionKey(txid), &modules_ids)

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -35,7 +35,11 @@ fn fixtures() -> Fixtures {
         MintClientInit,
         MintInit,
         MintGenParams {
-            consensus: MintGenParamsConsensus::new(2, FeeConsensus::zero()),
+            consensus: MintGenParamsConsensus::new(
+                2,
+                FeeConsensus::new(1_000).expect("Relative fee is within range"),
+            ),
+
             local: EmptyGenParams {},
         },
     );
@@ -149,19 +153,14 @@ async fn blind_nonce_index() -> anyhow::Result<()> {
     let mut dbtx = client_mint.db.begin_transaction().await;
     let operation_id = OperationId::new_random();
     let issuance_req = client_mint
-        .create_output(
-            &mut dbtx.to_ref_nc(),
-            operation_id,
-            1,
-            Amount::from_msats(1),
-        )
+        .create_output(&mut dbtx.to_ref_nc(), operation_id, 1, Amount::from_sats(1))
         .await;
     dbtx.commit_tx().await;
 
     let blind_nonce = issuance_req
         .outputs()
         .first()
-        .expect("There should be exactly one note in here")
+        .expect("There should be at least one note in here")
         .output
         .ensure_v0_ref()?
         .blind_nonce;


### PR DESCRIPTION
The 0.5.0 mint  client supports non-zero absolute and relative fees for inputs and outputs if it is allowed to slightly overfund transactions. Since only new federations can set non-zero fees anyways it is sufficient to only enable this in new deployments.


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
