### PR TITLE
cleanup: change to mempool.space for esplora default and mutinynet for only supported signet

### DIFF
--- a/fedimintd/src/envs.rs
+++ b/fedimintd/src/envs.rs
@@ -40,8 +40,5 @@ pub const FM_BIND_METRICS_API_ENV: &str = "FM_BIND_METRICS_API";
 // Env variable to TODO
 pub const FM_PORT_ESPLORA_ENV: &str = "FM_PORT_ESPLORA";
 
-/// Bitcoin API communicated to fedimint clients to use for deposits
-pub const FM_DEFAULT_ESPLORA_API_ENV: &str = "FM_DEFAULT_ESPLORA_API";
-
 // Can be used to absolutely override the values stored in the db
 pub const FM_FORCE_API_SECRETS_ENV: &str = "FM_FORCE_API_SECRETS";

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -15,29 +15,22 @@ pub use fedimintd::*;
 mod fedimintd;
 
 pub mod envs;
-use crate::envs::{FM_DEFAULT_ESPLORA_API_ENV, FM_PORT_ESPLORA_ENV};
+use crate::envs::FM_PORT_ESPLORA_ENV;
 
-#[allow(clippy::map_unwrap_or)]
 pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
-    let url = std::env::var(FM_DEFAULT_ESPLORA_API_ENV)
-        .ok()
-        .map(|s| SafeUrl::parse(&s).expect("Failed to parse default esplora server"))
-        .unwrap_or_else(|| match network {
-            Network::Bitcoin => SafeUrl::parse("https://blockstream.info/api/")
-                .expect("Failed to parse default esplora server"),
-            Network::Testnet => SafeUrl::parse("https://blockstream.info/testnet/api/")
-                .expect("Failed to parse default esplora server"),
+    BitcoinRpcConfig {
+        kind: "esplora".to_string(),
+        url: match network {
+            Network::Bitcoin => SafeUrl::parse("https://mempool.space/api/"),
+            Network::Testnet => SafeUrl::parse("https://mempool.space/testnet/api/"),
+            Network::Testnet4 => SafeUrl::parse("https://mempool.space/testnet4/api/"),
+            Network::Signet => SafeUrl::parse("https://mutinynet.com/api/"),
             Network::Regtest => SafeUrl::parse(&format!(
                 "http://127.0.0.1:{}/",
                 std::env::var(FM_PORT_ESPLORA_ENV).unwrap_or(String::from("50002"))
-            ))
-            .expect("Failed to parse default esplora server"),
-            Network::Signet => SafeUrl::parse("https://blockstream.info/signet/api/")
-                .expect("Failed to parse default esplora server"),
+            )),
             _ => panic!("Failed to parse default esplora server"),
-        });
-    BitcoinRpcConfig {
-        kind: "esplora".to_string(),
-        url,
+        }
+        .expect("Failed to parse default esplora server"),
     }
 }


### PR DESCRIPTION


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
