### PR TITLE
chore: turn off tor by default

### DIFF
--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -31,7 +31,7 @@ fedimint-mint-common = { workspace = true }
 fedimint-mint-server = { workspace = true }
 fedimint-portalloc = { workspace = true }
 fedimint-server = { workspace = true }
-fedimint-testing = { workspace = true }
+fedimint-testing = { workspace = true, features = ["tor"] }
 fedimint-unknown-server = { workspace = true }
 fedimint-wallet-client = { workspace = true, features = ["cli"] }
 fedimint-wallet-server = { workspace = true }

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -12,13 +12,12 @@ repository = "https://github.com/fedimint/fedimint"
 development = ["tokio-test"]
 
 [features]
-default = ["tor"]
 tor = [
     "dep:strum",
     "dep:curve25519-dalek",
     "arti-client/tokio",
     "arti-client/rustls",
-    "arti-client/onion-service-client"
+    "arti-client/onion-service-client",
 ]
 
 [lib]

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -31,9 +31,9 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.40"
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.6.0-alpha", default-features = false }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.6.0-alpha" }
 fedimint-bip39 = { workspace = true }
-fedimint-client = { path = "../fedimint-client", version = "=0.6.0-alpha", default-features = false }
+fedimint-client = { path = "../fedimint-client", version = "=0.6.0-alpha" }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-ln-client = { workspace = true, features = ["cli"] }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -17,7 +17,6 @@ normal = ["aquamarine"]
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
-default = ["tor"]
 tor = ["fedimint-api-client/tor"]
 
 [lib]
@@ -31,7 +30,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.6.0-alpha", default-features = false }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.6.0-alpha" }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/fedimint/fedimint"
 rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
-default = ["tor"]
 tor = ["ln-gateway/tor"]
 
 [lib]
@@ -38,7 +37,7 @@ fedimint-server = { workspace = true }
 fedimint-testing-core = { workspace = true }
 fs-lock = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway", version = "=0.6.0-alpha", default-features = false }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway", version = "=0.6.0-alpha" }
 rand = { workspace = true }
 tempfile = "3.15.0"
 tokio = { workspace = true }

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -135,7 +135,7 @@ impl FederationTest {
         gw.handle_connect_federation(ConnectFedPayload {
             invite_code: self.invite_code().to_string(),
             #[cfg(feature = "tor")]
-            use_tor: Some(false), // TODO: (@leonardo) Should we get it from self.configs too ?
+            use_tor: Some(false),
             recover: Some(false),
         })
         .await

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -31,7 +31,7 @@ fedimint-eventlog = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-mint-client = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { package = "fedimint-ln-gateway", path = "../ln-gateway", version = "=0.6.0-alpha", default-features = false }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../ln-gateway", version = "=0.6.0-alpha" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -9,7 +9,6 @@ readme = "../../README.md"
 repository = "https://github.com/fedimint/fedimint"
 
 [features]
-default = ["tor"]
 tor = ["fedimint-client/tor", "fedimint-api-client/tor"]
 
 [[bin]]
@@ -29,16 +28,16 @@ anyhow = { workspace = true }
 aquamarine = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
-axum = { version = "0.7.9", features = [ "json" ] }
+axum = { version = "0.7.9", features = ["json"] }
 bcrypt = { workspace = true }
 bitcoin = { workspace = true }
 clap = { workspace = true }
 erased-serde = { workspace = true }
 esplora-client = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.6.0-alpha", default-features = false }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.6.0-alpha" }
 fedimint-bip39 = { version = "=0.6.0-alpha", path = "../../fedimint-bip39" }
 fedimint-bitcoind = { workspace = true }
-fedimint-client = { path = "../../fedimint-client", version = "=0.6.0-alpha", default-features = false }
+fedimint-client = { path = "../../fedimint-client", version = "=0.6.0-alpha" }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-ln-client = { workspace = true }


### PR DESCRIPTION
Tor pulls in a sqlite dependency, which requires downstream projects that depend on these crates to depend on sqlite in order to build, even if they're not using tor. Tor is already a feature, I think it makes sense to be optional.