### PR TITLE
feat: gateway list lightning transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,9 +1328,9 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1338,7 +1338,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -3063,6 +3063,7 @@ dependencies = [
  "anyhow",
  "bcrypt",
  "bitcoin",
+ "chrono",
  "clap",
  "clap_complete",
  "fedimint-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
  "bon",
+ "chrono",
  "clap",
  "esplora-client 0.10.0",
  "fedimint-api-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ bitcoin_hashes = "0.14.0"
 bls12_381 = "0.8.0"
 bon = "3.3.2"
 bytes = "1.10.1"
+chrono = "0.4.40"
 clap = { version = "4.5.32", features = ["derive", "env"] }
 criterion = "0.5.1"
 devimint = { path = "./devimint", version = "=0.7.0-alpha" }

--- a/devimint/Cargo.toml
+++ b/devimint/Cargo.toml
@@ -18,6 +18,7 @@ axum = { workspace = true, features = ["tracing"] }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 bon = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 esplora-client = { workspace = true }
 fedimint-api-client = { workspace = true }

--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -12,7 +12,7 @@ use fedimint_core::task::TaskGroup;
 use fedimint_core::util::BoxStream;
 use fedimint_gateway_common::{
     CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, GetInvoiceRequest,
-    GetInvoiceResponse, OpenChannelRequest, SendOnchainRequest,
+    GetInvoiceResponse, ListTransactionsResponse, OpenChannelRequest, SendOnchainRequest,
 };
 use fedimint_lightning::{
     CreateInvoiceRequest, CreateInvoiceResponse, GetBalancesResponse, GetLnOnchainAddressResponse,
@@ -305,6 +305,12 @@ impl ILnRpcClient for FakeLightningTest {
     ) -> Result<Option<GetInvoiceResponse>, LightningRpcError> {
         Err(LightningRpcError::FailedToGetInvoice {
             failure_reason: "FakeLightningTest does not support getting invoices".to_string(),
+        })
+    }
+
+    async fn list_transactions(&self) -> Result<ListTransactionsResponse, LightningRpcError> {
+        Err(LightningRpcError::FailedToListTransactions {
+            failure_reason: "FakeLightningTest does not support listing transactions".to_string(),
         })
     }
 }

--- a/fedimint-testing/src/ln.rs
+++ b/fedimint-testing/src/ln.rs
@@ -308,7 +308,11 @@ impl ILnRpcClient for FakeLightningTest {
         })
     }
 
