### PR TITLE
feat: Gateway 24 hour payment summary

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -15,7 +15,7 @@ use fedimint_ln_server::common::lightning_invoice::Bolt11Invoice;
 use fedimint_lnv2_common::gateway_api::PaymentFee;
 use fedimint_testing::ln::LightningNodeType;
 use ln_gateway::envs::FM_GATEWAY_LIGHTNING_MODULE_MODE_ENV;
-use ln_gateway::rpc::{GatewayBalances, MnemonicResponse, V1_API_ENDPOINT};
+use ln_gateway::rpc::{GatewayBalances, MnemonicResponse, PaymentSummaryResponse, V1_API_ENDPOINT};
 use tracing::info;
 
 use crate::cmd;
@@ -615,5 +615,10 @@ impl Gatewayd {
         }
 
         Ok(())
+    }
+
+    pub async fn payment_summary(&self) -> Result<PaymentSummaryResponse> {
+        let out_json = cmd!(self, "payment-summary").out_json().await?;
+        Ok(serde_json::from_value(out_json).expect("Could not deserialize PaymentSummaryResponse"))
     }
 }

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -21,7 +21,7 @@ use fedimint_core::envs::{
 use fedimint_core::task::TaskGroup;
 use fedimint_core::time::now;
 use fedimint_core::txoproof::TxOutProof;
-use fedimint_core::util::{FmtCompactAnyhow, SafeUrl};
+use fedimint_core::util::{get_median, FmtCompactAnyhow, SafeUrl};
 use fedimint_core::{apply, async_trait_maybe_send, dyn_newtype_define, Feerate};
 use fedimint_logging::{LOG_BITCOIND, LOG_CORE};
 use feerate_source::{FeeRateSource, FetchJson};
@@ -322,19 +322,4 @@ fn get_bitcoin_polling_interval() -> Interval {
     } else {
         Duration::from_secs(30)
     })
-}
-
-/// Computes the median from a slice of `u64`s
-fn get_median(vals: &[u64]) -> Option<u64> {
-    if vals.is_empty() {
-        return None;
-    }
-    let len = vals.len();
-    let mid = len / 2;
-
-    if len % 2 == 0 {
-        Some((vals[mid - 1] + vals[mid]) / 2)
-    } else {
-        Some(vals[mid])
-    }
 }

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1217,15 +1217,15 @@ impl FedimintCli {
                     .await
                     .into_iter()
                     .map(|v| {
-                        let module_id = v.2.as_ref().map(|m| m.1);
-                        let module_kind = v.2.map(|m| m.0);
+                        let module_id = v.module.as_ref().map(|m| m.1);
+                        let module_kind = v.module.map(|m| m.0);
                         serde_json::json!({
-                            "id": v.0,
-                            "kind": v.1,
+                            "id": v.event_id,
+                            "kind": v.event_kind,
                             "module_kind": module_kind,
                             "module_id": module_id,
-                            "ts": v.3,
-                            "payload": v.4
+                            "ts": v.timestamp,
+                            "payload": v.value
                         })
                     })
                     .collect();

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -138,7 +138,7 @@ pub use fedimint_derive_secret as derivable_secret;
 use fedimint_derive_secret::DerivableSecret;
 use fedimint_eventlog::{
     self, run_event_log_ordering_task, DBTransactionEventLogExt, Event, EventKind, EventLogEntry,
-    EventLogId,
+    EventLogId, PersistedLogEntry,
 };
 use fedimint_logging::{LOG_CLIENT, LOG_CLIENT_NET_API, LOG_CLIENT_RECOVERY};
 use futures::stream::FuturesUnordered;
@@ -2188,13 +2188,7 @@ impl Client {
         &self,
         pos: Option<EventLogId>,
         limit: u64,
-    ) -> Vec<(
-        EventLogId,
-        EventKind,
-        Option<(ModuleKind, ModuleInstanceId)>,
-        u64,
-        serde_json::Value,
-    )> {
+    ) -> Vec<PersistedLogEntry> {
         self.get_event_log_dbtx(&mut self.db.begin_transaction_nc().await, pos, limit)
             .await
     }
@@ -2204,13 +2198,7 @@ impl Client {
         dbtx: &mut DatabaseTransaction<'_, Cap>,
         pos: Option<EventLogId>,
         limit: u64,
-    ) -> Vec<(
-        EventLogId,
-        EventKind,
-        Option<(ModuleKind, ModuleInstanceId)>,
-        u64,
-        serde_json::Value,
-    )>
+    ) -> Vec<PersistedLogEntry>
     where
         Cap: Send,
     {

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -479,6 +479,31 @@ where
     }
 }
 
