### PR TITLE
[Backport releases/v0.6] fix: update log message for unordered log key

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -584,7 +584,7 @@ pub fn get_core_client_database_migrations() -> BTreeMap<DatabaseVersion, CoreMi
                 while let Some((k, _v)) = unordered_log_entries.next().await {
                     trace!(target: LOG_CLIENT_DB,
                         k=%k.as_hex(),
-                        "Checking ordered log key"
+                        "Checking unordered log key"
                     );
                     if UnordedEventLogId::consensus_decode_whole(
                         &k[1..],


### PR DESCRIPTION
# Description
Backport of #6957 to `releases/v0.6`.