### PR TITLE
fix: add async feature to lnurlp

### DIFF
--- a/lnurlp/Cargo.toml
+++ b/lnurlp/Cargo.toml
@@ -20,6 +20,6 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 fedimint-core = { workspace = true }
 lightning-invoice = { workspace = true }
-lnurl-rs = { workspace = true }
+lnurl-rs = { workspace = true, features = ["async"] }
 reqwest = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
We'll fail to publish to crates.io since we can't build `lnurlp` without the `async` feature.

```
cargo build -p lnurlp
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
   Compiling lnurlp v0.7.0-beta.0 (/home/stachurski/code/fedimint/lnurlp)
error[E0433]: failed to resolve: could not find `AsyncClient` in `lnurl`
  --> lnurlp/src/main.rs:54:31
   |
54 |     let async_client = lnurl::AsyncClient::from_client(reqwest::Client::new());
   |                               ^^^^^^^^^^^ could not find `AsyncClient` in `lnurl`
```