### PR TITLE
refactor: remove core lightning from external daemons and faucet

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::{env, ffi};
 
 use anyhow::{Context, Result, anyhow, ensure};
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use fedimint_core::task::TaskGroup;
 use fedimint_core::util::{FmtCompactAnyhow as _, write_overwrite_async};
 use fedimint_logging::LOG_DEVIMINT;
@@ -18,9 +18,8 @@ use tracing::{debug, error, info, trace, warn};
 
 use crate::devfed::DevJitFed;
 use crate::envs::{
-    FM_BITCOIN_RPC_URL_ENV, FM_CLN_SOCKET_ENV, FM_DEVIMINT_STATIC_DATA_DIR_ENV,
-    FM_FAUCET_BIND_ADDR_ENV, FM_FED_SIZE_ENV, FM_INVITE_CODE_ENV, FM_LINK_TEST_DIR_ENV,
-    FM_NUM_FEDS_ENV, FM_OFFLINE_NODES_ENV, FM_PORT_GW_LND_ENV, FM_TEST_DIR_ENV,
+    FM_DEVIMINT_STATIC_DATA_DIR_ENV, FM_FED_SIZE_ENV, FM_INVITE_CODE_ENV, FM_LINK_TEST_DIR_ENV,
+    FM_NUM_FEDS_ENV, FM_OFFLINE_NODES_ENV, FM_TEST_DIR_ENV,
 };
 use crate::federation::Fedimintd;
 use crate::util::{ProcessManager, poll};
@@ -115,20 +114,6 @@ pub enum Cmd {
     /// for devimint as a cli
     #[clap(flatten)]
     Rpc(RpcCmd),
-}
-
-#[derive(Args, Debug, Clone)]
-pub struct FaucetOpts {
-    #[clap(long, env = FM_FAUCET_BIND_ADDR_ENV)]
-    pub bind_addr: String,
-    #[clap(long, env = FM_BITCOIN_RPC_URL_ENV)]
-    pub bitcoind_rpc: String,
-    #[clap(long, env = FM_CLN_SOCKET_ENV)]
-    pub cln_socket: String,
-    #[clap(long, env = FM_PORT_GW_LND_ENV)]
-    pub gw_lnd_port: u16,
-    #[clap(long, env = FM_INVITE_CODE_ENV)]
-    pub invite_code: Option<String>,
 }
 
 #[derive(Subcommand)]

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -115,9 +115,6 @@ pub enum Cmd {
     /// for devimint as a cli
     #[clap(flatten)]
     Rpc(RpcCmd),
-
-    /// Start built-in faucet (in the past called `devimint-faucet`)
-    Faucet(FaucetOpts),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -393,11 +390,6 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
 
                 Ok::<_, anyhow::Error>(daemons)
             };
-            Box::pin(cleanup_on_exit(main, task_group)).await?;
-        }
-        Cmd::Faucet(opts) => {
-            let (process_mgr, task_group) = setup(common_args).await?;
-            let main = async { crate::faucet::run(&process_mgr, opts).await };
             Box::pin(cleanup_on_exit(main, task_group)).await?;
         }
     }

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -395,7 +395,11 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
             };
             Box::pin(cleanup_on_exit(main, task_group)).await?;
         }
-        Cmd::Faucet(opts) => crate::faucet::run(opts).await?,
+        Cmd::Faucet(opts) => {
+            let (process_mgr, task_group) = setup(common_args).await?;
+            let main = async { crate::faucet::run(&process_mgr, opts).await };
+            Box::pin(cleanup_on_exit(main, task_group)).await?;
+        }
     }
     Ok(())
 }

--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -1,17 +1,3 @@
-// faucet.rs
-
-// Env variable to TODO
-pub const FM_FAUCET_BIND_ADDR_ENV: &str = "FM_FAUCET_BIND_ADDR";
-
-// Env variable to TODO
-pub const FM_BITCOIN_RPC_URL_ENV: &str = "FM_BITCOIN_RPC_URL";
-
-// Env variable to TODO
-pub const FM_CLN_SOCKET_ENV: &str = "FM_CLN_SOCKET";
-
-// Env variable to TODO
-pub const FM_PORT_GW_LND_ENV: &str = "FM_PORT_GW_LND";
-
 // tests.rs
 
 // Env variable to TODO

--- a/devimint/src/faucet.rs
+++ b/devimint/src/faucet.rs
@@ -1,95 +1,49 @@
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::Context;
 use axum::Router;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::routing::{get, post};
-use cln_rpc::ClnRpc;
-use cln_rpc::primitives::{Amount as ClnAmount, AmountOrAny};
 use fedimint_core::fedimint_build_code_version_env;
 use fedimint_core::util::handle_version_hash_command;
 use fedimint_gateway_common::V1_API_ENDPOINT;
