### PR TITLE
chore: have clippy warn about `watch::Sender::send`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+  { path = "tokio::sync::watch::Sender::send", reason = "send is error prone", replacement = "tokio::sync::watch::Sender::send_replace" },
+]

--- a/fedimint-bitcoind/src/shared.rs
+++ b/fedimint-bitcoind/src/shared.rs
@@ -60,7 +60,7 @@ impl ServerModuleSharedBitcoinInner {
             .spawn_fee_rate_update_task(&self.task_group, network, 1, {
                 move |feerate| {
                     debug!(target: LOG_BITCOIN, %feerate, "New feerate");
-                    let _ = tx.send(Some(feerate));
+                    tx.send_replace(Some(feerate));
                 }
             })?;
 
@@ -87,7 +87,7 @@ impl ServerModuleSharedBitcoinInner {
             .spawn_block_count_update_task(&self.task_group, {
                 move |block_count| {
                     debug!(target: LOG_BITCOIN, %block_count, "New block count");
-                    let _ = tx.send(Some(block_count));
+                    tx.send_replace(Some(block_count));
                 }
             });
 

--- a/fedimint-client-module/src/module/init.rs
+++ b/fedimint-client-module/src/module/init.rs
@@ -186,6 +186,8 @@ where
     }
 
     pub fn update_recovery_progress(&self, progress: RecoveryProgress) {
+        // we want a warning if the send channel was not connected to
+        #[allow(clippy::disallowed_methods)]
         if progress.is_done() {
             // Recovery is complete when the recovery function finishes. To avoid
             // confusing any downstream code, we never send completed process.

--- a/fedimint-client-module/src/transaction/sm.rs
+++ b/fedimint-client-module/src/transaction/sm.rs
@@ -174,7 +174,7 @@ impl TxSubmissionStates {
                 {
                     Ok(transaction_error.to_string())
                 } else {
-                    let _ = tx_submitted.send(true);
+                    tx_submitted.send_replace(true);
                     Err(anyhow::anyhow!("Transaction is still valid"))
                 }
             },

--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -831,7 +831,7 @@ impl Client {
                     dbtx.commit_tx().await;
                     num_responses += 1;
                     // ignore errors: we don't care if anyone is still listening
-                    let _ = num_responses_sender.send(num_responses);
+                    num_responses_sender.send_replace(num_responses);
                 }
             }
         }

--- a/fedimint-core/src/task/inner.rs
+++ b/fedimint-core/src/task/inner.rs
@@ -41,9 +41,12 @@ impl TaskGroupInner {
     pub fn shutdown(&self) {
         // Note: set the flag before starting to call shutdown handlers
         // to avoid confusion.
-        self.on_shutdown_tx
-            .send(true)
-            .expect("We must have on_shutdown_rx around so this never fails");
+        #[allow(clippy::disallowed_methods)]
+        {
+            self.on_shutdown_tx
+                .send(true)
+                .expect("We must have on_shutdown_rx around so this never fails");
+        }
 
         let subgroups = self.subgroups.lock().expect("locking failed").clone();
         for subgroup in subgroups {

--- a/fedimint-eventlog/src/lib.rs
+++ b/fedimint-eventlog/src/lib.rs
@@ -301,7 +301,7 @@ where
             panic!("Trying to overwrite event in the client event log");
         }
         self.on_commit(move || {
-            let _ = log_ordering_wakeup_tx.send(());
+            log_ordering_wakeup_tx.send_replace(());
         });
     }
 
@@ -392,7 +392,7 @@ pub async fn run_event_log_ordering_task(
         // fail to commit.
         dbtx.commit_tx().await;
         if !unordered_events.is_empty() {
-            let _ = log_event_added.send(());
+            log_event_added.send_replace(());
         }
 
         trace!(target: LOG_CLIENT_EVENT_LOG, "Event log ordering task waits for more events");

--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -269,7 +269,7 @@ impl ConsensusEngine {
             ),
         );
 
-        self.ord_latency_sender.send(None).ok();
+        self.ord_latency_sender.send_replace(None);
 
         let signed_session_outcome = self
             .complete_signed_session_outcome(
@@ -344,7 +344,7 @@ impl ConsensusEngine {
                                         None => timestamp.elapsed()
                                     };
 
-                                    self.ord_latency_sender.send(Some(latency)).ok();
+                                    self.ord_latency_sender.send_replace(Some(latency));
 
                                     CONSENSUS_ORDERING_LATENCY_SECONDS.observe(timestamp.elapsed().as_secs_f64());
                                 }
@@ -415,6 +415,7 @@ impl ConsensusEngine {
 
         // We send our own signature to the data provider to be submitted to the atomic
         // broadcast and collected by our peers
+        #[allow(clippy::disallowed_methods)]
         signature_sender.send(Some(keychain.sign(&header)))?;
 
         let mut signatures = BTreeMap::new();

--- a/fedimint-server/src/net/p2p.rs
+++ b/fedimint-server/src/net/p2p.rs
@@ -255,12 +255,14 @@ impl<M: Send + 'static> P2PConnectionStateMachine<M> {
     async fn state_transition(mut self) -> Option<Self> {
         match self.state {
             P2PConnectionSMState::Disconnected(backoff) => {
-                self.common.status_sender.send(None).ok();
+                self.common.status_sender.send_replace(None);
 
                 self.common.transition_disconnected(backoff).await
             }
             P2PConnectionSMState::Connected(connection) => {
-                self.common.status_sender.send(Some(connection.rtt())).ok();
+                self.common
+                    .status_sender
+                    .send_replace(Some(connection.rtt()));
 
                 self.common.transition_connected(connection).await
             }

--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -779,7 +779,7 @@ impl WalletClientModule {
 
                         let sender = self.pegin_monitor_wakeup_sender.clone();
                         dbtx.on_commit(move || {
-                            let _ = sender.send(());
+                            sender.send_replace(());
                         });
 
                         Ok((operation_id, address, tweak_idx))
@@ -1050,7 +1050,7 @@ impl WalletClientModule {
 
                         let sender = self.pegin_monitor_wakeup_sender.clone();
                         dbtx.on_commit(move || {
-                            let _ = sender.send(());
+                            sender.send_replace(());
                         });
 
                         Ok::<_, anyhow::Error>(())

--- a/modules/fedimint-wallet-client/src/pegin_monitor.rs
+++ b/modules/fedimint-wallet-client/src/pegin_monitor.rs
@@ -192,7 +192,7 @@ async fn check_and_claim_idx_pegins(
 
                             let claimed_sender = pengin_claimed_sender.clone();
                             dbtx.on_commit(move || {
-                                let _ = claimed_sender.send(());
+                                claimed_sender.send_replace(());
                             });
 
                             let peg_in_tweak_index_data = PegInTweakIndexData {

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -1803,6 +1803,7 @@ impl Wallet {
                         None
                     };
 
+                #[allow(clippy::disallowed_methods)]
                 if sender.send(all_peers_supported_version).is_err() {
                     warn!(target: LOG_MODULE_WALLET, "Failed to send consensus version to watch channel, stopping task");
                     break;


### PR DESCRIPTION
Require `#[allow(...)]` if it's semantics are actually needed

See motivation in: https://github.com/tokio-rs/tokio/issues/7228

In the places where we were just trowing the error away, we can just update to `send_replace` anyway, it's better to keep the latest value in there anyway, even if no one is going to subscribe and check it again.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
