### PR TITLE
fix: remove usage of assume_checked()

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -131,7 +131,9 @@ impl Bitcoind {
         if !skip_setup {
             // mine blocks
             let blocks = 101;
-            let address = block_in_place(|| client.get_new_address(None, None))?.assume_checked();
+            let address = block_in_place(|| client.get_new_address(None, None))?
+                .require_network(bitcoin::Network::Regtest)
+                .expect("Devimint always runs in regtest");
             debug!(target: LOG_DEVIMINT, blocks_num=blocks, %address, "Mining blocks to address");
             block_in_place(|| {
                 client
@@ -225,7 +227,12 @@ impl Bitcoind {
         let tx = self
             .wallet_client()
             .await?
-            .send_to_address(bitcoin::Address::from_str(&addr)?.assume_checked(), amount)
+            .send_to_address(
+                bitcoin::Address::from_str(&addr)?
+                    .require_network(bitcoin::Network::Regtest)
+                    .expect("Devimint always runs in regtest"),
+                amount,
+            )
             .await?;
         Ok(tx)
     }
@@ -327,7 +334,8 @@ impl Bitcoind {
         let client = self.wallet_client().await?.clone();
         let addr = spawn_blocking(move || client.client.get_new_address(None, None))
             .await??
-            .assume_checked();
+            .require_network(bitcoin::Network::Regtest)
+            .expect("Devimint always runs in regtest");
         Ok(addr)
     }
 

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -386,12 +386,12 @@ extensible_associated_module_type!(
 
 impl WalletOutput {
     pub fn new_v0_peg_out(
-        recipient: Address<NetworkUnchecked>,
+        recipient: Address,
         amount: bitcoin::Amount,
         fees: PegOutFees,
     ) -> WalletOutput {
         WalletOutput::V0(WalletOutputV0::PegOut(PegOut {
-            recipient,
+            recipient: recipient.into_unchecked(),
             amount,
             fees,
         }))

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -868,6 +868,9 @@ impl ServerModule for Wallet {
 
                     let tx = module.offline_wallet().create_tx(
                         bitcoin::Amount::from_sat(sats),
+                        // Note: While calling `assume_checked()` is generally unwise, it's fine
+                        // here since we're only returning a fee estimate, and we would still
+                        // reject a transaction with the wrong network upon attempted peg-out.
                         address.assume_checked().script_pubkey(),
                         vec![],
                         module.available_utxos(&mut context.dbtx().into_nc()).await,
@@ -1410,6 +1413,9 @@ impl Wallet {
         match output {
             WalletOutputV0::PegOut(peg_out) => self.offline_wallet().create_tx(
                 peg_out.amount,
+                // Note: While calling `assume_checked()` is generally unwise, checking the
+                // network here could be a consensus-breaking change. Ignoring the network
+                // is fine here since we validate it in `process_output()`.
                 peg_out.recipient.clone().assume_checked().script_pubkey(),
                 vec![],
                 self.available_utxos(dbtx).await,


### PR DESCRIPTION
Fixes #5203

Doesn't remove all usage of `assume_checked()`, since some uses are acceptable, such as in tests