### PR TITLE
chore: make Client::get_config sync

### DIFF
--- a/fedimint-cli/src/client.rs
+++ b/fedimint-cli/src/client.rs
@@ -626,7 +626,6 @@ pub async fn handle_command(
             } else {
                 let module_list: Vec<ModuleInfo> = client
                     .config()
-                    .await
                     .modules
                     .iter()
                     .map(|(id, ClientModuleConfig { kind, .. })| ModuleInfo {
@@ -645,7 +644,7 @@ pub async fn handle_command(
             }
         }
         ClientCmd::Config => {
-            let config = client.get_config_json().await;
+            let config = client.get_config_json();
             Ok(serde_json::to_value(config).expect("Client config is serializable"))
         }
         ClientCmd::SessionCount => {
@@ -671,7 +670,7 @@ async fn get_note_summary(client: &ClientHandleArc) -> anyhow::Result<serde_json
     Ok(serde_json::to_value(InfoResponse {
         federation_id: client.federation_id(),
         network: wallet_client.get_network(),
-        meta: client.config().await.global.meta.clone(),
+        meta: client.config().global.meta.clone(),
         total_amount_msat: summary.total_amount(),
         total_num_notes: summary.count_items(),
         denominations_msat: summary,

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1151,7 +1151,7 @@ impl FedimintCli {
 
                 let meta_fields = source
                     .fetch(
-                        &client.config().await,
+                        &client.config(),
                         &client.api_clone(),
                         FetchKind::Initial,
                         None,

--- a/fedimint-client/src/meta.rs
+++ b/fedimint-client/src/meta.rs
@@ -175,7 +175,7 @@ impl<S: MetaSource + ?Sized> MetaService<S> {
         let mut current_revision = self
             .current_revision(&mut client.db().begin_transaction_nc().await)
             .await;
-        let client_config = client.config().await;
+        let client_config = client.config();
         let meta_values = self
             .source
             .fetch(

--- a/fedimint-client/src/module/mod.rs
+++ b/fedimint-client/src/module/mod.rs
@@ -344,14 +344,14 @@ where
             .collect()
     }
 
-    pub async fn get_config(&self) -> ClientConfig {
-        self.client.get().config().await
+    pub fn get_config(&self) -> ClientConfig {
+        self.client.get().config()
     }
 
     /// Returns an invite code for the federation that points to an arbitrary
     /// guardian server for fetching the config
     pub async fn get_invite_code(&self) -> InviteCode {
-        let cfg = self.get_config().await.global;
+        let cfg = self.get_config().global;
         self.client
             .get()
             .invite_code(

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -806,8 +806,7 @@ impl Gateway {
                 self.federation_manager
                     .read()
                     .await
-                    .get_federation_config(federation_id)
-                    .await?,
+                    .get_federation_config(federation_id)?,
             );
             federations
         } else {
@@ -815,7 +814,6 @@ impl Gateway {
                 .read()
                 .await
                 .get_all_federation_configs()
-                .await
         };
 
         Ok(GatewayFedConfig { federations })
@@ -1111,13 +1109,13 @@ impl Gateway {
         // federation info here because short channel id is not yet persisted.
         let federation_info = FederationInfo {
             federation_id,
-            federation_name: federation_manager.federation_name(&client).await,
+            federation_name: FederationManager::federation_name(&client),
             balance_msat: client.get_balance().await,
             config: federation_config.clone(),
         };
 
         if self.is_running_lnv1() {
-            Self::check_lnv1_federation_network(&client, self.network).await?;
+            Self::check_lnv1_federation_network(&client, self.network)?;
             client
                 .get_first_module::<GatewayClientModule>()?
                 .try_register_with_federation(
@@ -1131,7 +1129,7 @@ impl Gateway {
         }
 
         if self.is_running_lnv2() {
-            Self::check_lnv2_federation_network(&client, self.network).await?;
+            Self::check_lnv2_federation_network(&client, self.network)?;
         }
 
         // no need to enter span earlier, because connect-fed has a span
@@ -1210,7 +1208,6 @@ impl Gateway {
             .read()
             .await
             .get_all_federation_configs()
-            .await
             .keys()
             .copied()
             .collect::<BTreeSet<_>>();
@@ -1740,12 +1737,12 @@ impl Gateway {
 
     /// Verifies that the supplied `network` matches the Bitcoin network in the
     /// connected client's LNv1 configuration.
-    async fn check_lnv1_federation_network(
+    fn check_lnv1_federation_network(
         client: &ClientHandleArc,
         network: Network,
     ) -> AdminResult<()> {
         let federation_id = client.federation_id();
-        let config = client.config().await;
+        let config = client.config();
         let cfg = config
             .modules
             .values()
@@ -1771,12 +1768,12 @@ impl Gateway {
 
     /// Verifies that the supplied `network` matches the Bitcoin network in the
     /// connected client's LNv2 configuration.
-    async fn check_lnv2_federation_network(
+    fn check_lnv2_federation_network(
         client: &ClientHandleArc,
         network: Network,
     ) -> AdminResult<()> {
         let federation_id = client.federation_id();
-        let config = client.config().await;
+        let config = client.config();
         let cfg = config
             .modules
             .values()

--- a/gateway/ln-gateway/src/state_machine/mod.rs
+++ b/gateway/ln-gateway/src/state_machine/mod.rs
@@ -379,7 +379,6 @@ impl GatewayClientModule {
         let federation_id = self
             .client_ctx
             .get_config()
-            .await
             .global
             .calculate_federation_id();
         if let Err(e) = self.module_api.register_gateway(&registration_info).await {
@@ -404,7 +403,6 @@ impl GatewayClientModule {
             let federation_id = self
                 .client_ctx
                 .get_config()
-                .await
                 .global
                 .calculate_federation_id();
             warn!("Failed to remove gateway {gateway_id} from federation {federation_id}: {e:?}");

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -44,7 +44,7 @@ async fn client_ignores_unknown_module() {
     let fed = fixtures().new_default_fed().await;
     let client = fed.new_client().await;
 
-    let mut cfg = client.config().await;
+    let mut cfg = client.config();
     let module_id = 2142;
     let extra_mod = ClientModuleConfig::from_typed(
         module_id,

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1174,7 +1174,6 @@ impl LightningClientModule {
                     gateway,
                     self.client_ctx
                         .get_config()
-                        .await
                         .global
                         .calculate_federation_id(),
                     rand::rngs::OsRng,


### PR DESCRIPTION
always use the correct lock for the job

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
