### PR TITLE
refactor(client): finalize_and_submit to return OutPointRange

### DIFF
--- a/fedimint-client/src/transaction/builder.rs
+++ b/fedimint-client/src/transaction/builder.rs
@@ -464,7 +464,7 @@ impl TransactionBuilder {
                     if let Some(input_idxs) = input_idxs.as_ref() {
                         (sm.state_machines)(OutPointRange::new(
                             txid,
-                            IdxRange::from(input_idxs.clone()),
+                            IdxRange::from_inclusive(input_idxs.clone()).expect("can't overflow"),
                         ))
                     } else {
                         vec![]
@@ -483,7 +483,8 @@ impl TransactionBuilder {
                         if let Some(output_idxs) = output_idxs.as_ref() {
                             (sm.state_machines)(OutPointRange::new(
                                 txid,
-                                IdxRange::from(output_idxs.clone()),
+                                IdxRange::from_inclusive(output_idxs.clone())
+                                    .expect("can't possibly overflow"),
                             ))
                         } else {
                             vec![]

--- a/fedimint-client/src/transaction/builder.rs
+++ b/fedimint-client/src/transaction/builder.rs
@@ -11,9 +11,11 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::transaction::{Transaction, TransactionSignature};
 use fedimint_core::Amount;
+use fedimint_logging::LOG_CLIENT;
 use itertools::multiunzip;
 use rand::{CryptoRng, Rng, RngCore};
 use secp256k1::Secp256k1;
+use tracing::warn;
 
 use crate::module::{IdxRange, OutPointRange, StateGenerator};
 use crate::sm::{self, DynState};
@@ -94,6 +96,10 @@ impl<I> ClientInputBundle<I, NeverClientStateMachine> {
     ///
     /// This avoids type inference issues of `S`, and saves some typing.
     pub fn new_no_sm(inputs: Vec<ClientInput<I>>) -> Self {
+        if inputs.is_empty() {
+            // TODO: Make it return Result or assert?
+            warn!(target: LOG_CLIENT, "Empty input bundle will be illegal in the future");
+        }
         Self {
             inputs,
             sms: vec![],
@@ -107,6 +113,10 @@ where
     S: sm::IState + MaybeSend + MaybeSync + 'static,
 {
     pub fn new(inputs: Vec<ClientInput<I>>, sms: Vec<ClientInputSM<S>>) -> Self {
+        if inputs.is_empty() {
+            // TODO: Make it return Result or assert?
+            warn!(target: LOG_CLIENT, "Empty input bundle will be illegal in the future");
+        }
         Self { inputs, sms }
     }
 
@@ -249,6 +259,10 @@ impl<O> ClientOutputBundle<O, NeverClientStateMachine> {
     ///
     /// This avoids type inference issues of `S`, and saves some typing.
     pub fn new_no_sm(outputs: Vec<ClientOutput<O>>) -> Self {
+        if outputs.is_empty() {
+            // TODO: Make it return Result or assert?
+            warn!(target: LOG_CLIENT, "Empty output bundle will be illegal in the future");
+        }
         Self {
             outputs,
             sms: vec![],
@@ -262,6 +276,10 @@ where
     S: sm::IState + MaybeSend + MaybeSync + 'static,
 {
     pub fn new(outputs: Vec<ClientOutput<O>>, sms: Vec<ClientOutputSM<S>>) -> Self {
+        if outputs.is_empty() {
+            // TODO: Make it return Result or assert?
+            warn!(target: LOG_CLIENT, "Empty output bundle will be illegal in the future");
+        }
         Self { outputs, sms }
     }
 
@@ -467,6 +485,8 @@ impl TransactionBuilder {
                             IdxRange::from_inclusive(input_idxs.clone()).expect("can't overflow"),
                         ))
                     } else {
+                        // TODO: In the future `InputBundle` and `OutputBundle` should make empty
+                        // bundles impossible, so this should not be possible
                         vec![]
                     }
                 })
@@ -487,6 +507,8 @@ impl TransactionBuilder {
                                     .expect("can't possibly overflow"),
                             ))
                         } else {
+                            // TODO: In the future `InputBundle` and `OutputBundle` should make
+                            // empty bundles impossible, so this should not be possible
                             vec![]
                         }
                     })

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -374,15 +374,16 @@ pub async fn remint_denomination(
         tx = tx.with_outputs(outputs);
     }
     drop(module_transaction);
-    let operation_meta_gen = |_txid, _outpoint| ();
-    let (txid, _) = client
+    let operation_meta_gen = |_| ();
+    let txid = client
         .finalize_and_submit_transaction(
             operation_id,
             MintCommonInit::KIND.as_str(),
             operation_meta_gen,
             tx,
         )
-        .await?;
+        .await?
+        .txid();
     let tx_subscription = client.transaction_updates(operation_id).await;
     tx_subscription
         .await_tx_accepted(txid)

--- a/gateway/ln-gateway/src/gateway_module_v2/mod.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/mod.rs
@@ -452,7 +452,7 @@ impl GatewayClientModuleV2 {
             .finalize_and_submit_transaction(
                 operation_id,
                 LightningCommonInit::KIND.as_str(),
-                |_, _| GatewayOperationMetaV2,
+                |_| GatewayOperationMetaV2,
                 transaction,
             )
             .await?;
@@ -523,7 +523,7 @@ impl GatewayClientModuleV2 {
             .finalize_and_submit_transaction(
                 operation_id,
                 LightningCommonInit::KIND.as_str(),
-                |_, _| GatewayOperationMetaV2,
+                |_| GatewayOperationMetaV2,
                 transaction,
             )
             .await?;

--- a/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/receive_sm.rs
@@ -318,7 +318,8 @@ impl ReceiveStateMachine {
             )
             .await
             .expect("Cannot claim input, additional funding needed")
-            .1;
+            .into_iter()
+            .collect();
 
         client_ctx
             .module

--- a/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/send_sm.rs
@@ -258,7 +258,8 @@ impl SendStateMachine {
                     .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
                     .await
                     .expect("Cannot claim input, additional funding needed")
-                    .1;
+                    .into_iter()
+                    .collect();
 
                 old_state.update(SendSMState::Claiming(Claiming {
                     preimage: payment_response.preimage,

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -29,7 +29,7 @@ use fedimint_core::core::{Decoder, IntoDynInstance, ModuleInstanceId, ModuleKind
 use fedimint_core::db::{AutocommitError, DatabaseTransaction};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::{ApiVersion, ModuleInit, MultiApiVersion};
-use fedimint_core::{apply, async_trait_maybe_send, secp256k1, Amount, OutPoint, TransactionId};
+use fedimint_core::{apply, async_trait_maybe_send, secp256k1, Amount, OutPoint};
 use fedimint_ln_client::api::LnFederationApi;
 use fedimint_ln_client::incoming::{
     FundingOfferState, IncomingSmCommon, IncomingSmError, IncomingSmStates, IncomingStateMachine,
@@ -462,7 +462,7 @@ impl GatewayClientModule {
         let tx = TransactionBuilder::new().with_outputs(self.client_ctx.make_client_outputs(
             ClientOutputBundle::new(vec![output], vec![client_output_sm]),
         ));
-        let operation_meta_gen = |_: TransactionId, _: Vec<OutPoint>| GatewayMeta::Receive;
+        let operation_meta_gen = |_: OutPointRange| GatewayMeta::Receive;
         self.client_ctx
             .finalize_and_submit_transaction(operation_id, KIND.as_str(), operation_meta_gen, tx)
             .await?;
@@ -503,7 +503,7 @@ impl GatewayClientModule {
         let tx = TransactionBuilder::new().with_outputs(self.client_ctx.make_client_outputs(
             ClientOutputBundle::new(vec![output], vec![client_output_sm]),
         ));
-        let operation_meta_gen = |_: TransactionId, _: Vec<OutPoint>| GatewayMeta::Receive;
+        let operation_meta_gen = |_: OutPointRange| GatewayMeta::Receive;
         self.client_ctx
             .finalize_and_submit_transaction(operation_id, KIND.as_str(), operation_meta_gen, tx)
             .await?;

--- a/gateway/ln-gateway/src/state_machine/pay.rs
+++ b/gateway/ln-gateway/src/state_machine/pay.rs
@@ -735,7 +735,8 @@ impl GatewayPayClaimOutgoingContract {
             .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
             .await
             .expect("Cannot claim input, additional funding needed")
-            .1;
+            .into_iter()
+            .collect();
         debug!("Claimed outgoing contract {contract:?} with out points {out_points:?}");
         GatewayPayStateMachine {
             common,
@@ -943,12 +944,15 @@ impl GatewayPayCancelContract {
             .fund_output(dbtx, ClientOutputBundle::new_no_sm(vec![client_output]))
             .await
         {
-            Ok((txid, _)) => {
-                info!("Canceled outgoing contract {contract:?} with txid {txid:?}");
+            Ok(change_range) => {
+                info!(
+                    "Canceled outgoing contract {contract:?} with txid {:?}",
+                    change_range.txid()
+                );
                 GatewayPayStateMachine {
                     common,
                     state: GatewayPayStates::Canceled {
-                        txid,
+                        txid: change_range.txid(),
                         contract_id: contract.contract.contract_id(),
                         error,
                     },

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -1,4 +1,5 @@
 use anyhow::bail;
+use fedimint_client::module::OutPointRange;
 use fedimint_client::transaction::{
     ClientInput, ClientInputBundle, ClientOutput, ClientOutputBundle, TransactionBuilder,
 };
@@ -96,9 +97,12 @@ async fn federation_should_abort_if_balance_sheet_is_negative() -> anyhow::Resul
 
     let tx = TransactionBuilder::new()
         .with_inputs(ClientInputBundle::new_no_sm(vec![input]).into_dyn(dummy.id));
-    let outpoint = |txid, _| OutPoint { txid, out_idx: 0 };
+    let meta_gen = |change_range: OutPointRange| OutPoint {
+        txid: change_range.txid(),
+        out_idx: 0,
+    };
     client
-        .finalize_and_submit_transaction(op_id, KIND.as_str(), outpoint, tx)
+        .finalize_and_submit_transaction(op_id, KIND.as_str(), meta_gen, tx)
         .await?;
 
     // Make sure we panicked with the right message

--- a/modules/fedimint-ln-client/src/incoming.rs
+++ b/modules/fedimint-ln-client/src/incoming.rs
@@ -355,17 +355,16 @@ impl DecryptingPreimageState {
             keys: vec![context.redeem_key],
         };
 
-        let out_points = global_context
+        let change_range = global_context
             .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
             .await
-            .expect("Cannot claim input, additional funding needed")
-            .1;
-        debug!("Refunded incoming contract {contract:?} with {out_points:?}");
+            .expect("Cannot claim input, additional funding needed");
+        debug!("Refunded incoming contract {contract:?} with {change_range:?}");
 
         IncomingStateMachine {
             common: old_state.common,
             state: IncomingSmStates::RefundSubmitted {
-                out_points,
+                out_points: change_range.into_iter().collect(),
                 error: IncomingSmError::InvalidPreimage { contract },
             },
         }

--- a/modules/fedimint-ln-client/src/pay.rs
+++ b/modules/fedimint-ln-client/src/pay.rs
@@ -549,7 +549,7 @@ async fn try_refund_outgoing_contract(
         keys: vec![refund_key],
     };
 
-    let (txid, out_points) = global_context
+    let change_range = global_context
         .claim_inputs(
             dbtx,
             // The input of the refund tx is managed by this state machine, so no new state
@@ -562,8 +562,8 @@ async fn try_refund_outgoing_contract(
     LightningPayStateMachine {
         common: old_state.common,
         state: LightningPayStates::Refund(LightningPayRefund {
-            txid,
-            out_points,
+            txid: change_range.txid(),
+            out_points: change_range.into_iter().collect(),
             error_reason,
         }),
     }

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -582,10 +582,10 @@ impl LightningClientModule {
             .finalize_and_submit_transaction(
                 operation_id,
                 LightningCommonInit::KIND.as_str(),
-                |funding_txid, funding_change_outpoints| {
+                |change_range| {
                     LightningOperationMeta::Send(SendOperationMeta {
-                        funding_txid,
-                        funding_change_outpoints,
+                        funding_txid: change_range.txid(),
+                        funding_change_outpoints: change_range.into_iter().collect(),
                         gateway: gateway_api.clone(),
                         contract: contract.clone(),
                         invoice: LightningInvoice::Bolt11(invoice.clone()),

--- a/modules/fedimint-lnv2-client/src/receive_sm.rs
+++ b/modules/fedimint-lnv2-client/src/receive_sm.rs
@@ -117,12 +117,11 @@ impl ReceiveStateMachine {
             keys: vec![old_state.common.claim_keypair],
         };
 
-        let out_points = global_context
+        let change_range = global_context
             .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
             .await
-            .expect("Cannot claim input, additional funding needed")
-            .1;
+            .expect("Cannot claim input, additional funding needed");
 
-        old_state.update(ReceiveSMState::Claiming(out_points))
+        old_state.update(ReceiveSMState::Claiming(change_range.into_iter().collect()))
     }
 }

--- a/modules/fedimint-lnv2-client/src/send_sm.rs
+++ b/modules/fedimint-lnv2-client/src/send_sm.rs
@@ -222,17 +222,16 @@ impl SendStateMachine {
                     keys: vec![old_state.common.refund_keypair],
                 };
 
-                let outpoints = global_context
+                let change_range = global_context
                     .claim_inputs(
                         dbtx,
                         // The input of the refund tx is managed by this state machine
                         ClientInputBundle::new_no_sm(vec![client_input]),
                     )
                     .await
-                    .expect("Cannot claim input, additional funding needed")
-                    .1;
+                    .expect("Cannot claim input, additional funding needed");
 
-                old_state.update(SendSMState::Refunding(outpoints))
+                old_state.update(SendSMState::Refunding(change_range.into_iter().collect()))
             }
         }
     }
@@ -281,12 +280,11 @@ impl SendStateMachine {
             keys: vec![old_state.common.refund_keypair],
         };
 
-        let outpoints = global_context
+        let change_range = global_context
             .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
             .await
-            .expect("Cannot claim input, additional funding needed")
-            .1;
+            .expect("Cannot claim input, additional funding needed");
 
-        old_state.update(SendSMState::Refunding(outpoints))
+        old_state.update(SendSMState::Refunding(change_range.into_iter().collect()))
     }
 }

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -218,7 +218,7 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
         .finalize_and_submit_transaction(
             OperationId::new_random(),
             "Claiming Outgoing Contract",
-            |_, _| (),
+            |_| (),
             TransactionBuilder::new().with_inputs(
                 ClientInputBundle::new_no_sm(vec![client_input]).into_dyn(lnv2_module_id),
             ),

--- a/modules/fedimint-mint-client/src/backup/recovery.rs
+++ b/modules/fedimint-mint-client/src/backup/recovery.rs
@@ -224,7 +224,8 @@ impl RecoveryFromHistory for MintRecovery {
                                     out_point_range: OutPointRange::new_single(
                                         out_point.txid,
                                         out_point.out_idx,
-                                    ),
+                                    )
+                                    .expect("Can't overflow"),
                                 },
                                 state: crate::output::MintOutputStates::Created(
                                     MintOutputStatesCreated {

--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -148,7 +148,8 @@ pub(crate) fn migrate_state_to_v2(
                     out_point_range: OutPointRange::new_single(
                         old_state.common.out_point.txid,
                         old_state.common.out_point.out_idx,
-                    ),
+                    )
+                    .expect("Can't possibly overflow"),
                 },
                 state: old_state.state,
             })
@@ -162,7 +163,8 @@ pub(crate) fn migrate_state_to_v2(
                     operation_id: old_state.common.operation_id,
                     out_point_range: OutPointRange::new(
                         old_state.common.txid,
-                        IdxRange::new_single(old_state.common.input_idx),
+                        IdxRange::new_single(old_state.common.input_idx)
+                            .expect("Can't possibly overflow"),
                     ),
                 },
                 state: old_state.state,

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1488,24 +1488,17 @@ impl MintClientModule {
 
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientModule::reissue_external_notes extra_meta is serializable");
-        let operation_meta_gen = |txid, out_points: Vec<OutPoint>| {
-            assert!(
-                out_points.iter().all(|out_point| out_point.txid == txid),
-                "Change outpoints didn't all have consistent transaction id."
-            );
-
-            MintOperationMeta {
-                variant: MintOperationMetaVariant::Reissuance {
-                    legacy_out_point: None,
-                    txid: Some(txid),
-                    out_point_indices: out_points
-                        .iter()
-                        .map(|out_point| out_point.out_idx)
-                        .collect(),
-                },
-                amount,
-                extra_meta: extra_meta.clone(),
-            }
+        let operation_meta_gen = |change_range: OutPointRange| MintOperationMeta {
+            variant: MintOperationMetaVariant::Reissuance {
+                legacy_out_point: None,
+                txid: Some(change_range.txid()),
+                out_point_indices: change_range
+                    .into_iter()
+                    .map(|out_point| out_point.out_idx)
+                    .collect(),
+            },
+            amount,
+            extra_meta: extra_meta.clone(),
         };
 
         self.client_ctx

--- a/modules/fedimint-mint-client/src/oob.rs
+++ b/modules/fedimint-mint-client/src/oob.rs
@@ -353,5 +353,5 @@ async fn try_cancel_oob_spend_multi(
         .claim_inputs(dbtx, ClientInputBundle::new(inputs, vec![sm]))
         .await
         .expect("Cannot claim input, additional funding needed")
-        .0
+        .txid()
 }

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -77,7 +77,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
         .finalize_and_submit_transaction(
             operation_id,
             "Claiming Invalid Ecash Note",
-            |_, _| (),
+            |_| (),
             TransactionBuilder::new().with_inputs(
                 client
                     .get_first_module::<MintClientModule>()?
@@ -87,7 +87,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
         )
         .await
         .expect("Failed to finalize transaction")
-        .0;
+        .txid();
 
     assert!(client
         .transaction_updates(operation_id)
@@ -171,12 +171,12 @@ async fn blind_nonce_index() -> anyhow::Result<()> {
 
     let tx = TransactionBuilder::new().with_outputs(client_mint.client_ctx.make_dyn(issuance_req));
 
-    let (txid, _) = client_mint
+    let change_range = client_mint
         .client_ctx
-        .finalize_and_submit_transaction(operation_id, "mint", |_, _| (), tx)
+        .finalize_and_submit_transaction(operation_id, "mint", |_| (), tx)
         .await?;
 
-    client.api().await_transaction(txid).await;
+    client.api().await_transaction(change_range.txid()).await;
 
     assert!(
         client_mint.api.check_blind_nonce_used(blind_nonce).await?,

--- a/modules/fedimint-wallet-client/src/deposit.rs
+++ b/modules/fedimint-wallet-client/src/deposit.rs
@@ -296,7 +296,7 @@ pub(crate) async fn transition_btc_tx_confirmed(
         amount,
     };
 
-    let (fm_txid, change) = global_context
+    let change_range = global_context
         .claim_inputs(dbtx, ClientInputBundle::new_no_sm(vec![client_input]))
         .await
         .expect("Cannot claim input, additional funding needed");
@@ -304,8 +304,8 @@ pub(crate) async fn transition_btc_tx_confirmed(
     DepositStateMachine {
         operation_id: old_state.operation_id,
         state: DepositStates::Claiming(ClaimingDepositState {
-            transaction_id: fm_txid,
-            change,
+            transaction_id: change_range.txid(),
+            change: change_range.into_iter().collect(),
         }),
     }
 }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -1028,12 +1028,12 @@ impl WalletClientModule {
                 .finalize_and_submit_transaction(
                     operation_id,
                     WalletCommonInit::KIND.as_str(),
-                    |_, change| WalletOperationMeta {
+                    |change_range: OutPointRange| WalletOperationMeta {
                         variant: WalletOperationMetaVariant::Withdraw {
                             address: address.clone(),
                             amount,
                             fee,
-                            change,
+                            change: change_range.into_iter().collect(),
                         },
                         extra_meta: extra_meta.clone(),
                     },
@@ -1069,10 +1069,10 @@ impl WalletClientModule {
             .finalize_and_submit_transaction(
                 operation_id,
                 WalletCommonInit::KIND.as_str(),
-                |_, change| WalletOperationMeta {
+                |change_range: OutPointRange| WalletOperationMeta {
                     variant: WalletOperationMetaVariant::RbfWithdraw {
                         rbf: rbf.clone(),
-                        change,
+                        change: change_range.into_iter().collect(),
                     },
                     extra_meta: extra_meta.clone(),
                 },


### PR DESCRIPTION
Notable changes:


* `await_primary_module_output` and similar do not return `Amount` as we no longer track per-output amount, and it didn't seem very used anywhere anyway, and it returned wrong value now as reported by @shaurya947 
* `OutPointRange` and `IdxRange` is a half-open range now, to allow expressing "txid without any change outputs"


If we're fine with this direction, I will attempt to backport, if it fails, we can backport just the `await_primary_module_output` side, I guess. I had to try the whole thing to ensure everything architecturally still works and makes sense.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
