### PR TITLE
chore(ci): fix timeouts on tests

### DIFF
--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -45,10 +45,9 @@ trap on_error ERR
 trap on_exit EXIT
 
 FM_RUN_TEST_TIMEOUT_SOFT=${FM_RUN_TEST_TIMEOUT:-310}
-FM_RUN_TEST_TIMEOUT_HARD=$((FM_RUN_TEST_TIMEOUT_SOFT + 10))
 
 command time -q --format="$time_fmt" -o "$time_out_path" \
-    timeout -k "$FM_RUN_TEST_TIMEOUT_SOFT" "$FM_RUN_TEST_TIMEOUT_HARD" \
+    timeout -k 10 "$FM_RUN_TEST_TIMEOUT_SOFT" \
     "$@" 2>&1 | ts -i "%.S" | ts -s "%M:%S" > "$test_out_path"
 
 awk 'BEGIN {FS="\t"} {printf "## STAT: %8.2fs %8dB %8dW %8dc\n", $1, $2, $3, $4}' < "$time_out_path"


### PR DESCRIPTION
`timeout -k <dur>` is *duration after the initial signal*, and not after the command started.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
