### PR TITLE
chore(ci): record hostname before build

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -89,6 +89,11 @@ jobs:
     timeout-minutes: ${{ matrix.timeout }}
 
     steps:
+      - name: Record hostname
+        if: github.event_name != 'pull_request' || matrix.build-in-pr
+        # the name of the runner is in the CWD
+        run: pwd
+
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
@@ -135,6 +140,11 @@ jobs:
     timeout-minutes: ${{ matrix.timeout }}
 
     steps:
+      - name: Record hostname
+        if: github.event_name != 'pull_request' || matrix.build-in-pr
+        # the name of the runner is in the CWD
+        run: pwd
+
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
@@ -256,6 +266,10 @@ jobs:
     runs-on: [self-hosted, linux]
     timeout-minutes: 45
     steps:
+      - name: Record hostname
+        # the name of the runner is in the CWD
+        run: pwd
+
       - uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -337,6 +351,11 @@ jobs:
     timeout-minutes: ${{ matrix.timeout }}
 
     steps:
+      - name: Record hostname
+        if: github.event_name != 'pull_request' || matrix.build-in-pr
+        # the name of the runner is in the CWD
+        run: pwd
+
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 


### PR DESCRIPTION
I've observered some segfaults in the CI, and it remainded me that it is often beneficial to know which one of the runner machines is a given build running on.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
