### PR TITLE
feat: allow customization of LNv2 Lightning and Transaction Fees

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -9,8 +9,9 @@ use fedimint_core::config::FederationId;
 use fedimint_core::envs::{is_env_var_set, FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV};
 use fedimint_core::secp256k1::PublicKey;
 use fedimint_core::util::{backoff_util, retry};
-use fedimint_core::BitcoinAmountOrAll;
+use fedimint_core::{Amount, BitcoinAmountOrAll};
 use fedimint_ln_server::common::lightning_invoice::Bolt11Invoice;
+use fedimint_lnv2_common::gateway_api::PaymentFee;
 use fedimint_testing::gateway::LightningNodeType;
 use ln_gateway::envs::FM_GATEWAY_LIGHTNING_MODULE_MODE_ENV;
 use ln_gateway::lightning::ChannelInfo;
@@ -23,7 +24,7 @@ use crate::external::{Bitcoind, LightningNode};
 use crate::federation::Federation;
 use crate::util::{poll, Command, ProcessHandle, ProcessManager};
 use crate::vars::utf8;
-use crate::version_constants::VERSION_0_5_0_ALPHA;
+use crate::version_constants::{VERSION_0_4_0_ALPHA, VERSION_0_5_0_ALPHA, VERSION_0_6_0_ALPHA};
 
 #[derive(Clone)]
 pub struct Gatewayd {
@@ -505,6 +506,106 @@ impl Gatewayd {
             Err(ControlFlow::Continue(anyhow!("Not synced to block")))
         })
         .await?;
