### PR TITLE
chore(ci): bump macos dev shell timeout

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -84,7 +84,7 @@ jobs:
           - host: macos
             runs-on: macos-14
             build-in-pr: false
-            timeout: 60
+            timeout: 120
 
     name: "Dev Shell on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
We're unable to merge the latest `nix flake update` since the dev shell for macos is timing out.

https://github.com/fedimint/fedimint/pull/7313
https://github.com/fedimint/fedimint/actions/runs/14652815200
![Screenshot_20250424_193819](https://github.com/user-attachments/assets/4860e9f7-daa7-4676-b894-20c9bc08dee6)
