### PR TITLE
chore: check nix formatting on pre-commit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -413,23 +413,31 @@
             };
 
             bootstrap = pkgs.mkShell { nativeBuildInputs = with pkgs; [ cachix ]; };
-          } // lib.attrsets.optionalAttrs (lib.lists.elem system ["x86_64-linux" "x86_64-darwin" "aarch64-darwin"]) {
-            # Shell with extra stuff to support cross-compilation with `cargo build --target <target>`
-            #
-            # This will pull extra stuff so to save time and download time to most common developers,
-            # was moved into another shell.
-            cross = flakeboxLib.mkDevShell (
-              commonShellArgs
-              // craneMultiBuild.commonEnvsCrossShell
-              // {
-                toolchain = toolchainAll;
-                shellHook = ''
-                  export REPO_ROOT="$(git rev-parse --show-toplevel)"
-                  export PATH="$REPO_ROOT/bin:$PATH"
-                '';
-              }
-            );
-          };
+          }
+          //
+            lib.attrsets.optionalAttrs
+              (lib.lists.elem system [
+                "x86_64-linux"
+                "x86_64-darwin"
+                "aarch64-darwin"
+              ])
+              {
+                # Shell with extra stuff to support cross-compilation with `cargo build --target <target>`
+                #
+                # This will pull extra stuff so to save time and download time to most common developers,
+                # was moved into another shell.
+                cross = flakeboxLib.mkDevShell (
+                  commonShellArgs
+                  // craneMultiBuild.commonEnvsCrossShell
+                  // {
+                    toolchain = toolchainAll;
+                    shellHook = ''
+                      export REPO_ROOT="$(git rev-parse --show-toplevel)"
+                      export PATH="$REPO_ROOT/bin:$PATH"
+                    '';
+                  }
+                );
+              };
       in
       {
         inherit devShells;

--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -178,6 +178,13 @@ function check_typos() {
 }
 export -f check_typos
 
+function check_nix_fmt() {
+    # we actually rely on word splitting here
+    # shellcheck disable=SC2046
+    nixfmt -c $(git ls-files | grep "\.nix$")
+}
+export -f check_nix_fmt
+
 parallel \
   --nonotice \
 ::: \
@@ -190,4 +197,5 @@ parallel \
     check_shellcheck \
     check_trailing_whitespace \
     check_typos \
-  check_nothing
+    check_nix_fmt \
+    check_nothing


### PR DESCRIPTION
I accidentally PRed an incorrectly formatted flake in #6430, which the pre-commit hook should have prevented. CI should also check it now since it just runs the pre-commit hooks.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
