### PR TITLE
chore(server): maintain a code version info in the db

### DIFF
--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -315,7 +315,7 @@ impl DatabaseDump {
                 );
             }
             // Module is a global prefix for all module data
-            ConsensusRange::DbKeyPrefix::Module => {}
+            ConsensusRange::DbKeyPrefix::Module | ConsensusRange::DbKeyPrefix::ServerInfo => {}
             ConsensusRange::DbKeyPrefix::ApiAnnouncements => {
                 push_db_pair_items_no_serde!(
                     dbtx,

--- a/fedimint-server-tests/tests/migration.rs
+++ b/fedimint-server-tests/tests/migration.rs
@@ -203,7 +203,7 @@ async fn test_server_db_migrations() -> anyhow::Result<()> {
                         info!(target: LOG_DB, "Validated AlephUnits");
                     }
                     // Module prefix is reserved for modules, no migration testing is needed
-                    DbKeyPrefix::Module => {}
+                    DbKeyPrefix::Module | DbKeyPrefix::ServerInfo => {}
                     DbKeyPrefix::ApiAnnouncements => {
                         let announcements = dbtx
                             .find_by_prefix(&ApiAnnouncementPrefix)

--- a/fedimint-server/src/consensus/db.rs
+++ b/fedimint-server/src/consensus/db.rs
@@ -25,6 +25,7 @@ pub enum DbKeyPrefix {
     AlephUnits = 0x05,
     // TODO: do we want to split the server DB into consensus/non-consensus?
     ApiAnnouncements = 0x06,
+    ServerInfo = 0x07,
     Module = MODULE_GLOBAL_PREFIX,
 }
 

--- a/fedimint-server/src/db.rs
+++ b/fedimint-server/src/db.rs
@@ -1,0 +1,22 @@
+use fedimint_core::encoding::{Decodable, Encodable};
+use fedimint_core::impl_db_record;
+
+use crate::consensus::db::DbKeyPrefix;
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct ServerInfoKey;
+
+#[derive(Clone, Debug, Encodable, Decodable)]
+pub struct ServerInfo {
+    /// The initial version that set up the consensus
+    pub init_version: String,
+    /// The last version that passed db migration checks
+    pub last_version: String,
+}
+
+impl_db_record!(
+    key = ServerInfoKey,
+    value = ServerInfo,
+    db_prefix = DbKeyPrefix::ServerInfo,
+    notify_on_modify = false,
+);


### PR DESCRIPTION
Our upgrade check in 0.4 was very crude and inconvenient, because we couldn't tell at which version the federation was set up. It's prudent to avoid such a problem in the future, even if we don't expect upgrades like these.

We can write a version of fedimint code that the federation was created with, and last one it was running with. Might come handy and doesn't cost much.

Thinking about where to put the "last version" update, it occured to me that it should be done atomically along with database migrations.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
