### PR TITLE
chore(ci): rm runLowPrio from upgrade tests

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -85,7 +85,7 @@ jobs:
             env -u RUSTC_WRAPPER \
             env TEST_KINDS="$TEST_KINDS" \
             env FM_DEVIMINT_DISABLE_MODULE_LNV2=1 \
-            runLowPrio ./scripts/tests/upgrade-test.sh "$VERSIONS"
+            ./scripts/tests/upgrade-test.sh "$VERSIONS"
 
   notifications:
     if: always() && github.repository == 'fedimint/fedimint'


### PR DESCRIPTION
Now that we run upgrade tests against PRs and in the merge queue, we shouldn't run the test with `runLowPrio`. A potential cause for the flakiness observed in https://github.com/fedimint/fedimint/issues/6718.