### PR TITLE
chore(build): some handling of how heavy our release builds are

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,3 +292,8 @@ opt-level = 1
 debug = "line-tables-only"
 lto = true
 codegen-units = 4
+
+[profile.release-heavy]
+inherits = "release"
+lto = "fat"
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,5 +290,5 @@ opt-level = 1
 
 [profile.release]
 debug = "line-tables-only"
-lto = "fat"
+lto = true
 codegen-units = 4

--- a/flake.nix
+++ b/flake.nix
@@ -266,6 +266,7 @@
             "ci"
             "test"
             "release"
+            "release-heavy"
           ];
         };
 

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -389,7 +389,9 @@ in
         // {
           cargoArtifacts = deps;
           meta = { inherit mainProgram; };
-          cargoBuildCommand = "runLowPrio cargo build --profile $CARGO_PROFILE";
+          # it's easy to hit memory limits during release builds (many binaries linked at the same time),
+          # cap it at one binary at the time
+          cargoBuildCommand = "if [ $CARGO_PROFILE = \"release\" ]; then export CARGO_BUILD_JOBS=1; fi; runLowPrio cargo build --profile $CARGO_PROFILE";
           cargoExtraArgs = "${pkgsArgs}";
 
           # If the build contains `devimint`, wrap it in a script that will set


### PR DESCRIPTION
After his:

* default/standard `release` build profile will be optimized for consuming minimum amount of resources while being a reasonable release build, at the cost of very slow build times
* new `release-heavy` custom build profile becomes the one optimized for end results at the expense of resource requirements

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
