### PR TITLE
feat: Added extract_federation_id function in core library

### DIFF
--- a/fedimint-client-wasm/src/lib.rs
+++ b/fedimint-client-wasm/src/lib.rs
@@ -66,6 +66,14 @@ impl WasmClient {
             .map_err(|x| JsError::new(&x.to_string()))
     }
 
+    #[wasm_bindgen]
+    /// Extract federation ID from an invite code without joining the federation
+    pub fn extract_federation_id(invite_code: String) -> Result<String, JsError> {
+        let invite_code = InviteCode::from_str(&invite_code)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(invite_code.federation_id().to_string())
+    }
+    
     async fn client_builder(db: Database) -> Result<fedimint_client::ClientBuilder, anyhow::Error> {
         let mut builder = fedimint_client::Client::builder(db).await?;
         builder.with_module(MintClientInit);


### PR DESCRIPTION
Closes [#80 in fedimint-web-sdk](https://github.com/fedimint/fedimint-web-sdk/issues/80) 


After searching extensively for the parseInviteCode function without success, I discovered that the pub fn federation_id(&self) -> FederationId function could be called directly.

```rs
#[test]
fn get_fed_id() {
    let invite_code_str = "fed11qgqpu8rhwden5te0vejkg6tdd9h8gepwd4cxcumxv4jzuen0duhsqqfqh6nl7sgk72caxfx8khtfnn8y436q3nhyrkev3qp8ugdhdllnh86qmp42pm";
    let invite_code = InviteCode::from_str(invite_code_str).expect("valid invite code");

    let fed_id = invite_code.federation_id();
    println!("{:?}", fed_id);
}
```

It successfully returned the federation_id.
Next, I added this function to `fedimint-client-wasm` for easier federation ID extraction without joining the federation:

```rs
#[wasm_bindgen]
/// Extract federation ID from an invite code without joining the federation
pub fn extract_federation_id(invite_code: String) -> Result<String, JsError> {
    let invite_code = InviteCode::from_str(&invite_code)
        .map_err(|e| JsError::new(&e.to_string()))?;
    Ok(invite_code.federation_id().to_string())
}
```

After building.
I tested it with a sample HTML and JS file:

```js
document.getElementById('extract-button').addEventListener('click', () => {
    const inviteCode = document.getElementById('invite-code').value;

    try {
        const federationId = WasmClient.extract_federation_id(inviteCode);
        document.getElementById('result').textContent = `Federation ID: ${federationId}`;
    } catch (error) {
        document.getElementById('result').textContent = `Error: ${error.message}`;
    }
});
```
 This worked perfectly, allowing me to extract the federation_id from an invite code without joining the federation.

![image](https://github.com/user-attachments/assets/763ae69b-10af-4a3e-884c-780d67313d37)
