### PR TITLE
chore: Backwards Compatibility/Upgrade tests with LNv2

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -55,8 +55,6 @@ jobs:
             VERSIONS_TO_TEST="v0.5.0"
           fi
 
-          export FM_DEVIMINT_DISABLE_MODULE_LNV2=1
-
           # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)
           # we need to use `nix develop -c` to be able to use `nix build` inside of backwards-compatibility-test
           # Disable `sccache`, it seems incompatible with self-hosted runner sandbox for some reason, and

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -60,7 +60,6 @@ jobs:
 
           # if empty, defaults to all test kinds within script
           export TEST_KINDS="${{ github.event.inputs.test_kinds }}"
-          export FM_DEVIMINT_DISABLE_MODULE_LNV2=1
 
           export FM_TEST_CI_ALL_JOBS
           export FM_TEST_UPGRADE_TIMEOUT

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -245,7 +245,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
             let main = {
                 let task_group = task_group.clone();
                 async move {
-                    let dev_fed = DevJitFed::new(&process_mgr, skip_setup).await?;
+                    let dev_fed = DevJitFed::new(&process_mgr, skip_setup)?;
 
                     let pegin_start_time = Instant::now();
                     debug!(target: LOG_DEVIMINT, "Peging in client and gateways");

--- a/devimint/src/federation/config.rs
+++ b/devimint/src/federation/config.rs
@@ -1,9 +1,6 @@
 use bitcoincore_rpc::bitcoin::Network;
 use fedimint_core::config::{EmptyGenParams, ServerModuleConfigGenParamsRegistry};
-use fedimint_core::envs::{
-    is_env_var_set, BitcoinRpcConfig, FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV,
-    FM_USE_UNKNOWN_MODULE_ENV,
-};
+use fedimint_core::envs::{is_env_var_set, BitcoinRpcConfig, FM_USE_UNKNOWN_MODULE_ENV};
 use fedimint_ln_server::common::config::{
     LightningGenParams, LightningGenParamsConsensus, LightningGenParamsLocal,
 };
@@ -22,6 +19,7 @@ use fedimintd::default_esplora_server;
 use fedimintd::envs::FM_DISABLE_META_MODULE_ENV;
 use legacy_types::{LegacyFeeConsensus, LegacyMintGenParams, LegacyMintGenParamsConsensus};
 
+use crate::util::supports_lnv2;
 use crate::version_constants::VERSION_0_5_0_ALPHA;
 
 /// Duplicate default fedimint module setup
@@ -83,9 +81,7 @@ pub fn attach_default_module_init_params(
 
     // TODO(support:v0.3): v0.5 introduced lnv2 modules, so we need to skip
     // attaching the module for old fedimintd versions
-    if fedimintd_version >= &VERSION_0_5_0_ALPHA
-        && !is_env_var_set(FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV)
-    {
+    if supports_lnv2() {
         module_init_params.attach_config_gen_params(
             fedimint_lnv2_server::LightningInit::kind(),
             fedimint_lnv2_common::config::LightningGenParams {

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -49,7 +49,7 @@ where
 
     let (process_mgr, task_group) = cli::setup(args).await?;
     log_binary_versions().await?;
-    let dev_fed = devfed::DevJitFed::new(&process_mgr, false).await?;
+    let dev_fed = devfed::DevJitFed::new(&process_mgr, false)?;
     // workaround https://github.com/tokio-rs/tokio/issues/6463
     // by waiting on all jits to complete, we make it less likely
     // that something is not finished yet and will block in `on_block`

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -462,8 +462,6 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 fedimintd_version
             );
 
-            info!(?paths, "JUMOELL printing paths");
-
             let mut dev_fed = dev_fed(process_mgr).await?;
             let client = dev_fed.fed.new_joined_client("test-client").await?;
             try_join!(stress_test_fed(&dev_fed, None), client.wait_session())?;

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -462,6 +462,8 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 fedimintd_version
             );
 
+            info!(?paths, "JUMOELL printing paths");
+
             let mut dev_fed = dev_fed(process_mgr).await?;
             let client = dev_fed.fed.new_joined_client("test-client").await?;
             try_join!(stress_test_fed(&dev_fed, None), client.wait_session())?;
@@ -2106,6 +2108,8 @@ pub enum TestCmd {
     UpgradeTests {
         #[clap(subcommand)]
         binary: UpgradeTest,
+        #[arg(long)]
+        lnv2: String,
     },
 }
 
@@ -2196,7 +2200,8 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
             let dev_fed = dev_fed(&process_mgr).await?;
             cannot_replay_tx_test(dev_fed).await?;
         }
-        TestCmd::UpgradeTests { binary } => {
+        TestCmd::UpgradeTests { binary, lnv2 } => {
+            std::env::set_var("FM_ENABLE_MODULE_LNV2", lnv2);
             let (process_mgr, _) = setup(common_args).await?;
             Box::pin(upgrade_tests(&process_mgr, binary)).await?;
         }

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -10,7 +10,7 @@ use bitcoin::Txid;
 use clap::Subcommand;
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::encoding::Decodable;
-use fedimint_core::envs::is_env_var_set;
+use fedimint_core::envs::{is_env_var_set, FM_ENABLE_MODULE_LNV2_ENV};
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::net::api_announcement::SignedApiAnnouncement;
 use fedimint_core::task::block_in_place;
@@ -2199,7 +2199,7 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
             cannot_replay_tx_test(dev_fed).await?;
         }
         TestCmd::UpgradeTests { binary, lnv2 } => {
-            std::env::set_var("FM_ENABLE_MODULE_LNV2", lnv2);
+            std::env::set_var(FM_ENABLE_MODULE_LNV2_ENV, lnv2);
             let (process_mgr, _) = setup(common_args).await?;
             Box::pin(upgrade_tests(&process_mgr, binary)).await?;
         }

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -14,7 +14,7 @@ use fedimint_core::admin_client::{
     ConfigGenParamsRequest, ConfigGenParamsResponse, PeerServerParams, ServerStatus,
 };
 use fedimint_core::config::ServerModuleConfigGenParamsRegistry;
-use fedimint_core::envs::is_env_var_set;
+use fedimint_core::envs::{is_env_var_set, FM_ENABLE_MODULE_LNV2_ENV};
 use fedimint_core::module::ApiAuth;
 use fedimint_core::task::{self, block_in_place, block_on};
 use fedimint_core::time::now;
@@ -1176,6 +1176,10 @@ fn to_command(cli: Vec<String>) -> Command {
         cmd,
         args_debug: cli,
     }
+}
+
+pub fn supports_lnv2() -> bool {
+    is_env_var_set(FM_ENABLE_MODULE_LNV2_ENV)
 }
 
 /// Returns true if running backwards-compatibility tests

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -2,11 +2,6 @@
 
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
-
-use fedimint_core::envs::{
-    is_env_var_set, FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV, FM_ENABLE_MODULE_LNV2_ENV,
-};
-
 pub trait ToEnvVar {
     fn to_env_value(&self) -> Option<String>;
 }
@@ -110,8 +105,6 @@ declare_vars! {
     Global = (test_dir: &Path, fed_size: usize, offline_nodes: usize) =>
     {
         FM_USE_UNKNOWN_MODULE: String = std::env::var(FM_USE_UNKNOWN_MODULE_ENV).unwrap_or_else(|_| "1".into()); env: "FM_USE_UNKNOWN_MODULE";
-        FM_ENABLE_MODULE_LNV2: String = if is_env_var_set(FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV) { "0".to_owned() } else { "1".into() }; env: FM_ENABLE_MODULE_LNV2_ENV;
-
 
         FM_FORCE_API_SECRETS: ApiSecrets = std::env::var(FM_FORCE_API_SECRETS_ENV).ok().and_then(|s| {
             ApiSecrets::from_str(&s).ok()

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -13,10 +13,6 @@ use tracing::warn;
 pub const FM_USE_UNKNOWN_MODULE_ENV: &str = "FM_USE_UNKNOWN_MODULE";
 
 pub const FM_ENABLE_MODULE_LNV2_ENV: &str = "FM_ENABLE_MODULE_LNV2";
-/// In certain devimint cases (e.g. upgrade tests), we'd like to test things
-/// without enabling lnv2. This should make deviming stop setting
-/// `FM_ENABLE_MODULE_LNV2_ENV`
-pub const FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV: &str = "FM_DEVIMINT_DISABLE_MODULE_LNV2";
 
 /// Check if env variable is set and not equal `0` or `false` which are common
 /// ways to disable something.

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -1,7 +1,7 @@
 use anyhow::ensure;
 use devimint::devfed::DevJitFed;
 use devimint::federation::Client;
-use devimint::version_constants::{VERSION_0_5_0_ALPHA, VERSION_0_7_0_ALPHA};
+use devimint::version_constants::VERSION_0_7_0_ALPHA;
 use devimint::{cmd, util, Gatewayd};
 use fedimint_core::core::OperationId;
 use fedimint_core::util::{backoff_util, retry};

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -4,7 +4,6 @@ use devimint::federation::Client;
 use devimint::version_constants::{VERSION_0_5_0_ALPHA, VERSION_0_7_0_ALPHA};
 use devimint::{cmd, util, Gatewayd};
 use fedimint_core::core::OperationId;
-use fedimint_core::envs::{is_env_var_set, FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV};
 use fedimint_core::util::{backoff_util, retry};
 use fedimint_lnv2_client::{FinalReceiveOperationState, FinalSendOperationState};
 use lightning_invoice::Bolt11Invoice;
@@ -15,26 +14,7 @@ use tracing::info;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     devimint::run_devfed_test(|dev_fed, _process_mgr| async move {
-        let fedimint_cli_version = util::FedimintCli::version_or_default().await;
-        let fedimintd_version = util::FedimintdCmd::version_or_default().await;
-        let gatewayd_version = util::Gatewayd::version_or_default().await;
-
-        if fedimint_cli_version < *VERSION_0_5_0_ALPHA {
-            info!(%fedimint_cli_version, "Version did not support lnv2 module, skipping");
-            return Ok(());
-        }
-
-        if fedimintd_version < *VERSION_0_5_0_ALPHA {
-            info!(%fedimintd_version, "Version did not support lnv2 module, skipping");
-            return Ok(());
-        }
-
-        if gatewayd_version < *VERSION_0_5_0_ALPHA {
-            info!(%gatewayd_version, "Version did not support lnv2 module, skipping");
-            return Ok(());
-        }
-
-        if is_env_var_set(FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV) {
+        if !devimint::util::supports_lnv2() {
             info!("lnv2 is disabled, skipping");
             return Ok(());
         }

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -203,7 +203,9 @@ function generate_matrix() {
 
           # bash doesn't allow returning arrays, however we can mimic the
           # behavior of returning an array by echoing each element
-          if supports_lnv2 $fed_version $client_version $gateway_version; then
+          if are_all_versions_current $fed_version $client_version $gateway_version; then
+              echo "FM: $fed_version CLI: $client_version GW: $gateway_version LNv2: 1"
+          elif supports_lnv2 $fed_version $client_version $gateway_version; then
             for enable_lnv2 in {0..1}; do
               echo "FM: $fed_version CLI: $client_version GW: $gateway_version LNv2: $enable_lnv2"
             done

--- a/scripts/tests/gateway-module-test.sh
+++ b/scripts/tests/gateway-module-test.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
+export FM_ENABLE_MODULE_LNV2=${FM_ENABLE_MODULE_LNV2:-1}
 
 source scripts/_common.sh
 build_workspace

--- a/scripts/tests/gateway-reboot-test.sh
+++ b/scripts/tests/gateway-reboot-test.sh
@@ -3,6 +3,7 @@
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
+export FM_ENABLE_MODULE_LNV2=${FM_ENABLE_MODULE_LNV2:-1}
 
 source scripts/_common.sh
 build_workspace

--- a/scripts/tests/lightning-reconnect-test.sh
+++ b/scripts/tests/lightning-reconnect-test.sh
@@ -3,6 +3,7 @@
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
+export FM_ENABLE_MODULE_LNV2=${FM_ENABLE_MODULE_LNV2:-1}
 
 source scripts/_common.sh
 build_workspace

--- a/scripts/tests/lnv2-module-test.sh
+++ b/scripts/tests/lnv2-module-test.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
+export FM_ENABLE_MODULE_LNV2=${FM_ENABLE_MODULE_LNV2:-1}
 
 source scripts/_common.sh
 build_workspace

--- a/scripts/tests/test-ci-all.sh
+++ b/scripts/tests/test-ci-all.sh
@@ -341,8 +341,25 @@ done
 
 tests_with_versions=()
 for version_combo in "${version_matrix[@]}"; do
+
+  # read the versions from the format "FM: $fed_version CLI: $client_version GW: $gateway_version"
+  IFS=' ' read -r -a tokens <<< "$version_combo"
+  fed_version="${tokens[1]}"
+  client_version="${tokens[3]}"
+  gateway_version="${tokens[5]}"
+
+  if are_all_versions_current "$fed_version" "$client_version" "$gateway_version"; then
+    lnv2_flags=("LNv2: 1")
+  elif supports_lnv2 "$fed_version" "$client_version" "$gateway_version"; then
+    lnv2_flags=("LNv2: 0" "LNv2: 1")
+  else
+    lnv2_flags=("LNv2: 0")
+  fi
+
   for test in "${tests_to_run_in_parallel[@]}"; do
-    tests_with_versions+=("run_test_for_versions $test $version_combo")
+    for lnv2 in "${lnv2_flags[@]}"; do
+      tests_with_versions+=("run_test_for_versions $test $version_combo $lnv2")
+    done
   done
 done
 

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -59,6 +59,12 @@ for upgrade_path in "${upgrade_paths[@]}"; do
   versions_str=$(IFS=,; echo "${versions[*]}")
   first_version="${versions[0]}"
 
+  if version_lt "$first_version" "$LNV2_STABLE_VERSION"; then
+    lnv2_flags=(0)
+  else
+    lnv2_flags=(0 1)
+  fi
+
   if contains "fedimintd" "${test_kinds[@]}"; then
     fedimintd_paths=()
     for version in "${versions[@]}"; do
@@ -76,19 +82,11 @@ for upgrade_path in "${upgrade_paths[@]}"; do
       fi
     done
 
-    # If the first version is before LNv2's stablization, then we run the upgrade tests with LNv2 off since that is how users will upgrade in production.
-    # If it is equal or greater than LNv2 stablization, then we need to run the upgrade tests with LNv2 on and off.
-    if version_lt $first_version $LNV2_STABLE_VERSION; then
+    for enable_lnv2 in "${lnv2_flags[@]}"; do
       upgrade_tests+=(
-        "fm-run-test fedimintd-${versions_str}-lnv2-0 devimint upgrade-tests --lnv2 0 fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
+        "fm-run-test fedimintd-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
       )
-    else
-      for enable_lnv2 in {0..1}; do
-        upgrade_tests+=(
-          "fm-run-test fedimintd-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
-        )
-      done
-    fi
+    done
   fi
 
   if contains "fedimint-cli" "${test_kinds[@]}"; then
@@ -102,17 +100,11 @@ for upgrade_path in "${upgrade_paths[@]}"; do
       fi
     done
 
-    if version_lt $first_version $LNV2_STABLE_VERSION; then
+    for enable_lnv2 in "${lnv2_flags[@]}"; do
       upgrade_tests+=(
-        "fm-run-test fedimint-cli-${versions_str}-lnv2-0 devimint upgrade-tests --lnv2 0 fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
+        "fm-run-test fedimint-cli-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
       )
-    else
-      for enable_lnv2 in {0..1}; do
-        upgrade_tests+=(
-          "fm-run-test fedimint-cli-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
-        )
-      done
-    fi
+    done
   fi
 
   if contains "gateway" "${test_kinds[@]}"; then
@@ -129,17 +121,11 @@ for upgrade_path in "${upgrade_paths[@]}"; do
       fi
     done
 
-    if version_lt $first_version $LNV2_STABLE_VERSION; then
+    for enable_lnv2 in "${lnv2_flags[@]}"; do
       upgrade_tests+=(
-        "fm-run-test gateway-${versions_str}-lnv2-0 devimint upgrade-tests --lnv2 0 gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
+        "fm-run-test gateway-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
       )
-    else
-      for enable_lnv2 in {0..1}; do
-        upgrade_tests+=(
-          "fm-run-test gateway-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
-        )
-      done
-    fi
+    done
   fi
 
   if contains "mnemonic" "${test_kinds[@]}"; then

--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -18,9 +18,6 @@ PATH="$(pwd)/scripts/dev/run-test/:$PATH"
 export FM_TEST_UPGRADE_TIMEOUT=${FM_TEST_UPGRADE_TIMEOUT:-800}
 export FM_RUN_TEST_TIMEOUT=$((FM_TEST_UPGRADE_TIMEOUT - 30))
 
-# TODO(v0.5.0): We do not need to run the `gatewayd-mnemonic` test from v0.4.0
-# -> v0.5.0 over and over again. Once we have verified this test passes for
-# v0.5.0, it can safely be removed.
 default_test_kinds=("fedimintd" "fedimint-cli" "gateway" "mnemonic")
 
 # runs a subset of tests if the user provides `TEST_KINDS`
@@ -60,6 +57,7 @@ for upgrade_path in "${upgrade_paths[@]}"; do
   IFS=' ' read -r -a versions <<< "$upgrade_path"
   echo "## Starting upgrade test for path: $upgrade_path"
   versions_str=$(IFS=,; echo "${versions[*]}")
+  first_version="${versions[0]}"
 
   if contains "fedimintd" "${test_kinds[@]}"; then
     fedimintd_paths=()
@@ -78,9 +76,19 @@ for upgrade_path in "${upgrade_paths[@]}"; do
       fi
     done
 
-    upgrade_tests+=(
-      "fm-run-test fedimintd-${versions_str} devimint upgrade-tests fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
-    )
+    # If the first version is before LNv2's stablization, then we run the upgrade tests with LNv2 off since that is how users will upgrade in production.
+    # If it is equal or greater than LNv2 stablization, then we need to run the upgrade tests with LNv2 on and off.
+    if version_lt $first_version $LNV2_STABLE_VERSION; then
+      upgrade_tests+=(
+        "fm-run-test fedimintd-${versions_str}-lnv2-0 devimint upgrade-tests --lnv2 0 fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
+      )
+    else
+      for enable_lnv2 in {0..1}; do
+        upgrade_tests+=(
+          "fm-run-test fedimintd-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
+        )
+      done
+    fi
   fi
 
   if contains "fedimint-cli" "${test_kinds[@]}"; then
@@ -94,9 +102,17 @@ for upgrade_path in "${upgrade_paths[@]}"; do
       fi
     done
 
-    upgrade_tests+=(
-      "fm-run-test fedimint-cli-${versions_str} devimint upgrade-tests fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
-    )
+    if version_lt $first_version $LNV2_STABLE_VERSION; then
+      upgrade_tests+=(
+        "fm-run-test fedimint-cli-${versions_str}-lnv2-0 devimint upgrade-tests --lnv2 0 fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
+      )
+    else
+      for enable_lnv2 in {0..1}; do
+        upgrade_tests+=(
+          "fm-run-test fedimint-cli-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
+        )
+      done
+    fi
   fi
 
   if contains "gateway" "${test_kinds[@]}"; then
@@ -113,9 +129,17 @@ for upgrade_path in "${upgrade_paths[@]}"; do
       fi
     done
 
-    upgrade_tests+=(
-      "fm-run-test gateway-${versions_str} devimint upgrade-tests gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
-    )
+    if version_lt $first_version $LNV2_STABLE_VERSION; then
+      upgrade_tests+=(
+        "fm-run-test gateway-${versions_str}-lnv2-0 devimint upgrade-tests --lnv2 0 gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
+      )
+    else
+      for enable_lnv2 in {0..1}; do
+        upgrade_tests+=(
+          "fm-run-test gateway-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
+        )
+      done
+    fi
   fi
 
   if contains "mnemonic" "${test_kinds[@]}"; then
@@ -124,12 +148,12 @@ for upgrade_path in "${upgrade_paths[@]}"; do
     old_gateway_cli=$(nix_build_binary_for_version 'gateway-cli' "v0.4.0")
     new_gateway_cli="gateway-cli"
 
+    # LNv2 is always set to off for the mnemonic test because the gateway has always had mnemonics since LNv2 stablization
     upgrade_tests+=(
-      "fm-run-test mnemonic-${versions_str} gateway-tests gatewayd-mnemonic --old-gatewayd-path $old_gatewayd --new-gatewayd-path $new_gatewayd --gw-type lnd --old-gateway-cli-path $old_gateway_cli --new-gateway-cli-path $new_gateway_cli"
+      "fm-run-test mnemonic-${versions_str} gateway-tests gatewayd-mnemonic --old-gatewayd-path $old_gatewayd --new-gatewayd-path $new_gatewayd --old-gateway-cli-path $old_gateway_cli --new-gateway-cli-path $new_gateway_cli"
     )
   fi
 done
-
 
 parsed_test_commands=$(printf "%s\n" "${upgrade_tests[@]}")
 


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/6795

1) Removes `FM_DEVIMINT_DISABLE_MODULE_LNV2` and replaces it with `supports_lnv2()` function, which just checks if `FM_ENABLE_MODULE_LNV2` is set. It is the responsibility of the bash scripts to set this variable.
2) For backwards compatibility tests, if the current set of versions supports LNv2, then each test is run 2x, once with LNv2 off and once with it on.
3) For upgrade tests, if the "first version" specified in the version set (ex: "v0.3.4-rc.1 v0.4.4" -> v0.3.4-rc.1 is the first version), then the upgrade test is executed with LNv2 off. If the first version in the version set does support LNv2 then the upgrade tests are executed 2x with LNv2 on/off.
4) For tests that are all on the current version, LNv2 is always on.

As it stands now, the backwards compatibility will become 2x slower once we start supporting LNv2. Open to suggestions on driving this down.

Since right now we are not testing backwards compatibility with LNv2, this PR is functionally equivalent to how it is setup now. We can easily adjust the version we want to support LNv2 by changing `LNV2_STABLE_VERSION` in `_common.sh`. Once we begin backwards compat/upgrade tests for LNv2, that's when the CI increase will happen.