### PR TITLE
chore: gateway returns federation info when not running

### DIFF
--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -113,12 +113,14 @@ pub struct GatewayInfo {
     pub federations: Vec<FederationInfo>,
     /// Mapping from short channel id to the federation id that it belongs to.
     // TODO: Remove this alias once it no longer breaks backwards compatibility.
+    // TODO(support:v0.5): Remove the `Option` wrapper.
     #[serde(alias = "channels")]
     pub federation_fake_scids: Option<BTreeMap<u64, FederationId>>,
     pub lightning_pub_key: Option<String>,
     pub lightning_alias: Option<String>,
     pub gateway_id: secp256k1::PublicKey,
     pub gateway_state: String,
+    // TODO(support:v0.5): Remove the `Option` wrapper.
     pub network: Option<Network>,
     // TODO: This is here to allow for backwards compatibility with old versions of this struct. We
     // should be able to remove it once 0.4.0 is released.


### PR DESCRIPTION
Previously when the gateway was not in the running state, it didn't return information related to what federations it was connected to, or the bitcoin network it was connected to, or the lightning mode it was running on. I don't believe there's any reason why we shouldn't allow for this data to be shown. Doing this also means that `GatewayInfo.federation_fake_scids` and `GatewayInfo.network` are never `None`. However, simply changing them would lead to backwards compatibility issues when using the new CLI with older versions of the gateway.