### PR TITLE
[backport] fix: prefix isolated databases with `ClientDatabase` prefix

### DIFF
--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -12,10 +12,9 @@ use fedimint_client::{Client, ClientBuilder};
 use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
-use fedimint_core::encoding::Encodable;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 
-use crate::db::FederationConfig;
+use crate::db::{FederationConfig, GatewayDbExt};
 use crate::error::AdminGatewayError;
 use crate::gateway_module_v2::GatewayClientInitV2;
 use crate::state_machine::GatewayClientInit;
@@ -106,9 +105,7 @@ impl GatewayClientBuilder {
             .await
             .map_err(AdminGatewayError::ClientCreationError)?;
         let federation_id = config.invite_code.federation_id();
-        let db = gateway
-            .gateway_db
-            .with_prefix(federation_id.consensus_encode_to_vec());
+        let db = gateway.gateway_db.get_client_database(&federation_id);
         let client_builder = self
             .create_client_builder(db, &config, gateway.clone())
             .await?;
@@ -157,9 +154,7 @@ impl GatewayClientBuilder {
             let root_secret = self.client_plainrootsecret(&db).await?;
             (db, root_secret)
         } else {
-            let db = gateway
-                .gateway_db
-                .with_prefix(federation_id.consensus_encode_to_vec());
+            let db = gateway.gateway_db.get_client_database(&federation_id);
             let secret = Self::derive_federation_secret(mnemonic, &federation_id);
             (db, secret)
         };


### PR DESCRIPTION
After the dev call (Jan 13), it occurred to me that upgrading from v0.4 -> v0.5 is not affected by https://github.com/fedimint/fedimint/issues/6579

This is because v0.4 handles client databases in the gateway differently. It uses a separate DB per client, which is not affected by the above issue. We have, and will always, still support the "legacy" way of opening databases.

Gateway operators can choose to migrate their joined clients if they want to by leaving and re-joining the federation. This behavior is tested in `mnemonic_upgrade_test`.

However, because v0.4 gateways are not affected, as long as v0.5 contains the fix, we do not need any database migrations or code that prevents database migrations from being run. 

v0.6 will include the database migrations that migrates previously affects v0.5 gateways.