### PR TITLE
chore: fedimint-cli to default to info log level

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -620,7 +620,7 @@ impl FedimintCli {
         handle_version_hash_command(version_hash);
 
         let cli_args = Opts::parse();
-        let base_level = if cli_args.verbose { "info" } else { "warn" };
+        let base_level = if cli_args.verbose { "debug" } else { "info" };
         TracingSetup::default()
             .with_base_level(base_level)
             .init()


### PR DESCRIPTION
So in 744df9be092cf1e88f4f84744d1d0ee254741c1d @elsirion changed the default logging level, I didn't notice, and it confused me a lot.

I also don't want fedimint-cli to print too much noise, but I think that should be done by downgrading noisy stuff to debug or trace, as this is not only about fedimint-cli, but also any other software using fedimint client.

I happened to recently discuss the logging level in our (soon to be) dependencies as well: https://github.com/n0-computer/iroh/issues/3071#issuecomment-2561477758

To me the `info` are the most important informative messages that the user probably wants, and anything else should go into debug or even trace.

In #6711 I already downgraded some offenders, and make the expiration notice logging level increasingly higher logging level, based on the remaining time, so there is some usability aspect to it as well.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
