### PR TITLE
chore: upgrade docker to latest on hetzner boxes

### DIFF
--- a/docker/deploy-fedimintd/.env
+++ b/docker/deploy-fedimintd/.env
@@ -1,7 +1,7 @@
 # Bitcoin auth information
 # generate with https://jlopp.github.io/bitcoin-core-rpc-auth-generator/,
 # default is user: bitcoin, pass: bitcoin
-BITCOIND_RPC_AUTH=bitcoin:54ae356e13a76dc8068e960eb43193cb$efeeb347a1f0b4a7b7832cc26e68861bc46f89126a8e136ff9932cad47739041
+BITCOIND_RPC_AUTH=bitcoin:54ae356e13a76dc8068e960eb43193cb$$efeeb347a1f0b4a7b7832cc26e68861bc46f89126a8e136ff9932cad47739041
 
 # This domain should point to the machine fedimintd is being deployed to
 FM_DOMAIN=my-super-host.com
@@ -15,4 +15,4 @@ FM_BITCOIN_RPC_URL=http://bitcoin:bitcoin@bitcoin:8332
 # FM_BITCOIN_RPC_URL=https://blockstream.info/api/
 
 # fedimintd image
-FEDIMINTD_IMAGE=fedimint/fedimintd:v0.6.0
+FEDIMINTD_IMAGE=fedimint/fedimintd:v0.6.1

--- a/docker/deploy-fedimintd/deploy.sh
+++ b/docker/deploy-fedimintd/deploy.sh
@@ -62,8 +62,6 @@ ssh -q "root@$ssh_host" << EOF
   systemctl stop fedimint-docker-compose 2>/dev/null || true
 
   if [ -e $host_dir  ] ; then
-    # Stop the docker-compose stack
-    cd $host_dir && docker-compose down 2>/dev/null || true
     # We remove only the fedimintd_data named volume
     docker volume rm fedimint-docker_fedimintd_data 2>/dev/null || true
   fi
@@ -90,8 +88,8 @@ After=docker.service
 
 [Service]
 WorkingDirectory=${host_dir}
-ExecStart=/usr/bin/docker-compose up
-ExecStop=/usr/bin/docker-compose down
+ExecStart=/usr/bin/docker compose up
+ExecStop=/usr/bin/docker compose down
 Restart=always
 
 [Install]
@@ -113,8 +111,6 @@ ssh -q "root@$ssh_host" << EOF
   ufw allow 22/tcp
   ufw --force enable
 
-  apt-get update && apt-get install -q -y docker-compose
-
   systemctl daemon-reload
   systemctl enable fedimint-docker-compose
   systemctl start fedimint-docker-compose
@@ -134,9 +130,9 @@ The firewall was configured and enabled for you.
 
 docker-compose services were defined in the $host_dir and
 if ever need arise you can adjust them from there. You can
-'cd' to that directory and use 'docker-compose' to do basic
-operations. E.g. 'docker-compose logs fedimintd' to view the
-logs, or 'docker-compose exec -u bitcoin bitcoin bash' to
+'cd' to that directory and use 'docker compose' to do basic
+operations. E.g. 'docker compose logs fedimintd' to view the
+logs, or 'docker compose exec -u bitcoin bitcoin bash' to
 "enter" bitcoind container.
 
 Systemd unit 'fedimint-docker-compose' was installed and

--- a/docker/deploy-fedimintd/docker-compose.yaml
+++ b/docker/deploy-fedimintd/docker-compose.yaml
@@ -1,8 +1,3 @@
-# See the .env file for config options
-
-# version of docker-compose format, do not change
-version: "3.3"
-
 services:
   traefik:
     image: "traefik:v2.10"


### PR DESCRIPTION
- I upgraded docker on the docker hetzner boxes
- I did a backup/restore on the bitcoin docker volume, so no need to resync
- Tested another deploy with these changes vs v0.6.1 and setup dkg in the UI

All commands captured in https://github.com/bradleystachurski/fedimint/commit/9236cc096da61386fa23f0d0038d5f4be0671d32