### PR TITLE
feat: enable LNv2 by default

### DIFF
--- a/devimint/src/util.rs
+++ b/devimint/src/util.rs
@@ -1124,7 +1124,8 @@ fn to_command(cli: Vec<String>) -> Command {
 }
 
 pub fn supports_lnv2() -> bool {
-    is_env_var_set(FM_ENABLE_MODULE_LNV2_ENV)
+    std::env::var_os(FM_ENABLE_MODULE_LNV2_ENV).is_none()
+        || is_env_var_set(FM_ENABLE_MODULE_LNV2_ENV)
 }
 
 /// Returns true if running backwards-compatibility tests

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -350,7 +350,10 @@ impl Fedimintd {
                 },
             );
 
-        let s = if is_env_var_set(FM_ENABLE_MODULE_LNV2_ENV) {
+        let enable_lnv2 = std::env::var_os(FM_ENABLE_MODULE_LNV2_ENV).is_none()
+            || is_env_var_set(FM_ENABLE_MODULE_LNV2_ENV);
+
+        let s = if enable_lnv2 {
             s.with_module_kind(fedimint_lnv2_server::LightningInit)
                 .with_module_instance(
                     fedimint_lnv2_server::LightningInit::kind(),

--- a/scripts/dev/mprocs/run.sh
+++ b/scripts/dev/mprocs/run.sh
@@ -10,6 +10,5 @@ add_target_dir_to_path
 
 # In our dev env we want to use the current aliases from the source code
 export FM_DEVIMINT_STATIC_DATA_DIR="${REPO_ROOT}/devimint/share"
-export FM_ENABLE_MODULE_LNV2=1
 
 devimint --link-test-dir "${CARGO_BUILD_TARGET_DIR:-$PWD/target}/devimint" "$@" dev-fed --exec bash -c 'mprocs -c misc/mprocs.yaml 2>$FM_LOGS_DIR/devimint-outer.log'

--- a/scripts/tests/gateway-module-test.sh
+++ b/scripts/tests/gateway-module-test.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
-export FM_ENABLE_MODULE_LNV2=${FM_ENABLE_MODULE_LNV2:-1}
 
 source scripts/_common.sh
 build_workspace

--- a/scripts/tests/gateway-reboot-test.sh
+++ b/scripts/tests/gateway-reboot-test.sh
@@ -3,7 +3,6 @@
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
-export FM_ENABLE_MODULE_LNV2=${FM_ENABLE_MODULE_LNV2:-1}
 
 source scripts/_common.sh
 build_workspace

--- a/scripts/tests/lightning-reconnect-test.sh
+++ b/scripts/tests/lightning-reconnect-test.sh
@@ -3,7 +3,6 @@
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
-export FM_ENABLE_MODULE_LNV2=${FM_ENABLE_MODULE_LNV2:-1}
 
 source scripts/_common.sh
 build_workspace

--- a/scripts/tests/lnv2-module-test.sh
+++ b/scripts/tests/lnv2-module-test.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 export RUST_LOG="${RUST_LOG:-info}"
-export FM_ENABLE_MODULE_LNV2=${FM_ENABLE_MODULE_LNV2:-1}
 
 source scripts/_common.sh
 build_workspace


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/7011

We have discussed enabling LNv2 by default on federations to incentivize wallet developers to implement it. This PR just changes the default of `FM_ENABLE_LNV2_MODULE` to true.

Testing infrastructure stays the same as it was before.