### PR TITLE
feat: Add `get_invoice` endpoint to gateway

### DIFF
--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -735,7 +735,7 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     info!("Testing CLN can pay LND directly");
     let (invoice, payment_hash) = lnd.invoice(1_000_000).await?;
     cln.pay_bolt11_invoice(invoice).await?;
-    lnd.wait_bolt11_invoice(payment_hash).await?;
+    gw_lnd.wait_bolt11_invoice(payment_hash).await?;
 
     // fedimintd introduced wpkh for single guardian federations in v0.3.0 (9e35bdb)
     // The code path is backwards-compatible, however this test will fail if we

--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -14,10 +14,11 @@ use fedimint_core::util::BoxStream;
 use fedimint_core::Amount;
 use fedimint_lightning::{
     CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
-    CreateInvoiceResponse, GetBalancesResponse, GetLnOnchainAddressResponse, GetNodeInfoResponse,
-    GetRouteHintsResponse, ILnRpcClient, InterceptPaymentRequest, InterceptPaymentResponse,
-    LightningRpcError, ListActiveChannelsResponse, OpenChannelRequest, OpenChannelResponse,
-    PayInvoiceResponse, RouteHtlcStream, SendOnchainRequest, SendOnchainResponse,
+    CreateInvoiceResponse, GetBalancesResponse, GetInvoiceRequest, GetInvoiceResponse,
+    GetLnOnchainAddressResponse, GetNodeInfoResponse, GetRouteHintsResponse, ILnRpcClient,
+    InterceptPaymentRequest, InterceptPaymentResponse, LightningRpcError,
+    ListActiveChannelsResponse, OpenChannelRequest, OpenChannelResponse, PayInvoiceResponse,
+    RouteHtlcStream, SendOnchainRequest, SendOnchainResponse,
 };
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::route_hints::RouteHint;
@@ -295,6 +296,15 @@ impl ILnRpcClient for FakeLightningTest {
             onchain_balance_sats: 0,
             lightning_balance_msats: 0,
             inbound_lightning_liquidity_msats: 0,
+        })
+    }
+
+    async fn get_invoice(
+        &self,
+        _get_invoice_request: GetInvoiceRequest,
+    ) -> Result<Option<GetInvoiceResponse>, LightningRpcError> {
+        Err(LightningRpcError::FailedToGetInvoice {
+            failure_reason: "FakeLightningTest does not support getting invoices".to_string(),
         })
     }
 }

--- a/gateway/cli/src/lightning_commands.rs
+++ b/gateway/cli/src/lightning_commands.rs
@@ -1,5 +1,6 @@
+use bitcoin::hashes::sha256;
 use clap::Subcommand;
-use fedimint_lightning::{CloseChannelsWithPeerRequest, OpenChannelRequest};
+use fedimint_lightning::{CloseChannelsWithPeerRequest, GetInvoiceRequest, OpenChannelRequest};
 use lightning_invoice::Bolt11Invoice;
 use ln_gateway::rpc::rpc_client::GatewayRpcClient;
 
@@ -48,6 +49,12 @@ pub enum LightningCommands {
     },
     /// List active channels.
     ListActiveChannels,
+    /// Get details about a specific invoice
+    GetInvoice {
+        /// The payment hash of the invoice
+        #[clap(long)]
+        payment_hash: sha256::Hash,
+    },
 }
 
 impl LightningCommands {
@@ -101,6 +108,12 @@ impl LightningCommands {
             }
             Self::ListActiveChannels => {
                 let response = create_client().list_active_channels().await?;
+                print_response(response);
+            }
+            Self::GetInvoice { payment_hash } => {
+                let response = create_client()
+                    .get_invoice(GetInvoiceRequest { payment_hash })
+                    .await?;
                 print_response(response);
             }
         };

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -75,9 +75,9 @@ use fedimint_lightning::ldk::{self, GatewayLdkChainSourceConfig};
 use fedimint_lightning::lnd::GatewayLndClient;
 use fedimint_lightning::{
     CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, CreateInvoiceRequest,
-    ILnRpcClient, InterceptPaymentRequest, InterceptPaymentResponse, InvoiceDescription,
-    LightningContext, LightningRpcError, OpenChannelRequest, PayInvoiceResponse, PaymentAction,
-    RouteHtlcStream, SendOnchainRequest,
+    GetInvoiceRequest, GetInvoiceResponse, ILnRpcClient, InterceptPaymentRequest,
+    InterceptPaymentResponse, InvoiceDescription, LightningContext, LightningRpcError,
+    OpenChannelRequest, PayInvoiceResponse, PaymentAction, RouteHtlcStream, SendOnchainRequest,
 };
 use fedimint_ln_client::pay::PaymentData;
 use fedimint_ln_common::config::LightningClientConfig;
