### PR TITLE
chore: inherit package metadata from workspace

### DIFF
--- a/crypto/aead/Cargo.toml
+++ b/crypto/aead/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-aead"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "aead utilities on top of ring"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/crypto/derive-secret/Cargo.toml
+++ b/crypto/derive-secret/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-derive-secret"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "Fedimint derivable secret implementation"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/crypto/hkdf/Cargo.toml
+++ b/crypto/hkdf/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-hkdf"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "RFC5869 HKDF implementation on top of bitcoin_hashes"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [lib]
 name = "hkdf"

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-tbs"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "tbs is a helper cryptography library for threshold blind signatures"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [features]
 default = []

--- a/crypto/tpe/Cargo.toml
+++ b/crypto/tpe/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-tpe"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "tpe is a helper cryptography library for threshold point encryption"
-license = "MIT"
+license = { workspace = true }
 
 [features]
 default = []

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-docs"
-edition = "2021"
-authors = ["The Fedimint Developers"]
+edition = { workspace = true }
+authors = { workspace = true }
 version = { workspace = true }
 publish = false
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [lib]
 name = "fedimint_docs"

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-api-client"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-api-client provides common code used by client."
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 development = ["tokio-test"]

--- a/fedimint-bip39/Cargo.toml
+++ b/fedimint-bip39/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fedimint-bip39"
 version = { workspace = true }
-edition = "2021"
-license = "MIT"
-readme = "../README.md"
+edition = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
 description = "Allows using bip39 mnemonic phrases to generate fedimint client keys"
-repository = "https://github.com/fedimint/fedimint"
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-bitcoind"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "Bitcoin Core connectivity used by Fedimint"
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-build/Cargo.toml
+++ b/fedimint-build/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-build"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "Fedimint build script utilities for including git version information in builds"
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [lib]
 name = "fedimint_build"

--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-edition = "2021"
+edition = { workspace = true }
 name = "fedimint-client-wasm"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
+authors = { workspace = true }
 description = "fedimint client for wasm"
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 # https://rustwasm.github.io/wasm-pack/book/cargo-toml-configuration.html
 [package.metadata.wasm-pack.profile.release]

--- a/fedimint-core/Cargo.toml
+++ b/fedimint-core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-core"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-core provides common code used by both client and server."
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 development = ["tokio-test"]

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fedimint-dbtool"
 version = { workspace = true }
-edition = "2021"
-license = "MIT"
-readme = "README.md"
+edition = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
 description = "Tool to inspect Fedimint client and server databases"
-repository = "https://github.com/fedimint/fedimint"
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-derive/Cargo.toml
+++ b/fedimint-derive/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-derive"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-derive provides helper macros for serialization."
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [features]
 diagnostics = []

--- a/fedimint-eventlog/Cargo.toml
+++ b/fedimint-eventlog/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-eventlog"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-eventlog provides a eventlog handling primitives for Fedimint."
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-load-test-tool/Cargo.toml
+++ b/fedimint-load-test-tool/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-load-test-tool"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-load-test-tool is a tool to load test the fedimint server and gateway."
-license = "MIT"
+license = { workspace = true }
 publish = false
 
 [[bin]]

--- a/fedimint-logging/Cargo.toml
+++ b/fedimint-logging/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-logging"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "contains some utilities for logging and tracing"
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [features]
 telemetry = [

--- a/fedimint-metrics/Cargo.toml
+++ b/fedimint-metrics/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fedimint-metrics"
 version = { workspace = true }
-edition = "2021"
-license = "MIT"
-readme = "README.md"
+edition = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
 description = "fedimint-metrics allows exporting prometheus metrics from Fedimint."
-repository = "https://github.com/fedimint/fedimint"
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-recoverytool/Cargo.toml
+++ b/fedimint-recoverytool/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-recoverytool"
 version = { workspace = true }
-edition = "2021"
-authors = ["The Fedimint Developers"]
+edition = { workspace = true }
+authors = { workspace = true }
 description = "Tool for retrieving on-chain funds from a decommissioned Fedimint federation"
-license = "MIT"
-readme = "README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-rocksdb"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-rocksdb provides a rocksdb-backed database implementation for Fedimint."
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-server"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-server' facilitates federated consensus with atomic broadcast and distributed configuration."
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-testing-core/Cargo.toml
+++ b/fedimint-testing-core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-testing-core"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-testing provides a basic utils for testing fedimint components"
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-testing"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-testing provides a library of shared objects and utilities for testing fedimint components"
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/fedimint-wasm-tests/Cargo.toml
+++ b/fedimint-wasm-tests/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fedimint-wasm-tests"
 version = { workspace = true }
-edition = "2021"
-license = "MIT"
+edition = { workspace = true }
+license = { workspace = true }
 description = "Wasm tests for the fedimint."
 publish = false
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-fuzz"
-edition = "2021"
-authors = ["The Fedimint Developers"]
+edition = { workspace = true }
+authors = { workspace = true }
 version = { workspace = true }
 publish = false
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata]
 cargo-fuzz = true

--- a/gateway/integration_tests/Cargo.toml
+++ b/gateway/integration_tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "gateway-tests"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "gateway-tests contain integration tests for the gateway"
-license = "MIT"
+license = { workspace = true }
 publish = false
 
 # workaround: cargo-deny in Nix needs to see at least one

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-ln-gateway"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-ln-gateway sends/receives Lightning Network payments on behalf of Fedimint clients"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [features]
 tor = ["fedimint-client/tor", "fedimint-api-client/tor"]

