### PR TITLE
chore(consensus): improve a noisy log statement

### DIFF
--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -822,8 +822,11 @@ impl ConsensusEngine {
 
             match result {
                 Ok(signed_session_outcome) => return signed_session_outcome,
-                Err(error) => {
-                    tracing::error!(target: LOG_CONSENSUS, "Error while requesting signed session outcome: {}", error);
+                Err(err) => {
+                    // Workaround: timeout messages here are annoying
+                    if !err.to_string().contains("Rpc error: Request timeout") {
+                        warn!(target: LOG_CONSENSUS, %err, "Error while requesting signed session outcome");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Timeouts here are normal and should go away after per-peer retries are released.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
