### PR TITLE
fix: dont restart ldk during gateway upgrade tests

### DIFF
--- a/devimint/src/gatewayd.rs
+++ b/devimint/src/gatewayd.rs
@@ -19,6 +19,7 @@ use fedimint_gateway_common::{
 };
 use fedimint_ln_server::common::lightning_invoice::Bolt11Invoice;
 use fedimint_lnv2_common::gateway_api::PaymentFee;
+use fedimint_logging::LOG_DEVIMINT;
 use fedimint_testing_core::node_type::LightningNodeType;
 use semver::Version;
 use tracing::{debug, info};
@@ -85,7 +86,7 @@ impl Gatewayd {
             (FM_PORT_LDK_ENV.to_owned(), lightning_node_port.to_string()),
         ]);
         if !supports_lnv2() {
-            tracing::info!("LNv2 is not supported, running gatewayd in LNv1 mode");
+            info!(target: LOG_DEVIMINT, "LNv2 is not supported, running gatewayd in LNv1 mode");
             gateway_env.insert(
                 "FM_GATEWAY_LIGHTNING_MODULE_MODE".to_owned(),
                 "LNv1".to_string(),
@@ -158,13 +159,13 @@ impl Gatewayd {
     }
 
     fn is_forced_current(&self) -> bool {
-        self.ln.ln_type() == LightningNodeType::Ldk && self.gatewayd_version < *VERSION_0_6_0_ALPHA
+        self.ln.ln_type() == LightningNodeType::Ldk && self.gatewayd_version < *VERSION_0_7_0_ALPHA
     }
 
     fn start_gatewayd(ln_type: &LightningNodeType, gatewayd_version: &Version) -> Command {
         // If an LDK gateway is trying to spawn prior to v0.6, just use most recent
         // version
-        if *ln_type == LightningNodeType::Ldk && *gatewayd_version < *VERSION_0_6_0_ALPHA {
+        if *ln_type == LightningNodeType::Ldk && *gatewayd_version < *VERSION_0_7_0_ALPHA {
             cmd!("gatewayd", ln_type)
         } else {
             cmd!(crate::util::Gatewayd, ln_type)
@@ -180,7 +181,7 @@ impl Gatewayd {
     }
 
     pub async fn stop_lightning_node(&mut self) -> Result<()> {
-        info!("Stopping lightning node");
+        info!(target: LOG_DEVIMINT, "Stopping lightning node");
         match self.ln.clone() {
             LightningNode::Lnd(lnd) => lnd.terminate().await,
             LightningNode::Ldk {
@@ -213,7 +214,7 @@ impl Gatewayd {
         unsafe { std::env::set_var("FM_GATEWAY_CLI_BASE_EXECUTABLE", gateway_cli_path) };
 
         if supports_lnv2() {
-            tracing::info!("LNv2 is now supported, running in All mode");
+            info!(target: LOG_DEVIMINT, "LNv2 is now supported, running in All mode");
             // TODO: Audit that the environment access only happens in single-threaded code.
             unsafe { std::env::set_var("FM_GATEWAY_LIGHTNING_MODULE_MODE", "All") };
         }
@@ -225,6 +226,7 @@ impl Gatewayd {
         let gatewayd_version = crate::util::Gatewayd::version_or_default().await;
         let gateway_cli_version = crate::util::GatewayCli::version_or_default().await;
         info!(
+            target: LOG_DEVIMINT,
             ?gatewayd_version,
             ?gateway_cli_version,
             "upgraded gatewayd and gateway-cli"
@@ -294,7 +296,7 @@ impl Gatewayd {
     pub async fn recover_fed(&self, fed: &Federation) -> Result<()> {
         let federation_id = fed.calculate_federation_id();
         let invite_code = fed.invite_code()?;
-        info!("Recovering {federation_id}...");
+        info!(target: LOG_DEVIMINT, federation_id = %federation_id, "Recovering...");
         poll("gateway connect-fed --recover=true", || async {
             cmd!(self, "connect-fed", invite_code.clone(), "--recover=true")
                 .run()

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -523,7 +523,7 @@ pub async fn upgrade_tests(process_mgr: &ProcessManager, binary: UpgradeTest) ->
                     .get(i)
                     .expect("Not enough gateway-cli paths");
 
-                let gateways = vec![&mut dev_fed.gw_lnd, &mut dev_fed.gw_ldk];
+                let gateways = vec![&mut dev_fed.gw_lnd];
 
                 try_join_all(gateways.into_iter().map(|gateway| {
                     gateway.restart_with_bin(process_mgr, new_gatewayd_path, new_gateway_cli_path)


### PR DESCRIPTION
When running our full suite of upgrade tests, we ran into an issue where LND could not pay the LDK gateway. Upon investigation, it appears that LDK didn't think the channel between itself and LND was active (while LND did), which caused the payment to fail.

Repro:
`env TEST_KINDS=gateway ./scripts/tests/upgrade-test.sh "v0.4.0 v0.4.1 v0.4.2 v0.4.3 v0.4.4 v0.5.0 v0.5.1 v0.6.0 v0.6.1 v0.7.0-beta.0"`

The upgrade tests have changed since we removed CLN. Previously with CLN, when upgrading a gateway there would be no impact on the gateway's channels. But now, since the LN node is embedded, upgrading the gateway causes the channel between LND and LDK to flip flop between active and inactive. This happens each restart, which in the above repro, is a lot of times (this bug does not repro with a lower number of restarts).

Looking at the logs, it looks like to me that LDK's active channels take longer to recover on each restart. I believe LDK is backing off with every restart to prevent gossip spam messages. If we wait for active channels to be populated, the test eventually just times out.

Anyway, this isn't really what we want to be validating with the upgrade tests. Removing LDK from restarting allows us to validate that `gatewayd` is able to upgrade between all versions.