### PR TITLE
Allow guardians to see statistics about client backups saved to their fedimintd

### DIFF
--- a/fedimint-api-client/src/api/global_api/with_cache.rs
+++ b/fedimint-api-client/src/api/global_api/with_cache.rs
@@ -9,13 +9,13 @@ use bitcoin::secp256k1;
 use fedimint_core::admin_client::{
     ConfigGenConnectionsRequest, ConfigGenParamsRequest, ConfigGenParamsResponse, PeerServerParams,
 };
-use fedimint_core::backup::ClientBackupSnapshot;
+use fedimint_core::backup::{BackupStatistics, ClientBackupSnapshot};
 use fedimint_core::core::backup::SignedBackupRequest;
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::endpoint_constants::{
     ADD_CONFIG_GEN_PEER_ENDPOINT, API_ANNOUNCEMENTS_ENDPOINT, AUDIT_ENDPOINT, AUTH_ENDPOINT,
     AWAIT_SESSION_OUTCOME_ENDPOINT, AWAIT_TRANSACTION_ENDPOINT, BACKUP_ENDPOINT,
-    CONFIG_GEN_PEERS_ENDPOINT, CONSENSUS_CONFIG_GEN_PARAMS_ENDPOINT,
+    BACKUP_STATISTICS_ENDPOINT, CONFIG_GEN_PEERS_ENDPOINT, CONSENSUS_CONFIG_GEN_PARAMS_ENDPOINT,
     DEFAULT_CONFIG_GEN_PARAMS_ENDPOINT, FEDIMINTD_VERSION_ENDPOINT,
     GUARDIAN_CONFIG_BACKUP_ENDPOINT, RECOVER_ENDPOINT, RESTART_FEDERATION_SETUP_ENDPOINT,
     RUN_DKG_ENDPOINT, SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT, SESSION_COUNT_ENDPOINT,
@@ -556,6 +556,15 @@ where
     async fn shutdown(&self, session: Option<u64>, auth: ApiAuth) -> FederationResult<()> {
         self.request_admin(SHUTDOWN_ENDPOINT, ApiRequestErased::new(session), auth)
             .await
+    }
+
+    async fn backup_statistics(&self, auth: ApiAuth) -> FederationResult<BackupStatistics> {
+        self.request_admin(
+            BACKUP_STATISTICS_ENDPOINT,
+            ApiRequestErased::default(),
+            auth,
+        )
+        .await
     }
 
     async fn fedimintd_version(&self, peer_id: PeerId) -> PeerResult<String> {

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -18,7 +18,7 @@ use fedimint_core::admin_client::{
     ConfigGenConnectionsRequest, ConfigGenParamsRequest, ConfigGenParamsResponse, PeerServerParams,
     ServerStatus,
 };
-use fedimint_core::backup::ClientBackupSnapshot;
+use fedimint_core::backup::{BackupStatistics, ClientBackupSnapshot};
 use fedimint_core::core::backup::SignedBackupRequest;
 use fedimint_core::core::{Decoder, DynOutputOutcome, ModuleInstanceId, OutputOutcome};
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -601,6 +601,9 @@ pub trait IGlobalFederationApi: IRawFederationApi {
 
     /// Returns the fedimintd version a peer is running
     async fn fedimintd_version(&self, peer_id: PeerId) -> PeerResult<String>;
+
+    /// Fetch the backup statistics from the federation (admin endpoint)
+    async fn backup_statistics(&self, auth: ApiAuth) -> FederationResult<BackupStatistics>;
 }
 
 pub fn deserialize_outcome<R>(

--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -379,6 +379,8 @@ enum AdminCmd {
         /// Session index to stop after
         session_idx: u64,
     },
+    /// Show statistics about client backups stored by the federation
+    BackupStatistics,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -932,6 +934,18 @@ impl FedimintCli {
                     .await?;
 
                 Ok(CliOutput::Raw(json!(null)))
+            }
+            Command::Admin(AdminCmd::BackupStatistics) => {
+                let client = self.client_open(&cli).await?;
+
+                let backup_statistics = cli
+                    .admin_client(&client.get_peer_urls().await, client.api_secret())?
+                    .backup_statistics(cli.auth()?)
+                    .await?;
+
+                Ok(CliOutput::Raw(
+                    serde_json::to_value(backup_statistics).expect("Can be encoded"),
+                ))
             }
             Command::Dev(DevCmd::Api {
                 method,

--- a/fedimint-core/src/backup.rs
+++ b/fedimint-core/src/backup.rs
@@ -33,7 +33,7 @@ pub struct ClientBackupSnapshot {
 }
 
 /// Statistics about backups stored in the federation
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct BackupStatistics {
     pub num_backups: usize,
     pub total_size: usize,

--- a/fedimint-core/src/backup.rs
+++ b/fedimint-core/src/backup.rs
@@ -31,3 +31,14 @@ pub struct ClientBackupSnapshot {
     #[serde(with = "fedimint_core::hex::serde")]
     pub data: Vec<u8>,
 }
+
+/// Statistics about backups stored in the federation
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BackupStatistics {
+    pub num_backups: usize,
+    pub total_size: usize,
+    pub refreshed_1d: usize,
+    pub refreshed_1w: usize,
+    pub refreshed_1m: usize,
+    pub refreshed_3m: usize,
+}

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -6,6 +6,7 @@ pub const AUTH_ENDPOINT: &str = "auth";
 #[deprecated(note = "https://github.com/fedimint/fedimint/issues/6671")]
 pub const AWAIT_OUTPUT_OUTCOME_ENDPOINT: &str = "await_output_outcome";
 pub const BACKUP_ENDPOINT: &str = "backup";
+pub const BACKUP_STATISTICS_ENDPOINT: &str = "backup_statistics";
 pub const CHECK_BITCOIN_STATUS_ENDPOINT: &str = "check_bitcoin_status";
 pub const CLIENT_CONFIG_ENDPOINT: &str = "client_config";
 pub const CLIENT_CONFIG_JSON_ENDPOINT: &str = "client_config_json";


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
