### PR TITLE
chore: unify fmt::Display for consensus items

### DIFF
--- a/modules/fedimint-ln-common/src/lib.rs
+++ b/modules/fedimint-ln-common/src/lib.rs
@@ -384,11 +384,11 @@ impl std::fmt::Display for LightningConsensusItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LightningConsensusItem::DecryptPreimage(contract_id, _) => {
-                write!(f, "LN Decryption Share for contract {contract_id}")
+                write!(f, "LN Decryption Share - contract_id: {contract_id}")
             }
-            LightningConsensusItem::BlockCount(count) => write!(f, "LN block count {count}"),
+            LightningConsensusItem::BlockCount(count) => write!(f, "LN Block Count {count}"),
             LightningConsensusItem::Default { variant, .. } => {
-                write!(f, "Unknown LN CI variant={variant}")
+                write!(f, "LN Unknown - variant={variant}")
             }
         }
     }

--- a/modules/fedimint-lnv2-common/src/lib.rs
+++ b/modules/fedimint-lnv2-common/src/lib.rs
@@ -139,7 +139,19 @@ pub enum LightningConsensusItem {
 
 impl std::fmt::Display for LightningConsensusItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "LightningConsensusItem")
+        match self {
+            LightningConsensusItem::BlockCountVote(c) => {
+                write!(f, "LNv2 Block Count {c}")
+            }
+            LightningConsensusItem::UnixTimeVote(t) => {
+                write!(f, "LNv2 Unix Time {t}")
+            }
+            LightningConsensusItem::Default { variant, bytes } => write!(
+                f,
+                "LNv2 Unknown - variant: {variant}, bytes_len: {}",
+                bytes.len()
+            ),
+        }
     }
 }
 

--- a/modules/fedimint-meta-common/src/lib.rs
+++ b/modules/fedimint-meta-common/src/lib.rs
@@ -276,6 +276,6 @@ impl fmt::Display for MetaOutputOutcome {
 
 impl fmt::Display for MetaConsensusItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "MetaConsensusItem")
+        write!(f, "Meta - len: {}", self.value.0.len())
     }
 }


### PR DESCRIPTION
When working on #7285 I've noticed they are all over the place and look weird.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
