### PR TITLE
feat: gateway CLI can generate bcrypt password hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,6 +2556,7 @@ name = "fedimint-gateway-cli"
 version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
+ "bcrypt",
  "bitcoin",
  "clap",
  "clap_complete",

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+bcrypt = { workspace = true }
 bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.38"

--- a/gateway/cli/src/general_commands.rs
+++ b/gateway/cli/src/general_commands.rs
@@ -50,6 +50,14 @@ pub enum GeneralCommands {
         #[clap(long)]
         event_kinds: Vec<EventKind>,
     },
+    /// Create a bcrypt hash of a password, for use in gateway deployment
+    CreatePasswordHash {
+        password: String,
+
+        /// The bcrypt cost factor to use when hashing the password
+        #[clap(long)]
+        cost: Option<u32>,
+    },
 }
 
 impl GeneralCommands {
@@ -124,6 +132,10 @@ impl GeneralCommands {
                     .await?;
                 print_response(payment_log);
             }
+            Self::CreatePasswordHash { password, cost } => print_response(
+                bcrypt::hash(password, cost.unwrap_or(bcrypt::DEFAULT_COST))
+                    .expect("Unable to create bcrypt hash"),
+            ),
         }
 
         Ok(())


### PR DESCRIPTION
Since we switched to using bcrypt password hashes in #6482, we should make it easier for to-be gateway operators to create password hashes to use in their deployments. Here we're adding a command to the gateway CLI to create a password hash.