--- a/modules/fedimint-dummy-client/Cargo.toml
+++ b/modules/fedimint-dummy-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-dummy-client"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-dummy is a dummy example fedimint module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-dummy-common/Cargo.toml
+++ b/modules/fedimint-dummy-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-dummy-common"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-dummy-common is a dummy example fedimint module. (common types)"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-dummy-server/Cargo.toml
+++ b/modules/fedimint-dummy-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-dummy-server"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-dummy is a dummy example fedimint module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-dummy-tests/Cargo.toml
+++ b/modules/fedimint-dummy-tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-dummy-tests"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-dummy is a dummy example fedimint module."
-license = "MIT"
+license = { workspace = true }
 publish = false
 
 [[test]]

--- a/modules/fedimint-empty-client/Cargo.toml
+++ b/modules/fedimint-empty-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-empty-client"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-empty is an empty fedimint module, good template for a new module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-empty-common/Cargo.toml
+++ b/modules/fedimint-empty-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-empty-common"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-empty-common is a empty fedimint module (common types)"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-empty-server/Cargo.toml
+++ b/modules/fedimint-empty-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-empty-server"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-empty is a empty fedimint module, good template for a new module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-ln-client/Cargo.toml
+++ b/modules/fedimint-ln-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-ln-client"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-ln is a lightning payment service module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one

--- a/modules/fedimint-ln-common/Cargo.toml
+++ b/modules/fedimint-ln-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-ln-common"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-ln-common is a lightning payment service module (common types)."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-ln-server"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-ln is a lightning payment service module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-ln-tests/Cargo.toml
+++ b/modules/fedimint-ln-tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-ln-tests"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-ln-tests contains integration tests for the lightning module"
-license = "MIT"
+license = { workspace = true }
 publish = false
 
 [[test]]

--- a/modules/fedimint-lnv2-client/Cargo.toml
+++ b/modules/fedimint-lnv2-client/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-lnv2-client"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-ln is a lightning payment service module."
-license = "MIT"
+license = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one

--- a/modules/fedimint-lnv2-common/Cargo.toml
+++ b/modules/fedimint-lnv2-common/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-lnv2-common"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-ln-common is a lightning payment service module (common types)."
-license = "MIT"
+license = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 # cargo udeps can't detect that one

--- a/modules/fedimint-lnv2-server/Cargo.toml
+++ b/modules/fedimint-lnv2-server/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-lnv2-server"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-ln is a lightning payment service module."
-license = "MIT"
+license = { workspace = true }
 
 [lib]
 name = "fedimint_lnv2_server"

--- a/modules/fedimint-lnv2-tests/Cargo.toml
+++ b/modules/fedimint-lnv2-tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-lnv2-tests"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-lnv2-tests contains integration tests for the lnv2 module"
-license = "MIT"
+license = { workspace = true }
 publish = false
 
 [[bin]]

--- a/modules/fedimint-meta-client/Cargo.toml
+++ b/modules/fedimint-meta-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-meta-client"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-meta is a meta consensus fedimint module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-meta-common/Cargo.toml
+++ b/modules/fedimint-meta-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-meta-common"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-meta-common is a meta-consensus fedimint module. (common types)"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-meta-server/Cargo.toml
+++ b/modules/fedimint-meta-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-meta-server"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-meta is a meta consensus fedimint module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-meta-tests/Cargo.toml
+++ b/modules/fedimint-meta-tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-meta-tests"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-mint-tests contains integration tests for the meta module"
-license = "MIT"
+license = { workspace = true }
 publish = false
 
 # workaround: cargo-deny in Nix needs to see at least one

--- a/modules/fedimint-mint-client/Cargo.toml
+++ b/modules/fedimint-mint-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-mint-client"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-mint is a chaumian ecash mint module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-mint-common/Cargo.toml
+++ b/modules/fedimint-mint-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-mint-common"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-mint-common is a chaumian ecash mint module. (common types)"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-mint-server/Cargo.toml
+++ b/modules/fedimint-mint-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-mint-server"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-mint is a chaumian ecash mint module."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-mint-tests/Cargo.toml
+++ b/modules/fedimint-mint-tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-mint-tests"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-mint-tests contains integration tests for the mint module"
-license = "MIT"
+license = { workspace = true }
 publish = false
 
 [[test]]

--- a/modules/fedimint-unknown-common/Cargo.toml
+++ b/modules/fedimint-unknown-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-unknown-common"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-unknown-common is a fedimint module that doesn't have any client side implementation. (common types)"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-unknown-server/Cargo.toml
+++ b/modules/fedimint-unknown-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-unknown-server"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-unknown-server is a test fedimint module that doesn't have any client side implementation."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-wallet-client"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-wallet-common/Cargo.toml
+++ b/modules/fedimint-wallet-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-wallet-common"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-wallet-common is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet. (common types)"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-wallet-server"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-wallet is a n on-chain bitcoin wallet module. It uses a key-value store and is not a standard HD wallet."
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fedimint-wallet-tests"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "fedimint-wallet-tests contains integration tests for the lightning module"
-license = "MIT"
+license = { workspace = true }
 publish = false
 
 [[bin]]

--- a/utils/portalloc/Cargo.toml
+++ b/utils/portalloc/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fedimint-portalloc"
 version = { workspace = true }
-authors = ["The Fedimint Developers"]
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
 description = "Port allocation utility for Fedimint"
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/fedimint/fedimint"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "tokio_unstable"]


### PR DESCRIPTION
Followup to https://github.com/fedimint/fedimint/pull/6706#discussion_r1917622102. We should first merge that PR so we can backport to `releases/v0.5`, which allows us to continue publishing `devimint` to crates.io for subsequent `v0.5.*` releases.