### PR TITLE
fix: correctly get invite-code on load-test-tool

### DIFF
--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -14,7 +14,7 @@ use fedimint_core::db::Database;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::CommonModuleInit;
-use fedimint_core::{secp256k1, Amount, OutPoint, TieredCounts};
+use fedimint_core::{secp256k1, Amount, OutPoint, PeerId, TieredCounts};
 use fedimint_ln_client::{
     LightningClientInit, LightningClientModule, LnPayState, OutgoingLightningPayment,
 };
@@ -31,8 +31,8 @@ use tracing::log::warn;
 
 use crate::MetricEvent;
 
-pub async fn get_invite_code_cli() -> anyhow::Result<InviteCode> {
-    cmd!(FedimintCli, "invite-code").out_json().await?["invite_code"]
+pub async fn get_invite_code_cli(peer: PeerId) -> anyhow::Result<InviteCode> {
+    cmd!(FedimintCli, "invite-code", peer).out_json().await?["invite_code"]
         .as_str()
         .map(InviteCode::from_str)
         .transpose()?

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -407,7 +407,7 @@ async fn invite_code_or_fallback(invite_code: Option<InviteCode>) -> Option<Invi
         Some(invite_code)
     } else {
         // Try to get an invite code through cli in a best effort basis
-        match get_invite_code_cli().await {
+        match get_invite_code_cli(0.into()).await {
             Ok(invite_code) => Some(invite_code),
             Err(e) => {
                 info!("No invite code provided and failed to get one with '{e}' error, will try to proceed without one...");


### PR DESCRIPTION
If no invite code is given to the load test tool, then it tries to get one from the command-line in a best-effort basis. It was broken because we don't have tests for it (and not sure if we need, it's not a critical feature).