### PR TITLE
[Backport releases/v0.6] fix: lnv2 small backwards compatibility fixes

### DIFF
--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -14,3 +14,5 @@ pub static VERSION_0_5_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.5.0-alpha").expect("version is parsable"));
 pub static VERSION_0_6_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.6.0-alpha").expect("version is parsable"));
+pub static VERSION_0_7_0_ALPHA: LazyLock<Version> =
+    LazyLock::new(|| Version::parse("0.7.0-alpha").expect("version is parsable"));

--- a/gateway/ln-gateway/src/lib.rs
+++ b/gateway/ln-gateway/src/lib.rs
@@ -1836,14 +1836,16 @@ impl Gateway {
     /// Iterates through all of the federations the gateway is registered with
     /// and requests to remove the registration record.
     pub async fn unannounce_from_all_federations(&self) {
-        let mut dbtx = self.gateway_db.begin_transaction_nc().await;
-        let gateway_keypair = dbtx.load_gateway_keypair_assert_exists().await;
+        if self.is_running_lnv1() {
+            let mut dbtx = self.gateway_db.begin_transaction_nc().await;
+            let gateway_keypair = dbtx.load_gateway_keypair_assert_exists().await;
 
-        self.federation_manager
-            .read()
-            .await
-            .unannounce_from_all_federations(gateway_keypair)
-            .await;
+            self.federation_manager
+                .read()
+                .await
+                .unannounce_from_all_federations(gateway_keypair)
+                .await;
+        }
     }
 
     fn create_lightning_client(

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -1,7 +1,7 @@
 use anyhow::ensure;
 use devimint::devfed::DevJitFed;
 use devimint::federation::Client;
-use devimint::version_constants::{VERSION_0_5_0_ALPHA, VERSION_0_7_0_ALPHA};
+use devimint::version_constants::VERSION_0_5_0_ALPHA;
 use devimint::{cmd, util, Gatewayd};
 use fedimint_core::core::OperationId;
 use fedimint_core::envs::{is_env_var_set, FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV};
@@ -304,30 +304,6 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     // Gateway pays: 1_000 msat LNv2 federation base fee, 1_000 msat LNv2 federation
     // relative fee. Gateway receives: 1_000_000 payment.
     test_fees(fed_id, &client, gw_lnd, gw_ldk, 1_000_000 - 1_000 - 1_000).await?;
-
-    let gatewayd_version = util::Gatewayd::version_or_default().await;
-    if gatewayd_version >= *VERSION_0_7_0_ALPHA {
-        info!("Testing payment summary...");
-        let lnd_payment_summary = gw_lnd.payment_summary().await?;
-        assert_eq!(lnd_payment_summary.outgoing.total_success, 4);
-        assert_eq!(lnd_payment_summary.outgoing.total_failure, 2);
-        assert_eq!(lnd_payment_summary.incoming.total_success, 3);
-        assert_eq!(lnd_payment_summary.incoming.total_failure, 0);
-        assert!(lnd_payment_summary.outgoing.median_latency.is_some());
-        assert!(lnd_payment_summary.outgoing.average_latency.is_some());
-        assert!(lnd_payment_summary.incoming.median_latency.is_some());
-        assert!(lnd_payment_summary.incoming.average_latency.is_some());
-
-        let ldk_payment_summary = gw_ldk.payment_summary().await?;
-        assert_eq!(ldk_payment_summary.outgoing.total_success, 4);
-        assert_eq!(ldk_payment_summary.outgoing.total_failure, 2);
-        assert_eq!(ldk_payment_summary.incoming.total_success, 4);
-        assert_eq!(ldk_payment_summary.incoming.total_failure, 0);
-        assert!(ldk_payment_summary.outgoing.median_latency.is_some());
-        assert!(ldk_payment_summary.outgoing.average_latency.is_some());
-        assert!(ldk_payment_summary.incoming.median_latency.is_some());
-        assert!(ldk_payment_summary.incoming.average_latency.is_some());
-    }
 
     Ok(())
 }

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -1,7 +1,7 @@
 use anyhow::ensure;
 use devimint::devfed::DevJitFed;
 use devimint::federation::Client;
-use devimint::version_constants::VERSION_0_5_0_ALPHA;
+use devimint::version_constants::{VERSION_0_5_0_ALPHA, VERSION_0_7_0_ALPHA};
 use devimint::{cmd, util, Gatewayd};
 use fedimint_core::core::OperationId;
 use fedimint_core::envs::{is_env_var_set, FM_DEVIMINT_DISABLE_MODULE_LNV2_ENV};
@@ -304,6 +304,30 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     // Gateway pays: 1_000 msat LNv2 federation base fee, 1_000 msat LNv2 federation
     // relative fee. Gateway receives: 1_000_000 payment.
     test_fees(fed_id, &client, gw_lnd, gw_ldk, 1_000_000 - 1_000 - 1_000).await?;
+
+    let gatewayd_version = util::Gatewayd::version_or_default().await;
+    if gatewayd_version >= *VERSION_0_7_0_ALPHA {
+        info!("Testing payment summary...");
+        let lnd_payment_summary = gw_lnd.payment_summary().await?;
+        assert_eq!(lnd_payment_summary.outgoing.total_success, 4);
+        assert_eq!(lnd_payment_summary.outgoing.total_failure, 2);
+        assert_eq!(lnd_payment_summary.incoming.total_success, 3);
+        assert_eq!(lnd_payment_summary.incoming.total_failure, 0);
+        assert!(lnd_payment_summary.outgoing.median_latency.is_some());
+        assert!(lnd_payment_summary.outgoing.average_latency.is_some());
+        assert!(lnd_payment_summary.incoming.median_latency.is_some());
+        assert!(lnd_payment_summary.incoming.average_latency.is_some());
+
+        let ldk_payment_summary = gw_ldk.payment_summary().await?;
+        assert_eq!(ldk_payment_summary.outgoing.total_success, 4);
+        assert_eq!(ldk_payment_summary.outgoing.total_failure, 2);
+        assert_eq!(ldk_payment_summary.incoming.total_success, 4);
+        assert_eq!(ldk_payment_summary.incoming.total_failure, 0);
+        assert!(ldk_payment_summary.outgoing.median_latency.is_some());
+        assert!(ldk_payment_summary.outgoing.average_latency.is_some());
+        assert!(ldk_payment_summary.incoming.median_latency.is_some());
+        assert!(ldk_payment_summary.incoming.average_latency.is_some());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Removes part of the test that is not present in v0.6