### PR TITLE
chore(client-wallet): new `fedimint-cli module wallet` cli commands

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -160,8 +160,10 @@ pub enum ClientCmd {
         no_update: bool,
     },
     /// Generate a new deposit address, funds sent to it can later be claimed
+    #[clap(hide = true)]
     DepositAddress,
     /// Wait for deposit on previously generated address
+    #[clap(hide = true)]
     AwaitDeposit { operation_id: OperationId },
     /// Withdraw funds from the federation
     Withdraw {
@@ -491,6 +493,9 @@ pub async fn handle_command(
             Ok(json!(&gateways))
         }
         ClientCmd::DepositAddress => {
+            eprintln!(
+                "`deposit-address` command is deprecated. Use `module wallet new-deposit-address` instead."
+            );
             let (operation_id, address, tweak_idx) = client
                 .get_first_module::<WalletClientModule>()?
                 .allocate_deposit_address_expert_only(())
@@ -504,9 +509,10 @@ pub async fn handle_command(
             })
         }
         ClientCmd::AwaitDeposit { operation_id } => {
+            eprintln!("`await-deposit` is deprecated. Use `module wallet await-deposit` instead.");
             client
                 .get_first_module::<WalletClientModule>()?
-                .await_num_deposit_by_operation_id(operation_id, 1)
+                .await_num_deposits_by_operation_id(operation_id, 1)
                 .await?;
 
             Ok(serde_json::to_value(()).unwrap())

--- a/modules/fedimint-wallet-client/src/cli.rs
+++ b/modules/fedimint-wallet-client/src/cli.rs
@@ -1,17 +1,26 @@
+use std::str::FromStr as _;
 use std::{ffi, iter};
 
+use anyhow::bail;
+use bitcoin::address::NetworkUnchecked;
 use clap::Parser;
 use fedimint_core::core::OperationId;
 use serde::Serialize;
 
 use super::WalletClientModule;
 use crate::api::WalletFederationApi;
+use crate::client_db::TweakIdx;
 
 #[derive(Parser, Serialize)]
 enum Opts {
     /// Await a deposit on a given deposit address
     AwaitDeposit {
-        operation_id: OperationId,
+        addr: Option<String>,
+        #[arg(long)]
+        operation_id: Option<OperationId>,
+        #[arg(long)]
+        tweak_idx: Option<TweakIdx>,
+        /// Await more than just one deposit
         #[arg(long, default_value = "1")]
         num: usize,
     },
@@ -22,6 +31,16 @@ enum Opts {
     },
     /// Returns the Bitcoin RPC kind and URL, if authenticated
     GetBitcoinRpcConfig,
+
+    NewDepositAddress,
+    /// Trigger wallet address check (in the background)
+    RecheckDepositAddress {
+        addr: Option<bitcoin::Address<NetworkUnchecked>>,
+        #[arg(long)]
+        operation_id: Option<OperationId>,
+        #[arg(long)]
+        tweak_idx: Option<TweakIdx>,
+    },
 }
 
 pub(crate) async fn handle_cli_command(
@@ -31,11 +50,40 @@ pub(crate) async fn handle_cli_command(
     let opts = Opts::parse_from(iter::once(&ffi::OsString::from("wallet")).chain(args.iter()));
 
     let res = match opts {
-        Opts::AwaitDeposit { operation_id, num } => {
-            module
-                .await_num_deposit_by_operation_id(operation_id, num)
-                .await?;
-            serde_json::Value::Null
+        Opts::AwaitDeposit {
+            operation_id,
+            num,
+            addr,
+            tweak_idx,
+        } => {
+            if u32::from(addr.is_some())
+                + u32::from(operation_id.is_some())
+                + u32::from(tweak_idx.is_some())
+                != 1
+            {
+                bail!("One and only one of the selector arguments must be set")
+            }
+            if let Some(tweak_idx) = tweak_idx {
+                module.await_num_deposits(tweak_idx, num).await?;
+            } else if let Some(operation_id) = operation_id {
+                module
+                    .await_num_deposits_by_operation_id(operation_id, num)
+                    .await?;
+            } else if let Some(addr) = addr {
+                if addr.len() == 64 {
+                    eprintln!("Interpreting addr as an operation_id for backward compatibility. Use `--operation-id` from now on.");
+                    let operation_id = OperationId::from_str(&addr)?;
+                    module
+                        .await_num_deposits_by_operation_id(operation_id, num)
+                        .await?;
+                } else {
+                    let addr = bitcoin::Address::from_str(&addr)?;
+                    module.await_num_deposits_by_address(addr, num).await?;
+                }
+            } else {
+                unreachable!()
+            }
+            serde_json::Value::Bool(true)
         }
         Opts::GetBitcoinRpcKind { peer_id } => {
             let kind = module
@@ -57,6 +105,40 @@ pub(crate) async fn handle_cli_command(
         Opts::GetConsensusBlockCount => {
             serde_json::to_value(module.module_api.fetch_consensus_block_count().await?)
                 .expect("JSON serialization failed")
+        }
+        Opts::RecheckDepositAddress {
+            addr,
+            operation_id,
+            tweak_idx,
+        } => {
+            if u32::from(addr.is_some())
+                + u32::from(operation_id.is_some())
+                + u32::from(tweak_idx.is_some())
+                != 1
+            {
+                bail!("One and only one of the selector arguments must be set")
+            }
+            if let Some(tweak_idx) = tweak_idx {
+                module.recheck_pegin_address(tweak_idx).await?;
+            } else if let Some(operation_id) = operation_id {
+                module.recheck_pegin_address_by_op_id(operation_id).await?;
+            } else if let Some(addr) = addr {
+                module.recheck_pegin_address_by_address(addr).await?;
+            } else {
+                unreachable!()
+            }
+            serde_json::Value::Bool(true)
+        }
+        Opts::NewDepositAddress => {
+            let (operation_id, address, tweak_idx) =
+                module.allocate_deposit_address_expert_only(()).await?;
+            serde_json::json! {
+                {
+                    "address": address,
+                    "operation_id": operation_id,
+                    "tweak_idx": tweak_idx.0
+                }
+            }
         }
     };
 

--- a/modules/fedimint-wallet-client/src/client_db.rs
+++ b/modules/fedimint-wallet-client/src/client_db.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use std::ops;
+use std::str::FromStr;
 use std::time::SystemTime;
 
 use fedimint_client::module::init::recovery::RecoveryFromHistoryCommon;
@@ -58,6 +59,14 @@ pub struct TweakIdx(pub u64);
 impl fmt::Display for TweakIdx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("TweakIdx({})", self.0))
+    }
+}
+
+impl FromStr for TweakIdx {
+    type Err = <u64 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(FromStr::from_str(s)?))
     }
 }
 

--- a/modules/fedimint-wallet-tests/src/bin/wallet-recovery-test.rs
+++ b/modules/fedimint-wallet-tests/src/bin/wallet-recovery-test.rs
@@ -1,7 +1,7 @@
 use anyhow::bail;
 use devimint::cmd;
 use devimint::util::{FedimintCli, FedimintdCmd};
-use devimint::version_constants::VERSION_0_4_0;
+use devimint::version_constants::{VERSION_0_4_0, VERSION_0_6_0_ALPHA};
 use fedimint_core::util::{backoff_util, retry};
 use futures::try_join;
 use tracing::info;
@@ -47,9 +47,15 @@ async fn main() -> anyhow::Result<()> {
                 .new_restored("restored-without-backup", fed.invite_code()?)
                 .await?;
 
-            cmd!(restored, "module", "wallet", "await-deposit", operation_id)
-                .run()
-                .await?;
+            if fedimint_cli_version < *VERSION_0_6_0_ALPHA {
+                cmd!(restored, "module", "wallet", "await-deposit", operation_id)
+                    .run()
+                    .await?;
+            } else {
+                cmd!(restored, "module", "wallet", "await-deposit", "--operation-id", operation_id)
+                    .run()
+                    .await?;
+            }
 
             info!("Check if claimed");
             assert_eq!(peg_in_amount_sats * 1000, restored.balance().await?);
@@ -78,9 +84,15 @@ async fn main() -> anyhow::Result<()> {
                 .new_restored("restored-with-backup", fed.invite_code()?)
                 .await?;
 
-            cmd!(restored, "module", "wallet", "await-deposit", operation_id)
-                .run()
-                .await?;
+            if fedimint_cli_version < *VERSION_0_6_0_ALPHA {
+                cmd!(restored, "module", "wallet", "await-deposit", operation_id)
+                    .run()
+                    .await?;
+            } else {
+                cmd!(restored, "module", "wallet", "await-deposit", "--operation-id", operation_id)
+                    .run()
+                    .await?;
+            }
 
             info!("Check if claimed");
             assert_eq!(peg_in_amount_sats * 1000 * 2, restored.balance().await?);
@@ -108,9 +120,15 @@ async fn main() -> anyhow::Result<()> {
                 .new_restored("client-slow-restored-without-backup", fed.invite_code()?)
                 .await?;
 
-            cmd!(restored, "module", "wallet", "await-deposit", operation_id)
-                .run()
-                .await?;
+            if fedimint_cli_version < *VERSION_0_6_0_ALPHA {
+                cmd!(restored, "module", "wallet", "await-deposit", operation_id)
+                    .run()
+                    .await?;
+            } else {
+                cmd!(restored, "module", "wallet", "await-deposit", "--operation-id", operation_id)
+                    .run()
+                    .await?;
+            }
 
             info!("Client slow: Check if claimed");
             assert_eq!(peg_in_amount_sats * 1000 * 2, restored.balance().await?);

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -82,7 +82,7 @@ async fn peg_in<'a>(
     bitcoin.mine_blocks(finality_delay).await;
 
     wallet_module
-        .await_num_deposit_by_operation_id(op, 1)
+        .await_num_deposits_by_operation_id(op, 1)
         .await?;
     assert_eq!(
         client.get_balance().await,
@@ -361,7 +361,7 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
         info!(?height, ?tx, txid = ?tx.compute_txid(), "First peg-in transaction mined");
         bitcoin.mine_blocks(finality_delay).await;
         wallet_module
-            .await_num_deposit_by_operation_id(op, 1)
+            .await_num_deposits_by_operation_id(op, 1)
             .await?;
         assert_eq!(
             client.get_balance().await,


### PR DESCRIPTION
Partially implements #6601 , plus moves a bit forward towards moving more stuff into module specific cli commands.


Notably I breaks backward compat of `fedimint-cli module wallet await-deposit` command, as I think it should default to `bitcoin::Address` argument, which the user probably cares more about than `OperationId`. Though both are still supported.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