@@ -1648,6 +1648,17 @@ impl Gateway {
             outgoing: PaymentStats::compute(&outgoing),
             incoming: PaymentStats::compute(&incoming),
         })
+    }
+
+    /// Retrieves an invoice by the payment hash if it exists, otherwise returns
+    /// `None`.
+    pub async fn handle_get_invoice_msg(
+        &self,
+        payload: GetInvoiceRequest,
+    ) -> AdminResult<Option<GetInvoiceResponse>> {
+        let lightning_context = self.get_lightning_context().await?;
+        let invoice = lightning_context.lnrpc.get_invoice(payload).await?;
+        Ok(invoice)
     }
 
     /// Registers the gateway with each specified federation.

--- a/gateway/ln-gateway/src/rpc/mod.rs
+++ b/gateway/ln-gateway/src/rpc/mod.rs
@@ -31,6 +31,7 @@ pub const CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT: &str = "/create_bolt11_in
 pub const GATEWAY_INFO_ENDPOINT: &str = "/info";
 pub const GET_BALANCES_ENDPOINT: &str = "/balances";
 pub const GATEWAY_INFO_POST_ENDPOINT: &str = "/info";
+pub const GET_INVOICE_ENDPOINT: &str = "/get_invoice";
 pub const GET_LN_ONCHAIN_ADDRESS_ENDPOINT: &str = "/get_ln_onchain_address";
 pub const LEAVE_FED_ENDPOINT: &str = "/leave_fed";
 pub const LIST_ACTIVE_CHANNELS_ENDPOINT: &str = "/list_active_channels";

--- a/gateway/ln-gateway/src/rpc/rpc_client.rs
+++ b/gateway/ln-gateway/src/rpc/rpc_client.rs
@@ -2,8 +2,8 @@ use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, Txid};
 use fedimint_core::util::SafeUrl;
 use fedimint_lightning::{
-    ChannelInfo, CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, OpenChannelRequest,
-    SendOnchainRequest,
+    ChannelInfo, CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, GetInvoiceRequest,
+    GetInvoiceResponse, OpenChannelRequest, SendOnchainRequest,
 };
 use lightning_invoice::Bolt11Invoice;
 use reqwest::{Method, StatusCode};
@@ -20,7 +20,7 @@ use super::{
     SpendEcashResponse, WithdrawPayload, WithdrawResponse, ADDRESS_ENDPOINT,
     ADDRESS_RECHECK_ENDPOINT, BACKUP_ENDPOINT, CLOSE_CHANNELS_WITH_PEER_ENDPOINT,
     CONFIGURATION_ENDPOINT, CONNECT_FED_ENDPOINT, CREATE_BOLT11_INVOICE_FOR_OPERATOR_ENDPOINT,
-    GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT,
+    GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT, GET_INVOICE_ENDPOINT,
     GET_LN_ONCHAIN_ADDRESS_ENDPOINT, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
     MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT,
     PAY_INVOICE_FOR_OPERATOR_ENDPOINT, RECEIVE_ECASH_ENDPOINT, SEND_ONCHAIN_ENDPOINT,
@@ -269,6 +269,17 @@ impl GatewayRpcClient {
         let url = self
             .base_url
             .join(PAYMENT_SUMMARY_ENDPOINT)
+            .expect("invalid base url");
+        self.call_post(url, payload).await
+    }
+
+    pub async fn get_invoice(
+        &self,
+        payload: GetInvoiceRequest,
+    ) -> GatewayRpcResult<Option<GetInvoiceResponse>> {
+        let url = self
+            .base_url
+            .join(GET_INVOICE_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
     }


### PR DESCRIPTION
Allows the gateway operator to query the status of an invoice if it knows the payment hash. Can be used for LNv2 invoices or invoices the gateway creates.

Currently this is only tested in the LNv1 tests with the LND gateway. This will be used to swap CLN for LDK, so that the LNv1 tests will still know when an invoice has been paid.