### PR TITLE
chore(devimint): ability to stop before dkg

### DIFF
--- a/devimint/src/envs.rs
+++ b/devimint/src/envs.rs
@@ -46,6 +46,9 @@ pub const FM_FEDERATIONS_BASE_PORT_ENV: &str = "FM_FEDERATIONS_BASE_PORT";
 // Env variable to set a federation's invite code
 pub const FM_INVITE_CODE_ENV: &str = "FM_INVITE_CODE";
 
+// Env variable to stop in a pre-dkg stage of devimint
+pub const FM_PRE_DKG_ENV: &str = "FM_PRE_DKG";
+
 // util.rs
 
 // Env variable to override gatewayd binary set:

--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -295,6 +295,7 @@ impl Federation {
         process_mgr: &ProcessManager,
         bitcoind: Bitcoind,
         skip_setup: bool,
+        pre_dkg: bool,
         // Which of the pre-allocated federations to use (most tests just use single `0` one)
         fed_index: usize,
         federation_name: String,
@@ -344,7 +345,7 @@ impl Federation {
             peer_to_env_vars_map.insert(peer_id.to_usize(), peer_env_vars);
         }
 
-        if !skip_setup {
+        if !skip_setup && !pre_dkg {
             // we don't guarantee backwards-compatibility for dkg, so we use the
             // fedimint-cli version that matches fedimintd
             let (original_fedimint_cli_path, original_fm_mint_client) =
@@ -395,7 +396,7 @@ impl Federation {
             move || async move {
                 let client = Client::open_or_create(federation_name.as_str())?;
                 let invite_code = Self::invite_code_static()?;
-                if !skip_setup {
+                if !skip_setup && !pre_dkg {
                     cmd!(client, "join-federation", invite_code).run().await?;
                 }
                 Ok(client)

--- a/devimint/src/lib.rs
+++ b/devimint/src/lib.rs
@@ -43,6 +43,7 @@ pub mod version_constants;
 pub async fn run_devfed_test<F, FF>(
     #[builder(finish_fn)] f: F,
     num_feds: Option<usize>,
+    pre_dkg: Option<bool>,
 ) -> anyhow::Result<()>
 where
     F: FnOnce(DevJitFed, ProcessManager) -> FF,
@@ -56,7 +57,7 @@ where
 
     let (process_mgr, task_group) = cli::setup(args).await?;
     log_binary_versions().await?;
-    let dev_fed = devfed::DevJitFed::new(&process_mgr, false)?;
+    let dev_fed = devfed::DevJitFed::new(&process_mgr, false, pre_dkg.unwrap_or_default())?;
     // workaround https://github.com/tokio-rs/tokio/issues/6463
     // by waiting on all jits to complete, we make it less likely
     // that something is not finished yet and will block in `on_block`

--- a/gateway/integration_tests/src/main.rs
+++ b/gateway/integration_tests/src/main.rs
@@ -368,6 +368,7 @@ async fn config_test(gw_type: LightningNodeType) -> anyhow::Result<()> {
                     &process_mgr,
                     bitcoind.clone(),
                     false,
+                    false,
                     1,
                     "config-test".to_string(),
                 )

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -130,6 +130,14 @@ tmuxinator:
 devimint-env *PARAMS:
   ./scripts/dev/devimint-env.sh {{PARAMS}}
 
+devimint-env-pre-dkg *PARAMS:
+  @>&2 echo "fedimint-0 UI: http://localhost:2002"
+  @>&2 echo "fedimint-1 UI: http://localhost:2006"
+  @>&2 echo "fedimint-2 UI: http://localhost:2010"
+  @>&2 echo "fedimint-3 UI: http://localhost:2014"
+  env FM_FEDERATIONS_BASE_PORT=2000 FM_PRE_DKG=true ./scripts/dev/devimint-env.sh {{PARAMS}}
+
+
 devimint-env-tmux *PARAMS:
   ./scripts/dev/tmuxinator/run.sh {{PARAMS}}
 


### PR DESCRIPTION
You can try with:

```
> just devimint-env-pre-dkg                                                                                                                   [0/9]
fedimint-0 UI: http://localhost:2002
fedimint-1 UI: http://localhost:2006
fedimint-2 UI: http://localhost:2010
fedimint-3 UI: http://localhost:2014
env FM_FEDERATIONS_BASE_PORT=2000 FM_PRE_DKG=true ./scripts/dev/devimint-env.sh
Lowering IO priority with chrt -i 0 ionice -c 3
   Compiling fedimint-client-module v0.7.0-alpha (/home/dpc/lab/fedimint/fedimint/fedimint-client-module)
...
```

On top of #7056 

This is to replace what @joschisan is removing in #7041 , in a (hopefully) more elegant way.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
