### PR TITLE
docs: clarify accessing the web UI using iroh docker

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -15,11 +15,19 @@ of this directory in the past releases for more info.
 For help please try [Fedimint Github Discussions](https://github.com/fedimint/fedimint/discussions)
 or `#mint-ops` channel on [Fedimint's Discord server](https://chat.fedimint.org/).
 
-## Iroh
+## Iroh (Experimental)
 
-We have an additional `docker-compose.yaml` that supports Iroh, but is considered experimental. To try it:
+To try the experimental Iroh integration, use the provided Docker Compose setup:
 
-```
+```bash
 cd iroh-fedimintd
 docker compose up -d
+```
+
+Then, access the web UI at [http://localhost:8175](http://localhost:8175).
+
+If Docker runs on a remote machine, forward the port locally with:
+
+```bash
+ssh -NL 8175:127.0.0.1:8175 <your_server>
 ```


### PR DESCRIPTION
For new users it's unclear how to access the web UI after starting the docker compose stack. This hopefully clarifies how to access the UI.

Additional context: https://discord.com/channels/990354215060795454/990354215878688860/1357792906836050163