### PR TITLE
chore: ILnRpcClient::list_active_channels() returns response

### DIFF
--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -18,10 +18,11 @@ use lightning_invoice::{
     Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret, DEFAULT_EXPIRY_TIME,
 };
 use ln_gateway::lightning::{
-    ChannelInfo, CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse,
+    CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse,
     GetBalancesResponse, GetLnOnchainAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse,
     ILnRpcClient, InterceptPaymentRequest, InterceptPaymentResponse, LightningRpcError,
-    OpenChannelResponse, PayInvoiceResponse, RouteHtlcStream, SendOnchainResponse,
+    ListActiveChannelsResponse, OpenChannelResponse, PayInvoiceResponse, RouteHtlcStream,
+    SendOnchainResponse,
 };
 use ln_gateway::rpc::{CloseChannelsWithPeerPayload, OpenChannelPayload, SendOnchainPayload};
 use rand::rngs::OsRng;
@@ -281,7 +282,7 @@ impl ILnRpcClient for FakeLightningTest {
         })
     }
 
-    async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError> {
+    async fn list_active_channels(&self) -> Result<ListActiveChannelsResponse, LightningRpcError> {
         Err(LightningRpcError::FailedToListActiveChannels {
             failure_reason: "FakeLightningTest does not support listing active channels"
                 .to_string(),

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1410,8 +1410,8 @@ impl Gateway {
         &self,
     ) -> AdminResult<Vec<lightning::ChannelInfo>> {
         let context = self.get_lightning_context().await?;
-        let channels = context.lnrpc.list_active_channels().await?;
-        Ok(channels)
+        let response = context.lnrpc.list_active_channels().await?;
+        Ok(response.channels)
     }
 
     /// Send funds from the gateway's lightning node on-chain wallet.

--- a/gateway/ln-gateway/src/lightning/ldk.rs
+++ b/gateway/ln-gateway/src/lightning/ldk.rs
@@ -23,7 +23,9 @@ use tokio::sync::mpsc::Sender;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{error, info};
 
-use super::{ChannelInfo, ILnRpcClient, LightningRpcError, RouteHtlcStream};
+use super::{
+    ChannelInfo, ILnRpcClient, LightningRpcError, ListActiveChannelsResponse, RouteHtlcStream,
+};
 use crate::lightning::{
     CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse,
     GetBalancesResponse, GetLnOnchainAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse,
@@ -579,7 +581,7 @@ impl ILnRpcClient for GatewayLdkClient {
         })
     }
 
-    async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError> {
+    async fn list_active_channels(&self) -> Result<ListActiveChannelsResponse, LightningRpcError> {
         let mut channels = Vec::new();
 
         for channel_details in self
@@ -600,7 +602,7 @@ impl ILnRpcClient for GatewayLdkClient {
             });
         }
 
-        Ok(channels)
+        Ok(ListActiveChannelsResponse { channels })
     }
 
     async fn get_balances(&self) -> Result<GetBalancesResponse, LightningRpcError> {

--- a/gateway/ln-gateway/src/lightning/lnd.rs
+++ b/gateway/ln-gateway/src/lightning/lnd.rs
@@ -42,7 +42,10 @@ use tonic_lnd::walletrpc::AddrRequest;
 use tonic_lnd::{connect, Client as LndClient};
 use tracing::{debug, error, info, trace, warn};
 
-use super::{ChannelInfo, ILnRpcClient, LightningRpcError, RouteHtlcStream, MAX_LIGHTNING_RETRIES};
+use super::{
+    ChannelInfo, ILnRpcClient, LightningRpcError, ListActiveChannelsResponse, RouteHtlcStream,
+    MAX_LIGHTNING_RETRIES,
+};
 use crate::db::GatewayDbtxNcExt;
 use crate::lightning::{
     CloseChannelsWithPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse,
@@ -1279,7 +1282,7 @@ impl ILnRpcClient for GatewayLndClient {
         })
     }
 
-    async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError> {
+    async fn list_active_channels(&self) -> Result<ListActiveChannelsResponse, LightningRpcError> {
         let mut client = self.connect().await?;
 
         match client
@@ -1293,57 +1296,59 @@ impl ILnRpcClient for GatewayLndClient {
             })
             .await
         {
-            Ok(response) => Ok(response
-                .into_inner()
-                .channels
-                .into_iter()
-                .map(|channel| {
-                    let channel_size_sats = channel.capacity.try_into().expect("i64 -> u64");
+            Ok(response) => Ok(ListActiveChannelsResponse {
+                channels: response
+                    .into_inner()
+                    .channels
+                    .into_iter()
+                    .map(|channel| {
+                        let channel_size_sats = channel.capacity.try_into().expect("i64 -> u64");
 
-                    let local_balance_sats: u64 =
-                        channel.local_balance.try_into().expect("i64 -> u64");
-                    let local_channel_reserve_sats: u64 = match channel.local_constraints {
-                        Some(constraints) => constraints.chan_reserve_sat,
-                        None => 0,
-                    };
-
-                    let outbound_liquidity_sats =
-                        if local_balance_sats >= local_channel_reserve_sats {
-                            // We must only perform this subtraction if the local balance is
-                            // greater than or equal to the channel reserve, otherwise we would
-                            // underflow and panic.
-                            local_balance_sats - local_channel_reserve_sats
-                        } else {
-                            0
+                        let local_balance_sats: u64 =
+                            channel.local_balance.try_into().expect("i64 -> u64");
+                        let local_channel_reserve_sats: u64 = match channel.local_constraints {
+                            Some(constraints) => constraints.chan_reserve_sat,
+                            None => 0,
                         };
 
-                    let remote_balance_sats: u64 =
-                        channel.remote_balance.try_into().expect("i64 -> u64");
-                    let remote_channel_reserve_sats: u64 = match channel.remote_constraints {
-                        Some(constraints) => constraints.chan_reserve_sat,
-                        None => 0,
-                    };
+                        let outbound_liquidity_sats =
+                            if local_balance_sats >= local_channel_reserve_sats {
+                                // We must only perform this subtraction if the local balance is
+                                // greater than or equal to the channel reserve, otherwise we would
+                                // underflow and panic.
+                                local_balance_sats - local_channel_reserve_sats
+                            } else {
+                                0
+                            };
 
-                    let inbound_liquidity_sats =
-                        if remote_balance_sats >= remote_channel_reserve_sats {
-                            // We must only perform this subtraction if the remote balance is
-                            // greater than or equal to the channel reserve, otherwise we would
-                            // underflow and panic.
-                            remote_balance_sats - remote_channel_reserve_sats
-                        } else {
-                            0
+                        let remote_balance_sats: u64 =
+                            channel.remote_balance.try_into().expect("i64 -> u64");
+                        let remote_channel_reserve_sats: u64 = match channel.remote_constraints {
+                            Some(constraints) => constraints.chan_reserve_sat,
+                            None => 0,
                         };
 
-                    ChannelInfo {
-                        remote_pubkey: PublicKey::from_str(&channel.remote_pubkey)
-                            .expect("Lightning node returned invalid remote channel pubkey"),
-                        channel_size_sats,
-                        outbound_liquidity_sats,
-                        inbound_liquidity_sats,
-                        short_channel_id: channel.chan_id,
-                    }
-                })
-                .collect()),
+                        let inbound_liquidity_sats =
+                            if remote_balance_sats >= remote_channel_reserve_sats {
+                                // We must only perform this subtraction if the remote balance is
+                                // greater than or equal to the channel reserve, otherwise we would
+                                // underflow and panic.
+                                remote_balance_sats - remote_channel_reserve_sats
+                            } else {
+                                0
+                            };
+
+                        ChannelInfo {
+                            remote_pubkey: PublicKey::from_str(&channel.remote_pubkey)
+                                .expect("Lightning node returned invalid remote channel pubkey"),
+                            channel_size_sats,
+                            outbound_liquidity_sats,
+                            inbound_liquidity_sats,
+                            short_channel_id: channel.chan_id,
+                        }
+                    })
+                    .collect(),
+            }),
             Err(e) => Err(LightningRpcError::FailedToListActiveChannels {
                 failure_reason: format!("Failed to list active channels {e:?}"),
             }),

--- a/gateway/ln-gateway/src/lightning/mod.rs
+++ b/gateway/ln-gateway/src/lightning/mod.rs
@@ -215,7 +215,7 @@ pub trait ILnRpcClient: Debug + Send + Sync {
     ) -> Result<CloseChannelsWithPeerResponse, LightningRpcError>;
 
     /// Lists the lightning node's active channels with all peers.
-    async fn list_active_channels(&self) -> Result<Vec<ChannelInfo>, LightningRpcError>;
+    async fn list_active_channels(&self) -> Result<ListActiveChannelsResponse, LightningRpcError>;
 
     /// Returns a summary of the lightning node's balance, including the onchain
     /// wallet, outbound liquidity, and inbound liquidity.
@@ -421,33 +421,13 @@ pub enum PaymentAction {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct GetRouteHintsRequest {
-    pub num_route_hints: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GetRouteHintsResponse {
     pub route_hints: Vec<RouteHint>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PayInvoiceRequest {
-    pub invoice: String,
-    pub max_delay: u64,
-    pub max_fee_msat: u64,
-    pub payment_hash: Vec<u8>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PayInvoiceResponse {
     pub preimage: Preimage,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PayPrunedInvoiceRequest {
-    pub pruned_invoice: Option<PrunedInvoice>,
-    pub max_delay: u64,
-    pub max_fee_msat: Amount,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
All other methods in the liquidity API return a response type (`CreateInvoiceResponse`, `GetLnOnchainAddressResponse`, etc...), let's use that pattern here too