### PR TITLE
chore(dev): always optimize regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,7 @@ ring = { opt-level = 3 }
 # due to some miscompilation(?) this seems actually neccessary,
 # otherwise we see segfaults in Nix sandbox
 librocksdb-sys = { opt-level = 3 }
+regex = { opt-level = 3 }
 rustls = { opt-level = 3 }
 secp256k1 = { opt-level = 3 }
 secp256k1-sys = { opt-level = 3 }


### PR DESCRIPTION
It is used to compile some regex by `tracing` and meaningfully important in dev/ci builds.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
