### PR TITLE
Reintroduce macos builds in CI

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -84,7 +84,7 @@ jobs:
           - host: macos
             runs-on: macos-14
             build-in-pr: false
-            timeout: 120
+            timeout: 60
 
     name: "Dev Shell on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -73,15 +73,18 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     strategy:
       matrix:
-        # TODO: try to reintroduce macos build
-        # https://github.com/fedimint/fedimint/issues/7346
         host:
           - linux
+          - macos
         include:
           - host: linux
             runs-on: [self-hosted, linux, x64]
             build-in-pr: false
             timeout: 30
+          - host: macos
+            runs-on: macos-14
+            build-in-pr: false
+            timeout: 120
 
     name: "Dev Shell on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}
@@ -107,16 +110,21 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     strategy:
       matrix:
-        # TODO: try to reintroduce macos build
-        # https://github.com/fedimint/fedimint/issues/7346
         host:
           - linux
+          - macos
         include:
           - host: linux
             runs-on: [self-hosted, linux, x64]
             build-in-pr: true
             timeout: 90
             run-tests: true
+          - host: macos
+            runs-on: macos-14
+            build-in-pr: false
+            # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
+            timeout: 75
+            run-tests: false
 
     name: "Build on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}
@@ -236,10 +244,9 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: try to reintroduce macos build
-        # https://github.com/fedimint/fedimint/issues/7346
         host:
           - linux
+          - macos
         toolchain:
           - aarch64-android
           - armv7-android
@@ -250,6 +257,18 @@ jobs:
             runs-on: [self-hosted, linux, x64]
             build-in-pr: true
             timeout: 20
+          - host: macos
+            runs-on: macos-14
+            build-in-pr: false
+            # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
+            timeout: 120
+        exclude:
+            # there's not enough macos runners available for our CI, so test only the more important cross-compilation toolchains
+            # if they work, rest probably works as well
+          - host: macos
+            toolchain: armv7-android
+          - host: macos
+            toolchain: x86_64-android
 
 
     runs-on: ${{ matrix.runs-on }}
@@ -394,8 +413,6 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: try to reintroduce macos build
-        # https://github.com/fedimint/fedimint/issues/7346
         platform:
           - name: linux
             runs-on: [self-hosted, linux, x64]
@@ -404,6 +421,13 @@ jobs:
             build-rpm: true
             build-bundled: true
             shasum-cmd: sha256sum
+          - name: macos-aarch64
+            runs-on: macos-14
+            timeout: 180
+            build-deb: false
+            build-rpm: false
+            build-bundled: false
+            shasum-cmd: shasum -a 256
         build:
           - flake-output: fedimint-pkgs
             bins: fedimintd,fedimint-cli,fedimint-dbtool,fedimint-recoverytool

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -246,7 +246,6 @@ jobs:
       matrix:
         host:
           - linux
-          - macos
         toolchain:
           - aarch64-android
           - armv7-android
@@ -257,18 +256,6 @@ jobs:
             runs-on: [self-hosted, linux, x64]
             build-in-pr: true
             timeout: 20
-          - host: macos
-            runs-on: macos-14
-            build-in-pr: false
-            # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
-            timeout: 120
-        exclude:
-            # there's not enough macos runners available for our CI, so test only the more important cross-compilation toolchains
-            # if they work, rest probably works as well
-          - host: macos
-            toolchain: armv7-android
-          - host: macos
-            toolchain: x86_64-android
 
 
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
Closes https://github.com/fedimint/fedimint/issues/7346

A few days ago (Monday), all merges to `master` were blocked due to macos runners so we removed all macos related jobs. The macos runners appear to be working again so we can reintroduce the macos related jobs. We run the risk of accumulating a bill for GH macos runners, however @elsirion and I synced out-of-band and he'll continue monitoring the usage in the admin dashboard.

In addition to the revert, this PR:
- Reduces the macos dev shell timeout back to 60 minutes (see: https://github.com/fedimint/fedimint/pull/7320 and https://github.com/fedimint/fedimint/pull/7313#issuecomment-2831175000)
- Removes macos cross-compile jobs, since we don't have a clear reason to cross-compile using macos to wasm and multiple android architectures