### PR TITLE
desc: encode oob notes in URL safe variant.

### DIFF
--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -346,19 +346,10 @@ impl FromStr for OOBNotes {
 }
 
 impl Display for OOBNotes {
-    /// Base64 encode a set of e-cash notes for out-of-band spending.
-    ///
-    /// Defaults to standard base64 for backwards compatibility.
-    /// For URL-safe base64 as alternative display use:
-    /// `format!("{:#}", oob_notes)`
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let bytes = Encodable::consensus_encode_to_vec(self);
 
-        if f.alternate() {
-            f.write_str(&BASE64_URL_SAFE.encode(&bytes))
-        } else {
-            f.write_str(&base64::engine::general_purpose::STANDARD.encode(&bytes))
-        }
+        f.write_str(&BASE64_URL_SAFE.encode(&bytes))
     }
 }
 


### PR DESCRIPTION
The decoding of this variant has been implemented
for so long, that backward compat. should not be
an issue anymore.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
