### PR TITLE
chore: make alephbft tasks log on lower level

### DIFF
--- a/fedimint-server/src/consensus/aleph_bft/spawner.rs
+++ b/fedimint-server/src/consensus/aleph_bft/spawner.rs
@@ -15,7 +15,7 @@ impl Spawner {
 
 impl aleph_bft::SpawnHandle for Spawner {
     fn spawn(&self, name: &str, task: impl futures::Future<Output = ()> + Send + 'static) {
-        self.task_group.spawn(name, |_| task);
+        self.task_group.spawn_silent(name, |_| task);
     }
 
     fn spawn_essential(
@@ -25,7 +25,7 @@ impl aleph_bft::SpawnHandle for Spawner {
     ) -> aleph_bft::TaskHandle {
         let (sender, receiver) = futures::channel::oneshot::channel();
 
-        self.task_group.spawn(name, |_| async {
+        self.task_group.spawn_silent(name, |_| async {
             task.await;
 
             if sender.send(()).is_err() {


### PR DESCRIPTION
On `debug` logging level, on every session switch we'll log finishing ~10 alephbft tasks, and starting of ~10 alephbft task for the next session. It's not very useful, and the default:

```
2025-01-31T00:37:04.100637Z  INFO spawn{task="main"}:run{id=0}: fm::consensus: Completed consensus session session_index=8
2025-01-31T00:37:04.100724Z  INFO spawn{task="main"}:run{id=0}: fm::consensus: Starting consensus session session_index=9
```

are all that we really need anyway. Especially in tests/devimint where we switch session every 10s or so.

Most other spawns kick in only once on start, so they are more useful.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
