### PR TITLE
test: dump gatewayd logs

### DIFF
--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -992,7 +992,9 @@ pub async fn open_channels_between_gateways(
                 .await;
 
                 if res.is_err() {
-                    error!(target: LOG_DEVIMINT, from=%gw_a_name, to=%gw_b_name, "Failed to open channel");
+                    error!(target: LOG_DEVIMINT, from=%gw_a_name, to=%gw_b_name, ?res, "Failed to open channel");
+                    gw_a.dump_logs()?;
+                    gw_b.dump_logs()?;
                 }
 
                 res


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/6908

Having some trouble debugging the flaky channel opens in devimint. Figured it would be a good time to dump the gateway's logs when channel openings fail or when `info` times out.