### PR TITLE
chore: size-optimized wasm bundle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,3 +251,5 @@ opt-level = 1
 
 [profile.release]
 debug = "line-tables-only"
+lto = "fat"
+codegen-units = 1

--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
+# https://rustwasm.github.io/wasm-pack/book/cargo-toml-configuration.html
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-Os']
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 name = "fedimint_client_wasm"

--- a/flake.nix
+++ b/flake.nix
@@ -478,6 +478,8 @@
             fedimint-pkgs
             devimint
             ;
+
+          wasmBundle = craneMultiBuild.wasm32-unknown.release.wasmBundle;
         };
 
         lib = {

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -648,6 +648,35 @@ in
         patchShebangs ./scripts; SKIP_CARGO_BUILD=1 ./scripts/tests/wasm-test.sh'';
     };
 
+    wasmBundleClientPkgDeps = craneLib.buildWorkspaceDepsOnly {
+      pname = "${commonArgs.pname}-client-wasm";
+      "CARGO_PROFILE_RELEASE_OPT_LEVEL" = "s";
+      buildPhaseCargoCommand = "runLowPrio cargo build --profile $CARGO_PROFILE --locked -p fedimint-client-wasm";
+    };
+
+    wasmBundleClientPkg = craneLib.buildWorkspace {
+      cargoArtifacts = wasmBundleClientPkgDeps;
+      pname = "${commonArgs.pname}-client-wasm";
+      "CARGO_PROFILE_RELEASE_OPT_LEVEL" = "s";
+      buildPhaseCargoCommand = "runLowPrio cargo build --profile $CARGO_PROFILE --locked -p fedimint-client-wasm";
+    };
+
+    wasmBundle = craneLibTests.mkCargoDerivation {
+      pname = "wasm-bundle";
+      cargoArtifacts = wasmBundleClientPkg;
+      "CARGO_PROFILE_RELEASE_OPT_LEVEL" = "s";
+      nativeBuildInputs = commonCliTestArgs.nativeBuildInputs ++ [
+        pkgs.wasm-bindgen-cli
+        pkgs.wasm-pack
+        pkgs.binaryen
+      ];
+      buildPhaseCargoCommand = ''
+        runLowPrio wasm-pack build fedimint-client-wasm
+        mkdir -p $out/share/fedimint-client-wasm
+        cp fedimint-client-wasm/pkg/* $out/share/fedimint-client-wasm
+      '';
+    };
+
     fedimint-pkgs = fedimintBuildPackageGroup {
       pname = "fedimint-pkgs";
 


### PR DESCRIPTION
To get:

```
> nix build .#wasmBundle
> ls -l result/share/fedimint-client-wasm/
total 5688
-r--r--r-- 3 root root   44832 Dec 31  1969 fedimint_client_wasm_bg.js
-r--r--r-- 3 root root 5770912 Dec 31  1969 fedimint_client_wasm_bg.wasm
-r--r--r-- 3 root root    3660 Dec 31  1969 fedimint_client_wasm_bg.wasm.d.ts
-r--r--r-- 3 root root    2323 Dec 31  1969 fedimint_client_wasm.d.ts
-r--r--r-- 3 root root     187 Dec 31  1969 fedimint_client_wasm.js
-r--r--r-- 3 root root     601 Dec 31  1969 package.json
```

Baseline I started with:

```
-rw-r--r-- 1 dpc dpc 9044484 Dec 18 22:52 fedimint-client-wasm/pkg/fedimint_client_wasm_bg.wasm
```

Not far from the [current fedimint-web-sdk bundle](https://github.com/fedimint/fedimint-web-sdk/blob/main/packages/wasm-bundler/fedimint_client_wasm_bg.wasm).

Then I added "fat" LTO with 1 codegen-unit:

```
-rw-r--r-- 1 dpc dpc 8100537 Dec 18 23:06 fedimint-client-wasm/pkg/fedimint_client_wasm_bg.wasm
```

Then I tried "fat" LTO + opt-level=s:

```
-rw-r--r-- 1 dpc dpc 5753599 Dec 18 23:11 fedimint-client-wasm/pkg/fedimint_client_wasm_bg.wasm
```

I didn't want to build native binaries with `opt-level=s`, so I added Nix output to specifically add wasm-bundling tweaks. We can keep LTO for native binaries, as it should help with their size and performance too.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
