### PR TITLE
fix: missed `todo!`

### DIFF
--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -919,7 +919,9 @@ fn jsonrpc_error_to_peer_error(jsonrpc_error: JsonRpcClientError) -> PeerError {
         JsonRpcClientError::Transport(error) => PeerError::Transport(anyhow!(error)),
         JsonRpcClientError::RestartNeeded(arc) => PeerError::Transport(anyhow!(arc)),
         JsonRpcClientError::ParseError(error) => PeerError::InvalidResponse(anyhow!(error)),
-        JsonRpcClientError::InvalidSubscriptionId => todo!(),
+        JsonRpcClientError::InvalidSubscriptionId => {
+            PeerError::Transport(anyhow!("Invalid subscription id"))
+        }
         JsonRpcClientError::InvalidRequestId(invalid_request_id) => {
             PeerError::InvalidRequest(anyhow!(invalid_request_id))
         }


### PR DESCRIPTION
I don't think it can actually happen, thankfully, but it shouldn't be there anyway.

Fix #7019

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
