### PR TITLE
refactor: Divorce LDK GW from LNv2

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -299,21 +299,21 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                                     .map(|_| ())
                             },
                             async {
-                                match dev_fed.gw_ldk_connected().await? {
-                                    Some(gw_ldk) => {
-                                        let pegin_addr = gw_ldk
-                                            .get_pegin_addr(
-                                                &dev_fed.fed().await?.calculate_federation_id(),
-                                            )
-                                            .await?;
-                                        dev_fed
-                                            .bitcoind()
-                                            .await?
-                                            .send_to(pegin_addr, GW_PEGIN_AMOUNT)
-                                            .await
-                                            .map(|_| ())
-                                    }
-                                    _ => Ok(()),
+                                if crate::util::supports_lnv2() {
+                                    let gw_ldk = dev_fed.gw_ldk_connected().await?;
+                                    let pegin_addr = gw_ldk
+                                        .get_pegin_addr(
+                                            &dev_fed.fed().await?.calculate_federation_id(),
+                                        )
+                                        .await?;
+                                    dev_fed
+                                        .bitcoind()
+                                        .await?
+                                        .send_to(pegin_addr, GW_PEGIN_AMOUNT)
+                                        .await
+                                        .map(|_| ())
+                                } else {
+                                    Ok(())
                                 }
                             },
                         )?;

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -35,11 +35,7 @@ async fn test_gateway_registration(dev_fed: &DevJitFed) -> anyhow::Result<()> {
         .await?;
 
     let gw_lnd = dev_fed.gw_lnd().await?;
-    let gw_ldk = dev_fed
-        .gw_ldk_connected()
-        .await?
-        .as_ref()
-        .expect("Gateways of version 0.5.0 or higher support LDK");
+    let gw_ldk = dev_fed.gw_ldk_connected().await?;
 
     let gateways = [gw_lnd.addr.clone(), gw_ldk.addr.clone()];
 
@@ -152,11 +148,7 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     assert_eq!(client.balance().await?, 10_000 * 1000);
 
     let gw_lnd = dev_fed.gw_lnd().await?;
-    let gw_ldk = dev_fed
-        .gw_ldk()
-        .await?
-        .as_ref()
-        .expect("Gateways of version 0.5.0 or higher support LDK");
+    let gw_ldk = dev_fed.gw_ldk().await?;
     let lnd = dev_fed.lnd().await?;
 
     let (hold_preimage, hold_invoice, hold_payment_hash) = lnd.create_hold_invoice(60000).await?;


### PR DESCRIPTION
Builds on https://github.com/fedimint/fedimint/pull/6781

Allows devimint to always spawn an LDK GW, regardless of the version (backwards compat, upgrade, etc). If the LDK GW version is "before" LNv2, then it just spawns the most recent GW version. When LNv2 is not active, operations that require LNv2 (i.e pegging in) are skipped and the LDK GW can be used as a normal lightning node.

Next step after this is removing CLN.