+/// Computes the median from a slice of sorted `u64`s
+pub fn get_median(vals: &[u64]) -> Option<u64> {
+    if vals.is_empty() {
+        return None;
+    }
+    let len = vals.len();
+    let mid = len / 2;
+
+    if len % 2 == 0 {
+        Some((vals[mid - 1] + vals[mid]) / 2)
+    } else {
+        Some(vals[mid])
+    }
+}
+
+/// Computes the average of the given `u64` slice.
+pub fn get_average(vals: &[u64]) -> Option<u64> {
+    if vals.is_empty() {
+        return None;
+    }
+
+    let sum: u64 = vals.iter().sum();
+    Some(sum / vals.len() as u64)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicU8, Ordering};

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -51,6 +51,7 @@ fedimint-wallet-client = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
+itertools = { workspace = true }
 lightning-invoice = { workspace = true }
 lockable = "0.1.1"
 prost = "0.13.4"
@@ -81,7 +82,6 @@ fedimint-lnv2-server = { workspace = true }
 fedimint-testing = { workspace = true }
 fedimint-unknown-common = { workspace = true }
 fedimint-unknown-server = { workspace = true }
-itertools = { workspace = true }
 
 [build-dependencies]
 fedimint-build = { workspace = true }

--- a/gateway/ln-gateway/src/events.rs
+++ b/gateway/ln-gateway/src/events.rs
@@ -1,12 +1,23 @@
-use fedimint_eventlog::{Event, EventKind};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use fedimint_client::ClientHandle;
+use fedimint_core::core::ModuleKind;
+use fedimint_core::util::{get_average, get_median};
+use fedimint_core::Amount;
+use fedimint_eventlog::{
+    DBTransactionEventLogExt, Event, EventKind, EventLogId, PersistedLogEntry,
+};
 use fedimint_mint_client::event::{OOBNotesReissued, OOBNotesSpent};
 use fedimint_wallet_client::events::{DepositConfirmed, WithdrawRequest};
+use itertools::Itertools;
 
 use crate::gateway_module_v2::events::{
     CompleteLightningPaymentSucceeded, IncomingPaymentFailed, IncomingPaymentStarted,
     IncomingPaymentSucceeded, OutgoingPaymentFailed, OutgoingPaymentStarted,
     OutgoingPaymentSucceeded,
 };
