### PR TITLE
chore: cleanup codepaths for version v0.4

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -1178,13 +1178,11 @@ async fn cli_set_config_gen_params(
     auth: &ApiAuth,
     mut server_gen_params: ServerModuleConfigGenParamsRegistry,
 ) -> Result<()> {
-    let fedimintd_version = crate::util::FedimintdCmd::version_or_default().await;
     self::config::attach_default_module_init_params(
         &BitcoinRpcConfig::get_defaults_from_env_vars()?,
         &mut server_gen_params,
         Network::Regtest,
         10,
-        &fedimintd_version,
     );
 
     let meta = iter::once(("federation_name".to_string(), "testfed".to_string())).collect();

--- a/devimint/src/tests.rs
+++ b/devimint/src/tests.rs
@@ -31,7 +31,7 @@ use crate::envs::{FM_DATA_DIR_ENV, FM_DEVIMINT_RUN_DEPRECATED_TESTS_ENV, FM_PASS
 use crate::federation::Client;
 use crate::gatewayd::LdkChainSource;
 use crate::util::{LoadTestTool, ProcessManager, poll};
-use crate::version_constants::{VERSION_0_5_0_ALPHA, VERSION_0_6_0_ALPHA, VERSION_0_7_0_ALPHA};
+use crate::version_constants::{VERSION_0_6_0_ALPHA, VERSION_0_7_0_ALPHA};
 use crate::{DevFed, Gatewayd, LightningNode, Lnd, cmd, dev_fed, poll_eq};
 
 pub struct Stats {
@@ -622,8 +622,6 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
         .await?;
     cmd!(client, "list-gateways").run().await?;
 
-    let fedimint_cli_version = crate::util::FedimintCli::version_or_default().await;
-
     let invite_code = cmd!(client, "dev", "decode", "invite-code", invite.clone())
         .out_json()
         .await?;
@@ -863,23 +861,19 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
     assert_eq!(post_withdraw_walletng_balance, expected_wallet_balance);
 
     // # peer-version command
+    let peer_0_fedimintd_version = cmd!(client, "dev", "peer-version", "--peer-id", "0")
+        .out_json()
+        .await?
+        .get("version")
+        .expect("Output didn't contain version")
+        .as_str()
+        .unwrap()
+        .to_owned();
 
-    // TODO(support:v0.4): peer-version command was introduced in 0.5
-    if fedimintd_version >= *VERSION_0_5_0_ALPHA && fedimint_cli_version >= *VERSION_0_5_0_ALPHA {
-        let peer_0_fedimintd_version = cmd!(client, "dev", "peer-version", "--peer-id", "0")
-            .out_json()
-            .await?
-            .get("version")
-            .expect("Output didn't contain version")
-            .as_str()
-            .unwrap()
-            .to_owned();
-
-        assert_eq!(
-            semver::Version::parse(&peer_0_fedimintd_version)?,
-            fedimintd_version
-        );
-    }
+    assert_eq!(
+        semver::Version::parse(&peer_0_fedimintd_version)?,
+        fedimintd_version
+    );
 
     // # API URL announcements
     let initial_announcements = serde_json::from_value::<BTreeMap<PeerId, SignedApiAnnouncement>>(
@@ -960,10 +954,6 @@ pub async fn cli_tests(dev_fed: DevFed) -> Result<()> {
 
 pub async fn cli_load_test_tool_test(dev_fed: DevFed) -> Result<()> {
     log_binary_versions().await?;
-    if crate::util::Gatewayd::version_or_default().await < *VERSION_0_5_0_ALPHA {
-        info!("Skipping load test because gatewayd is lower than v0.5.0");
-        return Ok(());
-    }
     let data_dir = env::var(FM_DATA_DIR_ENV)?;
     let load_test_temp = PathBuf::from(data_dir).join("load-test-temp");
     dev_fed

--- a/devimint/src/version_constants.rs
+++ b/devimint/src/version_constants.rs
@@ -2,8 +2,6 @@ use std::sync::LazyLock;
 
 use semver::Version;
 
-pub static VERSION_0_5_0_ALPHA: LazyLock<Version> =
-    LazyLock::new(|| Version::parse("0.5.0-alpha").expect("version is parsable"));
 pub static VERSION_0_6_0_ALPHA: LazyLock<Version> =
     LazyLock::new(|| Version::parse("0.6.0-alpha").expect("version is parsable"));
 pub static VERSION_0_7_0_ALPHA: LazyLock<Version> =

--- a/modules/fedimint-meta-tests/src/bin/meta-module-tests.rs
+++ b/modules/fedimint-meta-tests/src/bin/meta-module-tests.rs
@@ -2,10 +2,9 @@ use std::future::Future;
 
 use anyhow::{Result, bail};
 use clap::Parser;
+use devimint::cmd;
 use devimint::federation::Client;
 use devimint::util::poll_simple;
-use devimint::version_constants::VERSION_0_5_0_ALPHA;
-use devimint::{cmd, util};
 use fedimint_core::PeerId;
 use serde_json::json;
 use tracing::{info, warn};
@@ -27,8 +26,6 @@ async fn main() -> anyhow::Result<()> {
 async fn sanity_tests() -> anyhow::Result<()> {
     devimint::run_devfed_test()
         .call(|dev_fed, _process_mgr| async move {
-            let fedimint_cli_version = util::FedimintCli::version_or_default().await;
-
             let client = dev_fed
                 .fed()
                 .await?
@@ -185,20 +182,16 @@ async fn sanity_tests() -> anyhow::Result<()> {
             )
             .await?;
 
-            // TODO(support:v0.4): meta fields were introduced in v0.5.0
-            // see: https://github.com/fedimint/fedimint/pull/5781
-            if fedimint_cli_version >= *VERSION_0_5_0_ALPHA {
-                let meta_fields = get_meta_fields(&client).await?;
-                assert_eq!(
-                    meta_fields,
-                    json! {
-                        {
-                            "revision": 0,
-                            "values": submission_value,
-                        }
+            let meta_fields = get_meta_fields(&client).await?;
+            assert_eq!(
+                meta_fields,
+                json! {
+                    {
+                        "revision": 0,
+                        "values": submission_value,
                     }
-                );
-            }
+                }
+            );
 
             Ok(())
         })

--- a/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
+++ b/modules/fedimint-mint-tests/src/bin/mint-module-tests.rs
@@ -2,8 +2,6 @@ use anyhow::{Context as _, Result};
 use clap::Parser;
 use devimint::cmd;
 use devimint::federation::Federation;
-use devimint::util::FedimintCli;
-use devimint::version_constants::VERSION_0_5_0_ALPHA;
 use fedimint_logging::LOG_DEVIMINT;
 use rand::Rng;
 use tracing::info;
@@ -35,12 +33,6 @@ async fn restore() -> anyhow::Result<()> {
 
 pub async fn test_restore_gap_test(fed: &Federation) -> Result<()> {
     let client = fed.new_joined_client("restore-gap-test").await?;
-    let fedimint_cli_version = FedimintCli::version_or_default().await;
-
-    if fedimint_cli_version < *VERSION_0_5_0_ALPHA {
-        return Ok(());
-    }
-
     const PEGIN_SATS: u64 = 300000;
     fed.pegin_client(PEGIN_SATS, &client).await?;
 


### PR DESCRIPTION
We no longer test `v0.4` for back-compat or upgrade tests vs master, so we can remove deprecated test logic.