### PR TITLE
feat: scan LNv2 incoming contracts

### DIFF
--- a/modules/fedimint-lnv2-client/src/api.rs
+++ b/modules/fedimint-lnv2-client/src/api.rs
@@ -9,9 +9,11 @@ use fedimint_core::task::{MaybeSend, MaybeSync};
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{NumPeersExt, OutPoint, PeerId, apply, async_trait_maybe_send};
 use fedimint_lnv2_common::ContractId;
+use fedimint_lnv2_common::contracts::IncomingContract;
 use fedimint_lnv2_common::endpoint_constants::{
     ADD_GATEWAY_ENDPOINT, AWAIT_INCOMING_CONTRACT_ENDPOINT, AWAIT_PREIMAGE_ENDPOINT,
-    CONSENSUS_BLOCK_COUNT_ENDPOINT, GATEWAYS_ENDPOINT, REMOVE_GATEWAY_ENDPOINT,
+    CONSENSUS_BLOCK_COUNT_ENDPOINT, GATEWAYS_ENDPOINT, LIST_INCOMING_CONTRACTS_ENDPOINT,
+    REMOVE_GATEWAY_ENDPOINT,
 };
 use rand::seq::SliceRandom;
 
@@ -34,6 +36,8 @@ pub trait LightningFederationApi {
     async fn add_gateway(&self, auth: ApiAuth, gateway: SafeUrl) -> FederationResult<bool>;
 
     async fn remove_gateway(&self, auth: ApiAuth, gateway: SafeUrl) -> FederationResult<bool>;
+
+    async fn list_incoming_contracts(&self) -> FederationResult<Vec<IncomingContract>>;
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -133,5 +137,13 @@ where
             .await?;
 
         Ok(entry_existed)
+    }
+
+    async fn list_incoming_contracts(&self) -> FederationResult<Vec<IncomingContract>> {
+        self.request_current_consensus(
+            LIST_INCOMING_CONTRACTS_ENDPOINT.to_string(),
+            ApiRequestErased::new(()),
+        )
+        .await
     }
 }

--- a/modules/fedimint-lnv2-common/src/endpoint_constants.rs
+++ b/modules/fedimint-lnv2-common/src/endpoint_constants.rs
@@ -7,6 +7,7 @@ pub const CONSENSUS_BLOCK_COUNT_ENDPOINT: &str = "consensus_block_count";
 pub const GATEWAYS_ENDPOINT: &str = "gateways";
 pub const OUTGOING_CONTRACT_EXPIRATION_ENDPOINT: &str = "outgoing_contract_expiration";
 pub const REMOVE_GATEWAY_ENDPOINT: &str = "remove_gateway";
+pub const LIST_INCOMING_CONTRACTS_ENDPOINT: &str = "list_incoming_contracts";
 
 // Gateway endpoints
 pub const CREATE_BOLT11_INVOICE_ENDPOINT: &str = "/create_bolt11_invoice";

--- a/modules/fedimint-lnv2-tests/tests/tests.rs
+++ b/modules/fedimint-lnv2-tests/tests/tests.rs
@@ -202,6 +202,7 @@ async fn claiming_outgoing_contract_triggers_success() -> anyhow::Result<()> {
     let (contract, txid) = match operation.meta::<LightningOperationMeta>() {
         LightningOperationMeta::Send(meta) => (meta.contract, meta.change_outpoint_range.txid),
         LightningOperationMeta::Receive(..) => panic!("Operation Meta is a Receive variant"),
+        LightningOperationMeta::IncomingScan(..) => panic!("Operation Meta is a Receive variant"),
     };
 
     let client_input = ClientInput::<LightningInput> {


### PR DESCRIPTION
LNv2 was very well designed with deterministic recovery in mind. But it hasn't been implemented in the client yet. This PR adds a function `scan_incoming_contracts` to the LNv2 module that queries the federation for outstanding `IncomingContract`s and spawns a state machine if it is able to claim them.

It occurred to me that Lightning's recovery doesn't really match the generic recovery functions that the mint and wallet use. The Lightning module isn't really concerned with the history, it only needs to know about current contracts (outgoing or incoming) that it might need to spawn state machines for to get its money back. This process also shouldn't block the creation of the client. "Recovery" in this context is also potentially racy, since the client could receive and invoice directly after scanning the existing `IncomingContracts`.

I think the simplest solution is just to periodically scan for claimable contracts in the background. This can be pretty infrequent. Additionally, we will need similar logic for LNURL/recurringd in LNv2, so it would be ideal if this logic wasn't specific to recovery, but a general mechanism.