### PR TITLE
chore: remove v0.2 and v0.3 codepaths

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -49,7 +49,7 @@ jobs:
           # run a slimmed down back-compat test for PR push or each major version for merge queue
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
-            VERSIONS_TO_TEST="v0.3.4-rc.1 v0.4.4 v0.5.0"
+            VERSIONS_TO_TEST="v0.4.4 v0.5.0"
           else
             PERFIT_METRIC="aPuCAjrFT7uE5Oax_T4sMw"
             VERSIONS_TO_TEST="v0.5.0"

--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -49,10 +49,10 @@ jobs:
           # run a slimmed down back-compat test for PR push or each major version for merge queue
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
-            VERSIONS_TO_TEST="v0.4.4 v0.5.0"
+            VERSIONS_TO_TEST="v0.4.4 v0.5.0 v0.6.0"
           else
             PERFIT_METRIC="aPuCAjrFT7uE5Oax_T4sMw"
-            VERSIONS_TO_TEST="v0.5.0"
+            VERSIONS_TO_TEST="v0.6.0"
           fi
 
           # the default tmp dir is too long (/home/ubuntu/actions-runner/_work/_temp/)

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -56,7 +56,7 @@ jobs:
           # read versions from manually triggered workflows
           # default needed for cron or manual workflow without params
           VERSIONS="${{ github.event.inputs.versions }}"
-          VERSIONS=${VERSIONS:="v0.3.4-rc.1 current, v0.4.4 current, v0.5.0 current"}
+          VERSIONS=${VERSIONS:="v0.4.4 current, v0.5.0 current"}
 
           # if empty, defaults to all test kinds within script
           export TEST_KINDS="${{ github.event.inputs.test_kinds }}"

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -56,7 +56,7 @@ jobs:
           # read versions from manually triggered workflows
           # default needed for cron or manual workflow without params
           VERSIONS="${{ github.event.inputs.versions }}"
-          VERSIONS=${VERSIONS:="v0.4.4 current, v0.5.0 current"}
+          VERSIONS=${VERSIONS:="v0.4.4 current, v0.5.0 current, v0.6.0 current"}
 
           # if empty, defaults to all test kinds within script
           export TEST_KINDS="${{ github.event.inputs.test_kinds }}"

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -31,7 +31,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use crate::util::{ProcessHandle, ProcessManager, poll, poll_with_timeout};
 use crate::vars::utf8;
-use crate::version_constants::{VERSION_0_4_0_ALPHA, VERSION_0_5_0_ALPHA};
+use crate::version_constants::VERSION_0_5_0_ALPHA;
 use crate::{Gatewayd, cmd, poll_eq};
 
 #[derive(Clone)]
