### PR TITLE
chore: print more error information for `PeerError`

### DIFF
--- a/fedimint-api-client/src/api/error.rs
+++ b/fedimint-api-client/src/api/error.rs
@@ -55,21 +55,21 @@ pub enum PeerError {
     InvalidResponse(anyhow::Error),
 
     /// Server returned an internal error, suggesting something is wrong with it
-    #[error("Unspecified server error")]
+    #[error("Unspecified server error: {0}")]
     ServerError(anyhow::Error),
 
     /// Some condition on the response this not match
     ///
     /// Typically expected, and often used in `FilterMap` query strategy to
     /// reject responses that don't match some criteria.
-    #[error("Unspecified server error")]
+    #[error("Unspecified condition error: {0}")]
     ConditionFailed(anyhow::Error),
 
     /// An internal client error
     ///
     /// Things that shouldn't happen (better than panicking), logical errors,
     /// malfunctions caused by internal issues.
-    #[error("Unspecified internal client")]
+    #[error("Unspecified internal client error: {0}")]
     InternalClientError(anyhow::Error),
 }
 


### PR DESCRIPTION
Saw a warning due to an unspecified server error when fetching signed session outcomes and I'd like to know what they are about.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
