### PR TITLE
chore(nix): avoid running out of memory

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,17 +3,17 @@ substituters = "substituters"
 # trips on some base64 string in the test
 wel = "wel"
 # common mistake that typos doesn't detect automatically
-reasponse= "response"
+reasponse = "response"
 # useful for "in/out" in the code
-inout="inout"
+inout = "inout"
 # multi-user-chat
-muc="muc"
+muc = "muc"
 
 # short for "backup"
-bck="bck"
+bck = "bck"
 
 # metric id that typos doesn't like
-"Fo"="Fo"
+"Fo" = "Fo"
 
 [files]
 extend-exclude = [
@@ -21,4 +21,5 @@ extend-exclude = [
   "hfuzz_target/**",
   "hfuzz_workspace/**",
   "releases/**",
+  "fedimint-server-ui/assets/**",
 ]

--- a/flake.nix
+++ b/flake.nix
@@ -346,6 +346,7 @@
                   export FM_DISCOVER_API_VERSION_TIMEOUT=10
 
                   export FLAKEBOX_GIT_LS_IGNORE=fedimint-server-ui/assets/
+                  export FLAKEBOX_GIT_LS_TEXT_IGNORE=fedimint-server-ui/assets/
                   [ -f "$REPO_ROOT/.shrc.local" ] && source "$REPO_ROOT/.shrc.local"
 
                   if [ ''${#TMPDIR} -ge 40 ]; then
@@ -393,6 +394,7 @@
               nativeBuildInputs = [ pkgs.cargo-sort ];
               env = {
                 FLAKEBOX_GIT_LS_IGNORE = "fedimint-server-ui/assets/";
+                FLAKEBOX_GIT_LS_TEXT_IGNORE = "fedimint-server-ui/assets/";
               };
             };
 

--- a/nix/bin/cargo-with-memlimit.sh
+++ b/nix/bin/cargo-with-memlimit.sh
@@ -21,7 +21,7 @@ if [ "${CARGO_PROFILE:-}" != "release" ]; then
 fi
 
 
-# substract some fixed amount for fixed overhead, then divide by
+# subtract some fixed amount for fixed overhead, then divide by
 # approximation of how much one heavy compilation unit needs,
 # add +1 to round up
 max_jobs_by_memory=$(((total_mbs - 10000) / 7000 + 1))

--- a/nix/bin/cargo-with-memlimit.sh
+++ b/nix/bin/cargo-with-memlimit.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# get the number of memory upfront, just to verify
+# it works, can be moved down in the future
+if [ "$(uname)" = "Darwin" ]; then
+    total=$(sysctl -n hw.memsize)
+    total_mbs=$((total / 1024 / 1024))
+else
+    total=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
+    total_mbs=$((total / 1024))
+fi
+
+>&2 echo "Memory available: $total_mbs"
+
+# Don't mess with non-release builds
+if [ "${CARGO_PROFILE:-}" != "release" ]; then
+  >&2 echo "Will not limit number of jobs on non-release cargo build profile: ${CARGO_PROFILE:-}"
+  exec cargo "$@"
+fi
+
+
+# substract some fixed amount for fixed overhead, then divide by
+# approximation of how much one heavy compilation unit needs,
+# add +1 to round up
+max_jobs_by_memory=$(((total_mbs - 10000) / 7000 + 1))
+
+# handle underflow
+if [ "$max_jobs_by_memory" -lt 1 ]; then
+  max_jobs_by_memory=1
+fi
+
+ncpus=$(nproc)
+
+if [ "$ncpus" -lt "$max_jobs_by_memory" ]; then
+  export CARGO_BUILD_JOBS="$ncpus"
+else
+  export CARGO_BUILD_JOBS="$max_jobs_by_memory"
+fi
+
+>&2 echo "Overriding cargo max jobs to: $CARGO_BUILD_JOBS"
+exec cargo "$@"

--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -389,7 +389,7 @@ in
         // {
           cargoArtifacts = deps;
           meta = { inherit mainProgram; };
-          cargoBuildCommand = "runLowPrio cargo build --profile $CARGO_PROFILE";
+          cargoBuildCommand = "runLowPrio bash ${./bin/cargo-with-memlimit.sh} build --profile $CARGO_PROFILE";
           cargoExtraArgs = "${pkgsArgs}";
 
           # If the build contains `devimint`, wrap it in a script that will set


### PR DESCRIPTION
Alternative to #7135 that just caps number of jobs to based by the total memory of the system.
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
