### PR TITLE
fix: deactivate cross compile dev shell for aarch64-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -388,22 +388,6 @@
 
             lint = flakeboxLib.mkLintShell { nativeBuildInputs = [ pkgs.cargo-sort ]; };
 
-            # Shell with extra stuff to support cross-compilation with `cargo build --target <target>`
-            #
-            # This will pull extra stuff so to save time and download time to most common developers,
-            # was moved into another shell.
-            cross = flakeboxLib.mkDevShell (
-              commonShellArgs
-              // craneMultiBuild.commonEnvsCrossShell
-              // {
-                toolchain = toolchainAll;
-                shellHook = ''
-                  export REPO_ROOT="$(git rev-parse --show-toplevel)"
-                  export PATH="$REPO_ROOT/bin:$PATH"
-                '';
-              }
-            );
-
             # Like `cross` but only with wasm
             crossWasm = flakeboxLib.mkDevShell (
               commonShellArgs
@@ -429,6 +413,22 @@
             };
 
             bootstrap = pkgs.mkShell { nativeBuildInputs = with pkgs; [ cachix ]; };
+          } // lib.attrsets.optionalAttrs (lib.lists.elem system ["x86_64-linux" "x86_64-darwin" "aarch64-darwin"]) {
+            # Shell with extra stuff to support cross-compilation with `cargo build --target <target>`
+            #
+            # This will pull extra stuff so to save time and download time to most common developers,
+            # was moved into another shell.
+            cross = flakeboxLib.mkDevShell (
+              commonShellArgs
+              // craneMultiBuild.commonEnvsCrossShell
+              // {
+                toolchain = toolchainAll;
+                shellHook = ''
+                  export REPO_ROOT="$(git rev-parse --show-toplevel)"
+                  export PATH="$REPO_ROOT/bin:$PATH"
+                '';
+              }
+            );
           };
       in
       {


### PR DESCRIPTION
The dev shell for this architecture seems broken anyway, which prevents flake evaluation. No harm in deactivating the shell till someone actually wants to develop fedimint with cross-compilation on ARM Linux.

Fixes #6428

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