+use crate::rpc::PaymentStats;
 
 pub const ALL_GATEWAY_EVENTS: [EventKind; 11] = [
     OutgoingPaymentStarted::KIND,
@@ -22,4 +33,184 @@ pub const ALL_GATEWAY_EVENTS: [EventKind; 11] = [
     DepositConfirmed::KIND,
 ];
 
-// TODO: Add Gateway specific events
+/// Searches through the event log for all events that occurred within the
+/// specified time bounds.
+///
+/// Because it is inefficient to search the log backwards, instead this function
+/// traverses the log forwards, but in batches.
+/// All events are appended to an array until the cutoff event where the
+/// timestamp is greater than the start timestamp or the end of the log is hit.
+pub async fn get_events_for_duration(
+    client: &Arc<ClientHandle>,
+    start: SystemTime,
+    end: SystemTime,
+) -> Vec<PersistedLogEntry> {
+    const BATCH_SIZE: u64 = 10_000;
+
+    let start_micros = start
+        .duration_since(UNIX_EPOCH)
+        .expect("before unix epoch")
+        .as_micros() as u64;
+
+    let end_micros = end
+        .duration_since(UNIX_EPOCH)
+        .expect("before unix epoch")
+        .as_micros() as u64;
+
+    let batch_end = {
+        let mut dbtx = client.db().begin_transaction_nc().await;
+        dbtx.get_next_event_log_id().await
+    };
+
+    let mut batch_start = batch_end.saturating_sub(BATCH_SIZE);
+
+    // Find the "rough start" in the log by reading the log backwards in batches.
+    // Once an event with a timestamp before our start time is found, then we start
+    // traversing forward to find events that fall within our time bound.
+    while batch_start != EventLogId::LOG_START {
+        let batch = client.get_event_log(Some(batch_start), BATCH_SIZE).await;
+
+        match batch.first() {
+            Some(first_event) => {
+                if first_event.timestamp < start_micros {
+                    // Found the "rough start" where we can read forward
+                    break;
+                }
+            }
+            None => {
+                return vec![];
+            }
+        }
+
+        batch_start = batch_start.saturating_sub(BATCH_SIZE);
+    }
+
+    let mut all_events = Vec::new();
+    loop {
+        let batch = client.get_event_log(Some(batch_start), BATCH_SIZE).await;
+
+        if batch.is_empty() {
+            return all_events;
+        }
+
+        for event in batch {
+            if event.timestamp < start_micros {
+                continue;
+            }
+
+            if event.timestamp >= end_micros {
+                return all_events;
+            }
+
+            all_events.push(event);
+        }
+
+        batch_start = batch_start.saturating_add(BATCH_SIZE);
+    }
+}
+
+/// Filters the given `PersistedLogEntry` slice by the `EventKind` and
+/// `ModuleKind`.
+pub(crate) fn filter_events<'a, I>(
+    all_events: I,
+    event_kind: EventKind,
+    module_kind: ModuleKind,
+) -> impl Iterator<Item = &'a PersistedLogEntry> + 'a
+where
+    I: IntoIterator<Item = &'a PersistedLogEntry> + 'a,
+{
+    all_events.into_iter().filter(move |e| {
+        if let Some((m, _)) = &e.module {
+            e.event_kind == event_kind && *m == module_kind
+        } else {
+            false
+        }
+    })
+}
+
+/// Joins two sets of events on a predicate.
+///
+/// This function computes a "nested loop join" by first computing the cross
+/// product of the start event vector and the success/failure event vectors. The
+/// resulting cartesian product is then filtered according to the join predicate
+/// supplied in the parameters.
+///
+/// This function is intended for small data sets. If the data set relations
+/// grow, this function should implement a different join algorithm or be moved
+/// out of the gateway.
+pub(crate) fn join_events<'a, L, R, Res>(
+    events_l: &'a [&PersistedLogEntry],
+    events_r: &'a [&PersistedLogEntry],
+    predicate: impl Fn(L, R, u64) -> Option<Res> + 'a,
+) -> impl Iterator<Item = Res> + 'a
+where
+    L: Event,
+    R: Event,
+{
+    events_l
+        .iter()
+        .cartesian_product(events_r)
+        .filter_map(move |(l, r)| {
+            if let Some(latency) = r.timestamp.checked_sub(l.timestamp) {
+                let event_l: L =
+                    serde_json::from_value(l.value.clone()).expect("could not parse JSON");
+                let event_r: R =
+                    serde_json::from_value(r.value.clone()).expect("could not parse JSON");
+                predicate(event_l, event_r, latency)
+            } else {
+                None
+            }
+        })
+}
+
+/// Helper struct for storing computed data about outgoing and incoming
+/// payments.
+#[derive(Debug, Default)]
+pub struct StructuredPaymentEvents {
+    latencies: Vec<u64>,
+    fees: Vec<Amount>,
+    latencies_failure: Vec<u64>,
+}
+
+impl StructuredPaymentEvents {
+    pub fn new(
+        success_stats: &[(u64, Amount)],
+        failure_stats: Vec<u64>,
+    ) -> StructuredPaymentEvents {
+        let mut events = StructuredPaymentEvents {
+            latencies: success_stats.iter().map(|(l, _)| *l).collect(),
+            fees: success_stats.iter().map(|(_, f)| *f).collect(),
+            latencies_failure: failure_stats,
+        };
+        events.sort();
+        events
+    }
+
+    /// Combines this `StructuredPaymentEvents` with the `other`
+    /// `StructuredPaymentEvents` by appending all of the internal vectors.
+    pub fn combine(&mut self, other: &mut StructuredPaymentEvents) {
+        self.latencies.append(&mut other.latencies);
+        self.fees.append(&mut other.fees);
+        self.latencies_failure.append(&mut other.latencies_failure);
+        self.sort();
+    }
+
+    /// Sorts this `StructuredPaymentEvents` by sorting all of the internal
+    /// vectors.
+    fn sort(&mut self) {
+        self.latencies.sort_unstable();
+        self.fees.sort_unstable();
+        self.latencies_failure.sort_unstable();
+    }
+
+    /// Computes the payment statistics for the given input data.
+    pub fn compute_payment_stats(&self) -> PaymentStats {
+        PaymentStats {
+            average_latency: get_average(&self.latencies).map(Duration::from_micros),
+            median_latency: get_median(&self.latencies).map(Duration::from_micros),
+            total_fees: Amount::from_msats(self.fees.iter().map(|a| a.msats).sum()),
+            total_success: self.latencies.len(),
+            total_failure: self.latencies_failure.len(),
+        }
+    }
+}

