### PR TITLE
fix: remove forbidden watch::Sender::send

### DIFF
--- a/modules/fedimint-wallet-client/src/lib.rs
+++ b/modules/fedimint-wallet-client/src/lib.rs
@@ -694,9 +694,7 @@ impl WalletClientModule {
 
     pub async fn peg_in(&self, req: PegInRequest) -> anyhow::Result<PegInResponse> {
         let (operation_id, address, _) = self.safe_allocate_deposit_address(req.extra_meta).await?;
-        self.pegin_monitor_wakeup_sender
-            .send(())
-            .context("Failed to wake up peg-in monitor")?;
+        self.pegin_monitor_wakeup_sender.send_replace(());
 
         Ok(PegInResponse {
             deposit_address: Address::from_script(&address.script_pubkey(), self.get_network())?


### PR DESCRIPTION
Related to #7380, no clue why CI didn't catch it after looking at the nix CI code for a bit. At least this fixes the annoyance for me.

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
