### PR TITLE
fix: add zlib to resolve linker errors

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -228,6 +228,10 @@ let
     nativeBuildInputs =
       with pkgs;
       [
+        # TODO: this may be the wrong approach but unblocks v0.7.0 release
+        # https://github.com/fedimint/fedimint/issues/7190
+        zlib
+
         pkg-config
         moreutils-ts
 


### PR DESCRIPTION
`cargo build -p fedimint-gateway-client` fails with `mold: fatal: library not found: z`. This may not be the correct approach but is necessary to unblock the `v0.7.0` release.

Followup issue for ensuring the correct approach when @dpc is back: https://github.com/fedimint/fedimint/issues/7190