+use fedimint_ln_server::common::lightning_invoice::Bolt11Invoice;
 use fedimint_logging::TracingSetup;
 use tokio::net::TcpListener;
-use tokio::sync::Mutex;
 use tower_http::cors::CorsLayer;
 
 use crate::cli::FaucetOpts;
 use crate::envs::FM_CLIENT_DIR_ENV;
+use crate::util::ProcessManager;
+use crate::{Gatewayd, LightningNode};
 
 #[derive(Clone)]
 pub struct Faucet {
     #[allow(unused)]
     bitcoin: Arc<bitcoincore_rpc::Client>,
-    ln_rpc: Arc<Mutex<ClnRpc>>,
+    gw_ldk: Gatewayd,
 }
 
 impl Faucet {
-    pub async fn new(opts: &FaucetOpts) -> anyhow::Result<Self> {
+    pub async fn new(process_manager: &ProcessManager, opts: &FaucetOpts) -> anyhow::Result<Self> {
         let url = opts.bitcoind_rpc.parse()?;
         let (host, auth) = fedimint_bitcoind::bitcoincore::from_url_to_url_auth(&url)?;
         let bitcoin = Arc::new(bitcoincore_rpc::Client::new(&host, auth)?);
-        let ln_rpc = Arc::new(Mutex::new(
-            ClnRpc::new(&opts.cln_socket)
-                .await
-                .with_context(|| format!("couldn't open CLN socket {}", &opts.cln_socket))?,
-        ));
-        Ok(Faucet { bitcoin, ln_rpc })
+        let gw_ldk = Gatewayd::new(process_manager, LightningNode::Ldk).await?;
+        Ok(Faucet { bitcoin, gw_ldk })
     }
 
     async fn pay_invoice(&self, invoice: String) -> anyhow::Result<()> {
-        let invoice_status = self
-            .ln_rpc
-            .lock()
-            .await
-            .call_typed(&cln_rpc::model::requests::PayRequest {
-                bolt11: invoice,
-                amount_msat: None,
-                label: None,
-                riskfactor: None,
-                maxfeepercent: None,
-                retry_for: None,
-                maxdelay: None,
-                exemptfee: None,
-                localinvreqid: None,
-                exclude: None,
-                maxfee: None,
-                description: None,
-                partial_msat: None,
-            })
-            .await?
-            .status;
-
-        anyhow::ensure!(
-            matches!(
-                invoice_status,
-                cln_rpc::model::responses::PayStatus::COMPLETE
-            ),
-            "payment not complete"
-        );
+        self.gw_ldk
+            .pay_invoice(Bolt11Invoice::from_str(&invoice).expect("Could not parse invoice"))
+            .await?;
         Ok(())
     }
 
     async fn generate_invoice(&self, amount: u64) -> anyhow::Result<String> {
-        Ok(self
-            .ln_rpc
-            .lock()
-            .await
-            .call_typed(&cln_rpc::model::requests::InvoiceRequest {
-                amount_msat: AmountOrAny::Amount(ClnAmount::from_sat(amount)),
-                description: "lnd-gw-to-cln".to_string(),
-                label: format!("faucet-{}", rand::random::<u64>()),
-                expiry: None,
-                fallbacks: None,
-                preimage: None,
-                cltv: None,
-                deschashonly: None,
-                exposeprivatechannels: None,
-            })
-            .await?
-            .bolt11)
+        Ok(self.gw_ldk.create_invoice(amount).await?.to_string())
     }
 }
 
@@ -104,12 +58,12 @@ fn get_invite_code(invite_code: Option<String>) -> anyhow::Result<String> {
     }
 }
 
