### PR TITLE
refactor: share bitcoind monitoring between modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,6 +2524,7 @@ dependencies = [
  "esplora-client 0.10.0",
  "fedimint-core",
  "fedimint-logging",
+ "fedimint-server-core",
  "futures",
  "hex",
  "jaq-core",
@@ -3614,6 +3615,7 @@ dependencies = [
  "async-trait",
  "fedimint-api-client",
  "fedimint-core",
+ "tokio",
 ]
 
 [[package]]
@@ -3915,6 +3917,7 @@ dependencies = [
  "bitcoincore-rpc",
  "devimint",
  "fedimint-api-client",
+ "fedimint-bitcoind",
  "fedimint-client",
  "fedimint-core",
  "fedimint-dummy-client",

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -26,6 +26,7 @@ bitcoincore-rpc = { workspace = true, optional = true }
 esplora-client = { workspace = true, optional = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
+fedimint-server-core = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 jaq-core = { workspace = true }

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -35,6 +35,8 @@ pub mod bitcoincore;
 mod esplora;
 mod feerate_source;
 
+pub mod shared;
+
 // <https://blockstream.info/api/block-height/0>
 const MAINNET_GENESIS_BLOCK_HASH: &str =
     "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
@@ -199,7 +201,7 @@ impl DynBitcoindRpc {
         self,
         task_group: &TaskGroup,
         on_update: impl Fn(u64) + Send + Sync + 'static,
-    ) -> anyhow::Result<()> {
+    ) {
         let mut desired_interval = get_bitcoin_polling_interval();
 
         // Note: atomic only to workaround Send+Sync async closure limitation
@@ -238,7 +240,6 @@ impl DynBitcoindRpc {
                 }
             }
         });
-        Ok(())
     }
 
     /// Spawns a background task that queries the feerate periodically and sends

