### PR TITLE
chore(ui): delete meta key on enter keypress

### DIFF
--- a/fedimint-server-ui/src/meta.rs
+++ b/fedimint-server-ui/src/meta.rs
@@ -376,6 +376,7 @@ pub fn render_meta_edit_form(
             }
             div class="input-group mb-2" {
                 select class="form-select"
+                    id="delete-key"
                     name="delete_key"
                 {
                     option value="" {}
@@ -386,6 +387,7 @@ pub fn render_meta_edit_form(
                 button class="btn btn-primary btn-min-width"
                     hx-post="/meta/delete"
                     hx-swap="none"
+                    hx-trigger="click, keypress[key=='Enter'] from:#delete-key"
                     title="Delete a value in a meta proposal"
                 { "Delete" }
             }


### PR DESCRIPTION
If you select key to delete and press enter it will now work and delete the key. No changes visually.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
