### PR TITLE
chore: use line-table only debug symbols in dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,9 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 url = "2.5.4"
 
+[profile.dev]
+debug = "line-tables-only"
+
 # Workaround: https://github.com/rust-lang/cargo/issues/12457 which causes
 #             https://github.com/ipetkov/crane/issues/370
 [profile.dev.build-override]


### PR DESCRIPTION
Motivated by:
https://github.com/fedimint/fedimint/pull/6850#issuecomment-2669697615

Leads to significantly lower disk use and better compilation times.

We also might want to consolidate our test binaries (will do in the future).

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
