### PR TITLE
fix: default FM_WALLET_FEERATE_SOURCES for mempool.space

### DIFF
--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -253,7 +253,7 @@ impl DynBitcoindRpc {
     ) -> anyhow::Result<()> {
         let sources = std::env::var(FM_WALLET_FEERATE_SOURCES_ENV)
             .unwrap_or_else(|_| match network {
-                Network::Bitcoin => "https://mempool.space/api/v1/fees/recommended#.;https://blockstream.info/api/fee-estimates#.\"1\"".to_owned(),
+                Network::Bitcoin => "https://mempool.space/api/v1/fees/recommended#.hourFee;https://blockstream.info/api/fee-estimates#.\"1\"".to_owned(),
                 _ => String::new(),
             })
             .split(';')


### PR DESCRIPTION
```
> curl -s "https://mempool.space/api/v1/fees/recommended"
{"fastestFee":11,"halfHourFee":10,"hourFee":8,"economyFee":2,"minimumFee":1}
```

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
