### PR TITLE
chore: rename meta module tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3480,6 +3480,7 @@ name = "fedimint-meta-tests"
 version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
+ "clap",
  "devimint",
  "fedimint-core",
  "semver",

--- a/modules/fedimint-meta-tests/Cargo.toml
+++ b/modules/fedimint-meta-tests/Cargo.toml
@@ -10,11 +10,12 @@ publish = false
 # workaround: cargo-deny in Nix needs to see at least one
 # artifact here
 [[bin]]
-name = "meta-sanity-test"
-path = "src/bin/meta-sanity-test.rs"
+name = "meta-module-tests"
+path = "src/bin/meta-module-tests.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true }
 devimint = { workspace = true }
 fedimint-core = { workspace = true }
 semver = { workspace = true }

--- a/modules/fedimint-meta-tests/src/bin/meta-module-tests.rs
+++ b/modules/fedimint-meta-tests/src/bin/meta-module-tests.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 
 use anyhow::{Result, bail};
+use clap::Parser;
 use devimint::federation::Client;
 use devimint::util::poll_simple;
 use devimint::version_constants::VERSION_0_5_0_ALPHA;
@@ -9,8 +10,21 @@ use fedimint_core::PeerId;
 use serde_json::json;
 use tracing::{info, warn};
 
+#[derive(Parser, Debug)]
+pub enum TestCli {
+    Sanity,
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let opts = TestCli::parse();
+
+    match opts {
+        TestCli::Sanity => sanity_tests().await,
+    }
+}
+
+async fn sanity_tests() -> anyhow::Result<()> {
     devimint::run_devfed_test()
         .call(|dev_fed, _process_mgr| async move {
             let fedimint_cli_version = util::FedimintCli::version_or_default().await;

--- a/scripts/tests/meta-module-test.sh
+++ b/scripts/tests/meta-module-test.sh
@@ -8,4 +8,4 @@ source scripts/_common.sh
 build_workspace
 add_target_dir_to_path
 
-meta-sanity-test
+meta-module-tests sanity


### PR DESCRIPTION
To make it work and look like `wallet-module-tests` and `mint-module-tests`.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
