### PR TITLE
fix(client): prefix reuse

### DIFF
--- a/fedimint-client/src/client/builder.rs
+++ b/fedimint-client/src/client/builder.rs
@@ -191,7 +191,13 @@ impl ClientBuilder {
         self.meta_service = meta_service;
     }
 
-    async fn migrate_database(&self, db: &Database) -> anyhow::Result<()> {
+    /// Migrate client module databases
+    ///
+    /// Note: Client core db migration are done immediately in
+    /// [`Client::builder`], to ensure db matches the code at all times,
+    /// while migrating modules requires figuring out what modules actually
+    /// are first.
+    async fn migrate_module_dbs(&self, db: &Database) -> anyhow::Result<()> {
         // Only apply the client database migrations if the database has been
         // initialized.
         // This only works as long as you don't change the client config
@@ -562,7 +568,7 @@ impl ClientBuilder {
 
         // Migrate the database before interacting with it in case any on-disk data
         // structures have changed.
-        self.migrate_database(&db).await?;
+        self.migrate_module_dbs(&db).await?;
 
         let init_state = Self::load_init_state(&db).await;
 


### PR DESCRIPTION
Fix #7367

Tested manually in `devimint-env`, by doing a restore on an old version, then switching to new version:

```
2025-05-01T18:06:07.960066Z  INFO fm::db: Migrating module... kind="fedimint-client" current_db_version=DatabaseVersion(3) target_db_version=DatabaseVersion(4)
2025-05-01T18:06:07.960132Z DEBUG fm::client::db: Migrating old ClientModuleRecovery key module_id=0
2025-05-01T18:06:07.960281Z DEBUG fm::client::db: Migrating old ClientModuleRecovery key module_id=1
2025-05-01T18:06:07.960384Z DEBUG fm::client::db: Migrating old ClientModuleRecovery key module_id=2
2025-05-01T18:06:07.960461Z DEBUG fm::client::db: Migrating old ClientModuleRecovery key module_id=3
2025-05-01T18:06:07.960537Z DEBUG fm::client::db: Migrating old ClientModuleRecovery key module_id=4
2025-05-01T18:06:07.960611Z DEBUG fm::client::db: No more ClientModuleRecovery keys found for migartion module_id=5
2025-05-01T18:06:07.960684Z DEBUG fm::db: DB Version kind="fedimint-client" db_version=DatabaseVersion(4)
2025-05-01T18:06:07.962773Z DEBUG fedimint_client::client: Detected configuration for unsupported module id: 5, kind: unknown
```


```
> fedimint-dbtool --database-dir $FM_CLIENT_DIR/client.db list --prefix "31"
31 01020100
> fedimint-dbtool --database-dir $FM_CLIENT_DIR/client.db list --prefix "40"
4000 0101
4001 0101
4002 0101
4003 0101
4004 0101
```
<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
