### PR TITLE
chore: make deposits on test networks faster

### DIFF
--- a/fedimintd/src/lib.rs
+++ b/fedimintd/src/lib.rs
@@ -347,7 +347,7 @@ pub fn default_modules(
             },
             consensus: WalletGenParamsConsensus {
                 network,
-                finality_delay: 10,
+                finality_delay: default_finality_delay(network),
                 client_default_bitcoin_rpc: default_esplora_server(network),
                 fee_consensus: fedimint_wallet_server::common::config::FeeConsensus::default(),
             },
@@ -403,5 +403,15 @@ pub fn default_esplora_server(network: Network) -> BitcoinRpcConfig {
             _ => panic!("Failed to parse default esplora server"),
         }
         .expect("Failed to parse default esplora server"),
+    }
+}
+
+/// For real Bitcoin we want to have a responsible default, while for demos
+/// nobody wants to wait multiple minutes
+fn default_finality_delay(network: Network) -> u32 {
+    match network {
+        Network::Bitcoin | Network::Regtest => 10,
+        Network::Testnet | Network::Signet | Network::Testnet4 => 2,
+        _ => panic!("Unsupported network"),
     }
 }


### PR DESCRIPTION
Nobody has time to wait 5 minutes for a mutinynet deposit. Related to #7184, which turned out to be a bigger architectural lift than expected.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
