### PR TITLE
chore(nix): use older clang on Linux to avoid segfaults

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,16 @@
           };
         };
 
-        toolchainArgs = { };
+        toolchainArgs = lib.optionals stdenv.isLinux {
+          # TODO: we seem to be hitting some miscompilation(?) with
+          # the new (as of nixos-24.11 default: clang 18), which causes
+          # fedimint-cli segfault randomly, but only in Nix sandbox.
+          # Supper weird.
+          stdenv = pkgs.clang14Stdenv;
+          clang = pkgs.llvmPackages_14.clang;
+          libclang = pkgs.llvmPackages_14.libclang.lib;
+          clang-unwrapped = pkgs.llvmPackages_14.clang-unwrapped;
+        };
 
         stdTargets = flakeboxLib.mkStdTargets { };
         stdToolchains = flakeboxLib.mkStdToolchains toolchainArgs;


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
