### PR TITLE
[Backport releases/v0.5] chore: on wasm32 enable lowmemory feature of secp256k1

### DIFF
--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -74,3 +74,5 @@ getrandom = { version = "0.2.15", features = ["js"] }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 wasm-bindgen-futures = "0.4.42"
 js-sys = "0.3.69"
+# enable lowmemory for better bundle size
+secp256k1 = { workspace = true, features = ["lowmemory"] }


### PR DESCRIPTION
# Description
Backport of #6594 to `releases/v0.5`.