### PR TITLE
chore: port (some) mprocs aliases to devimint-env

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -24,9 +24,10 @@ else
 fi
 
 export CARGO_BUILD_TARGET_DIR="${CARGO_BUILD_TARGET_DIR:-"$REPO_ROOT/target"}"
+export CARGO_BUILD_TARGET_BIN_DIR="${CARGO_BUILD_TARGET_DIR:-$PWD/target}/${CARGO_PROFILE_DIR:-debug}"
 
 function add_target_dir_to_path() {
-  export PATH="${CARGO_BUILD_TARGET_DIR:-$PWD/target}/${CARGO_PROFILE_DIR:-debug}:$PATH"
+  export PATH="${CARGO_BUILD_TARGET_BIN_DIR}:$PATH"
 }
 
 function build_workspace() {

--- a/scripts/dev/aliases.sh
+++ b/scripts/dev/aliases.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 
+# The original binaries from the environment, before the aliases potentially took them over
+# This is so that aliases can call actual commands, instead of each other/itself leading
+# to infinite recursion.
+export FM_ALIAS_ORIG_FEDIMINT_CLI
+FM_ALIAS_ORIG_FEDIMINT_CLI="$(which fedimint-cli)"
+export FM_ALIAS_ORIG_GATEWAY_CLI
+FM_ALIAS_ORIG_GATEWAY_CLI="$(which gateway-cli)"
+
+export PATH="${REPO_ROOT}/scripts/dev/devimint/aliases/:${PATH}"
+
+# Note: Please add new aliases as script to the directory above,
+# and migrate existing ones over time, so they work cross-shells
+# and cross-tools.
+# Also, please see https://github.com/fedimint/fedimint/issues/6658
 alias lightning-cli="\$FM_LIGHTNING_CLI"
 alias lncli="\$FM_LNCLI"
 alias bitcoin-cli="\$FM_BTC_CLIENT"
-alias fedimint-cli="\$FM_MINT_CLIENT"
-alias gateway-lnd="\$FM_GWCLI_LND"
-alias gateway-ldk="\$FM_GWCLI_LDK"
 alias fedimint-dbtool-fedimintd-0="env FM_DBTOOL_CONFIG_DIR=\$FM_DATA_DIR/fedimintd-0 FM_PASSWORD=pass \$FM_DB_TOOL --database \$FM_DATA_DIR/fedimintd-0/database"
 alias fedimint-dbtool-fedimintd-1="env FM_DBTOOL_CONFIG_DIR=\$FM_DATA_DIR/fedimintd-1 FM_PASSWORD=pass \$FM_DB_TOOL --database \$FM_DATA_DIR/fedimintd-1/database"
 alias fedimint-dbtool-fedimintd-2="env FM_DBTOOL_CONFIG_DIR=\$FM_DATA_DIR/fedimintd-2 FM_PASSWORD=pass \$FM_DB_TOOL --database \$FM_DATA_DIR/fedimintd-2/database"

--- a/scripts/dev/devimint-env.sh
+++ b/scripts/dev/devimint-env.sh
@@ -20,6 +20,8 @@ function devimint_env {
   # For starship users, we can actually make the prompt distinct so there's
   # no confusion.
   export STARSHIP_CONFIG="${REPO_ROOT}/scripts/dev/devimint-env/starship.toml"
+  source "${REPO_ROOT}/scripts/dev/aliases.sh"
+
 
   >&2 echo "Devimint Env Shell Ready (exit to shutdown):"
   if [ "$SHELL" == "fish" ] || [[ "$SHELL" == */fish ]]; then

--- a/scripts/dev/devimint/aliases/fedimint-cli
+++ b/scripts/dev/devimint/aliases/fedimint-cli
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$FM_ALIAS_ORIG_FEDIMINT_CLI --data-dir "$FM_CLIENT_DIR" "$@"

--- a/scripts/dev/devimint/aliases/gateway-ldk
+++ b/scripts/dev/devimint/aliases/gateway-ldk
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$FM_ALIAS_ORIG_GATEWAY_CLI --rpcpassword=theresnosecondbest -a "http://127.0.0.1:$FM_PORT_GW_LDK/" "$@"

--- a/scripts/dev/devimint/aliases/gateway-lnd
+++ b/scripts/dev/devimint/aliases/gateway-lnd
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$FM_ALIAS_ORIG_GATEWAY_CLI --rpcpassword=theresnosecondbest -a "http://127.0.0.1:$FM_PORT_GW_LND/" "$@"


### PR DESCRIPTION
I'm not using `just mprocs` anymore, but I want aliases too!


To test, `just mprocs` and/or `just devimint-env` and see that `fedimint-cli info`, `gateway-ldk info` and `gateway-lnd info` work.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
