### PR TITLE
fix(ci): flaky esplora port allocation

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -1195,6 +1195,7 @@ impl Esplora {
 
         let btc_rpc_port = process_mgr.globals.FM_PORT_BTC_RPC;
         let esplora_port = process_mgr.globals.FM_PORT_ESPLORA;
+        let esplora_monitoring_port = process_mgr.globals.FM_PORT_ESPLORA_MONITORING;
         // spawn esplora
         let cmd = cmd!(
             crate::util::Esplora,
@@ -1204,7 +1205,7 @@ impl Esplora {
             "--network=regtest",
             "--daemon-rpc-addr=127.0.0.1:{btc_rpc_port}",
             "--http-addr=127.0.0.1:{esplora_port}",
-            "--monitoring-addr=127.0.0.1:0",
+            "--monitoring-addr=127.0.0.1:{esplora_monitoring_port}",
             "--jsonrpc-import", // Workaround for incompatible on-disk format
         );
         let process = process_mgr.spawn_daemon("esplora", cmd).await?;

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -139,6 +139,7 @@ declare_vars! {
         FM_PORT_ELECTRS: u16 = port_alloc(1)?; env: "FM_PORT_ELECTRS";
         FM_PORT_ELECTRS_MONITORING: u16 = port_alloc(1)?; env: "FM_PORT_ELECTRS_MONITORING";
         FM_PORT_ESPLORA: u16 = port_alloc(1)?; env: "FM_PORT_ESPLORA";
+        FM_PORT_ESPLORA_MONITORING: u16 = port_alloc(1)?; env: "FM_PORT_ESPLORA_MONITORING";
         // 3 = p2p + api + metrics env: "// ";
         FM_PORT_FEDIMINTD_BASE: u16 = port_alloc((3 * fed_size).try_into().unwrap())?; env: "FM_PORT_FEDIMINTD_BASE";
         FM_PORT_GW_CLN: u16 = port_alloc(1)?; env: "FM_PORT_GW_CLN";


### PR DESCRIPTION
`:0` is not a safe way to allocate any ports.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
