### PR TITLE
 chore: decouple context from migrations 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,6 +3725,7 @@ dependencies = [
  "async-trait",
  "fedimint-api-client",
  "fedimint-core",
+ "futures",
  "tokio",
 ]
 

--- a/fedimint-bitcoind/Cargo.toml
+++ b/fedimint-bitcoind/Cargo.toml
@@ -13,6 +13,9 @@ rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
 default = ["bitcoincore-rpc", "esplora-client"]
+# the code behind this flag is server-side only, interfers with wasm builds
+# and should just live in some `fedimint-bitcoind-server` or something (TODO)
+fedimint-server = ["dep:fedimint-server-core"]
 
 [lib]
 name = "fedimint_bitcoind"
@@ -26,7 +29,7 @@ bitcoincore-rpc = { workspace = true, optional = true }
 esplora-client = { workspace = true, optional = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
-fedimint-server-core = { workspace = true }
+fedimint-server-core = { workspace = true, optional = true }
 futures = { workspace = true }
 hex = { workspace = true }
 jaq-core = { workspace = true }

--- a/fedimint-bitcoind/src/lib.rs
+++ b/fedimint-bitcoind/src/lib.rs
@@ -35,6 +35,7 @@ pub mod bitcoincore;
 mod esplora;
 mod feerate_source;
 
+#[cfg(feature = "fedimint-server")]
 pub mod shared;
 
 // <https://blockstream.info/api/block-height/0>

--- a/fedimint-client-module/src/db.rs
+++ b/fedimint-client-module/src/db.rs
@@ -8,7 +8,7 @@ use fedimint_core::util::BoxFuture;
 
 /// `ClientMigrationFn` is a function that modules can implement to "migrate"
 /// the database to the next database version.
-pub type ClientMigrationFn = for<'r, 'tx> fn(
+pub type ClientModuleMigrationFn = for<'r, 'tx> fn(
     &'r mut DatabaseTransaction<'tx>,
     Vec<(Vec<u8>, OperationId)>, // active states
     Vec<(Vec<u8>, OperationId)>, // inactive states

--- a/fedimint-client-module/src/module/init.rs
+++ b/fedimint-client-module/src/module/init.rs
@@ -15,7 +15,7 @@ use tracing::warn;
 
 use super::ClientContext;
 use super::recovery::RecoveryProgress;
-use crate::db::ClientMigrationFn;
+use crate::db::ClientModuleMigrationFn;
 use crate::module::ClientModule;
 use crate::sm::ModuleNotifier;
 
@@ -236,7 +236,7 @@ pub trait ClientModuleInit: ModuleInit + Sized {
     /// Retrieves the database migrations from the module to be applied to the
     /// database before the module is initialized. The database migrations map
     /// is indexed on the "from" version.
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn> {
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
         BTreeMap::new()
     }
 

--- a/fedimint-client/src/module_init.rs
+++ b/fedimint-client/src/module_init.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use fedimint_api_client::api::DynGlobalApi;
-use fedimint_client_module::db::ClientMigrationFn;
+use fedimint_client_module::db::ClientModuleMigrationFn;
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
 };
@@ -74,7 +74,7 @@ pub trait IClientModuleInit: IDynCommonModuleInit + fmt::Debug + MaybeSend + May
         task_group: TaskGroup,
     ) -> anyhow::Result<DynClientModule>;
 
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn>;
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn>;
 
     /// See [`ClientModuleInit::used_db_prefixes`]
     fn used_db_prefixes(&self) -> Option<BTreeSet<u8>>;
@@ -203,7 +203,7 @@ where
         .into())
     }
 
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn> {
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
         <Self as ClientModuleInit>::get_database_migrations(self)
     }
 

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -2165,12 +2165,27 @@ macro_rules! push_db_key_items {
     };
 }
 
+// TODO: real things will go in here later
+pub trait IServerDbMigrationContext {}
+// TODO: this is just a placeholder
+pub struct FakeServerDbMigrationContext;
+impl IServerDbMigrationContext for FakeServerDbMigrationContext {}
+pub type ServerDbMigrationContext = Arc<dyn IServerDbMigrationContext + Send + Sync + 'static>;
+
+pub type ServerDbMigrationFnContext<'tx> = DbMigrationFnContext<'tx, ServerDbMigrationContext>;
+pub type ServerDbMigrationFn = DbMigrationFn<ServerDbMigrationContext>;
+
+// NOTE: client _module_ migrations are handled using separate structs due to
+// state machine migrations
+pub type ClientCoreDbMigrationFn = DbMigrationFn<()>;
+pub type ClientCoreDbMigrationFnContext<'tx> = DbMigrationFnContext<'tx, ()>;
+
 /// `CoreMigrationFn` that modules can implement to "migrate" the database
 /// to the next database version.