--- a/fedimint-bitcoind/src/shared.rs
+++ b/fedimint-bitcoind/src/shared.rs
@@ -1,0 +1,131 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use fedimint_core::task::TaskGroup;
+use fedimint_core::util::SafeUrl;
+use fedimint_core::Feerate;
+use fedimint_logging::LOG_BITCOIN;
+use fedimint_server_core::ServerModuleShared;
+use tokio::sync::{watch, Mutex};
+use tracing::debug;
+
+/// Used for estimating a feerate that will confirm within a target number of
+/// blocks.
+///
+/// Since the wallet's UTXOs are a shared resource, we need to reduce the risk
+/// of a peg-out transaction getting stuck in the mempool, hence we use a low
+/// confirmation target. Other fee bumping techniques, such as RBF and CPFP, can
+/// help mitigate this problem but are out-of-scope for this version of the
+/// wallet.
+pub const CONFIRMATION_TARGET: u16 = 1;
+
+use crate::DynBitcoindRpc;
+type SharedKey = (bitcoin::Network, SafeUrl);
+
+/// A (potentially) shared (between server modules) bitcoin utility trait
+///
+/// Multiple Fedimint modules might want same Bitcoin-network facilities
+/// like monitoring the feerate or block count, and each of them doing the same
+/// thing does not scale very well.
+///
+/// This type allows deduplicating the work, by sharing it via
+/// `ServerModuleInitArgs::shared`.
+///
+/// In theory different modules might be configured to use different Bitcoin
+/// network/bitcoin sources, so shared facilities here are keyed over the the
+/// Bitcoin rpc url to use.
+struct ServerModuleSharedBitcoinInner {
+    task_group: TaskGroup,
+    feerate_rx: tokio::sync::Mutex<BTreeMap<SharedKey, watch::Receiver<Option<Feerate>>>>,
+    block_count_rx: tokio::sync::Mutex<BTreeMap<SharedKey, watch::Receiver<Option<u64>>>>,
+}
+
+impl ServerModuleSharedBitcoinInner {
+    pub async fn feerate_receiver(
+        &self,
+        network: bitcoin::Network,
+        btc_rpc: DynBitcoindRpc,
+    ) -> anyhow::Result<watch::Receiver<Option<Feerate>>> {
+        let key = (network, btc_rpc.get_bitcoin_rpc_config().url);
+        let mut write = self.feerate_rx.lock().await;
+
+        if let Some(v) = write.get(&key) {
+            return Ok(v.clone());
+        }
+
+        let (tx, rx) = watch::channel(None);
+
+        btc_rpc
+            .clone()
+            .spawn_fee_rate_update_task(&self.task_group, network, 1, {
+                move |feerate| {
+                    debug!(target: LOG_BITCOIN, %feerate, "New feerate");
+                    let _ = tx.send(Some(feerate));
+                }
+            })?;
+
+        write.insert(key, rx.clone());
+
+        Ok(rx)
+    }
+    pub async fn block_count_receiver(
+        &self,
+        network: bitcoin::Network,
+        btc_rpc: DynBitcoindRpc,
+    ) -> watch::Receiver<Option<u64>> {
+        let key = (network, btc_rpc.get_bitcoin_rpc_config().url);
+        let mut write = self.block_count_rx.lock().await;
+
+        if let Some(v) = write.get(&key) {
+            return v.clone();
+        }
+
+        let (tx, rx) = watch::channel(None);
+
+        btc_rpc
+            .clone()
+            .spawn_block_count_update_task(&self.task_group, {
+                move |block_count| {
+                    debug!(target: LOG_BITCOIN, %block_count, "New block count");
+                    let _ = tx.send(Some(block_count));
+                }
+            });
+
+        write.insert(key, rx.clone());
+
+        rx
+    }
+}
+
+#[derive(Clone)]
+pub struct ServerModuleSharedBitcoin {
+    inner: Arc<ServerModuleSharedBitcoinInner>,
+}
+
+impl ServerModuleSharedBitcoin {
+    pub async fn feerate_receiver(
+        &self,
+        network: bitcoin::Network,
+        btc_rpc: DynBitcoindRpc,
+    ) -> anyhow::Result<watch::Receiver<Option<Feerate>>> {
+        self.inner.feerate_receiver(network, btc_rpc).await
+    }
+    pub async fn block_count_receiver(
+        &self,
+        network: bitcoin::Network,
+        btc_rpc: DynBitcoindRpc,
+    ) -> watch::Receiver<Option<u64>> {
+        self.inner.block_count_receiver(network, btc_rpc).await
+    }
+}
+impl ServerModuleShared for ServerModuleSharedBitcoin {
+    fn new(task_group: TaskGroup) -> Self {
+        Self {
+            inner: Arc::new(ServerModuleSharedBitcoinInner {
+                task_group,
+                feerate_rx: Mutex::default(),
+                block_count_rx: Mutex::default(),
+            }),
+        }
+    }
+}

--- a/fedimint-logging/src/lib.rs
+++ b/fedimint-logging/src/lib.rs
@@ -23,6 +23,7 @@ use tracing_subscriber::{EnvFilter, Layer};
 
 pub const LOG_CONSENSUS: &str = "fm::consensus";
 pub const LOG_CORE: &str = "fm::core";
+pub const LOG_SERVER: &str = "fm::server";
 pub const LOG_DB: &str = "fm::db";
 pub const LOG_DEVIMINT: &str = "fm::devimint";
 pub const LOG_NET: &str = "fm::net";
@@ -56,6 +57,7 @@ pub const LOG_GATEWAY: &str = "fm::gw";
 pub const LOG_BITCOIND_ESPLORA: &str = "fm::bitcoind::esplora";
 pub const LOG_BITCOIND_CORE: &str = "fm::bitcoind::bitcoincore";
 pub const LOG_BITCOIND: &str = "fm::bitcoind";
+pub const LOG_BITCOIN: &str = "fm::bitcoin";
 
 /// Consolidates the setup of server tracing into a helper
 #[derive(Default)]

--- a/fedimint-server-core/Cargo.toml
+++ b/fedimint-server-core/Cargo.toml
@@ -20,3 +20,4 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 fedimint-api-client = { workspace = true }
 fedimint-core = { workspace = true }
