### PR TITLE
chore(ci): dump LN node logs on test fail

### DIFF
--- a/devimint/src/cfg/lnd.conf
+++ b/devimint/src/cfg/lnd.conf
@@ -8,7 +8,7 @@ wtclient.active=false
 sync-freelist=true
 max-commit-fee-rate-anchors=5
 
-debuglevel=debug
+debuglevel=info
 
 [Bitcoin]
 

--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -37,9 +37,16 @@ on_error() {
   cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/gatewayd-lnd.log || true
   echo
   echo
+  echo "## LOG LND NODE:"
+  cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/lnd.log || true
+  echo
+  echo
   echo "## LOG LDK-0 GATEWAY:"
   cat "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/gatewayd-ldk-0.log || true
   echo
+  echo
+  echo "## LOG LDK-0 NODE:"
+  { cat  "$FM_RUN_TEST_TMPDIR"/devimint-*/gatewayd-ldk-0/ldk_node/logs/ldk_node_latest.log || true; } | grep -v "Failed to retrieve fee rate estimates" || true
   echo
   echo "## FAIL END $test_name$version_str."
 }


### PR DESCRIPTION
While at it, lower LND logging level, the debug
one is really chatty with stuff we probably
don't care about.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
