### PR TITLE
feat: ability to decode e-cash from a file

### DIFF
--- a/fedimint-cli/src/lib.rs
+++ b/fedimint-cli/src/lib.rs
@@ -410,7 +410,14 @@ enum DecodeType {
     /// Decode an invite code string into a JSON representation
     InviteCode { invite_code: InviteCode },
     /// Decode a string of ecash notes into a JSON representation
-    Notes { notes: OOBNotes },
+    #[group(required = true, multiple = false)]
+    Notes {
+        /// Base64 e-cash notes to be decoded
+        notes: Option<OOBNotes>,
+        /// File containing base64 e-cash notes to be decoded
+        #[arg(long)]
+        file: Option<PathBuf>,
+    },
     /// Decode a transaction hex string and print it to stdout
     Transaction { hex_string: String },
     /// Decode a setup code (as shared during a federation setup ceremony)
@@ -1054,7 +1061,17 @@ impl FedimintCli {
                     url: invite_code.url(),
                     federation_id: invite_code.federation_id(),
                 }),
-                DecodeType::Notes { notes } => {
+                DecodeType::Notes { notes, file } => {
+                    let notes = if let Some(notes) = notes {
+                        notes
+                    } else if let Some(file) = file {
+                        let notes_str =
+                            fs::read_to_string(file).map_err_cli_msg("failed to read file")?;
+                        OOBNotes::from_str(&notes_str).map_err_cli_msg("failed to decode notes")?
+                    } else {
+                        unreachable!("Clap enforces either notes or file being set");
+                    };
+
                     let notes_json = notes
                         .notes_json()
                         .map_err_cli_msg("failed to decode notes")?;


### PR DESCRIPTION
Sometimes the e-cash notes can become too big to feed in via the command line.

For e.g. splitting too large notes one can use:
```bash
$ fedimint-cli dev decode notes --file /path/to/notes > all_notes.json
$ # Choose the range accordingly, the last few rounds may produce empty note sets
$ for i in {0..20}; do jq -c "{
  federation_id_prefix: .federation_id_prefix,
  notes: (
    # Flatten notes into an array with denomination, signature, and spend_key
    [.notes | to_entries[] | .key as \$denom | .value[] | {denomination: \$denom, signature, spend_key}]
    # Take first 100 entries
    | .[$(( $i * 100 )):$(( $i * 100 + 100 ))]
    # Group by denomination
    | group_by(.denomination)
    # Convert back to object structure
    | map({key: .[0].denomination | tostring, value: [.[] | {signature, spend_key}]})
    | from_entries
  )
}" all_notes.json; done > notes_split.json
$ while read BAG; do fedimint-cli dev encode notes "$BAG" | jq -r .; done < notes_split.json > notes-split-enc.txt
```


<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
