### PR TITLE
feat: server side rendered guardian UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.28",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -616,7 +616,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -628,7 +628,41 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
+ "axum-core 0.5.0",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -670,6 +704,48 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
+dependencies = [
+ "axum 0.8.1",
+ "axum-core 0.5.0",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1256,6 +1332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "checked_int_cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,8 +1345,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -1390,6 +1474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1584,17 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "cordyceps"
@@ -3734,6 +3835,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fedimint-server-ui"
+version = "0.7.0-alpha"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum 0.8.1",
+ "axum-extra",
+ "chrono",
+ "fedimint-core",
+ "fedimint-lnv2-server",
+ "fedimint-server-core",
+ "fedimint-wallet-server",
+ "maud",
+ "qrcode",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "fedimint-tbs"
 version = "0.7.0-alpha"
 dependencies = [
@@ -4084,6 +4204,7 @@ dependencies = [
  "fedimint-mint-server",
  "fedimint-rocksdb",
  "fedimint-server",
+ "fedimint-server-ui",
  "fedimint-unknown-common",
  "fedimint-unknown-server",
  "fedimint-wallet-server",
@@ -5258,6 +5379,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "imbl"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6381,6 +6516,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6801,6 +6964,17 @@ name = "num-iter"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -7664,6 +7838,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "version_check",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7857,6 +8043,16 @@ dependencies = [
  "libc",
  "paste",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "qrcode"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d2f1455f3630c6e5107b4f2b94e74d76dea80736de0981fd27644216cff57f"
+dependencies = [
+ "checked_int_cast",
+ "image",
 ]
 
 [[package]]
@@ -10569,14 +10765,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "fedimint-server",
   "fedimint-server-core",
   "fedimint-server-tests",
+  "fedimint-server-ui",
   "fedimint-testing",
   "fedimint-testing-core",
   "fedimint-wasm-tests",
@@ -164,6 +165,7 @@ fedimint-portalloc = { path = "utils/portalloc", version = "=0.7.0-alpha" }
 fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.7.0-alpha" }
 fedimint-server = { path = "./fedimint-server", version = "=0.7.0-alpha" }
 fedimint-server-core = { path = "./fedimint-server-core", version = "=0.7.0-alpha" }
+fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.7.0-alpha" }
 fedimint-testing = { path = "./fedimint-testing", version = "=0.7.0-alpha" }
 fedimint-testing-core = { path = "./fedimint-testing-core", version = "=0.7.0-alpha" }
 fedimint-unknown-common = { path = "./modules/fedimint-unknown-common", version = "=0.7.0-alpha" }

--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -489,6 +489,7 @@ async fn run_ui(process_mgr: &ProcessManager) -> Result<(Vec<Fedimintd>, Externa
         async move {
             let peer_port = 10000 + 8137 + peer * 2;
             let api_port = peer_port + 1;
+            let ui_port = peer_port + 2;
             let metrics_port = 3510 + peer;
 
             // TODO: we should use this, and override ports that need to be fixed by an env
@@ -506,6 +507,7 @@ async fn run_ui(process_mgr: &ProcessManager) -> Result<(Vec<Fedimintd>, Externa
                 FM_P2P_URL: format!("fedimint://127.0.0.1:{peer_port}"),
                 FM_BIND_API: format!("127.0.0.1:{api_port}"),
                 FM_API_URL: format!("ws://127.0.0.1:{api_port}"),
+                FM_BIND_UI: format!("127.0.0.1:{ui_port}"),
                 FM_DATA_DIR: process_mgr
                     .globals
                     .FM_DATA_DIR

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -46,13 +46,16 @@ use crate::{poll_eq, vars};
 
 // TODO: Are we still using the 3rd port for anything?
 /// Number of ports we allocate for every `fedimintd` instance
-pub const PORTS_PER_FEDIMINTD: u16 = 3;
+pub const PORTS_PER_FEDIMINTD: u16 = 4;
 /// Which port is for p2p inside the range from [`PORTS_PER_FEDIMINTD`]
 pub const FEDIMINTD_P2P_PORT_OFFSET: u16 = 0;
 /// Which port is for api inside the range from [`PORTS_PER_FEDIMINTD`]
 pub const FEDIMINTD_API_PORT_OFFSET: u16 = 1;
+/// Which port is for the web ui inside the range from [`PORTS_PER_FEDIMINTD`]
+pub const FEDIMINTD_UI_PORT_OFFSET: u16 = 2;
 /// Which port is for prometheus inside the range from [`PORTS_PER_FEDIMINTD`]
-pub const FEDIMINTD_METRICS_PORT_OFFSET: u16 = 2;
+pub const FEDIMINTD_METRICS_PORT_OFFSET: u16 = 3;
+
 #[derive(Clone)]
 pub struct Federation {
     // client is only for internal use, use cli commands instead

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -108,7 +108,9 @@ use fedimintd::envs::FM_FORCE_API_SECRETS_ENV;
 use format as f;
 use net_overrides::{FederationsNetOverrides, FedimintdPeerOverrides};
 
-use crate::federation::{FEDIMINTD_METRICS_PORT_OFFSET, PORTS_PER_FEDIMINTD};
+use crate::federation::{
+    FEDIMINTD_METRICS_PORT_OFFSET, FEDIMINTD_UI_PORT_OFFSET, PORTS_PER_FEDIMINTD,
+};
 
 pub fn utf8(path: &Path) -> &str {
     path.as_os_str().to_str().expect("must be valid utf8")
@@ -233,6 +235,7 @@ declare_vars! {
         FM_BIND_API: String = format!("127.0.0.1:{}", overrides.api.port()); env: "FM_BIND_API";
         FM_P2P_URL: String =  format!("fedimint://127.0.0.1:{}", overrides.p2p.port()); env: "FM_P2P_URL";
         FM_API_URL: String =  format!("ws://127.0.0.1:{}", overrides.api.port()); env: "FM_API_URL";
+        FM_BIND_UI: String = format!("127.0.0.1:{}", overrides.base_port + FEDIMINTD_UI_PORT_OFFSET); env: "FM_BIND_UI";
         FM_BIND_METRICS_API: String = format!("127.0.0.1:{}", overrides.base_port + FEDIMINTD_METRICS_PORT_OFFSET); env: "FM_BIND_METRICS_API";
         FM_DATA_DIR: PathBuf = mkdir(globals.FM_DATA_DIR.join(format!("fedimintd-{federation_name}-{peer_id}"))).await?; env: "FM_DATA_DIR";
 

--- a/fedimint-core/src/endpoint_constants.rs
+++ b/fedimint-core/src/endpoint_constants.rs
@@ -8,7 +8,6 @@ pub const AWAIT_OUTPUT_OUTCOME_ENDPOINT: &str = "await_output_outcome";
 pub const BACKUP_ENDPOINT: &str = "backup";
 pub const ADD_CONFIG_GEN_PEER_ENDPOINT: &str = "add_config_gen_peer";
 pub const BACKUP_STATISTICS_ENDPOINT: &str = "backup_statistics";
-pub const CHECK_BITCOIN_STATUS_ENDPOINT: &str = "check_bitcoin_status";
 pub const CLIENT_CONFIG_ENDPOINT: &str = "client_config";
 pub const CLIENT_CONFIG_JSON_ENDPOINT: &str = "client_config_json";
 pub const SERVER_CONFIG_CONSENSUS_HASH_ENDPOINT: &str = "server_config_consensus_hash";

--- a/fedimint-server-core/src/dashboard_ui.rs
+++ b/fedimint-server-core/src/dashboard_ui.rs
@@ -1,0 +1,62 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fedimint_core::PeerId;
+use fedimint_core::core::ModuleKind;
+use fedimint_core::module::ApiAuth;
+use fedimint_core::module::audit::AuditSummary;
+
+use crate::{DynServerModule, ServerModule};
+
+pub type DynDashboardApi = Arc<dyn IDashboardApi + Send + Sync + 'static>;
+
+/// Interface for guardian dashboard API in a running federation
+#[async_trait]
+pub trait IDashboardApi {
+    /// Get the guardian's authentication details
+    async fn auth(&self) -> ApiAuth;
+
+    /// Get the guardian name
+    async fn guardian_name(&self) -> String;
+
+    /// Get the federation name
+    async fn federation_name(&self) -> String;
+
+    /// Get the current active session count
+    async fn session_count(&self) -> usize;
+
+    /// Returns a map of peer ID to connection status
+    async fn peer_connection_status(&self) -> BTreeMap<PeerId, bool>;
+
+    /// Get the federation invite code to share with users
+    async fn federation_invite_code(&self) -> String;
+
+    /// Get the federation audit summary
+    async fn federation_audit(&self) -> AuditSummary;
+
+    /// Get reference to a server module instance by module kind
+    fn get_module_by_kind(&self, kind: ModuleKind) -> Option<&DynServerModule>;
+
+    /// Create a trait object
+    fn into_dyn(self) -> DynDashboardApi
+    where
+        Self: Sized + Send + Sync + 'static,
+    {
+        Arc::new(self)
+    }
+}
+
+/// Extension trait for IDashboardApi providing type-safe module access
+pub trait DashboardApiModuleExt {
+    /// Get a typed reference to a server module instance by kind
+    fn get_module<M: ServerModule + 'static>(&self) -> Option<&M>;
+}
+
+impl DashboardApiModuleExt for DynDashboardApi {
+    fn get_module<M: ServerModule + 'static>(&self) -> Option<&M> {
+        self.get_module_by_kind(M::module_kind())?
+            .as_any()
+            .downcast_ref::<M>()
+    }
+}

--- a/fedimint-server-core/src/lib.rs
+++ b/fedimint-server-core/src/lib.rs
@@ -6,9 +6,11 @@
 //! and functionality that are only used on the server side.
 
 pub mod config;
+pub mod dashboard_ui;
 mod init;
 pub mod migration;
 pub mod net;
+pub mod setup_ui;
 
 use std::any::Any;
 use std::fmt::Debug;

--- a/fedimint-server-core/src/setup_ui.rs
+++ b/fedimint-server-core/src/setup_ui.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use fedimint_core::module::ApiAuth;
+
+pub type DynSetupApi = Arc<dyn ISetupApi + Send + Sync + 'static>;
+
+/// Interface for the web UI to interact with the config generation process
+#[async_trait]
+pub trait ISetupApi {
+    /// Get our connection info encoded as base32 string
+    async fn our_connection_info(&self) -> Option<String>;
+
+    /// Get the auth token for API calls
+    async fn auth(&self) -> Option<ApiAuth>;
+
+    /// Get list of names of connected peers
+    async fn connected_peers(&self) -> Vec<String>;
+
+    /// Reset all connection info (remove all peers)
+    async fn reset_connection_info(&self);
+
+    /// Set local guardian parameters
+    async fn set_local_parameters(
+        &self,
+        auth: ApiAuth,
+        name: String,
+        federation_name: Option<String>,
+    ) -> Result<String>;
+
+    /// Add peer connection info
+    async fn add_peer_connection_info(&self, info: String) -> Result<String>;
+
+    /// Start the distributed key generation process
+    async fn start_dkg(&self) -> Result<()>;
+
+    /// Create a trait object
+    fn into_dyn(self) -> DynSetupApi
+    where
+        Self: Sized + Send + Sync + 'static,
+    {
+        Arc::new(self)
+    }
+}

--- a/fedimint-server-ui/Cargo.toml
+++ b/fedimint-server-ui/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fedimint-server-ui"
+version = "0.7.0-alpha"
+edition = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true } 
+axum = "0.8.1" 
+axum-extra = { version = "0.10.0", features = ["cookie"] }
+chrono = "0.4"
+fedimint-core = { workspace = true }
+fedimint-lnv2-server = { workspace = true }
+fedimint-server-core = { workspace = true }
+fedimint-wallet-server = { workspace = true }
+maud = "0.27.0"
+qrcode = { version = "0.12", features = ["svg"] }
+serde = { workspace = true }
+tokio = { workspace = true }

--- a/fedimint-server-ui/src/audit.rs
+++ b/fedimint-server-ui/src/audit.rs
@@ -1,0 +1,48 @@
+use fedimint_core::module::audit::AuditSummary;
+use maud::{Markup, html};
+
+pub fn render_audit_summary(audit_summary: &AuditSummary) -> Markup {
+    html! {
+        div class="card h-100" {
+            div class="card-header dashboard-header" { "Audit Summary" }
+            div class="card-body" {
+                // Overall Summary
+                div class="mb-3" {
+                    div class="alert alert-info" {
+                        "Net Assets: " strong { (format!("{} msat", audit_summary.net_assets)) }
+                    }
+                }
+
+                // Per Module Breakdown
+                div class="accordion" id="auditAccordion" {
+                    @for (i, (module_id, module_summary)) in audit_summary.module_summaries.iter().enumerate() {
+                        div class="accordion-item" {
+                            h2 class="accordion-header" id=(format!("heading{}", i)) {
+                                button class="accordion-button collapsed" type="button"
+                                    data-bs-toggle="collapse" data-bs-target=(format!("#collapse{}", i))
+                                    aria-expanded="false" aria-controls=(format!("collapse{}", i)) {
+                                    strong { (module_summary.kind) }
+                                }
+                            }
+                            div id=(format!("collapse{}", i)) class="accordion-collapse collapse"
+                                aria-labelledby=(format!("heading{}", i)) data-bs-parent="#auditAccordion" {
+                                div class="accordion-body" {
+                                    table class="table table-sm" {
+                                        tr {
+                                            th { "Module ID" }
+                                            td { (module_id) }
+                                        }
+                                        tr {
+                                            th { "Net Assets" }
+                                            td { (format!("{} msat", module_summary.net_assets)) }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/fedimint-server-ui/src/connection_status.rs
+++ b/fedimint-server-ui/src/connection_status.rs
@@ -1,0 +1,43 @@
+use std::collections::BTreeMap;
+
+use fedimint_core::PeerId;
+use maud::{Markup, html};
+
+pub fn render_connection_status(peer_status: &BTreeMap<PeerId, bool>) -> Markup {
+    html! {
+        div class="card h-100" {
+            div class="card-header dashboard-header" { "P2P Connection Status" }
+            div class="card-body" {
+                @if peer_status.is_empty() {
+                    p { "No peer connections available." }
+                } @else {
+                    table class="table table-striped" {
+                        thead {
+                            tr {
+                                th { "Peer ID" }
+                                th { "Connection Status" }
+                            }
+                        }
+                        tbody {
+                            @for (peer_id, status) in peer_status {
+                                tr {
+                                    td { (peer_id.to_string()) }
+                                    td {
+                                        @match status {
+                                            true => {
+                                                span class="badge bg-success" { "Connected" }
+                                            }
+                                            false => {
+                                                span class="badge bg-danger" { "Disconnected" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/fedimint-server-ui/src/dashboard.rs
+++ b/fedimint-server-ui/src/dashboard.rs
@@ -1,0 +1,225 @@
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+
+use axum::Router;
+use axum::extract::{Form, State};
+use axum::response::{Html, IntoResponse, Redirect};
+use axum::routing::{get, post};
+use axum_extra::extract::cookie::CookieJar;
+use fedimint_core::task::TaskHandle;
+use fedimint_server_core::dashboard_ui::{DashboardApiModuleExt, DynDashboardApi};
+use maud::{DOCTYPE, Markup, html};
+use tokio::net::TcpListener;
+use {fedimint_lnv2_server, fedimint_wallet_server};
+
+use crate::{
+    LoginInput, audit, check_auth, common_styles, connection_status, invite_code, lnv2,
+    login_form_response, login_submit_response, wallet,
+};
+
+pub fn dashboard_layout(content: Markup) -> Markup {
+    html! {
+        (DOCTYPE)
+        html {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1.0";
+                title { "Guardian Dashboard"}
+                link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous";
+                style {
+                    (common_styles())
+                    r#"
+                    /* Dashboard-specific styles */
+                    
+                    /* Card header styling */
+                    .card-header.dashboard-header {
+                        font-size: 1.25rem;
+                        font-weight: 600;
+                        background-color: #f8f9fa;
+                        padding: 1rem 1.25rem;
+                    }
+                    
+                    /* Modal enhancements */
+                    .modal-header {
+                        border-bottom: 1px solid #dee2e6;
+                        background-color: #f8f9fa;
+                    }
+                    
+                    .modal-title {
+                        font-weight: 600;
+                    }
+                    
+                    .modal-footer {
+                        border-top: 1px solid #dee2e6;
+                    }
+                    
+                    /* Invite code text display */
+                    .user-select-all {
+                        user-select: all;
+                        font-size: 0.85rem;
+                        word-break: break-all;
+                    }
+                    
+                    /* For larger screens */
+                    @media (min-width: 1400px) {
+                        .container {
+                            max-width: 70% !important;
+                        }
+                    }
+                    
+                    /* QR Code Modal */
+                    #inviteCodeModal .modal-dialog {
+                        max-width: 360px;
+                    }
+                    
+                    /* Copy button styling */
+                    #copyInviteCodeBtn {
+                        padding: 0.5rem 1.5rem;
+                        font-size: 1rem;
+                    }
+                    "#
+                }
+            }
+            body {
+                div class="container" style="max-width: 66%;" {
+                    header class="text-center" {
+                        h1 class="header-title" { "Fedimint Guardian UI" }
+                    }
+
+                    (content)
+                }
+                script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" {}
+            }
+        }
+    }
+}
+
+// Dashboard login form handler
+async fn login_form(State(_api): State<DynDashboardApi>) -> impl IntoResponse {
+    login_form_response()
+}
+
+// Dashboard login submit handler
+async fn login_submit(
+    State(api): State<DynDashboardApi>,
+    jar: CookieJar,
+    Form(input): Form<LoginInput>,
+) -> impl IntoResponse {
+    login_submit_response(api.auth().await, jar, input).into_response()
+}
+
+// Main dashboard view
+async fn dashboard_view(State(api): State<DynDashboardApi>, jar: CookieJar) -> impl IntoResponse {
+    if !check_auth(api.auth().await, &jar).await {
+        return Redirect::to("/login").into_response();
+    }
+
+    let guardian_name = api.guardian_name().await;
+    let federation_name = api.federation_name().await;
+    let session_count = api.session_count().await;
+    let peer_status = api.peer_connection_status().await;
+    let invite_code = api.federation_invite_code().await;
+    let audit_summary = api.federation_audit().await;
+
+    let mut content = html! {
+        div class="row gy-4" {
+            // Guardian Information Column
+            div class="col-md-6" {
+                div class="card h-100" {
+                    div class="card-header dashboard-header" { "General Information" }
+                    div class="card-body" {
+                        table class="table" {
+                            tr {
+                                th { "Guardian Name" }
+                                td { (guardian_name) }
+                            }
+                            tr {
+                                th { "Federation Name" }
+                                td { (federation_name) }
+                            }
+                            tr {
+                                th { "Current Session Count" }
+                                td { (session_count) }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Invite Code Column
+            div class="col-md-6" {
+                (invite_code::invite_code_card())
+            }
+        }
+
+        // Render the invite code modal
+        (invite_code::invite_code_modal(&invite_code))
+
+        // Second row: Audit Summary and Peer Status
+        div class="row gy-4 mt-2" {
+            // Audit Information Column
+            div class="col-lg-8" {
+                (audit::render_audit_summary(&audit_summary))
+            }
+
+            // Peer Connection Status Column
+            div class="col-lg-4" {
+                (connection_status::render_connection_status(&peer_status))
+            }
+        }
+    };
+
+    // Conditionally add Lightning V2 UI if the module is available
+    if let Some(lightning) = api.get_module::<fedimint_lnv2_server::Lightning>() {
+        content = html! {
+            (content)
+            (lnv2::render(lightning).await)
+        };
+    }
+
+    // Conditionally add Wallet UI if the module is available
+    if let Some(wallet_module) = api.get_module::<fedimint_wallet_server::Wallet>() {
+        content = html! {
+            (content)
+            (wallet::render(wallet_module).await)
+        };
+    }
+
+    Html(dashboard_layout(content).into_string()).into_response()
+}
+
+pub fn start(
+    dashboard_api: DynDashboardApi,
+    ui_bind: SocketAddr,
+    task_handle: TaskHandle,
+) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    // Create a basic router with core routes
+    let mut app = Router::new()
+        .route("/", get(dashboard_view))
+        .route("/login", get(login_form).post(login_submit));
+
+    // Only add LNv2 gateway routes if the module exists
+    if dashboard_api
+        .get_module::<fedimint_lnv2_server::Lightning>()
+        .is_some()
+    {
+        app = app
+            .route("/lnv2_gateway_add", post(lnv2::add_gateway))
+            .route("/lnv2_gateway_remove", post(lnv2::remove_gateway));
+    }
+
+    // Finalize the router with state
+    let app = app.with_state(dashboard_api);
+
+    Box::pin(async move {
+        let listener = TcpListener::bind(ui_bind)
+            .await
+            .expect("Failed to bind dashboard UI");
+
+        axum::serve(listener, app.into_make_service())
+            .with_graceful_shutdown(task_handle.make_shutdown_rx())
+            .await
+            .expect("Failed to serve dashboard UI");
+    })
+}

--- a/fedimint-server-ui/src/invite_code.rs
+++ b/fedimint-server-ui/src/invite_code.rs
@@ -1,0 +1,65 @@
+use maud::{Markup, PreEscaped, html};
+use qrcode::QrCode;
+use qrcode::render::svg;
+
+// Function to generate QR code SVG from input string
+pub fn generate_qr_code_svg(data: &str) -> String {
+    QrCode::new(data)
+        .expect("Failed to generate QR code - should never happen with valid invite code")
+        .render()
+        .min_dimensions(300, 300)
+        .max_dimensions(300, 300)
+        .quiet_zone(false)
+        .dark_color(svg::Color("#000000"))
+        .light_color(svg::Color("#ffffff"))
+        .build()
+}
+
+// Card with button to open the invite code modal
+pub fn invite_code_card() -> Markup {
+    html! {
+        div class="card h-100" {
+            div class="card-header dashboard-header" { "Invite Code" }
+            div class="card-body d-flex flex-column justify-content-center align-items-center" {
+                // Information about the invite code
+                p class="text-center mb-4" {
+                    "Share this invite code with users to onboard them to your federation."
+                }
+
+                // Button to open the modal
+                button type="button" class="btn btn-primary setup-btn"
+                       data-bs-toggle="modal" data-bs-target="#inviteCodeModal" {
+                    "View Invite Code"
+                }
+            }
+        }
+    }
+}
+
+// Modal displaying the invite code QR code
+pub fn invite_code_modal(invite_code: &str) -> Markup {
+    html! {
+        // Modal for Invite Code QR
+        div class="modal fade" id="inviteCodeModal" tabindex="-1" aria-labelledby="inviteCodeModalLabel" aria-hidden="true" {
+            div class="modal-dialog modal-dialog-centered" style="max-width: 360px;" {
+                div class="modal-content" {
+                    div class="modal-header py-1" {
+                        h5 class="modal-title fs-6" id="inviteCodeModalLabel" { "Invite Code" }
+                        button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" {}
+                    }
+                    div class="modal-body" style="padding: 30px; text-align: center;" {
+                        // QR Code with 30px padding all around
+                        (PreEscaped(generate_qr_code_svg(invite_code)))
+                    }
+                    div class="modal-footer justify-content-center py-2" {
+                        // Copy button - centered and larger
+                        button type="button" class="btn btn-primary" id="copyInviteCodeBtn"
+                            onclick=(format!("navigator.clipboard.writeText('{}'); this.innerText='Copied!'; setTimeout(() => this.innerText='Copy Invite Code', 2000);", invite_code)) {
+                            "Copy Invite Code"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/fedimint-server-ui/src/lib.rs
+++ b/fedimint-server-ui/src/lib.rs
@@ -1,0 +1,219 @@
+pub mod audit;
+pub mod connection_status;
+pub mod dashboard;
+pub mod invite_code;
+pub mod lnv2;
+pub mod setup;
+pub mod wallet;
+
+use axum::response::{Html, IntoResponse, Redirect};
+use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use fedimint_core::module::ApiAuth;
+use maud::{DOCTYPE, Markup, html};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LoginInput {
+    pub password: String,
+}
+
+// Common CSS styling shared by all layouts
+pub fn common_styles() -> &'static str {
+    r#"
+    body {
+        background-color: #f8f9fa;
+        padding-top: 2rem;
+        padding-bottom: 2rem;
+    }
+    
+    .header-title {
+        color: #0d6efd;
+        margin-bottom: 2rem;
+    }
+    
+    .card {
+        border: none;
+        box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+        border-radius: 0.5rem;
+        margin-bottom: 1rem;
+    }
+    
+    .card-body {
+        padding: 1.25rem;
+    }
+    
+    .card-header {
+        background-color: #fff;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+        padding: 1rem 1.25rem;
+    }
+    
+    /* Form elements */
+    .form-control {
+        padding: 0.75rem;
+    }
+    
+    .form-group {
+        margin-bottom: 1rem;
+    }
+    
+    .field-description {
+        font-size: 0.875rem;
+        color: #6c757d;
+        margin-top: 0.25rem;
+    }
+    
+    .button-container {
+        margin-top: 2rem;
+        text-align: center;
+    }
+    
+    /* Alert and status messages */
+    .error-message {
+        color: #dc3545;
+        margin-top: 1rem;
+        font-weight: 500;
+    }
+    
+    .alert-info {
+        background-color: #e8f4f8;
+        border-color: #bee5eb;
+    }
+    
+    /* Connection and invite codes */
+    .connection-code {
+        background-color: #f8f9fa;
+        border: 1px solid #dee2e6;
+        border-radius: 0.25rem;
+        padding: 1rem;
+        overflow-x: auto;
+        font-family: monospace;
+        margin-bottom: 1rem;
+        word-break: break-all;
+        color: #000;
+    }
+    
+    .connection-code code {
+        color: #000 !important;
+    }
+    
+    /* Button styling */
+    .setup-btn {
+        width: auto;
+        min-width: 200px;
+        max-width: 300px;
+        padding: 0.5rem 1.5rem;
+        margin: 0 auto;
+    }
+    
+    /* Responsive adjustments */
+    @media (min-width: 992px) {
+        .narrow-container {
+            max-width: 500px;
+        }
+    }
+    
+    @media (max-width: 768px) {
+        .container {
+            padding-left: 15px;
+            padding-right: 15px;
+        }
+        
+        .card-body {
+            padding: 1rem;
+        }
+    }
+    "#
+}
+
+pub(crate) fn login_layout(title: &str, content: Markup) -> Markup {
+    html! {
+        (DOCTYPE)
+        html {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1.0";
+                title { (title) }
+                link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous";
+                style {
+                    (common_styles())
+                }
+            }
+            body {
+                div class="container" {
+                    div class="row justify-content-center" {
+                        div class="col-md-8 col-lg-5 narrow-container" {
+                            header class="text-center" {
+                                h1 class="header-title" { "Fedimint Guardian UI" }
+                            }
+
+                            div class="card" {
+                                div class="card-body" {
+                                    (content)
+                                }
+                            }
+                        }
+                    }
+                }
+                script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" {}
+            }
+        }
+    }
+}
+
+pub(crate) fn login_form_response() -> impl IntoResponse {
+    let content = html! {
+        form method="post" action="/login" {
+            div class="form-group mb-4" {
+                input type="password" class="form-control" id="password" name="password" placeholder="Your password" required;
+            }
+            div class="button-container" {
+                button type="submit" class="btn btn-primary setup-btn" { "Log In" }
+            }
+        }
+    };
+
+    Html(login_layout("Fedimint Guardian Login", content).into_string()).into_response()
+}
+
+pub(crate) fn login_submit_response(
+    auth: ApiAuth,
+    jar: CookieJar,
+    input: LoginInput,
+) -> impl IntoResponse {
+    if auth.0 == input.password {
+        let mut cookie = Cookie::new("guardian_api_auth", input.password);
+
+        cookie.set_http_only(true);
+        cookie.set_same_site(Some(SameSite::Lax));
+
+        return (jar.add(cookie), Redirect::to("/")).into_response();
+    }
+
+    let content = html! {
+        h2 class="mb-4 text-center" { "Guardian Login" }
+        div class="alert alert-danger" role="alert" {
+            "Invalid password. Please try again."
+        }
+        form method="post" action="/login" {
+            div class="form-group mb-4" {
+                label for="password" class="form-label" { "Guardian Password" }
+                input type="password" class="form-control" id="password" name="password" placeholder="Your password" required;
+            }
+            div class="button-container" {
+                button type="submit" class="btn btn-primary setup-btn" { "Log In" }
+            }
+        }
+    };
+
+    Html(login_layout("Login Failed", content).into_string()).into_response()
+}
+
+pub(crate) async fn check_auth(auth: ApiAuth, jar: &CookieJar) -> bool {
+    let session_password = match jar.get("guardian_api_auth") {
+        Some(cookie) => cookie.value().to_string(),
+        None => return false,
+    };
+
+    auth.0 == session_password
+}

--- a/fedimint-server-ui/src/lnv2.rs
+++ b/fedimint-server-ui/src/lnv2.rs
@@ -1,0 +1,148 @@
+use axum::extract::{Form, State};
+use axum::response::{IntoResponse, Redirect};
+use axum_extra::extract::cookie::CookieJar;
+use fedimint_core::util::SafeUrl;
+use fedimint_server_core::dashboard_ui::{DashboardApiModuleExt, DynDashboardApi};
+use maud::{Markup, html};
+
+use crate::check_auth;
+
+// Form for gateway management
+#[derive(serde::Deserialize)]
+pub struct GatewayForm {
+    pub gateway_url: SafeUrl,
+}
+
+// Function to render the Lightning V2 module UI section
+pub async fn render(lightning: &fedimint_lnv2_server::Lightning) -> Markup {
+    let gateways = lightning.gateways_ui().await;
+    let consensus_block_count = lightning.consensus_block_count_ui().await;
+    let consensus_unix_time = lightning.consensus_unix_time_ui().await;
+    let formatted_unix_time = chrono::DateTime::from_timestamp(consensus_unix_time as i64, 0)
+        .map(|dt| dt.to_rfc2822())
+        .unwrap_or("Invalid time".to_string());
+
+    html! {
+        div class="row gy-4 mt-2" {
+            div class="col-12" {
+                div class="card h-100" {
+                    div class="card-header dashboard-header" { "Lightning V2" }
+                    div class="card-body" {
+                        // Consensus status information
+                        div class="mb-4" {
+                            table class="table" {
+                                tr {
+                                    th { "Consensus Block Count" }
+                                    td { (consensus_block_count) }
+                                }
+                                tr {
+                                    th { "Consensus Unix Time" }
+                                    td { (formatted_unix_time) }
+                                }
+                            }
+                        }
+
+                        // Gateway management
+                        div {
+                            h5 { "Gateway Management" }
+                            // Add new gateway form
+                            div class="mb-4" {
+                                form action="/lnv2_gateway_add" method="post" class="row g-3" {
+                                    div class="col-md-9" {
+                                        div class="form-group" {
+                                            div class="text-muted mb-1" style="font-size: 0.875em;" {
+                                                "Please enter a valid URL starting with http:// or https://"
+                                            }
+                                            input
+                                                type="url"
+                                                class="form-control"
+                                                id="gateway-url"
+                                                name="gateway_url"
+                                                placeholder="Enter gateway URL"
+                                                pattern="https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
+                                                required;
+                                        }
+                                    }
+                                    div class="col-md-3" {
+                                        div style="margin-top: 24px;" {
+                                            button type="submit" class="btn btn-primary w-100 form-control" { "Add Gateway" }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Gateway list
+                            @if gateways.is_empty() {
+                                div class="alert alert-info" { "No gateways configured yet." }
+                            } @else {
+                                div class="table-responsive" {
+                                    table class="table table-hover" {
+                                        thead {
+                                            tr {
+                                                th { "Gateway URL" }
+                                                th class="text-end" { "Actions" }
+                                            }
+                                        }
+                                        tbody {
+                                            @for gateway in &gateways {
+                                                tr {
+                                                    td {
+                                                        a href=(gateway.to_string()) target="_blank" { (gateway.to_string()) }
+                                                    }
+                                                    td class="text-end" {
+                                                        form action="/lnv2_gateway_remove" method="post" style="display: inline;" {
+                                                            input type="hidden" name="gateway_url" value=(gateway.to_string());
+                                                            button type="submit" class="btn btn-sm btn-danger" {
+                                                                "Remove"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Handler for adding a new gateway
+pub async fn add_gateway(
+    State(api): State<DynDashboardApi>,
+    jar: CookieJar,
+    Form(form): Form<GatewayForm>,
+) -> impl IntoResponse {
+    if !check_auth(api.auth().await, &jar).await {
+        return Redirect::to("/login").into_response();
+    }
+
+    api.get_module::<fedimint_lnv2_server::Lightning>()
+        .expect("Route only mounted when Lightning V2 module exists")
+        .add_gateway_ui(form.gateway_url)
+        .await;
+
+    Redirect::to("/").into_response()
+}
+
+// Handler for removing a gateway
+pub async fn remove_gateway(
+    State(api): State<DynDashboardApi>,
+    jar: CookieJar,
+    Form(form): Form<GatewayForm>,
+) -> impl IntoResponse {
+    if !check_auth(api.auth().await, &jar).await {
+        return Redirect::to("/login").into_response();
+    }
+
+    api.get_module::<fedimint_lnv2_server::Lightning>()
+        .expect("Route only mounted when Lightning V2 module exists")
+        .remove_gateway_ui(form.gateway_url)
+        .await;
+
+    Redirect::to("/").into_response()
+}

--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -1,0 +1,370 @@
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+
+use axum::Router;
+use axum::extract::{Form, State};
+use axum::response::{Html, IntoResponse, Redirect};
+use axum::routing::{get, post};
+use axum_extra::extract::cookie::CookieJar;
+use fedimint_core::module::ApiAuth;
+use fedimint_core::task::TaskHandle;
+use fedimint_server_core::setup_ui::DynSetupApi;
+use maud::{DOCTYPE, Markup, html};
+use serde::Deserialize;
+use tokio::net::TcpListener;
+
+use crate::{LoginInput, check_auth, common_styles, login_form_response, login_submit_response};
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetupInput {
+    pub password: String,
+    pub name: String,
+    pub federation_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PeerInfoInput {
+    pub peer_info: String,
+}
+
+pub fn setup_layout(title: &str, content: Markup) -> Markup {
+    html! {
+        (DOCTYPE)
+        html {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1.0";
+                title { (title) }
+                link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous";
+                style {
+                    (common_styles())
+                }
+            }
+            body {
+                div class="container" {
+                    div class="row justify-content-center" {
+                        div class="col-md-8 col-lg-5 narrow-container" {
+                            header class="text-center" {
+                                h1 class="header-title" { "Fedimint Guardian UI" }
+                            }
+
+                            div class="card" {
+                                div class="card-body" {
+                                    (content)
+                                }
+                            }
+                        }
+                    }
+                }
+                script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" {}
+            }
+        }
+    }
+}
+
+// GET handler for the /setup route (display the setup form)
+async fn setup_form(State(config_api): State<DynSetupApi>) -> impl IntoResponse {
+    if config_api.our_connection_info().await.is_some() {
+        return Redirect::to("/federation-setup").into_response();
+    }
+
+    let content = html! {
+        form method="post" action="/" {
+            div class="form-group mb-4" {
+                label for="name" class="form-label" { "Guardian Name" }
+                input type="text" class="form-control" id="name" name="name"
+                     placeholder="Your guardian name"
+                     required;
+            }
+
+            div class="form-group mb-4" {
+                label for="federation_name" class="form-label" { "Federation Name (optional)" }
+                input type="text" class="form-control" id="federation_name" name="federation_name" placeholder="Federation name";
+                div class="field-description" {
+                    "The federation name needs to be set by exactly one guardian."
+                }
+            }
+
+            div class="form-group mb-4" {
+                label for="password" class="form-label" { "Guardian Password" }
+                input type="password" class="form-control" id="password" name="password" placeholder="Secure password" required;
+            }
+
+            div class="button-container" {
+                button type="submit" class="btn btn-primary setup-btn" { "Set Parameters" }
+            }
+        }
+    };
+
+    Html(setup_layout("Setup Fedimint Guardian", content).into_string()).into_response()
+}
+
+// POST handler for the /setup route (process the password setup form)
+async fn setup_submit(
+    State(config_api): State<DynSetupApi>,
+    Form(input): Form<SetupInput>,
+) -> impl IntoResponse {
+    match config_api
+        .set_local_parameters(
+            ApiAuth(input.password.clone()),
+            input.name,
+            input.federation_name,
+        )
+        .await
+    {
+        Ok(_) => Redirect::to("/login").into_response(),
+        Err(e) => {
+            let content = html! {
+                div class="alert alert-danger" { (e.to_string()) }
+                div class="button-container" {
+                    a href="/" class="btn btn-primary setup-btn" { "Try Again" }
+                }
+            };
+
+            Html(setup_layout("Setup Error", content).into_string()).into_response()
+        }
+    }
+}
+
+// GET handler for the /login route (display the login form)
+async fn login_form(State(config_api): State<DynSetupApi>) -> impl IntoResponse {
+    if config_api.our_connection_info().await.is_none() {
+        return Redirect::to("/").into_response();
+    }
+
+    login_form_response().into_response()
+}
+
+// POST handler for the /login route (authenticate and set session cookie)
+async fn login_submit(
+    State(config_api): State<DynSetupApi>,
+    jar: CookieJar,
+    Form(input): Form<LoginInput>,
+) -> impl IntoResponse {
+    let auth = match config_api.auth().await {
+        Some(auth) => auth,
+        None => return Redirect::to("/").into_response(),
+    };
+
+    login_submit_response(auth, jar, input).into_response()
+}
+
+// GET handler for the /federation-setup route (main federation management page)
+async fn federation_setup(
+    State(config_api): State<DynSetupApi>,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let auth = match config_api.auth().await {
+        Some(auth) => auth,
+        None => return Redirect::to("/").into_response(),
+    };
+
+    if !check_auth(auth, &jar).await {
+        return Redirect::to("/login").into_response();
+    }
+
+    let our_connection_info = config_api
+        .our_connection_info()
+        .await
+        .expect("Successful authentication ensures that the local parameters have been set");
+
+    let connected_peers = config_api.connected_peers().await;
+
+    let content = html! {
+        section class="mb-4" {
+            div class="alert alert-info mb-3" {
+                "Share this code with other guardians:"
+            }
+
+            div class="connection-code card p-3 mb-3" {
+                code { (our_connection_info) }
+            }
+
+            div class="text-center" {
+                button type="button" class="btn btn-outline-primary setup-btn"
+                    onclick=(format!("navigator.clipboard.writeText('{}')", our_connection_info)) {
+                    "Copy to Clipboard"
+                }
+            }
+        }
+
+        hr class="my-4" {}
+
+        section class="mb-4" {
+            h4 class="mb-3" { "Connect with Other Guardians" }
+
+            @if !connected_peers.is_empty() {
+                div class="mb-4" {
+                    ul class="list-group mb-4" {
+                        @for peer in connected_peers {
+                            li class="list-group-item" { (peer) }
+                        }
+
+                        div class="text-center" {
+                            form method="post" action="/reset-connection-info" {
+                                button type="submit" class="btn btn-warning setup-btn" {
+                                    "Reset Guardian Connections"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            form method="post" action="/add-connection-info" {
+                div class="mb-3" {
+                    input type="text" class="form-control mb-2" id="peer_info" name="peer_info"
+                        placeholder="Paste connection info from another guardian" required;
+                }
+
+                div class="text-center" {
+                    button type="submit" class="btn btn-primary setup-btn" { "Add Guardian" }
+                }
+            }
+        }
+
+        hr class="my-4" {}
+
+        section class="mb-4" {
+            h4 class="mb-3" { "Launch Federation" }
+
+            div class="alert alert-warning mb-4" {
+                "Make sure all information is correct and every guardian is ready before launching the federation. This process cannot be reversed once started."
+            }
+
+            div class="text-center" {
+                form method="post" action="/start-dkg" {
+                    button type="submit" class="btn btn-warning setup-btn" {
+                        "🚀 Launch Federation"
+                    }
+                }
+            }
+        }
+    };
+
+    Html(setup_layout("Federation Setup", content).into_string()).into_response()
+}
+
+// POST handler for adding peer connection info
+async fn add_peer_handler(
+    State(config_api): State<DynSetupApi>,
+    jar: CookieJar,
+    Form(input): Form<PeerInfoInput>,
+) -> impl IntoResponse {
+    let auth = match config_api.auth().await {
+        Some(auth) => auth,
+        None => return Redirect::to("/").into_response(),
+    };
+
+    if !check_auth(auth, &jar).await {
+        return Redirect::to("/login").into_response();
+    }
+
+    match config_api.add_peer_connection_info(input.peer_info).await {
+        Ok(..) => Redirect::to("/federation-setup").into_response(),
+        Err(e) => {
+            let content = html! {
+                h2 class="mb-4 text-center" { "Error Adding Guardian" }
+                div class="alert alert-danger" { (e.to_string()) }
+                div class="button-container" {
+                    a href="/federation-setup" class="btn btn-primary setup-btn" { "Back to Setup" }
+                }
+            };
+
+            Html(setup_layout("Error", content).into_string()).into_response()
+        }
+    }
+}
+
+// POST handler for starting the DKG process
+async fn start_dkg_handler(
+    State(config_api): State<DynSetupApi>,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let auth = match config_api.auth().await {
+        Some(auth) => auth,
+        None => return Redirect::to("/").into_response(),
+    };
+
+    if !check_auth(auth, &jar).await {
+        return Redirect::to("/login").into_response();
+    }
+
+    match config_api.start_dkg().await {
+        Ok(()) => {
+            // Show simple DKG success page
+            let content = html! {
+                div class="alert alert-success my-4" {
+                    "The distributed key generation has been started successfully. You can monitor the progress in your server logs."
+                }
+                p class="text-center" {
+                    "Once the distributed key generation completes, the Guardian Dashboard will become available at the root URL."
+                }
+                div class="button-container mt-4" {
+                    a href="/" class="btn btn-primary setup-btn" {
+                        "Go to Guardian Dashboard"
+                    }
+                }
+            };
+
+            Html(setup_layout("DKG Started", content).into_string()).into_response()
+        }
+        Err(e) => {
+            let content = html! {
+                h2 class="mb-4 text-center" { "Error Starting Federation" }
+                div class="alert alert-danger" { (e.to_string()) }
+                div class="button-container" {
+                    a href="/federation-setup" class="btn btn-primary setup-btn" { "Back to Setup" }
+                }
+            };
+
+            Html(setup_layout("Error", content).into_string()).into_response()
+        }
+    }
+}
+
+// POST handler for resetting peer connection info
+async fn reset_peers_handler(
+    State(config_api): State<DynSetupApi>,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let auth = match config_api.auth().await {
+        Some(auth) => auth,
+        None => return Redirect::to("/").into_response(),
+    };
+
+    if !check_auth(auth, &jar).await {
+        return Redirect::to("/login").into_response();
+    }
+
+    config_api.reset_connection_info().await;
+
+    Redirect::to("/federation-setup").into_response()
+}
+
+pub fn start(
+    config_api: DynSetupApi,
+    ui_bind: SocketAddr,
+    task_handle: TaskHandle,
+) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    let app = Router::new()
+        .route("/", get(setup_form).post(setup_submit))
+        .route("/login", get(login_form).post(login_submit))
+        .route("/federation-setup", get(federation_setup))
+        .route("/add-connection-info", post(add_peer_handler))
+        .route("/reset-connection-info", post(reset_peers_handler))
+        .route("/start-dkg", post(start_dkg_handler))
+        .with_state(config_api);
+
+    Box::pin(async move {
+        let listener = TcpListener::bind(ui_bind)
+            .await
+            .expect("Failed to bind setup UI");
+
+        axum::serve(listener, app.into_make_service())
+            .with_graceful_shutdown(task_handle.make_shutdown_rx())
+            .await
+            .expect("Failed to serve setup UI");
+    })
+}

--- a/fedimint-server-ui/src/wallet.rs
+++ b/fedimint-server-ui/src/wallet.rs
@@ -1,0 +1,221 @@
+use maud::{Markup, html};
+
+// Function to render the Wallet module UI section
+pub async fn render(wallet: &fedimint_wallet_server::Wallet) -> Markup {
+    let consensus_block_count = wallet.consensus_block_count_ui().await;
+    let consensus_fee_rate = wallet.consensus_feerate_ui().await;
+    let wallet_summary = wallet.get_wallet_summary_ui().await;
+
+    // Calculate total spendable balance
+    let total_spendable: u64 = wallet_summary
+        .spendable_utxos
+        .iter()
+        .map(|utxo| utxo.amount.to_sat())
+        .sum();
+
+    // Calculate pending outgoing (unsigned + unconfirmed)
+    let total_pending_outgoing: u64 = wallet_summary
+        .unsigned_peg_out_txos
+        .iter()
+        .chain(wallet_summary.unconfirmed_peg_out_txos.iter())
+        .map(|txo| txo.amount.to_sat())
+        .sum();
+
+    // Calculate pending incoming change
+    let total_pending_change: u64 = wallet_summary
+        .unsigned_change_utxos
+        .iter()
+        .chain(wallet_summary.unconfirmed_change_utxos.iter())
+        .map(|txo| txo.amount.to_sat())
+        .sum();
+
+    html! {
+        div class="row gy-4 mt-2" {
+            div class="col-12" {
+                div class="card h-100" {
+                    div class="card-header dashboard-header" { "Wallet" }
+                    div class="card-body" {
+                        // Blockchain status information
+                        div class="mb-4" {
+                            h5 { "Blockchain Status" }
+                            table class="table" {
+                                tr {
+                                    th { "Consensus Block Count" }
+                                    td { (consensus_block_count) }
+                                }
+                                tr {
+                                    th { "Consensus Fee Rate" }
+                                    td { (consensus_fee_rate.sats_per_kvb) " sats/kvB" }
+                                }
+                            }
+                        }
+
+                        // Wallet Balance Summary
+                        div class="mb-4" {
+                            h5 { "Balance Summary" }
+                            div class="row" {
+                                div class="col-md-4" {
+                                    div class="card bg-light mb-3" {
+                                        div class="card-body text-center" {
+                                            h6 class="card-title" { "Spendable Balance" }
+                                            p class="card-text fs-4" { (total_spendable) " sats" }
+                                        }
+                                    }
+                                }
+                                div class="col-md-4" {
+                                    div class="card bg-light mb-3" {
+                                        div class="card-body text-center" {
+                                            h6 class="card-title" { "Pending Outgoing" }
+                                            p class="card-text fs-4" { (total_pending_outgoing) " sats" }
+                                        }
+                                    }
+                                }
+                                div class="col-md-4" {
+                                    div class="card bg-light mb-3" {
+                                        div class="card-body text-center" {
+                                            h6 class="card-title" { "Pending Change" }
+                                            p class="card-text fs-4" { (total_pending_change) " sats" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // UTXOs Breakdown
+                        div class="mb-4" {
+                            h5 { "UTXO Details" }
+
+                            // Tabs for different UTXO categories
+                            ul class="nav nav-tabs" id="walletTabs" role="tablist" {
+                                li class="nav-item" role="presentation" {
+                                    button class="nav-link active" id="spendable-tab" data-bs-toggle="tab"
+                                        data-bs-target="#spendable" type="button" role="tab" aria-controls="spendable"
+                                        aria-selected="true" {
+                                        "Spendable UTXOs "
+                                        span class="badge bg-primary" { (wallet_summary.spendable_utxos.len()) }
+                                    }
+                                }
+                                li class="nav-item" role="presentation" {
+                                    button class="nav-link" id="unsigned-tab" data-bs-toggle="tab"
+                                        data-bs-target="#unsigned" type="button" role="tab" aria-controls="unsigned"
+                                        aria-selected="false" {
+                                        "Unsigned Outputs "
+                                        span class="badge bg-secondary" {
+                                            (wallet_summary.unsigned_peg_out_txos.len() + wallet_summary.unsigned_change_utxos.len())
+                                        }
+                                    }
+                                }
+                                li class="nav-item" role="presentation" {
+                                    button class="nav-link" id="unconfirmed-tab" data-bs-toggle="tab"
+                                        data-bs-target="#unconfirmed" type="button" role="tab" aria-controls="unconfirmed"
+                                        aria-selected="false" {
+                                        "Unconfirmed Outputs "
+                                        span class="badge bg-warning" {
+                                            (wallet_summary.unconfirmed_peg_out_txos.len() + wallet_summary.unconfirmed_change_utxos.len())
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Tab contents
+                            div class="tab-content pt-3" id="walletTabsContent" {
+                                div class="tab-pane fade show active" id="spendable" role="tabpanel" aria-labelledby="spendable-tab" {
+                                    @if wallet_summary.spendable_utxos.is_empty() {
+                                        p { "No spendable UTXOs available." }
+                                    } @else {
+                                        div class="table-responsive" {
+                                            table class="table table-sm" {
+                                                thead {
+                                                    tr {
+                                                        th { "Outpoint" }
+                                                        th { "Amount (sats)" }
+                                                    }
+                                                }
+                                                tbody {
+                                                    @for utxo in &wallet_summary.spendable_utxos {
+                                                        tr {
+                                                            td { (format!("{}:{}", utxo.outpoint.txid, utxo.outpoint.vout)) }
+                                                            td { (utxo.amount.to_sat()) }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                div class="tab-pane fade" id="unsigned" role="tabpanel" aria-labelledby="unsigned-tab" {
+                                    @if wallet_summary.unsigned_peg_out_txos.is_empty() && wallet_summary.unsigned_change_utxos.is_empty() {
+                                        p { "No unsigned outputs waiting for signatures." }
+                                    } @else {
+                                        div class="table-responsive" {
+                                            table class="table table-sm" {
+                                                thead {
+                                                    tr {
+                                                        th { "Type" }
+                                                        th { "Outpoint" }
+                                                        th { "Amount (sats)" }
+                                                    }
+                                                }
+                                                tbody {
+                                                    @for txo in &wallet_summary.unsigned_peg_out_txos {
+                                                        tr {
+                                                            td { "Peg-out" }
+                                                            td { (format!("{}:{}", txo.outpoint.txid, txo.outpoint.vout)) }
+                                                            td { (txo.amount.to_sat()) }
+                                                        }
+                                                    }
+                                                    @for txo in &wallet_summary.unsigned_change_utxos {
+                                                        tr {
+                                                            td { "Change" }
+                                                            td { (format!("{}:{}", txo.outpoint.txid, txo.outpoint.vout)) }
+                                                            td { (txo.amount.to_sat()) }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                div class="tab-pane fade" id="unconfirmed" role="tabpanel" aria-labelledby="unconfirmed-tab" {
+                                    @if wallet_summary.unconfirmed_peg_out_txos.is_empty() && wallet_summary.unconfirmed_change_utxos.is_empty() {
+                                        p { "No unconfirmed outputs waiting for blockchain confirmation." }
+                                    } @else {
+                                        div class="table-responsive" {
+                                            table class="table table-sm" {
+                                                thead {
+                                                    tr {
+                                                        th { "Type" }
+                                                        th { "Outpoint" }
+                                                        th { "Amount (sats)" }
+                                                    }
+                                                }
+                                                tbody {
+                                                    @for txo in &wallet_summary.unconfirmed_peg_out_txos {
+                                                        tr {
+                                                            td { "Peg-out" }
+                                                            td { (format!("{}:{}", txo.outpoint.txid, txo.outpoint.vout)) }
+                                                            td { (txo.amount.to_sat()) }
+                                                        }
+                                                    }
+                                                    @for txo in &wallet_summary.unconfirmed_change_utxos {
+                                                        tr {
+                                                            td { "Change" }
+                                                            td { (format!("{}:{}", txo.outpoint.txid, txo.outpoint.vout)) }
+                                                            td { (txo.amount.to_sat()) }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/fedimint-server/src/envs.rs
+++ b/fedimint-server/src/envs.rs
@@ -2,6 +2,9 @@
 pub const FM_MAX_CLIENT_CONNECTIONS_ENV: &str = "FM_MAX_CLIENT_CONNECTIONS";
 pub const FM_PEER_ID_SORT_BY_URL_ENV: &str = "FM_PEER_ID_SORT_BY_URL";
 
+/// Environment variable for UI bind address
+pub const FM_UI_BIND_ENV: &str = "FM_UI_BIND";
+
 /// Environment variable for the session count determining when to cleanup old
 /// checkpoints.
 pub const FM_DB_CHECKPOINT_RETENTION_ENV: &str = "FM_DB_CHECKPOINT_RETENTION";

--- a/fedimint-testing-core/src/config.rs
+++ b/fedimint-testing-core/src/config.rs
@@ -33,7 +33,7 @@ pub fn local_config_gen_params(
     let connections: BTreeMap<PeerId, PeerConnectionInfo> = peers
         .iter()
         .map(|peer| {
-            let peer_port = base_port + u16::from(*peer) * 2;
+            let peer_port = base_port + u16::from(*peer) * 3;
 
             let p2p_url = format!("fedimint://127.0.0.1:{peer_port}");
             let api_url = format!("ws://127.0.0.1:{}", peer_port + 1);
@@ -54,19 +54,12 @@ pub fn local_config_gen_params(
     peers
         .iter()
         .map(|peer| {
-            let peer_port = base_port + u16::from(*peer) * 2;
-
-            let p2p_bind = format!("127.0.0.1:{peer_port}");
-            let api_bind = format!("127.0.0.1:{}", peer_port + 1);
-
             let params = ConfigGenParams {
                 identity: *peer,
                 api_auth: API_AUTH.clone(),
                 tls_key: Some(tls_keys[peer].1.clone()),
                 iroh_api_sk: None,
                 iroh_p2p_sk: None,
-                p2p_bind: p2p_bind.parse().expect("Valid address"),
-                api_bind: api_bind.parse().expect("Valid address"),
                 peers: connections.clone(),
                 meta: BTreeMap::from([(
                     META_FEDERATION_NAME_KEY.to_owned(),

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -41,6 +41,7 @@ fedimint-mint-common = { workspace = true }
 fedimint-mint-server = { workspace = true }
 fedimint-rocksdb = { workspace = true }
 fedimint-server = { workspace = true }
+fedimint-server-ui = { workspace = true }
 fedimint-unknown-common = { workspace = true }
 fedimint-unknown-server = { workspace = true }
 fedimint-wallet-server = { workspace = true }

--- a/fedimintd/src/envs.rs
+++ b/fedimintd/src/envs.rs
@@ -25,6 +25,9 @@ pub const FM_BIND_API_ENV: &str = "FM_BIND_API";
 // Env variable to TODO
 pub const FM_API_URL_ENV: &str = "FM_API_URL";
 
+// Env variable to bind the web UI server
+pub const FM_BIND_UI_ENV: &str = "FM_BIND_UI";
+
 // Env variable to TODO
 pub const FM_BITCOIN_NETWORK_ENV: &str = "FM_BITCOIN_NETWORK";
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1003,6 +1003,7 @@ fn calculate_pegout_metrics(
 #[derive(Debug)]
 pub struct Wallet {
     cfg: WalletConfig,
+    db: Database,
     secp: Secp256k1<All>,
     btc_rpc: DynBitcoindRpc,
     our_peer_id: PeerId,
@@ -1083,6 +1084,7 @@ impl Wallet {
 
         let wallet = Wallet {
             cfg,
+            db: db.clone(),
             secp: Default::default(),
             btc_rpc,
             our_peer_id,
@@ -1654,6 +1656,24 @@ impl Wallet {
             let db = db.clone();
             run_broadcast_pending_tx(db, bitcoind, broadcast_pending_notify)
         });
+    }
+
+    /// Get the current consensus block count for UI display
+    pub async fn consensus_block_count_ui(&self) -> u32 {
+        self.consensus_block_count(&mut self.db.begin_transaction_nc().await)
+            .await
+    }
+
+    /// Get the current consensus fee rate for UI display
+    pub async fn consensus_feerate_ui(&self) -> Feerate {
+        self.consensus_fee_rate(&mut self.db.begin_transaction_nc().await)
+            .await
+    }
+
+    /// Get the current wallet summary for UI display
+    pub async fn get_wallet_summary_ui(&self) -> WalletSummary {
+        self.get_wallet_summary(&mut self.db.begin_transaction_nc().await)
+            .await
     }
 
     /// Shutdown the task group shared throughout fedimintd, giving 60 seconds


### PR DESCRIPTION
## Overview
This PR introduces a new server-side rendered UI for Fedimint guardians, implemented entirely in Rust using the Maud templating library and Axum web framework. This implementation replaces the currently broken JavaScript PWA, providing a more maintainable interface for federation guardians.

Furthermore, this UI supports the new setup via exchanging connection strings that is required for Iroh support. Hence this UI is a part of the larger effort to support Iroh and thereby Start9. A server side rendered UI should be trivial to serve on a Start9.

## Key Features

- **Complete Dashboard**: Provides comprehensive guardian overview with federation metrics, connection status, and module-specific data
- **Modular Architecture**: Code organized into separate components (audit, connection status, invite code, etc.) for better maintainability
- **Federation Management**: 
  - Guardian information display
  - Connection status monitoring
  - Federation audit visualization
  - Invite code generation with QR code display
- **Module-Specific UI Sections**:
  - Lightning (LNv2) module management
  - Wallet module status and metrics
- **Responsive Design**: Bootstrap-based UI that works across devices

### Architecture
The UI is directly integrated into `fedimintd` via dependency injection, allowing it to access guardian APIs without additional network requests. This integration provides:

1. **Direct API Access**: UI components access guardian modules directly and type safe through the DashboardAPI trait
2. **Zero Configuration**: No separate deployment or configuration required
3. **Automatic Module Detection**: UI automatically detects and renders relevant sections based on installed modules

### Implementation Highlights
- Built with Axum for routing and request handling
- Uses Maud for type-safe HTML templating
- Cleanly separated module structure with focused components
- Bootstrap 5 for styling with minimal custom CSS

This implementation provides a reliable UI that requires no additional setup beyond running `fedimintd`, eliminating the need for setting up an additional server to serve the the UI. Since Iroh removes the need for a traefik proxy, this should reduce a complete setup for a guardian to fedimintd.




<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
