### PR TITLE
feat: Add parse_bolt11_invoice function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,7 @@ dependencies = [
  "futures",
  "imbl",
  "js-sys",
+ "lightning-invoice",
  "rexie",
  "serde_json",
  "wasm-bindgen",

--- a/fedimint-client-wasm/Cargo.toml
+++ b/fedimint-client-wasm/Cargo.toml
@@ -35,3 +35,4 @@ serde_json = { workspace = true }
 wasm-bindgen = "=0.2.92"                      # must match the nix provided wasm-bindgen-cli version
 wasm-bindgen-futures = "0.4.42"
 wasm-bindgen-test = "0.3.34"
+lightning-invoice = { workspace = true }


### PR DESCRIPTION
Closes [#96](https://github.com/fedimint/fedimint-web-sdk/issues/96)

### 🚀 Add BOLT11 Invoice Parsing  
- Added parse_bolt11_invoice function to parse Lightning invoices.  
- Extracts and returns the following details in JSON format:  
  - amount: Invoice amount in satoshis.  
  - expiry: Expiry time in seconds.  
  - memo: Description or description hash.  
- Includes error handling for invalid invoice formats.