### PR TITLE
chore: reserve prefixes for external use

### DIFF
--- a/modules/fedimint-dummy-client/src/db.rs
+++ b/modules/fedimint-dummy-client/src/db.rs
@@ -17,6 +17,15 @@ pub enum DbKeyPrefix {
     // Used to verify that 0x50 key can be written to, which used to conflict with
     // `DatabaseVersionKeyV0`
     ClientName = 0x50,
+    /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
+    /// historical and future external use
+    ExternalReservedStart = 0xb0,
+    /// Prefixes between 0xd0..=0xff shall all be considered allocated for
+    /// historical and future internal use
+    CoreInternalReservedStart = 0xd0,
+    /// Prefixes between 0xd0..=0xff shall all be considered allocated for
+    /// historical and future internal use
+    CoreInternalReservedEnd = 0xff,
 }
 
 impl std::fmt::Display for DbKeyPrefix {

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -375,6 +375,9 @@ impl ModuleInit for DummyClientInit {
                         items.insert("Dummy Name".to_string(), Box::new(name));
                     }
                 }
+                DbKeyPrefix::ExternalReservedStart
+                | DbKeyPrefix::CoreInternalReservedStart
+                | DbKeyPrefix::CoreInternalReservedEnd => {}
             }
         }
 

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -353,6 +353,9 @@ mod fedimint_migration_tests {
                         // `DatabaseVersion` key
                         // was migrated successfully.
                     }
+                    fedimint_dummy_client::db::DbKeyPrefix::ExternalReservedStart
+                    | fedimint_dummy_client::db::DbKeyPrefix::CoreInternalReservedStart
+                    | fedimint_dummy_client::db::DbKeyPrefix::CoreInternalReservedEnd => {}
                 }
             }
 

--- a/modules/fedimint-ln-client/src/db.rs
+++ b/modules/fedimint-ln-client/src/db.rs
@@ -30,6 +30,13 @@ pub enum DbKeyPrefix {
     PaymentResult = 0x29,
     MetaOverridesDeprecated = 0x30,
     LightningGateway = 0x45,
+    /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
+    /// historical and future external use
+    ExternalReservedStart = 0xb0,
+    /// Prefixes between 0xd0..=0xff shall all be considered allocated for
+    /// historical and future internal use
+    CoreInternalReservedStart = 0xd0,
+    CoreInternalReservedEnd = 0xff,
 }
 
 impl std::fmt::Display for DbKeyPrefix {

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -295,6 +295,7 @@ impl ModuleInit for LightningClientInit {
         });
 
         for table in filtered_prefixes {
+            #[allow(clippy::match_same_arms)]
             match table {
                 DbKeyPrefix::ActiveGateway | DbKeyPrefix::MetaOverridesDeprecated => {
                     // Deprecated
@@ -319,6 +320,9 @@ impl ModuleInit for LightningClientInit {
                         "Lightning Gateways"
                     );
                 }
+                DbKeyPrefix::ExternalReservedStart
+                | DbKeyPrefix::CoreInternalReservedStart
+                | DbKeyPrefix::CoreInternalReservedEnd => {}
             }
         }
 

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -1280,6 +1280,9 @@ mod fedimint_migration_tests {
                             );
                             info!("Validated LightningGateways");
                         }
+                        fedimint_ln_client::db::DbKeyPrefix::CoreInternalReservedStart
+                        | fedimint_ln_client::db::DbKeyPrefix::ExternalReservedStart
+                        | fedimint_ln_client::db::DbKeyPrefix::CoreInternalReservedEnd => {}
                     }
                 }
 

--- a/modules/fedimint-lnv2-client/src/db.rs
+++ b/modules/fedimint-lnv2-client/src/db.rs
@@ -7,6 +7,16 @@ use fedimint_core::{impl_db_lookup, impl_db_record};
 #[derive(Clone, Debug)]
 pub enum DbKeyPrefix {
     Gateway = 0x41,
+    #[allow(dead_code)]
+    /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
+    /// historical and future external use
+    ExternalReservedStart = 0xb0,
+    #[allow(dead_code)]
+    /// Prefixes between 0xd0..=0xff shall all be considered allocated for
+    /// historical and future internal use
+    CoreInternalReservedStart = 0xd0,
+    #[allow(dead_code)]
+    CoreInternalReservedEnd = 0xff,
 }
 
 #[derive(Debug, Encodable, Decodable)]

