### PR TITLE
Docker test env fixes and fedimintd image version bump

### DIFF
--- a/docker/deploy-fedimintd/.env
+++ b/docker/deploy-fedimintd/.env
@@ -15,4 +15,4 @@ FM_BITCOIN_RPC_URL=http://bitcoin:bitcoin@bitcoin:8332
 # FM_BITCOIN_RPC_URL=https://blockstream.info/api/
 
 # fedimintd image
-FEDIMINTD_IMAGE=fedimint/fedimintd:v0.6.0-rc.1
+FEDIMINTD_IMAGE=fedimint/fedimintd:v0.6.0-rc.4

--- a/docker/deploy-fedimintd/.env
+++ b/docker/deploy-fedimintd/.env
@@ -1,7 +1,7 @@
 # Bitcoin auth information
 # generate with https://jlopp.github.io/bitcoin-core-rpc-auth-generator/,
 # default is user: bitcoin, pass: bitcoin
-BITCOIND_RPC_AUTH=bitcoin:54ae356e13a76dc8068e960eb43193cb\$efeeb347a1f0b4a7b7832cc26e68861bc46f89126a8e136ff9932cad47739041
+BITCOIND_RPC_AUTH=bitcoin:54ae356e13a76dc8068e960eb43193cb$efeeb347a1f0b4a7b7832cc26e68861bc46f89126a8e136ff9932cad47739041
 
 # This domain should point to the machine fedimintd is being deployed to
 FM_DOMAIN=my-super-host.com

--- a/docker/deploy-fedimintd/.env
+++ b/docker/deploy-fedimintd/.env
@@ -8,7 +8,7 @@ FM_DOMAIN=my-super-host.com
 
 # Where bitcoind is reachable
 FM_BITCOIN_RPC_KIND=bitcoind
-FM_BITCOIN_RPC_URL=http://bitcoin@bitcoin@127.0.0.1:8332
+FM_BITCOIN_RPC_URL=http://bitcoin:bitcoin@bitcoin:8332
 
 # For testing or fallback one can also use esplora
 # FM_BITCOIN_RPC_KIND=esplora

--- a/docker/deploy-fedimintd/docker-compose.yaml
+++ b/docker/deploy-fedimintd/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       - "8333:8333"
     command:
       -printtoconsole
-      -rpcallowip=172.17.0.0/16
+      -rpcallowip=0.0.0.0/0
       -rpcbind=0.0.0.0
       -rpcauth="${BITCOIND_RPC_AUTH}"
       -dbcache=2200


### PR DESCRIPTION
- Changes are tested and deployed
- Setup federation (surfaced some bugs with our docker env)
- Verified peers are on wallet module consensus version 2.2
  - Originally 2.0, then after next loop of task we automatically activated

```
./fedimint-cli --data-dir=/home/stachurski/code/fedimint/docker-client dev api --peer-id 0 --module wallet module_consensus_version
{
  "value": {
    "major": 2,
    "minor": 2
  }
}
```