### PR TITLE
chore: enable jemalloc on rocksdb itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,12 +2196,12 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.13.0",
- "jemallocator",
  "lightning-invoice",
  "rand",
  "serde",
  "serde_json",
  "thiserror",
+ "tikv-jemallocator",
  "time",
  "tokio",
  "tracing",
@@ -2645,7 +2645,6 @@ dependencies = [
  "futures-util",
  "hex",
  "itertools 0.13.0",
- "jemallocator",
  "ldk-node",
  "lightning",
  "lightning-invoice",
@@ -2659,6 +2658,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
@@ -3468,8 +3468,8 @@ dependencies = [
  "fedimint-unknown-server",
  "fedimint-wallet-server",
  "futures",
- "jemallocator",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
 ]
@@ -4643,26 +4643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4933,6 +4913,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
@@ -7383,6 +7364,26 @@ dependencies = [
  "log",
  "ordered-float 2.10.1",
  "threadpool",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.6.0-alpha
 thiserror = "1.0.69"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tokio = "1.41.1"
-jemallocator = "0.5"
+tikv-jemallocator = "0.5"
 tokio-rustls = "0.24.1"
 tokio-stream = "0.1.16"
 tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
@@ -214,7 +214,7 @@ fedimint-threshold-crypto = { opt-level = 3 }
 ff = { opt-level = 3 }
 group = { opt-level = 3 }
 hashbrown = { opt-level = 3 }
-jemalloc-sys = { opt-level = 3 }
+tikv-jemalloc-sys = { opt-level = 3 }
 libc = { opt-level = 3 }
 memchr = { opt-level = 3 }
 pairing = { opt-level = 3 }

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -59,4 +59,4 @@ tracing = { workspace = true }
 fedimint-build = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }

--- a/fedimint-cli/src/main.rs
+++ b/fedimint-cli/src/main.rs
@@ -1,7 +1,7 @@
 use fedimint_cli::FedimintCli;
 use fedimint_core::fedimint_build_code_version_env;
 #[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 fedimint-core = { workspace = true }
 futures = { workspace = true }
-rocksdb = { version = "0.22.0" }
+rocksdb = { version = "0.22.0", features = [ "jemalloc" ] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -51,4 +51,4 @@ tracing = { workspace = true }
 fedimint-build = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,7 +1,7 @@
 use fedimint_core::fedimint_build_code_version_env;
 use fedimintd::Fedimintd;
 #[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -88,4 +88,4 @@ itertools = { workspace = true }
 fedimint-build = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -13,9 +13,9 @@ use std::sync::Arc;
 use fedimint_core::fedimint_build_code_version_env;
 use fedimint_core::util::handle_version_hash_command;
 use fedimint_logging::TracingSetup;
-#[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
 use ln_gateway::Gateway;
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
 use tracing::info;
 
 #[cfg(not(target_env = "msvc"))]


### PR DESCRIPTION
It needs to be done via Cargo feature flag.

Switch to recommended version of tikv-jemallocator:

https://crates.io/crates/jemallocator:

> The project is also published as jemallocator for historical reasons. The two crates are the same except names. For new projects, it's recommended to use tikv-xxx versions instead.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
