### PR TITLE
[Backport releases/v0.6] fix(core): disambiguate macro impl

### DIFF
--- a/fedimint-core/src/macros.rs
+++ b/fedimint-core/src/macros.rs
@@ -786,7 +786,7 @@ macro_rules! extensible_associated_module_type {
                 use $crate::bitcoin::hashes::hex::DisplayHex;
                 match self {
                     $name::V0(v0) => {
-                        v0.fmt(f)?;
+                        std::fmt::Debug::fmt(v0, f)?;
                     }
                     $name::Default { variant, bytes } => {
                         f.debug_struct(stringify!($name))


### PR DESCRIPTION
# Description
Backport of #7204 to `releases/v0.6`.