### PR TITLE
fix(client): event log prefixes switched

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::time::SystemTime;
 
 use anyhow::{anyhow, bail};
+use bitcoin::hex::DisplayHex as _;
 use fedimint_api_client::api::ApiVersionSet;
 use fedimint_client_module::db::ClientMigrationFn;
 use fedimint_client_module::module::recovery::RecoveryProgress;
@@ -18,6 +19,9 @@ use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::SupportedApiVersionsSummary;
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::{PeerId, impl_db_lookup, impl_db_record};
+use fedimint_eventlog::{
+    DB_KEY_PREFIX_EVENT_LOG, DB_KEY_PREFIX_UNORDERED_EVENT_LOG, EventLogId, UnordedEventLogId,
+};
 use fedimint_logging::LOG_CLIENT_DB;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -508,6 +512,95 @@ pub fn get_core_client_database_migrations() -> BTreeMap<DatabaseVersion, CoreMi
         })
     });
 
+    // Fix #6948
+    migrations.insert(DatabaseVersion(2), |mut ctx| {
+        Box::pin(async move {
+            let mut dbtx = ctx.dbtx();
+
+            // Migrate unordered keys that got written to ordered table
+            {
+                let mut ordered_log_entries = dbtx
+                    .raw_find_by_prefix(&[DB_KEY_PREFIX_EVENT_LOG])
+                    .await
+                    .expect("DB operation failed");
+                let mut keys_to_migrate = vec![];
+                while let Some((k, _v)) = ordered_log_entries.next().await {
+                    trace!(target: LOG_CLIENT_DB,
+                        k=%k.as_hex(),
+                        "Checking ordered log key"
+                    );
+                    if EventLogId::consensus_decode_whole(&k[1..], &Default::default()).is_err() {
+                        assert!(
+                            UnordedEventLogId::consensus_decode_whole(&k[1..], &Default::default())
+                                .is_ok()
+                        );
+                        keys_to_migrate.push(k);
+                    }
+                }
+                drop(ordered_log_entries);
+                for mut key_to_migrate in keys_to_migrate {
+                    warn!(target: LOG_CLIENT_DB,
+                        k=%key_to_migrate.as_hex(),
+                        "Migrating unordered event log entry written to an ordered log"
+                    );
+                    let v = dbtx
+                        .raw_remove_entry(&key_to_migrate)
+                        .await
+                        .expect("DB operation failed")
+                        .expect("Was there a moment ago");
+                    assert_eq!(key_to_migrate[0], 0x39);
+                    key_to_migrate[0] = DB_KEY_PREFIX_UNORDERED_EVENT_LOG;
+                    assert_eq!(key_to_migrate[0], 0x3a);
+                    dbtx.raw_insert_bytes(&key_to_migrate, &v)
+                        .await
+                        .expect("DB operation failed");
+                }
+            }
+
+            // Migrate ordered keys that got written to unordered table
+            {
+                let mut unordered_log_entries = dbtx
+                    .raw_find_by_prefix(&[DB_KEY_PREFIX_UNORDERED_EVENT_LOG])
+                    .await
+                    .expect("DB operation failed");
+                let mut keys_to_migrate = vec![];
+                while let Some((k, _v)) = unordered_log_entries.next().await {
+                    trace!(target: LOG_CLIENT_DB,
+                        k=%k.as_hex(),
+                        "Checking ordered log key"
+                    );
+                    if UnordedEventLogId::consensus_decode_whole(&k[1..], &Default::default())
+                        .is_err()
+                    {
+                        assert!(
+                            EventLogId::consensus_decode_whole(&k[1..], &Default::default())
+                                .is_ok()
+                        );
+                        keys_to_migrate.push(k);
+                    }
+                }
+                drop(unordered_log_entries);
+                for mut key_to_migrate in keys_to_migrate {
+                    warn!(target: LOG_CLIENT_DB,
+                        k=%key_to_migrate.as_hex(),
+                        "Migrating ordered event log entry written to an unordered log"
+                    );
+                    let v = dbtx
+                        .raw_remove_entry(&key_to_migrate)
+                        .await
+                        .expect("DB operation failed")
+                        .expect("Was there a moment ago");
+                    assert_eq!(key_to_migrate[0], 0x3a);
+                    key_to_migrate[0] = DB_KEY_PREFIX_EVENT_LOG;
+                    assert_eq!(key_to_migrate[0], 0x39);
+                    dbtx.raw_insert_bytes(&key_to_migrate, &v)
+                        .await
+                        .expect("DB operation failed");
+                }
+            }
+            Ok(())
+        })
+    });
     migrations
 }
 

--- a/fedimint-eventlog/src/lib.rs
+++ b/fedimint-eventlog/src/lib.rs
@@ -38,8 +38,8 @@ use tracing::{debug, trace};
 /// so we use these constants to keep them in sync. Any other app that will
 /// want to store its own even log, will need to use the exact same prefixes,
 /// which in practice should not be a problem.
-pub const DB_KEY_PREFIX_UNORDERED_EVENT_LOG: u8 = 0x39;
-pub const DB_KEY_PREFIX_EVENT_LOG: u8 = 0x3a;
+pub const DB_KEY_PREFIX_UNORDERED_EVENT_LOG: u8 = 0x3a;
+pub const DB_KEY_PREFIX_EVENT_LOG: u8 = 0x39;
 
 pub trait Event: serde::Serialize + serde::de::DeserializeOwned {
     const MODULE: Option<ModuleKind>;


### PR DESCRIPTION
Fix https://github.com/fedimint/fedimint/issues/6948


How I tested it:

* Checkout 0.6.0 or just existing `master`, which has the prefixes switched.
* Start `just devimint-env`
* Run `fm-cli backup` or whatever, just to generate some more events.
* Verify events exist in `fedimint-dbtool --database-dir $FM_CLIENT_DIR/client.db list --prefix "39"` and `fedimint-dbtool --database-dir $FM_CLIENT_DIR/client.db list --prefix "3a"`. Pending events will be empty, as they get processed almost immediately :shrug: .
* Keep `devimint-env` working, checkout this branch.
* `cargo build` to build fixed client
* Run `env RUST_LOG=fm=debug,fm::client::db=trace fm-cli backup`. This will trigger db migration. All keys get migrated, since they were all in the wrong place. Everything still works.

Our upgrade tests will verify that the upgrade path from 0.5.0 (no bug) to this branch (bug fixed) works as well.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
