### PR TITLE
chore: fedimint-bitcoind cleanup

### DIFF
--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -10,25 +10,20 @@ use fedimint_core::encoding::Decodable;
 use fedimint_core::envs::{BitcoinRpcConfig, FM_BITCOIND_COOKIE_FILE_ENV};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::runtime::block_in_place;
-use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Feerate};
 use fedimint_logging::LOG_CORE;
 use tracing::{info, warn};
 
-use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
+use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory};
 
 #[derive(Debug)]
 pub struct BitcoindFactory;
 
 impl IBitcoindRpcFactory for BitcoindFactory {
-    fn create_connection(
-        &self,
-        url: &SafeUrl,
-        handle: TaskHandle,
-    ) -> anyhow::Result<DynBitcoindRpc> {
-        Ok(RetryClient::new(BitcoindClient::new(url)?, handle).into())
+    fn create_connection(&self, url: &SafeUrl) -> anyhow::Result<DynBitcoindRpc> {
+        Ok(BitcoindClient::new(url)?.into())
     }
 }
 

--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -28,17 +28,17 @@ impl IBitcoindRpcFactory for BitcoindFactory {
         url: &SafeUrl,
         handle: TaskHandle,
     ) -> anyhow::Result<DynBitcoindRpc> {
-        Ok(RetryClient::new(BitcoinClient::new(url)?, handle).into())
+        Ok(RetryClient::new(BitcoindClient::new(url)?, handle).into())
     }
 }
 
 #[derive(Debug)]
