### PR TITLE
[Backport releases/v0.5] fix(ci): some bundlers we use expect a missing `pname`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -216,6 +216,9 @@
             inherit system;
             inherit name;
 
+            # some bundlers want `pname` here, instead of `name`
+            pname = name;
+
             dontUnpack = true;
             dontStrip = !pkgs.stdenv.isDarwin;
 


### PR DESCRIPTION
# Description
Backport of #6407 to `releases/v0.5`.