### PR TITLE
feat: add docker-compose that supports iroh federations

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,3 +14,12 @@ of this directory in the past releases for more info.
 
 For help please try [Fedimint Github Discussions](https://github.com/fedimint/fedimint/discussions)
 or `#mint-ops` channel on [Fedimint's Discord server](https://chat.fedimint.org/).
+
+## Iroh
+
+We have an additional `docker-compose.yaml` that supports Iroh, but is considered experimental. To try it:
+
+```
+cd iroh-fedimintd
+docker compose up -d
+```

--- a/docker/iroh-fedimintd/docker-compose.yaml
+++ b/docker/iroh-fedimintd/docker-compose.yaml
@@ -1,0 +1,17 @@
+services:
+  fedimintd:
+    image: fedimint/fedimintd:master
+    ports:
+      - 8175:8175
+    volumes:
+      - fedimintd_data:/data
+    environment:
+      - FM_FORCE_IROH=1
+      - FM_BITCOIN_NETWORK=signet
+      - FM_BITCOIN_RPC_KIND=esplora
+      - FM_BITCOIN_RPC_URL=https://mutinynet.com/api
+      - FM_BIND_UI=0.0.0.0:8175
+    restart: always
+
+volumes:
+  fedimintd_data:


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/7005

Introduces a new `docker-compose` that supports Iroh. Unifying with the existing `docker-compose` isn't worth the effort yet while we're still in the early stages of testing Iroh in the wild.