### PR TITLE
chore: use `TMPDIR`, not `TMP`

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -55,7 +55,7 @@ function ensure_in_dev_shell() {
 function make_fm_test_marker() {
   if [ -n "${FM_TEST_NAME:-}" ]; then
     # make it easy to identify which tmp dir belongs to which test
-    touch "${TMP:-/tmp}/$(echo "$FM_TEST_NAME" |tr -cd '[:alnum:]-_')" || true
+    touch "${TMPDIR:-/tmp}/$(echo "$FM_TEST_NAME" |tr -cd '[:alnum:]-_')" || true
   fi
 }
 


### PR DESCRIPTION
Fix #6633

No other places seem to use `TMP`
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
