### PR TITLE
chore: add InPoint for TX inputs

### DIFF
--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -163,6 +163,37 @@ impl FromStr for BitcoinAmountOrAll {
     }
 }
 
+/// `InPoint` represents a globally unique input in a transaction
+///
+/// Hence, a transaction ID and the input index is required.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Deserialize,
+    Serialize,
+    Encodable,
+    Decodable,
+)]
+pub struct InPoint {
+    /// The referenced transaction ID
+    pub txid: TransactionId,
+    /// As a transaction may have multiple inputs, this refers to the index of
+    /// the input in a transaction
+    pub in_idx: u64,
+}
+
+impl std::fmt::Display for InPoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.txid, self.in_idx)
+    }
+}
+
 /// `OutPoint` represents a globally unique output in a transaction
 ///
 /// Hence, a transaction ID and the output index is required.

--- a/fedimint-server-core/src/lib.rs
+++ b/fedimint-server-core/src/lib.rs
@@ -21,7 +21,7 @@ use fedimint_core::module::{
     ApiEndpoint, ApiEndpointContext, ApiRequestErased, CommonModuleInit, InputMeta, ModuleCommon,
     ModuleInit, TransactionItemAmount,
 };
-use fedimint_core::{apply, async_trait_maybe_send, dyn_newtype_define, OutPoint, PeerId};
+use fedimint_core::{apply, async_trait_maybe_send, dyn_newtype_define, InPoint, OutPoint, PeerId};
 pub use init::*;
 
 #[apply(async_trait_maybe_send!)]
@@ -99,6 +99,7 @@ pub trait ServerModule: Debug + Sized {
         &'a self,
         dbtx: &mut DatabaseTransaction<'c>,
         input: &'b <Self::Common as ModuleCommon>::Input,
+        in_point: InPoint,
     ) -> Result<InputMeta, <Self::Common as ModuleCommon>::InputError>;
 
     /// Try to create an output (e.g. issue notes, peg-out BTC, …). On success
@@ -230,6 +231,7 @@ pub trait IServerModule: Debug {
         &'a self,
         dbtx: &mut DatabaseTransaction<'c>,
         input: &'b DynInput,
+        in_point: InPoint,
     ) -> Result<InputMeta, DynInputError>;
 
     /// Try to create an output (e.g. issue notes, peg-out BTC, …). On success
@@ -371,6 +373,7 @@ where
         &'a self,
         dbtx: &mut DatabaseTransaction<'c>,
         input: &'b DynInput,
