### PR TITLE
fix(api-client): don't panic on wrong peer_id

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1076,7 +1076,7 @@ impl ReconnectClientConnections {
         let res = self
             .connections
             .get(&peer)
-            .unwrap_or_else(|| panic!("Could not find client connection for peer {peer}"))
+            .ok_or_else(|| PeerError::InvalidPeerId { peer_id: peer })?
             .connection()
             .await
             .context("Failed to connect to peer")


### PR DESCRIPTION
It actually crashed the client on the api version discovery thread when `fedimint-cli --our-id` was used.

Since we don't have e2e testing of every single scenario everywhere, we should take it easy with panics, IMO.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
