### PR TITLE
[Backport releases/v0.5] fix(server): typo in log statement

### DIFF
--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -538,7 +538,9 @@ impl ServerConfig {
                     Ok((peer_id, DkgPeerMsg::Done)) => {
                         info!(
                             target: LOG_NET_PEER_DKG,
-                            pper_id = %peer_id, "Got completion confirmation");
+                            peer_id = %peer_id,
+                            "Got completion confirmation"
+                        );
                         done_peers.insert(peer_id);
                     },
                     Ok((peer_id, msg)) => {


### PR DESCRIPTION
# Description
Backport of #6501 to `releases/v0.5`.