### PR TITLE
chore(ci): rm fedimintd_data and use fedimintd image tag var

### DIFF
--- a/docker/current/.env
+++ b/docker/current/.env
@@ -13,3 +13,6 @@ FM_BITCOIN_RPC_URL=http://bitcoin@bitcoin@127.0.0.1:8332
 # For testing or fallback one can also use esplora
 # FM_BITCOIN_RPC_KIND=esplora
 # FM_BITCOIN_RPC_URL=https://blockstream.info/api/
+
+# fedimintd image
+FEDIMINTD_IMAGE=fedimint/fedimintd:v0.6.0-rc.1

--- a/docker/current/deploy.sh
+++ b/docker/current/deploy.sh
@@ -59,7 +59,12 @@ echo >&2 '### Wiping previous setup'
 ssh -q "root@$ssh_host" << EOF
   touch ~/.hushlogin
 
-  if [ -e $host_dir  ] ; then cd $host_dir && docker-compose down 2>/dev/null || true ; fi
+  if [ -e $host_dir  ] ; then
+    # Stop the docker-compose stack
+    cd $host_dir && docker-compose down 2>/dev/null || true
+    # We remove only the fedimintd_data named volume
+    docker volume rm fedimint-docker_fedimintd_data 2>/dev/null || true
+  fi
 
   systemctl stop fedimint-docker-compose 2>/dev/null || true
   rm -rf /root/fedimint-docker

--- a/docker/current/docker-compose.yaml
+++ b/docker/current/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
     restart: unless-stopped
 
   fedimintd:
-    image: fedimint/fedimintd:v0.5.0
+    image: ${FEDIMINTD_IMAGE}
     volumes:
       - fedimintd_data:/data
     ports:


### PR DESCRIPTION
I haven't verified against our Hetzner VMs, but I setup a personal VM and verified
- New deployment using existing logic
- Wipe using these changes and verified correct restart with new `fedimintd` tag and `bitcoin` named volume is untouched

Once we merge these changes, I'll deploy against our Hetzner VMs.