### PR TITLE
Run upgrade tests against PRs and reduce total test time

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -10,6 +10,14 @@ on:
   schedule:
     # run daily during low usage hours
     - cron:  '30 4 * * *'
+  push:
+    branches: [ "main", "master", "devel", "releases/v*" ]
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches: [ "main", "master", "devel", "releases/v*" ]
+  merge_group:
+    branches: [ "main", "master", "devel", "releases/v*" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -53,7 +53,7 @@ jobs:
           # read versions from manually triggered workflows
           # default needed for cron or manual workflow without params
           VERSIONS="${{ github.event.inputs.versions }}"
-          VERSIONS=${VERSIONS:="v0.3.3 v0.4.0 current"}
+          VERSIONS=${VERSIONS:="v0.3.4-rc.1 current, v0.4.4 current, v0.5.0 current"}
 
           # if empty, defaults to all test kinds within script
           TEST_KINDS="${{ github.event.inputs.test_kinds }}"
@@ -76,6 +76,7 @@ jobs:
             scripts/ci/run-in-fs-dir-cache.sh upgrade-tests \
             env -u RUSTC_WRAPPER \
             env TEST_KINDS="$TEST_KINDS" \
+            env FM_DEVIMINT_DISABLE_MODULE_LNV2=1 \
             runLowPrio ./scripts/tests/upgrade-test.sh "$VERSIONS"
 
   notifications:

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -179,7 +179,11 @@ pub async fn latency_tests(
             let mut ln_sends = Vec::with_capacity(iterations);
             for i in 0..iterations {
                 let invoice = cln
-                    .invoice(1_000_000, format!("Description{i}"), format!("Label{i}"))
+                    .invoice(
+                        1_000_000,
+                        format!("Description{i}"),
+                        format!("Label{}", rand::random::<u64>()),
+                    )
                     .await?;
                 let start_time = Instant::now();
                 ln_pay(&client, invoice, lnd_gw_id.clone(), false).await?;
@@ -207,7 +211,7 @@ pub async fn latency_tests(
                 .invoice(
                     10_000_000,
                     "LnReceiveLatencyDesc".to_string(),
-                    "LatencyLabel".to_string(),
+                    rand::random::<u64>().to_string(),
                 )
                 .await?;
             ln_pay(&client, invoice, lnd_gw_id.clone(), false).await?;

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -385,6 +385,10 @@ async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> 
     // cause the upgrade test to fail
     let assert_thresholds = false;
 
+    // running only one iteration greatly improves the total test time while still
+    // testing the same types of database entries
+    let iterations = 1;
+
     // skip restore test for client upgrades, since restoring a client doesn't
     // require a persistent data dir
     let restore_test = if clients.is_some() {
@@ -394,7 +398,7 @@ async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> 
             dev_fed.clone(),
             LatencyTest::Restore,
             clients,
-            20,
+            iterations,
             assert_thresholds,
         )
         .left_future()
@@ -406,7 +410,7 @@ async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> 
         dev_fed.clone(),
         LatencyTest::Reissue,
         clients,
-        20,
+        iterations,
         assert_thresholds,
     )
     .await?;
@@ -415,7 +419,7 @@ async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> 
         dev_fed.clone(),
         LatencyTest::LnSend,
         clients,
-        20,
+        iterations,
         assert_thresholds,
     )
     .await?;
@@ -424,7 +428,7 @@ async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> 
         dev_fed.clone(),
         LatencyTest::LnReceive,
         clients,
-        20,
+        iterations,
         assert_thresholds,
     )
     .await?;
@@ -433,7 +437,7 @@ async fn stress_test_fed(dev_fed: &DevFed, clients: Option<&UpgradeClients>) -> 
         dev_fed.clone(),
         LatencyTest::FmPay,
         clients,
-        20,
+        iterations,
         assert_thresholds,
     )
     .await?;

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -472,11 +472,6 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 // stress test with all peers online
                 try_join!(stress_test_fed(&dev_fed, None), client.wait_session())?;
 
