### PR TITLE
[backport releases/v0.6] chore: bump LDK Node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5835,9 +5835,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "ldk-node"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7cea380aa969af6604fd7375f0c877b83e81c6bf23a975a6ce94d96109a702"
+checksum = "fa6a4334b4e5bc2b3a19173bf9008099420657fc084cd2ce544e3f0d132e72e0"
 dependencies = [
  "base64 0.22.1",
  "bdk_chain",

--- a/gateway/fedimint-lightning/Cargo.toml
+++ b/gateway/fedimint-lightning/Cargo.toml
@@ -23,7 +23,7 @@ fedimint-ln-common = { workspace = true }
 fedimint-lnv2-common = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
-ldk-node = "0.4.2"
+ldk-node = "0.4.3"
 lightning = { workspace = true }
 lightning-invoice = { workspace = true }
 lockable = "0.1.1"


### PR DESCRIPTION
LDK Node had a issue that caused devimint to not work properly in downstream projects. v0.4.3 fixed that, I would like that to be included in v0.6