### PR TITLE
refactor(client): clarify handling of empty bundles

### DIFF
--- a/fedimint-client/src/transaction/builder.rs
+++ b/fedimint-client/src/transaction/builder.rs
@@ -481,8 +481,8 @@ impl TransactionBuilder {
         let input_states = self
             .inputs
             .into_iter()
-            .filter(|bundle| !bundle.is_empty())
             .enumerate()
+            .filter(|(_, bundle)| !bundle.is_empty())
             .flat_map(|(bundle_idx, bundle)| {
                 let input_idxs = find_range_of_matching_items(&input_idx_to_bundle_idx, bundle_idx)
                     .expect("Non empty bundles must always have a match");
@@ -497,8 +497,8 @@ impl TransactionBuilder {
         let output_states = self
             .outputs
             .into_iter()
-            .filter(|bundle| !bundle.is_empty())
             .enumerate()
+            .filter(|(_, bundle)| !bundle.is_empty())
             .flat_map(|(bundle_idx, bundle)| {
                 let output_idxs =
                     find_range_of_matching_items(&output_idx_to_bundle_idx, bundle_idx)
@@ -562,3 +562,6 @@ where
             .collect()
     })
 }
+
+#[cfg(test)]
+mod tests;

--- a/fedimint-client/src/transaction/builder.rs
+++ b/fedimint-client/src/transaction/builder.rs
@@ -87,7 +87,7 @@ impl sm::State for NeverClientStateMachine {
 #[derive(Clone, Debug)]
 pub struct ClientInputBundle<I = DynInput, S = DynState> {
     pub(crate) inputs: Vec<ClientInput<I>>,
-    pub(crate) sms: Vec<ClientInputSM<S>>,
+    pub(crate) sm_gens: Vec<ClientInputSM<S>>,
 }
 
 impl<I> ClientInputBundle<I, NeverClientStateMachine> {
@@ -102,7 +102,7 @@ impl<I> ClientInputBundle<I, NeverClientStateMachine> {
         }
         Self {
             inputs,
-            sms: vec![],
+            sm_gens: vec![],
         }
     }
 }
@@ -112,12 +112,8 @@ where
     I: IInput + MaybeSend + MaybeSync + 'static,
     S: sm::IState + MaybeSend + MaybeSync + 'static,
 {
-    pub fn new(inputs: Vec<ClientInput<I>>, sms: Vec<ClientInputSM<S>>) -> Self {
-        if inputs.is_empty() {
-            // TODO: Make it return Result or assert?
-            warn!(target: LOG_CLIENT, "Empty input bundle will be illegal in the future");
-        }
-        Self { inputs, sms }
+    pub fn new(inputs: Vec<ClientInput<I>>, sm_gens: Vec<ClientInputSM<S>>) -> Self {
+        Self { inputs, sm_gens }
     }
 
     pub fn inputs(&self) -> &[ClientInput<I>] {
@@ -125,7 +121,7 @@ where
     }
 
     pub fn sms(&self) -> &[ClientInputSM<S>] {
-        &self.sms
+        &self.sm_gens
     }
 
     pub fn into_instanceless(self) -> InstancelessDynClientInputBundle {
@@ -139,14 +135,21 @@ where
                     amount: input.amount,
                 })
                 .collect(),
-            sms: self
-                .sms
+            sm_gens: self
+                .sm_gens
                 .into_iter()
                 .map(|input_sm| InstancelessDynClientInputSM {
                     state_machines: states_to_instanceless_dyn(input_sm.state_machines),
                 })
                 .collect(),
         }
+    }
+}
+
+impl<I, S> ClientInputBundle<I, S> {
+    pub fn is_empty(&self) -> bool {
+        // Notably, sm_gen will not be called when inputs are empty anyway
+        self.inputs.is_empty()
     }
 }
 
@@ -193,8 +196,8 @@ where
                 .map(|input| input.into_dyn(module_instance_id))
                 .collect::<Vec<ClientInput>>(),
 
-            sms: self
-                .sms
+            sm_gens: self
+                .sm_gens
                 .into_iter()
                 .map(|input_sm| input_sm.into_dyn(module_instance_id))
                 .collect::<Vec<ClientInputSM>>(),
@@ -217,8 +220,8 @@ impl IntoDynInstance for InstancelessDynClientInputBundle {
                 })
                 .collect::<Vec<ClientInput>>(),
 