-                // ensure a degraded federation with the last peer online works, since the last
-                // peer is the last to restart
-                dev_fed.fed.terminate_server(1).await?;
-                try_join!(stress_test_fed(&dev_fed, None), client.wait_session())?;
-
                 let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
                 info!(
                     "### fedimintd passed stress test for version {}",

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -28,7 +28,7 @@ test-compatibility *VERSIONS="v0.3.4-rc.1 v0.4.4 v0.5.0":
 test-full-compatibility *VERSIONS="v0.2.1":
   env FM_FULL_VERSION_MATRIX=1 ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
-test-upgrades *VERSIONS="v0.3.3 v0.4.0 current":
+test-upgrades *VERSIONS="v0.3.4-rc.1 current, v0.4.4 current, v0.5.0 current":
   ./scripts/tests/upgrade-test.sh {{VERSIONS}}
 
 # `cargo udeps` check

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -10,14 +10,6 @@ if [ "$#" -eq 0 ]; then
   exit 1
 fi
 
-# allows versions to be passed in as either a single string or multiple params
-# e.g. `"v0.3.0 v0.4.0"` is the same as `v0.3.0 v0.4.0`
-if [ "$#" -eq 1 ]; then
-  IFS=' ' read -r -a versions <<< "$1"
-else
-  versions=("$@")
-fi
-
 # TODO(v0.5.0): We do not need to run the `gatewayd-mnemonic` test from v0.4.0
 # -> v0.5.0 over and over again. Once we have verified this test passes for
 # v0.5.0, it can safely be removed.
@@ -39,10 +31,6 @@ else
   done
 fi
 
-echo "## Running upgrade tests
-versions: ${versions[*]}
-kinds: ${test_kinds[*]}"
-
 build_workspace
 add_target_dir_to_path
 
@@ -50,67 +38,83 @@ export FM_BACKWARDS_COMPATIBILITY_TEST=1
 
 upgrade_tests=()
 
-if contains "fedimintd" "${test_kinds[@]}"; then
-  fedimintd_paths=()
-  for version in "${versions[@]}"; do
-    if [ "$version" == "current" ]; then
-      # Add current binaries from PATH
-      fedimintd_paths+=("fedimintd")
-    else
-      fedimintd_paths+=("$(nix_build_binary_for_version 'fedimintd' "$version")")
-    fi
-  done
+IFS=',' read -r -a upgrade_paths <<< "$@"
 
-  upgrade_tests+=(
-    "devimint upgrade-tests fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
-  )
-fi
+echo "## Running upgrade tests
+kinds: ${test_kinds[*]}
+upgrade paths:"
 
-if contains "fedimint-cli" "${test_kinds[@]}"; then
-  fedimint_cli_paths=()
-  for version in "${versions[@]}"; do
-    if [ "$version" == "current" ]; then
-      # Add current binaries from PATH
-      fedimint_cli_paths+=("fedimint-cli")
-    else
-      fedimint_cli_paths+=("$(nix_build_binary_for_version 'fedimint-cli' "$version")")
-    fi
-  done
+for upgrade_path in "${upgrade_paths[@]}"; do
+  echo "$upgrade_path"
+done
 
-  upgrade_tests+=(
-    "devimint upgrade-tests fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
-  )
-fi
+for upgrade_path in "${upgrade_paths[@]}"; do
+  IFS=' ' read -r -a versions <<< "$upgrade_path"
+  echo "## Starting upgrade test for path: $upgrade_path"
 
-if contains "gateway" "${test_kinds[@]}"; then
-  gatewayd_paths=()
-  gateway_cli_paths=()
-  for version in "${versions[@]}"; do
-    if [ "$version" == "current" ]; then
-      # Add current binaries from PATH
-      gatewayd_paths+=("gatewayd")
-      gateway_cli_paths+=("gateway-cli")
-    else
-      gatewayd_paths+=("$(nix_build_binary_for_version 'gatewayd' "$version")")
-      gateway_cli_paths+=("$(nix_build_binary_for_version 'gateway-cli' "$version")")
-    fi
-  done
+  if contains "fedimintd" "${test_kinds[@]}"; then
+    fedimintd_paths=()
+    for version in "${versions[@]}"; do
+      if [ "$version" == "current" ]; then
+        # Add current binaries from PATH
+        fedimintd_paths+=("fedimintd")
+      else
+        fedimintd_paths+=("$(nix_build_binary_for_version 'fedimintd' "$version")")
+      fi
+    done
 
-  upgrade_tests+=(
-    "devimint upgrade-tests gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
-  )
-fi
+    upgrade_tests+=(
+      "devimint upgrade-tests fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
+    )
+  fi
 
-if contains "mnemonic" "${test_kinds[@]}"; then
-  old_gatewayd=$(nix_build_binary_for_version 'gatewayd' "v0.4.0")
-  new_gatewayd="gatewayd"
-  old_gateway_cli=$(nix_build_binary_for_version 'gateway-cli' "v0.4.0")
-  new_gateway_cli="gateway-cli"
+  if contains "fedimint-cli" "${test_kinds[@]}"; then
+    fedimint_cli_paths=()
+    for version in "${versions[@]}"; do
+      if [ "$version" == "current" ]; then
+        # Add current binaries from PATH
+        fedimint_cli_paths+=("fedimint-cli")
+      else
+        fedimint_cli_paths+=("$(nix_build_binary_for_version 'fedimint-cli' "$version")")
+      fi
+    done
 
-  upgrade_tests+=(
-    "gateway-tests gatewayd-mnemonic --old-gatewayd-path $old_gatewayd --new-gatewayd-path $new_gatewayd --gw-type lnd --old-gateway-cli-path $old_gateway_cli --new-gateway-cli-path $new_gateway_cli"
-  )
-fi
+    upgrade_tests+=(
+      "devimint upgrade-tests fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
+    )
+  fi
+
+  if contains "gateway" "${test_kinds[@]}"; then
+    gatewayd_paths=()
+    gateway_cli_paths=()
+    for version in "${versions[@]}"; do
+      if [ "$version" == "current" ]; then
+        # Add current binaries from PATH
+        gatewayd_paths+=("gatewayd")
+        gateway_cli_paths+=("gateway-cli")
+      else
+        gatewayd_paths+=("$(nix_build_binary_for_version 'gatewayd' "$version")")
+        gateway_cli_paths+=("$(nix_build_binary_for_version 'gateway-cli' "$version")")
+      fi
+    done
+
+    upgrade_tests+=(
+      "devimint upgrade-tests gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
+    )
+  fi
+
+  if contains "mnemonic" "${test_kinds[@]}"; then
+    old_gatewayd=$(nix_build_binary_for_version 'gatewayd' "v0.4.0")
+    new_gatewayd="gatewayd"
+    old_gateway_cli=$(nix_build_binary_for_version 'gateway-cli' "v0.4.0")
+    new_gateway_cli="gateway-cli"
+
+    upgrade_tests+=(
+      "gateway-tests gatewayd-mnemonic --old-gatewayd-path $old_gatewayd --new-gatewayd-path $new_gatewayd --gw-type lnd --old-gateway-cli-path $old_gateway_cli --new-gateway-cli-path $new_gateway_cli"
+    )
+  fi
+done
+
 
 parsed_test_commands=$(printf "%s\n" "${upgrade_tests[@]}")
 


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/6282

This PR enables running upgrade tests against PRs and reduces the total time to run upgrade tests in CI vs the last three major versions from ~90 minutes to ~12 minutes ([CI run](https://github.com/fedimint/fedimint/actions/runs/12780718825/job/35640806526?pr=6619)).

These gains are accomplished by:
- Reducing the number of iterations run per upgrade test from 20 to 1, which still tests the same coverage of database entries
- Skipping running another round of `fedimintd` tests with the federation degraded, which is unnecessary since we have degraded federation test coverage throughout the test suite
- Parallelizing the upgrade tests to handle multiple upgrade paths in the same run

Since the total time is ~12 minutes, I don't see an advantage to only running against the latest version on push and the latest three in the merge queue, which is the approach we need to take with backwards-compatibility tests.