### PR TITLE
fix(docker): set default esplora server for mutinynet

### DIFF
--- a/docker/iroh-fedimintd/docker-compose.yaml
+++ b/docker/iroh-fedimintd/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - FM_BITCOIN_NETWORK=signet
       - FM_BITCOIN_RPC_KIND=esplora
       - FM_BITCOIN_RPC_URL=https://mutinynet.com/api
+      - FM_DEFAULT_ESPLORA_API=https://mutinynet.com/api
       - FM_BIND_P2P=0.0.0.0:8173
       - FM_BIND_API_IROH=0.0.0.0:8174
       - FM_BIND_API_WS=172.25.0.11:8174


### PR DESCRIPTION
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
