### PR TITLE
fix: use actual binary name for completions

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -1249,10 +1249,19 @@ impl FedimintCli {
                 ))
             }
             Command::Completion { shell } => {
+                let bin_path = PathBuf::from(
+                    std::env::args_os()
+                        .next()
+                        .expect("Binary name is always provided if we get this far"),
+                );
+                let bin_name = bin_path
+                    .file_name()
+                    .expect("path has file name")
+                    .to_string_lossy();
                 clap_complete::generate(
                     shell,
                     &mut Opts::command(),
-                    "fedimint-cli",
+                    bin_name.as_ref(),
                     &mut std::io::stdout(),
                 );
                 // HACK: prints true to stdout which is fine for shells


### PR DESCRIPTION
I have `fedimint-cli` installed as `fmcli` locally for quick access and want to setup completions.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
