### PR TITLE
 chore: show guardian names in more places 

### DIFF
--- a/fedimint-server-ui/assets/style.css
+++ b/fedimint-server-ui/assets/style.css
@@ -132,6 +132,13 @@ body {
   font-size: 1rem;
 }
 
+/* in case of very wide metadata, allow breaking lines */
+pre code {
+  white-space: pre-wrap;
+  word-break: break-all;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
 
 /* Too small buttons look weird */
 .btn-min-width {

--- a/fedimint-server-ui/src/dashboard.rs
+++ b/fedimint-server-ui/src/dashboard.rs
@@ -104,7 +104,10 @@ async fn dashboard_view(
     // Conditionally add Meta UI if the module is available
     let meta_content = html! {
         @if let Some(meta_module) = state.api.get_module::<fedimint_meta_server::Meta>() {
-            (meta::render(meta_module).await)
+            (meta::render(
+                meta_module,
+                &guardian_names,
+            ).await)
         }
     };
 
@@ -118,14 +121,14 @@ async fn dashboard_view(
                         table class="table table-sm mb-0" {
                             thead {
                                 tr {
-                                    th { "Guardian ID" }
+                                    th { "Peer ID" }
                                     th { "Guardian Name" }
                                 }
                             }
                             tbody {
-                                @for (guardian_id, name) in guardian_names {
+                                @for (guardian_id, name) in &guardian_names {
                                     tr {
-                                        td { (guardian_id.to_string()) }
+                                        td { (guardian_id) }
                                         td { (name) }
                                     }
                                 }
@@ -153,7 +156,7 @@ async fn dashboard_view(
 
             // Peer Connection Status Column
             div class="col-lg-6" {
-                (latency::render(consensus_ord_latency, &p2p_connection_status))
+                (latency::render(&guardian_names, consensus_ord_latency, &p2p_connection_status))
             }
         }
 
@@ -180,6 +183,7 @@ async fn dashboard_update(
         return Redirect::to("/login").into_response();
     }
 
+    let guardian_names = state.api.guardian_names().await;
     let session_count = state.api.session_count().await;
     let consensus_ord_latency = state.api.consensus_ord_latency().await;
     let p2p_connection_status = state.api.p2p_connection_status().await;
@@ -189,7 +193,11 @@ async fn dashboard_update(
     let content = html! {
         (render_session_count(session_count))
 
-        (latency::render(consensus_ord_latency, &p2p_connection_status))
+        (latency::render(
+            &guardian_names,
+            consensus_ord_latency,
+            &p2p_connection_status
+        ))
 
         @if let Some(lightning) = state.api.get_module::<fedimint_lnv2_server::Lightning>() {
             (lnv2::render(lightning).await)

--- a/fedimint-server-ui/src/latency.rs
+++ b/fedimint-server-ui/src/latency.rs
@@ -5,6 +5,7 @@ use fedimint_core::PeerId;
 use maud::{Markup, html};
 
 pub fn render(
+    guardian_name: &BTreeMap<PeerId, String>,
     consensus_ord_latency: Option<Duration>,
     p2p_connection_status: &BTreeMap<PeerId, Option<Duration>>,
 ) -> Markup {
@@ -33,7 +34,7 @@ pub fn render(
                     table class="table table-striped" {
                         thead {
                             tr {
-                                th { "ID" }
+                                th { "Peer" }
                                 th { "Status" }
                                 th { "Round Trip" }
                             }
@@ -41,7 +42,15 @@ pub fn render(
                         tbody {
                             @for (peer_id, rtt) in p2p_connection_status {
                                 tr {
-                                    td { (peer_id.to_string()) }
+                                    td { (
+                                        format!("{} ({})",
+                                        peer_id,
+                                        guardian_name
+                                            .get(peer_id)
+                                            .map(AsRef::as_ref)
+                                            .unwrap_or("")
+                                        )
+                                    ) }
                                     td {
                                         @match rtt {
                                             Some(_) => {

--- a/fedimint-server-ui/src/meta.rs
+++ b/fedimint-server-ui/src/meta.rs
@@ -400,6 +400,7 @@ pub fn render_meta_edit_form(
             }
             div class="input-group mb-2" {
                 select class="form-select"
+                    id="delete-key"
                     name="delete_key"
                 {
                     option value="" {}
@@ -410,6 +411,7 @@ pub fn render_meta_edit_form(
                 button class="btn btn-primary btn-min-width"
                     hx-post="/meta/delete"
                     hx-swap="none"
+                    hx-trigger="click, keypress[key=='Enter'] from:#delete-key"
                     title="Delete a value in a meta proposal"
                 { "Delete" }
             }


### PR DESCRIPTION
On top of #7108.

It's sometimes hard to mentally map PeerId and guardian name, and it isn't much of a lift to just display them alongside. 

![image](https://github.com/user-attachments/assets/4a620f69-2797-4c99-a1e4-416774e23304)

![image](https://github.com/user-attachments/assets/01c415cd-6b79-4cbe-82ec-ce23678a85ce)

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
