### PR TITLE
chore(devimint): ship aliases with `devimint` package

### DIFF
--- a/devimint/build.rs
+++ b/devimint/build.rs
@@ -1,3 +1,17 @@
+use std::env;
+
+pub const FM_DEVIMINT_STATIC_DATA_DIR_ENV: &str = "FM_DEVIMINT_STATIC_DATA_DIR";
+
 fn main() {
     fedimint_build::set_code_version();
+
+    println!("cargo:rerun-if-env-changed={FM_DEVIMINT_STATIC_DATA_DIR_ENV}");
+
+    if let Ok(data_dir) = env::var(FM_DEVIMINT_STATIC_DATA_DIR_ENV) {
+        // For Nix, and anyone else that is willing to customize
+        println!("cargo:rustc-env={FM_DEVIMINT_STATIC_DATA_DIR_ENV}={data_dir}");
+    } else {
+        // For "classic" distros following Linux FHS
+        println!("cargo:rustc-env={FM_DEVIMINT_STATIC_DATA_DIR_ENV}=/usr/share/devimint");
+    }
 }

--- a/devimint/share/aliases/fm-cli
+++ b/devimint/share/aliases/fm-cli
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+fedimint-cli --data-dir "$FM_CLIENT_DIR" "$@"

--- a/devimint/share/aliases/gateway-ldk
+++ b/devimint/share/aliases/gateway-ldk
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+gateway-cli --rpcpassword=theresnosecondbest -a "http://127.0.0.1:$FM_PORT_GW_LDK/" "$@"

--- a/devimint/share/aliases/gateway-lnd
+++ b/devimint/share/aliases/gateway-lnd
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+gateway-cli --rpcpassword=theresnosecondbest -a "http://127.0.0.1:$FM_PORT_GW_LND/" "$@"

--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -132,3 +132,13 @@ pub const FM_DEVIMINT_CMD_INHERIT_STDERR_ENV: &str = "FM_DEVIMINT_CMD_INHERIT_ST
 
 /// Force devimint to run a test with a deprecated configuration
 pub const FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV: &str = "FM_DEVIMINT_RUN_DEPRECATED_TESTS";
+
+/// Devimint's "data dir" (think `/usr/devimint/`).
+///
+/// "Static" because we use "data dir" for the directory `devimint` puts all the
+/// runtime state in, which is typically a per-invocation temporary directory.
+///
+/// Can be set during `cargo build` to force the default one, then available in
+/// Rust code during building, and also checked at runtime to allow
+/// overwriting.
+pub const FM_DEVIMINT_STATIC_DATA_DIR_ENV: &str = "FM_DEVIMINT_STATIC_DATA_DIR";