-            sms: self
-                .sms
+            sm_gens: self
+                .sm_gens
                 .into_iter()
                 .map(|input_sm| ClientInputSM {
                     state_machines: states_add_instance(
@@ -234,7 +237,7 @@ impl IntoDynInstance for InstancelessDynClientInputBundle {
 #[derive(Clone, Debug)]
 pub struct ClientOutputBundle<O = DynOutput, S = DynState> {
     pub(crate) outputs: Vec<ClientOutput<O>>,
-    pub(crate) sms: Vec<ClientOutputSM<S>>,
+    pub(crate) sm_gens: Vec<ClientOutputSM<S>>,
 }
 
 #[derive(Clone, Debug)]
@@ -265,7 +268,7 @@ impl<O> ClientOutputBundle<O, NeverClientStateMachine> {
         }
         Self {
             outputs,
-            sms: vec![],
+            sm_gens: vec![],
         }
     }
 }
@@ -275,12 +278,8 @@ where
     O: IOutput + MaybeSend + MaybeSync + 'static,
     S: sm::IState + MaybeSend + MaybeSync + 'static,
 {
-    pub fn new(outputs: Vec<ClientOutput<O>>, sms: Vec<ClientOutputSM<S>>) -> Self {
-        if outputs.is_empty() {
-            // TODO: Make it return Result or assert?
-            warn!(target: LOG_CLIENT, "Empty output bundle will be illegal in the future");
-        }
-        Self { outputs, sms }
+    pub fn new(outputs: Vec<ClientOutput<O>>, sm_gens: Vec<ClientOutputSM<S>>) -> Self {
+        Self { outputs, sm_gens }
     }
 
     pub fn outputs(&self) -> &[ClientOutput<O>] {
@@ -288,12 +287,12 @@ where
     }
 
     pub fn sms(&self) -> &[ClientOutputSM<S>] {
-        &self.sms
+        &self.sm_gens
     }
 
     pub fn with(mut self, other: Self) -> Self {
         self.outputs.extend(other.outputs);
-        self.sms.extend(other.sms);
+        self.sm_gens.extend(other.sm_gens);
         self
     }
 
@@ -307,14 +306,21 @@ where
                     amount: output.amount,
                 })
                 .collect(),
-            sms: self
-                .sms
+            sm_gens: self
+                .sm_gens
                 .into_iter()
                 .map(|output_sm| InstancelessDynClientOutputSM {
                     state_machines: states_to_instanceless_dyn(output_sm.state_machines),
                 })
                 .collect(),
         }
+    }
+}
+
+impl<O, S> ClientOutputBundle<O, S> {
+    pub fn is_empty(&self) -> bool {
+        // Notably, sm_gen will not be called when outputs are empty anyway
+        self.outputs.is_empty()
     }
 }
 
@@ -333,8 +339,8 @@ where
                 .map(|output| output.into_dyn(module_instance_id))
                 .collect::<Vec<ClientOutput>>(),
 
-            sms: self
-                .sms
+            sm_gens: self
+                .sm_gens
                 .into_iter()
                 .map(|output_sm| output_sm.into_dyn(module_instance_id))
                 .collect::<Vec<ClientOutputSM>>(),
@@ -356,8 +362,8 @@ impl IntoDynInstance for InstancelessDynClientOutputBundle {
                 })
                 .collect::<Vec<ClientOutput>>(),
 