-struct BitcoinClient {
+struct BitcoindClient {
     client: ::bitcoincore_rpc::Client,
     url: SafeUrl,
 }
 
-impl BitcoinClient {
+impl BitcoindClient {
     fn new(url: &SafeUrl) -> anyhow::Result<Self> {
         let safe_url = url.clone();
         let (url, auth) = from_url_to_url_auth(url)?;
@@ -50,7 +50,7 @@ impl BitcoinClient {
 }
 
 #[apply(async_trait_maybe_send!)]
-impl IBitcoindRpc for BitcoinClient {
+impl IBitcoindRpc for BitcoindClient {
     async fn get_network(&self) -> anyhow::Result<Network> {
         let network = block_in_place(|| self.client.get_blockchain_info())?;
         Ok(network.chain)

--- a/fedimint-bitcoind/src/electrum.rs
+++ b/fedimint-bitcoind/src/electrum.rs
@@ -6,7 +6,6 @@ use electrum_client::ElectrumApi;
 use electrum_client::Error::Protocol;
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::runtime::block_in_place;
-use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Feerate};
@@ -14,18 +13,14 @@ use hex::ToHex;
 use serde_json::{Map, Value};
 use tracing::info;
 
-use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
+use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory};
 
 #[derive(Debug)]
 pub struct ElectrumFactory;
 
 impl IBitcoindRpcFactory for ElectrumFactory {
-    fn create_connection(
-        &self,
-        url: &SafeUrl,
-        handle: TaskHandle,
-    ) -> anyhow::Result<DynBitcoindRpc> {
-        Ok(RetryClient::new(ElectrumClient::new(url)?, handle).into())
+    fn create_connection(&self, url: &SafeUrl) -> anyhow::Result<DynBitcoindRpc> {
+        Ok(ElectrumClient::new(url)?.into())
     }
 }
 

--- a/fedimint-bitcoind/src/electrum.rs
+++ b/fedimint-bitcoind/src/electrum.rs
@@ -29,7 +29,7 @@ impl IBitcoindRpcFactory for ElectrumFactory {
     }
 }
 
-pub struct ElectrumClient {
+struct ElectrumClient {
     client: electrum_client::Client,
     url: SafeUrl,
 }

--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -3,24 +3,19 @@ use std::collections::HashMap;
 use anyhow::{bail, format_err, Context};
 use bitcoin::{BlockHash, Network, ScriptBuf, Transaction, Txid};
 use fedimint_core::envs::BitcoinRpcConfig;
-use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, Feerate};
 use tracing::info;
 
-use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory, RetryClient};
+use crate::{DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory};
 
 #[derive(Debug)]
 pub struct EsploraFactory;
 
 impl IBitcoindRpcFactory for EsploraFactory {
-    fn create_connection(
-        &self,
-        url: &SafeUrl,
-        handle: TaskHandle,
-    ) -> anyhow::Result<DynBitcoindRpc> {
-        Ok(RetryClient::new(EsploraClient::new(url)?, handle).into())
+    fn create_connection(&self, url: &SafeUrl) -> anyhow::Result<DynBitcoindRpc> {
+        Ok(EsploraClient::new(url)?.into())
     }
 }
 

--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -25,7 +25,7 @@ impl IBitcoindRpcFactory for EsploraFactory {
 }
 
 #[derive(Debug)]
-pub struct EsploraClient {
+struct EsploraClient {
     client: esplora_client::AsyncClient,
     url: SafeUrl,
 }

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -14,8 +14,7 @@ use std::future::Future;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
-use anyhow::Context;
-pub use anyhow::Result;
+use anyhow::{Context, Result};
 use bitcoin::{Block, BlockHash, Network, ScriptBuf, Transaction, Txid};
 use fedimint_core::envs::{
     BitcoinRpcConfig, FM_FORCE_BITCOIN_RPC_KIND_ENV, FM_FORCE_BITCOIN_RPC_URL_ENV,

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -6,27 +6,21 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::similar_names)]
 
-use std::cmp::min;
 use std::collections::BTreeMap;
 use std::env;
 use std::fmt::Debug;
-use std::future::Future;
 use std::sync::{Arc, LazyLock, Mutex};
-use std::time::Duration;
 
 use anyhow::{Context, Result};
-use bitcoin::{Block, BlockHash, Network, ScriptBuf, Transaction, Txid};
+use bitcoin::{Block, BlockHash, ScriptBuf, Transaction, Txid};
 use fedimint_core::envs::{
     BitcoinRpcConfig, FM_FORCE_BITCOIN_RPC_KIND_ENV, FM_FORCE_BITCOIN_RPC_URL_ENV,
 };
-use fedimint_core::fmt_utils::OptStacktrace;
-use fedimint_core::runtime::sleep;
-use fedimint_core::task::TaskHandle;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{apply, async_trait_maybe_send, dyn_newtype_define, Feerate};
-use fedimint_logging::{LOG_BLOCKCHAIN, LOG_CORE};
-use tracing::{debug, info};
+use fedimint_logging::LOG_CORE;
+use tracing::debug;
 
 #[cfg(feature = "bitcoincore-rpc")]
 pub mod bitcoincore;
@@ -63,7 +57,7 @@ static BITCOIN_RPC_REGISTRY: LazyLock<Mutex<BTreeMap<String, DynBitcoindRpcFacto
     });
 
 /// Create a bitcoin RPC of a given kind
-pub fn create_bitcoind(config: &BitcoinRpcConfig, handle: TaskHandle) -> Result<DynBitcoindRpc> {
+pub fn create_bitcoind(config: &BitcoinRpcConfig) -> Result<DynBitcoindRpc> {
     let registry = BITCOIN_RPC_REGISTRY.lock().expect("lock poisoned");
 
     let kind = env::var(FM_FORCE_BITCOIN_RPC_KIND_ENV)
@@ -83,7 +77,7 @@ pub fn create_bitcoind(config: &BitcoinRpcConfig, handle: TaskHandle) -> Result<
             registry.keys()
         )
     })?;
-    factory.create_connection(&url, handle)
+    factory.create_connection(&url)
 }
 
 /// Register a new factory for creating bitcoin RPCs
@@ -95,7 +89,7 @@ pub fn register_bitcoind(kind: String, factory: DynBitcoindRpcFactory) {
 /// Trait for creating new bitcoin RPC clients
 pub trait IBitcoindRpcFactory: Debug + Send + Sync {
     /// Creates a new bitcoin RPC client connection
-    fn create_connection(&self, url: &SafeUrl, handle: TaskHandle) -> Result<DynBitcoindRpc>;
+    fn create_connection(&self, url: &SafeUrl) -> Result<DynBitcoindRpc>;
 }
 
 dyn_newtype_define! {
@@ -188,120 +182,4 @@ pub trait IBitcoindRpc: Debug {
 dyn_newtype_define! {
     #[derive(Clone)]
     pub DynBitcoindRpc(Arc<IBitcoindRpc>)
-}
-
-const RETRY_SLEEP_MIN_MS: Duration = Duration::from_millis(10);
-const RETRY_SLEEP_MAX_MS: Duration = Duration::from_millis(5000);
-
-/// Wrapper around [`IBitcoindRpc`] that will retry failed calls
-#[derive(Debug)]
-pub struct RetryClient<C> {
-    inner: C,
-    task_handle: TaskHandle,
-}
-
-impl<C> RetryClient<C> {
-    pub fn new(inner: C, task_handle: TaskHandle) -> Self {
-        Self { inner, task_handle }
-    }
-
-    /// Retries with an exponential backoff from `RETRY_SLEEP_MIN_MS` to
-    /// `RETRY_SLEEP_MAX_MS`
-    async fn retry_call<T, F, R>(&self, call_fn: F) -> Result<T>
-    where
-        F: Fn() -> R,
-        R: Future<Output = Result<T>>,
-    {
-        let mut retry_time = RETRY_SLEEP_MIN_MS;
-        let ret = loop {
-            match call_fn().await {
-                Ok(ret) => {
-                    break ret;
-                }
-                Err(e) => {
-                    if self.task_handle.is_shutting_down() {
-                        return Err(e);
-                    }
-
-                    info!(target: LOG_BLOCKCHAIN, "Bitcoind error {}, retrying", OptStacktrace(e));
-                    sleep(retry_time).await;
-                    retry_time = min(RETRY_SLEEP_MAX_MS, retry_time * 2);
-                }
-            }
-        };
-        Ok(ret)
-    }
-}
-
-#[apply(async_trait_maybe_send!)]
-impl<C> IBitcoindRpc for RetryClient<C>
-where
-    C: IBitcoindRpc + Sync + Send,
-{
-    async fn get_network(&self) -> Result<Network> {
-        self.retry_call(|| async { self.inner.get_network().await })
-            .await
-    }
-
-    async fn get_block_count(&self) -> Result<u64> {
-        self.retry_call(|| async { self.inner.get_block_count().await })
-            .await
-    }
-
-    async fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
-        self.retry_call(|| async { self.inner.get_block_hash(height).await })
-            .await
-    }
-
-    async fn get_block(&self, block_hash: &BlockHash) -> Result<Block> {
-        self.retry_call(|| async { self.inner.get_block(block_hash).await })
-            .await
-    }
-
-    async fn get_fee_rate(&self, confirmation_target: u16) -> Result<Option<Feerate>> {
-        self.retry_call(|| async { self.inner.get_fee_rate(confirmation_target).await })
-            .await
-    }
-
-    async fn submit_transaction(&self, transaction: Transaction) {
-        self.inner.submit_transaction(transaction.clone()).await;
-    }
-
-    async fn get_tx_block_height(&self, txid: &Txid) -> Result<Option<u64>> {
-        self.retry_call(|| async { self.inner.get_tx_block_height(txid).await })
-            .await
-    }
-
-    async fn is_tx_in_block(
-        &self,
-        txid: &Txid,
-        block_hash: &BlockHash,
-        block_height: u64,
-    ) -> Result<bool> {
-        self.retry_call(|| async {
-            self.inner
-                .is_tx_in_block(txid, block_hash, block_height)
-                .await
-        })
-        .await
-    }
-
-    async fn watch_script_history(&self, script: &ScriptBuf) -> Result<()> {
-        self.retry_call(|| async { self.inner.watch_script_history(script).await })
-            .await
-    }
-
-    async fn get_script_history(&self, script: &ScriptBuf) -> Result<Vec<Transaction>> {
-        self.retry_call(|| async { self.inner.get_script_history(script).await })
-            .await
-    }
-
-    async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof> {
-        self.retry_call(|| async { self.inner.get_txout_proof(txid).await })
-            .await
-    }
-
-    fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
-        self.inner.get_bitcoin_rpc_config()
-    }
 }

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -535,10 +535,9 @@ impl ConfigGenApi {
         &self,
         bitcoin_rpc_config: &BitcoinRpcConfig,
     ) -> ApiResult<BitcoinRpcConnectionStatus> {
-        let client =
-            create_bitcoind(bitcoin_rpc_config, self.task_group.make_handle()).map_err(|e| {
-                ApiError::server_error(format!("Failed to connect to bitcoin rpc: {e}"))
-            })?;
+        let client = create_bitcoind(bitcoin_rpc_config).map_err(|e| {
+            ApiError::server_error(format!("Failed to connect to bitcoin rpc: {e}"))
+        })?;
         // TODO: Find a better way to check if esplora is synced, just returning Synced
         // if it connects
         let _network_info = client

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -16,7 +16,7 @@ use bitcoin::{
 };
 use fedimint_bitcoind::{register_bitcoind, DynBitcoindRpc, IBitcoindRpc, IBitcoindRpcFactory};
 use fedimint_core::envs::BitcoinRpcConfig;
-use fedimint_core::task::{sleep_in_test, TaskHandle};
+use fedimint_core::task::sleep_in_test;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{Amount, Feerate};
@@ -48,7 +48,7 @@ impl FakeBitcoinFactory {
 }
 
 impl IBitcoindRpcFactory for FakeBitcoinFactory {
-    fn create_connection(&self, _url: &SafeUrl, _handle: TaskHandle) -> Result<DynBitcoindRpc> {
+    fn create_connection(&self, _url: &SafeUrl) -> Result<DynBitcoindRpc> {
         Ok(self.bitcoin.clone().into())
     }
 }

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -16,7 +16,7 @@ use fedimint_core::db::Database;
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{DynServerModuleInit, IServerModuleInit};
-use fedimint_core::task::{MaybeSend, MaybeSync, TaskGroup};
+use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::util::SafeUrl;
 use fedimint_logging::TracingSetup;
 use fedimint_testing_core::test_dir;
@@ -59,7 +59,6 @@ impl Fixtures {
         // Ensure tracing has been set once
         let _ = TracingSetup::default().init();
         let real_testing = Fixtures::is_real_test();
-        let task_group = TaskGroup::new();
         let (dyn_bitcoin_rpc, bitcoin, config): (
             DynBitcoindRpc,
             Arc<dyn BitcoinTest>,
@@ -79,7 +78,7 @@ impl Fixtures {
                     .expect("must provide valid default env vars"),
             };
 
-            let dyn_bitcoin_rpc = create_bitcoind(&rpc_config, task_group.make_handle()).unwrap();
+            let dyn_bitcoin_rpc = create_bitcoind(&rpc_config).unwrap();
             let bitcoincore_url = env::var(FM_TEST_BITCOIND_RPC_ENV)
                 .expect("Must have bitcoind RPC defined for real tests")
                 .parse()

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -23,7 +23,7 @@ use fedimint_core::module::{
     TransactionItemAmount, CORE_CONSENSUS_VERSION,
 };
 use fedimint_core::server::DynServerModule;
-use fedimint_core::task::{timeout, TaskGroup};
+use fedimint_core::task::timeout;
 use fedimint_core::time::duration_since_epoch;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{
@@ -178,7 +178,7 @@ impl ServerModuleInit for LightningInit {
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
-        Ok(Lightning::new(args.cfg().to_typed()?, &args.task_group().clone())?.into())
+        Ok(Lightning::new(args.cfg().to_typed()?)?.into())
     }
 
     fn trusted_dealer_gen(
@@ -631,8 +631,8 @@ impl ServerModule for Lightning {
 }
 
 impl Lightning {
-    fn new(cfg: LightningConfig, task_group: &TaskGroup) -> anyhow::Result<Self> {
-        let btc_rpc = create_bitcoind(&cfg.local.bitcoin_rpc, task_group.make_handle())?;
+    fn new(cfg: LightningConfig) -> anyhow::Result<Self> {
+        let btc_rpc = create_bitcoind(&cfg.local.bitcoin_rpc)?;
 
         Ok(Lightning { cfg, btc_rpc })
     }

--- a/modules/fedimint-wallet-client/src/backup.rs
+++ b/modules/fedimint-wallet-client/src/backup.rs
@@ -11,7 +11,6 @@ use fedimint_client::module::ClientContext;
 use fedimint_core::core::{IntoDynInstance, ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _};
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::task::TaskGroup;
 use fedimint_core::util::{backoff_util, retry};
 use fedimint_core::{apply, async_trait_maybe_send};
 use fedimint_logging::{LOG_CLIENT_MODULE_WALLET, LOG_CLIENT_RECOVERY};
@@ -141,7 +140,7 @@ impl RecoveryFromHistory for WalletRecovery {
             .clone()
             .unwrap_or(WalletClientModule::get_rpc_config(args.cfg()));
 
-        let btc_rpc = create_bitcoind(&rpc_config, TaskGroup::new().make_handle())?;
+        let btc_rpc = create_bitcoind(&rpc_config)?;
 
         let data = WalletClientModuleData {
             cfg: args.cfg().clone(),
@@ -222,7 +221,7 @@ impl RecoveryFromHistory for WalletRecovery {
             .clone()
             .unwrap_or(WalletClientModule::get_rpc_config(args.cfg()));
 
-        let btc_rpc = create_bitcoind(&rpc_config, TaskGroup::new().make_handle())?;
+        let btc_rpc = create_bitcoind(&rpc_config)?;
 
         let data = WalletClientModuleData {
             cfg: args.cfg().clone(),

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -233,7 +233,7 @@ impl ClientModuleInit for WalletClientInit {
 
         let db = args.db().clone();
 
-        let btc_rpc = create_bitcoind(&rpc_config, TaskGroup::new().make_handle())?;
+        let btc_rpc = create_bitcoind(&rpc_config)?;
         let module_api = args.module_api().clone();
 
         let (pegin_claimed_sender, pegin_claimed_receiver) = watch::channel(());

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -959,7 +959,7 @@ impl Wallet {
         task_group: &TaskGroup,
         our_peer_id: PeerId,
     ) -> anyhow::Result<Wallet> {
-        let btc_rpc = create_bitcoind(&cfg.local.bitcoin_rpc, task_group.make_handle())?;
+        let btc_rpc = create_bitcoind(&cfg.local.bitcoin_rpc)?;
         Ok(Self::new_with_bitcoind(cfg, db, btc_rpc, task_group, our_peer_id).await?)
     }
 


### PR DESCRIPTION
I recommend reviewing commit-by-commit

The biggest change here is the removal of the `RetryClient`. Its purpose is to wrap the [`IBitcoindRpc`](https://github.com/fedimint/fedimint/blob/330c0a3168b68b32c4458cce296ca4553b00439c/fedimint-bitcoind/src/lib.rs#L107-L187) trait to ensure automatic retrying of RPCs if the underlying chain info source is unreachable. However, since it retries indefinitely until success or daemon shutdown, an unreachable chain info source can lead to undesired behavior. For example, [this](https://github.com/fedimint/fedimint/blob/330c0a3168b68b32c4458cce296ca4553b00439c/fedimint-server/src/config/api.rs#L935-L942) endpoint will hang if the esplora node is offline since it calls [this](https://github.com/fedimint/fedimint/blob/330c0a3168b68b32c4458cce296ca4553b00439c/fedimint-server/src/config/api.rs#L534-L549) function.

While we could make the backoff eventually give up, automatic retrying is still not what a developer will typically expect. After reviewing the usage of all functions in `IBitcoindRpc`, I found that all usages either have built-in backoff retry (such as [here](https://github.com/fedimint/fedimint/blob/330c0a3168b68b32c4458cce296ca4553b00439c/modules/fedimint-wallet-server/src/lib.rs#L1225-L1229)) or some other form of retrying (such as [here](https://github.com/fedimint/fedimint/blob/330c0a3168b68b32c4458cce296ca4553b00439c/modules/fedimint-wallet-server/src/lib.rs#L1545-L1597)), so it should be safe to remove the automatic retry logic.