### PR TITLE
chore: bump docker fedimint tag to v0.6.0 

### DIFF
--- a/docker/deploy-fedimintd/.env
+++ b/docker/deploy-fedimintd/.env
@@ -15,4 +15,4 @@ FM_BITCOIN_RPC_URL=http://bitcoin:bitcoin@bitcoin:8332
 # FM_BITCOIN_RPC_URL=https://blockstream.info/api/
 
 # fedimintd image
-FEDIMINTD_IMAGE=fedimint/fedimintd:v0.6.0-rc.4
+FEDIMINTD_IMAGE=fedimint/fedimintd:v0.6.0

--- a/docker/deploy-fedimintd/docker-compose.yaml
+++ b/docker/deploy-fedimintd/docker-compose.yaml
@@ -31,8 +31,8 @@ services:
       - "8333:8333"
     command:
       -printtoconsole
-      -rpcallowip=0.0.0.0/0
-      -rpcbind=0.0.0.0
+      -rpcallowip=172.20.0.0/16
+      -rpcbind=172.20.0.10
       -rpcauth="${BITCOIND_RPC_AUTH}"
       -dbcache=2200
       -prune=550
@@ -43,7 +43,8 @@ services:
       -server=1
     restart: unless-stopped
     networks:
-      - fedimint_network
+      fedimint_network:
+        ipv4_address: 172.20.0.10
 
   fedimintd:
     image: ${FEDIMINTD_IMAGE}

--- a/docker/deploy-fedimintd/docker-compose.yaml
+++ b/docker/deploy-fedimintd/docker-compose.yaml
@@ -19,6 +19,8 @@ services:
       - "letsencrypt_data:/letsencrypt"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
     restart: unless-stopped
+    networks:
+      - fedimint_network
 
   bitcoin:
     image: "bitcoin/bitcoin:28.1"
@@ -40,6 +42,8 @@ services:
       -maxconnections=32
       -server=1
     restart: unless-stopped
+    networks:
+      - fedimint_network
 
   fedimintd:
     image: ${FEDIMINTD_IMAGE}
@@ -64,6 +68,8 @@ services:
       - "traefik.http.routers.fedimintd.entrypoints=websecure"
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
     restart: unless-stopped
+    networks:
+      - fedimint_network
 
   guardian-ui:
     image: fedimintui/guardian-ui:0.4.2
@@ -80,6 +86,16 @@ services:
       - "traefik.http.routers.guardian-ui.entrypoints=websecure"
       - "traefik.http.routers.guardian-ui.tls.certresolver=myresolver"
     restart: unless-stopped
+    networks:
+      - fedimint_network
+
+networks:
+  fedimint_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+          gateway: 172.20.0.1
 
 volumes:
   bitcoind_data:


### PR DESCRIPTION
Builds on top of https://github.com/fedimint/fedimint/pull/6913 (resolves merge conflict)

Bumps `fedimintd` image tag to `v0.6.0`. Deployed, setup with guardian ui, and joined with a new client.

Deploying also re-verified #6913 