### PR TITLE
fix: enable LNv2 in mprocs

### DIFF
--- a/scripts/dev/mprocs/run.sh
+++ b/scripts/dev/mprocs/run.sh
@@ -10,5 +10,6 @@ add_target_dir_to_path
 
 # In our dev env we want to use the current aliases from the source code
 export FM_DEVIMINT_STATIC_DATA_DIR="${REPO_ROOT}/devimint/share"
+export FM_ENABLE_MODULE_LNV2=1
 
 devimint --link-test-dir "${CARGO_BUILD_TARGET_DIR:-$PWD/target}/devimint" "$@" dev-fed --exec bash -c 'mprocs -c misc/mprocs.yaml 2>$FM_LOGS_DIR/devimint-outer.log'


### PR DESCRIPTION
https://github.com/fedimint/fedimint/pull/6781 forgot to enable LNv2 when running mprocs.