### PR TITLE
fix(wallet): verify utxo is known by server for v1 inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,6 +2101,7 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "jsonrpsee-core",
+ "jsonrpsee-types",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "lru",

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -34,6 +34,7 @@ fedimint-logging = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 jsonrpsee-core = { version = "0.24.7" }
+jsonrpsee-types = { version = "0.24.7" }
 lru = "0.12.5"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/fedimint-api-client/src/api/error.rs
+++ b/fedimint-api-client/src/api/error.rs
@@ -7,6 +7,7 @@ use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_core::PeerId;
 use fedimint_logging::LOG_CLIENT_NET_API;
 use jsonrpsee_core::client::Error as JsonRpcClientError;
+use jsonrpsee_types::error::METHOD_NOT_FOUND_CODE;
 #[cfg(target_family = "wasm")]
 use jsonrpsee_wasm_client::{Client as WsClient, WasmClientBuilder as WsClientBuilder};
 use serde::Serialize;
@@ -167,6 +168,15 @@ impl FederationError {
     /// Get errors from different peers.
     pub fn get_peer_errors(&self) -> impl Iterator<Item = (PeerId, &PeerError)> {
         self.peer_errors.iter().map(|(peer, error)| (*peer, error))
+    }
+
+    pub fn any_peer_error_method_not_found(&self) -> bool {
+        self.peer_errors.values().any(|peer_err| {
+            matches!(
+                peer_err,
+                PeerError::Rpc(JsonRpcClientError::Call(err)) if err.code() == METHOD_NOT_FOUND_CODE
+            )
+        })
     }
 }
 

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -43,10 +43,8 @@ where
             .await;
 
         if let Err(e) = &response {
-            for e in e.peer_errors.values() {
-                if e.to_string().contains("Method not found") {
-                    return Ok(ModuleConsensusVersion::new(2, 0));
-                }
+            if e.any_peer_error_method_not_found() {
+                return Ok(ModuleConsensusVersion::new(2, 0));
             }
         }
 

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -11,7 +11,6 @@ use fedimint_core::db::{
     AutocommitError, Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _,
 };
 use fedimint_core::envs::is_running_in_test_env;
-use fedimint_core::module::ModuleConsensusVersion;
 use fedimint_core::task::sleep;
 use fedimint_core::txoproof::TxOutProof;
 use fedimint_core::util::FmtCompactAnyhow as _;
@@ -380,8 +379,7 @@ async fn check_idx_pegins(
         debug!(target: LOG_CLIENT_MODULE_WALLET, %txid, %out_idx, %finality_delay, %tx_block_count, %current_consensus_block_count, "Ready to claim");
 
         let tx_out_proof = btc_rpc.get_txout_proof(txid).await?;
-
-        let consensus_version = module_rpc.module_consensus_version().await?;
+        let federation_knows_utxo = module_rpc.is_utxo_confirmed(outpoint).await?;
 
         claim_peg_in(
             client_ctx,
@@ -391,7 +389,7 @@ async fn check_idx_pegins(
             operation_id,
             outpoint,
             tx_out_proof,
-            consensus_version,
+            federation_knows_utxo,
         )
         .await?;
         outcomes.push(CheckOutcome::Claimed { outpoint });
@@ -408,7 +406,7 @@ async fn claim_peg_in(
     operation_id: OperationId,
     out_point: bitcoin::OutPoint,
     tx_out_proof: TxOutProof,
-    consensus_version: ModuleConsensusVersion,
+    federation_knows_utxo: bool,
 ) -> anyhow::Result<()> {
     async fn claim_peg_in_inner(
         client_ctx: &ClientContext<WalletClientModule>,
@@ -418,7 +416,7 @@ async fn claim_peg_in(
         tweak_key: Keypair,
         txout_proof: TxOutProof,
         operation_id: OperationId,
-        consensus_version: ModuleConsensusVersion,
+        federation_knows_utxo: bool,
     ) -> OutPointRange {
         let pegin_proof = PegInProof::new(
             txout_proof,
@@ -429,8 +427,7 @@ async fn claim_peg_in(
         .expect("TODO: handle API returning faulty proofs");
 
         let amount = pegin_proof.tx_output().value.into();
-
-        let wallet_input = if consensus_version >= ModuleConsensusVersion::new(2, 2) {
+        let wallet_input = if federation_knows_utxo {
             WalletInput::new_v1(&pegin_proof)
         } else {
             WalletInput::new_v0(pegin_proof)
@@ -480,7 +477,7 @@ async fn claim_peg_in(
                         tweak_key,
                         tx_out_proof.clone(),
                         operation_id,
-                        consensus_version,
+                        federation_knows_utxo,
                     )
                     .await;
 

--- a/modules/fedimint-wallet-common/src/endpoint_constants.rs
+++ b/modules/fedimint-wallet-common/src/endpoint_constants.rs
@@ -6,3 +6,4 @@ pub const BITCOIN_RPC_CONFIG_ENDPOINT: &str = "bitcoin_rpc_config";
 pub const MODULE_CONSENSUS_VERSION_ENDPOINT: &str = "module_consensus_version";
 pub const ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT: &str = "activate_consensus_version_voting";
 pub const WALLET_SUMMARY_ENDPOINT: &str = "wallet_summary";
+pub const UTXO_CONFIRMED_ENDPOINT: &str = "utxo_confirmed";

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -822,29 +822,6 @@ impl ServerModule for Wallet {
     fn api_endpoints(&self) -> Vec<ApiEndpoint<Self>> {
         vec![
             api_endpoint! {
-                MODULE_CONSENSUS_VERSION_ENDPOINT,
-                ApiVersion::new(0, 0),
-                async |module: &Wallet, context, _params: ()| -> ModuleConsensusVersion {
-                    Ok(module.consensus_module_consensus_version(&mut context.dbtx().into_nc()).await)
-                }
-            },
-            api_endpoint! {
-                ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT,
-                ApiVersion::new(0, 0),
-                async |_module: &Wallet, context, _params: ()| -> () {
-                    check_auth(context)?;
-
-                    let mut dbtx = context.dbtx();
-
-                    dbtx.insert_entry(&ConsensusVersionVotingActivationKey, &()).await;
-
-                    dbtx.commit_tx_result().await.map_err(|e| ApiError::server_error(e.to_string()))?;
-
-                    Ok(())
-
-                }
-            },
-            api_endpoint! {
                 BLOCK_COUNT_ENDPOINT,
                 ApiVersion::new(0, 0),
                 async |module: &Wallet, context, _params: ()| -> u32 {
@@ -921,6 +898,29 @@ impl ServerModule for Wallet {
                 ApiVersion::new(0, 1),
                 async |module: &Wallet, context, _params: ()| -> WalletSummary {
                     Ok(module.get_wallet_summary(&mut context.dbtx().into_nc()).await)
+                }
+            },
+            api_endpoint! {
+                MODULE_CONSENSUS_VERSION_ENDPOINT,
+                ApiVersion::new(0, 2),
+                async |module: &Wallet, context, _params: ()| -> ModuleConsensusVersion {
+                    Ok(module.consensus_module_consensus_version(&mut context.dbtx().into_nc()).await)
+                }
+            },
+            api_endpoint! {
+                ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT,
+                ApiVersion::new(0, 2),
+                async |_module: &Wallet, context, _params: ()| -> () {
+                    check_auth(context)?;
+
+                    let mut dbtx = context.dbtx();
+
+                    dbtx.insert_entry(&ConsensusVersionVotingActivationKey, &()).await;
+
+                    dbtx.commit_tx_result().await.map_err(|e| ApiError::server_error(e.to_string()))?;
+
+                    Ok(())
+
                 }
             },
         ]

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1257,7 +1257,8 @@ impl Wallet {
 
                 for transaction in block.txdata {
                     // We maintain the subset of unspent P2WSH transaction outputs created
-                    // since the federation was established in the database.
+                    // since the module was running on the new consensus version, which might be
+                    // the same time as the genesis session.
 
                     for tx_in in &transaction.input {
                         dbtx.remove_entry(&UnspentTxOutKey(tx_in.previous_output))

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -270,7 +270,7 @@ impl ServerModuleInit for WalletInit {
                 MODULE_CONSENSUS_VERSION.major,
                 MODULE_CONSENSUS_VERSION.minor,
             ),
-            &[(0, 1)],
+            &[(0, 2)],
         )
     }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1265,11 +1265,13 @@ impl Wallet {
                     }
 
                     for (vout, tx_out) in transaction.output.iter().enumerate() {
-                        if if self.cfg.consensus.peer_peg_in_keys.len() > 1 {
+                        let should_track_utxo = if self.cfg.consensus.peer_peg_in_keys.len() > 1 {
                             tx_out.script_pubkey.is_p2wsh()
                         } else {
                             tx_out.script_pubkey.is_p2wpkh()
-                        } {
+                        };
+
+                        if should_track_utxo {
                             let outpoint = bitcoin::OutPoint {
                                 txid: transaction.compute_txid(),
                                 vout: vout as u32,


### PR DESCRIPTION
The following edge case exists:
- Client sends funds to peg-in address
- Prior to claiming the peg-in, federation reaches consensus for 2.2
- Client attempts to claim peg-in, constructing V1 input since federation consensus is 2.2
- Federation rejects since UTXO is unknown, due to not persisting UTXO until 2.2 consensus is reached

This PR handles this by adding a new endpoint to check if the federation knows of the UTXO prior to submitting a V1 input. If the federation doesn't know of the UTXO, the client will fallback to V0 inputs.

Please note:
- The client no longer checks the consensus version since the federation will only know of the UTXO if the consensus version >= 2.2, thus the check is redundant
- This PR does not modify `modules/fedimint-wallet-client/src/deposit.rs` since the deposit flow is handled by the peg-in monitor since v0.4.0
  - To avoid further confusion, we should remove the legacy deposit logic https://github.com/fedimint/fedimint/issues/6675