### PR TITLE
fix: use mutinynet as the default signet

### DIFF
--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -28,7 +28,7 @@ pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
             std::env::var(FM_PORT_ESPLORA_ENV).unwrap_or(String::from("50002"))
         ))
         .expect("Failed to parse default esplora server"),
-        Network::Signet => SafeUrl::parse("https://blockstream.info/signet/api/")
+        Network::Signet => SafeUrl::parse("https://mutinynet.com/api/")
             .expect("Failed to parse default esplora server"),
         _ => panic!("Failed to parse default esplora server"),
     };


### PR DESCRIPTION
There is not clear way of overriding this anywhere and mutinynet is the only feasible signet for fedimint
