### PR TITLE
chore(ci): rerun the test if old known gatewayd bug was triggered

### DIFF
--- a/scripts/dev/run-test/fm-run-test
+++ b/scripts/dev/run-test/fm-run-test
@@ -65,7 +65,18 @@ FM_RUN_TEST_TIMEOUT_SOFT=${FM_RUN_TEST_TIMEOUT:-310}
 
 command time -q --format="$time_fmt" -o "$time_out_path" \
     timeout -k 10 "$FM_RUN_TEST_TIMEOUT_SOFT" \
-    "$@" 2>&1 | ts -i "%.S" | ts -s "%M:%S" > "$test_out_path"
+    "$@" 2>&1 | ts -i "%.S" | ts -s "%M:%S" > "$test_out_path"; exit_status=$?
+
+if [ $exit_status -ne 0 ]; then
+    if grep -q "please upgrade to gatewayd" "$FM_RUN_TEST_TMPDIR"/devimint-*/logs/gatewayd-lnd.log 2>/dev/null; then
+        echo "## RERUN $test_name$version_str - known old gatewayd bug."
+        command time -q --format="$time_fmt" -o "$time_out_path" \
+            timeout -k 10 "$FM_RUN_TEST_TIMEOUT_SOFT" \
+            "$@" 2>&1 | ts -i "%.S" | ts -s "%M:%S" > "$test_out_path"
+    else
+      exit $exit_status
+    fi
+fi
 
 awk 'BEGIN {FS="\t"} {printf "## STAT: %8.2fs %8dB %8dW %8dc\n", $1, $2, $3, $4}' < "$time_out_path"
 echo "## DONE $test_name$version_str."


### PR DESCRIPTION
Backward compat tests often fail because there is a lot of them, and each devimint
test has a 1/256 change to trigger the old bug that we've never fixed in old
releases.

It just occurred to me that we can relatively easily detect it and re-run the test
which typically should help.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