-            sms: self
-                .sms
+            sm_gens: self
+                .sm_gens
                 .into_iter()
                 .map(|output_sm| ClientOutputSM {
                     state_machines: states_add_instance(
@@ -475,44 +481,36 @@ impl TransactionBuilder {
         let input_states = self
             .inputs
             .into_iter()
+            .filter(|bundle| !bundle.is_empty())
             .enumerate()
             .flat_map(|(bundle_idx, bundle)| {
-                let input_idxs = find_range_of_matching_items(&input_idx_to_bundle_idx, bundle_idx);
-                bundle.sms.into_iter().flat_map(move |sm| {
-                    if let Some(input_idxs) = input_idxs.as_ref() {
-                        (sm.state_machines)(OutPointRange::new(
-                            txid,
-                            IdxRange::from_inclusive(input_idxs.clone()).expect("can't overflow"),
-                        ))
-                    } else {
-                        // TODO: In the future `InputBundle` and `OutputBundle` should make empty
-                        // bundles impossible, so this should not be possible
-                        vec![]
-                    }
+                let input_idxs = find_range_of_matching_items(&input_idx_to_bundle_idx, bundle_idx)
+                    .expect("Non empty bundles must always have a match");
+                bundle.sm_gens.into_iter().flat_map(move |sm| {
+                    (sm.state_machines)(OutPointRange::new(
+                        txid,
+                        IdxRange::from_inclusive(input_idxs.clone()).expect("can't overflow"),
+                    ))
                 })
             });
 
-        let output_states =
-            self.outputs
-                .into_iter()
-                .enumerate()
-                .flat_map(|(bundle_idx, bundle)| {
-                    let output_idxs =
-                        find_range_of_matching_items(&output_idx_to_bundle_idx, bundle_idx);
-                    bundle.sms.into_iter().flat_map(move |sm| {
-                        if let Some(output_idxs) = output_idxs.as_ref() {
-                            (sm.state_machines)(OutPointRange::new(
-                                txid,
-                                IdxRange::from_inclusive(output_idxs.clone())
-                                    .expect("can't possibly overflow"),
-                            ))
-                        } else {
-                            // TODO: In the future `InputBundle` and `OutputBundle` should make
-                            // empty bundles impossible, so this should not be possible
-                            vec![]
-                        }
-                    })
-                });
+        let output_states = self
+            .outputs
+            .into_iter()
+            .filter(|bundle| !bundle.is_empty())
+            .enumerate()
+            .flat_map(|(bundle_idx, bundle)| {
+                let output_idxs =
+                    find_range_of_matching_items(&output_idx_to_bundle_idx, bundle_idx)
+                        .expect("Non empty bundles must always have a match");
+                bundle.sm_gens.into_iter().flat_map(move |sm| {
+                    (sm.state_machines)(OutPointRange::new(
+                        txid,
+                        IdxRange::from_inclusive(output_idxs.clone())
+                            .expect("can't possibly overflow"),
+                    ))
+                })
+            });
         (transaction, input_states.chain(output_states).collect())
     }
 

--- a/fedimint-client/src/transaction/builder/tests.rs
+++ b/fedimint-client/src/transaction/builder/tests.rs
@@ -1,0 +1,182 @@
+use core::fmt;
+use std::fmt::Write as _;
+use std::sync::{Arc, Mutex};
+
+use bitcoin::key::Secp256k1;
+use fedimint_core::core::{Input, IntoDynInstance, ModuleKind, Output};
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::Amount;
+
+use super::{
+    ClientInputBundle, ClientOutput, ClientOutputBundle, ClientOutputSM, TransactionBuilder,
+};
+use crate::module::OutPointRange;
+use crate::transaction::{ClientInput, ClientInputSM};
+
+#[derive(Encodable, Decodable, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct NoopInput;
+
+impl fmt::Display for NoopInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("NoopInput")
+    }
+}
+
+impl Input for NoopInput {
+    const KIND: ModuleKind = ModuleKind::from_static_str("test");
+}
+
+impl IntoDynInstance for NoopInput {
+    type DynType = fedimint_core::core::DynInput;
+
+    fn into_dyn(self, instance_id: fedimint_core::core::ModuleInstanceId) -> Self::DynType {
+        fedimint_core::core::DynInput::from_typed(instance_id, self)
+    }
+}
+
+#[derive(Encodable, Decodable, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct NoopOutput;
+
+impl fmt::Display for NoopOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("NoopOutput")
+    }
+}
+
+impl Output for NoopOutput {
+    const KIND: ModuleKind = ModuleKind::from_static_str("test");
+}
+
+impl IntoDynInstance for NoopOutput {
+    type DynType = fedimint_core::core::DynOutput;
+
+    fn into_dyn(self, instance_id: fedimint_core::core::ModuleInstanceId) -> Self::DynType {
+        fedimint_core::core::DynOutput::from_typed(instance_id, self)
+    }
+}
+
+#[test]
+/// Exercise empty bundles
+///
+/// Actually exercise empty bundles (since it's rare in real code)
+/// and ensure that their SM-gens are *not* called, while the SM-gens
+/// of non-empty bundles work as expected.
+fn tx_builder_empty_bundles() {
+    // We'll collect ranges sms were called into this thing to compare at the end
+    let sm_called = Arc::new(Mutex::new(String::new()));
+
+    let no_call_input_sm = ClientInputSM {
+        state_machines: Arc::new(move |_out_point_range: OutPointRange| {
+            panic!("Don't call me maybe");
+        }),
+    };
+
+    let no_call_output_sm = ClientOutputSM {
+        state_machines: Arc::new(move |_out_point_range: OutPointRange| {
+            panic!("Don't call me maybe");
+        }),
+    };
+    let yes_call_input_sm = ClientInputSM {
+        state_machines: Arc::new({
+            let sm_called = sm_called.clone();
+            move |out_point_range: OutPointRange| {
+                sm_called
+                    .lock()
+                    .unwrap()
+                    .write_fmt(format_args!("i-{:?},", out_point_range.start_idx()))
+                    .expect("Can't fail");
+                vec![]
+            }
+        }),
+    };
+
+    let yes_call_output_sm = ClientOutputSM {
+        state_machines: Arc::new({
+            let sm_called = sm_called.clone();
+            move |out_point_range: OutPointRange| {
+                sm_called
+                    .clone()
+                    .lock()
+                    .unwrap()
+                    .write_fmt(format_args!("o-{:?},", out_point_range.start_idx()))
+                    .expect("Can't fail");
+                vec![]
+            }
+        }),
+    };
+
+    // This is ugly due to repetition, but the more manual, the better, and in real
+    // code some of these conversions are hidden in the generics. Oh well.
+    TransactionBuilder::new()
+        .with_inputs(
+            ClientInputBundle::<NoopInput>::new(vec![], vec![no_call_input_sm.clone()])
+                .into_instanceless()
+                .into_dyn(0),
+        )
+        .with_inputs(
+            ClientInputBundle::<NoopInput>::new(
+                vec![ClientInput {
+                    input: NoopInput,
+                    keys: vec![],
+                    amount: Amount::from_msats(1),
+                }],
+                vec![yes_call_input_sm.clone()],
+            )
+            .into_instanceless()
+            .into_dyn(3),
+        )
+        .with_inputs(
+            ClientInputBundle::<NoopInput>::new(vec![], vec![no_call_input_sm.clone()])
+                .into_instanceless()
+                .into_dyn(0),
+        )
+        .with_inputs(
+            ClientInputBundle::<NoopInput>::new(
+                vec![ClientInput {
+                    input: NoopInput,
+                    keys: vec![],
+                    amount: Amount::from_msats(1),
+                }],
+                vec![yes_call_input_sm],
+            )
+            .into_instanceless()
+            .into_dyn(3),
+        )
+        .with_outputs(
+            ClientOutputBundle::<NoopOutput>::new(vec![], vec![no_call_output_sm.clone()])
+                .into_instanceless()
+                .into_dyn(0),
+        )
+        .with_outputs(
+            ClientOutputBundle::<NoopOutput>::new(
+                vec![ClientOutput {
+                    output: NoopOutput,
+                    amount: Amount::from_msats(1),
+                }],
+                vec![yes_call_output_sm.clone()],
+            )
+            .into_instanceless()
+            .into_dyn(3),
+        )
+        .with_outputs(
+            ClientOutputBundle::<NoopOutput>::new(vec![], vec![no_call_output_sm.clone()])
+                .into_instanceless()
+                .into_dyn(0),
+        )
+        .with_outputs(
+            ClientOutputBundle::<NoopOutput>::new(
+                vec![ClientOutput {
+                    output: NoopOutput,
+                    amount: Amount::from_msats(1),
+                }],
+                vec![yes_call_output_sm],
+            )
+            .into_instanceless()
+            .into_dyn(3),
+        )
+        .build(&Secp256k1::new(), rand::thread_rng());
+
+    // This actually depends on how builder processes inputs and outputs,
+    // but if it ever changes, just adjust the string.
+    assert_eq!(*sm_called.lock().unwrap(), String::from("i-0,i-1,o-0,o-1,"));
+}


### PR DESCRIPTION
Trying to forbid "empty bundle" (no inputs/outputs) turned out to generate too much `Option`-noise downstream, so let's just embrace it.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
