### PR TITLE
fix: correct bash variable interpolation for lnv2 in upgrade tests

### DIFF
--- a/scripts/tests/upgrade-test.sh
+++ b/scripts/tests/upgrade-test.sh
@@ -84,7 +84,7 @@ for upgrade_path in "${upgrade_paths[@]}"; do
 
     for enable_lnv2 in "${lnv2_flags[@]}"; do
       upgrade_tests+=(
-        "fm-run-test fedimintd-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
+        "fm-run-test fedimintd-${versions_str}-lnv2-${enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimintd --paths $(printf "%s " "${fedimintd_paths[@]}")"
       )
     done
   fi
@@ -102,7 +102,7 @@ for upgrade_path in "${upgrade_paths[@]}"; do
 
     for enable_lnv2 in "${lnv2_flags[@]}"; do
       upgrade_tests+=(
-        "fm-run-test fedimint-cli-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
+        "fm-run-test fedimint-cli-${versions_str}-lnv2-${enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 fedimint-cli --paths $(printf "%s " "${fedimint_cli_paths[@]}")"
       )
     done
   fi
@@ -123,7 +123,7 @@ for upgrade_path in "${upgrade_paths[@]}"; do
 
     for enable_lnv2 in "${lnv2_flags[@]}"; do
       upgrade_tests+=(
-        "fm-run-test gateway-${versions_str}-lnv2-{$enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
+        "fm-run-test gateway-${versions_str}-lnv2-${enable_lnv2} devimint upgrade-tests --lnv2 $enable_lnv2 gatewayd --gatewayd-paths $(printf "%s " "${gatewayd_paths[@]}") --gateway-cli-paths $(printf "%s " "${gateway_cli_paths[@]}")"
       )
     done
   fi


### PR DESCRIPTION
@dpc spotted the formatting looked a bit off and it looks like we swapped `{$` for `${` in some bash variable expansions. Not a biggie since this only impacts the format of the upgrade test names.

before

```
## DONE: fedimintd-v0.3.4-rc.1,current-lnv2-{0}
```

after

```
## DONE: fedimintd-v0.3.4-rc.1,current-lnv2-0
```