### PR TITLE
fix: warn about pre-releases to avoid accidental mainnet usage

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -493,6 +493,18 @@ jobs:
 
     runs-on: [self-hosted, linux]
     timeout-minutes: 60
+
+    env:
+      PRERELEASE_MESSAGE: |
+        ⚠️ **Pre-release Notice**
+
+        - This is a release candidate version
+        - Features may be unstable
+        - You may not be able to upgrade to the final release
+        - Not recommended for mainnet use
+
+        Please report any issues you encounter.
+
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
@@ -566,6 +578,7 @@ jobs:
         with:
           files: "bins/**"
           prerelease: ${{ contains(github.ref, 'rc') }}
+          body: ${{ contains(github.ref, 'rc') && env.PRERELEASE_MESSAGE || '' }}
 
       - name: Build DEB package
         run: |
@@ -599,6 +612,7 @@ jobs:
         with:
           files: "debs/**.deb"
           prerelease: ${{ contains(github.ref, 'rc') }}
+          body: ${{ contains(github.ref, 'rc') && env.PRERELEASE_MESSAGE || '' }}
 
       - name: Upload RPM packages
         uses: actions/upload-artifact@v4
@@ -612,6 +626,7 @@ jobs:
         with:
           files: "rpms/**.rpm"
           prerelease: ${{ contains(github.ref, 'rc') }}
+          body: ${{ contains(github.ref, 'rc') && env.PRERELEASE_MESSAGE || '' }}
 
   status:
     name: Status


### PR DESCRIPTION
Fixes #6539

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
