### PR TITLE
fix: flaky latency test due to low arbitrary limits

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -124,7 +124,7 @@ pub async fn latency_tests(
     } = dev_fed;
 
     let max_p90_factor = 5.0;
-    let p90_median_factor = 7;
+    let p90_median_factor = 10;
 
     let client = match upgrade_clients {
         Some(c) => match r#type {


### PR DESCRIPTION
Locally I'm running test suite in a loop with `cpulimit`, trying to trigger and debug any flakiness, and this is one of the few things I'm still able to hit.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
