### PR TITLE
Recovery data usage improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,12 +736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64-serde"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c6d128af408d8ebd08331f0331cf2cf20d19e6c44a7aec58791641ecc8c0b5"
-
-[[package]]
 name = "base64-url"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,7 +2637,7 @@ dependencies = [
  "async-trait",
  "backon",
  "backtrace",
- "base64-serde",
+ "base64 0.22.1",
  "base64-url",
  "bech32 0.11.0",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c6d128af408d8ebd08331f0331cf2cf20d19e6c44a7aec58791641ecc8c0b5"
+
+[[package]]
 name = "base64-url"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2642,7 @@ dependencies = [
  "async-trait",
  "backon",
  "backtrace",
+ "base64-serde",
  "base64-url",
  "bech32 0.11.0",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,6 +2429,7 @@ dependencies = [
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "lru",
+ "rand",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -36,6 +36,7 @@ itertools = { workspace = true }
 jsonrpsee-core = { version = "0.24.7" }
 jsonrpsee-types = { version = "0.24.7" }
 lru = "0.12.5"
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/fedimint-api-client/src/api/global_api.rs
+++ b/fedimint-api-client/src/api/global_api.rs
@@ -54,6 +54,7 @@ use super::{
     DynModuleApi, FederationApiExt, FederationError, FederationResult, GuardianConfigBackup,
     IGlobalFederationApi, IRawFederationApi, PeerResult, StatusResponse,
 };
+use crate::api::VERSION_THAT_INTRODUCED_GET_SESSION_STATUS_V2;
 use crate::query::FilterMapThreshold;
 
 /// Convenience extension trait used for wrapping [`IRawFederationApi`] in
@@ -148,7 +149,7 @@ where
         broadcast_public_keys: &BTreeMap<PeerId, secp256k1::PublicKey>,
         decoders: &ModuleDecoderRegistry,
     ) -> anyhow::Result<SessionStatus> {
-        debug!(target: LOG_CLIENT_NET_API, block_index, "Fetching block's outcome from Federation");
+        debug!(target: LOG_CLIENT_NET_API, block_index, "Get session status raw v2");
         let params = ApiRequestErased::new(block_index);
         let mut last_error = None;
         // fetch serially
@@ -191,6 +192,7 @@ where
         block_index: u64,
         decoders: &ModuleDecoderRegistry,
     ) -> anyhow::Result<SessionStatus> {
+        debug!(target: LOG_CLIENT_NET_API, block_index, "Get session status raw v1");
         self.request_current_consensus::<SerdeModuleEncoding<SessionStatus>>(
             SESSION_STATUS_ENDPOINT.to_string(),
             ApiRequestErased::new(block_index),
@@ -261,7 +263,6 @@ where
         core_api_version: ApiVersion,
         broadcast_public_keys: Option<&BTreeMap<PeerId, secp256k1::PublicKey>>,
     ) -> anyhow::Result<SessionStatus> {
-        const VERSION_THAT_INTRODUCED_GET_SESSION_STATUS_V2: ApiVersion = ApiVersion::new(0, 5);
         let mut lru_lock = self.get_session_status_lru.lock().await;
 
         let entry_arc = lru_lock

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -481,6 +481,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
         &self,
         block_index: u64,
         decoders: &ModuleDecoderRegistry,
+        core_api_version: ApiVersion,
     ) -> anyhow::Result<SessionStatus>;
 
     async fn session_count(&self) -> FederationResult<u64>;

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -64,6 +64,11 @@ mod peer;
 pub use global_api::{GlobalFederationApiWithCache, GlobalFederationApiWithCacheExt};
 use peer::FederationPeer;
 
+pub const VERSION_THAT_INTRODUCED_GET_SESSION_STATUS_V2: ApiVersion = ApiVersion::new(0, 5);
+
+pub const VERSION_THAT_INTRODUCED_GET_SESSION_STATUS: ApiVersion =
+    ApiVersion { major: 0, minor: 1 };
+
 pub type PeerResult<T> = Result<T, PeerError>;
 pub type JsonRpcResult<T> = Result<T, JsonRpcClientError>;
 pub type FederationResult<T> = Result<T, FederationError>;

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -482,6 +482,7 @@ pub trait IGlobalFederationApi: IRawFederationApi {
         block_index: u64,
         decoders: &ModuleDecoderRegistry,
         core_api_version: ApiVersion,
+        broadcast_public_keys: Option<&BTreeMap<PeerId, secp256k1::PublicKey>>,
     ) -> anyhow::Result<SessionStatus>;
 
     async fn session_count(&self) -> FederationResult<u64>;

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -1951,7 +1951,6 @@ impl Client {
                 info!(
                     target: LOG_CLIENT,
                     module_instance_id,
-                    prev_progress = format!("{}/{}", prev_progress.complete, prev_progress.total),
                     progress = format!("{}/{}", progress.complete, progress.total),
                     "Recovery complete"
                 );
@@ -1967,7 +1966,6 @@ impl Client {
                 info!(
                     target: LOG_CLIENT,
                     module_instance_id,
-                    prev_progress = format!("{}/{}", prev_progress.complete, prev_progress.total),
                     progress = format!("{}/{}", progress.complete, progress.total),
                     "Recovery progress"
                 );

--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -216,6 +216,10 @@ pub trait ClientModuleInit: ModuleInit + Sized {
     /// that this client module implementation can use.
     fn supported_api_versions(&self) -> MultiApiVersion;
 
+    fn kind() -> ModuleKind {
+        <Self::Module as ClientModule>::kind()
+    }
+
     /// Recover the state of the client module, optionally from an existing
     /// snapshot.
     ///

--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -261,7 +261,9 @@ where
             futures::stream::iter(epoch_range.clone())
                 .map(move |session_idx| {
                     let api = api.clone();
-                    let decoders = decoders.clone();
+                    // When decoding we're only interested in items we can understand, so we don't
+                    // want to fail on a missing decoder of some unrelated module.
+                    let decoders = decoders.clone().with_fallback();
                     let task_group = task_group.clone();
                     let broadcast_public_keys = broadcast_public_keys.clone();
 

--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -336,7 +336,7 @@ where
             /// indexes, make the loop time-based, so the amount of
             /// progress we can loose on termination is time-bound,
             /// and thus more adaptive.
-            const PROGRESS_SNAPSHOT_BLOCKS: u64 = 10;
+            const PROGRESS_SNAPSHOT_BLOCKS: u64 = 100;
 
             let block_range = common_state.next_session
                 ..cmp::min(

--- a/fedimint-client/src/module/init/recovery.rs
+++ b/fedimint-client/src/module/init/recovery.rs
@@ -279,7 +279,7 @@ where
                                 let items_res = if core_api_version < VERSION_THAT_INTRODUCED_GET_SESSION_STATUS {
                                     api.await_block(session_idx, &decoders).await.map(|s| s.items)
                                 } else {
-                                    api.get_session_status(session_idx, &decoders).await.map(|s| match s {
+                                    api.get_session_status(session_idx, &decoders, core_api_version).await.map(|s| match s {
                                         SessionStatus::Initial => panic!("Federation missing session that existed when we started recovery"),
                                         SessionStatus::Pending(items) => items,
                                         SessionStatus::Complete(s) => s.items,

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -153,6 +153,8 @@ where
     pub fn global_api(&self) -> DynGlobalApi {
         self.client.get().api_clone()
     }
+
+    /// A set of all decoders of all modules of the client
     pub fn decoders(&self) -> ModuleDecoderRegistry {
         self.client.get().decoders().clone()
     }
@@ -165,7 +167,9 @@ where
             input
                 .as_any()
                 .downcast_ref::<<M::Common as ModuleCommon>::Input>()
-                .expect("instance_id just checked")
+                .unwrap_or_else(|| {
+                    panic!("instance_id {} just checked", input.module_instance_id())
+                })
         })
     }
 
@@ -177,7 +181,9 @@ where
             output
                 .as_any()
                 .downcast_ref::<<M::Common as ModuleCommon>::Output>()
-                .expect("instance_id just checked")
+                .unwrap_or_else(|| {
+                    panic!("instance_id {} just checked", output.module_instance_id())
+                })
         })
     }
 

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -25,6 +25,7 @@ async-recursion = "1.1.1"
 async-trait = { workspace = true }
 backon = { version = "1.3.0", default-features = false }
 backtrace = "0.3.74"
+base64-serde = "0.8.0"
 base64-url = { workspace = true }
 bech32 = "0.11.0"
 bincode = { workspace = true }

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -25,7 +25,7 @@ async-recursion = "1.1.1"
 async-trait = { workspace = true }
 backon = { version = "1.3.0", default-features = false }
 backtrace = "0.3.74"
-base64-serde = "0.8.0"
+base64 = { workspace = true }
 base64-url = { workspace = true }
 bech32 = "0.11.0"
 bincode = { workspace = true }

--- a/fedimint-core/src/encoding/as_base64.rs
+++ b/fedimint-core/src/encoding/as_base64.rs
@@ -1,0 +1,29 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use serde::Deserialize as _;
+
+use super::{Decodable, Encodable};
+use crate::module::registry::ModuleRegistry;
+
+pub fn serialize<T, S>(t: &T, ser: S) -> Result<S::Ok, S::Error>
+where
+    T: Encodable,
+    S: serde::Serializer,
+{
+    ser.serialize_str(&URL_SAFE_NO_PAD.encode(t.consensus_encode_to_vec()))
+}
+
+pub fn deserialize<'de, T: Decodable, D>(de: D) -> Result<T, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    Decodable::consensus_decode_whole(
+        &URL_SAFE_NO_PAD
+            .decode(&String::deserialize(de)?)
+            .map_err(|e| {
+                serde::de::Error::custom(format!("decodable deserialization failed: {e:#}"))
+            })?,
+        &ModuleRegistry::default(),
+    )
+    .map_err(|e| serde::de::Error::custom(format!("decodable deserialization failed: {e:#}")))
+}

--- a/fedimint-core/src/encoding/as_hex.rs
+++ b/fedimint-core/src/encoding/as_hex.rs
@@ -30,7 +30,7 @@ where
     D: serde::de::Deserializer<'de>,
 {
     Decodable::consensus_decode_hex(&String::deserialize(de)?, &ModuleRegistry::default())
-        .map_err(|e| serde::de::Error::custom(format!("decodable deserialization failed: {e:?}")))
+        .map_err(|e| serde::de::Error::custom(format!("decodable deserialization failed: {e:#}")))
 }
 
 #[macro_export]
@@ -43,7 +43,7 @@ macro_rules! serialize_as_encodable_hex {
             {
                 use $crate::Encodable;
                 serializer.serialize_str(&self.consensus_encode_to_hex().map_err(|e| {
-                    serde::ser::Error::custom(format!("encodable serialization failed: {e:?}"))
+                    serde::ser::Error::custom(format!("encodable serialization failed: {e:#}"))
                 })?)
             }
         }
@@ -63,7 +63,7 @@ macro_rules! deserialize_as_encodable_hex {
                     &Default::default(),
                 )
                 .map_err(|e| {
-                    serde::de::Error::custom(format!("decodable deserialization failed: {e:?}"))
+                    serde::de::Error::custom(format!("decodable deserialization failed: {e:#}"))
                 })
             }
         }

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -26,6 +26,8 @@ use std::io::{self, Error, Read, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
+use base64_serde::base64_serde_type;
+use base64_url::base64;
 use bitcoin::hashes::sha256;
 pub use fedimint_derive::{Decodable, Encodable};
 use hex::{FromHex, ToHex};
@@ -756,6 +758,11 @@ where
         }
     }
 }
+
+base64_serde_type!(
+    pub Base64UrlSafe,
+    base64::engine::general_purpose::URL_SAFE
+);
 
 #[cfg(test)]
 mod tests {

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -8,6 +8,7 @@
 //!
 //! See [`Encodable`] and [`Decodable`] for two main traits.
 
+pub mod as_base64;
 pub mod as_hex;
 mod bls12_381;
 pub mod btc;
@@ -26,8 +27,6 @@ use std::io::{self, Error, Read, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
-use base64_serde::base64_serde_type;
-use base64_url::base64;
 use bitcoin::hashes::sha256;
 pub use fedimint_derive::{Decodable, Encodable};
 use hex::{FromHex, ToHex};
@@ -758,11 +757,6 @@ where
         }
     }
 }
-
-base64_serde_type!(
-    pub Base64UrlSafe,
-    base64::engine::general_purpose::URL_SAFE
-);
 
 #[cfg(test)]
 mod tests {

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -591,7 +591,7 @@ impl DecodeError {
 
 impl std::fmt::Display for DecodeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.0, f)
+        f.write_fmt(format_args!("{:#}", self.0))
     }
 }
 

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -14,6 +14,7 @@ pub const SESSION_COUNT_ENDPOINT: &str = "session_count";
 pub const AWAIT_SESSION_OUTCOME_ENDPOINT: &str = "await_session_outcome";
 pub const AWAIT_SIGNED_SESSION_OUTCOME_ENDPOINT: &str = "await_signed_session_outcome";
 pub const SESSION_STATUS_ENDPOINT: &str = "session_status";
