### PR TITLE
fix: ignore RUSTSEC-2024-0402 which we don't care about

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,4 +9,9 @@
 #
 # See the full example in: https://raw.githubusercontent.com/rustsec/rustsec/main/cargo-audit/audit.toml.example
 [advisories]
-ignore = ["RUSTSEC-2023-0052", "RUSTSEC-2023-0071"]
+ignore = [
+  "RUSTSEC-2023-0052",
+  "RUSTSEC-2023-0071",
+  # we don't use borsch encoding
+  "RUSTSEC-2024-0402"
+]


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
