### PR TITLE
chore(ci): protect against accid. too large Nix closure sizes

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -540,6 +540,15 @@ jobs:
             if [[ $GITHUB_REF_TYPE == "tag" ]]; then
               >&2 echo "Building: $bin"
               nix build -L .#$bin
+
+              closure_size=$(nix path-info -rS --json .#bin| jq '. | to_entries[] | select(.value.ultimate == true) | .value.narSize')
+              >&2 echo "$bin's Nix closure size: $closure_size"
+
+              if [ 150000000 -lt $closure_size ]; then
+                >&2 echo "$bin's Nix closure size seems too big: $closure_size"
+                exit 1
+              fi
+
               >&2 echo "Pushing to cachix: $bin"
               cachix push fedimint -c 8 -j 8 $(nix-store --query --references $(readlink -f result)) $(readlink -f result)
               >&2 echo "Pining in cachix: fedimint-release-$bin:$BUILD_ID"


### PR DESCRIPTION
Re #6821 

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
