### PR TITLE
chore: improve iroh endpoint logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,7 @@ dependencies = [
  "tokio-rustls 0.26.0",
  "tracing",
  "webpki-roots 0.26.8",
+ "z32",
 ]
 
 [[package]]
@@ -3814,6 +3815,7 @@ dependencies = [
  "tokio-util",
  "tower 0.4.13",
  "tracing",
+ "z32",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,7 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 tracing-test = "0.2.5"
 url = "2.5.4"
+z32 = "1"
 
 [profile.dev]
 debug = "line-tables-only"

--- a/fedimint-api-client/Cargo.toml
+++ b/fedimint-api-client/Cargo.toml
@@ -19,7 +19,7 @@ tor = [
   "arti-client/rustls",
   "arti-client/onion-service-client",
 ]
-iroh = ["dep:iroh", "dep:iroh-base"]
+iroh = ["dep:iroh", "dep:iroh-base", "dep:z32"]
 
 [lib]
 name = "fedimint_api_client"
@@ -48,6 +48,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+z32 = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 jsonrpsee-ws-client = { version = "0.24.9", features = [

--- a/fedimint-api-client/src/api/mod.rs
+++ b/fedimint-api-client/src/api/mod.rs
@@ -1206,7 +1206,7 @@ mod iroh {
     use iroh::{Endpoint, NodeAddr, NodeId, PublicKey};
     use iroh_base::ticket::NodeTicket;
     use serde_json::Value;
-    use tracing::{trace, warn};
+    use tracing::{debug, trace, warn};
 
     use super::{DynClientConnection, IClientConnection, IClientConnector, PeerError, PeerResult};
 
@@ -1251,9 +1251,17 @@ mod iroh {
             let builder = Endpoint::builder().discovery_n0();
             #[cfg(not(target_family = "wasm"))]
             let builder = builder.discovery_dht();
+            let endpoint = builder.bind().await?;
+            debug!(
+                target: LOG_NET_IROH,
+                node_id = %endpoint.node_id(),
+                node_id_pkarr = %z32::encode(endpoint.node_id().as_bytes()),
+                "Iroh api client endpoint"
+            );
+
             Ok(Self {
                 node_ids,
-                endpoint: builder.bind().await?,
+                endpoint,
                 connection_overrides: BTreeMap::new(),
             })
         }

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -13,7 +13,7 @@ rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
 default = []
-iroh = ["fedimint-api-client/iroh"]
+iroh = ["fedimint-api-client/iroh", "dep:z32"]
 
 [lib]
 name = "fedimint_server"
@@ -67,6 +67,7 @@ tokio-rustls = { workspace = true }
 tokio-util = { version = "0.7.14", features = ["codec"] }
 tower = { version = "0.4.13", default-features = false }
 tracing = { workspace = true }
+z32 = { workspace = true, optional = true }
 
 [dev-dependencies]
 test-log = { workspace = true }

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -355,13 +355,20 @@ async fn start_iroh_api(
         .secret_key(secret_key)
         .alpns(vec![FEDIMINT_API_ALPN.to_vec()]);
 
-    info!(target: LOG_NET_IROH, addr=%bind_addr, "Iroh api bind addr");
     let builder = match bind_addr {
         SocketAddr::V4(addr_v4) => builder.bind_addr_v4(addr_v4),
         SocketAddr::V6(addr_v6) => builder.bind_addr_v6(addr_v6),
     };
 
     let endpoint = builder.bind().await.expect("Failed to bind iroh api");
+
+    info!(
+        target: LOG_NET_IROH,
+        %bind_addr,
+        node_id = %endpoint.node_id(),
+        node_id_pkarr = %z32::encode(endpoint.node_id().as_bytes()),
+        "Iroh api server endpoint"
+    );
 
     task_group.spawn_cancellable(
         "iroh-api",


### PR DESCRIPTION
This is to help debugging connectivity issues.

If the logs print:

```
2025-03-25T18:56:44.507980Z  INFO fm::net::iroh: Iroh p2p server endpoint bind_addr=127.0.0.1:14550 node_id=e7fe3258fd193b8b118683c5262482072ef74162c040befdb57b98c3e296e727 node_id_pkarr=h99drs87dr7asrcgoxn1cjrnyhzxqomnabym79pixqcc8awshhuo
```

You can query n0 DNS resolution like this:

```
> dig _iroh.h99drs87dr7asrcgoxn1cjrnyhzxqomnabym79pixqcc8awshhuo.dns.iroh.link. TXT

; <<>> DiG 9.18.33 <<>> _iroh.h99drs87dr7asrcgoxn1cjrnyhzxqomnabym79pixqcc8awshhuo.dns.iroh.link. TXT
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 48040
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;_iroh.h99drs87dr7asrcgoxn1cjrnyhzxqomnabym79pixqcc8awshhuo.dns.iroh.link. IN TXT

;; ANSWER SECTION:
_iroh.h99drs87dr7asrcgoxn1cjrnyhzxqomnabym79pixqcc8awshhuo.dns.iroh.link. 30 IN TXT "relay=https://use1-1.relay.iroh.network./"

;; Query time: 424 msec
;; SERVER: 127.0.0.1#53(127.0.0.1) (UDP)
;; WHEN: Tue Mar 25 11:58:44 PDT 2025
;; MSG SIZE  rcvd: 155
```

and/or check DHT resolution with:

https://app.pkarr.org/?pk=h99drs87dr7asrcgoxn1cjrnyhzxqomnabym79pixqcc8awshhuo

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
