### PR TITLE
cleanup: consolidate api binds into one argument

### DIFF
--- a/devimint/src/federation.rs
+++ b/devimint/src/federation.rs
@@ -3,17 +3,20 @@ mod config;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::ControlFlow;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::time::Duration;
 use std::{env, fs, iter};
 
 use anyhow::{Context, Result, anyhow, bail};
 use bitcoincore_rpc::bitcoin::Network;
 use fedimint_api_client::api::DynGlobalApi;
+use fedimint_api_client::api::net::Connector;
 use fedimint_client_module::module::ClientModule;
 use fedimint_core::admin_client::{ServerStatusLegacy, SetupStatus};
 use fedimint_core::config::{ClientConfig, ServerModuleConfigGenParamsRegistry, load_from_file};
 use fedimint_core::core::LEGACY_HARDCODED_INSTANCE_ID_WALLET;
 use fedimint_core::envs::BitcoinRpcConfig;
+use fedimint_core::invite_code::InviteCode;
 use fedimint_core::module::registry::ModuleDecoderRegistry;
 use fedimint_core::module::{ApiAuth, ModuleCommon};
 use fedimint_core::runtime::block_in_place;
@@ -39,7 +42,7 @@ use super::external::Bitcoind;
 use super::util::{Command, ProcessHandle, ProcessManager, cmd};
 use super::vars::utf8;
 use crate::envs::{FM_CLIENT_DIR_ENV, FM_DATA_DIR_ENV};
-use crate::util::{FedimintdCmd, poll, poll_with_timeout};
+use crate::util::{FedimintdCmd, poll, poll_simple, poll_with_timeout};
 use crate::version_constants::{VERSION_0_6_0_ALPHA, VERSION_0_7_0_ALPHA};
 use crate::{poll_eq, vars};
 
@@ -362,8 +365,27 @@ impl Federation {
             let client_dir = utf8(&process_mgr.globals.FM_CLIENT_DIR);
             let invite_code_filename_original = "invite-code";
 
+            for peer_env_vars in peer_to_env_vars_map.values() {
+                let peer_data_dir = utf8(&peer_env_vars.FM_DATA_DIR);
+
+                let invite_code = poll_simple("awaiting-invite-code", || async {
+                    tokio::fs::read_to_string(format!(
+                        "{peer_data_dir}/{invite_code_filename_original}"
+                    ))
+                    .await
+                    .map_err(Into::into)
+                })
+                .await
+                .context("Awaiting invite code file")?;
+
+                Connector::default()
+                    .download_from_invite_code(&InviteCode::from_str(&invite_code)?)
+                    .await?;
+            }
+
             // copy over invite-code file to client directory
             let peer_data_dir = utf8(&peer_to_env_vars_map[&0].FM_DATA_DIR);
+
             tokio::fs::copy(
                 format!("{peer_data_dir}/{invite_code_filename_original}"),
                 format!("{client_dir}/{invite_code_filename_original}"),
@@ -385,6 +407,7 @@ impl Federation {
                 .await
                 .context("moving invite-code file")?;
             }
+
             debug!("Moved invite-code files to client data directory");
         }
 
@@ -1154,21 +1177,6 @@ pub async fn run_cli_dkg_v2(
             .start_dkg(auth_for(peer), endpoint)
             .await?;
     }
-
-    for (peer, endpoint) in &endpoints {
-        let status = poll("awaiting-setup-status-consensus-is-running", || async {
-            crate::util::FedimintCli
-                .setup_status(auth_for(peer), endpoint)
-                .await
-                .map_err(ControlFlow::Continue)
-        })
-        .await
-        .unwrap();
-
-        assert_eq!(status, SetupStatus::ConsensusIsRunning);
-    }
-
-    debug!(target: LOG_DEVIMINT, "Consensus is running...");
 
     Ok(())
 }

--- a/fedimint-server/src/config/mod.rs
+++ b/fedimint-server/src/config/mod.rs
@@ -209,10 +209,8 @@ pub struct ServerConfigLocal {
 pub struct ConfigGenSettings {
     /// Bind address for our P2P connection (both iroh and tcp/tls)
     pub p2p_bind: SocketAddr,
-    /// Bind address for our websocket API connection
-    pub bind_api_ws: SocketAddr,
-    /// Bind address for our iroh API connection
-    pub bind_api_iroh: SocketAddr,
+    /// Bind address for our API
+    pub api_bind: SocketAddr,
     /// Bind address for our UI connection (always http)
     pub ui_bind: SocketAddr,
     /// URL for our P2P connection

--- a/fedimint-server/src/lib.rs
+++ b/fedimint-server/src/lib.rs
@@ -171,8 +171,7 @@ pub async fn run(
     Box::pin(consensus::run(
         connections,
         p2p_status_receivers,
-        settings.bind_api_ws,
-        settings.bind_api_iroh,
+        settings.api_bind,
         cfg,
         db,
         module_init_registry.clone(),
@@ -256,7 +255,7 @@ pub async fn run_config_gen(
     let api_handler = net::api::spawn(
         "setup",
         // config gen always uses ws api
-        settings.bind_api_ws,
+        settings.api_bind,
         rpc_module,
         10,
         api_secrets.clone(),

--- a/fedimint-testing/src/federation.rs
+++ b/fedimint-testing/src/federation.rs
@@ -294,7 +294,6 @@ impl FederationTestBuilder {
                     connections,
                     p2p_status_receivers,
                     api_bind,
-                    api_bind,
                     cfg.clone(),
                     db.clone(),
                     module_init_registry,


### PR DESCRIPTION
To clean this up and consolidate ws api bind and iroh api bind arguments into one argument we need to stop starting the iroh and websocket api in parallel. Hence, when we run on iroh we cannot use the admin setup status command anymore to wait for the dkg to complete and the api to come online as it does not support iroh. Therefore we need to poll the existence  of the invite code for the dkg to complete and join-federation for the api to come online.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
