### PR TITLE
fix: build fedimint-server with "net" feature

### DIFF
--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -58,7 +58,7 @@ tbs = { workspace = true }
 threshold_crypto = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
-tokio-stream = { workspace = true }
+tokio-stream = { workspace = true, features = ["net"] }
 tokio-util = { version = "0.7.13", features = ["codec"] }
 tower = { version = "0.4.13", default-features = false }
 tracing = { workspace = true }


### PR DESCRIPTION
This commit fixes a build failure in `fedimint-server` (without the `"net"` feature) encountered during the `v0.6.0` release. It was added to `releases/v0.6.0` before the version bump and tag. This diff isn’t needed on `master` since `tokio-stream` was removed from `fedimint-server` (https://github.com/fedimint/fedimint/commit/86005130a6b42e27e3319c94418ea0ca7eee3b7c).