### PR TITLE
fix(ci): don't fail on GitHub rate limitng requests

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -17,5 +17,13 @@ jobs:
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
 
+      # accept 429 only for PR runs where secret isn't available
       - name: Check links
-        run: nix run nixpkgs#lychee -- --verbose docs README.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          nix run nixpkgs#lychee -- \
+            --verbose \
+            --cache \
+            --accept '${{ github.event_name == 'pull_request' && '200, 429' || '200' }}' \
+            docs README.md


### PR DESCRIPTION
* Use GH token when running on master, so that we don't get rate-limited
* Accept 429 status code (rate limited) such that on PRs where the secret isn't available we have green CI

Fixes #7375

<!--

# Code Review Policy

* CI must pass (enforced)
* 1 review is mandatory (enforced), 2 or more ideal
* If you believe your change is simple, and non-controversial enough, and you want
  to avoid merge conflicts, or blocking work before it gets enough reviews, label it with
  `needs further review` label and Merge it.

See https://github.com/fedimint/fedimint/blob/master/CONTRIBUTING.md#code-review-policy for
full description.

-->
