### PR TITLE
chore(ui): consensus explorer

### DIFF
--- a/fedimint-server-core/src/dashboard_ui.rs
+++ b/fedimint-server-core/src/dashboard_ui.rs
@@ -7,6 +7,7 @@ use fedimint_core::bitcoin::Network;
 use fedimint_core::core::ModuleKind;
 use fedimint_core::module::ApiAuth;
 use fedimint_core::module::audit::AuditSummary;
+use fedimint_core::session_outcome::SessionStatusV2;
 use fedimint_core::util::SafeUrl;
 use fedimint_core::{Feerate, PeerId};
 
@@ -30,7 +31,10 @@ pub trait IDashboardApi {
     async fn federation_name(&self) -> String;
 
     /// Get the current active session count
-    async fn session_count(&self) -> usize;
+    async fn session_count(&self) -> u64;
+
+    /// Get items in a given session
+    async fn get_session_status(&self, session_idx: u64) -> SessionStatusV2;
 
     /// The time it took to order our last proposal in the current session
     async fn consensus_ord_latency(&self) -> Option<Duration>;

--- a/fedimint-server-ui/src/dashboard/consensus_explorer.rs
+++ b/fedimint-server-ui/src/dashboard/consensus_explorer.rs
@@ -1,0 +1,286 @@
+use axum::extract::{Path, State};
+use axum::response::{Html, IntoResponse};
+use fedimint_core::epoch::ConsensusItem;
+use fedimint_core::hex;
+use fedimint_core::session_outcome::{AcceptedItem, SessionStatusV2};
+use fedimint_core::transaction::TransactionSignature;
+use fedimint_server_core::dashboard_ui::DynDashboardApi;
+use maud::{Markup, html};
+
+use crate::UiState;
+use crate::auth::UserAuth;
+use crate::dashboard::dashboard_layout;
+
+/// Handler for the consensus explorer view
+pub async fn consensus_explorer_view(
+    State(state): State<UiState<DynDashboardApi>>,
+    _auth: UserAuth,
+    session_idx: Option<Path<u64>>,
+) -> impl IntoResponse {
+    let session_count = state.api.session_count().await;
+    let last_sessin_idx = session_count.saturating_sub(1);
+
+    // If a specific session index was provided, show only that session
+    // Otherwise, show the current session
+    let session_idx = session_idx.map(|p| p.0).unwrap_or(last_sessin_idx);
+
+    let (_sigs, items) = match state.api.get_session_status(session_idx).await {
+        SessionStatusV2::Initial => (None, vec![]),
+        SessionStatusV2::Pending(items) => (None, items),
+        SessionStatusV2::Complete(signed_session_outcome) => (
+            Some(signed_session_outcome.signatures),
+            signed_session_outcome.session_outcome.items,
+        ),
+    };
+
+    let content = html! {
+        div class="row mb-4" {
+            div class="col-12" {
+                div class="d-flex justify-content-between align-items-center" {
+                    h2 { "Consensus Explorer" }
+                    a href="/" class="btn btn-outline-primary" { "Back to Dashboard" }
+                }
+            }
+        }
+
+        div class="row mb-4" {
+            div class="col-12" {
+                div class="d-flex justify-content-between align-items-center" {
+                    // Session navigation
+                    div class="btn-group" role="group" aria-label="Session navigation" {
+                        @if 0 < session_idx {
+                            a href={ "/explorer/" (session_idx - 1) } class="btn btn-outline-secondary" {
+                                "← Previous Session"
+                            }
+                        } @else {
+                            button class="btn btn-outline-secondary" disabled { "← Previous Session" }
+                        }
+
+                        @if session_idx < last_sessin_idx {
+                            a href={ "/explorer/" (session_idx + 1) } class="btn btn-outline-secondary" {
+                                "Next Session →"
+                            }
+                        } @else {
+                            button class="btn btn-outline-secondary" disabled { "Next Session →" }
+                        }
+                    }
+
+                    // Jump to session form
+                    form class="d-flex" action="javascript:void(0);" onsubmit="window.location.href='/explorer/' + document.getElementById('session-jump').value" {
+                        div class="input-group" {
+                            input type="number" class="form-control" id="session-jump" min="0" max=(session_count - 1) placeholder="Session #";
+                            button class="btn btn-outline-primary" type="submit" { "Go" }
+                        }
+                    }
+                }
+            }
+        }
+
+        div class="row" {
+            div class="col-12" {
+                div class="card mb-4" {
+                    div class="card-header" {
+                        div class="d-flex justify-content-between align-items-center" {
+                            h5 class="mb-0" { "Session #" (session_idx) }
+                            span class="badge bg-primary" { (items.len()) " items" }
+                        }
+                    }
+                    div class="card-body" {
+                        @if items.is_empty() {
+                            div class="alert alert-secondary" {
+                                "This session contains no consensus items."
+                            }
+                        } @else {
+                            div class="table-responsive" {
+                                table class="table table-striped table-hover" {
+                                    thead {
+                                        tr {
+                                            th { "Item #" }
+                                            th { "Type" }
+                                            th { "Peer" }
+                                            th { "Details" }
+                                        }
+                                    }
+                                    tbody {
+                                        @for (item_idx, item) in items.iter().enumerate() {
+                                            tr {
+                                                td { (item_idx) }
+                                                td { (format_item_type(&item.item)) }
+                                                td { (item.peer) }
+                                                td { (format_item_details(&item)) }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Display signatures if available
+                            @if let Some(signatures) = _sigs {
+                                div class="mt-4" {
+                                    h5 { "Session Signatures" }
+                                    div class="alert alert-info" {
+                                        p { "This session was signed by the following peers:" }
+                                        ul class="mb-0" {
+                                            @for peer_id in signatures.keys() {
+                                                li { "Guardian " (peer_id.to_string()) }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    Html(dashboard_layout(content).into_string()).into_response()
+}
+
+/// Format the type of consensus item for display
+fn format_item_type(item: &ConsensusItem) -> String {
+    match item {
+        ConsensusItem::Transaction(_) => "Transaction".to_string(),
+        ConsensusItem::Module(_) => "Module".to_string(),
+        ConsensusItem::Default { variant, .. } => format!("Unknown ({})", variant),
+    }
+}
+
+/// Format details about a consensus item
+fn format_item_details(item: &AcceptedItem) -> Markup {
+    match &item.item {
+        ConsensusItem::Transaction(tx) => {
+            html! {
+                div class="consensus-item-details" {
+                    div class="mb-2" {
+                        "Transaction ID: " code { (tx.tx_hash()) }
+                    }
+                    div class="mb-2" {
+                        "Nonce: " code { (hex::encode(tx.nonce)) }
+                    }
+
+                    // Inputs section
+                    details class="mb-2" {
+                        summary { "Inputs: " strong { (tx.inputs.len()) } }
+                        @if tx.inputs.is_empty() {
+                            div class="alert alert-secondary mt-2" { "No inputs" }
+                        } @else {
+                            div class="table-responsive mt-2" {
+                                table class="table table-sm" {
+                                    thead {
+                                        tr {
+                                            th { "#" }
+                                            th { "Module ID" }
+                                            th { "Type" }
+                                        }
+                                    }
+                                    tbody {
+                                        @for (idx, input) in tx.inputs.iter().enumerate() {
+                                            tr {
+                                                td { (idx) }
+                                                td { (input.module_instance_id()) }
+                                                td { (input.to_string()) }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Outputs section
+                    details class="mb-2" {
+                        summary { "Outputs: " strong { (tx.outputs.len()) } }
+                        @if tx.outputs.is_empty() {
+                            div class="alert alert-secondary mt-2" { "No outputs" }
+                        } @else {
+                            div class="table-responsive mt-2" {
+                                table class="table table-sm" {
+                                    thead {
+                                        tr {
+                                            th { "#" }
+                                            th { "Module ID" }
+                                            th { "Type" }
+                                        }
+                                    }
+                                    tbody {
+                                        @for (idx, output) in tx.outputs.iter().enumerate() {
+                                            tr {
+                                                td { (idx) }
+                                                td { (output.module_instance_id()) }
+                                                td { (output.to_string()) }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Signature info
+                    details class="mb-2" {
+                        summary { "Signature Info" }
+                        div class="mt-2" {
+                            @match &tx.signatures {
+                                TransactionSignature::NaiveMultisig(sigs) => {
+                                    div { "Type: NaiveMultisig" }
+                                    div { "Signatures: " (sigs.len()) }
+                                }
+                                TransactionSignature::Default { variant, bytes } => {
+                                    div { "Type: Unknown (variant " (variant) ")" }
+                                    div { "Size: " (bytes.len()) " bytes" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ConsensusItem::Module(module_item) => {
+            html! {
+                div class="consensus-item-details" {
+                    div class="mb-2" {
+                        "Module Instance ID: " code { (module_item.module_instance_id()) }
+                    }
+
+                    @if let Some(kind) = module_item.module_kind() {
+                        div class="mb-2" {
+                            "Module Kind: " strong { (kind.to_string()) }
+                        }
+                    } @else {
+                        div class="alert alert-warning mb-2" {
+                            "Unknown Module Kind"
+                        }
+                    }
+
+                    div class="mb-2" {
+                        "Module Item: " code { (module_item.to_string()) }
+                    }
+                }
+            }
+        }
+        ConsensusItem::Default { variant, bytes } => {
+            html! {
+                div class="consensus-item-details" {
+                    div class="alert alert-warning mb-2" {
+                        "Unknown Consensus Item Type (variant " (variant) ")"
+                    }
+                    div class="mb-2" {
+                        "Size: " (bytes.len()) " bytes"
+                    }
+                    @if !bytes.is_empty() {
+                        details {
+                            summary { "Raw Data (Hex)" }
+                            div class="mt-2" {
+                                code class="user-select-all" style="word-break: break-all;" {
+                                    (hex::encode(bytes))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/fedimint-server-ui/src/dashboard/general.rs
+++ b/fedimint-server-ui/src/dashboard/general.rs
@@ -7,7 +7,7 @@ use maud::{Markup, html};
 /// guardian list
 pub fn render(
     federation_name: &str,
-    session_count: usize,
+    session_count: u64,
     guardian_names: &BTreeMap<PeerId, String>,
 ) -> Markup {
     html! {

--- a/fedimint-server-ui/src/dashboard/mod.rs
+++ b/fedimint-server-ui/src/dashboard/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod bitcoin;
+pub(crate) mod consensus_explorer;
 pub mod general;
 pub mod invite;
 pub mod latency;
@@ -10,6 +11,7 @@ use axum::extract::{Form, State};
 use axum::response::{Html, IntoResponse};
 use axum::routing::{get, post};
 use axum_extra::extract::cookie::CookieJar;
+use consensus_explorer::consensus_explorer_view;
 use fedimint_server_core::dashboard_ui::{DashboardApiModuleExt, DynDashboardApi};
 use maud::{DOCTYPE, Markup, html};
 use {fedimint_lnv2_server, fedimint_meta_server, fedimint_wallet_server};
@@ -18,8 +20,8 @@ use crate::assets::WithStaticRoutesExt as _;
 use crate::auth::UserAuth;
 use crate::dashboard::modules::{lnv2, meta, wallet};
 use crate::{
-    LOGIN_ROUTE, LoginInput, ROOT_ROUTE, UiState, common_head, login_form_response,
-    login_submit_response,
+    EXPLORER_IDX_ROUTE, EXPLORER_ROUTE, LOGIN_ROUTE, LoginInput, ROOT_ROUTE, UiState, common_head,
+    login_form_response, login_submit_response,
 };
 
 pub fn dashboard_layout(content: Markup) -> Markup {
@@ -141,6 +143,8 @@ pub fn router(api: DynDashboardApi) -> Router {
     let mut app = Router::new()
         .route(ROOT_ROUTE, get(dashboard_view))
         .route(LOGIN_ROUTE, get(login_form).post(login_submit))
+        .route(EXPLORER_ROUTE, get(consensus_explorer_view))
+        .route(EXPLORER_IDX_ROUTE, get(consensus_explorer_view))
         .with_static_routes();
 
     // routeradd LNv2 gateway routes if the module exists

--- a/fedimint-server-ui/src/lib.rs
+++ b/fedimint-server-ui/src/lib.rs
@@ -8,6 +8,7 @@ use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use fedimint_core::hex::ToHex;
 use fedimint_core::module::ApiAuth;
 use fedimint_core::secp256k1::rand::{Rng, thread_rng};
+use fedimint_server_core::dashboard_ui::DynDashboardApi;
 use maud::{DOCTYPE, Markup, html};
 use serde::Deserialize;
 
@@ -16,6 +17,8 @@ pub(crate) const LOG_UI: &str = "fm::ui";
 // Common route constants
 pub const ROOT_ROUTE: &str = "/";
 pub const LOGIN_ROUTE: &str = "/login";
+pub const EXPLORER_IDX_ROUTE: &str = "/explorer";
+pub const EXPLORER_ROUTE: &str = "/explorer/{session_idx}";
 
 pub fn common_head(title: &str) -> Markup {
     html! {
@@ -41,8 +44,10 @@ pub(crate) struct LoginInput {
 }
 
 /// Generic state for both setup and dashboard UIs
+///
+/// Most of code is written for dashboard, so `T` defaults to `DynDashboardApi`
 #[derive(Clone)]
-pub struct UiState<T> {
+pub struct UiState<T = DynDashboardApi> {
     pub(crate) api: T,
     pub(crate) auth_cookie_name: String,
     pub(crate) auth_cookie_value: String,

--- a/fedimint-server/src/consensus/api.rs
+++ b/fedimint-server/src/consensus/api.rs
@@ -564,8 +564,12 @@ impl IDashboardApi for ConsensusApi {
             .expect("Federation name must be set")
     }
 
-    async fn session_count(&self) -> usize {
-        self.session_count().await as usize
+    async fn session_count(&self) -> u64 {
+        self.session_count().await
+    }
+
+    async fn get_session_status(&self, session_idx: u64) -> SessionStatusV2 {
+        self.session_status(session_idx).await
     }
 
     async fn consensus_ord_latency(&self) -> Option<Duration> {

--- a/justfile.fedimint.just
+++ b/justfile.fedimint.just
@@ -146,6 +146,7 @@ tmuxinator:
 devimint-env *PARAMS:
   ./scripts/dev/devimint-env.sh {{PARAMS}}
 
+# Spawn devimint pre-dkg on fixed port numbers (useful for UI work)
 devimint-env-pre-dkg *PARAMS:
   @>&2 echo "fedimint-0 UI: http://localhost:2002"
   @>&2 echo "fedimint-1 UI: http://localhost:2006"
@@ -153,6 +154,13 @@ devimint-env-pre-dkg *PARAMS:
   @>&2 echo "fedimint-3 UI: http://localhost:2014"
   env FM_FEDERATIONS_BASE_PORT=2000 FM_PRE_DKG=true ./scripts/dev/devimint-env.sh {{PARAMS}}
 
+# Spawn devimint post-dkg on fixed port numbers (useful for UI work)
+devimint-env-post-dkg *PARAMS:
+  @>&2 echo "fedimint-0 UI: http://localhost:2002"
+  @>&2 echo "fedimint-1 UI: http://localhost:2006"
+  @>&2 echo "fedimint-2 UI: http://localhost:2010"
+  @>&2 echo "fedimint-3 UI: http://localhost:2014"
+  env FM_FEDERATIONS_BASE_PORT=2000 ./scripts/dev/devimint-env.sh {{PARAMS}}
 
 devimint-env-tmux *PARAMS:
   ./scripts/dev/tmuxinator/run.sh {{PARAMS}}


### PR DESCRIPTION
Add a simple consensus explorer to the Admin UI.

It's not linked anywhere yet, need to go to `/explorer` manually ATM.

![image](https://github.com/user-attachments/assets/13e0c550-55c5-4525-8f68-3ad0d7177893)


It's really just exposing existing consensus method, and then the LLM generated some UI.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