+tokio = { workspace = true }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use anyhow::bail;
@@ -76,6 +77,7 @@ pub async fn run(
         &None,
         &Connector::Tcp,
     );
+    let shared_anymap = Arc::new(RwLock::new(BTreeMap::default()));
 
     for (module_id, module_cfg) in &cfg.consensus.modules {
         match module_init_registry.get(&module_cfg.kind) {
@@ -99,6 +101,7 @@ pub async fn run(
                         task_group,
                         cfg.local.identity,
                         global_api.with_module(*module_id),
+                        shared_anymap.clone(),
                     )
                     .await?;
 

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -41,16 +41,6 @@ pub const MODULE_CONSENSUS_VERSION: ModuleConsensusVersion = ModuleConsensusVers
 pub const SAFE_DEPOSIT_MODULE_CONSENSUS_VERSION: ModuleConsensusVersion =
     ModuleConsensusVersion::new(2, 2);
 
-/// Used for estimating a feerate that will confirm within a target number of
-/// blocks.
-///
-/// Since the wallet's UTXOs are a shared resource, we need to reduce the risk
-/// of a peg-out transaction getting stuck in the mempool, hence we use a low
-/// confirmation target. Other fee bumping techniques, such as RBF and CPFP, can
-/// help mitigate this problem but are out-of-scope for this version of the
-/// wallet.
-pub const CONFIRMATION_TARGET: u16 = 1;
-
 /// To further mitigate the risk of a peg-out transaction getting stuck in the
 /// mempool, we multiply the feerate estimate returned from the backend by this
 /// value.
@@ -494,8 +484,6 @@ pub enum WalletCreationError {
     RpcError(String),
     #[error("Feerate source error: {0}")]
     FeerateSourceError(String),
-    #[error("Block count source error: {0}")]
-    BlockCountSourceError(String),
 }
 
 #[derive(Debug, Error, Encodable, Decodable, Hash, Clone, Eq, PartialEq)]

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -21,6 +21,7 @@ bitcoin = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 devimint = { workspace = true }
 fedimint-api-client = { workspace = true }
+fedimint-bitcoind = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -7,6 +7,7 @@ use assert_matches::assert_matches;
 use bitcoin::secp256k1;
 use fedimint_api_client::api::net::Connector;
 use fedimint_api_client::api::DynGlobalApi;
+use fedimint_bitcoind::shared::ServerModuleSharedBitcoin;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::ClientHandleArc;
 use fedimint_core::db::mem_impl::MemDatabase;
@@ -19,7 +20,7 @@ use fedimint_core::{sats, Amount, BitcoinHash, Feerate, InPoint, PeerId, Transac
 use fedimint_dummy_client::DummyClientInit;
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyInit;
-use fedimint_server::core::ServerModule;
+use fedimint_server::core::{ServerModule, ServerModuleShared as _};
 use fedimint_testing::btc::BitcoinTest;
 use fedimint_testing::envs::{FM_TEST_BACKEND_BITCOIN_RPC_KIND_ENV, FM_TEST_USE_REAL_DAEMONS_ENV};
 use fedimint_testing::fixtures::Fixtures;
@@ -658,6 +659,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         PeerId::from(0),
         // FIXME: use proper mock
         DynGlobalApi::from_endpoints([], &None, &Connector::Tcp).with_module(module_instance_id),
+        &ServerModuleSharedBitcoin::new(task_group.clone()),
     )
     .await?;
 


### PR DESCRIPTION
We're receiving reports of rate limitting issues
when using public block explorers.

Especially in 0.5 we've added sourcing of fee-rates from external web sources, which might add up
to existing block count sourcing.

One way to cut on the amount of requests we make is to not do duplicate work. Current all: wallet, ln and lnv2 modules just spawn their own monitoring tasks.

This change introduces a "anymap" share data structure where two modules can coordinate and re-use a type, as long as they both know about it and thus their
code and the type itself were implemented to facilitate such a sharing.

The first type to be used like this comes from `fedimint-bitcoind` and just hosts monitoring tasks, so all interested modules can share them.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
