### PR TITLE
chore: rename consensus_decode to consensus_decode_partial

### DIFF
--- a/crypto/tbs/benches/tbs.rs
+++ b/crypto/tbs/benches/tbs.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::io::Cursor;
 
 use bls12_381::{G2Projective, Scalar};
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -125,8 +124,7 @@ fn bench_decode_signature(c: &mut Criterion) {
 
     c.bench_function("signature decoding", |b| {
         b.iter(|| {
-            let mut sig_bytes_cursor = Cursor::new(&sig_bytes);
-            Signature::consensus_decode(&mut sig_bytes_cursor, &Default::default())
+            Signature::consensus_decode_whole(&sig_bytes, &Default::default())
                 .expect("Decoding works")
         })
     });

--- a/fedimint-bip39/src/lib.rs
+++ b/fedimint-bip39/src/lib.rs
@@ -35,10 +35,10 @@ impl<const WORD_COUNT: usize> RootSecretStrategy for Bip39RootSecretStrategy<WOR
         secret.to_entropy().consensus_encode(writer)
     }
 
-    fn consensus_decode(
+    fn consensus_decode_partial(
         reader: &mut impl Read,
     ) -> Result<Self::Encoding, fedimint_core::encoding::DecodeError> {
-        let bytes = Vec::<u8>::consensus_decode(reader, &ModuleRegistry::default())?;
+        let bytes = Vec::<u8>::consensus_decode_partial(reader, &ModuleRegistry::default())?;
         Mnemonic::from_entropy(&bytes).map_err(DecodeError::from_err)
     }
 

--- a/fedimint-bitcoind/src/bitcoincore.rs
+++ b/fedimint-bitcoind/src/bitcoincore.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::io::Cursor;
 use std::path::PathBuf;
 
 use anyhow::{anyhow as format_err, bail};
@@ -141,10 +140,8 @@ impl IBitcoindRpc for BitcoindClient {
     }
 
     async fn get_txout_proof(&self, txid: Txid) -> anyhow::Result<TxOutProof> {
-        TxOutProof::consensus_decode(
-            &mut Cursor::new(block_in_place(|| {
-                self.client.get_tx_out_proof(&[txid], None)
-            })?),
+        TxOutProof::consensus_decode_whole(
+            &block_in_place(|| self.client.get_tx_out_proof(&[txid], None))?,
             &ModuleDecoderRegistry::default(),
         )
         .map_err(|error| format_err!("Could not decode tx: {}", error))

--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -736,8 +736,10 @@ pub fn migrate_state(
 
         let decoders = ModuleDecoderRegistry::default();
         let mut cursor = std::io::Cursor::new(bytes);
-        let module_instance_id =
-            fedimint_core::core::ModuleInstanceId::consensus_decode(&mut cursor, &decoders)?;
+        let module_instance_id = fedimint_core::core::ModuleInstanceId::consensus_decode_partial(
+            &mut cursor,
+            &decoders,
+        )?;
 
         let state = match migrate(operation_id, &mut cursor)? {
             Some((mut state, operation_id)) => {
@@ -757,8 +759,10 @@ pub fn migrate_state(
 
         let decoders = ModuleDecoderRegistry::default();
         let mut cursor = std::io::Cursor::new(bytes);
-        let module_instance_id =
-            fedimint_core::core::ModuleInstanceId::consensus_decode(&mut cursor, &decoders)?;
+        let module_instance_id = fedimint_core::core::ModuleInstanceId::consensus_decode_partial(
+            &mut cursor,
+            &decoders,
+        )?;
 
         let state = match migrate(operation_id, &mut cursor)? {
             Some((mut state, operation_id)) => {

--- a/fedimint-client/src/lib.rs
+++ b/fedimint-client/src/lib.rs
@@ -983,7 +983,7 @@ impl Client {
 
         Ok(match client_secret {
             Some(client_secret) => Some(
-                T::consensus_decode(&mut client_secret.as_slice(), &ModuleRegistry::default())
+                T::consensus_decode_whole(&client_secret, &ModuleRegistry::default())
                     .map_err(|e| anyhow!("Decoding failed: {e}"))?,
             ),
             None => None,
@@ -3134,7 +3134,7 @@ pub async fn get_decoded_client_secret<T: Decodable>(db: &Database) -> anyhow::R
 
     match client_secret {
         Some(client_secret) => {
-            T::consensus_decode(&mut client_secret.as_slice(), &ModuleRegistry::default())
+            T::consensus_decode_whole(&client_secret, &ModuleRegistry::default())
                 .map_err(|e| anyhow!("Decoding failed: {e}"))
         }
         None => bail!("Encoded client secret not present in DB"),

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -380,16 +380,16 @@ impl Encodable for OperationLogEntry {
 }
 
 impl Decodable for OperationLogEntry {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         r: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let operation_type = String::consensus_decode(r, modules)?;
+        let operation_type = String::consensus_decode_partial(r, modules)?;
 
-        let meta_str = String::consensus_decode(r, modules)?;
+        let meta_str = String::consensus_decode_partial(r, modules)?;
         let meta = serde_json::from_str(&meta_str).map_err(DecodeError::from_err)?;
 
-        let outcome_str = Option::<String>::consensus_decode(r, modules)?;
+        let outcome_str = Option::<String>::consensus_decode_partial(r, modules)?;
         let outcome = outcome_str
             .map(|outcome_str| serde_json::from_str(&outcome_str).map_err(DecodeError::from_err))
             .transpose()?;

--- a/fedimint-client/src/secret.rs
+++ b/fedimint-client/src/secret.rs
@@ -65,7 +65,9 @@ pub trait RootSecretStrategy: Debug {
     ) -> std::io::Result<usize>;
 
     /// Deserialization function for the external encoding
-    fn consensus_decode(reader: &mut impl std::io::Read) -> Result<Self::Encoding, DecodeError>;
+    fn consensus_decode_partial(
+        reader: &mut impl std::io::Read,
+    ) -> Result<Self::Encoding, DecodeError>;
 
     /// Random generation function for the external secret type
     fn random<R>(rng: &mut R) -> Self::Encoding
@@ -92,8 +94,8 @@ impl RootSecretStrategy for PlainRootSecretStrategy {
         secret.consensus_encode(writer)
     }
 
-    fn consensus_decode(reader: &mut impl Read) -> Result<Self::Encoding, DecodeError> {
-        Self::Encoding::consensus_decode(reader, &ModuleRegistry::default())
+    fn consensus_decode_partial(reader: &mut impl Read) -> Result<Self::Encoding, DecodeError> {
+        Self::Encoding::consensus_decode_partial(reader, &ModuleRegistry::default())
     }
 
     fn random<R>(rng: &mut R) -> Self::Encoding

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -927,12 +927,12 @@ impl Encodable for ActiveStateKey {
 }
 
 impl Decodable for ActiveStateKey {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         reader: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let operation_id = OperationId::consensus_decode(reader, modules)?;
-        let state = DynState::consensus_decode(reader, modules)?;
+        let operation_id = OperationId::consensus_decode_partial(reader, modules)?;
+        let state = DynState::consensus_decode_partial(reader, modules)?;
 
         Ok(ActiveStateKey {
             operation_id,
@@ -958,12 +958,12 @@ impl Encodable for ActiveStateKeyBytes {
 }
 
 impl Decodable for ActiveStateKeyBytes {
-    fn consensus_decode<R: std::io::Read>(
+    fn consensus_decode_partial<R: std::io::Read>(
         reader: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let operation_id = OperationId::consensus_decode(reader, modules)?;
-        let module_instance_id = ModuleInstanceId::consensus_decode(reader, modules)?;
+        let operation_id = OperationId::consensus_decode_partial(reader, modules)?;
+        let module_instance_id = ModuleInstanceId::consensus_decode_partial(reader, modules)?;
         let mut bytes = Vec::new();
         reader
             .read_to_end(&mut bytes)
@@ -1099,12 +1099,12 @@ impl Encodable for InactiveStateKey {
 }
 
 impl Decodable for InactiveStateKey {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         reader: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let operation_id = OperationId::consensus_decode(reader, modules)?;
-        let state = DynState::consensus_decode(reader, modules)?;
+        let operation_id = OperationId::consensus_decode_partial(reader, modules)?;
+        let state = DynState::consensus_decode_partial(reader, modules)?;
 
         Ok(InactiveStateKey {
             operation_id,
@@ -1130,12 +1130,12 @@ impl Encodable for InactiveStateKeyBytes {
 }
 
 impl Decodable for InactiveStateKeyBytes {
-    fn consensus_decode<R: std::io::Read>(
+    fn consensus_decode_partial<R: std::io::Read>(
         reader: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let operation_id = OperationId::consensus_decode(reader, modules)?;
-        let module_instance_id = ModuleInstanceId::consensus_decode(reader, modules)?;
+        let operation_id = OperationId::consensus_decode_partial(reader, modules)?;
+        let module_instance_id = ModuleInstanceId::consensus_decode_partial(reader, modules)?;
         let mut bytes = Vec::new();
         reader
             .read_to_end(&mut bytes)

--- a/fedimint-client/src/sm/state.rs
+++ b/fedimint-client/src/sm/state.rs
@@ -361,11 +361,12 @@ impl Encodable for DynState {
     }
 }
 impl Decodable for DynState {
-    fn consensus_decode<R: std::io::Read>(
+    fn consensus_decode_partial<R: std::io::Read>(
         reader: &mut R,
         decoders: &::fedimint_core::module::registry::ModuleDecoderRegistry,
     ) -> Result<Self, fedimint_core::encoding::DecodeError> {
-        let module_id = fedimint_core::core::ModuleInstanceId::consensus_decode(reader, decoders)?;
+        let module_id =
+            fedimint_core::core::ModuleInstanceId::consensus_decode_partial(reader, decoders)?;
         decoders
             .get_expect(module_id)
             .decode_partial(reader, module_id, decoders)
@@ -467,12 +468,12 @@ impl<S> Decodable for OperationState<S>
 where
     S: State,
 {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         read: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let operation_id = OperationId::consensus_decode(read, modules)?;
-        let state = S::consensus_decode(read, modules)?;
+        let operation_id = OperationId::consensus_decode_partial(read, modules)?;
+        let state = S::consensus_decode_partial(read, modules)?;
 
         Ok(OperationState {
             operation_id,

--- a/fedimint-core/src/config.rs
+++ b/fedimint-core/src/config.rs
@@ -810,8 +810,8 @@ impl ServerModuleConfig {
     pub fn to_typed<T: TypedServerModuleConfig>(&self) -> anyhow::Result<T> {
         let local = serde_json::from_value(self.local.value().clone())?;
         let private = serde_json::from_value(self.private.value().clone())?;
-        let consensus = <T::Consensus>::consensus_decode(
-            &mut &self.consensus.config[..],
+        let consensus = <T::Consensus>::consensus_decode_whole(
+            &self.consensus.config[..],
             &ModuleRegistry::default(),
         )?;
 
@@ -830,8 +830,8 @@ pub trait TypedServerModuleConsensusConfig:
     fn version(&self) -> ModuleConsensusVersion;
 
     fn from_erased(erased: &ServerModuleConsensusConfig) -> anyhow::Result<Self> {
-        Ok(Self::consensus_decode(
-            &mut &erased.config[..],
+        Ok(Self::consensus_decode_whole(
+            &erased.config[..],
             &ModuleRegistry::default(),
         )?)
     }

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -289,12 +289,13 @@ impl DecoderBuilder {
                 } else {
                     &ModuleRegistry::default()
                 };
-                let typed_val = Type::consensus_decode(&mut reader, decoders).map_err(|err| {
-                    let err: anyhow::Error = err.into();
-                    DecodeError::new_custom(
-                        err.context(format!("while decoding Dyn type module_id={instance}")),
-                    )
-                })?;
+                let typed_val =
+                    Type::consensus_decode_partial(&mut reader, decoders).map_err(|err| {
+                        let err: anyhow::Error = err.into();
+                        DecodeError::new_custom(
+                            err.context(format!("while decoding Dyn type module_id={instance}")),
+                        )
+                    })?;
                 let dyn_val = typed_val.into_dyn(instance);
                 let any_val: Box<dyn Any> = Box::new(dyn_val);
                 Ok(any_val)

--- a/fedimint-core/src/encoding/bls12_381.rs
+++ b/fedimint-core/src/encoding/bls12_381.rs
@@ -10,11 +10,11 @@ impl Encodable for Scalar {
 }
 
 impl Decodable for Scalar {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let byte_array = <[u8; 32]>::consensus_decode(d, modules)?;
+        let byte_array = <[u8; 32]>::consensus_decode_partial(d, modules)?;
 
         Option::from(Self::from_bytes(&byte_array))
             .ok_or_else(|| DecodeError::from_str("Error decoding Scalar"))
@@ -28,11 +28,11 @@ impl Encodable for G1Affine {
 }
 
 impl Decodable for G1Affine {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let byte_array = <[u8; 48]>::consensus_decode(d, modules)?;
+        let byte_array = <[u8; 48]>::consensus_decode_partial(d, modules)?;
 
         Option::from(Self::from_compressed(&byte_array))
             .ok_or_else(|| DecodeError::from_str("Error decoding G1Affine"))
@@ -46,11 +46,11 @@ impl Encodable for G2Affine {
 }
 
 impl Decodable for G2Affine {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let byte_array = <[u8; 96]>::consensus_decode(d, modules)?;
+        let byte_array = <[u8; 96]>::consensus_decode_partial(d, modules)?;
 
         Option::from(Self::from_compressed(&byte_array))
             .ok_or_else(|| DecodeError::from_str("Error decoding G2Affine"))

--- a/fedimint-core/src/encoding/mod.rs
+++ b/fedimint-core/src/encoding/mod.rs
@@ -237,16 +237,7 @@ pub trait Decodable: Sized {
         let bytes = Vec::<u8>::from_hex(hex)
             .map_err(anyhow::Error::from)
             .map_err(DecodeError::new_custom)?;
-        let mut reader = std::io::Cursor::new(bytes);
-        Decodable::consensus_decode(&mut reader, modules)
-    }
-
-    fn consensus_decode_vec(
-        bytes: Vec<u8>,
-        modules: &ModuleDecoderRegistry,
-    ) -> Result<Self, DecodeError> {
-        let mut reader = std::io::Cursor::new(bytes);
-        Decodable::consensus_decode(&mut reader, modules)
+        Decodable::consensus_decode_whole(&bytes, modules)
     }
 }
 
@@ -966,7 +957,7 @@ mod tests {
 
         for (old, new) in test_vector {
             let old_bytes = old.consensus_encode_to_vec();
-            let decoded_new = New::consensus_decode_vec(old_bytes, &ModuleRegistry::default())
+            let decoded_new = New::consensus_decode_whole(&old_bytes, &ModuleRegistry::default())
                 .expect("Decoding failed");
             assert_eq!(decoded_new, new);
         }

--- a/fedimint-core/src/encoding/secp256k1.rs
+++ b/fedimint-core/src/encoding/secp256k1.rs
@@ -12,11 +12,11 @@ impl Encodable for secp256k1::ecdsa::Signature {
 }
 
 impl Decodable for secp256k1::ecdsa::Signature {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Self::from_compact(&<[u8; 64]>::consensus_decode(d, modules)?)
+        Self::from_compact(&<[u8; 64]>::consensus_decode_partial(d, modules)?)
             .map_err(DecodeError::from_err)
     }
 }
@@ -28,11 +28,12 @@ impl Encodable for secp256k1::PublicKey {
 }
 
 impl Decodable for secp256k1::PublicKey {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Self::from_slice(&<[u8; 33]>::consensus_decode(d, modules)?).map_err(DecodeError::from_err)
+        Self::from_slice(&<[u8; 33]>::consensus_decode_partial(d, modules)?)
+            .map_err(DecodeError::from_err)
     }
 }
 
@@ -43,11 +44,12 @@ impl Encodable for secp256k1::SecretKey {
 }
 
 impl Decodable for secp256k1::SecretKey {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Self::from_slice(&<[u8; 32]>::consensus_decode(d, modules)?).map_err(DecodeError::from_err)
+        Self::from_slice(&<[u8; 32]>::consensus_decode_partial(d, modules)?)
+            .map_err(DecodeError::from_err)
     }
 }
 
@@ -61,12 +63,13 @@ impl Encodable for secp256k1::schnorr::Signature {
 }
 
 impl Decodable for secp256k1::schnorr::Signature {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let bytes =
-            <[u8; secp256k1::constants::SCHNORR_SIGNATURE_SIZE]>::consensus_decode(d, modules)?;
+        let bytes = <[u8; secp256k1::constants::SCHNORR_SIGNATURE_SIZE]>::consensus_decode_partial(
+            d, modules,
+        )?;
         Self::from_slice(&bytes).map_err(DecodeError::from_err)
     }
 }
@@ -78,11 +81,11 @@ impl Encodable for bitcoin::key::Keypair {
 }
 
 impl Decodable for bitcoin::key::Keypair {
-    fn consensus_decode<D: Read>(
+    fn consensus_decode_partial<D: Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let sec_bytes = <[u8; 32]>::consensus_decode(d, modules)?;
+        let sec_bytes = <[u8; 32]>::consensus_decode_partial(d, modules)?;
         Self::from_seckey_slice(bitcoin::secp256k1::global::SECP256K1, &sec_bytes) // FIXME: evaluate security risk of global ctx
             .map_err(DecodeError::from_err)
     }

--- a/fedimint-core/src/encoding/threshold_crypto.rs
+++ b/fedimint-core/src/encoding/threshold_crypto.rs
@@ -22,14 +22,14 @@ impl Encodable for threshold_crypto::PublicKeySet {
 }
 
 impl Decodable for threshold_crypto::PublicKeySet {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         r: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let num_coeff = u64::consensus_decode(r, modules)?;
+        let num_coeff = u64::consensus_decode_partial(r, modules)?;
         (0..num_coeff)
             .map(|_| {
-                let bytes: [u8; 48] = Decodable::consensus_decode(r, modules)?;
+                let bytes: [u8; 48] = Decodable::consensus_decode_partial(r, modules)?;
                 let point = G1Affine::from_compressed(&bytes);
                 if point.is_some().unwrap_u8() == 1 {
                     let affine = point.unwrap();
@@ -52,11 +52,11 @@ impl Encodable for threshold_crypto::PublicKey {
 }
 
 impl Decodable for threshold_crypto::PublicKey {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         r: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let bytes: [u8; 48] = Decodable::consensus_decode(r, modules)?;
+        let bytes: [u8; 48] = Decodable::consensus_decode_partial(r, modules)?;
         Self::from_bytes(bytes).map_err(DecodeError::from_err)
     }
 }
@@ -68,11 +68,11 @@ impl Encodable for threshold_crypto::Ciphertext {
 }
 
 impl Decodable for threshold_crypto::Ciphertext {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         reader: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let ciphertext_bytes = Vec::<u8>::consensus_decode(reader, modules)?;
+        let ciphertext_bytes = Vec::<u8>::consensus_decode_partial(reader, modules)?;
         Self::from_bytes(&ciphertext_bytes).ok_or_else(|| {
             DecodeError::from_str("Error decoding threshold_crypto::Ciphertext from bytes")
         })
@@ -86,11 +86,11 @@ impl Encodable for threshold_crypto::DecryptionShare {
 }
 
 impl Decodable for threshold_crypto::DecryptionShare {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         reader: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let decryption_share_bytes = <[u8; 48]>::consensus_decode(reader, modules)?;
+        let decryption_share_bytes = <[u8; 48]>::consensus_decode_partial(reader, modules)?;
         Self::from_bytes(&decryption_share_bytes).ok_or_else(|| {
             DecodeError::from_str("Error decoding threshold_crypto::DecryptionShare from bytes")
         })

--- a/fedimint-core/src/invite_code.rs
+++ b/fedimint-core/src/invite_code.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
-use std::io::{Cursor, Read};
+use std::io::Read;
 use std::str::FromStr;
 
 use anyhow::ensure;
@@ -27,11 +27,11 @@ use crate::{NumPeersExt, PeerId};
 pub struct InviteCode(Vec<InviteCodePart>);
 
 impl Decodable for InviteCode {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         r: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let inner: Vec<InviteCodePart> = Decodable::consensus_decode(r, modules)?;
+        let inner: Vec<InviteCodePart> = Decodable::consensus_decode_partial(r, modules)?;
 
         if !inner
             .iter()
@@ -222,7 +222,7 @@ impl FromStr for InviteCode {
 
         ensure!(hrp == BECH32_HRP, "Invalid HRP in bech32 encoding");
 
-        let invite = Self::consensus_decode(&mut Cursor::new(data), &ModuleRegistry::default())?;
+        let invite = Self::consensus_decode_whole(&data, &ModuleRegistry::default())?;
 
         Ok(invite)
     }

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -205,7 +205,7 @@ impl Encodable for TransactionId {
 }
 
 impl Decodable for TransactionId {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         _modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {

--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -327,18 +327,18 @@ macro_rules! module_plugin_dyn_newtype_encode_decode {
         }
 
         impl Decodable for $name {
-            fn consensus_decode_from_finite_reader<R: std::io::Read>(
+            fn consensus_decode_partial_from_finite_reader<R: std::io::Read>(
                 reader: &mut R,
                 decoders: &$crate::module::registry::ModuleDecoderRegistry,
             ) -> Result<Self, fedimint_core::encoding::DecodeError> {
                 let module_instance_id =
-                    fedimint_core::core::ModuleInstanceId::consensus_decode_from_finite_reader(
+                    fedimint_core::core::ModuleInstanceId::consensus_decode_partial_from_finite_reader(
                         reader, decoders,
                     )?;
                 let val = match decoders.get(module_instance_id) {
                     Some(decoder) => {
                         let total_len_u64 =
-                            u64::consensus_decode_from_finite_reader(reader, decoders)?;
+                            u64::consensus_decode_partial_from_finite_reader(reader, decoders)?;
                         decoder.decode_complete(
                             reader,
                             total_len_u64,
@@ -357,7 +357,7 @@ macro_rules! module_plugin_dyn_newtype_encode_decode {
                         $crate::module::registry::DecodingMode::Fallback => $name::from_typed(
                             module_instance_id,
                             $crate::core::DynUnknown(
-                                Vec::<u8>::consensus_decode_from_finite_reader(
+                                Vec::<u8>::consensus_decode_partial_from_finite_reader(
                                     reader,
                                     &Default::default(),
                                 )?,

--- a/fedimint-core/src/tiered.rs
+++ b/fedimint-core/src/tiered.rs
@@ -130,11 +130,11 @@ impl<C> Decodable for Tiered<C>
 where
     C: Decodable,
 {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Ok(Self(BTreeMap::consensus_decode(d, modules)?))
+        Ok(Self(BTreeMap::consensus_decode_partial(d, modules)?))
     }
 }
 

--- a/fedimint-core/src/tiered_multi.rs
+++ b/fedimint-core/src/tiered_multi.rs
@@ -175,11 +175,11 @@ impl<C> Decodable for TieredMulti<C>
 where
     C: Decodable + 'static,
 {
-    fn consensus_decode_from_finite_reader<D: std::io::Read>(
+    fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Ok(Self(Tiered::consensus_decode_from_finite_reader(
+        Ok(Self(Tiered::consensus_decode_partial_from_finite_reader(
             d, modules,
         )?))
     }

--- a/fedimint-core/src/txoproof.rs
+++ b/fedimint-core/src/txoproof.rs
@@ -38,12 +38,12 @@ impl TxOutProof {
 }
 
 impl Decodable for TxOutProof {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let block_header = BlockHeader::consensus_decode(d, modules)?;
-        let merkle_proof = PartialMerkleTree::consensus_decode(d, modules)?;
+        let block_header = BlockHeader::consensus_decode_partial(d, modules)?;
+        let merkle_proof = PartialMerkleTree::consensus_decode_partial(d, modules)?;
 
         let mut transactions = Vec::new();
         let mut indices = Vec::new();
@@ -98,13 +98,13 @@ impl<'de> Deserialize<'de> for TxOutProof {
             let hex_str: Cow<str> = Deserialize::deserialize(deserializer)?;
             let bytes = Vec::from_hex(hex_str.as_ref()).map_err(D::Error::custom)?;
             Ok(
-                Self::consensus_decode(&mut Cursor::new(bytes), &empty_module_registry)
+                Self::consensus_decode_partial(&mut Cursor::new(bytes), &empty_module_registry)
                     .map_err(D::Error::custom)?,
             )
         } else {
             let bytes: &[u8] = Deserialize::deserialize(deserializer)?;
             Ok(
-                Self::consensus_decode(&mut Cursor::new(bytes), &empty_module_registry)
+                Self::consensus_decode_partial(&mut Cursor::new(bytes), &empty_module_registry)
                     .map_err(D::Error::custom)?,
             )
         }

--- a/fedimint-derive/src/lib.rs
+++ b/fedimint-derive/src/lib.rs
@@ -250,7 +250,7 @@ pub fn derive_decodable(input: TokenStream) -> TokenStream {
     let output = quote! {
         #[allow(deprecated)]
         impl ::fedimint_core::encoding::Decodable for #ident {
-            fn consensus_decode_from_finite_reader<D: std::io::Read>(d: &mut D, modules: &::fedimint_core::module::registry::ModuleDecoderRegistry) -> std::result::Result<Self, ::fedimint_core::encoding::DecodeError> {
+            fn consensus_decode_partial_from_finite_reader<D: std::io::Read>(d: &mut D, modules: &::fedimint_core::module::registry::ModuleDecoderRegistry) -> std::result::Result<Self, ::fedimint_core::encoding::DecodeError> {
                 use ::fedimint_core:: anyhow::Context;
                 #decode_inner
             }
@@ -300,7 +300,7 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
             quote! {
                 #variant_idx => {
                     // FIXME: feels like there's a way more elegant way to do this with limited readers
-                    let bytes: Vec<u8> = ::fedimint_core::encoding::Decodable::consensus_decode_from_finite_reader(d, modules)
+                    let bytes: Vec<u8> = ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(d, modules)
                         .context(concat!(
                             "Decoding bytes of ",
                             stringify!(#ident)
@@ -330,7 +330,7 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
     let default_match_arm = if variants.iter().any(is_default_variant_enforce_valid) {
         quote! {
             variant => {
-                let bytes: Vec<u8> = ::fedimint_core::encoding::Decodable::consensus_decode_from_finite_reader(d, modules)
+                let bytes: Vec<u8> = ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(d, modules)
                     .context(concat!(
                         "Decoding default variant of ",
                         stringify!(#ident)
@@ -351,7 +351,7 @@ fn derive_enum_decode(ident: &Ident, variants: &Punctuated<Variant, Comma>) -> T
     };
 
     quote! {
-        let variant = <u64 as ::fedimint_core::encoding::Decodable>::consensus_decode_from_finite_reader(d, modules)
+        let variant = <u64 as ::fedimint_core::encoding::Decodable>::consensus_decode_partial_from_finite_reader(d, modules)
             .context(concat!(
                 "Decoding default variant of ",
                 stringify!(#ident)
@@ -400,7 +400,7 @@ fn derive_tuple_decode_block(
     quote! {
         {
             #(
-                let #field_names = ::fedimint_core::encoding::Decodable::consensus_decode_from_finite_reader(#reader, modules)
+                let #field_names = ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(#reader, modules)
                     .context(concat!(
                         "Decoding tuple block ",
                         stringify!(#ident),
@@ -426,7 +426,7 @@ fn derive_named_decode_block(
     quote! {
         {
             #(
-                let #variant_fields = ::fedimint_core::encoding::Decodable::consensus_decode_from_finite_reader(#reader, modules)
+                let #variant_fields = ::fedimint_core::encoding::Decodable::consensus_decode_partial_from_finite_reader(#reader, modules)
                     .context(concat!(
                         "Decoding named block field: ",
                         stringify!(#ident),

--- a/fedimint-server/src/config/distributedgen.rs
+++ b/fedimint-server/src/config/distributedgen.rs
@@ -592,7 +592,7 @@ impl<'a> PeerHandleOps for PeerHandle<'a> {
                 .await?
             {
                 (peer, DkgPeerMsg::Module(bytes)) => {
-                    let received_data: T = T::consensus_decode_vec(bytes, &modules)
+                    let received_data: T = T::consensus_decode_whole(&bytes, &modules)
                         .map_err(|_| DkgError::ModuleDecodeError(kind.clone()))?;
                     peer_data.insert(peer, received_data);
                 }

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -386,7 +386,7 @@ impl ConsensusEngine {
                             }
                         }
 
-                        if let Ok(items) = Vec::<ConsensusItem>::consensus_decode(&mut bytes.as_slice(), &self.decoders()){
+                        if let Ok(items) = Vec::<ConsensusItem>::consensus_decode_whole(&bytes, &self.decoders()){
                             for item in items {
                                 if self.process_consensus_item(
                                     session_index,

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -1,4 +1,3 @@
-use std::io::Cursor;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -106,8 +105,8 @@ impl BitcoinTest for RealBitcoinTestNoLock {
             .client
             .get_raw_transaction(&id, Some(mined_block_hash))
             .expect(Self::ERROR);
-        let proof = TxOutProof::consensus_decode(
-            &mut Cursor::new(loop {
+        let proof = TxOutProof::consensus_decode_whole(
+            &loop {
                 match self.client.get_tx_out_proof(&[id], None) {
                     Ok(o) => break o,
                     Err(e) => {
@@ -119,7 +118,7 @@ impl BitcoinTest for RealBitcoinTestNoLock {
                         panic!("Could not get txoutproof: {e}");
                     }
                 }
-            }),
+            },
             &ModuleDecoderRegistry::default(),
         )
         .expect(Self::ERROR);

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -44,7 +44,7 @@ pub fn test_decodable_with_decoders<T>(data: &[u8], decoders: &ModuleDecoderRegi
 where
     T: Decodable + Encodable,
 {
-    if let Ok(v) = T::consensus_decode(&mut &data[..], decoders) {
+    if let Ok(v) = T::consensus_decode_partial(&mut &data[..], decoders) {
         assert!(data.len() <= encoding::MAX_DECODE_SIZE);
 
         let encoded_vec = v.consensus_encode_to_vec();
@@ -63,8 +63,8 @@ where
     T: Decodable + Encodable + fmt::Debug,
 {
     match (
-        T::consensus_decode(&mut &data[..], decoders),
-        T::consensus_decode(
+        T::consensus_decode_partial(&mut &data[..], decoders),
+        T::consensus_decode_partial(
             &mut &data[..],
             &ModuleDecoderRegistry::default().with_fallback(),
         ),

--- a/modules/fedimint-dummy-client/src/db.rs
+++ b/modules/fedimint-dummy-client/src/db.rs
@@ -86,7 +86,7 @@ pub(crate) fn get_v1_migrated_state(
     cursor: &mut Cursor<&[u8]>,
 ) -> anyhow::Result<Option<(Vec<u8>, OperationId)>> {
     let decoders = ModuleDecoderRegistry::default();
-    let dummy_sm_variant = u16::consensus_decode(cursor, &decoders)?;
+    let dummy_sm_variant = u16::consensus_decode_partial(cursor, &decoders)?;
 
     // We are only migrating the type of one of the variants, so we do nothing on
     // other discriminants.
@@ -94,10 +94,10 @@ pub(crate) fn get_v1_migrated_state(
         return Ok(None);
     }
 
-    let _unreachable_state_length = u16::consensus_decode(cursor, &decoders)?;
+    let _unreachable_state_length = u16::consensus_decode_partial(cursor, &decoders)?;
 
     // Migrate `Unreachable` states to `OutputDone`
-    let unreachable = Unreachable::consensus_decode(cursor, &decoders)?;
+    let unreachable = Unreachable::consensus_decode_partial(cursor, &decoders)?;
     let new_state = DummyStateMachine::OutputDone(
         unreachable.amount,
         unreachable.txid,
@@ -115,13 +115,13 @@ struct Unreachable {
 }
 
 impl Decodable for Unreachable {
-    fn consensus_decode<R: std::io::Read>(
+    fn consensus_decode_partial<R: std::io::Read>(
         reader: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, fedimint_core::encoding::DecodeError> {
-        let operation_id = OperationId::consensus_decode(reader, modules)?;
-        let txid = TransactionId::consensus_decode(reader, modules)?;
-        let amount = Amount::consensus_decode(reader, modules)?;
+        let operation_id = OperationId::consensus_decode_partial(reader, modules)?;
+        let txid = TransactionId::consensus_decode_partial(reader, modules)?;
+        let amount = Amount::consensus_decode_partial(reader, modules)?;
 
         Ok(Unreachable {
             operation_id,

--- a/modules/fedimint-ln-client/src/db.rs
+++ b/modules/fedimint-ln-client/src/db.rs
@@ -112,23 +112,23 @@ pub(crate) fn get_v1_migrated_state(
     }
 
     let decoders = ModuleDecoderRegistry::default();
-    let ln_sm_variant = u16::consensus_decode(cursor, &decoders)?;
+    let ln_sm_variant = u16::consensus_decode_partial(cursor, &decoders)?;
 
     // If the state machine is not a receive state machine, return None
     if ln_sm_variant != 2 {
         return Ok(None);
     }
 
-    let _ln_sm_len = u16::consensus_decode(cursor, &decoders)?;
-    let _operation_id = OperationId::consensus_decode(cursor, &decoders)?;
-    let receive_sm_variant = u16::consensus_decode(cursor, &decoders)?;
+    let _ln_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
+    let _operation_id = OperationId::consensus_decode_partial(cursor, &decoders)?;
+    let receive_sm_variant = u16::consensus_decode_partial(cursor, &decoders)?;
 
     let new = match receive_sm_variant {
         // SubmittedOfferV0
         0 => {
-            let _receive_sm_len = u16::consensus_decode(cursor, &decoders)?;
+            let _receive_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
 
-            let v0 = LightningReceiveSubmittedOfferV0::consensus_decode(cursor, &decoders)?;
+            let v0 = LightningReceiveSubmittedOfferV0::consensus_decode_partial(cursor, &decoders)?;
 
             let new_offer = LightningReceiveSubmittedOffer {
                 offer_txid: v0.offer_txid,
@@ -143,9 +143,9 @@ pub(crate) fn get_v1_migrated_state(
         }
         // ConfirmedInvoiceV0
         2 => {
-            let _receive_sm_len = u16::consensus_decode(cursor, &decoders)?;
+            let _receive_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
             let confirmed_old =
-                LightningReceiveConfirmedInvoiceV0::consensus_decode(cursor, &decoders)?;
+                LightningReceiveConfirmedInvoiceV0::consensus_decode_partial(cursor, &decoders)?;
             let confirmed_new = LightningReceiveConfirmedInvoice {
                 invoice: confirmed_old.invoice,
                 receiving_key: ReceivingKey::Personal(confirmed_old.receiving_key),
@@ -168,22 +168,22 @@ pub(crate) fn get_v2_migrated_state(
     cursor: &mut Cursor<&[u8]>,
 ) -> anyhow::Result<Option<(Vec<u8>, OperationId)>> {
     let decoders = ModuleDecoderRegistry::default();
-    let ln_sm_variant = u16::consensus_decode(cursor, &decoders)?;
+    let ln_sm_variant = u16::consensus_decode_partial(cursor, &decoders)?;
 
     // If the state machine is not a receive state machine, return None
     if ln_sm_variant != 2 {
         return Ok(None);
     }
 
-    let _ln_sm_len = u16::consensus_decode(cursor, &decoders)?;
-    let _operation_id = OperationId::consensus_decode(cursor, &decoders)?;
-    let receive_sm_variant = u16::consensus_decode(cursor, &decoders)?;
+    let _ln_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
+    let _operation_id = OperationId::consensus_decode_partial(cursor, &decoders)?;
+    let receive_sm_variant = u16::consensus_decode_partial(cursor, &decoders)?;
     if receive_sm_variant != 5 {
         return Ok(None);
     }
 
-    let _receive_sm_len = u16::consensus_decode(cursor, &decoders)?;
-    let old = LightningReceiveSubmittedOffer::consensus_decode(cursor, &decoders)?;
+    let _receive_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
+    let old = LightningReceiveSubmittedOffer::consensus_decode_partial(cursor, &decoders)?;
 
     let new_recv = LightningClientStateMachines::Receive(LightningReceiveStateMachine {
         operation_id,
@@ -201,18 +201,18 @@ pub(crate) fn get_v3_migrated_state(
     cursor: &mut Cursor<&[u8]>,
 ) -> anyhow::Result<Option<(Vec<u8>, OperationId)>> {
     let decoders = ModuleDecoderRegistry::default();
-    let ln_sm_variant = u16::consensus_decode(cursor, &decoders)?;
+    let ln_sm_variant = u16::consensus_decode_partial(cursor, &decoders)?;
 
     // If the state machine is not a pay state machine, return None
     if ln_sm_variant != 1 {
         return Ok(None);
     }
 
-    let _ln_sm_len = u16::consensus_decode(cursor, &decoders)?;
-    let common = LightningPayCommon::consensus_decode(cursor, &decoders)?;
-    let pay_sm_variant = u16::consensus_decode(cursor, &decoders)?;
+    let _ln_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
+    let common = LightningPayCommon::consensus_decode_partial(cursor, &decoders)?;
+    let pay_sm_variant = u16::consensus_decode_partial(cursor, &decoders)?;
 
-    let _pay_sm_len = u16::consensus_decode(cursor, &decoders)?;
+    let _pay_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
 
     // if the pay state machine is not `Refund` or `Funded` variant, return none
     match pay_sm_variant {
@@ -225,7 +225,7 @@ pub(crate) fn get_v3_migrated_state(
                 pub timelock: u32,
             }
 
-            let v0 = LightningPayFundedV0::consensus_decode(cursor, &decoders)?;
+            let v0 = LightningPayFundedV0::consensus_decode_partial(cursor, &decoders)?;
             let v1 = LightningPayFunded {
                 payload: v0.payload,
                 gateway: v0.gateway,
@@ -249,7 +249,7 @@ pub(crate) fn get_v3_migrated_state(
                 out_points: Vec<OutPoint>,
             }
 
-            let v0 = LightningPayRefundV0::consensus_decode(cursor, &decoders)?;
+            let v0 = LightningPayRefundV0::consensus_decode_partial(cursor, &decoders)?;
             let v1 = LightningPayRefund {
                 txid: v0.txid,
                 out_points: v0.out_points,

--- a/modules/fedimint-ln-common/src/contracts/incoming.rs
+++ b/modules/fedimint-ln-common/src/contracts/incoming.rs
@@ -102,13 +102,13 @@ impl Encodable for OfferId {
 }
 
 impl Decodable for OfferId {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Ok(OfferId::from_byte_array(Decodable::consensus_decode(
-            d, modules,
-        )?))
+        Ok(OfferId::from_byte_array(
+            Decodable::consensus_decode_partial(d, modules)?,
+        ))
     }
 }
 

--- a/modules/fedimint-ln-common/src/contracts/mod.rs
+++ b/modules/fedimint-ln-common/src/contracts/mod.rs
@@ -106,13 +106,13 @@ impl Encodable for ContractId {
 }
 
 impl Decodable for ContractId {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        Ok(ContractId::from_byte_array(Decodable::consensus_decode(
-            d, modules,
-        )?))
+        Ok(ContractId::from_byte_array(
+            Decodable::consensus_decode_partial(d, modules)?,
+        ))
     }
 }
 

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -276,11 +276,11 @@ impl Encodable for LightningGatewayRegistration {
 }
 
 impl Decodable for LightningGatewayRegistration {
-    fn consensus_decode<R: Read>(
+    fn consensus_decode_partial<R: Read>(
         r: &mut R,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
-        let json_repr = String::consensus_decode(r, modules)?;
+        let json_repr = String::consensus_decode_partial(r, modules)?;
         serde_json::from_str(&json_repr).map_err(|e| {
             DecodeError::new_custom(
                 anyhow::Error::new(e).context("Failed to deserialize LightningGatewayRegistration"),

--- a/modules/fedimint-meta-common/src/lib.rs
+++ b/modules/fedimint-meta-common/src/lib.rs
@@ -122,11 +122,11 @@ impl MetaValue {
 }
 
 impl Decodable for MetaValue {
-    fn consensus_decode<R: std::io::Read>(
+    fn consensus_decode_partial<R: std::io::Read>(
         r: &mut R,
         modules: &fedimint_core::module::registry::ModuleDecoderRegistry,
     ) -> Result<Self, fedimint_core::encoding::DecodeError> {
-        let bytes = Vec::consensus_decode(r, modules)?;
+        let bytes = Vec::consensus_decode_partial(r, modules)?;
 
         if Self::MAX_LEN_BYTES < bytes.len() {
             return Err(DecodeError::new_custom(anyhow::format_err!("Too long")));

--- a/modules/fedimint-mint-client/src/client_db.rs
+++ b/modules/fedimint-mint-client/src/client_db.rs
@@ -152,12 +152,12 @@ pub(crate) fn migrate_state_to_v2(
 ) -> anyhow::Result<Option<(Vec<u8>, OperationId)>> {
     let decoders = ModuleDecoderRegistry::default();
 
-    let mint_client_state_machine_variant = u16::consensus_decode(cursor, &decoders)?;
+    let mint_client_state_machine_variant = u16::consensus_decode_partial(cursor, &decoders)?;
 
     let new_mint_state_machine = match mint_client_state_machine_variant {
         0 => {
-            let _output_sm_len = u16::consensus_decode(cursor, &decoders)?;
-            let old_state = MintOutputStateMachineV0::consensus_decode(cursor, &decoders)?;
+            let _output_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
+            let old_state = MintOutputStateMachineV0::consensus_decode_partial(cursor, &decoders)?;
 
             MintClientStateMachines::Output(MintOutputStateMachine {
                 common: MintOutputCommon {
@@ -172,8 +172,8 @@ pub(crate) fn migrate_state_to_v2(
             })
         }
         1 => {
-            let _input_sm_len = u16::consensus_decode(cursor, &decoders)?;
-            let old_state = MintInputStateMachineV0::consensus_decode(cursor, &decoders)?;
+            let _input_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
+            let old_state = MintInputStateMachineV0::consensus_decode_partial(cursor, &decoders)?;
 
             MintClientStateMachines::Input(MintInputStateMachine {
                 common: MintInputCommon {
@@ -188,8 +188,8 @@ pub(crate) fn migrate_state_to_v2(
             })
         }
         2 => {
-            let _oob_sm_len = u16::consensus_decode(cursor, &decoders)?;
-            let old_state = MintOOBStateMachineV0::consensus_decode(cursor, &decoders)?;
+            let _oob_sm_len = u16::consensus_decode_partial(cursor, &decoders)?;
+            let old_state = MintOOBStateMachineV0::consensus_decode_partial(cursor, &decoders)?;
 
             let new_state = match old_state.state {
                 MintOOBStatesV0::Created(created) => MintOOBStates::Created(created),

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -1,4 +1,3 @@
-use std::io::Cursor;
 use std::time::Duration;
 
 use bls12_381::G1Affine;
@@ -302,11 +301,9 @@ async fn backup_encode_decode_roundtrip() -> anyhow::Result<()> {
 
     let backup_bin = fedimint_core::encoding::Encodable::consensus_encode_to_vec(&backup);
 
-    let backup_decoded: ClientBackup = fedimint_core::encoding::Decodable::consensus_decode(
-        &mut Cursor::new(&backup_bin),
-        client.decoders(),
-    )
-    .expect("decode");
+    let backup_decoded: ClientBackup =
+        fedimint_core::encoding::Decodable::consensus_decode_whole(&backup_bin, client.decoders())
+            .expect("decode");
 
     assert_eq!(backup, backup_decoded);
 

--- a/modules/fedimint-wallet-common/src/txoproof.rs
+++ b/modules/fedimint-wallet-common/src/txoproof.rs
@@ -197,15 +197,15 @@ fn validate_peg_in_proof(proof: &PegInProof) -> Result<(), anyhow::Error> {
 }
 
 impl Decodable for PegInProof {
-    fn consensus_decode<D: std::io::Read>(
+    fn consensus_decode_partial<D: std::io::Read>(
         d: &mut D,
         modules: &ModuleDecoderRegistry,
     ) -> Result<Self, DecodeError> {
         let slf = PegInProof {
-            txout_proof: TxOutProof::consensus_decode(d, modules)?,
-            transaction: Transaction::consensus_decode(d, modules)?,
-            output_idx: u32::consensus_decode(d, modules)?,
-            tweak_contract_key: PublicKey::consensus_decode(d, modules)?,
+            txout_proof: TxOutProof::consensus_decode_partial(d, modules)?,
+            transaction: Transaction::consensus_decode_partial(d, modules)?,
+            output_idx: u32::consensus_decode_partial(d, modules)?,
+            tweak_contract_key: PublicKey::consensus_decode_partial(d, modules)?,
         };
 
         validate_peg_in_proof(&slf).map_err(DecodeError::new_custom)?;
@@ -227,8 +227,6 @@ pub enum PegInProofError {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-
     use fedimint_core::encoding::Decodable;
     use fedimint_core::module::registry::ModuleDecoderRegistry;
     use fedimint_core::txoproof::TxOutProof;
@@ -250,8 +248,8 @@ mod tests {
         58a30f7ae5b909ffdd020073f04ff370000";
 
         let empty_module_registry = ModuleDecoderRegistry::default();
-        let txoutproof = TxOutProof::consensus_decode(
-            &mut Cursor::new(Vec::from_hex(txoutproof_hex).unwrap()),
+        let txoutproof = TxOutProof::consensus_decode_whole(
+            &Vec::from_hex(txoutproof_hex).unwrap(),
             &empty_module_registry,
         )
         .unwrap();


### PR DESCRIPTION
Recently I discovered that we were not checking if the keys and values in the DB were fully decoded, so I introduced `Decodable::consensus_decode_whole` to make it more visible and upfront.

I was just writting https://github.com/rust-bitcoin/rust-bitcoin/issues/3887 to share this lesson with `rust-bitcoin` devs, and there I wrote:

> I was (and still kind of am) considering renaming `consensus_decode` to `consensus_decode_partial`, (and `consensus_decode_from_finite_reader` to `consensus_decode_partial_from_finite_reader`.

and inspired by it, I decide to check some stuff, and indeed the helpers `Decodable::consensus_decode_hex` and `Decodable::consensus_decode_vec` were forwarding to `Decodable::consensus_decode`, which means they ignore extra bytes. I checked where they were used and they were all used in places where extra bytes should not be happening, and possibly even an issue.

This was the last straw that made me convinced that `_partial` must there in the names, because 99% of the time the user will want the behavior of `_whole`. `Decodable::consensus_decode` ignoring bytes seems like a default when you are designing this trait and implementing things like derives that compose types together, but after that is done, downstream users will only ever (99%) be decoding already framed messages etc. and not stream multiple types via a single reader.

After going through the refactor I discover lots of places where we should be just using `_whole`, but habitually we've just defaulted to partial.

<!--


# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
