### PR TITLE
fix: explicitly link traefik routers to services

### DIFF
--- a/docker/deploy-fedimintd/.env
+++ b/docker/deploy-fedimintd/.env
@@ -15,4 +15,4 @@ FM_BITCOIN_RPC_URL=http://bitcoin:bitcoin@bitcoin:8332
 # FM_BITCOIN_RPC_URL=https://blockstream.info/api/
 
 # fedimintd image
-FEDIMINTD_IMAGE=fedimint/fedimintd:v0.6.1
+FEDIMINTD_IMAGE=fedimint/fedimintd:v0.7.0-rc.1

--- a/docker/deploy-fedimintd/docker-compose.yaml
+++ b/docker/deploy-fedimintd/docker-compose.yaml
@@ -65,15 +65,18 @@ services:
     restart: always
     labels:
       - "traefik.enable=true"
-      - "traefik.http.services.fedimintd.loadbalancer.server.port=8174"
-      - "traefik.http.routers.fedimintd.rule=Host(`${FM_DOMAIN}`) && Path(`/ws/`)"
-      - "traefik.http.routers.fedimintd.entrypoints=websecure"
-      - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
-      # Add UI routes for the built-in guardian dashboard UI
-      - "traefik.http.services.fedimintd-ui.loadbalancer.server.port=8175"
+      # API Service
+      - "traefik.http.routers.fedimintd-api.rule=Host(`${FM_DOMAIN}`) && Path(`/ws/`)"
+      - "traefik.http.routers.fedimintd-api.entrypoints=websecure"
+      - "traefik.http.routers.fedimintd-api.tls.certresolver=myresolver"
+      - "traefik.http.routers.fedimintd-api.service=fedimintd-api"
+      - "traefik.http.services.fedimintd-api.loadbalancer.server.port=8174"
+      # UI Service
       - "traefik.http.routers.fedimintd-ui.rule=Host(`${FM_DOMAIN}`)"
       - "traefik.http.routers.fedimintd-ui.entrypoints=websecure"
       - "traefik.http.routers.fedimintd-ui.tls.certresolver=myresolver"
+      - "traefik.http.routers.fedimintd-ui.service=fedimintd-ui"
+      - "traefik.http.services.fedimintd-ui.loadbalancer.server.port=8175"
     networks:
       fedimint_network:
         ipv4_address: 172.20.0.11


### PR DESCRIPTION
Our standard docker env (no iroh) fails to load the UI with a 404 error when we navigate to `https://fedimintd-docker-<peer_id>.dev.fedimint.org`. Inspecting the traefik logs we see

```
root@ubuntu-4gb-fsn1-1:~/fedimint-docker# docker compose logs traefik
traefik  | time="2025-04-10T14:04:53Z" level=info msg="Configuration loaded from flags."
traefik  | time="2025-04-10T14:04:53Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=fedimintd-ui
traefik  | time="2025-04-10T14:04:53Z" level=error msg="Could not define the service name for the router: too many services" providerName=docker routerName=fedimintd
```

We can resolve this by explicitly linking each router to its corresponding service.

With these changes, I'm able to successfully setup a new federation on our Hetzner docker env and join the federation. When we cut `v0.7.0` I'll create an additional PR to bump the tag from `v0.7.0-rc.1`.