### PR TITLE
chore: allow en/decoding only for checked networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,9 +824,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ base64 = "0.22.1"
 base64-url = "3.0.0"
 bcrypt = "0.16.0"
 bincode = "1.3.3"
-bitcoin = { version = "0.32.4", features = ["serde"] }
+bitcoin = { version = "0.32.5", features = ["serde"] }
 bitcoincore-rpc = "0.19.0"
 bitcoin_hashes = "0.14.0"
 bls12_381 = "0.8.0"

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -131,7 +131,9 @@ impl Bitcoind {
         if !skip_setup {
             // mine blocks
             let blocks = 101;
-            let address = block_in_place(|| client.get_new_address(None, None))?.assume_checked();
+            let address = block_in_place(|| client.get_new_address(None, None))?
+                .require_network(bitcoin::Network::Regtest)
+                .expect("Devimint always runs in regtest");
             debug!(target: LOG_DEVIMINT, blocks_num=blocks, %address, "Mining blocks to address");
             block_in_place(|| {
                 client
@@ -225,7 +227,12 @@ impl Bitcoind {
         let tx = self
             .wallet_client()
             .await?
-            .send_to_address(bitcoin::Address::from_str(&addr)?.assume_checked(), amount)
+            .send_to_address(
+                bitcoin::Address::from_str(&addr)?
+                    .require_network(bitcoin::Network::Regtest)
+                    .expect("Devimint always runs in regtest"),
+                amount,
+            )
             .await?;
         Ok(tx)
     }
@@ -327,7 +334,8 @@ impl Bitcoind {
         let client = self.wallet_client().await?.clone();
         let addr = spawn_blocking(move || client.client.get_new_address(None, None))
             .await??
-            .assume_checked();
+            .require_network(bitcoin::Network::Regtest)
+            .expect("Devimint always runs in regtest");
         Ok(addr)
     }
 

--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -751,7 +751,6 @@ macro_rules! extensible_associated_module_type {
             Eq,
             PartialEq,
             Hash,
-            serde::Deserialize,
             serde::Serialize,
             fedimint_core::encoding::Encodable,
             fedimint_core::encoding::Decodable,

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -386,12 +386,12 @@ extensible_associated_module_type!(
 
 impl WalletOutput {
     pub fn new_v0_peg_out(
-        recipient: Address<NetworkUnchecked>,
+        recipient: Address,
         amount: bitcoin::Amount,
         fees: PegOutFees,
     ) -> WalletOutput {
         WalletOutput::V0(WalletOutputV0::PegOut(PegOut {
-            recipient,
+            recipient: recipient.into_unchecked(),
             amount,
             fees,
         }))

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -7,7 +7,6 @@
 
 use std::hash::Hasher;
 
-use bitcoin::address::NetworkUnchecked;
 use bitcoin::psbt::raw::ProprietaryKey;
 use bitcoin::{secp256k1, Address, Amount, BlockHash, TxOut, Txid};
 use config::WalletClientConfig;
@@ -243,9 +242,9 @@ impl PegOutFees {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Encodable, Decodable)]
 pub struct PegOut {
-    pub recipient: Address<NetworkUnchecked>,
+    pub recipient: Address,
     #[serde(with = "bitcoin::amount::serde::as_sat")]
     pub amount: bitcoin::Amount,
     pub fees: PegOutFees,
@@ -391,7 +390,7 @@ impl WalletOutput {
         fees: PegOutFees,
     ) -> WalletOutput {
         WalletOutput::V0(WalletOutputV0::PegOut(PegOut {
-            recipient: recipient.into_unchecked(),
+            recipient,
             amount,
             fees,
         }))
@@ -401,7 +400,7 @@ impl WalletOutput {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Encodable, Decodable)]
 pub enum WalletOutputV0 {
     PegOut(PegOut),
     Rbf(Rbf),
@@ -429,12 +428,7 @@ impl std::fmt::Display for WalletOutputV0 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             WalletOutputV0::PegOut(pegout) => {
-                write!(
-                    f,
-                    "Wallet PegOut {} to {}",
-                    pegout.amount,
-                    pegout.recipient.clone().assume_checked()
-                )
+                write!(f, "Wallet PegOut {} to {}", pegout.amount, pegout.recipient)
             }
             WalletOutputV0::Rbf(rbf) => write!(f, "Wallet RBF {:?} to {}", rbf.fees, rbf.txid),
         }


### PR DESCRIPTION
Requires #6517

Replace implementations of `Encodable` and `Decodable` for _unchecked_ addresses with implementations for _checked_ addresses. This should be safe since all places where we previously encoded unchecked addresses, we simply casted a checked address to an unchecked address. However, since checked addresses don't implement `serde::Deserialize`, we must drop support for it in those structs. For that reason, this change probably isn't a good idea, I just wanted to see if it would work.