### PR TITLE
chore: bump version to v0.5.1 in tests

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -49,7 +49,7 @@ jobs:
           # run a slimmed down back-compat test for PR push or each major version for merge queue
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             PERFIT_METRIC="90S3yoXDQ-SXB0UbXG4qHQ"
-            VERSIONS_TO_TEST="v0.4.4 v0.5.0 v0.6.1"
+            VERSIONS_TO_TEST="v0.4.4 v0.5.1 v0.6.1"
           else
             PERFIT_METRIC="aPuCAjrFT7uE5Oax_T4sMw"
             VERSIONS_TO_TEST="v0.6.1"

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -56,7 +56,7 @@ jobs:
           # read versions from manually triggered workflows
           # default needed for cron or manual workflow without params
           VERSIONS="${{ github.event.inputs.versions }}"
-          VERSIONS=${VERSIONS:="v0.4.4 current, v0.5.0 current, v0.6.1 current"}
+          VERSIONS=${VERSIONS:="v0.4.4 current, v0.5.1 current, v0.6.1 current"}
 
           # if empty, defaults to all test kinds within script
           export TEST_KINDS="${{ github.event.inputs.test_kinds }}"

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -22,13 +22,13 @@ test-ci-all:
 test-count:
   ./scripts/tests/test-cov.sh
 
-test-compatibility *VERSIONS="v0.4.4 v0.5.0 v0.6.1":
+test-compatibility *VERSIONS="v0.4.4 v0.5.1 v0.6.1":
   ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
 test-full-compatibility *VERSIONS="v0.4.4":
   env FM_FULL_VERSION_MATRIX=1 ./scripts/tests/test-ci-all-backcompat.sh {{VERSIONS}}
 
-test-upgrades *VERSIONS="v0.4.4 current, v0.5.0 current, v0.6.1 current":
+test-upgrades *VERSIONS="v0.4.4 current, v0.5.1 current, v0.6.1 current":
   ./scripts/tests/upgrade-test.sh {{VERSIONS}}
 
 # `cargo udeps` check


### PR DESCRIPTION
We cut `v0.5.1`, so time to bump our version in tests.