### PR TITLE
chore: update nix flake

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   self-care:
     name: Flake self-check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
       - name: Check Nix flake inputs

--- a/devimint/src/external.rs
+++ b/devimint/src/external.rs
@@ -275,7 +275,7 @@ impl Bitcoind {
             Ok(None) => {}
             // The RPC failed, or the transaction was found in the mempool. Return the result.
             other => return other,
-        };
+        }
 
         let block_height = self.get_block_count().await? - 1;
 
@@ -295,10 +295,10 @@ impl Bitcoind {
             match tx_or {
                 // The RPC succeeded, and the transaction was not found in the block. Continue to
                 // the next block.
-                Ok(None) => continue,
+                Ok(None) => {}
                 // The RPC failed, or the transaction was found in the block. Return the result.
                 other => return other,
-            };
+            }
         }
 
         // The transaction was not found in the mempool or any block.

--- a/fedimint-client-module/src/module/mod.rs
+++ b/fedimint-client-module/src/module/mod.rs
@@ -820,7 +820,6 @@ pub trait ClientModule: Debug + MaybeSend + MaybeSync + 'static {
     ///   takes the transaction id of the transaction in which the output was
     ///   used and the output index as input since these cannot be known at time
     ///   of calling `create_change_output` and have to be injected later.
-
     async fn create_final_inputs_and_outputs(
         &self,
         _dbtx: &mut DatabaseTransaction<'_>,

--- a/fedimint-core/src/db/mod.rs
+++ b/fedimint-core/src/db/mod.rs
@@ -3001,7 +3001,7 @@ mod test_utils {
                         assert!(value.eq(&TestVal(102)));
                     }
                     _ => {}
-                };
+                }
                 returned_keys + 1
             })
             .await;
@@ -3026,7 +3026,7 @@ mod test_utils {
                         assert!(value.eq(&TestVal(102)));
                     }
                     _ => {}
-                };
+                }
                 returned_keys + 1
             })
             .await;
@@ -3114,7 +3114,7 @@ mod test_utils {
                         assert!(value.eq(&TestVal(102)));
                     }
                     _ => {}
-                };
+                }
                 returned_keys + 1
             })
             .await;
@@ -3165,7 +3165,7 @@ mod test_utils {
                         assert!(value.eq(&TestVal(102)));
                     }
                     _ => {}
-                };
+                }
                 returned_keys + 1
             })
             .await;
@@ -3240,7 +3240,7 @@ mod test_utils {
                         assert!(value.eq(&TestVal(102)));
                     }
                     _ => {}
-                };
+                }
                 returned_keys + 1
             })
             .await;

--- a/fedimint-core/src/envs.rs
+++ b/fedimint-core/src/envs.rs
@@ -190,7 +190,7 @@ where
             };
 
             map.insert(k, v);
-        };
+        }
     }
 
     Ok(map)

--- a/fedimint-load-test-tool/src/main.rs
+++ b/fedimint-load-test-tool/src/main.rs
@@ -575,7 +575,7 @@ async fn get_required_notes(
             Err(e) => {
                 info!("Unable to get more notes: '{e}', will try to proceed without them");
             }
-        };
+        }
     } else {
         info!(
             "Current balance of {current_balance} already covers the minimum required of {minimum_amount_required}"
@@ -693,7 +693,7 @@ async fn do_load_test_user_task(
                 None => {
                     break;
                 }
-            };
+            }
             if generated_invoices_per_user_iterator.peek().is_some() {
                 // Only sleep while there are more invoices to pay
                 fedimint_core::task::sleep(ln_payment_sleep).await;
@@ -898,7 +898,7 @@ async fn run_two_gateways_strategy(
             )
             .await?;
         }
-    };
+    }
     Ok(())
 }
 

--- a/fedimint-server/src/consensus/mod.rs
+++ b/fedimint-server/src/consensus/mod.rs
@@ -154,7 +154,7 @@ pub async fn run(
                 modules.insert(*module_id, (module_cfg.kind.clone(), module));
             }
             None => bail!("Detected configuration for unsupported module id: {module_id}"),
-        };
+        }
     }
 
     let module_registry = ModuleRegistry::from(modules);

--- a/fedimint-server/src/net/p2p.rs
+++ b/fedimint-server/src/net/p2p.rs
@@ -298,7 +298,7 @@ impl<M: Send + 'static> P2PConnectionSMCommon<M> {
                          self.incoming_sender.send(message).await.ok()?;
                     },
                     Err(e) => return Some(self.disconnect(e)),
-                };
+                }
 
                 Some(P2PConnectionSMState::Connected(connection))
             },

--- a/fedimint-testing/src/btc/mock.rs
+++ b/fedimint-testing/src/btc/mock.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::iter::repeat;
+use std::iter::repeat_n;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -74,7 +74,7 @@ impl FakeBitcoinTest {
             .iter()
             .map(Transaction::compute_txid)
             .collect::<Vec<Txid>>();
-        let matches = repeat(true).take(txs.len()).collect::<Vec<bool>>();
+        let matches = repeat_n(true, txs.len()).collect::<Vec<bool>>();
         PartialMerkleTree::from_txids(txs.as_slice(), matches.as_slice())
     }
 

--- a/fedimint-testing/src/btc/real.rs
+++ b/fedimint-testing/src/btc/real.rs
@@ -77,7 +77,7 @@ impl BitcoinTest for RealBitcoinTestNoLock {
                     break;
                 }
             }
