### PR TITLE
refactor: use LDK in load tool test instead of CLN

### DIFF
--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -82,9 +82,6 @@ pub const FM_LOAD_TEST_TOOL_BASE_EXECUTABLE_ENV: &str = "FM_LOAD_TEST_TOOL_BASE_
 // Env variable to override lightning-cli binary set:
 pub const FM_LIGHTNING_CLI_BASE_EXECUTABLE_ENV: &str = "FM_LIGHTNING_CLI_BASE_EXECUTABLE";
 
-// Env variable to override lightning-cli default command set:
-pub const FM_LIGHTNING_CLI_ENV: &str = "FM_LIGHTNING_CLI";
-
 // Env variable to override lncli binary set:
 pub const FM_LNCLI_BASE_EXECUTABLE_ENV: &str = "FM_LNCLI_BASE_EXECUTABLE";
 
@@ -127,8 +124,11 @@ pub const FM_LOGS_DIR_ENV: &str = "FM_LOGS_DIR";
 // Env variable to TODO
 pub const FM_BACKWARDS_COMPATIBILITY_TEST_ENV: &str = "FM_BACKWARDS_COMPATIBILITY_TEST";
 
-// Env variable to define command for the LND client
+// Env variable to define command for the Gateway LND client
 pub const FM_GWCLI_LND_ENV: &str = "FM_GWCLI_LND";
+
+// Env variable to define command for the Gateway LDK client
+pub const FM_GWCLI_LDK_ENV: &str = "FM_GWCLI_LDK";
 
 /// Make `devimint` print stderr of called commands directly on its own stderr
 pub const FM_DEVIMINT_CMD_INHERIT_STDERR_ENV: &str = "FM_DEVIMINT_CMD_INHERIT_STDERR";

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -960,6 +960,10 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
 pub async fn cli_load_test_tool_test(dev_fed: DevFed) -> Result<()> {
     log_binary_versions().await?;
+    if crate::util::Gatewayd::version_or_default().await < *VERSION_0_5_0_ALPHA {
+        info!("Skipping load test because gatewayd is lower than v0.5.0");
+        return Ok(());
+    }
     let data_dir = env::var(FM_DATA_DIR_ENV)?;
     let load_test_temp = PathBuf::from(data_dir).join("load-test-temp");
     dev_fed

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -990,7 +990,7 @@ pub async fn run_standard_load_test(
         "--notes-per-user",
         "1",
         "--generate-invoice-with",
-        "cln-lightning-cli",
+        "ldk-lightning-cli",
         "--invite-code",
         invite_code
     )

--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -35,10 +35,11 @@ use crate::envs::{
     FM_ELECTRS_BASE_EXECUTABLE_ENV, FM_ESPLORA_BASE_EXECUTABLE_ENV,
     FM_FEDIMINT_CLI_BASE_EXECUTABLE_ENV, FM_FEDIMINT_DBTOOL_BASE_EXECUTABLE_ENV,
     FM_FEDIMINTD_BASE_EXECUTABLE_ENV, FM_GATEWAY_CLI_BASE_EXECUTABLE_ENV,
-    FM_GATEWAYD_BASE_EXECUTABLE_ENV, FM_GWCLI_LND_ENV, FM_LIGHTNING_CLI_BASE_EXECUTABLE_ENV,
-    FM_LIGHTNING_CLI_ENV, FM_LIGHTNINGD_BASE_EXECUTABLE_ENV, FM_LNCLI_BASE_EXECUTABLE_ENV,
-    FM_LNCLI_ENV, FM_LND_BASE_EXECUTABLE_ENV, FM_LOAD_TEST_TOOL_BASE_EXECUTABLE_ENV,
-    FM_LOGS_DIR_ENV, FM_MINT_CLIENT_ENV, FM_RECOVERYTOOL_BASE_EXECUTABLE_ENV,
+    FM_GATEWAYD_BASE_EXECUTABLE_ENV, FM_GWCLI_LDK_ENV, FM_GWCLI_LND_ENV,
+    FM_LIGHTNING_CLI_BASE_EXECUTABLE_ENV, FM_LIGHTNINGD_BASE_EXECUTABLE_ENV,
+    FM_LNCLI_BASE_EXECUTABLE_ENV, FM_LNCLI_ENV, FM_LND_BASE_EXECUTABLE_ENV,
+    FM_LOAD_TEST_TOOL_BASE_EXECUTABLE_ENV, FM_LOGS_DIR_ENV, FM_MINT_CLIENT_ENV,
+    FM_RECOVERYTOOL_BASE_EXECUTABLE_ENV,
 };
 
 // If a binary doesn't provide a clap version, default to the first stable
@@ -1018,25 +1019,22 @@ impl GatewayLndCli {
     }
 }
 
+pub struct GatewayLdkCli;
+impl GatewayLdkCli {
+    pub fn cmd(self) -> Command {
+        to_command(get_command_str_for_alias(
+            &[FM_GWCLI_LDK_ENV],
+            &["gateway-ldk"],
+        ))
+    }
+}
+
 pub struct LnCli;
 impl LnCli {
     pub fn cmd(self) -> Command {
         to_command(get_command_str_for_alias(
             &[FM_LNCLI_ENV],
             &get_lncli_path()
-                .iter()
-                .map(String::as_str)
-                .collect::<Vec<_>>(),
-        ))
-    }
-}
-
-pub struct ClnLightningCli;
-impl ClnLightningCli {
-    pub fn cmd(self) -> Command {
-        to_command(get_command_str_for_alias(
-            &[FM_LIGHTNING_CLI_ENV],
-            &get_lightning_cli_path()
                 .iter()
                 .map(String::as_str)
                 .collect::<Vec<_>>(),

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use anyhow::{Context, Result, anyhow, bail};
 use devimint::cmd;
 use devimint::util::{FedimintCli, GatewayLdkCli, LnCli};
+use devimint::version_constants::VERSION_0_7_0_ALPHA;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_client::transaction::TransactionBuilder;
 use fedimint_client::{Client, ClientHandleArc};
@@ -313,6 +314,11 @@ pub async fn ldk_pay_invoice(invoice: Bolt11Invoice) -> anyhow::Result<()> {
 }
 
 pub async fn ldk_wait_invoice_payment(invoice: &Bolt11Invoice) -> anyhow::Result<()> {
+    let gatewayd_version = devimint::util::Gatewayd::version_or_default().await;
+    if gatewayd_version < *VERSION_0_7_0_ALPHA {
+        return Ok(());
+    }
+
     let status = cmd!(
         GatewayLdkCli,
         "lightning",


### PR DESCRIPTION
One step closer to removing CLN.

Coverage remains the same, just using LDK as the Lightning node for LNv1 instead of CLN.