### PR TITLE
refactor: reference workspace for package dependencies

### DIFF
--- a/fedimint-cli/Cargo.toml
+++ b/fedimint-cli/Cargo.toml
@@ -31,9 +31,9 @@ bitcoin = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4.5.47"
 fedimint-aead = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.8.0-alpha" }
+fedimint-api-client = { workspace = true }
 fedimint-bip39 = { workspace = true }
-fedimint-client = { path = "../fedimint-client", version = "=0.8.0-alpha" }
+fedimint-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-ln-client = { workspace = true, features = ["cli"] }

--- a/fedimint-client-module/Cargo.toml
+++ b/fedimint-client-module/Cargo.toml
@@ -29,7 +29,7 @@ aquamarine = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
-fedimint-api-client = { path = "../fedimint-api-client", version = "=0.8.0-alpha" }
+fedimint-api-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }

--- a/fedimint-testing/Cargo.toml
+++ b/fedimint-testing/Cargo.toml
@@ -31,8 +31,8 @@ fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-gateway-common = { workspace = true }
-fedimint-gateway-server = { package = "fedimint-gateway-server", path = "../gateway/fedimint-gateway-server", version = "=0.8.0-alpha" }
-fedimint-lightning = { package = "fedimint-lightning", path = "../gateway/fedimint-lightning", version = "=0.8.0-alpha" }
+fedimint-gateway-server = { workspace = true }
+fedimint-lightning = { workspace = true }
 fedimint-ln-common = { workspace = true }
 fedimint-logging = { workspace = true }
 fedimint-portalloc = { workspace = true }

--- a/gateway/fedimint-gateway-common/Cargo.toml
+++ b/gateway/fedimint-gateway-common/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 bitcoin = { workspace = true }
 clap = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.8.0-alpha" }
+fedimint-api-client = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-eventlog = { workspace = true }
 fedimint-lnv2-common = { workspace = true }

--- a/gateway/fedimint-gateway-server/Cargo.toml
+++ b/gateway/fedimint-gateway-server/Cargo.toml
@@ -49,7 +49,7 @@ fedimint-gateway-common = { workspace = true }
 fedimint-gateway-server-db = { workspace = true }
 fedimint-gw-client = { workspace = true }
 fedimint-gwv2-client = { workspace = true }
-fedimint-lightning = { path = "../fedimint-lightning", version = "=0.8.0-alpha" }
+fedimint-lightning = { workspace = true }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
 fedimint-lnv2-client = { workspace = true }

--- a/gateway/fedimint-lightning/Cargo.toml
+++ b/gateway/fedimint-lightning/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
-fedimint-bip39 = { version = "=0.8.0-alpha", path = "../../fedimint-bip39" }
+fedimint-bip39 = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-gateway-common = { workspace = true }
 fedimint-ln-common = { workspace = true }

--- a/modules/fedimint-gw-client/Cargo.toml
+++ b/modules/fedimint-gw-client/Cargo.toml
@@ -26,13 +26,13 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitcoin = { workspace = true }
 erased-serde = { workspace = true }
-fedimint-api-client = { path = "../../fedimint-api-client", version = "=0.8.0-alpha" }
+fedimint-api-client = { workspace = true }
 fedimint-client = { workspace = true }
 fedimint-client-module = { workspace = true }
 fedimint-core = { workspace = true }
 fedimint-derive-secret = { workspace = true }
 fedimint-eventlog = { workspace = true }
-fedimint-lightning = { path = "../../gateway/fedimint-lightning", version = "=0.8.0-alpha" }
+fedimint-lightning = { workspace = true }
 fedimint-ln-client = { workspace = true }
 fedimint-ln-common = { workspace = true }
 futures = { workspace = true }


### PR DESCRIPTION
Working towards https://github.com/fedimint/fedimint/issues/7177.

This diff is straightforward except for [`3a03418` (#7237)](https://github.com/fedimint/fedimint/pull/7237/commits/3a034182d580fc69b6e4bd315744d987982eb9ad), which inspired me to make the initial PR smaller so this is carefully considered. Part of the discussions regarding https://github.com/fedimint/fedimint/pull/7183 included explicitly dropping support for the `bitcoincore-rpc` feature in `fedimint-wallet-client`.

Please voice any concerns if we should keep the `bitcoincore-rpc` in `fedimint-wallet-client` (cc: @m1sterc001guy @elsirion @joschisan).

Once we merge this, I'll have a followup PR that centralizes the remaining dependencies into the root `Cargo.toml`.