### PR TITLE
chore: bump docker iroh version to v0.7.0-beta.1

### DIFF
--- a/docker/iroh-fedimintd/docker-compose.yaml
+++ b/docker/iroh-fedimintd/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   fedimintd:
-    image: fedimint/fedimintd:da61291173e71a11358e1cd4154e649cf413d9e9
+    image: fedimint/fedimintd:v0.7.0-beta.1
     ports:
       - 8173:8173/tcp # p2p tls
       - 8173:8173/udp # p2p iroh


### PR DESCRIPTION
Verified:
- Setup a new federation with `v0.7.0-beta.1`
- Mixture of docker and start9
- Round trip deposit/withdrawal on mutinynet.

We should bump the version again when we cut `v0.7.0`, however it's useful to bump the tag early since we have users interested in kicking the tires.