### PR TITLE
[Backport releases/v0.6] chore: change lightning module mode default

### DIFF
--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -174,6 +174,7 @@ declare_vars! {
 
         FM_GATEWAY_SKIP_WAIT_FOR_SYNC: String = "1"; env: "FM_GATEWAY_SKIP_WAIT_FOR_SYNC";
         FM_GATEWAY_NETWORK: String = "regtest"; env: "FM_GATEWAY_NETWORK";
+        FM_GATEWAY_LIGHTNING_MODULE_MODE: String = "All"; env: "FM_GATEWAY_LIGHTNING_MODULE_MODE";
 
         FM_FAUCET_BIND_ADDR: String = f!("0.0.0.0:{FM_PORT_FAUCET}"); env: "FM_FAUCET_BIND_ADDR";
 

--- a/gateway/ln-gateway/src/config.rs
+++ b/gateway/ln-gateway/src/config.rs
@@ -88,7 +88,7 @@ pub struct GatewayOpts {
     num_route_hints: u32,
 
     /// The Lightning module to use: LNv1, LNv2, or both
-    #[arg(long = "lightning-module-mode", env = envs::FM_GATEWAY_LIGHTNING_MODULE_MODE_ENV, default_value_t = LightningModuleMode::All)]
+    #[arg(long = "lightning-module-mode", env = envs::FM_GATEWAY_LIGHTNING_MODULE_MODE_ENV, default_value_t = LightningModuleMode::LNv1)]
     lightning_module_mode: LightningModuleMode,
 }
 


### PR DESCRIPTION
# Description
Backport of #6854 to `releases/v0.6`.