### PR TITLE
chore(build): in release build link binaries one at the time

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -389,7 +389,9 @@ in
         // {
           cargoArtifacts = deps;
           meta = { inherit mainProgram; };
-          cargoBuildCommand = "runLowPrio cargo build --profile $CARGO_PROFILE";
+          # it's easy to hit memory limits during release builds (many binaries linked at the same time),
+          # cap it at one binary at the time
+          cargoBuildCommand = "if [ $CARGO_PROFILE = \"release\" ]; then export CARGO_BUILD_JOBS=1; fi; runLowPrio cargo build --profile $CARGO_PROFILE";
           cargoExtraArgs = "${pkgsArgs}";
 
           # If the build contains `devimint`, wrap it in a script that will set


### PR DESCRIPTION
A single fedimint binary requires up to 7GB to compile and link in release build profile. Even without `lto ="fat"`, it is still 5GB per compilation unit. Multiplied by number of binaries in our workspace, this can easily exceed memory limits of even decent systems.

This change makes compiling of the workspace crates (not deps) use `-j 1`, so one at the time. Much slower, but should be much easier to go through.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
