### PR TITLE
[Backport releases/v0.6] refactor: do not return written bytes from consensus_encode

### DIFF
--- a/fedimint-bip39/src/lib.rs
+++ b/fedimint-bip39/src/lib.rs
@@ -28,10 +28,7 @@ impl<const WORD_COUNT: usize> RootSecretStrategy for Bip39RootSecretStrategy<WOR
         )
     }
 
-    fn consensus_encode(
-        secret: &Self::Encoding,
-        writer: &mut impl Write,
-    ) -> std::io::Result<usize> {
+    fn consensus_encode(secret: &Self::Encoding, writer: &mut impl Write) -> std::io::Result<()> {
         secret.to_entropy().consensus_encode(writer)
     }
 

--- a/fedimint-client/src/oplog.rs
+++ b/fedimint-client/src/oplog.rs
@@ -361,21 +361,19 @@ impl OperationLogEntry {
 }
 
 impl Encodable for OperationLogEntry {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        let mut len = 0;
-        len += self.operation_module_kind.consensus_encode(writer)?;
-        len += serde_json::to_string(&self.meta)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.operation_module_kind.consensus_encode(writer)?;
+        serde_json::to_string(&self.meta)
             .expect("JSON serialization should not fail")
             .consensus_encode(writer)?;
-        len += self
-            .outcome
+        self.outcome
             .as_ref()
             .map(|outcome| {
                 serde_json::to_string(outcome).expect("JSON serialization should not fail")
             })
             .consensus_encode(writer)?;
 
-        Ok(len)
+        Ok(())
     }
 }
 

--- a/fedimint-client/src/secret.rs
+++ b/fedimint-client/src/secret.rs
@@ -62,7 +62,7 @@ pub trait RootSecretStrategy: Debug {
     fn consensus_encode(
         secret: &Self::Encoding,
         writer: &mut impl std::io::Write,
-    ) -> std::io::Result<usize>;
+    ) -> std::io::Result<()>;
 
     /// Deserialization function for the external encoding
     fn consensus_decode_partial(
@@ -87,10 +87,7 @@ impl RootSecretStrategy for PlainRootSecretStrategy {
         DerivableSecret::new_root(secret.as_ref(), FEDIMINT_CLIENT_NONCE)
     }
 
-    fn consensus_encode(
-        secret: &Self::Encoding,
-        writer: &mut impl Write,
-    ) -> std::io::Result<usize> {
+    fn consensus_encode(secret: &Self::Encoding, writer: &mut impl Write) -> std::io::Result<()> {
         secret.consensus_encode(writer)
     }
 

--- a/fedimint-client/src/sm/executor.rs
+++ b/fedimint-client/src/sm/executor.rs
@@ -918,11 +918,10 @@ impl ActiveStateKey {
 }
 
 impl Encodable for ActiveStateKey {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        let mut len = 0;
-        len += self.operation_id.consensus_encode(writer)?;
-        len += self.state.consensus_encode(writer)?;
-        Ok(len)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.operation_id.consensus_encode(writer)?;
+        self.state.consensus_encode(writer)?;
+        Ok(())
     }
 }
 
@@ -949,11 +948,10 @@ pub struct ActiveStateKeyBytes {
 }
 
 impl Encodable for ActiveStateKeyBytes {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        let mut len = 0;
-        len += self.operation_id.consensus_encode(writer)?;
-        len += writer.write(self.state.as_slice())?;
-        Ok(len)
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.operation_id.consensus_encode(writer)?;
+        writer.write_all(self.state.as_slice())?;
+        Ok(())
     }
 }
 
@@ -986,7 +984,7 @@ pub(crate) struct ActiveOperationStateKeyPrefix {
 }
 
 impl Encodable for ActiveOperationStateKeyPrefix {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.operation_id.consensus_encode(writer)
     }
 }
