### PR TITLE
Activate wallet consensus rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,7 @@ version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
+ "fedimint-api-client",
  "fedimint-core",
 ]
 
@@ -3810,6 +3811,7 @@ dependencies = [
  "async-trait",
  "bitcoin",
  "erased-serde 0.4.5",
+ "fedimint-api-client",
  "fedimint-bitcoind",
  "fedimint-core",
  "fedimint-logging",
@@ -3818,6 +3820,9 @@ dependencies = [
  "fedimint-wallet-common",
  "futures",
  "hex",
+ "itertools 0.13.0",
+ "jaq-core",
+ "jaq-json",
  "miniscript",
  "rand",
  "serde",
@@ -3837,6 +3842,7 @@ dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
  "devimint",
+ "fedimint-api-client",
  "fedimint-client",
  "fedimint-core",
  "fedimint-dummy-client",

--- a/fedimint-server-core/Cargo.toml
+++ b/fedimint-server-core/Cargo.toml
@@ -18,4 +18,5 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+fedimint-api-client = { workspace = true }
 fedimint-core = { workspace = true }

--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -6,6 +6,7 @@ use std::marker;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use fedimint_api_client::api::DynModuleApi;
 use fedimint_core::config::{
     ClientModuleConfig, CommonModuleInitRegistry, ConfigGenModuleParams, ModuleInitParams,
     ModuleInitRegistry, ServerModuleConfig, ServerModuleConsensusConfig,
@@ -44,6 +45,7 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
         db: Database,
         task_group: &TaskGroup,
         our_peer_id: PeerId,
+        module_api: DynModuleApi,
     ) -> anyhow::Result<DynServerModule>;
 
     fn validate_params(&self, params: &ConfigGenModuleParams) -> anyhow::Result<()>;
@@ -83,6 +85,7 @@ where
     task_group: TaskGroup,
     our_peer_id: PeerId,
     num_peers: NumPeers,
+    module_api: DynModuleApi,
     // ClientModuleInitArgs needs a bound because sometimes we need
     // to pass associated-types data, so let's just put it here right away
     _marker: marker::PhantomData<S>,
@@ -110,6 +113,10 @@ where
 
     pub fn our_peer_id(&self) -> PeerId {
         self.our_peer_id
+    }
+
+    pub fn module_api(&self) -> &DynModuleApi {
+        &self.module_api
     }
 }
 /// Module Generation trait with associated types
@@ -197,6 +204,7 @@ where
         db: Database,
         task_group: &TaskGroup,
         our_peer_id: PeerId,
+        module_api: DynModuleApi,
     ) -> anyhow::Result<DynServerModule> {
         <Self as ServerModuleInit>::init(
             self,
@@ -207,6 +215,7 @@ where
                 task_group: task_group.clone(),
                 our_peer_id,
                 _marker: PhantomData,
+                module_api,
             },
         )
         .await

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -75,6 +75,7 @@ pub async fn run(
             .map(|(&peer_id, url)| (peer_id, url.url.clone())),
         &None,
         &Connector::Tcp,
+        None,
     );
     for (module_id, module_cfg) in &cfg.consensus.modules {
         match module_init_registry.get(&module_cfg.kind) {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -67,6 +67,15 @@ pub async fn run(
 
     let mut modules = BTreeMap::new();
 
+    // TODO: make it work with all transports and federation secrets
+    let global_api = DynGlobalApi::from_endpoints(
+        cfg.consensus
+            .api_endpoints
+            .iter()
+            .map(|(&peer_id, url)| (peer_id, url.url.clone())),
+        &None,
+        &Connector::Tcp,
+    );
     for (module_id, module_cfg) in &cfg.consensus.modules {
         match module_init_registry.get(&module_cfg.kind) {
             Some(module_init) => {
@@ -88,6 +97,7 @@ pub async fn run(
                         db.with_prefix_module_id(*module_id).0,
                         task_group,
                         cfg.local.identity,
+                        global_api.with_module(*module_id),
                     )
                     .await?;
 

--- a/modules/fedimint-wallet-common/src/endpoint_constants.rs
+++ b/modules/fedimint-wallet-common/src/endpoint_constants.rs
@@ -4,6 +4,7 @@ pub const BLOCK_COUNT_LOCAL_ENDPOINT: &str = "block_count_local";
 pub const BITCOIN_KIND_ENDPOINT: &str = "bitcoin_kind";
 pub const BITCOIN_RPC_CONFIG_ENDPOINT: &str = "bitcoin_rpc_config";
 pub const MODULE_CONSENSUS_VERSION_ENDPOINT: &str = "module_consensus_version";
+pub const SUPPORTED_MODULE_CONSENSUS_VERSION_ENDPOINT: &str = "supported_module_consensus_version";
 pub const ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT: &str = "activate_consensus_version_voting";
 pub const WALLET_SUMMARY_ENDPOINT: &str = "wallet_summary";
 pub const UTXO_CONFIRMED_ENDPOINT: &str = "utxo_confirmed";

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 erased-serde = { workspace = true }
+fedimint-api-client = { workspace = true }
 fedimint-bitcoind = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
@@ -28,6 +29,9 @@ fedimint-server = { workspace = true }
 fedimint-wallet-common = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+itertools = { workspace = true }
+jaq-core = { workspace = true }
+jaq-json = { workspace = true }
 miniscript = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -71,7 +71,8 @@ use fedimint_wallet_common::config::{WalletClientConfig, WalletConfig, WalletGen
 use fedimint_wallet_common::endpoint_constants::{
     ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT, BITCOIN_KIND_ENDPOINT, BITCOIN_RPC_CONFIG_ENDPOINT,
     BLOCK_COUNT_ENDPOINT, BLOCK_COUNT_LOCAL_ENDPOINT, MODULE_CONSENSUS_VERSION_ENDPOINT,
-    PEG_OUT_FEES_ENDPOINT, UTXO_CONFIRMED_ENDPOINT, WALLET_SUMMARY_ENDPOINT,
+    PEG_OUT_FEES_ENDPOINT, SUPPORTED_MODULE_CONSENSUS_VERSION_ENDPOINT, UTXO_CONFIRMED_ENDPOINT,
+    WALLET_SUMMARY_ENDPOINT,
 };
 use fedimint_wallet_common::keys::CompressedPublicKey;
 use fedimint_wallet_common::tweakable::Tweakable;
@@ -898,6 +899,13 @@ impl ServerModule for Wallet {
                 ApiVersion::new(0, 2),
                 async |module: &Wallet, context, _params: ()| -> ModuleConsensusVersion {
                     Ok(module.consensus_module_consensus_version(&mut context.dbtx().into_nc()).await)
+                }
+            },
+            api_endpoint! {
+                SUPPORTED_MODULE_CONSENSUS_VERSION_ENDPOINT,
+                ApiVersion::new(0, 2),
+                async |_module: &Wallet, _context, _params: ()| -> ModuleConsensusVersion {
+                    Ok(MODULE_CONSENSUS_VERSION)
                 }
             },
             api_endpoint! {

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = { workspace = true }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 devimint = { workspace = true }
+fedimint-api-client = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use anyhow::{bail, Context};
 use assert_matches::assert_matches;
 use bitcoin::secp256k1;
+use fedimint_api_client::api::net::Connector;
+use fedimint_api_client::api::DynGlobalApi;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::ClientHandleArc;
 use fedimint_core::db::mem_impl::MemDatabase;
@@ -653,6 +655,9 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         dyn_bitcoin_rpc.clone(),
         &task_group,
         PeerId::from(0),
+        // FIXME: use proper mock
+        DynGlobalApi::from_endpoints([], &None, &Connector::Tcp, None)
+            .with_module(module_instance_id),
     )
     .await?;
 


### PR DESCRIPTION
Automatically activates wallet module consensus upgrades if **every guardian** supports a newer consensus version than is currently active. If not, we still rely on manual upgrade votes, which can activate new consensus versions with a threshold of guardians, kicking out the remaining ones.



<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
