### PR TITLE
chore: change lightning module mode default

### DIFF
--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -174,6 +174,7 @@ declare_vars! {
 
         FM_GATEWAY_SKIP_WAIT_FOR_SYNC: String = "1"; env: "FM_GATEWAY_SKIP_WAIT_FOR_SYNC";
         FM_GATEWAY_NETWORK: String = "regtest"; env: "FM_GATEWAY_NETWORK";
+        FM_GATEWAY_LIGHTNING_MODULE_MODE: String = "All"; env: "FM_GATEWAY_LIGHTNING_MODULE_MODE";
 
         FM_FAUCET_BIND_ADDR: String = f!("0.0.0.0:{FM_PORT_FAUCET}"); env: "FM_FAUCET_BIND_ADDR";
 

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -88,7 +88,7 @@ pub struct GatewayOpts {
     num_route_hints: u32,
 
     /// The Lightning module to use: LNv1, LNv2, or both
-    #[arg(long = "lightning-module-mode", env = envs::FM_GATEWAY_LIGHTNING_MODULE_MODE_ENV, default_value_t = LightningModuleMode::All)]
+    #[arg(long = "lightning-module-mode", env = envs::FM_GATEWAY_LIGHTNING_MODULE_MODE_ENV, default_value_t = LightningModuleMode::LNv1)]
     lightning_module_mode: LightningModuleMode,
 }
 


### PR DESCRIPTION
The default for the Lightning Module Mode is confusing because it defaults to `All` which is necessary in devimint but discouraged in production. This PR changes it to LNv1 to be backwards compatible with previous code.