### PR TITLE
test: verify LDK can connect to esplora

### DIFF
--- a/devimint/src/devfed.rs
+++ b/devimint/src/devfed.rs
@@ -13,7 +13,7 @@ use crate::external::{
     Bitcoind, Electrs, Esplora, Lnd, NamedGateway, open_channels_between_gateways,
 };
 use crate::federation::{Client, Federation};
-use crate::gatewayd::Gatewayd;
+use crate::gatewayd::{Gatewayd, LdkChainSource};
 use crate::util::{ProcessManager, supports_lnv2};
 
 async fn spawn_drop<T>(t: T)
@@ -217,6 +217,7 @@ impl DevJitFed {
                         name: "gatewayd-ldk-0".to_string(),
                         gw_port: process_mgr.globals.FM_PORT_GW_LDK,
                         ldk_port: process_mgr.globals.FM_PORT_LDK,
+                        chain_source: LdkChainSource::Bitcoind,
                     },
                 )
                 .await?;
@@ -235,6 +236,7 @@ impl DevJitFed {
                         name: "gatewayd-ldk-1".to_string(),
                         gw_port: process_mgr.globals.FM_PORT_GW_LDK2,
                         ldk_port: process_mgr.globals.FM_PORT_LDK2,
+                        chain_source: LdkChainSource::Bitcoind,
                     },
                 )
                 .await?;

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -26,6 +26,7 @@ use tonic_lnd::Client as LndClient;
 use tonic_lnd::lnrpc::GetInfoRequest;
 use tracing::{debug, info, trace};
 
+use crate::gatewayd::LdkChainSource;
 use crate::util::{ProcessHandle, ProcessManager, poll};
 use crate::vars::utf8;
 use crate::version_constants::VERSION_0_5_0_ALPHA;
@@ -747,6 +748,7 @@ pub enum LightningNode {
         name: String,
         gw_port: u16,
         ldk_port: u16,
+        chain_source: LdkChainSource,
     },
 }
 
