### PR TITLE
refactor(server): add `ServerModuleInit::Module`

### DIFF
--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -20,7 +20,7 @@ use fedimint_core::module::{
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{NumPeers, PeerId, apply, async_trait_maybe_send, dyn_newtype_define};
 
-use crate::DynServerModule;
+use crate::{DynServerModule, ServerModule};
 
 /// Interface for Module Generation
 ///
@@ -176,6 +176,7 @@ where
 /// `WalletConfigGenerator`, or `LightningConfigGenerator` structs.
 #[apply(async_trait_maybe_send!)]
 pub trait ServerModuleInit: ModuleInit + Sized {
+    type Module: ServerModule;
     type Params: ModuleInitParams;
 
     /// Version of the module consensus supported by this implementation given a

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -94,6 +94,7 @@ impl ModuleInit for DummyInit {
 /// Implementation of server module non-consensus functions
 #[async_trait]
 impl ServerModuleInit for DummyInit {
+    type Module = Dummy;
     type Params = DummyGenParams;
 
     /// Returns the version of this module

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -31,7 +31,7 @@ use fedimint_dummy_common::{
     DummyOutput, DummyOutputError, DummyOutputOutcome, MODULE_CONSENSUS_VERSION,
     broken_fed_public_key, fed_public_key,
 };
-use fedimint_server_core::{DynServerModule, ServerModule, ServerModuleInit, ServerModuleInitArgs};
+use fedimint_server_core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use futures::{FutureExt, StreamExt};
 use strum::IntoEnumIterator;
 
@@ -114,8 +114,8 @@ impl ServerModuleInit for DummyInit {
     }
 
     /// Initialize the module
-    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
-        Ok(Dummy::new(args.cfg().to_typed()?).into())
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
+        Ok(Dummy::new(args.cfg().to_typed()?))
     }
 
     /// Generates configs for all peers in a trusted manner for testing

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -76,6 +76,7 @@ impl ModuleInit for EmptyInit {
 /// Implementation of server module non-consensus functions
 #[async_trait]
 impl ServerModuleInit for EmptyInit {
+    type Module = Empty;
     type Params = EmptyGenParams;
 
     /// Returns the version of this module

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -26,7 +26,7 @@ use fedimint_empty_common::{
     EmptyCommonInit, EmptyConsensusItem, EmptyInput, EmptyInputError, EmptyModuleTypes,
     EmptyOutput, EmptyOutputError, EmptyOutputOutcome, MODULE_CONSENSUS_VERSION,
 };
-use fedimint_server_core::{DynServerModule, ServerModule, ServerModuleInit, ServerModuleInitArgs};
+use fedimint_server_core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use futures::StreamExt;
 use strum::IntoEnumIterator;
 
@@ -96,8 +96,8 @@ impl ServerModuleInit for EmptyInit {
     }
 
     /// Initialize the module
-    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
-        Ok(Empty::new(args.cfg().to_typed()?).into())
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
+        Ok(Empty::new(args.cfg().to_typed()?))
     }
 
     /// Generates configs for all peers in a trusted manner for testing

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -199,6 +199,7 @@ impl ModuleInit for LightningInit {
 
 #[apply(async_trait_maybe_send!)]
 impl ServerModuleInit for LightningInit {
+    type Module = Lightning;
     type Params = LightningGenParams;
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -58,9 +58,7 @@ use fedimint_ln_common::{
 };
 use fedimint_logging::LOG_MODULE_LN;
 use fedimint_server::config::distributedgen::PeerHandleOps;
-use fedimint_server::core::{
-    DynServerModule, ServerModule, ServerModuleInit, ServerModuleInitArgs,
-};
+use fedimint_server::core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use futures::StreamExt;
 use metrics::{LN_CANCEL_OUTGOING_CONTRACTS, LN_FUNDED_CONTRACT_SATS, LN_INCOMING_OFFER};
 use rand::rngs::OsRng;
@@ -217,15 +215,11 @@ impl ServerModuleInit for LightningInit {
         )
     }
 
-    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
         // Eagerly initialize metrics that trigger infrequently
         LN_CANCEL_OUTGOING_CONTRACTS.get();
 
-        Ok(
-            Lightning::new(args.cfg().to_typed()?, args.our_peer_id(), &args.shared())
-                .await?
-                .into(),
-        )
+        Ok(Lightning::new(args.cfg().to_typed()?, args.our_peer_id(), &args.shared()).await?)
     }
 
     fn trusted_dealer_gen(

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -171,6 +171,7 @@ impl ModuleInit for LightningInit {
 
 #[apply(async_trait_maybe_send!)]
 impl ServerModuleInit for LightningInit {
+    type Module = Lightning;
     type Params = LightningGenParams;
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -49,9 +49,7 @@ use fedimint_lnv2_common::{
 };
 use fedimint_logging::LOG_MODULE_LNV2;
 use fedimint_server::config::distributedgen::{PeerHandleOps, eval_poly_g1};
-use fedimint_server::core::{
-    DynServerModule, ServerModule, ServerModuleInit, ServerModuleInitArgs,
-};
+use fedimint_server::core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use fedimint_server::net::api::check_auth;
 use futures::StreamExt;
 use group::Curve;
@@ -189,10 +187,8 @@ impl ServerModuleInit for LightningInit {
         )
     }
 
-    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
-        Ok(Lightning::new(args.cfg().to_typed()?, &args.shared())
-            .await?
-            .into())
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
+        Ok(Lightning::new(args.cfg().to_typed()?, &args.shared()).await?)
     }
 
     fn trusted_dealer_gen(

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -42,9 +42,7 @@ use fedimint_meta_common::{
     MetaInputError, MetaKey, MetaModuleTypes, MetaOutput, MetaOutputError, MetaOutputOutcome,
     MetaValue,
 };
-use fedimint_server::core::{
-    DynServerModule, ServerModule, ServerModuleInit, ServerModuleInitArgs,
-};
+use fedimint_server::core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use futures::StreamExt;
 use rand::{Rng, thread_rng};
 use strum::IntoEnumIterator;
@@ -137,13 +135,12 @@ impl ServerModuleInit for MetaInit {
     }
 
     /// Initialize the module
-    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
         Ok(Meta {
             cfg: args.cfg().to_typed()?,
             our_peer_id: args.our_peer_id(),
             num_peers: args.num_peers(),
-        }
-        .into())
+        })
     }
 
     /// Generates configs for all peers in a trusted manner for testing

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -117,6 +117,7 @@ impl ModuleInit for MetaInit {
 /// Implementation of server module non-consensus functions
 #[async_trait]
 impl ServerModuleInit for MetaInit {
+    type Module = Meta;
     type Params = MetaGenParams;
 
     /// Returns the version of this module

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -128,6 +128,7 @@ impl ModuleInit for MintInit {
 
 #[apply(async_trait_maybe_send!)]
 impl ServerModuleInit for MintInit {
+    type Module = Mint;
     type Params = MintGenParams;
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {

--- a/modules/fedimint-mint-server/src/lib.rs
+++ b/modules/fedimint-mint-server/src/lib.rs
@@ -43,9 +43,7 @@ use fedimint_mint_common::{
 };
 use fedimint_server::config::distributedgen::{PeerHandleOps, eval_poly_g2};
 use fedimint_server::consensus::db::{MigrationContextExt, TypedModuleHistoryItem};
-use fedimint_server::core::{
-    DynServerModule, ServerModule, ServerModuleInit, ServerModuleInitArgs,
-};
+use fedimint_server::core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use futures::{FutureExt as _, StreamExt};
 use itertools::Itertools;
 use metrics::{
@@ -146,8 +144,8 @@ impl ServerModuleInit for MintInit {
         )
     }
 
-    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
-        Ok(Mint::new(args.cfg().to_typed()?).into())
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
+        Ok(Mint::new(args.cfg().to_typed()?))
     }
 
     fn trusted_dealer_gen(

--- a/modules/fedimint-unknown-server/src/lib.rs
+++ b/modules/fedimint-unknown-server/src/lib.rs
@@ -18,7 +18,7 @@ use fedimint_core::module::{
     ModuleInit, PeerHandle, SupportedModuleApiVersions, TransactionItemAmount,
 };
 use fedimint_core::{InPoint, OutPoint, PeerId};
-use fedimint_server_core::{DynServerModule, ServerModule, ServerModuleInit, ServerModuleInitArgs};
+use fedimint_server_core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 pub use fedimint_unknown_common as common;
 use fedimint_unknown_common::config::{
     UnknownClientConfig, UnknownConfig, UnknownConfigConsensus, UnknownConfigLocal,
@@ -71,8 +71,8 @@ impl ServerModuleInit for UnknownInit {
     }
 
     /// Initialize the module
-    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
-        Ok(Unknown::new(args.cfg().to_typed()?).into())
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
+        Ok(Unknown::new(args.cfg().to_typed()?))
     }
 
     /// Generates configs for all peers in a trusted manner for testing

--- a/modules/fedimint-unknown-server/src/lib.rs
+++ b/modules/fedimint-unknown-server/src/lib.rs
@@ -51,6 +51,7 @@ impl ModuleInit for UnknownInit {
 /// Implementation of server module non-consensus functions
 #[async_trait]
 impl ServerModuleInit for UnknownInit {
+    type Module = Unknown;
     type Params = UnknownGenParams;
 
     /// Returns the version of this module

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -67,9 +67,7 @@ use fedimint_core::{
 };
 use fedimint_logging::LOG_MODULE_WALLET;
 use fedimint_server::config::distributedgen::PeerHandleOps;
-use fedimint_server::core::{
-    DynServerModule, ServerModule, ServerModuleInit, ServerModuleInitArgs,
-};
+use fedimint_server::core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use fedimint_server::net::api::check_auth;
 pub use fedimint_wallet_common as common;
 use fedimint_wallet_common::config::{WalletClientConfig, WalletConfig, WalletGenParams};
@@ -276,7 +274,7 @@ impl ServerModuleInit for WalletInit {
         )
     }
 
-    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<DynServerModule> {
+    async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
         for direction in ["incoming", "outgoing"] {
             WALLET_INOUT_FEES_SATS
                 .with_label_values(&[direction])
@@ -299,8 +297,7 @@ impl ServerModuleInit for WalletInit {
             args.module_api().clone(),
             &args.shared(),
         )
-        .await?
-        .into())
+        .await?)
     }
 
     fn trusted_dealer_gen(

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -258,6 +258,7 @@ impl ModuleInit for WalletInit {
 
 #[apply(async_trait_maybe_send!)]
 impl ServerModuleInit for WalletInit {
+    type Module = Wallet;
     type Params = WalletGenParams;
 
     fn versions(&self, _core: CoreConsensusVersion) -> &[ModuleConsensusVersion] {


### PR DESCRIPTION
There's currently no way to get server module type for a given server module init type.

[`ClientModuleInit::Module`](https://docs.fedimint.org/fedimint_client_module/module/init/trait.ClientModuleInit.html#associatedtype.Module) already exists, so add one just like that.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
