### PR TITLE
 fix(ui): make it look OK on mobile devices 

### DIFF
--- a/fedimint-server-ui/src/dashboard.rs
+++ b/fedimint-server-ui/src/dashboard.rs
@@ -28,7 +28,7 @@ pub fn dashboard_layout(content: Markup) -> Markup {
                 (layout::common_head("Dashboard"))
             }
             body {
-                div class="container" style="max-width: 66%;" {
+                div class="container" {
                     header class="text-center" {
                         h1 class="header-title" { "Fedimint Guardian UI" }
                     }


### PR DESCRIPTION
On top of #7103 


That was the only thing that look bad. It's not going to win any mobile-UX contests, but defaults in bootstrap should be perfectly responsive and work OK on mobile.


![image](https://github.com/user-attachments/assets/f59b3973-ddee-4603-a993-2656d81cd2b2)

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
