### PR TITLE
chore: build release build with more cores

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,4 +290,4 @@ opt-level = 1
 [profile.release]
 debug = "line-tables-only"
 lto = "fat"
-codegen-units = 1
+codegen-units = 4


### PR DESCRIPTION
We're using "fat" LTO with a single codegen unit
for maximum LTO and runtime performance results, but this costs *a lot* at compilation time.

Using a couple more compilation units should significantly improve linking time on release builds.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
