### PR TITLE
chore: lower logging level of "api request complete"

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -377,7 +377,7 @@ impl ApiEndpoint<()> {
             if let Err(error) = &result {
                 tracing::warn!(target: LOG_NET_API, path = E::PATH, ?error, "api request error");
             } else {
-                tracing::debug!(target: LOG_NET_API, path = E::PATH, "api request complete");
+                tracing::trace!(target: LOG_NET_API, path = E::PATH, "api request complete");
             }
             result
         }


### PR DESCRIPTION
For every request we print two log lines (received + complete/error) and this one is less useful by default.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
