### PR TITLE
 fix: run main server task a cancellable task 

### DIFF
--- a/fedimint-core/src/task.rs
+++ b/fedimint-core/src/task.rs
@@ -69,6 +69,11 @@ impl TaskGroup {
         new_tg
     }
 
+    /// Is task group shutting down?
+    pub fn is_shutting_down(&self) -> bool {
+        self.inner.is_shutting_down()
+    }
+
     /// Tell all tasks in the group to shut down. This only initiates the
     /// shutdown process, it does not wait for the tasks to shut down.
     pub fn shutdown(&self) {


### PR DESCRIPTION
This reverts changes (only some) of #7304 w.r.t root task handling.

AFAIU, not running it as cancellable task leads to triggering a race between shutdown of alephbft and consensus task, which can lead to spurious errors.

However, I don't understand e2e why would it make the CI more flaky. I can only tell that it would lead to reporting (in logs) errors that it shouldn't.

While at it, it occurred to me that even the old code could (theoretically at least) also report this error, so added a patch for that.

Not sure if this will fix everything, but it should help debugging, and I think it's a correct thing to do. Consensus task is not special, and needs to be cancellable as well if want a unified shutdown procedure that reports all panics.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
