### PR TITLE
chore: fix devimint panic in upgrade-tests

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -245,7 +245,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
             let main = {
                 let task_group = task_group.clone();
                 async move {
-                    let dev_fed = DevJitFed::new(&process_mgr, skip_setup)?;
+                    let dev_fed = DevJitFed::new(&process_mgr, skip_setup).await?;
 
                     let pegin_start_time = Instant::now();
                     debug!(target: LOG_DEVIMINT, "Peging in client and gateways");

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -49,7 +49,7 @@ where
 
     let (process_mgr, task_group) = cli::setup(args).await?;
     log_binary_versions().await?;
-    let dev_fed = devfed::DevJitFed::new(&process_mgr, false)?;
+    let dev_fed = devfed::DevJitFed::new(&process_mgr, false).await?;
     // workaround https://github.com/tokio-rs/tokio/issues/6463
     // by waiting on all jits to complete, we make it less likely
     // that something is not finished yet and will block in `on_block`


### PR DESCRIPTION
```
2025-01-18T04:44:44.085057Z  INFO fm::devimint: Started lnd gateway elapsed_ms=698
thread 'tokio-runtime-worker' panicked at devimint/src/devfed.rs:297:34:
GW LDK should be present
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