--- a/gateway/ln-gateway/src/gateway_module_v2/events.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/events.rs
@@ -3,15 +3,16 @@ use std::time::SystemTime;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::Amount;
-use fedimint_eventlog::{Event, EventKind};
+use fedimint_eventlog::{Event, EventKind, PersistedLogEntry};
 use fedimint_lnv2_common::contracts::{Commitment, OutgoingContract, PaymentImage};
 use serde::{Deserialize, Serialize};
 use serde_millis;
 
 use super::send_sm::Cancelled;
+use crate::events::{filter_events, join_events, StructuredPaymentEvents};
 
 /// Event that is emitted when an outgoing payment attempt is initiated.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct OutgoingPaymentStarted {
     /// The timestamp that the operation begins, including the API calls to the
     /// federation to get the consensus block height.
@@ -39,7 +40,7 @@ impl Event for OutgoingPaymentStarted {
 }
 
 /// Event that is emitted when an outgoing payment attempt has succeeded.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct OutgoingPaymentSucceeded {
     /// The payment image of the invoice that was paid.
     pub payment_image: PaymentImage,
@@ -55,7 +56,7 @@ impl Event for OutgoingPaymentSucceeded {
 }
 
 /// Event that is emitted when an outgoing payment attempt has failed.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct OutgoingPaymentFailed {
     /// The payment image of the invoice that failed.
     pub payment_image: PaymentImage,
