### PR TITLE
chore: enable jemalloc on rocksdb itself (backport v0.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,13 +1469,13 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.12.1",
- "jemallocator",
  "lightning-invoice",
  "rand",
  "reqwest 0.12.5",
  "serde",
  "serde_json",
  "thiserror",
+ "tikv-jemallocator",
  "time",
  "tokio",
  "tracing",
@@ -1878,7 +1878,6 @@ dependencies = [
  "fedimint-wallet-client",
  "futures",
  "hex",
- "jemallocator",
  "lightning",
  "lightning-invoice",
  "prost",
@@ -1890,6 +1889,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -2685,7 +2685,6 @@ dependencies = [
  "http-body 1.0.0",
  "hyper 1.4.0",
  "itertools 0.12.1",
- "jemallocator",
  "jsonrpsee",
  "once_cell",
  "rand",
@@ -2695,6 +2694,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
@@ -3515,26 +3515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3769,6 +3749,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
@@ -5394,6 +5375,26 @@ dependencies = [
  "log",
  "ordered-float 2.10.1",
  "threadpool",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ strum_macros = "0.26"
 subtle = "2.6.1"
 futures = "0.3.30"
 futures-util = "0.3.30"
-jemallocator = "0.5"
+tikv-jemallocator = "0.5"
 lightning = "0.0.123"
 lightning-invoice = "0.31.0"
 once_cell = "1.19.0"
@@ -170,6 +170,7 @@ bls12_381 = { opt-level = 3 }
 subtle = { opt-level = 3 }
 ring = { opt-level = 3 }
 fedimint-threshold-crypto = { opt-level = 3 }
+tikv-jemalloc-sys = { opt-level = 3 }
 aleph-bft-crypto = { opt-level = 3 }
 aleph-bft-rmc = { opt-level = 3 }
 aleph-bft-types = { opt-level = 3 }

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -30,7 +30,7 @@ time = { version = "0.3.36", features = ["formatting"] }
 clap = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }
 lightning-invoice = { workspace = true }
 fedimint-aead = { version = "=0.4.4-rc.0", path = "../crypto/aead" }
 fedimint-bip39 = { version = "=0.4.4-rc.0", path = "../fedimint-bip39" }
@@ -63,3 +63,6 @@ reqwest = { workspace = true }
 
 [build-dependencies]
 fedimint-build = { version = "=0.4.4-rc.0", path = "../fedimint-build" }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }

--- a/fedimint-cli/src/main.rs
+++ b/fedimint-cli/src/main.rs
@@ -1,7 +1,7 @@
 use fedimint_cli::FedimintCli;
 use fedimint_core::fedimint_build_code_version_env;
 #[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 fedimint-core = { workspace = true }
 futures = { workspace = true }
-rocksdb = { version = "0.22.0" }
+rocksdb = { version = "0.22.0", features = [ "jemalloc" ] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -36,7 +36,7 @@ bytes = "1.6.0"
 clap = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }
 jsonrpsee = { version = "0.24.0", features = ["server"] }
 fedimint-bitcoind = { version = "=0.4.4-rc.0", path = "../fedimint-bitcoind" }
 fedimint-core = { workspace = true }
@@ -78,3 +78,6 @@ console-subscriber = "0.3.0"
 
 [build-dependencies]
 fedimint-build = { version = "=0.4.4-rc.0", path = "../fedimint-build" }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }

--- a/fedimintd/src/bin/main.rs
+++ b/fedimintd/src/bin/main.rs
@@ -1,7 +1,7 @@
 use fedimint_core::fedimint_build_code_version_env;
 use fedimintd::Fedimintd;
 #[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -39,7 +39,7 @@ clap = { workspace = true }
 # cln-plugin made semver incompatible change
 cln-plugin = "=0.1.7"
 cln-rpc = { workspace = true }
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-api-client = { workspace = true }
@@ -93,3 +93,6 @@ assert_matches = { workspace = true }
 [build-dependencies]
 fedimint-build = { version = "=0.4.4-rc.0", path = "../../fedimint-build" }
 tonic-build = "0.11.0"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }

--- a/gateway/ln-gateway/src/bin/gatewayd.rs
+++ b/gateway/ln-gateway/src/bin/gatewayd.rs
@@ -12,9 +12,9 @@ use fedimint_core::fedimint_build_code_version_env;
 use fedimint_core::task::TaskGroup;
 use fedimint_core::util::handle_version_hash_command;
 use fedimint_logging::TracingSetup;
-#[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
 use ln_gateway::Gateway;
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
 use tracing::info;
 
 #[cfg(not(target_env = "msvc"))]


### PR DESCRIPTION
Backport #6488 

It needs to be done via Cargo feature flag.

Switch to recommended version of tikv-jemallocator:

https://crates.io/crates/jemallocator:

> The project is also published as jemallocator for historical reasons. The two crates are the same except names. For new projects, it's recommended to use tikv-xxx versions instead.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
