### PR TITLE
chore: remove references to rust toolchain from binaries

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -246,6 +246,8 @@ let
         moreutils-ts
         parallel
         time
+
+        removeReferencesTo
       ]
       ++ builtins.attrValues { inherit (pkgs) cargo-nextest; }
       ++ [
@@ -285,6 +287,15 @@ let
     # and in case of errors and panics, would like to see the
     # line numbers etc.
     dontStrip = true;
+
+    postFixup = ''
+      # the toolchain package itself is handled by crane, so it's easiest
+      # to just recover its path from the current rustc binary itself
+      rust_toolchain_pkg=$(dirname $(dirname $(which rustc)))
+      >&2 echo "Removing references to $rust_toolchain_pkg"
+
+      find "$out" -type f -executable -exec remove-references-to -t $rust_toolchain_pkg '{}' +
+    '';
   };
 
   commonCliTestArgs = commonArgs // {


### PR DESCRIPTION
I don't know why this worked before, but I think we need to handle it manually here, especially if we want to retain some debug symbols and not strip the binary completely.

Fix #6821
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
