### PR TITLE
[Backport releases/v0.7] fix: add missing metadata to fedimint-recurringd Cargo.toml

### DIFF
--- a/fedimint-recurringd/Cargo.toml
+++ b/fedimint-recurringd/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "fedimint-recurringd"
-edition = "2021"
-version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
 license = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }
+readme = { workspace = true }
+description = "recurringd is a service that allows Fedimint users to receive recurring payments"
 
 [[bin]]
 name = "fedimint-recurringd"

--- a/fedimint-recurringd/README.md
+++ b/fedimint-recurringd/README.md
@@ -1,4 +1,4 @@
-# Recurrind
+# Recurringd
 
 `recurringd` is a service that allows Fedimint users to receive recurring payments. For now only LNURL is supported, but BOLT12 support is planned.
 The service is designed to run independently from guardians and gateways, but obviously can be colocated with any of these.

--- a/fedimint-recurringd/src/db.rs
+++ b/fedimint-recurringd/src/db.rs
@@ -17,7 +17,7 @@ pub struct FederationDbPrefix([u8; 16]);
 
 impl FederationDbPrefix {
     pub fn random() -> FederationDbPrefix {
-        FederationDbPrefix(thread_rng().gen())
+        FederationDbPrefix(thread_rng().r#gen())
     }
 
     fn prepend(&self, byte: u8) -> Vec<u8> {

--- a/fedimint-recurringd/src/lib.rs
+++ b/fedimint-recurringd/src/lib.rs
@@ -20,16 +20,16 @@ use fedimint_ln_client::{LightningClientInit, LightningClientModule, LnReceiveSt
 use fedimint_mint_client::MintClientInit;
 use futures::StreamExt;
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Sha256};
+use lnurl::Tag;
 use lnurl::lnurl::LnUrl;
 use lnurl::pay::{LnURLPayInvoice, PayResponse};
-use lnurl::Tag;
 use tokio::sync::{Notify, RwLock};
 use tracing::{info, warn};
 
 use crate::db::{
-    load_federation_client_databases, open_client_db, try_add_federation_database,
     FederationDbPrefix, PaymentCodeEntry, PaymentCodeInvoiceEntry, PaymentCodeInvoiceKey,
     PaymentCodeKey, PaymentCodeNextInvoiceIndexKey, PaymentCodeVariant,
+    load_federation_client_databases, open_client_db, try_add_federation_database,
 };
 
 mod db;

--- a/fedimint-recurringd/src/main.rs
+++ b/fedimint-recurringd/src/main.rs
@@ -1,17 +1,17 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
+use axum::Json;
 use axum::body::Body;
 use axum::extract::{Path, Query, State};
 use axum::http::{Response, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, put};
-use axum::Json;
 use clap::Parser;
+use fedimint_core::Amount;
 use fedimint_core::config::FederationId;
 use fedimint_core::invite_code::InviteCode;
 use fedimint_core::util::SafeUrl;
-use fedimint_core::Amount;
 use fedimint_ln_client::recurring::api::{
     RecurringPaymentRegistrationRequest, RecurringPaymentRegistrationResponse,
 };


### PR DESCRIPTION
# Description
Backport of #7162 to `releases/v0.7`.