@@ -1002,11 +1000,10 @@ pub(crate) struct ActiveModuleOperationStateKeyPrefix {
 }
 
 impl Encodable for ActiveModuleOperationStateKeyPrefix {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        let mut len = 0;
-        len += self.operation_id.consensus_encode(writer)?;
-        len += self.module_instance.consensus_encode(writer)?;
-        Ok(len)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.operation_id.consensus_encode(writer)?;
+        self.module_instance.consensus_encode(writer)?;
+        Ok(())
     }
 }
 
@@ -1018,8 +1015,8 @@ impl ::fedimint_core::db::DatabaseLookup for ActiveModuleOperationStateKeyPrefix
 pub struct ActiveStateKeyPrefix;
 
 impl Encodable for ActiveStateKeyPrefix {
-    fn consensus_encode<W: Write>(&self, _writer: &mut W) -> Result<usize, Error> {
-        Ok(0)
+    fn consensus_encode<W: Write>(&self, _writer: &mut W) -> Result<(), Error> {
+        Ok(())
     }
 }
 
@@ -1090,11 +1087,10 @@ impl InactiveStateKey {
 }
 
 impl Encodable for InactiveStateKey {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        let mut len = 0;
-        len += self.operation_id.consensus_encode(writer)?;
-        len += self.state.consensus_encode(writer)?;
-        Ok(len)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.operation_id.consensus_encode(writer)?;
+        self.state.consensus_encode(writer)?;
+        Ok(())
     }
 }
 
@@ -1121,11 +1117,10 @@ pub struct InactiveStateKeyBytes {
 }
 
 impl Encodable for InactiveStateKeyBytes {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        let mut len = 0;
-        len += self.operation_id.consensus_encode(writer)?;
-        len += writer.write(self.state.as_slice())?;
-        Ok(len)
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.operation_id.consensus_encode(writer)?;
+        writer.write_all(self.state.as_slice())?;
+        Ok(())
     }
 }
 
@@ -1158,7 +1153,7 @@ pub(crate) struct InactiveOperationStateKeyPrefix {
 }
 
 impl Encodable for InactiveOperationStateKeyPrefix {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.operation_id.consensus_encode(writer)
     }
 }
@@ -1174,11 +1169,10 @@ pub(crate) struct InactiveModuleOperationStateKeyPrefix {
 }
 
 impl Encodable for InactiveModuleOperationStateKeyPrefix {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        let mut len = 0;
-        len += self.operation_id.consensus_encode(writer)?;
-        len += self.module_instance.consensus_encode(writer)?;
-        Ok(len)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.operation_id.consensus_encode(writer)?;
+        self.module_instance.consensus_encode(writer)?;
+        Ok(())
     }
 }
 
