### PR TITLE
fix: backwards-incompatibilities vs v0.3.4-rc.1 v0.4.4 and v0.5.0

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -51,6 +51,15 @@ jobs:
 
       - name: Backwards-compatibility tests
         run: |
+          # TODO: should we create a separate perfit metric for merge queue vs pr push?
+
+          # run a slimmed down back-compat test for PR push or each major version for merge queue
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            VERSIONS_TO_TEST="v0.3.4-rc.1 v0.4.4 v0.5.0-rc.2"
+          else
+            VERSIONS_TO_TEST="v0.5.0-rc.2"
+          fi
+
           # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)
           # we need to use `nix develop -c` to be able to use `nix build` inside of backwards-compatibility-test
           # Disable `sccache`, it seems incompatible with self-hosted runner sandbox for some reason, and
@@ -68,7 +77,8 @@ jobs:
                 -- \
             scripts/ci/run-in-fs-dir-cache.sh backward-compat \
             env -u RUSTC_WRAPPER \
-            ./scripts/tests/test-ci-all-backcompat.sh v0.2.1
+            env FM_DEVIMINT_DISABLE_MODULE_LNV2=1 \
+            ./scripts/tests/test-ci-all-backcompat.sh "$VERSIONS_TO_TEST"
 
   notifications:
     if: always() && github.repository == 'fedimint/fedimint' && github.event_name != 'merge_group'

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -244,6 +244,7 @@ impl DevJitFed {
                 if gateway_cli_version <= *VERSION_0_4_0_ALPHA
                     || gatewayd_version <= *VERSION_0_4_0_ALPHA
                     || fedimintd_version <= *VERSION_0_4_0_ALPHA
+                    || is_env_var_set(FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV)
                 {
                     let lnd = lnd.get_try().await?.deref().clone();
                     let cln = cln.get_try().await?.deref().clone();

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -174,6 +174,9 @@ declare_vars! {
 
         // Enable to us to make an unbounded number of payments
         FM_DEFAULT_GATEWAY_FEES: String = "0,0"; env: "FM_DEFAULT_GATEWAY_FEES";
+        // TODO:(support:v0.4): we renamed to FM_DEFAULT_GATEWAY_FEES in v0.5.0
+        // see: https://github.com/fedimint/fedimint/pull/6023
+        FM_GATEWAY_FEES: String = "0,0"; env: "FM_GATEWAY_FEES";
         FM_GATEWAY_SKIP_WAIT_FOR_SYNC: String = "1"; env: "FM_GATEWAY_SKIP_WAIT_FOR_SYNC";
 
         FM_FAUCET_BIND_ADDR: String = f!("0.0.0.0:{FM_PORT_FAUCET}"); env: "FM_FAUCET_BIND_ADDR";

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -8,5 +8,7 @@ pub static VERSION_0_3_0: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.3.0").expect("version is parsable"));
 pub static VERSION_0_4_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.4.0-alpha").expect("version is parsable"));
+pub static VERSION_0_4_0: LazyLock<Version> =
+    LazyLock::new(|| Version::parse("0.4.0").expect("version is parsable"));
 pub static VERSION_0_5_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.5.0-alpha").expect("version is parsable"));

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -4,6 +4,7 @@ use devimint::federation::Client;
 use devimint::version_constants::VERSION_0_5_0_ALPHA;
 use devimint::{cmd, util};
 use fedimint_core::core::OperationId;
+use fedimint_core::envs::{is_env_var_set, FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV};
 use fedimint_core::util::{backoff_util, retry};
 use fedimint_lnv2_client::{FinalReceiveOperationState, FinalSendOperationState};
 use lightning_invoice::Bolt11Invoice;
@@ -30,6 +31,11 @@ async fn main() -> anyhow::Result<()> {
 
         if gatewayd_version < *VERSION_0_5_0_ALPHA {
             info!(%gatewayd_version, "Version did not support lnv2 module, skipping");
+            return Ok(());
+        }
+
+        if is_env_var_set(FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV) {
+            info!("lnv2 is disabled, skipping");
             return Ok(());
         }
 

--- a/modules/fedimint-wallet-tests/src/bin/wallet-recovery-test.rs
+++ b/modules/fedimint-wallet-tests/src/bin/wallet-recovery-test.rs
@@ -1,7 +1,7 @@
 use anyhow::bail;
 use devimint::cmd;
 use devimint::util::{FedimintCli, FedimintdCmd};
-use devimint::version_constants::VERSION_0_3_0_ALPHA;
+use devimint::version_constants::VERSION_0_4_0;
 use fedimint_core::util::{backoff_util, retry};
 use futures::try_join;
 use tracing::info;
@@ -11,7 +11,9 @@ async fn main() -> anyhow::Result<()> {
     devimint::run_devfed_test(|dev_fed, _process_mgr| async move {
         let fedimint_cli_version = FedimintCli::version_or_default().await;
         let fedimintd_version = FedimintdCmd::version_or_default().await;
-        if fedimint_cli_version < *VERSION_0_3_0_ALPHA || fedimintd_version < *VERSION_0_3_0_ALPHA {
+        // TODO(support:v0.4): recovery was introduced in v0.4.0
+        // see: https://github.com/fedimint/fedimint/pull/5546
+        if fedimint_cli_version < *VERSION_0_4_0 || fedimintd_version < *VERSION_0_4_0 {
             info!("Skipping whole test on old fedimint-cli/fedimintd that is missing some irrelevant bolts");
             return Ok(());
         }

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -249,7 +249,13 @@ function always_success_test() {
 }
 export -f always_success_test
 
-tagged_versions=("$@")
+# allows versions to be passed in as either a single string or multiple params
+# e.g. `"v0.3.0 v0.4.0"` is the same as `v0.3.0 v0.4.0`
+if [ "$#" -eq 1 ]; then
+  IFS=' ' read -r -a tagged_versions <<< "$1"
+else
+  tagged_versions=("$@")
+fi
 num_versions="$#"
 versions=( "${tagged_versions[@]}" "current" )
 if [[ "$num_versions" == "0" ]]; then


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/6460
Closes https://github.com/fedimint/fedimint/issues/6465

Ports backwards-compatibility fixes to `master` found in https://github.com/fedimint/fedimint/pull/6432 while testing `v0.5.0` release candidates.

These changes update backwards-compatibility tests to run vs `v0.5.0-rc.2` on each PR push (we'll update to `v0.5.0` after cutting the release) and vs `v0.3.4-rc.1`, `v0.4.4`, and `v0.5.0-rc.2` in the merge queue (takes ~20 minutes to complete). Increasing our coverage of versions will help prevent introducing multiple breaking tests, which delays the release process.

These changes no longer test vs `v0.2.1`, since it's reached End of Life as of `v0.6`. A later PR will remove code paths related to testing `v0.2.1`.

This CI [run](https://github.com/fedimint/fedimint/actions/runs/12288531881/job/34292480614?pr=6525) demonstrates a successful run vs `v0.3.4-rc.1`, `v0.4.4`, and `v0.5.0-rc.2`, which we'll hopefully replicate in the merge queue.