### PR TITLE
[Backport releases/v0.5] fix(ci): update flakebox to fix pname bundler issue again

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,17 +432,17 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1727478500,
-        "narHash": "sha256-nrDYdwIAI1nskNEE/r9rhDJDaouZ4tpSyURfndRsPho=",
+        "lastModified": 1732069381,
+        "narHash": "sha256-VxcRudAk01/4gj4o/xg7ByteA1qiUVU1HTvX10XO0vM=",
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "ee39d59b2c3779e5827f8fa2d269610c556c04c8",
+        "rev": "171f3a1d83652d9db33992322f8793326a3b4df3",
         "type": "github"
       },
       "original": {
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "ee39d59b2c3779e5827f8fa2d269610c556c04c8",
+        "rev": "171f3a1d83652d9db33992322f8793326a3b4df3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flakebox = {
-      url = "github:dpc/flakebox?rev=ee39d59b2c3779e5827f8fa2d269610c556c04c8";
+      url = "github:dpc/flakebox?rev=171f3a1d83652d9db33992322f8793326a3b4df3";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.fenix.follows = "fenix";
     };


### PR DESCRIPTION
# Description
Backport of #6411 to `releases/v0.5`.