### PR TITLE
fix: avoid devimint race condition during setup

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -253,6 +253,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
                 let task_group = task_group.clone();
                 async move {
                     let dev_fed = DevJitFed::new(&process_mgr, skip_setup)?;
+                    dev_fed.finalize(&process_mgr).await?;
 
                     let pegin_start_time = Instant::now();
                     debug!(target: LOG_DEVIMINT, "Peging in client and gateways");


### PR DESCRIPTION
I have a suspicion that the internal client is used during setup and that this is the reason for DB opening conflicts I experienced.

```
2025-03-14T07:13:09.663979Z  WARN fm::devimint: Main process failed, will shutdown err=command: fedimint-cli --data-dir=/tmp/nix-shell.0iNJHm/devimint-276195-224/clients/default-0 deposit-address: exit status: 1
stdout:
{
  "error": "could not open database: IO error: While lock file: /tmp/nix-shell.0iNJHm/devimint-276195-224/clients/default-0/client.db/LOCK: Resource temporarily unavailable"
}
```

After adding these changes I did not experience this error again, but it might have been luck. From first principles I think this PR should fix it though.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