@@ -758,6 +760,7 @@ impl LightningNode {
                 name: _,
                 gw_port: _,
                 ldk_port: _,
+                chain_source: _,
             } => LightningNodeType::Ldk,
         }
     }

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -159,9 +159,6 @@ declare_vars! {
         FM_FEDERATION_BASE_PORT: u16 = federation_base_ports; env: "FM_FEDERATION_BASE_PORT";
         fedimintd_overrides: FederationsNetOverrides = FederationsNetOverrides::new(FM_FEDERATION_BASE_PORT, num_feds, NumPeers::from(fed_size)); env: "NOT_USED_FOR_ANYTHING";
 
-        FM_LDK_ESPLORA_SERVER_URL: String = format!("http://localhost:{FM_PORT_ESPLORA}"); env: "FM_LDK_ESPLORA_SERVER_URL";
-        FM_LDK_BITCOIND_RPC_URL: String = format!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_LDK_BITCOIND_RPC_URL";
-
         FM_LND_DIR: PathBuf = mkdir(FM_TEST_DIR.join("lnd")).await?; env: "FM_LND_DIR";
         FM_LDK_DIR: PathBuf = mkdir(FM_TEST_DIR.join("ldk")).await?; env: "FM_LDK_DIR";
         FM_BTC_DIR: PathBuf = mkdir(FM_TEST_DIR.join("bitcoin")).await?; env: "FM_BTC_DIR";

--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -159,6 +159,7 @@ declare_vars! {
         FM_FEDERATION_BASE_PORT: u16 = federation_base_ports; env: "FM_FEDERATION_BASE_PORT";
         fedimintd_overrides: FederationsNetOverrides = FederationsNetOverrides::new(FM_FEDERATION_BASE_PORT, num_feds, NumPeers::from(fed_size)); env: "NOT_USED_FOR_ANYTHING";
 
+        FM_LDK_ESPLORA_SERVER_URL: String = format!("http://localhost:{FM_PORT_ESPLORA}"); env: "FM_LDK_ESPLORA_SERVER_URL";
         FM_LDK_BITCOIND_RPC_URL: String = format!("http://bitcoin:bitcoin@127.0.0.1:{FM_PORT_BTC_RPC}"); env: "FM_LDK_BITCOIND_RPC_URL";
 
         FM_LND_DIR: PathBuf = mkdir(FM_TEST_DIR.join("lnd")).await?; env: "FM_LND_DIR";

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -2043,18 +2043,24 @@ impl Gateway {
                 let chain_source_config = {
                     match (esplora_server_url, bitcoind_rpc_url) {
                         (Some(esplora_server_url), None) => GatewayLdkChainSourceConfig::Esplora {
-                            server_url: SafeUrl::parse(&esplora_server_url.clone()).unwrap(),
+                            server_url: SafeUrl::parse(&esplora_server_url.clone())
+                                .expect("Could not parse esplora server url"),
                         },
                         (None, Some(bitcoind_rpc_url)) => GatewayLdkChainSourceConfig::Bitcoind {
-                            server_url: SafeUrl::parse(&bitcoind_rpc_url.clone()).unwrap(),
+                            server_url: SafeUrl::parse(&bitcoind_rpc_url.clone())
+                                .expect("Could not parse bitcoind rpc url"),
                         },
                         (None, None) => {
                             panic!("Either esplora or bitcoind chain info source must be provided")
                         }
-                        (Some(_), Some(_)) => {
-                            panic!(
-                                "Either esplora or bitcoind chain info source must be provided, but not both"
-                            )
+                        (Some(_), Some(bitcoind_rpc_url)) => {
+                            warn!(
+                                "Esplora and bitcoind connection parameters are both set, using bitcoind..."
+                            );
+                            GatewayLdkChainSourceConfig::Bitcoind {
+                                server_url: SafeUrl::parse(&bitcoind_rpc_url.clone())
+                                    .expect("Could not parse bitcoind rpc url"),
+                            }
                         }
                     }
                 };

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -144,7 +144,15 @@ impl GatewayLdkClient {
                 );
             }
             GatewayLdkChainSourceConfig::Esplora { server_url } => {
-                node_builder.set_chain_source_esplora(server_url.to_string(), None);
+                // Esplora client cannot handle trailing slashes
+                let host = server_url
+                    .host_str()
+                    .ok_or(anyhow::anyhow!("Missing esplora host"))?;
+                let port = server_url
+                    .port()
+                    .ok_or(anyhow::anyhow!("Missing esplora port"))?;
+                let server_url = format!("{}://{}:{}", server_url.scheme(), host, port);
+                node_builder.set_chain_source_esplora(server_url, None);
             }
         };
         let Some(data_dir_str) = data_dir.to_str() else {

--- a/gateway/fedimint-lightning/src/ldk.rs
+++ b/gateway/fedimint-lightning/src/ldk.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -39,9 +40,23 @@ use crate::{
     SendOnchainResponse,
 };
 
+#[derive(Clone)]
 pub enum GatewayLdkChainSourceConfig {
     Bitcoind { server_url: SafeUrl },
     Esplora { server_url: SafeUrl },
+}
+
+impl fmt::Display for GatewayLdkChainSourceConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GatewayLdkChainSourceConfig::Bitcoind { server_url } => {
+                write!(f, "Bitcoind source with URL: {}", server_url)
+            }
+            GatewayLdkChainSourceConfig::Esplora { server_url } => {
+                write!(f, "Esplora source with URL: {}", server_url)
+            }
+        }
+    }
 }
 
 impl GatewayLdkChainSourceConfig {
@@ -129,7 +144,7 @@ impl GatewayLdkClient {
 
         let bitcoind_rpc = create_bitcoind(&chain_source_config.bitcoin_rpc_config())?;
 
-        match chain_source_config {
+        match chain_source_config.clone() {
             GatewayLdkChainSourceConfig::Bitcoind { server_url } => {
                 node_builder.set_chain_source_bitcoind_rpc(
                     server_url
@@ -160,6 +175,7 @@ impl GatewayLdkClient {
         };
         node_builder.set_storage_dir_path(data_dir_str.to_string());
 
+        info!(chain_source = %chain_source_config, data_dir = %data_dir_str, alias = %alias, "Starting LDK Node...");
         let node = Arc::new(node_builder.build()?);
         node.start_with_runtime(runtime).map_err(|err| {
             crit!(target: LOG_LIGHTNING, err = %err.fmt_compact(), "Failed to start LDK Node");
@@ -176,6 +192,7 @@ impl GatewayLdkClient {
             }
         });
 
+        info!("Successfully started LDK Gateway");
         Ok(GatewayLdkClient {
             node,
             bitcoind_rpc,


### PR DESCRIPTION
In https://github.com/fedimint/fedimint/pull/6561, we refactored LDK in devimint to use bitcoind instead of esplora because it is much faster. We technically still support esplora, but it isn't tested.

To my surprise, getting a devimint test to work with esplora was difficult (turns out the esplora client cannot handle trailing slashes). This PR enables `Gatewayd` in devimint to start with either bitcoind or esplora, with bitcoind being the default.

I modified the gateway reboot test to verify that LDK can connect to esplora after it reboots.