### PR TITLE
chore: lower logging of consensus proposals

### DIFF
--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -362,7 +362,7 @@ impl ServerModule for Lightning {
             .await;
 
         if let Ok(block_count_vote) = self.get_block_count() {
-            debug!(target: LOG_MODULE_LN, ?block_count_vote, "Proposing block count");
+            trace!(target: LOG_MODULE_LN, ?block_count_vote, "Proposing block count");
             items.push(LightningConsensusItem::BlockCount(block_count_vote));
         }
 

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -62,7 +62,7 @@ use tokio::sync::watch;
 use tpe::{
     derive_pk_share, AggregatePublicKey, DecryptionKeyShare, PublicKeyShare, SecretKeyShare,
 };
-use tracing::debug;
+use tracing::trace;
 
 use crate::db::{
     BlockCountVoteKey, BlockCountVotePrefix, DbKeyPrefix, DecryptionKeyShareKey,
@@ -338,7 +338,7 @@ impl ServerModule for Lightning {
         )];
 
         if let Ok(block_count) = self.get_block_count() {
-            debug!(target: LOG_MODULE_LNV2, ?block_count, "Proposing block count");
+            trace!(target: LOG_MODULE_LNV2, ?block_count, "Proposing block count");
             items.push(LightningConsensusItem::BlockCountVote(block_count));
         }
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -445,7 +445,7 @@ impl ServerModule for Wallet {
                     .await
                     .unwrap_or(0);
 
-                debug!(
+                trace!(
                     target: LOG_MODULE_WALLET,
                     ?current_vote,
                     ?block_count_vote,
@@ -500,12 +500,10 @@ impl ServerModule for Wallet {
         consensus_item: WalletConsensusItem,
         peer: PeerId,
     ) -> anyhow::Result<()> {
-        trace!(?consensus_item, "Received consensus proposals");
+        trace!(target: LOG_MODULE_WALLET, ?consensus_item, "Received consensus proposals");
 
         match consensus_item {
             WalletConsensusItem::BlockCount(block_count_vote) => {
-                debug!(target: LOG_MODULE_WALLET, ?peer, ?block_count_vote, "Received block count vote");
-
                 let current_vote = dbtx.get_value(&BlockCountVoteKey(peer)).await.unwrap_or(0);
 
                 if block_count_vote < current_vote {


### PR DESCRIPTION
Due to how AlephBFT works we generate consensus proposals over and over, and over and it's not very useful to know about that.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
