### PR TITLE
chore(ci): avoid hitting secondary rate limits

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,12 +8,13 @@ name: Daily check
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run cargo audit
+        run: |
+          nix flake update advisory-db || nix flake lock --update-input advisory-db
+          nix build -L .#ci.cargoAudit
 
   notifications:
     if: always() && github.repository == 'fedimint/fedimint'


### PR DESCRIPTION
Due to:

https://github.com/fedimint/fedimint/actions/runs/12270380989/job/34235492495

We might as well use the same Nix-based `cargo-audit` as we do in normal runs.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
