### PR TITLE
chore: inherit more from workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,12 +67,21 @@ resolver = "2"
 
 [workspace.package]
 version = "0.6.0-alpha"
+authors = ["The Fedimint Developers"]
+edition = "2021"
+description = "Fedimint is a Federated Chaumian E-Cash Mint, natively compatible with Bitcoin & the Lightning Network"
+documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
+readme = "README.md"
+homepage = "https://fedimint.org"
+repository = "https://github.com/fedimint/fedimint"
+license = "MIT"
+keywords = ["bitcoin", "lightning", "chaumian", "e-cash", "federated"]
 
 [workspace.metadata]
 name = "fedimint"
 authors = ["The Fedimint Developers"]
 edition = "2021"
-description = "Fedimint is a prototype Federated Chaumian E-Cash Mint implementation, natively compatible with Bitcoin & the Lightning Network. This project is under heavy development, DO NOT USE WITH REAL FUNDS."
+description = "Fedimint is a Federated Chaumian E-Cash Mint, natively compatible with Bitcoin & the Lightning Network"
 documentation = "https://github.com/fedimint/fedimint/tree/master/docs"
 readme = "README.md"
 homepage = "https://fedimint.org"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "fedimint-cli"
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
-description = "fedimint-cli is a command line interface wrapper for the client library."
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+readme = { workspace = true }
+description = "Fedimint client CLI interface"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "fedimint-client"
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
-description = "fedimint-client provides a library for sending transactions to the federation."
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+readme = { workspace = true }
+description = "Library for sending transactions to the Fedimint federation."
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "fedimintd"
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
-description = "fedimintd is the main consensus code for processing transactions and REST API"
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+readme = { workspace = true }
+description = "fedimintd daemon for Fedimint"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "fedimint-gateway-cli"
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 version = { workspace = true }
-edition = "2021"
-license = "MIT"
-readme = "../../README.md"
+readme = { workspace = true }
 description = "CLI tool to control lightning gateway"
-repository = "https://github.com/fedimint/fedimint"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]


### PR DESCRIPTION
I discovered that it's possible to inherit almost all fields in each `package` from the root `Cargo.toml`

This is just to show it by using in few packages.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
