### PR TITLE
 refactor: dbtool to depend only on fedimint-gateway-server-db 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,7 +2777,7 @@ dependencies = [
  "fedimint-client",
  "fedimint-client-module",
  "fedimint-core",
- "fedimint-gateway-server",
+ "fedimint-gateway-server-db",
  "fedimint-ln-client",
  "fedimint-ln-server",
  "fedimint-lnv2-client",
@@ -3033,6 +3033,7 @@ dependencies = [
  "fedimint-dummy-server",
  "fedimint-eventlog",
  "fedimint-gateway-common",
+ "fedimint-gateway-server-db",
  "fedimint-gw-client",
  "fedimint-gwv2-client",
  "fedimint-lightning",
@@ -3072,6 +3073,33 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "fedimint-gateway-server-db"
+version = "0.7.0-alpha"
+dependencies = [
+ "anyhow",
+ "bitcoin",
+ "erased-serde 0.4.6",
+ "fedimint-api-client",
+ "fedimint-client-module",
+ "fedimint-core",
+ "fedimint-eventlog",
+ "fedimint-gateway-common",
+ "fedimint-ln-client",
+ "fedimint-ln-common",
+ "fedimint-lnv2-common",
+ "fedimint-logging",
+ "fedimint-testing",
+ "futures",
+ "lightning-invoice",
+ "rand 0.8.5",
+ "serde",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "gateway/fedimint-gateway-client",
   "gateway/fedimint-gateway-common",
   "gateway/fedimint-gateway-server",
+  "gateway/fedimint-gateway-server-db",
   "gateway/fedimint-lightning",
   "gateway/integration_tests",
   "modules/fedimint-dummy-client",
@@ -143,6 +144,7 @@ fedimint-empty-common = { path = "./modules/fedimint-empty-common", version = "=
 fedimint-eventlog = { path = "./fedimint-eventlog", version = "=0.7.0-alpha" }
 fedimint-gateway-common = { package = "fedimint-gateway-common", path = "./gateway/fedimint-gateway-common", version = "=0.7.0-alpha" }
 fedimint-gateway-server = { package = "fedimint-gateway-server", path = "./gateway/fedimint-gateway-server", version = "=0.7.0-alpha" }
+fedimint-gateway-server-db = { package = "fedimint-gateway-server-db", path = "./gateway/fedimint-gateway-server-db", version = "=0.7.0-alpha" }
 fedimint-gw-client = { path = "./modules/fedimint-gw-client", version = "=0.7.0-alpha" }
 fedimint-gwv2-client = { path = "./modules/fedimint-gwv2-client", version = "=0.7.0-alpha" }
 fedimint-lightning = { package = "fedimint-lightning", path = "./gateway/fedimint-lightning", version = "=0.7.0-alpha" }

--- a/fedimint-dbtool/Cargo.toml
+++ b/fedimint-dbtool/Cargo.toml
@@ -26,7 +26,7 @@ erased-serde = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
-fedimint-gateway-server = { workspace = true }
+fedimint-gateway-server-db = { workspace = true }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-server = { workspace = true }
 fedimint-lnv2-client = { workspace = true }

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -15,7 +15,7 @@ use fedimint_core::db::{
 use fedimint_core::encoding::Encodable;
 use fedimint_core::module::registry::{ModuleDecoderRegistry, ModuleRegistry};
 use fedimint_core::push_db_pair_items;
-use fedimint_gateway_server::Gateway;
+use fedimint_gateway_server_db::GatewayDbtxNcExt as _;
 use fedimint_rocksdb::RocksDbReadOnly;
 use fedimint_server::config::ServerConfig;
 use fedimint_server::config::io::read_server_config;
@@ -199,7 +199,7 @@ impl DatabaseDump {
 
     async fn serialize_gateway(&mut self) -> anyhow::Result<()> {
         let mut dbtx = self.read_only_db.begin_transaction_nc().await;
-        let gateway_serialized = Gateway::dump_database(&mut dbtx, self.prefixes.clone()).await;
+        let gateway_serialized = dbtx.dump_database(self.prefixes.clone()).await;
         self.serialized
             .insert("gateway".to_string(), Box::new(gateway_serialized));
         Ok(())

--- a/gateway/fedimint-gateway-server-db/Cargo.toml
+++ b/gateway/fedimint-gateway-server-db/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "fedimint-gateway-server-db"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+description = "fedimint-gateway-server sends/receives Lightning Network payments on behalf of Fedimint clients (db defintions)"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+name = "fedimint_gateway_server_db"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+bitcoin = { workspace = true }
+erased-serde = { workspace = true }
+fedimint-api-client = { workspace = true }
+fedimint-client-module = { workspace = true }
+fedimint-core = { workspace = true }
+fedimint-eventlog = { workspace = true }
+fedimint-gateway-common = { workspace = true }
+fedimint-ln-client = { workspace = true }
+fedimint-ln-common = { workspace = true }
+fedimint-lnv2-common = { workspace = true }
+futures = { workspace = true }
+lightning-invoice = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true, features = ["log"] }
+
+[dev-dependencies]
+fedimint-logging = { workspace = true }
+fedimint-testing = { workspace = true }

--- a/gateway/fedimint-gateway-server-db/src/lib.rs
+++ b/gateway/fedimint-gateway-server-db/src/lib.rs
@@ -37,6 +37,7 @@ impl GatewayDbExt for Database {
     }
 }
 
+#[allow(async_fn_in_trait)]
 pub trait GatewayDbtxNcExt {
     async fn save_federation_config(&mut self, config: &FederationConfig);
     async fn load_federation_configs_v0(&mut self) -> BTreeMap<FederationId, FederationConfigV0>;
@@ -625,4 +626,4 @@ impl_db_record!(
 );
 
 #[cfg(test)]
-mod fedimint_migration_tests;
+mod migration_tests;

--- a/gateway/fedimint-gateway-server-db/src/migration_tests.rs
+++ b/gateway/fedimint-gateway-server-db/src/migration_tests.rs
@@ -1,0 +1,236 @@
+use std::str::FromStr;
+
+use anyhow::ensure;
+use bitcoin::hashes::Hash;
+use fedimint_core::PeerId;
+use fedimint_core::db::Database;
+use fedimint_core::db::mem_impl::MemDatabase;
+use fedimint_core::module::registry::ModuleDecoderRegistry;
+use fedimint_core::util::SafeUrl;
+use fedimint_lnv2_common::gateway_api::PaymentFee;
+use fedimint_logging::TracingSetup;
+use fedimint_testing::db::{
+    BYTE_32, snapshot_db_migrations_with_decoders, validate_migrations_global,
+};
+use strum::IntoEnumIterator;
+use tracing::info;
+
+use super::{
+    BTreeMap, Connector, DbKeyPrefix, Encodable, FederationConfig, FederationConfigKey,
+    FederationConfigKeyPrefix, FederationConfigKeyV0, FederationConfigV0, FederationId,
+    GatewayConfigurationKeyV0, GatewayConfigurationV0, GatewayDbExt, GatewayPublicKey,
+    IDatabaseTransactionOpsCoreTyped, InviteCode, Keypair, NetworkLegacyEncodingWrapper, OsRng,
+    PreimageAuthentication, PreimageAuthenticationPrefix, StreamExt,
+    get_gatewayd_database_migrations, migrate_federation_configs, secp256k1, sha256,
+};
+
+async fn create_gatewayd_db_data(db: Database) {
+    let mut dbtx = db.begin_transaction().await;
+    let federation_id = FederationId::dummy();
+    let invite_code = InviteCode::new(
+        SafeUrl::from_str("http://myexamplefed.com").expect("SafeUrl parsing can't fail"),
+        0.into(),
+        federation_id,
+        None,
+    );
+    let federation_config = FederationConfigV0 {
+        invite_code,
+        federation_index: 2,
+        timelock_delta: 10,
+        fees: PaymentFee::TRANSACTION_FEE_DEFAULT.into(),
+    };
+
+    dbtx.insert_new_entry(
+        &FederationConfigKeyV0 { id: federation_id },
+        &federation_config,
+    )
+    .await;
+
+    let context = secp256k1::Secp256k1::new();
+    let (secret, _) = context.generate_keypair(&mut OsRng);
+    let key_pair = secp256k1::Keypair::from_secret_key(&context, &secret);
+    dbtx.insert_new_entry(&GatewayPublicKey, &key_pair).await;
+
+    let gateway_configuration = GatewayConfigurationV0 {
+        password: "EXAMPLE".to_string(),
+        num_route_hints: 2,
+        routing_fees: PaymentFee::TRANSACTION_FEE_DEFAULT.into(),
+        network: NetworkLegacyEncodingWrapper(bitcoin::Network::Regtest),
+    };
+
+    dbtx.insert_new_entry(&GatewayConfigurationKeyV0, &gateway_configuration)
+        .await;
+
+    let preimage_auth = PreimageAuthentication {
+        payment_hash: sha256::Hash::from_slice(&BYTE_32).expect("Hash should not fail"),
+    };
+    let verification_hash = sha256::Hash::from_slice(&BYTE_32).expect("Hash should not fail");
+    dbtx.insert_new_entry(&preimage_auth, &verification_hash)
+        .await;
+
+    dbtx.commit_tx().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshot_server_db_migrations() -> anyhow::Result<()> {
+    snapshot_db_migrations_with_decoders(
+        "gatewayd",
+        |db| {
+            Box::pin(async {
+                create_gatewayd_db_data(db).await;
+            })
+        },
+        ModuleDecoderRegistry::from_iter([]),
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_server_db_migrations() -> anyhow::Result<()> {
+    let _ = TracingSetup::default().init();
+    validate_migrations_global(
+        |db| async move {
+            let mut dbtx = db.begin_transaction_nc().await;
+
+            for prefix in DbKeyPrefix::iter() {
+                match prefix {
+                    DbKeyPrefix::FederationConfig => {
+                        let configs = dbtx
+                            .find_by_prefix(&FederationConfigKeyPrefix)
+                            .await
+                            .collect::<Vec<_>>()
+                            .await;
+                        let num_configs = configs.len();
+                        ensure!(
+                            num_configs > 0,
+                            "validate_migrations was not able to read any FederationConfigs"
+                        );
+                        info!("Validated FederationConfig");
+                    }
+                    DbKeyPrefix::GatewayPublicKey => {
+                        let gateway_id = dbtx.get_value(&GatewayPublicKey).await;
+                        ensure!(
+                            gateway_id.is_some(),
+                            "validate_migrations was not able to read GatewayPublicKey"
+                        );
+                        info!("Validated GatewayPublicKey");
+                    }
+                    DbKeyPrefix::PreimageAuthentication => {
+                        let preimage_authentications = dbtx
+                            .find_by_prefix(&PreimageAuthenticationPrefix)
+                            .await
+                            .collect::<Vec<_>>()
+                            .await;
+                        let num_auths = preimage_authentications.len();
+                        ensure!(
+                            num_auths > 0,
+                            "validate_migrations was not able to read any PreimageAuthentication"
+                        );
+                        info!("Validated PreimageAuthentication");
+                    }
+                    _ => {}
+                }
+            }
+            Ok(())
+        },
+        (),
+        "gatewayd",
+        get_gatewayd_database_migrations(),
+        ModuleDecoderRegistry::from_iter([]),
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_isolated_db_migration() -> anyhow::Result<()> {
+    async fn create_isolated_record(prefix: Vec<u8>, db: &Database) {
+        // Create an isolated database the old way where there was no prefix
+        let isolated_db = db.with_prefix(prefix);
+        let mut isolated_dbtx = isolated_db.begin_transaction().await;
+
+        // Insert a record into the isolated db (doesn't matter what it is)
+        isolated_dbtx
+            .insert_new_entry(
+                &GatewayPublicKey,
+                &Keypair::new(secp256k1::SECP256K1, &mut rand::thread_rng()),
+            )
+            .await;
+        isolated_dbtx.commit_tx().await;
+    }
+
+    let nonconflicting_fed_id =
+        FederationId::from_str("1106afdc71a052d2787eab7e84c95803636d2a84c272eb81b4e01b27acb86c6f")
+            .expect("invalid federation ID");
+    let conflicting_fed_id =
+        FederationId::from_str("0406afdc71a052d2787eab7e84c95803636d2a84c272eb81b4e01b27acb86c6f")
+            .expect("invalid federation ID");
+    let _ = TracingSetup::default().init();
+    let db = Database::new(MemDatabase::new(), ModuleDecoderRegistry::default());
+    let mut dbtx = db.begin_transaction().await;
+    dbtx.insert_new_entry(
+        &FederationConfigKey {
+            id: conflicting_fed_id,
+        },
+        &FederationConfig {
+            invite_code: InviteCode::new(
+                SafeUrl::from_str("http://testfed.com").unwrap(),
+                PeerId::from(0),
+                conflicting_fed_id,
+                None,
+            ),
+            federation_index: 0,
+            lightning_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
+            transaction_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
+            connector: Connector::Tcp,
+        },
+    )
+    .await;
+
+    dbtx.insert_new_entry(
+        &FederationConfigKey {
+            id: nonconflicting_fed_id,
+        },
+        &FederationConfig {
+            invite_code: InviteCode::new(
+                SafeUrl::from_str("http://testfed2.com").unwrap(),
+                PeerId::from(0),
+                nonconflicting_fed_id,
+                None,
+            ),
+            federation_index: 1,
+            lightning_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
+            transaction_fee: PaymentFee::TRANSACTION_FEE_DEFAULT,
+            connector: Connector::Tcp,
+        },
+    )
+    .await;
+    dbtx.commit_tx().await;
+
+    create_isolated_record(conflicting_fed_id.consensus_encode_to_vec(), &db).await;
+    create_isolated_record(nonconflicting_fed_id.consensus_encode_to_vec(), &db).await;
+
+    let mut migration_dbtx = db.begin_transaction().await;
+    migrate_federation_configs(&mut migration_dbtx.to_ref_nc()).await?;
+    migration_dbtx.commit_tx().await;
+
+    let mut dbtx = db.begin_transaction_nc().await;
+
+    let num_configs = dbtx
+        .find_by_prefix(&FederationConfigKeyPrefix)
+        .await
+        .collect::<BTreeMap<_, _>>()
+        .await
+        .len();
+    assert_eq!(num_configs, 2);
+
+    // Verify that the client databases migrated successfully.
+    let isolated_db = db.get_client_database(&conflicting_fed_id);
+    let mut isolated_dbtx = isolated_db.begin_transaction_nc().await;
+    assert!(isolated_dbtx.get_value(&GatewayPublicKey).await.is_some());
+
+    let isolated_db = db.get_client_database(&nonconflicting_fed_id);
+    let mut isolated_dbtx = isolated_db.begin_transaction_nc().await;
+    assert!(isolated_dbtx.get_value(&GatewayPublicKey).await.is_some());
+
+    Ok(())
+}

--- a/gateway/fedimint-gateway-server/Cargo.toml
+++ b/gateway/fedimint-gateway-server/Cargo.toml
@@ -38,14 +38,15 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 erased-serde = { workspace = true }
 esplora-client = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.7.0-alpha" }
-fedimint-bip39 = { version = "=0.7.0-alpha", path = "../../fedimint-bip39" }
+fedimint-api-client = { workspace = true }
+fedimint-bip39 = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-gateway-common = { workspace = true }
+fedimint-gateway-server-db = { workspace = true }
 fedimint-gw-client = { workspace = true }
 fedimint-gwv2-client = { workspace = true }
 fedimint-lightning = { path = "../fedimint-lightning", version = "=0.7.0-alpha" }

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -14,10 +14,10 @@ use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_derive_secret::{ChildId, DerivableSecret};
 use fedimint_gateway_common::FederationConfig;
+use fedimint_gateway_server_db::GatewayDbExt as _;
 use fedimint_gw_client::GatewayClientInit;
 use fedimint_gwv2_client::GatewayClientInitV2;
 
-use crate::db::GatewayDbExt;
 use crate::error::AdminGatewayError;
 use crate::{AdminResult, Gateway};
 

--- a/gateway/fedimint-gateway-server/src/federation_manager.rs
+++ b/gateway/fedimint-gateway-server/src/federation_manager.rs
@@ -8,13 +8,13 @@ use fedimint_core::config::{FederationId, FederationIdPrefix, JsonClientConfig};
 use fedimint_core::db::{DatabaseTransaction, NonCommittable};
 use fedimint_core::util::Spanned;
 use fedimint_gateway_common::FederationInfo;
+use fedimint_gateway_server_db::GatewayDbtxNcExt as _;
 use fedimint_gw_client::GatewayClientModule;
 use fedimint_gwv2_client::GatewayClientModuleV2;
 use fedimint_logging::LOG_GATEWAY;
 use tracing::info;
 
 use crate::AdminResult;
-use crate::db::GatewayDbtxNcExt;
 use crate::error::{AdminGatewayError, FederationNotConnected};
 
 /// The first index that the gateway will assign to a federation.

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -15,7 +15,6 @@
 
 pub mod client;
 pub mod config;
-mod db;
 pub mod envs;
 mod error;
 mod events;
@@ -39,7 +38,6 @@ use clap::Parser;
 use client::GatewayClientBuilder;
 use config::GatewayOpts;
 pub use config::GatewayParameters;
-use db::GatewayDbtxNcExt;
 use envs::{FM_GATEWAY_OVERRIDE_LN_MODULE_CHECK_ENV, FM_GATEWAY_SKIP_WAIT_FOR_SYNC_ENV};
 use error::FederationNotConnected;
 use events::ALL_GATEWAY_EVENTS;
@@ -77,6 +75,7 @@ use fedimint_gateway_common::{
     ReceiveEcashPayload, ReceiveEcashResponse, SendOnchainRequest, SetFeesPayload,
     SpendEcashPayload, SpendEcashResponse, V1_API_ENDPOINT, WithdrawPayload, WithdrawResponse,
 };
+use fedimint_gateway_server_db::{GatewayDbtxNcExt as _, get_gatewayd_database_migrations};
 use fedimint_gw_client::events::compute_lnv1_stats;
 use fedimint_gw_client::pay::{OutgoingPaymentError, OutgoingPaymentErrorType};
 use fedimint_gw_client::{GatewayClientModule, GatewayExtPayStates, IGatewayClientV1};
@@ -114,7 +113,6 @@ use tokio::sync::RwLock;
 use tracing::{debug, info, info_span, warn};
 
 use crate::config::LightningModuleMode;
-use crate::db::get_gatewayd_database_migrations;
 use crate::envs::FM_GATEWAY_MNEMONIC_ENV;
 use crate::error::{AdminGatewayError, LNv1Error, LNv2Error, PublicGatewayError};
 use crate::events::get_events_for_duration;


### PR DESCRIPTION
On top of #7030 

`fedimint-testing` is slow to compile and depends on a lot of things.

`devimint` is slow to compile and depends on a lot of things.

`devimint` waiting for `fedimint-testing` to finish just to use
one struct and one function is absolutely terrible.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
