### PR TITLE
chore: try wild linker (only in dev shell)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,6 +491,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1739214665,
+        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1629252929,
@@ -547,7 +563,8 @@
         "flake-utils": "flake-utils_5",
         "flakebox": "flakebox_2",
         "nixpkgs": "nixpkgs_4",
-        "nixpkgs-old": "nixpkgs-old"
+        "nixpkgs-old": "nixpkgs-old",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "rust-analyzer-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,9 @@
     nixpkgs-old = {
       url = "github:nixos/nixpkgs/nixos-23.05";
     };
+    nixpkgs-unstable = {
+      url = "github:nixos/nixpkgs/nixos-unstable";
+    };
     flake-utils.url = "github:numtide/flake-utils";
     fenix = {
       url = "github:nix-community/fenix";
@@ -35,6 +38,7 @@
       self,
       nixpkgs,
       nixpkgs-old,
+      nixpkgs-unstable,
       flake-utils,
       flakebox,
       cargo-deluxe,
@@ -71,6 +75,7 @@
     // flake-utils.lib.eachDefaultSystem (
       system:
       let
+        pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
         pkgs-old = import nixpkgs-old {
           inherit system;
           overlays = [
@@ -318,6 +323,8 @@
                     pkgs.tokio-console
                     pkgs.git
 
+                    (pkgs-unstable.callPackage ./nix/pkgs/wild.nix { })
+
                     # Nix
                     pkgs.nixfmt-rfc-style
                     pkgs.shellcheck
@@ -374,6 +381,8 @@
                   if [ -z "$(git config --global merge.ours.driver)" ]; then
                       >&2 echo "⚠️  Recommended to run 'git config --global merge.ours.driver true' to enable better lock file handling. See https://blog.aspect.dev/easier-merges-on-lockfiles for more info"
                   fi
+
+                  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=--ld-path=wild"
                 '';
               };
           in

--- a/nix/pkgs/wild.nix
+++ b/nix/pkgs/wild.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "wild-${version}";
+  version = "0.3.0-git";
+
+  src = fetchFromGitHub {
+    owner = "davidlattimore";
+    repo = "wild";
+    rev = "d73f2be52184ab39c1db03be32e96dab77c69c0f";
+    sha256 = "sha256-A5izko2u18UgdmHDrIGQ6hOnvzKbR/9NJ7s6CpMEw+g=";
+  };
+
+  doCheck = false;
+
+  buildInputs = [
+    pkg-config
+  ];
+
+  cargoHash = "sha256-YPRGf0dRLiMoRn6/t27a8iWUFh5NCe7iEitSK0FhJQg=";
+
+  meta = with lib; {
+    description = "A very fast linker for Linux";
+    homepage = "https://github.com/davidlattimore/wild";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dpc ];
+    platforms = platforms.linux;
+  };
+}

--- a/scripts/bench-compilation.sh
+++ b/scripts/bench-compilation.sh
@@ -49,11 +49,11 @@ echo -e "                       total    user     sys"
 for profile in dev release ; do
   for command in check build ; do
 
-    if echo "$BENCH_COMP_SKIP_PROFILE" | grep -wq "$profile"; then
+    if echo "${BENCH_COMP_SKIP_PROFILE:-}" | grep -wq "$profile"; then
       continue
     fi
 
-    if echo "$BENCH_COMP_SKIP_COMMAND" | grep -wq "$command"; then
+    if echo "${BENCH_COMP_SKIP_COMMAND:-}" | grep -wq "$command"; then
       continue
     fi
 


### PR DESCRIPTION
Looks like it works, and does compile our stuff, but is ultimately slower.

Before (`mold`):


```
Date: 2025-02-12
Commit: ea28ca43019
                       total    user     sys
Full  check   debug:   50.40  808.07  103.93
Incr  check   debug:    4.31    7.01    5.51
Full  build   debug:  111.23 2107.94  188.77
Incr  build   debug:   20.36   29.92   19.34
Full  check release:   44.27  447.37   90.69
Incr  check release:   13.84   26.60    5.62
... got impatient waiting for this one
```

After (`wild`):

```
Date: 2025-02-12
Commit: b57dc1c421f
                       total    user     sys
Full  check   debug:   50.87  802.77  102.33
Incr  check   debug:    4.13    7.06    5.46
Full  build   debug:  164.35 2090.29  197.49
Incr  build   debug:   55.60   24.30   20.11
Full  check release:   46.51  433.51   86.26
Incr  check release:   13.84   26.51    5.62
Full  build release:  509.82 4023.17  802.12
Incr  build release:  375.34 3057.94  621.29
```

Seems it's because the handling of debug symbols is currently not optimized (that's why README mentions that binaries were stripped): https://github.com/davidlattimore/wild/issues/117

Well, I'm rooting for that project and looking forward to try it after that issue is addressed, as everyone would love faster linking in Rust...

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
