### PR TITLE
feat: allow specifying primary module kind

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -654,7 +654,7 @@ impl FedimintCli {
         let db = cli.load_rocks_db().await?;
         let mut client_builder = Client::builder(db).await.map_err_cli()?;
         client_builder.with_module_inits(self.module_inits.clone());
-        client_builder.with_primary_module(1);
+        client_builder.with_primary_module_kind(fedimint_mint_client::KIND);
 
         #[cfg(feature = "tor")]
         if cli.use_tor {

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2317,6 +2317,7 @@ impl ClientBuilder {
         ClientBuilder {
             module_inits: ModuleInitRegistry::new(),
             primary_module_instance: None,
+            primary_module_kind: None,
             connector: Connector::default(),
             admin_creds: None,
             db_no_decoders: db,
@@ -2330,6 +2331,7 @@ impl ClientBuilder {
         ClientBuilder {
             module_inits: client.module_inits.clone(),
             primary_module_instance: Some(client.primary_module_instance),
+            primary_module_kind: None,
             admin_creds: None,
             db_no_decoders: client.db.with_decoders(ModuleRegistry::default()),
             stopped: false,

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2363,9 +2363,26 @@ impl ClientBuilder {
     /// If there was a primary module specified previously
     #[deprecated(
         since = "0.6.0",
-        note = "Use `with_primary_module_kind` instead, as the instance id can't be known upfront"
+        note = "Use `with_primary_module_kind` instead, as the instance id can't be known upfront. If you *really* need the old behavior you can use `with_primary_module_instance_id`."
     )]
     pub fn with_primary_module(&mut self, primary_module_instance: ModuleInstanceId) {
+        self.with_primary_module_instance_id(primary_module_instance);
+    }
+
+    /// **You are likely looking for
+    /// [`ClientBuilder::with_primary_module_kind`]. This function is rarely
+    /// useful and often dangerous, handle with care.**
+    ///
+    /// Uses this module with the given instance id as the primary module. See
+    /// [`ClientModule::supports_being_primary`] for more information. Since the
+    /// module instance id of modules of a specific kind may differ between
+    /// different federations it is generally not recommended to specify it, but
+    /// rather to specify the module kind that should be used as primary. See
+    /// [`ClientBuilder::with_primary_module_kind`].
+    ///
+    /// ## Panics
+    /// If there was a primary module specified previously
+    pub fn with_primary_module_instance_id(&mut self, primary_module_instance: ModuleInstanceId) {
         let was_replaced = self
             .primary_module_instance
             .replace(primary_module_instance)

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -2300,6 +2300,7 @@ pub struct AdminCreds {
 pub struct ClientBuilder {
     module_inits: ClientModuleInitRegistry,
     primary_module_instance: Option<ModuleInstanceId>,
+    primary_module_kind: Option<ModuleKind>,
     admin_creds: Option<AdminCreds>,
     db_no_decoders: Database,
     meta_service: Arc<MetaService>,
@@ -2358,6 +2359,10 @@ impl ClientBuilder {
     ///
     /// ## Panics
     /// If there was a primary module specified previously
+    #[deprecated(
+        since = "0.6.0",
+        note = "Use `with_primary_module_kind` instead, as the instance id can't be known upfront"
+    )]
     pub fn with_primary_module(&mut self, primary_module_instance: ModuleInstanceId) {
         let was_replaced = self
             .primary_module_instance
@@ -2366,6 +2371,22 @@ impl ClientBuilder {
         assert!(
             !was_replaced,
             "Only one primary module can be given to the builder."
+        );
+    }
+
+    /// Uses this module kind as the primary module if present in the config.
+    /// See [`ClientModule::supports_being_primary`] for more information.
+    ///
+    /// ## Panics
+    /// If there was a primary module kind specified previously
+    pub fn with_primary_module_kind(&mut self, primary_module_kind: ModuleKind) {
+        let was_replaced = self
+            .primary_module_kind
+            .replace(primary_module_kind)
+            .is_some();
+        assert!(
+            !was_replaced,
+            "Only one primary module kind can be given to the builder."
         );
     }
 
@@ -2726,7 +2747,17 @@ impl ClientBuilder {
 
         let primary_module_instance = self
             .primary_module_instance
-            .ok_or(anyhow!("No primary module instance id was provided"))?;
+            .or_else(|| {
+                let primary_module_kind = self.primary_module_kind?;
+                config
+                    .modules
+                    .iter()
+                    .find_map(|(module_instance_id, module_config)| {
+                        (module_config.kind() == &primary_module_kind)
+                            .then_some(*module_instance_id)
+                    })
+            })
+            .ok_or(anyhow!("No primary module set or found"))?;
 
         let notifier = Notifier::new(db.clone());
 

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -153,7 +153,7 @@ pub async fn build_client(
     client_builder.with_module(MintClientInit);
     client_builder.with_module(LightningClientInit::default());
     client_builder.with_module(WalletClientInit::default());
-    client_builder.with_primary_module(1);
+    client_builder.with_primary_module_kind(fedimint_mint_client::KIND);
     let client_secret =
         Client::load_or_generate_client_secret(client_builder.db_no_decoders()).await?;
     let root_secret = PlainRootSecretStrategy::to_root_secret(&client_secret);

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -48,6 +48,7 @@ pub struct Fixtures {
     bitcoin_rpc: BitcoinRpcConfig,
     bitcoin: Arc<dyn BitcoinTest>,
     dyn_bitcoin_rpc: DynBitcoindRpc,
+    primary_module_kind: ModuleKind,
     id: ModuleInstanceId,
 }
 
@@ -101,6 +102,7 @@ impl Fixtures {
             bitcoin_rpc: config,
             bitcoin,
             dyn_bitcoin_rpc,
+            primary_module_kind: IClientModuleInit::module_kind(&client),
             id: 0,
         }
         .with_module(client, server, params)
@@ -152,6 +154,7 @@ impl Fixtures {
             self.params.clone(),
             ServerModuleInitRegistry::from(self.servers.clone()),
             ClientModuleInitRegistry::from(self.clients.clone()),
+            self.primary_module_kind.clone(),
         )
     }
 
@@ -178,7 +181,7 @@ impl Fixtures {
 
         // Create federation client builder for the gateway
         let client_builder: GatewayClientBuilder =
-            GatewayClientBuilder::new(path.clone(), registry, 0);
+            GatewayClientBuilder::new(path.clone(), registry, ModuleKind::from_static_str("dummy"));
 
         let lightning_builder: Arc<dyn LightningBuilder + Send + Sync> =
             Arc::new(FakeLightningBuilder);

--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -31,7 +31,7 @@ async fn make_client_builder() -> Result<fedimint_client::ClientBuilder> {
     builder.with_module(LightningClientInit::default());
     builder.with_module(MintClientInit);
     builder.with_module(WalletClientInit::default());
-    builder.with_primary_module(1);
+    builder.with_primary_module_kind(fedimint_mint_client::KIND);
 
     Ok(builder)
 }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -10,7 +10,7 @@ use fedimint_client::module::init::ClientModuleInitRegistry;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::{Client, ClientBuilder};
 use fedimint_core::config::FederationId;
-use fedimint_core::core::ModuleInstanceId;
+use fedimint_core::core::ModuleKind;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
@@ -25,19 +25,19 @@ use crate::{AdminResult, Gateway};
 pub struct GatewayClientBuilder {
     work_dir: PathBuf,
     registry: ClientModuleInitRegistry,
-    primary_module: ModuleInstanceId,
+    primary_module_kind: ModuleKind,
 }
 
 impl GatewayClientBuilder {
     pub fn new(
         work_dir: PathBuf,
         registry: ClientModuleInitRegistry,
-        primary_module: ModuleInstanceId,
+        primary_module_kind: ModuleKind,
     ) -> Self {
         Self {
             work_dir,
             registry,
-            primary_module,
+            primary_module_kind,
         }
     }
 
@@ -85,7 +85,7 @@ impl GatewayClientBuilder {
             .await
             .map_err(AdminGatewayError::ClientCreationError)?;
         client_builder.with_module_inits(registry);
-        client_builder.with_primary_module(self.primary_module);
+        client_builder.with_primary_module_kind(self.primary_module_kind.clone());
         client_builder.with_connector(connector);
         Ok(client_builder)
     }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -306,11 +306,8 @@ impl Gateway {
             decoders,
         );
 
-        let client_builder = GatewayClientBuilder::new(
-            opts.data_dir.clone(),
-            registry,
-            LEGACY_HARDCODED_INSTANCE_ID_MINT,
-        );
+        let client_builder =
+            GatewayClientBuilder::new(opts.data_dir.clone(), registry, fedimint_mint_client::KIND);
 
         info!(
             "Starting gatewayd (version: {})",


### PR DESCRIPTION
The primary module instance id cannot be known upfront, it may differ from federation to federation. 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
