### PR TITLE
feat(db): find_by_range_sorted_descending

### DIFF
--- a/fedimint-core/src/db/mem_impl.rs
+++ b/fedimint-core/src/db/mem_impl.rs
@@ -9,7 +9,8 @@ use imbl::OrdMap;
 use macro_rules_attribute::apply;
 
 use super::{
-    IDatabaseTransactionOps, IDatabaseTransactionOpsCore, IRawDatabase, IRawDatabaseTransaction,
+    next_prefix, IDatabaseTransactionOps, IDatabaseTransactionOpsCore, IRawDatabase,
+    IRawDatabaseTransaction,
 };
 use crate::async_trait_maybe_send;
 use crate::db::PrefixStream;
@@ -189,6 +190,26 @@ impl<'a> IDatabaseTransactionOpsCore for MemTransaction<'a> {
             })
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect::<Vec<_>>();
+        Ok(Box::pin(stream::iter(data)))
+    }
+
+    async fn raw_find_by_range_sorted_descending(
+        &mut self,
+        range: Range<&[u8]>,
+    ) -> Result<PrefixStream<'_>> {
+        let Some(start) = next_prefix(range.start) else {
+            // End of range, just return empty stream
+            return Ok(Box::pin(stream::iter(vec![])));
+        };
+        let data = if let Some(end) = next_prefix(range.end) {
+            self.tx_data.range(Range { start, end })
+        } else {
+            self.tx_data.range(start..)
+        };
+        let mut data = data
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Vec<_>>();
+        data.sort_by(|a, b| a.cmp(b).reverse());
         Ok(Box::pin(stream::iter(data)))
     }
 }


### PR DESCRIPTION
For https://github.com/fedimint/fedimint/pull/6351, I want to expose a "pagination API" that allows the client to query for the last N most recent transactions from the payment log (or N through 2N, 2N through 3N, and so on).

This is difficult to do with the current client log API, mainly because it uses `find_by_range` which iterates through records in the forward direction.  This PR adds the corollary function: `find_by_range_sorted_descending`, which allows us to iterate through records within a range in the backwards direction.

I know with `find_by_prefix_sorted_descending` there were some performance problems, and they are likely shared here too. When there's an option it is better to always use `find_by_range`, but I think for certain uses this API is still useful.

