### PR TITLE
[Backport releases/v0.5] fix(ci): missing `devimint-faucet` output

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -679,9 +679,19 @@ in
       packages = [ "fedimint-client-wasm" ];
     };
 
-    devimint = fedimintBuildPackageGroup {
+    devimint-pkgs = fedimintBuildPackageGroup {
       pname = "devimint";
       packages = [ "devimint" ];
+    };
+
+    devimint = flakeboxLib.pickBinary {
+      pkg = devimint-pkgs;
+      bin = "devimint";
+    };
+
+    devimint-faucet = flakeboxLib.pickBinary {
+      pkg = devimint-pkgs;
+      bin = "devimint-faucet";
     };
 
     fedimint-load-test-tool = fedimintBuildPackageGroup {


### PR DESCRIPTION
# Description
Backport of #6409 to `releases/v0.5`.