### PR TITLE
fix(wasm-tests): not whole balance necessarily available

### DIFF
--- a/fedimint-wasm-tests/src/lib.rs
+++ b/fedimint-wasm-tests/src/lib.rs
@@ -333,7 +333,7 @@ mod tests {
 
         futures::future::try_join_all(
             (0..10)
-                .map(|_| receive_once(client.clone(), Amount::from_sats(21), ln_gateway.clone())),
+                .map(|_| receive_once(client.clone(), Amount::from_sats(25), ln_gateway.clone())),
         )
         .await?;
         futures::future::try_join_all((0..10).map(|_| send_and_recv_ecash_once(client.clone())))


### PR DESCRIPTION
Given that our note selection can pull in extra notes, etc. Its possible to hit flakes here like:

https://github.com/fedimint/fedimint/actions/runs/13850780953/job/38757569355?pr=7030

https://github.com/fedimint/fedimint/actions/runs/13845186320/job/38754100255?pr=7028
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
