### PR TITLE
chore: remove suffix from iroh urls

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1220,11 +1220,7 @@ mod iroh {
             let node_ids = peers
                 .into_iter()
                 .map(|(peer, url)| {
-                    let host = url
-                        .host_str()
-                        .context("Url is missing host")?
-                        .strip_suffix(".ed25519")
-                        .context("Host does not have the ed25519 suffix")?;
+                    let host = url.host_str().context("Url is missing host")?;
 
                     let node_id = PublicKey::from_str(host).context("Failed to parse node id")?;
 

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -313,7 +313,7 @@ impl ServerConfigConsensus {
                 .map(|(peer, endpoints)| {
                     let url = PeerUrl {
                         name: endpoints.name.clone(),
-                        url: SafeUrl::parse(&format!("iroh://{}.ed25519", endpoints.api_pk))
+                        url: SafeUrl::parse(&format!("iroh://{}", endpoints.api_pk))
                             .expect("Failed to parse iroh url"),
                     };
 


### PR DESCRIPTION
Works here (`env FM_DEVIMINT_CMD_INHERIT_STDERR=1 FM_FORCE_IROH=true RUST_LOG=fm::net::iroh=trace,fm=debug,off j devimint-env` works)

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
