### PR TITLE
chore: check if running with LNv1 and LNv2 on mainnet

### DIFF
--- a/gateway/fedimint-gateway-server/src/envs.rs
+++ b/gateway/fedimint-gateway-server/src/envs.rs
@@ -37,4 +37,11 @@ pub const FM_GATEWAY_LIGHTNING_MODULE_MODE_ENV: &str = "FM_GATEWAY_LIGHTNING_MOD
 /// information.
 pub const FM_DEBUG_GATEWAY_ENV: &str = "FM_DEBUG_GATEWAY";
 
+/// Environment variable that instructs the gateway to skip waiting for the
+/// bitcoin node to sync to the chain.
 pub const FM_GATEWAY_SKIP_WAIT_FOR_SYNC_ENV: &str = "FM_GATEWAY_SKIP_WAIT_FOR_SYNC";
+
+/// Environment variable that instructs the gateway to skip checking if the
+/// Bitcoin network is set to mainnet and the lightning module mode is set to
+/// `All`
+pub const FM_GATEWAY_OVERRIDE_LN_MODULE_CHECK_ENV: &str = "FM_GATEWAY_OVERRIDE_LN_MODULE_CHECK";


### PR DESCRIPTION
It has been discouraged in the past to run with both LNv1 and LNv2 in the gateway, because the invoices cannot be paid using the same gateway. We haven't ever explicitly prevented doing this though.

We should. This PR adds a check on mainnet that prevents users from running with `LightningModuleMode::All`. Can be overridden if absolutely necessary.