-    async fn list_transactions(&self) -> Result<ListTransactionsResponse, LightningRpcError> {
+    async fn list_transactions(
+        &self,
+        _start_secs: u64,
+        _end_secs: u64,
+    ) -> Result<ListTransactionsResponse, LightningRpcError> {
         Err(LightningRpcError::FailedToListTransactions {
             failure_reason: "FakeLightningTest does not support listing transactions".to_string(),
         })

--- a/gateway/fedimint-gateway-client/Cargo.toml
+++ b/gateway/fedimint-gateway-client/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 bcrypt = { workspace = true }
 bitcoin = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.46"
 fedimint-core = { workspace = true }

--- a/gateway/fedimint-gateway-client/src/general_commands.rs
+++ b/gateway/fedimint-gateway-client/src/general_commands.rs
@@ -7,8 +7,7 @@ use fedimint_core::time::now;
 use fedimint_eventlog::{EventKind, EventLogId};
 use fedimint_gateway_client::GatewayRpcClient;
 use fedimint_gateway_common::{
-    ConnectFedPayload, LeaveFedPayload, ListTransactionsPayload, PaymentLogPayload,
-    PaymentSummaryPayload,
+    ConnectFedPayload, LeaveFedPayload, PaymentLogPayload, PaymentSummaryPayload,
 };
 
 use crate::print_response;
@@ -33,9 +32,6 @@ pub enum GeneralCommands {
         #[clap(long)]
         recover: Option<bool>,
     },
-    /// List the transactions that the Lightning node has processed (onchain and
-    /// lightning)
-    ListTransactions,
     /// Leave a federation.
     LeaveFed {
         #[clap(long)]
@@ -118,12 +114,6 @@ impl GeneralCommands {
                     })
                     .await?;
 
-                print_response(response);
-            }
-            Self::ListTransactions => {
-                let response = create_client()
-                    .list_transactions(ListTransactionsPayload {})
-                    .await?;
                 print_response(response);
             }
             Self::LeaveFed { federation_id } => {

--- a/gateway/fedimint-gateway-client/src/general_commands.rs
+++ b/gateway/fedimint-gateway-client/src/general_commands.rs
@@ -7,7 +7,8 @@ use fedimint_core::time::now;
 use fedimint_eventlog::{EventKind, EventLogId};
 use fedimint_gateway_client::GatewayRpcClient;
 use fedimint_gateway_common::{
-    ConnectFedPayload, LeaveFedPayload, PaymentLogPayload, PaymentSummaryPayload,
+    ConnectFedPayload, LeaveFedPayload, ListTransactionsPayload, PaymentLogPayload,
+    PaymentSummaryPayload,
 };
 
 use crate::print_response;
@@ -32,6 +33,9 @@ pub enum GeneralCommands {
         #[clap(long)]
         recover: Option<bool>,
     },
+    /// List the transactions that the Lightning node has processed (onchain and
+    /// lightning)
+    ListTransactions,
     /// Leave a federation.
     LeaveFed {
         #[clap(long)]
@@ -41,7 +45,7 @@ pub enum GeneralCommands {
     Seed,
     /// Safely stop the gateway
     Stop,
-    /// List the transactions that the gateway has processed
+    /// List the fedimint transactions that the gateway has processed
     PaymentLog {
         #[clap(long)]
         end_position: Option<EventLogId>,
@@ -114,6 +118,12 @@ impl GeneralCommands {
                     })
                     .await?;
 
+                print_response(response);
+            }
+            Self::ListTransactions => {
+                let response = create_client()
+                    .list_transactions(ListTransactionsPayload {})
+                    .await?;
                 print_response(response);
             }
             Self::LeaveFed { federation_id } => {

--- a/gateway/fedimint-gateway-client/src/lib.rs
+++ b/gateway/fedimint-gateway-client/src/lib.rs
@@ -10,7 +10,8 @@ use fedimint_gateway_common::{
     FederationInfo, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT, GET_BALANCES_ENDPOINT,
     GET_INVOICE_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT, GatewayBalances, GatewayFedConfig,
     GatewayInfo, GetInvoiceRequest, GetInvoiceResponse, LEAVE_FED_ENDPOINT,
-    LIST_ACTIVE_CHANNELS_ENDPOINT, LeaveFedPayload, MNEMONIC_ENDPOINT, MnemonicResponse,
+    LIST_ACTIVE_CHANNELS_ENDPOINT, LIST_TRANSACTIONS_ENDPOINT, LeaveFedPayload,
+    ListTransactionsPayload, ListTransactionsResponse, MNEMONIC_ENDPOINT, MnemonicResponse,
     OPEN_CHANNEL_ENDPOINT, OpenChannelRequest, PAY_INVOICE_FOR_OPERATOR_ENDPOINT,
     PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT, PayInvoiceForOperatorPayload,
     PaymentLogPayload, PaymentLogResponse, PaymentSummaryPayload, PaymentSummaryResponse,
@@ -277,6 +278,17 @@ impl GatewayRpcClient {
         let url = self
             .base_url
             .join(GET_INVOICE_ENDPOINT)
+            .expect("invalid base url");
+        self.call_post(url, payload).await
+    }
+
+    pub async fn list_transactions(
+        &self,
+        payload: ListTransactionsPayload,
+    ) -> GatewayRpcResult<ListTransactionsResponse> {
+        let url = self
+            .base_url
+            .join(LIST_TRANSACTIONS_ENDPOINT)
             .expect("invalid base url");
         self.call_post(url, payload).await
     }

--- a/gateway/fedimint-gateway-client/src/lightning_commands.rs
+++ b/gateway/fedimint-gateway-client/src/lightning_commands.rs
@@ -74,7 +74,7 @@ pub enum LightningCommands {
     },
 }
 
-pub(crate) fn parse_datetime(s: &str) -> Result<DateTime<Utc>, chrono::ParseError> {
+fn parse_datetime(s: &str) -> Result<DateTime<Utc>, chrono::ParseError> {
     s.parse::<DateTime<Utc>>()
 }
 
@@ -141,10 +141,12 @@ impl LightningCommands {
                 start_time,
                 end_time,
             } => {
+                let start_secs = start_time.timestamp().try_into()?;
+                let end_secs = end_time.timestamp().try_into()?;
                 let response = create_client()
                     .list_transactions(ListTransactionsPayload {
-                        start_secs: start_time.timestamp() as u64,
-                        end_secs: end_time.timestamp() as u64,
+                        start_secs,
+                        end_secs,
                     })
                     .await?;
                 print_response(response);

--- a/gateway/fedimint-gateway-client/src/lightning_commands.rs
+++ b/gateway/fedimint-gateway-client/src/lightning_commands.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use fedimint_gateway_client::GatewayRpcClient;
 use fedimint_gateway_common::{
     CloseChannelsWithPeerRequest, CreateInvoiceForOperatorPayload, GetInvoiceRequest,
-    OpenChannelRequest, PayInvoiceForOperatorPayload,
+    ListTransactionsPayload, OpenChannelRequest, PayInvoiceForOperatorPayload,
 };
 use lightning_invoice::Bolt11Invoice;
 
@@ -52,6 +52,9 @@ pub enum LightningCommands {
     },
     /// List active channels.
     ListActiveChannels,
+    /// List the Lightning transactions that the Lightning node has received and
+    /// sent
+    ListTransactions,
     /// Get details about a specific invoice
     GetInvoice {
         /// The payment hash of the invoice
@@ -116,6 +119,12 @@ impl LightningCommands {
             Self::GetInvoice { payment_hash } => {
                 let response = create_client()
                     .get_invoice(GetInvoiceRequest { payment_hash })
+                    .await?;
+                print_response(response);
+            }
+            Self::ListTransactions => {
+                let response = create_client()
+                    .list_transactions(ListTransactionsPayload {})
                     .await?;
                 print_response(response);
             }

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -341,7 +341,10 @@ pub struct GetInvoiceResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ListTransactionsPayload {}
+pub struct ListTransactionsPayload {
+    pub start_secs: u64,
+    pub end_secs: u64,
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ListTransactionsResponse {
@@ -356,7 +359,7 @@ pub struct PaymentDetails {
     pub amount: Amount,
     pub direction: PaymentDirection,
     pub status: PaymentStatus,
-    pub timestamp: u64,
+    pub timestamp_secs: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]

--- a/gateway/fedimint-gateway-common/src/lib.rs
+++ b/gateway/fedimint-gateway-common/src/lib.rs
@@ -40,6 +40,7 @@ pub const GET_INVOICE_ENDPOINT: &str = "/get_invoice";
 pub const GET_LN_ONCHAIN_ADDRESS_ENDPOINT: &str = "/get_ln_onchain_address";
 pub const LEAVE_FED_ENDPOINT: &str = "/leave_fed";
 pub const LIST_ACTIVE_CHANNELS_ENDPOINT: &str = "/list_active_channels";
+pub const LIST_TRANSACTIONS_ENDPOINT: &str = "/list_transactions";
 pub const MNEMONIC_ENDPOINT: &str = "/mnemonic";
 pub const OPEN_CHANNEL_ENDPOINT: &str = "/open_channel";
 pub const CLOSE_CHANNELS_WITH_PEER_ENDPOINT: &str = "/close_channels_with_peer";
@@ -337,6 +338,39 @@ pub struct GetInvoiceResponse {
     pub amount: Amount,
     pub created_at: SystemTime,
     pub status: PaymentStatus,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ListTransactionsPayload {}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ListTransactionsResponse {
+    pub transactions: Vec<PaymentDetails>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PaymentDetails {
+    pub payment_hash: Option<sha256::Hash>,
+    pub preimage: Option<String>,
+    pub payment_kind: PaymentKind,
+    pub amount: Amount,
+    pub direction: PaymentDirection,
+    pub status: PaymentStatus,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum PaymentKind {
+    Bolt11,
+    Bolt12Offer,
+    Bolt12Refund,
+    Onchain,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum PaymentDirection {
+    Outbound,
+    Inbound,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -1708,10 +1708,13 @@ impl Gateway {
 
     pub async fn handle_list_transactions_msg(
         &self,
-        _payload: ListTransactionsPayload,
+        payload: ListTransactionsPayload,
     ) -> AdminResult<ListTransactionsResponse> {
         let lightning_context = self.get_lightning_context().await?;
-        let response = lightning_context.lnrpc.list_transactions().await?;
+        let response = lightning_context
+            .lnrpc
+            .list_transactions(payload.start_secs, payload.end_secs)
+            .await?;
         Ok(response)
     }
 

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -70,10 +70,11 @@ use fedimint_gateway_common::{
     CreateInvoiceForOperatorPayload, DepositAddressPayload, DepositAddressRecheckPayload,
     FederationBalanceInfo, FederationConfig, FederationInfo, GatewayBalances, GatewayFedConfig,
     GatewayInfo, GetInvoiceRequest, GetInvoiceResponse, LeaveFedPayload, LightningMode,
-    MnemonicResponse, OpenChannelRequest, PayInvoiceForOperatorPayload, PaymentLogPayload,
-    PaymentLogResponse, PaymentStats, PaymentSummaryPayload, PaymentSummaryResponse,
-    ReceiveEcashPayload, ReceiveEcashResponse, SendOnchainRequest, SetFeesPayload,
-    SpendEcashPayload, SpendEcashResponse, V1_API_ENDPOINT, WithdrawPayload, WithdrawResponse,
+    ListTransactionsPayload, ListTransactionsResponse, MnemonicResponse, OpenChannelRequest,
+    PayInvoiceForOperatorPayload, PaymentLogPayload, PaymentLogResponse, PaymentStats,
+    PaymentSummaryPayload, PaymentSummaryResponse, ReceiveEcashPayload, ReceiveEcashResponse,
+    SendOnchainRequest, SetFeesPayload, SpendEcashPayload, SpendEcashResponse, V1_API_ENDPOINT,
+    WithdrawPayload, WithdrawResponse,
 };
 use fedimint_gateway_server_db::{GatewayDbtxNcExt as _, get_gatewayd_database_migrations};
 use fedimint_gw_client::events::compute_lnv1_stats;
@@ -1703,6 +1704,15 @@ impl Gateway {
         let lightning_context = self.get_lightning_context().await?;
         let invoice = lightning_context.lnrpc.get_invoice(payload).await?;
         Ok(invoice)
+    }
+
+    pub async fn handle_list_transactions_msg(
+        &self,
+        _payload: ListTransactionsPayload,
+    ) -> AdminResult<ListTransactionsResponse> {
+        let lightning_context = self.get_lightning_context().await?;
+        let response = lightning_context.lnrpc.list_transactions().await?;
+        Ok(response)
     }
 
     /// Registers the gateway with each specified federation.

--- a/gateway/fedimint-gateway-server/src/rpc_server.rs
+++ b/gateway/fedimint-gateway-server/src/rpc_server.rs
@@ -17,12 +17,13 @@ use fedimint_gateway_common::{
     DepositAddressRecheckPayload, GATEWAY_INFO_ENDPOINT, GATEWAY_INFO_POST_ENDPOINT,
     GET_BALANCES_ENDPOINT, GET_INVOICE_ENDPOINT, GET_LN_ONCHAIN_ADDRESS_ENDPOINT,
     GetInvoiceRequest, InfoPayload, LEAVE_FED_ENDPOINT, LIST_ACTIVE_CHANNELS_ENDPOINT,
-    LeaveFedPayload, MNEMONIC_ENDPOINT, OPEN_CHANNEL_ENDPOINT, OpenChannelRequest,
-    PAY_INVOICE_FOR_OPERATOR_ENDPOINT, PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT,
-    PayInvoiceForOperatorPayload, PaymentLogPayload, PaymentSummaryPayload, RECEIVE_ECASH_ENDPOINT,
-    ReceiveEcashPayload, SEND_ONCHAIN_ENDPOINT, SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT,
-    STOP_ENDPOINT, SendOnchainRequest, SetFeesPayload, SpendEcashPayload, V1_API_ENDPOINT,
-    WITHDRAW_ENDPOINT, WithdrawPayload,
+    LIST_TRANSACTIONS_ENDPOINT, LeaveFedPayload, ListTransactionsPayload, MNEMONIC_ENDPOINT,
+    OPEN_CHANNEL_ENDPOINT, OpenChannelRequest, PAY_INVOICE_FOR_OPERATOR_ENDPOINT,
+    PAYMENT_LOG_ENDPOINT, PAYMENT_SUMMARY_ENDPOINT, PayInvoiceForOperatorPayload,
+    PaymentLogPayload, PaymentSummaryPayload, RECEIVE_ECASH_ENDPOINT, ReceiveEcashPayload,
+    SEND_ONCHAIN_ENDPOINT, SET_FEES_ENDPOINT, SPEND_ECASH_ENDPOINT, STOP_ENDPOINT,
+    SendOnchainRequest, SetFeesPayload, SpendEcashPayload, V1_API_ENDPOINT, WITHDRAW_ENDPOINT,
+    WithdrawPayload,
 };
 use fedimint_ln_common::gateway_endpoint_constants::{
     GET_GATEWAY_ID_ENDPOINT, PAY_INVOICE_ENDPOINT,
@@ -167,6 +168,7 @@ fn v1_routes(gateway: Arc<Gateway>, task_group: TaskGroup) -> Router {
             post(close_channels_with_peer),
         )
         .route(LIST_ACTIVE_CHANNELS_ENDPOINT, get(list_active_channels))
+        .route(LIST_TRANSACTIONS_ENDPOINT, post(list_transactions))
         .route(SEND_ONCHAIN_ENDPOINT, post(send_onchain))
         .route(ADDRESS_RECHECK_ENDPOINT, post(recheck_address))
         .route(GET_BALANCES_ENDPOINT, get(get_balances))
@@ -465,4 +467,13 @@ async fn get_invoice(
 ) -> Result<impl IntoResponse, AdminGatewayError> {
     let invoice = gateway.handle_get_invoice_msg(payload).await?;
     Ok(Json(json!(invoice)))
+}
+
+#[instrument(target = LOG_GATEWAY, skip_all, err)]
+async fn list_transactions(
+    Extension(gateway): Extension<Arc<Gateway>>,
+    Json(payload): Json<ListTransactionsPayload>,
+) -> Result<impl IntoResponse, AdminGatewayError> {
+    let transactions = gateway.handle_list_transactions_msg(payload).await?;
+    Ok(Json(json!(transactions)))
 }

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -697,9 +697,9 @@ impl ILnRpcClient for GatewayLdkClient {
     async fn list_transactions(&self) -> Result<ListTransactionsResponse, LightningRpcError> {
         let transactions = self
             .node
-            .list_payments_with_filter(|_details| {
+            .list_payments_with_filter(|details| {
                 // TODO: Filter on timestamp
-                true
+                details.kind != PaymentKind::Onchain
             })
             .iter()
             .map(|details| {

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -694,12 +694,17 @@ impl ILnRpcClient for GatewayLdkClient {
         Ok(invoices.first().cloned())
     }
 
-    async fn list_transactions(&self) -> Result<ListTransactionsResponse, LightningRpcError> {
+    async fn list_transactions(
+        &self,
+        start_secs: u64,
+        end_secs: u64,
+    ) -> Result<ListTransactionsResponse, LightningRpcError> {
         let transactions = self
             .node
             .list_payments_with_filter(|details| {
-                // TODO: Filter on timestamp
                 details.kind != PaymentKind::Onchain
+                    && details.latest_update_timestamp >= start_secs
+                    && details.latest_update_timestamp < end_secs
             })
             .iter()
             .map(|details| {
@@ -727,7 +732,7 @@ impl ILnRpcClient for GatewayLdkClient {
                     ),
                     direction,
                     status,
-                    timestamp: details.latest_update_timestamp,
+                    timestamp_secs: details.latest_update_timestamp,
                 }
             })
             .collect::<Vec<_>>();

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -15,7 +15,7 @@ use fedimint_core::task::TaskGroup;
 use fedimint_core::util::{backoff_util, retry};
 use fedimint_gateway_common::{
     ChannelInfo, CloseChannelsWithPeerRequest, CloseChannelsWithPeerResponse, GetInvoiceRequest,
-    GetInvoiceResponse, OpenChannelRequest, SendOnchainRequest,
+    GetInvoiceResponse, ListTransactionsResponse, OpenChannelRequest, SendOnchainRequest,
 };
 use fedimint_ln_common::PrunedInvoice;
 pub use fedimint_ln_common::contracts::Preimage;
@@ -53,6 +53,8 @@ pub enum LightningRpcError {
     FailedToCloseChannelsWithPeer { failure_reason: String },
     #[error("Failed to get Invoice: {failure_reason}")]
     FailedToGetInvoice { failure_reason: String },
+    #[error("Failed to list transactions: {failure_reason}")]
+    FailedToListTransactions { failure_reason: String },
     #[error("Failed to get funding address: {failure_reason}")]
     FailedToGetLnOnchainAddress { failure_reason: String },
     #[error("Failed to withdraw funds on-chain: {failure_reason}")]
@@ -219,6 +221,8 @@ pub trait ILnRpcClient: Debug + Send + Sync {
         &self,
         get_invoice_request: GetInvoiceRequest,
     ) -> Result<Option<GetInvoiceResponse>, LightningRpcError>;
+
+    async fn list_transactions(&self) -> Result<ListTransactionsResponse, LightningRpcError>;
 }
 
 impl dyn ILnRpcClient {

--- a/gateway/fedimint-lightning/src/lib.rs
+++ b/gateway/fedimint-lightning/src/lib.rs
@@ -222,7 +222,11 @@ pub trait ILnRpcClient: Debug + Send + Sync {
         get_invoice_request: GetInvoiceRequest,
     ) -> Result<Option<GetInvoiceResponse>, LightningRpcError>;
 
-    async fn list_transactions(&self) -> Result<ListTransactionsResponse, LightningRpcError>;
+    async fn list_transactions(
+        &self,
+        start_secs: u64,
+        end_secs: u64,
+    ) -> Result<ListTransactionsResponse, LightningRpcError>;
 }
 
 impl dyn ILnRpcClient {

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -10,7 +10,9 @@ use fedimint_core::encoding::Encodable;
 use fedimint_core::task::{TaskGroup, sleep};
 use fedimint_core::util::FmtCompact;
 use fedimint_core::{Amount, BitcoinAmountOrAll, crit, secp256k1};
-use fedimint_gateway_common::ListTransactionsResponse;
+use fedimint_gateway_common::{
+    ListTransactionsResponse, PaymentDetails, PaymentDirection, PaymentKind,
+};
 use fedimint_ln_common::PrunedInvoice;
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::route_hints::{RouteHint, RouteHintHop};
@@ -31,8 +33,8 @@ use tonic_lnd::lnrpc::payment::PaymentStatus;
 use tonic_lnd::lnrpc::{
     ChanInfoRequest, ChannelBalanceRequest, ChannelPoint, CloseChannelRequest, ConnectPeerRequest,
     GetInfoRequest, Invoice, InvoiceSubscription, LightningAddress, ListChannelsRequest,
-    ListInvoiceRequest, ListPeersRequest, OpenChannelRequest, SendCoinsRequest,
-    WalletBalanceRequest,
+    ListInvoiceRequest, ListPaymentsRequest, ListPeersRequest, OpenChannelRequest,
+    SendCoinsRequest, WalletBalanceRequest,
 };
 use tonic_lnd::routerrpc::{
     CircuitKey, ForwardHtlcInterceptResponse, ResolveHoldForwardAction, SendPaymentRequest,
@@ -1404,6 +1406,7 @@ impl ILnRpcClient for GatewayLndClient {
             Ok(invoice) => invoice.into_inner(),
             Err(_) => return Ok(None),
         };
+        // TODO: Set to None if fails
         let preimage: [u8; 32] = invoice
             .clone()
             .r_preimage
@@ -1427,8 +1430,88 @@ impl ILnRpcClient for GatewayLndClient {
     }
 
     async fn list_transactions(&self) -> Result<ListTransactionsResponse, LightningRpcError> {
+        let mut client = self.connect().await?;
+        let payments = client
+            .lightning()
+            .list_payments(ListPaymentsRequest {
+                // TODO: add time bound here
+                ..Default::default()
+            })
+            .await
+            .map_err(|err| LightningRpcError::FailedToListTransactions {
+                failure_reason: err.to_string(),
+            })?
+            .into_inner();
+
+        let mut payments = payments
+            .payments
+            .iter()
+            .map(|payment| {
+                let payment_hash = sha256::Hash::from_str(&payment.payment_hash).ok();
+                let preimage = (!payment.payment_preimage.is_empty())
+                    .then_some(payment.payment_preimage.clone());
+                let status = match &payment.status() {
+                    PaymentStatus::Succeeded => fedimint_gateway_common::PaymentStatus::Succeeded,
+                    PaymentStatus::Failed => fedimint_gateway_common::PaymentStatus::Failed,
+                    _ => fedimint_gateway_common::PaymentStatus::Pending,
+                };
+                PaymentDetails {
+                    payment_hash,
+                    preimage,
+                    payment_kind: PaymentKind::Bolt11,
+                    amount: Amount::from_msats(payment.value_msat as u64),
+                    direction: PaymentDirection::Outbound,
+                    status,
+                    // TODO: Verify that this is the right type
+                    timestamp: payment.creation_time_ns as u64,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let invoices = client
+            .lightning()
+            .list_invoices(ListInvoiceRequest {
+                pending_only: false,
+                ..Default::default()
+            })
+            .await
+            .map_err(|err| LightningRpcError::FailedToListTransactions {
+                failure_reason: err.to_string(),
+            })?
+            .into_inner();
+
+        let mut incoming_payments = invoices
+            .invoices
+            .iter()
+            .filter_map(|invoice| {
+                // TODO: Filter by time bound
+                let status = match &invoice.state() {
+                    InvoiceState::Settled => fedimint_gateway_common::PaymentStatus::Succeeded,
+                    InvoiceState::Canceled => fedimint_gateway_common::PaymentStatus::Failed,
+                    _ => return None,
+                };
+                let preimage = (!invoice.r_preimage.is_empty())
+                    .then_some(invoice.r_preimage.encode_hex::<String>());
+                Some(PaymentDetails {
+                    payment_hash: Some(
+                        sha256::Hash::from_slice(&invoice.r_hash)
+                            .expect("Could not convert payment hash"),
+                    ),
+                    preimage,
+                    payment_kind: PaymentKind::Bolt11,
+                    amount: Amount::from_msats(invoice.value_msat as u64),
+                    direction: PaymentDirection::Inbound,
+                    status,
+                    timestamp: invoice.settle_date as u64,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        payments.append(&mut incoming_payments);
+        payments.sort_by_key(|p| p.timestamp);
+
         Ok(ListTransactionsResponse {
-            transactions: vec![],
+            transactions: payments,
         })
     }
 }

--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -10,6 +10,7 @@ use fedimint_core::encoding::Encodable;
 use fedimint_core::task::{TaskGroup, sleep};
 use fedimint_core::util::FmtCompact;
 use fedimint_core::{Amount, BitcoinAmountOrAll, crit, secp256k1};
+use fedimint_gateway_common::ListTransactionsResponse;
 use fedimint_ln_common::PrunedInvoice;
 use fedimint_ln_common::contracts::Preimage;
 use fedimint_ln_common::route_hints::{RouteHint, RouteHintHop};
@@ -1423,6 +1424,12 @@ impl ILnRpcClient for GatewayLndClient {
             created_at: UNIX_EPOCH + Duration::from_secs(invoice.creation_date as u64),
             status,
         }))
+    }
+
+    async fn list_transactions(&self) -> Result<ListTransactionsResponse, LightningRpcError> {
+        Ok(ListTransactionsResponse {
+            transactions: vec![],
+        })
     }
 }
 

--- a/modules/fedimint-ln-common/src/contracts/mod.rs
+++ b/modules/fedimint-ln-common/src/contracts/mod.rs
@@ -1,11 +1,13 @@
 pub mod incoming;
 pub mod outgoing;
 
+use std::fmt::Display;
 use std::io::Error;
 
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::{Hash as BitcoinHash, hash_newtype};
 use fedimint_core::encoding::{Decodable, DecodeError, Encodable};
+use fedimint_core::hex::ToHex;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::{OutPoint, secp256k1};
 use serde::{Deserialize, Serialize};
@@ -118,6 +120,12 @@ impl Decodable for ContractId {
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct Preimage(pub [u8; 32]);
+
+impl Display for Preimage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.encode_hex::<String>())
+    }
+}
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct PreimageKey(#[serde(with = "serde_big_array::BigArray")] pub [u8; 33]);


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/6389

We need to have an API to list the transactions the gateway has executed (outbound and inbound).

API takes a `DateTime` to limit the returned results.