### PR TITLE
[Backport releases/v0.7] fix: add zlib to resolve linker errors

### DIFF
--- a/nix/flakebox.nix
+++ b/nix/flakebox.nix
@@ -228,6 +228,10 @@ let
     nativeBuildInputs =
       with pkgs;
       [
+        # TODO: this may be the wrong approach but unblocks v0.7.0 release
+        # https://github.com/fedimint/fedimint/issues/7190
+        zlib
+
         pkg-config
         moreutils-ts
 


### PR DESCRIPTION
# Description
Backport of #7189 to `releases/v0.7`.