### PR TITLE
[Backport releases/v0.5] chore: size-optimized wasm bundle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,3 +246,5 @@ opt-level = 1
 
 [profile.release]
 debug = "line-tables-only"
+lto = "fat"
+codegen-units = 1

--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
+# https://rustwasm.github.io/wasm-pack/book/cargo-toml-configuration.html
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-Os']
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 name = "fedimint_client_wasm"

--- a/flake.nix
+++ b/flake.nix
@@ -462,6 +462,8 @@
             fedimint-pkgs
             devimint
             ;
+
+          wasmBundle = craneMultiBuild.wasm32-unknown.release.wasmBundle;
         };
 
         lib = {


### PR DESCRIPTION
# Description
Backport of #6586 to `releases/v0.5`.