### PR TITLE
fix: Federation rpc error formatting

### DIFF
--- a/fedimint-api-client/src/api/error.rs
+++ b/fedimint-api-client/src/api/error.rs
@@ -122,9 +122,9 @@ pub struct FederationError {
 
 impl Display for FederationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("Federation rpc error {")?;
+        f.write_str("Federation rpc error { ")?;
+        f.write_fmt(format_args!("method => {}, ", self.method))?;
         if let Some(general) = self.general.as_ref() {
-            f.write_fmt(format_args!("method => {}, ", self.method))?;
             f.write_fmt(format_args!(
                 "params => {:?}, ",
                 AbbreviateJson(&self.params)
@@ -135,12 +135,12 @@ impl Display for FederationError {
             }
         }
         for (i, (peer, e)) in self.peer_errors.iter().enumerate() {
-            f.write_fmt(format_args!("{peer} => {e:#})"))?;
-            if i == self.peer_errors.len() - 1 {
+            f.write_fmt(format_args!("{peer} => {e:#}"))?;
+            if i != self.peer_errors.len() - 1 {
                 f.write_str(", ")?;
             }
         }
-        f.write_str("}")?;
+        f.write_str(" }")?;
         Ok(())
     }
 }


### PR DESCRIPTION
Now:

```
{
  "error": "Federation rpc error { method => list_gateways, 1 => Connection failed: Failed to connect to peer, 2 => Connection failed: Failed to connect to peer }"
}
```
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
