### PR TITLE
replace bs58 base 58 encoding with our own base 32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,15 +1114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2225b558afc76c596898f5f1b3fc35cfce0eb1b13635cbd7d1b2a7177dc10ccd"
 
 [[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,7 +3645,6 @@ dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
  "bls12_381",
- "bs58",
  "bytes",
  "fedimint-aead",
  "fedimint-aleph-bft",

--- a/fedimint-core/src/base32.rs
+++ b/fedimint-core/src/base32.rs
@@ -1,0 +1,75 @@
+use std::collections::BTreeMap;
+
+use anyhow::Context;
+
+/// Lowercase RFC 4648 Base32hex alphabet (32 characters).
+const RFC4648: [u8; 32] = *b"0123456789abcdefghijklmnopqrstuv";
+
+/// Encodes the input bytes as Base32 (hex variant) using lowercase characters
+pub fn encode(input: &[u8]) -> String {
+    let mut output = Vec::with_capacity(((8 * input.len()) / 5) + 1);
+
+    let mut buffer = 0;
+    let mut bits = 0;
+
+    for byte in input {
+        buffer |= (*byte as usize) << bits;
+        bits += 8;
+
+        while bits >= 5 {
+            output.push(RFC4648[buffer & 0b11111]);
+
+            buffer >>= 5;
+            bits -= 5;
+        }
+    }
+
+    if bits > 0 {
+        output.push(RFC4648[buffer & 0b11111]);
+    }
+
+    String::from_utf8(output).unwrap()
+}
+
+/// Decodes a base 32 string back to raw bytes. Returns an error
+/// if any invalid character is encountered.
+pub fn decode(input: &str) -> anyhow::Result<Vec<u8>> {
+    let decode_table = RFC4648
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (*c, i))
+        .collect::<BTreeMap<u8, usize>>();
+
+    let mut output = Vec::with_capacity(((5 * input.len()) / 8) + 1);
+
+    let mut buffer = 0;
+    let mut bits = 0;
+
+    for byte in input.as_bytes() {
+        let value = decode_table
+            .get(byte)
+            .copied()
+            .context("Invalid character encountered")?;
+
+        buffer |= value << bits;
+        bits += 5;
+
+        while bits >= 8 {
+            output.push((buffer & 0xFF) as u8);
+
+            buffer >>= 8;
+            bits -= 8;
+        }
+    }
+
+    Ok(output)
+}
+
+#[test]
+fn test_base_32_roundtrip() {
+    let data: [u8; 10] = [0x50, 0xAB, 0x3F, 0x77, 0x01, 0xCD, 0x55, 0xFE, 0x10, 0x99];
+
+    for n in 1..10 {
+        assert_eq!(decode(&encode(&data[0..n])).unwrap(), data[0..n]);
+    }
+}

--- a/fedimint-core/src/lib.rs
+++ b/fedimint-core/src/lib.rs
@@ -88,6 +88,8 @@ pub mod invite_code;
 /// Common macros
 #[macro_use]
 pub mod macros;
+/// Base 32 encoding
+pub mod base32;
 /// Extendable module sysystem
 pub mod module;
 /// Peer networking

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -25,7 +25,6 @@ bincode = { workspace = true }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 bls12_381 = { workspace = true }
-bs58 = "0.5.1"
 bytes = { workspace = true }
 fedimint-aead = { workspace = true }
 fedimint-api-client = { workspace = true }

--- a/fedimint-server/src/config/api.rs
+++ b/fedimint-server/src/config/api.rs
@@ -327,7 +327,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConfigGenApi>> {
                     .await
                     .map_err(|e| ApiError::bad_request(e.to_string()))?;
 
-                Ok(info.encode_base58())
+                Ok(info.encode_base32())
             }
         },
         api_endpoint! {
@@ -336,7 +336,7 @@ pub fn server_endpoints() -> Vec<ApiEndpoint<ConfigGenApi>> {
             async |config: &ConfigGenApi, context, info: String| -> String {
                 check_auth(context)?;
 
-                let info = PeerConnectionInfo::decode_base58(&info)
+                let info = PeerConnectionInfo::decode_base32(&info)
                     .map_err(|e|ApiError::bad_request(e.to_string()))?;
 
                 config.add_peer_connection_info(info.clone()).await

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -23,7 +23,7 @@ use fedimint_core::module::{
 use fedimint_core::net::peers::{DynP2PConnections, Recipient};
 use fedimint_core::task::sleep;
 use fedimint_core::util::SafeUrl;
-use fedimint_core::{NumPeersExt, PeerId, secp256k1, timing};
+use fedimint_core::{NumPeersExt, PeerId, base32, secp256k1, timing};
 use fedimint_logging::LOG_NET_PEER_DKG;
 use fedimint_server_core::{DynServerModuleInit, ServerModuleInitRegistry};
 use hex::{FromHex, ToHex};
@@ -254,18 +254,18 @@ pub struct PeerConnectionInfo {
 }
 
 impl PeerConnectionInfo {
-    pub fn encode_base58(&self) -> String {
+    pub fn encode_base32(&self) -> String {
         format!(
             "fedimint{}",
-            bs58::encode(&self.consensus_encode_to_vec()).into_string()
+            base32::encode(&self.consensus_encode_to_vec())
         )
     }
 
-    pub fn decode_base58(s: &str) -> anyhow::Result<Self> {
+    pub fn decode_base32(s: &str) -> anyhow::Result<Self> {
         ensure!(s.starts_with("fedimint"), "Invalid Prefix");
 
         let params = Self::consensus_decode_whole(
-            &bs58::decode(&s[8..]).into_vec()?,
+            &base32::decode(&s[8..])?,
             &ModuleDecoderRegistry::default(),
         )?;
 


### PR DESCRIPTION
Right now we use different encodings (bech32, base64 and base58) for the invite code, ecash and connection strings. In order to reduce dependencies I propose to move to our own base32 lower hex encoding as the once and for all standard for oob byte encodings to strike a balance between compactness, implementation complexity and aesthetics.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