@@ -1190,8 +1184,8 @@ impl ::fedimint_core::db::DatabaseLookup for InactiveModuleOperationStateKeyPref
 pub struct InactiveStateKeyPrefix;
 
 impl Encodable for InactiveStateKeyPrefix {
-    fn consensus_encode<W: Write>(&self, _writer: &mut W) -> Result<usize, Error> {
-        Ok(0)
+    fn consensus_encode<W: Write>(&self, _writer: &mut W) -> Result<(), Error> {
+        Ok(())
     }
 }
 

--- a/fedimint-client/src/sm/state.rs
+++ b/fedimint-client/src/sm/state.rs
@@ -355,7 +355,7 @@ impl PartialEq for DynState {
 impl Eq for DynState {}
 
 impl Encodable for DynState {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         self.1.consensus_encode(writer)?;
         self.0.consensus_encode_dyn(writer)
     }
@@ -456,11 +456,10 @@ impl<S> Encodable for OperationState<S>
 where
     S: State,
 {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        let mut len = 0;
-        len += self.operation_id.consensus_encode(writer)?;
-        len += self.state.consensus_encode(writer)?;
-        Ok(len)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.operation_id.consensus_encode(writer)?;
+        self.state.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/fedimint-core/src/core.rs
+++ b/fedimint-core/src/core.rs
@@ -221,9 +221,9 @@ impl fmt::Display for DynUnknown {
 // not implement `Decodable` directly, and `Vec` here has len only
 // for the purpose of knowing how many bytes to carry.
 impl Encodable for DynUnknown {
-    fn consensus_encode<W: std::io::Write>(&self, w: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, w: &mut W) -> Result<(), std::io::Error> {
         w.write_all(&self.0[..])?;
-        Ok(self.0.len())
+        Ok(())
     }
 }
 

--- a/fedimint-core/src/encoding/bls12_381.rs
+++ b/fedimint-core/src/encoding/bls12_381.rs
@@ -4,7 +4,7 @@ use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 
 impl Encodable for Scalar {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         self.to_bytes().consensus_encode(writer)
     }
 }
@@ -22,7 +22,7 @@ impl Decodable for Scalar {
 }
 
 impl Encodable for G1Affine {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         self.to_compressed().consensus_encode(writer)
     }
 }
@@ -40,7 +40,7 @@ impl Decodable for G1Affine {
 }
 
 impl Encodable for G2Affine {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         self.to_compressed().consensus_encode(writer)
     }
 }

--- a/fedimint-core/src/encoding/collections.rs
+++ b/fedimint-core/src/encoding/collections.rs
@@ -9,25 +9,22 @@ impl<T> Encodable for &[T]
 where
     T: Encodable + 'static,
 {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<usize> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         if TypeId::of::<T>() == TypeId::of::<u8>() {
             // unsafe: we've just checked that T is `u8` so the transmute here is a no-op
             let bytes = unsafe { std::mem::transmute::<&[T], &[u8]>(self) };
 
-            let mut len = 0;
-            len += (bytes.len() as u64).consensus_encode(writer)?;
+            (bytes.len() as u64).consensus_encode(writer)?;
             writer.write_all(bytes)?;
-            len += bytes.len();
-            return Ok(len);
+            return Ok(());
         }
 
-        let mut len = 0;
-        len += (self.len() as u64).consensus_encode(writer)?;
+        (self.len() as u64).consensus_encode(writer)?;
 
         for item in *self {
-            len += item.consensus_encode(writer)?;
+            item.consensus_encode(writer)?;
         }
-        Ok(len)
+        Ok(())
     }
 }
 
@@ -35,7 +32,7 @@ impl<T> Encodable for Vec<T>
 where
     T: Encodable + 'static,
 {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<usize> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         (self as &[T]).consensus_encode(writer)
     }
 }
@@ -104,12 +101,12 @@ impl<T> Encodable for VecDeque<T>
 where
     T: Encodable + 'static,
 {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<usize> {
-        let mut len = (self.len() as u64).consensus_encode(writer)?;
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        (self.len() as u64).consensus_encode(writer)?;
         for i in self {
-            len += i.consensus_encode(writer)?;
+            i.consensus_encode(writer)?;
         }
-        Ok(len)
+        Ok(())
     }
 }
 
@@ -131,19 +128,18 @@ impl<T, const SIZE: usize> Encodable for [T; SIZE]
 where
     T: Encodable + 'static,
 {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         if TypeId::of::<T>() == TypeId::of::<u8>() {
             // unsafe: we've just checked that T is `u8` so the transmute here is a no-op
             let bytes = unsafe { std::mem::transmute::<&[T; SIZE], &[u8; SIZE]>(self) };
             writer.write_all(bytes)?;
-            return Ok(bytes.len());
+            return Ok(());
         }
 
-        let mut len = 0;
         for item in self {
-            len += item.consensus_encode(writer)?;
+            item.consensus_encode(writer)?;
         }
-        Ok(len)
+        Ok(())
     }
 }
 
@@ -188,14 +184,13 @@ where
     K: Encodable,
     V: Encodable,
 {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        let mut len = 0;
-        len += (self.len() as u64).consensus_encode(writer)?;
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        (self.len() as u64).consensus_encode(writer)?;
         for (k, v) in self {
-            len += k.consensus_encode(writer)?;
-            len += v.consensus_encode(writer)?;
+            k.consensus_encode(writer)?;
+            v.consensus_encode(writer)?;
         }
-        Ok(len)
+        Ok(())
     }
 }
 
