### PR TITLE
feat(wallet-server): ability to source fee rates from external sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3418,9 +3418,13 @@ dependencies = [
  "fedimint-wallet-common",
  "futures",
  "hex",
+ "jaq-core",
+ "jaq-json",
  "miniscript",
  "rand",
+ "reqwest 0.12.9",
  "serde",
+ "serde_json",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tokio",
@@ -4068,6 +4072,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
+name = "hifijson"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9958ab3ce3170c061a27679916bd9b969eceeb5e8b120438e6751d0987655c42"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4677,6 +4687,47 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jaq-core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03ee1b714d63f0a5820131180056b592ecd400b32879c848e53e58707f19df0"
+dependencies = [
+ "dyn-clone",
+ "once_cell",
+ "typed-arena",
+]
+
+[[package]]
+name = "jaq-json"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daf2b52304419d7bf5ec32891884c65274a3eedc0b5834b84627099901a1176"
+dependencies = [
+ "foldhash",
+ "hifijson",
+ "indexmap 2.2.5",
+ "jaq-core",
+ "jaq-std",
+ "serde_json",
+]
+
+[[package]]
+name = "jaq-std"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e2c65cceafd4c0019f15a0dac7c0dd659b0fcf5182fc3a10d15b89d89ac6e8"
+dependencies = [
+ "aho-corasick",
+ "base64 0.22.1",
+ "chrono",
+ "jaq-core",
+ "libm",
+ "log",
+ "regex-lite",
+ "urlencoding",
+]
 
 [[package]]
 name = "jobserver"
@@ -6364,6 +6415,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -8626,6 +8683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typed-index-collections"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8696,6 +8759,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf16_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,8 @@ hex-conservative = "0.3.0"
 hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.6.0-alpha" }
 hyper = "1.5"
 itertools = "0.13.0"
+jaq-core = "2.0.0"
+jaq-json = { version = "1.0.0", features = ["serde_json"] }
 lightning = "0.0.125"
 lightning-invoice = { version = "0.32.0", features = ["std"] }
 ln-gateway = { package = "fedimint-ln-gateway", path = "./gateway/ln-gateway", version = "=0.6.0-alpha" }

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -62,6 +62,14 @@ pub const FM_FORCE_BITCOIN_RPC_KIND_ENV: &str = "FM_FORCE_BITCOIND_RPC_KIND";
 /// Env var for bitcoin URL (default, takes priority over config settings)
 pub const FM_FORCE_BITCOIN_RPC_URL_ENV: &str = "FM_FORCE_BITCOIND_RPC_URL";
 
+/// List of json api endpoint sources to use as a source of
+/// fee rate estimation.
+///
+/// `;`-separated list of urls with part after `#`
+/// ("fragment") specifying jq filter to extract sats/vB fee rate.
+/// Eg. `https://mempool.space/api/v1/fees/recommended#.halfHourFee`
+pub const FM_WALLET_FEERATE_SOURCES_ENV: &str = "FM_WALLET_FEERATE_SOURCES";
+
 /// Env var that can be set to point at the bitcoind's cookie file to use for
 /// auth
 pub const FM_BITCOIND_COOKIE_FILE_ENV: &str = "FM_BITCOIND_COOKIE_FILE";

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -68,6 +68,9 @@ pub const FM_FORCE_BITCOIN_RPC_URL_ENV: &str = "FM_FORCE_BITCOIND_RPC_URL";
 /// `;`-separated list of urls with part after `#`
 /// ("fragment") specifying jq filter to extract sats/vB fee rate.
 /// Eg. `https://mempool.space/api/v1/fees/recommended#.halfHourFee`
+///
+/// Note that `#` is a standalone separator and *not* parsed as a part of the
+/// Url. Which means there's no need to escape it.
 pub const FM_WALLET_FEERATE_SOURCES_ENV: &str = "FM_WALLET_FEERATE_SOURCES";
 
 /// Env var that can be set to point at the bitcoind's cookie file to use for

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -185,6 +185,14 @@ impl SafeUrl {
 
         host.ends_with(".onion")
     }
+
+    pub fn fragment(&self) -> Option<&str> {
+        self.0.fragment()
+    }
+
+    pub fn set_fragment(&mut self, arg: Option<&str>) {
+        self.0.set_fragment(arg);
+    }
 }
 
 impl Display for SafeUrl {

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -480,12 +480,14 @@ plugin_types_trait_impl_common!(
     WalletOutputError
 );
 
-#[derive(Debug, Error, Encodable, Decodable, Hash, Clone, Eq, PartialEq)]
+#[derive(Debug, Error, Clone)]
 pub enum WalletCreationError {
     #[error("Connected bitcoind is on wrong network, expected {0}, got {1}")]
     WrongNetwork(NetworkLegacyEncodingWrapper, NetworkLegacyEncodingWrapper),
     #[error("Error querying bitcoind: {0}")]
     RpcError(String),
+    #[error("Feerate source error: {0}")]
+    FeerateSourceError(String),
 }
 
 #[derive(Debug, Error, Encodable, Decodable, Hash, Clone, Eq, PartialEq)]

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -28,9 +28,13 @@ fedimint-server = { workspace = true }
 fedimint-wallet-common = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+jaq-core = { workspace = true }
+jaq-json = { workspace = true }
 miniscript = { workspace = true }
 rand = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tokio = { workspace = true }

--- a/modules/fedimint-wallet-server/src/feerate_source.rs
+++ b/modules/fedimint-wallet-server/src/feerate_source.rs
@@ -1,0 +1,166 @@
+use std::str::FromStr;
+
+use anyhow::{anyhow, bail, Result};
+use fedimint_bitcoind::DynBitcoindRpc;
+use fedimint_core::util::SafeUrl;
+use fedimint_core::{apply, async_trait_maybe_send, Feerate};
+use fedimint_logging::LOG_MODULE_WALLET;
+use fedimint_wallet_common::CONFIRMATION_TARGET;
+use jaq_core::load::{Arena, File, Loader};
+use jaq_core::{Ctx, Native, RcIter};
+use jaq_json::Val;
+use tracing::{debug, trace};
+
+/// A feerate that we don't expect to ever happen in practice, that we are
+/// going to reject from a source to help catching mistakes and
+/// misconfigurations.
+const FEERATE_SOURCE_MAX_FEERATE_SATS_PER_VB: f64 = 10_000.0;
+
+/// Like [`FEERATE_SOURCE_MAX_FEERATE_SATS_PER_VB`], but minimum one we accept
+const FEERATE_SOURCE_MIN_FEERATE_SATS_PER_VB: f64 = 1.0;
+
+#[apply(async_trait_maybe_send!)]
+pub trait FeeRateSource: Send + Sync {
+    fn name(&self) -> String;
+    async fn fetch(&self) -> Result<Feerate>;
+}
+
+#[apply(async_trait_maybe_send!)]
+impl FeeRateSource for DynBitcoindRpc {
+    fn name(&self) -> String {
+        self.get_bitcoin_rpc_config().kind
+    }
+
+    async fn fetch(&self) -> Result<Feerate> {
+        self.get_fee_rate(CONFIRMATION_TARGET)
+            .await?
+            .ok_or_else(|| anyhow!("bitcoind did not return any feerate"))
+    }
+}
+
+pub struct FetchJson {
+    filter: jaq_core::Filter<Native<Val>>,
+    source_url: SafeUrl,
+}
+
+impl FetchJson {
+    pub fn from_str(source_str: &str) -> Result<Self> {
+        let (source_url, code) = {
+            let (url, code) = match source_str.split_once('#') {
+                Some(val) => val,
+                None => (source_str, "."),
+            };
+
+            (SafeUrl::parse(url)?, code)
+        };
+
+        debug!(target: LOG_MODULE_WALLET, url = %source_url, code = %code, "Setting fee rate json source");
+        let program = File { code, path: () };
+
+        let loader = Loader::new([]);
+        let arena = Arena::default();
+        let modules = loader.load(&arena, program).map_err(|errs| {
+            anyhow!(
+                "Error parsing jq filter for {source_url}: {}",
+                errs.into_iter()
+                    .map(|e| format!("{e:?}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        })?;
+
+        let filter = jaq_core::Compiler::<_, Native<_>>::default()
+            .compile(modules)
+            .map_err(|errs| anyhow!("Failed to compile program: {:?}", errs))?;
+
+        Ok(Self { filter, source_url })
+    }
+
+    fn apply_filter(&self, value: serde_json::Value) -> Result<Val> {
+        let inputs = RcIter::new(core::iter::empty());
+
+        let mut out = self.filter.run((Ctx::new([], &inputs), Val::from(value)));
+
+        out.next()
+            .ok_or_else(|| anyhow!("Missing value after applying filter"))?
+            .map_err(|e| anyhow!("Jaq err: {e}"))
+    }
+}
+
+#[apply(async_trait_maybe_send!)]
+impl FeeRateSource for FetchJson {
+    fn name(&self) -> String {
+        self.source_url
+            .host()
+            .map_or_else(|| "host-not-available".to_string(), |h| h.to_string())
+    }
+
+    async fn fetch(&self) -> Result<Feerate> {
+        let json_resp: serde_json::Value = reqwest::get(self.source_url.clone().to_unsafe())
+            .await?
+            .json()
+            .await?;
+
+        trace!(target: LOG_MODULE_WALLET, name = %self.name(), resp = ?json_resp, "Got json response");
+
+        let val = self.apply_filter(json_resp)?;
+
+        let rate = match val {
+            Val::Float(rate) => rate,
+            #[allow(clippy::cast_precision_loss)]
+            Val::Int(rate) => rate as f64,
+            Val::Num(rate) => FromStr::from_str(&rate)?,
+            _ => {
+                bail!("Value returned by feerate source has invalid type: {val:?}");
+            }
+        };
+        debug!(target: LOG_MODULE_WALLET, name = %self.name(), rate_sats_vb = %rate, "Got fee rate");
+
+        if rate < FEERATE_SOURCE_MIN_FEERATE_SATS_PER_VB {
+            bail!("Fee rate returned by source not positive: {rate}")
+        }
+
+        if FEERATE_SOURCE_MAX_FEERATE_SATS_PER_VB <= rate {
+            bail!("Fee rate returned by source too large: {rate}")
+        }
+
+        Ok(Feerate {
+            // just checked that it's not negative
+            #[allow(clippy::cast_sign_loss)]
+            sats_per_kvb: (rate * 1000.0).floor() as u64,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::rc::Rc;
+
+    use jaq_json::Val;
+
+    use crate::feerate_source::FetchJson;
+
+    fn val_str(s: &str) -> Val {
+        Val::Str(Rc::new(s.to_owned()))
+    }
+
+    #[test]
+    fn test_filter() {
+        let source_id = FetchJson::from_str("https://example.com#.").expect("Failed to parse url");
+        assert_eq!(
+            source_id
+                .apply_filter(serde_json::json!("foo"))
+                .expect("Failed to apply filter"),
+            val_str("foo")
+        );
+
+        let source_access_member =
+            FetchJson::from_str("https://example.com#.[0].foo").expect("Failed to parse url");
+        assert_eq!(
+            source_access_member
+                .apply_filter(serde_json::json!([{"foo": "bar"}, 1, 2, 3]))
+                .expect("Failed to apply filter"),
+            val_str("bar")
+        );
+    }
+}

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -9,9 +9,13 @@
 #![allow(clippy::too_many_lines)]
 
 pub mod db;
+mod feerate_source;
 
+use std::clone::Clone;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::Infallible;
+use std::iter;
+use std::sync::Arc;
 #[cfg(not(target_family = "wasm"))]
 use std::time::Duration;
 
@@ -29,8 +33,8 @@ use common::config::WalletConfigConsensus;
 use common::{
     proprietary_tweak_key, PegOutFees, PegOutSignatureItem, ProcessPegOutSigError, SpendableUTXO,
     TxOutputSummary, WalletCommonInit, WalletConsensusItem, WalletCreationError, WalletInput,
-    WalletModuleTypes, WalletOutput, WalletOutputOutcome, WalletSummary, CONFIRMATION_TARGET,
-    DEPRECATED_RBF_ERROR, FEERATE_MULTIPLIER,
+    WalletModuleTypes, WalletOutput, WalletOutputOutcome, WalletSummary, DEPRECATED_RBF_ERROR,
+    FEERATE_MULTIPLIER,
 };
 use fedimint_bitcoind::{create_bitcoind, DynBitcoindRpc};
 use fedimint_core::config::{
@@ -44,7 +48,10 @@ use fedimint_core::db::{
 };
 use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
-use fedimint_core::envs::{is_rbf_withdrawal_enabled, is_running_in_test_env, BitcoinRpcConfig};
+use fedimint_core::envs::{
+    is_rbf_withdrawal_enabled, is_running_in_test_env, BitcoinRpcConfig,
+    FM_WALLET_FEERATE_SOURCES_ENV,
+};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiError, ApiVersion, CoreConsensusVersion, InputMeta,
@@ -77,6 +84,7 @@ use fedimint_wallet_common::{
     Rbf, UnknownWalletInputVariantError, WalletInputError, WalletOutputError, WalletOutputV0,
     MODULE_CONSENSUS_VERSION,
 };
+use feerate_source::{FeeRateSource, FetchJson};
 use futures::{FutureExt, StreamExt};
 use metrics::{
     WALLET_INOUT_FEES_SATS, WALLET_INOUT_SATS, WALLET_PEGIN_FEES_SATS, WALLET_PEGIN_SATS,
@@ -982,7 +990,8 @@ impl Wallet {
         Self::spawn_broadcast_pending_task(task_group, &bitcoind, db);
 
         let (block_count_rx, fee_rate_rx) =
-            Self::spawn_bitcoin_update_task(&cfg, task_group, &bitcoind);
+            Self::spawn_bitcoin_update_task(&cfg, task_group, &bitcoind)
+                .map_err(|e| WalletCreationError::FeerateSourceError(e.to_string()))?;
 
         let bitcoind_rpc = bitcoind;
 
@@ -1547,9 +1556,23 @@ impl Wallet {
         cfg: &WalletConfig,
         task_group: &TaskGroup,
         bitcoind: &DynBitcoindRpc,
-    ) -> (watch::Receiver<Option<u32>>, watch::Receiver<Feerate>) {
+    ) -> anyhow::Result<(watch::Receiver<Option<u32>>, watch::Receiver<Feerate>)> {
         let (block_count_tx, block_count_rx) = watch::channel(None);
         let (fee_rate_tx, fee_rate_rx) = watch::channel(cfg.consensus.default_fee);
+
+        let sources = std::env::var(FM_WALLET_FEERATE_SOURCES_ENV)
+            .unwrap_or_else(|_| match cfg.consensus.network.0 {
+                Network::Bitcoin => "https://mempool.space/api/v1/fees/recommended#.;https://blockstream.info/api/fee-estimates#.\"1\"".to_owned(),
+                _ => String::new(),
+            })
+            .split(';')
+            .filter(|s| !s.is_empty())
+            .map(|s| Ok(Box::new(FetchJson::from_str(s)?) as Box<dyn FeeRateSource>))
+            .chain(iter::once(Ok(
+                Box::new(bitcoind.clone()) as Box<dyn FeeRateSource>
+            )))
+            .collect::<anyhow::Result<Vec<Box<dyn FeeRateSource>>>>()?;
+        let feerates = Arc::new(std::sync::Mutex::new(vec![None; sources.len()]));
 
         let mut desired_interval = tokio::time::interval(if is_running_in_test_env() {
             // In devimint, the setup is blocked by detecting block height changes,
@@ -1584,22 +1607,29 @@ impl Wallet {
                 let update_fee_rate = || async {
                     trace!(target: LOG_MODULE_WALLET, "Updating bitcoin fee rate");
 
-                    let res = bitcoind
-                       .get_fee_rate(CONFIRMATION_TARGET).await;
+                    let feerates_new = futures::future::join_all(sources.iter().map(|s| async { (s.name(), s.fetch().await) } )).await;
 
-                    match res {
-                        Ok(Some(r)) => {
-                            let feerate_with_multiplier = Feerate { sats_per_kvb: r.sats_per_kvb * FEERATE_MULTIPLIER };
-                            let _ = fee_rate_tx.send(feerate_with_multiplier);
+                    let mut feerates = feerates.lock().expect("lock poisoned");
+                    for (i, (name, res)) in feerates_new.into_iter().enumerate() {
+                        match res {
+                            Ok(ok) => feerates[i] = Some(ok),
+                            Err(err) => {
+                                warn!(target: LOG_MODULE_WALLET, %err, %name, "Error getting feerate from source");
+                            },
                         }
-                        Ok(None) => {
-                            // Regtest node never returns fee rate, so no point spamming about it
-                            if !is_running_in_test_env() {
-                                warn!(target: LOG_MODULE_WALLET, "Bitcoin node did not return a fee rate");
-                            }
-                        }
-                        Err(err) => {
-                            warn!(target: LOG_MODULE_WALLET, %err, "Unable to get fee rate from the node");
+                    }
+
+                    let mut available_feerates : Vec<_> = feerates.iter().filter_map(Clone::clone).map(|r| r.sats_per_kvb).collect();
+
+                    available_feerates.sort_unstable();
+
+                    if let Some(r) = get_median(&available_feerates) {
+                        let feerate_with_multiplier = Feerate { sats_per_kvb: r * FEERATE_MULTIPLIER };
+                        let _ = fee_rate_tx.send(feerate_with_multiplier);
+                    } else {
+                        // Regtest node never returns fee rate, so no point spamming about it
+                        if !is_running_in_test_env() {
+                            warn!(target: LOG_MODULE_WALLET, "Bitcoin node did not return a fee rate");
                         }
                     }
                 };
@@ -1616,7 +1646,7 @@ impl Wallet {
                 }
             }
         });
-        (block_count_rx, fee_rate_rx)
+        Ok((block_count_rx, fee_rate_rx))
     }
 
     /// Shutdown the task group shared throughout fedimintd, giving 60 seconds
@@ -2112,6 +2142,20 @@ impl Serialize for UnsignedTransaction {
         } else {
             serializer.serialize_bytes(&self.consensus_encode_to_vec())
         }
+    }
+}
+
+fn get_median(vals: &[u64]) -> Option<u64> {
+    if vals.is_empty() {
+        return None;
+    }
+    let len = vals.len();
+    let mid = len / 2;
+
+    if len % 2 == 0 {
+        Some((vals[mid - 1] + vals[mid]) / 2)
+    } else {
+        Some(vals[mid])
     }
 }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1580,7 +1580,7 @@ impl Wallet {
             debug!(target: LOG_MODULE_WALLET, "Running in devimint, using fast node polling");
             Duration::from_millis(100)
         } else {
-            Duration::from_secs(10)
+            Duration::from_secs(30)
         });
 
         task_group.spawn_cancellable("wallet module: background update", {


### PR DESCRIPTION

Introduces a `FM_WALLET_FEERATE_SOURCES` env var which allows specifing a list of urls along with `jq` filter syntax to extract the sats/vB feerate.

A default value is (will be - the exact contents are to be determined) provided per-network.

All sources are queried, along with the bitcoind, and a median is used to get the actual feerate to vote on during consensus.


Can be tested with:

```
env RUST_LOG=fm=info,fm::module::wallet=debug FM_WALLET_FEERATE_SOURCES="https://mempool.space/api/v1/fees/recommended#.halfHourFee;https://blockstream.info/api/fee-estimates#.\"1\"" j devimint-env
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
