### PR TITLE
fix(ci): prevent markdown link check rate limiting

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,28 +22,12 @@ jobs:
           restore-keys: cache-lychee-
 
       - name: Check links
-        # provide the GitHub token to lychee so API rate‐limits are lifted to 5k/hour
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          nix run nixpkgs#lychee -- \
-            --verbose \
-            --cache \
-            --github-token $GITHUB_TOKEN \
-            docs README.md
-
-      - name: Prune errors from lychee cache
-        if: always()
-        run: |
-          if [ -f .lycheecache ]; then
-            # keep only 2xx and 3xx results, drop all 4xx/5xx
-            grep -E ' [23][0-9]{2} ' .lycheecache > .lycheecache.pruned
-            mv .lycheecache.pruned .lycheecache
-          fi
-
-      - name: Save lychee cache
-        if: always()
-        uses: actions/cache@v4
+        uses: lycheeverse/lychee-action@v2
         with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
+          # TODO: add:
+          # --include-fragments
+          # when it is supported in lychee: https://github.com/lycheeverse/lychee/issues/1613
+          args: |
+            --no-progress
+            --cache
+            docs README.md

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -28,5 +28,22 @@ jobs:
         run: |
           nix run nixpkgs#lychee -- \
             --verbose \
+            --cache \
             --github-token $GITHUB_TOKEN \
             docs README.md
+
+      - name: Prune errors from lychee cache
+        if: always()
+        run: |
+          if [ -f .lycheecache ]; then
+            # keep only 2xx and 3xx results, drop all 4xx/5xx
+            grep -E ' [23][0-9]{2} ' .lycheecache > .lycheecache.pruned
+            mv .lycheecache.pruned .lycheecache
+          fi
+
+      - name: Save lychee cache
+        if: always()
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -28,6 +28,5 @@ jobs:
         run: |
           nix run nixpkgs#lychee -- \
             --verbose \
-            --cache \
             --github-token $GITHUB_TOKEN \
             docs README.md

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -2,6 +2,10 @@ on: [push, pull_request]
 
 name: Markdown Link Check
 
+# Grant the job read access to repo contents so ${{ secrets.GITHUB_TOKEN }} can be used
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: [self-hosted, linux, x64]
@@ -18,4 +22,12 @@ jobs:
           restore-keys: cache-lychee-
 
       - name: Check links
-        run: nix run nixpkgs#lychee -- --verbose docs README.md
+        # provide the GitHub token to lychee so API rate‐limits are lifted to 5k/hour
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          nix run nixpkgs#lychee -- \
+            --verbose \
+            --cache \
+            --github-token $GITHUB_TOKEN \
+            docs README.md


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint/issues/7375

There's more context in the associated issue, but the failure logs suggest

```
You could try setting a GitHub token and running lychee again
```

We also recently switched from using a github action to using the nix package and accidentally dropped the `--cache` flag, which uses the cache in `.lycheecache` that may also be the root cause for 429s.