### PR TITLE
chore(client): make the client db meta key/value private

### DIFF
--- a/fedimint-client/src/db.rs
+++ b/fedimint-client/src/db.rs
@@ -411,7 +411,7 @@ impl_db_record!(
 );
 
 #[derive(Encodable, Decodable, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct MetaFieldPrefix;
+pub(crate) struct MetaFieldPrefix;
 
 #[derive(Encodable, Decodable, Debug)]
 pub struct MetaServiceInfoKey;
@@ -425,10 +425,10 @@ pub struct MetaServiceInfo {
 #[derive(
     Encodable, Decodable, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize,
 )]
-pub struct MetaFieldKey(pub fedimint_client_module::meta::MetaFieldKey);
+pub(crate) struct MetaFieldKey(pub fedimint_client_module::meta::MetaFieldKey);
 
 #[derive(Encodable, Decodable, Debug, Clone, Serialize, Deserialize)]
-pub struct MetaFieldValue(pub fedimint_client_module::meta::MetaFieldValue);
+pub(crate) struct MetaFieldValue(pub fedimint_client_module::meta::MetaFieldValue);
 
 impl_db_record!(
     key = MetaFieldKey,


### PR DESCRIPTION
To be able to split fedimint-client and fedimint-client-module the logical type and db key/value types were split, so there are now two `MetaFieldKey` and `MetaFieldValue`, which is confusing downstream.

The one used for db access can only be used in fedimint-client itself, so should be `pub(crate)`

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
