### PR TITLE
chore: less spam in logs [broken]

### DIFF
--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -8,6 +8,7 @@
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 use std::{env, iter};
@@ -201,6 +202,8 @@ impl DynBitcoindRpc {
     ) -> anyhow::Result<()> {
         let mut desired_interval = get_bitcoin_polling_interval();
 
+        let last_block_count = AtomicU64::new(0);
+
         task_group.spawn_cancellable("block count background task", {
             async move {
                 debug!(target: LOG_BITCOIND, "Updating bitcoin block count");
@@ -211,8 +214,11 @@ impl DynBitcoindRpc {
                         .await;
 
                     match res {
-                        Ok(c) => {
-                            on_update(c);
+                        Ok(block_count) => {
+                            if last_block_count.load(Ordering::SeqCst) != block_count {
+                                on_update(block_count);
+                                last_block_count.store(block_count, Ordering::SeqCst);
+                            }
                         },
                         Err(err) => {
                             warn!(target: LOG_BITCOIND, err = %err.fmt_compact_anyhow(), "Unable to get block count from the node");
@@ -262,6 +268,8 @@ impl DynBitcoindRpc {
         task_group.spawn_cancellable("feerate background task", async move {
             debug!(target: LOG_BITCOIND, "Updating feerate");
 
+            let last_feerate = AtomicU64::new(0);
+
             let update_fee_rate = || async {
                 trace!(target: LOG_BITCOIND, "Updating bitcoin fee rate");
 
@@ -284,9 +292,11 @@ impl DynBitcoindRpc {
 
                 available_feerates.sort_unstable();
 
-                if let Some(r) = get_median(&available_feerates) {
-                    let feerate = Feerate { sats_per_kvb: r };
-                    on_update(feerate);
+                if let Some(feerate) = get_median(&available_feerates) {
+                    if feerate != last_feerate.load(Ordering::SeqCst) {
+                        on_update(Feerate { sats_per_kvb: feerate });
+                        last_feerate.store(feerate, Ordering::SeqCst);
+                    }
                 } else {
                     // During tests (regtest) we never get any real feerate, so no point spamming about it
                     if !is_running_in_test_env() {

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -25,7 +25,6 @@ use fedimint_core::util::{FmtCompactAnyhow, SafeUrl};
 use fedimint_core::{apply, async_trait_maybe_send, dyn_newtype_define, Feerate};
 use fedimint_logging::{LOG_BITCOIND, LOG_CORE};
 use feerate_source::{FeeRateSource, FetchJson};
-use tokio::sync::watch;
 use tokio::time::Interval;
 use tracing::{debug, trace, warn};
 
@@ -198,8 +197,8 @@ impl DynBitcoindRpc {
     pub fn spawn_block_count_update_task(
         self,
         task_group: &TaskGroup,
-    ) -> anyhow::Result<watch::Receiver<Option<u64>>> {
-        let (block_count_tx, block_count_rx) = watch::channel(None);
+        on_update: impl Fn(u64) + Send + Sync + 'static,
+    ) -> anyhow::Result<()> {
         let mut desired_interval = get_bitcoin_polling_interval();
 
         task_group.spawn_cancellable("block count background task", {
@@ -213,7 +212,7 @@ impl DynBitcoindRpc {
 
                     match res {
                         Ok(c) => {
-                            let _ = block_count_tx.send(Some(c));
+                            on_update(c);
                         },
                         Err(err) => {
                             warn!(target: LOG_BITCOIND, err = %err.fmt_compact_anyhow(), "Unable to get block count from the node");
@@ -232,7 +231,7 @@ impl DynBitcoindRpc {
                 }
             }
         });
-        Ok(block_count_rx)
+        Ok(())
     }
 
     /// Spawns a background task that queries the feerate periodically and sends
@@ -240,12 +239,10 @@ impl DynBitcoindRpc {
     pub fn spawn_fee_rate_update_task(
         self,
         task_group: &TaskGroup,
-        default_fee: Feerate,
         network: Network,
         confirmation_target: u16,
-    ) -> anyhow::Result<watch::Receiver<Feerate>> {
-        let (fee_rate_tx, fee_rate_rx) = watch::channel(default_fee);
-
+        on_update: impl Fn(Feerate) + Send + Sync + 'static,
+    ) -> anyhow::Result<()> {
         let sources = std::env::var(FM_WALLET_FEERATE_SOURCES_ENV)
             .unwrap_or_else(|_| match network {
                 Network::Bitcoin => "https://mempool.space/api/v1/fees/recommended#.;https://blockstream.info/api/fee-estimates#.\"1\"".to_owned(),
@@ -289,7 +286,7 @@ impl DynBitcoindRpc {
 
                 if let Some(r) = get_median(&available_feerates) {
                     let feerate = Feerate { sats_per_kvb: r };
-                    let _ = fee_rate_tx.send(feerate);
+                    on_update(feerate);
                 } else {
                     // During tests (regtest) we never get any real feerate, so no point spamming about it
                     if !is_running_in_test_env() {
@@ -309,7 +306,7 @@ impl DynBitcoindRpc {
             }
         });
 
-        Ok(fee_rate_rx)
+        Ok(())
     }
 }
 

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -629,8 +629,11 @@ impl ServerModule for Lightning {
 
 impl Lightning {
     fn new(cfg: LightningConfig, task_group: &TaskGroup) -> anyhow::Result<Self> {
+        let (block_count_tx, block_count_rx) = watch::channel(None);
         let btc_rpc = create_bitcoind(&cfg.local.bitcoin_rpc)?;
-        let block_count_rx = btc_rpc.spawn_block_count_update_task(task_group)?;
+        btc_rpc.spawn_block_count_update_task(task_group, move |count| {
+            let _ = block_count_tx.send(Some(count));
+        })?;
 
         Ok(Lightning {
             cfg,

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -1285,7 +1285,7 @@ async fn poll_supports_safe_deposit_version(db: Database, module_api: DynModuleA
         drop(dbtx);
 
         if is_running_in_test_env() {
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(30)).await;
         } else {
             sleep(Duration::from_secs(3600)).await;
         }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -597,6 +597,10 @@ impl ServerModule for Wallet {
 
                     dbtx.remove_entry(&PegOutTxSignatureCI(txid)).await;
                     dbtx.remove_entry(&UnsignedTransactionKey(txid)).await;
+                    let propose_citem_tx = self.propose_citem.clone();
+                    dbtx.on_commit(move || {
+                        propose_citem_tx.notify_one();
+                    });
                 }
             }
             WalletConsensusItem::ModuleConsensusVersion(module_consensus_version) => {

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -58,7 +58,7 @@ use fedimint_core::module::{
 };
 #[cfg(not(target_family = "wasm"))]
 use fedimint_core::task::sleep;
-use fedimint_core::task::{TaskGroup, TaskHandle};
+use fedimint_core::task::TaskGroup;
 use fedimint_core::util::{backoff_util, retry, FmtCompactAnyhow as _};
 use fedimint_core::{
     apply, async_trait_maybe_send, get_network_for_address, push_db_key_items, push_db_pair_items,
@@ -597,9 +597,11 @@ impl ServerModule for Wallet {
 
                     dbtx.remove_entry(&PegOutTxSignatureCI(txid)).await;
                     dbtx.remove_entry(&UnsignedTransactionKey(txid)).await;
-                    let propose_citem_tx = self.propose_citem.clone();
+                    let propose_citem = self.propose_citem.clone();
+                    let broadcast_pending = self.broadcast_pending.clone();
                     dbtx.on_commit(move || {
-                        propose_citem_tx.notify_one();
+                        propose_citem.notify_one();
+                        broadcast_pending.notify_one();
                     });
                 }
             }
@@ -1021,6 +1023,8 @@ pub struct Wallet {
 
     /// Consensus proposals will wait for this notification
     propose_citem: Arc<Notify>,
+    /// Broadcasting pending txes can be triggered immediately with this
+    broadcast_pending: Arc<Notify>,
 
     task_group: TaskGroup,
     /// Maximum consensus version supported by *all* our peers. Used to
@@ -1050,10 +1054,11 @@ impl Wallet {
         module_api: DynModuleApi,
     ) -> Result<Wallet, WalletCreationError> {
         let propose_citem = Arc::new(Notify::new());
+        let broadcast_pending = Arc::new(Notify::new());
         let (block_count_tx, block_count_rx) = watch::channel(None);
         let (fee_rate_tx, fee_rate_rx) = watch::channel(cfg.consensus.default_fee);
 
-        Self::spawn_broadcast_pending_task(task_group, &bitcoind, db);
+        Self::spawn_broadcast_pending_task(task_group, &bitcoind, db, broadcast_pending.clone());
         bitcoind
             .clone()
             .spawn_fee_rate_update_task(task_group, cfg.consensus.network.0, CONFIRMATION_TARGET, {
@@ -1108,6 +1113,7 @@ impl Wallet {
             task_group: task_group.clone(),
             peer_supported_consensus_version,
             propose_citem,
+            broadcast_pending,
         };
 
         Ok(wallet)
@@ -1661,13 +1667,12 @@ impl Wallet {
         task_group: &TaskGroup,
         bitcoind: &DynBitcoindRpc,
         db: &Database,
+        broadcast_pending_notify: Arc<Notify>,
     ) {
-        task_group.spawn("broadcast pending", {
+        task_group.spawn_cancellable("broadcast pending", {
             let bitcoind = bitcoind.clone();
             let db = db.clone();
-            |handle| async move {
-                run_broadcast_pending_tx(db, bitcoind, &handle).await;
-            }
+            run_broadcast_pending_tx(db, bitcoind, broadcast_pending_notify)
         });
     }
 
@@ -1793,10 +1798,11 @@ impl Wallet {
 }
 
 #[instrument(target = LOG_MODULE_WALLET, level = "debug", skip_all)]
-pub async fn run_broadcast_pending_tx(db: Database, rpc: DynBitcoindRpc, tg_handle: &TaskHandle) {
-    while !tg_handle.is_shutting_down() {
+pub async fn run_broadcast_pending_tx(db: Database, rpc: DynBitcoindRpc, broadcast: Arc<Notify>) {
+    loop {
+        // Unless something new happened, we broadcast once a minute
+        let _ = tokio::time::timeout(Duration::from_secs(60), broadcast.notified()).await;
         broadcast_pending_tx(db.begin_transaction_nc().await, &rpc).await;
-        sleep(Duration::from_secs(1)).await;
     }
 }
 
@@ -1811,12 +1817,14 @@ pub async fn broadcast_pending_tx(mut dbtx: DatabaseTransaction<'_>, rpc: &DynBi
         .iter()
         .filter_map(|tx| tx.rbf.clone().map(|rbf| rbf.txid))
         .collect();
-    debug!(
-        target: LOG_MODULE_WALLET,
-        "Broadcasting pending transactions (total={}, rbf={})",
-        pending_tx.len(),
-        rbf_txids.len()
-    );
+    if !pending_tx.is_empty() {
+        debug!(
+            target: LOG_MODULE_WALLET,
+            "Broadcasting pending transactions (total={}, rbf={})",
+            pending_tx.len(),
+            rbf_txids.len()
+        );
+    }
 
     for PendingTransaction { tx, .. } in pending_tx {
         if !rbf_txids.contains(&tx.compute_txid()) {

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1782,7 +1782,7 @@ impl Wallet {
                 }
 
                 if is_running_in_test_env() {
-                    sleep(Duration::from_secs(1)).await;
+                    sleep(Duration::from_secs(30)).await;
                 } else {
                     sleep(Duration::from_secs(3600)).await;
                 }


### PR DESCRIPTION
_Can I get Fedimint with consensus, api, db queries without the spam? Why not?! I! Don't. Like! Spam!_ (in logs)

[![Video Title](https://img.youtube.com/vi/anwy2MPT5RE/0.jpg)](https://www.youtube.com/watch?v=anwy2MPT5RE)

But more seriously - any redundant and unnecessary log output have a real and severe cost during debugging, even ignoring the performance. When you are trying to understand the behavior of the system, any irrelevant logs are obscuring and confusing.

Moreover - using notifications instead of polling, actually improves the latencies and lowers the performance usage. Lower latencies should also mean faster test times, because our system tends to be latency bottlenecked.

The complexity of it is small too. Add `Notify`, block on it (potentially with a timeout if desired), give it a name and meaning, make sure to notify after something relevant happened (usually a key was added/removed to a db).

This is a continuation (on top) of  #6765 :


* make LNv2 and LNv1 triggered by `Notify` like in #6765
* make module consensus polling less frequent in tests (it's annoying, and there's like what... 1 test that will be slightly slower because of it?)
* make broadcasting txes faster and less spamy using `Notify`

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
