### PR TITLE
Create Global Cached Bitcoin Rpc trait object in the Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3319,11 +3319,11 @@ dependencies = [
  "async-trait",
  "bitcoin_hashes 0.14.0",
  "erased-serde 0.4.6",
- "fedimint-bitcoind",
  "fedimint-core",
  "fedimint-ln-common",
  "fedimint-logging",
  "fedimint-metrics",
+ "fedimint-server-bitcoin-rpc",
  "fedimint-server-core",
  "fedimint-threshold-crypto",
  "futures",
@@ -3790,7 +3790,6 @@ dependencies = [
  "fedimint-aead",
  "fedimint-aleph-bft",
  "fedimint-api-client",
- "fedimint-bitcoind",
  "fedimint-build",
  "fedimint-core",
  "fedimint-logging",
@@ -3824,6 +3823,21 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "z32",
+]
+
+[[package]]
+name = "fedimint-server-bitcoin-rpc"
+version = "0.8.0-alpha"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitcoin",
+ "bitcoincore-rpc",
+ "esplora-client 0.10.0",
+ "fedimint-core",
+ "fedimint-logging",
+ "fedimint-server-core",
+ "tracing",
 ]
 
 [[package]]
@@ -3920,6 +3934,8 @@ dependencies = [
  "fedimint-portalloc",
  "fedimint-rocksdb",
  "fedimint-server",
+ "fedimint-server-bitcoin-rpc",
+ "fedimint-server-core",
  "fedimint-testing-core",
  "fs-lock",
  "lightning-invoice",
@@ -4175,6 +4191,7 @@ dependencies = [
  "fedimint-dummy-server",
  "fedimint-logging",
  "fedimint-server",
+ "fedimint-server-core",
  "fedimint-testing",
  "fedimint-testing-core",
  "fedimint-wallet-client",
@@ -4227,6 +4244,8 @@ dependencies = [
  "fedimint-mint-server",
  "fedimint-rocksdb",
  "fedimint-server",
+ "fedimint-server-bitcoin-rpc",
+ "fedimint-server-core",
  "fedimint-server-ui",
  "fedimint-unknown-common",
  "fedimint-unknown-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "fedimint-recurringd",
   "fedimint-rocksdb",
   "fedimint-server",
+  "fedimint-server-bitcoin-rpc",
   "fedimint-server-core",
   "fedimint-server-tests",
   "fedimint-server-ui",
@@ -168,6 +169,7 @@ fedimint-mint-server = { path = "./modules/fedimint-mint-server", version = "=0.
 fedimint-portalloc = { path = "utils/portalloc", version = "=0.8.0-alpha" }
 fedimint-rocksdb = { path = "./fedimint-rocksdb", version = "=0.8.0-alpha" }
 fedimint-server = { path = "./fedimint-server", version = "=0.8.0-alpha" }
+fedimint-server-bitcoin-rpc = { path = "./fedimint-server-bitcoin-rpc", version = "=0.8.0-alpha" }
 fedimint-server-core = { path = "./fedimint-server-core", version = "=0.8.0-alpha" }
 fedimint-server-ui = { path = "./fedimint-server-ui", version = "=0.8.0-alpha" }
 fedimint-testing = { path = "./fedimint-testing", version = "=0.8.0-alpha" }

--- a/fedimint-server-bitcoin-rpc/Cargo.toml
+++ b/fedimint-server-bitcoin-rpc/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fedimint-server-bitcoin-rpc"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+description = "Bitcoin RPC implementations for Fedimint server"
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+name = "fedimint_server_bitcoin_rpc"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+bitcoin = { workspace = true }
+bitcoincore-rpc = { workspace = true }
+esplora-client = { workspace = true }
+fedimint-core = { workspace = true }
+fedimint-logging = { workspace = true }
+fedimint-server-core = { workspace = true }
+tracing = { workspace = true } 

--- a/fedimint-server-bitcoin-rpc/src/bitcoind.rs
+++ b/fedimint-server-bitcoin-rpc/src/bitcoind.rs
@@ -1,0 +1,135 @@
+use std::env;
+use std::path::PathBuf;
+
+use anyhow::{anyhow as format_err, bail};
+use bitcoin::{BlockHash, Network, Transaction};
+use bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
+use bitcoincore_rpc::{Auth, RpcApi};
+use fedimint_core::Feerate;
+use fedimint_core::envs::{BitcoinRpcConfig, FM_BITCOIND_COOKIE_FILE_ENV};
+use fedimint_core::runtime::block_in_place;
+use fedimint_core::util::SafeUrl;
+use fedimint_logging::LOG_BITCOIND_CORE;
+use fedimint_server_core::bitcoin_rpc::IServerBitcoinRpc;
+use tracing::info;
+
+#[derive(Debug)]
+pub struct BitcoindClient {
+    client: ::bitcoincore_rpc::Client,
+    url: SafeUrl,
+}
+
+impl BitcoindClient {
+    pub fn new(url: &SafeUrl) -> anyhow::Result<Self> {
+        let safe_url = url.clone();
+        let (url, auth) = Self::from_url_to_url_auth(url)?;
+        Ok(Self {
+            client: ::bitcoincore_rpc::Client::new(&url, auth)?,
+            url: safe_url,
+        })
+    }
+
+    fn from_url_to_url_auth(url: &SafeUrl) -> anyhow::Result<(String, Auth)> {
+        Ok((
+            (if let Some(port) = url.port() {
+                format!(
+                    "{}://{}:{port}",
+                    url.scheme(),
+                    url.host_str().unwrap_or("127.0.0.1")
+                )
+            } else {
+                format!(
+                    "{}://{}",
+                    url.scheme(),
+                    url.host_str().unwrap_or("127.0.0.1")
+                )
+            }),
+            match (
+                !url.username().is_empty(),
+                env::var(FM_BITCOIND_COOKIE_FILE_ENV),
+            ) {
+                (true, Ok(_)) => {
+                    bail!(
+                        "When {FM_BITCOIND_COOKIE_FILE_ENV} is set, the url auth part must be empty."
+                    )
+                }
+                (true, Err(_)) => Auth::UserPass(
+                    url.username().to_owned(),
+                    url.password()
+                        .ok_or_else(|| format_err!("Password missing for {}", url.username()))?
+                        .to_owned(),
+                ),
+                (false, Ok(path)) => Auth::CookieFile(PathBuf::from(path)),
+                (false, Err(_)) => Auth::None,
+            },
+        ))
+    }
+}
+
+#[async_trait::async_trait]
+impl IServerBitcoinRpc for BitcoindClient {
+    fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
+        BitcoinRpcConfig {
+            kind: "bitcoind".to_string(),
+            url: self.url.clone(),
+        }
+    }
+
+    fn get_url(&self) -> SafeUrl {
+        self.url.clone()
+    }
+
+    async fn get_network(&self) -> anyhow::Result<Network> {
+        block_in_place(|| self.client.get_blockchain_info())
+            .map(|network| network.chain)
+            .map_err(anyhow::Error::from)
+    }
+
+    async fn get_block_count(&self) -> anyhow::Result<u64> {
+        // The RPC function is confusingly named and actually returns the block height
+        block_in_place(|| self.client.get_block_count())
+            .map(|height| height + 1)
+            .map_err(anyhow::Error::from)
+    }
+
+    async fn get_block_hash(&self, height: u64) -> anyhow::Result<BlockHash> {
+        block_in_place(|| self.client.get_block_hash(height)).map_err(anyhow::Error::from)
+    }
+
+    async fn get_block(&self, hash: &BlockHash) -> anyhow::Result<bitcoin::Block> {
+        block_in_place(|| self.client.get_block(hash)).map_err(anyhow::Error::from)
+    }
+
+    async fn get_feerate(&self) -> anyhow::Result<Option<Feerate>> {
+        let feerate = block_in_place(|| {
+            self.client
+                .estimate_smart_fee(1, Some(EstimateMode::Conservative))
+        })?
+        .fee_rate
+        .map(|per_kb| Feerate {
+            sats_per_kvb: per_kb.to_sat(),
+        });
+
+        Ok(feerate)
+    }
+
+    async fn submit_transaction(&self, transaction: Transaction) {
+        use bitcoincore_rpc::Error::JsonRpc;
+        use bitcoincore_rpc::jsonrpc::Error::Rpc;
+        match block_in_place(|| self.client.send_raw_transaction(&transaction)) {
+            // Bitcoin core's RPC will return error code -27 if a transaction is already in a block.
+            // This is considered a success case, so we don't surface the error log.
+            //
+            // https://github.com/bitcoin/bitcoin/blob/daa56f7f665183bcce3df146f143be37f33c123e/src/rpc/protocol.h#L48
+            Err(JsonRpc(Rpc(e))) if e.code == -27 => (),
+            Err(e) => info!(target: LOG_BITCOIND_CORE, ?e, "Error broadcasting transaction"),
+            Ok(_) => (),
+        }
+    }
+
+    async fn get_sync_percentage(&self) -> anyhow::Result<Option<f64>> {
+        Ok(Some(
+            block_in_place(|| self.client.get_blockchain_info())?.verification_progress,
+        ))
+    }
+}

--- a/fedimint-server-bitcoin-rpc/src/esplora.rs
+++ b/fedimint-server-bitcoin-rpc/src/esplora.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, bail};
+use bitcoin::{BlockHash, Network, Transaction};
+use fedimint_core::Feerate;
+use fedimint_core::envs::BitcoinRpcConfig;
+use fedimint_core::util::SafeUrl;
+use fedimint_logging::LOG_BITCOIND_ESPLORA;
+use fedimint_server_core::bitcoin_rpc::IServerBitcoinRpc;
+use tracing::info;
+
+// <https://blockstream.info/api/block-height/0>
+const MAINNET: &str = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+
+// <https://blockstream.info/testnet/api/block-height/0>
+const TESTNET: &str = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943";
+
+// <https://mempool.space/signet/api/block-height/0>
+const SIGNET: &str = "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6";
+
+// See <https://bitcoin.stackexchange.com/questions/122778/is-the-regtest-genesis-hash-always-the-same-or-not>
+// <https://github.com/bitcoin/bitcoin/blob/d82283950f5ff3b2116e705f931c6e89e5fdd0be/src/kernel/chainparams.cpp#L478>
+const REGTEST: &str = "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206";
+
+#[derive(Debug)]
+pub struct EsploraClient {
+    client: esplora_client::AsyncClient,
+    url: SafeUrl,
+}
+
+impl EsploraClient {
+    pub fn new(url: &SafeUrl) -> anyhow::Result<Self> {
+        // URL needs to have any trailing path including '/' removed
+        let without_trailing = url.as_str().trim_end_matches('/');
+
+        let builder = esplora_client::Builder::new(without_trailing);
+        let client = builder.build_async()?;
+        Ok(Self {
+            client,
+            url: url.clone(),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl IServerBitcoinRpc for EsploraClient {
+    fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
+        BitcoinRpcConfig {
+            kind: "esplora".to_string(),
+            url: self.url.clone(),
+        }
+    }
+
+    fn get_url(&self) -> SafeUrl {
+        self.url.clone()
+    }
+
+    async fn get_network(&self) -> anyhow::Result<Network> {
+        let genesis_hash = self.client.get_block_hash(0).await?;
+
+        let network = match genesis_hash.to_string().as_str() {
+            MAINNET => Network::Bitcoin,
+            TESTNET => Network::Testnet,
+            SIGNET => Network::Signet,
+            REGTEST => Network::Regtest,
+            hash => {
+                bail!("Unknown genesis hash {hash}");
+            }
+        };
+
+        Ok(network)
+    }
+
+    async fn get_block_count(&self) -> anyhow::Result<u64> {
+        match self.client.get_height().await {
+            Ok(height) => Ok(u64::from(height) + 1),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn get_block_hash(&self, height: u64) -> anyhow::Result<BlockHash> {
+        Ok(self.client.get_block_hash(u32::try_from(height)?).await?)
+    }
+
+    async fn get_block(&self, block_hash: &BlockHash) -> anyhow::Result<bitcoin::Block> {
+        self.client
+            .get_block_by_hash(block_hash)
+            .await?
+            .context("Block with this hash is not available")
+    }
+
+    async fn get_feerate(&self) -> anyhow::Result<Option<Feerate>> {
+        let fee_estimates: HashMap<u16, f64> = self.client.get_fee_estimates().await?;
+
+        let fee_rate_vb = esplora_client::convert_fee_rate(1, fee_estimates).unwrap_or(1.0);
+
+        let fee_rate_kvb = fee_rate_vb * 1_000f32;
+
+        Ok(Some(Feerate {
+            sats_per_kvb: (fee_rate_kvb).ceil() as u64,
+        }))
+    }
+
+    async fn submit_transaction(&self, transaction: Transaction) {
+        let _ = self.client.broadcast(&transaction).await.map_err(|error| {
+            // `esplora-client` v0.6.0 only surfaces HTTP error codes, which prevents us
+            // from detecting errors for transactions already submitted.
+            // TODO: Suppress `esplora-client` already submitted errors when client is
+            // updated
+            // https://github.com/fedimint/fedimint/issues/3732
+            info!(target: LOG_BITCOIND_ESPLORA, ?error, "Error broadcasting transaction");
+        });
+    }
+
+    async fn get_sync_percentage(&self) -> anyhow::Result<Option<f64>> {
+        Ok(None)
+    }
+}

--- a/fedimint-server-bitcoin-rpc/src/lib.rs
+++ b/fedimint-server-bitcoin-rpc/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod bitcoind;
+pub mod esplora;

--- a/fedimint-server-core/src/bitcoin_rpc.rs
+++ b/fedimint-server-core/src/bitcoin_rpc.rs
@@ -1,0 +1,171 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, ensure};
+use fedimint_core::Feerate;
+use fedimint_core::bitcoin::{Block, BlockHash, Network, Transaction};
+use fedimint_core::envs::BitcoinRpcConfig;
+use fedimint_core::task::TaskGroup;
+use fedimint_core::util::SafeUrl;
+use tokio::sync::watch;
+
+use crate::dashboard_ui::ServerBitcoinRpcStatus;
+
+#[derive(Debug, Clone)]
+pub struct ServerBitcoinRpcMonitor {
+    rpc: DynServerBitcoinRpc,
+    status_receiver: watch::Receiver<Option<ServerBitcoinRpcStatus>>,
+}
+
+impl ServerBitcoinRpcMonitor {
+    pub fn new(
+        rpc: DynServerBitcoinRpc,
+        update_interval: Duration,
+        task_group: &TaskGroup,
+    ) -> Self {
+        let (status_sender, status_receiver) = watch::channel(None);
+
+        let rpc_clone = rpc.clone();
+
+        task_group.spawn_cancellable("bitcoin-status-update", async move {
+            loop {
+                match Self::fetch_status(&rpc_clone).await {
+                    Ok(new_status) => {
+                        status_sender.send_replace(Some(new_status));
+                    }
+                    Err(..) => {
+                        status_sender.send_replace(None);
+                    }
+                }
+
+                fedimint_core::task::sleep(update_interval).await;
+            }
+        });
+
+        Self {
+            rpc,
+            status_receiver,
+        }
+    }
+
+    async fn fetch_status(rpc: &DynServerBitcoinRpc) -> Result<ServerBitcoinRpcStatus> {
+        let network = rpc.get_network().await?;
+        let block_count = rpc.get_block_count().await?;
+        let sync_percentage = rpc.get_sync_percentage().await?;
+
+        let fee_rate = if network == Network::Regtest {
+            Feerate { sats_per_kvb: 1000 }
+        } else {
+            rpc.get_feerate().await?.context("Feerate not available")?
+        };
+
+        Ok(ServerBitcoinRpcStatus {
+            network,
+            block_count,
+            fee_rate,
+            sync_percentage,
+        })
+    }
+
+    pub fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
+        self.rpc.get_bitcoin_rpc_config()
+    }
+
+    pub fn url(&self) -> SafeUrl {
+        self.rpc.get_url()
+    }
+
+    pub fn status(&self) -> Option<ServerBitcoinRpcStatus> {
+        self.status_receiver.borrow().clone()
+    }
+
+    pub async fn get_block(&self, hash: &BlockHash) -> Result<Block> {
+        ensure!(
+            self.status_receiver.borrow().is_some(),
+            "Not connected to bitcoin backend"
+        );
+
+        self.rpc.get_block(hash).await
+    }
+
+    pub async fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
+        ensure!(
+            self.status_receiver.borrow().is_some(),
+            "Not connected to bitcoin backend"
+        );
+
+        self.rpc.get_block_hash(height).await
+    }
+
+    pub async fn submit_transaction(&self, tx: Transaction) {
+        if self.status_receiver.borrow().is_some() {
+            self.rpc.submit_transaction(tx).await;
+        }
+    }
+}
+
+pub type DynServerBitcoinRpc = Arc<dyn IServerBitcoinRpc>;
+
+#[async_trait::async_trait]
+pub trait IServerBitcoinRpc: Debug + Send + Sync + 'static {
+    /// Returns the Bitcoin RPC config
+    fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig;
+
+    /// Returns the Bitcoin RPC url
+    fn get_url(&self) -> SafeUrl;
+
+    /// Returns the Bitcoin network the node is connected to
+    async fn get_network(&self) -> Result<Network>;
+
+    /// Returns the current block count
+    async fn get_block_count(&self) -> Result<u64>;
+
+    /// Returns the block hash at a given height
+    ///
+    /// # Panics
+    /// If the node does not know a block for that height. Make sure to only
+    /// query blocks of a height less to the one returned by
+    /// `Self::get_block_count`.
+    ///
+    /// While there is a corner case that the blockchain shrinks between these
+    /// two calls (through on average heavier blocks on a fork) this is
+    /// prevented by only querying hashes for blocks tailing the chain tip
+    /// by a certain number of blocks.
+    async fn get_block_hash(&self, height: u64) -> Result<BlockHash>;
+
+    async fn get_block(&self, block_hash: &BlockHash) -> Result<Block>;
+
+    /// Estimates the fee rate for a given confirmation target. Make sure that
+    /// all federation members use the same algorithm to avoid widely
+    /// diverging results. If the node is not ready yet to return a fee rate
+    /// estimation this function returns `None`.
+    async fn get_feerate(&self) -> Result<Option<Feerate>>;
+
+    /// Submits a transaction to the Bitcoin network
+    ///
+    /// This operation does not return anything as it never OK to consider its
+    /// success as final anyway. The caller should be retrying
+    /// broadcast periodically until it confirms the transaction was actually
+    /// via other means or decides that is no longer relevant.
+    ///
+    /// Also - most backends considers brodcasting a tx that is already included
+    /// in the blockchain as an error, which breaks idempotency and requires
+    /// brittle workarounds just to reliably ignore... just to retry on the
+    /// higher level anyway.
+    ///
+    /// Implementations of this error should log errors for debugging purposes
+    /// when it makes sense.
+    async fn submit_transaction(&self, transaction: Transaction);
+
+    /// Returns the node's estimated chain sync percentage as a float between
+    /// 0.0 and 1.0, or `None` if the node doesn't support this feature.
+    async fn get_sync_percentage(&self) -> Result<Option<f64>>;
+
+    fn into_dyn(self) -> DynServerBitcoinRpc
+    where
+        Self: Sized,
+    {
+        Arc::new(self)
+    }
+}

--- a/fedimint-server-core/src/dashboard_ui.rs
+++ b/fedimint-server-core/src/dashboard_ui.rs
@@ -3,10 +3,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use fedimint_core::PeerId;
+use fedimint_core::bitcoin::Network;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::module::ApiAuth;
 use fedimint_core::module::audit::AuditSummary;
+use fedimint_core::util::SafeUrl;
+use fedimint_core::{Feerate, PeerId};
 
 use crate::{DynServerModule, ServerModule};
 
@@ -42,6 +44,12 @@ pub trait IDashboardApi {
     /// Get the federation audit summary
     async fn federation_audit(&self) -> AuditSummary;
 
+    /// Get the url of the bitcoin rpc
+    async fn bitcoin_rpc_url(&self) -> SafeUrl;
+
+    /// Get the status of the bitcoin backend
+    async fn bitcoin_rpc_status(&self) -> Option<ServerBitcoinRpcStatus>;
+
     /// Get reference to a server module instance by module kind
     fn get_module_by_kind(&self, kind: ModuleKind) -> Option<&DynServerModule>;
 
@@ -66,4 +74,12 @@ impl DashboardApiModuleExt for DynDashboardApi {
             .as_any()
             .downcast_ref::<M>()
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerBitcoinRpcStatus {
+    pub network: Network,
+    pub block_count: u64,
+    pub fee_rate: Feerate,
+    pub sync_percentage: Option<f64>,
 }

--- a/fedimint-server-core/src/init.rs
+++ b/fedimint-server-core/src/init.rs
@@ -13,6 +13,7 @@ use fedimint_core::config::{
 };
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{Database, DatabaseVersion};
+use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::{
     CommonModuleInit, CoreConsensusVersion, IDynCommonModuleInit, ModuleConsensusVersion,
     ModuleInit, SupportedModuleApiVersions,
@@ -53,6 +54,7 @@ pub trait IServerModuleInit: IDynCommonModuleInit {
         our_peer_id: PeerId,
         module_api: DynModuleApi,
         shared: SharedAnymap,
+        bitcoin_rpc: BitcoinRpcConfig,
     ) -> anyhow::Result<DynServerModule>;
 
     fn validate_params(&self, params: &ConfigGenModuleParams) -> anyhow::Result<()>;
@@ -104,6 +106,7 @@ where
     our_peer_id: PeerId,
     num_peers: NumPeers,
     module_api: DynModuleApi,
+    bitcoin_rpc: BitcoinRpcConfig,
     // Things that can be shared between modules
     //
     // If two modules can coordinate on using a shared type, they can
@@ -140,6 +143,10 @@ where
 
     pub fn module_api(&self) -> &DynModuleApi {
         &self.module_api
+    }
+
+    pub fn bitcoin_rpc(&self) -> BitcoinRpcConfig {
+        self.bitcoin_rpc.clone()
     }
 
     pub fn with_shared<T, R>(&self, f: impl FnOnce(&T) -> R) -> R
@@ -276,6 +283,7 @@ where
         our_peer_id: PeerId,
         module_api: DynModuleApi,
         shared: SharedAnymap,
+        bitcoin_rpc: BitcoinRpcConfig,
     ) -> anyhow::Result<DynServerModule> {
         let module = <Self as ServerModuleInit>::init(
             self,
@@ -288,6 +296,7 @@ where
                 _marker: PhantomData,
                 module_api,
                 shared,
+                bitcoin_rpc,
             },
         )
         .await?;

--- a/fedimint-server-core/src/lib.rs
+++ b/fedimint-server-core/src/lib.rs
@@ -5,6 +5,7 @@
 //! This (Rust) module defines common interoperability types
 //! and functionality that are only used on the server side.
 
+pub mod bitcoin_rpc;
 pub mod config;
 pub mod dashboard_ui;
 mod init;

--- a/fedimint-server-ui/src/bitcoin.rs
+++ b/fedimint-server-ui/src/bitcoin.rs
@@ -1,0 +1,45 @@
+use fedimint_core::util::SafeUrl;
+use fedimint_server_core::dashboard_ui::ServerBitcoinRpcStatus;
+use maud::{Markup, html};
+
+pub fn render(url: SafeUrl, status: &Option<ServerBitcoinRpcStatus>) -> Markup {
+    html! {
+        div class="card h-100" {
+            div class="card-header dashboard-header" { "Bitcoin Rpc Connection" }
+            div class="card-body" {
+                div class="alert alert-info mb-3" {
+                    (url.to_unsafe().to_string())
+                }
+
+                @if let Some(status) = status {
+                    table class="table table-sm mb-0" {
+                        tbody {
+                            tr {
+                                th { "Network" }
+                                td { (format!("{:?}", status.network)) }
+                            }
+                            tr {
+                                th { "Block Count" }
+                                td { (status.block_count) }
+                            }
+                            tr {
+                                th { "Fee Rate" }
+                                td { (format!("{} sats/vB", status.fee_rate.sats_per_kvb / 1000)) }
+                            }
+                            @if let Some(sync) = status.sync_percentage {
+                                tr {
+                                    th { "Sync Progress" }
+                                    td { (format!("{:.1}%", sync)) }
+                                }
+                            }
+                        }
+                    }
+                } @else {
+                    div class="alert alert-warning mb-0" {
+                        "Failed to connect to bitcoin backend"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/fedimint-server-ui/src/dashboard.rs
+++ b/fedimint-server-ui/src/dashboard.rs
@@ -16,8 +16,8 @@ use {fedimint_lnv2_server, fedimint_meta_server, fedimint_wallet_server};
 use crate::assets::WithStaticRoutesExt as _;
 use crate::layout::{self};
 use crate::{
-    AuthState, LoginInput, audit, check_auth, invite_code, latency, lnv2, login_form_response,
-    login_submit_response, meta, wallet,
+    AuthState, LoginInput, audit, bitcoin, check_auth, invite_code, latency, lnv2,
+    login_form_response, login_submit_response, meta, wallet,
 };
 
 pub fn dashboard_layout(content: Markup) -> Markup {
@@ -86,6 +86,8 @@ async fn dashboard_view(
     let p2p_connection_status = state.api.p2p_connection_status().await;
     let invite_code = state.api.federation_invite_code().await;
     let audit_summary = state.api.federation_audit().await;
+    let bitcoin_rpc_url = state.api.bitcoin_rpc_url().await;
+    let bitcoin_rpc_status = state.api.bitcoin_rpc_status().await;
 
     // Conditionally add Lightning V2 UI if the module is available
     let lightning_content = html! {
@@ -151,6 +153,12 @@ async fn dashboard_view(
             // Peer Connection Status Column
             div class="col-lg-6" {
                 (latency::render(consensus_ord_latency, &p2p_connection_status))
+            }
+        }
+
+        div class="row gy-4 mt-2" {
+            div class="col-12" {
+                (bitcoin::render(bitcoin_rpc_url, &bitcoin_rpc_status))
             }
         }
 

--- a/fedimint-server-ui/src/lib.rs
+++ b/fedimint-server-ui/src/lib.rs
@@ -1,5 +1,6 @@
 pub(crate) mod assets;
 pub mod audit;
+pub mod bitcoin;
 pub mod dashboard;
 pub(crate) mod error;
 pub mod invite_code;

--- a/fedimint-server/Cargo.toml
+++ b/fedimint-server/Cargo.toml
@@ -31,7 +31,6 @@ bls12_381 = { workspace = true }
 bytes = { workspace = true }
 fedimint-aead = { workspace = true }
 fedimint-api-client = { workspace = true }
-fedimint-bitcoind = { workspace = true, features = ["fedimint-server"] }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-metrics = { workspace = true }

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -54,7 +54,8 @@ use fedimint_core::transaction::{
 use fedimint_core::util::{FmtCompact, SafeUrl};
 use fedimint_core::{OutPoint, PeerId, TransactionId, secp256k1};
 use fedimint_logging::LOG_NET_API;
-use fedimint_server_core::dashboard_ui::IDashboardApi;
+use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
+use fedimint_server_core::dashboard_ui::{IDashboardApi, ServerBitcoinRpcStatus};
 use fedimint_server_core::net::{GuardianAuthToken, check_auth};
 use fedimint_server_core::{DynServerModule, ServerModuleRegistry, ServerModuleRegistryExt};
 use futures::StreamExt;
@@ -91,6 +92,7 @@ pub struct ConsensusApi {
     pub ord_latency_receiver: watch::Receiver<Option<Duration>>,
     pub p2p_status_receivers: P2PStatusReceivers,
     pub ci_status_receivers: BTreeMap<PeerId, Receiver<Option<u64>>>,
+    pub bitcoin_rpc_connection: ServerBitcoinRpcMonitor,
     pub supported_api_versions: SupportedApiVersionsSummary,
     pub code_version_str: String,
 }
@@ -587,6 +589,14 @@ impl IDashboardApi for ConsensusApi {
         self.get_federation_audit()
             .await
             .expect("Failed to get federation audit")
+    }
+
+    async fn bitcoin_rpc_url(&self) -> SafeUrl {
+        self.bitcoin_rpc_connection.url()
+    }
+
+    async fn bitcoin_rpc_status(&self) -> Option<ServerBitcoinRpcStatus> {
+        self.bitcoin_rpc_connection.status()
     }
 
     fn get_module_by_kind(&self, kind: ModuleKind) -> Option<&DynServerModule> {

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -103,7 +103,11 @@ pub async fn run(
 
     let server_bitcoin_rpc_monitor = ServerBitcoinRpcMonitor::new(
         dyn_server_bitcoin_rpc,
-        Duration::from_secs(if is_running_in_test_env() { 1 } else { 60 }),
+        if is_running_in_test_env() {
+            Duration::from_millis(100)
+        } else {
+            Duration::from_secs(60)
+        },
         task_group,
     );
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -20,7 +20,7 @@ use fedimint_core::NumPeers;
 use fedimint_core::config::P2PMessage;
 use fedimint_core::core::{ModuleInstanceId, ModuleKind};
 use fedimint_core::db::{Database, apply_migrations_dbtx, verify_module_db_integrity_dbtx};
-use fedimint_core::envs::is_running_in_test_env;
+use fedimint_core::envs::{BitcoinRpcConfig, is_running_in_test_env};
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{ApiEndpoint, ApiError, ApiMethod, FEDIMINT_API_ALPN, IrohApiRequest};
@@ -66,6 +66,7 @@ pub async fn run(
     force_api_secrets: ApiSecrets,
     data_dir: PathBuf,
     code_version_str: String,
+    bitcoin_rpc: BitcoinRpcConfig,
     ui_bind_addr: SocketAddr,
     dashboard_ui_handler: Option<crate::DashboardUiHandler>,
 ) -> anyhow::Result<()> {
@@ -139,6 +140,7 @@ pub async fn run(
                         cfg.local.identity,
                         global_api.with_module(*module_id),
                         shared_anymap.clone(),
+                        bitcoin_rpc.clone(),
                     )
                     .await?;
 

--- a/fedimint-server/src/envs.rs
+++ b/fedimint-server/src/envs.rs
@@ -1,7 +1,3 @@
-/// The env var for maximum open connections the API can handle
-pub const FM_MAX_CLIENT_CONNECTIONS_ENV: &str = "FM_MAX_CLIENT_CONNECTIONS";
-pub const FM_PEER_ID_SORT_BY_URL_ENV: &str = "FM_PEER_ID_SORT_BY_URL";
-
 /// Environment variable for UI bind address
 pub const FM_UI_BIND_ENV: &str = "FM_UI_BIND";
 

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -35,6 +35,7 @@ use config::io::{PLAINTEXT_PASSWORD, read_server_config};
 use fedimint_aead::random_salt;
 use fedimint_core::config::P2PMessage;
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _};
+use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::net::peers::DynP2PConnections;
 use fedimint_core::task::{TaskGroup, TaskHandle};
@@ -97,6 +98,7 @@ pub async fn run(
     code_version_str: String,
     module_init_registry: &ServerModuleInitRegistry,
     task_group: TaskGroup,
+    bitcoin_rpc: BitcoinRpcConfig,
     dashboard_ui_handler: Option<DashboardUiHandler>,
     setup_ui_handler: Option<SetupUiHandler>,
 ) -> anyhow::Result<()> {
@@ -178,6 +180,7 @@ pub async fn run(
         force_api_secrets,
         data_dir,
         code_version_str,
+        bitcoin_rpc,
         settings.ui_bind,
         dashboard_ui_handler,
     ))

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -35,7 +35,6 @@ use config::io::{PLAINTEXT_PASSWORD, read_server_config};
 use fedimint_aead::random_salt;
 use fedimint_core::config::P2PMessage;
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped as _};
-use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::epoch::ConsensusItem;
 use fedimint_core::net::peers::DynP2PConnections;
 use fedimint_core::task::{TaskGroup, TaskHandle};
@@ -43,6 +42,7 @@ use fedimint_core::util::write_new;
 use fedimint_logging::{LOG_CONSENSUS, LOG_CORE};
 pub use fedimint_server_core as core;
 use fedimint_server_core::ServerModuleInitRegistry;
+use fedimint_server_core::bitcoin_rpc::DynServerBitcoinRpc;
 use fedimint_server_core::dashboard_ui::DynDashboardApi;
 use fedimint_server_core::setup_ui::{DynSetupApi, ISetupApi};
 use jsonrpsee::RpcModule;
@@ -98,7 +98,7 @@ pub async fn run(
     code_version_str: String,
     module_init_registry: &ServerModuleInitRegistry,
     task_group: TaskGroup,
-    bitcoin_rpc: BitcoinRpcConfig,
+    bitcoin_rpc: DynServerBitcoinRpc,
     dashboard_ui_handler: Option<DashboardUiHandler>,
     setup_ui_handler: Option<SetupUiHandler>,
 ) -> anyhow::Result<()> {

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -38,6 +38,8 @@ fedimint-logging = { workspace = true }
 fedimint-portalloc = { workspace = true }
 fedimint-rocksdb = { workspace = true }
 fedimint-server = { workspace = true }
+fedimint-server-bitcoin-rpc = { workspace = true }
+fedimint-server-core = { workspace = true }
 fedimint-testing-core = { workspace = true }
 fs-lock = { workspace = true }
 lightning-invoice = { workspace = true }

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -93,7 +93,9 @@ impl Fixtures {
             let bitcoin = RealBitcoinTest::new(&bitcoincore_url, dyn_bitcoin_rpc.clone());
 
             let bitcoin_rpc_connection = match rpc_config.kind.as_ref() {
-                "bitcoind" => BitcoindClient::new(&rpc_config.url).unwrap().into_dyn(),
+                "bitcoind" => BitcoindClient::new(&rpc_config.url, None)
+                    .unwrap()
+                    .into_dyn(),
                 "esplora" => EsploraClient::new(&rpc_config.url).unwrap().into_dyn(),
                 kind => panic!("Unknown bitcoin rpc kind {kind}"),
             };

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -23,6 +23,9 @@ use fedimint_gateway_server::config::LightningModuleMode;
 use fedimint_lightning::{ILnRpcClient, LightningContext};
 use fedimint_logging::TracingSetup;
 use fedimint_server::core::{DynServerModuleInit, IServerModuleInit, ServerModuleInitRegistry};
+use fedimint_server_bitcoin_rpc::bitcoind::BitcoindClient;
+use fedimint_server_bitcoin_rpc::esplora::EsploraClient;
+use fedimint_server_core::bitcoin_rpc::{DynServerBitcoinRpc, IServerBitcoinRpc};
 use fedimint_testing_core::test_dir;
 
 use crate::btc::BitcoinTest;
@@ -48,6 +51,7 @@ pub struct Fixtures {
     bitcoin_rpc: BitcoinRpcConfig,
     bitcoin: Arc<dyn BitcoinTest>,
     dyn_bitcoin_rpc: DynBitcoindRpc,
+    bitcoin_rpc_connection: DynServerBitcoinRpc,
     primary_module_kind: ModuleKind,
     id: ModuleInstanceId,
 }
@@ -61,10 +65,11 @@ impl Fixtures {
         // Ensure tracing has been set once
         let _ = TracingSetup::default().init();
         let real_testing = Fixtures::is_real_test();
-        let (dyn_bitcoin_rpc, bitcoin, config): (
+        let (dyn_bitcoin_rpc, bitcoin, config, bitcoin_rpc_connection): (
             DynBitcoindRpc,
             Arc<dyn BitcoinTest>,
             BitcoinRpcConfig,
+            DynServerBitcoinRpc,
         ) = if real_testing {
             // `backend-test.sh` overrides which Bitcoin RPC to use for electrs and esplora
             // backend tests
@@ -87,12 +92,27 @@ impl Fixtures {
                 .expect("Invalid bitcoind RPC URL");
             let bitcoin = RealBitcoinTest::new(&bitcoincore_url, dyn_bitcoin_rpc.clone());
 
-            (dyn_bitcoin_rpc, Arc::new(bitcoin), rpc_config)
+            let bitcoin_rpc_connection = match rpc_config.kind.as_ref() {
+                "bitcoind" => BitcoindClient::new(&rpc_config.url).unwrap().into_dyn(),
+                "esplora" => EsploraClient::new(&rpc_config.url).unwrap().into_dyn(),
+                kind => panic!("Unknown bitcoin rpc kind {kind}"),
+            };
+
+            (
+                dyn_bitcoin_rpc,
+                Arc::new(bitcoin),
+                rpc_config,
+                bitcoin_rpc_connection,
+            )
         } else {
             let FakeBitcoinFactory { bitcoin, config } = FakeBitcoinFactory::register_new();
             let dyn_bitcoin_rpc = DynBitcoindRpc::from(bitcoin.clone());
+
+            let bitcoin_rpc_connection = bitcoin.clone().into_dyn();
+
             let bitcoin = Arc::new(bitcoin);
-            (dyn_bitcoin_rpc, bitcoin, config)
+
+            (dyn_bitcoin_rpc, bitcoin, config, bitcoin_rpc_connection)
         };
 
         Self {
@@ -102,6 +122,7 @@ impl Fixtures {
             bitcoin_rpc: config,
             bitcoin,
             dyn_bitcoin_rpc,
+            bitcoin_rpc_connection,
             primary_module_kind: IClientModuleInit::module_kind(&client),
             id: 0,
         }
@@ -161,7 +182,7 @@ impl Fixtures {
             ClientModuleInitRegistry::from(self.clients.clone()),
             self.primary_module_kind.clone(),
             num_offline,
-            self.bitcoin_server(),
+            self.bitcoin_rpc_connection(),
         )
     }
 
@@ -265,5 +286,9 @@ impl Fixtures {
 
     pub fn dyn_bitcoin_rpc(&self) -> DynBitcoindRpc {
         self.dyn_bitcoin_rpc.clone()
+    }
+
+    pub fn bitcoin_rpc_connection(&self) -> DynServerBitcoinRpc {
+        self.bitcoin_rpc_connection.clone()
     }
 }

--- a/fedimint-testing/src/fixtures.rs
+++ b/fedimint-testing/src/fixtures.rs
@@ -161,6 +161,7 @@ impl Fixtures {
             ClientModuleInitRegistry::from(self.clients.clone()),
             self.primary_module_kind.clone(),
             num_offline,
+            self.bitcoin_server(),
         )
     }
 

--- a/fedimintd/Cargo.toml
+++ b/fedimintd/Cargo.toml
@@ -40,6 +40,8 @@ fedimint-mint-common = { workspace = true }
 fedimint-mint-server = { workspace = true }
 fedimint-rocksdb = { workspace = true }
 fedimint-server = { workspace = true }
+fedimint-server-bitcoin-rpc = { workspace = true }
+fedimint-server-core = { workspace = true }
 fedimint-server-ui = { workspace = true }
 fedimint-unknown-common = { workspace = true }
 fedimint-unknown-server = { workspace = true }

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -13,7 +13,8 @@ use fedimint_core::config::{
 use fedimint_core::core::ModuleKind;
 use fedimint_core::db::{Database, get_current_database_version};
 use fedimint_core::envs::{
-    BitcoinRpcConfig, FM_ENABLE_MODULE_LNV2_ENV, FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
+    BitcoinRpcConfig, FM_BITCOIN_RPC_KIND_ENV, FM_BITCOIN_RPC_URL_ENV, FM_ENABLE_MODULE_LNV2_ENV,
+    FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
 };
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{ServerApiVersionsSummary, ServerDbVersionsSummary};
@@ -67,6 +68,13 @@ struct ServerOpts {
     // the API
     #[arg(long, env = FM_PASSWORD_ENV)]
     password: Option<String>,
+
+    #[arg(long, env =  FM_BITCOIN_RPC_KIND_ENV)]
+    bitcoin_rpc_kind: String,
+
+    #[arg(long, env =  FM_BITCOIN_RPC_URL_ENV)]
+    bitcoin_rpc_url: SafeUrl,
+
     /// Enable tokio console logging
     #[arg(long, env = FM_TOKIO_CONSOLE_BIND_ENV)]
     tokio_console_bind: Option<SocketAddr>,
@@ -265,11 +273,12 @@ impl Fedimintd {
 
         info!("Starting fedimintd (version: {fedimint_version} version_hash: {code_version_hash})");
 
-        let bitcoind_rpc = BitcoinRpcConfig::get_defaults_from_env_vars()?;
-
         Ok(Self {
+            bitcoin_rpc: BitcoinRpcConfig {
+                kind: opts.bitcoin_rpc_kind.clone(),
+                url: opts.bitcoin_rpc_url.clone(),
+            },
             opts,
-            bitcoin_rpc: bitcoind_rpc,
             server_gens: ServerModuleInitRegistry::new(),
             server_gen_params: ServerModuleConfigGenParamsRegistry::default(),
             code_version_hash: code_version_hash.to_owned(),

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -204,7 +204,7 @@ pub struct Fedimintd {
     code_version_hash: String,
     code_version_str: String,
     opts: ServerOpts,
-    bitcoind_rpc: BitcoinRpcConfig,
+    bitcoin_rpc: BitcoinRpcConfig,
 }
 
 impl Fedimintd {
@@ -269,7 +269,7 @@ impl Fedimintd {
 
         Ok(Self {
             opts,
-            bitcoind_rpc,
+            bitcoin_rpc: bitcoind_rpc,
             server_gens: ServerModuleInitRegistry::new(),
             server_gen_params: ServerModuleConfigGenParamsRegistry::default(),
             code_version_hash: code_version_hash.to_owned(),
@@ -314,14 +314,15 @@ impl Fedimintd {
     pub fn with_default_modules(self) -> anyhow::Result<Self> {
         let network = self.opts.network;
 
-        let bitcoind_rpc = self.bitcoind_rpc.clone();
+        let bitcoin_rpc = self.bitcoin_rpc.clone();
+
         let s = self
             .with_module_kind(LightningInit)
             .with_module_instance(
                 LightningInit::kind(),
                 LightningGenParams {
                     local: LightningGenParamsLocal {
-                        bitcoin_rpc: bitcoind_rpc.clone(),
+                        bitcoin_rpc: bitcoin_rpc.clone(),
                     },
                     consensus: LightningGenParamsConsensus { network },
                 },
@@ -344,7 +345,7 @@ impl Fedimintd {
                 WalletInit::kind(),
                 WalletGenParams {
                     local: WalletGenParamsLocal {
-                        bitcoin_rpc: bitcoind_rpc.clone(),
+                        bitcoin_rpc: bitcoin_rpc.clone(),
                     },
                     consensus: WalletGenParamsConsensus {
                         network,
@@ -365,7 +366,7 @@ impl Fedimintd {
                     fedimint_lnv2_server::LightningInit::kind(),
                     fedimint_lnv2_common::config::LightningGenParams {
                         local: fedimint_lnv2_common::config::LightningGenParamsLocal {
-                            bitcoin_rpc: bitcoind_rpc.clone(),
+                            bitcoin_rpc: bitcoin_rpc.clone(),
                         },
                         consensus: fedimint_lnv2_common::config::LightningGenParamsConsensus {
                             // TODO: actually make the relative fee configurable
@@ -430,6 +431,7 @@ impl Fedimintd {
                 self.server_gens,
                 self.server_gen_params,
                 self.code_version_str,
+                self.bitcoin_rpc.clone(),
             )
             .await
             {
@@ -515,6 +517,7 @@ async fn run(
     module_inits: ServerModuleInitRegistry,
     module_inits_params: ServerModuleConfigGenParamsRegistry,
     code_version_str: String,
+    bitcoin_rpc: BitcoinRpcConfig,
 ) -> anyhow::Result<()> {
     if let Some(socket_addr) = opts.bind_metrics_api.as_ref() {
         task_group.spawn_cancellable("metrics-server", {
@@ -564,6 +567,7 @@ async fn run(
         code_version_str,
         &module_inits,
         task_group.clone(),
+        bitcoin_rpc,
         Some(Box::new(fedimint_server_ui::dashboard::start)),
         Some(Box::new(fedimint_server_ui::setup::start)),
     ))

--- a/fedimintd/src/fedimintd.rs
+++ b/fedimintd/src/fedimintd.rs
@@ -13,8 +13,8 @@ use fedimint_core::config::{
 use fedimint_core::core::ModuleKind;
 use fedimint_core::db::{Database, get_current_database_version};
 use fedimint_core::envs::{
-    BitcoinRpcConfig, FM_BITCOIN_RPC_KIND_ENV, FM_BITCOIN_RPC_URL_ENV, FM_ENABLE_MODULE_LNV2_ENV,
-    FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
+    BitcoinRpcConfig, FM_BITCOIN_RPC_KIND_ENV, FM_BITCOIN_RPC_URL_ENV, FM_BITCOIND_COOKIE_FILE_ENV,
+    FM_ENABLE_MODULE_LNV2_ENV, FM_USE_UNKNOWN_MODULE_ENV, is_env_var_set,
 };
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::module::{ServerApiVersionsSummary, ServerDbVersionsSummary};
@@ -81,6 +81,9 @@ struct ServerOpts {
 
     #[arg(long, env =  FM_BITCOIN_RPC_URL_ENV)]
     bitcoin_rpc_url: SafeUrl,
+
+    #[arg(long, env =  FM_BITCOIND_COOKIE_FILE_ENV)]
+    bitcoind_cookie_file: Option<PathBuf>,
 
     /// Enable tokio console logging
     #[arg(long, env = FM_TOKIO_CONSOLE_BIND_ENV)]
@@ -567,7 +570,9 @@ async fn run(
     );
 
     let dyn_server_bitcoin_rpc = match opts.bitcoin_rpc_kind.as_ref() {
-        "bitcoind" => BitcoindClient::new(&opts.bitcoin_rpc_url)?.into_dyn(),
+        "bitcoind" => {
+            BitcoindClient::new(&opts.bitcoin_rpc_url, opts.bitcoind_cookie_file)?.into_dyn()
+        }
         "esplora" => EsploraClient::new(&opts.bitcoin_rpc_url)?.into_dyn(),
         kind => bail!("Unknown bitcoin rpc kind {kind}"),
     };

--- a/modules/fedimint-ln-server/Cargo.toml
+++ b/modules/fedimint-ln-server/Cargo.toml
@@ -20,11 +20,11 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin_hashes = { workspace = true }
 erased-serde = { workspace = true }
-fedimint-bitcoind = { workspace = true, features = ["fedimint-server"] }
 fedimint-core = { workspace = true }
 fedimint-ln-common = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-metrics = { workspace = true }
+fedimint-server-bitcoin-rpc = { workspace = true }
 fedimint-server-core = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }

--- a/modules/fedimint-ln-server/src/lib.rs
+++ b/modules/fedimint-ln-server/src/lib.rs
@@ -8,10 +8,8 @@ pub mod db;
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
-use anyhow::{Context, bail, format_err};
+use anyhow::{Context, bail};
 use bitcoin_hashes::{Hash as BitcoinHash, sha256};
-use fedimint_bitcoind::create_bitcoind;
-use fedimint_bitcoind::shared::ServerModuleSharedBitcoin;
 use fedimint_core::config::{
     ConfigGenModuleParams, ServerModuleConfig, ServerModuleConsensusConfig,
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
@@ -20,7 +18,6 @@ use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{DatabaseTransaction, DatabaseValue, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::Encodable;
 use fedimint_core::encoding::btc::NetworkLegacyEncodingWrapper;
-use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     ApiEndpoint, ApiEndpointContext, ApiVersion, CORE_CONSENSUS_VERSION, CoreConsensusVersion,
@@ -58,6 +55,7 @@ use fedimint_ln_common::{
     create_gateway_remove_message,
 };
 use fedimint_logging::LOG_MODULE_LN;
+use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
 use fedimint_server_core::config::PeerHandleOps;
 use fedimint_server_core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
 use futures::StreamExt;
@@ -67,7 +65,6 @@ use strum::IntoEnumIterator;
 use threshold_crypto::poly::Commitment;
 use threshold_crypto::serde_impl::SerdeSecret;
 use threshold_crypto::{PublicKeySet, SecretKeyShare};
-use tokio::sync::watch;
 use tracing::{debug, error, info, info_span, trace, warn};
 
 use crate::db::{
@@ -220,13 +217,11 @@ impl ServerModuleInit for LightningInit {
         // Eagerly initialize metrics that trigger infrequently
         LN_CANCEL_OUTGOING_CONTRACTS.get();
 
-        Ok(Lightning::new(
-            args.cfg().to_typed()?,
-            args.our_peer_id(),
-            args.bitcoin_rpc(),
-            &args.shared(),
-        )
-        .await?)
+        Ok(Lightning {
+            cfg: args.cfg().to_typed()?,
+            our_peer_id: args.our_peer_id(),
+            server_bitcoin_rpc_monitor: args.server_bitcoin_rpc_monitor(),
+        })
     }
 
     fn trusted_dealer_gen(
@@ -346,8 +341,7 @@ impl ServerModuleInit for LightningInit {
 pub struct Lightning {
     cfg: LightningConfig,
     our_peer_id: PeerId,
-    /// Block count updated periodically by a background task
-    block_count_rx: watch::Receiver<Option<u64>>,
+    server_bitcoin_rpc_monitor: ServerBitcoinRpcMonitor,
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -950,27 +944,11 @@ impl ServerModule for Lightning {
 }
 
 impl Lightning {
-    async fn new(
-        cfg: LightningConfig,
-        our_peer_id: PeerId,
-        bitcoin_rpc: BitcoinRpcConfig,
-        shared: &ServerModuleSharedBitcoin,
-    ) -> anyhow::Result<Self> {
-        let btc_rpc = create_bitcoind(&bitcoin_rpc)?;
-        let block_count_rx = shared
-            .block_count_receiver(cfg.consensus.network.0, btc_rpc.clone())
-            .await;
-        Ok(Lightning {
-            cfg,
-            our_peer_id,
-            block_count_rx,
-        })
-    }
-
     fn get_block_count(&self) -> anyhow::Result<u64> {
-        self.block_count_rx
-            .borrow()
-            .ok_or_else(|| format_err!("Block count not available yet"))
+        self.server_bitcoin_rpc_monitor
+            .status()
+            .map(|status| status.block_count)
+            .context("Block count not available yet")
     }
 
     async fn consensus_block_count(&self, dbtx: &mut DatabaseTransaction<'_>) -> u64 {
@@ -1244,9 +1222,11 @@ fn record_funded_contract_metric(updated_contract_account: &ContractAccount) {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use assert_matches::assert_matches;
     use bitcoin_hashes::{Hash as BitcoinHash, sha256};
-    use fedimint_bitcoind::shared::ServerModuleSharedBitcoin;
+    use fedimint_core::bitcoin::{Block, BlockHash};
     use fedimint_core::config::ConfigGenModuleParams;
     use fedimint_core::db::mem_impl::MemDatabase;
     use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
@@ -1256,7 +1236,8 @@ mod tests {
     use fedimint_core::module::{InputMeta, TransactionItemAmount};
     use fedimint_core::secp256k1::{PublicKey, generate_keypair};
     use fedimint_core::task::TaskGroup;
-    use fedimint_core::{Amount, InPoint, OutPoint, PeerId, TransactionId};
+    use fedimint_core::util::SafeUrl;
+    use fedimint_core::{Amount, Feerate, InPoint, OutPoint, PeerId, TransactionId};
     use fedimint_ln_common::config::{
         LightningClientConfig, LightningConfig, LightningGenParams, LightningGenParamsConsensus,
         LightningGenParamsLocal, Network,
@@ -1270,11 +1251,57 @@ mod tests {
         PreimageKey,
     };
     use fedimint_ln_common::{ContractAccount, LightningInput, LightningOutput};
-    use fedimint_server_core::{ServerModule, ServerModuleInit, ServerModuleShared as _};
+    use fedimint_server_core::bitcoin_rpc::{IServerBitcoinRpc, ServerBitcoinRpcMonitor};
+    use fedimint_server_core::{ServerModule, ServerModuleInit};
     use rand::rngs::OsRng;
 
     use crate::db::{ContractKey, LightningAuditItemKey};
     use crate::{Lightning, LightningInit};
+
+    #[derive(Debug)]
+    struct MockBitcoinServerRpc;
+
+    #[async_trait::async_trait]
+    impl IServerBitcoinRpc for MockBitcoinServerRpc {
+        fn get_bitcoin_rpc_config(&self) -> BitcoinRpcConfig {
+            BitcoinRpcConfig {
+                kind: "mock".to_string(),
+                url: "http://mock".parse().unwrap(),
+            }
+        }
+
+        fn get_url(&self) -> SafeUrl {
+            "http://mock".parse().unwrap()
+        }
+
+        async fn get_network(&self) -> anyhow::Result<Network> {
+            Err(anyhow::anyhow!("Mock network error"))
+        }
+
+        async fn get_block_count(&self) -> anyhow::Result<u64> {
+            Err(anyhow::anyhow!("Mock block count error"))
+        }
+
+        async fn get_block_hash(&self, _height: u64) -> anyhow::Result<BlockHash> {
+            Err(anyhow::anyhow!("Mock block hash error"))
+        }
+
+        async fn get_block(&self, _block_hash: &BlockHash) -> anyhow::Result<Block> {
+            Err(anyhow::anyhow!("Mock block error"))
+        }
+
+        async fn get_feerate(&self) -> anyhow::Result<Option<Feerate>> {
+            Err(anyhow::anyhow!("Mock feerate error"))
+        }
+
+        async fn submit_transaction(&self, _transaction: fedimint_core::bitcoin::Transaction) {
+            // No-op for mock
+        }
+
+        async fn get_sync_percentage(&self) -> anyhow::Result<Option<f64>> {
+            Err(anyhow::anyhow!("Mock sync percentage error"))
+        }
+    }
 
     const MINTS: u16 = 4;
 
@@ -1324,17 +1351,15 @@ mod tests {
         let task_group = TaskGroup::new();
         let (server_cfg, client_cfg) = build_configs();
 
-        let server = Lightning::new(
-            server_cfg[0].clone(),
-            0.into(),
-            BitcoinRpcConfig {
-                kind: "esplora".to_string(),
-                url: "http://dummy.xyz".parse().unwrap(),
-            },
-            &ServerModuleSharedBitcoin::new(task_group),
-        )
-        .await
-        .unwrap();
+        let server = Lightning {
+            cfg: server_cfg[0].clone(),
+            our_peer_id: 0.into(),
+            server_bitcoin_rpc_monitor: ServerBitcoinRpcMonitor::new(
+                MockBitcoinServerRpc.into_dyn(),
+                Duration::from_secs(1),
+                &task_group,
+            ),
+        };
 
         let preimage = [42u8; 32];
         let encrypted_preimage = EncryptedPreimage(client_cfg.threshold_pub_key.encrypt([42; 32]));
@@ -1396,17 +1421,16 @@ mod tests {
         let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
         let mut dbtx = db.begin_transaction_nc().await;
         let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42).0;
-        let server = Lightning::new(
-            server_cfg[0].clone(),
-            0.into(),
-            BitcoinRpcConfig {
-                kind: "esplora".to_string(),
-                url: "http://dummy.xyz".parse().unwrap(),
-            },
-            &ServerModuleSharedBitcoin::new(task_group),
-        )
-        .await
-        .unwrap();
+
+        let server = Lightning {
+            cfg: server_cfg[0].clone(),
+            our_peer_id: 0.into(),
+            server_bitcoin_rpc_monitor: ServerBitcoinRpcMonitor::new(
+                MockBitcoinServerRpc.into_dyn(),
+                Duration::from_secs(1),
+                &task_group,
+            ),
+        };
 
         let preimage = PreimageKey(generate_keypair(&mut OsRng).1.serialize());
         let funded_incoming_contract = FundedContract::Incoming(FundedIncomingContract {
@@ -1474,17 +1498,16 @@ mod tests {
         let db = Database::new(MemDatabase::new(), ModuleRegistry::default());
         let mut dbtx = db.begin_transaction_nc().await;
         let mut module_dbtx = dbtx.to_ref_with_prefix_module_id(42).0;
-        let server = Lightning::new(
-            server_cfg[0].clone(),
-            0.into(),
-            BitcoinRpcConfig {
-                kind: "esplora".to_string(),
-                url: "http://dummy.xyz".parse().unwrap(),
-            },
-            &ServerModuleSharedBitcoin::new(task_group),
-        )
-        .await
-        .unwrap();
+
+        let server = Lightning {
+            cfg: server_cfg[0].clone(),
+            our_peer_id: 0.into(),
+            server_bitcoin_rpc_monitor: ServerBitcoinRpcMonitor::new(
+                MockBitcoinServerRpc.into_dyn(),
+                Duration::from_secs(1),
+                &task_group,
+            ),
+        };
 
         let preimage = Preimage([42u8; 32]);
         let gateway_key = random_pub_key();

--- a/modules/fedimint-lnv2-server/Cargo.toml
+++ b/modules/fedimint-lnv2-server/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bls12_381 = { workspace = true }
 erased-serde = { workspace = true }
-fedimint-bitcoind = { workspace = true, features = ["fedimint-server"] }
+fedimint-bitcoind = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-lnv2-common = { workspace = true }
 fedimint-logging = { workspace = true }

--- a/modules/fedimint-lnv2-server/src/lib.rs
+++ b/modules/fedimint-lnv2-server/src/lib.rs
@@ -7,10 +7,8 @@ mod db;
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
-use anyhow::{Context, anyhow, ensure, format_err};
+use anyhow::{Context, anyhow, ensure};
 use bls12_381::{G1Projective, Scalar};
-use fedimint_bitcoind::create_bitcoind;
-use fedimint_bitcoind::shared::ServerModuleSharedBitcoin;
 use fedimint_core::bitcoin::hashes::sha256;
 use fedimint_core::config::{
     ConfigGenModuleParams, ServerModuleConfig, ServerModuleConsensusConfig,
@@ -19,7 +17,6 @@ use fedimint_core::config::{
 use fedimint_core::core::ModuleInstanceId;
 use fedimint_core::db::{Database, DatabaseTransaction, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::encoding::Encodable;
-use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::audit::Audit;
 use fedimint_core::module::{
     ApiEndpoint, ApiError, ApiVersion, CORE_CONSENSUS_VERSION, CoreConsensusVersion, InputMeta,
@@ -49,6 +46,7 @@ use fedimint_lnv2_common::{
     LightningOutputOutcome, LightningOutputV0, MODULE_CONSENSUS_VERSION, OutgoingWitness,
 };
 use fedimint_logging::LOG_MODULE_LNV2;
+use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
 use fedimint_server_core::config::{PeerHandleOps, eval_poly_g1};
 use fedimint_server_core::net::check_auth;
 use fedimint_server_core::{ServerModule, ServerModuleInit, ServerModuleInitArgs};
@@ -58,7 +56,6 @@ use group::ff::Field;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use strum::IntoEnumIterator;
-use tokio::sync::watch;
 use tpe::{
     AggregatePublicKey, DecryptionKeyShare, PublicKeyShare, SecretKeyShare, derive_pk_share,
 };
@@ -200,13 +197,11 @@ impl ServerModuleInit for LightningInit {
     }
 
     async fn init(&self, args: &ServerModuleInitArgs<Self>) -> anyhow::Result<Self::Module> {
-        Ok(Lightning::new(
-            args.cfg().to_typed()?,
-            args.db(),
-            args.bitcoin_rpc(),
-            &args.shared(),
-        )
-        .await?)
+        Ok(Lightning {
+            cfg: args.cfg().to_typed()?,
+            db: args.db().clone(),
+            server_bitcoin_rpc_monitor: args.server_bitcoin_rpc_monitor(),
+        })
     }
 
     fn trusted_dealer_gen(
@@ -343,8 +338,7 @@ fn coefficient(index: u64) -> Scalar {
 pub struct Lightning {
     cfg: LightningConfig,
     db: Database,
-    /// Block count updated periodically by a background task
-    block_count_rx: watch::Receiver<Option<u64>>,
+    server_bitcoin_rpc_monitor: ServerBitcoinRpcMonitor,
 }
 
 #[apply(async_trait_maybe_send!)]
@@ -651,29 +645,11 @@ impl ServerModule for Lightning {
 }
 
 impl Lightning {
-    async fn new(
-        cfg: LightningConfig,
-        db: &Database,
-        bitcoin_rpc: BitcoinRpcConfig,
-        shared_bitcoin: &ServerModuleSharedBitcoin,
-    ) -> anyhow::Result<Self> {
-        let btc_rpc = create_bitcoind(&bitcoin_rpc)?;
-
-        let block_count_rx = shared_bitcoin
-            .block_count_receiver(cfg.consensus.network, btc_rpc.clone())
-            .await;
-
-        Ok(Lightning {
-            cfg,
-            db: db.clone(),
-            block_count_rx,
-        })
-    }
-
     fn get_block_count(&self) -> anyhow::Result<u64> {
-        self.block_count_rx
-            .borrow()
-            .ok_or_else(|| format_err!("Block count not available yet"))
+        self.server_bitcoin_rpc_monitor
+            .status()
+            .map(|status| status.block_count)
+            .context("Block count not available yet")
     }
 
     async fn consensus_block_count(&self, dbtx: &mut DatabaseTransaction<'_>) -> u64 {

--- a/modules/fedimint-wallet-common/src/lib.rs
+++ b/modules/fedimint-wallet-common/src/lib.rs
@@ -476,16 +476,6 @@ plugin_types_trait_impl_common!(
     WalletOutputError
 );
 
-#[derive(Debug, Error, Clone)]
-pub enum WalletCreationError {
-    #[error("Connected bitcoind is on wrong network, expected {0}, got {1}")]
-    WrongNetwork(NetworkLegacyEncodingWrapper, NetworkLegacyEncodingWrapper),
-    #[error("Error querying bitcoind: {0}")]
-    RpcError(String),
-    #[error("Feerate source error: {0}")]
-    FeerateSourceError(String),
-}
-
 #[derive(Debug, Error, Encodable, Decodable, Hash, Clone, Eq, PartialEq)]
 pub enum WalletInputError {
     #[error("Unknown block hash in peg-in proof: {0}")]

--- a/modules/fedimint-wallet-server/Cargo.toml
+++ b/modules/fedimint-wallet-server/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = { workspace = true }
 bitcoin = { workspace = true }
 erased-serde = { workspace = true }
 fedimint-api-client = { workspace = true }
-fedimint-bitcoind = { workspace = true, features = ["fedimint-server"] }
+fedimint-bitcoind = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-metrics = { workspace = true }

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -911,7 +911,7 @@ impl ServerModule for Wallet {
                     let config = module.btc_rpc.get_bitcoin_rpc_config();
 
                     // we need to remove auth, otherwise we'll send over the wire
-                    let without_auth = config.url.clone().without_auth().map_err(|_| {
+                    let without_auth = config.url.clone().without_auth().map_err(|()| {
                         ApiError::server_error("Unable to remove auth from bitcoin config URL".to_string())
                     })?;
 

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -32,13 +32,11 @@ use bitcoin::{Address, BlockHash, Network, ScriptBuf, Sequence, Transaction, TxI
 use common::config::WalletConfigConsensus;
 use common::{
     DEPRECATED_RBF_ERROR, PegOutFees, PegOutSignatureItem, ProcessPegOutSigError, SpendableUTXO,
-    TxOutputSummary, WalletCommonInit, WalletConsensusItem, WalletCreationError, WalletInput,
-    WalletModuleTypes, WalletOutput, WalletOutputOutcome, WalletSummary, proprietary_tweak_key,
+    TxOutputSummary, WalletCommonInit, WalletConsensusItem, WalletInput, WalletModuleTypes,
+    WalletOutput, WalletOutputOutcome, WalletSummary, proprietary_tweak_key,
 };
 use envs::get_feerate_multiplier;
 use fedimint_api_client::api::{DynModuleApi, FederationApiExt};
-use fedimint_bitcoind::shared::ServerModuleSharedBitcoin;
-use fedimint_bitcoind::{DynBitcoindRpc, create_bitcoind};
 use fedimint_core::config::{
     ConfigGenModuleParams, ServerModuleConfig, ServerModuleConsensusConfig,
     TypedServerModuleConfig, TypedServerModuleConsensusConfig,
@@ -65,6 +63,7 @@ use fedimint_core::{
     get_network_for_address, push_db_key_items, push_db_pair_items,
 };
 use fedimint_logging::LOG_MODULE_WALLET;
+use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
 use fedimint_server_core::config::{PeerHandleOps, PeerHandleOpsExt};
 use fedimint_server_core::migration::ServerModuleDbMigrationFn;
 use fedimint_server_core::net::check_auth;
@@ -295,8 +294,7 @@ impl ServerModuleInit for WalletInit {
             args.task_group(),
             args.our_peer_id(),
             args.module_api().clone(),
-            args.bitcoin_rpc(),
-            &args.shared(),
+            args.server_bitcoin_rpc_monitor(),
         )
         .await?)
     }
@@ -1006,16 +1004,10 @@ pub struct Wallet {
     cfg: WalletConfig,
     db: Database,
     secp: Secp256k1<All>,
-    btc_rpc: DynBitcoindRpc,
+    btc_rpc: ServerBitcoinRpcMonitor,
     our_peer_id: PeerId,
-    /// Block count updated periodically by a background task
-    block_count_rx: watch::Receiver<Option<u64>>,
-    /// Fee rate updated periodically by a background task
-    fee_rate_rx: watch::Receiver<Option<Feerate>>,
-
     /// Broadcasting pending txes can be triggered immediately with this
     broadcast_pending: Arc<Notify>,
-
     task_group: TaskGroup,
     /// Maximum consensus version supported by *all* our peers. Used to
     /// automatically activate new consensus versions as soon as everyone
@@ -1030,69 +1022,36 @@ impl Wallet {
         task_group: &TaskGroup,
         our_peer_id: PeerId,
         module_api: DynModuleApi,
-        bitcoin_rpc: BitcoinRpcConfig,
-        shared_bitcoin: &ServerModuleSharedBitcoin,
+        server_bitcoin_rpc_monitor: ServerBitcoinRpcMonitor,
     ) -> anyhow::Result<Wallet> {
-        let btc_rpc = create_bitcoind(&bitcoin_rpc)?;
-
-        Ok(Self::new_with_bitcoind(
-            cfg,
-            db,
-            btc_rpc,
-            task_group,
-            our_peer_id,
-            module_api,
-            shared_bitcoin,
-        )
-        .await?)
-    }
-
-    pub async fn new_with_bitcoind(
-        cfg: WalletConfig,
-        db: &Database,
-        btc_rpc: DynBitcoindRpc,
-        task_group: &TaskGroup,
-        our_peer_id: PeerId,
-        module_api: DynModuleApi,
-        shared_bitcoin: &ServerModuleSharedBitcoin,
-    ) -> Result<Wallet, WalletCreationError> {
-        let fee_rate_rx = shared_bitcoin
-            .feerate_receiver(cfg.consensus.network.0, btc_rpc.clone())
-            .await
-            .map_err(|e| {
-                WalletCreationError::FeerateSourceError(e.fmt_compact_anyhow().to_string())
-            })?;
-        let block_count_rx = shared_bitcoin
-            .block_count_receiver(cfg.consensus.network.0, btc_rpc.clone())
-            .await;
         let broadcast_pending = Arc::new(Notify::new());
-        Self::spawn_broadcast_pending_task(task_group, &btc_rpc, db, broadcast_pending.clone());
+        Self::spawn_broadcast_pending_task(
+            task_group,
+            &server_bitcoin_rpc_monitor,
+            db,
+            broadcast_pending.clone(),
+        );
 
         let peer_supported_consensus_version =
             Self::spawn_peer_supported_consensus_version_task(module_api, task_group, our_peer_id);
 
-        let bitcoind_net = NetworkLegacyEncodingWrapper(
-            retry("verify network", backoff_util::aggressive_backoff(), || {
-                btc_rpc.get_network()
-            })
-            .await
-            .map_err(|e| WalletCreationError::RpcError(e.to_string()))?,
-        );
-        if bitcoind_net != cfg.consensus.network {
-            return Err(WalletCreationError::WrongNetwork(
-                cfg.consensus.network,
-                bitcoind_net,
-            ));
-        }
+        let status = retry("verify network", backoff_util::aggressive_backoff(), || {
+            std::future::ready(
+                server_bitcoin_rpc_monitor
+                    .status()
+                    .context("No connection to bitcoin rpc"),
+            )
+        })
+        .await?;
+
+        ensure!(status.network == cfg.consensus.network.0, "Wrong Network");
 
         let wallet = Wallet {
             cfg,
             db: db.clone(),
             secp: Default::default(),
-            btc_rpc,
+            btc_rpc: server_bitcoin_rpc_monitor,
             our_peer_id,
-            block_count_rx,
-            fee_rate_rx,
             task_group: task_group.clone(),
             peer_supported_consensus_version,
             broadcast_pending,
@@ -1203,11 +1162,12 @@ impl Wallet {
     }
 
     fn get_block_count(&self) -> anyhow::Result<u32> {
-        self.block_count_rx
-            .borrow()
-            .ok_or_else(|| format_err!("Block count not available yet"))
-            .and_then(|block_count| {
-                block_count
+        self.btc_rpc
+            .status()
+            .context("No bitcoin rpc connection")
+            .and_then(|status| {
+                status
+                    .block_count
                     .try_into()
                     .map_err(|_| format_err!("Block count exceeds u32 limits"))
             })
@@ -1220,9 +1180,9 @@ impl Wallet {
         #[allow(clippy::cast_sign_loss)]
         Feerate {
             sats_per_kvb: ((self
-                .fee_rate_rx
-                .borrow()
-                .unwrap_or(self.cfg.consensus.default_fee)
+                .btc_rpc
+                .status()
+                .map_or(self.cfg.consensus.default_fee, |status| status.fee_rate)
                 .sats_per_kvb as f64
                 * get_feerate_multiplier())
             .round()) as u64,
@@ -1337,16 +1297,16 @@ impl Wallet {
             .await
             .expect("bitcoind rpc to get block hash");
 
+            let block = retry("get_block", backoff_util::background_backoff(), || {
+                self.btc_rpc.get_block(&block_hash)
+            })
+            .await
+            .expect("bitcoind rpc to get block");
+
             if self.consensus_module_consensus_version(dbtx).await
                 >= ModuleConsensusVersion::new(2, 2)
             {
-                let block = retry("get_block", backoff_util::background_backoff(), || {
-                    self.btc_rpc.get_block(&block_hash)
-                })
-                .await
-                .expect("bitcoind rpc to get block");
-
-                for transaction in block.txdata {
+                for transaction in block.txdata.clone() {
                     // We maintain the subset of unspent P2WSH transaction outputs created
                     // since the module was running on the new consensus version, which might be
                     // the same time as the genesis session.
@@ -1391,15 +1351,7 @@ impl Wallet {
                 "Recognizing change UTXOs"
             );
             for (txid, tx) in &pending_transactions {
-                let is_tx_in_block =
-                    retry("is_tx_in_block", backoff_util::background_backoff(), || {
-                        self.btc_rpc
-                            .is_tx_in_block(txid, &block_hash, u64::from(height))
-                    })
-                    .await
-                    .unwrap_or_else(|_| {
-                        panic!("Failed checking if tx is in block height {height}")
-                    });
+                let is_tx_in_block = block.txdata.iter().any(|tx| tx.compute_txid() == *txid);
 
                 if is_tx_in_block {
                     debug!(
@@ -1650,14 +1602,14 @@ impl Wallet {
 
     fn spawn_broadcast_pending_task(
         task_group: &TaskGroup,
-        bitcoind: &DynBitcoindRpc,
+        server_bitcoin_rpc_monitor: &ServerBitcoinRpcMonitor,
         db: &Database,
         broadcast_pending_notify: Arc<Notify>,
     ) {
         task_group.spawn_cancellable("broadcast pending", {
-            let bitcoind = bitcoind.clone();
+            let btc_rpc = server_bitcoin_rpc_monitor.clone();
             let db = db.clone();
-            run_broadcast_pending_tx(db, bitcoind, broadcast_pending_notify)
+            run_broadcast_pending_tx(db, btc_rpc, broadcast_pending_notify)
         });
     }
 
@@ -1830,7 +1782,11 @@ impl Wallet {
 }
 
 #[instrument(target = LOG_MODULE_WALLET, level = "debug", skip_all)]
-pub async fn run_broadcast_pending_tx(db: Database, rpc: DynBitcoindRpc, broadcast: Arc<Notify>) {
+pub async fn run_broadcast_pending_tx(
+    db: Database,
+    rpc: ServerBitcoinRpcMonitor,
+    broadcast: Arc<Notify>,
+) {
     loop {
         // Unless something new happened, we broadcast once a minute
         let _ = tokio::time::timeout(Duration::from_secs(60), broadcast.notified()).await;
@@ -1838,7 +1794,10 @@ pub async fn run_broadcast_pending_tx(db: Database, rpc: DynBitcoindRpc, broadca
     }
 }
 
-pub async fn broadcast_pending_tx(mut dbtx: DatabaseTransaction<'_>, rpc: &DynBitcoindRpc) {
+pub async fn broadcast_pending_tx(
+    mut dbtx: DatabaseTransaction<'_>,
+    rpc: &ServerBitcoinRpcMonitor,
+) {
     let pending_tx: Vec<PendingTransaction> = dbtx
         .find_by_prefix(&PendingTransactionPrefixKey)
         .await

--- a/modules/fedimint-wallet-server/src/lib.rs
+++ b/modules/fedimint-wallet-server/src/lib.rs
@@ -295,6 +295,7 @@ impl ServerModuleInit for WalletInit {
             args.task_group(),
             args.our_peer_id(),
             args.module_api().clone(),
+            args.bitcoin_rpc(),
             &args.shared(),
         )
         .await?)
@@ -1029,9 +1030,11 @@ impl Wallet {
         task_group: &TaskGroup,
         our_peer_id: PeerId,
         module_api: DynModuleApi,
+        bitcoin_rpc: BitcoinRpcConfig,
         shared_bitcoin: &ServerModuleSharedBitcoin,
     ) -> anyhow::Result<Wallet> {
-        let btc_rpc = create_bitcoind(&cfg.local.bitcoin_rpc)?;
+        let btc_rpc = create_bitcoind(&bitcoin_rpc)?;
+
         Ok(Self::new_with_bitcoind(
             cfg,
             db,

--- a/modules/fedimint-wallet-tests/Cargo.toml
+++ b/modules/fedimint-wallet-tests/Cargo.toml
@@ -28,6 +28,7 @@ fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-server = { workspace = true }
+fedimint-server-core = { workspace = true }
 fedimint-testing = { workspace = true }
 fedimint-testing-core = { workspace = true }
 fedimint-wallet-client = { workspace = true }

--- a/modules/fedimint-wallet-tests/tests/tests.rs
+++ b/modules/fedimint-wallet-tests/tests/tests.rs
@@ -7,20 +7,20 @@ use anyhow::{Context, anyhow, bail};
 use assert_matches::assert_matches;
 use bitcoin::secp256k1;
 use fedimint_api_client::api::DynGlobalApi;
-use fedimint_bitcoind::shared::ServerModuleSharedBitcoin;
 use fedimint_client::ClientHandleArc;
 use fedimint_client::secret::{PlainRootSecretStrategy, RootSecretStrategy};
 use fedimint_core::db::mem_impl::MemDatabase;
 use fedimint_core::db::{DatabaseTransaction, IRawDatabaseExt};
 use fedimint_core::envs::BitcoinRpcConfig;
 use fedimint_core::module::serde_json;
-use fedimint_core::task::sleep_in_test;
+use fedimint_core::task::{TaskGroup, sleep_in_test};
 use fedimint_core::util::{BoxStream, NextOrPending, SafeUrl, retry};
 use fedimint_core::{Amount, BitcoinHash, Feerate, InPoint, PeerId, TransactionId, sats};
 use fedimint_dummy_client::DummyClientInit;
 use fedimint_dummy_common::config::DummyGenParams;
 use fedimint_dummy_server::DummyInit;
-use fedimint_server::core::{ServerModule, ServerModuleShared as _};
+use fedimint_server::core::ServerModule;
+use fedimint_server_core::bitcoin_rpc::ServerBitcoinRpcMonitor;
 use fedimint_testing::btc::BitcoinTest;
 use fedimint_testing::envs::{FM_TEST_BACKEND_BITCOIN_RPC_KIND_ENV, FM_TEST_USE_REAL_DAEMONS_ENV};
 use fedimint_testing::federation::FederationTest;
@@ -669,6 +669,7 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
     let bitcoin = fixtures.bitcoin();
     let server_bitcoin_rpc_config = fixtures.bitcoin_server();
     let dyn_bitcoin_rpc = fixtures.dyn_bitcoin_rpc();
+    let bitcoin_rpc_connection = fixtures.bitcoin_rpc_connection();
     let db = MemDatabase::new().into_database();
     let task_group = fedimint_core::task::TaskGroup::new();
     info!("Starting test peg_ins_that_are_unconfirmed_are_rejected");
@@ -689,10 +690,9 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         .tweak(&pk, secp256k1::SECP256K1)
         .address(wallet_config.consensus.network.0)?;
 
-    let mut wallet = fedimint_wallet_server::Wallet::new_with_bitcoind(
+    let mut wallet = fedimint_wallet_server::Wallet::new(
         wallet_server_cfg[0].to_typed()?,
         &db,
-        dyn_bitcoin_rpc.clone(),
         &task_group,
         PeerId::from(0),
         // FIXME: use proper mock
@@ -705,7 +705,11 @@ async fn peg_ins_that_are_unconfirmed_are_rejected() -> anyhow::Result<()> {
         )
         .await?
         .with_module(module_instance_id),
-        &ServerModuleSharedBitcoin::new(task_group.clone()),
+        ServerBitcoinRpcMonitor::new(
+            bitcoin_rpc_connection.clone(),
+            Duration::from_secs(1),
+            &TaskGroup::new(),
+        ),
     )
     .await?;
 


### PR DESCRIPTION
In this pr we ignore the bitcoin rpc config in the modules local config and instead inject a global shared bitcoin rpc object via the server module init args. 

This so called ServerBitcoinRpcMonitor wraps a IServerBitcoinRpc trait object that is either esplora or bitcoind and fetches the network, feerate and block count every minute, such that we can display a connection status in the UI and do not hit rate limiting with public esplora backends. 

fedimintd parses the bitcoin rpc config from the environment variables via clap and created the appropriate  IServerBitcoinRpc trait object for injection into fedimint-server similar to the UI. This way fedimint-server does not depend on the new crate containing the implementation called fedimint-server-bitbcoin-rpc, again similar to fedimint-server-ui.

The IServerBitcoinRpc has the subset of the methods of the current IBitcoinRpc required for the server. In a follow up we intend to remove the dependence of fedimint-lightning and fedimint-wallet-client on fedimint-bitcoind such that the fedimint-bitcoind crate may be removed entirely. fedimint-wallet-client always assumed an esplora client and furthermore used methods disjoint to the fedimint-server so a shared trait object is misplaced here.


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
