### PR TITLE
chore: ban HashMap on server side

### DIFF
--- a/fedimint-server/clippy.toml
+++ b/fedimint-server/clippy.toml
@@ -1,0 +1,2 @@
+# Note: this file symlinked from multiple crates
+disallowed-types = ["std::collections::HashMap", "std::collections::HashSet"]

--- a/modules/fedimint-dummy-server/clippy.toml
+++ b/modules/fedimint-dummy-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-empty-server/clippy.toml
+++ b/modules/fedimint-empty-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-ln-server/clippy.toml
+++ b/modules/fedimint-ln-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-lnv2-server/clippy.toml
+++ b/modules/fedimint-lnv2-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-meta-server/clippy.toml
+++ b/modules/fedimint-meta-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-mint-server/clippy.toml
+++ b/modules/fedimint-mint-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-unknown-server/clippy.toml
+++ b/modules/fedimint-unknown-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/modules/fedimint-wallet-server/clippy.toml
+++ b/modules/fedimint-wallet-server/clippy.toml
@@ -1,0 +1,1 @@
+../../fedimint-server/clippy.toml

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -20,13 +20,13 @@ let
   gitHashPlaceholderValue = "01234569abcdef7afa1d2683a099c7af48a523c1";
 
   filterWorkspaceDepsBuildFilesRegex = [
-    "Cargo.lock"
-    "Cargo.toml"
+    "Cargo\\.lock"
+    "Cargo\\.toml"
     ".cargo"
     ".cargo/.*"
     ".config"
     ".config/.*"
-    ".*/Cargo.toml"
+    ".*/Cargo\\.toml"
     ".*/proto/.*"
   ];
 
@@ -73,12 +73,13 @@ let
     filterSrcWithRegexes (
       filterWorkspaceDepsBuildFilesRegex
       ++ [
-        ".*.rs"
-        ".*.html"
+        ".*\\.rs"
+        ".*\\.html"
         ".*/proto/.*"
+        ".*/clippy\\.toml"
         "db/migrations/.*"
         "devimint/src/cfg/.*"
-        "docs/.*.md"
+        "docs/.*\\.md"
       ]
     ) src;
 
@@ -88,13 +89,13 @@ let
     filterSrcWithRegexes (
       filterWorkspaceDepsBuildFilesRegex
       ++ [
-        ".*.rs"
-        ".*.html"
+        ".*\\.rs"
+        ".*\\.html"
         ".*/proto/.*"
         "db/migrations/.*"
         "devimint/src/cfg/.*"
         "scripts/.*"
-        "docs/.*.md"
+        "docs/.*\\.md"
       ]
     ) src;
 


### PR DESCRIPTION
use clippy disallowed types to ban hashmap and hashset from server and modules.

Looks like we are using it in many places
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
