### PR TITLE
chore(ci): increase timeout on MacOS build

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -89,7 +89,7 @@ jobs:
           - host: macos
             runs-on: macos-14
             build-in-pr: false
-            timeout: 30
+            timeout: 60
 
     name: "Dev Shell on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
MacOS is slow, and sometimes need some time to rebuild some new packages, etc.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
