### PR TITLE
Backport v0.5: chore: publish devimint to crates.io

### DIFF
--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "devimint"
 version = { workspace = true }
+authors = ["The Fedimint Developers"]
 edition = "2021"
+description = "devimint is a library useful for setting up a local environment to run the fedimint stack"
 license = "MIT"
-publish = false
+readme = "../README.md"
+repository = "https://github.com/fedimint/fedimint"
 
 [[bin]]
 name = "devimint"


### PR DESCRIPTION
Backports https://github.com/fedimint/fedimint/pull/6706

Using this instead of https://github.com/fedimint/fedimint/pull/6721, since we didn't have the `[package]` section of the root `Cargo.toml` until after v0.5. See https://github.com/fedimint/fedimint/pull/6721#issuecomment-2599167074