### PR TITLE
chore(wasm): disable cli feature

### DIFF
--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -39,7 +39,7 @@ fedimint-ln-client = { workspace = true, features = ["cli"] }
 fedimint-lnv2-client = { workspace = true, features = ["cli"] }
 fedimint-logging = { workspace = true }
 fedimint-meta-client = { workspace = true, features = ["cli"] }
-fedimint-mint-client = { workspace = true }
+fedimint-mint-client = { workspace = true, features = ["cli"] }
 fedimint-rocksdb = { workspace = true }
 fedimint-wallet-client = { workspace = true, features = ["cli"] }
 fs-lock = { workspace = true }

--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = { workspace = true }
 fedimint-api-client = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
-fedimint-ln-client = { workspace = true, features = ["cli"] }
+fedimint-ln-client = { workspace = true }
 fedimint-mint-client = { workspace = true }
 futures = { workspace = true }
 imbl = "3.0.0"

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -15,6 +15,10 @@ rustc-args = ["--cfg", "tokio_unstable"]
 # cargo udeps can't detect that one
 normal = ["aquamarine"]
 
+[features]
+default = []
+cli = ["dep:clap"]
+
 [lib]
 name = "fedimint_mint_client"
 path = "src/lib.rs"
@@ -33,7 +37,7 @@ base64 = { workspace = true }
 base64-url = { workspace = true }
 bitcoin_hashes = { workspace = true }
 bls12_381 = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, optional = true }
 erased-serde = { workspace = true }
 fedimint-api-client = { workspace = true }
 fedimint-client = { workspace = true }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -9,6 +9,7 @@
 // Backup and restore logic
 pub mod backup;
 /// Modularized Cli for sending and receiving out-of-band ecash
+#[cfg(feature = "cli")]
 mod cli;
 /// Database keys used throughout the mint client module
 pub mod client_db;
@@ -722,6 +723,7 @@ impl ClientModule for MintClientModule {
         Some(self.cfg.fee_consensus.fee(amount))
     }
 
+    #[cfg(feature = "cli")]
     async fn handle_cli_command(
         &self,
         args: &[std::ffi::OsString],


### PR DESCRIPTION
This costs around 90KB in a fully-optimized build.

I'm not sure if there was any reason to enable it, so pushing in a separate to #6586 PR .


BTW. For reference: If you want to debug wasm bundle sizes:

```
diff --git a/fedimint-client-wasm/Cargo.toml b/fedimint-client-wasm/Cargo.toml
index 40ffc19a3b..c28783beae 100644
--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/fedimint/fedimint"

 # https://rustwasm.github.io/wasm-pack/book/cargo-toml-configuration.html
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-Os']
+wasm-opt = false
```

```
nix shell nixpkgs#twiggy
nix build -L .#wasmBundle && ls -l result/share/fedimint-client-wasm/
twiggy top result/share/fedimint-client-wasm/fedimint_client_wasm_bg.wasm | less
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
