### PR TITLE
chore(ci): switch to determinatesystems installer

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -37,12 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint

--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint

--- a/.github/workflows/ci-fuzz.yml
+++ b/.github/workflows/ci-fuzz.yml
@@ -35,12 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint

--- a/.github/workflows/ci-fuzz.yml
+++ b/.github/workflows/ci-fuzz.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
@@ -138,7 +138,7 @@ jobs:
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         uses: ./.github/actions/prepare
 
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
         if: github.event_name != 'pull_request' || matrix.build-in-pr
       - uses: cachix/cachix-action@v15
         if: github.event_name != 'pull_request' || matrix.build-in-pr
@@ -217,7 +217,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint
@@ -245,7 +245,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint
@@ -321,7 +321,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
       - uses: cachix/cachix-action@v15
@@ -352,7 +352,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint
@@ -471,7 +471,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -45,12 +45,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint
@@ -99,13 +94,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
-      - uses: cachix/install-nix-action@v30
-        if: github.event_name != 'pull_request' || matrix.build-in-pr
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: cachix/cachix-action@v15
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
@@ -149,13 +138,8 @@ jobs:
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         uses: ./.github/actions/prepare
 
-      - uses: cachix/install-nix-action@v30
+      - uses: DeterminateSystems/nix-installer-action@v16
         if: github.event_name != 'pull_request' || matrix.build-in-pr
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
       - uses: cachix/cachix-action@v15
         if: github.event_name != 'pull_request' || matrix.build-in-pr
         with:
@@ -233,12 +217,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint
@@ -266,12 +245,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint
@@ -347,13 +321,8 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request' || matrix.build-in-pr
 
-      - uses: cachix/install-nix-action@v30
+      - uses: DeterminateSystems/nix-installer-action@v16
         if: github.event_name != 'pull_request' || matrix.build-in-pr
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
 
       - uses: cachix/cachix-action@v15
         if: github.event_name != 'pull_request' || matrix.build-in-pr
@@ -383,12 +352,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint
@@ -507,12 +471,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: cachix/cachix-action@v15
         with:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint

--- a/.github/workflows/flakebox-flakehub-publish.yml
+++ b/.github/workflows/flakebox-flakehub-publish.yml
@@ -12,7 +12,7 @@ jobs:
         ref: ${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || ''
           }}
     - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@v16
+    - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
     - name: Flakehub Push
       uses: DeterminateSystems/flakehub-push@main
       with:

--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
 
       - uses: cachix/cachix-action@v15
         with:

--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -60,12 +60,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
 
       - uses: cachix/cachix-action@v15
         with:

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -44,12 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
-      - uses: cachix/install-nix-action@v30
-        with:
-          nix_path: nixpkgs=channel:nixos-23.11
-          extra_nix_config: |
-            connect-timeout = 15
-            stalled-download-timeout = 15
+      - uses: DeterminateSystems/nix-installer-action@v16
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: dpc/nix-installer-action@dpc/jj-vqymqvyntouw
       - uses: cachix/cachix-action@v15
         with:
           name: fedimint


### PR DESCRIPTION
They have some MacOS fixes for problems that are otherwise causing random CI failures, like e.g.:

https://github.com/fedimint/fedimint/actions/runs/13172264947/job/36764693478

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
