### PR TITLE
chore(ci): use separate perfit metric for back-compat merge queue

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -55,8 +55,10 @@ jobs:
 
           # run a slimmed down back-compat test for PR push or each major version for merge queue
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
             VERSIONS_TO_TEST="v0.3.4-rc.1 v0.4.4 v0.5.0-rc.2"
           else
+            PERFIT_METRIC="aPuCAjrFT7uE5Oax_T4sMw"
             VERSIONS_TO_TEST="v0.5.0-rc.2"
           fi
 
@@ -72,7 +74,7 @@ jobs:
             nix shell 'github:rustshop/fs-dir-cache?rev=e9752d00ee16778c9d3d0b93a09c49c44013ac17' -c \
             nix run 'github:rustshop/perfit?rev=a2ea3bae86b0e70d2ebdbca1fd16a843b7f0a3bd#perfit' -- \
               run \
-                --metric aPuCAjrFT7uE5Oax_T4sMw \
+                --metric "$PERFIT_METRIC" \
                 --metadata "commit=${LAST_COMMIT_SHA}" \
                 -- \
             scripts/ci/run-in-fs-dir-cache.sh backward-compat \

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -654,7 +654,7 @@ async fn leave_federation(gw: &Gatewayd, fed_id: String, expected_scid: u64) -> 
     let federation_id: FederationId = serde_json::from_value(leave_fed["federation_id"].clone())?;
     assert_eq!(federation_id.to_string(), fed_id);
 
-    // TODO(support:v0.3): `federation_index` was introduced in v0.5.0
+    // TODO(support:v0.4): `federation_index` was introduced in v0.5.0
     // see: https://github.com/fedimint/fedimint/pull/5971
     let scid = if gatewayd_version < *VERSION_0_5_0_ALPHA {
         let channel_id: Option<u64> = serde_json::from_value(leave_fed["channel_id"].clone())?;


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/6545