### PR TITLE
cleanup: dont start websocket api when iroh is available

### DIFF
--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -187,14 +187,6 @@ pub async fn run(
 
     info!(target: LOG_CONSENSUS, "Starting Consensus Api...");
 
-    let api_handler = start_consensus_api(
-        &cfg.local,
-        consensus_api.clone(),
-        force_api_secrets.clone(),
-        ws_api_bind_addr,
-    )
-    .await;
-
     if let Some(iroh_api_sk) = cfg.private.iroh_api_sk.clone() {
         Box::pin(start_iroh_api(
             iroh_api_sk,
@@ -202,6 +194,14 @@ pub async fn run(
             consensus_api.clone(),
             task_group,
         ))
+        .await;
+    } else {
+        start_consensus_api(
+            &cfg.local,
+            consensus_api.clone(),
+            force_api_secrets.clone(),
+            ws_api_bind_addr,
+        )
         .await;
     }
 
@@ -255,12 +255,6 @@ pub async fn run(
     }
     .run()
     .await?;
-
-    api_handler
-        .stop()
-        .expect("Consensus api should still be running");
-
-    api_handler.stopped().await;
 
     Ok(())
 }


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
