### PR TITLE
feature: repurpose bitcoin status endpoint

### DIFF
--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -149,6 +149,11 @@ impl IBitcoindRpc for BitcoindClient {
         .map_err(|error| format_err!("Could not decode tx: {}", error))
     }
 
+    async fn get_sync_percentage(&self) -> anyhow::Result<Option<f64>> {
+        let blockchain_info = block_in_place(|| self.client.get_blockchain_info())?;
+        Ok(Some(blockchain_info.verification_progress))
+    }
+
     fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
         BitcoinRpcConfig {
             kind: "bitcoind".to_string(),

--- a/fedimint-bitcoind/src/esplora.rs
+++ b/fedimint-bitcoind/src/esplora.rs
@@ -168,6 +168,10 @@ impl IBitcoindRpc for EsploraClient {
         })
     }
 
+    async fn get_sync_percentage(&self) -> anyhow::Result<Option<f64>> {
+        Ok(None)
+    }
+
     fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
         BitcoinRpcConfig {
             kind: "esplora".to_string(),

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -171,6 +171,10 @@ pub trait IBitcoindRpc: Debug {
     /// Returns a proof that a tx is included in the bitcoin blockchain
     async fn get_txout_proof(&self, txid: Txid) -> Result<TxOutProof>;
 
+    /// Returns the node's estimated chain sync percentage as a float between
+    /// 0.0 and 1.0, or `None` if the node doesn't support this feature.
+    async fn get_sync_percentage(&self) -> Result<Option<f64>>;
+
     /// Returns the Bitcoin RPC config
     fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig;
 }

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -413,6 +413,10 @@ impl IBitcoindRpc for FakeBitcoinTest {
         Ok(proof.ok_or(format_err!("No proof stored"))?.clone())
     }
 
+    async fn get_sync_percentage(&self) -> anyhow::Result<Option<f64>> {
+        Ok(None)
+    }
+
     fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
         BitcoinRpcConfig {
             kind: "mock_kind".to_string(),


### PR DESCRIPTION
Change the return type of `check_bitcoin_status` from an enum containing info on whether the bitcoin backend is synced to a struct containing the latest block height, block time, and optional sync percentage estimate. This allows for consistent behavior for different bitcoin backends.

We're able to change the return type of this endpoint since it is only used by the guardian UI, and we require that the UI and guardian are upgraded in lockstep. In the UI, we will need to compare the block height and block time to the consensus block height and local system time in order to determine whether the guardian's bitcoin backend is stalled.