### PR TITLE
fix: improve our network setting policy

### DIFF
--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -247,6 +247,9 @@ impl Global {
 declare_vars! {
     Fedimintd = (globals: &Global, federation_name: String, peer_id: PeerId, overrides: &FedimintdPeerOverrides) => {
         FM_BIND_P2P: String = format!("127.0.0.1:{}", overrides.p2p.port()); env: "FM_BIND_P2P";
+        FM_BIND_API_WS: String = format!("127.0.0.1:{}", overrides.api.port()); env: "FM_BIND_API_WS";
+        FM_BIND_API_IROH: String = format!("127.0.0.1:{}", overrides.api.port()); env: "FM_BIND_API_IROH";
+        // for backwards compatibility with old versions
         FM_BIND_API: String = format!("127.0.0.1:{}", overrides.api.port()); env: "FM_BIND_API";
         FM_P2P_URL: String =  format!("fedimint://127.0.0.1:{}", overrides.p2p.port()); env: "FM_P2P_URL";
         FM_API_URL: String =  format!("ws://127.0.0.1:{}", overrides.api.port()); env: "FM_API_URL";

--- a/docker/deploy-fedimintd/docker-compose.yaml
+++ b/docker/deploy-fedimintd/docker-compose.yaml
@@ -1,3 +1,5 @@
+ # See the .env file for config options
+
 services:
   traefik:
     image: "traefik:v2.10"
@@ -53,8 +55,9 @@ services:
       - FM_BITCOIN_NETWORK=bitcoin
       - FM_BIND_P2P=0.0.0.0:8173
       - FM_P2P_URL=fedimint://${FM_DOMAIN}:8173
-      - FM_BIND_API=0.0.0.0:8174
       - FM_API_URL=wss://${FM_DOMAIN}/ws/
+      - FM_BIND_API_WS=172.20.0.11:8174
+      - FM_BIND_UI=172.20.0.11:8175
       - FM_REL_NOTES_ACK=0_4_xyz
     restart: always
     labels:
@@ -64,7 +67,8 @@ services:
       - "traefik.http.routers.fedimintd.entrypoints=websecure"
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
     networks:
-      - fedimint_network
+      fedimint_network:
+        ipv4_address: 172.20.0.11
 
   guardian-ui:
     image: fedimintui/guardian-ui:0.4.2

--- a/docker/iroh-fedimintd/docker-compose.yaml
+++ b/docker/iroh-fedimintd/docker-compose.yaml
@@ -2,6 +2,8 @@ services:
   fedimintd:
     image: fedimint/fedimintd:master
     ports:
+      - 8173:8173
+      - 8174:8174
       - 8175:8175
     volumes:
       - fedimintd_data:/data
@@ -10,8 +12,22 @@ services:
       - FM_BITCOIN_NETWORK=signet
       - FM_BITCOIN_RPC_KIND=esplora
       - FM_BITCOIN_RPC_URL=https://mutinynet.com/api
-      - FM_BIND_UI=0.0.0.0:8175
+      - FM_BIND_P2P=0.0.0.0:8173
+      - FM_BIND_API_IROH=0.0.0.0:8174
+      - FM_BIND_API_WS=172.25.0.11:8174
+      - FM_BIND_UI=172.25.0.11:8175
+    networks:
+      fedimint_network:
+        ipv4_address: 172.25.0.11
     restart: always
+
+networks:
+  fedimint_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.25.0.0/16
+          gateway: 172.25.0.1
 
 volumes:
   fedimintd_data:

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -207,16 +207,18 @@ pub struct ServerConfigLocal {
 /// All the info we configure prior to config gen starting
 #[derive(Debug, Clone)]
 pub struct ConfigGenSettings {
-    /// Bind address for our P2P connection
+    /// Bind address for our P2P connection (both iroh and tcp/tls)
     pub p2p_bind: SocketAddr,
-    /// Bind address for our API connection
-    pub api_bind: SocketAddr,
-    /// Bind address for our UI connection
+    /// Bind address for our websocket API connection
+    pub bind_api_ws: SocketAddr,
+    /// Bind address for our iroh API connection
+    pub bind_api_iroh: SocketAddr,
+    /// Bind address for our UI connection (always http)
     pub ui_bind: SocketAddr,
     /// URL for our P2P connection
-    pub p2p_url: SafeUrl,
+    pub p2p_url: Option<SafeUrl>,
     /// URL for our API connection
-    pub api_url: SafeUrl,
+    pub api_url: Option<SafeUrl>,
     /// Networking stack to use
     /// TODO: we might make it a part of the API  request when ready
     /// (move to `SetLocalParamsRequest`).

--- a/fedimint-server/src/config/setup.rs
+++ b/fedimint-server/src/config/setup.rs
@@ -177,8 +177,17 @@ impl ISetupApi for SetupApi {
                     iroh_api_sk: None,
                     iroh_p2p_sk: None,
                     endpoints: PeerEndpoints::Tcp {
-                        api_url: self.settings.api_url.clone(),
-                        p2p_url: self.settings.p2p_url.clone(),
+                        api_url: self
+                            .settings
+                            .api_url
+                            .clone()
+                            .ok_or_else(|| anyhow::format_err!("Api URL must be configured"))?,
+                        p2p_url: self
+                            .settings
+                            .p2p_url
+                            .clone()
+                            .ok_or_else(|| anyhow::format_err!("P2P URL must be configured"))?,
+
                         cert: tls_cert.0,
                     },
                     name,

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -169,7 +169,8 @@ pub async fn run(
     Box::pin(consensus::run(
         connections,
         p2p_status_receivers,
-        settings.api_bind,
+        settings.bind_api_ws,
+        settings.bind_api_iroh,
         cfg,
         db,
         module_init_registry.clone(),
@@ -251,7 +252,8 @@ pub async fn run_config_gen(
 
     let api_handler = net::api::spawn(
         "setup",
-        settings.api_bind,
+        // config gen always uses ws api
+        settings.bind_api_ws,
         rpc_module,
         10,
         api_secrets.clone(),

--- a/fedimint-server/src/net/api/mod.rs
+++ b/fedimint-server/src/net/api/mod.rs
@@ -99,7 +99,7 @@ pub async fn spawn<T>(
     max_connections: u32,
     api_secrets: ApiSecrets,
 ) -> ServerHandle {
-    info!(target: LOG_NET_API, "Starting api on ws://{api_bind}");
+    info!(target: LOG_NET_API, "Starting http api on ws://{api_bind}");
 
     let builder = tower::ServiceBuilder::new().layer(HttpAuthLayer::new(api_secrets.get_all()));
 

--- a/fedimint-server/src/net/p2p_connector.rs
+++ b/fedimint-server/src/net/p2p_connector.rs
@@ -25,7 +25,7 @@ use tokio_rustls::rustls::RootCertStore;
 use tokio_rustls::rustls::server::AllowAnyAuthenticatedClient;
 use tokio_rustls::{TlsAcceptor, TlsConnector, TlsStream, rustls};
 use tokio_util::codec::LengthDelimitedCodec;
-use tracing::trace;
+use tracing::{info, trace};
 
 use crate::net::p2p_connection::{DynP2PConnection, IP2PConnection};
 
@@ -283,6 +283,8 @@ impl IrohConnector {
             .discovery_dht()
             .secret_key(secret_key)
             .alpns(vec![FEDIMINT_P2P_ALPN.to_vec()]);
+
+        info!(target: LOG_NET_IROH, addr=%bind_addr, "Iroh p2p bind addr");
 
         let builder = match bind_addr {
             SocketAddr::V4(addr_v4) => builder.bind_addr_v4(addr_v4),

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -287,6 +287,7 @@ impl FederationTestBuilder {
                     connections,
                     p2p_status_receivers,
                     api_bind,
+                    api_bind,
                     cfg.clone(),
                     db.clone(),
                     module_init_registry,

--- a/fedimintd/src/envs.rs
+++ b/fedimintd/src/envs.rs
@@ -23,6 +23,12 @@ pub const FM_P2P_URL_ENV: &str = "FM_P2P_URL";
 pub const FM_BIND_API_ENV: &str = "FM_BIND_API";
 
 // Env variable to TODO
+pub const FM_BIND_API_WS_ENV: &str = "FM_BIND_API_WS";
+
+// Env variable to TODO
+pub const FM_BIND_API_IROH_ENV: &str = "FM_BIND_API_IROH";
+
+// Env variable to TODO
 pub const FM_API_URL_ENV: &str = "FM_API_URL";
 
 // Env variable to bind the web UI server


### PR DESCRIPTION
Fundamentally Iroh typically needs to be bound to 0.0.0.0, while our http apis to 127.0.0.1. We need two different settings for binding it, as we run both APIs at the same time (at least sometimes).

We can set the defaults to typical production settings:

* p2p (iroh/tls): 0.0.0.0
* iroh api: 0.0.0.0
* ws api: 127.0.0.1

Add some documentation with mention of typical settings, so `--help` is more informative.

Fix our docker examples, as at least Iroh one was setting iroh to bind to 127.0.0.1, which probably only worked because of fallback TCP connections to public relays.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