@@ -45,23 +45,13 @@ impl Bitcoind {
     pub async fn new(processmgr: &ProcessManager, skip_setup: bool) -> Result<Self> {
         let btc_dir = utf8(&processmgr.globals.FM_BTC_DIR);
 
-        // TODO(support:v0.3)
-        // we need to run with txindex for versions before 0.4.0-alpha to correctly
-        // process change outputs
-        let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
-        let tx_index = if fedimintd_version < *VERSION_0_4_0_ALPHA {
-            "1"
-        } else {
-            "0"
-        };
-
         let conf = format!(
             include_str!("cfg/bitcoin.conf"),
             rpc_port = processmgr.globals.FM_PORT_BTC_RPC,
             p2p_port = processmgr.globals.FM_PORT_BTC_P2P,
             zmq_pub_raw_block = processmgr.globals.FM_PORT_BTC_ZMQ_PUB_RAW_BLOCK,
             zmq_pub_raw_tx = processmgr.globals.FM_PORT_BTC_ZMQ_PUB_RAW_TX,
-            tx_index = tx_index,
+            tx_index = "0",
         );
         write_overwrite_async(processmgr.globals.FM_BTC_DIR.join("bitcoin.conf"), conf).await?;
         let process = processmgr

--- a/devimint/src/federation/config.rs
+++ b/devimint/src/federation/config.rs
@@ -79,8 +79,6 @@ pub fn attach_default_module_init_params(
         },
     );
 
-    // TODO(support:v0.3): v0.5 introduced lnv2 modules, so we need to skip
-    // attaching the module for old fedimintd versions
     if supports_lnv2() {
         module_init_params.attach_config_gen_params(
             fedimint_lnv2_server::LightningInit::kind(),

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -25,9 +25,7 @@ use crate::external::{Bitcoind, LightningNode};
 use crate::federation::Federation;
 use crate::util::{Command, ProcessHandle, ProcessManager, poll, supports_lnv2};
 use crate::vars::utf8;
-use crate::version_constants::{
-    VERSION_0_4_0_ALPHA, VERSION_0_5_0_ALPHA, VERSION_0_6_0_ALPHA, VERSION_0_7_0_ALPHA,
-};
+use crate::version_constants::{VERSION_0_5_0_ALPHA, VERSION_0_6_0_ALPHA, VERSION_0_7_0_ALPHA};
 
 #[derive(Clone)]
 pub struct Gatewayd {
@@ -562,14 +560,7 @@ impl Gatewayd {
         ppm: u64,
     ) -> Result<()> {
         let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-        if gatewayd_version < *VERSION_0_4_0_ALPHA {
-            let fees = format!("{base},{ppm}");
-            cmd!(self, "set-configuration", "--routing-fees", fees)
-                .run()
-                .await?;
-        } else if gatewayd_version >= *VERSION_0_4_0_ALPHA
-            && gatewayd_version < *VERSION_0_6_0_ALPHA
-        {
+        if gatewayd_version < *VERSION_0_6_0_ALPHA {
             let new_fed_routing_fees = format!("{fed_id},{base},{ppm}");
             cmd!(
                 self,

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -537,6 +537,7 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                 }))
                 .await?;
 
+                dev_fed.fed.await_gateways_registered().await?;
                 try_join!(stress_test_fed(&dev_fed, None), client.wait_session())?;
                 let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
                 let gateway_cli_version = crate::util::GatewayCli::version_or_default().await;

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -19,7 +19,6 @@ use fedimint_gateway_common::GatewayInfo;
 use fedimint_ln_client::cli::LnInvoiceResponse;
 use fedimint_logging::LOG_DEVIMINT;
 use futures::future::try_join_all;
-use hex::ToHex;
 use serde_json::json;
 use tokio::net::TcpStream;
 use tokio::{fs, try_join};
@@ -29,9 +28,7 @@ use crate::cli::{CommonArgs, cleanup_on_exit, exec_user_command, setup, write_re
 use crate::envs::{FM_DATA_DIR_ENV, FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV, FM_PASSWORD_ENV};
 use crate::federation::Client;
 use crate::util::{LoadTestTool, ProcessManager, poll};
-use crate::version_constants::{
-    VERSION_0_3_0, VERSION_0_3_0_ALPHA, VERSION_0_4_0, VERSION_0_4_0_ALPHA, VERSION_0_5_0_ALPHA,
-};
+use crate::version_constants::{VERSION_0_4_0_ALPHA, VERSION_0_5_0_ALPHA};
 use crate::{DevFed, Gatewayd, LightningNode, Lightningd, Lnd, cmd, dev_fed, poll_eq};
 
 pub struct Stats {
@@ -112,13 +109,6 @@ pub async fn latency_tests(
 ) -> Result<()> {
     log_binary_versions().await?;
 
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    if fedimint_cli_version < *VERSION_0_3_0 || gatewayd_version < *VERSION_0_3_0 {
-        info!("fedmint-cli version that didn't support unknown modules");
-        return Ok(());
-    }
-
     let DevFed {
         cln, fed, gw_lnd, ..
     } = dev_fed;
@@ -137,7 +127,6 @@ pub async fn latency_tests(
         None => fed.new_joined_client("latency-tests-client").await?,
     };
 
-    client.use_gateway(&gw_lnd).await?;
     let initial_balance_sats = 100_000_000;
     fed.pegin_client(initial_balance_sats, &client).await?;
 
@@ -247,31 +236,16 @@ pub async fn latency_tests(
             let mut fm_internal_pay = Vec::with_capacity(iterations);
             let sender = fed.new_joined_client("internal-swap-sender").await?;
             fed.pegin_client(10_000_000, &sender).await?;
-            // TODO(support:v0.2): 0.3 removed the active gateway concept and requires an
-            // explicit gateway or `force-internal`
-            let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-            let default_internal = fedimint_cli_version <= *VERSION_0_3_0;
             for _ in 0..iterations {
-                let recv = if default_internal {
-                    cmd!(
-                        client,
-                        "ln-invoice",
-                        "--amount=1000000msat",
-                        "--description=internal-swap-invoice"
-                    )
-                    .out_json()
-                    .await?
-                } else {
-                    cmd!(
-                        client,
-                        "ln-invoice",
-                        "--amount=1000000msat",
-                        "--description=internal-swap-invoice",
-                        "--force-internal"
-                    )
-                    .out_json()
-                    .await?
-                };
+                let recv = cmd!(
+                    client,
+                    "ln-invoice",
+                    "--amount=1000000msat",
+                    "--description=internal-swap-invoice",
+                    "--force-internal"
+                )
+                .out_json()
+                .await?;
 
                 let invoice = recv["invoice"]
                     .as_str()
@@ -283,13 +257,9 @@ pub async fn latency_tests(
                     .to_owned();
 
                 let start_time = Instant::now();
-                if default_internal {
-                    cmd!(sender, "ln-pay", invoice).run().await?;
-                } else {
-                    cmd!(sender, "ln-pay", invoice, "--force-internal")
-                        .run()
-                        .await?;
-                }
+                cmd!(sender, "ln-pay", invoice, "--force-internal")
+                    .run()
+                    .await?;
 
                 cmd!(client, "await-invoice", recv_op).run().await?;
                 fm_internal_pay.push(start_time.elapsed());
@@ -313,46 +283,23 @@ pub async fn latency_tests(
                 .as_str()
                 .map(ToOwned::to_owned)
                 .unwrap();
-            let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-            let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
-            if !is_env_var_set(FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV)
-                && (fedimint_cli_version < *VERSION_0_3_0_ALPHA
-                    || fedimintd_version < *VERSION_0_3_0_ALPHA)
-            {
+            if !is_env_var_set(FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV) {
                 info!("Skipping tests, as in previous versions restore was very slow to test");
                 return Ok(());
             }
 
             let start_time = Instant::now();
-            if *VERSION_0_3_0_ALPHA <= fedimint_cli_version {
-                let restore_client = Client::create("restore").await?;
-                cmd!(
-                    restore_client,
-                    "restore",
-                    "--mnemonic",
-                    &backup_secret,
-                    "--invite-code",
-                    fed.invite_code()?
-                )
-                .run()
-                .await?;
-            } else {
-                let client = client.new_forked("restore-without-backup").await?;
-                let _ = cmd!(client, "wipe", "--force",).out_json().await?;
-
-                assert_eq!(
-                    0,
-                    cmd!(client, "info").out_json().await?["total_amount_msat"]
-                        .as_u64()
-                        .unwrap()
-                );
-
-                let _post_balance = cmd!(client, "restore", &backup_secret)
-                    .out_json()
-                    .await?
-                    .as_u64()
-                    .unwrap();
-            }
+            let restore_client = Client::create("restore").await?;
+            cmd!(
+                restore_client,
+                "restore",
+                "--mnemonic",
+                &backup_secret,
+                "--invite-code",
+                fed.invite_code()?
+            )
+            .run()
+            .await?;
             let restore_time = start_time.elapsed();
 
             println!("### LATENCY RESTORE: {restore_time:?}");
@@ -619,16 +566,9 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         ..
     } = dev_fed;
 
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
     let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
-    if fedimint_cli_version < *VERSION_0_3_0 || gatewayd_version < *VERSION_0_3_0 {
-        info!("fedmint-cli version that didn't support unknown modules");
-        return Ok(());
-    }
 
     let client = fed.new_joined_client("cli-tests-client").await?;
-    client.use_gateway(&gw_lnd).await?;
     let lnd_gw_id = gw_lnd.gateway_id().await?;
 
     cmd!(
@@ -690,34 +630,19 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
     let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
 
-    let invite_code = if fedimint_cli_version >= *VERSION_0_3_0_ALPHA {
-        cmd!(client, "dev", "decode", "invite-code", invite.clone())
-    } else {
-        cmd!(client, "dev", "decode-invite-code", invite.clone())
-    }
-    .out_json()
-    .await?;
+    let invite_code = cmd!(client, "dev", "decode", "invite-code", invite.clone())
+        .out_json()
+        .await?;
 
-    let encode_invite_output = if fedimint_cli_version >= *VERSION_0_3_0_ALPHA {
-        cmd!(
-            client,
-            "dev",
-            "encode",
-            "invite-code",
-            format!("--url={}", invite_code["url"].as_str().unwrap()),
-            "--federation_id={fed_id}",
-            "--peer=0"
-        )
-    } else {
-        cmd!(
-            client,
-            "dev",
-            "encode-invite-code",
-            format!("--url={}", invite_code["url"].as_str().unwrap()),
-            "--federation_id={fed_id}",
-            "--peer=0"
-        )
-    }
+    let encode_invite_output = cmd!(
+        client,
+        "dev",
+        "encode",
+        "invite-code",
+        format!("--url={}", invite_code["url"].as_str().unwrap()),
+        "--federation_id={fed_id}",
+        "--peer=0"
+    )
     .out_json()
     .await?;
 
@@ -745,24 +670,19 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     cln.pay_bolt11_invoice(invoice).await?;
     gw_lnd.wait_bolt11_invoice(payment_hash).await?;
 
-    // fedimintd introduced wpkh for single guardian federations in v0.3.0 (9e35bdb)
-    // The code path is backwards-compatible, however this test will fail if we
-    // check against earlier fedimintd versions.
-    if fedimintd_version >= *VERSION_0_3_0_ALPHA {
-        // # Test the correct descriptor is used
-        let config = cmd!(client, "config").out_json().await?;
-        let guardian_count = config["global"]["api_endpoints"].as_object().unwrap().len();
-        let descriptor = config["modules"]["2"]["peg_in_descriptor"]
-            .as_str()
-            .unwrap()
-            .to_owned();
+    // # Test the correct descriptor is used
+    let config = cmd!(client, "config").out_json().await?;
+    let guardian_count = config["global"]["api_endpoints"].as_object().unwrap().len();
+    let descriptor = config["modules"]["2"]["peg_in_descriptor"]
+        .as_str()
+        .unwrap()
+        .to_owned();
 
-        info!("Testing generated descriptor for {guardian_count} guardian federation");
-        if guardian_count == 1 {
-            assert!(descriptor.contains("wpkh("));
-        } else {
-            assert!(descriptor.contains("wsh(sortedmulti("));
-        }
+    info!("Testing generated descriptor for {guardian_count} guardian federation");
+    if guardian_count == 1 {
+        assert!(descriptor.contains("wpkh("));
+    } else {
+        assert!(descriptor.contains("wsh(sortedmulti("));
     }
 
     // # Client tests
@@ -832,27 +752,15 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .as_str()
         .map(ToOwned::to_owned)
         .unwrap();
-    let client_reissue_amt = if fedimint_cli_version >= *VERSION_0_3_0_ALPHA {
-        cmd!(client, "module", "mint", "reissue", reissue_notes)
-    } else {
-        cmd!(
-            client,
-            "module",
-            "--module",
-            "mint",
-            "reissue",
-            reissue_notes
-        )
-    }
-    .out_json()
-    .await?
-    .as_u64()
-    .unwrap();
+    let client_reissue_amt = cmd!(client, "module", "mint", "reissue", reissue_notes)
+        .out_json()
+        .await?
+        .as_u64()
+        .unwrap();
     assert_eq!(client_reissue_amt, reissue_amount);
 
     // LND gateway tests
     info!("Testing LND gateway");
-    client.use_gateway(&gw_lnd).await?;
 
     // OUTGOING: fedimint-cli pays CLN via LND gateway
     info!("Testing outgoing payment from client to CLN via LND gateway");
@@ -1060,40 +968,6 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     Ok(())
 }
 
-pub async fn start_hold_invoice_payment(
-    client: &Client,
-    gw_cln: &Gatewayd,
-    gw_cln_id: String,
-    lnd: &Lnd,
-) -> anyhow::Result<([u8; 32], cln_rpc::primitives::Sha256, String)> {
-    client.use_gateway(gw_cln).await?;
-    let (preimage, payment_request, hash) = lnd.create_hold_invoice(1000).await?;
-    let operation_id = ln_pay(client, payment_request, gw_cln_id, true).await?;
-    Ok((preimage, hash, operation_id))
-}
-
-pub async fn finish_hold_invoice_payment(
-    client: &Client,
-    hold_invoice_operation_id: String,
-    lnd: &Lnd,
-    hold_invoice_hash: cln_rpc::primitives::Sha256,
-    hold_invoice_preimage: [u8; 32],
-) -> anyhow::Result<()> {
-    lnd.settle_hold_invoice(hold_invoice_preimage, hold_invoice_hash)
-        .await?;
-    let received_preimage = cmd!(client, "await-ln-pay", hold_invoice_operation_id)
-        .out_json()
-        .await?["preimage"]
-        .as_str()
-        .context("missing preimage")?
-        .to_owned();
-    assert_eq!(
-        received_preimage,
-        hold_invoice_preimage.encode_hex::<String>()
-    );
-    Ok(())
-}
-
 pub async fn cli_load_test_tool_test(dev_fed: DevFed) -> Result<()> {
     log_binary_versions().await?;
     let data_dir = env::var(FM_DATA_DIR_ENV)?;
@@ -1244,12 +1118,6 @@ pub async fn lightning_gw_reconnect_test(
     process_mgr: &ProcessManager,
 ) -> Result<()> {
     log_binary_versions().await?;
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    if fedimint_cli_version < *VERSION_0_3_0 || gatewayd_version < *VERSION_0_3_0 {
-        info!("fedmint-cli version that didn't support unknown modules");
-        return Ok(());
-    }
 
     let DevFed {
         bitcoind,
@@ -1263,7 +1131,6 @@ pub async fn lightning_gw_reconnect_test(
     let client = fed
         .new_joined_client("lightning-gw-reconnect-test-client")
         .await?;
-    client.use_gateway(&gw_lnd).await?;
 
     info!("Pegging-in both gateways");
     fed.pegin_gateways(99_999, vec![&gw_lnd]).await?;
@@ -1327,13 +1194,6 @@ pub async fn lightning_gw_reconnect_test(
 pub async fn gw_reboot_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Result<()> {
     log_binary_versions().await?;
 
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    if fedimint_cli_version < *VERSION_0_3_0 || gatewayd_version < *VERSION_0_3_0 {
-        info!("fedmint-cli version that didn't support unknown modules");
-        return Ok(());
-    }
-
     let DevFed {
         bitcoind,
         cln,
@@ -1345,25 +1205,19 @@ pub async fn gw_reboot_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
     } = dev_fed;
 
     let client = fed.new_joined_client("gw-reboot-test-client").await?;
-    client.use_gateway(&gw_lnd).await?;
     fed.pegin_client(10_000, &client).await?;
 
     // Wait for gateways to sync to chain
-    let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    // TODO(support:v0.3): `block_height` field was introduced in v0.4.0
-    // see: https://github.com/fedimint/fedimint/pull/4514
-    if gatewayd_version >= *VERSION_0_4_0 {
-        let block_height = bitcoind.get_block_count().await? - 1;
-        match &gw_ldk {
-            Some(gw_ldk) => {
-                try_join!(
-                    gw_lnd.wait_for_block_height(block_height),
-                    gw_ldk.wait_for_block_height(block_height),
-                )?;
-            }
-            _ => {
-                try_join!(gw_lnd.wait_for_block_height(block_height),)?;
-            }
+    let block_height = bitcoind.get_block_count().await? - 1;
+    match &gw_ldk {
+        Some(gw_ldk) => {
+            try_join!(
+                gw_lnd.wait_for_block_height(block_height),
+                gw_ldk.wait_for_block_height(block_height),
+            )?;
+        }
+        _ => {
+            try_join!(gw_lnd.wait_for_block_height(block_height),)?;
         }
     }
 
@@ -1489,7 +1343,6 @@ pub async fn do_try_create_and_pay_invoice(
     .await?;
 
     tracing::info!("Creating invoice....");
-    client.use_gateway(gw).await?;
     let invoice = ln_invoice(
         client,
         Amount::from_msats(1000),
@@ -1520,19 +1373,7 @@ async fn ln_pay(
     gw_id: String,
     finish_in_background: bool,
 ) -> anyhow::Result<String> {
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-
-    // TODO(support:v0.2): 0.3 removed the active gateway concept and requires a
-    // `gateway-id` parameter for lightning sends
-    let value = if fedimint_cli_version < *VERSION_0_3_0_ALPHA {
-        if finish_in_background {
-            cmd!(client, "ln-pay", invoice, "--finish-in-background",)
-                .out_json()
-                .await?
-        } else {
-            cmd!(client, "ln-pay", invoice,).out_json().await?
-        }
-    } else if finish_in_background {
+    let value = if finish_in_background {
         cmd!(
             client,
             "ln-pay",
@@ -1562,32 +1403,17 @@ async fn ln_invoice(
     description: String,
     gw_id: String,
 ) -> anyhow::Result<LnInvoiceResponse> {
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    // TODO(support:v0.2): 0.3 removed the active gateway concept and requires a
-    // `gateway-id` parameter for lightning receives
-    let ln_response_val = if fedimint_cli_version < *VERSION_0_3_0_ALPHA {
-        cmd!(
-            client,
-            "ln-invoice",
-            "--amount",
-            amount.msats,
-            format!("--description='{description}'"),
-        )
-        .out_json()
-        .await?
-    } else {
-        cmd!(
-            client,
-            "ln-invoice",
-            "--amount",
-            amount.msats,
-            format!("--description='{description}'"),
-            "--gateway-id",
-            gw_id,
-        )
-        .out_json()
-        .await?
-    };
+    let ln_response_val = cmd!(
+        client,
+        "ln-invoice",
+        "--amount",
+        amount.msats,
+        format!("--description='{description}'"),
+        "--gateway-id",
+        gw_id,
+    )
+    .out_json()
+    .await?;
 
     let ln_invoice_response: LnInvoiceResponse = serde_json::from_value(ln_response_val)?;
 
@@ -1596,13 +1422,6 @@ async fn ln_invoice(
 
 pub async fn reconnect_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Result<()> {
     log_binary_versions().await?;
-
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    if fedimint_cli_version < *VERSION_0_3_0 || gatewayd_version < *VERSION_0_3_0 {
-        info!("fedmint-cli version that didn't support unknown modules");
-        return Ok(());
-    }
 
     let DevFed {
         bitcoind, mut fed, ..
@@ -1640,26 +1459,6 @@ pub async fn reconnect_test(dev_fed: DevFed, process_mgr: &ProcessManager) -> Re
 
 pub async fn recoverytool_test(dev_fed: DevFed) -> Result<()> {
     log_binary_versions().await?;
-
-    let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
-
-    // TODO(support:v0.3): remove
-    if fedimintd_version < *VERSION_0_4_0_ALPHA {
-        info!(
-            "Recoverytool tests in fedmintd version that didn't have short session times when running in tests"
-        );
-        // And worst comes to worst, users that want to recover can just use a
-        // recoverytool version corresponding to the version of fedimintd they were
-        // using.
-        return Ok(());
-    }
-
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
-    if fedimint_cli_version < *VERSION_0_3_0 || gatewayd_version < *VERSION_0_3_0 {
-        info!("fedmint-cli version that didn't support unknown modules");
-        return Ok(());
-    }
 
     let DevFed { bitcoind, fed, .. } = dev_fed;
 
@@ -1835,15 +1634,6 @@ pub async fn guardian_backup_test(dev_fed: DevFed, process_mgr: &ProcessManager)
 
     log_binary_versions().await?;
 
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-    let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
-
-    // TODO(support:v0.2): remove
-    if fedimint_cli_version < *VERSION_0_3_0_ALPHA || fedimintd_version < *VERSION_0_3_0_ALPHA {
-        info!("Guardian backups didn't exist pre-0.3.0, so can't be tested, exiting");
-        return Ok(());
-    }
-
     let DevFed { mut fed, .. } = dev_fed;
 
     fed.await_all_peers()
@@ -1977,7 +1767,6 @@ async fn all_peer_block_count(
 
 pub async fn cannot_replay_tx_test(dev_fed: DevFed) -> Result<()> {
     log_binary_versions().await?;
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
 
     let DevFed { fed, .. } = dev_fed;
 
@@ -2032,18 +1821,9 @@ pub async fn cannot_replay_tx_test(dev_fed: DevFed) -> Result<()> {
         CLIENT_START_AMOUNT - CLIENT_SPEND_AMOUNT
     );
 
-    // TODO(support:v0.2): remove
-    if fedimint_cli_version >= *VERSION_0_3_0_ALPHA {
-        cmd!(double_spend_client, "reissue", double_spend_notes)
-            .assert_error_contains("The transaction had an invalid input")
-            .await?;
-    } else {
-        // v0.2 clients don't write json errors to stdout, so we can't parse
-        cmd!(double_spend_client, "reissue", double_spend_notes)
-            .run()
-            .await
-            .expect_err("double spend must fail");
-    }
+    cmd!(double_spend_client, "reissue", double_spend_notes)
+        .assert_error_contains("The transaction had an invalid input")
+        .await?;
 
     let double_spend_client_post_spend_balance = double_spend_client.balance().await?;
     assert_eq!(

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -2,10 +2,6 @@ use std::sync::LazyLock;
 
 use semver::Version;
 
-pub static VERSION_0_4_0_ALPHA: LazyLock<Version> =
-    LazyLock::new(|| Version::parse("0.4.0-alpha").expect("version is parsable"));
-pub static VERSION_0_4_0: LazyLock<Version> =
-    LazyLock::new(|| Version::parse("0.4.0").expect("version is parsable"));
 pub static VERSION_0_5_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.5.0-alpha").expect("version is parsable"));
 pub static VERSION_0_6_0_ALPHA: LazyLock<Version> =

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -2,10 +2,6 @@ use std::sync::LazyLock;
 
 use semver::Version;
 
-pub static VERSION_0_3_0_ALPHA: LazyLock<Version> =
-    LazyLock::new(|| Version::parse("0.3.0-alpha").expect("version is parsable"));
-pub static VERSION_0_3_0: LazyLock<Version> =
-    LazyLock::new(|| Version::parse("0.3.0").expect("version is parsable"));
 pub static VERSION_0_4_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.4.0-alpha").expect("version is parsable"));
 pub static VERSION_0_4_0: LazyLock<Version> =

--- a/modules/fedimint-meta-tests/src/bin/meta-sanity-test.rs
+++ b/modules/fedimint-meta-tests/src/bin/meta-sanity-test.rs
@@ -3,10 +3,9 @@ use std::future::Future;
 use anyhow::{Result, bail};
 use devimint::federation::Client;
 use devimint::util::poll_simple;
-use devimint::version_constants::{VERSION_0_4_0, VERSION_0_5_0_ALPHA};
+use devimint::version_constants::VERSION_0_5_0_ALPHA;
 use devimint::{cmd, util};
 use fedimint_core::PeerId;
-use semver::Version;
 use serde_json::json;
 use tracing::{info, warn};
 
@@ -14,25 +13,6 @@ use tracing::{info, warn};
 async fn main() -> anyhow::Result<()> {
     devimint::run_devfed_test(|dev_fed, _process_mgr| async move {
         let fedimint_cli_version = util::FedimintCli::version_or_default().await;
-        let fedimintd_version = util::FedimintdCmd::version_or_default().await;
-
-        // TODO(support:v0.2): remove
-        if fedimint_cli_version < Version::parse("0.3.0-rc.2").unwrap() {
-            info!(%fedimint_cli_version, "Version did not support meta module, skipping");
-            return Ok(());
-        }
-
-        // TODO(support:v0.2): remove
-        if fedimintd_version < Version::parse("0.3.0-rc.2").unwrap() {
-            info!(%fedimintd_version, "Version did not support meta module, skipping");
-            return Ok(());
-        }
-
-        // TODO:(support:v0.3): remove
-        if fedimintd_version <= Version::parse("0.3.4-rc.1").unwrap() {
-            info!(%fedimintd_version, "Version causes extreme flakiness, skipping");
-            return Ok(());
-        }
 
         let client = dev_fed
             .fed()
@@ -152,61 +132,57 @@ async fn main() -> anyhow::Result<()> {
             serde_json::Value::Bool(true)
         );
 
-        // TODO(support:v0.3): a fix for a race condition was introduced in v0.4.0
-        // see: https://github.com/fedimint/fedimint/pull/4772
-        if fedimintd_version >= *VERSION_0_4_0 {
-            info!(expected = %submission_value, "Checking consensus");
-            if let Err(e) = poll_value(
-                "consensus set",
-                || async { get_consensus(&client).await },
+        info!(expected = %submission_value, "Checking consensus");
+        if let Err(e) = poll_value(
+            "consensus set",
+            || async { get_consensus(&client).await },
+            json! {
+                {
+                    "revision": 0,
+                    "value":submission_value
+                }
+            },
+        )
+        .await
+        {
+            let submissions = get_submissions(&client, PeerId::from(3)).await?;
+            warn!(%submissions, "Getting expected consensus value failed");
+            return Err(e);
+        }
+
+        // minority vote should be still visible
+        poll_value(
+            "minor submission visible",
+            || async { get_submissions(&client, PeerId::from(0)).await },
+            json! {
+                {  "0": minority_submission_value}
+            },
+        )
+        .await?;
+
+        // If the peer with outstanding vote votes for the consensu value,
+        // their submission will clear.
+        submit(&client, PeerId::from(0), &submission_value).await?;
+        poll_value(
+            "submission cleared",
+            || async { get_submissions(&client, PeerId::from(1)).await },
+            json! { {} },
+        )
+        .await?;
+
+        // TODO(support:v0.4): meta fields were introduced in v0.5.0
+        // see: https://github.com/fedimint/fedimint/pull/5781
+        if fedimint_cli_version >= *VERSION_0_5_0_ALPHA {
+            let meta_fields = get_meta_fields(&client).await?;
+            assert_eq!(
+                meta_fields,
                 json! {
                     {
                         "revision": 0,
-                        "value":submission_value
+                        "values": submission_value,
                     }
-                },
-            )
-            .await
-            {
-                let submissions = get_submissions(&client, PeerId::from(3)).await?;
-                warn!(%submissions, "Getting expected consensus value failed");
-                return Err(e);
-            }
-
-            // minority vote should be still visible
-            poll_value(
-                "minor submission visible",
-                || async { get_submissions(&client, PeerId::from(0)).await },
-                json! {
-                    {  "0": minority_submission_value}
-                },
-            )
-            .await?;
-
-            // If the peer with outstanding vote votes for the consensu value,
-            // their submission will clear.
-            submit(&client, PeerId::from(0), &submission_value).await?;
-            poll_value(
-                "submission cleared",
-                || async { get_submissions(&client, PeerId::from(1)).await },
-                json! { {} },
-            )
-            .await?;
-
-            // TODO(support:v0.4): meta fields were introduced in v0.5.0
-            // see: https://github.com/fedimint/fedimint/pull/5781
-            if fedimint_cli_version >= *VERSION_0_5_0_ALPHA {
-                let meta_fields = get_meta_fields(&client).await?;
-                assert_eq!(
-                    meta_fields,
-                    json! {
-                        {
-                            "revision": 0,
-                            "values": submission_value,
-                        }
-                    }
-                );
-            }
+                }
+            );
         }
 
         Ok(())

--- a/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
+++ b/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
@@ -112,7 +112,6 @@ pub async fn test_restore_gap_test(fed: &Federation) -> Result<()> {
         .out_json()
         .await?;
 
-        // `wait-complete` was introduced in v0.3.0 (90f3082)
         let _ = cmd!(client, "dev", "wait-complete").out_json().await?;
         let post_notes = cmd!(client, "info").out_json().await?;
         let post_balance = post_notes["total_amount_msat"].as_u64().unwrap();

--- a/modules/fedimint-wallet-tests/src/bin/wallet-module-tests.rs
+++ b/modules/fedimint-wallet-tests/src/bin/wallet-module-tests.rs
@@ -7,8 +7,8 @@ use bitcoincore_rpc::bitcoin::address::Address;
 use clap::Parser;
 use devimint::cmd;
 use devimint::federation::Client;
-use devimint::util::{FedimintCli, FedimintdCmd};
-use devimint::version_constants::{VERSION_0_4_0, VERSION_0_6_0_ALPHA};
+use devimint::util::FedimintCli;
+use devimint::version_constants::VERSION_0_6_0_ALPHA;
 use fedimint_core::encoding::Decodable;
 use fedimint_core::util::{backoff_util, retry};
 use fedimint_logging::LOG_TEST;
@@ -36,19 +36,12 @@ async fn main() -> anyhow::Result<()> {
 async fn wallet_recovery_test_1() -> anyhow::Result<()> {
     devimint::run_devfed_test(|dev_fed, _process_mgr| async move {
         let fedimint_cli_version = FedimintCli::version_or_default().await;
-        let fedimintd_version = FedimintdCmd::version_or_default().await;
-        // TODO(support:v0.4): recovery was introduced in v0.4.0
-        // see: https://github.com/fedimint/fedimint/pull/5546
-        if fedimint_cli_version < *VERSION_0_4_0 || fedimintd_version < *VERSION_0_4_0 {
-            info!("Skipping whole test on old fedimint-cli/fedimintd that is missing some irrelevant bolts");
-            return Ok(());
-        }
 
         let (fed, _bitcoind) = try_join!(dev_fed.fed(), dev_fed.bitcoind())?;
 
         let peg_in_amount_sats = 100_000;
 
-            // Start this client early, as we need to test waiting for session to close
+        // Start this client early, as we need to test waiting for session to close
         let client_slow = fed
             .new_joined_client("wallet-client-recovery-origin")
             .await?;
@@ -78,9 +71,16 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
                     .run()
                     .await?;
             } else {
-                cmd!(restored, "module", "wallet", "await-deposit", "--operation-id", operation_id)
-                    .run()
-                    .await?;
+                cmd!(
+                    restored,
+                    "module",
+                    "wallet",
+                    "await-deposit",
+                    "--operation-id",
+                    operation_id
+                )
+                .run()
+                .await?;
             }
 
             info!("Check if claimed");
@@ -115,9 +115,16 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
                     .run()
                     .await?;
             } else {
-                cmd!(restored, "module", "wallet", "await-deposit", "--operation-id", operation_id)
-                    .run()
-                    .await?;
+                cmd!(
+                    restored,
+                    "module",
+                    "wallet",
+                    "await-deposit",
+                    "--operation-id",
+                    operation_id
+                )
+                .run()
+                .await?;
             }
 
             info!("Check if claimed");
@@ -128,12 +135,16 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
         {
             let client = client_slow;
 
-            retry("wait for next session", backoff_util::aggressive_backoff(), || async {
-                if client_slow_pegin_session_count < client.get_session_count().await? {
-                    return Ok(());
-                }
-                bail!("Session didn't close")
-            })
+            retry(
+                "wait for next session",
+                backoff_util::aggressive_backoff(),
+                || async {
+                    if client_slow_pegin_session_count < client.get_session_count().await? {
+                        return Ok(());
+                    }
+                    bail!("Session didn't close")
+                },
+            )
             .await
             .expect("timeouted waiting for session to close");
 
@@ -151,9 +162,16 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
                     .run()
                     .await?;
             } else {
-                cmd!(restored, "module", "wallet", "await-deposit", "--operation-id", operation_id)
-                    .run()
-                    .await?;
+                cmd!(
+                    restored,
+                    "module",
+                    "wallet",
+                    "await-deposit",
+                    "--operation-id",
+                    operation_id
+                )
+                .run()
+                .await?;
             }
 
             info!("Client slow: Check if claimed");
@@ -167,15 +185,6 @@ async fn wallet_recovery_test_1() -> anyhow::Result<()> {
 
 async fn wallet_recovery_test_2() -> anyhow::Result<()> {
     devimint::run_devfed_test(|dev_fed, _process_mgr| async move {
-        let fedimint_cli_version = FedimintCli::version_or_default().await;
-        let fedimintd_version = FedimintdCmd::version_or_default().await;
-        // TODO(support:v0.4): recovery was introduced in v0.4.0
-        // see: https://github.com/fedimint/fedimint/pull/5546
-        if fedimint_cli_version < *VERSION_0_4_0 || fedimintd_version < *VERSION_0_4_0 {
-            info!(target: LOG_TEST, "Skipping whole test on old fedimint-cli/fedimintd that is missing some irrelevant bolts");
-            return Ok(());
-        }
-
         let (fed, _bitcoind) = try_join!(dev_fed.fed(), dev_fed.bitcoind())?;
 
         let peg_in_amount_sats = 100_000;

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -209,7 +209,7 @@ function generate_matrix() {
   done
 }
 
-export LNV2_STABLE_VERSION="v0.6.0-rc.1"
+export LNV2_STABLE_VERSION="v0.6.0"
 function version_lt() {
   if [ "$1" = "current" ]; then
     return 1


### PR DESCRIPTION
Removes `v0.2` and `v0.3` codepaths from devimint and other integration tests.

Adds `v0.6.0` to backwards compatibility and upgrade tests. Changes `LNV2_STABLE_VERSION` to be `v0.6.0`.