### PR TITLE
[Backport releases/v0.5] chore: switch to using jemalloc on all major binaries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.13.0",
+ "jemallocator",
  "lightning-invoice",
  "rand",
  "serde",
@@ -2654,6 +2655,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "jemallocator",
  "ldk-node",
  "lightning",
  "lightning-invoice",
@@ -3473,6 +3475,7 @@ dependencies = [
  "fedimint-unknown-server",
  "fedimint-wallet-server",
  "futures",
+ "jemallocator",
  "serde_json",
  "tokio",
  "tracing",
@@ -4645,6 +4648,26 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.5.0-rc.0"
 thiserror = "1.0.68"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tokio = "1.41.1"
+jemallocator = "0.5"
 tokio-rustls = "0.24.1"
 tokio-stream = "0.1.16"
 tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -56,3 +56,6 @@ tracing = { workspace = true }
 
 [build-dependencies]
 fedimint-build = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { workspace = true }

--- a/fedimint-cli/src/main.rs
+++ b/fedimint-cli/src/main.rs
@@ -1,5 +1,12 @@
 use fedimint_cli::FedimintCli;
 use fedimint_core::fedimint_build_code_version_env;
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+// rocksdb suffers from memory fragmentation when using standard allocator
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -49,3 +49,6 @@ tracing = { workspace = true }
 
 [build-dependencies]
 fedimint-build = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { workspace = true }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,5 +1,12 @@
 use fedimint_core::fedimint_build_code_version_env;
 use fedimintd::Fedimintd;
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+// rocksdb suffers from memory fragmentation when using standard allocator
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -89,3 +89,6 @@ fedimint-unknown-server = { workspace = true }
 
 [build-dependencies]
 fedimint-build = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { workspace = true }

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -12,8 +12,15 @@ use fedimint_core::fedimint_build_code_version_env;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::util::handle_version_hash_command;
 use fedimint_logging::TracingSetup;
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
 use ln_gateway::Gateway;
 use tracing::info;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+// rocksdb suffers from memory fragmentation when using standard allocator
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {


### PR DESCRIPTION
# Description
Backport of #6357 to `releases/v0.5`.