+pub const SESSION_STATUS_V2_ENDPOINT: &str = "signed_session_status";
 pub const SHUTDOWN_ENDPOINT: &str = "shutdown";
 pub const CONFIG_GEN_PEERS_ENDPOINT: &str = "config_gen_peers";
 pub const CONSENSUS_CONFIG_GEN_PARAMS_ENDPOINT: &str = "consensus_config_gen_params";

--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -350,7 +350,7 @@ macro_rules! module_plugin_dyn_newtype_encode_decode {
                         $crate::module::registry::DecodingMode::Reject => {
                             return Err(fedimint_core::encoding::DecodeError::new_custom(
                                 anyhow::anyhow!(
-                                    "Module decoder not available: {module_instance_id} when decoding {}", std::any::type_name::<Self>()
+                                    "Module decoder not available for module instance: {module_instance_id} when decoding {}", std::any::type_name::<Self>()
                                 ),
                             ));
                         }

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -958,7 +958,7 @@ pub struct SerdeModuleEncoding<T: Encodable + Decodable>(
 /// Same as [`SerdeModuleEncoding`] but uses base64 instead of hex encoding.
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct SerdeModuleEncodingBase64<T: Encodable + Decodable>(
-    #[serde(with = "::fedimint_core::encoding::Base64UrlSafe")] Vec<u8>,
+    #[serde(with = "::fedimint_core::encoding::as_base64")] Vec<u8>,
     #[serde(skip)] PhantomData<T>,
 );
 

--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -957,7 +957,7 @@ pub struct SerdeModuleEncoding<T: Encodable + Decodable>(
 
 /// Same as [`SerdeModuleEncoding`] but uses base64 instead of hex encoding.
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct SerdeModuleEncoding2<T: Encodable + Decodable>(
+pub struct SerdeModuleEncodingBase64<T: Encodable + Decodable>(
     #[serde(with = "::fedimint_core::encoding::Base64UrlSafe")] Vec<u8>,
     #[serde(skip)] PhantomData<T>,
 );
@@ -1017,7 +1017,7 @@ impl<T: Encodable + Decodable + 'static> SerdeModuleEncoding<T> {
     }
 }
 
-impl<T> fmt::Debug for SerdeModuleEncoding2<T>
+impl<T> fmt::Debug for SerdeModuleEncodingBase64<T>
 where
     T: Encodable + Decodable,
 {
@@ -1029,7 +1029,7 @@ where
     }
 }
 
-impl<T: Encodable + Decodable> From<&T> for SerdeModuleEncoding2<T> {
+impl<T: Encodable + Decodable> From<&T> for SerdeModuleEncodingBase64<T> {
     fn from(value: &T) -> Self {
         let mut bytes = vec![];
         fedimint_core::encoding::Encodable::consensus_encode(value, &mut bytes)
@@ -1038,7 +1038,7 @@ impl<T: Encodable + Decodable> From<&T> for SerdeModuleEncoding2<T> {
     }
 }
 
-impl<T: Encodable + Decodable + 'static> SerdeModuleEncoding2<T> {
+impl<T: Encodable + Decodable + 'static> SerdeModuleEncodingBase64<T> {
     pub fn try_into_inner(&self, modules: &ModuleDecoderRegistry) -> Result<T, DecodeError> {
         Decodable::consensus_decode_whole(&self.0, modules)
     }

--- a/fedimint-core/src/session_outcome.rs
+++ b/fedimint-core/src/session_outcome.rs
@@ -79,3 +79,22 @@ pub enum SessionStatus {
     Pending(Vec<AcceptedItem>),
     Complete(SessionOutcome),
 }
+
+#[derive(Debug, Clone, Eq, PartialEq, Encodable, Decodable)]
+pub enum SessionStatusV2 {
+    Initial,
+    Pending(Vec<AcceptedItem>),
+    Complete(SignedSessionOutcome),
+}
+
+impl From<SessionStatusV2> for SessionStatus {
+    fn from(value: SessionStatusV2) -> Self {
+        match value {
+            SessionStatusV2::Initial => Self::Initial,
+            SessionStatusV2::Pending(items) => Self::Pending(items),
+            SessionStatusV2::Complete(signed_session_outcome) => {
+                Self::Complete(signed_session_outcome.session_outcome)
+            }
+        }
+    }
+}

--- a/fedimint-core/src/util/mod.rs
+++ b/fedimint-core/src/util/mod.rs
@@ -467,7 +467,7 @@ where
                 } else {
                     warn!(
                         target: LOG_CORE,
-                        ?err,
+                        err = %err.fmt_compact_anyhow(),
                         %attempts,
                         "{} failed",
                         op_name,

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -199,7 +199,7 @@ impl ServerConfig {
     pub fn supported_api_versions() -> SupportedCoreApiVersions {
         SupportedCoreApiVersions {
             core_consensus: CORE_CONSENSUS_VERSION,
-            api: MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 4 }])
+            api: MultiApiVersion::try_from_iter([ApiVersion { major: 0, minor: 5 }])
                 .expect("not version conflicts"),
         }
     }

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -26,22 +26,25 @@ use fedimint_core::endpoint_constants::{
     CLIENT_CONFIG_ENDPOINT, CLIENT_CONFIG_JSON_ENDPOINT, FEDERATION_ID_ENDPOINT,
     FEDIMINTD_VERSION_ENDPOINT, GUARDIAN_CONFIG_BACKUP_ENDPOINT, INVITE_CODE_ENDPOINT,
     RECOVER_ENDPOINT, SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT, SESSION_COUNT_ENDPOINT,
-    SESSION_STATUS_ENDPOINT, SHUTDOWN_ENDPOINT, SIGN_API_ANNOUNCEMENT_ENDPOINT, STATUS_ENDPOINT,
-    SUBMIT_API_ANNOUNCEMENT_ENDPOINT, SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
+    SESSION_STATUS_ENDPOINT, SESSION_STATUS_V2_ENDPOINT, SHUTDOWN_ENDPOINT,
+    SIGN_API_ANNOUNCEMENT_ENDPOINT, STATUS_ENDPOINT, SUBMIT_API_ANNOUNCEMENT_ENDPOINT,
+    SUBMIT_TRANSACTION_ENDPOINT, VERSION_ENDPOINT,
 };
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::audit::{Audit, AuditSummary};
 use fedimint_core::module::registry::ServerModuleRegistry;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased, ApiVersion,
-    SerdeModuleEncoding, SupportedApiVersionsSummary,
+    SerdeModuleEncoding, SerdeModuleEncoding2, SupportedApiVersionsSummary,
 };
 use fedimint_core::net::api_announcement::{
     ApiAnnouncement, SignedApiAnnouncement, SignedApiAnnouncementSubmission,
 };
 use fedimint_core::secp256k1::{PublicKey, SECP256K1};
 use fedimint_core::server::DynServerModule;
-use fedimint_core::session_outcome::{SessionOutcome, SessionStatus, SignedSessionOutcome};
+use fedimint_core::session_outcome::{
+    SessionOutcome, SessionStatus, SessionStatusV2, SignedSessionOutcome,
+};
 use fedimint_core::transaction::{
     SerdeTransaction, Transaction, TransactionError, TransactionSubmissionOutcome,
 };
@@ -190,23 +193,22 @@ impl ConsensusApi {
             .0
     }
 
-    pub async fn session_status(&self, session_index: u64) -> SessionStatus {
+    pub async fn session_status(&self, session_index: u64) -> SessionStatusV2 {
         let mut dbtx = self.db.begin_transaction_nc().await;
 
         match session_index.cmp(&get_finished_session_count_static(&mut dbtx).await) {
-            Ordering::Greater => SessionStatus::Initial,
-            Ordering::Equal => SessionStatus::Pending(
+            Ordering::Greater => SessionStatusV2::Initial,
+            Ordering::Equal => SessionStatusV2::Pending(
                 dbtx.find_by_prefix(&AcceptedItemPrefix)
                     .await
                     .map(|entry| entry.1)
                     .collect()
                     .await,
             ),
-            Ordering::Less => SessionStatus::Complete(
+            Ordering::Less => SessionStatusV2::Complete(
                 dbtx.get_value(&SignedSessionOutcomeKey(session_index))
                     .await
-                    .expect("There are no gaps in session outcomes")
-                    .session_outcome,
+                    .expect("There are no gaps in session outcomes"),
             ),
         }
     }
@@ -634,6 +636,13 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
             SESSION_STATUS_ENDPOINT,
             ApiVersion::new(0, 1),
             async |fedimint: &ConsensusApi, _context, index: u64| -> SerdeModuleEncoding<SessionStatus> {
+                Ok((&SessionStatus::from(fedimint.session_status(index).await)).into())
+            }
+        },
+        api_endpoint! {
+            SESSION_STATUS_V2_ENDPOINT,
+            ApiVersion::new(0, 5),
+            async |fedimint: &ConsensusApi, _context, index: u64| -> SerdeModuleEncoding2<SessionStatusV2> {
                 Ok((&fedimint.session_status(index).await).into())
             }
         },

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -35,7 +35,7 @@ use fedimint_core::module::audit::{Audit, AuditSummary};
 use fedimint_core::module::registry::ServerModuleRegistry;
 use fedimint_core::module::{
     api_endpoint, ApiEndpoint, ApiEndpointContext, ApiError, ApiRequestErased, ApiVersion,
-    SerdeModuleEncoding, SerdeModuleEncoding2, SupportedApiVersionsSummary,
+    SerdeModuleEncoding, SerdeModuleEncodingBase64, SupportedApiVersionsSummary,
 };
 use fedimint_core::net::api_announcement::{
     ApiAnnouncement, SignedApiAnnouncement, SignedApiAnnouncementSubmission,
@@ -642,7 +642,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConsensusApi>> {
         api_endpoint! {
             SESSION_STATUS_V2_ENDPOINT,
             ApiVersion::new(0, 5),
-            async |fedimint: &ConsensusApi, _context, index: u64| -> SerdeModuleEncoding2<SessionStatusV2> {
+            async |fedimint: &ConsensusApi, _context, index: u64| -> SerdeModuleEncodingBase64<SessionStatusV2> {
                 Ok((&fedimint.session_status(index).await).into())
             }
         },


### PR DESCRIPTION
goal: reduce data usage for recovery

- changed from hex to base64: 33% saving
- client can only download from single peer and verify using signature: num peers times saving

for 4 guardian federation: overall 6x less data download

Happy new year!

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