+        in_point: InPoint,
     ) -> Result<InputMeta, DynInputError> {
         <Self as ServerModule>::process_input(
             self,
@@ -379,6 +382,7 @@ where
                 .as_any()
                 .downcast_ref::<<<Self as ServerModule>::Common as ModuleCommon>::Input>()
                 .expect("incorrect input type passed to module plugin"),
+            in_point,
         )
         .await
         .map(Into::into)

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -21,7 +21,7 @@ use fedimint_core::module::{
     ApiEndpoint, CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit, PeerHandle,
     SupportedModuleApiVersions, TransactionItemAmount, CORE_CONSENSUS_VERSION,
 };
-use fedimint_core::{push_db_pair_items, Amount, OutPoint, PeerId};
+use fedimint_core::{push_db_pair_items, Amount, InPoint, OutPoint, PeerId};
 use fedimint_dummy_common::config::{
     DummyClientConfig, DummyConfig, DummyConfigConsensus, DummyConfigLocal, DummyConfigPrivate,
     DummyGenParams,
@@ -223,6 +223,7 @@ impl ServerModule for Dummy {
         &'a self,
         dbtx: &mut DatabaseTransaction<'c>,
         input: &'b DummyInput,
+        _in_point: InPoint,
     ) -> Result<InputMeta, DummyInputError> {
         let current_funds = dbtx
             .get_value(&DummyFundsKeyV1(input.account))

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -17,7 +17,7 @@ use fedimint_core::module::{
     ApiEndpoint, CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit, PeerHandle,
     SupportedModuleApiVersions, TransactionItemAmount, CORE_CONSENSUS_VERSION,
 };
-use fedimint_core::{push_db_pair_items, OutPoint, PeerId};
+use fedimint_core::{push_db_pair_items, InPoint, OutPoint, PeerId};
 use fedimint_empty_common::config::{
     EmptyClientConfig, EmptyConfig, EmptyConfigConsensus, EmptyConfigLocal, EmptyConfigPrivate,
     EmptyGenParams,
@@ -197,6 +197,7 @@ impl ServerModule for Empty {
         &'a self,
         _dbtx: &mut DatabaseTransaction<'c>,
         _input: &'b EmptyInput,
+        _in_point: InPoint,
     ) -> Result<InputMeta, EmptyInputError> {
         Err(EmptyInputError::NotSupported)
     }

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -28,7 +28,8 @@ use fedimint_core::module::{
 use fedimint_core::secp256k1::{Message, PublicKey, SECP256K1};
 use fedimint_core::task::{sleep, TaskGroup};
 use fedimint_core::{
-    apply, async_trait_maybe_send, push_db_pair_items, Amount, NumPeersExt, OutPoint, PeerId,
+    apply, async_trait_maybe_send, push_db_pair_items, Amount, InPoint, NumPeersExt, OutPoint,
+    PeerId,
 };
 pub use fedimint_ln_common as common;
 use fedimint_ln_common::config::{
@@ -530,6 +531,7 @@ impl ServerModule for Lightning {
         &'a self,
         dbtx: &mut DatabaseTransaction<'c>,
         input: &'b LightningInput,
+        _in_point: InPoint,
     ) -> Result<InputMeta, LightningInputError> {
         let input = input.ensure_v0_ref()?;
 
@@ -1261,7 +1263,7 @@ mod tests {
     use fedimint_core::module::{InputMeta, TransactionItemAmount};
     use fedimint_core::secp256k1::{generate_keypair, PublicKey};
     use fedimint_core::task::TaskGroup;
-    use fedimint_core::{Amount, OutPoint, PeerId, TransactionId};
+    use fedimint_core::{Amount, InPoint, OutPoint, PeerId, TransactionId};
     use fedimint_ln_common::config::{
         LightningClientConfig, LightningConfig, LightningGenParams, LightningGenParamsConsensus,
         LightningGenParamsLocal, Network,
@@ -1425,7 +1427,14 @@ mod tests {
             .await;
 
         let processed_input_meta = server
-            .process_input(&mut module_dbtx.to_ref_nc(), &lightning_input)
+            .process_input(
+                &mut module_dbtx.to_ref_nc(),
+                &lightning_input,
+                InPoint {
+                    txid: TransactionId::all_zeros(),
+                    in_idx: 0,
+                },
+            )
             .await
             .expect("should process valid incoming contract");
         let expected_input_meta = InputMeta {
@@ -1479,7 +1488,14 @@ mod tests {
             .await;
 
         let processed_input_meta = server
-            .process_input(&mut module_dbtx.to_ref_nc(), &lightning_input)
+            .process_input(
+                &mut module_dbtx.to_ref_nc(),
+                &lightning_input,
+                InPoint {
+                    txid: TransactionId::all_zeros(),
+                    in_idx: 0,
+                },
+            )
             .await
             .expect("should process valid outgoing contract");
 

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -28,7 +28,7 @@ use fedimint_core::task::{timeout, TaskGroup};
 use fedimint_core::time::duration_since_epoch;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{
-    apply, async_trait_maybe_send, push_db_pair_items, BitcoinHash, NumPeers, NumPeersExt,
+    apply, async_trait_maybe_send, push_db_pair_items, BitcoinHash, InPoint, NumPeers, NumPeersExt,
     OutPoint, PeerId,
 };
 use fedimint_lnv2_common::config::{
@@ -383,6 +383,7 @@ impl ServerModule for Lightning {
         &'a self,
         dbtx: &mut DatabaseTransaction<'c>,
         input: &'b LightningInput,
+        _in_point: InPoint,
     ) -> Result<InputMeta, LightningInputError> {
         let (pub_key, amount) = match input.ensure_v0_ref()? {
             LightningInputV0::Outgoing(contract_id, outgoing_witness) => {

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -26,7 +26,7 @@ use fedimint_core::module::{
     ModuleConsensusVersion, ModuleInit, PeerHandle, SupportedModuleApiVersions,
     TransactionItemAmount, CORE_CONSENSUS_VERSION,
 };
-use fedimint_core::{push_db_pair_items, NumPeers, OutPoint, PeerId};
+use fedimint_core::{push_db_pair_items, InPoint, NumPeers, OutPoint, PeerId};
 use fedimint_logging::LOG_MODULE_META;
 use fedimint_meta_common::config::{
     MetaClientConfig, MetaConfig, MetaConfigConsensus, MetaConfigLocal, MetaConfigPrivate,
@@ -388,6 +388,7 @@ impl ServerModule for Meta {
         &'a self,
         _dbtx: &mut DatabaseTransaction<'c>,
         _input: &'b MetaInput,
+        _in_point: InPoint,
     ) -> Result<InputMeta, MetaInputError> {
         Err(MetaInputError::NotSupported)
     }

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -27,8 +27,8 @@ use fedimint_core::module::{
 };
 use fedimint_core::util::BoxFuture;
 use fedimint_core::{
-    apply, async_trait_maybe_send, push_db_key_items, push_db_pair_items, Amount, NumPeersExt,
-    OutPoint, PeerId, Tiered, TieredMulti,
+    apply, async_trait_maybe_send, push_db_key_items, push_db_pair_items, Amount, InPoint,
+    NumPeersExt, OutPoint, PeerId, Tiered, TieredMulti,
 };
 use fedimint_logging::LOG_MODULE_MINT;
 pub use fedimint_mint_common as common;
@@ -456,6 +456,7 @@ impl ServerModule for Mint {
         &'a self,
         dbtx: &mut DatabaseTransaction<'c>,
         input: &'b MintInput,
+        _in_point: InPoint,
     ) -> Result<InputMeta, MintInputError> {
         let input = input.ensure_v0_ref()?;
 
@@ -746,7 +747,7 @@ mod test {
     use fedimint_core::db::Database;
     use fedimint_core::module::registry::ModuleRegistry;
     use fedimint_core::module::ModuleConsensusVersion;
-    use fedimint_core::{secp256k1, Amount, PeerId};
+    use fedimint_core::{secp256k1, Amount, BitcoinHash, InPoint, PeerId, TransactionId};
     use fedimint_mint_common::config::FeeConsensus;
     use fedimint_mint_common::{MintInput, Nonce, Note};
     use fedimint_server::core::{ServerModule, ServerModuleInit};
@@ -865,6 +866,10 @@ mod test {
         mint.process_input(
             &mut dbtx.to_ref_with_prefix_module_id(42).0.into_nc(),
             &input,
+            InPoint {
+                txid: TransactionId::all_zeros(),
+                in_idx: 0,
+            },
         )
         .await
         .expect("Spend of valid e-cash works");
@@ -872,6 +877,10 @@ mod test {
             mint.process_input(
                 &mut dbtx.to_ref_with_prefix_module_id(42).0.into_nc(),
                 &input,
+                InPoint {
+                    txid: TransactionId::all_zeros(),
+                    in_idx: 0
+                },
             )
             .await,
             Err(_)

--- a/modules/fedimint-unknown-server/src/lib.rs
+++ b/modules/fedimint-unknown-server/src/lib.rs
@@ -17,7 +17,7 @@ use fedimint_core::module::{
     ApiEndpoint, CoreConsensusVersion, InputMeta, ModuleConsensusVersion, ModuleInit, PeerHandle,
     SupportedModuleApiVersions, TransactionItemAmount, CORE_CONSENSUS_VERSION,
 };
-use fedimint_core::{OutPoint, PeerId};
+use fedimint_core::{InPoint, OutPoint, PeerId};
 use fedimint_server_core::{DynServerModule, ServerModule, ServerModuleInit, ServerModuleInitArgs};
 pub use fedimint_unknown_common as common;
 use fedimint_unknown_common::config::{
@@ -176,6 +176,7 @@ impl ServerModule for Unknown {
         &'a self,
         _dbtx: &mut DatabaseTransaction<'c>,
         _input: &'b UnknownInput,
+        _in_point: InPoint,
     ) -> Result<InputMeta, UnknownInputError> {
         unreachable!();
     }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -62,7 +62,7 @@ use fedimint_core::task::TaskGroup;
 use fedimint_core::util::{backoff_util, retry, FmtCompactAnyhow as _};
 use fedimint_core::{
     apply, async_trait_maybe_send, get_network_for_address, push_db_key_items, push_db_pair_items,
-    Feerate, NumPeersExt, OutPoint, PeerId,
+    Feerate, InPoint, NumPeersExt, OutPoint, PeerId,
 };
 use fedimint_logging::LOG_MODULE_WALLET;
 use fedimint_server::config::distributedgen::PeerHandleOps;
@@ -624,6 +624,7 @@ impl ServerModule for Wallet {
         &'a self,
         dbtx: &mut DatabaseTransaction<'c>,
         input: &'b WalletInput,
+        _in_point: InPoint,
     ) -> Result<InputMeta, WalletInputError> {
         let (outpoint, value, pub_key) = match input {
             WalletInput::V0(input) => {

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -15,7 +15,7 @@ use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::serde_json;
 use fedimint_core::task::sleep_in_test;
 use fedimint_core::util::{retry, BoxStream, NextOrPending};
-use fedimint_core::{sats, Amount, Feerate, PeerId};
+use fedimint_core::{sats, Amount, BitcoinHash, Feerate, InPoint, PeerId, TransactionId};
 use fedimint_dummy_client::DummyClientInit;
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyInit;
@@ -708,6 +708,10 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
                 .0
                 .into_nc(),
             &input,
+            InPoint {
+                txid: TransactionId::all_zeros(),
+                in_idx: 0,
+            },
         )
         .await
     {
@@ -741,6 +745,10 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
                     .0
                     .into_nc(),
                 &input,
+                InPoint {
+                    txid: TransactionId::all_zeros(),
+                    in_idx: 0,
+                },
             )
             .await,
         Ok(_)


### PR DESCRIPTION
Similar to `OutPoint`, allows us to have access to the txid within process_input

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
