### PR TITLE
chore: bump macos release packages timeout

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -425,7 +425,7 @@ jobs:
             shasum-cmd: sha256sum
           - name: macos-aarch64
             runs-on: macos-14
-            timeout: 90
+            timeout: 180
             build-deb: false
             build-rpm: false
             build-bundled: false


### PR DESCRIPTION
During the `v0.7.0` release, the macOS build timed out after 90 minutes:

https://github.com/fedimint/fedimint/actions/runs/14391263459/job/40363731901

I suggest we don't attempt to rerun the build solely to publish macOS artifacts unless specifically requested by a user.