-        };
+        }
 
         mined_block_hashes
     }

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -377,7 +377,7 @@ pub fn default_modules(
     if !is_env_var_set(FM_DISABLE_META_MODULE_ENV) {
         server_gens.attach(MetaInit);
         server_gen_params.attach_config_gen_params(MetaInit::kind(), MetaGenParams::default());
-    };
+    }
 
     if is_env_var_set(FM_USE_UNKNOWN_MODULE_ENV) {
         server_gens.attach(UnknownInit);

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1742713221,
-        "narHash": "sha256-PbtSoLB1FEAMy++3kPW6Kh+o4pPy5Ks92jeUyYIdh5E=",
+        "lastModified": 1744288177,
+        "narHash": "sha256-HxYhdWc6YJ8Q8gOZtv7+teCucmDf6+Ntickvb62Au58=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "c8a7050cd4ecc35651f5a138a162bcb7730c5a9e",
+        "rev": "1273f0099ce6882659ff64b852c8fdb5f8cdd5b9",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
-        "lastModified": 1742452566,
-        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
+        "lastModified": 1745476721,
+        "narHash": "sha256-mzHbTTjBuJ9JsFEbpEGlqI9lSR9yrySthJaS3CxqxdE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
+        "rev": "1c5dcb66d7bc947cae65227fa50928dbb70d4550",
         "type": "github"
       },
       "original": {
@@ -508,11 +508,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
+        "lastModified": 1745279238,
+        "narHash": "sha256-AQ7M9wTa/Pa/kK5pcGTgX/DGqMHyzsyINfN7ktsI7Fo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
+        "rev": "9684b53175fc6c09581e94cc85f05ab77464c7e3",
         "type": "github"
       },
       "original": {
@@ -553,11 +553,11 @@
     "rust-analyzer-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1742296961,
-        "narHash": "sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0=",
+        "lastModified": 1745419660,
+        "narHash": "sha256-TjiBJgWxrZhHWQG/EHCX58arVcUIQQMBMsvVJwoh1x8=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "15d87419f1a123d8f888d608129c3ce3ff8f13d4",
+        "rev": "3d00e247dd2464ec2e19d9a2b64b1761a78a196f",
         "type": "github"
       },
       "original": {

--- a/gateway/fedimint-gateway-client/src/lightning_commands.rs
+++ b/gateway/fedimint-gateway-client/src/lightning_commands.rs
@@ -211,7 +211,7 @@ impl LightningCommands {
                     .await?;
                 print_response(response);
             }
-        };
+        }
 
         Ok(())
     }

--- a/gateway/fedimint-gateway-server/src/federation_manager.rs
+++ b/gateway/fedimint-gateway-server/src/federation_manager.rs
@@ -114,7 +114,7 @@ impl FederationManager {
                             let lnv1 = client.value().get_first_module::<GatewayClientModule>()?;
                             lnv1.await_completion(op_id).await;
                         }
-                        _ => continue,
+                        _ => {}
                     }
                 }
             }

--- a/gateway/fedimint-gateway-server/src/lib.rs
+++ b/gateway/fedimint-gateway-server/src/lib.rs
@@ -584,7 +584,7 @@ impl Gateway {
                             "Gateway isn't in a running state, cannot handle incoming payments."
                         );
                         break;
-                    };
+                    }
                 }
             })
             .await
@@ -1067,7 +1067,7 @@ impl Gateway {
                 other => {
                     debug!(target: LOG_GATEWAY, state = ?other, contract_id = %contract_id, "Got state while paying invoice");
                 }
-            };
+            }
         }
 
         Err(PublicGatewayError::LNv1(LNv1Error::OutgoingPayment(
@@ -2529,7 +2529,6 @@ impl IGatewayClientV1 for Gateway {
                 Err(err) => {
                     warn!(target: LOG_GATEWAY, err = %err.fmt_compact(), "Failure trying to complete payment");
                     sleep(Duration::from_secs(5)).await;
-                    continue;
                 }
             }
         };

--- a/gateway/fedimint-gateway-server/tests/tests.rs
+++ b/gateway/fedimint-gateway-server/tests/tests.rs
@@ -903,7 +903,7 @@ async fn test_gateway_executes_swaps_between_connected_federations() -> anyhow::
         let funded = receive_sub.ok().await?;
         assert_matches!(funded, LnReceiveState::Funded);
         let waiting_funds = receive_sub.ok().await?;
-        assert_matches!(waiting_funds, LnReceiveState::AwaitingFunds { .. });
+        assert_matches!(waiting_funds, LnReceiveState::AwaitingFunds);
         let claimed = receive_sub.ok().await?;
         assert_matches!(claimed, LnReceiveState::Claimed);
         assert_eq!(client2.get_balance().await, invoice_amt);

--- a/modules/fedimint-ln-client/src/lib.rs
+++ b/modules/fedimint-ln-client/src/lib.rs
@@ -1964,7 +1964,7 @@ impl LightningClientModule {
                     debug!(target: LOG_CLIENT_MODULE_LN, ?update, "Wait for ln payment state update");
                 }
             }
-        };
+        }
         bail!("Lightning Payment failed")
     }
 }
@@ -2167,7 +2167,7 @@ pub async fn get_invoice(
                     bail!("We don't support invoices without an amount")
                 }
                 _ => {}
-            };
+            }
             Ok(invoice)
         }
         Err(e) => {

--- a/modules/fedimint-mint-client/src/lib.rs
+++ b/modules/fedimint-mint-client/src/lib.rs
@@ -1752,7 +1752,7 @@ impl MintClientModule {
             MintOperationMetaVariant::SpendOOB { .. }
         ) {
             bail!("Operation is not a out-of-band spend");
-        };
+        }
 
         let client_ctx = self.client_ctx.clone();
 


### PR DESCRIPTION
This PR deviates slightly from our normal `nix flake update` PRs:
- Resolve clippy warning related to Rust `v.1.86.0`
- Switch flake self-check job to self hosted runner (related to https://github.com/fedimint/fedimint/issues/7346)