### PR TITLE
[Backport releases/v0.5] chore(recovery): save reused note indices

### DIFF
--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -15,7 +15,7 @@ use crate::backup::recovery::MintRecoveryState;
 use crate::input::{MintInputCommon, MintInputStateMachine, MintInputStateMachineV0};
 use crate::oob::{MintOOBStateMachine, MintOOBStateMachineV0, MintOOBStates, MintOOBStatesV0};
 use crate::output::{MintOutputCommon, MintOutputStateMachine, MintOutputStateMachineV0};
-use crate::{MintClientStateMachines, SpendableNoteUndecoded};
+use crate::{MintClientStateMachines, NoteIndex, SpendableNoteUndecoded};
 
 #[repr(u8)]
 #[derive(Clone, EnumIter, Debug)]
@@ -25,6 +25,7 @@ pub enum DbKeyPrefix {
     CancelledOOBSpend = 0x2b,
     RecoveryState = 0x2c,
     RecoveryFinalized = 0x2d,
+    ReusedNoteIndices = 0x2e,
 }
 
 impl std::fmt::Display for DbKeyPrefix {
@@ -87,6 +88,15 @@ impl_db_record!(
     key = RecoveryFinalizedKey,
     value = bool,
     db_prefix = DbKeyPrefix::RecoveryFinalized,
+);
+
+#[derive(Debug, Clone, Encodable, Decodable, Serialize)]
+pub struct ReusedNoteIndices;
+
+impl_db_record!(
+    key = ReusedNoteIndices,
+    value = Vec<(Amount, NoteIndex)>,
+    db_prefix = DbKeyPrefix::ReusedNoteIndices,
 );
 
 #[derive(Debug, Clone, Encodable, Decodable, Serialize)]

--- a/modules/fedimint-mint-client/src/output.rs
+++ b/modules/fedimint-mint-client/src/output.rs
@@ -666,4 +666,12 @@ impl NoteIssuanceRequest {
             spend_key: self.spend_key,
         }
     }
+
+    pub fn blinding_key(&self) -> &BlindingKey {
+        &self.blinding_key
+    }
+
+    pub fn spend_key(&self) -> &Keypair {
+        &self.spend_key
+    }
 }

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -530,7 +530,7 @@ mod fedimint_migration_tests {
     };
     use fedimint_logging::TracingSetup;
     use fedimint_mint_client::backup::recovery::{
-        MintRecovery, MintRecoveryState, MintRecoveryStateV0,
+        MintRecovery, MintRecoveryState, MintRecoveryStateV2,
     };
     use fedimint_mint_client::backup::{EcashBackup, EcashBackupV0};
     use fedimint_mint_client::client_db::{
@@ -671,7 +671,7 @@ mod fedimint_migration_tests {
 
         let backup = create_ecash_backup_v0(spendable_note, secret.clone());
 
-        let mint_recovery_state = MintRecoveryState::V1(MintRecoveryStateV0::from_backup(
+        let mint_recovery_state = MintRecoveryState::V2(MintRecoveryStateV2::from_backup(
             backup,
             10,
             tbs_pks,
@@ -877,6 +877,7 @@ mod fedimint_migration_tests {
                             );
                             info!("Validated RecoveryFinalized");
                         }
+                        fedimint_mint_client::client_db::DbKeyPrefix::ReusedNoteIndices => {}
                     }
                 }
 


### PR DESCRIPTION
# Description
Backport of #6458 to `releases/v0.5`.