### PR TITLE
refactor(devimint): iroh support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,6 +2018,7 @@ dependencies = [
  "fs-lock",
  "futures",
  "hex",
+ "iroh-base",
  "itertools 0.13.0",
  "nix 0.29.0",
  "rand 0.8.5",

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -45,6 +45,7 @@ fedimintd = { workspace = true }
 fs-lock = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+iroh-base = { workspace = true, features = ["ticket"] }
 itertools = { workspace = true }
 nix = { version = "0.29.0", features = ["signal"] }
 rand = { workspace = true }

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -156,7 +156,8 @@ pub async fn setup(arg: CommonArgs) -> Result<(ProcessManager, TaskGroup)> {
         .with_directive("jsonrpsee-client=off")
         .init()?;
 
-    let globals = vars::Global::new(test_dir, arg.fed_size, arg.offline_nodes).await?;
+    // TODO: allocate a single fed by default
+    let globals = vars::Global::new(test_dir, 2, arg.fed_size, arg.offline_nodes).await?;
 
     if let Some(link_test_dir) = arg.link_test_dir.as_ref() {
         update_test_dir_link(link_test_dir, &arg.test_dir()).await?;

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -487,6 +487,16 @@ async fn run_ui(process_mgr: &ProcessManager) -> Result<(Vec<Fedimintd>, Externa
             let api_port = peer_port + 1;
             let metrics_port = 3510 + peer;
 
+            // TODO: we should use this, and override ports that need to be fixed by an env
+            // var and/or just scap `run-ui` altogether
+            // let peer_id = PeerId::new(peer as u16);
+            // let peer_env_vars = vars::Fedimintd::init(
+            //     &process_mgr.globals,
+            //     "ui-test-federation".to_string(),
+            //     peer_id,
+            //     process_mgr.globals.fedimintd_overrides.peer_expect(peer_id),
+            // )
+            // .await?;
             let vars = vars::Fedimintd {
                 FM_BIND_P2P: format!("127.0.0.1:{peer_port}"),
                 FM_P2P_URL: format!("fedimint://127.0.0.1:{peer_port}"),
@@ -502,6 +512,8 @@ async fn run_ui(process_mgr: &ProcessManager) -> Result<(Vec<Fedimintd>, Externa
                     process_mgr.globals.FM_PORT_BTC_RPC
                 ),
                 FM_FORCE_BITCOIN_RPC_KIND: "bitcoind".into(),
+                FM_IROH_P2P_SECRET_KEY_OVERRIDE: String::new(),
+                FM_IROH_API_SECRET_KEY_OVERRIDE: String::new(),
             };
             let fm = Fedimintd::new(
                 process_mgr,

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -169,7 +169,7 @@ impl DevJitFed {
                 debug!(target: LOG_DEVIMINT, "Starting federation...");
                 let start_time = fedimint_core::time::now();
                 let mut fed =
-                    Federation::new(&process_mgr, bitcoind, skip_setup, "default".to_string())
+                    Federation::new(&process_mgr, bitcoind, skip_setup, 0, "default".to_string())
                         .await?;
 
                 // Create a degraded federation if there are offline nodes

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -168,14 +168,9 @@ impl DevJitFed {
                 let bitcoind = bitcoind.get_try().await?.deref().clone();
                 debug!(target: LOG_DEVIMINT, "Starting federation...");
                 let start_time = fedimint_core::time::now();
-                let mut fed = Federation::new(
-                    &process_mgr,
-                    bitcoind,
-                    fed_size,
-                    skip_setup,
-                    "default".to_string(),
-                )
-                .await?;
+                let mut fed =
+                    Federation::new(&process_mgr, bitcoind, skip_setup, "default".to_string())
+                        .await?;
 
                 // Create a degraded federation if there are offline nodes
                 fed.degrade_federation(&process_mgr).await?;

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -292,6 +292,8 @@ impl Federation {
         process_mgr: &ProcessManager,
         bitcoind: Bitcoind,
         skip_setup: bool,
+        // Which of the pre-allocated federations to use (most tests just use single `0` one)
+        fed_index: usize,
         federation_name: String,
     ) -> Result<Self> {
         let num_peers = NumPeers::from(process_mgr.globals.FM_FED_SIZE);
@@ -312,7 +314,10 @@ impl Federation {
                 &process_mgr.globals,
                 federation_name.clone(),
                 peer_id,
-                process_mgr.globals.fedimintd_overrides.peer_expect(peer_id),
+                process_mgr
+                    .globals
+                    .fedimintd_overrides
+                    .peer_expect(fed_index, peer_id),
             )
             .await?;
             members.insert(

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -310,7 +310,7 @@ impl Federation {
         for peer_id in num_peers.peer_ids() {
             let peer_env_vars = vars::Fedimintd::init(
                 &process_mgr.globals,
-                "default".into(),
+                federation_name.clone(),
                 peer_id,
                 process_mgr.globals.fedimintd_overrides.peer_expect(peer_id),
             )

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -141,6 +141,8 @@ declare_vars! {
         FM_PORT_GW_LDK: u16 = port_alloc(1)?; env: "FM_PORT_GW_LDK";
         FM_PORT_FAUCET: u16 = 15243u16; env: "FM_PORT_FAUCET";
 
+        FM_FEDERATION_BASE_PORT: u16 =  port_alloc((3 * fed_size).try_into().unwrap())?; env: "FM_FEDERATION_BASE_PORT";
+
         FM_LDK_BITCOIND_RPC_URL: String = format!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_LDK_BITCOIND_RPC_URL";
 
         FM_CLN_DIR: PathBuf = mkdir(FM_TEST_DIR.join("cln")).await?; env: "FM_CLN_DIR";

--- a/devimint/src/vars/iroh.rs
+++ b/devimint/src/vars/iroh.rs
@@ -1,0 +1,119 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use fedimint_core::envs::FM_IROH_CONNECT_OVERRIDES_ENV;
+use fedimint_core::{NumPeers, PeerId};
+use iroh_base::NodeAddr;
+use iroh_base::ticket::{NodeTicket, Ticket};
+
+use super::ToEnvVar;
+use crate::federation::{
+    FEDIMINTD_API_PORT_OFFSET, FEDIMINTD_P2P_PORT_OFFSET, PORTS_PER_FEDIMINTD,
+};
+
+#[derive(Debug, Clone)]
+pub struct FedimintdEndpoint {
+    node_id: iroh_base::NodeId,
+    secret_key: iroh_base::SecretKey,
+    port: u16,
+}
+
+impl FedimintdEndpoint {
+    fn new(port: u16) -> Self {
+        let secret_key = iroh_base::SecretKey::generate(&mut rand::thread_rng());
+
+        Self {
+            node_id: secret_key.public(),
+            secret_key,
+            port,
+        }
+    }
+
+    pub fn secret_key(&self) -> String {
+        self.secret_key.to_string()
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    fn to_override(&self) -> String {
+        let node_addr = NodeAddr {
+            node_id: self.node_id,
+            relay_url: None,
+            direct_addresses: BTreeSet::from([SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::LOCALHOST,
+                self.port,
+            ))]),
+        };
+        format!(
+            "{}={},",
+            self.node_id,
+            Ticket::serialize(&NodeTicket::from(node_addr))
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FedimintdPeerOverrides {
+    pub p2p: FedimintdEndpoint,
+    pub api: FedimintdEndpoint,
+    pub base_port: u16,
+}
+
+impl FedimintdPeerOverrides {
+    fn new(base_port: u16) -> Self {
+        Self {
+            p2p: FedimintdEndpoint::new(base_port + FEDIMINTD_P2P_PORT_OFFSET),
+            api: FedimintdEndpoint::new(base_port + FEDIMINTD_API_PORT_OFFSET),
+            base_port,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FedimintdOverrides {
+    pub base_port: u16,
+    pub num_peers: NumPeers,
+    pub peers: BTreeMap<PeerId, FedimintdPeerOverrides>,
+}
+
+impl FedimintdOverrides {
+    pub fn new(base_port: u16, num_peers: NumPeers) -> Self {
+        let peers = num_peers
+            .peer_ids()
+            .map(|peer_id| {
+                (peer_id, {
+                    FedimintdPeerOverrides::new(
+                        base_port
+                            + u16::try_from(peer_id.to_usize()).expect("Can't fail")
+                                * PORTS_PER_FEDIMINTD,
+                    )
+                })
+            })
+            .collect();
+        Self {
+            base_port,
+            num_peers,
+            peers,
+        }
+    }
+
+    pub fn peer_expect(&self, peer_id: PeerId) -> &FedimintdPeerOverrides {
+        self.peers.get(&peer_id).expect("Wrong peer_id?")
+    }
+}
+
+impl ToEnvVar for FedimintdOverrides {
+    fn to_env_values(&self, _base_env: &str) -> impl Iterator<Item = (String, String)> {
+        vec![(
+            FM_IROH_CONNECT_OVERRIDES_ENV.to_string(),
+            self.peers
+                .values()
+                .map(|peer| format!("{},{}", peer.p2p.to_override(), peer.api.to_override(),))
+                .collect::<Vec<String>>()
+                .join(","),
+        )]
+        .into_iter()
+    }
+}

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -176,6 +176,14 @@ pub fn legacy_consensus_config_hash(cfg: &ServerConfigConsensus) -> sha256::Hash
     .consensus_hash_sha256()
 }
 
+/// The type of networking `fedimintd` should use
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub enum NetworkingStack {
+    #[default]
+    Tcp,
+    Iroh,
+}
+
 // FIXME: (@leonardo) Should this have another field for the expected transport
 // ? (e.g. clearnet/tor/...)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,6 +214,10 @@ pub struct ConfigGenSettings {
     pub p2p_url: SafeUrl,
     /// URL for our API connection
     pub api_url: SafeUrl,
+    /// Networking stack to use
+    /// TODO: we might make it a part of the API  request when ready
+    /// (move to `SetLocalParamsRequest`).
+    pub networking: NetworkingStack,
     /// Guardian-defined key-value pairs that will be passed to the client
     pub meta: BTreeMap<String, String>,
     /// Set the params (if leader) or just the local params (if follower)

--- a/fedimint-server/src/envs.rs
+++ b/fedimint-server/src/envs.rs
@@ -6,6 +6,9 @@ pub const FM_PEER_ID_SORT_BY_URL_ENV: &str = "FM_PEER_ID_SORT_BY_URL";
 /// checkpoints.
 pub const FM_DB_CHECKPOINT_RETENTION_ENV: &str = "FM_DB_CHECKPOINT_RETENTION";
 
-// Default number of checkpoints from the current session should be retained on
-// disk.
+/// Default number of checkpoints from the current session should be retained on
+/// disk.
 pub const FM_DB_CHECKPOINT_RETENTION_DEFAULT: u64 = 1;
+
+/// Use iroh for networking
+pub const FM_FORCE_IROH_ENV: &str = "FM_FORCE_IROH";

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -92,6 +92,7 @@ pub async fn run(
             } else {
                 IrohConnector::new(
                     cfg.private.iroh_p2p_sk.clone().unwrap(),
+                    settings.p2p_bind,
                     cfg.consensus
                         .iroh_endpoints
                         .iter()
@@ -254,6 +255,7 @@ pub async fn run_config_gen(
     } else {
         IrohConnector::new(
             cg_params.iroh_p2p_sk.clone().unwrap(),
+            settings.p2p_bind,
             cg_params
                 .iroh_endpoints()
                 .iter()

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -139,7 +139,10 @@ pub async fn run(
 
     initialize_gauge_metrics(&db).await;
 
-    start_api_announcement_service(&db, &task_group, &cfg, force_api_secrets.get_active()).await?;
+    if cfg.consensus.iroh_endpoints.is_empty() {
+        start_api_announcement_service(&db, &task_group, &cfg, force_api_secrets.get_active())
+            .await?;
+    }
 
     info!(target: LOG_CONSENSUS, "Starting consensus...");
 

--- a/fedimint-server/src/net/p2p_connector.rs
+++ b/fedimint-server/src/net/p2p_connector.rs
@@ -249,9 +249,10 @@ const FEDIMINT_P2P_ALPN: &[u8] = b"FEDIMINT_P2P_ALPN";
 impl IrohConnector {
     pub async fn new(
         secret_key: SecretKey,
+        p2p_bind_addr: SocketAddr,
         node_ids: BTreeMap<PeerId, NodeId>,
     ) -> anyhow::Result<Self> {
-        let mut s = Self::new_no_overrides(secret_key, node_ids).await;
+        let mut s = Self::new_no_overrides(secret_key, p2p_bind_addr, node_ids).await;
 
         for (k, v) in parse_kv_list_from_env::<_, NodeTicket>(FM_IROH_CONNECT_OVERRIDES_ENV)? {
             s = s.with_connection_override(k, v.into());
@@ -262,6 +263,7 @@ impl IrohConnector {
 
     pub async fn new_no_overrides(
         secret_key: SecretKey,
+        bind_addr: SocketAddr,
         node_ids: BTreeMap<PeerId, NodeId>,
     ) -> Self {
         let identity = *node_ids
@@ -270,19 +272,22 @@ impl IrohConnector {
             .expect("Our public key is not part of the keyset")
             .0;
 
+        let builder = Endpoint::builder()
+            .discovery_n0()
+            .discovery_dht()
+            .secret_key(secret_key)
+            .alpns(vec![FEDIMINT_P2P_ALPN.to_vec()]);
+
+        let builder = match bind_addr {
+            SocketAddr::V4(addr_v4) => builder.bind_addr_v4(addr_v4),
+            SocketAddr::V6(addr_v6) => builder.bind_addr_v6(addr_v6),
+        };
         Self {
             node_ids: node_ids
                 .into_iter()
                 .filter(|entry| entry.0 != identity)
                 .collect(),
-            endpoint: Endpoint::builder()
-                .discovery_n0()
-                .discovery_dht()
-                .secret_key(secret_key)
-                .alpns(vec![FEDIMINT_P2P_ALPN.to_vec()])
-                .bind()
-                .await
-                .expect("Could not bind to port"),
+            endpoint: builder.bind().await.expect("Could not bind to port"),
             connection_overrides: BTreeMap::default(),
         }
     }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -29,8 +29,9 @@ use fedimint_meta_server::{MetaGenParams, MetaInit};
 use fedimint_mint_server::MintInit;
 use fedimint_mint_server::common::config::{MintGenParams, MintGenParamsConsensus};
 use fedimint_server::config::io::{DB_FILE, PLAINTEXT_PASSWORD};
-use fedimint_server::config::{ConfigGenSettings, ServerConfig};
+use fedimint_server::config::{ConfigGenSettings, NetworkingStack, ServerConfig};
 use fedimint_server::core::{ServerModuleInit, ServerModuleInitRegistry};
+use fedimint_server::envs::FM_FORCE_IROH_ENV;
 use fedimint_server::net::api::ApiSecrets;
 use fedimint_unknown_common::config::UnknownGenParams;
 use fedimint_unknown_server::UnknownInit;
@@ -520,6 +521,7 @@ async fn run(
     if let Some(password) = opts.password {
         write_overwrite(data_dir.join(PLAINTEXT_PASSWORD), password)?;
     };
+    let use_iroh = is_env_var_set(FM_FORCE_IROH_ENV);
 
     // TODO: meh, move, refactor
     let settings = ConfigGenSettings {
@@ -530,6 +532,11 @@ async fn run(
         meta: opts.extra_dkg_meta.clone(),
         modules: module_inits_params.clone(),
         registry: module_inits.clone(),
+        networking: if use_iroh {
+            NetworkingStack::Iroh
+        } else {
+            NetworkingStack::default()
+        },
     };
 
     let db = Database::new(

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -364,6 +364,7 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
                 &process_mgr,
                 bitcoind.clone(),
                 false,
+                1,
                 "config-test".to_string(),
             )
             .await?;

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -363,7 +363,6 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
             let new_fed = Federation::new(
                 &process_mgr,
                 bitcoind.clone(),
-                4,
                 false,
                 "config-test".to_string(),
             )


### PR DESCRIPTION
Start with refactoring some clumsy handling of fedimintd ports in devimint. Now allocation happens upfront in the `Global`s. There seem to be no good reason to do it later (when starting fedimintd). Some other cleanups/changes were needed.

Thanks to having it upfront we can add iroh overrides. For every fedimintd iroh endpoints will be seeded with secret keys, and overrides for making connections to iroh endpoints are globally set.

State:

Normal tcp-based connectivity should be not affected.

It's now possible to enable Iroh in devimint e.g. with:

```
env FM_FORCE_IROH=true RUST_LOG=fm::net::iroh=trace,fm=debug,warn just devimint-env
```

DKG completes, but announcement handling seems to be panicking both in the server and client:

```
Unrecoverable decoding DatabaseValue as fedimint_core::net::api_announcement::SignedApiAnnouncement; err=Other decoding error: Decoding named block
 field: SignedApiAnnouncement{ ... api_announcement ... }: Decoding named block field: ApiAnnouncement{ ... api_url ... }: invalid port number, key
_bytes=0600, val_bytes=4f69726f683a2f2f613030646230343137366463633531366339326133386239346566613565663539373965623061616464336661656333663337303336
6331-145
```

I added a temporary workaround for that (not start announcement), and with that I can see consensus working, AFAICT over iroh.


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
