### PR TITLE
Fixes and tests for consensus version voting activation

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1109,7 +1109,7 @@ impl ReconnectClientConnections {
         let res = self
             .connections
             .get(&peer)
-            .expect("Could not find client connection for peer {peer}")
+            .unwrap_or_else(|| panic!("Could not find client connection for peer {peer}"))
             .connection()
             .await
             .context("Failed to connect to peer")

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -43,6 +43,8 @@ pub struct FederationTest {
     client_init: ClientModuleInitRegistry,
     primary_module_kind: ModuleKind,
     _task: TaskGroup,
+    num_peers: u16,
+    num_offline: u16,
 }
 
 impl FederationTest {
@@ -145,6 +147,12 @@ impl FederationTest {
         .await
         .expect("Failed to connect federation");
     }
+
+    /// Return all online PeerIds
+    pub fn online_peer_ids(&self) -> impl Iterator<Item = PeerId> {
+        // we can assume this ordering since peers are started in ascending order
+        (0..(self.num_peers - self.num_offline)).map(PeerId::from)
+    }
 }
 
 /// Builder struct for creating a `FederationTest`.
@@ -166,11 +174,12 @@ impl FederationTestBuilder {
         server_init: ServerModuleInitRegistry,
         client_init: ClientModuleInitRegistry,
         primary_module_kind: ModuleKind,
+        num_offline: u16,
     ) -> FederationTestBuilder {
         let num_peers = 4;
         Self {
             num_peers,
-            num_offline: 1,
+            num_offline,
             base_port: block_in_place(|| fedimint_portalloc::port_alloc(num_peers * 2))
                 .expect("Failed to allocate a port range"),
             primary_module_kind,
@@ -304,6 +313,8 @@ impl FederationTestBuilder {
             client_init: self.client_init,
             primary_module_kind: self.primary_module_kind,
             _task: task_group,
+            num_peers: self.num_peers,
+            num_offline: self.num_offline,
         }
     }
 }

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -142,19 +142,25 @@ impl Fixtures {
         self
     }
 
-    /// Starts a new federation with default number of peers for testing
-    pub async fn new_default_fed(&self) -> FederationTest {
-        self.new_fed_builder().build().await
+    /// Starts a new federation with 3/4 peers online
+    pub async fn new_fed_degraded(&self) -> FederationTest {
+        self.new_fed_builder(1).build().await
+    }
+
+    /// Starts a new federation with 4/4 peers online
+    pub async fn new_fed_not_degraded(&self) -> FederationTest {
+        self.new_fed_builder(0).build().await
     }
 
     /// Creates a new `FederationTestBuilder` that can be used to build up a
     /// `FederationTest` for module tests.
-    pub fn new_fed_builder(&self) -> FederationTestBuilder {
+    pub fn new_fed_builder(&self, num_offline: u16) -> FederationTestBuilder {
         FederationTestBuilder::new(
             self.params.clone(),
             ServerModuleInitRegistry::from(self.servers.clone()),
             ClientModuleInitRegistry::from(self.clients.clone()),
             self.primary_module_kind.clone(),
+            num_offline,
         )
     }
 

--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -115,7 +115,7 @@ where
     let fixtures = fixtures();
     let other_ln = FakeLightningTest::new();
 
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let gateway = fixtures.new_gateway(LightningModuleMode::LNv1).await;
     fed.connect_gateway(&gateway).await;
     let user_client = fed.new_client().await;
@@ -138,8 +138,8 @@ where
     B: Future<Output = anyhow::Result<()>>,
 {
     let fixtures = fixtures();
-    let fed1 = fixtures.new_default_fed().await;
-    let fed2 = fixtures.new_default_fed().await;
+    let fed1 = fixtures.new_fed_degraded().await;
+    let fed2 = fixtures.new_fed_degraded().await;
     let gateway = fixtures.new_gateway(LightningModuleMode::LNv1).await;
 
     f(gateway, fed1, fed2, fixtures.bitcoin()).await?;
@@ -982,7 +982,7 @@ async fn send_msats_to_gateway(gateway: &Gateway, federation_id: FederationId, m
 #[tokio::test(flavor = "multi_thread")]
 async fn lnv2_incoming_contract_with_invalid_preimage_is_refunded() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
 
     let gateway = fixtures.new_gateway(LightningModuleMode::LNv2).await;
 
@@ -1026,7 +1026,7 @@ async fn lnv2_incoming_contract_with_invalid_preimage_is_refunded() -> anyhow::R
 #[tokio::test(flavor = "multi_thread")]
 async fn lnv2_expired_incoming_contract_is_rejected() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
 
     let gateway = fixtures.new_gateway(LightningModuleMode::LNv2).await;
 
@@ -1070,7 +1070,7 @@ async fn lnv2_expired_incoming_contract_is_rejected() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn lnv2_malleated_incoming_contract_is_rejected() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
 
     let gateway = fixtures.new_gateway(LightningModuleMode::LNv2).await;
 
@@ -1126,8 +1126,8 @@ async fn lnv2_malleated_incoming_contract_is_rejected() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn gateway_read_payment_log() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed1 = fixtures.new_default_fed().await;
-    let fed2 = fixtures.new_default_fed().await;
+    let fed1 = fixtures.new_fed_degraded().await;
+    let fed2 = fixtures.new_fed_degraded().await;
     let gateway = fixtures.new_gateway(LightningModuleMode::LNv2).await;
     fed1.connect_gateway(&gateway).await;
     fed2.connect_gateway(&gateway).await;

--- a/modules/fedimint-dummy-tests/tests/tests.rs
+++ b/modules/fedimint-dummy-tests/tests/tests.rs
@@ -21,7 +21,7 @@ fn fixtures() -> Fixtures {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_print_and_send_money() -> anyhow::Result<()> {
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let (client1, client2) = fed.two_clients().await;
 
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>()?;
@@ -41,7 +41,7 @@ async fn can_print_and_send_money() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn client_ignores_unknown_module() {
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let client = fed.new_client().await;
 
     let mut cfg = client.config().await;
@@ -65,7 +65,7 @@ async fn client_ignores_unknown_module() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn federation_should_abort_if_balance_sheet_is_negative() -> anyhow::Result<()> {
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let client = fed.new_client().await;
 
     let (panic_sender, panic_receiver) = std::sync::mpsc::channel::<()>();
@@ -117,7 +117,7 @@ async fn federation_should_abort_if_balance_sheet_is_negative() -> anyhow::Resul
 /// the federation should reject because it's unbalanced.
 #[tokio::test(flavor = "multi_thread")]
 async fn unbalanced_transactions_get_rejected() -> anyhow::Result<()> {
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let client = fed.new_client().await;
 
     let dummy_module = client.get_first_module::<DummyClientModule>()?;

--- a/modules/fedimint-ln-tests/tests/tests.rs
+++ b/modules/fedimint-ln-tests/tests/tests.rs
@@ -81,7 +81,7 @@ async fn pay_invoice(
 #[tokio::test(flavor = "multi_thread")]
 async fn test_can_attach_extra_meta_to_receive_operation() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>()?;
 
@@ -143,7 +143,7 @@ async fn test_can_attach_extra_meta_to_receive_operation() -> anyhow::Result<()>
 #[tokio::test(flavor = "multi_thread")]
 async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>()?;
 
@@ -222,7 +222,7 @@ async fn cannot_pay_same_internal_invoice_twice() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let gw = gateway(&fixtures, &fed).await;
     let client = fed.new_client().await;
     let dummy_module = client.get_first_module::<DummyClientModule>()?;
@@ -290,7 +290,7 @@ async fn cannot_pay_same_external_invoice_twice() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>()?;
 
@@ -389,7 +389,7 @@ async fn makes_internal_payments_within_federation() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_receive_for_other_user() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>()?;
 
@@ -518,7 +518,7 @@ async fn can_receive_for_other_user() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_receive_for_other_user_tweaked() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let gw = gateway(&fixtures, &fed).await;
     let (client1, client2) = fed.two_clients().await;
     let client2_dummy_module = client2.get_first_module::<DummyClientModule>()?;
@@ -594,7 +594,7 @@ async fn can_receive_for_other_user_tweaked() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn rejects_wrong_network_invoice() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let gw = gateway(&fixtures, &fed).await;
     let client1 = fed.new_client().await;
 

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -41,7 +41,7 @@ fn fixtures() -> Fixtures {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
 
     // Print money for client
@@ -92,7 +92,7 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn refund_failed_payment() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
 
     // Print money for client
@@ -129,7 +129,7 @@ async fn refund_failed_payment() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn unilateral_refund_of_outgoing_contracts() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
 
     // Print money for client
@@ -165,7 +165,7 @@ async fn unilateral_refund_of_outgoing_contracts() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
 
     // Print money for client
@@ -234,7 +234,7 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn receive_operation_expires() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
 
     let op = client
@@ -264,7 +264,7 @@ async fn receive_operation_expires() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn rejects_wrong_network_invoice() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
 
     assert_eq!(

--- a/modules/fedimint-mint-tests/tests/tests.rs
+++ b/modules/fedimint-mint-tests/tests/tests.rs
@@ -53,7 +53,7 @@ struct BackupTestMetadata {
 #[tokio::test(flavor = "multi_thread")]
 async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
 
     let keypair = Keypair::new(secp256k1::SECP256K1, &mut rand::thread_rng());
@@ -101,7 +101,7 @@ async fn transaction_with_invalid_signature_is_rejected() -> anyhow::Result<()> 
 #[tokio::test(flavor = "multi_thread")]
 async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let (client1, client2) = fed.two_clients().await;
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>()?;
     let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
@@ -139,7 +139,7 @@ async fn sends_ecash_out_of_band() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn blind_nonce_index() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let client = fed.new_client().await;
     let client_dummy_module = client.get_first_module::<DummyClientModule>()?;
     let (op, outpoint) = client_dummy_module.print_money(sats(1000)).await?;
@@ -189,7 +189,7 @@ async fn blind_nonce_index() -> anyhow::Result<()> {
 #[ignore] // TODO: flaky https://github.com/fedimint/fedimint/issues/4508
 async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let client1 = fed.new_client_rocksdb().await;
     let client2 = fed.new_client_rocksdb().await;
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>()?;
@@ -287,7 +287,7 @@ async fn sends_ecash_oob_highly_parallel() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn backup_encode_decode_roundtrip() -> anyhow::Result<()> {
     // Print notes for client
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let client = fed.new_client().await;
     let client_dummy_module = client.get_first_module::<DummyClientModule>()?;
     let (op, outpoint) = client_dummy_module.print_money(sats(1000)).await?;
@@ -313,7 +313,7 @@ async fn backup_encode_decode_roundtrip() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn ecash_backup_can_recover_metadata() -> anyhow::Result<()> {
     // Print notes for client
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let client = fed.new_client().await;
     let client_dummy_module = client.get_first_module::<DummyClientModule>()?;
     let (op, outpoint) = client_dummy_module.print_money(sats(1000)).await?;
@@ -336,7 +336,7 @@ async fn ecash_backup_can_recover_metadata() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let client = fed.new_client().await;
     let dummy_module = client.get_first_module::<DummyClientModule>()?;
     let (op, outpoint) = dummy_module.print_money(sats(1000)).await?;
@@ -372,7 +372,7 @@ async fn sends_ecash_out_of_band_cancel() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn sends_ecash_out_of_band_cancel_partial() -> anyhow::Result<()> {
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let (client, client2) = fed.two_clients().await;
     let dummy_module = client.get_first_module::<DummyClientModule>()?;
     info!("### PRINT NOTES");
@@ -452,7 +452,7 @@ async fn sends_ecash_out_of_band_cancel_partial() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let (client1, _client2) = fed.two_clients().await;
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>()?;
     let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;
@@ -479,7 +479,7 @@ async fn error_zero_value_oob_spend() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn error_zero_value_oob_receive() -> anyhow::Result<()> {
     // Print notes for client1
-    let fed = fixtures().new_default_fed().await;
+    let fed = fixtures().new_fed_degraded().await;
     let (client1, _client2) = fed.two_clients().await;
     let client1_dummy_module = client1.get_first_module::<DummyClientModule>()?;
     let (op, outpoint) = client1_dummy_module.print_money(sats(1000)).await?;

--- a/modules/fedimint-wallet-client/src/api.rs
+++ b/modules/fedimint-wallet-client/src/api.rs
@@ -5,9 +5,9 @@ use fedimint_core::module::{ApiAuth, ApiRequestErased, ModuleConsensusVersion};
 use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::{apply, async_trait_maybe_send, PeerId};
 use fedimint_wallet_common::endpoint_constants::{
-    BITCOIN_KIND_ENDPOINT, BITCOIN_RPC_CONFIG_ENDPOINT, BLOCK_COUNT_ENDPOINT,
-    MODULE_CONSENSUS_VERSION_ENDPOINT, PEG_OUT_FEES_ENDPOINT, UTXO_CONFIRMED_ENDPOINT,
-    WALLET_SUMMARY_ENDPOINT,
+    ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT, BITCOIN_KIND_ENDPOINT, BITCOIN_RPC_CONFIG_ENDPOINT,
+    BLOCK_COUNT_ENDPOINT, MODULE_CONSENSUS_VERSION_ENDPOINT, PEG_OUT_FEES_ENDPOINT,
+    UTXO_CONFIRMED_ENDPOINT, WALLET_SUMMARY_ENDPOINT,
 };
 use fedimint_wallet_common::{PegOutFees, WalletSummary};
 
@@ -30,6 +30,8 @@ pub trait WalletFederationApi {
     async fn fetch_wallet_summary(&self) -> FederationResult<WalletSummary>;
 
     async fn is_utxo_confirmed(&self, outpoint: bitcoin::OutPoint) -> FederationResult<bool>;
+
+    async fn activate_consensus_version_voting(&self, auth: ApiAuth) -> FederationResult<()>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -113,6 +115,15 @@ where
         self.request_current_consensus(
             WALLET_SUMMARY_ENDPOINT.to_string(),
             ApiRequestErased::default(),
+        )
+        .await
+    }
+
+    async fn activate_consensus_version_voting(&self, auth: ApiAuth) -> FederationResult<()> {
+        self.request_admin(
+            ACTIVATE_CONSENSUS_VERSION_VOTING_ENDPOINT,
+            ApiRequestErased::default(),
+            auth,
         )
         .await
     }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -1263,6 +1263,20 @@ impl WalletClientModule {
                 }
             }))
     }
+
+    fn admin_auth(&self) -> anyhow::Result<ApiAuth> {
+        self.admin_auth
+            .clone()
+            .ok_or_else(|| anyhow::format_err!("Admin auth not set"))
+    }
+
+    pub async fn activate_consensus_version_voting(&self) -> anyhow::Result<()> {
+        self.module_api
+            .activate_consensus_version_voting(self.admin_auth()?)
+            .await?;
+
+        Ok(())
+    }
 }
 
 /// Polls the federation checking if the activated module consensus version

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1721,6 +1721,13 @@ impl Wallet {
                                 peer,
                             )
                             .await
+                            .inspect(|res| debug!(
+                                target: LOG_MODULE_WALLET,
+                                %peer,
+                                %our_peer_id,
+                                ?res,
+                                "Fetched supported module consensus version from peer"
+                            ))
                             .inspect_err(|err| warn!(
                                 target: LOG_MODULE_WALLET,
                                  %peer,

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -60,7 +60,7 @@ use fedimint_core::module::{
 #[cfg(not(target_family = "wasm"))]
 use fedimint_core::task::sleep;
 use fedimint_core::task::TaskGroup;
-use fedimint_core::util::{backoff_util, retry, FmtCompactAnyhow as _};
+use fedimint_core::util::{backoff_util, retry, FmtCompact, FmtCompactAnyhow as _};
 use fedimint_core::{
     apply, async_trait_maybe_send, get_network_for_address, push_db_key_items, push_db_pair_items,
     Feerate, InPoint, NumPeersExt, OutPoint, PeerId,
@@ -1056,7 +1056,7 @@ impl Wallet {
         Self::spawn_broadcast_pending_task(task_group, &btc_rpc, db, broadcast_pending.clone());
 
         let peer_supported_consensus_version =
-            Self::spawn_peer_supported_consensus_version_task(module_api, task_group);
+            Self::spawn_peer_supported_consensus_version_task(module_api, task_group, our_peer_id);
 
         let bitcoind_net = NetworkLegacyEncodingWrapper(
             retry("verify network", backoff_util::aggressive_backoff(), || {
@@ -1702,13 +1702,18 @@ impl Wallet {
     fn spawn_peer_supported_consensus_version_task(
         api_client: DynModuleApi,
         task_group: &TaskGroup,
+        our_peer_id: PeerId,
     ) -> watch::Receiver<Option<ModuleConsensusVersion>> {
         let (sender, receiver) = watch::channel(None);
         task_group.spawn_cancellable("fetch-peer-consensus-versions", async move {
             loop {
-                let request_futures = api_client.all_peers().iter().map(|&peer| {
+                let request_futures = api_client.all_peers().iter().filter_map(|&peer| {
+                    if peer == our_peer_id {
+                        return None;
+                    }
+
                     let api_client_inner = api_client.clone();
-                    async move {
+                    Some(async move {
                         api_client_inner
                             .request_single_peer::<ModuleConsensusVersion>(
                                 SUPPORTED_MODULE_CONSENSUS_VERSION_ENDPOINT.to_owned(),
@@ -1716,8 +1721,14 @@ impl Wallet {
                                 peer,
                             )
                             .await
+                            .inspect_err(|err| warn!(
+                                target: LOG_MODULE_WALLET,
+                                 %peer,
+                                 err=%err.fmt_compact(),
+                                "Failed to fetch consensus version from peer"
+                            ))
                             .ok()
-                    }
+                    })
                 });
 
                 let peer_consensus_versions = join_all(request_futures)
@@ -1745,6 +1756,10 @@ impl Wallet {
 
                         Some(min_supported_version)
                     } else {
+                        assert!(
+                            sorted_consensus_versions.len() <= api_client.all_peers().len(),
+                            "Too many peer responses",
+                        );
                         trace!(
                             target: LOG_MODULE_WALLET,
                             ?sorted_consensus_versions,
@@ -1762,7 +1777,7 @@ impl Wallet {
                     // Even in tests we don't want to spam the federation with requests about it
                     sleep(Duration::from_secs(30)).await;
                 } else {
-                    sleep(Duration::from_secs(3600)).await;
+                    sleep(Duration::from_secs(600)).await;
                 }
             }
         });

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -941,6 +941,7 @@ impl ServerModule for Wallet {
                 async |_module: &Wallet, context, _params: ()| -> () {
                     check_auth(context)?;
 
+                    // api_endpoint! calls dbtx.commit_tx_result
                     let mut dbtx = context.dbtx();
                     dbtx.insert_entry(&ConsensusVersionVotingActivationKey, &()).await;
                     Ok(())

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1783,7 +1783,7 @@ impl Wallet {
 
                 if is_running_in_test_env() {
                     // Even in tests we don't want to spam the federation with requests about it
-                    sleep(Duration::from_secs(30)).await;
+                    sleep(Duration::from_secs(5)).await;
                 } else {
                     sleep(Duration::from_secs(600)).await;
                 }

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -998,6 +998,16 @@ async fn construct_wallet_summary() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn verify_auto_consensus_voting() -> anyhow::Result<()> {
+    let fixtures = fixtures();
+    let fed = fixtures.new_fed_not_degraded().await;
+    let client = fed.new_client().await;
+    await_consensus_upgrade(&client, &fed).await?;
+
+    Ok(())
+}
+
 async fn sync_wallet_to_block(
     dbtx: &mut DatabaseTransaction<'_>,
     wallet: &mut fedimint_wallet_server::Wallet,

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -23,6 +23,7 @@ use fedimint_dummy_server::DummyInit;
 use fedimint_server::core::{ServerModule, ServerModuleShared as _};
 use fedimint_testing::btc::BitcoinTest;
 use fedimint_testing::envs::{FM_TEST_BACKEND_BITCOIN_RPC_KIND_ENV, FM_TEST_USE_REAL_DAEMONS_ENV};
+use fedimint_testing::federation::{FederationTest, API_AUTH};
 use fedimint_testing::fixtures::Fixtures;
 use fedimint_wallet_client::api::WalletFederationApi;
 use fedimint_wallet_client::{DepositStateV2, WalletClientInit, WalletClientModule, WithdrawState};
@@ -54,11 +55,12 @@ async fn peg_in<'a>(
     client: &'a ClientHandleArc,
     bitcoin: &dyn BitcoinTest,
     finality_delay: u64,
+    fed: &FederationTest,
 ) -> anyhow::Result<(BoxStream<'a, Amount>, bitcoin::Transaction)> {
     let mut balance_sub = client.subscribe_balance_changes().await;
     let initial_balance = balance_sub.ok().await?;
 
-    await_consensus_upgrade(client).await;
+    await_consensus_upgrade(client, fed).await?;
 
     let wallet_module = &client.get_first_module::<WalletClientModule>()?;
     let (op, address, _) = wallet_module
@@ -117,7 +119,37 @@ async fn await_consensus_to_catch_up(
     }
 }
 
-async fn await_consensus_upgrade(client: &ClientHandleArc) {
+async fn activate_manual_voting_for_online_peers(
+    client: &ClientHandleArc,
+    fed: &FederationTest,
+) -> anyhow::Result<()> {
+    let wallet_module_client_id = client.get_first_module::<WalletClientModule>()?.id;
+    let activation_futures = fed.online_peer_ids().map(|peer_id| {
+        info!("activating consensus version voting for peer {peer_id}");
+
+        async move {
+            fed.new_admin_api(peer_id)
+                .with_module(wallet_module_client_id)
+                .activate_consensus_version_voting(API_AUTH.clone())
+                .await
+        }
+    });
+
+    futures::future::try_join_all(activation_futures).await?;
+
+    Ok(())
+}
+
+async fn await_consensus_upgrade(
+    client: &ClientHandleArc,
+    fed: &FederationTest,
+) -> anyhow::Result<()> {
+    // we need all peers to be online for automatic consensus version voting, so we
+    // activate manual voting if the federation is degraded
+    if fed.is_degraded() {
+        activate_manual_voting_for_online_peers(client, fed).await?;
+    }
+
     retry(
         "waiting for consensus upgrade",
         fedimint_core::util::backoff_util::aggressive_backoff(),
@@ -133,6 +165,8 @@ async fn await_consensus_upgrade(client: &ClientHandleArc) {
     )
     .await
     .expect("Consensus upgrade didn't happen in time");
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -190,7 +224,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     let finality_delay = 10;
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
-    await_consensus_upgrade(&client).await;
+    await_consensus_upgrade(&client, &fed).await?;
 
     assert_eq!(client.get_balance().await, sats(0));
     let (op, address, _) = wallet_module
@@ -343,7 +377,7 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
     let starting_balance = client.get_balance().await;
     info!(?starting_balance, "Starting balance");
 
-    await_consensus_upgrade(&client).await;
+    await_consensus_upgrade(&client, &fed).await?;
 
     let wallet_module = &client.get_first_module::<WalletClientModule>()?;
     let (op, address, tweak_idx) = wallet_module
@@ -417,7 +451,7 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let (mut balance_sub, _) = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+    let (mut balance_sub, _) = peg_in(&client, bitcoin.as_ref(), finality_delay, &fed).await?;
 
     info!("Peg-in finished for test peg_out_fail_refund");
     // Peg-out test, requires block to recognize change UTXOs
@@ -463,7 +497,7 @@ async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let (mut balance_sub, _) = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+    let (mut balance_sub, _) = peg_in(&client, bitcoin.as_ref(), finality_delay, &fed).await?;
 
     info!("Peg-in finished for test rbf_withdrawals_are_rejected");
     let address = bitcoin.get_new_address().await;
@@ -557,7 +591,7 @@ async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
     bitcoin.mine_blocks(finality_delay).await;
     await_consensus_to_catch_up(&client, 1).await?;
 
-    let (mut balance_sub, _) = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+    let (mut balance_sub, _) = peg_in(&client, bitcoin.as_ref(), finality_delay, &fed).await?;
 
     info!("Peg-in finished for test peg_outs_must_wait_for_available_utxos");
     let address = bitcoin.get_new_address().await;
@@ -782,7 +816,7 @@ async fn construct_wallet_summary() -> anyhow::Result<()> {
 
     // generate 3 peg-ins, verifying wallet summary after each
     for _ in 0..3 {
-        let (_, tx) = peg_in(&client, bitcoin.as_ref(), finality_delay).await?;
+        let (_, tx) = peg_in(&client, bitcoin.as_ref(), finality_delay, &fed).await?;
         let expected_peg_in_amount =
             PEG_IN_AMOUNT_SATS + (wallet_module.get_fee_consensus().peg_in_abs.msats / 1000);
 

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -122,11 +122,12 @@ async fn await_consensus_upgrade(client: &ClientHandleArc) {
         "waiting for consensus upgrade",
         fedimint_core::util::backoff_util::aggressive_backoff(),
         || async {
-            client
+            let is_upgraded = client
                 .get_first_module::<WalletClientModule>()?
                 .btc_tx_has_no_size_limit()
                 .await?;
 
+            anyhow::ensure!(is_upgraded);
             Ok(())
         },
     )

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -138,7 +138,7 @@ async fn await_consensus_upgrade(client: &ClientHandleArc) {
 #[tokio::test(flavor = "multi_thread")]
 async fn sanity_check_bitcoin_blocks() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     // Avoid other tests from interfering here
@@ -180,7 +180,7 @@ async fn sanity_check_bitcoin_blocks() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
     let wallet_module = client.get_first_module::<WalletClientModule>()?;
     let bitcoin = fixtures.bitcoin();
@@ -330,7 +330,7 @@ async fn on_chain_peg_in_and_peg_out_happy_case() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
@@ -407,7 +407,7 @@ async fn on_chain_peg_in_detects_multiple() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_out_fail_refund() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;
@@ -452,7 +452,7 @@ async fn peg_out_fail_refund() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     // Need lock to keep tx in mempool from getting mined
@@ -544,7 +544,7 @@ async fn rbf_withdrawals_are_rejected() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_outs_must_wait_for_available_utxos() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     // This test has many assumptions about bitcoin L1 blocks
@@ -763,7 +763,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn construct_wallet_summary() -> anyhow::Result<()> {
     let fixtures = fixtures();
-    let fed = fixtures.new_default_fed().await;
+    let fed = fixtures.new_fed_degraded().await;
     let client = fed.new_client().await;
     let bitcoin = fixtures.bitcoin();
     let bitcoin = bitcoin.lock_exclusive().await;


### PR DESCRIPTION
This builds on and replaces https://github.com/fedimint/fedimint/pull/6852.

Previously, `await_consensus_upgrade` only confirmed that `btc_tx_has_no_size_limit` returned `Ok` without checking the result. This led to consensus upgrades not activating, but tests passed since we continue to use the old consensus logic.

Our tests setup degraded federations, which prevents automatic activation of consensus version voting. We should keep running existing tests in a degraded state, so `await_consensus_upgrade` will trigger manual voting for degraded federations. There's a new test that verifies a 4/4 federation will trigger automatic voting.

There's another sneaky bug in the activate consensus version voting endpoint. We call `dbtx.commit_tx_result`, which causes the endpoint to return an error since the `api_endpoint!` macro also calls `commit_tx_result`.