### PR TITLE
feat: Added guardian status rpc endpoint

### DIFF
--- a/fedimint-client/src/client.rs
+++ b/fedimint-client/src/client.rs
@@ -88,6 +88,7 @@ use crate::sm::executor::{
     ActiveModuleOperationStateKeyPrefix, ActiveOperationStateKeyPrefix, Executor,
     InactiveModuleOperationStateKeyPrefix, InactiveOperationStateKeyPrefix,
 };
+use fedimint_api_client::api::StatusResponse;
 
 pub(crate) mod builder;
 pub(crate) mod global_ctx;
@@ -260,6 +261,13 @@ impl Client {
 
     pub fn federation_id(&self) -> FederationId {
         self.federation_id
+    }
+
+    pub async fn get_guardian_status(&self)-> anyhow::Result<StatusResponse>
+        self.api()
+            .status()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to fetch guardian status: {}", e))
     }
 
     fn context_gen(self: &Arc<Self>) -> ModuleGlobalContextGen {
@@ -1395,6 +1403,10 @@ impl Client {
                             "progress": progress
                         });
                     }
+                }
+                "guardian_status" => {
+                    let status=self.get_guardian_status().await?;
+                    yield serde_json::to_value(status);
                 }
                 _ => {
                     Err(anyhow::format_err!("Unknown method: {}", method))?;


### PR DESCRIPTION
Added an RPC endpoint to fetch guardian status, so that web SDK and clients can retrieve the current status of the federation's guardian nodes