### PR TITLE
chore: update toolchain to 1.85.0

### DIFF
--- a/fedimint-client/src/api_announcements.rs
+++ b/fedimint-client/src/api_announcements.rs
@@ -80,8 +80,7 @@ pub async fn run_api_announcement_sync(client_inner: Arc<Client>) {
                             for (peer, new_announcement) in announcements_inner {
                                 let replace_current_announcement = dbtx
                                     .get_value(&ApiAnnouncementKey(peer))
-                                    .await
-                                    .map_or(true, |current_announcement| {
+                                    .await.is_none_or(|current_announcement| {
                                         current_announcement.api_announcement.nonce
                                             < new_announcement.api_announcement.nonce
                                     });

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -2264,7 +2264,7 @@ pub async fn apply_migrations_dbtx(
         .await?
         .filter(|(key, _v)| {
             std::future::ready(
-                external_prefixes_above.map_or(true, |external_prefixes_above| {
+                external_prefixes_above.is_none_or(|external_prefixes_above| {
                     !key.is_empty() && key[0] < external_prefixes_above
                 }),
             )

--- a/fedimint-core/src/module/version.rs
+++ b/fedimint-core/src/module/version.rs
@@ -222,7 +222,7 @@ impl MultiApiVersion {
             .fold((None, true), |(prev, is_sorted), next| {
                 (
                     Some(*next),
-                    is_sorted && prev.map_or(true, |prev| prev.major < next.major),
+                    is_sorted && prev.is_none_or(|prev| prev.major < next.major),
                 )
             })
             .1

--- a/fedimint-server-core/src/lib.rs
+++ b/fedimint-server-core/src/lib.rs
@@ -385,7 +385,6 @@ where
             in_point,
         )
         .await
-        .map(Into::into)
         .map_err(|v| DynInputError::from_typed(input.module_instance_id(), v))
     }
 
@@ -430,7 +429,6 @@ where
                 .expect("incorrect input type passed to module plugin"),
         )
         .await
-        .map(Into::into)
         .map_err(|v| DynInputError::from_typed(input.module_instance_id(), v))
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
-        "lastModified": 1737700483,
-        "narHash": "sha256-1778bR4GDDc51/iZQvcshGLZ4JU87zCzqei8Hn7vU1A=",
+        "lastModified": 1740119667,
+        "narHash": "sha256-8LsFuU6ORym0DUIqp0Kga95w5T+9UnN3aHaephEakvw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "bab2a2840bc2d5ae7c6a133602185edbe4ca7daa",
+        "rev": "019d950c784141c8f3ba6ad5d8a53f72fee0953f",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
     "rust-analyzer-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1737634189,
-        "narHash": "sha256-AG5G9KDsl0Ngby9EfWvlemma7WWG0KCADTIccPJuzUE=",
+        "lastModified": 1740077634,
+        "narHash": "sha256-KlYdDhon/hy91NutuBeN8e3qTKf3FXgsudWsjnHud68=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "84d44d0a574630aa8500ed62b6c01ccd3fae2473",
+        "rev": "88fbdcd510e79ef3bcd81d6d9d4f07bdce84be8c",
         "type": "github"
       },
       "original": {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -2013,7 +2013,7 @@ async fn select_notes_from_stream<Note>(
     loop {
         if let Some((note_amount, note)) = stream.next().await {
             assert!(
-                previous_amount.map_or(true, |previous| previous >= note_amount),
+                previous_amount.is_none_or(|previous| previous >= note_amount),
                 "notes are not sorted in descending order"
             );
             previous_amount = Some(note_amount);


### PR DESCRIPTION
```
> rustc -vV
rustc 1.85.0 (4d91de4e4 2025-02-17)
binary: rustc
commit-hash: 4d91de4e48198da2e33413efdcd9cd2cc0c46688
commit-date: 2025-02-17
host: x86_64-unknown-linux-gnu
release: 1.85.0
LLVM version: 19.1.7
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
