### PR TITLE
chore: add Bitcoind::get_block_height()

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -770,7 +770,7 @@ impl Federation {
         }
 
         self.bitcoind.mine_blocks(21).await?;
-        let bitcoind_block_height: u64 = self.bitcoind.get_block_count().await? - 1;
+        let bitcoind_block_height: u64 = self.bitcoind.get_block_height().await?;
         try_join_all(gateways.into_iter().map(|gw| {
             poll("gateway pegin", || async {
                 let gatewayd_version = crate::util::Gatewayd::version_or_default().await;

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -384,7 +384,7 @@ impl Gatewayd {
         .await?;
         let txid: bitcoin::Txid = serde_json::from_value(value)?;
         bitcoind.mine_blocks(21).await?;
-        let block_height = bitcoind.get_block_count().await? - 1;
+        let block_height = bitcoind.get_block_height().await?;
         bitcoind.poll_get_transaction(txid).await?;
         self.wait_for_block_height(block_height).await?;
         Ok(())
@@ -405,7 +405,7 @@ impl Gatewayd {
             .await?;
         }
         bitcoind.mine_blocks(50).await?;
-        let block_height = bitcoind.get_block_count().await? - 1;
+        let block_height = bitcoind.get_block_height().await?;
         self.wait_for_block_height(block_height).await?;
 
         Ok(())

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1506,7 +1506,7 @@ pub async fn gw_reboot_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
     // TODO(support:v0.3): `block_height` field was introduced in v0.4.0
     // see: https://github.com/fedimint/fedimint/pull/4514
     if gatewayd_version >= *VERSION_0_4_0 {
-        let block_height = bitcoind.get_block_count().await? - 1;
+        let block_height = bitcoind.get_block_height().await?;
         if let Some(gw_ldk) = &gw_ldk {
             try_join!(
                 gw_lnd.wait_for_block_height(block_height),


### PR DESCRIPTION
In all but one place where `get_block_count()` is called, we subtract 1. Let's add `get_block_height()` so we can get rid of that and make the code slightly easier on the eyes.