@@ -231,13 +226,12 @@ impl<K> Encodable for BTreeSet<K>
 where
     K: Encodable,
 {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        let mut len = 0;
-        len += (self.len() as u64).consensus_encode(writer)?;
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        (self.len() as u64).consensus_encode(writer)?;
         for k in self {
-            len += k.consensus_encode(writer)?;
+            k.consensus_encode(writer)?;
         }
-        Ok(len)
+        Ok(())
     }
 }
 

--- a/fedimint-core/src/encoding/iroh.rs
+++ b/fedimint-core/src/encoding/iroh.rs
@@ -4,7 +4,7 @@ use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 
 impl Encodable for iroh::SecretKey {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.to_bytes().consensus_encode(writer)
     }
 }
@@ -21,7 +21,7 @@ impl Decodable for iroh::SecretKey {
 }
 
 impl Encodable for iroh::PublicKey {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.as_bytes().consensus_encode(writer)
     }
 }

--- a/fedimint-core/src/encoding/secp256k1.rs
+++ b/fedimint-core/src/encoding/secp256k1.rs
@@ -4,10 +4,10 @@ use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 
 impl Encodable for secp256k1::ecdsa::Signature {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         let bytes = self.serialize_compact();
         writer.write_all(&bytes)?;
-        Ok(bytes.len())
+        Ok(())
     }
 }
 
@@ -22,7 +22,7 @@ impl Decodable for secp256k1::ecdsa::Signature {
 }
 
 impl Encodable for secp256k1::PublicKey {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         self.serialize().consensus_encode(writer)
     }
 }
@@ -38,7 +38,7 @@ impl Decodable for secp256k1::PublicKey {
 }
 
 impl Encodable for secp256k1::SecretKey {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         self.secret_bytes().consensus_encode(writer)
     }
 }
@@ -54,11 +54,11 @@ impl Decodable for secp256k1::SecretKey {
 }
 
 impl Encodable for secp256k1::schnorr::Signature {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         let bytes = &self[..];
         assert_eq!(bytes.len(), secp256k1::constants::SCHNORR_SIGNATURE_SIZE);
         writer.write_all(bytes)?;
-        Ok(secp256k1::constants::SCHNORR_SIGNATURE_SIZE)
+        Ok(())
     }
 }
 
@@ -75,7 +75,7 @@ impl Decodable for secp256k1::schnorr::Signature {
 }
 
 impl Encodable for bitcoin::key::Keypair {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.secret_bytes().consensus_encode(writer)
     }
 }

--- a/fedimint-core/src/encoding/threshold_crypto.rs
+++ b/fedimint-core/src/encoding/threshold_crypto.rs
@@ -7,17 +7,16 @@ use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::module::registry::ModuleDecoderRegistry;
 
 impl Encodable for threshold_crypto::PublicKeySet {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        let mut len = 0;
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         let num_coeff = self.coefficients().len() as u64;
-        len += num_coeff.consensus_encode(writer)?;
+        num_coeff.consensus_encode(writer)?;
         for coefficient in self.coefficients() {
-            len += coefficient
+            coefficient
                 .to_affine()
                 .to_compressed()
                 .consensus_encode(writer)?;
         }
-        Ok(len)
+        Ok(())
     }
 }
 
@@ -46,7 +45,7 @@ impl Decodable for threshold_crypto::PublicKeySet {
 }
 
 impl Encodable for threshold_crypto::PublicKey {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.to_bytes().consensus_encode(writer)
     }
 }
@@ -62,7 +61,7 @@ impl Decodable for threshold_crypto::PublicKey {
 }
 
 impl Encodable for threshold_crypto::Ciphertext {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.to_bytes().consensus_encode(writer)
     }
 }
@@ -80,7 +79,7 @@ impl Decodable for threshold_crypto::Ciphertext {
 }
 
 impl Encodable for threshold_crypto::DecryptionShare {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.to_bytes().consensus_encode(writer)
     }
 }

