### PR TITLE
feat: LNv1 Payment Events

### DIFF
--- a/gateway/ln-gateway/src/state_machine/events.rs
+++ b/gateway/ln-gateway/src/state_machine/events.rs
@@ -1,0 +1,46 @@
+use fedimint_core::core::ModuleKind;
+use fedimint_core::Amount;
+use fedimint_eventlog::{Event, EventKind};
+use fedimint_ln_common::contracts::outgoing::OutgoingContractAccount;
+use fedimint_ln_common::contracts::ContractId;
+use serde::{Deserialize, Serialize};
+
+use super::pay::OutgoingPaymentError;
+
+#[derive(Serialize, Deserialize)]
+pub struct OutgoingPaymentStarted {
+    pub contract_id: ContractId,
+    pub invoice_amount: Amount,
+}
+
+impl Event for OutgoingPaymentStarted {
+    const MODULE: Option<ModuleKind> = Some(fedimint_ln_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("outgoing-payment-started");
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct OutgoingPaymentSucceeded {
+    pub outgoing_contract: OutgoingContractAccount,
+    pub contract_id: ContractId,
+    pub preimage: String,
+}
+
+impl Event for OutgoingPaymentSucceeded {
+    const MODULE: Option<ModuleKind> = Some(fedimint_ln_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("outgoing-payment-succeeded");
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct OutgoingPaymentFailed {
+    pub outgoing_contract: OutgoingContractAccount,
+    pub contract_id: ContractId,
+    pub error: OutgoingPaymentError,
+}
+
+impl Event for OutgoingPaymentFailed {
+    const MODULE: Option<ModuleKind> = Some(fedimint_ln_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("outgoing-payment-failed");
+}

--- a/gateway/ln-gateway/src/state_machine/events.rs
+++ b/gateway/ln-gateway/src/state_machine/events.rs
@@ -1,4 +1,4 @@
-use fedimint_core::core::ModuleKind;
+use fedimint_core::core::{ModuleKind, OperationId};
 use fedimint_core::Amount;
 use fedimint_eventlog::{Event, EventKind};
 use fedimint_ln_common::contracts::outgoing::OutgoingContractAccount;
@@ -15,6 +15,9 @@ pub struct OutgoingPaymentStarted {
 
     /// The amount of the invoice that is being paid.
     pub invoice_amount: Amount,
+
+    /// The operation ID of the outgoing payment
+    pub operation_id: OperationId,
 }
 
 impl Event for OutgoingPaymentStarted {
@@ -75,6 +78,9 @@ pub struct IncomingPaymentStarted {
 
     /// The amount offered in the contract.
     pub contract_amount: Amount,
+
+    /// The operation ID of the outgoing payment
+    pub operation_id: OperationId,
 }
 
 impl Event for IncomingPaymentStarted {

--- a/gateway/ln-gateway/src/state_machine/events.rs
+++ b/gateway/ln-gateway/src/state_machine/events.rs
@@ -7,9 +7,13 @@ use serde::{Deserialize, Serialize};
 
 use super::pay::OutgoingPaymentError;
 
+/// LNv1 event that is emitted when an outgoing payment attempt is initiated.
 #[derive(Serialize, Deserialize)]
 pub struct OutgoingPaymentStarted {
+    /// The contract ID that uniquely identifies the outgoing contract.
     pub contract_id: ContractId,
+
+    /// The amount of the invoice that is being paid.
     pub invoice_amount: Amount,
 }
 
@@ -19,10 +23,16 @@ impl Event for OutgoingPaymentStarted {
     const KIND: EventKind = EventKind::from_static("outgoing-payment-started");
 }
 
+/// LNv1 event that is emitted when an outgoing payment attempt has succeeded.
 #[derive(Serialize, Deserialize)]
 pub struct OutgoingPaymentSucceeded {
+    /// LNv1 outgoing contract
     pub outgoing_contract: OutgoingContractAccount,
+
+    /// The contract ID that uniquely identifies the outgoing contract.
     pub contract_id: ContractId,
+
+    /// The preimage acquired from successfully paying the invoice.
     pub preimage: String,
 }
 
@@ -32,10 +42,16 @@ impl Event for OutgoingPaymentSucceeded {
     const KIND: EventKind = EventKind::from_static("outgoing-payment-succeeded");
 }
 
+/// LNv1 event that is emitted when an outgoing payment attempt has failed.
 #[derive(Serialize, Deserialize)]
 pub struct OutgoingPaymentFailed {
+    /// LNv1 outgoing contract
     pub outgoing_contract: OutgoingContractAccount,
+
+    /// The contract ID that uniquely identifies the outgoing contract.
     pub contract_id: ContractId,
+
+    /// The reason the outgoing payment failed.
     pub error: OutgoingPaymentError,
 }
 
@@ -43,4 +59,72 @@ impl Event for OutgoingPaymentFailed {
     const MODULE: Option<ModuleKind> = Some(fedimint_ln_common::KIND);
 
     const KIND: EventKind = EventKind::from_static("outgoing-payment-failed");
+}
+
+/// LNv1 event that is emitted when an incoming payment attempt has started.
+#[derive(Serialize, Deserialize)]
+pub struct IncomingPaymentStarted {
+    /// The contract ID that uniquely identifies the incoming contract.
+    pub contract_id: ContractId,
+
+    /// The payment hash of the invoice that is being paid.
+    pub payment_hash: bitcoin::hashes::sha256::Hash,
+
+    /// The amount specified in the invoice.
+    pub invoice_amount: Amount,
+
+    /// The amount offered in the contract.
+    pub contract_amount: Amount,
+}
+
+impl Event for IncomingPaymentStarted {
+    const MODULE: Option<ModuleKind> = Some(fedimint_ln_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("incoming-payment-started");
+}
+
+/// LNv1 event that is emitted when an incoming payment attempt was successful.
+#[derive(Serialize, Deserialize)]
+pub struct IncomingPaymentSucceeded {
+    /// The payment hash of the invoice that was paid.
+    pub payment_hash: bitcoin::hashes::sha256::Hash,
+
+    /// The decrypted preimage that was acquired from the federation.
+    pub preimage: String,
+}
+
+impl Event for IncomingPaymentSucceeded {
+    const MODULE: Option<ModuleKind> = Some(fedimint_ln_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("incoming-payment-succeeded");
+}
+
+/// LNv1 event that is emitted when an incoming payment attempt has failed.
+#[derive(Serialize, Deserialize)]
+pub struct IncomingPaymentFailed {
+    /// The payment hash of the invoice that failed to be paid.
+    pub payment_hash: bitcoin::hashes::sha256::Hash,
+
+    /// The reason the incoming payment attempt failed.
+    pub error: String,
+}
+
+impl Event for IncomingPaymentFailed {
+    const MODULE: Option<ModuleKind> = Some(fedimint_ln_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("incoming-payment-failed");
+}
+
+/// LNv1 event that is emitted when a preimage was successfully revealed to the
+/// Lightning Network.
+#[derive(Serialize, Deserialize)]
+pub struct CompleteLightningPaymentSucceeded {
+    /// The payment hash of the payment.
+    pub payment_hash: bitcoin::hashes::sha256::Hash,
+}
+
+impl Event for CompleteLightningPaymentSucceeded {
+    const MODULE: Option<ModuleKind> = Some(fedimint_ln_common::KIND);
+
+    const KIND: EventKind = EventKind::from_static("complete-lightning-payment-succeeded");
 }

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -476,6 +476,7 @@ impl GatewayClientModule {
                     payment_hash: htlc.payment_hash,
                     invoice_amount: htlc.outgoing_amount_msat,
                     contract_amount: amount,
+                    operation_id,
                 },
             )
             .await;
@@ -624,6 +625,7 @@ impl GatewayClientModule {
                         self.client_ctx.log_event(dbtx, OutgoingPaymentStarted {
                             contract_id: payload.contract_id,
                             invoice_amount: payload.payment_data.amount().expect("LNv1 invoices should have an amount"),
+                            operation_id,
                         }).await;
 
                         let state_machines =


### PR DESCRIPTION
Similar to https://github.com/fedimint/fedimint/pull/6351, this PR adds payment events for LNv1. It allows us to compute profit, fees, and latency for LNv1.

The LNv2 events are a bit better structured, but this still gives us the necessary data. Since we will be supporting LNv1 for a bit I figured it would be good to add this as well (might even be fun to compare with LNv2).