### PR TITLE
chore: default feerate multiplier 4 -> 2 and ability to customize it

### DIFF
--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -49,7 +49,7 @@ pub const CONFIRMATION_TARGET: u16 = 1;
 /// To further mitigate the risk of a peg-out transaction getting stuck in the
 /// mempool, we multiply the feerate estimate returned from the backend by this
 /// value.
-pub const FEERATE_MULTIPLIER: u64 = 2;
+pub const FEERATE_MULTIPLIER_DEFAULT: f64 = 2.0;
 
 pub type PartialSig = Vec<u8>;
 

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -49,7 +49,7 @@ pub const CONFIRMATION_TARGET: u16 = 1;
 /// To further mitigate the risk of a peg-out transaction getting stuck in the
 /// mempool, we multiply the feerate estimate returned from the backend by this
 /// value.
-pub const FEERATE_MULTIPLIER: u64 = 4;
+pub const FEERATE_MULTIPLIER: u64 = 2;
 
 pub type PartialSig = Vec<u8>;
 

--- a/modules/fedimint-wallet-server/src/envs.rs
+++ b/modules/fedimint-wallet-server/src/envs.rs
@@ -1,0 +1,23 @@
+use fedimint_core::util::FmtCompact as _;
+use fedimint_logging::LOG_MODULE_WALLET;
+use fedimint_wallet_common::FEERATE_MULTIPLIER_DEFAULT;
+use tracing::warn;
+
+pub const FM_WALLET_FEERATE_MULTIPLIER_ENV: &str = "FM_WALLET_FEERATE_MULTIPLIER";
+
+pub fn get_feerate_multiplier() -> f64 {
+    if let Ok(mult) = std::env::var(FM_WALLET_FEERATE_MULTIPLIER_ENV) {
+        match mult.parse::<f64>() {
+            Ok(mult) => return mult.clamp(1.0, 32.0),
+            Err(err) => {
+                warn!(
+                    target: LOG_MODULE_WALLET,
+                    err = %err.fmt_compact(),
+                    "Invalid fee multiplier string"
+                );
+            }
+        }
+    }
+
+    FEERATE_MULTIPLIER_DEFAULT
+}


### PR DESCRIPTION
Now that we have an ability to get fee rates from sources better than bitcoind estimation, our fee rates should be much more accurate.


Besides, I am yet to hear about a single instance of peg-outs getting stuck in the mempool, while I heard about and experience myself a decent amount of instances, when a person got robbed blind by a peg-out fee.

While at it, make it override-able from an env var.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
