### PR TITLE
feat: Added get_note_counts_by_denomination in fedimint-client-wasm

### DIFF
--- a/fedimint-client-wasm/src/lib.rs
+++ b/fedimint-client-wasm/src/lib.rs
@@ -82,17 +82,6 @@ impl WasmClient {
         Ok(serde_json::to_string(&result).map_err(|e| JsError::new(&e.to_string()))?)
     }
 
-    #[wasm_bindgen]
-    pub async fn get_note_counts_by_denomination(&self) -> Result<String, JsError> {
-        let mint = self
-            .client
-            .get_first_module::<fedimint_mint_client::MintClientModule>()
-            .map_err(|e| JsError::new(&e.to_string()))?
-            .inner();
-        let note_counts = mint.get_note_counts_by_denomination().await.map_err(|e| JsError::new(&e.to_string()))?;
-        Ok(serde_json::to_string(&note_counts).unwrap())
-    }
-
     async fn client_builder(db: Database) -> Result<fedimint_client::ClientBuilder, anyhow::Error> {
         let mut builder = fedimint_client::Client::builder(db).await?;
         builder.with_module(MintClientInit);

--- a/fedimint-client-wasm/src/lib.rs
+++ b/fedimint-client-wasm/src/lib.rs
@@ -82,6 +82,17 @@ impl WasmClient {
         Ok(serde_json::to_string(&result).map_err(|e| JsError::new(&e.to_string()))?)
     }
 
+    #[wasm_bindgen]
+    pub async fn get_note_counts_by_denomination(&self) -> Result<String, JsError> {
+        let mint = self
+            .client
+            .get_first_module::<fedimint_mint_client::MintClientModule>()
+            .map_err(|e| JsError::new(&e.to_string()))?
+            .inner();
+        let note_counts = mint.get_note_counts_by_denomination().await.map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(serde_json::to_string(&note_counts).unwrap())
+    }
+
     async fn client_builder(db: Database) -> Result<fedimint_client::ClientBuilder, anyhow::Error> {
         let mut builder = fedimint_client::Client::builder(db).await?;
         builder.with_module(MintClientInit);

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -875,7 +875,7 @@ impl ClientModule for MintClientModule {
                     yield serde_json::to_value(value)?;
                 }
                 "note_counts_by_denomination" => {
-                    let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
+                    let mut dbtx = self.client_ctx.module_db().begin_transaction_nc().await;
                     let note_counts = self.get_note_counts_by_denomination(&mut dbtx).await;
                     yield serde_json::to_value(note_counts)?;
                 }

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -874,6 +874,11 @@ impl ClientModule for MintClientModule {
                     let value = self.await_spend_oob_refund(req.operation_id).await;
                     yield serde_json::to_value(value)?;
                 }
+                "note_counts_by_denomination" => {
+                    let mut dbtx = self.client_ctx.module_db().begin_transaction().await;
+                    let note_counts = self.get_note_counts_by_denomination(&mut dbtx).await;
+                    yield serde_json::to_value(note_counts)?;
+                }
                 _ => {
                     Err(anyhow::format_err!("Unknown method: {}", method))?;
                     unreachable!()


### PR DESCRIPTION
Currently Web SDK have no functions to get note counts by the denomination so that users can see how their eCash is distributed across different denominations.

Have added `get_note_counts_by_denomination` function in fedimint-client-wasm that should be beneficiary in future for web SDK usage and wallet implemention.