### PR TITLE
fix: add mprocs after nixpkgs 24.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -313,6 +313,7 @@
                     (pkgs.hiPrio pkgs.bashInteractive)
                     pkgs.tmux
                     pkgs.tmuxinator
+                    pkgs.mprocs
                     pkgs.docker-compose
                     pkgs.tokio-console
                     pkgs.git


### PR DESCRIPTION
`just mprocs` isn't booting for me without it.