### PR TITLE
refactor: remove LND's access to the gateway's database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,6 @@ dependencies = [
  "fedimint-bitcoind",
  "fedimint-core",
  "fedimint-ln-common",
- "fedimint-lnv2-common",
  "fedimint-tonic-lnd",
  "futures",
  "hex",

--- a/gateway/fedimint-lightning/Cargo.toml
+++ b/gateway/fedimint-lightning/Cargo.toml
@@ -20,7 +20,6 @@ fedimint-bip39 = { version = "=0.7.0-alpha", path = "../../fedimint-bip39" }
 fedimint-bitcoind = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-ln-common = { workspace = true }
-fedimint-lnv2-common = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 ldk-node = "0.4.3"

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -17,7 +17,6 @@ use fedimint_core::{secp256k1, Amount, BitcoinAmountOrAll};
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::route_hints::RouteHint;
 use fedimint_ln_common::PrunedInvoice;
-use fedimint_lnv2_common::contracts::PaymentImage;
 use futures::stream::BoxStream;
 use lightning_invoice::Bolt11Invoice;
 use serde::{Deserialize, Serialize};
@@ -398,10 +397,4 @@ pub struct SendOnchainRequest {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CloseChannelsWithPeerRequest {
     pub pubkey: secp256k1::PublicKey,
-}
-
-// TODO: Move into `fedimint-gateway-v2` crate
-#[async_trait]
-pub trait LightningV2Manager: Debug + Send + Sync {
-    async fn contains_incoming_contract(&self, payment_image: PaymentImage) -> bool;
 }

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -75,8 +75,8 @@ use fedimint_lightning::lnd::GatewayLndClient;
 use fedimint_lightning::{
     CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
     ILnRpcClient, InterceptPaymentRequest, InterceptPaymentResponse, InvoiceDescription,
-    LightningContext, LightningRpcError, LightningV2Manager, OpenChannelRequest,
-    PayInvoiceResponse, PaymentAction, RouteHtlcStream, SendOnchainRequest,
+    LightningContext, LightningRpcError, OpenChannelRequest, PayInvoiceResponse, PaymentAction,
+    RouteHtlcStream, SendOnchainRequest,
 };
 use fedimint_ln_client::pay::PaymentData;
 use fedimint_ln_common::config::LightningClientConfig;
@@ -1923,7 +1923,6 @@ impl Gateway {
                 lnd_tls_cert,
                 lnd_macaroon,
                 None,
-                Arc::new(self.clone()),
             )),
             LightningMode::Ldk {
                 esplora_server_url,
@@ -2212,18 +2211,6 @@ impl Gateway {
     fn is_running_lnv1(&self) -> bool {
         self.lightning_module_mode == LightningModuleMode::LNv1
             || self.lightning_module_mode == LightningModuleMode::All
-    }
-}
-
-#[async_trait]
-impl LightningV2Manager for Gateway {
-    async fn contains_incoming_contract(&self, payment_image: PaymentImage) -> bool {
-        self.gateway_db
-            .begin_transaction_nc()
-            .await
-            .load_registered_incoming_contract(payment_image)
-            .await
-            .is_some()
     }
 }
 


### PR DESCRIPTION
I don't like that the LND lightning implementation is dependent on the gateway's database.

It currently dependent on the database because, before spawning a subscription task to monitor the status of an invoice, we check if the invoice was created using LNv2.

This isn't strictly necessary though. We can just spawn the subscription task for all HOLD invoices, and if the invoice is a "real" invoice, the gateway won't be able to complete it anyway because there is no contract in the federation. So this PR removes this lookup. There might be a few more tasks spawned but I think this makes the code much cleaner.

There is already test coverage for this. The LNv2 tests pay a real HOLD invoice to verify nothing is broken.