### PR TITLE
chore(ci): do not pin pre-releases in cachix

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -543,7 +543,11 @@ jobs:
               >&2 echo "Pushing to cachix: $bin"
               cachix push fedimint -c 8 -j 8 $(nix-store --query --references $(readlink -f result)) $(readlink -f result)
               >&2 echo "Pining in cachix: fedimint-release-$bin:$BUILD_ID"
-              cachix pin fedimint "fedimint-release-$bin:$BUILD_ID" $(readlink -f result)
+              if [[ $var == *"-rc."* ]] || [[ $var == *"-alpha."* ]] || [[ $var == *"-testing."* ]] ; then
+                >&2 echo "Will not pin in cachix, as looks like a pre-release"
+              else
+                cachix pin fedimint "fedimint-release-$bin:$BUILD_ID" $(readlink -f result)
+              fi
             fi
             # Note: keep in sync with sign.sh
             >&2 echo "Building bundled: $bin"


### PR DESCRIPTION
They are not all that important, and with our relatively small cache just waste space over time.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
