### PR TITLE
wip: build macos dev shell in ci for caching

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -84,7 +84,7 @@ jobs:
           - host: macos
             runs-on: macos-14
             build-in-pr: false
-            timeout: 120
+            timeout: 60
 
     name: "Dev Shell on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -84,7 +84,7 @@ jobs:
           - host: macos
             runs-on: macos-14
             build-in-pr: true
-            timeout: 60
+            timeout: 120
 
     name: "Dev Shell on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -73,15 +73,18 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     strategy:
       matrix:
-        # TODO: try to reintroduce macos build
-        # https://github.com/fedimint/fedimint/issues/7346
         host:
           - linux
+          - macos
         include:
           - host: linux
             runs-on: [self-hosted, linux, x64]
             build-in-pr: false
             timeout: 30
+          - host: macos
+            runs-on: macos-14
+            build-in-pr: false
+            timeout: 120
 
     name: "Dev Shell on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}
@@ -107,16 +110,21 @@ jobs:
     if: github.repository == 'fedimint/fedimint'
     strategy:
       matrix:
-        # TODO: try to reintroduce macos build
-        # https://github.com/fedimint/fedimint/issues/7346
         host:
           - linux
+          - macos
         include:
           - host: linux
             runs-on: [self-hosted, linux, x64]
             build-in-pr: true
             timeout: 90
             run-tests: true
+          - host: macos
+            runs-on: macos-14
+            build-in-pr: false
+            # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
+            timeout: 75
+            run-tests: false
 
     name: "Build on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}
@@ -236,10 +244,9 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: try to reintroduce macos build
-        # https://github.com/fedimint/fedimint/issues/7346
         host:
           - linux
+          - macos
         toolchain:
           - aarch64-android
           - armv7-android
@@ -250,6 +257,18 @@ jobs:
             runs-on: [self-hosted, linux, x64]
             build-in-pr: true
             timeout: 20
+          - host: macos
+            runs-on: macos-14
+            build-in-pr: false
+            # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
+            timeout: 120
+        exclude:
+            # there's not enough macos runners available for our CI, so test only the more important cross-compilation toolchains
+            # if they work, rest probably works as well
+          - host: macos
+            toolchain: armv7-android
+          - host: macos
+            toolchain: x86_64-android
 
 
     runs-on: ${{ matrix.runs-on }}
@@ -394,8 +413,6 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: try to reintroduce macos build
-        # https://github.com/fedimint/fedimint/issues/7346
         platform:
           - name: linux
             runs-on: [self-hosted, linux, x64]
@@ -404,6 +421,13 @@ jobs:
             build-rpm: true
             build-bundled: true
             shasum-cmd: sha256sum
+          - name: macos-aarch64
+            runs-on: macos-14
+            timeout: 180
+            build-deb: false
+            build-rpm: false
+            build-bundled: false
+            shasum-cmd: shasum -a 256
         build:
           - flake-output: fedimint-pkgs
             bins: fedimintd,fedimint-cli,fedimint-dbtool,fedimint-recoverytool

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -83,7 +83,7 @@ jobs:
             timeout: 30
           - host: macos
             runs-on: macos-14
-            build-in-pr: false
+            build-in-pr: true
             timeout: 60
 
     name: "Dev Shell on ${{ matrix.host }}"

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -246,7 +246,6 @@ jobs:
       matrix:
         host:
           - linux
-          - macos
         toolchain:
           - aarch64-android
           - armv7-android
@@ -257,18 +256,6 @@ jobs:
             runs-on: [self-hosted, linux, x64]
             build-in-pr: true
             timeout: 20
-          - host: macos
-            runs-on: macos-14
-            build-in-pr: false
-            # TODO: Too slow; see https://github.com/actions/runner-images/issues/1336
-            timeout: 120
-        exclude:
-            # there's not enough macos runners available for our CI, so test only the more important cross-compilation toolchains
-            # if they work, rest probably works as well
-          - host: macos
-            toolchain: armv7-android
-          - host: macos
-            toolchain: x86_64-android
 
 
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
WIP

Reintroducing the macos runners is hanging in the merge queue. My hunch is we need to keep retrying the build until it's cached.

More context in https://github.com/fedimint/fedimint/pull/7360