@@ -72,7 +73,7 @@ impl Event for OutgoingPaymentFailed {
 
 /// Event that is emitted when an incoming payment attempt has started. Includes
 /// both internal swaps and outside LN payments.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct IncomingPaymentStarted {
     /// The timestamp that the operation begins, including any metadata checks
     /// before the state machine has spawned.
@@ -94,7 +95,7 @@ impl Event for IncomingPaymentStarted {
 
 /// Event that is emitted when an incoming payment attempt has succeeded.
 /// Includes both internal swaps and outside LN payments.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct IncomingPaymentSucceeded {
     /// The payment image of the invoice that was paid.
     pub payment_image: PaymentImage,
@@ -107,7 +108,7 @@ impl Event for IncomingPaymentSucceeded {
 }
 
 /// Event that is emitted when an incoming payment attempt has failed.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct IncomingPaymentFailed {
     /// The payment image of the invoice that failed
     pub payment_image: PaymentImage,
@@ -125,7 +126,7 @@ impl Event for IncomingPaymentFailed {
 /// Event that is emitted when a preimage is revealed to the Lightning network.
 /// Only emitted for payments that are received from an external Lightning node,
 /// not internal swaps.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CompleteLightningPaymentSucceeded {
     /// The payment image of the invoice that was paid.
     pub payment_image: PaymentImage,
@@ -135,4 +136,115 @@ impl Event for CompleteLightningPaymentSucceeded {
     const MODULE: Option<ModuleKind> = Some(fedimint_lnv2_common::KIND);
 
     const KIND: EventKind = EventKind::from_static("complete-lightning-payment-succeeded");
+}
+
+/// Computes the `StructurePaymentEvents` for all LNv2 payments.
+///
+/// Filters the event set for LNv2 events and joins them together.
+pub fn compute_lnv2_stats(
+    all_events: &[PersistedLogEntry],
+) -> (StructuredPaymentEvents, StructuredPaymentEvents) {
+    let outgoing_start_events = filter_events(
+        all_events,
+        OutgoingPaymentStarted::KIND,
+        fedimint_lnv2_common::KIND,
+    )
+    .collect::<Vec<_>>();
+    let outgoing_success_events = filter_events(
+        all_events,
+        OutgoingPaymentSucceeded::KIND,
+        fedimint_lnv2_common::KIND,
+    )
+    .collect::<Vec<_>>();
+    let outgoing_failure_events = filter_events(
+        all_events,
+        OutgoingPaymentFailed::KIND,
+        fedimint_lnv2_common::KIND,
+    )
+    .collect::<Vec<_>>();
+
+    let outgoing_success_stats =
+        join_events::<OutgoingPaymentStarted, OutgoingPaymentSucceeded, (u64, Amount)>(
+            &outgoing_start_events,
+            &outgoing_success_events,
+            |start_event, success_event, latency| {
+                if start_event.outgoing_contract.payment_image == success_event.payment_image {
+                    start_event
+                        .min_contract_amount
+                        .checked_sub(start_event.invoice_amount)
+                        .map(|fee| (latency, fee))
+                } else {
+                    None
+                }
+            },
+        )
+        .collect::<Vec<_>>();
+
+    let outgoing_failure_stats = join_events::<OutgoingPaymentStarted, OutgoingPaymentFailed, u64>(
+        &outgoing_start_events,
+        &outgoing_failure_events,
+        |start_event, fail_event, latency| {
+            if start_event.outgoing_contract.payment_image == fail_event.payment_image {
+                Some(latency)
+            } else {
+                None
+            }
+        },
+    )
+    .collect::<Vec<_>>();
+
+    let incoming_start_events = filter_events(
+        all_events,
+        IncomingPaymentStarted::KIND,
+        fedimint_lnv2_common::KIND,
+    )
+    .collect::<Vec<_>>();
+    let incoming_success_events = filter_events(
+        all_events,
+        IncomingPaymentSucceeded::KIND,
+        fedimint_lnv2_common::KIND,
+    )
+    .collect::<Vec<_>>();
+    let incoming_failure_events = filter_events(
+        all_events,
+        IncomingPaymentFailed::KIND,
+        fedimint_lnv2_common::KIND,
+    )
+    .collect::<Vec<_>>();
+
+    let incoming_success_stats =
+        join_events::<IncomingPaymentStarted, IncomingPaymentSucceeded, (u64, Amount)>(
+            &incoming_start_events,
+            &incoming_success_events,
+            |start_event, success_event, latency| {
+                if start_event.incoming_contract_commitment.payment_image
+                    == success_event.payment_image
+                {
+                    start_event
+                        .invoice_amount
+                        .checked_sub(start_event.incoming_contract_commitment.amount)
+                        .map(|fee| (latency, fee))
+                } else {
+                    None
+                }
+            },
+        )
+        .collect::<Vec<_>>();
+
+    let incoming_failure_stats = join_events::<IncomingPaymentStarted, IncomingPaymentFailed, u64>(
+        &incoming_start_events,
+        &incoming_failure_events,
+        |start_event, fail_event, latency| {
+            if start_event.incoming_contract_commitment.payment_image == fail_event.payment_image {
+                Some(latency)
+            } else {
+                None
+            }
+        },
+    )
+    .collect::<Vec<_>>();
+
+    let outgoing = StructuredPaymentEvents::new(&outgoing_success_stats, outgoing_failure_stats);
+    let incoming = StructuredPaymentEvents::new(&incoming_success_stats, incoming_failure_stats);
+    (outgoing, incoming)
 }

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -2,13 +2,14 @@ pub mod rpc_client;
 pub mod rpc_server;
 
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Network};
 use fedimint_core::config::{FederationId, JsonClientConfig};
-use fedimint_core::core::{ModuleInstanceId, ModuleKind, OperationId};
+use fedimint_core::core::OperationId;
 use fedimint_core::{secp256k1, Amount, BitcoinAmountOrAll};
-use fedimint_eventlog::{EventKind, EventLogId};
+use fedimint_eventlog::{EventKind, EventLogId, PersistedLogEntry};
 use fedimint_mint_client::OOBNotes;
 use fedimint_wallet_client::PegOutFees;
 use lightning_invoice::Bolt11Invoice;
@@ -37,20 +38,13 @@ pub const OPEN_CHANNEL_ENDPOINT: &str = "/open_channel";
 pub const CLOSE_CHANNELS_WITH_PEER_ENDPOINT: &str = "/close_channels_with_peer";
 pub const PAY_INVOICE_FOR_OPERATOR_ENDPOINT: &str = "/pay_invoice_for_operator";
 pub const PAYMENT_LOG_ENDPOINT: &str = "/payment_log";
+pub const PAYMENT_SUMMARY_ENDPOINT: &str = "/payment_summary";
 pub const RECEIVE_ECASH_ENDPOINT: &str = "/receive_ecash";
 pub const SET_FEES_ENDPOINT: &str = "/set_fees";
 pub const STOP_ENDPOINT: &str = "/stop";
 pub const SEND_ONCHAIN_ENDPOINT: &str = "/send_onchain";
 pub const SPEND_ECASH_ENDPOINT: &str = "/spend_ecash";
 pub const WITHDRAW_ENDPOINT: &str = "/withdraw";
-
-type GatewayTransactionEvent = (
-    EventLogId,
-    EventKind,
-    Option<(ModuleKind, ModuleInstanceId)>,
-    u64,
-    serde_json::Value,
-);
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ConnectFedPayload {
@@ -244,4 +238,25 @@ pub struct PaymentLogPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PaymentLogResponse(pub Vec<GatewayTransactionEvent>);
+pub struct PaymentLogResponse(pub Vec<PersistedLogEntry>);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PaymentSummaryResponse {
+    pub outgoing: PaymentStats,
+    pub incoming: PaymentStats,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PaymentStats {
+    pub average_latency: Option<Duration>,
+    pub median_latency: Option<Duration>,
+    pub total_fees: Amount,
+    pub total_success: usize,
+    pub total_failure: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PaymentSummaryPayload {
+    pub start_millis: u64,
+    pub end_millis: u64,
+}

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -15,13 +15,14 @@ use super::{
     BackupPayload, ConfigPayload, ConnectFedPayload, CreateInvoiceForOperatorPayload,
     DepositAddressPayload, DepositAddressRecheckPayload, FederationInfo, GatewayBalances,
     GatewayFedConfig, GatewayInfo, LeaveFedPayload, MnemonicResponse, PayInvoiceForOperatorPayload,
-    PaymentLogPayload, PaymentLogResponse, ReceiveEcashPayload, ReceiveEcashResponse,
-    SetFeesPayload, SpendEcashPayload, SpendEcashResponse, WithdrawPayload, WithdrawResponse,
-    ADDRESS_ENDPOINT, ADDRESS_RECHECK_ENDPOINT, BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
+    PaymentLogPayload, PaymentLogResponse, PaymentSummaryPayload, PaymentSummaryResponse,
+    ReceiveEcashPayload, ReceiveEcashResponse, SetFeesPayload, SpendEcashPayload,
+    SpendEcashResponse, WithdrawPayload, WithdrawResponse, ADDRESS_ENDPOINT,
+    ADDRESS_RECHECK_ENDPOINT, BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
     CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT,
     GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT,
     GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAYMENT_LOG_ENDPOINT,
+    MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT,
     PAY_INVOICE_FOR_OPERATOR_ENDPOINT, RECEIVE_ECASH_ENDPOINT, SEND_ONCHAIN_ENDPOINT,
     SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, WITHDRAW_ENDPOINT,
 };
@@ -258,6 +259,17 @@ impl GatewayRpcClient {
             .base_url
             .join(PAYMENT_LOG_ENDPOINT)
             .expect("Invalid base url");
+        self.call_post(url, payload).await
+    }
+
+    pub async fn payment_summary(
+        &self,
+        payload: PaymentSummaryPayload,
+    ) -> GatewayRpcResult<PaymentSummaryResponse> {
+        let url = self
+            .base_url
+            .join(PAYMENT_SUMMARY_ENDPOINT)
+            .expect("invalid base url");
         self.call_post(url, payload).await
     }
 

--- a/gateway/ln-gateway/src/rpc/rpc_server.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_server.rs
@@ -26,14 +26,15 @@ use tracing::{error, info, instrument};
 use super::{
     BackupPayload, ConnectFedPayload, CreateInvoiceForOperatorPayload, DepositAddressPayload,
     DepositAddressRecheckPayload, InfoPayload, LeaveFedPayload, PayInvoiceForOperatorPayload,
-    PaymentLogPayload, ReceiveEcashPayload, SetFeesPayload, SpendEcashPayload, WithdrawPayload,
-    ADDRESS_ENDPOINT, ADDRESS_RECHECK_ENDPOINT, BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
-    CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT,
-    GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT,
-    GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAYMENT_LOG_ENDPOINT,
-    PAY_INVOICE_FOR_OPERATOR_ENDPOINT, RECEIVE_ECASH_ENDPOINT, SEND_ONCHAIN_ENDPOINT,
-    SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT, V1_API_ENDPOINT, WITHDRAW_ENDPOINT,
+    PaymentLogPayload, PaymentSummaryPayload, ReceiveEcashPayload, SetFeesPayload,
+    SpendEcashPayload, WithdrawPayload, ADDRESS_ENDPOINT, ADDRESS_RECHECK_ENDPOINT,
+    BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT, CONFIGURATION_ENDPOINT,
+    CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT, GATEWAY_INFO_ENDPOINT,
+    GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT,
+    LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT,
+    PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT, PAY_INVOICE_FOR_OPERATOR_ENDPOINT,
+    RECEIVE_ECASH_ENDPOINT, SEND_ONCHAIN_ENDPOINT, SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT,
+    STOP_ENDPOINT, V1_API_ENDPOINT, WITHDRAW_ENDPOINT,
 };
 use crate::error::{AdminGatewayError, PublicGatewayError};
 use crate::rpc::ConfigPayload;
@@ -168,6 +169,7 @@ fn v1_routes(gateway: Arc<Gateway>, task_group: TaskGroup) -> Router {
         .route(MNEMONIC_ENDPOINT, get(mnemonic))
         .route(STOP_ENDPOINT, get(stop))
         .route(PAYMENT_LOG_ENDPOINT, post(payment_log))
+        .route(PAYMENT_SUMMARY_ENDPOINT, post(payment_summary))
         .route(SET_FEES_ENDPOINT, post(set_fees))
         .route(CONFIGURATION_ENDPOINT, post(configuration))
         // FIXME: deprecated >= 0.3.0
@@ -440,4 +442,13 @@ async fn payment_log(
 ) -> Result<impl IntoResponse, AdminGatewayError> {
     let payment_log = gateway.handle_payment_log_msg(payload).await?;
     Ok(Json(json!(payment_log)))
+}
+
+#[instrument(target = LOG_GATEWAY, skip_all, err)]
+async fn payment_summary(
+    Extension(gateway): Extension<Arc<Gateway>>,
+    Json(payload): Json<PaymentSummaryPayload>,
+) -> Result<impl IntoResponse, AdminGatewayError> {
+    let payment_summary = gateway.handle_payment_summary_msg(payload).await?;
+    Ok(Json(json!(payment_summary)))
 }

--- a/gateway/ln-gateway/tests/tests.rs
+++ b/gateway/ln-gateway/tests/tests.rs
@@ -1262,14 +1262,14 @@ async fn gateway_read_payment_log() -> anyhow::Result<()> {
         .0
         .iter()
         .tuple_windows()
-        .all(|(e1, e2)| e1.3 > e2.3));
+        .all(|(e1, e2)| e1.timestamp > e2.timestamp));
 
     // Verify that we retrieve the rest of the events
     let start_event = transactions
         .0
         .last()
         .expect("no transactions")
-        .0
+        .event_id
         .saturating_sub(1);
 
     let transactions = gateway


### PR DESCRIPTION
Adds a 24 hour payment summary command to the gateway. Useful to get an "at a glance" summary of what happened over the last day.

![image](https://github.com/user-attachments/assets/e9e5dd32-9747-4c0f-9ee3-af6bf800e6d8)
