### PR TITLE
chore: try i18n using rust-i18n

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "archery"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "base62"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10e52a7bcb1d6beebee21fb5053af9e3cbb7a7ed1a4909e534040e676437ab1f"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1217,16 @@ name = "bounded-vec-deque"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2225b558afc76c596898f5f1b3fc35cfce0eb1b13635cbd7d1b2a7177dc10ccd"
+
+[[package]]
+name = "bstr"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -3864,6 +3889,7 @@ dependencies = [
  "fedimint-wallet-server",
  "maud",
  "qrcode",
+ "rust-i18n",
  "serde",
  "tokio",
 ]
@@ -4621,6 +4647,30 @@ name = "glob-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "gloo-net"
@@ -5391,6 +5441,22 @@ dependencies = [
  "tokio",
  "url",
  "xmltree",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.6",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -6188,6 +6254,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6890,6 +6966,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7391,7 +7476,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -8519,6 +8604,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-i18n"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71b3a6e1c6565b77c86d868eea3068b0eb39582510f9c78cfbd5c67bd36fda9b"
+dependencies = [
+ "globwalk",
+ "once_cell",
+ "regex",
+ "rust-i18n-macro",
+ "rust-i18n-support",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-i18n-macro"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6180d8506af2b485ffc1eab7fc6d15678336a694f2b5efac5f2ca78c52928275"
+dependencies = [
+ "glob",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "rust-i18n-support",
+ "serde",
+ "serde_json",
+ "serde_yml",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "rust-i18n-support"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938f16094e2b09e893b1f85c9da251739a832d4272a5957217977da3a0713bb6"
+dependencies = [
+ "arc-swap",
+ "base62",
+ "globwalk",
+ "itertools 0.11.0",
+ "lazy_static",
+ "normpath",
+ "once_cell",
+ "proc-macro2",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yml",
+ "siphasher 1.0.1",
+ "toml",
+ "triomphe",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8998,6 +9137,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap 2.2.5",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9114,6 +9268,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -10854,6 +11014,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+dependencies = [
+ "arc-swap",
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11054,9 +11225,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visibility"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ reqwest = { version = "0.12.9", features = [
   "stream",
 ], default-features = false }
 ring = "0.17.14"
+rust-i18n = "3.1.3"
 scopeguard = "1.2.0"
 secp256k1 = { version = "0.29.0", default-features = false }
 semver = "1.0.26"

--- a/fedimint-server-ui/Cargo.toml
+++ b/fedimint-server-ui/Cargo.toml
@@ -8,6 +8,9 @@ license = { workspace = true }
 readme = { workspace = true }
 repository = { workspace = true }
 
+[package.metadata.i18n]
+available-locales = ["en", "es", "pl"]
+
 [lib]
 name = "fedimint_server_ui"
 path = "src/lib.rs"
@@ -24,5 +27,6 @@ fedimint-server-core = { workspace = true }
 fedimint-wallet-server = { workspace = true }
 maud = "0.27.0"
 qrcode = { version = "0.12", features = ["svg"] }
+rust-i18n = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }

--- a/fedimint-server-ui/locales/app.yml
+++ b/fedimint-server-ui/locales/app.yml
@@ -1,0 +1,9 @@
+_version: 2
+Fedimint Guardian UI:
+  en: Fedimint Guardian UI
+  pl: Interfejs Opiekuna Fedimint
+Guardian name:
+  en: Guardian name
+  pl: Nazwa opiekuna
+
+

--- a/fedimint-server-ui/src/lib.rs
+++ b/fedimint-server-ui/src/lib.rs
@@ -12,7 +12,10 @@ use fedimint_core::hex::ToHex;
 use fedimint_core::module::ApiAuth;
 use fedimint_core::secp256k1::rand::{Rng, thread_rng};
 use maud::{DOCTYPE, Markup, html};
+use rust_i18n::t;
 use serde::Deserialize;
+
+rust_i18n::i18n!(fallback = "en");
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct LoginInput {
@@ -147,7 +150,7 @@ pub(crate) fn login_layout(title: &str, content: Markup) -> Markup {
                     div class="row justify-content-center" {
                         div class="col-md-8 col-lg-5 narrow-container" {
                             header class="text-center" {
-                                h1 class="header-title" { "Fedimint Guardian UI" }
+                                h1 class="header-title" { (t!("Fedimint Guardian UI")) }
                             }
 
                             div class="card" {

--- a/fedimint-server-ui/src/setup.rs
+++ b/fedimint-server-ui/src/setup.rs
@@ -11,6 +11,7 @@ use fedimint_core::module::ApiAuth;
 use fedimint_core::task::TaskHandle;
 use fedimint_server_core::setup_ui::DynSetupApi;
 use maud::{DOCTYPE, Markup, html};
+use rust_i18n::t;
 use serde::Deserialize;
 use tokio::net::TcpListener;
 
@@ -50,7 +51,7 @@ pub fn setup_layout(title: &str, content: Markup) -> Markup {
                     div class="row justify-content-center" {
                         div class="col-md-8 col-lg-5 narrow-container" {
                             header class="text-center" {
-                                h1 class="header-title" { "Fedimint Guardian UI" }
+                                h1 class="header-title" { (t!("Fedimint Guardian UI")) }
                             }
 
                             div class="card" {
@@ -88,7 +89,7 @@ async fn setup_form(State(state): State<AuthState<DynSetupApi>>) -> impl IntoRes
             }
 
             div class="form-group mb-4" {
-                input type="text" class="form-control" id="name" name="name" placeholder="Guardian name" required;
+                input type="text" class="form-control" id="name" name="name" placeholder=(t!("Guardian name")) required;
             }
 
             div class="form-group mb-4" {
@@ -346,6 +347,10 @@ pub fn start(
     ui_bind: SocketAddr,
     task_handle: TaskHandle,
 ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    if let Ok(locale) = std::env::var("FM_UI_LOCALE") {
+        rust_i18n::set_locale(&locale);
+    }
+
     let app = Router::new()
         .route("/", get(setup_form).post(setup_submit))
         .route("/login", get(login_form).post(login_submit))

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
         (import ./nix/overlays/esplora-electrs.nix)
         (import ./nix/overlays/darwin-compile-fixes.nix)
         (import ./nix/overlays/cargo-honggfuzz.nix)
+        (import ./nix/overlays/rust-i18n.nix)
         (import ./nix/overlays/trustedcoin.nix)
       ];
     in
@@ -55,6 +56,7 @@
         wasm-bindgen = import ./nix/overlays/wasm-bindgen.nix;
         darwin-compile-fixes = import ./nix/overlays/darwin-compile-fixes.nix;
         cargo-honggfuzz = import ./nix/overlays/cargo-honggfuzz.nix;
+        rust-i18n= import ./nix/overlays/rust-i18n.nix;
       };
 
       bundlers = bundlers.bundlers;
@@ -318,6 +320,7 @@
 
                     # marked as broken on MacOS
                     pkgs.cargo-llvm-cov
+                    pkgs.rust-i18n-cli
                   ];
 
                 shellHook = ''

--- a/nix/overlays/rust-i18n.nix
+++ b/nix/overlays/rust-i18n.nix
@@ -1,0 +1,5 @@
+final: prev: {
+  rust-i18n-cli = prev.callPackage ../pkgs/rust-i18n.nix {
+    inherit (prev.darwin.apple_sdk.frameworks) Security;
+  };
+}

--- a/nix/pkgs/rust-i18n.nix
+++ b/nix/pkgs/rust-i18n.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  stdenv,
+  fetchCrate,
+  Security,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "rust-i18n-cli";
+  version = "3.1.1";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-kQ4ZkGRrxrA5UOWSao2MdAPHKmNvqJWFML51X0l2eRc=";
+  };
+
+  cargoHash = "sha256-Wt4cI3uB7f5Sx9DR0Nrl8kdRf6Z4c93TOFLg5dssNWI=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+}


### PR DESCRIPTION
I did a bit of searching for i18n and `rust-i18n` LGTM.

https://github.com/longbridge/rust-i18n/

It's compile time based, so less moving parts.

It comes down to wrapping a text in `t!(...)` macro, and then maintaining translations in a yaml file.

It has a simple CLI tool that can scan project for missing translations. ATM it seems to require `cd`-ing to a given crate first.


You can try this change with:

```
env FM_UI_LOCALE=pl just devimint-env-pre-dkg
```

In the future, we could use it for translating user errors as well.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
