### PR TITLE
fix: improve errors when alephbft tasks are gone

### DIFF
--- a/fedimint-server/src/consensus/engine.rs
+++ b/fedimint-server/src/consensus/engine.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aleph_bft::Keychain as KeychainTrait;
-use anyhow::{anyhow, bail};
+use anyhow::{Context as _, anyhow, bail};
 use async_channel::Receiver;
 use fedimint_api_client::api::{DynGlobalApi, FederationApiExt, PeerError};
 use fedimint_api_client::query::FilterMap;
@@ -330,7 +330,7 @@ impl ConsensusEngine {
         loop {
             tokio::select! {
                 ordered_unit = ordered_unit_receiver.recv() => {
-                    let ordered_unit = ordered_unit?;
+                    let ordered_unit = ordered_unit.with_context(|| format!("Alepbft task exited prematurely. session_idx: {session_index}, item_idx: {item_index}"))?;
 
                     if ordered_unit.round >= self.cfg.consensus.broadcast_rounds_per_session {
                         break;

--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -23,7 +23,7 @@ use fedimint_core::envs::{
 };
 use fedimint_core::module::registry::ModuleRegistry;
 use fedimint_core::task::TaskGroup;
-use fedimint_core::util::{SafeUrl, handle_version_hash_command};
+use fedimint_core::util::{FmtCompactAnyhow as _, SafeUrl, handle_version_hash_command};
 use fedimint_core::{crit, timing};
 use fedimint_ln_common::config::{
     LightningGenParams, LightningGenParamsConsensus, LightningGenParamsLocal,
@@ -276,7 +276,9 @@ pub async fn run(
         server_opts.db_checkpoint_retention,
     )
     .await
-    .inspect_err(|e| crit!(target: LOG_SERVER, ?e, "Main task returned error"))
+    .inspect_err(
+        |err| crit!(target: LOG_SERVER, err = %err.fmt_compact_anyhow(), "Main task returned error"),
+    )
     .ok();
 
     info!(target: LOG_CORE, "Awaiting shutdown of root task group");


### PR DESCRIPTION
In #7330 you can see that when this happens, which often has nothing to do with consensus or aleph,
a long ugly stacktrace is printed, distracting
the user from the fact that probably something else caused the error.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
