### PR TITLE
fix: enforce api endpoints using non committable db transactions

### DIFF
--- a/fedimint-core/src/module/mod.rs
+++ b/fedimint-core/src/module/mod.rs
@@ -42,6 +42,7 @@ use crate::core::{
 };
 use crate::db::{
     Committable, Database, DatabaseKey, DatabaseKeyWithNotify, DatabaseRecord, DatabaseTransaction,
+    NonCommittable,
 };
 use crate::encoding::{Decodable, DecodeError, Encodable};
 use crate::fmt_utils::AbbreviateHexBytes;
@@ -186,13 +187,13 @@ impl<'a> ApiEndpointContext<'a> {
     }
 
     /// Database tx handle, will be committed
-    pub fn dbtx<'s, 'mtx>(&'s mut self) -> DatabaseTransaction<'mtx, Committable>
+    pub fn dbtx<'s, 'mtx>(&'s mut self) -> DatabaseTransaction<'mtx, NonCommittable>
     where
         'a: 'mtx,
         's: 'mtx,
     {
         // dbtx is already isolated.
-        self.dbtx.to_ref()
+        self.dbtx.to_ref_nc()
     }
 
     /// Returns the auth set on the request (regardless of whether it was

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -17,8 +17,8 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    Committable, CoreMigrationFn, DatabaseTransaction, DatabaseVersion,
-    IDatabaseTransactionOpsCoreTyped, NonCommittable,
+    CoreMigrationFn, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
+    NonCommittable,
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -468,7 +468,7 @@ impl ServerModule for Meta {
 impl Meta {
     async fn handle_submit_request(
         &self,
-        dbtx: &mut DatabaseTransaction<'_, Committable>,
+        dbtx: &mut DatabaseTransaction<'_, NonCommittable>,
         _auth: &ApiAuth,
         req: &SubmitRequest,
     ) -> Result<(), ApiError> {

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -942,13 +942,8 @@ impl ServerModule for Wallet {
                     check_auth(context)?;
 
                     let mut dbtx = context.dbtx();
-
                     dbtx.insert_entry(&ConsensusVersionVotingActivationKey, &()).await;
-
-                    dbtx.commit_tx_result().await.map_err(|e| ApiError::server_error(e.to_string()))?;
-
                     Ok(())
-
                 }
             },
             api_endpoint! {


### PR DESCRIPTION
Recently there was a bug in the wallet module where the server was committing a database transaction where it shouldn't be. https://github.com/fedimint/fedimint/pull/6869

Api endpoints do not own the database transaction, it is passed in through the `ApiContext`. This PR enforces that the db transaction passed in is non-committable, which enforces that the api endpoints themselves do not commit the database transaction. 

The db transaction is later committed as part of the api endpoint macro and any changes applied in the endpoint will be committed then.