### PR TITLE
chore: update back-compat version from v0.5.0-rc.2 to v0.5.0

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -56,10 +56,10 @@ jobs:
           # run a slimmed down back-compat test for PR push or each major version for merge queue
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
-            VERSIONS_TO_TEST="v0.3.4-rc.1 v0.4.4 v0.5.0-rc.2"
+            VERSIONS_TO_TEST="v0.3.4-rc.1 v0.4.4 v0.5.0"
           else
             PERFIT_METRIC="aPuCAjrFT7uE5Oax_T4sMw"
-            VERSIONS_TO_TEST="v0.5.0-rc.2"
+            VERSIONS_TO_TEST="v0.5.0"
           fi
 
           # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -31,6 +31,8 @@ The release process evolves each cycle, so don't hesitate to make frequent edits
 - Start upgrade tests using the new tag
   - https://github.com/fedimint/fedimint/actions/workflows/upgrade-tests.yml
   - The upgrade paths and upgrade test kinds varies based on the release (coordinated shutdown vs staggered, etc)
+- Update backwards-compatibility versions to use the new tag
+  - `.github/workflows/ci-backwards-compatibility.yml`
 
 ### Commands
 

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -22,7 +22,7 @@ test-ci-all:
 test-count:
   ./scripts/tests/test-cov.sh
 
-test-compatibility *VERSIONS="v0.2.1":
+test-compatibility *VERSIONS="v0.3.4-rc.1 v0.4.4 v0.5.0":
   ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
 test-full-compatibility *VERSIONS="v0.2.1":


### PR DESCRIPTION
We should update the version used in backwards-compatibility tests in CI vs master as part of the release process.