### PR TITLE
feat: add OOB Spend/Receive and Wallet Deposit/Withdraw events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -430,7 +430,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -447,7 +447,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -546,7 +546,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -777,7 +777,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -950,7 +950,7 @@ checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1212,7 +1212,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1482,7 +1482,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1530,7 +1530,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1644,7 +1644,7 @@ dependencies = [
  "quote",
  "sha3",
  "strum 0.26.3",
- "syn 2.0.90",
+ "syn 2.0.87",
  "void",
 ]
 
@@ -1709,7 +1709,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
  "unicode-xid",
 ]
 
@@ -1810,7 +1810,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1930,7 +1930,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2373,7 +2373,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3118,7 +3118,7 @@ dependencies = [
  "fedimint-threshold-crypto",
  "futures",
  "hex",
- "hyper 1.5.1",
+ "hyper 1.5.0",
  "itertools 0.13.0",
  "jsonrpsee",
  "parity-scale-codec",
@@ -3347,6 +3347,7 @@ dependencies = [
  "fedimint-bitcoind",
  "fedimint-client",
  "fedimint-core",
+ "fedimint-eventlog",
  "fedimint-logging",
  "fedimint-wallet-common",
  "futures",
@@ -3689,7 +3690,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4185,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4226,7 +4227,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.5.1",
+ "hyper 1.5.0",
  "hyper-util",
  "rustls 0.23.7",
  "rustls-pki-types",
@@ -4254,7 +4255,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 1.5.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4272,7 +4273,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -4419,7 +4420,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4494,7 +4495,7 @@ dependencies = [
  "autocfg",
  "impl-tools-lib",
  "proc-macro-error2",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4506,7 +4507,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4765,7 +4766,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.0",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5410,7 +5411,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5724,7 +5725,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5753,7 +5754,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5893,7 +5894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5982,9 +5983,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -6073,7 +6074,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.3",
  "regex",
- "syn 2.0.90",
+ "syn 2.0.87",
  "tempfile",
  "which",
 ]
@@ -6101,7 +6102,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6114,7 +6115,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6417,7 +6418,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
@@ -6820,7 +6821,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6911,7 +6912,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7182,7 +7183,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7195,7 +7196,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7226,9 +7227,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7258,7 +7259,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7330,7 +7331,7 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7350,7 +7351,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7497,7 +7498,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7673,7 +7674,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.0",
  "hyper-timeout 0.5.1",
  "hyper-util",
  "percent-encoding",
@@ -7700,7 +7701,7 @@ dependencies = [
  "proc-macro2",
  "prost-build 0.12.3",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8501,7 +8502,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8579,7 +8580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8710,7 +8711,7 @@ checksum = "b3fd98999db9227cf28e59d83e1f120f42bc233d4b152e8fab9bc87d5bb1e0f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8794,7 +8795,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -8828,7 +8829,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8861,7 +8862,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9259,7 +9260,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -9280,7 +9281,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9300,7 +9301,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -9321,7 +9322,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9343,7 +9344,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/gateway/ln-gateway/src/events.rs
+++ b/gateway/ln-gateway/src/events.rs
@@ -1,4 +1,6 @@
 use fedimint_eventlog::{Event, EventKind};
+use fedimint_mint_client::event::{OOBNotesReissued, OOBNotesSpent};
+use fedimint_wallet_client::events::{DepositConfirmed, WithdrawRequest};
 
 use crate::gateway_module_v2::events::{
     CompleteLightningPaymentSucceeded, IncomingPaymentFailed, IncomingPaymentStarted,
@@ -6,7 +8,7 @@ use crate::gateway_module_v2::events::{
     OutgoingPaymentSucceeded,
 };
 
-pub const ALL_GATEWAY_EVENTS: [EventKind; 7] = [
+pub const ALL_GATEWAY_EVENTS: [EventKind; 11] = [
     OutgoingPaymentStarted::KIND,
     OutgoingPaymentSucceeded::KIND,
     OutgoingPaymentFailed::KIND,
@@ -14,6 +16,10 @@ pub const ALL_GATEWAY_EVENTS: [EventKind; 7] = [
     IncomingPaymentSucceeded::KIND,
     IncomingPaymentFailed::KIND,
     CompleteLightningPaymentSucceeded::KIND,
+    OOBNotesSpent::KIND,
+    OOBNotesReissued::KIND,
+    WithdrawRequest::KIND,
+    DepositConfirmed::KIND,
 ];
 
 // TODO: Add Gateway specific events

--- a/modules/fedimint-mint-client/src/event.rs
+++ b/modules/fedimint-mint-client/src/event.rs
@@ -1,10 +1,15 @@
+use std::time::Duration;
+
 use fedimint_core::core::ModuleKind;
+use fedimint_core::Amount;
 use fedimint_eventlog::{Event, EventKind};
 use fedimint_mint_common::{Nonce, KIND};
 use serde::{Deserialize, Serialize};
 
+/// Event that is emitted when a note is created.
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct NoteCreated {
+    /// The nonce of the note
     pub nonce: Nonce,
 }
 
@@ -14,8 +19,10 @@ impl Event for NoteCreated {
     const KIND: EventKind = EventKind::from_static("note-created");
 }
 
+/// Event that is emitted when a note is spent.
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct NoteSpent {
+    /// The nonce of the note
     pub nonce: Nonce,
 }
 
@@ -23,4 +30,40 @@ impl Event for NoteSpent {
     const MODULE: Option<ModuleKind> = Some(KIND);
 
     const KIND: EventKind = EventKind::from_static("note-spent");
+}
+
+/// Event that is emitted when ecash is spent out of band
+#[derive(Serialize, Deserialize)]
+pub struct OOBNotesSpent {
+    /// The requested amount to spend out of band
+    pub requested_amount: Amount,
+
+    /// The actual amount of ecash spent
+    pub spent_amount: Amount,
+
+    /// The timeout before attempting to refund
+    pub timeout: Duration,
+
+    /// Boolean that indicates if the invite code was included in the note
+    /// serialization
+    pub include_invite: bool,
+}
+
+impl Event for OOBNotesSpent {
+    const MODULE: Option<ModuleKind> = Some(KIND);
+
+    const KIND: EventKind = EventKind::from_static("oob-notes-spent");
+}
+
+/// Event that is emitted when out of band ecash is reissued
+#[derive(Serialize, Deserialize)]
+pub struct OOBNotesReissued {
+    /// The amount of out of band ecash being reissued
+    pub amount: Amount,
+}
+
+impl Event for OOBNotesReissued {
+    const MODULE: Option<ModuleKind> = Some(KIND);
+
+    const KIND: EventKind = EventKind::from_static("oob-notes-reissued");
 }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -30,6 +30,7 @@ erased-serde = { workspace = true }
 fedimint-api-client = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
+fedimint-eventlog = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-wallet-common = { workspace = true }
 futures = { workspace = true }

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -276,7 +276,7 @@ pub(crate) async fn transition_btc_tx_confirmed(
 
     let pegin_proof = PegInProof::new(
         txout_proof,
-        awaiting_confirmation_state.btc_transaction,
+        awaiting_confirmation_state.btc_transaction.clone(),
         awaiting_confirmation_state.out_idx,
         awaiting_confirmation_state.tweak_key.public_key(),
     )

--- a/modules/fedimint-wallet-client/src/events.rs
+++ b/modules/fedimint-wallet-client/src/events.rs
@@ -1,0 +1,37 @@
+use bitcoin::Txid;
+use fedimint_core::core::ModuleKind;
+use fedimint_core::Amount;
+use fedimint_eventlog::{Event, EventKind};
+use serde::{Deserialize, Serialize};
+
+/// Event that is emitted when the client pegs-out ecash onchain
+#[derive(Serialize, Deserialize)]
+pub struct WithdrawRequest {
+    /// The bitcoin transaction ID
+    pub txid: Txid,
+}
+
+impl Event for WithdrawRequest {
+    const MODULE: Option<ModuleKind> = Some(fedimint_wallet_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("withdraw-request");
+}
+
+/// Event that is emitted when the client confirms an onchain deposit.
+#[derive(Serialize, Deserialize)]
+pub struct DepositConfirmed {
+    /// The bitcoin transaction ID
+    pub txid: Txid,
+
+    /// The out index of the deposit transaction
+    pub out_idx: u32,
+
+    /// The amount being deposited
+    pub amount: Amount,
+}
+
+impl Event for DepositConfirmed {
+    const MODULE: Option<ModuleKind> = Some(fedimint_wallet_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("deposit-confirmed");
+}

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -15,6 +15,7 @@ pub mod client_db;
 /// Legacy, state-machine based peg-ins, replaced by `pegin_monitor`
 /// but retained for time being to ensure existing peg-ins complete.
 mod deposit;
+pub mod events;
 /// Peg-in monitor: a task monitoring deposit addresses for peg-ins.
 mod pegin_monitor;
 mod withdraw;
@@ -391,6 +392,7 @@ impl ClientModule for WalletClientModule {
             wallet_descriptor: self.cfg().peg_in_descriptor.clone(),
             wallet_decoder: self.decoder(),
             secp: Secp256k1::default(),
+            client_ctx: self.client_ctx.clone(),
         }
     }
 
@@ -478,6 +480,7 @@ pub struct WalletClientContext {
     wallet_descriptor: PegInDescriptor,
     wallet_decoder: Decoder,
     secp: Secp256k1<All>,
+    pub client_ctx: ClientContext<WalletClientModule>,
 }
 
 impl Context for WalletClientContext {

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -28,6 +28,7 @@ use crate::client_db::{
     ClaimedPegInData, ClaimedPegInKey, PegInTweakIndexData, PegInTweakIndexKey,
     PegInTweakIndexPrefix, TweakIdx,
 };
+use crate::events::DepositConfirmed;
 use crate::{WalletClientModule, WalletClientModuleData};
 
 /// A helper struct meant to combined data from all addresses/records
@@ -439,6 +440,17 @@ async fn claim_peg_in(
             keys: vec![tweak_key],
             amount,
         };
+
+        client_ctx
+            .log_event(
+                dbtx,
+                DepositConfirmed {
+                    txid: btc_transaction.compute_txid(),
+                    out_idx,
+                    amount,
+                },
+            )
+            .await;
 
         client_ctx
             .claim_inputs(


### PR DESCRIPTION
Adds events to the event log for when ecash notes are spent OOB and when an onchain deposit or withdraw happens. Will be useful for the gateway's payment log to see when non-lightning transactions happen.