### PR TITLE
chore(ci): bump macos dev shell timeout from 60 to 90 mins

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -84,7 +84,7 @@ jobs:
           - host: macos
             runs-on: macos-14
             build-in-pr: false
-            timeout: 60
+            timeout: 90
 
     name: "Dev Shell on ${{ matrix.host }}"
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
We recently reintroduced the macos jobs in CI (see: https://github.com/fedimint/fedimint/pull/7360) and noticed jobs failing the merge queue due to the dev shell timeout (https://github.com/fedimint/fedimint/pull/7368#issuecomment-2845922764).