### PR TITLE
feat: gateway auth redesign

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bcrypt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1866ecef4f2d06a0bb77880015fdf2b89e25a1c2e5addacb87e459c86dc67e"
+dependencies = [
+ "base64 0.22.1",
+ "blowfish",
+ "getrandom",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bdk-macros"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +995,16 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -2613,6 +2636,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.7.9",
+ "bcrypt",
  "bitcoin",
  "clap",
  "erased-serde",
@@ -3164,6 +3188,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "bcrypt",
  "bitcoin",
  "bitcoincore-rpc",
  "fedimint-api-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ async-trait = "0.1.83"
 axum = "0.7.9"
 base64 = "0.22.1"
 base64-url = "3.0.0"
+bcrypt = "0.16.0"
 bincode = "1.3.3"
 bitcoin = { version = "0.32.4", features = ["serde"] }
 bitcoincore-rpc = "0.19.0"

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -162,19 +162,6 @@ impl Gatewayd {
         )
     }
 
-    pub fn change_password(&self, old_password: &str, new_password: &str) -> Command {
-        cmd!(
-            crate::util::get_gateway_cli_path(),
-            "--rpcpassword",
-            old_password,
-            "-a",
-            &self.addr,
-            "set-configuration",
-            "--password",
-            new_password,
-        )
-    }
-
     pub async fn get_info(&self) -> Result<serde_json::Value> {
         retry(
             "Getting gateway info via gateway-cli info",

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -166,9 +166,13 @@ declare_vars! {
         FM_LND_TLS_CERT: PathBuf = FM_LND_DIR.join("tls.cert"); env: "FM_LND_TLS_CERT";
         FM_LND_MACAROON: PathBuf = FM_LND_DIR.join("data/chain/bitcoin/regtest/admin.macaroon"); env: "FM_LND_MACAROON";
 
+        // TODO(support:v0.5): Remove this. It was used prior to `FM_GATEWAY_BCRYPT_PASSWORD_HASH` to provide a plaintext password to the gateway.
         FM_GATEWAY_PASSWORD: String = "theresnosecondbest"; env: "FM_GATEWAY_PASSWORD";
 
-         // Enable to us to make an unbounded number of payments
+        // Bcrypt hash of "theresnosecondbest" with a cost of 10.
+        FM_GATEWAY_BCRYPT_PASSWORD_HASH: String = "$2y$10$Q/UTDeO84VGG1mRncxw.Nubqyi/HsNRJ40k0TSexFy9eVess1yi/u"; env: "FM_GATEWAY_BCRYPT_PASSWORD_HASH";
+
+        // Enable to us to make an unbounded number of payments
         FM_DEFAULT_GATEWAY_FEES: String = "0,0"; env: "FM_DEFAULT_GATEWAY_FEES";
         FM_GATEWAY_SKIP_WAIT_FOR_SYNC: String = "1"; env: "FM_GATEWAY_SKIP_WAIT_FOR_SYNC";
 

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
+bcrypt = { workspace = true }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 fedimint-api-client = { workspace = true }

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -206,7 +207,10 @@ impl Fixtures {
             client_builder,
             listen,
             address.clone(),
-            Some(DEFAULT_GATEWAY_PASSWORD.to_string()),
+            bcrypt::HashParts::from_str(
+                &bcrypt::hash(DEFAULT_GATEWAY_PASSWORD, bcrypt::DEFAULT_COST).unwrap(),
+            )
+            .unwrap(),
             Some(bitcoin::Network::Regtest),
             RoutingFees {
                 base_msat: 0,

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -74,9 +74,6 @@ pub enum GeneralCommands {
     /// Set or update the gateway configuration.
     SetConfiguration {
         #[clap(long)]
-        password: Option<String>,
-
-        #[clap(long)]
         num_route_hints: Option<u32>,
 
         /// Default routing fee for all new federations. Setting it won't affect
@@ -168,7 +165,6 @@ impl GeneralCommands {
                 print_response(response);
             }
             Self::SetConfiguration {
-                password,
                 num_route_hints,
                 routing_fees,
                 network,
@@ -178,7 +174,6 @@ impl GeneralCommands {
                     .map(|input| input.into_iter().map(Into::into).collect());
                 create_client()
                     .set_configuration(SetConfigurationPayload {
-                        password,
                         num_route_hints,
                         routing_fees,
                         network,

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -388,21 +388,12 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
                 );
                 info!("Verified per-federation routing fees changed");
 
-                // Change password for gateway
-                gw.change_password("theresnosecondbest", "newpassword")
-                    .run()
-                    .await?;
-                get_gateway_info(gw)
-                    .await
-                    .expect_err("Expected info to return error since the password has changed");
-                gw.change_password("newpassword", "theresnosecondbest")
-                    .run()
-                    .await?;
+                // Try to change the network while connected to a lightning node
                 cmd!(gw, "set-configuration", "--network", "regtest")
                     .run()
                     .await
                     .expect_err("Cannot change the network while connected to a federation");
-                info!("Verified password change and network cannot be changed.");
+                info!("Verified network cannot be changed.");
 
                 // Get the federation's config and verify it parses correctly
                 let config_val = cmd!(gw, "config", "--federation-id", fed_id)

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -30,6 +30,7 @@ aquamarine = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 axum = { version = "0.7.9", features = [ "json" ] }
+bcrypt = { workspace = true }
 bitcoin = { workspace = true }
 clap = { workspace = true }
 erased-serde = { workspace = true }

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -32,9 +32,9 @@ pub struct GatewayOpts {
     #[arg(long = "api-addr", env = envs::FM_GATEWAY_API_ADDR_ENV)]
     api_addr: SafeUrl,
 
-    /// Gateway webserver authentication password
-    #[arg(long = "password", env = envs::FM_GATEWAY_PASSWORD_ENV)]
-    password: Option<String>,
+    /// Gateway webserver authentication bcrypt password hash
+    #[arg(long = "bcrypt-password-hash", env = envs::FM_GATEWAY_BCRYPT_PASSWORD_HASH_ENV)]
+    bcrypt_password_hash: String,
 
     /// Bitcoin network this gateway will be running on
     #[arg(long = "network", env = envs::FM_GATEWAY_NETWORK_ENV)]
@@ -68,10 +68,13 @@ impl GatewayOpts {
                 api_addr = self.api_addr,
             )
         })?;
+
+        let bcrypt_password_hash = bcrypt::HashParts::from_str(&self.bcrypt_password_hash)?;
+
         Ok(GatewayParameters {
             listen: self.listen,
             versioned_api,
-            password: self.password.clone(),
+            bcrypt_password_hash,
             network: self.network,
             num_route_hints: self.num_route_hints,
             fees: self.default_fees.clone(),
@@ -86,11 +89,11 @@ impl GatewayOpts {
 ///
 /// If `GatewayConfiguration is set in the database, that takes precedence and
 /// the optional parameters will have no affect.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct GatewayParameters {
     pub listen: SocketAddr,
     pub versioned_api: SafeUrl,
-    pub password: Option<String>,
+    pub bcrypt_password_hash: bcrypt::HashParts,
     pub network: Option<Network>,
     pub num_route_hints: u32,
     pub fees: Option<GatewayFee>,

--- a/gateway/ln-gateway/src/envs.rs
+++ b/gateway/ln-gateway/src/envs.rs
@@ -9,9 +9,8 @@ pub const FM_GATEWAY_LISTEN_ADDR_ENV: &str = "FM_GATEWAY_LISTEN_ADDR";
 /// requests to the gateway.
 pub const FM_GATEWAY_API_ADDR_ENV: &str = "FM_GATEWAY_API_ADDR";
 
-/// Environment variable that specifies the password. This is only applied if
-/// there is no password set, otherwise it is ignored.
-pub const FM_GATEWAY_PASSWORD_ENV: &str = "FM_GATEWAY_PASSWORD";
+/// Environment variable that specifies the bcrypt password hash.
+pub const FM_GATEWAY_BCRYPT_PASSWORD_HASH_ENV: &str = "FM_GATEWAY_BCRYPT_PASSWORD_HASH";
 
 /// Environment variable that specifies that Bitcoin network that the gateway
 /// should use. Must match the network of the Lightning node.

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -175,7 +175,6 @@ impl FromStr for FederationRoutingFees {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SetConfigurationPayload {
-    pub password: Option<String>,
     pub num_route_hints: Option<u32>,
     pub routing_fees: Option<FederationRoutingFees>,
     pub network: Option<Network>,

--- a/gateway/ln-gateway/tests/tests.rs
+++ b/gateway/ln-gateway/tests/tests.rs
@@ -266,7 +266,6 @@ async fn test_gateway_enforces_fees() -> anyhow::Result<()> {
             let fee = "10,10000".to_string();
             let federation_fee = FederationRoutingFees::from_str(&fee)?;
             let set_configuration_payload = SetConfigurationPayload {
-                password: None,
                 num_route_hints: None,
                 routing_fees: None,
                 network: None,
@@ -826,7 +825,6 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
         // setting specific routing fees for fed1
         let fed_routing_fees = FederationRoutingFees::from_str("10,10000")?;
         let set_configuration_payload = SetConfigurationPayload {
-            password: None,
             num_route_hints: None,
             routing_fees: None,
             network: None,


### PR DESCRIPTION
Fixes #6427

Previously, the gateway stored its password in its DB and required that a password be provided via an environment variable or CLI argument on first-time startup, after which any provided password was ignored. In this PR, we remove the password from the gateway DB and require that a bcrypt password hash be provided on _every_ startup (either through an environment variable or a CLI argument).

This allows several downstream changes, including:
* Removing `GatewayState::Configuring` since all it was waiting on was for a password to be set, whereas now an unset bcrypt password hash will cause the gateway to panic and exit.
* Merging `GatewayState::Initializing` into `GatewayState::Disconnected` since without the `Configuring` state, the two behave identically.
* Remove the distinction between always-authenticated API routes and authenticated-after-config API routes