### PR TITLE
fix(ci): devimint initialization flake

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -679,9 +679,19 @@ in
       packages = [ "fedimint-client-wasm" ];
     };
 
-    devimint = fedimintBuildPackageGroup {
+    devimint-pkgs = fedimintBuildPackageGroup {
       pname = "devimint";
       packages = [ "devimint" ];
+    };
+
+    devimint = flakeboxLib.pickBinary {
+      pkg = devimint-pkgs;
+      bin = "devimint";
+    };
+
+    devimint-faucet = flakeboxLib.pickBinary {
+      pkg = devimint-pkgs;
+      bin = "devimint-faucet";
     };
 
     fedimint-load-test-tool = fedimintBuildPackageGroup {


### PR DESCRIPTION
Block height can be null here apparently.

```
00:00:04 2024-11-19T22:50:56.566417Z  INFO fm::devimint: Devimint data dir path=/tmp/gateway_restore_test-WmPp/devimint-2727858-976
00:00:04 2024-11-19T22:50:56.713974Z  INFO devimint::tests: fedimint_cli_version="fedimint-cli 0.6.0-alpha"
00:00:04 2024-11-19T22:50:56.724145Z  INFO devimint::tests: fedimint_cli_version_hash="7147143b3e5c9425000000001e92942661eb6476"
00:00:04 2024-11-19T22:50:56.904345Z  INFO devimint::tests: gateway_cli_version="fedimint-gateway-cli 0.6.0-alpha"
00:00:05 2024-11-19T22:50:57.043152Z  INFO devimint::tests: gateway_cli_version_hash="7147143b3e5c9425000000001e92942661eb6476"
00:00:05 2024-11-19T22:50:57.204232Z  INFO devimint::tests: fedimintd_version_hash="7147143b3e5c9425000000001e92942661eb6476"
00:00:05 2024-11-19T22:50:57.226494Z  INFO devimint::tests: gatewayd_version_hash="7147143b3e5c9425000000001e92942661eb6476"
00:00:25 2024-11-19T22:51:17.498045Z  INFO fm::devimint: DKG completed
00:00:39 thread 'tokio-runtime-worker' panicked at devimint/src/gatewayd.rs:506:60:
00:00:39 Could not parse block height: Error("invalid type: null, expected u32", line: 0, column: 0)
00:00:39 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
00:01:01 2024-11-19T22:51:53.369233Z  INFO fm::devimint: Consensus running
00:01:02 2024-11-19T22:51:54.204659Z  INFO devimint::federation: federation is degraded fed_size=4 offline_nodes=1
00:01:04 2024-11-19T22:51:56.097634Z  WARN fm::task: Jit value panicked err=task 58 panicked with message "Could not parse block height: Error(\"invalid type: null, expected u32\", line: 0, column: 0)" ty
pe_name=alloc::sync::Arc<()>
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
