### PR TITLE
chore(ci): warn about `set -euo pipefail` not enabled

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -2,6 +2,9 @@
 
 export REPO_ROOT
 
+if [[ ! $- =~ e ]] || [[ ! $- =~ u ]] || ! shopt -p pipefail | grep -q "set -o pipefail" ; then
+  echo "Warning: 'set -euo pipefail' is not fully enabled."
+fi
 if [ -z "${REPO_ROOT:-}" ]; then
   if command -v git &> /dev/null; then
     REPO_ROOT="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
