### PR TITLE
fix: use saturating sub when calculating LND liquidity

### DIFF
--- a/gateway/fedimint-lightning/src/lnd.rs
+++ b/gateway/fedimint-lightning/src/lnd.rs
@@ -1365,8 +1365,10 @@ impl ILnRpcClient for GatewayLndClient {
         let pending_outbound = channel_balance_response
             .pending_open_local_balance
             .unwrap_or_default();
-        let lightning_balance_msats =
-            total_outbound.msat - unsettled_outbound.msat - pending_outbound.msat;
+        let lightning_balance_msats = total_outbound
+            .msat
+            .saturating_sub(unsettled_outbound.msat)
+            .saturating_sub(pending_outbound.msat);
 
         let total_inbound = channel_balance_response.remote_balance.unwrap_or_default();
         let unsettled_inbound = channel_balance_response
@@ -1375,8 +1377,10 @@ impl ILnRpcClient for GatewayLndClient {
         let pending_inbound = channel_balance_response
             .pending_open_remote_balance
             .unwrap_or_default();
-        let inbound_lightning_liquidity_msats =
-            total_inbound.msat - unsettled_inbound.msat - pending_inbound.msat;
+        let inbound_lightning_liquidity_msats = total_inbound
+            .msat
+            .saturating_sub(unsettled_inbound.msat)
+            .saturating_sub(pending_inbound.msat);
 
         Ok(GetBalancesResponse {
             onchain_balance_sats: (wallet_balance_response.total_balance


### PR DESCRIPTION
We hit an underflow bug in the gateway https://github.com/fedimint/fedimint/actions/runs/14711340067/job/41284259447#step:6:4437

It looks as though unsettled and pending might overflow and end up being greater than total inbound/outbound. For our case, it doesn't matter, this is just displaying the balances for the operator. Using `saturating_sub` here so that it rounds to 0 is fine.