### PR TITLE
fix: prevent v0.5 gateways from joining clashing federations

### DIFF
--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1112,6 +1112,10 @@ impl Gateway {
 
         let federation_id = invite_code.federation_id();
 
+        if federation_id.to_prefix().to_bytes().starts_with(&[0x04]) {
+            return Err(AdminGatewayError::Unexpected(anyhow!("gatewayd v0.5 cannot join federation {federation_id}, please upgrade to gatewayd v0.6")));
+        }
+
         let mut federation_manager = self.federation_manager.write().await;
 
         // Check if this federation has already been registered


### PR DESCRIPTION
Adds a check that prevents v0.5.1 gateways from joining affected federations of https://github.com/fedimint/fedimint/issues/6579

Upgrade scenarios:
 - v0.4 -> v0.5.1. Gateways upgrading from v0.4 will continue to work normally, even if they have already joined an affected federation (because v0.4 handled databases differently and this is supported in future versions as well). 
 - v0.5 -> v0.5.1. If a gateway is on v0.5 and has already joined an affected federation, the gateway will not be able to boot (because `load_clients` will expose the bug and crash the gateway). v0.5.1 does not fix that. v0.5.1 will prevent gateways from joining new federations that are affected. Unaffected v0.5 gateways can safely upgrade to v0.5.1 and will not hit the bug moving forward. 
 - v0.6 will fix the bug. Unaffected or affected gateways can upgrade to this and the bug will no longer be present.
