### PR TITLE
chore: require saturating or checked subtraction for Amount

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -248,7 +248,7 @@ pub async fn handle_command(
                     )
                     .await?;
 
-                let overspend_amount = notes.total_amount() - amount;
+                let overspend_amount = notes.total_amount().saturating_sub(amount);
                 if overspend_amount != Amount::ZERO {
                     warn!(
                         "Selected notes {} worth more than requested",

--- a/fedimint-core/src/amount.rs
+++ b/fedimint-core/src/amount.rs
@@ -198,16 +198,6 @@ impl std::iter::Sum for Amount {
     }
 }
 
-impl std::ops::Sub for Amount {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self {
-            msats: self.msats - rhs.msats,
-        }
-    }
-}
-
 impl FromStr for Amount {
     type Err = ParseAmountError;
 

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -557,7 +557,7 @@ async fn get_required_notes(
 ) -> anyhow::Result<()> {
     let current_balance = coordinator.get_balance().await;
     if current_balance < minimum_amount_required {
-        let diff = minimum_amount_required - current_balance;
+        let diff = minimum_amount_required.saturating_sub(current_balance);
         info!("Current balance {current_balance} on coordinator not enough, trying to get {diff} more through fedimint-cli");
         match try_get_notes_cli(&diff, 5).await {
             Ok(notes) => {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1512,7 +1512,7 @@ impl Gateway {
                 )
                 .await?;
 
-            let overspend_amount = notes.total_amount() - payload.amount;
+            let overspend_amount = notes.total_amount().saturating_sub(payload.amount);
             if overspend_amount != Amount::ZERO {
                 warn!(
                     "Selected notes {} worth more than requested",

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -412,11 +412,12 @@ impl GatewayPayInvoice {
         debug!("Buying preimage over lightning for contract {contract:?}");
 
         let max_delay = buy_preimage.max_delay;
-        let max_fee = buy_preimage.max_send_amount
-            - buy_preimage
+        let max_fee = buy_preimage.max_send_amount.saturating_sub(
+            buy_preimage
                 .payment_data
                 .amount()
-                .expect("We already checked that an amount was supplied");
+                .expect("We already checked that an amount was supplied"),
+        );
 
         let Ok(lightning_context) = context.gateway.get_lightning_context().await else {
             return Self::gateway_pay_cancel_contract(

--- a/gateway/ln-gateway/tests/tests.rs
+++ b/gateway/ln-gateway/tests/tests.rs
@@ -531,7 +531,7 @@ async fn test_gateway_client_intercept_valid_htlc() -> anyhow::Result<()> {
             GatewayExtReceiveStates::Preimage { .. }
         );
         assert_eq!(
-            initial_gateway_balance - invoice_amount,
+            initial_gateway_balance.saturating_sub(invoice_amount),
             gateway_client.get_balance().await
         );
 

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -113,7 +113,7 @@ impl ClientModule for DummyClientModule {
 
         match input_amount.cmp(&output_amount) {
             Ordering::Less => {
-                let missing_input_amount = output_amount - input_amount;
+                let missing_input_amount = output_amount.saturating_sub(input_amount);
 
                 // Check and subtract from our funds
                 let our_funds = get_funds(dbtx).await;
@@ -122,7 +122,7 @@ impl ClientModule for DummyClientModule {
                     return Err(format_err!("Insufficient funds"));
                 }
 
-                let updated = our_funds - missing_input_amount;
+                let updated = our_funds.saturating_sub(missing_input_amount);
 
                 dbtx.insert_entry(&DummyClientFundsKeyV1, &updated).await;
 
@@ -154,7 +154,7 @@ impl ClientModule for DummyClientModule {
                 ClientOutputBundle::new(vec![], vec![]),
             )),
             Ordering::Greater => {
-                let missing_output_amount = input_amount - output_amount;
+                let missing_output_amount = input_amount.saturating_sub(output_amount);
                 let output = ClientOutput {
                     output: DummyOutput {
                         amount: missing_output_amount,

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -245,7 +245,7 @@ impl ServerModule for Dummy {
             // The printer is broken
             current_funds
         } else {
-            current_funds - input.amount
+            current_funds.saturating_sub(input.amount)
         };
 
         dbtx.insert_entry(&DummyFundsKeyV1(input.account), &updated_funds)

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -90,12 +90,9 @@ impl SendOperationMeta {
     /// Calculate the absolute fee paid to the gateway on success.
     pub fn gateway_fee(&self) -> Amount {
         match &self.invoice {
-            LightningInvoice::Bolt11(invoice) => {
-                self.contract.amount
-                    - Amount::from_msats(
-                        invoice.amount_milli_satoshis().expect("Invoice has amount"),
-                    )
-            }
+            LightningInvoice::Bolt11(invoice) => self.contract.amount.saturating_sub(
+                Amount::from_msats(invoice.amount_milli_satoshis().expect("Invoice has amount")),
+            ),
         }
     }
 }
@@ -114,7 +111,7 @@ impl ReceiveOperationMeta {
         match &self.invoice {
             LightningInvoice::Bolt11(invoice) => {
                 Amount::from_msats(invoice.amount_milli_satoshis().expect("Invoice has amount"))
-                    - self.contract.commitment.amount
+                    .saturating_sub(self.contract.commitment.amount)
             }
         }
     }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -784,7 +784,12 @@ impl ClientModule for MintClientModule {
             .sum();
 
         let outputs = self
-            .create_output(dbtx, operation_id, 2, input_amount - output_amount)
+            .create_output(
+                dbtx,
+                operation_id,
+                2,
+                input_amount.saturating_sub(output_amount),
+            )
             .await;
 
         Ok((
@@ -2039,7 +2044,7 @@ async fn select_notes_from_stream<Note>(
                 return Ok(notes);
             }
 
-            let total_amount = requested_amount - pending_amount;
+            let total_amount = requested_amount.saturating_sub(pending_amount);
             // not enough notes, return
             return Err(InsufficientBalanceError {
                 requested_amount,


### PR DESCRIPTION
Remove implementation of `std::ops::Sub` for `Amount`, requiring the usage of `Amount::saturating_sub()` or `Amount::checked_sub()` instead