### PR TITLE
refactor(core): make migration fn a closure

### DIFF
--- a/gateway/fedimint-gateway-server/src/db.rs
+++ b/gateway/fedimint-gateway-server/src/db.rs
@@ -407,11 +407,26 @@ impl_db_lookup!(
 
 pub fn get_gatewayd_database_migrations() -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
     let mut migrations: BTreeMap<DatabaseVersion, CoreMigrationFn> = BTreeMap::new();
-    migrations.insert(DatabaseVersion(0), |ctx| migrate_to_v1(ctx).boxed());
-    migrations.insert(DatabaseVersion(1), |ctx| migrate_to_v2(ctx).boxed());
-    migrations.insert(DatabaseVersion(2), |ctx| migrate_to_v3(ctx).boxed());
-    migrations.insert(DatabaseVersion(3), |ctx| migrate_to_v4(ctx).boxed());
-    migrations.insert(DatabaseVersion(4), |ctx| migrate_to_v5(ctx).boxed());
+    migrations.insert(
+        DatabaseVersion(0),
+        Box::new(|ctx| migrate_to_v1(ctx).boxed()),
+    );
+    migrations.insert(
+        DatabaseVersion(1),
+        Box::new(|ctx| migrate_to_v2(ctx).boxed()),
+    );
+    migrations.insert(
+        DatabaseVersion(2),
+        Box::new(|ctx| migrate_to_v3(ctx).boxed()),
+    );
+    migrations.insert(
+        DatabaseVersion(3),
+        Box::new(|ctx| migrate_to_v4(ctx).boxed()),
+    );
+    migrations.insert(
+        DatabaseVersion(4),
+        Box::new(|ctx| migrate_to_v5(ctx).boxed()),
+    );
     migrations
 }
 

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -180,7 +180,10 @@ impl ServerModuleInit for DummyInit {
     /// DB migrations to move from old to newer versions
     fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
         let mut migrations: BTreeMap<DatabaseVersion, CoreMigrationFn> = BTreeMap::new();
-        migrations.insert(DatabaseVersion(0), |ctx| migrate_to_v1(ctx).boxed());
+        migrations.insert(
+            DatabaseVersion(0),
+            Box::new(|ctx| migrate_to_v1(ctx).boxed()),
+        );
         migrations
     }
 }

--- a/modules/fedimint-unknown-server/src/lib.rs
+++ b/modules/fedimint-unknown-server/src/lib.rs
@@ -133,7 +133,7 @@ impl ServerModuleInit for UnknownInit {
         let mut migrations: BTreeMap<DatabaseVersion, CoreMigrationFn> = BTreeMap::new();
         // Unknown module prior to v0.5.0 had a `DATABASE_VERSION` of 1, so we must
         // insert a no-op migration to ensure that upgrades work.
-        migrations.insert(DatabaseVersion(0), |_| Box::pin(async { Ok(()) }));
+        migrations.insert(DatabaseVersion(0), Box::new(|_| Box::pin(async { Ok(()) })));
         migrations
     }
 }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -405,7 +405,10 @@ impl ServerModuleInit for WalletInit {
     /// DB migrations to move from old to newer versions
     fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
         let mut migrations: BTreeMap<DatabaseVersion, CoreMigrationFn> = BTreeMap::new();
-        migrations.insert(DatabaseVersion(0), |ctx| migrate_to_v1(ctx).boxed());
+        migrations.insert(
+            DatabaseVersion(0),
+            Box::new(|ctx| migrate_to_v1(ctx).boxed()),
+        );
         migrations
     }
 


### PR DESCRIPTION
Functions have a lot of limitations, that I'm hitting in a larger refactoring I'm trying to get done.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
