### PR TITLE
chore(wallet-server): don't spam citems

### DIFF
--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -25,7 +25,6 @@ use fedimint_core::util::{FmtCompactAnyhow, SafeUrl};
 use fedimint_core::{apply, async_trait_maybe_send, dyn_newtype_define, Feerate};
 use fedimint_logging::{LOG_BITCOIND, LOG_CORE};
 use feerate_source::{FeeRateSource, FetchJson};
-use tokio::sync::watch;
 use tokio::time::Interval;
 use tracing::{debug, trace, warn};
 
@@ -198,8 +197,8 @@ impl DynBitcoindRpc {
     pub fn spawn_block_count_update_task(
         self,
         task_group: &TaskGroup,
-    ) -> anyhow::Result<watch::Receiver<Option<u64>>> {
-        let (block_count_tx, block_count_rx) = watch::channel(None);
+        on_update: impl Fn(u64) + Send + Sync + 'static,
+    ) -> anyhow::Result<()> {
         let mut desired_interval = get_bitcoin_polling_interval();
 
         task_group.spawn_cancellable("block count background task", {
@@ -213,7 +212,7 @@ impl DynBitcoindRpc {
 
                     match res {
                         Ok(c) => {
-                            let _ = block_count_tx.send(Some(c));
+                            on_update(c);
                         },
                         Err(err) => {
                             warn!(target: LOG_BITCOIND, err = %err.fmt_compact_anyhow(), "Unable to get block count from the node");
@@ -232,7 +231,7 @@ impl DynBitcoindRpc {
                 }
             }
         });
-        Ok(block_count_rx)
+        Ok(())
     }
 
     /// Spawns a background task that queries the feerate periodically and sends
@@ -240,12 +239,10 @@ impl DynBitcoindRpc {
     pub fn spawn_fee_rate_update_task(
         self,
         task_group: &TaskGroup,
-        default_fee: Feerate,
         network: Network,
         confirmation_target: u16,
-    ) -> anyhow::Result<watch::Receiver<Feerate>> {
-        let (fee_rate_tx, fee_rate_rx) = watch::channel(default_fee);
-
+        on_update: impl Fn(Feerate) + Send + Sync + 'static,
+    ) -> anyhow::Result<()> {
         let sources = std::env::var(FM_WALLET_FEERATE_SOURCES_ENV)
             .unwrap_or_else(|_| match network {
                 Network::Bitcoin => "https://mempool.space/api/v1/fees/recommended#.;https://blockstream.info/api/fee-estimates#.\"1\"".to_owned(),
@@ -289,7 +286,7 @@ impl DynBitcoindRpc {
 
                 if let Some(r) = get_median(&available_feerates) {
                     let feerate = Feerate { sats_per_kvb: r };
-                    let _ = fee_rate_tx.send(feerate);
+                    on_update(feerate);
                 } else {
                     // During tests (regtest) we never get any real feerate, so no point spamming about it
                     if !is_running_in_test_env() {
@@ -309,7 +306,7 @@ impl DynBitcoindRpc {
             }
         });
 
-        Ok(fee_rate_rx)
+        Ok(())
     }
 }
 

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -629,8 +629,11 @@ impl ServerModule for Lightning {
 
 impl Lightning {
     fn new(cfg: LightningConfig, task_group: &TaskGroup) -> anyhow::Result<Self> {
+        let (block_count_tx, block_count_rx) = watch::channel(None);
         let btc_rpc = create_bitcoind(&cfg.local.bitcoin_rpc)?;
-        let block_count_rx = btc_rpc.spawn_block_count_update_task(task_group)?;
+        btc_rpc.spawn_block_count_update_task(task_group, move |count| {
+            let _ = block_count_tx.send(Some(count));
+        })?;
 
         Ok(Lightning {
             cfg,

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -15,6 +15,7 @@ pub mod envs;
 use std::clone::Clone;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::Infallible;
+use std::sync::Arc;
 #[cfg(not(target_family = "wasm"))]
 use std::time::Duration;
 
@@ -95,7 +96,7 @@ use miniscript::{translate_hash_fail, Descriptor, TranslatePk};
 use rand::rngs::OsRng;
 use serde::Serialize;
 use strum::IntoEnumIterator;
-use tokio::sync::watch;
+use tokio::sync::{watch, Notify};
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::db::{
@@ -416,6 +417,14 @@ impl ServerModule for Wallet {
         &'a self,
         dbtx: &mut DatabaseTransaction<'_>,
     ) -> Vec<WalletConsensusItem> {
+        if tokio::time::timeout(Duration::from_secs(15), self.propose_citem.notified())
+            .await
+            .is_err()
+        {
+            // No notifications, return no citem, just so the caller know we didn't hang
+            return vec![];
+        }
+
         let mut items = dbtx
             .find_by_prefix(&PegOutTxSignatureCIPrefix)
             .await
@@ -588,6 +597,10 @@ impl ServerModule for Wallet {
 
                     dbtx.remove_entry(&PegOutTxSignatureCI(txid)).await;
                     dbtx.remove_entry(&UnsignedTransactionKey(txid)).await;
+                    let propose_citem_tx = self.propose_citem.clone();
+                    dbtx.on_commit(move || {
+                        propose_citem_tx.notify_one();
+                    });
                 }
             }
             WalletConsensusItem::ModuleConsensusVersion(module_consensus_version) => {
@@ -779,6 +792,11 @@ impl ServerModule for Wallet {
 
         dbtx.insert_new_entry(&PegOutTxSignatureCI(txid), &sigs)
             .await;
+
+        let propose_citem_tx = self.propose_citem.clone();
+        dbtx.on_commit(move || {
+            propose_citem_tx.notify_one();
+        });
 
         dbtx.insert_new_entry(
             &PegOutBitcoinTransaction(out_point),
@@ -1000,6 +1018,10 @@ pub struct Wallet {
     block_count_rx: watch::Receiver<Option<u64>>,
     /// Fee rate updated periodically by a background task
     fee_rate_rx: watch::Receiver<Feerate>,
+
+    /// Consensus proposals will wait for this notification
+    propose_citem: Arc<Notify>,
+
     task_group: TaskGroup,
     /// Maximum consensus version supported by *all* our peers. Used to
     /// automatically activate new consensus versions as soon as everyone
@@ -1027,20 +1049,30 @@ impl Wallet {
         our_peer_id: PeerId,
         module_api: DynModuleApi,
     ) -> Result<Wallet, WalletCreationError> {
-        Self::spawn_broadcast_pending_task(task_group, &bitcoind, db);
+        let propose_citem = Arc::new(Notify::new());
+        let (block_count_tx, block_count_rx) = watch::channel(None);
+        let (fee_rate_tx, fee_rate_rx) = watch::channel(cfg.consensus.default_fee);
 
-        let fee_rate_rx = bitcoind
+        Self::spawn_broadcast_pending_task(task_group, &bitcoind, db);
+        bitcoind
             .clone()
-            .spawn_fee_rate_update_task(
-                task_group,
-                cfg.consensus.default_fee,
-                cfg.consensus.network.0,
-                CONFIRMATION_TARGET,
-            )
+            .spawn_fee_rate_update_task(task_group, cfg.consensus.network.0, CONFIRMATION_TARGET, {
+                let propose_citem = propose_citem.clone();
+                move |feerate| {
+                    let _ = fee_rate_tx.send(feerate);
+                    propose_citem.notify_one();
+                }
+            })
             .map_err(|e| WalletCreationError::FeerateSourceError(e.to_string()))?;
-        let block_count_rx = bitcoind
+        bitcoind
             .clone()
-            .spawn_block_count_update_task(task_group)
+            .spawn_block_count_update_task(task_group, {
+                let propose_citem = propose_citem.clone();
+                move |count| {
+                    let _ = block_count_tx.send(Some(count));
+                    propose_citem.notify_one();
+                }
+            })
             .map_err(|e| WalletCreationError::BlockCountSourceError(e.to_string()))?;
 
         let peer_supported_consensus_version =
@@ -1062,6 +1094,10 @@ impl Wallet {
             ));
         }
 
+        // Propose consensus items right after start, just for good startup
+        // latency
+        propose_citem.notify_one();
+
         let wallet = Wallet {
             cfg,
             secp: Default::default(),
@@ -1071,6 +1107,7 @@ impl Wallet {
             fee_rate_rx,
             task_group: task_group.clone(),
             peer_supported_consensus_version,
+            propose_citem,
         };
 
         Ok(wallet)


### PR DESCRIPTION
In theory wallet-server proposing citems all the time shouldn't matter, as redudant citems will get discarded

In practice it is spamming logs, generates more unnecessary noise making debugging harder and is simply unnecessary. It also makes the peer start after restart slower, as it has to re-process (re-reject as redundant) all the items from the currently opened session, which there might be a lot.

In 0.6 some `target`s on `debug!` etc. were fixed, exposing the spam.


There are 3 things that cause us to want to propose a quick citem:

* block count (periodic)
* fee rate (periodic)
* tx signature ci

This change adds an additional watch channel to make the wallet-server propose things when any of these 3 sent an update. This will lower rate of citem proposals from ~2 ever second per peer to ~1 every 15-30 seconds.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
