### PR TITLE
chore(ci): specify architecture for self-hosted runners

### DIFF
--- a/.github/workflows/ci-backwards-compatibility.yml
+++ b/.github/workflows/ci-backwards-compatibility.yml
@@ -30,7 +30,7 @@ jobs:
   tests:
     if: github.repository == 'fedimint/fedimint'
     name: "Backwards-compatibility tests"
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 60
 
     steps:
@@ -76,7 +76,7 @@ jobs:
     if: always() && github.repository == 'fedimint/fedimint' && github.event_name != 'merge_group'
     name: "Notifications"
     timeout-minutes: 1
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     needs: [ tests ]
 
     steps:

--- a/.github/workflows/ci-fuzz.yml
+++ b/.github/workflows/ci-fuzz.yml
@@ -28,7 +28,7 @@ jobs:
   tests:
     if: github.repository == 'fedimint/fedimint'
     name: "Quick fuzzing"
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 60
 
     steps:
@@ -65,7 +65,7 @@ jobs:
     if: always() && github.repository == 'fedimint/fedimint' && github.event_name != 'merge_group'
     name: "Notifications"
     timeout-minutes: 1
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     needs: [ tests ]
 
     steps:

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -41,7 +41,7 @@ jobs:
 
   lint:
     name: "Lint"
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           - macos
         include:
           - host: linux
-            runs-on: [self-hosted, linux]
+            runs-on: [self-hosted, linux, x64]
             build-in-pr: false
             timeout: 30
           - host: macos
@@ -115,7 +115,7 @@ jobs:
           - macos
         include:
           - host: linux
-            runs-on: [self-hosted, linux]
+            runs-on: [self-hosted, linux, x64]
             build-in-pr: true
             timeout: 90
             run-tests: true
@@ -215,7 +215,7 @@ jobs:
   audit:
     if: github.repository == 'fedimint/fedimint'
     name: "Audit"
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     # sometimes we can't fix these immediately, yet
     # we don't want to stop the world because of it
@@ -254,7 +254,7 @@ jobs:
           - wasm32-unknown
         include:
           - host: linux
-            runs-on: [self-hosted, linux]
+            runs-on: [self-hosted, linux, x64]
             build-in-pr: true
             # TODO: debugging network issues, should reduce to 20 minutes
             # https://github.com/fedimint/fedimint/issues/4488
@@ -303,7 +303,7 @@ jobs:
   containers:
     if: github.repository == 'fedimint/fedimint'
     name: "Containers"
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 60
     steps:
       - name: Checkout Code
@@ -417,7 +417,7 @@ jobs:
       matrix:
         platform:
           - name: linux
-            runs-on: [self-hosted, linux]
+            runs-on: [self-hosted, linux, x64]
             timeout: 60
             build-deb: true
             build-rpm: true
@@ -596,7 +596,7 @@ jobs:
     name: Status
     needs: [lint, shell, build, cross, containers, pkgs]
     if: ${{ always() }}
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Check status of all jobs
         if: >-
@@ -610,7 +610,7 @@ jobs:
     if: always() && github.repository == 'fedimint/fedimint' && github.event_name != 'merge_group'
     name: "Notifications"
     timeout-minutes: 1
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     # note: we don't depend on `audit` because it will
     # be often broken, and we can't fix it immediately
     needs: [ lint, build, shell, cross, containers, pkgs ]

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ name: Daily check
 
 jobs:
   audit:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
       - name: Run cargo audit
@@ -20,7 +20,7 @@ jobs:
     if: always() && github.repository == 'fedimint/fedimint'
     name: "Notifications"
     timeout-minutes: 1
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     needs: [ audit ]
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docs:
     name: Publish docs
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     if: always() && github.repository == 'fedimint/fedimint' && github.event_name != 'merge_group'
     name: "Notifications"
     timeout-minutes: 1
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     needs: [ docs ]
 
     steps:

--- a/.github/workflows/hourly-run.yml
+++ b/.github/workflows/hourly-run.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - host: linux
             # no one is in the rush for this to funish, so use default (free) Ubuntu instances
-            runs-on: [self-hosted, linux]
+            runs-on: [self-hosted, linux, x64]
             timeout: 75
             run-tests: true
             free-disk-space-ubuntu: false
@@ -87,7 +87,7 @@ jobs:
     if: always() && github.repository == 'fedimint/fedimint' && github.event_name != 'merge_group'
     name: "Notifications"
     timeout-minutes: 1
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     # note: we don't depend on `audit` because it will
     # be often broken, and we can't fix it immediately
     needs: [ test ]

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -37,7 +37,7 @@ jobs:
   tests:
     if: github.repository == 'fedimint/fedimint'
     name: "Upgrade tests"
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 120
 
     steps:
@@ -96,7 +96,7 @@ jobs:
     if: always() && github.repository == 'fedimint/fedimint'
     name: "Notifications"
     timeout-minutes: 1
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, x64]
     needs: [ tests ]
 
     steps:


### PR DESCRIPTION
I'm provisioning an arm64 CI runner in preparation for #3006 but had to deactivate it so it wouldn't receive normal build jobs. This PR specifies x64 (aka x86, amd64) as the runner architecture for all existing workflows running on self-hosted runners.

![Screenshot 2025-04-17 at 17-48-05 Runners · fedimint_fedimint](https://github.com/user-attachments/assets/e0b89a69-d619-4171-9159-14c25e382cbd)


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
