### PR TITLE
feat: add LNv2 failure events

### DIFF
--- a/gateway/ln-gateway/src/events.rs
+++ b/gateway/ln-gateway/src/events.rs
@@ -1,112 +1,19 @@
-use std::time::SystemTime;
-
-use fedimint_core::config::FederationId;
-use fedimint_core::core::ModuleKind;
-use fedimint_core::Amount;
 use fedimint_eventlog::{Event, EventKind};
-use fedimint_lnv2_common::contracts::{Commitment, OutgoingContract, PaymentImage};
-use serde::{Deserialize, Serialize};
-use serde_millis;
 
-/// All gateway events will be emitted using the same module kind.
-pub const GATEWAY_KIND: ModuleKind = ModuleKind::from_static_str("ln-gateway-core");
+use crate::gateway_module_v2::events::{
+    CompleteLightningPaymentSucceeded, IncomingPaymentFailed, IncomingPaymentStarted,
+    IncomingPaymentSucceeded, OutgoingPaymentFailed, OutgoingPaymentStarted,
+    OutgoingPaymentSucceeded,
+};
 
-pub const ALL_GATEWAY_EVENTS: [EventKind; 5] = [
+pub const ALL_GATEWAY_EVENTS: [EventKind; 7] = [
     OutgoingPaymentStarted::KIND,
     OutgoingPaymentSucceeded::KIND,
+    OutgoingPaymentFailed::KIND,
     IncomingPaymentStarted::KIND,
     IncomingPaymentSucceeded::KIND,
+    IncomingPaymentFailed::KIND,
     CompleteLightningPaymentSucceeded::KIND,
 ];
 
-/// Event that is emitted when an outgoing payment attempt is initiated.
-#[derive(Serialize, Deserialize)]
-pub struct OutgoingPaymentStarted {
-    /// The timestamp that the operation begins, including the API calls to the
-    /// federation to get the consensus block height.
-    #[serde(with = "serde_millis")]
-    pub operation_start: SystemTime,
-
-    /// The outgoing contract for this payment.
-    pub outgoing_contract: OutgoingContract,
-
-    /// The minimum amount that must be escrowed for the payment (includes the
-    /// gateway's fee)
-    pub min_contract_amount: Amount,
-
-    /// The amount requested in the invoice.
-    pub invoice_amount: Amount,
-
-    /// The max delay of the payment in blocks.
-    pub max_delay: u64,
-}
-
-impl Event for OutgoingPaymentStarted {
-    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
-
-    const KIND: EventKind = EventKind::from_static("outgoing-payment-started");
-}
-
-/// Event that is emitted when an outgoing payment attempt has succeeded.
-#[derive(Serialize, Deserialize)]
-pub struct OutgoingPaymentSucceeded {
-    /// The target federation ID if a swap was performed, otherwise `None`.
-    pub target_federation: Option<FederationId>,
-}
-
-impl Event for OutgoingPaymentSucceeded {
-    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
-
-    const KIND: EventKind = EventKind::from_static("outgoing-payment-succeeded");
-}
-
-/// Event that is emitted when an incoming payment attempt has started. Includes
-/// both internal swaps and outside LN payments.
-#[derive(Serialize, Deserialize)]
-pub struct IncomingPaymentStarted {
-    /// The timestamp that the operation begins, including any metadata checks
-    /// before the state machine has spawned.
-    #[serde(with = "serde_millis")]
-    pub operation_start: SystemTime,
-
-    /// The commitment for the incoming contract.
-    pub incoming_contract_commitment: Commitment,
-
-    /// The amount requested in the invoice.
-    pub invoice_amount: Amount,
-}
-
-impl Event for IncomingPaymentStarted {
-    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
-
-    const KIND: EventKind = EventKind::from_static("incoming-payment-started");
-}
-
-/// Event that is emitted when an incoming payment attempt has succeeded.
-/// Includes both internal swaps and outside LN payments.
-#[derive(Serialize, Deserialize)]
-pub struct IncomingPaymentSucceeded {
-    /// The payment hash of the invoice that was paid.
-    pub payment_hash: PaymentImage,
-}
-
-impl Event for IncomingPaymentSucceeded {
-    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
-
-    const KIND: EventKind = EventKind::from_static("incoming-payment-succeeded");
-}
-
-/// Event that is emitted when a preimage is revealed to the Lightning network.
-/// Only emitted for payments that are received from an external Lightning node,
-/// not internal swaps.
-#[derive(Serialize, Deserialize)]
-pub struct CompleteLightningPaymentSucceeded {
-    /// The payment hash of the invoice that was paid.
-    pub payment_hash: PaymentImage,
-}
-
-impl Event for CompleteLightningPaymentSucceeded {
-    const MODULE: Option<ModuleKind> = Some(GATEWAY_KIND);
-
-    const KIND: EventKind = EventKind::from_static("complete-lightning-payment-succeeded");
-}
+// TODO: Add Gateway specific events

--- a/gateway/ln-gateway/src/gateway_module_v2/complete_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/complete_sm.rs
@@ -10,8 +10,8 @@ use fedimint_ln_common::contracts::Preimage;
 use fedimint_lnv2_common::contracts::PaymentImage;
 use tracing::warn;
 
+use super::events::CompleteLightningPaymentSucceeded;
 use super::FinalReceiveState;
-use crate::events::CompleteLightningPaymentSucceeded;
 use crate::gateway_module_v2::GatewayClientContextV2;
 use crate::lightning::{InterceptPaymentResponse, PaymentAction};
 
@@ -188,7 +188,7 @@ impl CompleteStateMachine {
             .log_event(
                 &mut dbtx.module_tx(),
                 CompleteLightningPaymentSucceeded {
-                    payment_hash: PaymentImage::Hash(old_state.common.payment_hash),
+                    payment_image: PaymentImage::Hash(old_state.common.payment_hash),
                 },
             )
             .await;

--- a/gateway/ln-gateway/src/gateway_module_v2/events.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/events.rs
@@ -1,0 +1,138 @@
+use std::time::SystemTime;
+
+use fedimint_core::config::FederationId;
+use fedimint_core::core::ModuleKind;
+use fedimint_core::Amount;
+use fedimint_eventlog::{Event, EventKind};
+use fedimint_lnv2_common::contracts::{Commitment, OutgoingContract, PaymentImage};
+use serde::{Deserialize, Serialize};
+use serde_millis;
+
+use super::send_sm::Cancelled;
+
+/// Event that is emitted when an outgoing payment attempt is initiated.
+#[derive(Serialize, Deserialize)]
+pub struct OutgoingPaymentStarted {
+    /// The timestamp that the operation begins, including the API calls to the
+    /// federation to get the consensus block height.
+    #[serde(with = "serde_millis")]
+    pub operation_start: SystemTime,
+
+    /// The outgoing contract for this payment.
+    pub outgoing_contract: OutgoingContract,
+
+    /// The minimum amount that must be escrowed for the payment (includes the
+    /// gateway's fee)
+    pub min_contract_amount: Amount,
+
+    /// The amount requested in the invoice.
+    pub invoice_amount: Amount,
+
+    /// The max delay of the payment in blocks.
+    pub max_delay: u64,
+}
+
+impl Event for OutgoingPaymentStarted {
+    const MODULE: Option<ModuleKind> = Some(fedimint_lnv2_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("outgoing-payment-started");
+}
+
+/// Event that is emitted when an outgoing payment attempt has succeeded.
+#[derive(Serialize, Deserialize)]
+pub struct OutgoingPaymentSucceeded {
+    /// The payment image of the invoice that was paid.
+    pub payment_image: PaymentImage,
+
+    /// The target federation ID if a swap was performed, otherwise `None`.
+    pub target_federation: Option<FederationId>,
+}
+
+impl Event for OutgoingPaymentSucceeded {
+    const MODULE: Option<ModuleKind> = Some(fedimint_lnv2_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("outgoing-payment-succeeded");
+}
+
+/// Event that is emitted when an outgoing payment attempt has failed.
+#[derive(Serialize, Deserialize)]
+pub struct OutgoingPaymentFailed {
+    /// The payment image of the invoice that failed.
+    pub payment_image: PaymentImage,
+
+    /// The reason the outgoing payment was cancelled.
+    pub error: Cancelled,
+}
+
+impl Event for OutgoingPaymentFailed {
+    const MODULE: Option<ModuleKind> = Some(fedimint_lnv2_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("outgoing-payment-failed");
+}
+
+/// Event that is emitted when an incoming payment attempt has started. Includes
+/// both internal swaps and outside LN payments.
+#[derive(Serialize, Deserialize)]
+pub struct IncomingPaymentStarted {
+    /// The timestamp that the operation begins, including any metadata checks
+    /// before the state machine has spawned.
+    #[serde(with = "serde_millis")]
+    pub operation_start: SystemTime,
+
+    /// The commitment for the incoming contract.
+    pub incoming_contract_commitment: Commitment,
+
+    /// The amount requested in the invoice.
+    pub invoice_amount: Amount,
+}
+
+impl Event for IncomingPaymentStarted {
+    const MODULE: Option<ModuleKind> = Some(fedimint_lnv2_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("incoming-payment-started");
+}
+
+/// Event that is emitted when an incoming payment attempt has succeeded.
+/// Includes both internal swaps and outside LN payments.
+#[derive(Serialize, Deserialize)]
+pub struct IncomingPaymentSucceeded {
+    /// The payment image of the invoice that was paid.
+    pub payment_image: PaymentImage,
+}
+
+impl Event for IncomingPaymentSucceeded {
+    const MODULE: Option<ModuleKind> = Some(fedimint_lnv2_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("incoming-payment-succeeded");
+}
+
+/// Event that is emitted when an incoming payment attempt has failed.
+#[derive(Serialize, Deserialize)]
+pub struct IncomingPaymentFailed {
+    /// The payment image of the invoice that failed
+    pub payment_image: PaymentImage,
+
+    /// The reason the incoming payment failed
+    pub error: String,
+}
+
+impl Event for IncomingPaymentFailed {
+    const MODULE: Option<ModuleKind> = Some(fedimint_lnv2_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("incoming-payment-failed");
+}
+
+/// Event that is emitted when a preimage is revealed to the Lightning network.
+/// Only emitted for payments that are received from an external Lightning node,
+/// not internal swaps.
+#[derive(Serialize, Deserialize)]
+pub struct CompleteLightningPaymentSucceeded {
+    /// The payment image of the invoice that was paid.
+    pub payment_image: PaymentImage,
+}
+
+impl Event for CompleteLightningPaymentSucceeded {
+    const MODULE: Option<ModuleKind> = Some(fedimint_lnv2_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("complete-lightning-payment-succeeded");
+}

--- a/gateway/ln-gateway/src/gateway_module_v2/mod.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/mod.rs
@@ -1,5 +1,6 @@
 mod api;
 mod complete_sm;
+pub mod events;
 mod receive_sm;
 mod send_sm;
 
@@ -10,6 +11,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, ensure};
 use bitcoin::hashes::sha256;
 use bitcoin::secp256k1::Message;
+use events::{IncomingPaymentStarted, OutgoingPaymentStarted};
 use fedimint_api_client::api::DynModuleApi;
 use fedimint_client::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client::module::recovery::NoModuleBackup;
@@ -44,7 +46,6 @@ use serde::{Deserialize, Serialize};
 use tpe::{AggregatePublicKey, PublicKeyShare};
 use tracing::{info, warn};
 
-use crate::events::{IncomingPaymentStarted, OutgoingPaymentStarted};
 use crate::gateway_module_v2::api::GatewayFederationApi;
 use crate::gateway_module_v2::complete_sm::{
     CompleteSMCommon, CompleteSMState, CompleteStateMachine,

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -17,7 +17,7 @@ pub mod config;
 mod db;
 pub mod envs;
 mod error;
-pub mod events;
+mod events;
 mod federation_manager;
 pub mod gateway_module_v2;
 pub mod lightning;

--- a/gateway/ln-gateway/tests/tests.rs
+++ b/gateway/ln-gateway/tests/tests.rs
@@ -49,7 +49,7 @@ use futures::Future;
 use itertools::Itertools;
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
 use ln_gateway::config::LightningModuleMode;
-use ln_gateway::events::{
+use ln_gateway::gateway_module_v2::events::{
     CompleteLightningPaymentSucceeded, IncomingPaymentStarted, IncomingPaymentSucceeded,
     OutgoingPaymentStarted, OutgoingPaymentSucceeded,
 };
@@ -1150,6 +1150,7 @@ async fn gateway_read_payment_log() -> anyhow::Result<()> {
             .log_event(
                 &mut fed1_module_dbtx,
                 OutgoingPaymentSucceeded {
+                    payment_image: PaymentImage::Hash([0_u8; 32].consensus_hash()),
                     target_federation: Some(fed2.id()),
                 },
             )
@@ -1191,13 +1192,13 @@ async fn gateway_read_payment_log() -> anyhow::Result<()> {
             .log_event(
                 &mut fed2_module_dbtx,
                 IncomingPaymentSucceeded {
-                    payment_hash: PaymentImage::Hash([0_u8; 32].consensus_hash()),
+                    payment_image: PaymentImage::Hash([0_u8; 32].consensus_hash()),
                 },
             )
             .await;
 
         let complete_payment_event = CompleteLightningPaymentSucceeded {
-            payment_hash: PaymentImage::Hash([0_u8; 32].consensus_hash()),
+            payment_image: PaymentImage::Hash([0_u8; 32].consensus_hash()),
         };
         fed2_lnv2
             .client_ctx


### PR DESCRIPTION
Moves existing gateway events into LNv2 module, they won't be re-usable for LNv1.

Adds failure events for outgoing and incoming payments.