### PR TITLE
chore: use static hash for iroh docker image version

### DIFF
--- a/docker/iroh-fedimintd/docker-compose.yaml
+++ b/docker/iroh-fedimintd/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   fedimintd:
-    image: fedimint/fedimintd:master
+    image: fedimint/fedimintd:da61291173e71a11358e1cd4154e649cf413d9e9
     ports:
       - 8173:8173/tcp # p2p tls
       - 8173:8173/udp # p2p iroh


### PR DESCRIPTION
https://discord.com/channels/990354215060795454/1354146374677041163/1354146911002693884