### PR TITLE
chore: Simplify devimint channel opens

### DIFF
--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -256,29 +256,22 @@ impl DevJitFed {
                 // other.
                 let bitcoind = bitcoind.get_try().await?.deref().clone();
 
-                tokio::try_join!(
-                    async {
-                        let gw_ldk = gw_ldk.get_try().await?.deref();
-                        let gw_lnd = gw_lnd.get_try().await?.deref();
-                        let gateways: &[NamedGateway<'_>] = &[(gw_lnd, "LND"), (gw_ldk, "LDK")];
+                let gw_ldk = gw_ldk.get_try().await?.deref();
+                let gw_lnd = gw_lnd.get_try().await?.deref();
+                let gateways: &[NamedGateway<'_>] = &[(gw_lnd, "LND"), (gw_ldk, "LDK")];
 
-                        debug!(target: LOG_DEVIMINT, "Opening channels between gateways...");
-                        let start_time = fedimint_core::time::now();
-                        open_channels_between_gateways(&bitcoind, gateways).await?;
-                        info!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed()?.as_millis(), "Opened channels between gateways");
-                        anyhow::Ok(())
-                    },
-                    async {
-                        let lnd = lnd.get_try().await?.deref().clone();
-                        let cln = cln.get_try().await?.deref().clone();
+                debug!(target: LOG_DEVIMINT, "Opening channels between gateways...");
+                let start_time = fedimint_core::time::now();
+                open_channels_between_gateways(&bitcoind, gateways).await?;
+                info!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed()?.as_millis(), "Opened channels between gateways");
 
-                        debug!(target: LOG_DEVIMINT, "Opening channels between cln and lnd...");
-                        let start_time = fedimint_core::time::now();
-                        open_channel(&process_mgr, &bitcoind, &cln, &lnd).await?;
-                        info!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed()?.as_millis(), "Opened channels between cln and lnd");
-                        anyhow::Ok(())
-                    }
-                )?;
+                let lnd = lnd.get_try().await?.deref().clone();
+                let cln = cln.get_try().await?.deref().clone();
+
+                debug!(target: LOG_DEVIMINT, "Opening channels between cln and lnd...");
+                let start_time = fedimint_core::time::now();
+                open_channel(&process_mgr, &bitcoind, &cln, &lnd).await?;
+                info!(target: LOG_DEVIMINT, elapsed_ms = %start_time.elapsed()?.as_millis(), "Opened channels between cln and lnd");
 
                 Ok(Arc::new(()))
             }

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -930,6 +930,8 @@ pub async fn open_channel(
     })
     .await?;
 
+    info!(target: LOG_DEVIMINT, "open_channel successful");
+
     Ok(())
 }
 