-pub async fn run(opts: FaucetOpts) -> anyhow::Result<()> {
+pub async fn run(process_mgr: &ProcessManager, opts: FaucetOpts) -> anyhow::Result<()> {
     TracingSetup::default().init()?;
 
     handle_version_hash_command(fedimint_build_code_version_env!());
 
-    let faucet = Faucet::new(&opts).await?;
+    let faucet = Faucet::new(process_mgr, &opts).await?;
     let router = Router::new()
         .route(
             "/connect-string",

--- a/devimint/src/faucet.rs
+++ b/devimint/src/faucet.rs
@@ -1,38 +1,28 @@
-use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use axum::Router;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::routing::{get, post};
-use fedimint_core::fedimint_build_code_version_env;
-use fedimint_core::util::handle_version_hash_command;
 use fedimint_gateway_common::V1_API_ENDPOINT;
 use fedimint_ln_server::common::lightning_invoice::Bolt11Invoice;
-use fedimint_logging::TracingSetup;
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 
-use crate::cli::FaucetOpts;
-use crate::envs::FM_CLIENT_DIR_ENV;
-use crate::util::ProcessManager;
-use crate::{Gatewayd, LightningNode};
+use crate::federation::Federation;
+use crate::{DevFed, Gatewayd};
 
 #[derive(Clone)]
 pub struct Faucet {
-    #[allow(unused)]
-    bitcoin: Arc<bitcoincore_rpc::Client>,
     gw_ldk: Gatewayd,
+    fed: Federation,
 }
 
 impl Faucet {
-    pub async fn new(process_manager: &ProcessManager, opts: &FaucetOpts) -> anyhow::Result<Self> {
-        let url = opts.bitcoind_rpc.parse()?;
-        let (host, auth) = fedimint_bitcoind::bitcoincore::from_url_to_url_auth(&url)?;
-        let bitcoin = Arc::new(bitcoincore_rpc::Client::new(&host, auth)?);
-        let gw_ldk = Gatewayd::new(process_manager, LightningNode::Ldk).await?;
-        Ok(Faucet { bitcoin, gw_ldk })
+    pub fn new(dev_fed: &DevFed) -> Self {
+        let gw_ldk = dev_fed.gw_ldk.clone();
+        let fed = dev_fed.fed.clone();
+        Faucet { gw_ldk, fed }
     }
 
     async fn pay_invoice(&self, invoice: String) -> anyhow::Result<()> {
@@ -45,30 +35,24 @@ impl Faucet {
     async fn generate_invoice(&self, amount: u64) -> anyhow::Result<String> {
         Ok(self.gw_ldk.create_invoice(amount).await?.to_string())
     }
-}
 
-fn get_invite_code(invite_code: Option<String>) -> anyhow::Result<String> {
-    if let Some(s) = invite_code {
-        Ok(s)
-    } else {
-        let data_dir = std::env::var(FM_CLIENT_DIR_ENV)?;
-        Ok(std::fs::read_to_string(
-            PathBuf::from(data_dir).join("invite-code"),
-        )?)
+    fn get_invite_code(&self) -> anyhow::Result<String> {
+        self.fed.invite_code()
     }
 }
 
-pub async fn run(process_mgr: &ProcessManager, opts: FaucetOpts) -> anyhow::Result<()> {
-    TracingSetup::default().init()?;
-
-    handle_version_hash_command(fedimint_build_code_version_env!());
-
-    let faucet = Faucet::new(process_mgr, &opts).await?;
+pub async fn run(
+    dev_fed: &DevFed,
+    fauct_bind_addr: String,
+    gw_lnd_port: u16,
+) -> anyhow::Result<()> {
+    let faucet = Faucet::new(dev_fed);
     let router = Router::new()
         .route(
             "/connect-string",
-            get(|| async {
-                get_invite_code(opts.invite_code)
+            get(|State(faucet): State<Faucet>| async move {
+                faucet
+                    .get_invite_code()
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{e:?}")))
             }),
         )
@@ -95,14 +79,12 @@ pub async fn run(process_mgr: &ProcessManager, opts: FaucetOpts) -> anyhow::Resu
         )
         .route(
             "/gateway-api",
-            get(move || async move {
-                format!("http://127.0.0.1:{}/{V1_API_ENDPOINT}", opts.gw_lnd_port)
-            }),
+            get(move || async move { format!("http://127.0.0.1:{gw_lnd_port}/{V1_API_ENDPOINT}") }),
         )
         .layer(CorsLayer::permissive())
         .with_state(faucet);
 
-    let listener = TcpListener::bind(&opts.bind_addr).await?;
+    let listener = TcpListener::bind(fauct_bind_addr).await?;
     axum::serve(listener, router.into_make_service()).await?;
     Ok(())
 }

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -1906,7 +1906,7 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                             error!("Error spawning faucet: {err}");
                         }
                     });
-                    try_join!(fed.pegin_gateways(20_000, vec![&gw_lnd]), async {
+                    try_join!(fed.pegin_gateways(30_000, vec![&gw_lnd]), async {
                         poll("waiting for faucet startup", || async {
                             TcpStream::connect(format!(
                                 "127.0.0.1:{}",
@@ -1919,7 +1919,6 @@ pub async fn handle_command(cmd: TestCmd, common_args: CommonArgs) -> Result<()>
                         .await?;
                         Ok(())
                     },)?;
-                    //let daemons = write_ready_file(&process_mgr.globals, Ok(dev_fed)).await?;
                     if let Some(exec) = exec {
                         exec_user_command(exec).await?;
                         task_group.shutdown();


### PR DESCRIPTION
Prepping for Core Lightning to be removed from the codebase. The external daemons and devimint faucet still depend on it. This PR removes that dependency.