### PR TITLE
chore(lnv2-server): vote on unix ts in minimum increments

### DIFF
--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -71,6 +71,8 @@ use crate::db::{
     PreimagePrefix, UnixTimeVoteKey, UnixTimeVotePrefix,
 };
 
+const MIN_UNIX_TIME_VOTE_INCREMENT_SECS: u64 = 30;
+
 #[derive(Debug, Clone)]
 pub struct LightningInit;
 
@@ -369,6 +371,11 @@ impl ServerModule for Lightning {
                     .unwrap_or(0);
 
                 ensure!(current_vote < vote, "Unix time vote is redundant");
+
+                ensure!(
+                    current_vote + MIN_UNIX_TIME_VOTE_INCREMENT_SECS < vote,
+                    "Unit time vote is not incremented enough"
+                );
 
                 Ok(())
             }


### PR DESCRIPTION
I've noticed that currently lnv2 produces 4 citem every second, which seems excessive. I doubt we are trying to maintain a consensus on a precise clock here.

By rejecting votes that don't increment previous vote by at least 30s, we can cut the amount of citems produced by 30.

Since we take a threshold of votes to calculate a consensus value, in a 4 peer federation the time will still be advanced quite smoothly, in smaller increments, with a slight lag (the expected value can be estimated and compensated for if the lag would ever to matter). Should be enough for our purposes.


The exact value is up to a debate. 15s and 45s would probably work too, depends on how sensitive the functionality is to accurate time.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
