### PR TITLE
docs: update release process docs for final releases

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -16,21 +16,23 @@ The release process evolves each cycle, so don't hesitate to make frequent edits
     - Bump the cargo version to a new release candidate (e.g `0.4.3-rc.0`)
     - Open a PR targeting the `releases/v*` branch
     - Once this PR is merged, pull the release branch locally and push a new signed tag to GH
+  - Start upgrade tests using the new tag
+    - https://github.com/fedimint/fedimint/actions/workflows/upgrade-tests.yml
+    - The upgrade paths and upgrade test kinds varies based on the release (coordinated shutdown vs staggered, etc)
 - For final releases
   - Bump the cargo version to a final release (e.g. `0.4.3`)
   - Create a new branch off of `releases/v*` with the final release tag (e.g. `releases/v0.4.3`)
     - This new branch isn't protected, so you can push directly to GH
   - Create a new signed tag and push to GH
+  - Publish to crates
+    - `just publish-release`
+    - `@elsirion`, `@dpc`, and `@bradleystachurski` are the only users with permissions
+  - Sign binaries
+    - `just sign-release <tag>`
+    - ex: `just sign-release v0.5.0`
+  - Bump the version on `releases/v0.*` to the next minor `-alpha`
+    - example on `releases/v0.5`: `just bump-version 0.5.0-rc.5 0.5.1-alpha`
 - When a tag is pushed, the GH workflow will automatically publish a new release with this tag
-- Publish to crates
-  - `just publish-release`
-  - `@elsirion`, `@dpc`, and `@bradleystachurski` are the only users with permissions
-- Sign binaries
-  - `just sign-release <tag>`
-  - ex: `just sign-release v0.5.0`
-- Start upgrade tests using the new tag
-  - https://github.com/fedimint/fedimint/actions/workflows/upgrade-tests.yml
-  - The upgrade paths and upgrade test kinds varies based on the release (coordinated shutdown vs staggered, etc)
 - Update backwards-compatibility versions to use the new tag
   - `.github/workflows/ci-backwards-compatibility.yml`
 


### PR DESCRIPTION
- Adds new convention to bump `releases/v0.*` to use `-alpha` suffix after final release
  - First proposed in https://github.com/fedimint/fedimint/pull/6613
- Reorgs final release steps for clarity