### PR TITLE
fix(ci): `devimint-faucet` is now `devimint faucet`

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -406,7 +406,7 @@ jobs:
             bins: gateway-cli,gatewayd
             deb: fedimint-gateway
           - flake-output: devimint
-            bins: devimint,devimint-faucet
+            bins: devimint
             deb: devimint
 
     runs-on: [self-hosted, linux]

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -111,7 +111,7 @@ pub enum Cmd {
     #[clap(flatten)]
     Rpc(RpcCmd),
 
-    /// Start devimint-faucet
+    /// Start built-in faucet (in the past called `devimint-faucet`)
     Faucet(FaucetOpts),
 }
 

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -765,11 +765,6 @@ in
       ];
     };
 
-    devimint-faucet = flakeboxLib.pickBinary {
-      pkg = devimint-pkgs;
-      bin = "devimint-faucet";
-    };
-
     fedimint-load-test-tool = fedimintBuildPackageGroup {
       pname = "fedimint-load-test-tool";
       packages = [ "fedimint-load-test-tool" ];


### PR DESCRIPTION
No need to build/package it separately.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
