### PR TITLE
refactor(client): introduce interface betwen client and client modules

### DIFF
--- a/fedimint-client/src/module/init.rs
+++ b/fedimint-client/src/module/init.rs
@@ -20,7 +20,7 @@ use tokio::sync::watch;
 use tracing::warn;
 
 use super::recovery::{DynModuleBackup, RecoveryProgress};
-use super::{ClientContext, FinalClient};
+use super::{ClientContext, FinalClientIface};
 use crate::db::ClientMigrationFn;
 use crate::module::{ClientModule, DynClientModule};
 use crate::sm::{ModuleNotifier, Notifier};
@@ -263,7 +263,7 @@ pub trait IClientModuleInit: IDynCommonModuleInit + Debug + MaybeSend + MaybeSyn
     #[allow(clippy::too_many_arguments)]
     async fn recover(
         &self,
-        final_client: FinalClient,
+        final_client: FinalClientIface,
         federation_id: FederationId,
         num_peers: NumPeers,
         cfg: ClientModuleConfig,
@@ -283,7 +283,7 @@ pub trait IClientModuleInit: IDynCommonModuleInit + Debug + MaybeSend + MaybeSyn
     #[allow(clippy::too_many_arguments)]
     async fn init(
         &self,
-        final_client: FinalClient,
+        final_client: FinalClientIface,
         federation_id: FederationId,
         peer_num: usize,
         cfg: ClientModuleConfig,
@@ -324,7 +324,7 @@ where
 
     async fn recover(
         &self,
-        final_client: FinalClient,
+        final_client: FinalClientIface,
         federation_id: FederationId,
         num_peers: NumPeers,
         cfg: ClientModuleConfig,
@@ -381,7 +381,7 @@ where
 
     async fn init(
         &self,
-        final_client: FinalClient,
+        final_client: FinalClientIface,
         federation_id: FederationId,
         peer_num: usize,
         cfg: ClientModuleConfig,

--- a/gateway/ln-gateway/tests/tests.rs
+++ b/gateway/ln-gateway/tests/tests.rs
@@ -1237,7 +1237,10 @@ async fn gateway_read_payment_log() -> anyhow::Result<()> {
             if transactions.0.len() == 20 {
                 Ok(())
             } else {
-                Err(anyhow::anyhow!("Invalid number of transactions"))
+                Err(anyhow::anyhow!(
+                    "Invalid number of transactions: {}, expected 20",
+                    transactions.0.len()
+                ))
             }
         },
     )

--- a/modules/fedimint-lnv2-client/src/lib.rs
+++ b/modules/fedimint-lnv2-client/src/lib.rs
@@ -582,7 +582,7 @@ impl LightningClientModule {
             .finalize_and_submit_transaction(
                 operation_id,
                 LightningCommonInit::KIND.as_str(),
-                |change_range| {
+                move |change_range| {
                     LightningOperationMeta::Send(SendOperationMeta {
                         funding_txid: change_range.txid(),
                         funding_change_outpoints: change_range.into_iter().collect(),

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1493,7 +1493,7 @@ impl MintClientModule {
 
         let extra_meta = serde_json::to_value(extra_meta)
             .expect("MintClientModule::reissue_external_notes extra_meta is serializable");
-        let operation_meta_gen = |change_range: OutPointRange| MintOperationMeta {
+        let operation_meta_gen = move |change_range: OutPointRange| MintOperationMeta {
             variant: MintOperationMetaVariant::Reissuance {
                 legacy_out_point: None,
                 txid: Some(change_range.txid()),

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -1069,14 +1069,17 @@ impl WalletClientModule {
                 .finalize_and_submit_transaction(
                     operation_id,
                     WalletCommonInit::KIND.as_str(),
-                    |change_range: OutPointRange| WalletOperationMeta {
-                        variant: WalletOperationMetaVariant::Withdraw {
-                            address: address.clone().into_unchecked(),
-                            amount,
-                            fee,
-                            change: change_range.into_iter().collect(),
-                        },
-                        extra_meta: extra_meta.clone(),
+                    {
+                        let address = address.clone();
+                        move |change_range: OutPointRange| WalletOperationMeta {
+                            variant: WalletOperationMetaVariant::Withdraw {
+                                address: address.clone().into_unchecked(),
+                                amount,
+                                fee,
+                                change: change_range.into_iter().collect(),
+                            },
+                            extra_meta: extra_meta.clone(),
+                        }
                     },
                     tx_builder,
                 )
@@ -1110,7 +1113,7 @@ impl WalletClientModule {
             .finalize_and_submit_transaction(
                 operation_id,
                 WalletCommonInit::KIND.as_str(),
-                |change_range: OutPointRange| WalletOperationMeta {
+                move |change_range: OutPointRange| WalletOperationMeta {
                     variant: WalletOperationMetaVariant::RbfWithdraw {
                         rbf: rbf.clone(),
                         change: change_range.into_iter().collect(),


### PR DESCRIPTION
As a follow-up we'll break the `fedimint-client` into `fedimint-client-module` and `fedimint-client`, so that client modules depend only on the `fedimint-client-module`.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
