### PR TITLE
chore(ci): document why we run tests with wasm32-unknown toolchain

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -174,6 +174,11 @@ jobs:
       - name: Tests
         if: (github.event_name != 'pull_request' || matrix.build-in-pr) && matrix.run-tests
         run: |
+          # Note: wasm32-unknown is a toolchain that contains both the native
+          # toolchain and wasm32-unknown. Since we want to run both native (in this step)
+          # and wasm32 tests (in a different CI step) we can build everything once using
+          # wasm32-unknown and share most of the artifacts. The native parts don't
+          # mind that the toolchain supports extra targets.
           env \
             PERFIT_ACCESS_TOKEN="${{ secrets.PERFIT_ACCESS_TOKEN }}" \
             nix run 'github:rustshop/perfit?rev=a2ea3bae86b0e70d2ebdbca1fd16a843b7f0a3bd#perfit' -- \


### PR DESCRIPTION
Fix #7020

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