@@ -982,13 +984,10 @@ pub async fn open_channels_between_gateways(
 
     let sats_per_side = 5_000_000;
     for ((gw_a, gw_a_name), (gw_b, gw_b_name)) in &gateway_pairs {
-        // Sometimes channel openings just after funding the lightning nodes don't work
-        // right away.
-        let txid = poll(&format!("Open channel from {gw_a_name} to {gw_b_name}"), || async {
-            info!(target: LOG_DEVIMINT, from=%gw_a_name, to=%gw_b_name, "Opening channel with {sats_per_side} sats on each side...");
-            gw_a.open_channel(gw_b, sats_per_side * 2, Some(sats_per_side)).await.map_err(ControlFlow::Continue)
-        })
-        .await?;
+        info!(target: LOG_DEVIMINT, from=%gw_a_name, to=%gw_b_name, "Opening channel with {sats_per_side} sats on each side...");
+        let txid = gw_a
+            .open_channel(gw_b, sats_per_side * 2, Some(sats_per_side))
+            .await?;
 
         if let Some(txid) = txid {
             bitcoind.poll_get_transaction(txid).await?;
@@ -1020,6 +1019,8 @@ pub async fn open_channels_between_gateways(
         wait_for_ready_channel_on_gateway_with_counterparty(gw_b, gw_a_node_pubkey).await?;
         wait_for_ready_channel_on_gateway_with_counterparty(gw_a, gw_b_node_pubkey).await?;
     }
+
+    info!(target: LOG_DEVIMINT, "open_channels_between_gateways successful");
 
     Ok(())
 }

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -27,9 +27,9 @@ use tokio::task::spawn_blocking;
 use tokio::time::Instant;
 use tonic_lnd::Client as LndClient;
 use tonic_lnd::lnrpc::{ChanInfoRequest, GetInfoRequest, ListChannelsRequest};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
-use crate::util::{ProcessHandle, ProcessManager, poll, poll_with_timeout};
+use crate::util::{ProcessHandle, ProcessManager, poll};
 use crate::vars::utf8;
 use crate::version_constants::VERSION_0_5_0_ALPHA;
 use crate::{Gatewayd, cmd, poll_eq};
@@ -845,7 +845,8 @@ pub async fn open_channel(
         .bech32
         .context("bech32 should be present")?;
 
-    bitcoind.send_to(cln_addr, 100_000_000).await?;
+    let txid = bitcoind.send_to(cln_addr, 100_000_000).await?;
+    bitcoind.poll_get_transaction(txid).await?;
     bitcoind.mine_blocks(10).await?;
 
     let lnd_pubkey = lnd.pub_key().await?;
@@ -890,7 +891,7 @@ pub async fn open_channel(
 
     bitcoind.mine_blocks(10).await?;
 
-    poll("Wait LND for channel update", || async {
+    poll("Legacy Wait LND for channel update", || async {
         let mut lnd_client = lnd.client.lock().await;
         let channels = lnd_client
             .lightning()
@@ -948,13 +949,16 @@ pub async fn open_channels_between_gateways(
     )
     .await?;
 
-    debug!(target: LOG_DEVIMINT, "Funding all gateway lightning nodes...");
+    info!(target: LOG_DEVIMINT, "Funding all gateway lightning nodes...");
     for (gw, _gw_name) in gateways {
         let funding_addr = gw.get_ln_onchain_address().await?;
-        bitcoind.send_to(funding_addr, 100_000_000).await?;
+        let txid = bitcoind.send_to(funding_addr, 100_000_000).await?;
+        bitcoind.poll_get_transaction(txid).await?;
     }
 
     bitcoind.mine_blocks(10).await?;
+
+    info!(target: LOG_DEVIMINT, "Gateway lightning nodes funded.");
 
     let block_height = bitcoind.get_block_count().await? - 1;
     debug!(target: LOG_DEVIMINT, ?block_height, "Syncing gateway lightning nodes to block height...");
@@ -976,65 +980,26 @@ pub async fn open_channels_between_gateways(
         gateways.iter().circular_tuple_windows::<(_, _)>().collect()
     };
 
-    let open_channel_tasks = gateway_pairs.iter()
-        .map(|((gw_a, gw_a_name), (gw_b, gw_b_name))| {
-            let gw_a = (*gw_a).clone();
-            let gw_a_name = (*gw_a_name).to_string();
-            let gw_b = (*gw_b).clone();
-            let gw_b_name = (*gw_b_name).to_string();
-
-            let sats_per_side = 5_000_000;
-            debug!(target: LOG_DEVIMINT, from=%gw_a_name, to=%gw_b_name, "Opening channel with {sats_per_side} sats on each side...");
-            tokio::task::spawn(async move {
-                // Sometimes channel openings just after funding the lightning nodes don't work right away.
-                let res = poll_with_timeout(&format!("Open channel from {gw_a_name} to {gw_b_name}"), Duration::from_secs(30), || async {
-                    gw_a.open_channel(&gw_b, sats_per_side * 2, Some(sats_per_side)).await.map_err(ControlFlow::Continue)
-                })
-                .await;
-
-                if res.is_err() {
-                    error!(target: LOG_DEVIMINT, from=%gw_a_name, to=%gw_b_name, ?res, "Failed to open channel");
-                    gw_a.dump_logs()?;
-                    gw_b.dump_logs()?;
-                }
-
-                res
-            })
+    let sats_per_side = 5_000_000;
+    for ((gw_a, gw_a_name), (gw_b, gw_b_name)) in &gateway_pairs {
+        // Sometimes channel openings just after funding the lightning nodes don't work
+        // right away.
+        let txid = poll(&format!("Open channel from {gw_a_name} to {gw_b_name}"), || async {
+            info!(target: LOG_DEVIMINT, from=%gw_a_name, to=%gw_b_name, "Opening channel with {sats_per_side} sats on each side...");
+            gw_a.open_channel(gw_b, sats_per_side * 2, Some(sats_per_side)).await.map_err(ControlFlow::Continue)
         })
-        .collect::<Vec<_>>();
-    let open_channel_task_results: Vec<Result<Result<_, _>, _>> =
-        futures::future::join_all(open_channel_tasks).await;
+        .await?;
 
-    let mut channel_funding_txids = Vec::new();
-    for open_channel_task_result in open_channel_task_results {
-        match open_channel_task_result {
-            Ok(Ok(txid)) => {
-                channel_funding_txids.push(txid);
-            }
-            Ok(Err(e)) => {
-                return Err(anyhow::anyhow!(e));
-            }
-            Err(e) => {
-                return Err(anyhow::anyhow!(e));
-            }
-        }
-    }
-
-    // Wait for all channel funding transaction to be known by bitcoind.
-    let mut is_missing_any_txids = false;
-    for txid_or in &channel_funding_txids {
-        if let Some(txid) = txid_or {
-            bitcoind.poll_get_transaction(*txid).await?;
-        } else {
-            is_missing_any_txids = true;
+        if let Some(txid) = txid {
+            bitcoind.poll_get_transaction(txid).await?;
         }
     }
 
     // `open_channel` may not have sent out the channel funding transaction
     // immediately. Since it didn't return a funding txid, we need to wait for
     // it to get to the mempool.
-    if is_missing_any_txids {
-        fedimint_core::runtime::sleep(Duration::from_secs(2)).await;
+    if crate::util::Gatewayd::version_or_default().await < *VERSION_0_5_0_ALPHA {
+        fedimint_core::runtime::sleep(Duration::from_secs(5)).await;
     }
 
     bitcoind.mine_blocks(10).await?;
@@ -1080,7 +1045,6 @@ async fn wait_for_ready_channel_on_gateway_with_counterparty(
             }
 
             debug!(target: LOG_DEVIMINT, ?channels, gw = gw.gw_name, "Counterparty channels not found open");
-
             Err(ControlFlow::Continue(anyhow!("channel not found")))
         },
     )

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -845,8 +845,7 @@ pub async fn open_channel(
         .bech32
         .context("bech32 should be present")?;
 
-    let txid = bitcoind.send_to(cln_addr, 100_000_000).await?;
-    bitcoind.poll_get_transaction(txid).await?;
+    bitcoind.send_to(cln_addr, 100_000_000).await?;
     bitcoind.mine_blocks(10).await?;
 
     let lnd_pubkey = lnd.pub_key().await?;
@@ -954,8 +953,7 @@ pub async fn open_channels_between_gateways(
     info!(target: LOG_DEVIMINT, "Funding all gateway lightning nodes...");
     for (gw, _gw_name) in gateways {
         let funding_addr = gw.get_ln_onchain_address().await?;
-        let txid = bitcoind.send_to(funding_addr, 100_000_000).await?;
-        bitcoind.poll_get_transaction(txid).await?;
+        bitcoind.send_to(funding_addr, 100_000_000).await?;
     }
 
     bitcoind.mine_blocks(10).await?;
@@ -982,6 +980,7 @@ pub async fn open_channels_between_gateways(
         gateways.iter().circular_tuple_windows::<(_, _)>().collect()
     };
 
+    info!(target: LOG_DEVIMINT, block_height = %block_height, "devimint current block");
     let sats_per_side = 5_000_000;
     for ((gw_a, gw_a_name), (gw_b, gw_b_name)) in &gateway_pairs {
         info!(target: LOG_DEVIMINT, from=%gw_a_name, to=%gw_b_name, "Opening channel with {sats_per_side} sats on each side...");

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -527,7 +527,10 @@ impl Gatewayd {
                 let Some(block_height) = block_height else {
                     return Err(ControlFlow::Continue(anyhow!("Not synced any blocks yet")));
                 };
-                if block_height >= target_block_height as u32 {
+                let synced = info["synced_to_chain"]
+                    .as_bool()
+                    .expect("Could not get synced_to_chain");
+                if block_height >= target_block_height as u32 && synced {
                     return Ok(());
                 }
             }

--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 use std::ops::ControlFlow;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -20,7 +18,7 @@ use fedimint_ln_server::common::lightning_invoice::Bolt11Invoice;
 use fedimint_lnv2_common::gateway_api::PaymentFee;
 use fedimint_testing::ln::LightningNodeType;
 use semver::Version;
-use tracing::{error, info};
+use tracing::info;
 
 use crate::cmd;
 use crate::envs::{FM_GATEWAY_API_ADDR_ENV, FM_GATEWAY_DATA_DIR_ENV, FM_GATEWAY_LISTEN_ADDR_ENV};
@@ -126,19 +124,6 @@ impl Gatewayd {
         }
     }
 
-    pub fn dump_logs(&self) -> Result<()> {
-        let mut logs = File::open(self.log_path.clone())?;
-        let mut contents = String::new();
-        logs.read_to_string(&mut contents)?;
-        info!("================ {} LOGS ================", self.gw_name);
-        info!("{contents}");
-        info!(
-            "================ {} LOGS DONE ================",
-            self.gw_name
-        );
-        Ok(())
-    }
-
     pub async fn terminate(self) -> Result<()> {
         self.process.terminate().await
     }
@@ -214,18 +199,13 @@ impl Gatewayd {
     }
 
     pub async fn get_info(&self) -> Result<serde_json::Value> {
-        let res = retry(
+        retry(
             "Getting gateway info via gateway-cli info",
             backoff_util::aggressive_backoff(),
             || async { cmd!(self, "info").out_json().await },
         )
         .await
-        .context("Getting gateway info via gateway-cli info");
-        if let Err(err) = &res {
-            error!(?err, "gateway-cli failed to get info");
-            self.dump_logs()?;
-        }
-        res
+        .context("Getting gateway info via gateway-cli info")
     }
 
     pub async fn gateway_id(&self) -> Result<String> {

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -512,6 +512,7 @@ impl Gateway {
             info!("Gateway is already synced to chain");
         } else {
             self.set_gateway_state(GatewayState::Syncing).await;
+            info!(target: LOG_GATEWAY, "Waiting for chain sync");
             if let Err(e) = ln_client.wait_for_chain_sync().await {
                 error!(?e, "Failed to wait for chain sync");
                 return ReceivePaymentStreamAction::RetryAfterDelay;

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -99,6 +99,7 @@ use fedimint_lnv2_common::contracts::{IncomingContract, PaymentImage};
 use fedimint_lnv2_common::gateway_api::{
     CreateBolt11InvoicePayload, PaymentFee, RoutingInfo, SendPaymentPayload,
 };
+use fedimint_logging::LOG_GATEWAY;
 use fedimint_mint_client::{
     MintClientInit, MintClientModule, MintCommonInit, SelectNotesWithAtleastAmount,
     SelectNotesWithExactAmount,
@@ -1343,8 +1344,10 @@ impl Gateway {
     /// Instructs the Gateway's Lightning node to open a channel to a peer
     /// specified by `pubkey`.
     pub async fn handle_open_channel_msg(&self, payload: OpenChannelRequest) -> AdminResult<Txid> {
+        info!(target: LOG_GATEWAY, pubkey = %payload.pubkey, host = %payload.host, amount = %payload.channel_size_sats, "Opening Lightning channel...");
         let context = self.get_lightning_context().await?;
         let res = context.lnrpc.open_channel(payload).await?;
+        info!(target: LOG_GATEWAY, txid = %res.funding_txid, "Initiated channel open");
         Txid::from_str(&res.funding_txid).map_err(|e| {
             AdminGatewayError::Lightning(LightningRpcError::InvalidMetadata {
                 failure_reason: format!("Received invalid channel funding txid string {e}"),


### PR DESCRIPTION
CLN and LND need to be synced when opening channels. When channels are opened in parallel, two threads are mining blocks which causes the lightning nodes to not be synced for a small period of time. The `open_channel` requests then can fail, which fails the devimint setup.

Solution is to remove the parallelism in channel opens and wait for the lightning node to be synced before opening channels.