### PR TITLE
refactor: cleanup FederationInfo

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -531,7 +531,12 @@ impl Gatewayd {
             })
             .ok_or_else(|| anyhow!("Federation not found"))?;
 
-        let lightning_fee = fed[fee_key].clone();
+        let lightning_fee = if gatewayd_version >= *VERSION_0_6_0_ALPHA {
+            fed["config"][fee_key].clone()
+        } else {
+            fed[fee_key].clone()
+        };
+
         let base: Amount = serde_json::from_value(lightning_fee[base_key].clone())
             .map_err(|e| anyhow!("Couldnt parse base: {}", e))?;
         let parts_per_million: u64 = serde_json::from_value(lightning_fee[ppm_key].clone())

--- a/gateway/cli/src/config_commands.rs
+++ b/gateway/cli/src/config_commands.rs
@@ -52,14 +52,15 @@ impl ConfigCommands {
             }
             Self::Display { federation_id } => {
                 let info = create_client().get_info().await?;
-                let federations = if let Some(id) = federation_id {
-                    info.federations
-                        .into_iter()
-                        .filter(|f| id == f.federation_id)
-                        .collect::<Vec<_>>()
-                } else {
-                    info.federations
-                };
+                let federations = info
+                    .federations
+                    .into_iter()
+                    .filter_map(|f| match federation_id {
+                        Some(id) if id == f.federation_id => Some(f.config),
+                        Some(_) => None,
+                        None => Some(f.config),
+                    })
+                    .collect::<Vec<_>>();
                 print_response(federations);
             }
             Self::SetFees {

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -627,8 +627,10 @@ async fn leave_federation(gw: &Gatewayd, fed_id: String, expected_scid: u64) -> 
     let scid = if gatewayd_version < *VERSION_0_5_0_ALPHA {
         let channel_id: Option<u64> = serde_json::from_value(leave_fed["channel_id"].clone())?;
         channel_id.expect("must have channel id")
-    } else {
+    } else if gatewayd_version >= *VERSION_0_5_0_ALPHA && gatewayd_version < *VERSION_0_6_0_ALPHA {
         serde_json::from_value::<u64>(leave_fed["federation_index"].clone())?
+    } else {
+        serde_json::from_value::<u64>(leave_fed["config"]["federation_index"].clone())?
     };
 
     assert_eq!(scid, expected_scid);

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -763,7 +763,7 @@ impl Gateway {
             .iter()
             .map(|federation_info| {
                 (
-                    federation_info.federation_index,
+                    federation_info.config.federation_index,
                     federation_info.federation_id,
                 )
             })
@@ -1113,9 +1113,7 @@ impl Gateway {
             federation_id,
             federation_name: federation_manager.federation_name(&client).await,
             balance_msat: client.get_balance().await,
-            federation_index,
-            lightning_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
-            transaction_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
+            config: federation_config.clone(),
         };
 
         if self.is_running_lnv1() {

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -9,12 +9,12 @@ use fedimint_core::config::{FederationId, JsonClientConfig};
 use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
 use fedimint_core::{secp256k1, Amount, BitcoinAmountOrAll};
 use fedimint_eventlog::{EventKind, EventLogId};
-use fedimint_lnv2_common::gateway_api::PaymentFee;
 use fedimint_mint_client::OOBNotes;
 use fedimint_wallet_client::PegOutFees;
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
 
+use crate::db::FederationConfig;
 use crate::lightning::LightningMode;
 use crate::SafeUrl;
 
@@ -102,9 +102,7 @@ pub struct FederationInfo {
     pub federation_id: FederationId,
     pub federation_name: Option<String>,
     pub balance_msat: Amount,
-    pub federation_index: u64,
-    pub lightning_fee: PaymentFee,
-    pub transaction_fee: PaymentFee,
+    pub config: FederationConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
`FederationConfig` and `FederationInfo` have overlapping fields and its confusing when each one is used. This PR refactors it so that `FederationConfig` is a field inside of `FederationInfo`. `FederationInfo` is what is displayed to the gateway operator during the `info` command. `FederationConfig` is what is stored in the database.

`FederationConfig` can be printed using `gateway-cli cfg display`.