### PR TITLE
chore: rm deprecated `REL_NOTES_ACK` references

### DIFF
--- a/devimint/src/vars.rs
+++ b/devimint/src/vars.rs
@@ -128,7 +128,6 @@ declare_vars! {
         FM_API_SECRET: Option<String> = std::env::var("FM_API_SECRET").ok().or_else(|| FM_FORCE_API_SECRETS.get_active()); env: "FM_API_SECRET";
 
         FM_IN_DEVIMINT: String = "1".to_string(); env: FM_IN_DEVIMINT_ENV;
-        FM_SKIP_REL_NOTES_ACK: String = "1".to_string(); env: "FM_SKIP_REL_NOTES_ACK";
 
         FM_FED_SIZE: usize = fed_size; env: "FM_FED_SIZE";
         FM_NUM_FEDS: usize = num_feds; env: "FM_NUM_FEDS";

--- a/docker/deploy-fedimintd/docker-compose.yaml
+++ b/docker/deploy-fedimintd/docker-compose.yaml
@@ -61,7 +61,6 @@ services:
       - FM_API_URL=wss://${FM_DOMAIN}/ws/
       - FM_BIND_API_WS=172.20.0.11:8174
       - FM_BIND_UI=172.20.0.11:8175
-      - FM_REL_NOTES_ACK=0_4_xyz
     restart: always
     labels:
       - "traefik.enable=true"


### PR DESCRIPTION
We deprecated checking the `REL_NOTES_ACK` during startup quite a while ago so this is safe to remove.