### PR TITLE
chore: remove stale markdown-link-check elements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,7 @@ Here are the recommended steps for new developers:
 
 Small PRs fixing typos, TODOs, or broken links are always welcome. Please discuss larger changes on Discord or GitHub before proceeding.
 
-<!-- markdown-link-check-disable -->
-
 For commit messages, please use the [imperative mood](https://stackoverflow.com/questions/3580013/should-i-use-past-or-present-tense-in-git-commit-messages/3580764#3580764).
-
-<!-- markdown-link-check-enable -->
 
 **Note:** Contributing to the core Fedimint repo requires expertise in Rust and distributed systems. If you're new to coding, Bitcoin, or Rust, consider starting with our more approachable projects like UIs, clients, or other services to familiarize yourself with Fedimint before tackling the core repo. Finding a good issue that matches your skillset is crucial—please reach out to @kodylow to ensure a smooth start.
 

--- a/docs/deploying/docker-mutiny.md
+++ b/docs/deploying/docker-mutiny.md
@@ -202,13 +202,9 @@ The install script lets you install one or all of:
 
 and it'll start the services on the following ports:
 
-<!-- markdown-link-check-disable -->
-
 - Fedimintd Guardian Dashboard: http://your.ip.add.ress:3000
 - Lightning Gateway Dashboard: http://your.ip.add.ress:3001
 - RTL Lightning Node Management: http://your.ip.add.ress.198:3003
-
-<!-- markdown-link-check-enable -->
 
 <p align="center">
 <img src="../setup-docs-assets/install_scripts.png" alt="Install Scripts" width="500">
@@ -405,11 +401,7 @@ docker-compose -f fedimintd/docker-compose.yaml exec fedimintd fedimint-cli help
 
 ### Lightning Gateway Dashboard
 
-<!-- markdown-link-check-disable -->
-
 Now that you're connected, you can go to the lightning gateway dashboard at http://your.ip.add.ress:3001 and see the gateway status.
-
-<!-- markdown-link-check-enable -->
 
 <p align="center">
 <img src="../setup-docs-assets/fed_deposit_addr.png" alt="Fed Deposit Address" width="500">

--- a/docs/recoverable_e-cash.md
+++ b/docs/recoverable_e-cash.md
@@ -125,8 +125,6 @@ The implicit per key type derivation (ChaCha20-Poly1305 vs secp256k1) makes the 
 
 [^1]: See BSI [TR-03111] section 4.1.1 and [TR-02102] section B.4 for details.
 
-<!-- markdown-link-check-disable -->
-
 [BIP39]: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
 [SLIP39]: https://github.com/satoshilabs/slips/blob/master/slip-0039.md
 [CODEX32]: https://github.com/roconnor-blockstream/SSS32/blob/ms32/MasterSeed32.md 

--- a/docs/rustdoc-index.md
+++ b/docs/rustdoc-index.md
@@ -1,8 +1,6 @@
 # Fedimint Technical Reference Documentation
 
 <!-- this page is used a landing page for https://docs.fedimint.org/ -->
-<!-- lots of links in this document are relative to the generated document, so disabling linkcheck altogether: -->
-<!-- markdown-link-check-disable -->
 
 ## Target audience
 


### PR DESCRIPTION
These are no longer needed now that we moved from markdown link check to lychee.