### PR TITLE
chore: on wasm32 enable lowmemory feature of secp256k1

### DIFF
--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -75,3 +75,5 @@ getrandom = { version = "0.2.15", features = ["js"] }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 wasm-bindgen-futures = "0.4.42"
 js-sys = "0.3.69"
+# enable lowmemory for better bundle size
+secp256k1 = { workspace = true, features = ["lowmemory"] }


### PR DESCRIPTION
```
-r--r--r--  2 root root 4329542 Dec 31  1969 fedimint_client_wasm_bg.wasm
```

:rocket: 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