+        Ok(())
+    }
+
+    pub async fn get_lightning_fee(&self, fed_id: String) -> Result<PaymentFee> {
+        let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
+        let (fee_key, base_key, ppm_key) = if gatewayd_version >= *VERSION_0_6_0_ALPHA {
+            ("lightning_fee", "base", "parts_per_million")
+        } else {
+            ("routing_fees", "base_msat", "proportional_millionths")
+        };
+
+        let info_value = self.get_info().await?;
+        let federations = info_value["federations"]
+            .as_array()
+            .expect("federations is an array");
+
+        let fed = federations
+            .iter()
+            .find(|fed| {
+                serde_json::from_value::<String>(fed["federation_id"].clone())
+                    .expect("could not deserialize federation_id")
+                    == fed_id
+            })
+            .ok_or_else(|| anyhow!("Federation not found"))?;
+
+        let lightning_fee = fed[fee_key].clone();
+        let base: Amount = serde_json::from_value(lightning_fee[base_key].clone())
+            .map_err(|e| anyhow!("Couldnt parse base: {}", e))?;
+        let parts_per_million: u64 = serde_json::from_value(lightning_fee[ppm_key].clone())
+            .map_err(|e| anyhow!("Couldnt parse parts_per_million: {}", e))?;
+
+        Ok(PaymentFee {
+            base,
+            parts_per_million,
+        })
+    }
+
+    pub async fn set_federation_routing_fee(
+        &self,
+        fed_id: String,
+        base: u64,
+        ppm: u64,
+    ) -> Result<()> {
+        let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
+        if gatewayd_version < *VERSION_0_4_0_ALPHA {
+            return Ok(());
+        } else if gatewayd_version >= *VERSION_0_4_0_ALPHA
+            && gatewayd_version < *VERSION_0_6_0_ALPHA
+        {
+            let new_fed_routing_fees = format!("{fed_id},{base},{ppm}");
+            cmd!(
+                self,
+                "set-configuration",
+                "--per-federation-routing-fees",
+                new_fed_routing_fees
+            )
+            .run()
+            .await?;
+        } else {
+            cmd!(
+                self,
+                "cfg",
+                "set-fees",
+                "--federation-id",
+                fed_id,
+                "--ln-base",
+                base,
+                "--ln-ppm",
+                ppm
+            )
+            .run()
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn set_federation_transaction_fee(
+        &self,
+        fed_id: String,
+        base: u64,
+        ppm: u64,
+    ) -> Result<()> {
+        let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
+        if gatewayd_version >= *VERSION_0_6_0_ALPHA {
+            cmd!(
+                self,
+                "cfg",
+                "set-fees",
+                "--federation-id",
+                fed_id,
+                "--tx-base",
+                base,
+                "--tx-ppm",
+                ppm
+            )
+            .run()
+            .await?;
+        }
+
         Ok(())
     }
 }

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -551,7 +551,10 @@ impl Gatewayd {
     ) -> Result<()> {
         let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
         if gatewayd_version < *VERSION_0_4_0_ALPHA {
-            return Ok(());
+            let fees = format!("{base},{ppm}");
+            cmd!(self, "set-configuration", "--routing-fees", fees)
+                .run()
+                .await?;
         } else if gatewayd_version >= *VERSION_0_4_0_ALPHA
             && gatewayd_version < *VERSION_0_6_0_ALPHA
         {

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -675,6 +675,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     gw_lnd
         .set_federation_routing_fee(fed_id.clone(), 0, 0)
         .await?;
+    cmd!(client, "list-gateways").run().await?;
 
     let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
 

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -671,6 +671,11 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     let fed_id = fed.calculate_federation_id();
     let invite = fed.invite_code()?;
 
+    // LNv1 expects no gateway routing fees
+    gw_lnd
+        .set_federation_routing_fee(fed_id.clone(), 0, 0)
+        .await?;
+
     let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
 
     let invite_code = if fedimint_cli_version >= *VERSION_0_3_0_ALPHA {
@@ -869,12 +874,6 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     // Assert balances changed by 2_000_000 msat (amount sent) + 0 msat (fee)
     let final_lnd_outgoing_client_balance = client.balance().await?;
     let final_lnd_outgoing_gateway_balance = gw_lnd.ecash_balance(fed_id.clone()).await?;
-    //anyhow::ensure!(
-    //    final_lnd_incoming_client_balance - final_lnd_outgoing_client_balance ==
-    // 2_000_000,    "Client balance changed by {} on LND outgoing payment,
-    // expected 2_000_000",    (final_lnd_incoming_client_balance -
-    // final_lnd_outgoing_client_balance)
-    //);
     anyhow::ensure!(
         final_lnd_outgoing_gateway_balance - initial_lnd_gateway_balance == 2_000_000,
         "LND Gateway balance changed by {} on LND outgoing payment, expected 2_000_000",
@@ -1105,6 +1104,10 @@ pub async fn cli_load_test_tool_test(dev_fed: DevFed) -> Result<()> {
         .pegin_client(10_000, dev_fed.fed.internal_client().await?)
         .await?;
     let invite_code = dev_fed.fed.invite_code()?;
+    dev_fed
+        .gw_lnd
+        .set_federation_routing_fee(dev_fed.fed.calculate_federation_id(), 0, 0)
+        .await?;
     run_standard_load_test(&load_test_temp, &invite_code).await?;
     run_ln_circular_load_test(&load_test_temp, &invite_code).await?;
     Ok(())
@@ -2276,6 +2279,10 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                 let task_group = task_group.clone();
                 async move {
                     let dev_fed = dev_fed(&process_mgr).await?;
+                    dev_fed
+                        .gw_lnd
+                        .set_federation_routing_fee(dev_fed.fed.calculate_federation_id(), 0, 0)
+                        .await?;
                     let ((), faucet) = try_join!(
                         dev_fed.fed.pegin_gateways(20_000, vec![&dev_fed.gw_lnd]),
                         async {

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -172,12 +172,8 @@ declare_vars! {
         // Bcrypt hash of "theresnosecondbest" with a cost of 10.
         FM_GATEWAY_BCRYPT_PASSWORD_HASH: String = "$2y$10$Q/UTDeO84VGG1mRncxw.Nubqyi/HsNRJ40k0TSexFy9eVess1yi/u"; env: "FM_GATEWAY_BCRYPT_PASSWORD_HASH";
 
-        // Enable to us to make an unbounded number of payments
-        FM_DEFAULT_GATEWAY_FEES: String = "0,0"; env: "FM_DEFAULT_GATEWAY_FEES";
-        // TODO:(support:v0.4): we renamed to FM_DEFAULT_GATEWAY_FEES in v0.5.0
-        // see: https://github.com/fedimint/fedimint/pull/6023
-        FM_GATEWAY_FEES: String = "0,0"; env: "FM_GATEWAY_FEES";
         FM_GATEWAY_SKIP_WAIT_FOR_SYNC: String = "1"; env: "FM_GATEWAY_SKIP_WAIT_FOR_SYNC";
+        FM_GATEWAY_NETWORK: String = "regtest"; env: "FM_GATEWAY_NETWORK";
 
         FM_FAUCET_BIND_ADDR: String = f!("0.0.0.0:{FM_PORT_FAUCET}"); env: "FM_FAUCET_BIND_ADDR";
 

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -12,3 +12,5 @@ pub static VERSION_0_4_0: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.4.0").expect("version is parsable"));
 pub static VERSION_0_5_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.5.0-alpha").expect("version is parsable"));
+pub static VERSION_0_6_0_ALPHA: LazyLock<Version> =
+    LazyLock::new(|| Version::parse("0.6.0-alpha").expect("version is parsable"));

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -21,7 +21,6 @@ use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::util::SafeUrl;
 use fedimint_logging::TracingSetup;
 use fedimint_testing_core::test_dir;
-use lightning_invoice::RoutingFees;
 use ln_gateway::client::GatewayClientBuilder;
 use ln_gateway::config::LightningModuleMode;
 use ln_gateway::lightning::{ILnRpcClient, LightningBuilder, LightningContext};
@@ -214,11 +213,7 @@ impl Fixtures {
                 &bcrypt::hash(DEFAULT_GATEWAY_PASSWORD, bcrypt::DEFAULT_COST).unwrap(),
             )
             .unwrap(),
-            Some(bitcoin::Network::Regtest),
-            RoutingFees {
-                base_msat: 0,
-                proportional_millionths: 0,
-            },
+            bitcoin::Network::Regtest,
             0,
             gateway_db,
             // Manually set the gateway's state to `Running`. In tests, we do don't run the

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -1,11 +1,13 @@
 #![deny(clippy::pedantic, clippy::nursery)]
 
+mod config_commands;
 mod ecash_commands;
 mod general_commands;
 mod lightning_commands;
 mod onchain_commands;
 
 use clap::{CommandFactory, Parser, Subcommand};
+use config_commands::ConfigCommands;
 use ecash_commands::EcashCommands;
 use fedimint_core::util::SafeUrl;
 use fedimint_logging::TracingSetup;
@@ -39,6 +41,8 @@ enum Commands {
     Ecash(EcashCommands),
     #[command(subcommand)]
     Onchain(OnchainCommands),
+    #[command(subcommand)]
+    Cfg(ConfigCommands),
     Completion {
         shell: clap_complete::Shell,
     },
@@ -57,6 +61,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Lightning(lightning_command) => lightning_command.handle(create_client).await?,
         Commands::Ecash(ecash_command) => ecash_command.handle(create_client).await?,
         Commands::Onchain(onchain_command) => onchain_command.handle(create_client).await?,
+        Commands::Cfg(config_commands) => config_commands.handle(create_client).await?,
         Commands::Completion { shell } => {
             clap_complete::generate(
                 shell,

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -60,7 +60,6 @@ impl GatewayClientBuilder {
     ) -> AdminResult<ClientBuilder> {
         let FederationConfig {
             federation_index,
-            timelock_delta,
             connector,
             ..
         } = federation_config.to_owned();
@@ -69,7 +68,6 @@ impl GatewayClientBuilder {
 
         if gateway.is_running_lnv1() {
             registry.attach(GatewayClientInit {
-                timelock_delta,
                 federation_index,
                 gateway: gateway.clone(),
             });

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -6,7 +6,6 @@ use std::str::FromStr;
 use bitcoin::Network;
 use clap::Parser;
 use fedimint_core::util::SafeUrl;
-use fedimint_ln_common::config::GatewayFee;
 
 use super::envs;
 use super::lightning::LightningMode;
@@ -38,12 +37,7 @@ pub struct GatewayOpts {
 
     /// Bitcoin network this gateway will be running on
     #[arg(long = "network", env = envs::FM_GATEWAY_NETWORK_ENV)]
-    network: Option<Network>,
-
-    /// Configured gateway routing fees
-    /// Format: <base_msat>,<proportional_millionths>
-    #[arg(long = "default-fees", env = envs::FM_DEFAULT_GATEWAY_FEES_ENV)]
-    default_fees: Option<GatewayFee>,
+    network: Network,
 
     /// Number of route hints to return in invoices
     #[arg(
@@ -77,7 +71,6 @@ impl GatewayOpts {
             bcrypt_password_hash,
             network: self.network,
             num_route_hints: self.num_route_hints,
-            fees: self.default_fees.clone(),
             lightning_module_mode: self.lightning_module_mode,
         })
     }
@@ -94,9 +87,8 @@ pub struct GatewayParameters {
     pub listen: SocketAddr,
     pub versioned_api: SafeUrl,
     pub bcrypt_password_hash: bcrypt::HashParts,
-    pub network: Option<Network>,
+    pub network: Network,
     pub num_route_hints: u32,
-    pub fees: Option<GatewayFee>,
     pub lightning_module_mode: LightningModuleMode,
 }
 

--- a/gateway/ln-gateway/src/db.rs
+++ b/gateway/ln-gateway/src/db.rs
@@ -283,7 +283,6 @@ pub struct FederationConfig {
     // federation.
     #[serde(alias = "mint_channel_id")]
     pub federation_index: u64,
-    pub timelock_delta: u64,
     pub lightning_fee: PaymentFee,
     pub transaction_fee: PaymentFee,
     pub connector: Connector,
@@ -498,7 +497,6 @@ async fn migrate_to_v4(mut ctx: MigrationContext<'_>) -> Result<(), anyhow::Erro
             let new_fed_config = FederationConfig {
                 invite_code: old_federation_config.invite_code,
                 federation_index: old_federation_config.federation_index,
-                timelock_delta: old_federation_config.timelock_delta,
                 lightning_fee: old_federation_config.fees.into(),
                 transaction_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
                 connector: Connector::default(),

--- a/gateway/ln-gateway/src/envs.rs
+++ b/gateway/ln-gateway/src/envs.rs
@@ -16,11 +16,6 @@ pub const FM_GATEWAY_BCRYPT_PASSWORD_HASH_ENV: &str = "FM_GATEWAY_BCRYPT_PASSWOR
 /// should use. Must match the network of the Lightning node.
 pub const FM_GATEWAY_NETWORK_ENV: &str = "FM_GATEWAY_NETWORK";
 
-/// Environment variable that specifies the default routing fees the gateway
-/// takes for outgoing and incoming payments. Only applied to newly joined
-/// federations.
-pub const FM_DEFAULT_GATEWAY_FEES_ENV: &str = "FM_DEFAULT_GATEWAY_FEES";
-
 /// Environment variable that instructs the gateway how many route hints to
 /// include in LNv1 invoices.
 pub const FM_NUMBER_OF_ROUTE_HINTS_ENV: &str = "FM_NUMBER_OF_ROUTE_HINTS";

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1085,7 +1085,6 @@ impl Gateway {
         let federation_config = FederationConfig {
             invite_code,
             federation_index,
-            timelock_delta: 10,
             lightning_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
             transaction_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
             connector,

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -12,14 +12,14 @@ use super::{
     CreateInvoiceForOperatorPayload, DepositAddressPayload, FederationInfo, GatewayBalances,
     GatewayFedConfig, GatewayInfo, LeaveFedPayload, MnemonicResponse, OpenChannelPayload,
     PayInvoiceForOperatorPayload, PaymentLogPayload, PaymentLogResponse, ReceiveEcashPayload,
-    ReceiveEcashResponse, SendOnchainPayload, SetConfigurationPayload, SpendEcashPayload,
+    ReceiveEcashResponse, SendOnchainPayload, SetFeesPayload, SpendEcashPayload,
     SpendEcashResponse, WithdrawPayload, WithdrawResponse, ADDRESS_ENDPOINT, BACKUP_ENDPOINT,
     CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT,
     CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
     GET_BALANCES_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT,
     LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAYMENT_LOG_ENDPOINT,
     PAY_INVOICE_FOR_OPERATOR_ENDPOINT, RECEIVE_ECASH_ENDPOINT, SEND_ONCHAIN_ENDPOINT,
-    SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, WITHDRAW_ENDPOINT,
+    SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use crate::lightning::{ChannelInfo, CloseChannelsWithPeerResponse};
 
@@ -120,13 +120,10 @@ impl GatewayRpcClient {
         self.call_post(url, payload).await
     }
 
-    pub async fn set_configuration(
-        &self,
-        payload: SetConfigurationPayload,
-    ) -> GatewayRpcResult<()> {
+    pub async fn set_fees(&self, payload: SetFeesPayload) -> GatewayRpcResult<()> {
         let url = self
             .base_url
-            .join(SET_CONFIGURATION_ENDPOINT)
+            .join(SET_FEES_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
     }

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -25,14 +25,14 @@ use super::{
     BackupPayload, CloseChannelsWithPeerPayload, ConnectFedPayload,
     CreateInvoiceForOperatorPayload, DepositAddressPayload, InfoPayload, LeaveFedPayload,
     OpenChannelPayload, PayInvoiceForOperatorPayload, PaymentLogPayload, ReceiveEcashPayload,
-    SendOnchainPayload, SetConfigurationPayload, SpendEcashPayload, WithdrawPayload,
-    ADDRESS_ENDPOINT, BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
+    SendOnchainPayload, SetFeesPayload, SpendEcashPayload, WithdrawPayload, ADDRESS_ENDPOINT,
+    BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
     CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT, GATEWAY_INFO_ENDPOINT,
     GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT,
     LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT,
     PAYMENT_LOG_ENDPOINT, PAY_INVOICE_FOR_OPERATOR_ENDPOINT, RECEIVE_ECASH_ENDPOINT,
-    SEND_ONCHAIN_ENDPOINT, SET_CONFIGURATION_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT,
-    V1_API_ENDPOINT, WITHDRAW_ENDPOINT,
+    SEND_ONCHAIN_ENDPOINT, SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, V1_API_ENDPOINT,
+    WITHDRAW_ENDPOINT,
 };
 use crate::error::{AdminGatewayError, PublicGatewayError};
 use crate::rpc::ConfigPayload;
@@ -166,7 +166,7 @@ fn v1_routes(gateway: Arc<Gateway>, task_group: TaskGroup) -> Router {
         .route(MNEMONIC_ENDPOINT, get(mnemonic))
         .route(STOP_ENDPOINT, get(stop))
         .route(PAYMENT_LOG_ENDPOINT, post(payment_log))
-        .route(SET_CONFIGURATION_ENDPOINT, post(set_configuration))
+        .route(SET_FEES_ENDPOINT, post(set_fees))
         .route(CONFIGURATION_ENDPOINT, post(configuration))
         // FIXME: deprecated >= 0.3.0
         .route(GATEWAY_INFO_POST_ENDPOINT, post(handle_post_info))
@@ -294,11 +294,11 @@ async fn backup(
 }
 
 #[instrument(skip_all, err, fields(?payload))]
-async fn set_configuration(
+async fn set_fees(
     Extension(gateway): Extension<Arc<Gateway>>,
-    Json(payload): Json<SetConfigurationPayload>,
+    Json(payload): Json<SetFeesPayload>,
 ) -> Result<impl IntoResponse, AdminGatewayError> {
-    gateway.handle_set_configuration_msg(payload).await?;
+    gateway.handle_set_fees_msg(payload).await?;
     Ok(Json(json!(())))
 }
 

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -115,7 +115,6 @@ pub enum GatewayMeta {
 
 #[derive(Debug, Clone)]
 pub struct GatewayClientInit {
-    pub timelock_delta: u64,
     pub federation_index: u64,
     pub gateway: Arc<Gateway>,
 }
@@ -150,7 +149,6 @@ impl ClientModuleInit for GatewayClientInit {
                 .child_key(ChildId(0))
                 .to_secp_key(&fedimint_core::secp256k1::Secp256k1::new()),
             module_api: args.module_api().clone(),
-            timelock_delta: self.timelock_delta,
             federation_index: self.federation_index,
             client_ctx: args.context(),
             gateway: self.gateway.clone(),
@@ -161,7 +159,6 @@ impl ClientModuleInit for GatewayClientInit {
 #[derive(Debug, Clone)]
 pub struct GatewayClientContext {
     redeem_key: Keypair,
-    timelock_delta: u64,
     secp: Secp256k1<All>,
     pub ln_decoder: Decoder,
     notifier: ModuleNotifier<GatewayClientStateMachines>,
@@ -192,7 +189,6 @@ pub struct GatewayClientModule {
     cfg: LightningClientConfig,
     pub notifier: ModuleNotifier<GatewayClientStateMachines>,
     pub redeem_key: Keypair,
-    timelock_delta: u64,
     federation_index: u64,
     module_api: DynModuleApi,
     client_ctx: ClientContext<Self>,
@@ -209,7 +205,6 @@ impl ClientModule for GatewayClientModule {
     fn context(&self) -> Self::ModuleStateMachineContext {
         Self::ModuleStateMachineContext {
             redeem_key: self.redeem_key,
-            timelock_delta: self.timelock_delta,
             secp: Secp256k1::new(),
             ln_decoder: self.decoder(),
             notifier: self.notifier.clone(),

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -31,6 +31,8 @@ use crate::state_machine::events::{OutgoingPaymentFailed, OutgoingPaymentSucceed
 use crate::state_machine::GatewayClientModule;
 use crate::GatewayState;
 
+const TIMELOCK_DELTA: u64 = 10;
+
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// State machine that executes the Lightning payment on behalf of
 /// the fedimint user that requested an invoice to be paid.
@@ -374,7 +376,6 @@ impl GatewayPayInvoice {
             let payment_parameters = Self::validate_outgoing_account(
                 &outgoing_contract_account,
                 context.redeem_key,
-                context.timelock_delta,
                 consensus_block_count.unwrap(),
                 &payment_data,
                 config.lightning_fee.into(),
@@ -581,7 +582,6 @@ impl GatewayPayInvoice {
     fn validate_outgoing_account(
         account: &OutgoingContractAccount,
         redeem_key: bitcoin::key::Keypair,
-        timelock_delta: u64,
         consensus_block_count: u64,
         payment_data: &PaymentData,
         routing_fees: RoutingFees,
@@ -611,7 +611,7 @@ impl GatewayPayInvoice {
 
         let max_delay = u64::from(account.contract.timelock)
             .checked_sub(consensus_block_count.saturating_sub(1))
-            .and_then(|delta| delta.checked_sub(timelock_delta));
+            .and_then(|delta| delta.checked_sub(TIMELOCK_DELTA));
         if max_delay.is_none() {
             return Err(OutgoingContractError::TimeoutTooClose);
         }

--- a/modules/fedimint-lnv2-tests/tests/mock.rs
+++ b/modules/fedimint-lnv2-tests/tests/mock.rs
@@ -93,14 +93,11 @@ impl GatewayConnection for MockGatewayConnection {
         Ok(Some(RoutingInfo {
             lightning_public_key: self.keypair.public_key(),
             module_public_key: self.keypair.public_key(),
-            send_fee_default: PaymentFee::SEND_FEE_LIMIT,
-            send_fee_minimum: PaymentFee {
-                base: Amount::from_sats(50),
-                parts_per_million: 5_000,
-            },
+            send_fee_default: PaymentFee::TRANSACTION_FEE_DEFAULT,
+            send_fee_minimum: PaymentFee::TRANSACTION_FEE_DEFAULT,
             expiration_delta_default: 500,
             expiration_delta_minimum: 144,
-            receive_fee: PaymentFee::RECEIVE_FEE_LIMIT,
+            receive_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
         }))
     }
 


### PR DESCRIPTION
I think it is important that we allow customization of the various fees in the gateway for LNv2. Not all federations will be run for profit (private federations, smaller communities, etc) and I think gateways should have the option to change their fees to also be cheaper. LNv2 lightning fees are currently very expensive (1.5%), which is often higher than Lightning.

This PR also adds customization for the "transaction fees" which are applied to every transaction (send or receive).