### PR TITLE
chore(ci): switch linkchecking to lychee

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -8,6 +8,22 @@ jobs:
     continue-on-error: true # can fail for external reasons, so don't be a blocker
     steps:
       - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+
+      # Persist lychee cache, so we don't bother with checking same links all the time
+      # Should also minimize number of flakes.
+      - uses: actions/cache@v4
         with:
-          use-quiet-mode: 'yes'
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # TODO: add:
+          # --include-fragments
+          # when it is supported in lychee: https://github.com/lycheeverse/lychee/issues/1613
+          args: |
+            --no-progress
+            --cache
+            docs README.md

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+http://your.ip.add.ress:3000/
+http://your.ip.add.ress:3001/
+# some fake links in rustdoc-index.md
+file://.*/\b\w+(_\w+)*\b/index.html

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
   <a href="https://app.radicle.xyz/nodes/radicle.fedimint.org/rad:z2eeB9LF8fDNJQaEcvAWxQmU7h2PG">
     <img src="https://img.shields.io/badge/Radicle-explore-blue" alt="View on Radicle">
   </a>
-  <img alt="Lines of code" src="https://tokei.rs/b1/github/fedimint/fedimint">
 </p>
 
 [Fedimint](https://fedimint.org) is a module based system for building federated applications. It is designed to be a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,7 @@ The current implementation allows users to make private and low-cost payments th
 All e-cash is backed by bitcoin with deposits and withdrawals that can occur on-chain or via Lightning.
 
 ## Crate organization
+
 The [Fedimint federation](#Federation-Nodes) consists of nodes that are primarily built from the following crates:
 * `fedimint` - the main consensus code for processing transactions and REST API
 * `fedimint-derive` - helper macros for serialization
@@ -27,6 +28,7 @@ The [LN gateway](#LN-Gateway):
 * `gateway/cli` - provides cli access and control of a running gatewayd instance
 
 ## Federation Nodes
+
 Each of the nodes spawns three long-running tasks in parallel: an API task, an [AlephBFT protocol](https://docs.rs/aleph-bft/latest/aleph_bft/) task, and a Fedimint consensus task.
 
 The API task in `net:api:run_server` allows clients to submit a `Transaction` and retrieve its `TransactionStatus`.
@@ -40,6 +42,7 @@ The `FedimintConsensus` task processes each `ConsensusOutcome` by validating the
 For instance, the consensus thread may receive a peg-out proposal, validate the PSBT signature and transaction balances, then sign and submit the transaction to the Bitcoin network.
 
 ## Modules
+
 There currently are three `FederationModule`s used in `FedimintConsensus` that exist in the [crates](#Crate-organization) previously described:
 * [Wallet module](wallet_module.md) - handles bitcoin on-chain `PegInProof` inputs and `PegOut` outputs
 * `Mint` module - verifies `Note` input signatures and issues `BlindNote` outputs of different denominations

--- a/docs/rustdoc-index.md
+++ b/docs/rustdoc-index.md
@@ -48,7 +48,7 @@ Some additional built-in modules are also available:
 * [fedimint-empty-server](./fedimint_empty_server/index.html) and [fedimint-empty-client](./fedimint_empty_client/index.html) are a reference "empty" module that can be used as a starting point for new modules.
 * [fedimint-dummy-server](./fedimint_dummy_server/index.html) and [fedimint-dummy-client](./fedimint_dummy_client/index.html) are a test-only modules, possibly useful as a simple example.
 
-Developers and builders are encouraged to create their own modules. Check ["Fedimint Modules" Discussions](https://github.com/fedimint/fedimint/discussions/categories/fedimint-modules/index.html) for ideas and help.
+Developers and builders are encouraged to create their own modules. Check ["Fedimint Modules" Discussions](https://github.com/fedimint/fedimint/discussions/categories/fedimint-modules/) for ideas and help.
 
 # Notable crates
 


### PR DESCRIPTION
The output of existing link checker is super verbose and annoys me every time there's an issue, while it is no longer maintained:

https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/193

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
