### PR TITLE
feat: allow guardians to set custom client_default_bitcoin_rpc during…

### DIFF
--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -17,7 +17,16 @@ mod fedimintd;
 pub mod envs;
 use crate::envs::FM_PORT_ESPLORA_ENV;
 
+const FM_CUSTOM_BITCOIN_RPC_URL: &str = "FM_CUSTOM_BITCOIN_RPC_URL";
+
 pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
+    if let Ok(custom_url) = std::env::var(FM_CUSTOM_BITCOIN_RPC_URL) {
+        return BitcoinRpcConfig {
+            kind: "esplora".to_string(),
+            url: SafeUrl::parse(&custom_url).expect("Failed to parse custom Bitcoin RPC URL"),
+        };
+    }
+
     let url = match network {
         Network::Bitcoin => SafeUrl::parse("https://blockstream.info/api/")
             .expect("Failed to parse default esplora server"),


### PR DESCRIPTION
## Description
This PR resolves #3531 by allowing guardians to set a custom `client_default_bitcoin_rpc` during setup. Currently, the default is hardcoded to `blockstream.info`, which limits flexibility for self-hosted setups.

## Changes
- Added a new environment variable `FM_CUSTOM_BITCOIN_RPC_URL` to allow guardians to specify a custom Bitcoin RPC URL.
- Modified the `default_esplora_server` function to check for the custom URL and fallback to `blockstream.info` if not provided.
- Updated the `BitcoinRpcConfig` initialization to use the custom or default URL.

## Usage
Guardians can now set a custom Bitcoin RPC URL using the `FM_CUSTOM_BITCOIN_RPC_URL` environment variable:
```bash
export FM_CUSTOM_BITCOIN_RPC_URL="http://custom.bitcoin.rpc.url:8332"
```

Fixes: #3531