--- a/flake.lock
+++ b/flake.lock
@@ -413,17 +413,17 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1734551360,
-        "narHash": "sha256-C2Mur/p/fn5WkKeb/4bfFdlSugwLaeue/BLxycKV9Cw=",
+        "lastModified": 1736282508,
+        "narHash": "sha256-IlNjz7jNSoQQSPGaYI0cphbQUMf0DttwQeNO5Kp9X2A=",
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "28e43cc8d5c67b0cc13cca1499fbe3fe6a5196f5",
+        "rev": "56ee87b7dd205c7af169ff72e818e3a92560b424",
         "type": "github"
       },
       "original": {
         "owner": "dpc",
         "repo": "flakebox",
-        "rev": "28e43cc8d5c67b0cc13cca1499fbe3fe6a5196f5",
+        "rev": "56ee87b7dd205c7af169ff72e818e3a92560b424",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flakebox = {
-      url = "github:dpc/flakebox?rev=28e43cc8d5c67b0cc13cca1499fbe3fe6a5196f5";
+      url = "github:dpc/flakebox?rev=56ee87b7dd205c7af169ff72e818e3a92560b424";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.fenix.follows = "fenix";
     };

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -24,9 +24,10 @@ else
 fi
 
 export CARGO_BUILD_TARGET_DIR="${CARGO_BUILD_TARGET_DIR:-"$REPO_ROOT/target"}"
+export CARGO_BUILD_TARGET_BIN_DIR="${CARGO_BUILD_TARGET_DIR:-$PWD/target}/${CARGO_PROFILE_DIR:-debug}"
 
 function add_target_dir_to_path() {
-  export PATH="${CARGO_BUILD_TARGET_DIR:-$PWD/target}/${CARGO_PROFILE_DIR:-debug}:$PATH"
+  export PATH="${CARGO_BUILD_TARGET_BIN_DIR}:$PATH"
 }
 
 function build_workspace() {

--- a/scripts/dev/aliases.sh
+++ b/scripts/dev/aliases.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
+# Note: Please add new aliases as script to the `./devimint/share/aliases`
+# and migrate existing ones over time, so they work cross-shells
+# and cross-tools.
+# Also, please see https://github.com/fedimint/fedimint/issues/6658
 alias lightning-cli="\$FM_LIGHTNING_CLI"
 alias lncli="\$FM_LNCLI"
 alias bitcoin-cli="\$FM_BTC_CLIENT"
-alias fedimint-cli="\$FM_MINT_CLIENT"
-alias gateway-lnd="\$FM_GWCLI_LND"
-alias gateway-ldk="\$FM_GWCLI_LDK"
 alias fedimint-dbtool-fedimintd-0="env FM_DBTOOL_CONFIG_DIR=\$FM_DATA_DIR/fedimintd-0 FM_PASSWORD=pass \$FM_DB_TOOL --database \$FM_DATA_DIR/fedimintd-0/database"
 alias fedimint-dbtool-fedimintd-1="env FM_DBTOOL_CONFIG_DIR=\$FM_DATA_DIR/fedimintd-1 FM_PASSWORD=pass \$FM_DB_TOOL --database \$FM_DATA_DIR/fedimintd-1/database"
 alias fedimint-dbtool-fedimintd-2="env FM_DBTOOL_CONFIG_DIR=\$FM_DATA_DIR/fedimintd-2 FM_PASSWORD=pass \$FM_DB_TOOL --database \$FM_DATA_DIR/fedimintd-2/database"

--- a/scripts/dev/devimint-env.sh
+++ b/scripts/dev/devimint-env.sh
@@ -20,6 +20,7 @@ function devimint_env {
   # For starship users, we can actually make the prompt distinct so there's
   # no confusion.
   export STARSHIP_CONFIG="${REPO_ROOT}/scripts/dev/devimint-env/starship.toml"
+  source "${REPO_ROOT}/scripts/dev/aliases.sh"
 
   >&2 echo "Devimint Env Shell Ready (exit to shutdown):"
   if [ "$SHELL" == "fish" ] || [[ "$SHELL" == */fish ]]; then
@@ -37,6 +38,9 @@ function devimint_env {
   fi
 }
 export -f devimint_env
+
+# In our dev env we want to use the current aliases from the source code
+export FM_DEVIMINT_STATIC_DATA_DIR="${REPO_ROOT}/devimint/share"
 
 env RUST_LOG="${RUST_LOG:-info,jsonrpsee-client=off}" \
   devimint --link-test-dir "${CARGO_BUILD_TARGET_DIR:-$PWD/target}/devimint" "$@" dev-fed \

--- a/scripts/dev/mprocs/run.sh
+++ b/scripts/dev/mprocs/run.sh
@@ -8,4 +8,7 @@ ensure_in_dev_shell
 build_workspace
 add_target_dir_to_path
 
+# In our dev env we want to use the current aliases from the source code
+export FM_DEVIMINT_STATIC_DATA_DIR="${REPO_ROOT}/devimint/share"
+
 devimint --link-test-dir "${CARGO_BUILD_TARGET_DIR:-$PWD/target}/devimint" "$@" dev-fed --exec bash -c 'mprocs -c misc/mprocs.yaml 2>$FM_LOGS_DIR/devimint-outer.log'

--- a/scripts/dev/user-shell.sh
+++ b/scripts/dev/user-shell.sh
@@ -20,7 +20,7 @@ echo Done!
 echo
 echo "This shell provides the following aliases:"
 echo ""
-echo "  fedimint-cli   - cli client to interact with the federation"
+echo "  fm-cli   - cli client to interact with the federation"
 echo "  lightning-cli  - cli client for Core Lightning"
 echo "  lncli          - cli client for LND"
 echo "  bitcoin-cli    - cli client for bitcoind"


### PR DESCRIPTION
Superseeds #6655

Make aliases standalone binaries, so they work in any setup, tooling, shell.

Ship `aliases` as a part of "static data" of devimint package. The location of the "static data" defaults to `/usr/devimint`, but can be overridden during build time and runtime. On Nix packaging will take care of setting the default either through a shell script (our flake case), or by setting it during build time (probably easiest approach in NixOS).
 


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
