### PR TITLE
fix: LNv1 unannounce when LN node is disconnected

### DIFF
--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -484,6 +484,8 @@ impl Gateway {
                         crit!(target: LOG_GATEWAY, err = %err.fmt_compact_anyhow(), "Lightning payment stream task group shutdown");
                     }
 
+                    self_copy.unannounce_from_all_federations().await;
+
                     match route_payments_response {
                         ReceivePaymentStreamAction::RetryAfterDelay => {
                             warn!(target: LOG_GATEWAY, retry_interval = %PAYMENT_STREAM_RETRY_SECONDS, "Disconnected from lightning node");


### PR DESCRIPTION
Fixes: https://github.com/fedimint/fedimint/issues/6519

In LNv1, gateway will un-announce itself from all federations when it is disconnected from its Lightning node so that clients don't accidentally use it while the LN node is offline.