--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -26,6 +26,13 @@ pub enum DbKeyPrefix {
     RecoveryState = 0x2c,
     RecoveryFinalized = 0x2d,
     ReusedNoteIndices = 0x2e,
+    /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
+    /// historical and future external use
+    ExternalReservedStart = 0xb0,
+    /// Prefixes between 0xd0..=0xff shall all be considered allocated for
+    /// historical and future internal use
+    CoreInternalReservedStart = 0xd0,
+    CoreInternalReservedEnd = 0xff,
 }
 
 impl std::fmt::Display for DbKeyPrefix {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -571,7 +571,11 @@ impl ModuleInit for MintClientInit {
                         mint_client_items.insert("RecoveryFinalized".to_string(), Box::new(val));
                     }
                 }
-                DbKeyPrefix::RecoveryState | DbKeyPrefix::ReusedNoteIndices => {}
+                DbKeyPrefix::RecoveryState
+                | DbKeyPrefix::ReusedNoteIndices
+                | DbKeyPrefix::ExternalReservedStart
+                | DbKeyPrefix::CoreInternalReservedStart
+                | DbKeyPrefix::CoreInternalReservedEnd => {}
             }
         }
 

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -882,6 +882,10 @@ mod fedimint_migration_tests {
                             info!("Validated RecoveryFinalized");
                         }
                         fedimint_mint_client::client_db::DbKeyPrefix::ReusedNoteIndices => {}
+                        fedimint_mint_client::client_db::DbKeyPrefix::ExternalReservedStart
+                        | fedimint_mint_client::client_db::DbKeyPrefix::CoreInternalReservedEnd
+                        | fedimint_mint_client::client_db::DbKeyPrefix::CoreInternalReservedStart =>
+                            {}
                     }
                 }
 

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -18,6 +18,15 @@ pub enum DbKeyPrefix {
     ClaimedPegIn = 0x2e,
     RecoveryFinalized = 0x2f,
     RecoveryState = 0x30,
+    /// Prefixes between 0xb0..=0xcf shall all be considered allocated for
+    /// historical and future external use
+    ExternalReservedStart = 0xb0,
+    /// Prefixes between 0xd0..=0xff shall all be considered allocated for
+    /// historical and future internal use
+    CoreInternalReservedStart = 0xd0,
+    /// Prefixes between 0xd0..=0xff shall all be considered allocated for
+    /// historical and future internal use
+    CoreInternalReservedEnd = 0xff,
 }
 
 impl std::fmt::Display for DbKeyPrefix {

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -203,7 +203,10 @@ impl ModuleInit for WalletClientInit {
                         wallet_client_items.insert("RecoveryFinalized".to_string(), Box::new(val));
                     }
                 }
-                DbKeyPrefix::RecoveryState => {}
+                DbKeyPrefix::RecoveryState
+                | DbKeyPrefix::ExternalReservedStart
+                | DbKeyPrefix::CoreInternalReservedStart
+                | DbKeyPrefix::CoreInternalReservedEnd => {}
             }
         }
 

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -1487,6 +1487,9 @@ mod fedimint_migration_tests {
                         client_db::DbKeyPrefix::ClaimedPegIn => {}
                         client_db::DbKeyPrefix::RecoveryFinalized => {}
                         client_db::DbKeyPrefix::RecoveryState => {}
+                        client_db::DbKeyPrefix::ExternalReservedStart
+                        | client_db::DbKeyPrefix::CoreInternalReservedStart
+                        | client_db::DbKeyPrefix::CoreInternalReservedEnd => {}
                     }
                 }
 


### PR DESCRIPTION
reserves some prefixes for external integrator use in all client module databases

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
