### PR TITLE
chore: bump version to v0.5.1-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.7",
@@ -2080,7 +2080,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2212,14 +2212,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -2437,11 +2437,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2486,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-cli"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -2579,14 +2579,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-gateway"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.7",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3014,7 +3014,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "bls12_381",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3457,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "fedimint-api-client",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0-rc.5"
+version = "0.5.1-alpha"
 
 [workspace.metadata]
 name = "fedimint"
@@ -100,7 +100,7 @@ bytes = "1.7.2"
 clap = { version = "4.5.20", features = ["derive", "env"] }
 cln-rpc = { package = "fedimint-cln-rpc", version = "0.5.0" }
 criterion = "0.5.1"
-devimint = { path = "./devimint", version = "=0.5.0-rc.5" }
+devimint = { path = "./devimint", version = "=0.5.1-alpha" }
 electrum-client = { version = "0.21.0", default-features = false, features = [
     "proxy",
     "use-rustls-ring",
@@ -109,55 +109,55 @@ erased-serde = "0.4"
 esplora-client = { version = "0.10.0", default-features = false, features = [
     "async-https-rustls",
 ] }
-fedimintd = { path = "./fedimintd", version = "=0.5.0-rc.5" }
-fedimint-aead = { path = "./crypto/aead", version = "=0.5.0-rc.5" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.5.0-rc.5" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.5.0-rc.5" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.5.0-rc.5" }
-fedimint-build = { path = "./fedimint-build", version = "=0.5.0-rc.5" }
-fedimint-client = { path = "./fedimint-client", version = "=0.5.0-rc.5" }
-fedimint-core = { path = "./fedimint-core", version = "=0.5.0-rc.5" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.5.0-rc.5" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.5.0-rc.5" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.5.0-rc.5" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.5.0-rc.5" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.5.0-rc.5" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.5.0-rc.5" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.5.0-rc.5" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.5.0-rc.5" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.5.0-rc.5" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.5.0-rc.5" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.5.0-rc.5" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.5.0-rc.5" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.5.0-rc.5" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.5.0-rc.5" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.5.0-rc.5" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.5.0-rc.5" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.5.0-rc.5" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.5.0-rc.5" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.5.0-rc.5" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.5.0-rc.5" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.5.0-rc.5" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.5.0-rc.5" }
-fedimint-server = { path = "./fedimint-server", version = "=0.5.0-rc.5" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.5.0-rc.5" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.5.0-rc.5" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.5.0-rc.5" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.5.0-rc.5" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.5.0-rc.5" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.5.0-rc.5" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.5.0-rc.5" }
+fedimintd = { path = "./fedimintd", version = "=0.5.1-alpha" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.5.1-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.5.1-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.5.1-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.5.1-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.5.1-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.5.1-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.5.1-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.5.1-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.5.1-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.5.1-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.5.1-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.5.1-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.5.1-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.5.1-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.5.1-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.5.1-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.5.1-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.5.1-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.5.1-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.5.1-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.5.1-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.5.1-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.5.1-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.5.1-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.5.1-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.5.1-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.5.1-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.5.1-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.5.1-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.5.1-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.5.1-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.5.1-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.5.1-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.5.1-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.5.1-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.5.1-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.5.1-alpha" }
 fs-lock = "0.1.6"
 futures = "0.3.31"
 futures-util = "0.3.30"
 group = "0.13.0"
 hex = "0.4.3"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.5.0-rc.5" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.5.1-alpha" }
 hyper = "1.5"
 itertools = "0.13.0"
 lightning = "0.0.125"
 lightning-invoice = { version = "0.32.0", features = ["std"] }
-ln-gateway = { package = "fedimint-ln-gateway", path = "./gateway/ln-gateway", version = "=0.5.0-rc.5" }
+ln-gateway = { package = "fedimint-ln-gateway", path = "./gateway/ln-gateway", version = "=0.5.1-alpha" }
 miniscript = "12.2.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
@@ -181,7 +181,7 @@ strum = "0.26"
 strum_macros = "0.26"
 subtle = "2.6.1"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.5.0-rc.5" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.5.1-alpha" }
 thiserror = "1.0.68"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tikv-jemallocator = "0.5"
@@ -192,7 +192,7 @@ tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
     "lightningrpc",
     "routerrpc",
 ] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.5.0-rc.5" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.5.1-alpha" }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = "2.5.3"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -30,9 +30,9 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.37"
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.5.0-rc.5", default-features = false }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.5.1-alpha", default-features = false }
 fedimint-bip39 = { workspace = true }
-fedimint-client = { path = "../fedimint-client", version = "=0.5.0-rc.5", default-features = false }
+fedimint-client = { path = "../fedimint-client", version = "=0.5.1-alpha", default-features = false }
 fedimint-core = { workspace = true }
 fedimint-ln-client = { workspace = true, features = ["cli"] }
 fedimint-lnv2-client = { workspace = true, features = ["cli"] }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -30,7 +30,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.5.0-rc.5", default-features = false }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.5.1-alpha", default-features = false }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-logging = { workspace = true }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -37,7 +37,7 @@ fedimint-server = { workspace = true }
 fedimint-testing-core = { workspace = true }
 fs-lock = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway", version = "=0.5.0-rc.5", default-features = false }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway", version = "=0.5.1-alpha", default-features = false }
 rand = { workspace = true }
 tempfile = "3.14.0"
 tokio = { workspace = true }

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -27,7 +27,7 @@ fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-mint-client = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { package = "fedimint-ln-gateway", path = "../ln-gateway", version = "=0.5.0-rc.5", default-features = false }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../ln-gateway", version = "=0.5.1-alpha", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -41,9 +41,9 @@ cln-plugin = "0.2.0"
 cln-rpc = { workspace = true }
 erased-serde = { workspace = true }
 esplora-client = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.5.0-rc.5", default-features = false }
-fedimint-bip39 = { version = "=0.5.0-rc.5", path = "../../fedimint-bip39" }
-fedimint-client = { path = "../../fedimint-client", version = "=0.5.0-rc.5", default-features = false }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.5.1-alpha", default-features = false }
+fedimint-bip39 = { version = "=0.5.1-alpha", path = "../../fedimint-bip39" }
+fedimint-client = { path = "../../fedimint-client", version = "=0.5.1-alpha", default-features = false }
 fedimint-core = { workspace = true }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -45,6 +45,6 @@ tracing = { workspace = true }
 fedimint-bitcoind = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-fedimint-bitcoind = { version = "=0.5.0-rc.5", path = "../../fedimint-bitcoind", default-features = false, features = [
+fedimint-bitcoind = { version = "=0.5.1-alpha", path = "../../fedimint-bitcoind", default-features = false, features = [
     "esplora-client",
 ] }


### PR DESCRIPTION
> If you deploy something (e.g. to infra) using patches on top of releases/v0.5 then the fact that it shows 0.5.0-rc.x is a bit confusing.
Because technically I'm running v0.5.0 + patches

-- @dpc 
https://discord.com/channels/990354215060795454/990354215878688860/1319792791085125663

It is confusing to see you're running `0.5.0-rc.*`, when you're not actually running the release candidate. To stick with the convention defined on `master`, I propose we bump the minor version with `-alpha` suffix on the `releases/v0.*` branches. So for `releases/v0.5`, instead of using `0.5.0-rc5`, we'll use `0.5.1-alpha`, then bump the alpha to the release candidate when we're ready.