### PR TITLE
fix: wait for epochs before pegging in

### DIFF
--- a/devimint/src/cli.rs
+++ b/devimint/src/cli.rs
@@ -263,6 +263,7 @@ pub async fn handle_command(cmd: Cmd, common_args: CommonArgs) -> Result<()> {
 
                         let (operation_id, (), ()) = tokio::try_join!(
                             async {
+                                dev_fed.epochs_generated().await?;
                                 let (address, operation_id) =
                                     dev_fed.internal_client().await?.get_deposit_addr().await?;
                                 debug!(

--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -362,6 +362,10 @@ impl DevJitFed {
     pub async fn bitcoind(&self) -> anyhow::Result<&Bitcoind> {
         Ok(self.bitcoind.get_try().await?.deref())
     }
+    pub async fn epochs_generated(&self) -> anyhow::Result<()> {
+        let _ = self.fed_epoch_generated.get_try().await?;
+        Ok(())
+    }
 
     pub async fn internal_client(&self) -> anyhow::Result<Client> {
         Ok(self.fed().await?.internal_client().await?.clone())


### PR DESCRIPTION
Alternative to https://github.com/fedimint/fedimint/pull/7039

Just waits for epochs to be generated on the fed rather than waiting for all services.