### PR TITLE
chore: add cargo publish to just file

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -25,6 +25,9 @@ The release process evolves each cycle, so don't hesitate to make frequent edits
 - Publish to crates
   - `just publish-release`
   - `@elsirion`, `@dpc`, and `@bradleystachurski` are the only users with permissions
+- Sign binaries
+  - `just sign-release <tag>`
+  - ex: `just sign-release v0.5.0`
 - Start upgrade tests using the new tag
   - https://github.com/fedimint/fedimint/actions/workflows/upgrade-tests.yml
   - The upgrade paths and upgrade test kinds varies based on the release (coordinated shutdown vs staggered, etc)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -23,7 +23,7 @@ The release process evolves each cycle, so don't hesitate to make frequent edits
   - Create a new signed tag and push to GH
 - When a tag is pushed, the GH workflow will automatically publish a new release with this tag
 - Publish to crates
-  - `cargo workspaces publish --from-git`
+  - `just publish-release`
   - `@elsirion`, `@dpc`, and `@bradleystachurski` are the only users with permissions
 - Start upgrade tests using the new tag
   - https://github.com/fedimint/fedimint/actions/workflows/upgrade-tests.yml

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -251,6 +251,10 @@ docs: build-docs
 bump-version FROM_VERSION TO_VERSION:
   find . -name 'Cargo.toml' -exec sed -i 's/{{FROM_VERSION}}/{{TO_VERSION}}/g' {} +
 
+publish-release:
+  # We need to add CARGO_PROFILE_DEV_OPT_LEVEL because jemalloc fails to compile on our toolchain without optimizations enabled
+  CARGO_PROFILE_DEV_OPT_LEVEL=2 cargo workspaces publish --from-git --allow-dirty
+
 cargo_sort_defaults := "-w -g --order package,features,bin,lib,test,bench,dependencies,dev-dependencies,build-dependencies"
 
 # Fix sort order in `Cargo.toml` files


### PR DESCRIPTION
Referencing release docs