### PR TITLE
refactor: move LNv1 module into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
  "fedimint-core",
  "fedimint-logging",
  "futures",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "test-log",
@@ -2926,6 +2927,31 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "fedimint-gw-client"
+version = "0.7.0-alpha"
+dependencies = [
+ "anyhow",
+ "aquamarine",
+ "async-stream",
+ "async-trait",
+ "bitcoin",
+ "erased-serde 0.4.5",
+ "fedimint-api-client",
+ "fedimint-client",
+ "fedimint-core",
+ "fedimint-eventlog",
+ "fedimint-lightning",
+ "fedimint-ln-client",
+ "fedimint-ln-common",
+ "futures",
+ "lightning-invoice",
+ "serde",
+ "thiserror 2.0.11",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3033,6 +3059,7 @@ dependencies = [
  "fedimint-dummy-common",
  "fedimint-dummy-server",
  "fedimint-eventlog",
+ "fedimint-gw-client",
  "fedimint-lightning",
  "fedimint-ln-client",
  "fedimint-ln-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "modules/fedimint-empty-client",
     "modules/fedimint-empty-common",
     "modules/fedimint-empty-server",
+    "modules/fedimint-gw-client",
     "modules/fedimint-ln-client",
     "modules/fedimint-ln-common",
     "modules/fedimint-ln-server",
@@ -136,6 +137,7 @@ fedimint-dummy-common = { path = "./modules/fedimint-dummy-common", version = "=
 fedimint-dummy-server = { path = "./modules/fedimint-dummy-server", version = "=0.7.0-alpha" }
 fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=0.7.0-alpha" }
 fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.7.0-alpha" }
+fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.7.0-alpha" }
 fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.7.0-alpha" }
 fedimint-lnv2-client = { path = "./modules/fedimint-lnv2-client", version = "=0.7.0-alpha" }
 fedimint-lnv2-common = { path = "./modules/fedimint-lnv2-common", version = "=0.7.0-alpha" }

--- a/fedimint-eventlog/Cargo.toml
+++ b/fedimint-eventlog/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 futures = { workspace = true }
+itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time", "macros", "rt"] }

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -400,7 +400,7 @@ pub struct CloseChannelsWithPeerRequest {
     pub pubkey: secp256k1::PublicKey,
 }
 
-// Trait that specifies how to interact with the gateway's lightning node.
+// TODO: Move into `fedimint-gateway-v2` crate
 #[async_trait]
 pub trait LightningV2Manager: Debug + Send + Sync {
     async fn contains_incoming_contract(&self, payment_image: PaymentImage) -> bool;

--- a/gateway/ln-gateway/Cargo.toml
+++ b/gateway/ln-gateway/Cargo.toml
@@ -39,6 +39,7 @@ fedimint-bip39 = { version = "=0.7.0-alpha", path = "../../fedimint-bip39" }
 fedimint-client = { path = "../../fedimint-client", version = "=0.7.0-alpha" }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
+fedimint-gw-client = { workspace = true }
 fedimint-lightning = { path = "../fedimint-lightning", version = "=0.7.0-alpha" }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
@@ -51,7 +52,6 @@ fedimint-wallet-client = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
-itertools = { workspace = true }
 lightning-invoice = { workspace = true }
 lockable = "0.1.1"
 prost = "0.13.4"
@@ -82,6 +82,7 @@ fedimint-lnv2-server = { workspace = true }
 fedimint-testing = { workspace = true }
 fedimint-unknown-common = { workspace = true }
 fedimint-unknown-server = { workspace = true }
+itertools = { workspace = true }
 
 [build-dependencies]
 fedimint-build = { workspace = true }

--- a/gateway/ln-gateway/src/client.rs
+++ b/gateway/ln-gateway/src/client.rs
@@ -13,11 +13,11 @@ use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_gw_client::GatewayClientInit;
 
 use crate::db::{FederationConfig, GatewayDbExt};
 use crate::error::AdminGatewayError;
 use crate::gateway_module_v2::GatewayClientInitV2;
-use crate::state_machine::GatewayClientInit;
 use crate::{AdminResult, Gateway};
 
 #[derive(Debug, Clone)]
@@ -72,7 +72,7 @@ impl GatewayClientBuilder {
         if gateway.is_running_lnv1() {
             registry.attach(GatewayClientInit {
                 federation_index,
-                gateway: gateway.clone(),
+                lightning_manager: gateway.clone(),
             });
         }
 

--- a/gateway/ln-gateway/src/error.rs
+++ b/gateway/ln-gateway/src/error.rs
@@ -4,13 +4,13 @@ use axum::response::{IntoResponse, Response};
 use fedimint_core::config::{FederationId, FederationIdPrefix};
 use fedimint_core::envs::is_env_var_set;
 use fedimint_core::fmt_utils::OptStacktrace;
+use fedimint_gw_client::pay::OutgoingPaymentError;
 use fedimint_lightning::LightningRpcError;
 use reqwest::StatusCode;
 use thiserror::Error;
 use tracing::error;
 
 use crate::envs::FM_DEBUG_GATEWAY_ENV;
-use crate::state_machine::pay::OutgoingPaymentError;
 
 /// Errors that unauthenticated endpoints can encounter. For privacy reasons,
 /// the error messages are intended to be redacted before returning to the

--- a/gateway/ln-gateway/src/events.rs
+++ b/gateway/ln-gateway/src/events.rs
@@ -1,23 +1,18 @@
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use fedimint_client::ClientHandle;
-use fedimint_core::core::ModuleKind;
-use fedimint_core::util::{get_average, get_median};
-use fedimint_core::Amount;
 use fedimint_eventlog::{
     DBTransactionEventLogExt, Event, EventKind, EventLogId, PersistedLogEntry,
 };
 use fedimint_mint_client::event::{OOBNotesReissued, OOBNotesSpent};
 use fedimint_wallet_client::events::{DepositConfirmed, WithdrawRequest};
-use itertools::Itertools;
 
 use crate::gateway_module_v2::events::{
     CompleteLightningPaymentSucceeded, IncomingPaymentFailed, IncomingPaymentStarted,
     IncomingPaymentSucceeded, OutgoingPaymentFailed, OutgoingPaymentStarted,
     OutgoingPaymentSucceeded,
 };
-use crate::rpc::PaymentStats;
 
 pub const ALL_GATEWAY_EVENTS: [EventKind; 11] = [
     OutgoingPaymentStarted::KIND,
@@ -106,111 +101,5 @@ pub async fn get_events_for_duration(
         }
 
         batch_start = batch_start.saturating_add(BATCH_SIZE);
-    }
-}
-
-/// Filters the given `PersistedLogEntry` slice by the `EventKind` and
-/// `ModuleKind`.
-pub(crate) fn filter_events<'a, I>(
-    all_events: I,
-    event_kind: EventKind,
-    module_kind: ModuleKind,
-) -> impl Iterator<Item = &'a PersistedLogEntry> + 'a
-where
-    I: IntoIterator<Item = &'a PersistedLogEntry> + 'a,
-{
-    all_events.into_iter().filter(move |e| {
-        if let Some((m, _)) = &e.module {
-            e.event_kind == event_kind && *m == module_kind
-        } else {
-            false
-        }
-    })
-}
-
-/// Joins two sets of events on a predicate.
-///
-/// This function computes a "nested loop join" by first computing the cross
-/// product of the start event vector and the success/failure event vectors. The
-/// resulting cartesian product is then filtered according to the join predicate
-/// supplied in the parameters.
-///
-/// This function is intended for small data sets. If the data set relations
-/// grow, this function should implement a different join algorithm or be moved
-/// out of the gateway.
-pub(crate) fn join_events<'a, L, R, Res>(
-    events_l: &'a [&PersistedLogEntry],
-    events_r: &'a [&PersistedLogEntry],
-    predicate: impl Fn(L, R, u64) -> Option<Res> + 'a,
-) -> impl Iterator<Item = Res> + 'a
-where
-    L: Event,
-    R: Event,
-{
-    events_l
-        .iter()
-        .cartesian_product(events_r)
-        .filter_map(move |(l, r)| {
-            if let Some(latency) = r.timestamp.checked_sub(l.timestamp) {
-                let event_l: L =
-                    serde_json::from_value(l.value.clone()).expect("could not parse JSON");
-                let event_r: R =
-                    serde_json::from_value(r.value.clone()).expect("could not parse JSON");
-                predicate(event_l, event_r, latency)
-            } else {
-                None
-            }
-        })
-}
-
-/// Helper struct for storing computed data about outgoing and incoming
-/// payments.
-#[derive(Debug, Default)]
-pub struct StructuredPaymentEvents {
-    latencies: Vec<u64>,
-    fees: Vec<Amount>,
-    latencies_failure: Vec<u64>,
-}
-
-impl StructuredPaymentEvents {
-    pub fn new(
-        success_stats: &[(u64, Amount)],
-        failure_stats: Vec<u64>,
-    ) -> StructuredPaymentEvents {
-        let mut events = StructuredPaymentEvents {
-            latencies: success_stats.iter().map(|(l, _)| *l).collect(),
-            fees: success_stats.iter().map(|(_, f)| *f).collect(),
-            latencies_failure: failure_stats,
-        };
-        events.sort();
-        events
-    }
-
-    /// Combines this `StructuredPaymentEvents` with the `other`
-    /// `StructuredPaymentEvents` by appending all of the internal vectors.
-    pub fn combine(&mut self, other: &mut StructuredPaymentEvents) {
-        self.latencies.append(&mut other.latencies);
-        self.fees.append(&mut other.fees);
-        self.latencies_failure.append(&mut other.latencies_failure);
-        self.sort();
-    }
-
-    /// Sorts this `StructuredPaymentEvents` by sorting all of the internal
-    /// vectors.
-    fn sort(&mut self) {
-        self.latencies.sort_unstable();
-        self.fees.sort_unstable();
-        self.latencies_failure.sort_unstable();
-    }
-
-    /// Computes the payment statistics for the given input data.
-    pub fn compute_payment_stats(&self) -> PaymentStats {
-        PaymentStats {
-            average_latency: get_average(&self.latencies).map(Duration::from_micros),
-            median_latency: get_median(&self.latencies).map(Duration::from_micros),
-            total_fees: Amount::from_msats(self.fees.iter().map(|a| a.msats).sum()),
-            total_success: self.latencies.len(),
-            total_failure: self.latencies_failure.len(),
-        }
     }
 }

--- a/gateway/ln-gateway/src/federation_manager.rs
+++ b/gateway/ln-gateway/src/federation_manager.rs
@@ -7,13 +7,13 @@ use fedimint_client::ClientHandleArc;
 use fedimint_core::config::{FederationId, FederationIdPrefix, JsonClientConfig};
 use fedimint_core::db::{DatabaseTransaction, NonCommittable};
 use fedimint_core::util::Spanned;
+use fedimint_gw_client::GatewayClientModule;
 use tracing::info;
 
 use crate::db::GatewayDbtxNcExt;
 use crate::error::{AdminGatewayError, FederationNotConnected};
 use crate::gateway_module_v2::GatewayClientModuleV2;
 use crate::rpc::FederationInfo;
-use crate::state_machine::GatewayClientModule;
 use crate::AdminResult;
 
 /// The first index that the gateway will assign to a federation.

--- a/gateway/ln-gateway/src/gateway_module_v2/events.rs
+++ b/gateway/ln-gateway/src/gateway_module_v2/events.rs
@@ -3,13 +3,15 @@ use std::time::SystemTime;
 use fedimint_core::config::FederationId;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::Amount;
-use fedimint_eventlog::{Event, EventKind, PersistedLogEntry};
+use fedimint_eventlog::{
+    filter_events_by_kind, join_events, Event, EventKind, PersistedLogEntry,
+    StructuredPaymentEvents,
+};
 use fedimint_lnv2_common::contracts::{Commitment, OutgoingContract, PaymentImage};
 use serde::{Deserialize, Serialize};
 use serde_millis;
 
 use super::send_sm::Cancelled;
-use crate::events::{filter_events, join_events, StructuredPaymentEvents};
 
 /// Event that is emitted when an outgoing payment attempt is initiated.
 #[derive(Serialize, Deserialize, Debug)]
@@ -144,22 +146,22 @@ impl Event for CompleteLightningPaymentSucceeded {
 pub fn compute_lnv2_stats(
     all_events: &[PersistedLogEntry],
 ) -> (StructuredPaymentEvents, StructuredPaymentEvents) {
-    let outgoing_start_events = filter_events(
+    let outgoing_start_events = filter_events_by_kind(
         all_events,
+        fedimint_lnv2_common::KIND,
         OutgoingPaymentStarted::KIND,
-        fedimint_lnv2_common::KIND,
     )
     .collect::<Vec<_>>();
-    let outgoing_success_events = filter_events(
+    let outgoing_success_events = filter_events_by_kind(
         all_events,
+        fedimint_lnv2_common::KIND,
         OutgoingPaymentSucceeded::KIND,
-        fedimint_lnv2_common::KIND,
     )
     .collect::<Vec<_>>();
-    let outgoing_failure_events = filter_events(
+    let outgoing_failure_events = filter_events_by_kind(
         all_events,
-        OutgoingPaymentFailed::KIND,
         fedimint_lnv2_common::KIND,
+        OutgoingPaymentFailed::KIND,
     )
     .collect::<Vec<_>>();
 
@@ -193,22 +195,22 @@ pub fn compute_lnv2_stats(
     )
     .collect::<Vec<_>>();
 
-    let incoming_start_events = filter_events(
+    let incoming_start_events = filter_events_by_kind(
         all_events,
+        fedimint_lnv2_common::KIND,
         IncomingPaymentStarted::KIND,
-        fedimint_lnv2_common::KIND,
     )
     .collect::<Vec<_>>();
-    let incoming_success_events = filter_events(
+    let incoming_success_events = filter_events_by_kind(
         all_events,
+        fedimint_lnv2_common::KIND,
         IncomingPaymentSucceeded::KIND,
-        fedimint_lnv2_common::KIND,
     )
     .collect::<Vec<_>>();
-    let incoming_failure_events = filter_events(
+    let incoming_failure_events = filter_events_by_kind(
         all_events,
-        IncomingPaymentFailed::KIND,
         fedimint_lnv2_common::KIND,
+        IncomingPaymentFailed::KIND,
     )
     .collect::<Vec<_>>();
 

--- a/gateway/ln-gateway/tests/tests.rs
+++ b/gateway/ln-gateway/tests/tests.rs
@@ -23,6 +23,12 @@ use fedimint_dummy_client::{DummyClientInit, DummyClientModule};
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyInit;
 use fedimint_eventlog::Event;
+use fedimint_gw_client::pay::{
+    OutgoingContractError, OutgoingPaymentError, OutgoingPaymentErrorType,
+};
+use fedimint_gw_client::{
+    GatewayClientModule, GatewayExtPayStates, GatewayExtReceiveStates, GatewayMeta, Htlc,
+};
 use fedimint_ln_client::api::LnFederationApi;
 use fedimint_ln_client::pay::{PayInvoicePayload, PaymentData};
 use fedimint_ln_client::{
@@ -56,12 +62,6 @@ use ln_gateway::gateway_module_v2::events::{
 };
 use ln_gateway::gateway_module_v2::{FinalReceiveState, GatewayClientModuleV2};
 use ln_gateway::rpc::{PaymentLogPayload, SetFeesPayload};
-use ln_gateway::state_machine::pay::{
-    OutgoingContractError, OutgoingPaymentError, OutgoingPaymentErrorType,
-};
-use ln_gateway::state_machine::{
-    GatewayClientModule, GatewayExtPayStates, GatewayExtReceiveStates, GatewayMeta, Htlc,
-};
 use ln_gateway::Gateway;
 use secp256k1::{Keypair, PublicKey};
 use tpe::G1Affine;

--- a/modules/fedimint-gw-client/Cargo.toml
+++ b/modules/fedimint-gw-client/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "fedimint-gw-client"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+description = "fedimint-gw-client is a crate for servicing lightning payments on behalf of fedimint clients"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "tokio_unstable"]
+
+[package.metadata.cargo-udeps.ignore]
+# cargo udeps can't detect that one
+normal = ["aquamarine"]
+
+[lib]
+name = "fedimint_gw_client"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+aquamarine = { workspace = true }
+async-stream = { workspace = true }
+async-trait = { workspace = true }
+bitcoin = { workspace = true }
+erased-serde = { workspace = true }
+fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.0-alpha" }
+fedimint-client = { path = "../../fedimint-client", version = "=0.7.0-alpha" }
+fedimint-core = { workspace = true }
+fedimint-eventlog = { workspace = true }
+fedimint-lightning = { path = "../../gateway/fedimint-lightning", version = "=0.7.0-alpha" }
+fedimint-ln-client = { workspace = true }
+fedimint-ln-common = { workspace = true }
+futures = { workspace = true }
+lightning-invoice = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true, features = ["log"] }

--- a/modules/fedimint-gw-client/src/events.rs
+++ b/modules/fedimint-gw-client/src/events.rs
@@ -1,12 +1,14 @@
 use fedimint_core::core::{ModuleKind, OperationId};
 use fedimint_core::Amount;
-use fedimint_eventlog::{Event, EventKind, PersistedLogEntry};
+use fedimint_eventlog::{
+    filter_events_by_kind, join_events, Event, EventKind, PersistedLogEntry,
+    StructuredPaymentEvents,
+};
 use fedimint_ln_common::contracts::outgoing::OutgoingContractAccount;
 use fedimint_ln_common::contracts::ContractId;
 use serde::{Deserialize, Serialize};
 
 use super::pay::OutgoingPaymentError;
-use crate::events::{filter_events, join_events, StructuredPaymentEvents};
 
 /// LNv1 event that is emitted when an outgoing payment attempt is initiated.
 #[derive(Serialize, Deserialize, Debug)]
@@ -142,22 +144,22 @@ impl Event for CompleteLightningPaymentSucceeded {
 pub fn compute_lnv1_stats(
     all_events: &[PersistedLogEntry],
 ) -> (StructuredPaymentEvents, StructuredPaymentEvents) {
-    let outgoing_start_events = filter_events(
+    let outgoing_start_events = filter_events_by_kind(
         all_events,
+        fedimint_ln_common::KIND,
         OutgoingPaymentStarted::KIND,
-        fedimint_ln_common::KIND,
     )
     .collect::<Vec<_>>();
-    let outgoing_success_events = filter_events(
+    let outgoing_success_events = filter_events_by_kind(
         all_events,
+        fedimint_ln_common::KIND,
         OutgoingPaymentSucceeded::KIND,
-        fedimint_ln_common::KIND,
     )
     .collect::<Vec<_>>();
-    let outgoing_failure_events = filter_events(
+    let outgoing_failure_events = filter_events_by_kind(
         all_events,
-        OutgoingPaymentFailed::KIND,
         fedimint_ln_common::KIND,
+        OutgoingPaymentFailed::KIND,
     )
     .collect::<Vec<_>>();
 
@@ -192,22 +194,22 @@ pub fn compute_lnv1_stats(
     )
     .collect::<Vec<_>>();
 
-    let incoming_start_events = filter_events(
+    let incoming_start_events = filter_events_by_kind(
         all_events,
+        fedimint_ln_common::KIND,
         IncomingPaymentStarted::KIND,
-        fedimint_ln_common::KIND,
     )
     .collect::<Vec<_>>();
-    let incoming_success_events = filter_events(
+    let incoming_success_events = filter_events_by_kind(
         all_events,
+        fedimint_ln_common::KIND,
         IncomingPaymentSucceeded::KIND,
-        fedimint_ln_common::KIND,
     )
     .collect::<Vec<_>>();
-    let incoming_failure_events = filter_events(
+    let incoming_failure_events = filter_events_by_kind(
         all_events,
-        IncomingPaymentFailed::KIND,
         fedimint_ln_common::KIND,
+        IncomingPaymentFailed::KIND,
     )
     .collect::<Vec<_>>();
     let incoming_success_stats =


### PR DESCRIPTION
Moves the LNv1 module into its own crate called `fedimint-gateway-v1`. LNv2 will be done in a follow up.

The core idea is that that gateway's database and the lightning node are resources that the gateway manages, not the modules. There will be a separate trait per LN module `LightningV1Manager` and `LightningV2Manager` that will define how the module interacts with the gateway.

Some of the recently added event code also needed to be refactored so that the LNv1 and LNv2 modules can share it.