### PR TITLE
fix: fix possible double counting of previous response by the same peer

### DIFF
--- a/fedimint-api-client/src/query.rs
+++ b/fedimint-api-client/src/query.rs
@@ -115,15 +115,13 @@ impl<R> ThresholdConsensus<R> {
     }
 }
 
-impl<R: Eq> QueryStrategy<R> for ThresholdConsensus<R> {
+impl<R: Eq + Clone> QueryStrategy<R> for ThresholdConsensus<R> {
     fn process(&mut self, peer: PeerId, response: R) -> QueryStep<R> {
-        let current_count = self.responses.values().filter(|r| **r == response).count();
+        self.responses.insert(peer, response.clone());
 
-        if current_count + 1 >= self.threshold {
+        if self.responses.values().filter(|r| **r == response).count() == self.threshold {
             return QueryStep::Success(response);
         }
-
-        self.responses.insert(peer, response);
 
         assert!(self.retry.insert(peer));
 


### PR DESCRIPTION
This fixes a race condition where a response that is fetched twice from the same peer is also counted twice with respect the threshold, hence leading the client to believe a threshold has been established even though we have had the response returned by t - 1 peers. 

In a 3/4 federation you actually get the unique situation where t - 1 <= 2 / n which at least theoretically can break chronologic order of events as observed by the client such as a decreasing block count.

This may have lead to the previously observed unknown block hash / unknown utxo error.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
