### PR TITLE
fix: add lib secrion to server-ui Cargo.toml

### DIFF
--- a/fedimint-server-ui/Cargo.toml
+++ b/fedimint-server-ui/Cargo.toml
@@ -1,12 +1,21 @@
 [package]
 name = "fedimint-server-ui"
-version = "0.7.0-alpha"
+version = { workspace = true }
+authors = { workspace = true }
 edition = { workspace = true }
+description = "fedimint-server-ui is a server-side rendered admin web UI for fedimintd."
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+name = "fedimint_server_ui"
+path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true } 
-axum = "0.8.1" 
+async-trait = { workspace = true }
+axum = "0.8.1"
 axum-extra = { version = "0.10.0", features = ["cookie"] }
 chrono = "0.4"
 fedimint-core = { workspace = true }


### PR DESCRIPTION
Without an explicit lib or bin section cargo deny can't parse the manifest and fails in CI.

See https://github.com/fedimint/fedimint/pull/7033#issuecomment-2732586431

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
