### PR TITLE
fix(core): disambiguate macro impl

### DIFF
--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -785,7 +785,7 @@ macro_rules! extensible_associated_module_type {
                 use $crate::bitcoin::hashes::hex::DisplayHex;
                 match self {
                     $name::V0(v0) => {
-                        v0.fmt(f)?;
+                        std::fmt::Debug::fmt(v0, f)?;
                     }
                     $name::Default { variant, bytes } => {
                         f.debug_struct(stringify!($name))


### PR DESCRIPTION
If a V0 type impls both Debug and Display, the macro fails with:

```
   --> /home/dpc/.cargo/git/checkouts/fedimint-6aee50a66a9b36ef/4d2a165/fedimint-core/src/macros.rs:789:25
    |
789 |                         Debug::fmt(&v0, f)?;
    |                         ~~~~~~~~~~~~~~~~~~
help: disambiguate the method for candidate #2
   --> /home/dpc/.cargo/git/checkouts/fedimint-6aee50a66a9b36ef/4d2a165/fedimint-core/src/macros.rs:789:25
    |
789 |                         std::fmt::Display::fmt(&v0, f)?;
    |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

or similar.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
