### PR TITLE
fix: expose LNV2 preimage when payment is successful

### DIFF
--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -76,7 +76,10 @@ async fn can_pay_external_invoice_exactly_once() -> anyhow::Result<()> {
 
     assert_eq!(sub.ok().await?, SendOperationState::Funding);
     assert_eq!(sub.ok().await?, SendOperationState::Funded);
-    assert_eq!(sub.ok().await?, SendOperationState::Success);
+    assert_eq!(
+        sub.ok().await?,
+        SendOperationState::Success(MOCK_INVOICE_PREIMAGE)
+    );
 
     assert_eq!(
         client
@@ -226,7 +229,10 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
         .await
         .expect("Failed to claim outgoing contract");
 
-    assert_eq!(sub.ok().await?, SendOperationState::Success);
+    assert_eq!(
+        sub.ok().await?,
+        SendOperationState::Success(MOCK_INVOICE_PREIMAGE)
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Preimage is a proof of payment, some Lightning wallets might want to display it or save it for future reference (Harbor Wallet does this)