### PR TITLE
chore(docs): generalize "setting up Fedimint" docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ a [Lightning Gateway](https://github.com/fedimint/fedimint/blob/master/docs/gate
 is willing to swap ecash in exchange for sending/receiving lightning payments. The Lightning Gateway is not a guardian
 and acts as an untrusted economic actor serving the federation.
 
-### Running Fedimint on Mutinynet
+### Setting up Federations
 
-See the [Fedimint Mutinynet Setup Guide](./docs/setup-docs.md). You can modify the configuration options to deploy it
-with.
+If you are interested in setting up a Fedimint federation, refer to [Setting up Fedimint federation](./docs/deploying.md)
+documentation.
 
 ## For Developers
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,0 +1,55 @@
+# Setting up Fedimint federation
+
+This guide is meant for users interested in being Fedimint guardians
+and setting up own federation.
+
+## Target audience
+
+Using an existing Fedimint federation as an user is easy and comes
+down to downloading a client application on a device like a phone.
+
+Setting up and maintaining Federation is more challenging as it
+requires better understanding of its architecture and handling of its
+server side components.
+
+In near future we expect many hosted Fedimint solutions, which should
+make setting up federations relatively easy.
+
+Self-hosting your own federation is preferable. It is very similar
+to self-hosting any other software and requires some technical
+understanding in this area.
+
+## Overview
+
+What federation really is are 4 or more Guardians independently running `fedimintd` server software.
+
+A `fedimintd` setup requires:
+
+* setting DNS domain
+* prunned `bitcoind` node
+* TLS termination software like `caddy` or `nginx`
+
+
+In addition, a practical federation requires a Lightning Gateway
+to join the federation, and someone needs to set it up and
+run, though one gateway can join and server multiple
+federations.
+
+A `ln-gateway` setup requires:
+
+* an unprunned `bitcoind` node
+* possibly setting up lightning node
+
+## Guides
+
+Due to diverse nature of server-side software, it is impossible to come up with a single
+guide that would cover all scenarios. We are trying to create and maintain guides
+for variety of cases.
+
+For help please try [Fedimint Github Discussions](https://github.com/fedimint/fedimint/discussions)
+or #mint-ops channel on [Fedimint dev chat](https://chat.fedimint.org/).
+
+Please see following guides:
+
+* [Fedimint Mutinynet Setup Guide](./deploying/docker-mutiny.md) - a detailed guide setting up both Fedimint and Lightning Gateway using `docker`
+* [Fedimint NixOS Deployment Repo](https://github.com/fedimint/nixos-deployment) - an example template for setting up Fedimint using NixOS server.

--- a/docs/deploying/docker-mutiny.md
+++ b/docs/deploying/docker-mutiny.md
@@ -1,4 +1,4 @@
-# Setting up a Federation + Lightning Gateway
+# Setting up a Fedimint federation and Lightning Gateway
 
 This is a guide for setting up a 3/4 federation + lightning gateway. You can run this same setup on a different test network or on mainnet with real bitcoin,
 


### PR DESCRIPTION
Currently from the README we link straight into very long and detailed and hands-on guide.


I think we need a single page that does some prep-talk, overviews and then points the reader at more detailed and specific guides, in which the existing guide will be just one of the items.


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
