### PR TITLE
refactor(rocksdb): lock rocksdb by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,6 +3761,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "fedimint-core",
+ "fedimint-logging",
+ "fs-lock",
  "futures",
  "rocksdb",
  "tempfile",

--- a/fedimint-dbtool/src/dump.rs
+++ b/fedimint-dbtool/src/dump.rs
@@ -75,7 +75,7 @@ impl DatabaseDump {
         modules: Vec<String>,
         prefixes: Vec<String>,
     ) -> anyhow::Result<DatabaseDump> {
-        let Ok(read_only_rocks_db) = RocksDbReadOnly::open_read_only(data_dir.clone()) else {
+        let Ok(read_only_rocks_db) = RocksDbReadOnly::open_read_only(data_dir.clone()).await else {
             panic!("Error reading RocksDB database. Quitting...");
         };
 

--- a/fedimint-load-test-tool/src/common.rs
+++ b/fedimint-load-test-tool/src/common.rs
@@ -144,7 +144,7 @@ pub async fn build_client(
 ) -> anyhow::Result<(ClientHandleArc, Option<InviteCode>)> {
     let db = if let Some(rocksdb) = rocksdb {
         Database::new(
-            fedimint_rocksdb::RocksDb::open(rocksdb)?,
+            fedimint_rocksdb::RocksDb::open(rocksdb).await?,
             ModuleRegistry::default(),
         )
     } else {

--- a/fedimint-rocksdb/Cargo.toml
+++ b/fedimint-rocksdb/Cargo.toml
@@ -19,12 +19,19 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 fedimint-core = { workspace = true }
+fedimint-logging = { workspace = true }
+fs-lock = { workspace = true }
 futures = { workspace = true }
-rocksdb = { version = "0.22.0", features = [ "jemalloc" ] }
+rocksdb = { version = "0.22.0", features = ["jemalloc"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.17.1"
 
 [target.'cfg(not(target_family="wasm"))'.dependencies]
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = [
+  "rt",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -68,6 +68,7 @@ impl FederationTest {
         self.new_client_with(
             client_config,
             RocksDb::open(tempfile::tempdir().expect("Couldn't create temp dir"))
+                .await
                 .expect("Couldn't open DB")
                 .into(),
             None,

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -549,7 +549,7 @@ async fn run(
     };
 
     let db = Database::new(
-        fedimint_rocksdb::RocksDb::open(data_dir.join(DB_FILE))?,
+        fedimint_rocksdb::RocksDb::open(data_dir.join(DB_FILE)).await?,
         ModuleRegistry::default(),
     );
 

--- a/gateway/fedimint-gateway-server/src/client.rs
+++ b/gateway/fedimint-gateway-server/src/client.rs
@@ -152,6 +152,7 @@ impl GatewayClientBuilder {
 
         let (db, root_secret) = if db_path.exists() {
             let rocksdb = fedimint_rocksdb::RocksDb::open(db_path.clone())
+                .await
                 .map_err(AdminGatewayError::ClientCreationError)?;
             let db = Database::new(rocksdb, ModuleDecoderRegistry::default());
             let root_secret = self.client_plainrootsecret(&db).await?;

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -298,7 +298,7 @@ impl Gateway {
         let decoders = registry.available_decoders(DEFAULT_MODULE_KINDS.iter().copied())?;
 
         let gateway_db = Database::new(
-            fedimint_rocksdb::RocksDb::open(opts.data_dir.join(DB_FILE))?,
+            fedimint_rocksdb::RocksDb::open(opts.data_dir.join(DB_FILE)).await?,
             decoders,
         );
 


### PR DESCRIPTION
This should be common functionality, so there is no doubt
that dbtool and other things respect locking.

While at it, fix the async/blocking IO handling.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
