### PR TITLE
chore: lower logging level of some timings

### DIFF
--- a/fedimint-core/src/timing.rs
+++ b/fedimint-core/src/timing.rs
@@ -92,7 +92,7 @@ impl TimeReporter {
         Self {
             inner: Some(TimeReporterInner {
                 name: name.into(),
-                level: Level::DEBUG,
+                level: Level::TRACE,
                 start: crate::time::now(),
                 threshold: None,
             }),

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -601,7 +601,7 @@ impl ConsensusEngine {
         let session_checkpoint_dir = checkpoint_dir.join(format!("{session_index}"));
 
         {
-            let _timing /* logs on drop */ = timing::TimeReporter::new("database-checkpoint").level(Level::DEBUG);
+            let _timing /* logs on drop */ = timing::TimeReporter::new("database-checkpoint").level(Level::TRACE);
             match self.db.checkpoint(&session_checkpoint_dir) {
                 Ok(()) => {
                     debug!(target: LOG_CONSENSUS, ?session_checkpoint_dir, ?session_index, "Created db checkpoint");
@@ -614,7 +614,7 @@ impl ConsensusEngine {
 
         {
             // Check if any old checkpoint need to be cleaned up
-            let _timing /* logs on drop */ = timing::TimeReporter::new("remove-database-checkpoint").level(Level::DEBUG);
+            let _timing /* logs on drop */ = timing::TimeReporter::new("remove-database-checkpoint").level(Level::TRACE);
             if let Err(e) = self.delete_old_database_checkpoint(session_index, &checkpoint_dir) {
                 warn!(target: LOG_CONSENSUS, ?e, "Could not delete old checkpoints");
             }


### PR DESCRIPTION
We don't really use these as much anymore, at least usually.

W.r.t. db checkpoints we've verified in real settings that they are very cheap, so no need to log it anymore as much.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
