### PR TITLE
feat: Allow customization of `Gatewayd` name in devimint

### DIFF
--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -214,7 +214,13 @@ impl DevJitFed {
             move || async move {
                 debug!(target: LOG_DEVIMINT, "Starting ldk gateway...");
                 let start_time = fedimint_core::time::now();
-                let ldk_gw = Gatewayd::new(&process_mgr, LightningNode::Ldk).await?;
+                let ldk_gw = Gatewayd::new(
+                    &process_mgr,
+                    LightningNode::Ldk {
+                        name: "gatewayd-ldk-0".to_string(),
+                    },
+                )
+                .await?;
                 info!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed()?.as_millis(), "Started ldk gateway");
                 Ok(Arc::new(ldk_gw))
             }

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -1082,14 +1082,14 @@ async fn wait_for_ready_channel_on_gateway_with_counterparty(
 #[derive(Clone)]
 pub enum LightningNode {
     Lnd(Lnd),
-    Ldk,
+    Ldk { name: String },
 }
 
 impl LightningNode {
-    pub fn name(&self) -> LightningNodeType {
+    pub fn ln_type(&self) -> LightningNodeType {
         match self {
             LightningNode::Lnd(_) => LightningNodeType::Lnd,
-            LightningNode::Ldk => LightningNodeType::Ldk,
+            LightningNode::Ldk { name: _ } => LightningNodeType::Ldk,
         }
     }
 }

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -731,7 +731,7 @@ impl Federation {
             .out_json()
             .await?;
             let response: WithdrawResponse = serde_json::from_value(value)?;
-            peg_outs.insert(gw.ln_type(), (prev_fed_ecash_balance, response));
+            peg_outs.insert(gw.ln.ln_type(), (prev_fed_ecash_balance, response));
         }
         self.bitcoind.mine_blocks(21).await?;
 
@@ -752,7 +752,7 @@ impl Federation {
                 .expect("Gateway has not joined federation")
                 .ecash_balance_msats;
 
-            let ln_type = gw.ln_type();
+            let ln_type = gw.ln.ln_type();
             let prev_balance = peg_outs
                 .get(&ln_type)
                 .expect("peg out does not exist")

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -31,33 +31,38 @@ use crate::version_constants::{VERSION_0_5_0_ALPHA, VERSION_0_6_0_ALPHA, VERSION
 #[derive(Clone)]
 pub struct Gatewayd {
     pub(crate) process: ProcessHandle,
-    pub ln: Option<LightningNode>,
+    pub ln: LightningNode,
     pub addr: String,
     pub(crate) lightning_node_addr: String,
     pub gatewayd_version: Version,
+    pub gw_name: String,
 }
 
 impl Gatewayd {
     pub async fn new(process_mgr: &ProcessManager, ln: LightningNode) -> Result<Self> {
-        let ln_name = ln.name();
+        let ln_type = ln.ln_type();
+        let gw_name = match &ln {
+            LightningNode::Lnd(_) => "gatewayd-lnd".to_string(),
+            LightningNode::Ldk { name } => name.to_owned(),
+        };
         let test_dir = &process_mgr.globals.FM_TEST_DIR;
 
         let port = match ln {
             LightningNode::Lnd(_) => process_mgr.globals.FM_PORT_GW_LND,
-            LightningNode::Ldk => process_mgr.globals.FM_PORT_GW_LDK,
+            LightningNode::Ldk { name: _ } => process_mgr.globals.FM_PORT_GW_LDK,
         };
         let addr = format!("http://127.0.0.1:{port}/{V1_API_ENDPOINT}");
 
         let lightning_node_port = match ln {
             LightningNode::Lnd(_) => process_mgr.globals.FM_PORT_LND_LISTEN,
-            LightningNode::Ldk => process_mgr.globals.FM_PORT_LDK,
+            LightningNode::Ldk { name: _ } => process_mgr.globals.FM_PORT_LDK,
         };
         let lightning_node_addr = format!("127.0.0.1:{lightning_node_port}");
 
         let mut gateway_env: HashMap<String, String> = HashMap::from_iter([
             (
                 FM_GATEWAY_DATA_DIR_ENV.to_owned(),
-                format!("{}/{ln_name}", utf8(test_dir)),
+                format!("{}/{ln_type}", utf8(test_dir)),
             ),
             (
                 FM_GATEWAY_LISTEN_ADDR_ENV.to_owned(),
@@ -75,17 +80,18 @@ impl Gatewayd {
         let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
         let process = process_mgr
             .spawn_daemon(
-                &format!("gatewayd-{ln_name}"),
-                Gatewayd::start_gatewayd(&ln_name, &gatewayd_version).envs(gateway_env),
+                &gw_name,
+                Gatewayd::start_gatewayd(&ln_type, &gatewayd_version).envs(gateway_env),
             )
             .await?;
 
         let gatewayd = Self {
-            ln: Some(ln),
+            ln,
             process,
             addr,
             lightning_node_addr,
             gatewayd_version,
+            gw_name,
         };
         poll(
             "waiting for gateway to be ready to respond to rpc",
@@ -96,7 +102,7 @@ impl Gatewayd {
     }
 
     fn is_forced_current(&self) -> bool {
-        self.ln_type() == LightningNodeType::Ldk && self.gatewayd_version < *VERSION_0_6_0_ALPHA
+        self.ln.ln_type() == LightningNodeType::Ldk && self.gatewayd_version < *VERSION_0_6_0_ALPHA
     }
 
     fn start_gatewayd(ln_type: &LightningNodeType, gatewayd_version: &Version) -> Command {
@@ -109,31 +115,23 @@ impl Gatewayd {
         }
     }
 
-    pub fn ln_type(&self) -> LightningNodeType {
-        self.ln
-            .as_ref()
-            .expect("Gatewayd has no lightning node type")
-            .name()
-    }
-
     pub async fn terminate(self) -> Result<()> {
         self.process.terminate().await
     }
 
     pub fn set_lightning_node(&mut self, ln_node: LightningNode) {
-        self.ln = Some(ln_node);
+        self.ln = ln_node;
     }
 
     pub async fn stop_lightning_node(&mut self) -> Result<()> {
         info!("Stopping lightning node");
-        match self.ln.take() {
-            Some(LightningNode::Lnd(lnd)) => lnd.terminate().await,
-            Some(LightningNode::Ldk) => {
+        match self.ln.clone() {
+            LightningNode::Lnd(lnd) => lnd.terminate().await,
+            LightningNode::Ldk { name: _ } => {
                 // This is not implemented because the LDK node lives in
                 // the gateway process and cannot be stopped independently.
                 unimplemented!("LDK node termination not implemented")
             }
-            None => Err(anyhow!("Cannot stop an already stopped Lightning Node")),
         }
     }
 
@@ -145,11 +143,7 @@ impl Gatewayd {
         gatewayd_path: &PathBuf,
         gateway_cli_path: &PathBuf,
     ) -> Result<()> {
-        let ln = self
-            .ln
-            .as_ref()
-            .expect("Lightning Node should exist")
-            .clone();
+        let ln = self.ln.clone();
 
         self.process.terminate().await?;
         // TODO: Audit that the environment access only happens in single-threaded code.
@@ -257,13 +251,6 @@ impl Gatewayd {
             .run()
             .await?;
         Ok(())
-    }
-
-    pub fn lightning_node_type(&self) -> LightningNodeType {
-        self.ln
-            .as_ref()
-            .expect("Gateway has no lightning node")
-            .name()
     }
 
     pub async fn get_pegin_addr(&self, fed_id: &str) -> Result<String> {
@@ -653,7 +640,7 @@ impl Gatewayd {
         let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
         if gatewayd_version < *VERSION_0_7_0_ALPHA {
             match &self.ln {
-                Some(LightningNode::Lnd(lnd)) => {
+                LightningNode::Lnd(lnd) => {
                     return lnd.wait_bolt11_invoice(payment_hash).await;
                 }
                 _ => panic!("Cannot wait on invoice in LDK before v0.7.0"),

--- a/gateway/fedimint-gateway-common/src/envs.rs
+++ b/gateway/fedimint-gateway-common/src/envs.rs
@@ -26,3 +26,6 @@ pub const FM_LDK_NETWORK: &str = "FM_LDK_NETWORK";
 /// Environment variable the specifies the port that the LDK Node should use.
 /// Necessary for LDK configuration.
 pub const FM_PORT_LDK: &str = "FM_PORT_LDK";
+
+/// The alias for the LDK Node
+pub const FM_LDK_ALIAS_ENV: &str = "FM_LDK_ALIAS";

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -6,8 +6,8 @@ use bitcoin::hashes::sha256;
 use bitcoin::{Address, Network};
 use clap::Subcommand;
 use envs::{
-    FM_LDK_BITCOIND_RPC_URL, FM_LDK_ESPLORA_SERVER_URL, FM_LDK_NETWORK, FM_LND_MACAROON_ENV,
-    FM_LND_RPC_ADDR_ENV, FM_LND_TLS_CERT_ENV, FM_PORT_LDK,
+    FM_LDK_ALIAS_ENV, FM_LDK_BITCOIND_RPC_URL, FM_LDK_ESPLORA_SERVER_URL, FM_LDK_NETWORK,
+    FM_LND_MACAROON_ENV, FM_LND_RPC_ADDR_ENV, FM_LND_TLS_CERT_ENV, FM_PORT_LDK,
 };
 use fedimint_api_client::api::net::Connector;
 use fedimint_core::config::{FederationId, JsonClientConfig};
@@ -381,5 +381,9 @@ pub enum LightningMode {
         /// LDK lightning server port
         #[arg(long = "ldk-lightning-port", env = FM_PORT_LDK)]
         lightning_port: u16,
+
+        /// LDK's Alias
+        #[arg(long = "ldk-alias", env = FM_LDK_ALIAS_ENV)]
+        alias: String,
     },
 }

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1954,6 +1954,7 @@ impl Gateway {
                 bitcoind_rpc_url,
                 network,
                 lightning_port,
+                alias,
             } => {
                 let chain_source_config = {
                     match (esplora_server_url, bitcoind_rpc_url) {
@@ -1980,6 +1981,7 @@ impl Gateway {
                         chain_source_config,
                         network,
                         lightning_port,
+                        alias,
                         self.mnemonic.clone(),
                         runtime,
                     )

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -93,21 +93,13 @@ impl GatewayLdkClient {
         chain_source_config: GatewayLdkChainSourceConfig,
         network: Network,
         lightning_port: u16,
+        alias: String,
         mnemonic: Mnemonic,
         runtime: Arc<tokio::runtime::Runtime>,
     ) -> anyhow::Result<Self> {
-        // In devimint, gateways must allow for other gateways to open channels to them.
-        // To ensure this works, we must set a node alias to signal to ldk-node that we
-        // should accept incoming public channels. However, on mainnet we can disable
-        // this for better privacy.
-        let node_alias = if network == Network::Bitcoin {
-            None
-        } else {
-            let alias = format!("{network} LDK Gateway");
-            let mut bytes = [0u8; 32];
-            bytes[..alias.len()].copy_from_slice(alias.as_bytes());
-            Some(NodeAlias(bytes))
-        };
+        let mut bytes = [0u8; 32];
+        bytes[..alias.len()].copy_from_slice(alias.as_bytes());
+        let node_alias = Some(NodeAlias(bytes));
 
         let mut node_builder = ldk_node::Builder::from_config(ldk_node::config::Config {
             network,

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -17,7 +17,7 @@ use fedimint_core::config::FederationId;
 use fedimint_core::util::backoff_util::aggressive_backoff_long;
 use fedimint_core::util::retry;
 use fedimint_core::{Amount, BitcoinAmountOrAll};
-use fedimint_gateway_common::{GatewayBalances, GatewayFedConfig, GatewayInfo};
+use fedimint_gateway_common::{FederationInfo, GatewayBalances, GatewayFedConfig};
 use fedimint_testing::ln::LightningNodeType;
 use itertools::Itertools;
 use tracing::{debug, info, warn};
@@ -130,6 +130,7 @@ async fn stop_and_recover_gateway(
 
     // Stop the Gateway
     let gw_type = old_gw.ln.ln_type();
+    let gw_name = old_gw.gw_name.clone();
     old_gw.terminate().await?;
     info!("Terminated Gateway");
 
@@ -138,13 +139,13 @@ async fn stop_and_recover_gateway(
         .expect("Data dir is not set")
         .parse()
         .expect("Could not parse data dir");
-    let gw_db = data_dir.join(gw_type.to_string()).join("gatewayd.db");
+    let gw_db = data_dir.join(gw_name.clone()).join("gatewayd.db");
     remove_dir_all(gw_db)?;
     info!("Deleted the Gateway's database");
 
     if gw_type == LightningNodeType::Ldk {
         // Delete LDK's database as well
-        let ldk_data_dir = data_dir.join(gw_type.to_string()).join("ldk_node");
+        let ldk_data_dir = data_dir.join(gw_name).join("ldk_node");
         remove_dir_all(ldk_data_dir)?;
         info!("Deleted LDK's database");
     }
@@ -157,8 +158,10 @@ async fn stop_and_recover_gateway(
     assert_eq!(mnemonic, new_mnemonic);
     info!("Verified mnemonic is the same after creating new Gateway");
 
-    let info = serde_json::from_value::<GatewayInfo>(new_gw.get_info().await?)?;
-    assert_eq!(0, info.federations.len());
+    let federations = serde_json::from_value::<Vec<FederationInfo>>(
+        new_gw.get_info().await?["federations"].clone(),
+    )?;
+    assert_eq!(0, federations.len());
     info!("Verified new Gateway has no federations");
 
     new_gw.recover_fed(fed).await?;
@@ -255,7 +258,9 @@ async fn mnemonic_upgrade_test(
                 .expect("Data dir is not set")
                 .parse()
                 .expect("Could not parse data dir");
-            let gw_fed_db = data_dir.join("lnd").join(format!("{federation_id}.db"));
+            let gw_fed_db = data_dir
+                .join(gw_lnd.gw_name.clone())
+                .join(format!("{federation_id}.db"));
             remove_dir_all(gw_fed_db)?;
 
             gw_lnd.connect_fed(fed).await?;

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -94,10 +94,7 @@ async fn backup_restore_test() -> anyhow::Result<()> {
 
             // Recover without a backup
             info!("Wiping gateway and recovering without a backup...");
-            let ln = gw
-                .ln
-                .clone()
-                .expect("Gateway is not connected to Lightning Node");
+            let ln = gw.ln.clone();
             let new_gw = stop_and_recover_gateway(
                 process_mgr.clone(),
                 mnemonic.clone(),
@@ -132,7 +129,7 @@ async fn stop_and_recover_gateway(
     let before_onchain_balance = gateway_balances.onchain_balance_sats;
 
     // Stop the Gateway
-    let gw_type = old_gw.lightning_node_type();
+    let gw_type = old_gw.ln.ln_type();
     old_gw.terminate().await?;
     info!("Terminated Gateway");
 
@@ -496,7 +493,7 @@ async fn liquidity_test() -> anyhow::Result<()> {
         let gateway_matrix = gateways
             .iter()
             .cartesian_product(gateways.iter())
-            .filter(|(a, b)| a.ln_type() != b.ln_type());
+            .filter(|(a, b)| a.ln.ln_type() != b.ln.ln_type());
 
         info!("Pegging-in gateways...");
 
@@ -508,8 +505,8 @@ async fn liquidity_test() -> anyhow::Result<()> {
         for (gw_send, gw_receive) in gateway_matrix.clone() {
             info!(
                 "Testing ecash payment: {} -> {}",
-                gw_send.ln_type(),
-                gw_receive.ln_type()
+                gw_send.ln.ln_type(),
+                gw_receive.ln.ln_type()
             );
 
             let fed_id = federation.calculate_federation_id();
@@ -528,8 +525,8 @@ async fn liquidity_test() -> anyhow::Result<()> {
         for (gw_send, gw_receive) in gateway_matrix.clone() {
             info!(
                 "Testing lightning payment: {} -> {}",
-                gw_send.ln_type(),
-                gw_receive.ln_type()
+                gw_send.ln.ln_type(),
+                gw_receive.ln.ln_type()
             );
 
             let invoice = gw_receive.create_invoice(1_000_000).await?;

--- a/misc/mprocs.yaml
+++ b/misc/mprocs.yaml
@@ -13,7 +13,7 @@ procs:
   lnd-gw:
     shell: tail -n +0 -F $FM_LOGS_DIR/gatewayd-lnd.log
   ldk-gw:
-    shell: tail -n +0 -F $FM_LOGS_DIR/gatewayd-ldk.log
+    shell: tail -n +0 -F $FM_LOGS_DIR/gatewayd-ldk-0.log
   cln:
     shell: tail -n +0 -F $FM_LOGS_DIR/lightningd.log
   lnd:

--- a/misc/mprocs.yaml
+++ b/misc/mprocs.yaml
@@ -19,7 +19,7 @@ procs:
   lnd:
     shell: tail -n +0 -F $FM_LOGS_DIR/lnd.log
   ldk:
-    shell: tail -n +0 -F $FM_DATA_DIR/ldk/ldk_node/logs/ldk_node_latest.log
+    shell: tail -n +0 -F $FM_DATA_DIR/gatewayd-ldk-0/ldk_node/logs/ldk_node_latest.log
   bitcoind:
     shell: tail -n +0 -F $FM_LOGS_DIR/bitcoind.log
   devimint:

--- a/modules/fedimint-lnv2-tests/bin/tests.rs
+++ b/modules/fedimint-lnv2-tests/bin/tests.rs
@@ -168,8 +168,8 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     for (gw_send, gw_receive) in gateway_matrix {
         info!(
             "Testing refund of payment: client -> {} -> {} -> client",
-            gw_send.ln.as_ref().unwrap().name(),
-            gw_receive.ln.as_ref().unwrap().name()
+            gw_send.ln.ln_type(),
+            gw_receive.ln.ln_type()
         );
 
         let invoice = receive(&client, &gw_receive.addr, 1_000_000).await?.0;
@@ -194,8 +194,8 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     for (gw_send, gw_receive) in gateway_matrix {
         info!(
             "Testing payment: client -> {} -> {} -> client",
-            gw_send.ln_type(),
-            gw_receive.ln_type()
+            gw_send.ln.ln_type(),
+            gw_receive.ln.ln_type()
         );
 
         let (invoice, receive_op) = receive(&client, &gw_receive.addr, 1_000_000).await?;
@@ -216,8 +216,8 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     for (gw_send, gw_receive) in gateway_pairs {
         info!(
             "Testing payment: client -> {} -> {}",
-            gw_send.ln_type(),
-            gw_receive.ln_type()
+            gw_send.ln.ln_type(),
+            gw_receive.ln.ln_type()
         );
 
         let invoice = gw_receive.create_invoice(1_000_000).await?;
@@ -236,8 +236,8 @@ async fn test_payments(dev_fed: &DevJitFed) -> anyhow::Result<()> {
     for (gw_send, gw_receive) in gateway_pairs {
         info!(
             "Testing payment: {} -> {} -> client",
-            gw_send.ln_type(),
-            gw_receive.ln_type()
+            gw_send.ln.ln_type(),
+            gw_receive.ln.ln_type()
         );
 
         let (invoice, receive_op) = receive(&client, &gw_receive.addr, 1_000_000).await?;


### PR DESCRIPTION
In devimint, we currently make an assumption that there is only 1 LDK Gateway. When we add a second one, we will need the paths that are used for the data directory to be unique and the logs directory to be unique. This PR makes some devimint cleanups to allow us to customize the name.

Additionally, the LDK Gateway has a bug where it does not set the node's alias on mainnet. This prevents other nodes from opening channels to it. https://docs.rs/ldk-node/0.4.3/ldk_node/config/struct.Config.html#structfield.node_alias. This is a bug, we want other nodes to be able to open channels to it.