### PR TITLE
refactor: gateway owns its task group

### DIFF
--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -11,7 +11,6 @@
 use std::sync::Arc;
 
 use fedimint_core::fedimint_build_code_version_env;
-use fedimint_core::task::TaskGroup;
 use fedimint_core::util::handle_version_hash_command;
 use fedimint_logging::TracingSetup;
 #[cfg(not(target_env = "msvc"))]
@@ -29,10 +28,8 @@ fn main() -> Result<(), anyhow::Error> {
     runtime.block_on(async {
         handle_version_hash_command(fedimint_build_code_version_env!());
         TracingSetup::default().init()?;
-        let tg = TaskGroup::new();
-        tg.install_kill_handler();
         let gatewayd = Gateway::new_with_default_modules().await?;
-        let shutdown_receiver = gatewayd.clone().run(tg, runtime.clone()).await?;
+        let shutdown_receiver = gatewayd.clone().run(runtime.clone()).await?;
         shutdown_receiver.await;
         gatewayd.unannounce_from_all_federations().await;
         info!("Gatewayd exiting...");

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -41,7 +41,8 @@ use crate::rpc::ConfigPayload;
 use crate::Gateway;
 
 /// Creates the webserver's routes and spawns the webserver in a separate task.
-pub async fn run_webserver(gateway: Arc<Gateway>, task_group: TaskGroup) -> anyhow::Result<()> {
+pub async fn run_webserver(gateway: Arc<Gateway>) -> anyhow::Result<()> {
+    let task_group = gateway.task_group.clone();
     let v1_routes = v1_routes(gateway.clone(), task_group.clone());
     let api_v1 = Router::new()
         .nest(&format!("/{V1_API_ENDPOINT}"), v1_routes.clone())


### PR DESCRIPTION
There are several methods on the `Gateway` struct that currently require a `TaskGroup` argument. In practice the same task group is always used when calling all of these methods, so let's have the `Gateway` hold it as a struct field to make the purpose/ownership more clear.