### PR TITLE
fix: add unit test

### DIFF
--- a/fedimint-api-client/src/query.rs
+++ b/fedimint-api-client/src/query.rs
@@ -132,3 +132,34 @@ impl<R: Eq + Clone> QueryStrategy<R> for ThresholdConsensus<R> {
         }
     }
 }
+
+#[test]
+fn test_threshold_consensus() {
+    let mut consensus = ThresholdConsensus::<u64>::new(NumPeers::from(4));
+
+    assert!(matches!(
+        consensus.process(PeerId::from(0), 1),
+        QueryStep::Continue
+    ));
+    assert!(matches!(
+        consensus.process(PeerId::from(1), 1),
+        QueryStep::Continue
+    ));
+    assert!(matches!(
+        consensus.process(PeerId::from(2), 0),
+        QueryStep::Retry(..)
+    ));
+
+    assert!(matches!(
+        consensus.process(PeerId::from(0), 1),
+        QueryStep::Continue
+    ));
+    assert!(matches!(
+        consensus.process(PeerId::from(1), 1),
+        QueryStep::Continue
+    ));
+    assert!(matches!(
+        consensus.process(PeerId::from(2), 1),
+        QueryStep::Success(1)
+    ));
+}


### PR DESCRIPTION
This is a follow up to https://github.com/fedimint/fedimint/pull/7329.

This test verifies that the query strategy does not count the same response on a retry by a peer twice with respect to the threshold, which was the original issue fixed by the aforementioned pr.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