--- a/fedimint-core/src/encoding/tls.rs
+++ b/fedimint-core/src/encoding/tls.rs
@@ -6,7 +6,9 @@ use tokio_rustls::rustls;
 use crate::encoding::Encodable;
 
 impl Encodable for rustls::Certificate {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        self.0.encode_hex::<String>().consensus_encode(writer)
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.0.encode_hex::<String>().consensus_encode(writer)?;
+
+        Ok(())
     }
 }

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -195,10 +195,10 @@ impl std::fmt::Display for OutPoint {
 }
 
 impl Encodable for TransactionId {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
         let bytes = &self[..];
         writer.write_all(bytes)?;
-        Ok(bytes.len())
+        Ok(())
     }
 }
 

--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -313,16 +313,15 @@ macro_rules! module_plugin_dyn_newtype_encode_decode {
             fn consensus_encode<W: std::io::Write>(
                 &self,
                 writer: &mut W,
-            ) -> Result<usize, std::io::Error> {
-                let mut written = self.module_instance_id.consensus_encode(writer)?;
+            ) -> Result<(), std::io::Error> {
+                self.module_instance_id.consensus_encode(writer)?;
 
                 let mut buf = Vec::with_capacity(512);
-                let buf_written = self.inner.consensus_encode_dyn(&mut buf)?;
-                assert_eq!(buf.len(), buf_written);
+                self.inner.consensus_encode_dyn(&mut buf)?;
 
-                written += buf.consensus_encode(writer)?;
+                buf.consensus_encode(writer)?;
 
-                Ok(written)
+                Ok(())
             }
         }
 

--- a/fedimint-core/src/tiered.rs
+++ b/fedimint-core/src/tiered.rs
@@ -121,8 +121,9 @@ impl<C> Encodable for Tiered<C>
 where
     C: Encodable,
 {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        self.0.consensus_encode(writer)
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.0.consensus_encode(writer)?;
+        Ok(())
     }
 }
 

--- a/fedimint-core/src/tiered_multi.rs
+++ b/fedimint-core/src/tiered_multi.rs
@@ -166,7 +166,7 @@ impl<C> Encodable for TieredMulti<C>
 where
     C: Encodable + 'static,
 {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         self.0.consensus_encode(writer)
     }
 }

--- a/fedimint-core/src/txoproof.rs
+++ b/fedimint-core/src/txoproof.rs
@@ -65,13 +65,11 @@ impl Decodable for TxOutProof {
 }
 
 impl Encodable for TxOutProof {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        let mut written = 0;
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        self.block_header.consensus_encode(writer)?;
+        self.merkle_proof.consensus_encode(writer)?;
 
-        written += self.block_header.consensus_encode(writer)?;
-        written += self.merkle_proof.consensus_encode(writer)?;
-
-        Ok(written)
+        Ok(())
     }
 }
 

--- a/modules/fedimint-ln-common/src/contracts/incoming.rs
+++ b/modules/fedimint-ln-common/src/contracts/incoming.rs
@@ -96,7 +96,7 @@ impl IdentifiableContract for IncomingContract {
 }
 
 impl Encodable for OfferId {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.to_byte_array().consensus_encode(writer)
     }
 }

--- a/modules/fedimint-ln-common/src/contracts/mod.rs
+++ b/modules/fedimint-ln-common/src/contracts/mod.rs
@@ -100,7 +100,7 @@ impl Contract {
 }
 
 impl Encodable for ContractId {
-    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.to_byte_array().consensus_encode(writer)
     }
 }

--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -263,7 +263,7 @@ pub struct LightningGatewayRegistration {
 }
 
 impl Encodable for LightningGatewayRegistration {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         let json_repr = serde_json::to_string(self).map_err(|e| {
             Error::new(
                 ErrorKind::Other,

--- a/modules/fedimint-wallet-common/src/keys.rs
+++ b/modules/fedimint-wallet-common/src/keys.rs
@@ -23,7 +23,7 @@ impl CompressedPublicKey {
 }
 
 impl Encodable for CompressedPublicKey {
-    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
+    fn consensus_encode<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.key.serialize().consensus_encode(writer)
     }
 }


### PR DESCRIPTION
# Description
Backport of #6754 to `releases/v0.6`.