### PR TITLE
feat(gateway): add JWT authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,7 @@ dependencies = [
  "futures-util",
  "hex",
  "itertools 0.13.0",
+ "jsonwebtoken",
  "ldk-node",
  "lightning",
  "lightning-invoice",
@@ -4881,6 +4882,19 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "url",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "ring 0.17.8",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -50,6 +50,8 @@ pub enum GeneralCommands {
         #[clap(long)]
         event_kinds: Vec<EventKind>,
     },
+    /// request a JWT token for future interactions
+    GetSessionJwtAuth,
 }
 
 impl GeneralCommands {
@@ -124,8 +126,11 @@ impl GeneralCommands {
                     .await?;
                 print_response(payment_log);
             }
+            Self::GetSessionJwtAuth => {
+                let response = create_client().get_session_jwt_auth().await?;
+                print_response(response);
+            }
         }
-
         Ok(())
     }
 }

--- a/gateway/cli/src/main.rs
+++ b/gateway/cli/src/main.rs
@@ -29,6 +29,8 @@ struct Cli {
     /// WARNING: Passing in a password from the command line may be less secure!
     #[clap(long)]
     rpcpassword: Option<String>,
+    #[clap(long)]
+    rpcjwt: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -54,7 +56,13 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
     let versioned_api = cli.address.join(V1_API_ENDPOINT)?;
-    let create_client = || GatewayRpcClient::new(versioned_api.clone(), cli.rpcpassword.clone());
+    let create_client = || {
+        GatewayRpcClient::new(
+            versioned_api.clone(),
+            cli.rpcpassword.clone(),
+            cli.rpcjwt.clone(),
+        )
+    };
 
     match cli.command {
         Commands::General(general_command) => general_command.handle(create_client).await?,

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -51,6 +51,7 @@ fedimint-wallet-client = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
+jsonwebtoken = { version = "9.3.0", default-features = false }
 ldk-node = "0.4.2"
 lightning = { workspace = true }
 lightning-invoice = { workspace = true }

--- a/gateway/ln-gateway/src/auth_manager.rs
+++ b/gateway/ln-gateway/src/auth_manager.rs
@@ -1,0 +1,59 @@
+use std::time::UNIX_EPOCH;
+
+use fedimint_core::secp256k1::PublicKey;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+
+const SESSION_EXPIRY_SECONDS: u64 = 60 * 30; // 30 minute
+
+pub struct AuthManager {
+    ///gateway id
+    gateway_id: PublicKey,
+    /// A secret key to encode a JWT with
+    pub encoding_secret: [u8; 16],
+}
+
+impl AuthManager {
+    /// Create a new auth manager
+    pub fn new(encoding_secret: [u8; 16], gateway_id: PublicKey) -> Self {
+        Self {
+            gateway_id,
+            encoding_secret,
+        }
+    }
+    pub fn generate_session(&self) -> anyhow::Result<Session> {
+        let session = Session::new(self.gateway_id, SESSION_EXPIRY_SECONDS);
+        Ok(session)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Session {
+    /// the unique identifier of the session.
+    pub id: PublicKey,
+    /// the expire time of the session
+    pub exp: u64,
+}
+
+impl Session {
+    pub fn new(id: PublicKey, expiry: u64) -> Self {
+        let now = fedimint_core::time::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        Self {
+            id,
+            exp: now + expiry,
+        }
+    }
+
+    pub fn encode_jwt(self, encoding_secret: &[u8; 16]) -> anyhow::Result<String> {
+        let claim = self;
+        encode(
+            &Header::default(),
+            &claim,
+            &EncodingKey::from_secret(encoding_secret),
+        )
+        .map_err(|_| anyhow::anyhow!("Unable to generate jwt token session"))
+    }
+}

--- a/gateway/ln-gateway/src/error.rs
+++ b/gateway/ln-gateway/src/error.rs
@@ -92,6 +92,8 @@ pub enum AdminGatewayError {
     RegistrationError { federation_id: FederationId },
     #[error("Error withdrawing funds onchain: {failure_reason}")]
     WithdrawError { failure_reason: String },
+    #[error("Unauthorized")]
+    Unauthorized,
 }
 
 impl IntoResponse for AdminGatewayError {

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::similar_names)]
 #![allow(clippy::too_many_lines)]
 
+pub mod auth_manager;
 pub mod client;
 pub mod config;
 mod db;
@@ -34,6 +35,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context};
+use auth_manager::AuthManager;
 use bitcoin::hashes::sha256;
 use bitcoin::{Address, Network, Txid};
 use clap::Parser;
@@ -87,8 +89,8 @@ use lightning::{
     InterceptPaymentResponse, InvoiceDescription, LightningBuilder, LightningRpcError,
     PaymentAction,
 };
-use lightning_invoice::Bolt11Invoice;
-use rand::thread_rng;
+use lightning_invoice::{Bolt11Invoice, RoutingFees};
+use rand::{thread_rng, Rng};
 use rpc::{
     CloseChannelsWithPeerPayload, CreateInvoiceForOperatorPayload, FederationInfo,
     GatewayFedConfig, GatewayInfo, LeaveFedPayload, MnemonicResponse, OpenChannelPayload,
@@ -97,7 +99,7 @@ use rpc::{
     SpendEcashResponse, WithdrawResponse, V1_API_ENDPOINT,
 };
 use state_machine::{GatewayClientModule, GatewayExtPayStates};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, error, info, info_span, warn};
 
 use crate::config::LightningModuleMode;
@@ -186,6 +188,9 @@ enum ReceivePaymentStreamAction {
 pub struct Gateway {
     /// The gateway's federation manager.
     federation_manager: Arc<RwLock<FederationManager>>,
+
+    /// The gateway's authentication manager
+    auth_manager: Arc<Mutex<AuthManager>>,
 
     /// Builder struct that allows the gateway to build a `ILnRpcClient`, which
     /// represents a connection to a lightning node.
@@ -353,12 +358,21 @@ impl Gateway {
         let task_group = TaskGroup::new();
         task_group.install_kill_handler();
 
+        let gateway_id = Self::load_or_create_gateway_id(&gateway_db).await;
+
+        // for JWT it is necessary to create an encoding secret that will be used each
+        // time a new JWT token is generated. The encoding secret ensures token's
+        // integrity and authenticity, so it is necessary to use a secure random
+        // number generator to generate strong keys.
+        let encoding_secret: [u8; 16] = rand::thread_rng().gen();
+
         Ok(Self {
             federation_manager: Arc::new(RwLock::new(FederationManager::new())),
+            auth_manager: Arc::new(Mutex::new(AuthManager::new(encoding_secret, gateway_id))),
             lightning_builder,
             state: Arc::new(RwLock::new(gateway_state)),
             client_builder,
-            gateway_id: Self::load_or_create_gateway_id(&gateway_db).await,
+            gateway_id,
             gateway_db,
             versioned_api: gateway_parameters.versioned_api,
             listen: gateway_parameters.listen,

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -21,6 +21,7 @@ use crate::SafeUrl;
 pub const V1_API_ENDPOINT: &str = "v1";
 
 pub const ADDRESS_ENDPOINT: &str = "/address";
+pub const AUTH_SESSION_ENDPOINT: &str = "/auth/session";
 pub const BACKUP_ENDPOINT: &str = "/backup";
 pub const CONFIGURATION_ENDPOINT: &str = "/config";
 pub const CONNECT_FED_ENDPOINT: &str = "/connect_fed";

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::UNIX_EPOCH;
 
 use axum::extract::Request;
 use axum::http::{header, StatusCode};
@@ -22,17 +23,7 @@ use tower_http::cors::CorsLayer;
 use tracing::{error, info, instrument};
 
 use super::{
-    BackupPayload, CloseChannelsWithPeerPayload, ConnectFedPayload,
-    CreateInvoiceForOperatorPayload, DepositAddressPayload, InfoPayload, LeaveFedPayload,
-    OpenChannelPayload, PayInvoiceForOperatorPayload, PaymentLogPayload, ReceiveEcashPayload,
-    SendOnchainPayload, SetFeesPayload, SpendEcashPayload, WithdrawPayload, ADDRESS_ENDPOINT,
-    BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
-    CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT, GATEWAY_INFO_ENDPOINT,
-    GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT,
-    LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT,
-    PAYMENT_LOG_ENDPOINT, PAY_INVOICE_FOR_OPERATOR_ENDPOINT, RECEIVE_ECASH_ENDPOINT,
-    SEND_ONCHAIN_ENDPOINT, SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, V1_API_ENDPOINT,
-    WITHDRAW_ENDPOINT,
+    BackupPayload, CloseChannelsWithPeerPayload, ConnectFedPayload, CreateInvoiceForOperatorPayload, DepositAddressPayload, InfoPayload, LeaveFedPayload, OpenChannelPayload, PayInvoiceForOperatorPayload, PaymentLogPayload, ReceiveEcashPayload, SendOnchainPayload, SetFeesPayload, SpendEcashPayload, WithdrawPayload, ADDRESS_ENDPOINT, AUTH_SESSION_ENDPOINT, BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAYMENT_LOG_ENDPOINT, PAY_INVOICE_FOR_OPERATOR_ENDPOINT, RECEIVE_ECASH_ENDPOINT, SEND_ONCHAIN_ENDPOINT, SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, V1_API_ENDPOINT, WITHDRAW_ENDPOINT
 };
 use crate::error::{AdminGatewayError, PublicGatewayError};
 use crate::rpc::ConfigPayload;
@@ -83,21 +74,58 @@ fn extract_bearer_token(request: &Request) -> Result<String, StatusCode> {
 }
 
 /// Middleware to authenticate an incoming request. Routes that are
-/// authenticated with this middleware always require a Bearer token to be
-/// supplied in the Authorization header.
-async fn auth_middleware(
+/// authenticated with this middleware always require a Bearer token
+/// with the JWT generated previously to be supplied in the Authorization
+/// header. If jwt fails, try to check authentication with password
+async fn auth_jwt_middleware_with_password_fallback(
     Extension(gateway): Extension<Arc<Gateway>>,
     request: Request,
     next: Next,
 ) -> Result<impl IntoResponse, StatusCode> {
     let token = extract_bearer_token(&request)?;
+    let auth_manager = gateway.auth_manager.lock().await;
+    if let Ok(decoded_token_data) = jsonwebtoken::decode::<crate::auth_manager::Session>(
+        &token,
+        &jsonwebtoken::DecodingKey::from_secret(auth_manager.encoding_secret.as_ref()),
+        &jsonwebtoken::Validation::default(),
+    ) {
+        let now = fedimint_core::time::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        if now > decoded_token_data.claims.exp {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        return Ok(next.run(request).await);
+    }
+    //TODO remove this fallback when all the callers support JWT auth
+    // fallback to check for password
     if bcrypt::verify(token, &gateway.bcrypt_password_hash.to_string())
         .expect("Bcrypt hash is valid since we just stringified it")
     {
         return Ok(next.run(request).await);
     }
-
     Err(StatusCode::UNAUTHORIZED)
+}
+
+async fn auth_get_jwt_session(
+    Extension(gateway): Extension<Arc<Gateway>>,
+    request: Request,
+) -> Result<impl IntoResponse, AdminGatewayError> {
+    let token = extract_bearer_token(&request).map_err(|_| AdminGatewayError::Unauthorized)?;
+    if bcrypt::verify(token, &gateway.bcrypt_password_hash.to_string())
+        .expect("Bcrypt hash is valid since we just stringified it")
+    {
+        let auth_manager = gateway.auth_manager.lock().await;
+        let session = auth_manager
+            .generate_session()
+            .map_err(|_| AdminGatewayError::Unauthorized)?;
+        let token = session
+            .encode_jwt(&auth_manager.encoding_secret)
+            .map_err(|_| AdminGatewayError::Unauthorized)?;
+        return Ok(Json(json!(token)));
+    }
+    Err(AdminGatewayError::Unauthorized)
 }
 
 /// Public routes that are used in the LNv1 protocol
@@ -171,11 +199,16 @@ fn v1_routes(gateway: Arc<Gateway>, task_group: TaskGroup) -> Router {
         // FIXME: deprecated >= 0.3.0
         .route(GATEWAY_INFO_POST_ENDPOINT, post(handle_post_info))
         .route(GATEWAY_INFO_ENDPOINT, get(info))
-        .layer(middleware::from_fn(auth_middleware));
+        .layer(middleware::from_fn(
+            auth_jwt_middleware_with_password_fallback,
+        ));
+
+    let auth_routes = Router::new().route(AUTH_SESSION_ENDPOINT, get(auth_get_jwt_session));
 
     Router::new()
         .merge(public_routes)
         .merge(authenticated_routes)
+        .merge(auth_routes)
         .layer(Extension(gateway))
         .layer(Extension(task_group))
         .layer(CorsLayer::permissive())


### PR DESCRIPTION
closes #4128 
# Motivation
Add support for JWT gateway authentication
# This PR adds one additional endpoint:
- `/auth/session` if the password is correct, this endpoint returns a JWT token that must be used in the other endpoints that require authentication.
# How to test it using the CLI:
`gateway-cli --address=http://127.0.0.1:16265/v1 --rpcpassword=theresnosecondbest get-session-jwt-auth` 

`gateway-cli --address=http://127.0.0.1:16265/v1 --rpcjwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6IjAzY2I1MTBjOWJiMzA5ODNkOTYzODk3ZWUyNjlkM2FiZmY3Nzg0YTVjMmVkYWM3YjQzMzg1NjIyMmMzZGIxYWQ1ZSIsImV4cCI6MTczMzg1ODUxN30.4FNxyn6Y-M_vfPRstxgrv4weK9MMRv31Inijw6JJo80 get-balances`