-pub type CoreMigrationFn = Box<
+pub type DbMigrationFn<C> = Box<
     maybe_add_send!(
         dyn for<'tx> Fn(
-            MigrationContext<'tx>,
+            DbMigrationFnContext<'tx, C>,
         ) -> Pin<
             Box<maybe_add_send!(dyn futures::Future<Output = anyhow::Result<()>> + 'tx)>,
         >
@@ -2201,38 +2216,45 @@ pub fn get_current_database_version<F>(
 
 /// See [`apply_migrations_server_dbtx`]
 pub async fn apply_migrations_server(
+    ctx: ServerDbMigrationContext,
     db: &Database,
     kind: String,
-    migrations: BTreeMap<DatabaseVersion, CoreMigrationFn>,
+    migrations: BTreeMap<DatabaseVersion, ServerDbMigrationFn>,
 ) -> Result<(), anyhow::Error> {
     let mut global_dbtx = db.begin_transaction().await;
     global_dbtx.ensure_global()?;
-    apply_migrations_server_dbtx(&mut global_dbtx.to_ref_nc(), kind, migrations).await?;
+    apply_migrations_server_dbtx(&mut global_dbtx.to_ref_nc(), ctx, kind, migrations).await?;
     global_dbtx.commit_tx_result().await
 }
 
 /// Applies the database migrations to a non-isolated database.
 pub async fn apply_migrations_server_dbtx(
     global_dbtx: &mut DatabaseTransaction<'_>,
+    ctx: ServerDbMigrationContext,
     kind: String,
-    migrations: BTreeMap<DatabaseVersion, CoreMigrationFn>,
+    migrations: BTreeMap<DatabaseVersion, ServerDbMigrationFn>,
 ) -> Result<(), anyhow::Error> {
     global_dbtx.ensure_global()?;
-    apply_migrations_dbtx(global_dbtx, kind, migrations, None, None).await
+    apply_migrations_dbtx(global_dbtx, ctx, kind, migrations, None, None).await
 }
 
-pub async fn apply_migrations(
+pub async fn apply_migrations<C>(
     db: &Database,
+    ctx: C,
     kind: String,
-    migrations: BTreeMap<DatabaseVersion, CoreMigrationFn>,
+    migrations: BTreeMap<DatabaseVersion, DbMigrationFn<C>>,
     module_instance_id: Option<ModuleInstanceId>,
     // When used in client side context, we can/should ignore keys that external app
     // is allowed to use, and but since this function is shared, we make it optional argument
     external_prefixes_above: Option<u8>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), anyhow::Error>
+where
+    C: Clone,
+{
     let mut dbtx = db.begin_transaction().await;
     apply_migrations_dbtx(
         &mut dbtx.to_ref_nc(),
+        ctx,
         kind,
         migrations,
         module_instance_id,
@@ -2253,15 +2275,19 @@ pub async fn apply_migrations(
 /// happen atomically). This function is called before the module is initialized
 /// and as long as the correct migrations are supplied in the migrations map,
 /// the module will be able to read and write from the database successfully.
-pub async fn apply_migrations_dbtx(
+pub async fn apply_migrations_dbtx<C>(
     global_dbtx: &mut DatabaseTransaction<'_>,
+    ctx: C,
     kind: String,
-    migrations: BTreeMap<DatabaseVersion, CoreMigrationFn>,
+    migrations: BTreeMap<DatabaseVersion, DbMigrationFn<C>>,
     module_instance_id: Option<ModuleInstanceId>,
     // When used in client side context, we can/should ignore keys that external app
     // is allowed to use, and but since this function is shared, we make it optional argument
     external_prefixes_above: Option<u8>,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), anyhow::Error>
+where
+    C: Clone,
+{
     // Newly created databases will not have any data since they have just been
     // instantiated.
     let is_new_db = global_dbtx
@@ -2308,9 +2334,10 @@ pub async fn apply_migrations_dbtx(
         while current_db_version < target_db_version {
             if let Some(migration) = migrations.get(&current_db_version) {
                 info!(target: LOG_DB, ?kind, ?current_db_version, ?target_db_version, "Migrating module...");
-                migration(MigrationContext {
+                migration(DbMigrationFnContext {
                     dbtx: global_dbtx.to_ref_nc(),
                     module_instance_id,
+                    ctx: ctx.clone(),
                 })
                 .await?;
             } else {
@@ -2318,6 +2345,7 @@ pub async fn apply_migrations_dbtx(
             }
 
             current_db_version = current_db_version.increment();
+
             global_dbtx
                 .insert_entry(
                     &DatabaseVersionKey(module_instance_id_key),
@@ -2447,12 +2475,14 @@ fn module_instance_id_or_global(module_instance_id: Option<ModuleInstanceId>) ->
     )
 }
 
-pub struct MigrationContext<'tx> {
+pub struct DbMigrationFnContext<'tx, C> {
     dbtx: DatabaseTransaction<'tx>,
     module_instance_id: Option<ModuleInstanceId>,
+    #[allow(dead_code)]
+    ctx: C,
 }
 
-impl<'tx> MigrationContext<'tx> {
+impl<'tx, C> DbMigrationFnContext<'tx, C> {
     pub fn dbtx(&mut self) -> DatabaseTransaction {
         if let Some(module_instance_id) = self.module_instance_id {
             self.dbtx.to_ref_with_prefix_module_id(module_instance_id).0
@@ -2476,15 +2506,15 @@ mod test_utils {
     use std::collections::BTreeMap;
     use std::time::Duration;
 
-    use fedimint_core::db::MigrationContext;
+    use fedimint_core::db::DbMigrationFnContext;
     use futures::future::ready;
     use futures::{Future, FutureExt, StreamExt};
     use rand::Rng;
     use tokio::join;
 
     use super::{
-        CoreMigrationFn, Database, DatabaseTransaction, DatabaseVersion, DatabaseVersionKey,
-        DatabaseVersionKeyV0, apply_migrations,
+        Database, DatabaseTransaction, DatabaseVersion, DatabaseVersionKey, DatabaseVersionKeyV0,
+        DbMigrationFn, apply_migrations,
     };
     use crate::core::ModuleKind;
     use crate::db::mem_impl::MemDatabase;
@@ -3230,14 +3260,14 @@ mod test_utils {
             .await;
         dbtx.commit_tx().await;
 
-        let mut migrations: BTreeMap<DatabaseVersion, CoreMigrationFn> = BTreeMap::new();
+        let mut migrations: BTreeMap<DatabaseVersion, DbMigrationFn<()>> = BTreeMap::new();
 
         migrations.insert(
             DatabaseVersion(0),
             Box::new(|ctx| migrate_test_db_version_0(ctx).boxed()),
         );
 
-        apply_migrations(&db, "TestModule".to_string(), migrations, None, None)
+        apply_migrations(&db, (), "TestModule".to_string(), migrations, None, None)
             .await
             .expect("Error applying migrations for TestModule");
 
@@ -3266,7 +3296,9 @@ mod test_utils {
     }
 
     #[allow(dead_code)]
-    async fn migrate_test_db_version_0(mut ctx: MigrationContext<'_>) -> Result<(), anyhow::Error> {
+    async fn migrate_test_db_version_0(
+        mut ctx: DbMigrationFnContext<'_, ()>,
+    ) -> Result<(), anyhow::Error> {
         let mut dbtx = ctx.dbtx();
         let example_keys_v0 = dbtx
             .find_by_prefix(&DbPrefixTestPrefixV0)

--- a/fedimint-server-core/Cargo.toml
+++ b/fedimint-server-core/Cargo.toml
@@ -20,4 +20,5 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 fedimint-api-client = { workspace = true }
 fedimint-core = { workspace = true }
+futures = { workspace = true }
 tokio = { workspace = true }

--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -12,7 +12,7 @@ use fedimint_core::config::{
     ModuleInitRegistry, ServerModuleConfig, ServerModuleConsensusConfig,
 };
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
-use fedimint_core::db::{CoreMigrationFn, Database, DatabaseVersion};
+use fedimint_core::db::{Database, DatabaseVersion, ServerDbMigrationFn};
 use fedimint_core::module::{
     CommonModuleInit, CoreConsensusVersion, IDynCommonModuleInit, ModuleConsensusVersion,
     ModuleInit, PeerHandle, SupportedModuleApiVersions,
@@ -75,7 +75,7 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
     /// Retrieves the migrations map from the server module to be applied to the
     /// database before the module is initialized. The migrations map is
     /// indexed on the from version.
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn>;
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn>;
 
     /// See [`ServerModuleInit::used_db_prefixes`]
     fn used_db_prefixes(&self) -> Option<BTreeSet<u8>>;
@@ -229,7 +229,7 @@ pub trait ServerModuleInit: ModuleInit + Sized {
     /// Retrieves the migrations map from the server module to be applied to the
     /// database before the module is initialized. The migrations map is
     /// indexed on the from version.
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
         BTreeMap::new()
     }
 
@@ -326,7 +326,7 @@ where
         )
     }
 
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
         <Self as ServerModuleInit>::get_database_migrations(self)
     }
 

--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -12,7 +12,7 @@ use fedimint_core::config::{
     ModuleInitRegistry, ServerModuleConfig, ServerModuleConsensusConfig,
 };
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
-use fedimint_core::db::{Database, DatabaseVersion, ServerDbMigrationFn};
+use fedimint_core::db::{Database, DatabaseVersion};
 use fedimint_core::module::{
     CommonModuleInit, CoreConsensusVersion, IDynCommonModuleInit, ModuleConsensusVersion,
     ModuleInit, PeerHandle, SupportedModuleApiVersions,
@@ -20,6 +20,10 @@ use fedimint_core::module::{
 use fedimint_core::task::TaskGroup;
 use fedimint_core::{NumPeers, PeerId, apply, async_trait_maybe_send, dyn_newtype_define};
 
+use crate::migration::{
+    DynServerDbMigrationFn, ServerDbMigrationFnContext, ServerModuleDbMigrationContext,
+    ServerModuleDbMigrationFn,
+};
 use crate::{DynServerModule, ServerModule};
 
 /// Interface for Module Generation
@@ -75,7 +79,7 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
     /// Retrieves the migrations map from the server module to be applied to the
     /// database before the module is initialized. The migrations map is
     /// indexed on the from version.
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn>;
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, DynServerDbMigrationFn>;
 
     /// See [`ServerModuleInit::used_db_prefixes`]
     fn used_db_prefixes(&self) -> Option<BTreeSet<u8>>;
@@ -229,7 +233,9 @@ pub trait ServerModuleInit: ModuleInit + Sized {
     /// Retrieves the migrations map from the server module to be applied to the
     /// database before the module is initialized. The migrations map is
     /// indexed on the from version.
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
+    fn get_database_migrations(
+        &self,
+    ) -> BTreeMap<DatabaseVersion, ServerModuleDbMigrationFn<Self::Module>> {
         BTreeMap::new()
     }
 
@@ -325,9 +331,20 @@ where
             <Self as ServerModuleInit>::get_client_config(self, config)?,
         )
     }
-
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, DynServerDbMigrationFn> {
         <Self as ServerModuleInit>::get_database_migrations(self)
+            .into_iter()
+            .map(|(k, f)| {
+                (k, {
+                    let closure: DynServerDbMigrationFn =
+                        Box::new(move |ctx: ServerDbMigrationFnContext<'_>| {
+                            let map = ctx.map(ServerModuleDbMigrationContext::new);
+                            Box::pin(f(map))
+                        });
+                    closure
+                })
+            })
+            .collect()
     }
 
     fn used_db_prefixes(&self) -> Option<BTreeSet<u8>> {

--- a/fedimint-server-core/src/lib.rs
+++ b/fedimint-server-core/src/lib.rs
@@ -6,6 +6,8 @@
 //! and functionality that are only used on the server side.
 
 mod init;
+pub mod migration;
+
 use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/fedimint-server-core/src/migration.rs
+++ b/fedimint-server-core/src/migration.rs
@@ -1,0 +1,171 @@
+use std::collections::BTreeMap;
+use std::marker;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fedimint_core::core::{DynInput, DynModuleConsensusItem, DynOutput, ModuleInstanceId};
+use fedimint_core::db::{
+    Database, DatabaseTransaction, DatabaseVersion, DbMigrationFn, DbMigrationFnContext,
+    apply_migrations_dbtx,
+};
+use fedimint_core::module::ModuleCommon;
+use fedimint_core::util::BoxStream;
+use fedimint_core::{apply, async_trait_maybe_send};
+use futures::StreamExt as _;
+
+use crate::ServerModule;
+
+/// Typed history item of a module
+pub enum DynModuleHistoryItem {
+    ConsensusItem(DynModuleConsensusItem),
+    Input(DynInput),
+    Output(DynOutput),
+}
+
+/// Typed history item of a module
+pub enum ModuleHistoryItem<M: ModuleCommon> {
+    ConsensusItem(M::ConsensusItem),
+    Input(M::Input),
+    Output(M::Output),
+}
+
+/// An interface a server module db migration context needs to implement
+///
+/// An instance of this type is injected to server-side migrations from
+/// `fedimint-server`, but users of it (and `fedimint-server-core`) do not need
+/// to know the implementation.
+#[apply(async_trait_maybe_send!)]
+pub trait IServerDbMigrationContext {
+    /// Get a stream of historical consensus items belonging to the module
+    async fn get_module_history_stream<'s, 'tx>(
+        &'s self,
+        module_id: ModuleInstanceId,
+        dbtx: &'s mut DatabaseTransaction<'tx>,
+    ) -> BoxStream<'s, DynModuleHistoryItem>;
+}
+
+/// A type-erased value implementing [`IServerDbMigrationContext`]
+pub type DynServerDbMigrationContext = Arc<dyn IServerDbMigrationContext + Send + Sync + 'static>;
+
+/// A module-typed wrapper over a typed-erased [`DynServerDbMigrationContext`]
+///
+/// This is to wrap erased [`IServerDbMigrationContext`] interfaces and
+/// expose typed interfaces to the server module db migrations.
+pub struct ServerModuleDbMigrationContext<M> {
+    ctx: DynServerDbMigrationContext,
+    module: marker::PhantomData<M>,
+}
+
+impl<M> ServerModuleDbMigrationContext<M> {
+    pub(crate) fn new(ctx: DynServerDbMigrationContext) -> Self {
+        Self {
+            ctx,
+            module: marker::PhantomData,
+        }
+    }
+
+    fn ctx(&self) -> &DynServerDbMigrationContext {
+        &self.ctx
+    }
+}
+
+/// A type alias of a [`DbMigrationFnContext`] with inner context
+/// set to module-specific-typed [`ServerModuleDbMigrationContext`]
+pub type ServerModuleDbMigrationFnContext<'tx, M> =
+    DbMigrationFnContext<'tx, ServerModuleDbMigrationContext<M>>;
+
+/// An extension trait to access module-specific-typed apis of
+/// [`IServerDbMigrationContext`] injected by the `fedimint-server`.
+///
+/// Needs to be an extension trait, as `fedimint-server-core` can't
+/// implement things on general-purpose [`DbMigrationFnContext`]
+#[async_trait]
+pub trait ServerModuleDbMigrationFnContextExt<M>
+where
+    M: ServerModule,
+{
+    async fn get_typed_module_history_stream(
+        &mut self,
+    ) -> BoxStream<ModuleHistoryItem<<M as ServerModule>::Common>>;
+}
+
+#[async_trait]
+impl<M> ServerModuleDbMigrationFnContextExt<M> for ServerModuleDbMigrationFnContext<'_, M>
+where
+    M: ServerModule + Send + Sync,
+{
+    async fn get_typed_module_history_stream(
+        &mut self,
+    ) -> BoxStream<ModuleHistoryItem<<M as ServerModule>::Common>> {
+        let module_instance_id = self
+            .module_instance_id()
+            .expect("module_instance_id must be set");
+        let (dbtx, ctx) = self.split_dbtx_ctx();
+
+        Box::pin(
+            ctx
+                .ctx()
+                .get_module_history_stream(
+                    module_instance_id,
+                    dbtx
+                )
+                .await
+                .map(|item| match item {
+                    DynModuleHistoryItem::ConsensusItem(ci) => ModuleHistoryItem::ConsensusItem(
+                        ci.as_any()
+                            .downcast_ref::<<<M as ServerModule>::Common as ModuleCommon>::ConsensusItem>()
+                            .expect("Wrong module type")
+                            .clone(),
+                    ),
+                    DynModuleHistoryItem::Input(input) => ModuleHistoryItem::Input(
+                        input
+                            .as_any()
+                            .downcast_ref::<<<M as ServerModule>::Common as ModuleCommon>::Input>()
+                            .expect("Wrong module type")
+                            .clone(),
+                    ),
+                    DynModuleHistoryItem::Output(output) => ModuleHistoryItem::Output(
+                        output
+                            .as_any()
+                            .downcast_ref::<<<M as ServerModule>::Common as ModuleCommon>::Output>()
+                            .expect("Wrong module type")
+                            .clone(),
+                    ),
+                }),
+        )
+    }
+}
+
+/// A [`DbMigrationFn`] with inner-context type-specific for a given server
+/// module
+pub type ServerModuleDbMigrationFn<M> = DbMigrationFn<ServerModuleDbMigrationContext<M>>;
+
+/// A [`DbMigrationFn`] with inner-context type-erased for all server modules
+pub type DynServerDbMigrationFn = DbMigrationFn<DynServerDbMigrationContext>;
+/// A [`DbMigrationFnContext`] with inner-context type-erased around
+/// [`IServerDbMigrationContext`]
+pub type ServerDbMigrationFnContext<'tx> = DbMigrationFnContext<'tx, DynServerDbMigrationContext>;
+
+/// See [`apply_migrations_server_dbtx`]
+pub async fn apply_migrations_server(
+    ctx: DynServerDbMigrationContext,
+    db: &Database,
+    kind: String,
+    migrations: BTreeMap<DatabaseVersion, DynServerDbMigrationFn>,
+) -> Result<(), anyhow::Error> {
+    let mut global_dbtx = db.begin_transaction().await;
+    global_dbtx.ensure_global()?;
+    apply_migrations_server_dbtx(&mut global_dbtx.to_ref_nc(), ctx, kind, migrations).await?;
+    global_dbtx.commit_tx_result().await
+}
+
+/// Applies the database migrations to a non-isolated database.
+pub async fn apply_migrations_server_dbtx(
+    global_dbtx: &mut DatabaseTransaction<'_>,
+    ctx: DynServerDbMigrationContext,
+    kind: String,
+    migrations: BTreeMap<DatabaseVersion, DynServerDbMigrationFn>,
+) -> Result<(), anyhow::Error> {
+    global_dbtx.ensure_global()?;
+    apply_migrations_dbtx(global_dbtx, ctx, kind, migrations, None, None).await
+}

--- a/fedimint-server-tests/tests/migration.rs
+++ b/fedimint-server-tests/tests/migration.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::ensure;
 use bitcoin::key::Keypair;
@@ -23,8 +24,8 @@ use fedimint_dummy_server::Dummy;
 use fedimint_logging::{LOG_DB, TracingSetup};
 use fedimint_server::consensus::db::{
     AcceptedItemKey, AcceptedItemPrefix, AcceptedTransactionKey, AcceptedTransactionKeyPrefix,
-    AlephUnitsKey, AlephUnitsPrefix, SignedSessionOutcomeKey, SignedSessionOutcomePrefix,
-    get_global_database_migrations,
+    AlephUnitsKey, AlephUnitsPrefix, ServerDbMigrationContext, SignedSessionOutcomeKey,
+    SignedSessionOutcomePrefix, get_global_database_migrations,
 };
 use fedimint_server::core::ServerModule;
 use fedimint_server::db::DbKeyPrefix;
@@ -221,6 +222,7 @@ async fn test_server_db_migrations() -> anyhow::Result<()> {
             }
             Ok(())
         },
+        Arc::new(ServerDbMigrationContext) as Arc<_>,
         "fedimint-server",
         get_global_database_migrations(),
         ModuleDecoderRegistry::from_iter([(

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -28,7 +28,7 @@ bls12_381 = { workspace = true }
 bytes = { workspace = true }
 fedimint-aead = { workspace = true }
 fedimint-api-client = { workspace = true }
-fedimint-bitcoind = { workspace = true }
+fedimint-bitcoind = { workspace = true, features = ["fedimint-server"] }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-metrics = { workspace = true }

--- a/fedimint-server/src/consensus/db.rs
+++ b/fedimint-server/src/consensus/db.rs
@@ -3,7 +3,8 @@ use std::fmt::Debug;
 
 use fedimint_core::core::{DynInput, DynModuleConsensusItem, DynOutput, ModuleInstanceId};
 use fedimint_core::db::{
-    CoreMigrationFn, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, MigrationContext,
+    DatabaseVersion, DbMigrationFnContext, IDatabaseTransactionOpsCoreTyped,
+    ServerDbMigrationContext, ServerDbMigrationFn,
 };
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::ConsensusItem;
@@ -78,7 +79,7 @@ impl_db_record!(
 );
 impl_db_lookup!(key = AlephUnitsKey, query_prefix = AlephUnitsPrefix);
 
-pub fn get_global_database_migrations() -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
+pub fn get_global_database_migrations() -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
     BTreeMap::new()
 }
 
@@ -104,7 +105,7 @@ pub trait MigrationContextExt {
 }
 
 #[apply(async_trait_maybe_send!)]
-impl MigrationContextExt for MigrationContext<'_> {
+impl MigrationContextExt for DbMigrationFnContext<'_, ServerDbMigrationContext> {
     async fn get_module_history_stream(&mut self) -> BoxStream<ModuleHistoryItem> {
         let module_instance_id = self
             .module_instance_id()

--- a/fedimint-server/src/consensus/db.rs
+++ b/fedimint-server/src/consensus/db.rs
@@ -1,17 +1,16 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
-use fedimint_core::core::{DynInput, DynModuleConsensusItem, DynOutput, ModuleInstanceId};
-use fedimint_core::db::{
-    DatabaseVersion, DbMigrationFnContext, IDatabaseTransactionOpsCoreTyped,
-    ServerDbMigrationContext, ServerDbMigrationFn,
-};
+use fedimint_core::core::ModuleInstanceId;
+use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::epoch::ConsensusItem;
-use fedimint_core::module::ModuleCommon;
 use fedimint_core::session_outcome::{AcceptedItem, SignedSessionOutcome};
 use fedimint_core::util::BoxStream;
 use fedimint_core::{TransactionId, apply, async_trait_maybe_send, impl_db_lookup, impl_db_record};
+use fedimint_server_core::migration::{
+    DynModuleHistoryItem, DynServerDbMigrationFn, IServerDbMigrationContext,
+};
 use futures::StreamExt;
 use serde::Serialize;
 
@@ -79,51 +78,37 @@ impl_db_record!(
 );
 impl_db_lookup!(key = AlephUnitsKey, query_prefix = AlephUnitsPrefix);
 
-pub fn get_global_database_migrations() -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
+pub fn get_global_database_migrations() -> BTreeMap<DatabaseVersion, DynServerDbMigrationFn> {
     BTreeMap::new()
 }
 
-pub enum ModuleHistoryItem {
-    ConsensusItem(DynModuleConsensusItem),
-    Input(DynInput),
-    Output(DynOutput),
-}
-
-pub enum TypedModuleHistoryItem<M: ModuleCommon> {
-    ConsensusItem(M::ConsensusItem),
-    Input(M::Input),
-    Output(M::Output),
-}
+/// A concrete implementation of [`IServerDbMigrationContext`] APIs
+/// available for server-module db migrations.
+pub struct ServerDbMigrationContext;
 
 #[apply(async_trait_maybe_send!)]
-pub trait MigrationContextExt {
-    async fn get_module_history_stream(&mut self) -> BoxStream<ModuleHistoryItem>;
-
-    async fn get_typed_module_history_stream<M: ModuleCommon>(
-        &mut self,
-    ) -> BoxStream<TypedModuleHistoryItem<M>>;
-}
-
-#[apply(async_trait_maybe_send!)]
-impl MigrationContextExt for DbMigrationFnContext<'_, ServerDbMigrationContext> {
-    async fn get_module_history_stream(&mut self) -> BoxStream<ModuleHistoryItem> {
-        let module_instance_id = self
-            .module_instance_id()
-            .expect("module_instance_id must be set");
+impl IServerDbMigrationContext for ServerDbMigrationContext {
+    async fn get_module_history_stream<'s, 'tx>(
+        &'s self,
+        module_instance_id: ModuleInstanceId,
+        dbtx: &'s mut DatabaseTransaction<'tx>,
+    ) -> BoxStream<'s, DynModuleHistoryItem>
+    where
+        'tx: 's,
+    {
+        dbtx.ensure_global().expect("Dbtx must be global");
 
         // Items of the currently ongoing session, that have already been processed. We
         // have to query them in full first and collect them into a vector so we don't
         // hold two references to the dbtx at the same time.
-        let active_session_items = self
-            .__global_dbtx()
+        let active_session_items = dbtx
             .find_by_prefix(&AcceptedItemPrefix)
             .await
             .map(|(_, item)| item)
             .collect::<Vec<_>>()
             .await;
 
-        let stream = self
-            .__global_dbtx()
+        let stream = dbtx
             .find_by_prefix(&SignedSessionOutcomePrefix)
             .await
             // Transform the session stream into an accepted item stream
@@ -140,16 +125,16 @@ impl MigrationContextExt for DbMigrationFnContext<'_, ServerDbMigrationContext> 
                         .into_iter()
                         .filter_map(|input| {
                             (input.module_instance_id() == module_instance_id)
-                                .then_some(ModuleHistoryItem::Input(input))
+                                .then_some(DynModuleHistoryItem::Input(input))
                         })
                         .chain(tx.outputs.into_iter().filter_map(|output| {
                             (output.module_instance_id() == module_instance_id)
-                                .then_some(ModuleHistoryItem::Output(output))
+                                .then_some(DynModuleHistoryItem::Output(output))
                         }))
                         .collect::<Vec<_>>(),
                     ConsensusItem::Module(mci) => {
                         if mci.module_instance_id() == module_instance_id {
-                            vec![ModuleHistoryItem::ConsensusItem(mci)]
+                            vec![DynModuleHistoryItem::ConsensusItem(mci)]
                         } else {
                             vec![]
                         }
@@ -162,34 +147,5 @@ impl MigrationContextExt for DbMigrationFnContext<'_, ServerDbMigrationContext> 
             });
 
         Box::pin(stream)
-    }
-
-    async fn get_typed_module_history_stream<M: ModuleCommon>(
-        &mut self,
-    ) -> BoxStream<TypedModuleHistoryItem<M>> {
-        Box::pin(self.get_module_history_stream().await.map(|item| {
-            match item {
-                ModuleHistoryItem::ConsensusItem(ci) => TypedModuleHistoryItem::ConsensusItem(
-                    ci.as_any()
-                        .downcast_ref::<M::ConsensusItem>()
-                        .expect("Wrong module type")
-                        .clone(),
-                ),
-                ModuleHistoryItem::Input(input) => TypedModuleHistoryItem::Input(
-                    input
-                        .as_any()
-                        .downcast_ref::<M::Input>()
-                        .expect("Wrong module type")
-                        .clone(),
-                ),
-                ModuleHistoryItem::Output(output) => TypedModuleHistoryItem::Output(
-                    output
-                        .as_any()
-                        .downcast_ref::<M::Output>()
-                        .expect("Wrong module type")
-                        .clone(),
-                ),
-            }
-        }))
     }
 }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -14,14 +14,11 @@ use std::time::Duration;
 
 use anyhow::bail;
 use async_channel::Sender;
-use db::get_global_database_migrations;
+use db::{ServerDbMigrationContext, get_global_database_migrations};
 use fedimint_api_client::api::{DynGlobalApi, P2PConnectionStatus};
 use fedimint_core::config::P2PMessage;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
-use fedimint_core::db::{
-    Database, FakeServerDbMigrationContext, apply_migrations_dbtx, apply_migrations_server_dbtx,
-    verify_module_db_integrity_dbtx,
-};
+use fedimint_core::db::{Database, apply_migrations_dbtx, verify_module_db_integrity_dbtx};
 use fedimint_core::envs::is_running_in_test_env;
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::registry::ModuleRegistry;
@@ -31,6 +28,7 @@ use fedimint_core::task::TaskGroup;
 use fedimint_core::util::FmtCompactAnyhow as _;
 use fedimint_core::{NumPeers, PeerId};
 use fedimint_logging::{LOG_CONSENSUS, LOG_CORE, LOG_NET_API};
+use fedimint_server_core::migration::apply_migrations_server_dbtx;
 use fedimint_server_core::{DynServerModule, ServerModuleInitRegistry};
 use futures::FutureExt;
 use iroh::Endpoint;
@@ -71,7 +69,7 @@ pub async fn run(
     let mut global_dbtx = db.begin_transaction().await;
     apply_migrations_server_dbtx(
         &mut global_dbtx.to_ref_nc(),
-        Arc::new(FakeServerDbMigrationContext),
+        Arc::new(ServerDbMigrationContext),
         "fedimint-server".to_string(),
         get_global_database_migrations(),
     )
@@ -106,7 +104,7 @@ pub async fn run(
                 let mut dbtx = db.begin_transaction().await;
                 apply_migrations_dbtx(
                     &mut dbtx.to_ref_nc(),
-                    Arc::new(FakeServerDbMigrationContext) as Arc<_>,
+                    Arc::new(ServerDbMigrationContext) as Arc<_>,
                     module_init.module_kind().to_string(),
                     module_init.get_database_migrations(),
                     Some(*module_id),

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -19,7 +19,8 @@ use fedimint_api_client::api::{DynGlobalApi, P2PConnectionStatus};
 use fedimint_core::config::P2PMessage;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{
-    Database, apply_migrations_dbtx, apply_migrations_server_dbtx, verify_module_db_integrity_dbtx,
+    Database, FakeServerDbMigrationContext, apply_migrations_dbtx, apply_migrations_server_dbtx,
+    verify_module_db_integrity_dbtx,
 };
 use fedimint_core::envs::is_running_in_test_env;
 use fedimint_core::epoch::ConsensusItem;
@@ -70,6 +71,7 @@ pub async fn run(
     let mut global_dbtx = db.begin_transaction().await;
     apply_migrations_server_dbtx(
         &mut global_dbtx.to_ref_nc(),
+        Arc::new(FakeServerDbMigrationContext),
         "fedimint-server".to_string(),
         get_global_database_migrations(),
     )
@@ -104,6 +106,7 @@ pub async fn run(
                 let mut dbtx = db.begin_transaction().await;
                 apply_migrations_dbtx(
                     &mut dbtx.to_ref_nc(),
+                    Arc::new(FakeServerDbMigrationContext) as Arc<_>,
                     module_init.module_kind().to_string(),
                     module_init.get_database_migrations(),
                     Some(*module_id),

--- a/gateway/fedimint-gateway-server/Cargo.toml
+++ b/gateway/fedimint-gateway-server/Cargo.toml
@@ -9,7 +9,11 @@ readme = { workspace = true }
 repository = { workspace = true }
 
 [features]
-tor = ["fedimint-client/tor", "fedimint-api-client/tor", "fedimint-gateway-common/tor"]
+tor = [
+  "fedimint-client/tor",
+  "fedimint-api-client/tor",
+  "fedimint-gateway-common/tor",
+]
 
 [[bin]]
 name = "gatewayd"

--- a/gateway/fedimint-gateway-server/src/db.rs
+++ b/gateway/fedimint-gateway-server/src/db.rs
@@ -4,8 +4,8 @@ use bitcoin::hashes::{Hash, sha256};
 use fedimint_api_client::api::net::Connector;
 use fedimint_core::config::FederationId;
 use fedimint_core::db::{
-    Database, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCore,
-    IDatabaseTransactionOpsCoreTyped, ServerDbMigrationFn, ServerDbMigrationFnContext,
+    Database, DatabaseTransaction, DatabaseVersion, GeneralDbMigrationFn,
+    GeneralDbMigrationFnContext, IDatabaseTransactionOpsCore, IDatabaseTransactionOpsCoreTyped,
 };
 use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -405,8 +405,8 @@ impl_db_lookup!(
     query_prefix = PreimageAuthenticationPrefix
 );
 
-pub fn get_gatewayd_database_migrations() -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
-    let mut migrations: BTreeMap<DatabaseVersion, ServerDbMigrationFn> = BTreeMap::new();
+pub fn get_gatewayd_database_migrations() -> BTreeMap<DatabaseVersion, GeneralDbMigrationFn> {
+    let mut migrations: BTreeMap<DatabaseVersion, GeneralDbMigrationFn> = BTreeMap::new();
     migrations.insert(
         DatabaseVersion(0),
         Box::new(|ctx| migrate_to_v1(ctx).boxed()),
@@ -430,7 +430,7 @@ pub fn get_gatewayd_database_migrations() -> BTreeMap<DatabaseVersion, ServerDbM
     migrations
 }
 
-async fn migrate_to_v1(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v1(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
     /// Creates a password hash by appending a 4 byte salt to the plaintext
     /// password.
     fn hash_password(plaintext_password: &str, salt: [u8; 16]) -> sha256::Hash {
@@ -460,7 +460,7 @@ async fn migrate_to_v1(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), an
     Ok(())
 }
 
-async fn migrate_to_v2(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v2(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
     let mut dbtx = ctx.dbtx();
 
     // If there is no old federation configuration, there is nothing to do.
@@ -488,7 +488,7 @@ async fn migrate_to_v2(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), an
     Ok(())
 }
 
-async fn migrate_to_v3(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v3(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
     let mut dbtx = ctx.dbtx();
 
     // If there is no old gateway configuration, there is nothing to do.
@@ -505,7 +505,7 @@ async fn migrate_to_v3(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), an
     Ok(())
 }
 
-async fn migrate_to_v4(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v4(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
     let mut dbtx = ctx.dbtx();
 
     dbtx.remove_entry(&GatewayConfigurationKeyV2).await;
@@ -535,7 +535,7 @@ async fn migrate_to_v4(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), an
 /// record and the isolated databases used for each client. We must migrate the
 /// isolated databases to be behind the `ClientDatabase` prefix to allow the
 /// gateway to properly read the federation configs.
-async fn migrate_to_v5(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+async fn migrate_to_v5(mut ctx: GeneralDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
     let mut dbtx = ctx.dbtx();
     migrate_federation_configs(&mut dbtx).await
 }

--- a/gateway/fedimint-gateway-server/src/db/fedimint_migration_tests.rs
+++ b/gateway/fedimint-gateway-server/src/db/fedimint_migration_tests.rs
@@ -133,6 +133,7 @@ async fn test_server_db_migrations() -> anyhow::Result<()> {
             }
             Ok(())
         },
+        (),
         "gatewayd",
         get_gatewayd_database_migrations(),
         ModuleDecoderRegistry::from_iter([]),

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -54,7 +54,9 @@ use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET, ModuleInstanceId,
     ModuleKind,
 };
-use fedimint_core::db::{Database, DatabaseTransaction, apply_migrations_server};
+use fedimint_core::db::{
+    Database, DatabaseTransaction, FakeServerDbMigrationContext, apply_migrations_server,
+};
 use fedimint_core::envs::is_env_var_set;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::CommonModuleInit;
@@ -342,6 +344,7 @@ impl Gateway {
         // Apply database migrations before using the database to ensure old database
         // structures are readable.
         apply_migrations_server(
+            Arc::new(FakeServerDbMigrationContext),
             &gateway_db,
             "gatewayd".to_string(),
             get_gatewayd_database_migrations(),

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -54,9 +54,7 @@ use fedimint_core::core::{
     LEGACY_HARDCODED_INSTANCE_ID_MINT, LEGACY_HARDCODED_INSTANCE_ID_WALLET, ModuleInstanceId,
     ModuleKind,
 };
-use fedimint_core::db::{
-    Database, DatabaseTransaction, FakeServerDbMigrationContext, apply_migrations_server,
-};
+use fedimint_core::db::{Database, DatabaseTransaction, apply_migrations};
 use fedimint_core::envs::is_env_var_set;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::CommonModuleInit;
@@ -343,11 +341,13 @@ impl Gateway {
     ) -> anyhow::Result<Gateway> {
         // Apply database migrations before using the database to ensure old database
         // structures are readable.
-        apply_migrations_server(
-            Arc::new(FakeServerDbMigrationContext),
+        apply_migrations(
             &gateway_db,
+            (),
             "gatewayd".to_string(),
             get_gatewayd_database_migrations(),
+            None,
+            None,
         )
         .await?;
 

--- a/modules/fedimint-dummy-client/src/lib.rs
+++ b/modules/fedimint-dummy-client/src/lib.rs
@@ -12,7 +12,7 @@ use anyhow::{Context as _, anyhow, format_err};
 use common::broken_fed_key_pair;
 use db::{DbKeyPrefix, DummyClientFundsKeyV1, DummyClientNameKey, migrate_to_v1};
 use fedimint_api_client::api::{FederationApiExt, SerdeOutputOutcome, deserialize_outcome};
-use fedimint_client_module::db::{ClientMigrationFn, migrate_state};
+use fedimint_client_module::db::{ClientModuleMigrationFn, migrate_state};
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
@@ -433,8 +433,8 @@ impl ClientModuleInit for DummyClientInit {
         })
     }
 
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn> {
-        let mut migrations: BTreeMap<DatabaseVersion, ClientMigrationFn> = BTreeMap::new();
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
+        let mut migrations: BTreeMap<DatabaseVersion, ClientModuleMigrationFn> = BTreeMap::new();
         migrations.insert(DatabaseVersion(0), |dbtx, _, _| {
             Box::pin(migrate_to_v1(dbtx))
         });

--- a/modules/fedimint-dummy-server/src/db.rs
+++ b/modules/fedimint-dummy-server/src/db.rs
@@ -1,4 +1,4 @@
-use fedimint_core::db::{IDatabaseTransactionOpsCoreTyped, MigrationContext};
+use fedimint_core::db::{IDatabaseTransactionOpsCoreTyped, ServerDbMigrationFnContext};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::secp256k1::PublicKey;
 use fedimint_core::{Amount, OutPoint, impl_db_lookup, impl_db_record};
@@ -53,7 +53,7 @@ impl_db_record!(
 impl_db_lookup!(key = DummyFundsKeyV1, query_prefix = DummyFundsPrefixV1);
 
 /// Example DB migration from version 0 to version 1
-pub async fn migrate_to_v1(mut ctx: MigrationContext<'_>) -> Result<(), anyhow::Error> {
+pub async fn migrate_to_v1(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
     let mut dbtx = ctx.dbtx();
     // Select old entries
     let v0_entries = dbtx

--- a/modules/fedimint-dummy-server/src/db.rs
+++ b/modules/fedimint-dummy-server/src/db.rs
@@ -1,12 +1,13 @@
-use fedimint_core::db::{IDatabaseTransactionOpsCoreTyped, ServerDbMigrationFnContext};
+use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::secp256k1::PublicKey;
 use fedimint_core::{Amount, OutPoint, impl_db_lookup, impl_db_record};
+use fedimint_server_core::migration::ServerModuleDbMigrationFnContext;
 use futures::StreamExt;
 use serde::Serialize;
 use strum_macros::EnumIter;
 
-use crate::DummyOutputOutcome;
+use crate::{Dummy, DummyOutputOutcome};
 
 /// Namespaces DB keys for this module
 #[repr(u8)]
@@ -53,7 +54,9 @@ impl_db_record!(
 impl_db_lookup!(key = DummyFundsKeyV1, query_prefix = DummyFundsPrefixV1);
 
 /// Example DB migration from version 0 to version 1
-pub async fn migrate_to_v1(mut ctx: ServerDbMigrationFnContext<'_>) -> Result<(), anyhow::Error> {
+pub async fn migrate_to_v1(
+    mut ctx: ServerModuleDbMigrationFnContext<'_, Dummy>,
+) -> Result<(), anyhow::Error> {
     let mut dbtx = ctx.dbtx();
     // Select old entries
     let v0_entries = dbtx

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -14,7 +14,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    CoreMigrationFn, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
+    DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, ServerDbMigrationFn,
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -179,8 +179,8 @@ impl ServerModuleInit for DummyInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
-        let mut migrations: BTreeMap<DatabaseVersion, CoreMigrationFn> = BTreeMap::new();
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
+        let mut migrations: BTreeMap<DatabaseVersion, ServerDbMigrationFn> = BTreeMap::new();
         migrations.insert(
             DatabaseVersion(0),
             Box::new(|ctx| migrate_to_v1(ctx).boxed()),

--- a/modules/fedimint-dummy-server/src/lib.rs
+++ b/modules/fedimint-dummy-server/src/lib.rs
@@ -13,9 +13,7 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{
-    DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, ServerDbMigrationFn,
-};
+use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     ApiEndpoint, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
@@ -31,6 +29,7 @@ use fedimint_dummy_common::{
     DummyOutput, DummyOutputError, DummyOutputOutcome, MODULE_CONSENSUS_VERSION,
     broken_fed_public_key, fed_public_key,
 };
+use fedimint_server_core::migration::ServerModuleDbMigrationFn;
 use fedimint_server_core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use futures::{FutureExt, StreamExt};
 use strum::IntoEnumIterator;
@@ -179,8 +178,11 @@ impl ServerModuleInit for DummyInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
-        let mut migrations: BTreeMap<DatabaseVersion, ServerDbMigrationFn> = BTreeMap::new();
+    fn get_database_migrations(
+        &self,
+    ) -> BTreeMap<DatabaseVersion, ServerModuleDbMigrationFn<Dummy>> {
+        let mut migrations: BTreeMap<DatabaseVersion, ServerModuleDbMigrationFn<Dummy>> =
+            BTreeMap::new();
         migrations.insert(
             DatabaseVersion(0),
             Box::new(|ctx| migrate_to_v1(ctx).boxed()),

--- a/modules/fedimint-empty-client/src/lib.rs
+++ b/modules/fedimint-empty-client/src/lib.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeMap;
 
 use db::DbKeyPrefix;
-use fedimint_client_module::db::ClientMigrationFn;
+use fedimint_client_module::db::ClientModuleMigrationFn;
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule};
@@ -127,7 +127,7 @@ impl ClientModuleInit for EmptyClientInit {
         })
     }
 
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn> {
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
         BTreeMap::new()
     }
 }

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -11,7 +11,7 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{CoreMigrationFn, DatabaseTransaction, DatabaseVersion};
+use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, ServerDbMigrationFn};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     ApiEndpoint, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
@@ -155,7 +155,7 @@ impl ServerModuleInit for EmptyInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
         BTreeMap::new()
     }
 }

--- a/modules/fedimint-empty-server/src/lib.rs
+++ b/modules/fedimint-empty-server/src/lib.rs
@@ -11,7 +11,7 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, ServerDbMigrationFn};
+use fedimint_core::db::{DatabaseTransaction, DatabaseVersion};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     ApiEndpoint, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
@@ -26,6 +26,7 @@ use fedimint_empty_common::{
     EmptyCommonInit, EmptyConsensusItem, EmptyInput, EmptyInputError, EmptyModuleTypes,
     EmptyOutput, EmptyOutputError, EmptyOutputOutcome, MODULE_CONSENSUS_VERSION,
 };
+use fedimint_server_core::migration::ServerModuleDbMigrationFn;
 use fedimint_server_core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use futures::StreamExt;
 use strum::IntoEnumIterator;
@@ -155,7 +156,9 @@ impl ServerModuleInit for EmptyInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
+    fn get_database_migrations(
+        &self,
+    ) -> BTreeMap<DatabaseVersion, ServerModuleDbMigrationFn<Empty>> {
         BTreeMap::new()
     }
 }

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -29,7 +29,7 @@ use db::{
     DbKeyPrefix, LightningGatewayKey, LightningGatewayKeyPrefix, PaymentResult, PaymentResultKey,
 };
 use fedimint_api_client::api::DynModuleApi;
-use fedimint_client_module::db::{ClientMigrationFn, migrate_state};
+use fedimint_client_module::db::{ClientModuleMigrationFn, migrate_state};
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
 use fedimint_client_module::module::{ClientContext, ClientModule, IClientModule, OutPointRange};
@@ -350,8 +350,8 @@ impl ClientModuleInit for LightningClientInit {
         Ok(LightningClientModule::new(args, self.gateway_conn.clone()))
     }
 
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn> {
-        let mut migrations: BTreeMap<DatabaseVersion, ClientMigrationFn> = BTreeMap::new();
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
+        let mut migrations: BTreeMap<DatabaseVersion, ClientModuleMigrationFn> = BTreeMap::new();
         migrations.insert(DatabaseVersion(0), |dbtx, _, _| {
             Box::pin(async {
                 dbtx.remove_entry(&crate::db::ActiveGatewayKey).await;

--- a/modules/fedimint-meta-client/src/lib.rs
+++ b/modules/fedimint-meta-client/src/lib.rs
@@ -15,7 +15,7 @@ use api::MetaFederationApi;
 use common::{KIND, MetaConsensusValue, MetaKey, MetaValue};
 use db::DbKeyPrefix;
 use fedimint_api_client::api::{DynGlobalApi, DynModuleApi};
-use fedimint_client_module::db::ClientMigrationFn;
+use fedimint_client_module::db::ClientModuleMigrationFn;
 use fedimint_client_module::meta::{FetchKind, LegacyMetaSource, MetaSource, MetaValues};
 use fedimint_client_module::module::init::{ClientModuleInit, ClientModuleInitArgs};
 use fedimint_client_module::module::recovery::NoModuleBackup;
@@ -197,7 +197,7 @@ impl ClientModuleInit for MetaClientInit {
         })
     }
 
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn> {
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
         BTreeMap::new()
     }
 }

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -18,7 +18,6 @@ use fedimint_core::config::{
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
     DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, NonCommittable,
-    ServerDbMigrationFn,
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -42,6 +41,7 @@ use fedimint_meta_common::{
     MetaInputError, MetaKey, MetaModuleTypes, MetaOutput, MetaOutputError, MetaOutputOutcome,
     MetaValue,
 };
+use fedimint_server::core::migration::ServerModuleDbMigrationFn;
 use fedimint_server::core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use futures::StreamExt;
 use rand::{Rng, thread_rng};
@@ -198,7 +198,9 @@ impl ServerModuleInit for MetaInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
+    fn get_database_migrations(
+        &self,
+    ) -> BTreeMap<DatabaseVersion, ServerModuleDbMigrationFn<Meta>> {
         BTreeMap::new()
     }
 }

--- a/modules/fedimint-meta-server/src/lib.rs
+++ b/modules/fedimint-meta-server/src/lib.rs
@@ -17,8 +17,8 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    CoreMigrationFn, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
-    NonCommittable,
+    DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped, NonCommittable,
+    ServerDbMigrationFn,
 };
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
@@ -198,7 +198,7 @@ impl ServerModuleInit for MetaInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
         BTreeMap::new()
     }
 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -44,7 +44,7 @@ use client_db::{
     migrate_to_v1,
 };
 use event::{NoteSpent, OOBNotesReissued, OOBNotesSpent};
-use fedimint_client_module::db::{ClientMigrationFn, migrate_state};
+use fedimint_client_module::db::{ClientModuleMigrationFn, migrate_state};
 use fedimint_client_module::module::init::{
     ClientModuleInit, ClientModuleInitArgs, ClientModuleRecoverArgs,
 };
@@ -554,8 +554,8 @@ impl ClientModuleInit for MintClientInit {
             .await
     }
 
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientMigrationFn> {
-        let mut migrations: BTreeMap<DatabaseVersion, ClientMigrationFn> = BTreeMap::new();
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ClientModuleMigrationFn> {
+        let mut migrations: BTreeMap<DatabaseVersion, ClientModuleMigrationFn> = BTreeMap::new();
         migrations.insert(DatabaseVersion(0), |dbtx, _, _| {
             Box::pin(migrate_to_v1(dbtx))
         });

--- a/modules/fedimint-unknown-server/src/lib.rs
+++ b/modules/fedimint-unknown-server/src/lib.rs
@@ -11,7 +11,7 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{CoreMigrationFn, DatabaseTransaction, DatabaseVersion};
+use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, ServerDbMigrationFn};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     ApiEndpoint, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
@@ -130,8 +130,8 @@ impl ServerModuleInit for UnknownInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
-        let mut migrations: BTreeMap<DatabaseVersion, CoreMigrationFn> = BTreeMap::new();
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
+        let mut migrations: BTreeMap<DatabaseVersion, ServerDbMigrationFn> = BTreeMap::new();
         // Unknown module prior to v0.5.0 had a `DATABASE_VERSION` of 1, so we must
         // insert a no-op migration to ensure that upgrades work.
         migrations.insert(DatabaseVersion(0), Box::new(|_| Box::pin(async { Ok(()) })));

--- a/modules/fedimint-unknown-server/src/lib.rs
+++ b/modules/fedimint-unknown-server/src/lib.rs
@@ -11,13 +11,14 @@ use fedimint_core::config::{
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
 };
 use fedimint_core::core::ModuleInstanceId;
-use fedimint_core::db::{DatabaseTransaction, DatabaseVersion, ServerDbMigrationFn};
+use fedimint_core::db::{DatabaseTransaction, DatabaseVersion};
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     ApiEndpoint, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta, ModuleConsensusVersion,
     ModuleInit, PeerHandle, SupportedModuleApiVersions, TransactionItemAmount,
 };
 use fedimint_core::{InPoint, OutPoint, PeerId};
+use fedimint_server_core::migration::ServerModuleDbMigrationFn;
 use fedimint_server_core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 pub use fedimint_unknown_common as common;
 use fedimint_unknown_common::config::{
@@ -130,8 +131,11 @@ impl ServerModuleInit for UnknownInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
-        let mut migrations: BTreeMap<DatabaseVersion, ServerDbMigrationFn> = BTreeMap::new();
+    fn get_database_migrations(
+        &self,
+    ) -> BTreeMap<DatabaseVersion, ServerModuleDbMigrationFn<Unknown>> {
+        let mut migrations: BTreeMap<DatabaseVersion, ServerModuleDbMigrationFn<_>> =
+            BTreeMap::new();
         // Unknown module prior to v0.5.0 had a `DATABASE_VERSION` of 1, so we must
         // insert a no-op migration to ensure that upgrades work.
         migrations.insert(DatabaseVersion(0), Box::new(|_| Box::pin(async { Ok(()) })));

--- a/modules/fedimint-wallet-server/src/db.rs
+++ b/modules/fedimint-wallet-server/src/db.rs
@@ -1,6 +1,8 @@
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::{BlockHash, OutPoint, TxOut, Txid};
-use fedimint_core::db::{IDatabaseTransactionOpsCoreTyped, MigrationContext};
+use fedimint_core::db::{
+    DbMigrationFnContext, IDatabaseTransactionOpsCoreTyped, ServerDbMigrationContext,
+};
 use fedimint_core::encoding::{Decodable, Encodable};
 use fedimint_core::module::ModuleConsensusVersion;
 use fedimint_core::{PeerId, impl_db_lookup, impl_db_record};
@@ -198,7 +200,9 @@ impl_db_lookup!(
 );
 
 /// Migrate to v1, backfilling all previously pegged-in outpoints
-pub async fn migrate_to_v1(mut ctx: MigrationContext<'_>) -> Result<(), anyhow::Error> {
+pub async fn migrate_to_v1(
+    mut ctx: DbMigrationFnContext<'_, ServerDbMigrationContext>,
+) -> Result<(), anyhow::Error> {
     let outpoints =
         ctx.get_typed_module_history_stream::<WalletModuleTypes>()
             .await

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -45,8 +45,8 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
-    CoreMigrationFn, Database, DatabaseTransaction, DatabaseVersion,
-    IDatabaseTransactionOpsCoreTyped,
+    Database, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
+    ServerDbMigrationFn,
 };
 use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -401,8 +401,8 @@ impl ServerModuleInit for WalletInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, CoreMigrationFn> {
-        let mut migrations: BTreeMap<DatabaseVersion, CoreMigrationFn> = BTreeMap::new();
+    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
+        let mut migrations: BTreeMap<DatabaseVersion, ServerDbMigrationFn> = BTreeMap::new();
         migrations.insert(
             DatabaseVersion(0),
             Box::new(|ctx| migrate_to_v1(ctx).boxed()),

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -46,7 +46,6 @@ use fedimint_core::config::{
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{
     Database, DatabaseTransaction, DatabaseVersion, IDatabaseTransactionOpsCoreTyped,
-    ServerDbMigrationFn,
 };
 use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
 use fedimint_core::encoding::{Decodable, Encodable};
@@ -67,6 +66,7 @@ use fedimint_core::{
 };
 use fedimint_logging::LOG_MODULE_WALLET;
 use fedimint_server::config::distributedgen::PeerHandleOps;
+use fedimint_server::core::migration::ServerModuleDbMigrationFn;
 use fedimint_server::core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use fedimint_server::net::api::check_auth;
 pub use fedimint_wallet_common as common;
@@ -401,8 +401,11 @@ impl ServerModuleInit for WalletInit {
     }
 
     /// DB migrations to move from old to newer versions
-    fn get_database_migrations(&self) -> BTreeMap<DatabaseVersion, ServerDbMigrationFn> {
-        let mut migrations: BTreeMap<DatabaseVersion, ServerDbMigrationFn> = BTreeMap::new();
+    fn get_database_migrations(
+        &self,
+    ) -> BTreeMap<DatabaseVersion, ServerModuleDbMigrationFn<Wallet>> {
+        let mut migrations: BTreeMap<DatabaseVersion, ServerModuleDbMigrationFn<Wallet>> =
+            BTreeMap::new();
         migrations.insert(
             DatabaseVersion(0),
             Box::new(|ctx| migrate_to_v1(ctx).boxed()),


### PR DESCRIPTION
Ultimately I'd like to server module to stop depending on `fedimint-server` and only on `fedimint-server-core`.

The biggest obstacle for this is the way database transactions are bolted on.

Unfortunately the amount of stuff required to decoupled them is larger than I wish, and I even hit some Rust borrow checker limitation. :/

But it works and is relatively sane, I think, if you can wrap your head around it.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
