### PR TITLE
chore: bump master to 0.7.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "devimint"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -2375,7 +2375,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fedimint-aead"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-api-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bip39"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-bitcoind"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2515,14 +2515,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-build"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "fedimint-cli"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-client-wasm"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-core"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dbtool"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-derive-secret"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -2745,11 +2745,11 @@ dependencies = [
 
 [[package]]
 name = "fedimint-docs"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 
 [[package]]
 name = "fedimint-dummy-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-server"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-dummy-tests"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-empty-server"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-eventlog"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-fuzz"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "fedimint-core",
  "fedimint-ln-common",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-gateway-cli"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "bcrypt",
@@ -2909,14 +2909,14 @@ dependencies = [
 
 [[package]]
 name = "fedimint-hkdf"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
 name = "fedimint-lightning"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2973,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-gateway"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-server"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-ln-tests"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-server"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-tests"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-load-test-tool"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-logging"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-server"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3299,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-meta-tests"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "devimint",
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-metrics"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-server"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-mint-tests"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-portalloc"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-recoverytool"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-rocksdb"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-core"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-server-tests"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "bitcoin",
  "fedimint-api-client",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tbs"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "bls12_381",
  "criterion",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-testing-core"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-client",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-tpe"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "bls12_381",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-unknown-server"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -3805,7 +3805,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-server"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wallet-tests"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-wasm-tests"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "fedimint-api-client",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-tests"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 authors = ["The Fedimint Developers"]
 edition = "2021"
 description = "Fedimint is a Federated Chaumian E-Cash Mint, natively compatible with Bitcoin & the Lightning Network"
@@ -115,59 +115,59 @@ bytes = "1.9.0"
 clap = { version = "4.5.26", features = ["derive", "env"] }
 cln-rpc = { package = "fedimint-cln-rpc", version = "0.5.0" }
 criterion = "0.5.1"
-devimint = { path = "./devimint", version = "=0.6.0-alpha" }
+devimint = { path = "./devimint", version = "=0.7.0-alpha" }
 erased-serde = "0.4"
 esplora-client = { version = "0.10.0", default-features = false, features = [
     "async-https-rustls",
 ] }
-fedimintd = { path = "./fedimintd", version = "=0.6.0-alpha" }
-fedimint-aead = { path = "./crypto/aead", version = "=0.6.0-alpha" }
-fedimint-api-client = { path = "./fedimint-api-client", version = "=0.6.0-alpha" }
-fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.6.0-alpha" }
-fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.6.0-alpha" }
-fedimint-build = { path = "./fedimint-build", version = "=0.6.0-alpha" }
-fedimint-client = { path = "./fedimint-client", version = "=0.6.0-alpha" }
-fedimint-core = { path = "./fedimint-core", version = "=0.6.0-alpha" }
-fedimint-derive = { path = "./fedimint-derive", version = "=0.6.0-alpha" }
-fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.6.0-alpha" }
-fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.6.0-alpha" }
-fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.6.0-alpha" }
-fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.6.0-alpha" }
-fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.6.0-alpha" }
-fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.6.0-alpha" }
-fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.6.0-alpha" }
-fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.6.0-alpha" }
-fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.6.0-alpha" }
-fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.6.0-alpha" }
-fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.6.0-alpha" }
-fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.6.0-alpha" }
-fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.6.0-alpha" }
-fedimint-logging = { path = "./fedimint-logging", version = "=0.6.0-alpha" }
-fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.6.0-alpha" }
-fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.6.0-alpha" }
-fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.6.0-alpha" }
-fedimint-metrics = { path = "./fedimint-metrics", version = "=0.6.0-alpha" }
-fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.6.0-alpha" }
-fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.6.0-alpha" }
-fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.6.0-alpha" }
-fedimint-portalloc = { path = "utils/portalloc", version = "=0.6.0-alpha" }
-fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.6.0-alpha" }
-fedimint-server = { path = "./fedimint-server", version = "=0.6.0-alpha" }
-fedimint-server-core = { path = "./fedimint-server-core", version = "=0.6.0-alpha" }
-fedimint-testing = { path = "./fedimint-testing", version = "=0.6.0-alpha" }
-fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.6.0-alpha" }
-fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.6.0-alpha" }
-fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.6.0-alpha" }
-fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.6.0-alpha" }
-fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.6.0-alpha" }
-fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.6.0-alpha" }
+fedimintd = { path = "./fedimintd", version = "=0.7.0-alpha" }
+fedimint-aead = { path = "./crypto/aead", version = "=0.7.0-alpha" }
+fedimint-api-client = { path = "./fedimint-api-client", version = "=0.7.0-alpha" }
+fedimint-bip39 = { path = "./fedimint-bip39", version = "=0.7.0-alpha" }
+fedimint-bitcoind = { path = "./fedimint-bitcoind", version = "=0.7.0-alpha" }
+fedimint-build = { path = "./fedimint-build", version = "=0.7.0-alpha" }
+fedimint-client = { path = "./fedimint-client", version = "=0.7.0-alpha" }
+fedimint-core = { path = "./fedimint-core", version = "=0.7.0-alpha" }
+fedimint-derive = { path = "./fedimint-derive", version = "=0.7.0-alpha" }
+fedimint-derive-secret = { path = "./crypto/derive-secret", version = "=0.7.0-alpha" }
+fedimint-dummy-client = { path = "./modules/fedimint-dummy-client", version = "=0.7.0-alpha" }
+fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=0.7.0-alpha" }
+fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.7.0-alpha" }
+fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.7.0-alpha" }
+fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.7.0-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.7.0-alpha" }
+fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.7.0-alpha" }
+fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.7.0-alpha" }
+fedimint-lnv2-server = { path = "./modules/fedimint-lnv2-server", version = "=0.7.0-alpha" }
+fedimint-ln-client = { path = "./modules/fedimint-ln-client", version = "=0.7.0-alpha" }
+fedimint-ln-common = { path = "./modules/fedimint-ln-common", version = "=0.7.0-alpha" }
+fedimint-ln-server = { path = "./modules/fedimint-ln-server", version = "=0.7.0-alpha" }
+fedimint-logging = { path = "./fedimint-logging", version = "=0.7.0-alpha" }
+fedimint-meta-client = { path = "./modules/fedimint-meta-client", version = "=0.7.0-alpha" }
+fedimint-meta-common = { path = "./modules/fedimint-meta-common", version = "=0.7.0-alpha" }
+fedimint-meta-server = { path = "./modules/fedimint-meta-server", version = "=0.7.0-alpha" }
+fedimint-metrics = { path = "./fedimint-metrics", version = "=0.7.0-alpha" }
+fedimint-mint-client = { path = "./modules/fedimint-mint-client", version = "=0.7.0-alpha" }
+fedimint-mint-common = { path = "./modules/fedimint-mint-common", version = "=0.7.0-alpha" }
+fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.7.0-alpha" }
+fedimint-portalloc = { path = "utils/portalloc", version = "=0.7.0-alpha" }
+fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.7.0-alpha" }
+fedimint-server = { path = "./fedimint-server", version = "=0.7.0-alpha" }
+fedimint-server-core = { path = "./fedimint-server-core", version = "=0.7.0-alpha" }
+fedimint-testing = { path = "./fedimint-testing", version = "=0.7.0-alpha" }
+fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.7.0-alpha" }
+fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.7.0-alpha" }
+fedimint-unknown-server = { path = "./modules/fedimint-unknown-server", version = "=0.7.0-alpha" }
+fedimint-wallet-client = { path = "./modules/fedimint-wallet-client", version = "=0.7.0-alpha" }
+fedimint-wallet-common = { path = "./modules/fedimint-wallet-common", version = "=0.7.0-alpha" }
+fedimint-wallet-server = { path = "./modules/fedimint-wallet-server", version = "=0.7.0-alpha" }
 fs-lock = "0.1.7"
 futures = "0.3.31"
 futures-util = "0.3.30"
 group = "0.13.0"
 hex = "0.4.3"
 hex-conservative = "0.3.0"
-hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.6.0-alpha" }
+hkdf = { package = "fedimint-hkdf", path = "./crypto/hkdf", version = "=0.7.0-alpha" }
 hyper = "1.5"
 iroh = { version = "0.30.0", default-features = false }
 itertools = "0.13.0"
@@ -175,7 +175,7 @@ jaq-core = "2.0.0"
 jaq-json = { version = "1.0.0", features = ["serde_json"] }
 lightning = "0.0.125"
 lightning-invoice = { version = "0.32.0", features = ["std"] }
-ln-gateway = { package = "fedimint-ln-gateway", path = "./gateway/ln-gateway", version = "=0.6.0-alpha" }
+ln-gateway = { package = "fedimint-ln-gateway", path = "./gateway/ln-gateway", version = "=0.7.0-alpha" }
 miniscript = "12.3.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
@@ -199,7 +199,7 @@ strum = "0.26"
 strum_macros = "0.26"
 subtle = "2.6.1"
 test-log = { version = "0.2", features = ["trace"], default-features = false }
-tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.6.0-alpha" }
+tbs = { package = "fedimint-tbs", path = "./crypto/tbs", version = "=0.7.0-alpha" }
 thiserror = "2.0.11"
 threshold_crypto = { version = "0.2.1", package = "fedimint-threshold-crypto" }
 tokio = "1.43.0"
@@ -210,7 +210,7 @@ tonic_lnd = { version = "0.2.0", package = "fedimint-tonic-lnd", features = [
     "lightningrpc",
     "routerrpc",
 ] }
-tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.6.0-alpha" }
+tpe = { package = "fedimint-tpe", path = "./crypto/tpe", version = "=0.7.0-alpha" }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 url = "2.5.4"

--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -31,9 +31,9 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.42"
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.6.0-alpha" }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.0-alpha" }
 fedimint-bip39 = { workspace = true }
-fedimint-client = { path = "../fedimint-client", version = "=0.6.0-alpha" }
+fedimint-client = { path = "../fedimint-client", version = "=0.7.0-alpha" }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-ln-client = { workspace = true, features = ["cli"] }

--- a/fedimint-client/Cargo.toml
+++ b/fedimint-client/Cargo.toml
@@ -30,7 +30,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.6.0-alpha" }
+fedimint-api-client = { path = "../fedimint-api-client", version = "=0.7.0-alpha" }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -29,7 +29,7 @@ fedimint-api-client = { workspace = true }
 fedimint-bitcoind = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
-fedimint-lightning = { package = "fedimint-lightning", path = "../gateway/fedimint-lightning", version = "=0.6.0-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "../gateway/fedimint-lightning", version = "=0.7.0-alpha" }
 fedimint-ln-common = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-portalloc = { workspace = true }
@@ -38,7 +38,7 @@ fedimint-server = { workspace = true }
 fedimint-testing-core = { workspace = true }
 fs-lock = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway", version = "=0.6.0-alpha" }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../gateway/ln-gateway", version = "=0.7.0-alpha" }
 rand = { workspace = true }
 tempfile = "3.15.0"
 tokio = { workspace = true }

--- a/gateway/cli/Cargo.toml
+++ b/gateway/cli/Cargo.toml
@@ -28,11 +28,11 @@ clap = { workspace = true }
 clap_complete = "4.5.42"
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
-fedimint-lightning = { package = "fedimint-lightning", path = "../fedimint-lightning", version = "=0.6.0-alpha" }
+fedimint-lightning = { package = "fedimint-lightning", path = "../fedimint-lightning", version = "=0.7.0-alpha" }
 fedimint-logging = { workspace = true }
 fedimint-mint-client = { workspace = true }
 lightning-invoice = { workspace = true }
-ln-gateway = { package = "fedimint-ln-gateway", path = "../ln-gateway", version = "=0.6.0-alpha" }
+ln-gateway = { package = "fedimint-ln-gateway", path = "../ln-gateway", version = "=0.7.0-alpha" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/gateway/fedimint-lightning/Cargo.toml
+++ b/gateway/fedimint-lightning/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
-fedimint-bip39 = { version = "=0.6.0-alpha", path = "../../fedimint-bip39" }
+fedimint-bip39 = { version = "=0.7.0-alpha", path = "../../fedimint-bip39" }
 fedimint-bitcoind = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-ln-common = { workspace = true }

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -34,12 +34,12 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 erased-serde = { workspace = true }
 esplora-client = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.6.0-alpha" }
-fedimint-bip39 = { version = "=0.6.0-alpha", path = "../../fedimint-bip39" }
-fedimint-client = { path = "../../fedimint-client", version = "=0.6.0-alpha" }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.0-alpha" }
+fedimint-bip39 = { version = "=0.7.0-alpha", path = "../../fedimint-bip39" }
+fedimint-client = { path = "../../fedimint-client", version = "=0.7.0-alpha" }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
-fedimint-lightning = { path = "../fedimint-lightning", version = "=0.6.0-alpha" }
+fedimint-lightning = { path = "../fedimint-lightning", version = "=0.7.0-alpha" }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
 fedimint-lnv2-client = { workspace = true }

--- a/modules/fedimint-wallet-client/Cargo.toml
+++ b/modules/fedimint-wallet-client/Cargo.toml
@@ -46,6 +46,6 @@ tracing = { workspace = true }
 fedimint-bitcoind = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-fedimint-bitcoind = { version = "=0.6.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = [
+fedimint-bitcoind = { version = "=0.7.0-alpha", path = "../../fedimint-bitcoind", default-features = false, features = [
     "esplora-client",
 ] }


### PR DESCRIPTION
We cut the `releases/v0.6`, so time to bump master to `0.7.0-alpha`.